### PR TITLE
[BugFix] LocalTabletsChannel incremental_open missed merge_condition/partial_update_mode options

### DIFF
--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -92,6 +92,50 @@ LocalTabletsChannel::LocalTabletsChannel(LoadChannel* load_channel, const Tablet
     _tablets_profile = std::make_unique<RuntimeProfile>("TabletsProfile");
 }
 
+DeltaWriterOptions LocalTabletsChannel::_build_delta_writer_options(const PTabletWriterOpenRequest& params,
+                                                                    const PTabletWithPartition& tablet,
+                                                                    int32_t schema_hash,
+                                                                    const std::vector<SlotDescriptor*>* index_slots) {
+    DeltaWriterOptions options;
+    options.tablet_id = tablet.tablet_id();
+    options.schema_hash = schema_hash;
+    options.txn_id = _txn_id;
+    options.partition_id = tablet.partition_id();
+    options.load_id = params.id();
+    options.slots = index_slots;
+    options.global_dicts = &_global_dicts;
+    options.parent_span = _load_channel->get_span();
+    options.index_id = _index_id;
+    options.node_id = _node_id;
+    options.sink_id = params.sink_id();
+    options.timeout_ms = params.timeout_ms();
+    options.write_quorum = params.write_quorum();
+    options.miss_auto_increment_column = params.miss_auto_increment_column();
+    options.ptable_schema_param = &(params.schema());
+    options.column_to_expr_value = &(_column_to_expr_value);
+    options.merge_condition = params.merge_condition();
+    options.partial_update_mode = params.partial_update_mode();
+    options.immutable_tablet_size = params.immutable_tablet_size();
+
+    if (params.is_replicated_storage()) {
+        for (auto& replica : tablet.replicas()) {
+            options.replicas.emplace_back(replica);
+            if (_node_id_to_endpoint.count(replica.node_id()) == 0) {
+                _node_id_to_endpoint[replica.node_id()] = replica;
+            }
+        }
+        if (!options.replicas.empty() && options.replicas[0].node_id() == options.node_id) {
+            options.replica_state = Primary;
+        } else {
+            options.replica_state = Secondary;
+        }
+    } else {
+        options.replica_state = Peer;
+    }
+
+    return options;
+}
+
 LocalTabletsChannel::~LocalTabletsChannel() {
     _s_tablet_writer_count -= _delta_writers.size();
     _mem_pool.reset();
@@ -731,41 +775,7 @@ Status LocalTabletsChannel::_open_all_writers(const PTabletWriterOpenRequest& pa
     tablet_ids.reserve(params.tablets_size());
     std::vector<int64_t> failed_tablet_ids;
     for (const PTabletWithPartition& tablet : params.tablets()) {
-        DeltaWriterOptions options;
-        options.tablet_id = tablet.tablet_id();
-        options.schema_hash = schema_hash;
-        options.txn_id = _txn_id;
-        options.partition_id = tablet.partition_id();
-        options.load_id = params.id();
-        options.slots = index_slots;
-        options.global_dicts = &_global_dicts;
-        options.parent_span = _load_channel->get_span();
-        options.index_id = _index_id;
-        options.node_id = _node_id;
-        options.sink_id = params.sink_id();
-        options.timeout_ms = params.timeout_ms();
-        options.write_quorum = params.write_quorum();
-        options.miss_auto_increment_column = params.miss_auto_increment_column();
-        options.ptable_schema_param = &(params.schema());
-        options.column_to_expr_value = &(_column_to_expr_value);
-        if (params.is_replicated_storage()) {
-            for (auto& replica : tablet.replicas()) {
-                options.replicas.emplace_back(replica);
-                if (_node_id_to_endpoint.count(replica.node_id()) == 0) {
-                    _node_id_to_endpoint[replica.node_id()] = replica;
-                }
-            }
-            if (options.replicas.size() > 0 && options.replicas[0].node_id() == options.node_id) {
-                options.replica_state = Primary;
-            } else {
-                options.replica_state = Secondary;
-            }
-        } else {
-            options.replica_state = Peer;
-        }
-        options.merge_condition = params.merge_condition();
-        options.partial_update_mode = params.partial_update_mode();
-        options.immutable_tablet_size = params.immutable_tablet_size();
+        DeltaWriterOptions options = _build_delta_writer_options(params, tablet, schema_hash, index_slots);
 
         auto res = AsyncDeltaWriter::open(options, _mem_tracker);
         if (res.status().ok()) {
@@ -937,39 +947,7 @@ Status LocalTabletsChannel::incremental_open(const PTabletWriterOpenRequest& par
         }
         incremental_tablet_num++;
 
-        DeltaWriterOptions options;
-        options.tablet_id = tablet.tablet_id();
-        options.schema_hash = schema_hash;
-        options.txn_id = _txn_id;
-        options.partition_id = tablet.partition_id();
-        options.load_id = params.id();
-        options.slots = index_slots;
-        options.global_dicts = &_global_dicts;
-        options.parent_span = _load_channel->get_span();
-        options.index_id = _index_id;
-        options.node_id = _node_id;
-        options.sink_id = params.sink_id();
-        options.timeout_ms = params.timeout_ms();
-        options.write_quorum = params.write_quorum();
-        options.miss_auto_increment_column = params.miss_auto_increment_column();
-        options.ptable_schema_param = &(params.schema());
-        options.immutable_tablet_size = params.immutable_tablet_size();
-        options.column_to_expr_value = &(_column_to_expr_value);
-        if (params.is_replicated_storage()) {
-            for (auto& replica : tablet.replicas()) {
-                options.replicas.emplace_back(replica);
-                if (_node_id_to_endpoint.count(replica.node_id()) == 0) {
-                    _node_id_to_endpoint[replica.node_id()] = replica;
-                }
-            }
-            if (options.replicas.size() > 0 && options.replicas[0].node_id() == options.node_id) {
-                options.replica_state = Primary;
-            } else {
-                options.replica_state = Secondary;
-            }
-        } else {
-            options.replica_state = Peer;
-        }
+        DeltaWriterOptions options = _build_delta_writer_options(params, tablet, schema_hash, index_slots);
 
         auto res = AsyncDeltaWriter::open(options, _mem_tracker);
         RETURN_IF_ERROR(res.status());

--- a/be/src/runtime/local_tablets_channel.h
+++ b/be/src/runtime/local_tablets_channel.h
@@ -173,6 +173,10 @@ private:
         std::shared_ptr<WriteContext> _context;
     };
 
+    DeltaWriterOptions _build_delta_writer_options(const PTabletWriterOpenRequest& params,
+                                                   const PTabletWithPartition& tablet, int32_t schema_hash,
+                                                   const std::vector<SlotDescriptor*>* index_slots);
+
     Status _open_all_writers(const PTabletWriterOpenRequest& params);
 
     StatusOr<std::shared_ptr<WriteContext>> _create_write_context(Chunk* chunk,

--- a/test/sql/test_condition_update/R/test_condition_update
+++ b/test/sql/test_condition_update/R/test_condition_update
@@ -123,3 +123,33 @@ select * from tab1;
 300	k3_300	300	300	300	v4_300	v5_300
 200	k2_200	222	200	200	v4_200	v5_200
 -- !result
+CREATE table expr_partition_tbl (
+      org_id INT,
+      id INT,
+      v1 INT,
+      modified_at INT
+)
+ENGINE=OLAP
+PRIMARY KEY(`org_id`,`id`)
+PARTITION BY (`org_id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result
+-- !result
+shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label:conditional_update_expr_partition_tbl" -H "column_separator:," -H "row_delimiter:|" -H "merge_condition:modified_at" -d "1,2,1,1|1,2,0,0"  -XPUT ${url}/api/test_condition_update_2fdsiou12s/expr_partition_tbl/_stream_load
+-- result:
+0
+{
+    "Status": "Success",
+    "Message": "OK"
+}
+-- !result
+sync;
+-- result:
+-- !result
+select * from expr_partition_tbl;
+-- result:
+1	2	1	1
+-- !result

--- a/test/sql/test_condition_update/T/test_condition_update
+++ b/test/sql/test_condition_update/T/test_condition_update
@@ -46,3 +46,21 @@ shell: curl --location-trusted -u root: -T ${root_path}/lib/../common/data/strea
 sync;
 select * from tab1;
 
+
+CREATE table expr_partition_tbl (
+      org_id INT,
+      id INT,
+      v1 INT,
+      modified_at INT
+)
+ENGINE=OLAP
+PRIMARY KEY(`org_id`,`id`)
+PARTITION BY (`org_id`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+shell: curl --location-trusted -u root: -H "Expect:100-continue" -H "label:conditional_update_expr_partition_tbl" -H "column_separator:," -H "row_delimiter:|" -H "merge_condition:modified_at" -d "1,2,1,1|1,2,0,0"  -XPUT ${url}/api/test_condition_update_2fdsiou12s/expr_partition_tbl/_stream_load
+sync;
+select * from expr_partition_tbl;


### PR DESCRIPTION
## Why I'm doing:

Fixes incorrect write semantics in the incremental open path of LocalTabletsChannel: merge_condition and partial_update_mode were not propagated to DeltaWriterOptions, leading to wrong behavior for MERGE/partial-update loads routed through incremental_open.


## What I'm doing:

Centralize the construction of DeltaWriterOptions in a single helper and use it for both _open_all_writers and incremental_open. Ensure merge_condition and partial_update_mode are always set.

Fixes #issue

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 4.0
  - [X] 3.5
  - [X] 3.4
  - [X] 3.3
