### PR TITLE
[Refactor] Improve the maintainability and clarity of type serialization and deserialization

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/AggregateFunction.java
@@ -372,9 +372,9 @@ public class AggregateFunction extends Function {
         TAggregateFunction aggFn = new TAggregateFunction();
         aggFn.setIs_analytic_only_fn(isAnalyticFn && !isAggregateFn);
         if (intermediateType != null) {
-            aggFn.setIntermediate_type(intermediateType.toThrift());
+            aggFn.setIntermediate_type(TypeSerializer.toThrift(intermediateType));
         } else {
-            aggFn.setIntermediate_type(getReturnType().toThrift());
+            aggFn.setIntermediate_type(TypeSerializer.toThrift(getReturnType()));
         }
         if (isAscOrder != null && !isAscOrder.isEmpty()) {
             aggFn.setIs_asc_order(isAscOrder);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -456,7 +456,7 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         TColumn tColumn = new TColumn();
         tColumn.setColumn_name(this.columnId.getId());
         tColumn.setIndex_len(this.getOlapColumnIndexSize());
-        tColumn.setType_desc(this.type.toThrift());
+        tColumn.setType_desc(TypeSerializer.toThrift(this.type));
         if (null != this.aggregationType) {
             tColumn.setAggregation_type(toThrift(aggregationType));
         }
@@ -474,7 +474,7 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
 
         // scalar type or nested type
         // If this field is set, column_type will be ignored.
-        tColumn.setType_desc(type.toThrift());
+        tColumn.setType_desc(TypeSerializer.toThrift(type));
         tColumn.setCol_unique_id(uniqueId);
 
         return tColumn;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnAccessPath.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ColumnAccessPath.java
@@ -236,7 +236,7 @@ public class ColumnAccessPath {
         tColumnAccessPath.setFrom_predicate(fromPredicate);
         tColumnAccessPath.setExtended(extended);
         if (valueType != null) {
-            tColumnAccessPath.setType_desc(valueType.toThrift());
+            tColumnAccessPath.setType_desc(TypeSerializer.toThrift(valueType));
         }
         return tColumnAccessPath;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
@@ -48,8 +48,10 @@ import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.FunctionName;
 import com.starrocks.thrift.TFunction;
 import com.starrocks.thrift.TFunctionBinaryType;
+import com.starrocks.thrift.TTypeDesc;
 import org.apache.commons.lang.ArrayUtils;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -496,6 +498,7 @@ public class Function implements Writable {
         }
         return true;
     }
+
     /**
      * Returns true if 'this' is a supertype of 'other'. Each argument in other must
      * be implicitly castable to the matching argument in this.
@@ -743,8 +746,14 @@ public class Function implements Writable {
         if (location != null) {
             fn.setHdfs_location(location.toString());
         }
-        fn.setArg_types(Type.toThrift(argTypes));
-        fn.setRet_type(getReturnType().toThrift());
+
+        ArrayList<TTypeDesc> result = Lists.newArrayList();
+        for (Type t : argTypes) {
+            result.add(TypeSerializer.toThrift(t));
+        }
+        fn.setArg_types(result);
+
+        fn.setRet_type(TypeSerializer.toThrift(getReturnType()));
         fn.setHas_var_args(hasVarArgs);
         fn.setId(id);
         fn.setFid(functionId);
@@ -904,7 +913,6 @@ public class Function implements Writable {
         }
         return obj != null && obj.getClass() == this.getClass() && isIdentical((Function) obj);
     }
-
 
     // just shallow copy
     public Function copy() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MapType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MapType.java
@@ -17,13 +17,7 @@ package com.starrocks.catalog;
 import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
 import com.google.gson.annotations.SerializedName;
-import com.starrocks.persist.gson.GsonUtils;
 
 import java.util.Arrays;
 
@@ -170,21 +164,6 @@ public class MapType extends Type {
             clone.selectedFields = this.selectedFields.clone();
         }
         return clone;
-    }
-
-    // Todo: remove it after remove selectedFields
-    public static class MapTypeDeserializer implements JsonDeserializer<MapType> {
-        @Override
-        public MapType deserialize(JsonElement jsonElement, java.lang.reflect.Type type,
-                                   JsonDeserializationContext jsonDeserializationContext)
-                throws JsonParseException {
-            JsonObject dumpJsonObject = jsonElement.getAsJsonObject();
-            JsonObject key = dumpJsonObject.getAsJsonObject("keyType");
-            Type keyType = GsonUtils.GSON.fromJson(key, Type.class);
-            JsonObject value = dumpJsonObject.getAsJsonObject("valueType");
-            Type valueType = GsonUtils.GSON.fromJson(value, Type.class);
-            return new MapType(keyType, valueType);
-        }
     }
 
     public String toMysqlDataTypeString() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -37,12 +37,9 @@ package com.starrocks.catalog;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.gson.annotations.SerializedName;
-import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
-import com.starrocks.proto.PScalarType;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariableConstants;
-import com.starrocks.thrift.TPrimitiveType;
 
 import java.util.Objects;
 
@@ -126,28 +123,6 @@ public class ScalarType extends Type implements Cloneable {
         return res;
     }
 
-    public static ScalarType createType(PScalarType ptype) {
-        TPrimitiveType tPrimitiveType = TPrimitiveType.findByValue(ptype.type);
-
-        switch (tPrimitiveType) {
-            case CHAR:
-                return createCharType(ptype.len);
-            case VARCHAR:
-                return createVarcharType(ptype.len);
-            case VARBINARY:
-                return createVarbinary(ptype.len);
-            case DECIMALV2:
-                return createDecimalV2Type(ptype.precision, ptype.precision);
-            case DECIMAL32:
-            case DECIMAL64:
-            case DECIMAL128:
-            case DECIMAL256:
-                return createDecimalV3Type(PrimitiveType.fromThrift(tPrimitiveType), ptype.precision, ptype.scale);
-            default:
-                return createType(PrimitiveType.fromThrift(tPrimitiveType));
-        }
-    }
-
     public static ScalarType createCharType(int len) {
         ScalarType type = new ScalarType(PrimitiveType.CHAR);
         type.len = len;
@@ -156,15 +131,6 @@ public class ScalarType extends Type implements Cloneable {
 
     private static boolean isDecimalV3Enabled() {
         return Config.enable_decimal_v3;
-    }
-
-    public static void checkEnableDecimalV3() throws AnalysisException {
-        if (!isDecimalV3Enabled()) {
-            throw new AnalysisException("Config field enable_decimal_v3 is false now, " +
-                    "turn it on before decimal32/64/128/256 are used, " +
-                    "execute cmd 'admin set frontend config (\"enable_decimal_v3\" = \"true\")' " +
-                    "on every FE server");
-        }
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StructType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StructType.java
@@ -20,14 +20,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
 import com.google.gson.annotations.SerializedName;
-import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.sql.analyzer.SemanticException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -293,26 +286,6 @@ public class StructType extends Type {
             structFields.add(field.clone());
         }
         return new StructType(structFields);
-    }
-
-    // Todo: remove it after remove selectedFields
-    public static class StructTypeDeserializer implements JsonDeserializer<StructType> {
-        @Override
-        public StructType deserialize(JsonElement jsonElement, java.lang.reflect.Type type,
-                                      JsonDeserializationContext jsonDeserializationContext)
-                throws JsonParseException {
-            JsonObject dumpJsonObject = jsonElement.getAsJsonObject();
-            boolean isNamed = false;
-            if (dumpJsonObject.get("named") != null) {
-                isNamed = dumpJsonObject.get("named").getAsBoolean();
-            }
-            JsonArray fields = dumpJsonObject.getAsJsonArray("fields");
-            ArrayList<StructField> structFields = new ArrayList<>(fields.size());
-            for (JsonElement field : fields) {
-                structFields.add(GsonUtils.GSON.fromJson(field, StructField.class));
-            }
-            return new StructType(structFields, isNamed);
-        }
     }
 
     public String toMysqlDataTypeString() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunction.java
@@ -160,7 +160,7 @@ public class TableFunction extends Function {
         TFunction fn = super.toThrift();
         TTableFunction tableFn = new TTableFunction();
         tableFn.setSymbol(symbolName);
-        tableFn.setRet_types(tableFnReturnTypes.stream().map(Type::toThrift).collect(Collectors.toList()));
+        tableFn.setRet_types(tableFnReturnTypes.stream().map(TypeSerializer::toThrift).collect(Collectors.toList()));
         tableFn.setIs_left_join(isLeftJoin);
         fn.setTable_fn(tableFn);
         return fn;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -38,13 +38,8 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.Lists;
 import com.starrocks.catalog.combinator.AggStateDesc;
-import com.starrocks.sql.analyzer.SemanticException;
-import com.starrocks.thrift.TTypeDesc;
-import com.starrocks.thrift.TTypeNode;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -1106,13 +1101,6 @@ public abstract class Type implements Cloneable {
         throw new IllegalStateException("getTypeSize() not implemented for type " + toSql());
     }
 
-    public TTypeDesc toThrift() {
-        TTypeDesc container = new TTypeDesc();
-        container.setTypes(new ArrayList<TTypeNode>());
-        TypeSerializer.toThrift(this, container);
-        return container;
-    }
-
     /**
      * Returns true if the other can be fully compatible with this type.
      * fully compatible means that all possible values of this type can be represented by the other type,
@@ -1289,18 +1277,6 @@ public abstract class Type implements Cloneable {
             Preconditions.checkState(isScalarType());
         }
         return false;
-    }
-
-    public static List<TTypeDesc> toThrift(Type[] types) {
-        return toThrift(Lists.newArrayList(types));
-    }
-
-    public static List<TTypeDesc> toThrift(ArrayList<Type> types) {
-        ArrayList<TTypeDesc> result = Lists.newArrayList();
-        for (Type t : types) {
-            result.add(t.toThrift());
-        }
-        return result;
     }
 
     /**
@@ -1519,8 +1495,6 @@ public abstract class Type implements Cloneable {
         }
     }
 
-
-
     /**
      * @return scalar scale if type is decimal
      * 31 if type is float or double
@@ -1569,7 +1543,8 @@ public abstract class Type implements Cloneable {
         if (type.isArrayType()) {
             return getInnermostType(((ArrayType) type).getItemType());
         }
-        throw new SemanticException("Cannot get innermost type of '" + type + "'");
+
+        return null;
     }
 
     public String canonicalName() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TypeDeserializer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TypeDeserializer.java
@@ -148,7 +148,7 @@ public class TypeDeserializer {
         switch (tTypeNodeType) {
             case SCALAR: {
                 PScalarType scalarType = pTypeDesc.types.get(nodeIndex).scalarType;
-                return new Pair<>(ScalarType.createType(scalarType), 1);
+                return new Pair<>(createType(scalarType), 1);
             }
             case ARRAY: {
                 Preconditions.checkState(pTypeDesc.types.size() > nodeIndex + 1);
@@ -182,5 +182,27 @@ public class TypeDeserializer {
         // NEVER REACH.
         Preconditions.checkState(false);
         return null;
+    }
+
+    public static ScalarType createType(PScalarType ptype) {
+        TPrimitiveType tPrimitiveType = TPrimitiveType.findByValue(ptype.type);
+
+        switch (tPrimitiveType) {
+            case CHAR:
+                return ScalarType.createCharType(ptype.len);
+            case VARCHAR:
+                return ScalarType.createVarcharType(ptype.len);
+            case VARBINARY:
+                return ScalarType.createVarbinary(ptype.len);
+            case DECIMALV2:
+                return ScalarType.createDecimalV2Type(ptype.precision, ptype.precision);
+            case DECIMAL32:
+            case DECIMAL64:
+            case DECIMAL128:
+            case DECIMAL256:
+                return ScalarType.createDecimalV3Type(PrimitiveType.fromThrift(tPrimitiveType), ptype.precision, ptype.scale);
+            default:
+                return ScalarType.createType(PrimitiveType.fromThrift(tPrimitiveType));
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TypeSerializer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TypeSerializer.java
@@ -22,12 +22,21 @@ import com.starrocks.thrift.TTypeDesc;
 import com.starrocks.thrift.TTypeNode;
 import com.starrocks.thrift.TTypeNodeType;
 
+import java.util.ArrayList;
+
 /**
  * Utility class for serializing Type objects to Thrift format.
  * This class centralizes all type serialization logic.
  * For deserialization, see {@link TypeDeserializer}.
  */
 public class TypeSerializer {
+
+    public static TTypeDesc toThrift(Type type) {
+        TTypeDesc container = new TTypeDesc();
+        container.setTypes(new ArrayList<>());
+        TypeSerializer.toThrift(type, container);
+        return container;
+    }
 
     /**
      * Converts a Type to its Thrift representation.

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -69,6 +69,7 @@ import com.starrocks.catalog.TableProperty;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
+import com.starrocks.catalog.TypeSerializer;
 import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReportException;
@@ -983,7 +984,7 @@ public class LeaderImpl {
                 for (Column column : rangePartitionInfo.getPartitionColumns(olapTable.getIdToColumn())) {
                     TColumnMeta columnMeta = new TColumnMeta();
                     columnMeta.setColumnName(column.getName());
-                    columnMeta.setColumnType(column.getType().toThrift());
+                    columnMeta.setColumnType(TypeSerializer.toThrift(column.getType()));
                     columnMeta.setKey(column.isKey());
                     if (column.getAggregationType() != null) {
                         columnMeta.setAggregationType(column.getAggregationType().name());
@@ -1055,7 +1056,7 @@ public class LeaderImpl {
                     for (Column column : materializedIndexMeta.getSchema()) {
                         TColumnMeta columnMeta = new TColumnMeta();
                         columnMeta.setColumnName(column.getName());
-                        columnMeta.setColumnType(column.getType().toThrift());
+                        columnMeta.setColumnType(TypeSerializer.toThrift(column.getType()));
                         columnMeta.setKey(column.isKey());
                         columnMeta.setAllowNull(column.isAllowNull());
                         if (column.getAggregationType() != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RawValuesNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RawValuesNode.java
@@ -17,12 +17,13 @@ package com.starrocks.planner;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.Type;
-import com.starrocks.thrift.TRawValuesNode;
+import com.starrocks.catalog.TypeSerializer;
 import com.starrocks.thrift.TExplainLevel;
-import com.starrocks.thrift.TPlanNode;
-import com.starrocks.thrift.TPlanNodeType;
 import com.starrocks.thrift.TNormalPlanNode;
 import com.starrocks.thrift.TNormalRawValuesNode;
+import com.starrocks.thrift.TPlanNode;
+import com.starrocks.thrift.TPlanNodeType;
+import com.starrocks.thrift.TRawValuesNode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -93,7 +94,7 @@ public class RawValuesNode extends PlanNode {
         msg.node_type = TPlanNodeType.RAW_VALUES_NODE;
         msg.raw_values_node = new TRawValuesNode();
         msg.raw_values_node.tuple_id = tupleIds.get(0).asInt();
-        msg.raw_values_node.constant_type = constantType.toThrift();
+        msg.raw_values_node.constant_type = TypeSerializer.toThrift(constantType);
         PrimitiveType primitiveType = constantType.getPrimitiveType();
 
         if (primitiveType.isIntegerType()) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SlotDescriptor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SlotDescriptor.java
@@ -42,6 +42,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnStats;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
+import com.starrocks.catalog.TypeSerializer;
 import com.starrocks.common.FeConstants;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.expression.Expr;
@@ -264,10 +265,10 @@ public class SlotDescriptor {
         tSlotDescriptor.setId(id.asInt());
         tSlotDescriptor.setParent(parent.getId().asInt());
         if (originType != null) {
-            tSlotDescriptor.setSlotType(originType.toThrift());
+            tSlotDescriptor.setSlotType(TypeSerializer.toThrift(originType));
         } else {
             type = type.isNull() ? ScalarType.BOOLEAN : type;
-            tSlotDescriptor.setSlotType(type.toThrift());
+            tSlotDescriptor.setSlotType(TypeSerializer.toThrift(type));
             if (column != null) {
                 LOG.debug("column id:{}, column unique id:{}",
                         column.getColumnId(), column.getUniqueId());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/Expr.java
@@ -45,6 +45,7 @@ import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
+import com.starrocks.catalog.TypeSerializer;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.TreeNode;
@@ -640,7 +641,7 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         Preconditions.checkState(java.util.Objects.equals(type, AnalyzerUtils.replaceNullType2Boolean(type)),
                 "NULL_TYPE is illegal in thrift stage");
 
-        msg.type = type.toThrift();
+        msg.type = TypeSerializer.toThrift(type);
         msg.num_children = children.size();
         msg.setHas_nullable_child(hasNullableChild());
         msg.setIs_nullable(isNullable());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ExprToThriftVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ExprToThriftVisitor.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.ast.expression;
 
 import com.google.common.base.Preconditions;
+import com.starrocks.catalog.TypeSerializer;
 import com.starrocks.planner.SlotDescriptor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.common.ErrorType;
@@ -240,7 +241,7 @@ public class ExprToThriftVisitor implements AstVisitorExtendInterface<Void, TExp
         msg.setOpcode(node.getOpcode());
         msg.setOutput_column(node.getOutputColumn());
         if (node.getChild(0).getType().isComplexType()) {
-            msg.setChild_type_desc(node.getChild(0).getType().toThrift());
+            msg.setChild_type_desc(TypeSerializer.toThrift(node.getChild(0).getType()));
         } else {
             msg.setChild_type(node.getChild(0).getType().getPrimitiveType().toThrift());
         }
@@ -279,7 +280,7 @@ public class ExprToThriftVisitor implements AstVisitorExtendInterface<Void, TExp
         msg.setOpcode(node.getOpcode());
         msg.setVector_opcode(node.getVectorOpcode());
         if (node.getChild(0).getType().isComplexType()) {
-            msg.setChild_type_desc(node.getChild(0).getType().toThrift());
+            msg.setChild_type_desc(TypeSerializer.toThrift(node.getChild(0).getType()));
         } else {
             msg.setChild_type(node.getChild(0).getType().getPrimitiveType().toThrift());
         }
@@ -314,7 +315,7 @@ public class ExprToThriftVisitor implements AstVisitorExtendInterface<Void, TExp
         msg.setOpcode(node.getOpcode());
         msg.setVector_opcode(node.getVectorOpcode());
         if (node.getChild(0).getType().isComplexType()) {
-            msg.setChild_type_desc(node.getChild(0).getType().toThrift());
+            msg.setChild_type_desc(TypeSerializer.toThrift(node.getChild(0).getType()));
         } else {
             msg.setChild_type(node.getChild(0).getType().getPrimitiveType().toThrift());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/TypeDef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/TypeDef.java
@@ -181,6 +181,9 @@ public class TypeDef implements ParseNode {
 
     private void analyzeArrayType(ArrayType type) {
         Type baseType = Type.getInnermostType(type);
+        if (baseType == null) {
+            throw new SemanticException("Cannot get innermost type of '" + type + "'");
+        }
         analyze(baseType);
         if (baseType.isHllType() || baseType.isBitmapType() || baseType.isPseudoType() || baseType.isPercentile()) {
             throw new SemanticException("Invalid data type: " + type.toSql());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -9435,10 +9435,11 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             }
             return ScalarType.createUnifiedDecimalType(10, 0);
         } else if (context.DECIMAL32() != null || context.DECIMAL64() != null || context.DECIMAL128() != null) {
-            try {
-                ScalarType.checkEnableDecimalV3();
-            } catch (AnalysisException e) {
-                throw new SemanticException(e.getMessage());
+            if (!Config.enable_decimal_v3) {
+                throw new SemanticException("Config field enable_decimal_v3 is false now, " +
+                        "turn it on before decimal32/64/128/256 are used, " +
+                        "execute cmd 'admin set frontend config (\"enable_decimal_v3\" = \"true\")' " +
+                        "on every FE server");
             }
             final PrimitiveType primitiveType = PrimitiveType.valueOf(context.children.get(0).getText().toUpperCase());
             if (precision != null) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This pull request refactors and centralizes the logic for serializing type information to Thrift format in the StarRocks codebase. The main changes involve removing direct calls to `Type.toThrift()` in favor of a new utility class, `TypeSerializer`, and relocating deserialization logic to `TypeDeserializer`. This improves code maintainability and consistency in type serialization/deserialization.

**Type Serialization Refactoring:**

* Introduced the `TypeSerializer` utility class with a static `toThrift(Type)` method, consolidating all logic for serializing `Type` objects to Thrift format. All previous usages of `Type.toThrift()` have been updated to use `TypeSerializer.toThrift()`. (`TypeSerializer.java`, `Type.java`, `AggregateFunction.java`, `Column.java`, `ColumnAccessPath.java`, `Function.java`, `TableFunction.java`, `LeaderImpl.java`) [[1]](diffhunk://#diff-737ac75c80f00e2ea4a0df1a78437c232952c02130206f1fa0fd5a01fb9bb35cR25-R40) [[2]](diffhunk://#diff-26c46289de6cd6c28bdc3290983853d3f33ed6fe7fa985f6eef5e6b27eeab604L1109-L1115) [[3]](diffhunk://#diff-fbb29d1e5a694b26efb486deb8b12d9b63f3f9c5c6983ab7b5caedd6ba07dfdaL375-R377) [[4]](diffhunk://#diff-6916aac17b45d953dcb4b59d9cc3b155059e58a3b51b39e9e123aa55f11fc347L459-R459) [[5]](diffhunk://#diff-6916aac17b45d953dcb4b59d9cc3b155059e58a3b51b39e9e123aa55f11fc347L477-R477) [[6]](diffhunk://#diff-f25da4a94e763b3f709eba32da7b319da96f5fa0b3539e3db8581787f2d6636bL239-R239) [[7]](diffhunk://#diff-f06c1d51d50fef26d423750928b2c9f1bd9f0d607c094cc4768185821a570dc4L746-R756) [[8]](diffhunk://#diff-8086d3b79cac2725467eea7dab21180ba01332ef52f4df3f97b5b86585c32620L163-R163) [[9]](diffhunk://#diff-31eb7bce27c09fe0bbc2e709965211e4476f2b569c0ebb19a21bdff0ca02d30eL986-R987) [[10]](diffhunk://#diff-31eb7bce27c09fe0bbc2e709965211e4476f2b569c0ebb19a21bdff0ca02d30eL1058-R1059)

**Type Deserialization Refactoring:**

* Moved the logic for creating `ScalarType` from `PScalarType` from `ScalarType` to a new static method in `TypeDeserializer`, and updated usages accordingly. (`ScalarType.java`, `TypeDeserializer.java`) [[1]](diffhunk://#diff-2873ccf5945e79b7e65fe36968b37b724965f6b1167588d1e5012e9c1f2b9c08L129-L150) [[2]](diffhunk://#diff-942afe673697706e52e6a4251610ac563437dfaa66520f57116eac00dd41c20fL151-R151) [[3]](diffhunk://#diff-942afe673697706e52e6a4251610ac563437dfaa66520f57116eac00dd41c20fR186-R207)

**Code Cleanup and Legacy Removal:**

* Removed deprecated or unused deserialization code for `MapType` and `StructType`, as well as unnecessary imports and methods related to type serialization/deserialization. (`MapType.java`, `StructType.java`, `ScalarType.java`, `Type.java`) [[1]](diffhunk://#diff-6c37aca06af7464dd2b5d1a7d0708afe7b8c75184306b22733fc108e13b776bdL20-L26) [[2]](diffhunk://#diff-6c37aca06af7464dd2b5d1a7d0708afe7b8c75184306b22733fc108e13b776bdL175-L189) [[3]](diffhunk://#diff-645e562027c31121d5526456ab235158c49ba9bf6da1ea21e1bd299c2e20ea03L23-L30) [[4]](diffhunk://#diff-645e562027c31121d5526456ab235158c49ba9bf6da1ea21e1bd299c2e20ea03L298-L317) [[5]](diffhunk://#diff-2873ccf5945e79b7e65fe36968b37b724965f6b1167588d1e5012e9c1f2b9c08L161-L169) [[6]](diffhunk://#diff-26c46289de6cd6c28bdc3290983853d3f33ed6fe7fa985f6eef5e6b27eeab604L1294-L1305)

**Minor Adjustments and Cleanups:**

* Updated error handling and return values for type-related utility methods to improve robustness and clarity.
* Removed unused imports and minor formatting cleanups across several files. [[1]](diffhunk://#diff-2873ccf5945e79b7e65fe36968b37b724965f6b1167588d1e5012e9c1f2b9c08L40-L45) [[2]](diffhunk://#diff-26c46289de6cd6c28bdc3290983853d3f33ed6fe7fa985f6eef5e6b27eeab604L41-L47) [[3]](diffhunk://#diff-f06c1d51d50fef26d423750928b2c9f1bd9f0d607c094cc4768185821a570dc4R51-R54) [[4]](diffhunk://#diff-f06c1d51d50fef26d423750928b2c9f1bd9f0d607c094cc4768185821a570dc4R501) [[5]](diffhunk://#diff-f06c1d51d50fef26d423750928b2c9f1bd9f0d607c094cc4768185821a570dc4L908) [[6]](diffhunk://#diff-26c46289de6cd6c28bdc3290983853d3f33ed6fe7fa985f6eef5e6b27eeab604L1522-L1523)

These changes collectively improve the maintainability and clarity of type serialization and deserialization throughout the codebase.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes type Thrift serialization via TypeSerializer and relocates type deserialization and JSON adapters, with minor type/parsing adjustments and broad call-site updates.
> 
> - **Type Serialization**:
>   - Introduce `TypeSerializer.toThrift(...)` (wrapper + helpers) and replace all usages of `Type.toThrift()` across code (`AggregateFunction`, `Function`, `Column`, `SlotDescriptor`, `Expr`, `ExprToThriftVisitor`, `RawValuesNode`, `TableFunction`, `LeaderImpl`, etc.).
>   - Remove `Type.toThrift()` and bulk `Type.toThrift(...)` list helpers.
> - **Type Deserialization**:
>   - Move `PScalarType`→`ScalarType` construction to `TypeDeserializer.createType(...)`; remove the former method from `ScalarType`.
> - **Gson Adapters**:
>   - Remove in-class deserializers from `MapType` and `StructType`; re-add as dedicated inner classes in `GsonUtils` and register there.
> - **Parsing/Type Tweaks**:
>   - In `AstBuilder`, check `Config.enable_decimal_v3` directly for DECIMAL32/64/128; adjust error.
>   - `Type.getInnermostType(...)` now returns `null` for unsupported types; `TypeDef.analyzeArrayType(...)` guards against null.
> - **Cleanups**:
>   - Prune unused imports and minor formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cdf4415c65b52fd10adce630fe9ce23c53c34cb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->