### PR TITLE
[Enhancement] Add session variable to convert decimal multiplication overflow to double (backport #64680)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -240,6 +240,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String EVENT_SCHEDULER = "event_scheduler";
     public static final String STORAGE_ENGINE = "storage_engine";
     public static final String DIV_PRECISION_INCREMENT = "div_precision_increment";
+    public static final String DECIMAL_OVERFLOW_TO_DOUBLE = "decimal_overflow_to_double";
 
     // see comment of `starrocks_max_scan_key_num` and `max_pushdown_conditions_per_column` in BE config
     public static final String MAX_SCAN_KEY_NUM = "max_scan_key_num";
@@ -1446,6 +1447,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = DIV_PRECISION_INCREMENT)
     private int divPrecisionIncrement = 4;
 
+    @VariableMgr.VarAttr(name = DECIMAL_OVERFLOW_TO_DOUBLE)
+    private boolean decimalOverflowToDouble = false;
+
     // -1 means unset, BE will use its config value
     @VariableMgr.VarAttr(name = MAX_SCAN_KEY_NUM)
     private int maxScanKeyNum = -1;
@@ -2635,6 +2639,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isCboDecimalCastStringStrict() {
         return cboDecimalCastStringStrict;
+    }
+
+    public boolean isDecimalOverflowToDouble() {
+        return decimalOverflowToDouble;
+    }
+
+    public void setDecimalOverflowToDouble(boolean decimalOverflowToDouble) {
+        this.decimalOverflowToDouble = decimalOverflowToDouble;
     }
 
     @VarAttr(name = ENABLE_ARRAY_DISTINCT_AFTER_AGG_OPT)

--- a/test/sql/test_decimal/R/test_decimal_to_double.sql
+++ b/test/sql/test_decimal/R/test_decimal_to_double.sql
@@ -1,0 +1,281 @@
+-- name: test_decimal_to_double
+DROP DATABASE IF EXISTS test_decimal_to_double;
+-- result:
+-- !result
+CREATE DATABASE test_decimal_to_double;
+-- result:
+-- !result
+USE test_decimal_to_double;
+-- result:
+-- !result
+CREATE TABLE `t_decimal_precision_overflow` (
+  `c_id` int(11) NOT NULL,
+  `c_d64_max` decimal64(18,9) NOT NULL,
+  `c_d128_large` decimal128(30,10) NOT NULL,
+  `c_d128_max` decimal128(38,15) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c_id`)
+DISTRIBUTED BY HASH(`c_id`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO `t_decimal_precision_overflow` (c_id, c_d64_max, c_d128_large, c_d128_max) values
+   (1, 123456789.123456789, 12345678901234567890.1234567890, 12345678901234567890123.123456789012345),
+   (2, -123456789.123456789, -12345678901234567890.1234567890, -12345678901234567890123.123456789012345),
+   (3, 987654321.987654321, 98765432109876543210.9876543210, 98765432109876543210987.987654321098765),
+   (4, 111222333.444555666, 11122233344455566677.8899001122, 11122233344455566677889.900112233445566),
+   (5, 555666777.888999111, 55566677788899911122.2333444555, 55566677788899911122233.344455566677888);
+-- result:
+-- !result
+set decimal_overflow_to_double = false;
+-- result:
+-- !result
+select c_d64_max * c_d64_max from t_decimal_precision_overflow where c_id = 1;
+-- result:
+15241578780673678.515622620750190521
+-- !result
+select c_d64_max * c_d64_max from t_decimal_precision_overflow where c_id = 2;
+-- result:
+15241578780673678.515622620750190521
+-- !result
+select c_d64_max * c_d64_max from t_decimal_precision_overflow where c_id = 3;
+-- result:
+975461059740893157.555403139789971041
+-- !result
+select c_d64_max * c_d64_max from t_decimal_precision_overflow where c_id = 4;
+-- result:
+12370407456851925.839407296172703556
+-- !result
+select c_d64_max * c_d64_max from t_decimal_precision_overflow where c_id = 5;
+-- result:
+308765568049542271.320789913358790321
+-- !result
+select c_d128_large * c_d64_max from t_decimal_precision_overflow where c_id = 1;
+-- result:
+None
+-- !result
+select c_d128_large * c_d64_max from t_decimal_precision_overflow where c_id = 2;
+-- result:
+None
+-- !result
+select c_d128_large * c_d64_max from t_decimal_precision_overflow where c_id = 3;
+-- result:
+None
+-- !result
+select c_d128_large * c_d64_max from t_decimal_precision_overflow where c_id = 4;
+-- result:
+None
+-- !result
+select c_d128_large * c_d64_max from t_decimal_precision_overflow where c_id = 5;
+-- result:
+None
+-- !result
+select c_d128_max * c_d128_max from t_decimal_precision_overflow where c_id = 1;
+-- result:
+None
+-- !result
+select c_d128_max * c_d128_max from t_decimal_precision_overflow where c_id = 2;
+-- result:
+None
+-- !result
+select c_d128_max * c_d128_max from t_decimal_precision_overflow where c_id = 3;
+-- result:
+None
+-- !result
+select 123456789012345678901234567890.123456789 * 987654321098765432109876543210.987654321;
+-- result:
+None
+-- !result
+select 12345678901234567890123456789012.12345678901 * 98765432109876543210.12345678901;
+-- result:
+None
+-- !result
+select 1234567890123456789012345678.12345678 * 9876543210987654321098765432.87654321;
+-- result:
+None
+-- !result
+select 12345678901234567890123456.123456 * 98765432109876543210987654.876543;
+-- result:
+None
+-- !result
+set decimal_overflow_to_double = true;
+-- result:
+-- !result
+select c_d64_max * c_d64_max from t_decimal_precision_overflow where c_id = 1;
+-- result:
+15241578780673678.515622620750190521
+-- !result
+select c_d64_max * c_d64_max from t_decimal_precision_overflow where c_id = 2;
+-- result:
+15241578780673678.515622620750190521
+-- !result
+select c_d64_max * c_d64_max from t_decimal_precision_overflow where c_id = 3;
+-- result:
+975461059740893157.555403139789971041
+-- !result
+select c_d64_max * c_d64_max from t_decimal_precision_overflow where c_id = 4;
+-- result:
+12370407456851925.839407296172703556
+-- !result
+select c_d64_max * c_d64_max from t_decimal_precision_overflow where c_id = 5;
+-- result:
+308765568049542271.320789913358790321
+-- !result
+select c_d128_large * c_d64_max from t_decimal_precision_overflow where c_id = 1;
+-- result:
+1.5241578766956256e+27
+-- !result
+select c_d128_large * c_d64_max from t_decimal_precision_overflow where c_id = 2;
+-- result:
+1.5241578766956256e+27
+-- !result
+select c_d128_large * c_d64_max from t_decimal_precision_overflow where c_id = 3;
+-- result:
+9.754610588629782e+28
+-- !result
+select c_d128_large * c_d64_max from t_decimal_precision_overflow where c_id = 4;
+-- result:
+1.2370407456851927e+27
+-- !result
+select c_d128_large * c_d64_max from t_decimal_precision_overflow where c_id = 5;
+-- result:
+3.087655680495423e+28
+-- !result
+select c_d128_max * c_d128_max from t_decimal_precision_overflow where c_id = 1;
+-- result:
+1.5241578753238837e+44
+-- !result
+select c_d128_max * c_d128_max from t_decimal_precision_overflow where c_id = 2;
+-- result:
+1.5241578753238837e+44
+-- !result
+select c_d128_max * c_d128_max from t_decimal_precision_overflow where c_id = 3;
+-- result:
+9.754610579850631e+45
+-- !result
+select 123456789012345678901234567890.123456789 * 987654321098765432109876543210.987654321;
+-- result:
+1.2193263113702178e+59
+-- !result
+select 12345678901234567890123456789012.12345678901 * 98765432109876543210.12345678901;
+-- result:
+1.2193263113702178e+51
+-- !result
+select 1234567890123456789012345678.12345678 * 9876543210987654321098765432.87654321;
+-- result:
+1.219326311370218e+55
+-- !result
+select 12345678901234567890123456.123456 * 98765432109876543210987654.876543;
+-- result:
+1.2193263113702181e+51
+-- !result
+set decimal_overflow_to_double = false;
+-- result:
+-- !result
+select 1234567890123456789.1234567890123456789 * 1.0000000000000000000;
+-- result:
+None
+-- !result
+set decimal_overflow_to_double = true;
+-- result:
+-- !result
+select 1234567890123456789.1234567890123456789 * 1.0000000000000000000;
+-- result:
+1.2345678901234568e+18
+-- !result
+set decimal_overflow_to_double = false;
+-- result:
+-- !result
+select 12345678901234567890123456789012345678.0 * 1.0;
+-- result:
+12345678901234567890123456789012345678.0
+-- !result
+set decimal_overflow_to_double = true;
+-- result:
+-- !result
+select 12345678901234567890123456789012345678.0 * 1.1;
+-- result:
+1.3580246791358026e+37
+-- !result
+set decimal_overflow_to_double = true;
+-- result:
+-- !result
+select c_id, c_d128_large * c_d64_max + 1.0 from t_decimal_precision_overflow where c_id <= 2;
+-- result:
+1	1.5241578766956256e+27
+2	1.5241578766956256e+27
+-- !result
+select c_id, (c_d128_max * c_d128_max) / 2.0 from t_decimal_precision_overflow where c_id <= 2;
+-- result:
+1	7.620789376619419e+43
+2	7.620789376619419e+43
+-- !result
+set decimal_overflow_to_double = false;
+-- result:
+-- !result
+select 12345678901234567890123456789012345678.0 * 98765432109876543210987654321098765432.0;
+-- result:
+None
+-- !result
+set decimal_overflow_to_double = true;
+-- result:
+-- !result
+select 12345678901234567890123456789012345678.0 * 98765432109876543210987654321098765432.0;
+-- result:
+1.2193263113702179e+75
+-- !result
+set decimal_overflow_to_double = false;
+-- result:
+-- !result
+select 123456789012345678901234567890123456.78 * 987654321098765432109876543210987654.32;
+-- result:
+None
+-- !result
+set decimal_overflow_to_double = true;
+-- result:
+-- !result
+select 123456789012345678901234567890123456.78 * 987654321098765432109876543210987654.32;
+-- result:
+1.219326311370218e+71
+-- !result
+set decimal_overflow_to_double = false;
+-- result:
+-- !result
+select 1111222233334444555566667777.8888 * 8888777766665555444433332222.1111;
+-- result:
+None
+-- !result
+set decimal_overflow_to_double = true;
+-- result:
+-- !result
+select 1111222233334444555566667777.8888 * 8888777766665555444433332222.1111;
+-- result:
+9.877407481487654e+54
+-- !result
+set decimal_overflow_to_double = false;
+-- result:
+-- !result
+select 123456789012345678901234567890.123456 * 987654321098765432109876543210.654321;
+-- result:
+None
+-- !result
+set decimal_overflow_to_double = true;
+-- result:
+-- !result
+select 123456789012345678901234567890.123456 * 987654321098765432109876543210.654321;
+-- result:
+1.2193263113702178e+59
+-- !result
+SELECT(0.58000000 * 0.970825897017235893 * 3021621.785498);
+-- result:
+1701411.8346046924
+-- !result
+set decimal_overflow_to_double = false;
+-- result:
+-- !result
+SELECT(0.58000000 * 0.970825897017235893 * 3021621.785498);
+-- result:
+None
+-- !result

--- a/test/sql/test_decimal/T/test_decimal_to_double.sql
+++ b/test/sql/test_decimal/T/test_decimal_to_double.sql
@@ -1,0 +1,150 @@
+-- name: test_decimal_to_double
+
+DROP DATABASE IF EXISTS test_decimal_to_double;
+CREATE DATABASE test_decimal_to_double;
+USE test_decimal_to_double;
+
+CREATE TABLE `t_decimal_precision_overflow` (
+  `c_id` int(11) NOT NULL,
+  `c_d64_max` decimal64(18,9) NOT NULL,
+  `c_d128_large` decimal128(30,10) NOT NULL,
+  `c_d128_max` decimal128(38,15) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c_id`)
+DISTRIBUTED BY HASH(`c_id`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+
+-- Insert test data that will definitely cause precision overflow when multiplied
+-- decimal64(18,9) * decimal64(18,9) = precision 36, scale 18 (fits in decimal128)
+-- decimal128(30,10) * decimal64(18,9) = precision 48, scale 19 (overflow!)
+-- decimal128(38,15) * decimal128(38,15) = precision 76, scale 30 (overflow!)
+INSERT INTO `t_decimal_precision_overflow` (c_id, c_d64_max, c_d128_large, c_d128_max) values
+   (1, 123456789.123456789, 12345678901234567890.1234567890, 12345678901234567890123.123456789012345),
+   (2, -123456789.123456789, -12345678901234567890.1234567890, -12345678901234567890123.123456789012345),
+   (3, 987654321.987654321, 98765432109876543210.9876543210, 98765432109876543210987.987654321098765),
+   (4, 111222333.444555666, 11122233344455566677.8899001122, 11122233344455566677889.900112233445566),
+   (5, 555666777.888999111, 55566677788899911122.2333444555, 55566677788899911122233.344455566677888);
+
+-- Test 1: decimal_overflow_to_double = false (default behavior)
+set decimal_overflow_to_double = false;
+
+-- These should NOT cause overflow (precision 36, scale 18 <= 38)
+select c_d64_max * c_d64_max from t_decimal_precision_overflow where c_id = 1;
+select c_d64_max * c_d64_max from t_decimal_precision_overflow where c_id = 2;
+select c_d64_max * c_d64_max from t_decimal_precision_overflow where c_id = 3;
+select c_d64_max * c_d64_max from t_decimal_precision_overflow where c_id = 4;
+select c_d64_max * c_d64_max from t_decimal_precision_overflow where c_id = 5;
+
+-- These SHOULD cause precision overflow (precision 48, scale 19) but use decimal128 truncation
+select c_d128_large * c_d64_max from t_decimal_precision_overflow where c_id = 1;
+select c_d128_large * c_d64_max from t_decimal_precision_overflow where c_id = 2;
+select c_d128_large * c_d64_max from t_decimal_precision_overflow where c_id = 3;
+select c_d128_large * c_d64_max from t_decimal_precision_overflow where c_id = 4;
+select c_d128_large * c_d64_max from t_decimal_precision_overflow where c_id = 5;
+
+-- These SHOULD cause major precision overflow (precision 76, scale 30) but use decimal128 truncation
+select c_d128_max * c_d128_max from t_decimal_precision_overflow where c_id = 1;
+select c_d128_max * c_d128_max from t_decimal_precision_overflow where c_id = 2;
+select c_d128_max * c_d128_max from t_decimal_precision_overflow where c_id = 3;
+
+-- Test literal multiplication that definitely causes precision overflow
+-- precision 60, scale 18 -> overflow!
+select 123456789012345678901234567890.123456789 * 987654321098765432109876543210.987654321;
+-- precision 52, scale 20 -> overflow!
+select 12345678901234567890123456789012.12345678901 * 98765432109876543210.12345678901;
+-- precision 50, scale 16 -> overflow!
+select 1234567890123456789012345678.12345678 * 9876543210987654321098765432.87654321;
+-- precision 44, scale 12 -> overflow!
+select 12345678901234567890123456.123456 * 98765432109876543210987654.876543;
+
+-- Test 2: decimal_overflow_to_double = true (new behavior)
+set decimal_overflow_to_double = true;
+
+-- These should still return decimal128 (no overflow, precision 36, scale 18 <= 38)
+select c_d64_max * c_d64_max from t_decimal_precision_overflow where c_id = 1;
+select c_d64_max * c_d64_max from t_decimal_precision_overflow where c_id = 2;
+select c_d64_max * c_d64_max from t_decimal_precision_overflow where c_id = 3;
+select c_d64_max * c_d64_max from t_decimal_precision_overflow where c_id = 4;
+select c_d64_max * c_d64_max from t_decimal_precision_overflow where c_id = 5;
+
+-- These SHOULD now return double instead of decimal128 (precision 48 > 38, scale 19 <= 38)
+select c_d128_large * c_d64_max from t_decimal_precision_overflow where c_id = 1;
+select c_d128_large * c_d64_max from t_decimal_precision_overflow where c_id = 2;
+select c_d128_large * c_d64_max from t_decimal_precision_overflow where c_id = 3;
+select c_d128_large * c_d64_max from t_decimal_precision_overflow where c_id = 4;
+select c_d128_large * c_d64_max from t_decimal_precision_overflow where c_id = 5;
+
+-- These SHOULD now return double instead of decimal128 (precision 76 > 38, scale 30 <= 38)
+select c_d128_max * c_d128_max from t_decimal_precision_overflow where c_id = 1;
+select c_d128_max * c_d128_max from t_decimal_precision_overflow where c_id = 2;
+select c_d128_max * c_d128_max from t_decimal_precision_overflow where c_id = 3;
+
+-- Test literal multiplication that causes precision overflow - should return double
+-- precision 60 > 38, scale 18 <= 38 -> should convert to double
+select 123456789012345678901234567890.123456789 * 987654321098765432109876543210.987654321;
+-- precision 52 > 38, scale 20 <= 38 -> should convert to double
+select 12345678901234567890123456789012.12345678901 * 98765432109876543210.12345678901;
+-- precision 50 > 38, scale 16 <= 38 -> should convert to double
+select 1234567890123456789012345678.12345678 * 9876543210987654321098765432.87654321;
+-- precision 44 > 38, scale 12 <= 38 -> should convert to double
+select 12345678901234567890123456.123456 * 98765432109876543210987654.876543;
+
+set decimal_overflow_to_double = false;
+select 1234567890123456789.1234567890123456789 * 1.0000000000000000000;
+
+set decimal_overflow_to_double = true;
+select 1234567890123456789.1234567890123456789 * 1.0000000000000000000;
+
+set decimal_overflow_to_double = false;
+select 12345678901234567890123456789012345678.0 * 1.0;
+
+set decimal_overflow_to_double = true;
+select 12345678901234567890123456789012345678.0 * 1.1;
+
+-- Test 4: Mixed operations
+set decimal_overflow_to_double = true;
+-- Test multiplication in expressions - these should convert to double due to overflow
+select c_id, c_d128_large * c_d64_max + 1.0 from t_decimal_precision_overflow where c_id <= 2;
+select c_id, (c_d128_max * c_d128_max) / 2.0 from t_decimal_precision_overflow where c_id <= 2;
+
+-- Test 6: Additional extreme overflow cases
+set decimal_overflow_to_double = false;
+-- Extreme case: very large precision overflow (should use decimal128 truncation)
+select 12345678901234567890123456789012345678.0 * 98765432109876543210987654321098765432.0;
+
+set decimal_overflow_to_double = true;
+-- Same extreme case: should convert to double
+select 12345678901234567890123456789012345678.0 * 98765432109876543210987654321098765432.0;
+
+-- Test 7: Verify behavior with different scale combinations
+set decimal_overflow_to_double = false;
+-- High precision, low scale (should use decimal128 truncation)
+select 123456789012345678901234567890123456.78 * 987654321098765432109876543210987654.32;
+
+set decimal_overflow_to_double = true;
+-- Same case: should convert to double (precision 72 > 38, scale 4 <= 38)
+select 123456789012345678901234567890123456.78 * 987654321098765432109876543210987654.32;
+
+-- Test 8: More diverse precision overflow cases
+set decimal_overflow_to_double = false;
+-- Medium precision overflow
+select 1111222233334444555566667777.8888 * 8888777766665555444433332222.1111;
+
+set decimal_overflow_to_double = true;
+-- Same case with session variable enabled
+select 1111222233334444555566667777.8888 * 8888777766665555444433332222.1111;
+
+-- Different scale patterns
+set decimal_overflow_to_double = false;
+select 123456789012345678901234567890.123456 * 987654321098765432109876543210.654321;
+
+set decimal_overflow_to_double = true;
+select 123456789012345678901234567890.123456 * 987654321098765432109876543210.654321;
+
+SELECT(0.58000000 * 0.970825897017235893 * 3021621.785498);
+
+set decimal_overflow_to_double = false;
+
+SELECT(0.58000000 * 0.970825897017235893 * 3021621.785498);


### PR DESCRIPTION
## Why I'm doing:
When performing decimal multiplication operations, if the resulting precision exceeds the maximum decimal precision (38), StarRocks currently returns NULL as the default behavior. This can cause queries to lose meaningful results in scenarios involving high-precision decimal calculations.

Users may prefer to get an approximate result rather than NULL when precision overflow occurs. If users can accept some precision loss, they should have the option to convert the result to double type to maintain a meaningful calculation result instead of getting NULL.

## What I'm doing:
**Added new session variable**: `decimal_overflow_to_double` (default: false)
   - When enabled, decimal multiplication operations that would cause precision overflow (precision > 38) are automatically converted to double type instead of returning NULL
   - When disabled, maintains the original behavior (returns NULL on precision overflow)

   
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

