### PR TITLE
[Refactor] Move restore related logic from OlapTable to RestoreJob

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -27,7 +27,6 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.authentication.AuthenticationMgr;
 import com.starrocks.authorization.PrivilegeBuiltinConstants;
 import com.starrocks.backup.Status;
-import com.starrocks.backup.mv.MvBackupInfo;
 import com.starrocks.backup.mv.MvBaseTableBackupInfo;
 import com.starrocks.backup.mv.MvRestoreContext;
 import com.starrocks.catalog.constraint.ForeignKeyConstraint;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -2353,26 +2353,6 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         return GsonUtils.GSON.toJson(this);
     }
 
-    @Override
-    public Status resetIdsForRestore(GlobalStateMgr globalStateMgr,
-                                     Database db, int restoreReplicationNum,
-                                     MvRestoreContext mvRestoreContext) {
-        // change db_id to new restore id
-        MvId oldMvId = new MvId(dbId, id);
-
-        this.dbId = db.getId();
-        Status status = super.resetIdsForRestore(globalStateMgr, db, restoreReplicationNum, mvRestoreContext);
-        if (!status.ok()) {
-            return status;
-        }
-        // store new mvId to for old mvId
-        MvId newMvId = new MvId(dbId, id);
-        MvBackupInfo mvBackupInfo = mvRestoreContext.getMvIdToTableNameMap()
-                .computeIfAbsent(oldMvId, x -> new MvBackupInfo(db.getFullName(), name));
-        mvBackupInfo.setLocalMvId(newMvId);
-        return Status.OK;
-    }
-
     /**
      * Post actions after restore. Rebuild the materialized view by using table name instead of table ids
      * because the table ids have changed since the restore.

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -198,7 +198,7 @@ public class OlapTable extends Table {
          * or ROLLUP).
          * The query plan which is generate during this state is invalid because the meta
          * during the creation of the logical plan and the physical plan might be inconsistent.
-        */
+         */
         UPDATING_META,
         OPTIMIZE,
         DYNAMIC_TABLET
@@ -357,7 +357,7 @@ public class OlapTable extends Table {
     public static List<Index> getIndexesBySchema(List<Index> indexes, List<Column> schema) {
         List<Index> hitIndexes = Lists.newArrayList();
         Set<ColumnId> columnIdsSetForSchema =
-                            schema.stream().map(col -> col.getColumnId()).collect(Collectors.toSet());
+                schema.stream().map(col -> col.getColumnId()).collect(Collectors.toSet());
 
         for (Index index : indexes) {
             Set<ColumnId> columnIdsSetForIndex = index.getColumns().stream().collect(Collectors.toSet());
@@ -762,7 +762,7 @@ public class OlapTable extends Table {
         }
         setMaxColUniqueId(maxColUniqueId);
         LOG.debug("after rebuild full schema. table {}, schema: {}, max column unique id: {}",
-                 name, fullSchema, maxColUniqueId);
+                name, fullSchema, maxColUniqueId);
     }
 
     public boolean deleteIndexInfo(String indexName) {
@@ -855,204 +855,6 @@ public class OlapTable extends Table {
         Preconditions.checkState(column != null, "column of name: " + oldName + " does not exist");
         column.setName(newName);
         this.nameToColumn.put(newName, column);
-    }
-
-    public Status resetIdsForRestore(GlobalStateMgr globalStateMgr, Database db, int restoreReplicationNum,
-                                     MvRestoreContext mvRestoreContext) {
-        // copy an origin index id to name map
-        Map<Long, String> origIdxIdToName = Maps.newHashMap();
-        for (Map.Entry<String, Long> entry : indexNameToId.entrySet()) {
-            origIdxIdToName.put(entry.getValue(), entry.getKey());
-        }
-
-        // reset table id
-        setId(globalStateMgr.getNextId());
-
-        // reset all 'indexIdToXXX' map
-        Map<Long, MaterializedIndexMeta> origIndexIdToMeta = Maps.newHashMap(indexIdToMeta);
-        indexIdToMeta.clear();
-        for (Map.Entry<Long, String> entry : origIdxIdToName.entrySet()) {
-            long newIdxId = globalStateMgr.getNextId();
-            if (entry.getValue().equals(name)) {
-                // base index
-                baseIndexId = newIdxId;
-            }
-            MaterializedIndexMeta indexMeta = origIndexIdToMeta.get(entry.getKey());
-            indexMeta.setIndexIdForRestore(newIdxId);
-            indexMeta.setSchemaId(newIdxId);
-            indexIdToMeta.put(newIdxId, indexMeta);
-            indexNameToId.put(entry.getValue(), newIdxId);
-        }
-
-        // generate a partition old id to new id map
-        Map<Long, Long> partitionOldIdToNewId = Maps.newHashMap();
-        for (Long id : idToPartition.keySet()) {
-            partitionOldIdToNewId.put(id, globalStateMgr.getNextId());
-            // reset replication number for partition info
-            partitionInfo.setReplicationNum(id, (short) restoreReplicationNum);
-        }
-
-        // reset partition info
-        partitionInfo.setPartitionIdsForRestore(partitionOldIdToNewId);
-
-        // reset partitions
-        List<Partition> partitions = Lists.newArrayList(idToPartition.values());
-        idToPartition.clear();
-        physicalPartitionIdToPartitionId.clear();
-        physicalPartitionNameToPartitionId.clear();
-        for (Partition partition : partitions) {
-            long newPartitionId = partitionOldIdToNewId.get(partition.getId());
-            partition.setIdForRestore(newPartitionId);
-            idToPartition.put(newPartitionId, partition);
-            List<PhysicalPartition> origPhysicalPartitions = Lists.newArrayList(partition.getSubPartitions());
-            origPhysicalPartitions.forEach(physicalPartition -> {
-                // after refactor, the first physicalPartition id is different from logical partition id
-                if (physicalPartition.getParentId() != newPartitionId) {
-                    partition.removeSubPartition(physicalPartition.getId());
-                }
-            });
-            origPhysicalPartitions.forEach(physicalPartition -> {
-                // after refactor, the first physicalPartition id is different from logical partition id
-                if (physicalPartition.getParentId() != newPartitionId) {
-                    physicalPartition.setIdForRestore(GlobalStateMgr.getCurrentState().getNextId());
-                    physicalPartition.setParentId(newPartitionId);
-                    partition.addSubPartition(physicalPartition);
-                }
-                physicalPartitionIdToPartitionId.put(physicalPartition.getId(), newPartitionId);
-                physicalPartitionNameToPartitionId.put(physicalPartition.getName(), newPartitionId);
-            });
-        }
-
-        // reset replication number for olaptable
-        setReplicationNum((short) restoreReplicationNum);
-
-        // for each partition, reset rollup index map
-        for (Map.Entry<Long, Partition> entry : idToPartition.entrySet()) {
-            Partition partition = entry.getValue();
-            for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
-                Map<Long, MaterializedIndex> origIdToIndex = Maps.newHashMapWithExpectedSize(origIdxIdToName.size());
-                for (Map.Entry<Long, String> entry2 : origIdxIdToName.entrySet()) {
-                    MaterializedIndex idx = physicalPartition.getIndex(entry2.getKey());
-                    origIdToIndex.put(entry2.getKey(), idx);
-                    long newIdxId = indexNameToId.get(entry2.getValue());
-                    if (newIdxId != baseIndexId) {
-                        // not base table, delete old index
-                        physicalPartition.deleteRollupIndex(entry2.getKey());
-                    }
-                }
-                for (Map.Entry<Long, String> entry2 : origIdxIdToName.entrySet()) {
-                    MaterializedIndex idx = origIdToIndex.get(entry2.getKey());
-                    long newIdxId = indexNameToId.get(entry2.getValue());
-                    int schemaHash = indexIdToMeta.get(newIdxId).getSchemaHash();
-                    idx.setIdForRestore(newIdxId);
-                    if (newIdxId != baseIndexId) {
-                        // not base table, reset
-                        physicalPartition.createRollupIndex(idx);
-                    }
-
-                    // generate new tablets in origin tablet order
-                    int tabletNum = idx.getTablets().size();
-                    idx.clearTabletsForRestore();
-                    Status status = createTabletsForRestore(tabletNum, idx, globalStateMgr,
-                            partitionInfo.getReplicationNum(entry.getKey()), physicalPartition.getVisibleVersion(),
-                            schemaHash, physicalPartition.getId(), db);
-                    if (!status.ok()) {
-                        return status;
-                    }
-                }
-            }
-        }
-
-        return Status.OK;
-    }
-
-    public Status createTabletsForRestore(int tabletNum, MaterializedIndex index, GlobalStateMgr globalStateMgr,
-                                          int replicationNum, long version, int schemaHash,
-                                          long partitionId, Database db) {
-        Preconditions.checkArgument(replicationNum > 0);
-        boolean isColocate = (this.colocateGroup != null && !this.colocateGroup.isEmpty() && db != null);
-
-        if (isColocate) {
-            try {
-                isColocate = GlobalStateMgr.getCurrentState().getColocateTableIndex()
-                                            .addTableToGroup(db, this, this.colocateGroup, false);
-            } catch (Exception e) {
-                return new Status(ErrCode.COMMON_ERROR,
-                    "check colocate restore failed, errmsg: " + e.getMessage() +
-                    ", you can disable colocate restore by turn off Config.enable_colocate_restore");
-            }
-        }
-
-        if (isColocate) {
-            ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
-            ColocateTableIndex.GroupId groupId = colocateTableIndex.getGroup(this.id);
-            List<List<Long>> backendsPerBucketSeq = colocateTableIndex.getBackendsPerBucketSeq(groupId);
-            boolean chooseBackendsArbitrary = backendsPerBucketSeq == null || backendsPerBucketSeq.isEmpty();
-
-            if (chooseBackendsArbitrary) {
-                backendsPerBucketSeq = Lists.newArrayList();
-            }
-
-            for (int i = 0; i < tabletNum; ++i) {
-                long newTabletId = globalStateMgr.getNextId();
-                LocalTablet newTablet = new LocalTablet(newTabletId);
-                index.addTablet(newTablet, null /* tablet meta */, false/* update inverted index */);
-
-                // replicas
-                List<Long> beIds;
-                if (chooseBackendsArbitrary) {
-                    // This is the first colocate table in the group, or just a normal table,
-                    // randomly choose backends
-                    beIds = GlobalStateMgr.getCurrentState().getNodeMgr()
-                        .getClusterInfo().getNodeSelector().seqChooseBackendIds(replicationNum, true, true, getLocation());
-                    backendsPerBucketSeq.add(beIds);
-                } else {
-                    // get backends from existing backend sequence
-                    beIds = backendsPerBucketSeq.get(i);
-                }
-
-                if (CollectionUtils.isEmpty(beIds)) {
-                    return new Status(ErrCode.COMMON_ERROR, "failed to find "
-                            + replicationNum
-                            + " different hosts to create table: " + name);
-                }
-                for (Long beId : beIds) {
-                    long newReplicaId = globalStateMgr.getNextId();
-                    Replica replica = new Replica(newReplicaId, beId, ReplicaState.NORMAL,
-                            version, schemaHash);
-                    newTablet.addReplica(replica, false/* update inverted index */);
-                }
-                Preconditions.checkState(beIds.size() == replicationNum,
-                                         beIds.size() + " vs. " + replicationNum);
-            }
-
-            // first colocate table in CG
-            if (groupId != null && chooseBackendsArbitrary) {
-                colocateTableIndex.addBackendsPerBucketSeq(groupId, backendsPerBucketSeq);
-            }
-        } else {
-            for (int i = 0; i < tabletNum; i++) {
-                long newTabletId = globalStateMgr.getNextId();
-                LocalTablet newTablet = new LocalTablet(newTabletId);
-                index.addTablet(newTablet, null /* tablet meta */, false/* update inverted index */);
-
-                // replicas
-                List<Long> beIds = GlobalStateMgr.getCurrentState().getNodeMgr()
-                        .getClusterInfo().getNodeSelector().seqChooseBackendIds(replicationNum, true, true, getLocation());
-                if (CollectionUtils.isEmpty(beIds)) {
-                    return new Status(ErrCode.COMMON_ERROR, "failed to find "
-                            + replicationNum
-                            + " different hosts to create table: " + name);
-                }
-                for (Long beId : beIds) {
-                    long newReplicaId = globalStateMgr.getNextId();
-                    Replica replica = new Replica(newReplicaId, beId, ReplicaState.NORMAL,
-                            version, schemaHash);
-                    newTablet.addReplica(replica, false/* update inverted index */);
-                }
-            }
-        }
-        return Status.OK;
     }
 
     public Status doAfterRestore(MvRestoreContext mvRestoreContext) throws DdlException {
@@ -1283,10 +1085,11 @@ public class OlapTable extends Table {
 
     /**
      * NOTE: Only list partitioned olap table can call this method.
+     *
      * @return : table's partition name to all list partition cells.
      * eg:
-     *  partition columns   : (a, b, c)
-     *  values              : [[1, 2, 3], [4, 5, 6]]
+     * partition columns   : (a, b, c)
+     * values              : [[1, 2, 3], [4, 5, 6]]
      */
     public Map<String, PListCell> getListPartitionItems() {
         return getListPartitionItems(Optional.empty());
@@ -1401,7 +1204,7 @@ public class OlapTable extends Table {
     /**
      * Infer the distribution info based on partitions and cluster status:
      * - For hash distribution, if bucket num is not set, we will set it to
-     *  average bucket num of recent partitions.
+     * average bucket num of recent partitions.
      * - For random distribution, if mutable bucket num is not set, we will set it with a deduced value.
      */
     public void inferDistribution(DistributionInfo info) throws DdlException {
@@ -1706,6 +1509,18 @@ public class OlapTable extends Table {
     @Override
     public Collection<Partition> getPartitions() {
         return idToPartition.values();
+    }
+
+    public Map<Long, Partition> getIdToPartition() {
+        return idToPartition;
+    }
+
+    public Map<Long, Long> getPhysicalPartitionIdToPartitionId() {
+        return physicalPartitionIdToPartitionId;
+    }
+
+    public Map<String, Long> getPhysicalPartitionNameToPartitionId() {
+        return physicalPartitionNameToPartitionId;
     }
 
     /**
@@ -2784,7 +2599,7 @@ public class OlapTable extends Table {
             tableProperty = new TableProperty(new HashMap<>());
         }
         tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_FILE_BUNDLING,
-                        Boolean.valueOf(fileBundling).toString());
+                Boolean.valueOf(fileBundling).toString());
         tableProperty.buildFileBundling();
     }
 
@@ -3034,7 +2849,7 @@ public class OlapTable extends Table {
     }
 
     public PhysicalPartition replacePhysicalPartition(long oldPhysicalPartitionId,
-            PhysicalPartition newPhysicalPartition, boolean moveOldToTemp) {
+                                                      PhysicalPartition newPhysicalPartition, boolean moveOldToTemp) {
         Partition partition = getPartition(newPhysicalPartition.getParentId());
         if (partition == null || partition.getId() != newPhysicalPartition.getParentId()) {
             return null;
@@ -3551,8 +3366,8 @@ public class OlapTable extends Table {
         }
 
         if (getCompactionStrategy() != TCompactionStrategy.DEFAULT) {
-            properties.put(PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY, 
-                                TableProperty.compactionStrategyToString(getCompactionStrategy()));
+            properties.put(PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY,
+                    TableProperty.compactionStrategyToString(getCompactionStrategy()));
         }
 
         Map<String, String> tableProperties = tableProperty != null ? tableProperty.getProperties() : Maps.newLinkedHashMap();

--- a/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
@@ -121,7 +121,7 @@ public class LakeRestoreJob extends RestoreJob {
             LakeTablet tablet = null;
             try {
                 OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                            .getTable(db.getId(), idChain.getTblId());
+                        .getTable(db.getId(), idChain.getTblId());
                 Partition part = tbl.getPartition(idChain.getPartId());
                 MaterializedIndex index = part.getDefaultPhysicalPartition().getIndex(idChain.getIdxId());
                 tablet = (LakeTablet) index.getTablet(idChain.getTabletId());
@@ -153,7 +153,7 @@ public class LakeRestoreJob extends RestoreJob {
         request.restoreInfos = Lists.newArrayList();
         for (SnapshotInfo info : beSnapshotInfos) {
             OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                        .getTable(db.getId(), info.getTblId());
+                    .getTable(db.getId(), info.getTblId());
             if (tbl == null) {
                 status = new Status(Status.ErrCode.NOT_FOUND, "restored table "
                         + info.getTblId() + " does not exist");
@@ -261,9 +261,6 @@ public class LakeRestoreJob extends RestoreJob {
         // It is no need to release snapshots for lake table.
     }
 
-
-
-
     @Override
     protected void modifyInvertedIndex(OlapTable restoreTbl, Partition restorePart) {
         for (MaterializedIndex restoredIdx : restorePart.getDefaultPhysicalPartition()
@@ -282,7 +279,7 @@ public class LakeRestoreJob extends RestoreJob {
     protected void addRestoredPartitions(Database db, boolean modify) {
         for (Pair<String, Partition> entry : restoredPartitions) {
             OlapTable localTbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                        .getTable(db.getFullName(), entry.first);
+                    .getTable(db.getFullName(), entry.first);
             Partition restorePart = entry.second;
             OlapTable remoteTbl = (OlapTable) backupMeta.getTable(entry.first);
             RangePartitionInfo localPartitionInfo = (RangePartitionInfo) localTbl.getPartitionInfo();
@@ -311,7 +308,7 @@ public class LakeRestoreJob extends RestoreJob {
             LakeTable remoteLakeTbl = (LakeTable) remoteOlapTbl;
             StorageInfo storageInfo = remoteLakeTbl.getTableProperty().getStorageInfo();
             remoteLakeTbl.setStorageInfo(pathInfo, storageInfo.getDataCacheInfo());
-            remoteLakeTbl.resetIdsForRestore(globalStateMgr, db, restoreReplicationNum, new MvRestoreContext());
+            resetIdsForRestore(globalStateMgr, remoteOlapTbl, db, restoreReplicationNum, new MvRestoreContext());
         } catch (DdlException e) {
             return new Status(Status.ErrCode.COMMON_ERROR, e.getMessage());
         }

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobMaterializedViewTest.java
@@ -246,18 +246,18 @@ public class BackupJobMaterializedViewTest {
                 OlapTable backupTbl = (OlapTable) backupMeta.getTable(UnitTestUtil.TABLE_NAME);
                 List<String> partNames = Lists.newArrayList(backupTbl.getPartitionNames());
                 Assertions.assertNotNull(backupTbl);
-                Assertions.assertEquals(backupTbl.getSignature(BackupHandler.SIGNATURE_VERSION, partNames, true),
-                            ((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                                        .getTable(db.getId(), tblId)).getSignature(BackupHandler.SIGNATURE_VERSION, partNames,
+                Assertions.assertEquals(RestoreJob.getSignature(backupTbl, BackupHandler.SIGNATURE_VERSION, partNames, true),
+                            RestoreJob.getSignature(((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                        .getTable(db.getId(), tblId)), BackupHandler.SIGNATURE_VERSION, partNames,
                                         true));
             }
             {
                 OlapTable backupTbl = (OlapTable) backupMeta.getTable(UnitTestUtil.MATERIALIZED_VIEW_NAME);
                 List<String> partNames = Lists.newArrayList(backupTbl.getPartitionNames());
                 Assertions.assertNotNull(backupTbl);
-                Assertions.assertEquals(backupTbl.getSignature(BackupHandler.SIGNATURE_VERSION, partNames, true),
-                            ((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                                        .getTable(db.getId(), tblId + 1)).getSignature(BackupHandler.SIGNATURE_VERSION, partNames,
+                Assertions.assertEquals(RestoreJob.getSignature(backupTbl, BackupHandler.SIGNATURE_VERSION, partNames, true),
+                            RestoreJob.getSignature(((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                        .getTable(db.getId(), tblId + 1)), BackupHandler.SIGNATURE_VERSION, partNames,
                                         true));
             }
         }
@@ -366,18 +366,18 @@ public class BackupJobMaterializedViewTest {
                 Assertions.assertNotNull(olapTable);
                 Assertions.assertNotNull(restoreMetaInfo.getTable(UnitTestUtil.TABLE_NAME));
                 List<String> names = Lists.newArrayList(olapTable.getPartitionNames());
-                Assertions.assertEquals(((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                                        .getTable(db.getId(), tblId)).getSignature(BackupHandler.SIGNATURE_VERSION, names, true),
-                            olapTable.getSignature(BackupHandler.SIGNATURE_VERSION, names, true));
+                Assertions.assertEquals(RestoreJob.getSignature(((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                                        .getTable(db.getId(), tblId)), BackupHandler.SIGNATURE_VERSION, names, true),
+                            RestoreJob.getSignature(olapTable, BackupHandler.SIGNATURE_VERSION, names, true));
             }
             {
                 MaterializedView mv = (MaterializedView) restoreMetaInfo.getTable(tblId + 1);
                 Assertions.assertNotNull(mv);
                 Assertions.assertNotNull(restoreMetaInfo.getTable(UnitTestUtil.MATERIALIZED_VIEW_NAME));
                 List<String> names = Lists.newArrayList(mv.getPartitionNames());
-                Assertions.assertEquals(((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                            .getTable(db.getId(), tblId + 1)).getSignature(BackupHandler.SIGNATURE_VERSION, names,
-                            true), mv.getSignature(BackupHandler.SIGNATURE_VERSION, names, true));
+                Assertions.assertEquals(RestoreJob.getSignature(((OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(db.getId(), tblId + 1)), BackupHandler.SIGNATURE_VERSION, names,
+                            true), RestoreJob.getSignature(mv, BackupHandler.SIGNATURE_VERSION, names, true));
             }
 
             restoreJobInfo = BackupJobInfo.fromFile(job.getLocalJobInfoFilePath());

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobPrimaryKeyTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobPrimaryKeyTest.java
@@ -387,10 +387,10 @@ public class RestoreJobPrimaryKeyTest {
         OlapTable tbl = (OlapTable) db.getTable(CatalogMocker.TEST_TBL_NAME);
         List<String> partNames = Lists.newArrayList(tbl.getPartitionNames());
         System.out.println(partNames);
-        System.out.println("tbl signature: " + tbl.getSignature(BackupHandler.SIGNATURE_VERSION, partNames, true));
+        System.out.println("tbl signature: " + RestoreJob.getSignature(tbl, BackupHandler.SIGNATURE_VERSION, partNames, true));
         tbl.setName("newName");
         partNames = Lists.newArrayList(tbl.getPartitionNames());
-        System.out.println("tbl signature: " + tbl.getSignature(BackupHandler.SIGNATURE_VERSION, partNames, true));
+        System.out.println("tbl signature: " + RestoreJob.getSignature(tbl, BackupHandler.SIGNATURE_VERSION, partNames, true));
     }
 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/OlapTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/OlapTableTest.java
@@ -37,6 +37,7 @@ package com.starrocks.catalog;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
+import com.starrocks.backup.RestoreJob;
 import com.starrocks.backup.mv.MvRestoreContext;
 import com.starrocks.catalog.Table.TableType;
 import com.starrocks.common.AnalysisException;
@@ -83,7 +84,8 @@ public class OlapTableTest {
             if (table.getType() != TableType.OLAP) {
                 continue;
             }
-            ((OlapTable) table).resetIdsForRestore(GlobalStateMgr.getCurrentState(), db, 3, new MvRestoreContext());
+            RestoreJob restoreJob = new RestoreJob();
+            restoreJob.resetIdsForRestore(GlobalStateMgr.getCurrentState(), (OlapTable) table, db, 3, new MvRestoreContext());
         }
     }
 
@@ -419,13 +421,13 @@ public class OlapTableTest {
         schema.add(k3);
 
         Index index1 = new Index(1L, "index1", Lists.newArrayList(ColumnId.create("k1"), ColumnId.create("k2")),
-                                 IndexDef.IndexType.BITMAP, "comment", null);
+                IndexDef.IndexType.BITMAP, "comment", null);
 
         Index index2 = new Index(2L, "index2", Lists.newArrayList(ColumnId.create("k2"), ColumnId.create("k3")),
-                                 IndexDef.IndexType.BITMAP, "comment", null);
+                IndexDef.IndexType.BITMAP, "comment", null);
 
         Index index3 = new Index(3L, "index3", Lists.newArrayList(ColumnId.create("k4")), IndexDef.IndexType.BITMAP,
-                                 "comment", null);
+                "comment", null);
         indexesInTable.add(index1);
         indexesInTable.add(index2);
         indexesInTable.add(index3);


### PR DESCRIPTION
## Why I'm doing:
Currently, a large amount of restore logic is coupled within OlapTable, which hinders the development of shared-data restore functionality in the future.No logical changes
## What I'm doing:

This pull request primarily removes the restore-related logic and signature calculation methods from the `OlapTable` and `MaterializedView` classes, along with associated unused imports. Additionally, it exposes several internal partition mapping structures via new getter methods. These changes simplify the codebase by cleaning up unused or unnecessary code and making some internal state more accessible.

**Removal of restore and signature logic:**

* Removed the `resetIdsForRestore` method from both `OlapTable` and `MaterializedView`, including all logic responsible for resetting IDs and restoring table/partition/index state after a backup restore. [[1]](diffhunk://#diff-171dae9f0bb57d4016183d17e215ac2dba38e31e0902cd331ec11660212eba4bL860-L1057) [[2]](diffhunk://#diff-30af13c1a1cdd2dcedc3200a0a9a3497645f60a2a173ec4b2ca17217af93afb0L2356-L2375)
* Removed the `createTabletsForRestore` method from `OlapTable`, which was used as a helper for tablet creation during restore.
* Removed the `getSignature` and `getSignatureSequence` methods from `OlapTable`, which calculated and reported table signatures for backup/restore consistency checks.

**API and visibility improvements:**

* Added getter methods for internal partition mapping fields in `OlapTable`: `getIdToPartition`, `getPhysicalPartitionIdToPartitionId`, and `getPhysicalPartitionNameToPartitionId`.

**General cleanup:**

* Removed unused imports related to backup/restore and utility classes from both `OlapTable` and `MaterializedView`. [[1]](diffhunk://#diff-171dae9f0bb57d4016183d17e215ac2dba38e31e0902cd331ec11660212eba4bL53) [[2]](diffhunk://#diff-171dae9f0bb57d4016183d17e215ac2dba38e31e0902cd331ec11660212eba4bL81) [[3]](diffhunk://#diff-171dae9f0bb57d4016183d17e215ac2dba38e31e0902cd331ec11660212eba4bL142) [[4]](diffhunk://#diff-171dae9f0bb57d4016183d17e215ac2dba38e31e0902cd331ec11660212eba4bL163) [[5]](diffhunk://#diff-30af13c1a1cdd2dcedc3200a0a9a3497645f60a2a173ec4b2ca17217af93afb0L30)
* Minor JavaDoc formatting fix in `getRangePartitionMap`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
