### PR TITLE
[BugFix] Fix possible NPE in EliminateOveruseColumnAccessPathRule

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/EliminateOveruseColumnAccessPathRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/EliminateOveruseColumnAccessPathRule.java
@@ -40,7 +40,7 @@ package com.starrocks.sql.optimizer.rule.tree;
  * <p>The rule processes the query tree top-down, propagating column usage information from parent
  * operators to child operators to make informed decisions about which access paths can be eliminated.</p>
  */
-import com.google.common.base.Preconditions;
+
 import com.google.common.collect.ImmutableList;
 import com.starrocks.catalog.ColumnAccessPath;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -49,6 +49,8 @@ import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.task.TaskContext;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Map;
@@ -58,6 +60,8 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public class EliminateOveruseColumnAccessPathRule implements TreeRewriteRule {
+    private static final Logger LOG = LogManager.getLogger(EliminateOveruseColumnAccessPathRule.class);
+
     @Override
     public OptExpression rewrite(OptExpression root, TaskContext taskContext) {
         Visitor.processTopdown(root, ColumnRefSet.of());
@@ -80,8 +84,10 @@ public class EliminateOveruseColumnAccessPathRule implements TreeRewriteRule {
 
         @Override
         public Optional<ColumnRefSet> visitPhysicalOlapScan(OptExpression optExpression,
-                                                        ColumnRefSet parentUsedColumnRefs) {
-            Preconditions.checkState(parentUsedColumnRefs != null);
+                                                            ColumnRefSet parentUsedColumnRefs) {
+            if (parentUsedColumnRefs == null) {
+                throw new IllegalStateException("parentUsedColumnRefs is null in visitPhysicalOlapScan");
+            }
             PhysicalScanOperator scan = optExpression.getOp().cast();
             if (parentUsedColumnRefs.isEmpty() || scan.getColumnAccessPaths() == null ||
                     scan.getColumnAccessPaths().isEmpty()) {
@@ -98,13 +104,21 @@ public class EliminateOveruseColumnAccessPathRule implements TreeRewriteRule {
             List<ColumnAccessPath> nonSubfieldPruningProjectings = accessPathGroups.get(false);
             List<ColumnAccessPath> subfieldPruningProjectings = accessPathGroups.get(true);
 
-            if (subfieldPruningProjectings.isEmpty()) {
+            if (subfieldPruningProjectings == null || subfieldPruningProjectings.isEmpty()) {
                 return Optional.empty();
             }
 
             Map<String, ColumnRefOperator> columnNameToIdMap = scan.getColRefToColumnMetaMap().entrySet()
                     .stream()
                     .collect(Collectors.toMap(e -> e.getValue().getName(), Map.Entry::getKey));
+
+            for (ColumnAccessPath accessPath : subfieldPruningProjectings) {
+                if (!columnNameToIdMap.containsKey(accessPath.getPath())) {
+                    LOG.warn("ColumnAccessPath {} not found in scan's column map {}, skip eliminating overuse",
+                            accessPath.getPath(), scan.getColRefToColumnMetaMap());
+                    return Optional.empty();
+                }
+            }
 
             Predicate<ColumnAccessPath> isOveruseProjecting = accessPath ->
                     columnNameToIdMap.containsKey(accessPath.getPath()) &&


### PR DESCRIPTION
## Why I'm doing:
```
java.lang.NullPointerException: null
	at java.util.Objects.requireNonNull(Objects.java:222) ~[?:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.lambda$visitPhysicalScan$4(EliminateOveruseColumnAccessPathRule.java:84) ~[starrocks-fe.jar:?]
	at java.util.stream.Collectors.lambda$partitioningBy$62(Collectors.java:1388) ~[?:?]
	at java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169) ~[?:?]
	at java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655) ~[?:?]
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484) ~[?:?]
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474) ~[?:?]
	at java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913) ~[?:?]
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234) ~[?:?]
	at java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578) ~[?:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.visitPhysicalScan(EliminateOveruseColumnAccessPathRule.java:88) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.visitPhysicalScan(EliminateOveruseColumnAccessPathRule.java:41) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.OptExpressionVisitor.visitPhysicalOlapScan(OptExpressionVisitor.java:122) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator.accept(PhysicalOlapScanOperator.java:237) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.processTopdown(EliminateOveruseColumnAccessPathRule.java:107) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.lambda$processTopdown$5(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at java.util.ArrayList.forEach(ArrayList.java:1541) ~[?:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.processTopdown(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.lambda$processTopdown$5(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at java.util.ArrayList.forEach(ArrayList.java:1541) ~[?:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.processTopdown(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.lambda$processTopdown$5(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at java.util.ArrayList.forEach(ArrayList.java:1541) ~[?:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.processTopdown(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.lambda$processTopdown$5(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at java.util.ArrayList.forEach(ArrayList.java:1541) ~[?:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.processTopdown(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.lambda$processTopdown$5(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at java.util.ArrayList.forEach(ArrayList.java:1541) ~[?:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.processTopdown(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.lambda$processTopdown$5(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at java.util.ArrayList.forEach(ArrayList.java:1541) ~[?:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.processTopdown(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.lambda$processTopdown$5(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at java.util.ArrayList.forEach(ArrayList.java:1541) ~[?:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.processTopdown(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.lambda$processTopdown$5(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at java.util.ArrayList.forEach(ArrayList.java:1541) ~[?:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.processTopdown(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.lambda$processTopdown$5(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at java.util.ArrayList.forEach(ArrayList.java:1541) ~[?:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.processTopdown(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.lambda$processTopdown$5(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at java.util.ArrayList.forEach(ArrayList.java:1541) ~[?:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.processTopdown(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.lambda$processTopdown$5(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at java.util.ArrayList.forEach(ArrayList.java:1541) ~[?:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.processTopdown(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.lambda$processTopdown$5(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at java.util.ArrayList.forEach(ArrayList.java:1541) ~[?:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.processTopdown(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.lambda$processTopdown$5(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at java.util.ArrayList.forEach(ArrayList.java:1541) ~[?:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.processTopdown(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.lambda$processTopdown$5(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at java.util.ArrayList.forEach(ArrayList.java:1541) ~[?:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.processTopdown(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.lambda$processTopdown$5(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at java.util.ArrayList.forEach(ArrayList.java:1541) ~[?:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.processTopdown(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.lambda$processTopdown$5(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at java.util.ArrayList.forEach(ArrayList.java:1541) ~[?:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.processTopdown(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.lambda$processTopdown$5(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at java.util.ArrayList.forEach(ArrayList.java:1541) ~[?:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.processTopdown(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.lambda$processTopdown$5(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at java.util.ArrayList.forEach(ArrayList.java:1541) ~[?:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.processTopdown(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.lambda$processTopdown$5(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at java.util.ArrayList.forEach(ArrayList.java:1541) ~[?:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule$Visitor.processTopdown(EliminateOveruseColumnAccessPathRule.java:108) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.rule.tree.EliminateOveruseColumnAccessPathRule.rewrite(EliminateOveruseColumnAccessPathRule.java:37) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.Optimizer.physicalRuleRewrite(Optimizer.java:997) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.Optimizer.optimizeByCost(Optimizer.java:311) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.optimizer.Optimizer.optimize(Optimizer.java:214) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.StatementPlanner.createQueryPlan(StatementPlanner.java:300) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:143) ~[starrocks-fe.jar:?]
	at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:104) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:606) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:392) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:592) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:930) ~[starrocks-fe.jar:?]
	at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:71) ~[starrocks-fe.jar:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?]
	at java.lang.Thread.run(Thread.java:829) ~[?:?]
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
