### PR TITLE
[BugFix] Fix JSON merging for empty remain objects

### DIFF
--- a/be/src/util/json_flattener.h
+++ b/be/src/util/json_flattener.h
@@ -249,6 +249,8 @@ private:
 
     void _add_level_paths_impl(const std::string_view& path, JsonFlatPath* root);
 
+    void _check_has_non_null_values(const JsonFlatPath* root, size_t index, bool* has_non_null_values);
+
 private:
     std::vector<std::string> _src_paths;
     bool _has_remain = false;

--- a/test/sql/test_semi/R/test_flat_json_consistency
+++ b/test/sql/test_semi/R/test_flat_json_consistency
@@ -53,7 +53,7 @@ select * from test_json_cast_map order by c1;
 -- !result
 select flat_json_meta(c2) from test_json_cast_map [_META_];
 -- result:
-["nulls(TINYINT), 100.200.300(VARCHAR), level1.level2.level3.level4.5(VARCHAR)"]
+["nulls(TINYINT), 100.200.300(VARCHAR), level1.level2.level3.level4.5(VARCHAR), remain(JSON)"]
 -- !result
 truncate table test_json_cast_map;
 -- result:
@@ -72,7 +72,7 @@ select * from test_json_cast_map order by c1;
 -- !result
 select flat_json_meta(c2) from test_json_cast_map [_META_];
 -- result:
-["nulls(TINYINT), level1.level2.level3.level4.5(VARCHAR), level1.level2.level3.level4.6(VARCHAR)"]
+["nulls(TINYINT), level1.level2.level3.level4.5(VARCHAR), level1.level2.level3.level4.6(VARCHAR), remain(JSON)"]
 -- !result
 truncate table test_json_cast_map;
 -- result:
@@ -85,6 +85,63 @@ insert into test_json_cast_map values
 select * from test_json_cast_map order by c1;
 -- result:
 2	{"level1": {"level2": {"level3": {"level4": {}}}}}
+9	{"100": {"200": {"300": "abc"}}}
+-- !result
+select flat_json_meta(c2) from test_json_cast_map [_META_];
+-- result:
+["nulls(TINYINT), 100.200.300(VARCHAR), remain(JSON)"]
+-- !result
+truncate table test_json_cast_map;
+-- result:
+-- !result
+insert into test_json_cast_map values
+(1, '{"level1": {"level2": {"level3": {"level4": {"5":"abc"}}}}}'),
+(2, '{"level1": {"level2": {"level3": {"level4": {}}}}}'),
+(3, '{"level1": {"level2": {"level3": {}}}}'),
+(4, '{"level1": {"level2": {}}}'),
+(5, '{"level1": {}}');
+-- result:
+-- !result
+select * from test_json_cast_map order by c1;
+-- result:
+1	{"level1": {"level2": {"level3": {"level4": {"5": "abc"}}}}}
+2	{"level1": {"level2": {"level3": {"level4": {}}}}}
+3	{"level1": {"level2": {"level3": {}}}}
+4	{"level1": {"level2": {}}}
+5	{"level1": {}}
+-- !result
+select flat_json_meta(c2) from test_json_cast_map [_META_];
+-- result:
+[]
+-- !result
+truncate table test_json_cast_map;
+-- result:
+-- !result
+insert into test_json_cast_map values
+(1, '{"level1": {"level2": {"level3": {"level4": {"5":"abc"}}}}}'),
+(5, '{"level1": {}}');
+-- result:
+-- !result
+select * from test_json_cast_map order by c1;
+-- result:
+1	{"level1": {"level2": {"level3": {"level4": {"5": "abc"}}}}}
+5	{"level1": {}}
+-- !result
+select flat_json_meta(c2) from test_json_cast_map [_META_];
+-- result:
+["nulls(TINYINT), level1.level2.level3.level4.5(VARCHAR), remain(JSON)"]
+-- !result
+truncate table test_json_cast_map;
+-- result:
+-- !result
+insert into test_json_cast_map values
+(1, '{"100": {}}'),
+(9, '{"100": {"200": {"300": "abc"}}}');
+-- result:
+-- !result
+select * from test_json_cast_map order by c1;
+-- result:
+1	{"100": {}}
 9	{"100": {"200": {"300": "abc"}}}
 -- !result
 select flat_json_meta(c2) from test_json_cast_map [_META_];

--- a/test/sql/test_semi/R/test_flat_json_consistency
+++ b/test/sql/test_semi/R/test_flat_json_consistency
@@ -53,7 +53,7 @@ select * from test_json_cast_map order by c1;
 -- !result
 select flat_json_meta(c2) from test_json_cast_map [_META_];
 -- result:
-["nulls(TINYINT), 100.200.300(VARCHAR), level1.level2.level3.level4.5(VARCHAR), remain(JSON)"]
+["nulls(TINYINT), 100.200.300(VARCHAR), level1.level2.level3.level4.5(VARCHAR)"]
 -- !result
 truncate table test_json_cast_map;
 -- result:
@@ -72,7 +72,7 @@ select * from test_json_cast_map order by c1;
 -- !result
 select flat_json_meta(c2) from test_json_cast_map [_META_];
 -- result:
-["nulls(TINYINT), level1.level2.level3.level4.5(VARCHAR), level1.level2.level3.level4.6(VARCHAR), remain(JSON)"]
+["nulls(TINYINT), level1.level2.level3.level4.5(VARCHAR), level1.level2.level3.level4.6(VARCHAR)"]
 -- !result
 truncate table test_json_cast_map;
 -- result:

--- a/test/sql/test_semi/R/test_flat_json_consistency
+++ b/test/sql/test_semi/R/test_flat_json_consistency
@@ -1,0 +1,32 @@
+-- name: test_flat_json_consistency
+CREATE TABLE `test_json_cast_map` (
+  `c1` bigint(20) NULL COMMENT "",
+  `c2` json NULL COMMENT ""
+);
+-- result:
+-- !result
+insert into test_json_cast_map values
+(1, '{"level1": {"level2": {"level3": {"level4": {"5":"abc"}}}}}'),
+(9, '{"100": {"200": {"300": "abc"}}}');
+-- result:
+-- !result
+select * from test_json_cast_map order by c1;
+-- result:
+1	{"level1": {"level2": {"level3": {"level4": {"5": "abc"}}}}}
+9	{"100": {"200": {"300": "abc"}}}
+-- !result
+select flat_json_meta(c2) from test_json_cast_map [_META_];
+-- result:
+["nulls(TINYINT), 100.200.300(VARCHAR), level1.level2.level3.level4.5(VARCHAR)"]
+-- !result
+select get_json_string(c2, '$.100.200.300') from test_json_cast_map where c1 = 1;
+-- result:
+None
+-- !result
+select get_json_string(c2, '$.level1.level2.level3.level4.5') from test_json_cast_map where c1 = 9;
+-- result:
+None
+-- !result
+DROP TABLE test_json_cast_map;
+-- result:
+-- !result

--- a/test/sql/test_semi/R/test_flat_json_consistency
+++ b/test/sql/test_semi/R/test_flat_json_consistency
@@ -7,6 +7,42 @@ CREATE TABLE `test_json_cast_map` (
 -- !result
 insert into test_json_cast_map values
 (1, '{"level1": {"level2": {"level3": {"level4": {"5":"abc"}}}}}'),
+(2, '{"level1": {"level2": {"level3": {"level4": {}}}}}'),
+(9, '{"100": {"200": {"300": "abc"}}}');
+-- result:
+-- !result
+select * from test_json_cast_map order by c1;
+-- result:
+1	{"level1": {"level2": {"level3": {"level4": {"5": "abc"}}}}}
+2	{"level1": {"level2": {"level3": {"level4": {}}}}}
+9	{"100": {"200": {"300": "abc"}}}
+-- !result
+select flat_json_meta(c2) from test_json_cast_map [_META_];
+-- result:
+["nulls(TINYINT), 100.200.300(VARCHAR), level1.level2.level3.level4.5(VARCHAR), remain(JSON)"]
+-- !result
+truncate table test_json_cast_map;
+-- result:
+-- !result
+insert into test_json_cast_map values
+(1, '{"level1": {"level2": {"level3": {"level4": {"5":"abc"}}}}}'),
+(2, '{"level1": {"level2": {"level3": {"level4": {}}}}}');
+-- result:
+-- !result
+select * from test_json_cast_map order by c1;
+-- result:
+1	{"level1": {"level2": {"level3": {"level4": {"5": "abc"}}}}}
+2	{"level1": {"level2": {"level3": {"level4": {}}}}}
+-- !result
+select flat_json_meta(c2) from test_json_cast_map [_META_];
+-- result:
+["nulls(TINYINT), level1.level2.level3.level4.5(VARCHAR), remain(JSON)"]
+-- !result
+truncate table test_json_cast_map;
+-- result:
+-- !result
+insert into test_json_cast_map values
+(1, '{"level1": {"level2": {"level3": {"level4": {"5":"abc"}}}}}'),
 (9, '{"100": {"200": {"300": "abc"}}}');
 -- result:
 -- !result
@@ -19,14 +55,25 @@ select flat_json_meta(c2) from test_json_cast_map [_META_];
 -- result:
 ["nulls(TINYINT), 100.200.300(VARCHAR), level1.level2.level3.level4.5(VARCHAR)"]
 -- !result
-select get_json_string(c2, '$.100.200.300') from test_json_cast_map where c1 = 1;
+truncate table test_json_cast_map;
 -- result:
-None
 -- !result
-select get_json_string(c2, '$.level1.level2.level3.level4.5') from test_json_cast_map where c1 = 9;
+insert into test_json_cast_map values
+(1, '{"level1": {"level2": {"level3": {"level4": {"5":"abc"}}}}}'),
+(2, '{"level1": {"level2": {"level3": {"level4": {"5":"def"}}}}}'),
+(3, '{"level1": {"level2": {"level3": {"level4": {"6":"ghi"}}}}}');
 -- result:
-None
 -- !result
-DROP TABLE test_json_cast_map;
+select * from test_json_cast_map order by c1;
+-- result:
+1	{"level1": {"level2": {"level3": {"level4": {"5": "abc"}}}}}
+2	{"level1": {"level2": {"level3": {"level4": {"5": "def"}}}}}
+3	{"level1": {"level2": {"level3": {"level4": {"6": "ghi"}}}}}
+-- !result
+select flat_json_meta(c2) from test_json_cast_map [_META_];
+-- result:
+["nulls(TINYINT), level1.level2.level3.level4.5(VARCHAR), level1.level2.level3.level4.6(VARCHAR)"]
+-- !result
+drop table test_json_cast_map;
 -- result:
 -- !result

--- a/test/sql/test_semi/R/test_flat_json_consistency
+++ b/test/sql/test_semi/R/test_flat_json_consistency
@@ -74,6 +74,23 @@ select flat_json_meta(c2) from test_json_cast_map [_META_];
 -- result:
 ["nulls(TINYINT), level1.level2.level3.level4.5(VARCHAR), level1.level2.level3.level4.6(VARCHAR)"]
 -- !result
+truncate table test_json_cast_map;
+-- result:
+-- !result
+insert into test_json_cast_map values
+(2, '{"level1": {"level2": {"level3": {"level4": {}}}}}'),
+(9, '{"100": {"200": {"300": "abc"}}}');
+-- result:
+-- !result
+select * from test_json_cast_map order by c1;
+-- result:
+2	{"level1": {"level2": {"level3": {"level4": {}}}}}
+9	{"100": {"200": {"300": "abc"}}}
+-- !result
+select flat_json_meta(c2) from test_json_cast_map [_META_];
+-- result:
+["nulls(TINYINT), 100.200.300(VARCHAR), remain(JSON)"]
+-- !result
 drop table test_json_cast_map;
 -- result:
 -- !result

--- a/test/sql/test_semi/R/test_flat_json_consistency
+++ b/test/sql/test_semi/R/test_flat_json_consistency
@@ -2,7 +2,7 @@
 CREATE TABLE `test_json_cast_map` (
   `c1` bigint(20) NULL COMMENT "",
   `c2` json NULL COMMENT ""
-);
+) DISTRIBUTED BY HASH(c1) BUCKETS 1;
 -- result:
 -- !result
 insert into test_json_cast_map values

--- a/test/sql/test_semi/T/test_flat_json_consistency
+++ b/test/sql/test_semi/T/test_flat_json_consistency
@@ -59,5 +59,39 @@ insert into test_json_cast_map values
 select * from test_json_cast_map order by c1;
 select flat_json_meta(c2) from test_json_cast_map [_META_];
 
+-- Test 6: Same path with different values - should be flattenable
+truncate table test_json_cast_map;
+
+insert into test_json_cast_map values
+(1, '{"level1": {"level2": {"level3": {"level4": {"5":"abc"}}}}}'),
+(2, '{"level1": {"level2": {"level3": {"level4": {}}}}}'),
+(3, '{"level1": {"level2": {"level3": {}}}}'),
+(4, '{"level1": {"level2": {}}}'),
+(5, '{"level1": {}}');
+
+select * from test_json_cast_map order by c1;
+select flat_json_meta(c2) from test_json_cast_map [_META_];
+
+-- Test 7: Different paths but consistent structure - should be flattenable
+truncate table test_json_cast_map;
+
+insert into test_json_cast_map values
+(1, '{"level1": {"level2": {"level3": {"level4": {"5":"abc"}}}}}'),
+(5, '{"level1": {}}');
+
+select * from test_json_cast_map order by c1;
+select flat_json_meta(c2) from test_json_cast_map [_META_];
+
+
+-- Test 8: empty root object
+truncate table test_json_cast_map;
+
+insert into test_json_cast_map values
+(1, '{"100": {}}'),
+(9, '{"100": {"200": {"300": "abc"}}}');
+
+select * from test_json_cast_map order by c1;
+select flat_json_meta(c2) from test_json_cast_map [_META_];
+
 
 drop table test_json_cast_map;

--- a/test/sql/test_semi/T/test_flat_json_consistency
+++ b/test/sql/test_semi/T/test_flat_json_consistency
@@ -8,23 +8,45 @@ CREATE TABLE `test_json_cast_map` (
   `c2` json NULL COMMENT ""
 );
 
--- Insert test data with different JSON structures
--- Row 1: Only has level1.level2.level3.level4.5 path
--- Row 9: Only has 100.200.300 path
+-- Test 1: Inconsistent nested structure - should be rejected
+-- Some rows have level1.level2.level3.level4.5, others have level1.level2.level3.level4 but no 5
+insert into test_json_cast_map values
+(1, '{"level1": {"level2": {"level3": {"level4": {"5":"abc"}}}}}'),
+(2, '{"level1": {"level2": {"level3": {"level4": {}}}}}'),
+(9, '{"100": {"200": {"300": "abc"}}}');
+
+select * from test_json_cast_map order by c1;
+select flat_json_meta(c2) from test_json_cast_map [_META_];
+
+-- Test 2: Same inconsistent nested structure - should be rejected
+truncate table test_json_cast_map;
+
+insert into test_json_cast_map values
+(1, '{"level1": {"level2": {"level3": {"level4": {"5":"abc"}}}}}'),
+(2, '{"level1": {"level2": {"level3": {"level4": {}}}}}');
+
+select * from test_json_cast_map order by c1;
+select flat_json_meta(c2) from test_json_cast_map [_META_];
+
+-- Test 3: Different paths but consistent structure - should be flattenable
+truncate table test_json_cast_map;
+
 insert into test_json_cast_map values
 (1, '{"level1": {"level2": {"level3": {"level4": {"5":"abc"}}}}}'),
 (9, '{"100": {"200": {"300": "abc"}}}');
 
--- Verify the original data is stored correctly
 select * from test_json_cast_map order by c1;
-
--- Test FlatJSON meta to see what paths are extracted
 select flat_json_meta(c2) from test_json_cast_map [_META_];
 
--- Test JSON path extraction to verify consistency
--- These should return NULL for non-existent paths, not empty objects
-select get_json_string(c2, '$.100.200.300') from test_json_cast_map where c1 = 1;
-select get_json_string(c2, '$.level1.level2.level3.level4.5') from test_json_cast_map where c1 = 9;
+-- Test 4: Same path with different values - should be flattenable
+truncate table test_json_cast_map;
 
--- Clean up
-DROP TABLE test_json_cast_map;
+insert into test_json_cast_map values
+(1, '{"level1": {"level2": {"level3": {"level4": {"5":"abc"}}}}}'),
+(2, '{"level1": {"level2": {"level3": {"level4": {"5":"def"}}}}}'),
+(3, '{"level1": {"level2": {"level3": {"level4": {"6":"ghi"}}}}}');
+
+select * from test_json_cast_map order by c1;
+select flat_json_meta(c2) from test_json_cast_map [_META_];
+
+drop table test_json_cast_map;

--- a/test/sql/test_semi/T/test_flat_json_consistency
+++ b/test/sql/test_semi/T/test_flat_json_consistency
@@ -6,7 +6,7 @@
 CREATE TABLE `test_json_cast_map` (
   `c1` bigint(20) NULL COMMENT "",
   `c2` json NULL COMMENT ""
-);
+) DISTRIBUTED BY HASH(c1) BUCKETS 1;
 
 -- Test 1: Inconsistent nested structure - should be rejected
 -- Some rows have level1.level2.level3.level4.5, others have level1.level2.level3.level4 but no 5

--- a/test/sql/test_semi/T/test_flat_json_consistency
+++ b/test/sql/test_semi/T/test_flat_json_consistency
@@ -49,4 +49,15 @@ insert into test_json_cast_map values
 select * from test_json_cast_map order by c1;
 select flat_json_meta(c2) from test_json_cast_map [_META_];
 
+-- Test 5: Same path with different values - should be flattenable
+truncate table test_json_cast_map;
+
+insert into test_json_cast_map values
+(2, '{"level1": {"level2": {"level3": {"level4": {}}}}}'),
+(9, '{"100": {"200": {"300": "abc"}}}');
+
+select * from test_json_cast_map order by c1;
+select flat_json_meta(c2) from test_json_cast_map [_META_];
+
+
 drop table test_json_cast_map;

--- a/test/sql/test_semi/T/test_flat_json_consistency
+++ b/test/sql/test_semi/T/test_flat_json_consistency
@@ -1,0 +1,30 @@
+-- name: test_flat_json_consistency
+
+-- Test case for FlatJSON consistency issue where non-existent fields
+-- were being created as empty objects during reconstruction
+
+CREATE TABLE `test_json_cast_map` (
+  `c1` bigint(20) NULL COMMENT "",
+  `c2` json NULL COMMENT ""
+);
+
+-- Insert test data with different JSON structures
+-- Row 1: Only has level1.level2.level3.level4.5 path
+-- Row 9: Only has 100.200.300 path
+insert into test_json_cast_map values
+(1, '{"level1": {"level2": {"level3": {"level4": {"5":"abc"}}}}}'),
+(9, '{"100": {"200": {"300": "abc"}}}');
+
+-- Verify the original data is stored correctly
+select * from test_json_cast_map order by c1;
+
+-- Test FlatJSON meta to see what paths are extracted
+select flat_json_meta(c2) from test_json_cast_map [_META_];
+
+-- Test JSON path extraction to verify consistency
+-- These should return NULL for non-existent paths, not empty objects
+select get_json_string(c2, '$.100.200.300') from test_json_cast_map where c1 = 1;
+select get_json_string(c2, '$.level1.level2.level3.level4.5') from test_json_cast_map where c1 = 9;
+
+-- Clean up
+DROP TABLE test_json_cast_map;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fix incorrect JSON merging when remain JSON contains empty objects that correspond to flattened paths. Previously, structures like {"100": {}} were incorrectly dropped during merge, resulting in empty JSON objects {} instead of preserving the original structure.

The root cause was in three areas:
1. Intermediate nodes were not marked as remain when all children    were flattened but the node itself appeared in some rows
2. Empty remain objects were skipped during merge when IN_TREE=true,   causing loss of original JSON structure
3. Keys from remain were duplicated in the second merge loop when   IN_TREE=true

Fixes:
- Mark intermediate nodes as remain in _dfs_finalize if node was  visited, even when all children are flattened
- Preserve empty remain object structures in _merge_json_with_remain  when IN_TREE=true to maintain original JSON structure
- Skip keys already processed from remain in second loop when  IN_TREE=true to avoid duplicate processing

Example fix:
```
create table test_json_cast_map (c1 int, c2 json);

insert into test_json_cast_map values
(1, '{"level1": {"level2": {"level3": {"level4": {"5":"abc"}}}}}'),
(2, '{"level1": {"level2": {"level3": {"level4": {}}}}}'),
(9, '{"100": {"200": {"300": "abc"}}}');

select * from test_json_cast_map order by c1;

-- Before
1  {"level1": {"level2": {"level3": {"level4": {"5": "abc"}}}}}
2 {"level1": {"level2": {"level3": {"level4": {}}}}}
9  {"100":'{"200": {"300": "abc"}}',"level1":'{"level2": {"level3": {"4": {}}}}'}
 
-- After
1  {"level1": {"level2": {"level3": {"level4": {"5": "abc"}}}}}
2 {"level1": {"level2": {"level3": {"level4": {}}}}}
9  {"100": {"200": {"300": "abc"}}}
```

Fixes #https://github.com/StarRocks/StarRocksTest/issues/10489

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
