### PR TITLE
[UT] Fix unstable ut

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
@@ -142,7 +142,7 @@ public class BrokerLoadJobTest {
                                   @Mocked GlobalStateMgr globalStateMgr) {
 
         String label = "label";
-        long dbId = 1;
+        long dbId = System.currentTimeMillis();
         String tableName = "table";
         String databaseName = "database";
         List<DataDescription> dataDescriptionList = Lists.newArrayList();
@@ -209,7 +209,7 @@ public class BrokerLoadJobTest {
                               @Mocked GlobalStateMgr globalStateMgr) {
 
         String label = "label";
-        long dbId = 1;
+        long dbId = System.currentTimeMillis();
         String tableName = "table";
         String databaseName = "database";
         List<DataDescription> dataDescriptionList = Lists.newArrayList();

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadJobTest.java
@@ -95,11 +95,15 @@ public class LoadJobTest {
     }
 
     @Test
-    public void testGetDbNotExists(@Mocked GlobalStateMgr globalStateMgr) {
+    public void testGetDbNotExists() {
         LoadJob loadJob = new BrokerLoadJob();
         Deencapsulation.setField(loadJob, "dbId", 1L);
         new Expectations() {
             {
+                GlobalStateMgr.getCurrentState();
+                minTimes = 0;
+                result = globalStateMgr;
+
                 globalStateMgr.getLocalMetastore().getDb(1L);
                 minTimes = 0;
                 result = null;
@@ -294,11 +298,15 @@ public class LoadJobTest {
     }
 
     @Test
-    public void testProcessTimeout(@Mocked GlobalStateMgr globalStateMgr, @Mocked EditLog editLog) {
+    public void testProcessTimeout(@Mocked EditLog editLog) {
         LoadJob loadJob = new BrokerLoadJob();
         Deencapsulation.setField(loadJob, "timeoutSecond", 0);
         new Expectations() {
             {
+                GlobalStateMgr.getCurrentState();
+                minTimes = 0;
+                result = globalStateMgr;
+
                 globalStateMgr.getEditLog();
                 minTimes = 0;
                 result = editLog;


### PR DESCRIPTION
## Why I'm doing:

```
com.starrocks.load.loadv2.LoadJobTest.testGetDbNotExists(GlobalStateMgr) -- Time elapsed: 2.379 s <<< FAILURE!
  org.opentest4j.AssertionFailedError
 	at com.starrocks.load.loadv2.LoadJobTest.testGetDbNotExists(LoadJobTest.java:111)
 	Suppressed: Missing 1 invocation to:
  com.starrocks.server.GlobalStateMgr#getLocalMetastore()
      on mock instance: com.starrocks.server.GlobalStateMgr@7a69f4e3
 	Caused by: Missing invocations
 		at com.starrocks.server.GlobalStateMgr.getLocalMetastore(GlobalStateMgr.java)
 		at com.starrocks.load.loadv2.LoadJobTest$1.<init>(LoadJobTest.java:103)
 		at com.starrocks.load.loadv2.LoadJobTest.testGetDbNotExists(LoadJobTest.java:101)

com.starrocks.load.loadv2.BrokerLoadJobTest.testFromLoadStmt2(LoadStmt, DataDescription, LabelName, Database, OlapTable, GlobalStateMgr) -- Time elapsed: 3.168 s <<< ERROR!
 java.lang.IllegalMonitorStateException: Attempt to unlock lock, not locked by current locker
 	at com.starrocks.common.util.concurrent.lock.Locker.release(Locker.java:109)
 	at com.starrocks.common.util.concurrent.lock.Locker.unLockDatabase(Locker.java:246)
 	at com.starrocks.load.loadv2.BulkLoadJob.checkAndSetDataSourceInfo(BulkLoadJob.java:187)
 	at com.starrocks.load.loadv2.BulkLoadJob.fromLoadStmt(BulkLoadJob.java:164)
 	at com.starrocks.load.loadv2.BrokerLoadJobTest.testFromLoadStmt2(BrokerLoadJobTest.java:191)
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
