### PR TITLE
[BugFix] Fix runtime filter with low-cardinality optimization on share-data

### DIFF
--- a/be/src/connector/connector.h
+++ b/be/src/connector/connector.h
@@ -75,7 +75,7 @@ public:
     void set_runtime_filters(RuntimeFilterProbeCollector* runtime_filters) { _runtime_filters = runtime_filters; }
     void set_read_limit(const uint64_t limit) { _read_limit = limit; }
     void set_split_context(pipeline::ScanSplitContext* split_context) { _split_context = split_context; }
-    Status parse_runtime_filters(RuntimeState* state);
+    virtual Status parse_runtime_filters(RuntimeState* state);
     void update_has_any_predicate();
     // Called frequently, don't do heavy work
     virtual const std::string get_custom_coredump_msg() const { return ""; }

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -55,6 +55,11 @@ public:
         _reader->get_split_tasks(split_tasks);
     }
 
+    // parse_runtime_filters is used to generate min-max predicates from runtime filters, while LakeDataSource already
+    // generates predicates by ScanConjunctsManager, so skip parse_runtime_filters to make the parse logic is consistent
+    // to the share-nothing mode.
+    Status parse_runtime_filters(RuntimeState* state) override { return Status::OK(); }
+
 private:
     Status get_tablet(const TInternalScanRange& scan_range);
     Status init_global_dicts(TabletReaderParams* params);


### PR DESCRIPTION
## Update (2026-02-25)

In versions <= 3.5, runtime filters generated by Top-N also have this issue. It occurs when the Top-N `ORDER BY` column has low cardinality.

----

## Why I'm doing:

#63919 added low-cardinality optimization for broadcast hash joins, which introduced a mismatch: runtime filters are `INT`, but predicates pushed down to storage must use the original `VARCHAR` type. To address this in `olap_scan_prepare`, we convert the pushed-down runtime filter’s `IN` predicates and min–max predicates from `INT` to `VARCHAR`.

However, in share-data mode, runtime filters are parsed not only by `olap_scan_prepare` but also by `ConnectorDataSource::parse_runtime_filters`. In #63919 we missed handling the `INT` ↔ `VARCHAR` conversion there.

Changes:
- For `olap_scan`, remove `ConnectorDataSource::parse_runtime_filters`. It was only used to derive min–max predicates from runtime filters, which is already handled in `olap_scan_prepare`.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
