### PR TITLE
[BugFix] fix wrong plan generated by rewriting min/max stats when column stats is empty

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToMetaScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToMetaScanRule.java
@@ -274,6 +274,7 @@ public class RewriteSimpleAggToMetaScanRule extends TransformationRule {
                         .getStats(new ColumnIdentifier(table.getId(), c.getColumnId()),
                                 new StatsVersion(-1, lastUpdateTimestamp));
                 if (minMax.isEmpty()) {
+                    newAggCalls.put(entry.getKey(), entry.getValue());
                     continue;
                 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateMetaTest.java
@@ -46,5 +46,23 @@ public class AggregateMetaTest extends PlanTestBase {
                 + "  0:UNION\n"
                 + "     constant exprs: \n"
                 + "         NULL");
+        new MockUp<ColumnMinMaxMgr>() {
+            @Mock
+            public Optional<IMinMaxStatsMgr.ColumnMinMax> getStats(ColumnIdentifier identifier, StatsVersion version) {
+                if (identifier.getColumnName().getId().equals("v3")) {
+                    return Optional.of(new IMinMaxStatsMgr.ColumnMinMax("1", "200"));
+                } else {
+                    return Optional.empty();
+                }
+            }
+        };
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  2:Project\n" +
+                "  |  <slot 4> : 4: max\n" +
+                "  |  <slot 5> : 1\n" +
+                "  |  \n" +
+                "  1:AGGREGATE (update finalize)\n" +
+                "  |  output: max(2: v2)\n" +
+                "  |  group by:");
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

fix the following error
```
First has 0, Second has 1:  "E: (1064, 'only found column statistics: {}, but missing statistic of col: 4: min.')" : sql result not match:
- [SQL]: select min(c0),max(c0),min(c1),max(c1),min(c2),max(c2) from t0;
- [exp]: ['2024-01-01\t2024-01-05\t1\t5\t1\t5']
- [act]: ["E: (1064, 'only found column statistics: {}, but missing statistic of col: 4: min.')"]
```

when using min/max stats to rewrite simple aggregate functions, we should handle the cases that min/max stats is empty.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
