### PR TITLE
[UT] fix flaky test test_analyze_column & test_be_proc_profile_simple

### DIFF
--- a/be/src/http/action/proc_profile_file_action.cpp
+++ b/be/src/http/action/proc_profile_file_action.cpp
@@ -188,8 +188,10 @@ Status ProcProfileFileAction::convert_pprof_to_flame(const std::string& pprof_fi
         // First, decompress the gzipped pprof file to a temporary location
         std::string gunzip_cmd = "gunzip -c '" + pprof_file_path + "' > '" + temp_pprof + "'";
         int gunzip_result = system(gunzip_cmd.c_str());
-        RETURN_IF(gunzip_result != 0, Status::InternalError("Failed to decompress pprof file, gunzip returned: " +
-                                                            std::to_string(gunzip_result)));
+        RETURN_IF(gunzip_result != 0,
+                  Status::InternalError(fmt::format(
+                          "Failed to decompress pprof file, gunzip returned: {}, errno: {}, error: {}, command: {}",
+                          gunzip_result, errno, strerror(errno), gunzip_cmd)));
 
         std::string pprof_path = config::flamegraph_tool_dir + "/pprof";
         std::string stackcollapse_path = config::flamegraph_tool_dir + "/stackcollapse-go.pl";

--- a/test/sql/test_analyze_statistics/R/test_analyze_column
+++ b/test/sql/test_analyze_statistics/R/test_analyze_column
@@ -38,11 +38,17 @@ INSERT INTO t1 VALUES
     (null,'2020-10-27 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
 -- result:
 -- !result
+drop stats t1;
+-- result:
+-- !result
 analyze sample table t1;
 -- result:
 test_analyze_column.t1	sample	status	OK
 -- !result
 select column_name, row_count from _statistics_.column_statistics where table_name = 'test_analyze_column.t1' order by column_name ;
+-- result:
+-- !result
+drop stats t1;
 -- result:
 -- !result
 analyze full table t1(k1,k2);
@@ -54,16 +60,20 @@ select column_name, row_count from _statistics_.column_statistics where table_na
 k1	5
 k2	5
 -- !result
+drop stats t1;
+-- result:
+-- !result
 analyze full table t1(k3,k4);
 -- result:
 test_analyze_column.t1	analyze	status	OK
 -- !result
 select column_name, row_count from _statistics_.column_statistics where table_name = 'test_analyze_column.t1' order by column_name ;
 -- result:
-k1	5
-k2	5
 k3	5
 k4	5
+-- !result
+drop stats t1;
+-- result:
 -- !result
 analyze sample table t1(k3,k4);
 -- result:
@@ -71,10 +81,9 @@ test_analyze_column.t1	sample	status	OK
 -- !result
 select column_name, row_count from _statistics_.column_statistics where table_name = 'test_analyze_column.t1' order by column_name ;
 -- result:
-k1	5
-k2	5
-k3	5
-k4	5
+-- !result
+drop stats t1;
+-- result:
 -- !result
 analyze sample table t1;
 -- result:
@@ -82,10 +91,9 @@ test_analyze_column.t1	sample	status	OK
 -- !result
 select column_name, row_count from _statistics_.column_statistics where table_name = 'test_analyze_column.t1' order by column_name ;
 -- result:
-k1	5
-k2	5
-k3	5
-k4	5
+-- !result
+drop stats t1;
+-- result:
 -- !result
 analyze full table t1;
 -- result:
@@ -111,6 +119,9 @@ drop stats t1;
 -- result:
 -- !result
 select column_name, row_count from _statistics_.column_statistics where table_name = 'test_analyze_column.t1' order by column_name ;
+-- result:
+-- !result
+drop stats t1;
 -- result:
 -- !result
 analyze sample table t1;

--- a/test/sql/test_analyze_statistics/T/test_analyze_column
+++ b/test/sql/test_analyze_statistics/T/test_analyze_column
@@ -31,27 +31,34 @@ INSERT INTO t1 VALUES
     (null,'2020-10-26 12:12:12',null,null,null,null,null,null,null,null,1,1.12,2.889),
     (null,'2020-10-27 12:12:12','k3','k4',0,1,2,3,4,5,1.1,1.12,2.889);
 
+drop stats t1;
 analyze sample table t1;
 select column_name, row_count from _statistics_.column_statistics where table_name = 'test_analyze_column.t1' order by column_name ;
 
+drop stats t1;
 analyze full table t1(k1,k2);
 select column_name, row_count from _statistics_.column_statistics where table_name = 'test_analyze_column.t1' order by column_name ;
 
+drop stats t1;
 analyze full table t1(k3,k4);
 select column_name, row_count from _statistics_.column_statistics where table_name = 'test_analyze_column.t1' order by column_name ;
 
+drop stats t1;
 analyze sample table t1(k3,k4);
 select column_name, row_count from _statistics_.column_statistics where table_name = 'test_analyze_column.t1' order by column_name ;
 
+drop stats t1;
 analyze sample table t1;
 select column_name, row_count from _statistics_.column_statistics where table_name = 'test_analyze_column.t1' order by column_name ;
 
+drop stats t1;
 analyze full table t1;
 select column_name, row_count from _statistics_.column_statistics where table_name = 'test_analyze_column.t1' order by column_name ;
 
 drop stats t1;
 select column_name, row_count from _statistics_.column_statistics where table_name = 'test_analyze_column.t1' order by column_name ;
 
+drop stats t1;
 analyze sample table t1;
 select column_name, row_count from _statistics_.column_statistics where table_name = 'test_analyze_column.t1' order by column_name ;
 

--- a/test/sql/test_proc_profile/R/test_be_proc_profile_simple
+++ b/test/sql/test_proc_profile/R/test_be_proc_profile_simple
@@ -19,7 +19,7 @@ shell: curl -s -u root: "http://$(cat be_ip.txt):$(cat be_http_port.txt)/proc_pr
 0
 1
 -- !result
-shell: curl -s -u root: "http://$(cat be_ip.txt):$(cat be_http_port.txt)/proc_profile" | grep -o 'filename=[^"]*\.gz' | head -1 | cut -d'=' -f2 > be_profile_file.txt
+shell: curl -s -u root: "http://$(cat be_ip.txt):$(cat be_http_port.txt)/proc_profile" | grep -o 'filename=[^"]*\.gz' | tail -1 | cut -d'=' -f2 > be_profile_file.txt
 -- result:
 0
 
@@ -27,7 +27,7 @@ shell: curl -s -u root: "http://$(cat be_ip.txt):$(cat be_http_port.txt)/proc_pr
 [UC]shell: cat be_profile_file.txt
 -- result:
 0
-cpu-profile-20251022-105520-pprof.gz
+cpu-profile-20251027-140332-pprof.gz
 -- !result
 shell: if [ $(curl -s -u root: "http://$(cat be_ip.txt):$(cat be_http_port.txt)/proc_profile/file?filename=$(cat be_profile_file.txt)" | wc -l) -gt 0 ]; then echo "exist"; else echo "empty"; fi
 -- result:

--- a/test/sql/test_proc_profile/T/test_be_proc_profile_simple
+++ b/test/sql/test_proc_profile/T/test_be_proc_profile_simple
@@ -11,7 +11,7 @@ shell: curl -s -u root: "http://$(cat be_ip.txt):$(cat be_http_port.txt)/proc_pr
 
 -- Test BE /proc_profile/file endpoint with a valid filename (if profiles exist)
 -- Get a profile filename from the main page and test accessing it
-shell: curl -s -u root: "http://$(cat be_ip.txt):$(cat be_http_port.txt)/proc_profile" | grep -o 'filename=[^"]*\.gz' | head -1 | cut -d'=' -f2 > be_profile_file.txt
+shell: curl -s -u root: "http://$(cat be_ip.txt):$(cat be_http_port.txt)/proc_profile" | grep -o 'filename=[^"]*\.gz' | tail -1 | cut -d'=' -f2 > be_profile_file.txt
 [UC]shell: cat be_profile_file.txt
 shell: if [ $(curl -s -u root: "http://$(cat be_ip.txt):$(cat be_http_port.txt)/proc_profile/file?filename=$(cat be_profile_file.txt)" | wc -l) -gt 0 ]; then echo "exist"; else echo "empty"; fi
 shell: if [ $(curl -s -u root: "http://$(cat be_ip.txt):$(cat be_http_port.txt)/proc_profile/file?filename=$(cat be_profile_file.txt)" | wc -l) -gt 0 ]; then echo "exist"; else echo "empty"; fi


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:


**test/sql/test_analyze_statistics/R/test_analyze_column**
execute the `drop stats` before analyze to avoid polluted by the previous analyze

**test/sql/test_proc_profile/R/test_be_proc_profile_simple**
use the oldest prof instead of latest, to avoid concurrency conflict with running pprof, which might report error "file not found".


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
