### PR TITLE
[Enhancement] Push down heavy exprs involving regexp to storage layer to leverage io threads to evaluate

### DIFF
--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -71,6 +71,8 @@ Status ScanOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(SourceOperator::prepare(state));
 
     _unique_metrics->add_info_string("MorselQueueType", _morsel_queue->name());
+    auto num_heavy_exprs = down_cast<ScanOperatorFactory*>(_factory)->scan_node()->get_heavy_expr_ctxs().size();
+    _unique_metrics->add_info_string("NumHeavyExprs", std::to_string(num_heavy_exprs));
     _peak_buffer_size_counter = _unique_metrics->AddHighWaterMarkCounter(
             "PeakChunkBufferSize", TUnit::UNIT,
             RuntimeProfile::Counter::create_strategy(TUnit::UNIT, TCounterMergeType::SKIP_ALL),
@@ -662,6 +664,8 @@ Status ScanOperatorFactory::prepare(RuntimeState* state) {
     TEST_SUCC_POINT("ScanOperatorFactory::prepare");
 
     RETURN_IF_ERROR(OperatorFactory::prepare(state));
+    RETURN_IF_ERROR(Expr::prepare(_scan_node->get_heavy_expr_ctxs(), state));
+    RETURN_IF_ERROR(Expr::open(_scan_node->get_heavy_expr_ctxs(), state));
     RETURN_IF_ERROR(do_prepare(state));
 
     return Status::OK();
@@ -673,7 +677,9 @@ OperatorPtr ScanOperatorFactory::create(int32_t degree_of_parallelism, int32_t d
 
 void ScanOperatorFactory::close(RuntimeState* state) {
     do_close(state);
-
+    // Do not call Expr::close, since async io task would access heavy exprs after
+    // they are closed; exprs in scan operators are auto-closed by ExprContext.
+    // Expr::close(_scan_node->get_heavy_expr_ctxs(), state);
     OperatorFactory::close(state);
 }
 

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -314,6 +314,7 @@ public:
     SourceOperatorFactory::AdaptiveState adaptive_initial_state() const override { return AdaptiveState::ACTIVE; }
 
     std::shared_ptr<workgroup::ScanTaskGroup> scan_task_group() const { return _scan_task_group; }
+    ScanNode* scan_node() { return _scan_node; }
 
 protected:
     ScanNode* const _scan_node;

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -146,6 +146,14 @@ public:
         this->_back_pressure_throttle_time_upper_bound = value;
     }
 
+    void set_heavy_expr_slot_ids(std::vector<SlotId>&& slot_ids) { _heavy_expr_slot_ids = std::move(slot_ids); }
+
+    void set_heavy_expr_ctxs(std::vector<ExprContext*>& ctxs) { _heavy_expr_ctxs = std::move(ctxs); }
+
+    std::vector<SlotId>& get_heavy_expr_slot_ids() { return _heavy_expr_slot_ids; }
+
+    std::vector<ExprContext*>& get_heavy_expr_ctxs() { return _heavy_expr_ctxs; }
+
 protected:
     RuntimeProfile::Counter* _bytes_read_counter = nullptr; // # bytes read from the scanner
     // # rows/tuples read from the scanner (including those discarded by eval_conjucts())
@@ -171,6 +179,9 @@ protected:
     size_t _back_pressure_num_rows = 10240;
     int64_t _back_pressure_throttle_time = 500;
     int64_t _back_pressure_throttle_time_upper_bound = 5000;
+
+    std::vector<SlotId> _heavy_expr_slot_ids;
+    std::vector<ExprContext*> _heavy_expr_ctxs;
 };
 
 } // namespace starrocks

--- a/be/src/exprs/string_functions.h
+++ b/be/src/exprs/string_functions.h
@@ -70,6 +70,8 @@ struct StringFunctionsState {
     DriverMap driver_regex_map; // regex for each pipeline_driver, to make it driver-local
 
     bool use_hyperscan = false;
+    std::optional<std::string> opt_const_rpl{};
+    bool global_mode = true;
     int size_of_pattern = -1;
 
     // a pointer to the generated database that responsible for parsed expression.

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -101,6 +101,7 @@ import com.starrocks.thrift.TNormalOlapScanNode;
 import com.starrocks.thrift.TNormalPlanNode;
 import com.starrocks.thrift.TOlapScanNode;
 import com.starrocks.thrift.TPlanNode;
+import com.starrocks.thrift.TPlanNodeCommon;
 import com.starrocks.thrift.TPlanNodeType;
 import com.starrocks.thrift.TPrimitiveType;
 import com.starrocks.thrift.TScanRange;
@@ -117,6 +118,7 @@ import org.apache.spark.util.SizeEstimator;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -847,6 +849,29 @@ public class OlapScanNode extends ScanNode {
             }
         }
 
+        if (!getHeavyExprs().isEmpty()) {
+            output.append(prefix).append("heavy exprs: ").append("\n");
+            List<Pair<SlotId, Expr>> outputColumns = new ArrayList<>();
+            for (Map.Entry<SlotId, Expr> kv : getHeavyExprs().entrySet()) {
+                outputColumns.add(new Pair<>(kv.getKey(), kv.getValue()));
+            }
+            outputColumns.sort(Comparator.comparingInt(o -> o.first.asInt()));
+
+            for (Pair<SlotId, Expr> kv : outputColumns) {
+                output.append(prefix).append(prefix);
+                if (detailLevel == TExplainLevel.VERBOSE) {
+                    output.append(kv.first).append(" <-> ")
+                            .append(kv.second.explain()).append("\n");
+                } else {
+                    output.append("<slot ").
+                            append(kv.first).
+                            append("> : ").
+                            append(explainExpr(kv.second)).
+                            append("\n");
+                }
+            }
+        }
+
         if (detailLevel != TExplainLevel.VERBOSE) {
             if (isPreAggregation) {
                 output.append(prefix).append("PREAGGREGATION: ON").append("\n");
@@ -1001,6 +1026,13 @@ public class OlapScanNode extends ScanNode {
         List<TColumn> columnsDesc = new ArrayList<TColumn>();
         Set<ColumnId> bfColumns = olapTable.getBfColumnIds();
         long schemaId = 0;
+
+        if (!getHeavyExprs().isEmpty()) {
+            TPlanNodeCommon common = new TPlanNodeCommon();
+            getHeavyExprs().forEach(
+                    (key, value) -> common.putToHeavy_exprs(key.asInt(), ExprToThriftVisitor.treeToThrift(value)));
+            msg.setCommon(common);
+        }
 
         if (selectedIndexId != -1) {
             MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(selectedIndexId);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
@@ -36,6 +36,7 @@ package com.starrocks.planner;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.Maps;
 import com.starrocks.catalog.ColumnAccessPath;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.connector.BucketProperty;
@@ -75,6 +76,8 @@ public abstract class ScanNode extends PlanNode {
     // NOTE: To avoid trigger a new compute resource creation, set the value when the scan node needs to use it.
     // The compute resource used by this scan node.
     protected ComputeResource computeResource = WarehouseManager.DEFAULT_RESOURCE;
+
+    private Map<SlotId, Expr> heavyExprs = Maps.newHashMap();
 
     public ScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName) {
         super(id, desc.getId().asList(), planNodeName);
@@ -249,5 +252,13 @@ public abstract class ScanNode extends PlanNode {
             output.append("\n");
         }
         return output.toString();
+    }
+
+    public void setHeavyExprs(Map<SlotId, Expr> heavyExprs) {
+        this.heavyExprs = heavyExprs;
+    }
+
+    public Map<SlotId, Expr> getHeavyExprs() {
+        return heavyExprs;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -987,6 +987,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_INSERT_SELECT_EXTERNAL_AUTO_REFRESH = "enable_insert_select_external_auto_refresh";
 
+    public static final String PUSH_DOWN_HEAVY_EXPRS = "push_down_heavy_exprs";
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(MAX_EXECUTION_TIME)
@@ -2034,6 +2036,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_INSERT_SELECT_EXTERNAL_AUTO_REFRESH)
     private boolean enableInsertSelectExternalAutoRefresh = true;
+
+    @VarAttr(name = PUSH_DOWN_HEAVY_EXPRS)
+    private boolean pushDownHeavyExprs = true;
 
     public int getCboPruneJsonSubfieldDepth() {
         return cboPruneJsonSubfieldDepth;
@@ -5491,6 +5496,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableInsertSelectExternalAutoRefresh(boolean enableInsertSelectExternalAutoRefresh) {
         this.enableInsertSelectExternalAutoRefresh = enableInsertSelectExternalAutoRefresh;
+    }
+
+    public void setPushDownHeavyExprs(boolean flag) {
+        this.pushDownHeavyExprs = flag;
+    }
+
+    public boolean isPushDownHeavyExprs() {
+        return this.pushDownHeavyExprs;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/test/java/com/starrocks/planner/PushDownHeavyExprsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/PushDownHeavyExprsTest.java
@@ -1,0 +1,69 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.common.FeConstants;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.util.Utility;
+import com.starrocks.statistic.StatsConstants;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static com.starrocks.sql.optimizer.statistics.CachedStatisticStorageTest.DEFAULT_CREATE_TABLE_TEMPLATE;
+
+public class PushDownHeavyExprsTest {
+    protected static ConnectContext ctx;
+    protected static StarRocksAssert starRocksAssert;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        FeConstants.runningUnitTest = true;
+        UtFrameUtils.createMinStarRocksCluster();
+        ctx = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(ctx);
+        starRocksAssert.withDatabase(StatsConstants.STATISTICS_DB_NAME).useDatabase(StatsConstants.STATISTICS_DB_NAME)
+                .withTable(DEFAULT_CREATE_TABLE_TEMPLATE);
+        starRocksAssert.withDatabase("test").useDatabase("test");
+        Utility.getClickBenchCreateTableSqlList().forEach(createTblSql -> {
+            try {
+                starRocksAssert.withTable(createTblSql);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Test
+    public void test() throws Exception {
+        String q =
+                Utility.getClickBenchQueryList().stream().filter(p -> p.first.equals("Q29")).findFirst().get().second;
+        String plan = UtFrameUtils.getFragmentPlan(ctx, q);
+        Assertions.assertTrue(plan.contains("  0:OlapScanNode\n" +
+                "     TABLE: hits\n" + "     heavy exprs: \n" +
+                "          <slot 106> : regexp_replace(15: Referer, '^https?://(?:www.)?([^/]+)/.*$', '1')"), plan);
+
+        plan = UtFrameUtils.getVerboseFragmentPlan(ctx, q);
+        System.out.println(plan);
+        Assertions.assertTrue(plan.contains("  0:OlapScanNode\n" +
+                "     table: hits, rollup: hits\n" +
+                "     heavy exprs: \n" +
+                "          106 <-> regexp_replace[([15: Referer, VARCHAR(65533), false], " +
+                "'^https?://(?:www.)?([^/]+)/.*$', '1'); args: VARCHAR,VARCHAR,VARCHAR; " +
+                "result: VARCHAR; args nullable: false; result nullable: true]\n"), plan);
+    }
+}

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -1369,7 +1369,11 @@ struct TStreamAggregationNode {
   24: optional i32 agg_func_set_version = 1
 }
 
-
+struct TPlanNodeCommon {
+  // heavy_exprs are extracted from projection and shall be push down to ScanNode and
+  // it is evaluated by ScanNode's ChunkSource in io threads.
+  1: optional map<Types.TSlotId, Exprs.TExpr> heavy_exprs
+}
 // This is essentially a union of all messages corresponding to subclasses
 // of PlanNode.
 struct TPlanNode {
@@ -1386,6 +1390,7 @@ struct TPlanNode {
 
   // Produce data in compact format.
   8: required bool compact_data
+  9: optional TPlanNodeCommon common
 
   // one field per PlanNode subclass
   11: optional THashJoinNode hash_join_node

--- a/test/sql/test_push_down_heavy_exprs/R/test_push_down_heavy_exprs
+++ b/test/sql/test_push_down_heavy_exprs/R/test_push_down_heavy_exprs
@@ -1,0 +1,78 @@
+-- name: test_push_down_heavy_exprs
+create table t0 (
+c0 string
+) properties("replication_num"="1");
+-- result:
+-- !result
+insert into t0 with cte as (
+select i from table(generate_series(1,10000)) t(i)
+)
+select concat(i, ".", "foo", case i%3 when 0 then ".bar" when 1 then ".buzz" else "" end, ".xxxx") c0 
+from cte;
+-- result:
+-- !result
+create table result (
+fp bigint 
+) properties("replication_num"="1");
+-- result:
+-- !result
+insert into result 
+with cte as (
+select distinct regexp_replace(c0, "^\\d+(\\.foo\.b\\w+).*$", "\\1") as c0 from t0 
+)
+select /*+SET_VAR(push_down_heavy_exprs=true)*/sum(murmur_hash3_32(cte.c0)) fp from cte;
+-- result:
+-- !result
+insert into result 
+with cte as (
+select distinct regexp_replace(c0, "^\\d+(\\.foo\.b\\w+).*$", "\\1") as c0 from t0 
+)
+select /*+SET_VAR(push_down_heavy_exprs=false)*/sum(murmur_hash3_32(cte.c0)) fp from cte;
+-- result:
+-- !result
+select assert_true(count(fp)=2 and count(distinct fp)=1) from result;
+-- result:
+1
+-- !result
+truncate table result;
+-- result:
+-- !result
+insert into result 
+with cte as (
+select distinct regexp_replace(c0, "\\d+(\\.foo\.b\\w+).*", "\\1") as c0 from t0 
+)
+select /*+SET_VAR(push_down_heavy_exprs=true)*/sum(murmur_hash3_32(cte.c0)) fp from cte;
+-- result:
+-- !result
+insert into result 
+with cte as (
+select distinct regexp_replace(c0, "\\d+(\\.foo\.b\\w+).*", "\\1") as c0 from t0 
+)
+select /*+SET_VAR(push_down_heavy_exprs=false)*/sum(murmur_hash3_32(cte.c0)) fp from cte;
+-- result:
+-- !result
+select assert_true(count(fp)=2 and count(distinct fp)=1) from result;
+-- result:
+1
+-- !result
+truncate table result;
+-- result:
+-- !result
+insert into result 
+with cte as (
+select distinct regexp_replace(c0, ".*foo.bar*", "deadbeef") as c0 from t0 
+)
+select /*+SET_VAR(push_down_heavy_exprs=true)*/sum(murmur_hash3_32(cte.c0)) fp from cte;
+-- result:
+-- !result
+insert into result 
+with cte as (
+select distinct regexp_replace(c0, ".*foo.bar*", "deadbeef") as c0 from t0 
+)
+select /*+SET_VAR(push_down_heavy_exprs=false)*/sum(murmur_hash3_32(cte.c0)) fp from cte;
+-- result:
+-- !result
+select assert_true(count(fp)=2 and count(distinct fp)=1) from result;
+-- result:
+1
+-- !result

--- a/test/sql/test_push_down_heavy_exprs/T/test_push_down_heavy_exprs
+++ b/test/sql/test_push_down_heavy_exprs/T/test_push_down_heavy_exprs
@@ -1,0 +1,62 @@
+-- name: test_push_down_heavy_exprs
+
+create table t0 (
+c0 string
+) properties("replication_num"="1");
+
+insert into t0 with cte as (
+select i from table(generate_series(1,10000)) t(i)
+)
+select concat(i, ".", "foo", case i%3 when 0 then ".bar" when 1 then ".buzz" else "" end, ".xxxx") c0 
+from cte;
+
+create table result (
+fp bigint 
+) properties("replication_num"="1");
+
+insert into result 
+with cte as (
+select distinct regexp_replace(c0, "^\\d+(\\.foo\.b\\w+).*$", "\\1") as c0 from t0 
+)
+select /*+SET_VAR(push_down_heavy_exprs=true)*/sum(murmur_hash3_32(cte.c0)) fp from cte;
+
+
+insert into result 
+with cte as (
+select distinct regexp_replace(c0, "^\\d+(\\.foo\.b\\w+).*$", "\\1") as c0 from t0 
+)
+select /*+SET_VAR(push_down_heavy_exprs=false)*/sum(murmur_hash3_32(cte.c0)) fp from cte;
+
+select assert_true(count(fp)=2 and count(distinct fp)=1) from result;
+
+truncate table result;
+
+insert into result 
+with cte as (
+select distinct regexp_replace(c0, "\\d+(\\.foo\.b\\w+).*", "\\1") as c0 from t0 
+)
+select /*+SET_VAR(push_down_heavy_exprs=true)*/sum(murmur_hash3_32(cte.c0)) fp from cte;
+
+insert into result 
+with cte as (
+select distinct regexp_replace(c0, "\\d+(\\.foo\.b\\w+).*", "\\1") as c0 from t0 
+)
+select /*+SET_VAR(push_down_heavy_exprs=false)*/sum(murmur_hash3_32(cte.c0)) fp from cte;
+
+select assert_true(count(fp)=2 and count(distinct fp)=1) from result;
+
+truncate table result;
+
+insert into result 
+with cte as (
+select distinct regexp_replace(c0, ".*foo.bar*", "deadbeef") as c0 from t0 
+)
+select /*+SET_VAR(push_down_heavy_exprs=true)*/sum(murmur_hash3_32(cte.c0)) fp from cte;
+
+insert into result 
+with cte as (
+select distinct regexp_replace(c0, ".*foo.bar*", "deadbeef") as c0 from t0 
+)
+select /*+SET_VAR(push_down_heavy_exprs=false)*/sum(murmur_hash3_32(cte.c0)) fp from cte;
+
+select assert_true(count(fp)=2 and count(distinct fp)=1) from result;


### PR DESCRIPTION
## Why I'm doing:
Two optimizatons as follows:
1. push heavy exprs involving regexp to chunk source to leverage io threads to evaluate, since io dop is 4x or 16x of pipeline dop; 
2. in regexp_replace, if the pattern starts with "^" or ends with "$", then we can use re2::RE2::Replace instead of re2::RE2::GlobalReplace, and if the replacement str is constant str, a new process branch is introduced.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pushes heavy regexp expressions from projection to scan/IO threads and optimizes regexp_replace, wiring through FE/BE/Thrift with a session switch and tests.
> 
> - **Execution (BE)**:
>   - Evaluate heavy expressions in `ChunkSource` and append results; add `NumHeavyExprs` metric.
>   - `ScanOperatorFactory` prepares/opens heavy exprs; expose `scan_node()`.
>   - `ScanNode` parses, stores, and exposes heavy expr slot IDs and contexts from plan.
> - **Frontend (FE)**:
>   - Detect heavy exprs (regexp) in `PlanFragmentBuilder` and push them to `OlapScanNode`; create non-materialized slots; handle in `ProjectNode` normal form and trivial checks.
>   - `OlapScanNode` includes/explains heavy exprs and serializes them.
>   - Session var `push_down_heavy_exprs` (default true) to control behavior.
> - **Thrift/Plan**:
>   - Add `TPlanNodeCommon.heavy_exprs` and embed in `TPlanNode`.
> - **String Functions**:
>   - Optimize `regexp_replace`: detect global vs single replace, fast path for constant replacement, platform-specific RE2 paths.
> - **Tests**:
>   - Add unit and SQL tests validating identical results with pushdown on/off.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbcef58775a50013c864fbf3f49cf19908cd3629. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->