### PR TITLE
[WIP] Fix use after free for builtin inverted index writer

### DIFF
--- a/be/src/storage/rowset/bitmap_index_writer.cpp
+++ b/be/src/storage/rowset/bitmap_index_writer.cpp
@@ -256,7 +256,7 @@ public:
         if (it != _mem_index.end()) {
             it->second.add(_rid);
             if (it->second.update_estimate_size(&_reverted_index_size)) {
-                _late_update_context_vector.push_back(&(it->second));
+                _late_update_context_vector.push_back(it->second.context());
             }
         } else {
             // new value, copy value and insert new key->bitmap pair
@@ -365,7 +365,7 @@ public:
     uint64_t size() const override {
         uint64_t size = 0;
         size += _null_bitmap.getSizeInBytes(false);
-        for (BitmapUpdateContextRefOrSingleValue* update_context : _late_update_context_vector) {
+        for (BitmapUpdateContext* update_context : _late_update_context_vector) {
             update_context->flush_pending_adds();
             update_context->late_update_size(&_reverted_index_size);
         }
@@ -392,7 +392,7 @@ private:
 
     // roaring bitmap size
     mutable uint64_t _reverted_index_size = 0;
-    mutable std::vector<BitmapUpdateContextRefOrSingleValue*> _late_update_context_vector;
+    mutable std::vector<BitmapUpdateContext*> _late_update_context_vector;
 };
 
 struct BitmapIndexWriterBuilder {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2870,7 +2870,7 @@ public class SchemaChangeHandler extends AlterHandler {
         IndexDef indexDef = alterClause.getIndexDef();
         Index newIndex;
         // Only assign meaningful indexId for OlapTable
-        if (olapTable.isOlapTableOrMaterializedView()) {
+        if (olapTable.isOlapTableOrMaterializedView() || olapTable.isCloudNativeTableOrMaterializedView()) {
             long indexId = IndexDef.IndexType.isCompatibleIndex(indexDef.getIndexType()) ? 
                     olapTable.incAndGetMaxIndexId() : -1;
             newIndex = new Index(indexId, indexDef.getIndexName(),


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Avoids use-after-free by storing `BitmapUpdateContext*` in late-update vector and enables indexId assignment for cloud-native tables when adding indexes.
> 
> - **Backend (BE)**:
>   - **Bitmap index writer** (`be/src/storage/rowset/bitmap_index_writer.cpp`):
>     - Store `BitmapUpdateContext*` in `_late_update_context_vector` and push `it->second.context()` to avoid dangling references.
>     - Update iteration and type definitions accordingly in `size()` and class members.
> - **Frontend (FE)**:
>   - **Schema change** (`fe/.../SchemaChangeHandler.java`):
>     - When adding an index, also treat cloud-native tables/MVs as assignable for meaningful `indexId` (`isCloudNativeTableOrMaterializedView`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7650d62c33a31d3754fd0cf08a7a0920514ca816. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->