### PR TITLE
[Doc] Update Apache Ranger restart command for version compatibility

### DIFF
--- a/docs/en/administration/user_privs/authorization/ranger_plugin.md
+++ b/docs/en/administration/user_privs/authorization/ranger_plugin.md
@@ -75,9 +75,16 @@ Also, please notice that if you didn't install the ranger-starrocks-plugin, then
 
 3. Restart Ranger Admin.
 
-   ```SQL
-   ranger-admin restart
-   ```
+   -  Ranger 0.5.x:
+
+      ```SQL
+      ranger-admin restart
+      ```
+   - Ranger 2.x and above:
+   
+      ```SQL
+      ./ews/ranger-admin-services.sh restart
+      ```
 
 ### Configure StarRocks Service on Ranger Admin
 

--- a/docs/ja/administration/user_privs/authorization/ranger_plugin.md
+++ b/docs/ja/administration/user_privs/authorization/ranger_plugin.md
@@ -73,9 +73,16 @@ Ranger クラスターを操作する権限がない場合や、この機能が�
 
 3. Ranger Admin を再起動します。
 
-   ```SQL
-   ranger-admin restart
-   ```
+   -  Ranger 0.5.x:
+
+      ```SQL
+      ranger-admin restart
+      ```
+   - Ranger 2.x and above:
+   
+      ```SQL
+      ./ews/ranger-admin-services.sh restart
+      ```
 
 ### Ranger Admin で StarRocks Service を設定する
 

--- a/docs/zh/administration/user_privs/authorization/ranger_plugin.md
+++ b/docs/zh/administration/user_privs/authorization/ranger_plugin.md
@@ -70,9 +70,16 @@ StarRocks 集成 Apache Ranger 后可以实现以下权限控制方式：
 
 3. 重启 Ranger Admin。
 
-   ```SQL
-   ranger-admin restart
-   ```
+   -  Ranger 0.5.x:
+
+      ```SQL
+      ranger-admin restart
+      ```
+   - Ranger 2.x and above:
+   
+      ```SQL
+      ./ews/ranger-admin-services.sh restart
+      ```
 
 ### 在 Ranger Admin 上配置 StarRocks Service
 


### PR DESCRIPTION
## Why I'm doing:

The StarRocks Apache Ranger integration documentation specifies "Apache Ranger 2.1.0 or later" as a prerequisite, but provides the Ranger 0.5.x restart command (`ranger-admin restart`). This causes deployment failures when users follow the documentation with Ranger 2.x installations.

## What I'm doing:

Updating the restart command section to provide version-specific guidance that aligns with the documentation prerequisites.

Fixes #64671

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

## Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have signed off my commits using `git commit -s` (DCO sign-off)
- [x] This PR only contains documentation changes
- [x] I have added [Doc] prefix to the PR title
- [ ] I have added test cases for my bug fix or my new feature *(N/A - Documentation fix)*
- [ ] This PR needs user documentation (for new or modified features or behaviors) *(N/A - Documentation fix)*
- [ ] I have added documentation for my new feature or new function *(N/A - Documentation fix)*
- [ ] This is a backport PR *(N/A - Documentation fix)*

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

Signed-off-by: Arvind Kandpal [arvind.kandpal@ksolves.com](mailto:arvind.kandpal@ksolves.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies Ranger Admin restart instructions by adding version-specific commands for Ranger 0.5.x and 2.x+ across EN/JA/ZH ranger_plugin docs.
> 
> - **Docs**:
>   - **Ranger plugin guides (`docs/*/administration/user_privs/authorization/ranger_plugin.md`)**:
>     - Add version-specific restart instructions:
>       - Ranger 0.5.x: `ranger-admin restart`
>       - Ranger 2.x+: `./ews/ranger-admin-services.sh restart`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e5ea1dc4de5b63d739448501ded0bc5c527779c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->