### PR TITLE
[Enhancement]Enable auth for metric about connection of per user

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -1203,7 +1203,8 @@ public final class MetricRepo {
             ExecuteEnv.getInstance().getScheduler().getUserConnectionMap().forEach((user, count) -> {
                 GaugeMetricImpl<Integer> metric = new GaugeMetricImpl<>("connection_total",
                         MetricUnit.CONNECTIONS, "total connection");
-                metric.addLabel(new MetricLabel("user", user)).setValue(count.get());
+                metric.addLabel(new MetricLabel("user", user));
+                metric.setValue(count.get());
                 visitor.visit(metric);
             });
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -97,7 +97,6 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import javax.management.Attribute;
 import javax.management.AttributeList;
@@ -1210,7 +1209,7 @@ public final class MetricRepo {
         } else {
             GaugeMetricImpl<Integer> metric = new GaugeMetricImpl<>("connection_total",
                     MetricUnit.CONNECTIONS, "total connections");
-            metric.setValue(ExecuteEnv.getInstance().getScheduler().getTotalConnCount());
+            metric.setValue(ExecuteEnv.getInstance().getScheduler().getConnectionNum());
             visitor.visit(metric);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -490,6 +490,16 @@ public final class MetricRepo {
         };
         STARROCKS_METRIC_REGISTER.addMetric(totalTabletCount);
 
+        // connections
+        GaugeMetric<Integer> connections = new GaugeMetric<Integer>(
+                "connection_total", MetricUnit.CONNECTIONS, "total connections") {
+            @Override
+            public Integer getValue() {
+                return ExecuteEnv.getInstance().getScheduler().getConnectionNum();
+            }
+        };
+        STARROCKS_METRIC_REGISTER.addMetric(connections);
+
         // 2. counter
         COUNTER_REQUEST_ALL = new LongCounterMetric("request_total", MetricUnit.REQUESTS, "total request");
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_REQUEST_ALL);
@@ -1039,7 +1049,9 @@ public final class MetricRepo {
 
 
         //collect connections for per user
-        collectUserConnMetrics(visitor);
+        if (requestParams.isCollectUserConnMetrics()) {
+            collectUserConnMetrics(visitor);
+        }
 
         // collect runnning txns of per db
         collectDbRunningTxnMetrics(visitor);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
@@ -274,6 +274,10 @@ public class ConnectScheduler {
                 (Predicate<ConnectContext>) c -> customQueryId.equals(c.getCustomQueryId())).findFirst().orElse(null);
     }
 
+    public int getConnectionNum() {
+        return numberConnection.get();
+    }
+
     public Map<String, AtomicInteger> getUserConnectionMap() {
         return connCountByUser;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/http/MetricsActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/MetricsActionTest.java
@@ -204,4 +204,54 @@ public class MetricsActionTest {
             Assertions.assertTrue(params.isMinifyTableMetrics());
         }
     }
+
+    @Test
+    public void testParseRequestParamsWithUserConnections() {
+        ActionController controller = new ActionController();
+        MockMetricsAction action = new MockMetricsAction(controller);
+
+        // Test with user connections parameter but no auth
+        {
+            BaseRequest request = buildBaseRequest("/metrics?with_user_connections=all", false);
+            new Expectations(request) {
+                {
+                    request.getAuthorizationHeader();
+                    minTimes = 1;
+                }
+            };
+            MetricsAction.RequestParams params = action.callParseRequestParams(request);
+            Assertions.assertNotNull(params);
+            Assertions.assertFalse(params.isCollectUserConnMetrics());
+        }
+
+        // Test with user connections parameter and auth
+        {
+            BaseRequest request = buildBaseRequest("/metrics?with_user_connections=all", true);
+            new Expectations(request) {
+                {
+                    request.getHostString();
+                    result = "127.0.0.1";
+                }
+            };
+            MetricsAction.RequestParams params = action.callParseRequestParams(request);
+            Assertions.assertNotNull(params);
+            Assertions.assertTrue(params.isCollectUserConnMetrics());
+        }
+
+        // Test combined parameters
+        {
+            BaseRequest request = buildBaseRequest("/metrics?with_table_metrics=all&with_user_connections=all", true);
+            new Expectations(request) {
+                {
+                    request.getHostString();
+                    result = "127.0.0.1";
+                }
+            };
+            MetricsAction.RequestParams params = action.callParseRequestParams(request);
+            Assertions.assertNotNull(params);
+            Assertions.assertTrue(params.isCollectTableMetrics());
+            Assertions.assertFalse(params.isMinifyTableMetrics());
+            Assertions.assertTrue(params.isCollectUserConnMetrics());
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/metric/MetricRepoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/metric/MetricRepoTest.java
@@ -69,7 +69,7 @@ public class MetricRepoTest extends PlanTestBase {
 
         // verify metric
         JsonMetricVisitor visitor = new JsonMetricVisitor("m");
-        MetricsAction.RequestParams params = new MetricsAction.RequestParams(true, true, true, true);
+        MetricsAction.RequestParams params = new MetricsAction.RequestParams(true, true, true, true, true);
         MetricRepo.getMetric(visitor, params);
         String json = visitor.build();
         Assertions.assertTrue(StringUtils.isNotEmpty(json));
@@ -263,7 +263,7 @@ public class MetricRepoTest extends PlanTestBase {
             Config.enable_routine_load_lag_time_metrics = true;
             
             JsonMetricVisitor visitor = new JsonMetricVisitor("test");
-            MetricsAction.RequestParams params = new MetricsAction.RequestParams(true, true, true, true);
+            MetricsAction.RequestParams params = new MetricsAction.RequestParams(true, true, true, true, true);
             
             // This should execute line 914 and call RoutineLoadLagTimeMetricMgr.getInstance().collectRoutineLoadLagTimeMetrics(visitor)
             String result = MetricRepo.getMetric(visitor, params);


### PR DESCRIPTION
## Why I'm doing:

Currently when we get connections for per user using no authentication, it led to a severe security issue: getting all usernames from metrics api without any authentication.

## What I'm doing:

Enable auth when we get connections for per user.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `with_user_connections` to `/metrics` to expose per-user connection counts only with admin auth; otherwise returns total connections, with corresponding code and tests updated.
> 
> - **Metrics API (`/metrics`)**:
>   - Add `with_user_connections` query param and extend `RequestParams` to control user-connection metrics.
>   - Include user-connection metrics in auth check; on auth failure, disable these collections.
> - **Metrics Collection**:
>   - Replace per-user collection with `collectConnectionMetrics(...)` in `MetricRepo`:
>     - If requested (and authorized), emit `connection_total{user=...}` per-user.
>     - Otherwise, emit aggregated `connection_total` using `ConnectScheduler.getConnectionNum()`.
>   - Minor log message adjustment.
> - **QE**:
>   - `ConnectScheduler`: add `getConnectionNum()`.
> - **Tests**:
>   - New `MetricsActionTest.testParseRequestParamsWithUserConnections`.
>   - Update existing tests to account for new `RequestParams` argument and behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e5b6ba297a0f8a53d56478fb824fa818b4974e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->