### PR TITLE
[Refactor] Remove unused toThrift methods from expression classes and add ExprToThriftVisitor for serialization

### DIFF
--- a/fe/fe-core/build.gradle.kts
+++ b/fe/fe-core/build.gradle.kts
@@ -276,6 +276,7 @@ dependencies {
     implementation("org.xerial.snappy:snappy-java")
     implementation("software.amazon.awssdk:bundle")
     implementation("tools.profiler:async-profiler")
+    implementation("com.github.vertical-blank:sql-formatter:2.0.4")
     // dependency sync end
 
     // extra dependencies pom.xml does not have

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/AnalyticExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/AnalyticExpr.java
@@ -46,7 +46,6 @@ import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.ast.HintNode;
 import com.starrocks.sql.ast.OrderByElement;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
 import org.apache.commons.collections.CollectionUtils;
 
 import java.util.ArrayList;
@@ -248,9 +247,6 @@ public class AnalyticExpr extends Expr {
                 .toString();
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-    }
 
     public static boolean isAnalyticFn(Function fn) {
         return fn instanceof AggregateFunction

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ArithmeticExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ArithmeticExpr.java
@@ -48,8 +48,6 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
 import com.starrocks.thrift.TExprOpcode;
 
 import java.util.Arrays;
@@ -426,12 +424,6 @@ public class ArithmeticExpr extends Expr {
         return new ArithmeticExpr(this);
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.node_type = TExprNodeType.ARITHMETIC_EXPR;
-        msg.setOpcode(op.getOpcode());
-        msg.setOutput_column(outputColumn);
-    }
 
     @Override
     public boolean equalsWithoutChild(Object obj) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ArrayExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ArrayExpr.java
@@ -20,8 +20,6 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,10 +40,6 @@ public class ArrayExpr extends Expr {
         super(other);
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.setNode_type(TExprNodeType.ARRAY_EXPR);
-    }
 
     @Override
     public Expr clone() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ArraySliceExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ArraySliceExpr.java
@@ -36,8 +36,6 @@ package com.starrocks.sql.ast.expression;
 
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
 
 public class ArraySliceExpr extends Expr {
     public ArraySliceExpr(Expr expr, Expr lowerBound, Expr upperBound) {
@@ -50,10 +48,6 @@ public class ArraySliceExpr extends Expr {
         super(other);
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.setNode_type(TExprNodeType.ARRAY_SLICE_EXPR);
-    }
 
     @Override
     public Expr clone() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ArrowExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ArrowExpr.java
@@ -18,10 +18,7 @@ package com.starrocks.sql.ast.expression;
 import com.google.common.base.Preconditions;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
-import com.starrocks.sql.common.ErrorType;
-import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
 
 /**
  * ArrowExpr: col->'xxx'
@@ -53,10 +50,6 @@ public class ArrowExpr extends Expr {
         return getChild(1);
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        throw new StarRocksPlannerException("not support", ErrorType.INTERNAL_ERROR);
-    }
 
     @Override
     public Expr clone() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/BetweenPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/BetweenPredicate.java
@@ -38,7 +38,6 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
 
 /**
  * Class describing between predicates. After successful analysis, we equal
@@ -75,11 +74,6 @@ public class BetweenPredicate extends Predicate {
         return isNotBetween;
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        throw new IllegalStateException(
-                "BetweenPredicate needs to be rewritten into a CompoundPredicate.");
-    }
 
     @Override
     public int hashCode() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/BinaryPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/BinaryPredicate.java
@@ -40,8 +40,6 @@ import com.starrocks.common.io.Writable;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
 
 import java.util.Objects;
 
@@ -140,17 +138,6 @@ public class BinaryPredicate extends Predicate implements Writable {
         return ((BinaryPredicate) obj).opcode == this.opcode;
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.node_type = TExprNodeType.BINARY_PRED;
-        msg.setOpcode(opcode);
-        msg.setVector_opcode(vectorOpcode);
-        if (getChild(0).getType().isComplexType()) {
-            msg.setChild_type_desc(getChild(0).getType().toThrift());
-        } else {
-            msg.setChild_type(getChild(0).getType().getPrimitiveType().toThrift());
-        }
-    }
 
     /*
      * the follow persistence code is only for TableFamilyDeleteInfo.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/BoolLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/BoolLiteral.java
@@ -40,9 +40,6 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TBoolLiteral;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -144,11 +141,6 @@ public class BoolLiteral extends LiteralExpr {
         return value ? 1.0 : 0.0;
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.node_type = TExprNodeType.BOOL_LITERAL;
-        msg.bool_literal = new TBoolLiteral(value);
-    }
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/CaseExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/CaseExpr.java
@@ -40,9 +40,6 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TCaseExpr;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
 
 import java.util.List;
 
@@ -137,12 +134,6 @@ public class CaseExpr extends Expr {
         return hasElseExpr;
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.node_type = TExprNodeType.CASE_EXPR;
-        msg.case_expr = new TCaseExpr(hasCaseExpr, hasElseExpr);
-        msg.setChild_type(getChild(0).getType().getPrimitiveType().toThrift());
-    }
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) throws SemanticException {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/CastExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/CastExpr.java
@@ -43,8 +43,6 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
 import com.starrocks.thrift.TExprOpcode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -126,17 +124,6 @@ public class CastExpr extends Expr {
         return new CastExpr(this);
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.node_type = TExprNodeType.CAST_EXPR;
-        msg.setOpcode(opcode);
-        msg.setOutput_column(outputColumn);
-        if (getChild(0).getType().isComplexType()) {
-            msg.setChild_type_desc(getChild(0).getType().toThrift());
-        } else {
-            msg.setChild_type(getChild(0).getType().getPrimitiveType().toThrift());
-        }
-    }
 
     public boolean isImplicit() {
         return isImplicit;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/CloneExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/CloneExpr.java
@@ -18,8 +18,6 @@ package com.starrocks.sql.ast.expression;
 import com.starrocks.catalog.Type;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
 
 public class CloneExpr extends Expr {
     public CloneExpr(Expr child) {
@@ -39,10 +37,6 @@ public class CloneExpr extends Expr {
         getChild(0).setType(type);
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.setNode_type(TExprNodeType.CLONE_EXPR);
-    }
 
     @Override
     public Expr clone() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/CollectionElementExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/CollectionElementExpr.java
@@ -38,8 +38,6 @@ import com.starrocks.catalog.Type;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
 
 public class CollectionElementExpr extends Expr {
 
@@ -70,15 +68,6 @@ public class CollectionElementExpr extends Expr {
         this.checkIsOutOfBounds = other.checkIsOutOfBounds;
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        if (getChild(0).getType().isArrayType()) {
-            msg.setNode_type(TExprNodeType.ARRAY_ELEMENT_EXPR);
-        } else {
-            msg.setNode_type(TExprNodeType.MAP_ELEMENT_EXPR);
-        }
-        msg.setCheck_is_out_of_bounds(checkIsOutOfBounds);
-    }
 
     @Override
     public Expr clone() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/CompoundPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/CompoundPredicate.java
@@ -39,8 +39,6 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
 import com.starrocks.thrift.TExprOpcode;
 
 import java.util.Objects;
@@ -84,11 +82,6 @@ public class CompoundPredicate extends Predicate {
         return super.equalsWithoutChild(obj) && ((CompoundPredicate) obj).op == op;
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.node_type = TExprNodeType.COMPOUND_PRED;
-        msg.setOpcode(op.toThrift());
-    }
 
     public enum Operator {
         AND("AND", TExprOpcode.COMPOUND_AND),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/DateLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/DateLiteral.java
@@ -44,9 +44,6 @@ import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
-import com.starrocks.thrift.TDateLiteral;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -289,11 +286,6 @@ public class DateLiteral extends LiteralExpr {
         }
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.node_type = TExprNodeType.DATE_LITERAL;
-        msg.date_literal = new TDateLiteral(getStringValue());
-    }
 
     @Override
     public Expr uncheckedCastTo(Type targetType) throws AnalysisException {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/DecimalLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/DecimalLiteral.java
@@ -47,9 +47,6 @@ import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.optimizer.validate.ValidateException;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TDecimalLiteral;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -396,15 +393,6 @@ public class DecimalLiteral extends LiteralExpr {
         return value.doubleValue();
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        // TODO(hujie01) deal with loss information
-        msg.setNode_type(TExprNodeType.DECIMAL_LITERAL);
-        TDecimalLiteral decimalLiteral = new TDecimalLiteral();
-        decimalLiteral.setValue(value.toPlainString());
-        decimalLiteral.setInteger_value(packDecimal());
-        msg.setDecimal_literal(decimalLiteral);
-    }
 
     @Override
     public void swapSign() throws NotImplementedException {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/DefaultValueExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/DefaultValueExpr.java
@@ -18,7 +18,6 @@ package com.starrocks.sql.ast.expression;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
 
 public class DefaultValueExpr extends Expr {
 
@@ -26,10 +25,6 @@ public class DefaultValueExpr extends Expr {
         super(pos);
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-
-    }
 
     @Override
     public Expr clone() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/DictMappingExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/DictMappingExpr.java
@@ -17,8 +17,6 @@ package com.starrocks.sql.ast.expression;
 
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
 
 // DictMappingExpr.
 // The original expression will be rewritten as a dictionary mapping function in the global field optimization.
@@ -47,10 +45,6 @@ public class DictMappingExpr extends Expr {
         super(other);
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.setNode_type(TExprNodeType.DICT_EXPR);
-    }
 
     @Override
     public Expr clone() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/DictQueryExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/DictQueryExpr.java
@@ -21,8 +21,6 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.thrift.TDictQueryExpr;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
 
 import java.util.List;
 
@@ -48,11 +46,6 @@ public class DictQueryExpr extends FunctionCallExpr {
     }
 
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.setNode_type(TExprNodeType.DICT_QUERY_EXPR);
-        msg.setDict_query_expr(dictQueryExpr);
-    }
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/DictionaryGetExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/DictionaryGetExpr.java
@@ -20,8 +20,6 @@ import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.thrift.TDictionaryGetExpr;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
 
 import java.util.List;
 
@@ -60,18 +58,6 @@ public class DictionaryGetExpr extends Expr {
         this.type = other.getType();
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        TDictionaryGetExpr dictionaryGetExpr = new TDictionaryGetExpr();
-        dictionaryGetExpr.setDict_id(dictionaryId);
-        dictionaryGetExpr.setTxn_id(dictionaryTxnId);
-        dictionaryGetExpr.setKey_size(keySize);
-        dictionaryGetExpr.setNull_if_not_exist(nullIfNotExist);
-        setDictionaryGetExpr(dictionaryGetExpr);
-
-        msg.setNode_type(TExprNodeType.DICTIONARY_GET_EXPR);
-        msg.setDictionary_get_expr(dictionaryGetExpr);
-    }
 
     @Override
     public Expr clone() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ExistsPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ExistsPredicate.java
@@ -39,7 +39,6 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
 
 import java.util.Objects;
 
@@ -71,11 +70,6 @@ public class ExistsPredicate extends Predicate {
         return new ExistsPredicate((Subquery) getChild(0), !notExists);
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        // Cannot serialize a nested predicate
-        Preconditions.checkState(false);
-    }
 
     @Override
     public Expr clone() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/Expr.java
@@ -60,8 +60,6 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.ast.ParseNode;
-import com.starrocks.sql.common.ErrorType;
-import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.common.UnsupportedException;
 import com.starrocks.sql.formatter.AST2SQLVisitor;
 import com.starrocks.sql.formatter.ExprExplainVisitor;
@@ -340,6 +338,10 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
 
     public int getOutputColumn() {
         return outputColumn;
+    }
+
+    public TExprOpcode getVectorOpcode() {
+        return vectorOpcode;
     }
 
     public boolean isFilter() {
@@ -662,8 +664,8 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
 
     // Convert this expr into msg (excluding children), which requires setting
     // msg.op as well as the expr-specific field.
-    protected void toThrift(TExprNode msg) {
-        throw new StarRocksPlannerException("Not implement toThrift function", ErrorType.INTERNAL_ERROR);
+    protected final void toThrift(TExprNode msg) {
+        ExprToThriftVisitor.INSTANCE.visit(this, msg);
     }
 
     public List<String> childrenToSql() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ExprToThriftVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ExprToThriftVisitor.java
@@ -1,0 +1,391 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast.expression;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.planner.SlotDescriptor;
+import com.starrocks.sql.ast.AstVisitorExtendInterface;
+import com.starrocks.sql.common.ErrorType;
+import com.starrocks.sql.common.StarRocksPlannerException;
+import com.starrocks.thrift.TAggregateExpr;
+import com.starrocks.thrift.TBinaryLiteral;
+import com.starrocks.thrift.TBoolLiteral;
+import com.starrocks.thrift.TCaseExpr;
+import com.starrocks.thrift.TDateLiteral;
+import com.starrocks.thrift.TDecimalLiteral;
+import com.starrocks.thrift.TDictionaryGetExpr;
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.thrift.TFloatLiteral;
+import com.starrocks.thrift.TInPredicate;
+import com.starrocks.thrift.TInfoFunc;
+import com.starrocks.thrift.TIntLiteral;
+import com.starrocks.thrift.TLargeIntLiteral;
+import com.starrocks.thrift.TPlaceHolder;
+import com.starrocks.thrift.TSlotRef;
+import com.starrocks.thrift.TStringLiteral;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Convert {@link Expr} nodes into their Thrift representation via {@link AstVisitorExtendInterface}.
+ */
+public class ExprToThriftVisitor implements AstVisitorExtendInterface<Void, TExprNode> {
+
+    public static final ExprToThriftVisitor INSTANCE = new ExprToThriftVisitor();
+
+    private ExprToThriftVisitor() {
+    }
+
+    @Override
+    public Void visitExpression(Expr node, TExprNode msg) {
+        throw new StarRocksPlannerException("Not implement toThrift function", ErrorType.INTERNAL_ERROR);
+    }
+
+    @Override
+    public Void visitBetweenPredicate(BetweenPredicate node, TExprNode msg) {
+        throw new IllegalStateException(
+                "BetweenPredicate needs to be rewritten into a CompoundPredicate.");
+    }
+
+    @Override
+    public Void visitArrayExpr(ArrayExpr node, TExprNode msg) {
+        msg.setNode_type(TExprNodeType.ARRAY_EXPR);
+        return null;
+    }
+
+    @Override
+    public Void visitCollectionElementExpr(CollectionElementExpr node, TExprNode msg) {
+        if (node.getChild(0).getType().isArrayType()) {
+            msg.setNode_type(TExprNodeType.ARRAY_ELEMENT_EXPR);
+        } else {
+            msg.setNode_type(TExprNodeType.MAP_ELEMENT_EXPR);
+        }
+        msg.setCheck_is_out_of_bounds(node.isCheckIsOutOfBounds());
+        return null;
+    }
+
+    @Override
+    public Void visitArrowExpr(ArrowExpr node, TExprNode msg) {
+        throw new StarRocksPlannerException("not support", ErrorType.INTERNAL_ERROR);
+    }
+
+    @Override
+    public Void visitStringLiteral(StringLiteral node, TExprNode msg) {
+        msg.node_type = TExprNodeType.STRING_LITERAL;
+        msg.string_literal = new TStringLiteral(node.getUnescapedValue());
+        return null;
+    }
+
+    @Override
+    public Void visitArithmeticExpr(ArithmeticExpr node, TExprNode msg) {
+        msg.node_type = TExprNodeType.ARITHMETIC_EXPR;
+        msg.setOpcode(node.getOp().getOpcode());
+        msg.setOutput_column(node.getOutputColumn());
+        return null;
+    }
+
+    @Override
+    public Void visitDictQueryExpr(DictQueryExpr node, TExprNode msg) {
+        msg.setNode_type(TExprNodeType.DICT_QUERY_EXPR);
+        msg.setDict_query_expr(node.getDictQueryExpr());
+        return null;
+    }
+
+    @Override
+    public Void visitLikePredicate(LikePredicate node, TExprNode msg) {
+        msg.node_type = TExprNodeType.FUNCTION_CALL;
+        return null;
+    }
+
+    @Override
+    public Void visitLambdaArguments(LambdaArgument node, TExprNode msg) {
+        throw new StarRocksPlannerException("not support", ErrorType.INTERNAL_ERROR);
+    }
+
+    @Override
+    public Void visitInformationFunction(InformationFunction node, TExprNode msg) {
+        msg.node_type = TExprNodeType.INFO_FUNC;
+        msg.info_func = new TInfoFunc(node.getIntValue(), node.getStrValue());
+        return null;
+    }
+
+    @Override
+    public Void visitSubqueryExpr(Subquery node, TExprNode msg) {
+        return null;
+    }
+
+    @Override
+    public Void visitArraySliceExpr(ArraySliceExpr node, TExprNode msg) {
+        msg.setNode_type(TExprNodeType.ARRAY_SLICE_EXPR);
+        return null;
+    }
+
+    @Override
+    public Void visitSlot(SlotRef node, TExprNode msg) {
+        msg.node_type = TExprNodeType.SLOT_REF;
+        SlotDescriptor desc = node.getDesc();
+        if (desc != null) {
+            if (desc.getParent() != null) {
+                msg.slot_ref = new TSlotRef(desc.getId().asInt(), desc.getParent().getId().asInt());
+            } else {
+                msg.slot_ref = new TSlotRef(desc.getId().asInt(), 0);
+            }
+        } else {
+            msg.slot_ref = new TSlotRef(0, 0);
+        }
+        msg.setOutput_column(node.getOutputColumn());
+        return null;
+    }
+
+    @Override
+    public Void visitDecimalLiteral(DecimalLiteral node, TExprNode msg) {
+        msg.setNode_type(TExprNodeType.DECIMAL_LITERAL);
+        TDecimalLiteral decimalLiteral = new TDecimalLiteral();
+        decimalLiteral.setValue(node.getValue().toPlainString());
+        decimalLiteral.setInteger_value(node.packDecimal());
+        msg.setDecimal_literal(decimalLiteral);
+        return null;
+    }
+
+    @Override
+    public Void visitCaseWhenExpr(CaseExpr node, TExprNode msg) {
+        msg.node_type = TExprNodeType.CASE_EXPR;
+        msg.case_expr = new TCaseExpr(node.hasCaseExpr(), node.hasElseExpr());
+        msg.setChild_type(node.getChild(0).getType().getPrimitiveType().toThrift());
+        return null;
+    }
+
+    @Override
+    public Void visitDictionaryGetExpr(DictionaryGetExpr node, TExprNode msg) {
+        TDictionaryGetExpr dictionaryGetExpr = new TDictionaryGetExpr();
+        dictionaryGetExpr.setDict_id(node.getDictionaryId());
+        dictionaryGetExpr.setTxn_id(node.getDictionaryTxnId());
+        dictionaryGetExpr.setKey_size(node.getKeySize());
+        dictionaryGetExpr.setNull_if_not_exist(node.getNullIfNotExist());
+        node.setDictionaryGetExpr(dictionaryGetExpr);
+
+        msg.setNode_type(TExprNodeType.DICTIONARY_GET_EXPR);
+        msg.setDictionary_get_expr(dictionaryGetExpr);
+        return null;
+    }
+
+    @Override
+    public Void visitVarBinaryLiteral(VarBinaryLiteral node, TExprNode msg) {
+        msg.node_type = TExprNodeType.BINARY_LITERAL;
+        msg.binary_literal = new TBinaryLiteral(ByteBuffer.wrap(node.getValue()));
+        return null;
+    }
+
+    @Override
+    public Void visitFunctionCall(FunctionCallExpr node, TExprNode msg) {
+        if (node.isAggregate() || node.isAnalyticFnCall()) {
+            msg.node_type = TExprNodeType.AGG_EXPR;
+            msg.setAgg_expr(new TAggregateExpr(node.isMergeAggFn()));
+        } else {
+            msg.node_type = TExprNodeType.FUNCTION_CALL;
+        }
+        return null;
+    }
+
+    @Override
+    public Void visitIsNullPredicate(IsNullPredicate node, TExprNode msg) {
+        msg.node_type = TExprNodeType.FUNCTION_CALL;
+        return null;
+    }
+
+    @Override
+    public Void visitMatchExpr(MatchExpr node, TExprNode msg) {
+        msg.node_type = TExprNodeType.MATCH_EXPR;
+        msg.setOpcode(node.getMatchOperator().getOpcode());
+        return null;
+    }
+
+    @Override
+    public Void visitLambdaFunctionExpr(LambdaFunctionExpr node, TExprNode msg) {
+        msg.setNode_type(TExprNodeType.LAMBDA_FUNCTION_EXPR);
+        msg.setOutput_column(node.getCommonSubOperatorNum());
+        return null;
+    }
+
+    @Override
+    public Void visitCompoundPredicate(CompoundPredicate node, TExprNode msg) {
+        msg.node_type = TExprNodeType.COMPOUND_PRED;
+        msg.setOpcode(node.getOp().toThrift());
+        return null;
+    }
+
+    @Override
+    public Void visitLargeIntLiteral(LargeIntLiteral node, TExprNode msg) {
+        msg.node_type = TExprNodeType.LARGE_INT_LITERAL;
+        msg.large_int_literal = new TLargeIntLiteral(node.getValue().toString());
+        return null;
+    }
+
+    @Override
+    public Void visitCastExpr(CastExpr node, TExprNode msg) {
+        msg.node_type = TExprNodeType.CAST_EXPR;
+        msg.setOpcode(node.getOpcode());
+        msg.setOutput_column(node.getOutputColumn());
+        if (node.getChild(0).getType().isComplexType()) {
+            msg.setChild_type_desc(node.getChild(0).getType().toThrift());
+        } else {
+            msg.setChild_type(node.getChild(0).getType().getPrimitiveType().toThrift());
+        }
+        return null;
+    }
+
+    @Override
+    public Void visitSubfieldExpr(SubfieldExpr node, TExprNode msg) {
+        msg.setNode_type(TExprNodeType.SUBFIELD_EXPR);
+        msg.setUsed_subfield_names(node.getFieldNames());
+        msg.setCopy_flag(node.isCopyFlag());
+        return null;
+    }
+
+    @Override
+    public Void visitMaxLiteral(MaxLiteral node, TExprNode msg) {
+        return null;
+    }
+
+    @Override
+    public Void visitCloneExpr(CloneExpr node, TExprNode msg) {
+        msg.setNode_type(TExprNodeType.CLONE_EXPR);
+        return null;
+    }
+
+    @Override
+    public Void visitLargeInPredicate(LargeInPredicate node, TExprNode msg) {
+        throw new UnsupportedOperationException(
+                "LargeInPredicate cannot be serialized to Thrift. " +
+                "It should be transformed to Left semi/anti join via LargeInPredicateToJoinRule.");
+    }
+
+    @Override
+    public Void visitBinaryPredicate(BinaryPredicate node, TExprNode msg) {
+        msg.node_type = TExprNodeType.BINARY_PRED;
+        msg.setOpcode(node.getOpcode());
+        msg.setVector_opcode(node.getVectorOpcode());
+        if (node.getChild(0).getType().isComplexType()) {
+            msg.setChild_type_desc(node.getChild(0).getType().toThrift());
+        } else {
+            msg.setChild_type(node.getChild(0).getType().getPrimitiveType().toThrift());
+        }
+        return null;
+    }
+
+    @Override
+    public Void visitIntLiteral(IntLiteral node, TExprNode msg) {
+        msg.node_type = TExprNodeType.INT_LITERAL;
+        msg.int_literal = new TIntLiteral(node.getValue());
+        return null;
+    }
+
+    @Override
+    public Void visitDateLiteral(DateLiteral node, TExprNode msg) {
+        msg.node_type = TExprNodeType.DATE_LITERAL;
+        msg.date_literal = new TDateLiteral(node.getStringValue());
+        return null;
+    }
+
+    @Override
+    public Void visitMapExpr(MapExpr node, TExprNode msg) {
+        msg.setNode_type(TExprNodeType.MAP_EXPR);
+        return null;
+    }
+
+    @Override
+    public Void visitInPredicate(InPredicate node, TExprNode msg) {
+        Preconditions.checkState(!node.contains(Subquery.class));
+        msg.in_predicate = new TInPredicate(node.isNotIn());
+        msg.node_type = TExprNodeType.IN_PRED;
+        msg.setOpcode(node.getOpcode());
+        msg.setVector_opcode(node.getVectorOpcode());
+        if (node.getChild(0).getType().isComplexType()) {
+            msg.setChild_type_desc(node.getChild(0).getType().toThrift());
+        } else {
+            msg.setChild_type(node.getChild(0).getType().getPrimitiveType().toThrift());
+        }
+        return null;
+    }
+
+    @Override
+    public Void visitFieldReference(FieldReference node, TExprNode msg) {
+        throw new StarRocksPlannerException("FieldReference not implement toThrift", ErrorType.INTERNAL_ERROR);
+    }
+
+    @Override
+    public Void visitAnalyticExpr(AnalyticExpr node, TExprNode msg) {
+        return null;
+    }
+
+    @Override
+    public Void visitTimestampArithmeticExpr(TimestampArithmeticExpr node, TExprNode msg) {
+        msg.node_type = TExprNodeType.COMPUTE_FUNCTION_CALL;
+        msg.setOpcode(node.getOpcode());
+        return null;
+    }
+
+    @Override
+    public Void visitBoolLiteral(BoolLiteral node, TExprNode msg) {
+        msg.node_type = TExprNodeType.BOOL_LITERAL;
+        msg.bool_literal = new TBoolLiteral(node.getValue());
+        return null;
+    }
+
+    @Override
+    public Void visitFloatLiteral(FloatLiteral node, TExprNode msg) {
+        msg.node_type = TExprNodeType.FLOAT_LITERAL;
+        msg.float_literal = new TFloatLiteral(node.getValue());
+        return null;
+    }
+
+    @Override
+    public Void visitExistsPredicate(ExistsPredicate node, TExprNode msg) {
+        Preconditions.checkState(false);
+        return null;
+    }
+
+    @Override
+    public Void visitIntervalLiteral(IntervalLiteral node, TExprNode msg) {
+        throw new StarRocksPlannerException("IntervalLiteral not implement toThrift", ErrorType.INTERNAL_ERROR);
+    }
+
+    @Override
+    public Void visitDictMappingExpr(DictMappingExpr node, TExprNode msg) {
+        msg.setNode_type(TExprNodeType.DICT_EXPR);
+        return null;
+    }
+
+    @Override
+    public Void visitNullLiteral(NullLiteral node, TExprNode msg) {
+        msg.node_type = TExprNodeType.NULL_LITERAL;
+        return null;
+    }
+
+    @Override
+    public Void visitPlaceHolderExpr(PlaceHolderExpr node, TExprNode msg) {
+        msg.setNode_type(TExprNodeType.PLACEHOLDER_EXPR);
+        msg.setVslot_ref(new TPlaceHolder());
+        msg.vslot_ref.setNullable(node.isNullable());
+        msg.vslot_ref.setSlot_id(node.getSlotId());
+        return null;
+    }
+
+    @Override
+    public Void visitDefaultValueExpr(DefaultValueExpr node, TExprNode msg) {
+        return null;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/FieldReference.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/FieldReference.java
@@ -16,9 +16,6 @@ package com.starrocks.sql.ast.expression;
 
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
-import com.starrocks.sql.common.ErrorType;
-import com.starrocks.sql.common.StarRocksPlannerException;
-import com.starrocks.thrift.TExprNode;
 
 import java.util.Objects;
 
@@ -72,8 +69,4 @@ public class FieldReference extends Expr {
         return new FieldReference(fieldIndex, tblName);
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        throw new StarRocksPlannerException("FieldReference not implement toThrift", ErrorType.INTERNAL_ERROR);
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/FloatLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/FloatLiteral.java
@@ -41,9 +41,6 @@ import com.starrocks.common.NotImplementedException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
-import com.starrocks.thrift.TFloatLiteral;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
@@ -173,11 +170,6 @@ public class FloatLiteral extends LiteralExpr {
         return value;
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.node_type = TExprNodeType.FLOAT_LITERAL;
-        msg.float_literal = new TFloatLiteral(value);
-    }
 
     public double getValue() {
         return value;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/FunctionCallExpr.java
@@ -45,9 +45,6 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TAggregateExpr;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
 
 import java.util.List;
 import java.util.Objects;
@@ -237,17 +234,6 @@ public class FunctionCallExpr extends Expr {
         return fnParams.isDistinct();
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        // TODO: we never serialize this to thrift if it's an aggregate function
-        // except in test cases that do it explicitly.
-        if (isAggregate() || isAnalyticFnCall) {
-            msg.node_type = TExprNodeType.AGG_EXPR;
-            msg.setAgg_expr(new TAggregateExpr(isMergeAggFn));
-        } else {
-            msg.node_type = TExprNodeType.FUNCTION_CALL;
-        }
-    }
 
     public void setMergeAggFnHasNullableChild(boolean value) {
         this.mergeAggFnHasNullableChild = value;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/InPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/InPredicate.java
@@ -40,10 +40,7 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
 import com.starrocks.thrift.TExprOpcode;
-import com.starrocks.thrift.TInPredicate;
 
 import java.util.List;
 
@@ -128,20 +125,6 @@ public class InPredicate extends Predicate {
         return true;
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        // Can't serialize a predicate with a subquery
-        Preconditions.checkState(!contains(Subquery.class));
-        msg.in_predicate = new TInPredicate(isNotIn);
-        msg.node_type = TExprNodeType.IN_PRED;
-        msg.setOpcode(opcode);
-        msg.setVector_opcode(vectorOpcode);
-        if (getChild(0).getType().isComplexType()) {
-            msg.setChild_type_desc(getChild(0).getType().toThrift());
-        } else {
-            msg.setChild_type(getChild(0).getType().getPrimitiveType().toThrift());
-        }
-    }
 
     @Override
     public String toString() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/InformationFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/InformationFunction.java
@@ -37,9 +37,6 @@ package com.starrocks.sql.ast.expression;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
-import com.starrocks.thrift.TInfoFunc;
 
 public class InformationFunction extends Expr {
     private final String funcType;
@@ -100,11 +97,6 @@ public class InformationFunction extends Expr {
         return strValue;
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.node_type = TExprNodeType.INFO_FUNC;
-        msg.info_func = new TInfoFunc(intValue, strValue);
-    }
 
     /**
      * Below function is added by new analyzer

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/IntLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/IntLiteral.java
@@ -44,9 +44,6 @@ import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.validate.ValidateException;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
-import com.starrocks.thrift.TIntLiteral;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -333,11 +330,6 @@ public class IntLiteral extends LiteralExpr {
         return (double) value;
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.node_type = TExprNodeType.INT_LITERAL;
-        msg.int_literal = new TIntLiteral(value);
-    }
 
     @Override
     public Expr uncheckedCastTo(Type targetType) throws AnalysisException {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/IntervalLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/IntervalLiteral.java
@@ -17,10 +17,7 @@ package com.starrocks.sql.ast.expression;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.ast.UnitIdentifier;
-import com.starrocks.sql.common.ErrorType;
-import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
 
 
 public class IntervalLiteral extends LiteralExpr {
@@ -45,10 +42,6 @@ public class IntervalLiteral extends LiteralExpr {
         return unitIdentifier;
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        throw new StarRocksPlannerException("IntervalLiteral not implement toThrift", ErrorType.INTERNAL_ERROR);
-    }
 
     @Override
     public Expr clone() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/IsNullPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/IsNullPredicate.java
@@ -42,8 +42,6 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
 import com.starrocks.thrift.TFunctionBinaryType;
 
 public class IsNullPredicate extends Predicate {
@@ -96,10 +94,6 @@ public class IsNullPredicate extends Predicate {
         return ((IsNullPredicate) obj).isNotNull == isNotNull;
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.node_type = TExprNodeType.FUNCTION_CALL;
-    }
 
     /**
      * Negates an IsNullPredicate.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/LambdaArgument.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/LambdaArgument.java
@@ -17,10 +17,7 @@ package com.starrocks.sql.ast.expression;
 
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
-import com.starrocks.sql.common.ErrorType;
-import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
-import com.starrocks.thrift.TExprNode;
 
 public class LambdaArgument extends Expr {
     private String name;
@@ -58,10 +55,6 @@ public class LambdaArgument extends Expr {
         this.nullable = nullable;
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        throw new StarRocksPlannerException("not support", ErrorType.INTERNAL_ERROR);
-    }
 
     @Override
     public Expr clone() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/LambdaFunctionExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/LambdaFunctionExpr.java
@@ -19,8 +19,6 @@ import com.google.common.base.Preconditions;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
 
 import java.util.List;
 import java.util.Map;
@@ -69,11 +67,6 @@ public class LambdaFunctionExpr extends Expr {
         }
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.setNode_type(TExprNodeType.LAMBDA_FUNCTION_EXPR);
-        msg.setOutput_column(commonSubOperatorNum);
-    }
 
     @Override
     public Expr clone() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/LargeInPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/LargeInPredicate.java
@@ -19,7 +19,6 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
 
 import java.util.List;
 import java.util.Objects;
@@ -172,14 +171,6 @@ public class LargeInPredicate extends InPredicate {
         }
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        // LargeInPredicate should never be serialized to Thrift.
-        // It must be transformed to Left semi/anti join before execution.
-        throw new UnsupportedOperationException(
-                "LargeInPredicate cannot be serialized to Thrift. " +
-                "It should be transformed to Left semi/anti join via LargeInPredicateToJoinRule.");
-    }
 
     @Override
     public String toString() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/LargeIntLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/LargeIntLiteral.java
@@ -41,9 +41,6 @@ import com.starrocks.common.io.Text;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
-import com.starrocks.thrift.TLargeIntLiteral;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -202,11 +199,6 @@ public class LargeIntLiteral extends LiteralExpr {
         return value.doubleValue();
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.node_type = TExprNodeType.LARGE_INT_LITERAL;
-        msg.large_int_literal = new TLargeIntLiteral(value.toString());
-    }
 
     @Override
     public Expr uncheckedCastTo(Type targetType) throws AnalysisException {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/LikePredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/LikePredicate.java
@@ -39,8 +39,6 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
 
 import java.util.Objects;
 
@@ -101,10 +99,6 @@ public class LikePredicate extends Predicate {
         return ((LikePredicate) obj).op == op;
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.node_type = TExprNodeType.FUNCTION_CALL;
-    }
 
     @Override
     public int hashCode() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/MapExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/MapExpr.java
@@ -23,8 +23,6 @@ import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.common.TypeManager;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -88,10 +86,6 @@ public class MapExpr extends Expr {
         return e;
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.setNode_type(TExprNodeType.MAP_EXPR);
-    }
 
     @Override
     public Expr clone() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/MatchExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/MatchExpr.java
@@ -20,8 +20,6 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
 import com.starrocks.thrift.TExprOpcode;
 
 import java.util.Objects;
@@ -94,11 +92,6 @@ public class MatchExpr extends Expr {
         return new MatchExpr(this);
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.node_type = TExprNodeType.MATCH_EXPR;
-        msg.setOpcode(matchOperator.getOpcode());
-    }
 
     @Override
     public int hashCode() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/MaxLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/MaxLiteral.java
@@ -19,7 +19,6 @@ package com.starrocks.sql.ast.expression;
 
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
-import com.starrocks.thrift.TExprNode;
 
 public final class MaxLiteral extends LiteralExpr {
 
@@ -46,9 +45,6 @@ public final class MaxLiteral extends LiteralExpr {
         return 1;
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-    }
 
     @Override
     public String toString() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/NullLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/NullLiteral.java
@@ -40,8 +40,6 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
 
 import java.nio.ByteBuffer;
 
@@ -147,10 +145,6 @@ public class NullLiteral extends LiteralExpr {
         return this;
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.node_type = TExprNodeType.NULL_LITERAL;
-    }
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/PlaceHolderExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/PlaceHolderExpr.java
@@ -42,13 +42,10 @@ public class PlaceHolderExpr extends Expr {
         this.type = type;
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.setNode_type(TExprNodeType.PLACEHOLDER_EXPR);
-        msg.setVslot_ref(new TPlaceHolder());
-        msg.vslot_ref.setNullable(nullable);
-        msg.vslot_ref.setSlot_id(slotId);
+    public int getSlotId() {
+        return slotId;
     }
+
 
     @Override
     public void toNormalForm(TExprNode msg, FragmentNormalizer normalizer) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/SlotRef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/SlotRef.java
@@ -225,8 +225,6 @@ public class SlotRef extends Expr {
     }
 
     public SlotDescriptor getDesc() {
-        Preconditions.checkState(isAnalyzed);
-        Preconditions.checkNotNull(desc);
         return desc;
     }
 
@@ -314,23 +312,6 @@ public class SlotRef extends Expr {
         return tblName;
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.node_type = TExprNodeType.SLOT_REF;
-        if (desc != null) {
-            if (desc.getParent() != null) {
-                msg.slot_ref = new TSlotRef(desc.getId().asInt(), desc.getParent().getId().asInt());
-            } else {
-                // tuple id is meaningless here
-                msg.slot_ref = new TSlotRef(desc.getId().asInt(), 0);
-            }
-        } else {
-            // slot id and tuple id are meaningless here
-            msg.slot_ref = new TSlotRef(0, 0);
-        }
-
-        msg.setOutput_column(outputColumn);
-    }
 
     @Override
     public void toNormalForm(TExprNode msg, FragmentNormalizer normalizer) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/StringLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/StringLiteral.java
@@ -42,9 +42,6 @@ import com.starrocks.common.io.Text;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
-import com.starrocks.thrift.TStringLiteral;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -138,11 +135,6 @@ public class StringLiteral extends LiteralExpr {
         return false;
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.node_type = TExprNodeType.STRING_LITERAL;
-        msg.string_literal = new TStringLiteral(getUnescapedValue());
-    }
 
     // FIXME: modify by zhaochun
     public String getUnescapedValue() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/SubfieldExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/SubfieldExpr.java
@@ -21,8 +21,6 @@ import com.starrocks.catalog.Type;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
 
 import java.util.List;
 import java.util.Objects;
@@ -85,12 +83,6 @@ public class SubfieldExpr extends Expr {
         return ((AstVisitorExtendInterface<R, C>) visitor).visitSubfieldExpr(this, context);
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.setNode_type(TExprNodeType.SUBFIELD_EXPR);
-        msg.setUsed_subfield_names(fieldNames);
-        msg.setCopy_flag(copyFlag);
-    }
 
     @Override
     public Expr clone() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/Subquery.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/Subquery.java
@@ -40,7 +40,6 @@ import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -110,9 +109,6 @@ public class Subquery extends Expr {
         return ret;
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-    }
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) throws SemanticException {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/TimestampArithmeticExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/TimestampArithmeticExpr.java
@@ -39,8 +39,6 @@ import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.ast.expression.ArithmeticExpr.Operator;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -117,11 +115,6 @@ public class TimestampArithmeticExpr extends Expr {
         return new TimestampArithmeticExpr(this);
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.node_type = TExprNodeType.COMPUTE_FUNCTION_CALL;
-        msg.setOpcode(opcode);
-    }
 
     public ArithmeticExpr.Operator getOp() {
         return op;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/VarBinaryLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/VarBinaryLiteral.java
@@ -22,11 +22,7 @@ import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.sql.parser.ParsingException;
-import com.starrocks.thrift.TBinaryLiteral;
-import com.starrocks.thrift.TExprNode;
-import com.starrocks.thrift.TExprNodeType;
 
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Objects;
@@ -125,16 +121,15 @@ public class VarBinaryLiteral extends LiteralExpr {
         return value;
     }
 
+    public byte[] getValue() {
+        return value;
+    }
+
     @Override
     public boolean isMinValue() {
         return false;
     }
 
-    @Override
-    protected void toThrift(TExprNode msg) {
-        msg.node_type = TExprNodeType.BINARY_LITERAL;
-        msg.binary_literal = new TBinaryLiteral(ByteBuffer.wrap(value));
-    }
 
     @Override
     public String getStringValue() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/ExprToThriftVisitorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/ExprToThriftVisitorTest.java
@@ -1,0 +1,569 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast.expression;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.AggregateFunction;
+import com.starrocks.catalog.ArrayType;
+import com.starrocks.catalog.MapType;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.ScalarFunction;
+import com.starrocks.catalog.ScalarType;
+import com.starrocks.catalog.Type;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.planner.SlotDescriptor;
+import com.starrocks.planner.SlotId;
+import com.starrocks.sql.ast.QueryRelation;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.UnitIdentifier;
+import com.starrocks.sql.common.StarRocksPlannerException;
+import com.starrocks.sql.parser.NodePosition;
+import com.starrocks.thrift.TExpr;
+import com.starrocks.thrift.TExprNode;
+import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.thrift.TExprOpcode;
+import com.starrocks.thrift.TInPredicate;
+import com.starrocks.thrift.TInfoFunc;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class ExprToThriftVisitorTest {
+
+    @Test
+    public void testExprToThriftCoverage() {
+        for (ExprCase exprCase : ExprCaseFactory.ALL_CASES) {
+            if (exprCase.expectedException != null) {
+                Assertions.assertThrows(exprCase.expectedException,
+                        () -> convert(exprCase.factory.get()),
+                        () -> "Expected exception for " + exprCase.name);
+                continue;
+            }
+
+            TExprNode node = Assertions.assertDoesNotThrow(
+                    () -> convert(exprCase.factory.get()),
+                    () -> "Conversion failed for " + exprCase.name);
+
+            if (exprCase.expectedNodeType != null) {
+                Assertions.assertEquals(exprCase.expectedNodeType, node.getNode_type(),
+                        () -> "Unexpected node type for " + exprCase.name);
+            }
+
+            if (exprCase.afterCheck != null) {
+                exprCase.afterCheck.accept(node);
+            }
+        }
+    }
+
+    private static TExprNode convert(Expr expr) {
+        TExpr thrift = expr.treeToThrift();
+        Assertions.assertFalse(thrift.getNodes().isEmpty(), "No nodes produced");
+        return thrift.getNodes().get(0);
+    }
+
+    private record ExprCase(String name,
+                            Supplier<Expr> factory,
+                            TExprNodeType expectedNodeType,
+                            Class<? extends Throwable> expectedException,
+                            java.util.function.Consumer<TExprNode> afterCheck) {
+    }
+
+    private static final class ExprCaseFactory {
+        private static final List<ExprCase> ALL_CASES = buildCases();
+
+        private static List<ExprCase> buildCases() {
+            List<ExprCase> cases = new ArrayList<>();
+
+            // Literals
+            cases.add(nodeCase("IntLiteral", () -> withType(new IntLiteral(7), Type.INT), TExprNodeType.INT_LITERAL));
+            cases.add(nodeCase("FloatLiteral", ExprCaseFactory::buildFloatLiteral,
+                    TExprNodeType.FLOAT_LITERAL));
+            cases.add(nodeCase("DecimalLiteral", ExprCaseFactory::buildDecimalLiteral,
+                    TExprNodeType.DECIMAL_LITERAL));
+            cases.add(nodeCase("StringLiteral", () -> withType(new StringLiteral("starrocks"),
+                    ScalarType.createVarchar(16)), TExprNodeType.STRING_LITERAL));
+            cases.add(nodeCase("BoolLiteral", () -> withType(new BoolLiteral(true), Type.BOOLEAN),
+                    TExprNodeType.BOOL_LITERAL));
+            cases.add(nodeCase("VarBinaryLiteral", () -> withType(new VarBinaryLiteral(new byte[] {1, 2}),
+                    Type.VARBINARY), TExprNodeType.BINARY_LITERAL));
+            cases.add(nodeCase("DateLiteral", ExprCaseFactory::buildDateLiteral, TExprNodeType.DATE_LITERAL));
+            cases.add(nodeCase("NullLiteral", () -> NullLiteral.create(Type.INT), TExprNodeType.NULL_LITERAL));
+            cases.add(nodeCase("LargeIntLiteral", ExprCaseFactory::buildLargeIntLiteral,
+                    TExprNodeType.LARGE_INT_LITERAL));
+            cases.add(nodeCase("MaxLiteral", ExprCaseFactory::buildMaxLiteral, null,
+                    node -> Assertions.assertFalse(node.isSetNode_type())));
+
+            // Collection & JSON related
+            cases.add(nodeCase("ArrayExpr", ExprCaseFactory::buildArrayExpr, TExprNodeType.ARRAY_EXPR));
+            cases.add(nodeCase("CollectionElementArray", ExprCaseFactory::buildArrayElementExpr,
+                    TExprNodeType.ARRAY_ELEMENT_EXPR));
+            cases.add(nodeCase("CollectionElementMap", ExprCaseFactory::buildMapElementExpr,
+                    TExprNodeType.MAP_ELEMENT_EXPR));
+            cases.add(nodeCase("ArraySliceExpr", ExprCaseFactory::buildArraySliceExpr,
+                    TExprNodeType.ARRAY_SLICE_EXPR));
+            cases.add(nodeCase("MapExpr", ExprCaseFactory::buildMapExpr, TExprNodeType.MAP_EXPR));
+            cases.add(nodeCase("SubfieldExpr", ExprCaseFactory::buildSubfieldExpr, TExprNodeType.SUBFIELD_EXPR));
+            cases.add(nodeCase("CloneExpr", ExprCaseFactory::buildCloneExpr, TExprNodeType.CLONE_EXPR));
+            cases.add(nodeCase("DictMappingExpr", ExprCaseFactory::buildDictMappingExpr, TExprNodeType.DICT_EXPR));
+
+            // Functions and operators
+            cases.add(nodeCase("ArithmeticExpr", ExprCaseFactory::buildArithmeticExpr,
+                    TExprNodeType.ARITHMETIC_EXPR));
+            cases.add(nodeCase("CaseExpr", ExprCaseFactory::buildCaseExpr, TExprNodeType.CASE_EXPR));
+            cases.add(nodeCase("FunctionCall", ExprCaseFactory::buildScalarFunctionCall,
+                    TExprNodeType.FUNCTION_CALL));
+            cases.add(nodeCase("AggregateFunctionCall", ExprCaseFactory::buildAggregateFunctionCall,
+                    TExprNodeType.AGG_EXPR));
+            cases.add(nodeCase("AnalyticExpr", ExprCaseFactory::buildAnalyticExpr, null, node -> {
+                // AnalyticExpr historically leaves node type unset
+                Assertions.assertFalse(node.isSetNode_type());
+            }));
+            cases.add(nodeCase("InformationFunction", ExprCaseFactory::buildInformationFunction,
+                    TExprNodeType.INFO_FUNC, node -> Assertions.assertEquals(new TInfoFunc(11, "cluster"),
+                    node.getInfo_func())));
+            cases.add(nodeCase("TimestampArithmeticExpr", ExprCaseFactory::buildTimestampArithmeticExpr,
+                    TExprNodeType.COMPUTE_FUNCTION_CALL));
+            cases.add(nodeCase("LambdaFunctionExpr", ExprCaseFactory::buildLambdaFunctionExpr,
+                    TExprNodeType.LAMBDA_FUNCTION_EXPR, node -> Assertions.assertEquals(1, node.getOutput_column())));
+
+            // Predicates
+            cases.add(nodeCase("BinaryPredicate", ExprCaseFactory::buildBinaryPredicate, TExprNodeType.BINARY_PRED));
+            cases.add(nodeCase("CompoundPredicate", ExprCaseFactory::buildCompoundPredicate,
+                    TExprNodeType.COMPOUND_PRED));
+            cases.add(nodeCase("InPredicate", ExprCaseFactory::buildInPredicate, TExprNodeType.IN_PRED,
+                    node -> Assertions.assertEquals(new TInPredicate(false), node.getIn_predicate())));
+            cases.add(nodeCase("LikePredicate", ExprCaseFactory::buildLikePredicate, TExprNodeType.FUNCTION_CALL));
+            cases.add(nodeCase("MatchExpr", ExprCaseFactory::buildMatchExpr, TExprNodeType.MATCH_EXPR));
+            cases.add(nodeCase("IsNullPredicate", ExprCaseFactory::buildIsNullPredicate, TExprNodeType.FUNCTION_CALL));
+
+            // Exception expected predicates
+            cases.add(exceptionCase("BetweenPredicate", ExprCaseFactory::buildBetweenPredicate,
+                    IllegalStateException.class));
+            cases.add(exceptionCase("ExistsPredicate", ExprCaseFactory::buildExistsPredicate,
+                    IllegalStateException.class));
+            cases.add(exceptionCase("LargeInPredicate", ExprCaseFactory::buildLargeInPredicate,
+                    UnsupportedOperationException.class));
+
+            // Dictionary functions
+            cases.add(nodeCase("DictionaryGetExpr", ExprCaseFactory::buildDictionaryGetExpr,
+                    TExprNodeType.DICTIONARY_GET_EXPR));
+            cases.add(nodeCase("DictQueryExpr", ExprCaseFactory::buildDictQueryExpr, TExprNodeType.DICT_QUERY_EXPR));
+
+            // References
+            cases.add(nodeCase("SlotRef", ExprCaseFactory::buildSlotRef, TExprNodeType.SLOT_REF,
+                    node -> Assertions.assertEquals(9, node.getOutput_column())));
+            cases.add(nodeCase("PlaceHolderExpr", ExprCaseFactory::buildPlaceHolderExpr,
+                    TExprNodeType.PLACEHOLDER_EXPR));
+            cases.add(exceptionCase("FieldReference", ExprCaseFactory::buildFieldReference,
+                    StarRocksPlannerException.class));
+            cases.add(exceptionCase("LambdaArgument", ExprCaseFactory::buildLambdaArgument,
+                    StarRocksPlannerException.class));
+            cases.add(exceptionCase("ArrowExpr", ExprCaseFactory::buildArrowExpr,
+                    StarRocksPlannerException.class));
+
+            // Miscellaneous
+            cases.add(nodeCase("Subquery", ExprCaseFactory::buildSubquery, null,
+                    node -> Assertions.assertFalse(node.isSetNode_type())));
+            cases.add(nodeCase("DefaultValueExpr", ExprCaseFactory::buildDefaultValueExpr, null,
+                    node -> Assertions.assertFalse(node.isSetNode_type())));
+            cases.add(exceptionCase("IntervalLiteral", ExprCaseFactory::buildIntervalLiteral,
+                    StarRocksPlannerException.class));
+
+            return cases;
+        }
+
+        private static ExprCase nodeCase(String name, Supplier<Expr> factory, TExprNodeType nodeType) {
+            return nodeCase(name, factory, nodeType, null);
+        }
+
+        private static ExprCase nodeCase(String name, Supplier<Expr> factory, TExprNodeType nodeType,
+                                         java.util.function.Consumer<TExprNode> afterCheck) {
+            return new ExprCase(name, factory, nodeType, null, afterCheck);
+        }
+
+        private static ExprCase exceptionCase(String name, Supplier<Expr> factory,
+                                              Class<? extends Throwable> expectedException) {
+            return new ExprCase(name, factory, null, expectedException, null);
+        }
+
+        private static Expr buildFloatLiteral() {
+            try {
+                FloatLiteral literal = new FloatLiteral(3.14);
+                literal.setType(Type.DOUBLE);
+                literal.setOriginType(Type.DOUBLE);
+                return literal;
+            } catch (AnalysisException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private static Expr buildDecimalLiteral() {
+            try {
+                DecimalLiteral literal = new DecimalLiteral("1.23");
+                ScalarType type = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 6, 2);
+                literal.setType(type);
+                literal.setOriginType(type);
+                return literal;
+            } catch (AnalysisException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private static Expr buildDateLiteral() {
+            try {
+                DateLiteral literal = new DateLiteral("2024-01-02", Type.DATE);
+                literal.setOriginType(Type.DATE);
+                return literal;
+            } catch (AnalysisException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private static Expr buildLargeIntLiteral() {
+            LargeIntLiteral literal = LargeIntLiteral.createMaxValue();
+            literal.setOriginType(Type.LARGEINT);
+            return literal;
+        }
+
+        private static Expr buildMaxLiteral() {
+            MaxLiteral max = MaxLiteral.MAX_VALUE;
+            max.setType(Type.INT);
+            max.setOriginType(Type.INT);
+            return max;
+        }
+
+        private static Expr buildArrayExpr() {
+            ArrayExpr arrayExpr = new ArrayExpr(new ArrayType(Type.INT),
+                    Lists.newArrayList(new IntLiteral(1), new IntLiteral(2)));
+            arrayExpr.setOriginType(arrayExpr.getType());
+            return arrayExpr;
+        }
+
+        private static Expr buildArrayElementExpr() {
+            ArrayExpr arrayExpr = (ArrayExpr) buildArrayExpr();
+            CollectionElementExpr expr =
+                    new CollectionElementExpr(Type.INT, arrayExpr, new IntLiteral(0), false);
+            expr.setOriginType(Type.INT);
+            return expr;
+        }
+
+        private static Expr buildMapExpr() {
+            List<Expr> children = List.of(
+                    withType(new StringLiteral("k"), ScalarType.createVarchar(8)),
+                    withType(new IntLiteral(1), Type.INT),
+                    withType(new StringLiteral("k2"), ScalarType.createVarchar(8)),
+                    withType(new IntLiteral(2), Type.INT));
+            MapExpr mapExpr = new MapExpr(new MapType(ScalarType.createVarchar(8), Type.INT), children);
+            mapExpr.setOriginType(mapExpr.getType());
+            return mapExpr;
+        }
+
+        private static Expr buildMapElementExpr() {
+            MapExpr mapExpr = (MapExpr) buildMapExpr();
+            CollectionElementExpr expr =
+                    new CollectionElementExpr(Type.INT, mapExpr, withType(new StringLiteral("k"),
+                            ScalarType.createVarchar(8)), true);
+            expr.setOriginType(Type.INT);
+            return expr;
+        }
+
+        private static Expr buildArraySliceExpr() {
+            ArrayExpr arrayExpr = (ArrayExpr) buildArrayExpr();
+            ArraySliceExpr sliceExpr =
+                    new ArraySliceExpr(arrayExpr, new IntLiteral(0), new IntLiteral(1));
+            sliceExpr.setType(arrayExpr.getType());
+            sliceExpr.setOriginType(arrayExpr.getType());
+            return sliceExpr;
+        }
+
+        private static Expr buildSubfieldExpr() {
+            SlotRef structRef = buildSlotRef();
+            SubfieldExpr expr = new SubfieldExpr(structRef, List.of("f1", "f2"));
+            expr.setType(Type.INT);
+            expr.setOriginType(Type.INT);
+            return expr;
+        }
+
+        private static Expr buildCloneExpr() {
+            CloneExpr expr = new CloneExpr(new IntLiteral(5));
+            expr.setType(Type.INT);
+            expr.setOriginType(Type.INT);
+            return expr;
+        }
+
+        private static Expr buildDictMappingExpr() {
+            DictMappingExpr expr = new DictMappingExpr(buildSlotRef(), withType(new StringLiteral("expr"),
+                    ScalarType.createVarchar(16)));
+            expr.setType(ScalarType.createVarchar(16));
+            expr.setOriginType(expr.getType());
+            return expr;
+        }
+
+        private static Expr buildArithmeticExpr() {
+            ArithmeticExpr expr = new ArithmeticExpr(ArithmeticExpr.Operator.ADD,
+                    new IntLiteral(1), new IntLiteral(2));
+            expr.setType(Type.INT);
+            expr.setOriginType(Type.INT);
+            return expr;
+        }
+
+        private static Expr buildCaseExpr() {
+            CaseExpr expr = new CaseExpr(new IntLiteral(1),
+                    List.of(new CaseWhenClause(new IntLiteral(1), new StringLiteral("x"))),
+                    new StringLiteral("y"));
+            expr.setType(ScalarType.createVarchar(8));
+            expr.setOriginType(expr.getType());
+            return expr;
+        }
+
+        private static Expr buildScalarFunctionCall() {
+            FunctionCallExpr call = new FunctionCallExpr("abs", List.of(new IntLiteral(-3)));
+            ScalarFunction fn = ScalarFunction.createBuiltinOperator("abs", Lists.newArrayList(Type.INT), Type.INT);
+            call.setFn(fn);
+            call.setType(Type.INT);
+            call.setOriginType(Type.INT);
+            return call;
+        }
+
+        private static Expr buildAggregateFunctionCall() {
+            FunctionCallExpr call = new FunctionCallExpr("sum", List.of(new IntLiteral(3)));
+            AggregateFunction fn = AggregateFunction.createBuiltin("sum", List.of(Type.INT), Type.INT, Type.INT,
+                    false, false, false, false);
+            call.setFn(fn);
+            call.setType(Type.INT);
+            call.setOriginType(Type.INT);
+            return call;
+        }
+
+        private static Expr buildAnalyticExpr() {
+            FunctionCallExpr call = new FunctionCallExpr("row_number", Collections.emptyList());
+            AggregateFunction fn = AggregateFunction.createBuiltin("row_number", Collections.emptyList(),
+                    Type.BIGINT, Type.BIGINT, false, false, true, true);
+            call.setFn(fn);
+            call.setType(Type.BIGINT);
+            call.setOriginType(Type.BIGINT);
+            call.setIsAnalyticFnCall(true);
+            AnalyticExpr analyticExpr = new AnalyticExpr(call, List.of(new IntLiteral(1)),
+                    Collections.emptyList(), null, null);
+            analyticExpr.setType(Type.BIGINT);
+            analyticExpr.setOriginType(Type.BIGINT);
+            return analyticExpr;
+        }
+
+        private static Expr buildInformationFunction() {
+            InformationFunction infoFunction = new InformationFunction("CURRENT_CATALOG", "cluster", 11);
+            infoFunction.setType(ScalarType.createVarchar(16));
+            infoFunction.setOriginType(infoFunction.getType());
+            return infoFunction;
+        }
+
+        private static Expr buildTimestampArithmeticExpr() {
+            try {
+                DateLiteral dateLiteral = new DateLiteral("2024-01-01", Type.DATE);
+                TimestampArithmeticExpr expr =
+                        new TimestampArithmeticExpr(ArithmeticExpr.Operator.ADD, dateLiteral,
+                                new IntLiteral(1), "DAY", false);
+                expr.setType(Type.DATE);
+                expr.setOriginType(Type.DATE);
+                expr.opcode = TExprOpcode.ADD;
+                return expr;
+            } catch (AnalysisException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        private static Expr buildLambdaFunctionExpr() {
+            SlotRef argSlot = buildSlotRef();
+            LambdaFunctionExpr lambda =
+                    new LambdaFunctionExpr(List.of(new IntLiteral(1), argSlot),
+                            Map.of(argSlot, new IntLiteral(2)));
+            lambda.setType(Type.INT);
+            lambda.setOriginType(Type.INT);
+            return lambda;
+        }
+
+        private static Expr buildBinaryPredicate() {
+            BinaryPredicate predicate =
+                    new BinaryPredicate(BinaryType.EQ, new IntLiteral(1), new IntLiteral(1));
+            predicate.setType(Type.BOOLEAN);
+            predicate.setOriginType(Type.BOOLEAN);
+            return predicate;
+        }
+
+        private static Expr buildCompoundPredicate() {
+            CompoundPredicate predicate =
+                    new CompoundPredicate(CompoundPredicate.Operator.AND, new BoolLiteral(true),
+                            new BoolLiteral(false));
+            predicate.setType(Type.BOOLEAN);
+            predicate.setOriginType(Type.BOOLEAN);
+            return predicate;
+        }
+
+        private static Expr buildInPredicate() {
+            InPredicate predicate =
+                    new InPredicate(new IntLiteral(1), Lists.newArrayList(new IntLiteral(2), new IntLiteral(3)), false);
+            predicate.setType(Type.BOOLEAN);
+            predicate.setOriginType(Type.BOOLEAN);
+            return predicate;
+        }
+
+        private static Expr buildLikePredicate() {
+            LikePredicate predicate =
+                    new LikePredicate(LikePredicate.Operator.LIKE, new StringLiteral("abc"),
+                            new StringLiteral("a%"));
+            predicate.setType(Type.BOOLEAN);
+            predicate.setOriginType(Type.BOOLEAN);
+            return predicate;
+        }
+
+        private static Expr buildMatchExpr() {
+            MatchExpr expr = new MatchExpr(new StringLiteral("field"), new StringLiteral("value"));
+            expr.setType(Type.BOOLEAN);
+            expr.setOriginType(Type.BOOLEAN);
+            return expr;
+        }
+
+        private static Expr buildIsNullPredicate() {
+            IsNullPredicate predicate = new IsNullPredicate(new IntLiteral(1), false);
+            predicate.setType(Type.BOOLEAN);
+            predicate.setOriginType(Type.BOOLEAN);
+            return predicate;
+        }
+
+        private static Expr buildBetweenPredicate() {
+            BetweenPredicate predicate =
+                    new BetweenPredicate(new IntLiteral(1), new IntLiteral(0), new IntLiteral(2), false);
+            predicate.setType(Type.BOOLEAN);
+            predicate.setOriginType(Type.BOOLEAN);
+            return predicate;
+        }
+
+        private static Expr buildExistsPredicate() {
+            ExistsPredicate predicate = new ExistsPredicate(buildSubquery(), false);
+            predicate.setType(Type.BOOLEAN);
+            predicate.setOriginType(Type.BOOLEAN);
+            return predicate;
+        }
+
+        private static Expr buildLargeInPredicate() {
+            LargeInPredicate predicate = new LargeInPredicate(new IntLiteral(1), "(1,2,3)",
+                    List.of(1, 2, 3), 3, false, List.of(new IntLiteral(1)), NodePosition.ZERO);
+            predicate.setType(Type.BOOLEAN);
+            predicate.setOriginType(Type.BOOLEAN);
+            return predicate;
+        }
+
+        private static Expr buildDictionaryGetExpr() {
+            DictionaryGetExpr expr = new DictionaryGetExpr(List.of(new IntLiteral(1)));
+            expr.setDictionaryId(99L);
+            expr.setDictionaryTxnId(100L);
+            expr.setKeySize(10);
+            expr.setNullIfNotExist(true);
+            expr.setType(Type.INT);
+            expr.setOriginType(Type.INT);
+            return expr;
+        }
+
+        private static Expr buildDictQueryExpr() {
+            DictQueryExpr expr = new DictQueryExpr(List.of(new StringLiteral("dict")));
+            expr.setDictQueryExpr(new com.starrocks.thrift.TDictQueryExpr());
+            expr.setType(Type.INT);
+            expr.setOriginType(Type.INT);
+            return expr;
+        }
+
+        private static SlotRef buildSlotRef() {
+            SlotDescriptor descriptor = new SlotDescriptor(new SlotId(3), "col", Type.INT, true);
+            SlotRef slotRef = new SlotRef(descriptor);
+            slotRef.setType(Type.INT);
+            slotRef.setOriginType(Type.INT);
+            slotRef.outputColumn = 9;
+            return slotRef;
+        }
+
+        private static Expr buildPlaceHolderExpr() {
+            PlaceHolderExpr expr = new PlaceHolderExpr(5, true, Type.INT);
+            expr.setOriginType(Type.INT);
+            return expr;
+        }
+
+        private static Expr buildFieldReference() {
+            FieldReference ref = new FieldReference(1, new TableName("db", "tbl"));
+            ref.setType(Type.INT);
+            ref.setOriginType(Type.INT);
+            return ref;
+        }
+
+        private static Expr buildLambdaArgument() {
+            LambdaArgument arg = new LambdaArgument("arg");
+            arg.setType(Type.INT);
+            arg.setOriginType(Type.INT);
+            return arg;
+        }
+
+        private static Expr buildArrowExpr() {
+            ArrowExpr arrowExpr = new ArrowExpr(new StringLiteral("k"), new StringLiteral("v"));
+            ScalarType varchar = ScalarType.createVarchar(8);
+            arrowExpr.setType(varchar);
+            arrowExpr.setOriginType(varchar);
+            return arrowExpr;
+        }
+
+        private static Subquery buildSubquery() {
+            DummyRelation relation = new DummyRelation();
+            QueryStatement statement = new QueryStatement(relation);
+            Subquery subquery = new Subquery(statement);
+            subquery.setType(Type.INT);
+            subquery.setOriginType(Type.INT);
+            return subquery;
+        }
+
+        private static Expr buildDefaultValueExpr() {
+            DefaultValueExpr expr = new DefaultValueExpr(NodePosition.ZERO);
+            expr.setType(Type.INT);
+            expr.setOriginType(Type.INT);
+            return expr;
+        }
+
+        private static Expr buildIntervalLiteral() {
+            IntervalLiteral intervalLiteral = new IntervalLiteral(new IntLiteral(1), new UnitIdentifier("DAY"));
+            intervalLiteral.setType(Type.INT);
+            intervalLiteral.setOriginType(Type.INT);
+            return intervalLiteral;
+        }
+
+        private static <T extends Expr> T withType(T expr, Type type) {
+            expr.setType(type);
+            expr.setOriginType(type);
+            return expr;
+        }
+    }
+
+    private static final class DummyRelation extends QueryRelation {
+        DummyRelation() {
+            super(NodePosition.ZERO);
+        }
+
+        @Override
+        public List<Expr> getOutputExpression() {
+            return List.of(new IntLiteral(1));
+        }
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This pull request primarily removes the `toThrift` serialization logic and related Thrift imports from various SQL expression AST classes in the `fe-core` module. This streamlines the codebase by eliminating now-unnecessary code and dependencies, likely as part of a broader refactor or migration away from Thrift-based serialization for these AST nodes. Additionally, a new dependency is added for SQL formatting.

The most important changes are:

**Removal of Thrift Serialization Logic from AST Expressions:**
* Deleted the `toThrift` method implementations and associated Thrift imports (such as `TExprNode`, `TExprNodeType`, etc.) from numerous classes in the `com.starrocks.sql.ast.expression` package, including (but not limited to) `AnalyticExpr`, `ArithmeticExpr`, `ArrayExpr`, `ArraySliceExpr`, `ArrowExpr`, `BetweenPredicate`, `BinaryPredicate`, `BoolLiteral`, `CaseExpr`, `CastExpr`, `CloneExpr`, `CollectionElementExpr`, `CompoundPredicate`, `DateLiteral`, `DecimalLiteral`, `DefaultValueExpr`, and `DictMappingExpr`. This results in cleaner class definitions and reduces coupling to Thrift. [[1]](diffhunk://#diff-5d535d5560339d3210890fb544ff48b666a9d3505cbe87de868226758f716ebfL49) [[2]](diffhunk://#diff-5d535d5560339d3210890fb544ff48b666a9d3505cbe87de868226758f716ebfL251-L253) [[3]](diffhunk://#diff-fad75da1b86f53cf6d225eda2ed73a03c22b854b349f2884a55ab7ac31488119L51-L52) [[4]](diffhunk://#diff-fad75da1b86f53cf6d225eda2ed73a03c22b854b349f2884a55ab7ac31488119L429-L434) [[5]](diffhunk://#diff-e13f633da38c1cba6af9f4f427793668584d38a0f728f948aa0d33281b6c7fc5L23-L24) [[6]](diffhunk://#diff-e13f633da38c1cba6af9f4f427793668584d38a0f728f948aa0d33281b6c7fc5L45-L48) [[7]](diffhunk://#diff-81a855b45cf8f370be29639c213197407e0f6dd37b55c0879e1eb012e73582f9L39-L40) [[8]](diffhunk://#diff-81a855b45cf8f370be29639c213197407e0f6dd37b55c0879e1eb012e73582f9L53-L56) [[9]](diffhunk://#diff-2ff55cf0755b110fdc5a27c48e8f461baf128c64d49a1ff4eb74ba3720855968L21-L24) [[10]](diffhunk://#diff-2ff55cf0755b110fdc5a27c48e8f461baf128c64d49a1ff4eb74ba3720855968L56-L59) [[11]](diffhunk://#diff-94b59e5e266414f4ee76f003e31a0ce31c183d721db67a32319ac84a6b2db056L41) [[12]](diffhunk://#diff-94b59e5e266414f4ee76f003e31a0ce31c183d721db67a32319ac84a6b2db056L78-L82) [[13]](diffhunk://#diff-92d6b335b2e4fffe9515eae4b746927040b74f21a6f65782c495f7148208c2aeL43-L44) [[14]](diffhunk://#diff-92d6b335b2e4fffe9515eae4b746927040b74f21a6f65782c495f7148208c2aeL143-L153) [[15]](diffhunk://#diff-ecc48c8d2609abd9a4e5405d798308a8e162f6f16fc7b21f38c5f7927e1f252bL43-L45) [[16]](diffhunk://#diff-ecc48c8d2609abd9a4e5405d798308a8e162f6f16fc7b21f38c5f7927e1f252bL147-L151) [[17]](diffhunk://#diff-a06d65827c845d57861356aecc29fcf65dccfdb710d04e84504ea090986e5e39L43-L45) [[18]](diffhunk://#diff-a06d65827c845d57861356aecc29fcf65dccfdb710d04e84504ea090986e5e39L140-L145) [[19]](diffhunk://#diff-2076bfa66c1a2ca9c28026d25521e89cb41329f0260a39a810249db50c253201L46-L47) [[20]](diffhunk://#diff-2076bfa66c1a2ca9c28026d25521e89cb41329f0260a39a810249db50c253201L129-L139) [[21]](diffhunk://#diff-3748ff79e368236f948ccd3c7f421f0c6f4e7e11194c887798cd7238d237e98fL21-L22) [[22]](diffhunk://#diff-3748ff79e368236f948ccd3c7f421f0c6f4e7e11194c887798cd7238d237e98fL42-L45) [[23]](diffhunk://#diff-8e7cde24d5a212d1bed346a40bd6e6f6615bbfa620374e28e6430d61df4ffd0dL41-L42) [[24]](diffhunk://#diff-8e7cde24d5a212d1bed346a40bd6e6f6615bbfa620374e28e6430d61df4ffd0dL73-L81) [[25]](diffhunk://#diff-75d54def250f77e1a87aaba3243e89dd1cd03e6c7af217447be6906c1ad473c3L42-L43) [[26]](diffhunk://#diff-75d54def250f77e1a87aaba3243e89dd1cd03e6c7af217447be6906c1ad473c3L87-L91) [[27]](diffhunk://#diff-8736123299df91bdc93760556b9114195641f5857721ebe7481e8720b80c19bcL47-L49) [[28]](diffhunk://#diff-8736123299df91bdc93760556b9114195641f5857721ebe7481e8720b80c19bcL292-L296) [[29]](diffhunk://#diff-cad6a0c71c15d972fbdfd2ca7ecd787f7f645470342a77b157a1689cbdb4200eL50-L52) [[30]](diffhunk://#diff-cad6a0c71c15d972fbdfd2ca7ecd787f7f645470342a77b157a1689cbdb4200eL399-L407) [[31]](diffhunk://#diff-0f8bfb1dbfe19763c7866214f0f00b8911cad67fc064b1da202840f3b50f2aa7L21-L32) [[32]](diffhunk://#diff-7afc56f325c1bf96dbc7f09026f4e293c12d415fbf04d46f9feb39c56578188cL20-L21)

**Dependency Update:**
* Added the `com.github.vertical-blank:sql-formatter:2.0.4` dependency to `fe-core/build.gradle.kts`, which will facilitate SQL formatting features in the project.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
