### PR TITLE
[Enhancement] Add a session variable to control whether partial column update is used during  execution

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -810,6 +810,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String PARTIAL_UPDATE_MODE = "partial_update_mode";
 
+    public static final String ENABLE_INSERT_PARTIAL_UPDATE = "enable_insert_partial_update";
+
     public static final String SCAN_OR_TO_UNION_LIMIT = "scan_or_to_union_limit";
 
     public static final String SCAN_OR_TO_UNION_THRESHOLD = "scan_or_to_union_threshold";
@@ -1880,6 +1882,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = PARTIAL_UPDATE_MODE)
     private String partialUpdateMode = "auto";
 
+    @VariableMgr.VarAttr(name = ENABLE_INSERT_PARTIAL_UPDATE)
+    private boolean enableInsertPartialUpdate = true;
+
     @VariableMgr.VarAttr(name = HDFS_BACKEND_SELECTOR_HASH_ALGORITHM, flag = VariableMgr.INVISIBLE)
     private String hdfsBackendSelectorHashAlgorithm = "consistent";
 
@@ -2119,6 +2124,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public String getPartialUpdateMode() {
         return this.partialUpdateMode;
+    }
+
+    public void setEnableInsertPartialUpdate(boolean enableInsertPartialUpdate) {
+        this.enableInsertPartialUpdate = enableInsertPartialUpdate;
+    }
+
+    public boolean isEnableInsertPartialUpdate() {
+        return this.enableInsertPartialUpdate;
     }
 
     public boolean isEnableSortAggregate() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -288,7 +288,8 @@ public class InsertAnalyzer {
                         String missingKeyColumns = String.join(",", requiredKeyColumns);
                         ErrorReport.reportSemanticException(ErrorCode.ERR_MISSING_KEY_COLUMNS, missingKeyColumns);
                     }
-                    if (targetColumns.size() < olapTable.getBaseSchemaWithoutGeneratedColumn().size()) {
+                    if (targetColumns.size() < olapTable.getBaseSchemaWithoutGeneratedColumn().size() && 
+                            session.getSessionVariable().isEnableInsertPartialUpdate()) {
                         insertStmt.setUsePartialUpdate();
                         // mark if partial update for auto increment column if and only if:
                         // 1. There is auto increment defined in base schema

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SessionVariableTest.java
@@ -83,4 +83,14 @@ public class SessionVariableTest {
                     e.getMessage());
         }
     }
+
+    @Test
+    public void testSetEnableInsertPartialUpdate() {
+        SessionVariable sessionVariable = new SessionVariable();
+        sessionVariable.setEnableInsertPartialUpdate(true);
+        Assertions.assertTrue(sessionVariable.isEnableInsertPartialUpdate());
+
+        sessionVariable.setEnableInsertPartialUpdate(false);
+        Assertions.assertFalse(sessionVariable.isEnableInsertPartialUpdate());
+    }
 }

--- a/test/sql/test_insert_empty/R/test_insert_partial_update
+++ b/test/sql/test_insert_empty/R/test_insert_partial_update
@@ -102,7 +102,7 @@ insert into test4 values(1, 'v0', 1), (2, 'v2', 2);
 -- !result
 insert into test4 (pk, v0) values(1, 'v0_1'), (3, 'v3_1');
 -- result:
-E: (5609, '172.26.95.128: partial update on table with sort key must provide all sort key columns')
+[REGEX].*partial update on table with sort key must provide all sort key columns.*
 -- !result
 -- name: test_non_replicated_storage_multi_replica_pk
 CREATE TABLE `t_non_replicated_storage_multi_replica_pk` (

--- a/test/sql/test_insert_empty/R/test_insert_partial_update
+++ b/test/sql/test_insert_empty/R/test_insert_partial_update
@@ -102,5 +102,26 @@ insert into test4 values(1, 'v0', 1), (2, 'v2', 2);
 -- !result
 insert into test4 (pk, v0) values(1, 'v0_1'), (3, 'v3_1');
 -- result:
-E: (5609, '172.26.95.127: partial update on table with sort key must provide all sort key columns')
+E: (5609, '172.26.95.128: partial update on table with sort key must provide all sort key columns')
+-- !result
+-- name: test_non_replicated_storage_multi_replica_pk
+CREATE TABLE `t_non_replicated_storage_multi_replica_pk` (
+  `k` STRING NOT NULL COMMENT "",
+  `v1` int DEFAULT "10",
+  `v2` int
+) ENGINE=OLAP 
+PRIMARY KEY(`k`)
+DISTRIBUTED BY HASH(`k`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "2",
+"replicated_storage" = "false"
+);
+-- result:
+-- !result
+insert into t_non_replicated_storage_multi_replica_pk (k,v2) select "abc", 10;
+-- result:
+-- !result
+select * from t_non_replicated_storage_multi_replica_pk;
+-- result:
+abc	10	10
 -- !result

--- a/test/sql/test_insert_empty/R/test_insert_partial_update
+++ b/test/sql/test_insert_empty/R/test_insert_partial_update
@@ -25,6 +25,23 @@ select * from test order by pk;
 1	v0	11
 2	v2	2
 -- !result
+insert into test values(1, 'v0', 1), (2, 'v2', 2);
+-- result:
+-- !result
+set enable_insert_partial_update = false;
+-- result:
+-- !result
+insert into test (pk, v1) values(1, 111);
+-- result:
+-- !result
+select * from test order by pk;
+-- result:
+1	defaultv0	111
+2	v2	2
+-- !result
+set enable_insert_partial_update = true;
+-- result:
+-- !result
 create table test2 (pk bigint NOT NULL, v0 string not null, v1 int not null default '100001')
 primary KEY (pk) DISTRIBUTED BY HASH(pk) BUCKETS 1 PROPERTIES("replication_num" = "1");
 -- result:
@@ -38,6 +55,25 @@ insert into test2 (pk, v1) values(1, 11), (3, 3);
 select * from test2 order by pk;
 -- result:
 1	v0	11
+2	v2	2
+3		3
+-- !result
+insert into test2 values(1, 'v0', 1), (2, 'v2', 2);
+-- result:
+-- !result
+set enable_insert_partial_update = false;
+-- result:
+-- !result
+insert into test2 (pk, v1) values(1, 11), (3, 3);
+-- result:
+E: (1064, "Getting analyzing error. Detail message: 'v0' must be explicitly mentioned in column permutation:  pk  v1 .")
+-- !result
+set enable_insert_partial_update = true;
+-- result:
+-- !result
+select * from test2 order by pk;
+-- result:
+1	v0	1
 2	v2	2
 3		3
 -- !result
@@ -66,26 +102,5 @@ insert into test4 values(1, 'v0', 1), (2, 'v2', 2);
 -- !result
 insert into test4 (pk, v0) values(1, 'v0_1'), (3, 'v3_1');
 -- result:
-[REGEX].*partial update on table with sort key must provide all sort key columns.*
--- !result
--- name: test_non_replicated_storage_multi_replica_pk
-CREATE TABLE `t_non_replicated_storage_multi_replica_pk` (
-  `k` STRING NOT NULL COMMENT "",
-  `v1` int DEFAULT "10",
-  `v2` int
-) ENGINE=OLAP 
-PRIMARY KEY(`k`)
-DISTRIBUTED BY HASH(`k`) BUCKETS 1
-PROPERTIES (
-"replication_num" = "2",
-"replicated_storage" = "false"
-);
--- result:
--- !result
-insert into t_non_replicated_storage_multi_replica_pk (k,v2) select "abc", 10;
--- result:
--- !result
-select * from t_non_replicated_storage_multi_replica_pk;
--- result:
-abc	10	10
+E: (5609, '172.26.95.127: partial update on table with sort key must provide all sort key columns')
 -- !result

--- a/test/sql/test_insert_empty/T/test_insert_partial_update
+++ b/test/sql/test_insert_empty/T/test_insert_partial_update
@@ -12,6 +12,13 @@ insert into test values(1, 'v0', 1), (2, 'v2', 2);
 insert into test (pk, v1) values(1, 11);
 select * from test order by pk;
 
+-- without partial update
+insert into test values(1, 'v0', 1), (2, 'v2', 2);
+set enable_insert_partial_update = false;
+insert into test (pk, v1) values(1, 111);
+select * from test order by pk;
+set enable_insert_partial_update = true;
+
 -- v0 is not null but does not have default value
 create table test2 (pk bigint NOT NULL, v0 string not null, v1 int not null default '100001')
 primary KEY (pk) DISTRIBUTED BY HASH(pk) BUCKETS 1 PROPERTIES("replication_num" = "1");
@@ -19,6 +26,13 @@ primary KEY (pk) DISTRIBUTED BY HASH(pk) BUCKETS 1 PROPERTIES("replication_num" 
 -- partial update
 insert into test2 values(1, 'v0', 1), (2, 'v2', 2);
 insert into test2 (pk, v1) values(1, 11), (3, 3);
+select * from test2 order by pk;
+
+-- without partial update
+insert into test2 values(1, 'v0', 1), (2, 'v2', 2);
+set enable_insert_partial_update = false;
+insert into test2 (pk, v1) values(1, 11), (3, 3);
+set enable_insert_partial_update = true;
 select * from test2 order by pk;
 
 -- update with generated column


### PR DESCRIPTION
## Why I'm doing:
Partial column updates can have some impact on import performance. In certain cases, users need a way to evaluate whether partial column updates should be enabled during INSERT execution for their specific scenario.

## What I'm doing:
This pull request introduces a new session variable to control the behavior of partial updates during insert operations. It adds the `enable_insert_partial_update` variable, allowing users to enable or disable partial updates on a session basis. The changes include updates to the session variable management, the insert analyzer logic, and the addition of relevant test cases to verify the new functionality.

**Session variable management:**

* Added the `enable_insert_partial_update` session variable, including its definition, default value (`true`), and getter/setter methods in `SessionVariable.java`. [[1]](diffhunk://#diff-727d043183218b8a4cbbc92d0fc2796a9e1637cd2f21219c7c26add24b13972dR812-R813) [[2]](diffhunk://#diff-727d043183218b8a4cbbc92d0fc2796a9e1637cd2f21219c7c26add24b13972dR1881-R1883) [[3]](diffhunk://#diff-727d043183218b8a4cbbc92d0fc2796a9e1637cd2f21219c7c26add24b13972dR2125-R2132)

**Partial update logic:**

* Modified the logic in `InsertAnalyzer.java` so that partial update behavior during insert operations is now gated by the `enable_insert_partial_update` session variable. Partial updates are only performed if this variable is enabled.

**Testing and verification:**

* Enhanced SQL test cases to cover scenarios with `enable_insert_partial_update` both enabled and disabled, ensuring correct behavior and error handling for partial updates. This includes new test inputs, expected results, and error messages in `test_insert_partial_update` test files. [[1]](diffhunk://#diff-f9def9da446735874ecb59266e10cce9fd64cb71da02bc00f7f56e4fd1784a32R28-R44) [[2]](diffhunk://#diff-f9def9da446735874ecb59266e10cce9fd64cb71da02bc00f7f56e4fd1784a32R61-R79) [[3]](diffhunk://#diff-f9def9da446735874ecb59266e10cce9fd64cb71da02bc00f7f56e4fd1784a32L69-R105) [[4]](diffhunk://#diff-4c5f9296d15b9bad7aee6c6e17e8c453a6acc6b4e2fefa3365de993087281088R15-R21) [[5]](diffhunk://#diff-4c5f9296d15b9bad7aee6c6e17e8c453a6acc6b4e2fefa3365de993087281088R31-R37)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
