### PR TITLE
[BugFix] Fix wrong result when apply aggregate in filters

### DIFF
--- a/be/src/exprs/runtime_filter_bank.cpp
+++ b/be/src/exprs/runtime_filter_bank.cpp
@@ -82,13 +82,8 @@ RuntimeFilter* RuntimeFilterHelper::create_runtime_bloom_filter(ObjectPool* pool
 }
 
 RuntimeFilter* RuntimeFilterHelper::create_agg_runtime_in_filter(ObjectPool* pool, LogicalType type, int8_t join_mode) {
-    return scalar_type_dispatch(type, [pool]<LogicalType ltype>() -> RuntimeFilter* {
-        auto rf = new InRuntimeFilter<ltype>();
-        if (pool != nullptr) {
-            return pool->add(rf);
-        }
-        return rf;
-    });
+    return scalar_type_dispatch(
+            type, [pool]<LogicalType ltype>() -> RuntimeFilter* { return InRuntimeFilter<ltype>::create(pool); });
 }
 
 RuntimeFilter* RuntimeFilterHelper::create_runtime_bitset_filter(ObjectPool* pool, LogicalType type, int8_t join_mode) {

--- a/test/sql/test_agg/R/test_agg_with_limit_seq
+++ b/test/sql/test_agg/R/test_agg_with_limit_seq
@@ -1,0 +1,51 @@
+-- name: test_agg_with_limit_seq @sequential
+create table base_table (
+    c0 int,
+    c1 int,
+    c2 string,
+    c3 int
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 3 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into base_table SELECT generate_series % 4, generate_series % 9, generate_series % 9, generate_series %9 FROM TABLE(generate_series(1,  10000));
+-- result:
+-- !result
+create table agg_with_limit_seq (
+    c0 int,
+    c1 int,
+    c2 string,
+    c3 int
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into agg_with_limit_seq SELECT * FROM base_table;
+-- result:
+-- !result
+admin enable failpoint 'scan_chunk_sleep_after_read';
+-- result:
+-- !result
+set streaming_preaggregation_mode="force_streaming";
+-- result:
+-- !result
+select * from (select max(c3), sum(c3) sc3, c0 from agg_with_limit_seq group by c0 limit 10) t order by 3;
+-- result:
+8	10003	0
+8	10000	1
+8	9998	2
+8	9996	3
+-- !result
+select * from (select max(c3), sum(c3) sc3, c1 from agg_with_limit_seq group by c1 limit 10) t order by 3;
+-- result:
+0	0	0
+1	1112	1
+2	2222	2
+3	3333	3
+4	4444	4
+5	5555	5
+6	6666	6
+7	7777	7
+8	8888	8
+-- !result
+admin disable failpoint 'scan_chunk_sleep_after_read';
+-- result:
+-- !result

--- a/test/sql/test_agg/T/test_agg_with_limit_seq
+++ b/test/sql/test_agg/T/test_agg_with_limit_seq
@@ -1,0 +1,24 @@
+-- name: test_agg_with_limit_seq @sequential
+
+create table base_table (
+    c0 int,
+    c1 int,
+    c2 string,
+    c3 int
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 3 PROPERTIES('replication_num' = '1');
+insert into base_table SELECT generate_series % 4, generate_series % 9, generate_series % 9, generate_series %9 FROM TABLE(generate_series(1,  10000));
+
+create table agg_with_limit_seq (
+    c0 int,
+    c1 int,
+    c2 string,
+    c3 int
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+insert into agg_with_limit_seq SELECT * FROM base_table;
+
+admin enable failpoint 'scan_chunk_sleep_after_read';
+
+set streaming_preaggregation_mode="force_streaming";
+select * from (select max(c3), sum(c3) sc3, c0 from agg_with_limit_seq group by c0 limit 10) t order by 3;
+select * from (select max(c3), sum(c3) sc3, c1 from agg_with_limit_seq group by c1 limit 10) t order by 3;
+admin disable failpoint 'scan_chunk_sleep_after_read';


### PR DESCRIPTION
## Why I'm doing:

When InRuntimeFilters not push down to storage layer, it should be always true

fix test_case test_agg_with_limit

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
