### PR TITLE
[BugFix] Using tenann library built on centos7

### DIFF
--- a/thirdparty/vars-aarch64.sh
+++ b/thirdparty/vars-aarch64.sh
@@ -55,7 +55,7 @@ JINDOSDK_MD5SUM="27a4e2cd9a403c6e21079a866287d88b"
 TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.0-RELEASE/tenann-v0.5.0-RELEASE-arm64.tar.gz"
 TENANN_NAME="tenann-v0.5.0-RELEASE-arm64.tar.gz"
 TENANN_SOURCE="tenann-v0.5.0-RELEASE"
-TENANN_MD5SUM="397632c3b81a25e636177c8f80291cc3"
+TENANN_MD5SUM="40553a135f7bd05b9538801f40772f6c"
 
 # starcache
 STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v3.5-rc4/starcache-centos7_arm64.tar.gz"

--- a/thirdparty/vars-x86_64.sh
+++ b/thirdparty/vars-x86_64.sh
@@ -55,7 +55,7 @@ JINDOSDK_MD5SUM="5436e4fe39c4dfdc942e41821f1dd8a9"
 TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.0-RELEASE/tenann-v0.5.0-RELEASE-x86_64.tar.gz"
 TENANN_NAME="tenann-v0.5.0-RELEASE-x86_64.tar.gz"
 TENANN_SOURCE="tenann-v0.5.0-RELEASE"
-TENANN_MD5SUM="192ef22c00cf39315a91f54dab120855"
+TENANN_MD5SUM="826674dd5499bece2a409a2b4c3291b2"
 
 # starcache
 STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v3.5-rc4/starcache-centos7_amd64.tar.gz"


### PR DESCRIPTION
## Why I'm doing:

The newly added tenann library was built on ubuntu22, which break builds on centos7

## What I'm doing:

I've rebuilt tenann on centos7 add upload a new release package, this PR use the new package

Fixes: https://github.com/StarRocks/StarRocksTest/issues/10493

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
