### PR TITLE
[Refactor] Transform task related edit logs to WAL format

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -518,12 +518,12 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
             if (currentTask == null) {
                 task = TaskBuilder.buildMvTask(materializedView, dbName);
                 TaskBuilder.updateTaskInfo(task, refreshSchemeDesc, materializedView);
-                taskManager.createTask(task, false);
+                taskManager.createTask(task);
             } else {
                 Task changedTask = TaskBuilder.rebuildMvTask(materializedView, dbName, currentTask.getProperties(),
                         currentTask);
                 TaskBuilder.updateTaskInfo(changedTask, refreshSchemeDesc, materializedView);
-                taskManager.alterTask(currentTask, changedTask, false);
+                taskManager.alterTask(currentTask, changedTask);
                 task = currentTask;
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/MergePartitionJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/MergePartitionJob.java
@@ -505,7 +505,7 @@ public class MergePartitionJob extends AlterJobV2 implements GsonPostProcessable
         TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
         for (OptimizeTask rewriteTask : rewriteTasks) {
             try {
-                taskManager.createTask(rewriteTask, false);
+                taskManager.createTask(rewriteTask);
                 taskManager.executeTask(rewriteTask.getName());
                 LOG.info("create rewrite task {}", rewriteTask.toString());
             } catch (DdlException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeJobV2.java
@@ -288,7 +288,7 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
         TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
         for (OptimizeTask rewriteTask : rewriteTasks) {
             try {
-                taskManager.createTask(rewriteTask, false);
+                taskManager.createTask(rewriteTask);
                 SubmitResult r = taskManager.executeTask(rewriteTask.getName());
                 if (r.getStatus() == SubmitResult.SubmitStatus.SUBMITTED) {
                     rewriteTask.setOptimizeTaskState(Constants.TaskRunState.RUNNING);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1256,7 +1256,12 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
         Task refreshTask = taskManager.getTask(TaskBuilder.getMvTaskName(getId()));
         if (refreshTask != null) {
-            taskManager.dropTasks(Lists.newArrayList(refreshTask.getId()), replay);
+            List<Long> taskIds = Lists.newArrayList(refreshTask.getId());
+            if (replay) {
+                taskManager.replayDropTasks(taskIds);
+            } else {
+                taskManager.dropTasks(taskIds);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/Pipe.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/Pipe.java
@@ -446,7 +446,7 @@ public class Pipe implements GsonPostProcessable {
             TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
             Task task = TaskBuilder.buildPipeTask(taskDesc);
             try {
-                taskManager.createTask(task, false);
+                taskManager.createTask(task);
             } catch (DdlException e) {
                 recordTaskError(taskDesc, "create task failed");
                 return;

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/PipeTaskDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/PipeTaskDesc.java
@@ -114,7 +114,7 @@ public class PipeTaskDesc {
         TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
         Task task = taskManager.getTask(uniqueTaskName);
         if (task != null) {
-            taskManager.dropTasks(Lists.newArrayList(task.getId()), false);
+            taskManager.dropTasks(Lists.newArrayList(task.getId()));
         }
 
         this.state = PipeTaskState.RUNNABLE;

--- a/fe/fe-core/src/main/java/com/starrocks/persist/AlterTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/AlterTaskInfo.java
@@ -1,0 +1,52 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.persist;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.io.Writable;
+import com.starrocks.scheduler.Constants;
+import com.starrocks.scheduler.persist.TaskSchedule;
+
+public class AlterTaskInfo implements Writable {
+    @SerializedName("name")
+    private String name;
+
+    @SerializedName("type")
+    private Constants.TaskType type;
+
+    @SerializedName("schedule")
+    private TaskSchedule schedule;
+
+    public AlterTaskInfo() {
+        // for persist
+    }
+
+    public AlterTaskInfo(String name, Constants.TaskType type, TaskSchedule schedule) {
+        this.name = name;
+        this.type = type;
+        this.schedule = schedule;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Constants.TaskType getType() {
+        return type;
+    }
+
+    public TaskSchedule getSchedule() {
+        return schedule;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -688,8 +688,8 @@ public class EditLog {
                     break;
                 }
                 case OperationType.OP_ALTER_TASK: {
-                    final Task task = (Task) journal.data();
-                    globalStateMgr.getTaskManager().replayAlterTask(task);
+                    final AlterTaskInfo alterTaskInfo = (AlterTaskInfo) journal.data();
+                    globalStateMgr.getTaskManager().replayAlterTask(alterTaskInfo);
                     break;
                 }
                 case OperationType.OP_CREATE_TASK_RUN: {
@@ -1470,24 +1470,24 @@ public class EditLog {
         logJsonObject(OperationType.OP_RESOURCE_GROUP, op);
     }
 
-    public void logCreateTask(Task info) {
-        logJsonObject(OperationType.OP_CREATE_TASK, info);
+    public void logCreateTask(Task info, WALApplier applier) {
+        logJsonObject(OperationType.OP_CREATE_TASK, info, applier);
     }
 
-    public void logDropTasks(List<Long> taskIdList) {
-        logJsonObject(OperationType.OP_DROP_TASKS, new DropTasksLog(taskIdList));
+    public void logDropTasks(DropTasksLog tasksLog, WALApplier applier) {
+        logJsonObject(OperationType.OP_DROP_TASKS, tasksLog, applier);
     }
 
-    public void logTaskRunCreateStatus(TaskRunStatus status) {
-        logJsonObject(OperationType.OP_CREATE_TASK_RUN, status);
+    public void logTaskRunCreateStatus(TaskRunStatus status, WALApplier applier) {
+        logJsonObject(OperationType.OP_CREATE_TASK_RUN, status, applier);
     }
 
-    public void logUpdateTaskRun(TaskRunStatusChange statusChange) {
-        logJsonObject(OperationType.OP_UPDATE_TASK_RUN, statusChange);
+    public void logUpdateTaskRun(TaskRunStatusChange statusChange, WALApplier applier) {
+        logJsonObject(OperationType.OP_UPDATE_TASK_RUN, statusChange, applier);
     }
 
-    public void logArchiveTaskRuns(ArchiveTaskRunsLog log) {
-        logJsonObject(OperationType.OP_ARCHIVE_TASK_RUNS, log);
+    public void logArchiveTaskRuns(ArchiveTaskRunsLog log, WALApplier applier) {
+        logJsonObject(OperationType.OP_ARCHIVE_TASK_RUNS, log, applier);
     }
 
     public void logAlterRunningTaskRunProgress(TaskRunPeriodStatusChange info) {
@@ -2148,8 +2148,8 @@ public class EditLog {
         logJsonObject(OperationType.OP_MODIFY_TABLE_ADD_OR_DROP_COLUMNS, info);
     }
 
-    public void logAlterTask(Task changedTask) {
-        logJsonObject(OperationType.OP_ALTER_TASK, changedTask);
+    public void logAlterTask(AlterTaskInfo info, WALApplier applier) {
+        logJsonObject(OperationType.OP_ALTER_TASK, info, applier);
     }
 
     public void logSetDefaultStorageVolume(SetDefaultStorageVolumeLog log) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLogDeserializer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLogDeserializer.java
@@ -162,7 +162,7 @@ public class EditLogDeserializer {
             .put(OperationType.OP_DROP_RESOURCE, DropResourceOperationLog.class)
             .put(OperationType.OP_RESOURCE_GROUP, ResourceGroupOpEntry.class)
             .put(OperationType.OP_CREATE_TASK, Task.class)
-            .put(OperationType.OP_ALTER_TASK, Task.class)
+            .put(OperationType.OP_ALTER_TASK, AlterTaskInfo.class)
             .put(OperationType.OP_DROP_TASKS, DropTasksLog.class)
             .put(OperationType.OP_CREATE_TASK_RUN, TaskRunStatus.class)
             .put(OperationType.OP_UPDATE_TASK_RUN, TaskRunStatusChange.class)

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -1081,7 +1081,7 @@ public class DDLStmtExecutor {
                         "DROP MATERIALIZED VIEW to drop task, when the materialized view is deleted, " +
                         "the related task will be deleted automatically.");
             }
-            taskManager.dropTasks(Collections.singletonList(task.getId()), false);
+            taskManager.dropTasks(Collections.singletonList(task.getId()));
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
@@ -247,13 +247,13 @@ public class TaskBuilder {
         if (currentTask == null) {
             task = TaskBuilder.buildMvTask(materializedView, dbName);
             TaskBuilder.updateTaskInfo(task, materializedView);
-            taskManager.createTask(task, false);
+            taskManager.createTask(task);
         } else {
             Map<String, String> previousTaskProperties = currentTask.getProperties() == null ?
                     Maps.newHashMap() : Maps.newHashMap(currentTask.getProperties());
             Task changedTask = TaskBuilder.rebuildMvTask(materializedView, dbName, previousTaskProperties, currentTask);
             TaskBuilder.updateTaskInfo(changedTask, materializedView);
-            taskManager.alterTask(currentTask, changedTask, false);
+            taskManager.alterTask(currentTask, changedTask);
             task = currentTask;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -33,6 +33,7 @@ import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.QueryableReentrantLock;
 import com.starrocks.memory.MemoryTrackable;
+import com.starrocks.persist.AlterTaskInfo;
 import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
 import com.starrocks.persist.metablock.SRMetaBlockException;
@@ -45,6 +46,7 @@ import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.scheduler.history.TaskRunHistory;
 import com.starrocks.scheduler.persist.ArchiveTaskRunsLog;
+import com.starrocks.scheduler.persist.DropTasksLog;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.scheduler.persist.TaskRunStatusChange;
 import com.starrocks.scheduler.persist.TaskSchedule;
@@ -157,7 +159,7 @@ public class TaskManager implements MemoryTrackable {
         }
     }
 
-    private void clearUnfinishedTaskRun() {
+    protected void clearUnfinishedTaskRun() {
         if (!taskRunManager.tryTaskRunLock()) {
             return;
         }
@@ -165,67 +167,102 @@ public class TaskManager implements MemoryTrackable {
             // clear pending task runs
             List<TaskRun> taskRuns = taskRunScheduler.getCopiedPendingTaskRuns();
             for (TaskRun taskRun : taskRuns) {
-                taskRun.getStatus().setErrorMessage("Fe abort the task");
-                taskRun.getStatus().setErrorCode(-1);
-                taskRun.getStatus().setState(Constants.TaskRunState.FAILED);
+                final String errorMsg = "Fe abort the task";
+                final int errorCode = -1;
 
-                taskRunManager.getTaskRunHistory().addHistory(taskRun.getStatus());
                 TaskRunStatusChange statusChange = new TaskRunStatusChange(taskRun.getTaskId(), taskRun.getStatus(),
                         Constants.TaskRunState.PENDING, Constants.TaskRunState.FAILED);
-                GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange);
+                statusChange.setErrorMessage(errorMsg);
+                statusChange.setErrorCode(errorCode);
 
-                // remove pending task run
-                taskRunScheduler.removePendingTaskRun(taskRun, Constants.TaskRunState.FAILED);
+                GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange, wal -> {
+                    taskRun.getStatus().setErrorMessage(errorMsg);
+                    taskRun.getStatus().setErrorCode(errorCode);
+                    taskRun.getStatus().setState(Constants.TaskRunState.FAILED);
+
+                    taskRunManager.getTaskRunHistory().addHistory(taskRun.getStatus());
+                    // remove pending task run
+                    taskRunScheduler.removePendingTaskRun(taskRun, Constants.TaskRunState.FAILED);
+                });
             }
 
             // clear running task runs
             Set<Long> runningTaskIds = taskRunScheduler.getCopiedRunningTaskIds();
             for (Long taskId : runningTaskIds) {
-                TaskRun taskRun = taskRunScheduler.getRunningTaskRun(taskId);
-                taskRun.getStatus().setErrorMessage("Fe abort the task");
-                taskRun.getStatus().setErrorCode(-1);
-                taskRun.getStatus().setState(Constants.TaskRunState.FAILED);
-                taskRun.getStatus().setFinishTime(System.currentTimeMillis());
+                final String errorMsg = "Fe abort the task";
+                final int errorCode = -1;
+                final long finishTime = System.currentTimeMillis();
 
-                taskRunManager.getTaskRunHistory().addHistory(taskRun.getStatus());
+                TaskRun taskRun = taskRunScheduler.getRunningTaskRun(taskId);
                 TaskRunStatusChange statusChange = new TaskRunStatusChange(taskRun.getTaskId(), taskRun.getStatus(),
                         Constants.TaskRunState.RUNNING, Constants.TaskRunState.FAILED);
-                GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange);
+                statusChange.setErrorCode(errorCode);
+                statusChange.setErrorMessage(errorMsg);
+                statusChange.setFinishTime(finishTime);
 
-                // remove running task run
-                taskRunScheduler.removeRunningTask(taskId);
+                GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange, wal -> {
+                    taskRun.getStatus().setErrorMessage(errorMsg);
+                    taskRun.getStatus().setErrorCode(errorCode);
+                    taskRun.getStatus().setState(Constants.TaskRunState.FAILED);
+                    taskRun.getStatus().setFinishTime(finishTime);
+
+                    taskRunManager.getTaskRunHistory().addHistory(taskRun.getStatus());
+                    // remove running task run
+                    taskRunScheduler.removeRunningTask(taskId);
+                });
+
             }
         } finally {
             taskRunManager.taskRunUnlock();
         }
     }
 
-    public void createTask(Task task, boolean isReplay) throws DdlException {
+    public void createTask(Task task) throws DdlException {
         takeTaskLock();
         try {
             if (nameToTaskMap.containsKey(task.getName())) {
                 throw new DdlException("Task [" + task.getName() + "] already exists");
             }
-            if (!isReplay) {
-                // TaskId should be assigned by the framework
-                Preconditions.checkArgument(task.getId() == 0);
-                task.setId(GlobalStateMgr.getCurrentState().getNextId());
-            }
+
+            // TaskId should be assigned by the framework
+            Preconditions.checkArgument(task.getId() == 0, "TaskId should be assigned by the framework");
+            task.setId(GlobalStateMgr.getCurrentState().getNextId());
+
             if (task.getType() == Constants.TaskType.PERIODICAL) {
                 task.setState(Constants.TaskState.ACTIVE);
-                if (!isReplay) {
-                    TaskSchedule schedule = task.getSchedule();
-                    if (schedule == null) {
-                        throw new DdlException("Task [" + task.getName() + "] has no scheduling information");
-                    }
-                    registerScheduler(task);
+                TaskSchedule schedule = task.getSchedule();
+                if (schedule == null) {
+                    throw new DdlException("Task [" + task.getName() + "] has no scheduling information");
                 }
             }
-            nameToTaskMap.put(task.getName(), task);
-            idToTaskMap.put(task.getId(), task);
-            if (!isReplay) {
-                GlobalStateMgr.getCurrentState().getEditLog().logCreateTask(task);
+            GlobalStateMgr.getCurrentState().getEditLog().logCreateTask(task, wal -> addTask((Task) wal));
+            if (task.getType() == Constants.TaskType.PERIODICAL) {
+                registerScheduler(task);
             }
+        } finally {
+            taskUnlock();
+        }
+    }
+
+    private void addTask(Task task) {
+        nameToTaskMap.put(task.getName(), task);
+        idToTaskMap.put(task.getId(), task);
+    }
+
+    public void replayCreateTask(Task task) {
+        if (task.getType() == Constants.TaskType.PERIODICAL) {
+            TaskSchedule taskSchedule = task.getSchedule();
+            if (taskSchedule == null) {
+                LOG.warn("replay a null schedule period Task [{}]", task.getName());
+                return;
+            }
+        }
+        if (task.getExpireTime() > 0 && System.currentTimeMillis() > task.getExpireTime()) {
+            return;
+        }
+        takeTaskLock();
+        try {
+            addTask(task);
         } finally {
             taskUnlock();
         }
@@ -486,7 +523,7 @@ public class TaskManager implements MemoryTrackable {
         }
     }
 
-    public void dropTasks(List<Long> taskIdList, boolean isReplay) {
+    public void dropTasks(List<Long> taskIdList) {
         takeTaskLock();
         try {
             for (long taskId : taskIdList) {
@@ -495,27 +532,46 @@ public class TaskManager implements MemoryTrackable {
                     LOG.warn("drop taskId {} failed because task is null", taskId);
                     continue;
                 }
-                if (task.getType() == Constants.TaskType.PERIODICAL && !isReplay) {
+                if (task.getType() == Constants.TaskType.PERIODICAL) {
                     boolean isCancel = stopScheduler(task.getName());
                     if (!isCancel) {
                         continue;
                     }
                     periodFutureMap.remove(task.getId());
                 }
-                if (!killTask(task.getName(), true)) {
-                    LOG.warn("kill task failed: {}", task.getName());
-                }
-                idToTaskMap.remove(task.getId());
-                nameToTaskMap.remove(task.getName());
             }
 
-            if (!isReplay) {
-                GlobalStateMgr.getCurrentState().getEditLog().logDropTasks(taskIdList);
-            }
+            GlobalStateMgr.getCurrentState().getEditLog().logDropTasks(new DropTasksLog(taskIdList),
+                    wal -> killAndDeleteTasks(((DropTasksLog) wal).getTaskIdList()));
         } finally {
             taskUnlock();
         }
         LOG.info("drop tasks:{}", taskIdList);
+    }
+
+    private void killAndDeleteTasks(List<Long> taskIdList) {
+        for (long taskId : taskIdList) {
+            Task task = idToTaskMap.get(taskId);
+            if (task == null) {
+                LOG.warn("delete taskId {} failed because task is null", taskId);
+                continue;
+            }
+
+            if (!killTask(task.getName(), true)) {
+                LOG.warn("kill task failed: {}", task.getName());
+            }
+            idToTaskMap.remove(task.getId());
+            nameToTaskMap.remove(task.getName());
+        }
+    }
+
+    public void replayDropTasks(List<Long> taskIdList) {
+        takeTaskLock();
+        try {
+            killAndDeleteTasks(taskIdList);
+        } finally {
+            taskUnlock();
+        }
     }
 
     private boolean isTaskMatched(Task task, TGetTasksParams params) {
@@ -541,7 +597,7 @@ public class TaskManager implements MemoryTrackable {
         return taskList;
     }
 
-    public void alterTask(Task currentTask, Task changedTask, boolean isReplay) {
+    public void alterTask(Task currentTask, Task changedTask) {
         Constants.TaskType currentType = currentTask.getType();
         Constants.TaskType changedType = changedTask.getType();
         boolean hasChanged = false;
@@ -554,34 +610,47 @@ public class TaskManager implements MemoryTrackable {
                 hasChanged = true;
             }
         } else if (currentTask.getType() == Constants.TaskType.PERIODICAL) {
-            if (!isReplay) {
-                boolean isCancel = stopScheduler(currentTask.getName());
-                if (!isCancel) {
-                    throw new RuntimeException("stop scheduler failed");
-                }
+            boolean isCancel = stopScheduler(currentTask.getName());
+            if (!isCancel) {
+                throw new RuntimeException("stop scheduler failed");
             }
-            periodFutureMap.remove(currentTask.getId());
-            currentTask.setState(Constants.TaskState.UNKNOWN);
-            currentTask.setSchedule(null);
             hasChanged = true;
         }
 
         if (changedType == Constants.TaskType.PERIODICAL) {
-            currentTask.setState(Constants.TaskState.ACTIVE);
-            TaskSchedule schedule = changedTask.getSchedule();
-            currentTask.setSchedule(schedule);
-            if (!isReplay) {
-                registerScheduler(currentTask);
-            }
             hasChanged = true;
         }
 
         if (hasChanged) {
-            currentTask.setType(changedTask.getType());
-            if (!isReplay) {
-                GlobalStateMgr.getCurrentState().getEditLog().logAlterTask(changedTask);
+            GlobalStateMgr.getCurrentState().getEditLog().logAlterTask(
+                    new AlterTaskInfo(currentTask.getName(), changedType, changedTask.getSchedule()),
+                    wal -> {
+                        AlterTaskInfo alterTaskInfo = (AlterTaskInfo) wal;
+                        changeTask(currentTask, alterTaskInfo.getType(), alterTaskInfo.getSchedule());
+                    }
+            );
+            if (changedType == Constants.TaskType.PERIODICAL) {
+                registerScheduler(currentTask);
             }
         }
+    }
+
+    private void changeTask(Task currentTask, Constants.TaskType changedType, TaskSchedule changedSchedule) {
+        if (currentTask.getType() == Constants.TaskType.PERIODICAL) {
+            periodFutureMap.remove(currentTask.getId());
+            currentTask.setState(Constants.TaskState.UNKNOWN);
+            currentTask.setSchedule(null);
+        }
+        if (changedType == Constants.TaskType.PERIODICAL) {
+            currentTask.setState(Constants.TaskState.ACTIVE);
+            currentTask.setSchedule(changedSchedule);
+        }
+        currentTask.setType(changedType);
+    }
+
+    public void replayAlterTask(AlterTaskInfo alterTaskInfo) {
+        Task currentTask = getTask(alterTaskInfo.getName());
+        changeTask(currentTask, alterTaskInfo.getType(), alterTaskInfo.getSchedule());
     }
 
     @VisibleForTesting
@@ -666,11 +735,6 @@ public class TaskManager implements MemoryTrackable {
         periodFutureMap.put(task.getId(), future);
     }
 
-    public void replayAlterTask(Task task) {
-        Task currentTask = getTask(task.getName());
-        alterTask(currentTask, task, true);
-    }
-
     private boolean tryTaskLock() {
         try {
             if (!taskLock.tryLock(5, TimeUnit.SECONDS)) {
@@ -704,27 +768,6 @@ public class TaskManager implements MemoryTrackable {
         this.taskLock.unlock();
     }
 
-    public void replayCreateTask(Task task) {
-        if (task.getType() == Constants.TaskType.PERIODICAL) {
-            TaskSchedule taskSchedule = task.getSchedule();
-            if (taskSchedule == null) {
-                LOG.warn("replay a null schedule period Task [{}]", task.getName());
-                return;
-            }
-        }
-        if (task.getExpireTime() > 0 && System.currentTimeMillis() > task.getExpireTime()) {
-            return;
-        }
-        try {
-            createTask(task, true);
-        } catch (DdlException e) {
-            LOG.warn("failed to replay create task [{}]", task.getName(), e);
-        }
-    }
-
-    public void replayDropTasks(List<Long> taskIdList) {
-        dropTasks(taskIdList, true);
-    }
 
     public TaskRunManager getTaskRunManager() {
         return taskRunManager;
@@ -743,7 +786,7 @@ public class TaskManager implements MemoryTrackable {
         String taskName = task.getName();
         SubmitResult submitResult;
         try {
-            createTask(task, false);
+            createTask(task);
             if (task.getType() == Constants.TaskType.MANUAL) {
                 submitResult = executeTask(task.getName());
             } else {
@@ -1073,7 +1116,7 @@ public class TaskManager implements MemoryTrackable {
             taskUnlock();
         }
         // this will do in checkpoint thread and does not need write log
-        dropTasks(taskIdToDelete, true);
+        replayDropTasks(taskIdToDelete);
     }
 
     public void removeExpiredTaskRuns(boolean archiveHistory) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -252,10 +252,8 @@ public class TaskManager implements MemoryTrackable {
     public void replayCreateTask(Task task) {
         if (task.getType() == Constants.TaskType.PERIODICAL) {
             TaskSchedule taskSchedule = task.getSchedule();
-            if (taskSchedule == null) {
-                LOG.warn("replay a null schedule period Task [{}]", task.getName());
-                return;
-            }
+            Preconditions.checkState(taskSchedule != null,
+                    "TaskSchedule cannot be null for periodical task");
         }
         if (task.getExpireTime() > 0 && System.currentTimeMillis() > task.getExpireTime()) {
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunExecutor.java
@@ -51,10 +51,6 @@ public class TaskRunExecutor {
             return false;
         }
 
-        // Synchronously update the status, to make sure they can be persisted
-        status.setState(Constants.TaskRunState.RUNNING);
-        status.setProcessStartTime(System.currentTimeMillis());
-
         CompletableFuture<Constants.TaskRunState> future = CompletableFuture.supplyAsync(() -> {
             try {
                 Constants.TaskRunState runState = taskRun.executeTaskRun();

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunExecutor.java
@@ -19,6 +19,8 @@ import com.starrocks.common.Config;
 import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.scheduler.persist.TaskRunStatus;
+import com.starrocks.scheduler.persist.TaskRunStatusChange;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.warehouse.WarehouseIdleChecker;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -50,6 +52,14 @@ public class TaskRunExecutor {
                     status.getQueryId(), status.getState());
             return false;
         }
+
+        // Persist state change
+        TaskRunStatusChange statusChange = new TaskRunStatusChange(taskRun.getTaskId(), taskRun.getStatus(),
+                Constants.TaskRunState.PENDING, Constants.TaskRunState.RUNNING);
+        GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange, wal -> {
+            taskRun.getStatus().setState(Constants.TaskRunState.RUNNING);
+            taskRun.getStatus().setProcessStartTime(System.currentTimeMillis());
+        });
 
         CompletableFuture<Constants.TaskRunState> future = CompletableFuture.supplyAsync(() -> {
             try {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -280,14 +280,6 @@ public class TaskRunManager implements MemoryTrackable {
         taskRunScheduler.scheduledPendingTaskRun(pendingTaskRun -> {
             if (taskRunExecutor.executeTaskRun(pendingTaskRun)) {
                 LOG.info("start to schedule pending task run to execute: {}", pendingTaskRun);
-                long taskId = pendingTaskRun.getTaskId();
-                // RUNNING state persistence is for FE FOLLOWER update state
-                TaskRunStatusChange statusChange = new TaskRunStatusChange(taskId, pendingTaskRun.getStatus(),
-                        Constants.TaskRunState.PENDING, Constants.TaskRunState.RUNNING);
-                GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange, wal -> {
-                    pendingTaskRun.getStatus().setState(Constants.TaskRunState.RUNNING);
-                    pendingTaskRun.getStatus().setProcessStartTime(System.currentTimeMillis());
-                });
             } else {
                 LOG.warn("failed to scheduled task-run {}", pendingTaskRun);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -84,12 +84,10 @@ public class TaskRunManager implements MemoryTrackable {
         status.setPriority(option.getPriority());
         status.setMergeRedundant(option.isMergeRedundant());
         status.setProperties(option.getTaskRunProperties());
-        if (!arrangeTaskRun(taskRun, false)) {
+        if (!arrangeTaskRun(taskRun)) {
             LOG.warn("Submit task run to pending queue failed, reject the submit:{}", taskRun);
             return new SubmitResult(null, SubmitResult.SubmitStatus.REJECTED);
         }
-        // Only log create task run status when it's not rejected and created.
-        GlobalStateMgr.getCurrentState().getEditLog().logTaskRunCreateStatus(status);
         return new SubmitResult(queryId, SubmitResult.SubmitStatus.SUBMITTED, taskRun.getFuture());
     }
 
@@ -163,7 +161,7 @@ public class TaskRunManager implements MemoryTrackable {
     // The manual priority is higher. For manual tasks, we do not merge operations.
     // For automatic tasks, we will compare the definition, and if they are the same,
     // we will perform the merge operation.
-    public boolean arrangeTaskRun(TaskRun taskRun, boolean isReplay) {
+    public boolean arrangeTaskRun(TaskRun taskRun) {
         if (!tryTaskRunLock()) {
             return false;
         }
@@ -225,35 +223,27 @@ public class TaskRunManager implements MemoryTrackable {
 
             // recheck it again to avoid pending task run is too much
             long validPendingCount = taskRunScheduler.getPendingQueueCount();
-            if (validPendingCount >= Config.task_runs_queue_length || !taskRunScheduler.addPendingTaskRun(taskRun)) {
+            if (validPendingCount >= Config.task_runs_queue_length) {
                 LOG.warn("failed to offer task: {}", taskRun);
                 return false;
             }
+            GlobalStateMgr.getCurrentState().getEditLog().logTaskRunCreateStatus(taskRun.getStatus(),
+                    wal -> taskRunScheduler.addPendingTaskRun(taskRun));
 
-            // if it 's not replay, update the status of the old TaskRun to MERGED in FOLLOWER/LEADER.
-            // if it is replay, no need to update the status of the old TaskRun because follower FE cannot
-            // update edit log.
-            if (!isReplay) {
-                // TODO: support batch update to reduce the number of edit logs.
-                for (TaskRun oldTaskRun : mergedTaskRuns) {
-                    oldTaskRun.getStatus().setFinishTime(System.currentTimeMillis());
-                    // update the state of the old TaskRun to MERGED in FOLLOWER
-                    TaskRunStatusChange statusChange = new TaskRunStatusChange(oldTaskRun.getTaskId(), oldTaskRun.getStatus(),
-                            oldTaskRun.getStatus().getState(), Constants.TaskRunState.MERGED);
-                    GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange);
+            // TODO: support batch update to reduce the number of edit logs.
+            for (TaskRun oldTaskRun : mergedTaskRuns) {
+                final long finishTime = System.currentTimeMillis();
+                // update the state of the old TaskRun to MERGED in FOLLOWER
+                TaskRunStatusChange statusChange = new TaskRunStatusChange(oldTaskRun.getTaskId(), oldTaskRun.getStatus(),
+                        oldTaskRun.getStatus().getState(), Constants.TaskRunState.MERGED);
+                statusChange.setFinishTime(finishTime);
+                GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange, wal -> {
                     // update the state of the old TaskRun to MERGED in LEADER
+                    oldTaskRun.getStatus().setFinishTime(finishTime);
                     oldTaskRun.getStatus().setState(Constants.TaskRunState.MERGED);
                     taskRunScheduler.removePendingTaskRun(oldTaskRun, Constants.TaskRunState.MERGED);
                     taskRunHistory.addHistory(oldTaskRun.getStatus());
-                }
-            } else {
-                for (TaskRun oldTaskRun : mergedTaskRuns) {
-                    // update the state of the old TaskRun to MERGED in LEADER
-                    oldTaskRun.getStatus().setFinishTime(System.currentTimeMillis());
-                    oldTaskRun.getStatus().setState(Constants.TaskRunState.MERGED);
-                    taskRunScheduler.removePendingTaskRun(oldTaskRun, Constants.TaskRunState.MERGED);
-                    taskRunHistory.addHistory(oldTaskRun.getStatus());
-                }
+                });
             }
         } finally {
             taskRunUnlock();
@@ -274,13 +264,13 @@ public class TaskRunManager implements MemoryTrackable {
 
             Future<?> future = taskRun.getFuture();
             if (future.isDone()) {
-                taskRunScheduler.removeRunningTask(taskId);
                 LOG.info("Task run is done from state RUNNING to {}, {}", taskRun.getStatus().getState(), taskRun);
-
-                taskRunHistory.addHistory(taskRun.getStatus());
                 TaskRunStatusChange statusChange = new TaskRunStatusChange(taskRun.getTaskId(), taskRun.getStatus(),
                         Constants.TaskRunState.RUNNING, taskRun.getStatus().getState());
-                GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange);
+                GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange, wal -> {
+                    taskRunScheduler.removeRunningTask(taskId);
+                    taskRunHistory.addHistory(taskRun.getStatus());
+                });
             }
         }
     }
@@ -294,7 +284,10 @@ public class TaskRunManager implements MemoryTrackable {
                 // RUNNING state persistence is for FE FOLLOWER update state
                 TaskRunStatusChange statusChange = new TaskRunStatusChange(taskId, pendingTaskRun.getStatus(),
                         Constants.TaskRunState.PENDING, Constants.TaskRunState.RUNNING);
-                GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange);
+                GlobalStateMgr.getCurrentState().getEditLog().logUpdateTaskRun(statusChange, wal -> {
+                    pendingTaskRun.getStatus().setState(Constants.TaskRunState.RUNNING);
+                    pendingTaskRun.getStatus().setProcessStartTime(System.currentTimeMillis());
+                });
             } else {
                 LOG.warn("failed to scheduled task-run {}", pendingTaskRun);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TaskRunHistory.java
@@ -199,15 +199,11 @@ public class TaskRunHistory {
             Stopwatch watch = Stopwatch.createStarted();
             historyTable.addHistories(runs);
 
-            // 2. Remove from memory
-            for (var run : runs) {
-                removeTaskByQueryId(run.getQueryId());
-            }
-
-            // 3. Write EditLog
+            // 2. Write EditLog
             List<String> queryIdList = runs.stream().map(TaskRunStatus::getQueryId).collect(Collectors.toList());
             ArchiveTaskRunsLog log = new ArchiveTaskRunsLog(queryIdList);
-            GlobalStateMgr.getCurrentState().getEditLog().logArchiveTaskRuns(log);
+            GlobalStateMgr.getCurrentState().getEditLog().logArchiveTaskRuns(log,
+                    wal -> replay((ArchiveTaskRunsLog) wal));
             LOG.info("archive task-run history, {} records took {}ms",
                     runs.size(), watch.elapsed(TimeUnit.MILLISECONDS));
         } catch (Throwable e) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -523,7 +523,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             tasksParams.setDb(dbName);
             List<Long> dropTaskIdList = taskManager.filterTasks(tasksParams)
                     .stream().map(Task::getId).collect(Collectors.toList());
-            taskManager.dropTasks(dropTaskIdList, false);
+            taskManager.dropTasks(dropTaskIdList);
 
             DropDbInfo info = new DropDbInfo(db.getFullName(), isForceDrop);
             GlobalStateMgr.getCurrentState().getEditLog().logDropDb(info);
@@ -610,7 +610,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                 if (refreshType != MaterializedViewRefreshType.SYNC) {
                     Task task = TaskBuilder.buildMvTask(materializedView, db.getFullName());
                     TaskBuilder.updateTaskInfo(task, materializedView);
-                    taskManager.createTask(task, false);
+                    taskManager.createTask(task);
                 }
             }
 
@@ -3272,7 +3272,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             }
 
             TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
-            taskManager.createTask(task, false);
+            taskManager.createTask(task);
             if (refreshMoment.equals(MaterializedView.RefreshMoment.IMMEDIATE)) {
                 taskManager.executeTask(task.getName());
             }
@@ -3333,7 +3333,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             if (!taskManager.containTask(mvTaskName)) {
                 Task task = TaskBuilder.buildMvTask(materializedView, dbName);
                 TaskBuilder.updateTaskInfo(task, materializedView);
-                taskManager.createTask(task, false);
+                taskManager.createTask(task);
             }
             return taskManager.executeTask(mvTaskName, executeOption).getQueryId();
         }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowTaskTest.java
@@ -83,7 +83,7 @@ public class ShowTaskTest {
         SubmitTaskStmt submitTaskStmt = (SubmitTaskStmt) UtFrameUtils.parseStmtWithNewParser(submitSQL, connectContext);
         Task manualTask = TaskBuilder.buildTask(submitTaskStmt, connectContext);
         manualTask.setId(0);
-        taskManager.createTask(manualTask, true);
+        taskManager.replayCreateTask(manualTask);
 
         Task periodTask = new Task("test_periodical");
         periodTask.setId(1);
@@ -95,7 +95,7 @@ public class ShowTaskTest {
         TaskSchedule taskSchedule = new TaskSchedule(startTime, 5, TimeUnit.SECONDS);
         periodTask.setSchedule(taskSchedule);
         periodTask.setType(Constants.TaskType.PERIODICAL);
-        taskManager.createTask(periodTask, true);
+        taskManager.replayCreateTask(periodTask);
 
         UserIdentity currentUserIdentity = connectContext.getCurrentUserIdentity();
         TGetTasksParams tGetTasksParams = new TGetTasksParams();
@@ -110,7 +110,7 @@ public class ShowTaskTest {
                 Assertions.assertEquals(task.getSchedule(),"MANUAL");
             }
         }
-        taskManager.dropTasks(ImmutableList.of(periodTask.getId(), manualTask.getId()), false);
+        taskManager.dropTasks(ImmutableList.of(periodTask.getId(), manualTask.getId()));
     }
 
     @Test
@@ -123,7 +123,7 @@ public class ShowTaskTest {
         SubmitTaskStmt submitTaskStmt = (SubmitTaskStmt) UtFrameUtils.parseStmtWithNewParser(submitSQL, connectContext);
         Task manualTask = TaskBuilder.buildTask(submitTaskStmt, connectContext);
         manualTask.setId(0);
-        taskManager.createTask(manualTask, true);
+        taskManager.replayCreateTask(manualTask);
 
         Task unknownTask = new Task("test_unknown");
         unknownTask.setId(1);
@@ -135,7 +135,7 @@ public class ShowTaskTest {
         TaskSchedule taskSchedule = new TaskSchedule(startTime, 5, TimeUnit.SECONDS);
         unknownTask.setSchedule(taskSchedule);
         unknownTask.setType(null);
-        taskManager.createTask(unknownTask, true);
+        taskManager.replayCreateTask(unknownTask);
 
         UserIdentity currentUserIdentity = connectContext.getCurrentUserIdentity();
         TGetTasksParams tGetTasksParams = new TGetTasksParams();
@@ -150,6 +150,6 @@ public class ShowTaskTest {
                 Assertions.assertEquals(task.getSchedule(),"MANUAL");
             }
         }
-        taskManager.dropTasks(ImmutableList.of(unknownTask.getId(), manualTask.getId()), false);
+        taskManager.dropTasks(ImmutableList.of(unknownTask.getId(), manualTask.getId()));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -350,7 +350,7 @@ public class MaterializedViewTestBase extends PlanTestBase {
         if (task == null) {
             task = TaskBuilder.buildMvTask(mv, dbName);
             TaskBuilder.updateTaskInfo(task, mv);
-            taskManager.createTask(task, false);
+            taskManager.createTask(task);
         }
         taskManager.executeTaskSync(task);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerEditLogTest.java
@@ -1,0 +1,890 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler;
+
+import com.starrocks.persist.AlterTaskInfo;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.scheduler.persist.DropTasksLog;
+import com.starrocks.scheduler.persist.TaskRunStatus;
+import com.starrocks.scheduler.persist.TaskRunStatusChange;
+import com.starrocks.scheduler.persist.TaskSchedule;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class TaskManagerEditLogTest {
+    private TaskManager masterTaskManager;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        // Initialize test environment
+        UtFrameUtils.setUpForPersistTest();
+
+        // Create TaskManager instance
+        masterTaskManager = new TaskManager();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    @Test
+    public void testCreateTaskNormalCase() throws Exception {
+        // 1. Prepare test data
+        String taskName = "test_task";
+        Task task = new Task(taskName);
+        task.setType(Constants.TaskType.MANUAL);
+        task.setDefinition("SELECT 1");
+        task.setDbName("test_db");
+        task.setCatalogName("test_catalog");
+
+        // 2. Verify initial state
+        Assertions.assertNull(masterTaskManager.getTask(taskName));
+        Assertions.assertEquals(0, masterTaskManager.filterTasks(null).size());
+
+        // 3. Execute createTask operation (master side)
+        masterTaskManager.createTask(task);
+
+        // 4. Verify master state
+        Assertions.assertNotNull(masterTaskManager.getTask(taskName));
+        Assertions.assertEquals(1, masterTaskManager.filterTasks(null).size());
+        
+        // Verify task details
+        Task createdTask = masterTaskManager.getTask(taskName);
+        Assertions.assertNotNull(createdTask);
+        Assertions.assertEquals(taskName, createdTask.getName());
+        Assertions.assertEquals(Constants.TaskType.MANUAL, createdTask.getType());
+        Assertions.assertEquals("SELECT 1", createdTask.getDefinition());
+        Assertions.assertEquals("test_db", createdTask.getDbName());
+        Assertions.assertEquals("test_catalog", createdTask.getCatalogName());
+        Assertions.assertTrue(createdTask.getId() > 0); // ID should be assigned
+
+        // 5. Test follower replay functionality
+        TaskManager followerTaskManager = new TaskManager();
+        
+        // Verify follower initial state
+        Assertions.assertNull(followerTaskManager.getTask(taskName));
+        Assertions.assertEquals(0, followerTaskManager.filterTasks(null).size());
+
+        // Create a copy of the task for replay testing
+        Task replayTask = (Task) UtFrameUtils.PseudoJournalReplayer.replayNextJournal(OperationType.OP_CREATE_TASK);
+        
+        // Execute follower replay
+        followerTaskManager.replayCreateTask(replayTask);
+
+        // 6. Verify follower state is consistent with master
+        Assertions.assertNotNull(followerTaskManager.getTask(taskName));
+        Assertions.assertEquals(1, followerTaskManager.filterTasks(null).size());
+        
+        Task followerTask = followerTaskManager.getTask(taskName);
+        Assertions.assertNotNull(followerTask);
+        Assertions.assertEquals(taskName, followerTask.getName());
+        Assertions.assertEquals(Constants.TaskType.MANUAL, followerTask.getType());
+        Assertions.assertEquals("SELECT 1", followerTask.getDefinition());
+        Assertions.assertEquals("test_db", followerTask.getDbName());
+        Assertions.assertEquals("test_catalog", followerTask.getCatalogName());
+        Assertions.assertEquals(createdTask.getId(), followerTask.getId());
+    }
+
+    @Test
+    public void testCreateTaskEditLogException() throws Exception {
+        // 1. Prepare test data
+        String taskName = "exception_task";
+        Task task = new Task(taskName);
+        task.setType(Constants.TaskType.MANUAL);
+        task.setDefinition("SELECT 1");
+        task.setDbName("test_db");
+        task.setCatalogName("test_catalog");
+
+        // 2. Create a separate TaskManager for exception testing
+        TaskManager exceptionTaskManager = new TaskManager();
+        EditLog spyEditLog = spy(new EditLog(null));
+        
+        // 3. Mock EditLog.logCreateTask to throw exception
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logCreateTask(any(Task.class), any());
+        
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // Verify initial state
+        Assertions.assertNull(exceptionTaskManager.getTask(taskName));
+        Assertions.assertEquals(0, exceptionTaskManager.filterTasks(null).size());
+        
+        // Save initial state snapshot
+        int initialTaskCount = exceptionTaskManager.filterTasks(null).size();
+
+        // 4. Execute createTask operation and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            exceptionTaskManager.createTask(task);
+        });
+        Assertions.assertEquals("EditLog write failed", exception.getMessage());
+
+        // 5. Verify leader memory state remains unchanged after exception
+        Assertions.assertNull(exceptionTaskManager.getTask(taskName));
+        Assertions.assertEquals(initialTaskCount, exceptionTaskManager.filterTasks(null).size());
+        
+        // Verify no task was accidentally added
+        Assertions.assertNull(exceptionTaskManager.getTask(taskName));
+    }
+
+    @Test
+    public void testCreateTaskDuplicateName() throws Exception {
+        // 1. First create a task
+        String taskName = "duplicate_test_task";
+        Task task1 = new Task(taskName);
+        task1.setType(Constants.TaskType.MANUAL);
+        task1.setDefinition("SELECT 1");
+        task1.setDbName("test_db");
+        task1.setCatalogName("test_catalog");
+        
+        masterTaskManager.createTask(task1);
+        Assertions.assertNotNull(masterTaskManager.getTask(taskName));
+        Assertions.assertEquals(1, masterTaskManager.filterTasks(null).size());
+
+        // 2. Try to create another task with the same name
+        Task task2 = new Task(taskName);
+        task2.setType(Constants.TaskType.MANUAL);
+        task2.setDefinition("SELECT 2");
+        task2.setDbName("test_db2");
+        task2.setCatalogName("test_catalog2");
+
+        // 3. Expect DdlException to be thrown
+        try {
+            masterTaskManager.createTask(task2);
+            Assertions.fail("Expected DdlException to be thrown");
+        } catch (Exception e) {
+            Assertions.assertTrue(e.toString().contains("already exists"));
+        }
+
+        // 4. Verify state remains unchanged (only the original task)
+        Assertions.assertEquals(1, masterTaskManager.filterTasks(null).size());
+        Task existingTask = masterTaskManager.getTask(taskName);
+        Assertions.assertNotNull(existingTask);
+        Assertions.assertEquals("SELECT 1", existingTask.getDefinition()); // Original definition preserved
+        Assertions.assertEquals("test_db", existingTask.getDbName()); // Original db name preserved
+    }
+
+    @Test
+    public void testCreateTaskPeriodicalWithoutSchedule() throws Exception {
+        // 1. Prepare test data for periodical task without schedule
+        String taskName = "periodical_task_no_schedule";
+        Task task = new Task(taskName);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setDefinition("SELECT 1");
+        task.setDbName("test_db");
+        task.setCatalogName("test_catalog");
+        // Note: No schedule is set
+
+        // 2. Verify initial state
+        Assertions.assertNull(masterTaskManager.getTask(taskName));
+        Assertions.assertEquals(0, masterTaskManager.filterTasks(null).size());
+
+        // 3. Execute createTask operation and expect DdlException
+        try {
+            masterTaskManager.createTask(task);
+            Assertions.fail("Expected DdlException to be thrown");
+        } catch (Exception e) {
+            Assertions.assertTrue(e.toString().contains("has no scheduling information"));
+        }
+
+        // 4. Verify state remains unchanged
+        Assertions.assertNull(masterTaskManager.getTask(taskName));
+        Assertions.assertEquals(0, masterTaskManager.filterTasks(null).size());
+    }
+
+    @Test
+    public void testCreateTaskPeriodicalWithSchedule() throws Exception {
+        // 1. Prepare test data for periodical task with schedule
+        String taskName = "periodical_task_with_schedule";
+        Task task = new Task(taskName);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setDefinition("SELECT 1");
+        task.setDbName("test_db");
+        task.setCatalogName("test_catalog");
+        
+        // Set up schedule
+        TaskSchedule schedule = new TaskSchedule();
+        schedule.setStartTime(System.currentTimeMillis() / 1000);
+        schedule.setPeriod(3600); // 1 hour
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+
+        // 2. Verify initial state
+        Assertions.assertNull(masterTaskManager.getTask(taskName));
+        Assertions.assertEquals(0, masterTaskManager.filterTasks(null).size());
+
+        // 3. Execute createTask operation (master side)
+        masterTaskManager.createTask(task);
+
+        // 4. Verify master state
+        Assertions.assertNotNull(masterTaskManager.getTask(taskName));
+        Assertions.assertEquals(1, masterTaskManager.filterTasks(null).size());
+		Assertions.assertNotNull(masterTaskManager.getPeriodFutureMap().get(task.getId()));
+        
+        // Verify task details
+        Task createdTask = masterTaskManager.getTask(taskName);
+        Assertions.assertNotNull(createdTask);
+        Assertions.assertEquals(taskName, createdTask.getName());
+        Assertions.assertEquals(Constants.TaskType.PERIODICAL, createdTask.getType());
+        Assertions.assertEquals(Constants.TaskState.ACTIVE, createdTask.getState()); // Should be set to ACTIVE
+        Assertions.assertNotNull(createdTask.getSchedule());
+        Assertions.assertEquals(3600, createdTask.getSchedule().getPeriod());
+        Assertions.assertEquals(TimeUnit.SECONDS, createdTask.getSchedule().getTimeUnit());
+        Assertions.assertTrue(createdTask.getId() > 0); // ID should be assigned
+
+        // 5. Test follower replay functionality
+        TaskManager followerTaskManager = new TaskManager();
+        
+        // Verify follower initial state
+        Assertions.assertNull(followerTaskManager.getTask(taskName));
+        Assertions.assertEquals(0, followerTaskManager.filterTasks(null).size());
+
+        // Create a copy of the task for replay testing
+        Task replayTask = (Task) UtFrameUtils.PseudoJournalReplayer.replayNextJournal(OperationType.OP_CREATE_TASK);
+        
+        // Execute follower replay
+        followerTaskManager.replayCreateTask(replayTask);
+
+        // 6. Verify follower state is consistent with master
+        Assertions.assertNotNull(followerTaskManager.getTask(taskName));
+        Assertions.assertEquals(1, followerTaskManager.filterTasks(null).size());
+        
+        Task followerTask = followerTaskManager.getTask(taskName);
+        Assertions.assertNotNull(followerTask);
+        Assertions.assertEquals(taskName, followerTask.getName());
+        Assertions.assertEquals(Constants.TaskType.PERIODICAL, followerTask.getType());
+        Assertions.assertEquals(Constants.TaskState.ACTIVE, followerTask.getState());
+        Assertions.assertNotNull(followerTask.getSchedule());
+        Assertions.assertEquals(3600, followerTask.getSchedule().getPeriod());
+        Assertions.assertEquals(TimeUnit.SECONDS, followerTask.getSchedule().getTimeUnit());
+        Assertions.assertEquals(createdTask.getId(), followerTask.getId());
+    }
+
+    @Test
+    public void testCreateTaskWithNonZeroId() throws Exception {
+        // 1. Prepare test data with non-zero ID (should be rejected)
+        String taskName = "task_with_id";
+        Task task = new Task(taskName);
+        task.setId(123L); // Set non-zero ID
+        task.setType(Constants.TaskType.MANUAL);
+        task.setDefinition("SELECT 1");
+        task.setDbName("test_db");
+        task.setCatalogName("test_catalog");
+
+        // 2. Verify initial state
+        Assertions.assertNull(masterTaskManager.getTask(taskName));
+        Assertions.assertEquals(0, masterTaskManager.filterTasks(null).size());
+
+        // 3. Execute createTask operation and expect IllegalArgumentException
+        IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            masterTaskManager.createTask(task);
+        });
+        Assertions.assertTrue(exception.getMessage().contains("TaskId should be assigned by the framework"));
+
+        // 4. Verify state remains unchanged
+        Assertions.assertNull(masterTaskManager.getTask(taskName));
+        Assertions.assertEquals(0, masterTaskManager.filterTasks(null).size());
+    }
+
+    @Test
+    public void testDropTasksNormalCase() throws Exception {
+        // 1. Prepare test data - create multiple tasks first
+        String taskName1 = "test_task_1";
+        String taskName2 = "test_task_2";
+        String taskName3 = "test_task_3";
+        
+        Task task1 = new Task(taskName1);
+        task1.setType(Constants.TaskType.MANUAL);
+        task1.setDefinition("SELECT 1");
+        task1.setDbName("test_db");
+        task1.setCatalogName("test_catalog");
+        
+        Task task2 = new Task(taskName2);
+        task2.setType(Constants.TaskType.MANUAL);
+        task2.setDefinition("SELECT 2");
+        task2.setDbName("test_db");
+        task2.setCatalogName("test_catalog");
+        
+        Task task3 = new Task(taskName3);
+        task3.setType(Constants.TaskType.MANUAL);
+        task3.setDefinition("SELECT 3");
+        task3.setDbName("test_db");
+        task3.setCatalogName("test_catalog");
+
+        // 2. Create tasks
+        masterTaskManager.createTask(task1);
+        masterTaskManager.createTask(task2);
+        masterTaskManager.createTask(task3);
+
+        // 3. Verify initial state
+        Assertions.assertNotNull(masterTaskManager.getTask(taskName1));
+        Assertions.assertNotNull(masterTaskManager.getTask(taskName2));
+        Assertions.assertNotNull(masterTaskManager.getTask(taskName3));
+        Assertions.assertEquals(3, masterTaskManager.filterTasks(null).size());
+
+        // 4. Prepare task IDs to drop (drop task1 and task3, keep task2)
+        List<Long> taskIdsToDrop = new ArrayList<>();
+        taskIdsToDrop.add(task1.getId());
+        taskIdsToDrop.add(task3.getId());
+
+        // 5. Execute dropTasks operation (master side)
+        masterTaskManager.dropTasks(taskIdsToDrop);
+
+        // 6. Verify master state after dropping
+        Assertions.assertNull(masterTaskManager.getTask(taskName1));
+        Assertions.assertNotNull(masterTaskManager.getTask(taskName2)); // Should still exist
+        Assertions.assertNull(masterTaskManager.getTask(taskName3));
+        Assertions.assertEquals(1, masterTaskManager.filterTasks(null).size());
+
+        // 7. Test follower replay functionality
+        TaskManager followerTaskManager = new TaskManager();
+        
+        // First create the same tasks in follower
+        Task followerTask1 = new Task(taskName1);
+        followerTask1.setId(task1.getId());
+        followerTask1.setType(Constants.TaskType.MANUAL);
+        followerTask1.setDefinition("SELECT 1");
+        followerTask1.setDbName("test_db");
+        followerTask1.setCatalogName("test_catalog");
+        followerTask1.setCreateTime(task1.getCreateTime());
+        
+        Task followerTask2 = new Task(taskName2);
+        followerTask2.setId(task2.getId());
+        followerTask2.setType(Constants.TaskType.MANUAL);
+        followerTask2.setDefinition("SELECT 2");
+        followerTask2.setDbName("test_db");
+        followerTask2.setCatalogName("test_catalog");
+        followerTask2.setCreateTime(task2.getCreateTime());
+        
+        Task followerTask3 = new Task(taskName3);
+        followerTask3.setId(task3.getId());
+        followerTask3.setType(Constants.TaskType.MANUAL);
+        followerTask3.setDefinition("SELECT 3");
+        followerTask3.setDbName("test_db");
+        followerTask3.setCatalogName("test_catalog");
+        followerTask3.setCreateTime(task3.getCreateTime());
+        
+        followerTaskManager.replayCreateTask(followerTask1);
+        followerTaskManager.replayCreateTask(followerTask2);
+        followerTaskManager.replayCreateTask(followerTask3);
+        
+        Assertions.assertEquals(3, followerTaskManager.filterTasks(null).size());
+
+        // Replay the drop operation
+        DropTasksLog dropTasksLog = (DropTasksLog) UtFrameUtils.PseudoJournalReplayer.replayNextJournal(OperationType.OP_DROP_TASKS);
+        followerTaskManager.replayDropTasks(dropTasksLog.getTaskIdList());
+
+        // 8. Verify follower state is consistent with master
+        Assertions.assertNull(followerTaskManager.getTask(taskName1));
+        Assertions.assertNotNull(followerTaskManager.getTask(taskName2)); // Should still exist
+        Assertions.assertNull(followerTaskManager.getTask(taskName3));
+        Assertions.assertEquals(1, followerTaskManager.filterTasks(null).size());
+    }
+
+    @Test
+    public void testDropTasksEditLogException() throws Exception {
+        // 1. Prepare test data - create tasks first
+        String taskName1 = "drop_exception_task_1";
+        String taskName2 = "drop_exception_task_2";
+        
+        Task task1 = new Task(taskName1);
+        task1.setType(Constants.TaskType.MANUAL);
+        task1.setDefinition("SELECT 1");
+        task1.setDbName("test_db");
+        task1.setCatalogName("test_catalog");
+        
+        Task task2 = new Task(taskName2);
+        task2.setType(Constants.TaskType.MANUAL);
+        task2.setDefinition("SELECT 2");
+        task2.setDbName("test_db");
+        task2.setCatalogName("test_catalog");
+
+        // Create a separate TaskManager for exception testing
+        TaskManager exceptionTaskManager = new TaskManager();
+        
+        // Create tasks first
+        exceptionTaskManager.createTask(task1);
+        exceptionTaskManager.createTask(task2);
+        Assertions.assertEquals(2, exceptionTaskManager.filterTasks(null).size());
+
+        // 2. Prepare task IDs to drop
+        List<Long> taskIdsToDrop = new ArrayList<>();
+        taskIdsToDrop.add(task1.getId());
+
+        // 3. Mock EditLog.logDropTasks to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logDropTasks(any(DropTasksLog.class), any());
+        
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // Save initial state snapshot
+        int initialTaskCount = exceptionTaskManager.filterTasks(null).size();
+
+        // 4. Execute dropTasks operation and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            exceptionTaskManager.dropTasks(taskIdsToDrop);
+        });
+        Assertions.assertEquals("EditLog write failed", exception.getMessage());
+
+        // 5. Verify leader memory state remains unchanged after exception
+        Assertions.assertNotNull(exceptionTaskManager.getTask(taskName1));
+        Assertions.assertNotNull(exceptionTaskManager.getTask(taskName2));
+        Assertions.assertEquals(initialTaskCount, exceptionTaskManager.filterTasks(null).size());
+        
+        // Verify both tasks still exist
+        Task existingTask1 = exceptionTaskManager.getTask(taskName1);
+        Task existingTask2 = exceptionTaskManager.getTask(taskName2);
+        Assertions.assertNotNull(existingTask1);
+        Assertions.assertNotNull(existingTask2);
+    }
+
+    @Test
+    public void testDropTasksWithPeriodicalTask() throws Exception {
+        // 1. Prepare test data - create periodical task
+        String taskName = "periodical_drop_task";
+        Task task = new Task(taskName);
+        task.setType(Constants.TaskType.PERIODICAL);
+        task.setDefinition("SELECT 1");
+        task.setDbName("test_db");
+        task.setCatalogName("test_catalog");
+        
+        // Set up schedule
+        TaskSchedule schedule = new TaskSchedule();
+        schedule.setStartTime(System.currentTimeMillis() / 1000);
+        schedule.setPeriod(3600); // 1 hour
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        task.setSchedule(schedule);
+
+        // 2. Create periodical task
+        masterTaskManager.createTask(task);
+
+        // 3. Verify initial state
+        Assertions.assertNotNull(masterTaskManager.getTask(taskName));
+        Assertions.assertEquals(1, masterTaskManager.filterTasks(null).size());
+        Assertions.assertNotNull(masterTaskManager.getPeriodFutureMap().get(task.getId()));
+
+        // 4. Prepare task ID to drop
+        List<Long> taskIdsToDrop = new ArrayList<>();
+        taskIdsToDrop.add(task.getId());
+
+        // 5. Execute dropTasks operation
+        masterTaskManager.dropTasks(taskIdsToDrop);
+
+        // 6. Verify task is dropped and scheduler is stopped
+        Assertions.assertNull(masterTaskManager.getTask(taskName));
+        Assertions.assertEquals(0, masterTaskManager.filterTasks(null).size());
+        Assertions.assertNull(masterTaskManager.getPeriodFutureMap().get(task.getId()));
+    }
+
+    @Test
+    public void testDropTasksNonExistentTaskId() throws Exception {
+        // 1. Prepare test data - create one task
+        String taskName = "existing_task";
+        Task task = new Task(taskName);
+        task.setType(Constants.TaskType.MANUAL);
+        task.setDefinition("SELECT 1");
+        task.setDbName("test_db");
+        task.setCatalogName("test_catalog");
+        
+        masterTaskManager.createTask(task);
+        Assertions.assertEquals(1, masterTaskManager.filterTasks(null).size());
+
+        // 2. Prepare task IDs to drop (including non-existent ID)
+        List<Long> taskIdsToDrop = new ArrayList<>();
+        taskIdsToDrop.add(task.getId());
+        taskIdsToDrop.add(99999L); // Non-existent task ID
+
+        // 3. Execute dropTasks operation
+        masterTaskManager.dropTasks(taskIdsToDrop);
+
+        // 4. Verify existing task is dropped, non-existent ID is ignored
+        Assertions.assertNull(masterTaskManager.getTask(taskName));
+        Assertions.assertEquals(0, masterTaskManager.filterTasks(null).size());
+    }
+
+    @Test
+    public void testDropTasksEmptyList() throws Exception {
+        // 1. Prepare test data - create one task
+        String taskName = "existing_task";
+        Task task = new Task(taskName);
+        task.setType(Constants.TaskType.MANUAL);
+        task.setDefinition("SELECT 1");
+        task.setDbName("test_db");
+        task.setCatalogName("test_catalog");
+        
+        masterTaskManager.createTask(task);
+        Assertions.assertEquals(1, masterTaskManager.filterTasks(null).size());
+
+        // 2. Prepare empty task ID list
+        List<Long> taskIdsToDrop = new ArrayList<>();
+
+        // 3. Execute dropTasks operation with empty list
+        masterTaskManager.dropTasks(taskIdsToDrop);
+
+        // 4. Verify no tasks are dropped
+        Assertions.assertNotNull(masterTaskManager.getTask(taskName));
+        Assertions.assertEquals(1, masterTaskManager.filterTasks(null).size());
+    }
+
+    @Test
+    public void testClearUnfinishedTaskRunNormalCase() throws Exception {
+        // 1. Prepare test data - create a task first
+        String taskName = "clear_unfinished_task";
+        Task task = new Task(taskName);
+        task.setType(Constants.TaskType.MANUAL);
+        task.setDefinition("SELECT 1");
+        task.setDbName("test_db");
+        task.setCatalogName("test_catalog");
+        
+        masterTaskManager.createTask(task);
+        long taskId = task.getId();
+        Assertions.assertNotNull(masterTaskManager.getTask(taskName));
+
+        // 2. Create pending TaskRun
+        TaskRun pendingTaskRun = TaskRunBuilder.newBuilder(task).build();
+        pendingTaskRun.setTaskId(taskId);
+        pendingTaskRun.initStatus("pending_query_1", System.currentTimeMillis());
+        pendingTaskRun.getStatus().setState(Constants.TaskRunState.PENDING);
+        masterTaskManager.getTaskRunScheduler().addPendingTaskRun(pendingTaskRun);
+        Assertions.assertEquals(1, masterTaskManager.getTaskRunScheduler().getPendingQueueCount());
+
+        // 3. Create running TaskRun (simulate by adding to running map)
+        TaskRun runningTaskRun = TaskRunBuilder.newBuilder(task).build();
+        runningTaskRun.setTaskId(taskId);
+        runningTaskRun.initStatus("running_query_1", System.currentTimeMillis());
+        runningTaskRun.getStatus().setState(Constants.TaskRunState.RUNNING);
+        masterTaskManager.getTaskRunScheduler().addRunningTaskRun(runningTaskRun);
+        Assertions.assertEquals(1, masterTaskManager.getTaskRunScheduler().getRunningTaskCount());
+
+        // 4. Execute clearUnfinishedTaskRun operation
+        masterTaskManager.clearUnfinishedTaskRun();
+
+        // 5. Verify pending and running task runs are cleared
+        Assertions.assertEquals(0, masterTaskManager.getTaskRunScheduler().getPendingQueueCount());
+        Assertions.assertEquals(0, masterTaskManager.getTaskRunScheduler().getRunningTaskCount());
+
+        // 6. Test follower replay functionality
+        TaskManager followerTaskManager = new TaskManager();
+        
+        // First create the task in follower
+        Task followerTask = new Task(taskName);
+        followerTask.setId(taskId);
+        followerTask.setType(Constants.TaskType.MANUAL);
+        followerTask.setDefinition("SELECT 1");
+        followerTask.setDbName("test_db");
+        followerTask.setCatalogName("test_catalog");
+        followerTask.setCreateTime(task.getCreateTime());
+        followerTaskManager.replayCreateTask(followerTask);
+
+        // Create pending TaskRun in follower
+        TaskRun followerPendingTaskRun = TaskRunBuilder.newBuilder(followerTask).build();
+        followerPendingTaskRun.setTaskId(taskId);
+        followerPendingTaskRun.initStatus("pending_query_1", System.currentTimeMillis());
+        followerPendingTaskRun.getStatus().setState(Constants.TaskRunState.PENDING);
+        followerTaskManager.getTaskRunScheduler().addPendingTaskRun(followerPendingTaskRun);
+        
+        // Create running TaskRun in follower
+        TaskRun followerRunningTaskRun = TaskRunBuilder.newBuilder(followerTask).build();
+        followerRunningTaskRun.setTaskId(taskId);
+        followerRunningTaskRun.initStatus("running_query_1", System.currentTimeMillis());
+        followerRunningTaskRun.getStatus().setState(Constants.TaskRunState.RUNNING);
+        followerTaskManager.getTaskRunScheduler().addRunningTaskRun(followerRunningTaskRun);
+        
+        Assertions.assertEquals(1, followerTaskManager.getTaskRunScheduler().getPendingQueueCount());
+        Assertions.assertEquals(1, followerTaskManager.getTaskRunScheduler().getRunningTaskCount());
+
+        // Replay the first status change (for pending TaskRun)
+        TaskRunStatusChange statusChange1 = (TaskRunStatusChange) UtFrameUtils
+                .PseudoJournalReplayer.replayNextJournal(OperationType.OP_UPDATE_TASK_RUN);
+        followerTaskManager.replayUpdateTaskRun(statusChange1);
+
+        // Replay the second status change (for running TaskRun)
+        TaskRunStatusChange statusChange2 = (TaskRunStatusChange) UtFrameUtils
+                .PseudoJournalReplayer.replayNextJournal(OperationType.OP_UPDATE_TASK_RUN);
+        followerTaskManager.replayUpdateTaskRun(statusChange2);
+
+        // 7. Verify follower state is consistent with master
+        Assertions.assertEquals(0, followerTaskManager.getTaskRunScheduler().getPendingQueueCount());
+        Assertions.assertEquals(0, followerTaskManager.getTaskRunScheduler().getRunningTaskCount());
+    }
+
+    @Test
+    public void testClearUnfinishedTaskRunEditLogException() throws Exception {
+        // 1. Prepare test data - create a task first
+        String taskName = "clear_unfinished_exception_task";
+        Task task = new Task(taskName);
+        task.setType(Constants.TaskType.MANUAL);
+        task.setDefinition("SELECT 1");
+        task.setDbName("test_db");
+        task.setCatalogName("test_catalog");
+
+        // Create a separate TaskManager for exception testing
+        TaskManager exceptionTaskManager = new TaskManager();
+        
+        exceptionTaskManager.createTask(task);
+        long taskId = task.getId();
+        Assertions.assertNotNull(exceptionTaskManager.getTask(taskName));
+
+        // 2. Create pending TaskRun
+        TaskRun pendingTaskRun = TaskRunBuilder.newBuilder(task).build();
+        pendingTaskRun.setTaskId(taskId);
+        pendingTaskRun.initStatus("pending_query_1", System.currentTimeMillis());
+        pendingTaskRun.getStatus().setState(Constants.TaskRunState.PENDING);
+        exceptionTaskManager.getTaskRunScheduler().addPendingTaskRun(pendingTaskRun);
+        Assertions.assertEquals(1, exceptionTaskManager.getTaskRunScheduler().getPendingQueueCount());
+
+        // 3. Mock EditLog.logUpdateTaskRun to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logUpdateTaskRun(any(TaskRunStatusChange.class), any());
+        
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // Save initial state snapshot
+        long initialPendingCount = exceptionTaskManager.getTaskRunScheduler().getPendingQueueCount();
+
+        // 4. Execute clearUnfinishedTaskRun operation and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            exceptionTaskManager.clearUnfinishedTaskRun();
+        });
+        Assertions.assertEquals("EditLog write failed", exception.getMessage());
+
+        // 5. Verify leader memory state remains unchanged after exception
+        Assertions.assertEquals(initialPendingCount, exceptionTaskManager.getTaskRunScheduler().getPendingQueueCount());
+        
+        // Verify pending task run still exists
+        Assertions.assertEquals(1, exceptionTaskManager.getTaskRunScheduler().getPendingQueueCount());
+    }
+
+    @Test
+    public void testAlterTaskNormalCase() throws Exception {
+        // 1. Prepare test data - create a manual task first
+        String taskName = "alter_task_test";
+        Task currentTask = new Task(taskName);
+        currentTask.setType(Constants.TaskType.MANUAL);
+        currentTask.setDefinition("SELECT 1");
+        currentTask.setDbName("test_db");
+        currentTask.setCatalogName("test_catalog");
+        
+        masterTaskManager.createTask(currentTask);
+        Task createdTask = masterTaskManager.getTask(taskName);
+        Assertions.assertNotNull(createdTask);
+        Assertions.assertEquals(Constants.TaskType.MANUAL, createdTask.getType());
+
+        // 2. Prepare changed task - change from MANUAL to PERIODICAL
+        Task changedTask = new Task(taskName);
+        changedTask.setType(Constants.TaskType.PERIODICAL);
+        changedTask.setDefinition("SELECT 1");
+        changedTask.setDbName("test_db");
+        changedTask.setCatalogName("test_catalog");
+        
+        // Set up schedule for periodical task
+        TaskSchedule schedule = new TaskSchedule();
+        schedule.setStartTime(System.currentTimeMillis() / 1000);
+        schedule.setPeriod(3600); // 1 hour
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        changedTask.setSchedule(schedule);
+
+        // 3. Execute alterTask operation (master side)
+        masterTaskManager.alterTask(createdTask, changedTask);
+
+        // 4. Verify master state after alteration
+        Task alteredTask = masterTaskManager.getTask(taskName);
+        Assertions.assertNotNull(alteredTask);
+        Assertions.assertEquals(Constants.TaskType.PERIODICAL, alteredTask.getType());
+        Assertions.assertEquals(Constants.TaskState.ACTIVE, alteredTask.getState());
+        Assertions.assertNotNull(alteredTask.getSchedule());
+        Assertions.assertEquals(3600, alteredTask.getSchedule().getPeriod());
+        Assertions.assertNotNull(masterTaskManager.getPeriodFutureMap().get(alteredTask.getId()));
+
+        // 5. Test follower replay functionality
+        TaskManager followerTaskManager = new TaskManager();
+        
+        // First create the task in follower
+        Task followerTask = new Task(taskName);
+        followerTask.setId(createdTask.getId());
+        followerTask.setType(Constants.TaskType.MANUAL);
+        followerTask.setDefinition("SELECT 1");
+        followerTask.setDbName("test_db");
+        followerTask.setCatalogName("test_catalog");
+        followerTask.setCreateTime(createdTask.getCreateTime());
+        followerTaskManager.replayCreateTask(followerTask);
+        
+        Assertions.assertEquals(Constants.TaskType.MANUAL, followerTaskManager.getTask(taskName).getType());
+
+        // Replay the alter operation
+        AlterTaskInfo alterTaskInfo = (AlterTaskInfo) UtFrameUtils
+                .PseudoJournalReplayer.replayNextJournal(OperationType.OP_ALTER_TASK);
+        
+        followerTaskManager.replayAlterTask(alterTaskInfo);
+
+        // 6. Verify follower state is consistent with master
+        Task followerAlteredTask = followerTaskManager.getTask(taskName);
+        Assertions.assertNotNull(followerAlteredTask);
+        Assertions.assertEquals(Constants.TaskType.PERIODICAL, followerAlteredTask.getType());
+        Assertions.assertEquals(Constants.TaskState.ACTIVE, followerAlteredTask.getState());
+        Assertions.assertNotNull(followerAlteredTask.getSchedule());
+        Assertions.assertEquals(3600, followerAlteredTask.getSchedule().getPeriod());
+    }
+
+    @Test
+    public void testAlterTaskEditLogException() throws Exception {
+        // 1. Prepare test data - create a manual task first
+        String taskName = "alter_exception_task";
+        Task currentTask = new Task(taskName);
+        currentTask.setType(Constants.TaskType.MANUAL);
+        currentTask.setDefinition("SELECT 1");
+        currentTask.setDbName("test_db");
+        currentTask.setCatalogName("test_catalog");
+
+        // Create a separate TaskManager for exception testing
+        TaskManager exceptionTaskManager = new TaskManager();
+        
+        exceptionTaskManager.createTask(currentTask);
+        Task createdTask = exceptionTaskManager.getTask(taskName);
+        Assertions.assertNotNull(createdTask);
+        Assertions.assertEquals(Constants.TaskType.MANUAL, createdTask.getType());
+
+        // 2. Prepare changed task - change from MANUAL to PERIODICAL
+        Task changedTask = new Task(taskName);
+        changedTask.setType(Constants.TaskType.PERIODICAL);
+        changedTask.setDefinition("SELECT 1");
+        changedTask.setDbName("test_db");
+        changedTask.setCatalogName("test_catalog");
+        
+        TaskSchedule schedule = new TaskSchedule();
+        schedule.setStartTime(System.currentTimeMillis() / 1000);
+        schedule.setPeriod(3600);
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        changedTask.setSchedule(schedule);
+
+        // 3. Mock EditLog.logAlterTask to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logAlterTask(any(AlterTaskInfo.class), any());
+        
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // Save initial state snapshot
+        Constants.TaskType initialType = createdTask.getType();
+
+        // 4. Execute alterTask operation and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            exceptionTaskManager.alterTask(createdTask, changedTask);
+        });
+        Assertions.assertEquals("EditLog write failed", exception.getMessage());
+
+        // 5. Verify leader memory state remains unchanged after exception
+        Task unchangedTask = exceptionTaskManager.getTask(taskName);
+        Assertions.assertNotNull(unchangedTask);
+        Assertions.assertEquals(initialType, unchangedTask.getType());
+        Assertions.assertNull(unchangedTask.getSchedule());
+    }
+
+    @Test
+    public void testAlterTaskFromPeriodicalToManual() throws Exception {
+        // 1. Prepare test data - create a periodical task first
+        String taskName = "alter_periodical_to_manual_task";
+        Task currentTask = new Task(taskName);
+        currentTask.setType(Constants.TaskType.PERIODICAL);
+        currentTask.setDefinition("SELECT 1");
+        currentTask.setDbName("test_db");
+        currentTask.setCatalogName("test_catalog");
+        
+        TaskSchedule schedule = new TaskSchedule();
+        schedule.setStartTime(System.currentTimeMillis() / 1000);
+        schedule.setPeriod(3600);
+        schedule.setTimeUnit(TimeUnit.SECONDS);
+        currentTask.setSchedule(schedule);
+        
+        masterTaskManager.createTask(currentTask);
+        Task createdTask = masterTaskManager.getTask(taskName);
+        Assertions.assertNotNull(createdTask);
+        Assertions.assertEquals(Constants.TaskType.PERIODICAL, createdTask.getType());
+        Assertions.assertNotNull(masterTaskManager.getPeriodFutureMap().get(createdTask.getId()));
+        
+        // Save schedule before alteration (since alterTask will set it to null)
+        TaskSchedule originalSchedule = createdTask.getSchedule();
+        Assertions.assertNotNull(originalSchedule);
+
+        // 2. Prepare changed task - change from PERIODICAL to MANUAL
+        Task changedTask = new Task(taskName);
+        changedTask.setType(Constants.TaskType.MANUAL);
+        changedTask.setDefinition("SELECT 1");
+        changedTask.setDbName("test_db");
+        changedTask.setCatalogName("test_catalog");
+
+        // 3. Execute alterTask operation
+        masterTaskManager.alterTask(createdTask, changedTask);
+
+        // 4. Verify master state after alteration
+        Task alteredTask = masterTaskManager.getTask(taskName);
+        Assertions.assertNotNull(alteredTask);
+        Assertions.assertEquals(Constants.TaskType.MANUAL, alteredTask.getType());
+        Assertions.assertEquals(Constants.TaskState.UNKNOWN, alteredTask.getState());
+        Assertions.assertNull(alteredTask.getSchedule());
+        Assertions.assertNull(masterTaskManager.getPeriodFutureMap().get(alteredTask.getId()));
+
+        // 5. Test follower replay functionality
+        TaskManager followerTaskManager = new TaskManager();
+        
+        // First create the periodical task in follower (use original schedule before alteration)
+        Task followerTask = new Task(taskName);
+        followerTask.setId(createdTask.getId());
+        followerTask.setType(Constants.TaskType.PERIODICAL);
+        followerTask.setState(Constants.TaskState.ACTIVE);
+        followerTask.setDefinition("SELECT 1");
+        followerTask.setDbName("test_db");
+        followerTask.setCatalogName("test_catalog");
+        followerTask.setCreateTime(createdTask.getCreateTime());
+        followerTask.setSchedule(originalSchedule);
+        followerTaskManager.replayCreateTask(followerTask);
+        
+        Task followerTaskAfterCreate = followerTaskManager.getTask(taskName);
+        Assertions.assertNotNull(followerTaskAfterCreate, "Follower task should be created");
+        Assertions.assertEquals(Constants.TaskType.PERIODICAL, followerTaskAfterCreate.getType());
+
+        // Replay the alter operation
+        AlterTaskInfo alterTaskInfo = (AlterTaskInfo) UtFrameUtils
+                .PseudoJournalReplayer.replayNextJournal(OperationType.OP_ALTER_TASK);
+        
+        followerTaskManager.replayAlterTask(alterTaskInfo);
+
+        // 6. Verify follower state is consistent with master
+        Task followerAlteredTask = followerTaskManager.getTask(taskName);
+        Assertions.assertNotNull(followerAlteredTask);
+        Assertions.assertEquals(Constants.TaskType.MANUAL, followerAlteredTask.getType());
+        Assertions.assertEquals(Constants.TaskState.UNKNOWN, followerAlteredTask.getState());
+        Assertions.assertNull(followerAlteredTask.getSchedule());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerEditLogTest.java
@@ -18,7 +18,6 @@ import com.starrocks.persist.AlterTaskInfo;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.OperationType;
 import com.starrocks.scheduler.persist.DropTasksLog;
-import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.scheduler.persist.TaskRunStatusChange;
 import com.starrocks.scheduler.persist.TaskSchedule;
 import com.starrocks.server.GlobalStateMgr;
@@ -245,7 +244,7 @@ public class TaskManagerEditLogTest {
         // 4. Verify master state
         Assertions.assertNotNull(masterTaskManager.getTask(taskName));
         Assertions.assertEquals(1, masterTaskManager.filterTasks(null).size());
-		Assertions.assertNotNull(masterTaskManager.getPeriodFutureMap().get(task.getId()));
+        Assertions.assertNotNull(masterTaskManager.getPeriodFutureMap().get(task.getId()));
         
         // Verify task details
         Task createdTask = masterTaskManager.getTask(taskName);
@@ -397,7 +396,8 @@ public class TaskManagerEditLogTest {
         Assertions.assertEquals(3, followerTaskManager.filterTasks(null).size());
 
         // Replay the drop operation
-        DropTasksLog dropTasksLog = (DropTasksLog) UtFrameUtils.PseudoJournalReplayer.replayNextJournal(OperationType.OP_DROP_TASKS);
+        DropTasksLog dropTasksLog = (DropTasksLog) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_DROP_TASKS);
         followerTaskManager.replayDropTasks(dropTasksLog.getTaskIdList());
 
         // 8. Verify follower state is consistent with master

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -146,7 +146,7 @@ public class TaskManagerTest {
         String realDbName = task.getDbName();
         TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
 
-        taskManager.createTask(task, true);
+        taskManager.replayCreateTask(task);
         TaskRunManager taskRunManager = taskManager.getTaskRunManager();
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.setProcessor(new MockTaskRunProcessor());
@@ -240,8 +240,8 @@ public class TaskManagerTest {
         taskRun2.initStatus("2", now);
         taskRun2.getStatus().setPriority(10);
 
-        taskRunManager.arrangeTaskRun(taskRun1, false);
-        taskRunManager.arrangeTaskRun(taskRun2, false);
+        taskRunManager.arrangeTaskRun(taskRun1);
+        taskRunManager.arrangeTaskRun(taskRun2);
 
         TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
         List<TaskRun> taskRuns = Lists.newArrayList(taskRunScheduler.getPendingTaskRunsByTaskId(taskId));
@@ -276,8 +276,8 @@ public class TaskManagerTest {
         taskRun2.initStatus("2", now);
         taskRun2.getStatus().setPriority(10);
 
-        taskRunManager.arrangeTaskRun(taskRun2, false);
-        taskRunManager.arrangeTaskRun(taskRun1, false);
+        taskRunManager.arrangeTaskRun(taskRun2);
+        taskRunManager.arrangeTaskRun(taskRun1);
 
         TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
         List<TaskRun> taskRuns = Lists.newArrayList(taskRunScheduler.getPendingTaskRunsByTaskId(taskId));
@@ -313,8 +313,8 @@ public class TaskManagerTest {
         taskRun2.initStatus("2", now);
         taskRun2.getStatus().setPriority(0);
 
-        taskRunManager.arrangeTaskRun(taskRun1, false);
-        taskRunManager.arrangeTaskRun(taskRun2, false);
+        taskRunManager.arrangeTaskRun(taskRun1);
+        taskRunManager.arrangeTaskRun(taskRun2);
 
         TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
         List<TaskRun> taskRuns = Lists.newArrayList(taskRunScheduler.getPendingTaskRunsByTaskId(taskId));
@@ -350,8 +350,8 @@ public class TaskManagerTest {
         taskRun2.initStatus("2", now);
         taskRun2.getStatus().setPriority(0);
 
-        taskRunManager.arrangeTaskRun(taskRun2, false);
-        taskRunManager.arrangeTaskRun(taskRun1, false);
+        taskRunManager.arrangeTaskRun(taskRun2);
+        taskRunManager.arrangeTaskRun(taskRun1);
 
         TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
         List<TaskRun> taskRuns = Lists.newArrayList(taskRunScheduler.getPendingTaskRunsByTaskId(taskId));
@@ -395,9 +395,9 @@ public class TaskManagerTest {
         taskRun3.initStatus("3", now + 10);
         taskRun3.getStatus().setPriority(10);
 
-        taskRunManager.arrangeTaskRun(taskRun2, false);
-        taskRunManager.arrangeTaskRun(taskRun1, false);
-        taskRunManager.arrangeTaskRun(taskRun3, false);
+        taskRunManager.arrangeTaskRun(taskRun2);
+        taskRunManager.arrangeTaskRun(taskRun1);
+        taskRunManager.arrangeTaskRun(taskRun3);
 
         TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
         Collection<TaskRun> taskRuns = taskRunScheduler.getPendingTaskRunsByTaskId(taskId);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunManagerEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunManagerEditLogTest.java
@@ -25,8 +25,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.CompletableFuture;
-
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunManagerEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskRunManagerEditLogTest.java
@@ -1,0 +1,471 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler;
+
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.scheduler.persist.TaskRunStatus;
+import com.starrocks.scheduler.persist.TaskRunStatusChange;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class TaskRunManagerEditLogTest {
+    private TaskManager masterTaskManager;
+    private TaskRunManager masterTaskRunManager;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        // Initialize test environment
+        UtFrameUtils.setUpForPersistTest();
+
+        // Create TaskManager instance
+        masterTaskManager = new TaskManager();
+        masterTaskRunManager = masterTaskManager.getTaskRunManager();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    @Test
+    public void testArrangeTaskRunNormalCase() throws Exception {
+        // 1. Prepare test data - create a task first
+        String taskName = "arrange_task_run_test";
+        Task task = new Task(taskName);
+        task.setType(Constants.TaskType.MANUAL);
+        task.setDefinition("SELECT 1");
+        task.setDbName("test_db");
+        task.setCatalogName("test_catalog");
+        
+        masterTaskManager.createTask(task);
+        long taskId = task.getId();
+        Assertions.assertNotNull(masterTaskManager.getTask(taskName));
+
+        // 2. Verify initial state
+        Assertions.assertEquals(0, masterTaskRunManager.getTaskRunScheduler().getPendingQueueCount());
+
+        // 3. Create and arrange a TaskRun
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.setTaskId(taskId);
+        String queryId = "test_query_id_1";
+        taskRun.initStatus(queryId, System.currentTimeMillis());
+        taskRun.getStatus().setPriority(10);
+        taskRun.getStatus().setMergeRedundant(true);
+
+        // 4. Execute arrangeTaskRun operation (master side)
+        boolean arranged = masterTaskRunManager.arrangeTaskRun(taskRun);
+        Assertions.assertTrue(arranged);
+
+        // 5. Verify master state
+        Assertions.assertEquals(1, masterTaskRunManager.getTaskRunScheduler().getPendingQueueCount());
+        TaskRun pendingTaskRun = masterTaskRunManager.getTaskRunScheduler()
+                .getTaskRunByQueryId(taskId, queryId);
+        Assertions.assertNotNull(pendingTaskRun);
+        Assertions.assertEquals(Constants.TaskRunState.PENDING, pendingTaskRun.getStatus().getState());
+
+        // 6. Test follower replay functionality
+        TaskManager followerTaskManager = new TaskManager();
+        
+        // First create the task in follower
+        Task followerTask = new Task(taskName);
+        followerTask.setId(taskId);
+        followerTask.setType(Constants.TaskType.MANUAL);
+        followerTask.setDefinition("SELECT 1");
+        followerTask.setDbName("test_db");
+        followerTask.setCatalogName("test_catalog");
+        followerTask.setCreateTime(task.getCreateTime());
+        followerTaskManager.replayCreateTask(followerTask);
+
+        // Verify follower initial state
+        Assertions.assertEquals(0, followerTaskManager.getTaskRunScheduler().getPendingQueueCount());
+
+        // Replay the create TaskRun operation
+        TaskRunStatus status = (TaskRunStatus) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_CREATE_TASK_RUN);
+        followerTaskManager.replayCreateTaskRun(status);
+
+        // 7. Verify follower state is consistent with master
+        Assertions.assertEquals(1, followerTaskManager.getTaskRunScheduler().getPendingQueueCount());
+        TaskRun followerPendingTaskRun = followerTaskManager.getTaskRunScheduler()
+                .getTaskRunByQueryId(taskId, queryId);
+        Assertions.assertNotNull(followerPendingTaskRun);
+        Assertions.assertEquals(Constants.TaskRunState.PENDING, followerPendingTaskRun.getStatus().getState());
+        Assertions.assertEquals(queryId, followerPendingTaskRun.getStatus().getQueryId());
+    }
+
+    @Test
+    public void testArrangeTaskRunEditLogException() throws Exception {
+        // 1. Prepare test data - create a task first
+        String taskName = "arrange_exception_task";
+        Task task = new Task(taskName);
+        task.setType(Constants.TaskType.MANUAL);
+        task.setDefinition("SELECT 1");
+        task.setDbName("test_db");
+        task.setCatalogName("test_catalog");
+
+        // Create a separate TaskManager for exception testing
+        TaskManager exceptionTaskManager = new TaskManager();
+        
+        exceptionTaskManager.createTask(task);
+        long taskId = task.getId();
+        Assertions.assertNotNull(exceptionTaskManager.getTask(taskName));
+
+        // 2. Mock EditLog.logTaskRunCreateStatus to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logTaskRunCreateStatus(any(TaskRunStatus.class), any());
+        
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // Verify initial state
+        Assertions.assertEquals(0, exceptionTaskManager.getTaskRunScheduler().getPendingQueueCount());
+
+        // 3. Create a TaskRun
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.setTaskId(taskId);
+        String queryId = "test_query_id_exception";
+        taskRun.initStatus(queryId, System.currentTimeMillis());
+
+        // Save initial state snapshot
+        long initialPendingCount = exceptionTaskManager.getTaskRunScheduler().getPendingQueueCount();
+
+        // 4. Execute arrangeTaskRun operation and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            exceptionTaskManager.getTaskRunManager().arrangeTaskRun(taskRun);
+        });
+        Assertions.assertEquals("EditLog write failed", exception.getMessage());
+
+        // 5. Verify leader memory state remains unchanged after exception
+        Assertions.assertEquals(initialPendingCount, exceptionTaskManager.getTaskRunScheduler().getPendingQueueCount());
+        Assertions.assertNull(exceptionTaskManager.getTaskRunScheduler()
+                .getTaskRunByQueryId(taskId, queryId));
+    }
+
+    @Test
+    public void testArrangeTaskRunWithMerge() throws Exception {
+        // 1. Prepare test data - create a task first
+        String taskName = "arrange_merge_task";
+        Task task = new Task(taskName);
+        task.setType(Constants.TaskType.MANUAL);
+        task.setDefinition("SELECT 1");
+        task.setDbName("test_db");
+        task.setCatalogName("test_catalog");
+        
+        masterTaskManager.createTask(task);
+        long taskId = task.getId();
+
+        // 2. Create and arrange first TaskRun
+        TaskRun taskRun1 = TaskRunBuilder.newBuilder(task).build();
+        taskRun1.setTaskId(taskId);
+        String queryId1 = "test_query_id_1";
+        taskRun1.initStatus(queryId1, System.currentTimeMillis());
+        taskRun1.getStatus().setPriority(10);
+        // Set ExecuteOption to allow merging
+        ExecuteOption mergeOption1 = ExecuteOption.makeMergeRedundantOption();
+        mergeOption1.setPriority(10);
+        taskRun1.setExecuteOption(mergeOption1);
+
+        boolean arranged1 = masterTaskRunManager.arrangeTaskRun(taskRun1);
+        Assertions.assertTrue(arranged1);
+        Assertions.assertEquals(1, masterTaskRunManager.getTaskRunScheduler().getPendingQueueCount());
+
+        // 3. Create and arrange second TaskRun with same definition (should merge)
+        TaskRun taskRun2 = TaskRunBuilder.newBuilder(task).build();
+        taskRun2.setTaskId(taskId);
+        String queryId2 = "test_query_id_2";
+        taskRun2.initStatus(queryId2, System.currentTimeMillis());
+        taskRun2.getStatus().setPriority(10);
+        // Set ExecuteOption to allow merging
+        ExecuteOption mergeOption2 = ExecuteOption.makeMergeRedundantOption();
+        mergeOption2.setPriority(10);
+        taskRun2.setExecuteOption(mergeOption2);
+
+        boolean arranged2 = masterTaskRunManager.arrangeTaskRun(taskRun2);
+        Assertions.assertTrue(arranged2);
+
+        // 4. Verify merge occurred - old task run should be merged
+        Assertions.assertEquals(1, masterTaskRunManager.getTaskRunScheduler().getPendingQueueCount());
+        
+        // Verify the TaskRun creation and merge were logged
+        // First OP_CREATE_TASK_RUN is for taskRun1
+        TaskRunStatus createStatus1 = (TaskRunStatus) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_CREATE_TASK_RUN);
+        Assertions.assertNotNull(createStatus1);
+        Assertions.assertEquals(queryId1, createStatus1.getQueryId());
+        
+        // Second OP_CREATE_TASK_RUN is for taskRun2
+        TaskRunStatus createStatus2 = (TaskRunStatus) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_CREATE_TASK_RUN);
+        Assertions.assertNotNull(createStatus2);
+        Assertions.assertEquals(queryId2, createStatus2.getQueryId());
+        
+        // OP_UPDATE_TASK_RUN is for merging taskRun1
+        TaskRunStatusChange mergeStatusChange = (TaskRunStatusChange) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_UPDATE_TASK_RUN);
+        Assertions.assertNotNull(mergeStatusChange);
+        Assertions.assertEquals(Constants.TaskRunState.MERGED, mergeStatusChange.getToStatus());
+        Assertions.assertEquals(queryId1, mergeStatusChange.getQueryId());
+    }
+
+    @Test
+    public void testCheckRunningTaskRunNormalCase() throws Exception {
+        // 1. Prepare test data - create a task first
+        String taskName = "check_running_task";
+        Task task = new Task(taskName);
+        task.setType(Constants.TaskType.MANUAL);
+        task.setDefinition("SELECT 1");
+        task.setDbName("test_db");
+        task.setCatalogName("test_catalog");
+        
+        masterTaskManager.createTask(task);
+        long taskId = task.getId();
+
+        // 2. Create a TaskRun and add it to running map directly
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.setTaskId(taskId);
+        String queryId = "test_query_id_running";
+        taskRun.initStatus(queryId, System.currentTimeMillis());
+        taskRun.getStatus().setState(Constants.TaskRunState.RUNNING);
+        
+        // Set status to SUCCESS first, then complete the future to simulate finished task
+        taskRun.getStatus().setState(Constants.TaskRunState.SUCCESS);
+        taskRun.getFuture().complete(Constants.TaskRunState.SUCCESS);
+        
+        masterTaskRunManager.getTaskRunScheduler().addRunningTaskRun(taskRun);
+        Assertions.assertEquals(1, masterTaskRunManager.getTaskRunScheduler().getRunningTaskCount());
+
+        // 3. Execute checkRunningTaskRun operation (master side)
+        masterTaskRunManager.checkRunningTaskRun();
+
+        // 4. Verify master state - task run should be removed from running and added to history
+        Assertions.assertEquals(0, masterTaskRunManager.getTaskRunScheduler().getRunningTaskCount());
+        Assertions.assertNotNull(masterTaskRunManager.getTaskRunHistory().getTask(queryId));
+
+        // 5. Test follower replay functionality
+        TaskManager followerTaskManager = new TaskManager();
+        
+        // First create the task in follower
+        Task followerTask = new Task(taskName);
+        followerTask.setId(taskId);
+        followerTask.setType(Constants.TaskType.MANUAL);
+        followerTask.setDefinition("SELECT 1");
+        followerTask.setDbName("test_db");
+        followerTask.setCatalogName("test_catalog");
+        followerTask.setCreateTime(task.getCreateTime());
+        followerTaskManager.replayCreateTask(followerTask);
+
+        // Create and add running TaskRun in follower
+        TaskRun followerTaskRun = TaskRunBuilder.newBuilder(followerTask).build();
+        followerTaskRun.setTaskId(taskId);
+        followerTaskRun.initStatus(queryId, System.currentTimeMillis());
+        followerTaskRun.getStatus().setState(Constants.TaskRunState.RUNNING);
+        followerTaskManager.getTaskRunScheduler().addRunningTaskRun(followerTaskRun);
+        
+        Assertions.assertEquals(1, followerTaskManager.getTaskRunScheduler().getRunningTaskCount());
+
+        // Replay the status change (from RUNNING to SUCCESS)
+        TaskRunStatusChange statusChange = (TaskRunStatusChange) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_UPDATE_TASK_RUN);
+        followerTaskManager.replayUpdateTaskRun(statusChange);
+
+        // 6. Verify follower state is consistent with master
+        Assertions.assertEquals(0, followerTaskManager.getTaskRunScheduler().getRunningTaskCount());
+        Assertions.assertNotNull(followerTaskManager.getTaskRunHistory().getTask(queryId));
+    }
+
+    @Test
+    public void testCheckRunningTaskRunEditLogException() throws Exception {
+        // 1. Prepare test data - create a task first
+        String taskName = "check_running_exception_task";
+        Task task = new Task(taskName);
+        task.setType(Constants.TaskType.MANUAL);
+        task.setDefinition("SELECT 1");
+        task.setDbName("test_db");
+        task.setCatalogName("test_catalog");
+
+        // Create a separate TaskManager for exception testing
+        TaskManager exceptionTaskManager = new TaskManager();
+        
+        exceptionTaskManager.createTask(task);
+        long taskId = task.getId();
+        TaskRunManager exceptionTaskRunManager = exceptionTaskManager.getTaskRunManager();
+
+        // 2. Create a TaskRun and add it to running map
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.setTaskId(taskId);
+        String queryId = "test_query_id_exception_running";
+        taskRun.initStatus(queryId, System.currentTimeMillis());
+        taskRun.getStatus().setState(Constants.TaskRunState.RUNNING);
+        
+        // Set status to SUCCESS first, then complete the future to simulate finished task
+        taskRun.getStatus().setState(Constants.TaskRunState.SUCCESS);
+        taskRun.getFuture().complete(Constants.TaskRunState.SUCCESS);
+        
+        exceptionTaskRunManager.getTaskRunScheduler().addRunningTaskRun(taskRun);
+        Assertions.assertEquals(1, exceptionTaskRunManager.getTaskRunScheduler().getRunningTaskCount());
+
+        // 3. Mock EditLog.logUpdateTaskRun to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logUpdateTaskRun(any(TaskRunStatusChange.class), any());
+        
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // Save initial state snapshot
+        long initialRunningCount = exceptionTaskRunManager.getTaskRunScheduler().getRunningTaskCount();
+
+        // 4. Execute checkRunningTaskRun operation and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            exceptionTaskRunManager.checkRunningTaskRun();
+        });
+        Assertions.assertEquals("EditLog write failed", exception.getMessage());
+
+        // 5. Verify leader memory state remains unchanged after exception
+        Assertions.assertEquals(initialRunningCount, exceptionTaskRunManager.getTaskRunScheduler().getRunningTaskCount());
+        Assertions.assertNotNull(exceptionTaskRunManager.getTaskRunScheduler().getRunningTaskRun(taskId));
+    }
+
+    @Test
+    public void testScheduledPendingTaskRunNormalCase() throws Exception {
+        // 1. Prepare test data - create a task first
+        String taskName = "scheduled_pending_task";
+        Task task = new Task(taskName);
+        task.setType(Constants.TaskType.MANUAL);
+        task.setDefinition("SELECT 1");
+        task.setDbName("test_db");
+        task.setCatalogName("test_catalog");
+        
+        masterTaskManager.createTask(task);
+        long taskId = task.getId();
+
+        // 2. Create a TaskRun and add it to pending queue
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.setTaskId(taskId);
+        String queryId = "test_query_id_pending";
+        taskRun.initStatus(queryId, System.currentTimeMillis());
+        taskRun.getStatus().setState(Constants.TaskRunState.PENDING);
+        
+        masterTaskRunManager.getTaskRunScheduler().addPendingTaskRun(taskRun);
+        Assertions.assertEquals(1, masterTaskRunManager.getTaskRunScheduler().getPendingQueueCount());
+
+        // 3. Execute scheduledPendingTaskRun operation (master side)
+        // Note: This requires TaskRunExecutor to return true, which we can't easily mock
+        // So we'll verify that the EditLog was called when executeTaskRun succeeds
+        // For a more complete test, we'd need to mock TaskRunExecutor
+        
+        // We'll verify the structure by checking that the operation doesn't throw
+        // In a real scenario, executeTaskRun might return false if conditions aren't met
+        masterTaskRunManager.scheduledPendingTaskRun();
+
+        // 4. Verify that if executeTaskRun returned true, the status change was logged
+        // Since we can't easily control executeTaskRun, we'll just verify the method executes without error
+        // and that pending queue state is managed correctly
+        
+        // 5. Test follower replay functionality
+        TaskManager followerTaskManager = new TaskManager();
+        
+        // First create the task in follower
+        Task followerTask = new Task(taskName);
+        followerTask.setId(taskId);
+        followerTask.setType(Constants.TaskType.MANUAL);
+        followerTask.setDefinition("SELECT 1");
+        followerTask.setDbName("test_db");
+        followerTask.setCatalogName("test_catalog");
+        followerTask.setCreateTime(task.getCreateTime());
+        followerTaskManager.replayCreateTask(followerTask);
+
+        // Create pending TaskRun in follower
+        TaskRun followerTaskRun = TaskRunBuilder.newBuilder(followerTask).build();
+        followerTaskRun.setTaskId(taskId);
+        followerTaskRun.initStatus(queryId, System.currentTimeMillis());
+        followerTaskRun.getStatus().setState(Constants.TaskRunState.PENDING);
+        followerTaskManager.getTaskRunScheduler().addPendingTaskRun(followerTaskRun);
+        
+        Assertions.assertEquals(1, followerTaskManager.getTaskRunScheduler().getPendingQueueCount());
+
+        // If there was a status change logged, replay it
+        // Note: This will only work if executeTaskRun returned true in master
+        // In practice, we'd need to ensure the task run can actually be executed
+        // For now, we verify the replay mechanism exists
+    }
+
+    @Test
+    public void testScheduledPendingTaskRunEditLogException() throws Exception {
+        // 1. Prepare test data - create a task first
+        String taskName = "scheduled_pending_exception_task";
+        Task task = new Task(taskName);
+        task.setType(Constants.TaskType.MANUAL);
+        task.setDefinition("SELECT 1");
+        task.setDbName("test_db");
+        task.setCatalogName("test_catalog");
+
+        // Create a separate TaskManager for exception testing
+        TaskManager exceptionTaskManager = new TaskManager();
+        
+        exceptionTaskManager.createTask(task);
+        long taskId = task.getId();
+        TaskRunManager exceptionTaskRunManager = exceptionTaskManager.getTaskRunManager();
+
+        // 2. Create a TaskRun and add it to pending queue
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.setTaskId(taskId);
+        String queryId = "test_query_id_pending_exception";
+        taskRun.initStatus(queryId, System.currentTimeMillis());
+        taskRun.getStatus().setState(Constants.TaskRunState.PENDING);
+        
+        exceptionTaskRunManager.getTaskRunScheduler().addPendingTaskRun(taskRun);
+        Assertions.assertEquals(1, exceptionTaskRunManager.getTaskRunScheduler().getPendingQueueCount());
+
+        // 3. Mock EditLog.logUpdateTaskRun to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logUpdateTaskRun(any(TaskRunStatusChange.class), any());
+        
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 4. Execute scheduledPendingTaskRun operation
+        // Note: The exception will only be thrown if executeTaskRun returns true
+        // We can't easily control this, so we'll verify the method handles exceptions gracefully
+        // If executeTaskRun returns false, no EditLog call is made and no exception occurs
+        
+        // For this test, we verify that if executeTaskRun would succeed but EditLog fails,
+        // the exception is propagated. However, since we can't easily mock executeTaskRun,
+        // we verify the exception handling structure is in place
+        try {
+            exceptionTaskRunManager.scheduledPendingTaskRun();
+            // If executeTaskRun returns false, no exception occurs - this is acceptable
+        } catch (RuntimeException e) {
+            // If executeTaskRun returns true and EditLog fails, exception should be thrown
+            Assertions.assertEquals("EditLog write failed", e.getMessage());
+            
+            // 5. Verify state handling - the task run should remain in pending if exception occurred
+            // (though this depends on the exact error handling implementation)
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryEditLogTest.java
@@ -18,14 +18,12 @@ import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.OperationType;
+import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.persist.ArchiveTaskRunsLog;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.scheduler.history.TableKeeper;
-import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.utframe.UtFrameUtils;
-import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.jupiter.api.AfterEach;
@@ -347,13 +345,13 @@ public class TaskRunHistoryEditLogTest {
 
         // 4. Verify only finished task runs were archived
         for (String queryId : finishedQueryIds) {
-            Assertions.assertNull(masterHistory.getTask(queryId), 
-                "Finished task run " + queryId + " should be archived");
+            Assertions.assertNull(masterHistory.getTask(queryId),
+                    "Finished task run " + queryId + " should be archived");
         }
         
         for (String queryId : unfinishedQueryIds) {
-            Assertions.assertNotNull(masterHistory.getTask(queryId), 
-                "Unfinished task run " + queryId + " should not be archived");
+            Assertions.assertNotNull(masterHistory.getTask(queryId),
+                    "Unfinished task run " + queryId + " should not be archived");
         }
         
         Assertions.assertEquals(2, masterHistory.getTaskRunCount());

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/history/TaskRunHistoryEditLogTest.java
@@ -1,0 +1,462 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.history;
+
+import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.scheduler.Constants;
+import com.starrocks.scheduler.persist.ArchiveTaskRunsLog;
+import com.starrocks.scheduler.persist.TaskRunStatus;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.scheduler.history.TableKeeper;
+import com.starrocks.qe.SimpleExecutor;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+/**
+ * Test TaskRunHistory.archiveHistory() EditLog functionality
+ * This test uses a test subclass to expose the protected archiveHistory() method
+ * and to enable archive history functionality in unit test environment
+ */
+public class TaskRunHistoryEditLogTest {
+    private TestableTaskRunHistory masterHistory;
+    private boolean originalRunningUnitTest;
+
+    /**
+     * Testable subclass that exposes archiveHistory() and allows enabling archive in tests
+     */
+    private static class TestableTaskRunHistory extends TaskRunHistory {
+        private boolean enableArchive = false;
+
+        public void setEnableArchive(boolean enable) {
+            this.enableArchive = enable;
+        }
+
+        // Override to allow enabling archive in test environment
+        @Override
+        protected void archiveHistory() {
+            // Temporarily set FeConstants.runningUnitTest to false to enable archive
+            boolean originalFlag = FeConstants.runningUnitTest;
+            try {
+                FeConstants.runningUnitTest = !enableArchive;
+                super.archiveHistory();
+            } finally {
+                FeConstants.runningUnitTest = originalFlag;
+            }
+        }
+
+        public void testArchiveHistory() {
+            archiveHistory();
+        }
+    }
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        // Initialize test environment
+        UtFrameUtils.setUpForPersistTest();
+
+        // Save original runningUnitTest flag
+        originalRunningUnitTest = FeConstants.runningUnitTest;
+        
+        // Mock TableKeeper to make it ready
+        new MockUp<TableKeeper>() {
+            @Mock
+            public boolean isReady() {
+                return true;
+            }
+        };
+        
+        // Mock SimpleExecutor to avoid database operations
+        // Use MockUp to replace getRepoExecutor() and executeDML() behavior
+        new MockUp<SimpleExecutor>() {
+            @Mock
+            public static SimpleExecutor getRepoExecutor() {
+                // Return a mock instance that doesn't execute SQL
+                return new SimpleExecutor("MockExecutor", 
+                    com.starrocks.thrift.TResultSinkType.HTTP_PROTOCAL) {
+                    @Override
+                    public void executeDML(String sql) {
+                        // Do nothing - just allow the method to succeed
+                    }
+                };
+            }
+        };
+        
+        // Create testable history instance
+        masterHistory = new TestableTaskRunHistory();
+        masterHistory.setEnableArchive(true);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        // Restore original runningUnitTest flag
+        FeConstants.runningUnitTest = originalRunningUnitTest;
+        Config.enable_task_history_archive = true; // Restore default
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    @Test
+    public void testArchiveHistoryNormalCase() throws Exception {
+        // 1. Prepare test data - create finished task runs
+        String queryId1 = "test_query_id_1";
+        String queryId2 = "test_query_id_2";
+        String queryId3 = "test_query_id_3";
+        
+        TaskRunStatus status1 = new TaskRunStatus();
+        status1.setQueryId(queryId1);
+        status1.setTaskName("test_task_1");
+        status1.setState(Constants.TaskRunState.SUCCESS);
+        status1.setExpireTime(System.currentTimeMillis() + 100000);
+        
+        TaskRunStatus status2 = new TaskRunStatus();
+        status2.setQueryId(queryId2);
+        status2.setTaskName("test_task_2");
+        status2.setState(Constants.TaskRunState.FAILED);
+        status2.setExpireTime(System.currentTimeMillis() + 100000);
+        
+        TaskRunStatus status3 = new TaskRunStatus();
+        status3.setQueryId(queryId3);
+        status3.setTaskName("test_task_3");
+        status3.setState(Constants.TaskRunState.PENDING); // Not finished, should not be archived
+        status3.setExpireTime(System.currentTimeMillis() + 100000);
+        
+        // 2. Add history to master
+        masterHistory.addHistory(status1);
+        masterHistory.addHistory(status2);
+        masterHistory.addHistory(status3);
+        
+        // Verify initial state
+        Assertions.assertNotNull(masterHistory.getTask(queryId1));
+        Assertions.assertNotNull(masterHistory.getTask(queryId2));
+        Assertions.assertNotNull(masterHistory.getTask(queryId3));
+        Assertions.assertEquals(3, masterHistory.getTaskRunCount());
+
+        // 3. Enable archive and set Config
+        Config.enable_task_history_archive = true;
+        
+        // 4. Execute archiveHistory operation (master side)
+        masterHistory.testArchiveHistory();
+
+        // 5. Verify master state - only finished task runs should be archived and removed
+        Assertions.assertNull(masterHistory.getTask(queryId1)); // SUCCESS - archived
+        Assertions.assertNull(masterHistory.getTask(queryId2)); // FAILED - archived
+        Assertions.assertNotNull(masterHistory.getTask(queryId3)); // PENDING - not archived
+        Assertions.assertEquals(1, masterHistory.getTaskRunCount());
+
+        // 6. Test follower replay functionality
+        TestableTaskRunHistory followerHistory = new TestableTaskRunHistory();
+        
+        // First add the same task runs to follower
+        TaskRunStatus followerStatus1 = new TaskRunStatus();
+        followerStatus1.setQueryId(queryId1);
+        followerStatus1.setTaskName("test_task_1");
+        followerStatus1.setState(Constants.TaskRunState.SUCCESS);
+        followerStatus1.setExpireTime(status1.getExpireTime());
+        
+        TaskRunStatus followerStatus2 = new TaskRunStatus();
+        followerStatus2.setQueryId(queryId2);
+        followerStatus2.setTaskName("test_task_2");
+        followerStatus2.setState(Constants.TaskRunState.FAILED);
+        followerStatus2.setExpireTime(status2.getExpireTime());
+        
+        followerHistory.addHistory(followerStatus1);
+        followerHistory.addHistory(followerStatus2);
+        
+        Assertions.assertEquals(2, followerHistory.getTaskRunCount());
+
+        // Replay the archive operation
+        ArchiveTaskRunsLog archiveLog = (ArchiveTaskRunsLog) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_ARCHIVE_TASK_RUNS);
+        followerHistory.replay(archiveLog);
+
+        // 7. Verify follower state is consistent with master
+        Assertions.assertNull(followerHistory.getTask(queryId1));
+        Assertions.assertNull(followerHistory.getTask(queryId2));
+        Assertions.assertEquals(0, followerHistory.getTaskRunCount());
+        
+        // Verify the archived query IDs match
+        List<String> archivedQueryIds = archiveLog.getTaskRuns();
+        Assertions.assertNotNull(archivedQueryIds);
+        Assertions.assertEquals(2, archivedQueryIds.size());
+        Assertions.assertTrue(archivedQueryIds.contains(queryId1));
+        Assertions.assertTrue(archivedQueryIds.contains(queryId2));
+    }
+
+    @Test
+    public void testArchiveHistoryEditLogException() throws Exception {
+        // 1. Prepare test data - create finished task runs
+        String queryId1 = "exception_query_id_1";
+        String queryId2 = "exception_query_id_2";
+        
+        TaskRunStatus status1 = new TaskRunStatus();
+        status1.setQueryId(queryId1);
+        status1.setTaskName("exception_task_1");
+        status1.setState(Constants.TaskRunState.SUCCESS);
+        status1.setExpireTime(System.currentTimeMillis() + 100000);
+        
+        TaskRunStatus status2 = new TaskRunStatus();
+        status2.setQueryId(queryId2);
+        status2.setTaskName("exception_task_2");
+        status2.setState(Constants.TaskRunState.FAILED);
+        status2.setExpireTime(System.currentTimeMillis() + 100000);
+        
+        // 2. Create a separate history for exception testing
+        TestableTaskRunHistory exceptionHistory = new TestableTaskRunHistory();
+        exceptionHistory.setEnableArchive(true);
+        exceptionHistory.addHistory(status1);
+        exceptionHistory.addHistory(status2);
+        
+        Assertions.assertEquals(2, exceptionHistory.getTaskRunCount());
+
+        // 3. Mock EditLog.logArchiveTaskRuns to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logArchiveTaskRuns(any(ArchiveTaskRunsLog.class), any());
+        
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // Enable archive and set Config
+        Config.enable_task_history_archive = true;
+
+        // Save initial state snapshot
+        long initialTaskRunCount = exceptionHistory.getTaskRunCount();
+        Assertions.assertNotNull(exceptionHistory.getTask(queryId1));
+        Assertions.assertNotNull(exceptionHistory.getTask(queryId2));
+
+        // 4. Execute archiveHistory operation
+        // Note: archiveHistory() catches Throwable and logs warning, so exception won't propagate
+        // However, the editlog write will fail, causing the replay() callback not to be invoked
+        // This means addHistories() may have executed (persisting to table), but memory state
+        // should remain because replay() removes from memory and it won't be called if editlog fails
+        exceptionHistory.testArchiveHistory();
+
+        // 5. Verify leader memory state after exception
+        // Since editlog failed, the replay() callback was not invoked, so task runs should
+        // remain in memory even though they may have been persisted to the table
+        // The key point is that without successful editlog, followers won't see the archive,
+        // so memory state should be preserved for consistency
+        Assertions.assertEquals(initialTaskRunCount, exceptionHistory.getTaskRunCount());
+        Assertions.assertNotNull(exceptionHistory.getTask(queryId1));
+        Assertions.assertNotNull(exceptionHistory.getTask(queryId2));
+    }
+
+    @Test
+    public void testArchiveHistoryEmptyList() throws Exception {
+        // 1. Prepare test data - create task runs that are not finished
+        String queryId1 = "running_query_id_1";
+        String queryId2 = "pending_query_id_2";
+        
+        TaskRunStatus status1 = new TaskRunStatus();
+        status1.setQueryId(queryId1);
+        status1.setTaskName("running_task_1");
+        status1.setState(Constants.TaskRunState.RUNNING); // Not finished
+        status1.setExpireTime(System.currentTimeMillis() + 100000);
+        
+        TaskRunStatus status2 = new TaskRunStatus();
+        status2.setQueryId(queryId2);
+        status2.setTaskName("pending_task_2");
+        status2.setState(Constants.TaskRunState.PENDING); // Not finished
+        status2.setExpireTime(System.currentTimeMillis() + 100000);
+        
+        // 2. Add history to master
+        masterHistory.addHistory(status1);
+        masterHistory.addHistory(status2);
+        
+        Assertions.assertEquals(2, masterHistory.getTaskRunCount());
+
+        // 3. Enable archive and set Config
+        Config.enable_task_history_archive = true;
+        
+        // 4. Execute archiveHistory operation
+        masterHistory.testArchiveHistory();
+
+        // 5. Verify no task runs were archived (all are still in memory)
+        Assertions.assertNotNull(masterHistory.getTask(queryId1));
+        Assertions.assertNotNull(masterHistory.getTask(queryId2));
+        Assertions.assertEquals(2, masterHistory.getTaskRunCount());
+        
+        // Verify no editlog was written (since there are no finished task runs)
+        // We can't directly check this, but the behavior shows no archive occurred
+    }
+
+    @Test
+    public void testArchiveHistoryMixedStates() throws Exception {
+        // 1. Prepare test data - mix of finished and unfinished task runs
+        List<String> finishedQueryIds = new ArrayList<>();
+        List<String> unfinishedQueryIds = new ArrayList<>();
+        
+        // Create finished task runs
+        for (int i = 1; i <= 3; i++) {
+            String queryId = "finished_query_" + i;
+            finishedQueryIds.add(queryId);
+            TaskRunStatus status = new TaskRunStatus();
+            status.setQueryId(queryId);
+            status.setTaskName("finished_task_" + i);
+            status.setState(i % 2 == 0 ? Constants.TaskRunState.SUCCESS : Constants.TaskRunState.FAILED);
+            status.setExpireTime(System.currentTimeMillis() + 100000);
+            masterHistory.addHistory(status);
+        }
+        
+        // Create unfinished task runs
+        for (int i = 1; i <= 2; i++) {
+            String queryId = "unfinished_query_" + i;
+            unfinishedQueryIds.add(queryId);
+            TaskRunStatus status = new TaskRunStatus();
+            status.setQueryId(queryId);
+            status.setTaskName("unfinished_task_" + i);
+            status.setState(Constants.TaskRunState.RUNNING);
+            status.setExpireTime(System.currentTimeMillis() + 100000);
+            masterHistory.addHistory(status);
+        }
+        
+        Assertions.assertEquals(5, masterHistory.getTaskRunCount());
+
+        // 2. Enable archive and set Config
+        Config.enable_task_history_archive = true;
+        
+        // 3. Execute archiveHistory operation
+        masterHistory.testArchiveHistory();
+
+        // 4. Verify only finished task runs were archived
+        for (String queryId : finishedQueryIds) {
+            Assertions.assertNull(masterHistory.getTask(queryId), 
+                "Finished task run " + queryId + " should be archived");
+        }
+        
+        for (String queryId : unfinishedQueryIds) {
+            Assertions.assertNotNull(masterHistory.getTask(queryId), 
+                "Unfinished task run " + queryId + " should not be archived");
+        }
+        
+        Assertions.assertEquals(2, masterHistory.getTaskRunCount());
+
+        // 5. Test follower replay functionality
+        TestableTaskRunHistory followerHistory = new TestableTaskRunHistory();
+        
+        // Add finished task runs to follower
+        for (int i = 1; i <= 3; i++) {
+            String queryId = "finished_query_" + i;
+            TaskRunStatus status = new TaskRunStatus();
+            status.setQueryId(queryId);
+            status.setTaskName("finished_task_" + i);
+            status.setState(i % 2 == 0 ? Constants.TaskRunState.SUCCESS : Constants.TaskRunState.FAILED);
+            status.setExpireTime(System.currentTimeMillis() + 100000);
+            followerHistory.addHistory(status);
+        }
+        
+        Assertions.assertEquals(3, followerHistory.getTaskRunCount());
+
+        // Replay the archive operation
+        ArchiveTaskRunsLog archiveLog = (ArchiveTaskRunsLog) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_ARCHIVE_TASK_RUNS);
+        followerHistory.replay(archiveLog);
+
+        // 6. Verify follower state is consistent with master
+        Assertions.assertEquals(0, followerHistory.getTaskRunCount());
+        for (String queryId : finishedQueryIds) {
+            Assertions.assertNull(followerHistory.getTask(queryId));
+        }
+        
+        // Verify the archived query IDs match
+        List<String> archivedQueryIds = archiveLog.getTaskRuns();
+        Assertions.assertNotNull(archivedQueryIds);
+        Assertions.assertEquals(3, archivedQueryIds.size());
+        for (String queryId : finishedQueryIds) {
+            Assertions.assertTrue(archivedQueryIds.contains(queryId));
+        }
+    }
+
+    @Test
+    public void testArchiveHistoryFollowerReplayNormalCase() throws Exception {
+        // 1. Prepare test data - create finished task runs in master
+        String queryId1 = "replay_query_id_1";
+        String queryId2 = "replay_query_id_2";
+        
+        TaskRunStatus status1 = new TaskRunStatus();
+        status1.setQueryId(queryId1);
+        status1.setTaskName("replay_task_1");
+        status1.setState(Constants.TaskRunState.SUCCESS);
+        status1.setExpireTime(System.currentTimeMillis() + 100000);
+        
+        TaskRunStatus status2 = new TaskRunStatus();
+        status2.setQueryId(queryId2);
+        status2.setTaskName("replay_task_2");
+        status2.setState(Constants.TaskRunState.FAILED);
+        status2.setExpireTime(System.currentTimeMillis() + 100000);
+        
+        masterHistory.addHistory(status1);
+        masterHistory.addHistory(status2);
+        Assertions.assertEquals(2, masterHistory.getTaskRunCount());
+
+        // 2. Enable archive and archive in master
+        Config.enable_task_history_archive = true;
+        masterHistory.testArchiveHistory();
+        
+        Assertions.assertNull(masterHistory.getTask(queryId1));
+        Assertions.assertNull(masterHistory.getTask(queryId2));
+
+        // 3. Test follower replay
+        TestableTaskRunHistory followerHistory = new TestableTaskRunHistory();
+        
+        // Add same task runs to follower (simulating follower state before archive)
+        TaskRunStatus followerStatus1 = new TaskRunStatus();
+        followerStatus1.setQueryId(queryId1);
+        followerStatus1.setTaskName("replay_task_1");
+        followerStatus1.setState(Constants.TaskRunState.SUCCESS);
+        followerStatus1.setExpireTime(status1.getExpireTime());
+        
+        TaskRunStatus followerStatus2 = new TaskRunStatus();
+        followerStatus2.setQueryId(queryId2);
+        followerStatus2.setTaskName("replay_task_2");
+        followerStatus2.setState(Constants.TaskRunState.FAILED);
+        followerStatus2.setExpireTime(status2.getExpireTime());
+        
+        followerHistory.addHistory(followerStatus1);
+        followerHistory.addHistory(followerStatus2);
+        Assertions.assertEquals(2, followerHistory.getTaskRunCount());
+
+        // Replay the archive operation
+        ArchiveTaskRunsLog archiveLog = (ArchiveTaskRunsLog) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_ARCHIVE_TASK_RUNS);
+        
+        Assertions.assertNotNull(archiveLog);
+        Assertions.assertNotNull(archiveLog.getTaskRuns());
+        Assertions.assertEquals(2, archiveLog.getTaskRuns().size());
+        
+        followerHistory.replay(archiveLog);
+
+        // 4. Verify follower state matches master
+        Assertions.assertEquals(0, followerHistory.getTaskRunCount());
+        Assertions.assertNull(followerHistory.getTask(queryId1));
+        Assertions.assertNull(followerHistory.getTask(queryId2));
+    }
+}
+

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
@@ -389,7 +389,7 @@ public abstract class MVTestBase extends StarRocksTestBase {
         Task task = taskManager.getTask(mv);
         if (task == null) {
             task = TaskBuilder.buildMvTask(mv, dbName);
-            taskManager.createTask(task, false);
+            taskManager.createTask(task);
         }
 
         Map<String, String> testProperties = task.getProperties();


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Refer #63357

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors task and task-run persistence to WAL-style edit logs with in-memory appliers, simplifies TaskManager APIs, introduces `AlterTaskInfo`, and updates callers and tests accordingly.
> 
> - **Scheduler/Core**:
>   - Convert task and task-run operations to WAL with in-memory appliers: `createTask`, `alterTask`, `dropTasks`, `logTaskRunCreateStatus`, `logUpdateTaskRun`, `logArchiveTaskRuns`.
>   - Remove `isReplay` flags; register schedulers and state changes via WAL callbacks.
>   - Refactor `TaskManager`/`TaskRunManager` flows (pending/running clearing, arrange/merge, execution state transitions) to use WAL appliers.
>   - Expose `clearUnfinishedTaskRun()` as `protected` and adjust callers.
> - **Persistence/Logging**:
>   - Add `persist.AlterTaskInfo`; switch OP_ALTER_TASK payload to `AlterTaskInfo`.
>   - Update `EditLog` methods to applier variants (e.g., `logCreateTask(Task, WALApplier)`, `logDropTasks(DropTasksLog, WALApplier)`, etc.).
>   - Update `EditLogDeserializer` mappings for new payload types.
> - **API Callers Updated**:
>   - Replace `createTask(task, false)`/`alterTask(..., false)` with `createTask(task)`/`alterTask(...)` across MV, optimize/merge jobs, pipe, metastore, tests, and DDL executor.
>   - Use `replayDropTasks` path when replaying MV drops.
> - **Materialized View / Pipe / Metastore**:
>   - Align MV task (create/alter/execute) and Pipe task lifecycle with new TaskManager APIs and WAL.
> - **Tests**:
>   - Add comprehensive UTs for WAL behavior and failure scenarios: task create/alter/drop, task-run arrange/merge/status updates, archiving history via WAL.
>   - Adjust existing tests to new replay/create APIs and drop semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6522ee4a315351e5cc366ab71432201a849d8652. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->