### PR TITLE
[BugFix] Fix global runtime filter descriptor not attaching observer

### DIFF
--- a/be/src/exec/pipeline/operator.cpp
+++ b/be/src/exec/pipeline/operator.cpp
@@ -406,6 +406,8 @@ void OperatorFactory::acquire_runtime_filter(RuntimeState* state) {
             continue;
         }
 
+        VLOG_FILE << "OperatorFactory::acquire_runtime_filter(shared). filter_id = " << filter_id
+                  << ", filter = " << grf->debug_string();
         desc->set_shared_runtime_filter(grf);
     }
 }

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -160,6 +160,7 @@ Status PipelineDriver::prepare(RuntimeState* runtime_state) {
             for (const auto& [_, desc] : global_rf_collector->descriptors()) {
                 if (!desc->skip_wait()) {
                     _global_rf_descriptors.emplace_back(desc);
+                    desc->add_observer(_runtime_state, &_observer);
                 }
             }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Attach observers to global runtime filter descriptors during driver preparation; add verbose logging when acquiring shared runtime filters.
> 
> - **Runtime filters**:
>   - Attach observer to each non-skipped global runtime filter `desc` in `pipeline_driver.cpp` during driver preparation (`desc->add_observer(...)`).
>   - Add verbose log in `OperatorFactory::acquire_runtime_filter` when installing a shared runtime filter (`VLOG_FILE` with `filter_id` and `debug_string`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 780a86aa532abc88b681878e8fd110228cf57add. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->