### PR TITLE
[Enhancement] Support unified session variable setters

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariableConstants.java
@@ -42,6 +42,10 @@ public class SessionVariableConstants {
     public static final String ELASTIC = "elastic";
     public static final String BALANCE = "balance";
 
+    public static final String ETL = "etl";
+    public static final String DEFAULT = "default";
+
+
     public enum ChooseInstancesMode {
 
         // the number of chosen instances is the same as the max number of instances from its children fragments

--- a/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/VariableMgr.java
@@ -220,9 +220,17 @@ public class VariableMgr {
         String v = VariableVarConverters.convert(varName, raw);
         try {
             if (type == boolean.class || type == Boolean.class) {
-                return v.equalsIgnoreCase("ON")
+                if (v.equalsIgnoreCase("ON")
                         || v.equalsIgnoreCase("TRUE")
-                        || v.equals("1");
+                        || v.equals("1")) {
+                    return true;
+                } else if (v.equalsIgnoreCase("OFF")
+                        || v.equalsIgnoreCase("FALSE")
+                        || v.equalsIgnoreCase("0")) {
+                    return false;
+                } else {
+                    throw new NumberFormatException();
+                }
             }
             if (type == byte.class || type == Byte.class) {
                 return Byte.parseByte(v);


### PR DESCRIPTION
## Why I'm doing:

This change introduces the following improvements:

1. Build SETTER_MAP in SessionVariable to allow unified setter invocation
2. Add a new session variable `exec_mode` with DEFAULT and ETL modes - Setting `exec_mode = etl` automatically enables phased scheduler and spill
3. Refactor VariableMgr to use reflection-based setter dispatch

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces reflection-based setter invocation for session variables and a new `exec_mode` (DEFAULT/ETL) that toggles phased scheduling and spill, with tests covering SQL-based setting of all vars.
> 
> - **QE/Session Variables**:
>   - Build `SessionVariable.SETTER_MAP` to map fields to setters and enable unified reflection-based setter invocation.
>   - Add `exec_mode` (`DEFAULT`/`ETL`); `setExecMode` toggles `enable_phased_scheduler` and `enable_spill`.
>   - Extend `SessionVariableConstants` with `ETL` and `DEFAULT` literals.
> - **VariableMgr**:
>   - Refactor `setValue` to use `SETTER_MAP` and centralized `parseValue(...)` for type-safe conversion and error reporting.
> - **Tests**:
>   - Add `testSetAllSessionVariablesBySql` to verify every `@VarAttr` can be set via `SET` SQL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 386e7dd63acc45edb139dc7dee330f106702b896. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->