### PR TITLE
[BugFix] Fix the use-after-free bug in MemTracker within AsyncFlushOutputStream.

### DIFF
--- a/be/src/io/async_flush_output_stream.cpp
+++ b/be/src/io/async_flush_output_stream.cpp
@@ -14,7 +14,12 @@
 
 #include "async_flush_output_stream.h"
 
+#include "runtime/current_thread.h"
+#include "util/failpoint/fail_point.h"
+
 namespace starrocks::io {
+
+DEFINE_FAIL_POINT(async_flush_output_stream_sleep);
 
 int64_t AsyncFlushOutputStream::SliceChunk::append(const uint8_t* data, int64_t size) {
     int64_t old_size = static_cast<int64_t>(buffer_.size());
@@ -53,15 +58,19 @@ Status AsyncFlushOutputStream::write(const uint8_t* data, int64_t size) {
             _releasable_bytes.fetch_add(chunk->get_buffer_ptr()->capacity());
 
             auto task = [this, chunk]() {
-                SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_runtime_state->instance_mem_tracker());
-                CurrentThread::current().set_query_id(_runtime_state->query_id());
-                CurrentThread::current().set_fragment_instance_id(_runtime_state->fragment_instance_id());
-                auto buffer = chunk->get_buffer_ptr();
-                DeferOp op([this, chunk, capacity = buffer->capacity()] {
-                    _releasable_bytes.fetch_sub(capacity);
-                    delete chunk;
-                });
-                auto status = _file->append(Slice(buffer->data(), buffer->size()));
+                Status status;
+                {
+                    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_runtime_state->instance_mem_tracker());
+                    CurrentThread::current().set_query_id(_runtime_state->query_id());
+                    CurrentThread::current().set_fragment_instance_id(_runtime_state->fragment_instance_id());
+                    auto buffer = chunk->get_buffer_ptr();
+                    DeferOp op([this, chunk, capacity = buffer->capacity()] {
+                        _releasable_bytes.fetch_sub(capacity);
+                        delete chunk;
+                        FAIL_POINT_TRIGGER_EXECUTE(async_flush_output_stream_sleep, { sleep(2); });
+                    });
+                    status = _file->append(Slice(buffer->data(), buffer->size()));
+                }
                 {
                     std::scoped_lock lock(_mutex);
                     _io_status.update(status);
@@ -97,15 +106,18 @@ Status AsyncFlushOutputStream::close() {
         _slice_chunk_queue.pop_front();
         _releasable_bytes.fetch_add(chunk->get_buffer_ptr()->capacity());
         auto task = [&, chunk]() {
-            SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_runtime_state->instance_mem_tracker());
-            CurrentThread::current().set_query_id(_runtime_state->query_id());
-            CurrentThread::current().set_fragment_instance_id(_runtime_state->fragment_instance_id());
-            auto buffer = chunk->get_buffer_ptr();
-            DeferOp op([this, chunk, capacity = buffer->capacity()] {
-                _releasable_bytes.fetch_sub(capacity);
-                delete chunk;
-            });
-            auto status = _file->append(Slice(buffer->data(), buffer->size()));
+            Status status;
+            {
+                SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_runtime_state->instance_mem_tracker());
+                CurrentThread::current().set_query_id(_runtime_state->query_id());
+                CurrentThread::current().set_fragment_instance_id(_runtime_state->fragment_instance_id());
+                auto buffer = chunk->get_buffer_ptr();
+                DeferOp op([this, chunk, capacity = buffer->capacity()] {
+                    _releasable_bytes.fetch_sub(capacity);
+                    delete chunk;
+                });
+                status = _file->append(Slice(buffer->data(), buffer->size()));
+            }
             {
                 std::scoped_lock lock(_mutex);
                 _io_status.update(status);
@@ -125,10 +137,13 @@ Status AsyncFlushOutputStream::close() {
     }
 
     auto close_task = [&]() {
-        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_runtime_state->instance_mem_tracker());
-        CurrentThread::current().set_query_id(_runtime_state->query_id());
-        CurrentThread::current().set_fragment_instance_id(_runtime_state->fragment_instance_id());
-        auto status = _file->close();
+        Status status;
+        {
+            SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_runtime_state->instance_mem_tracker());
+            CurrentThread::current().set_query_id(_runtime_state->query_id());
+            CurrentThread::current().set_fragment_instance_id(_runtime_state->fragment_instance_id());
+            status = _file->close();
+        }
         {
             std::scoped_lock lock(_mutex);
             _io_status.update(status);

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -198,6 +198,9 @@ MemTracker::~MemTracker() {
     if (parent()) {
         unregister_from_parent();
     }
+    // When the mem_tracker is destroyed, manually setting _consumption to null can easily
+    // trigger a use-after-free bug in MemTracker.
+    _consumption = nullptr;
 }
 
 Status MemTracker::check_mem_limit(const std::string& msg) const {

--- a/test/sql/test_external_file/R/test_async_write_parquet_file
+++ b/test/sql/test_external_file/R/test_async_write_parquet_file
@@ -1,0 +1,38 @@
+-- name: test_async_write_parquet_file @sequential
+shell: ossutil64 mkdir oss://${oss_bucket}/test_async_write_parquet_file/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+admin enable failpoint 'async_flush_output_stream_sleep';
+-- result:
+-- !result
+insert into files
+(
+    "path" = "oss://${oss_bucket}/test_async_write_parquet_file/${uuid0}/000/",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}"
+)
+select repeat(cast(generate_series as string), 100) from table(generate_series(0,50000));
+-- result:
+-- !result
+admin disable failpoint 'async_flush_output_stream_sleep';
+-- result:
+-- !result
+select count(*) from files(
+    "path" = "oss://${oss_bucket}/test_async_write_parquet_file/${uuid0}/000/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}"
+);
+-- result:
+50001
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_async_write_parquet_file/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_external_file/T/test_async_write_parquet_file
+++ b/test/sql/test_external_file/T/test_async_write_parquet_file
@@ -1,0 +1,27 @@
+-- name: test_async_write_parquet_file @sequential
+
+shell: ossutil64 mkdir oss://${oss_bucket}/test_async_write_parquet_file/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null
+
+admin enable failpoint 'async_flush_output_stream_sleep';
+
+insert into files
+(
+    "path" = "oss://${oss_bucket}/test_async_write_parquet_file/${uuid0}/000/",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}"
+)
+select repeat(cast(generate_series as string), 100) from table(generate_series(0,50000));
+
+admin disable failpoint 'async_flush_output_stream_sleep';
+
+select count(*) from files(
+    "path" = "oss://${oss_bucket}/test_async_write_parquet_file/${uuid0}/000/*",
+    "format" = "parquet",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}"
+);
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_async_write_parquet_file/${uuid0}/ >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
## Why I'm doing:

```
*** Aborted at 1755550827 (unix time) try "date -d @1755550827" if you are using GNU date ***
PC: @          0x4fafef1 starrocks::CurrentThread::MemCacheManager::commit(bool)
*** SIGSEGV (@0x0) received by PID 25 (TID 0x7f86b0a64640) from PID 0; stack trace: ***
    @     0x7f87c21bfee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @          0x9b1ba89 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f87c3053526 os::Linux::chained_handler(int, siginfo_t*, void*)
    @     0x7f87c305921b JVM_handle_linux_signal
    @     0x7f87c304c07c signalHandler(int, siginfo_t*, void*)
    @     0x7f87c2168520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @          0x4fafef1 starrocks::CurrentThread::MemCacheManager::commit(bool)
    @          0x748d3e2 std::_Function_handler<void (), starrocks::io::AsyncFlushOutputStream::close()::{lambda()#1}>::_M_invoke(std::_Any_data const&)
    @          0x4f8007d starrocks::PriorityThreadPool::work_thread(int)
    @          0x9ace5bb thread_proxy
    @     0x7f87c21baac3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
    @     0x7f87c224ba04 clone
```

or

```
*** Aborted at 1756245837 (unix time) try "date -d @1756245837" if you are using GNU date ***
PC: @          0x4fafefb starrocks::CurrentThread::MemCacheManager::commit(bool)
*** SIGSEGV (@0x0) received by PID 25 (TID 0x7f0100b63640) from PID 0; stack trace: ***
    @     0x7f033b9eaee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @          0x9b1ba89 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f033c87e526 os::Linux::chained_handler(int, siginfo_t*, void*)
    @     0x7f033c88421b JVM_handle_linux_signal
    @     0x7f033c87707c signalHandler(int, siginfo_t*, void*)
    @     0x7f033b993520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @          0x4fafefb starrocks::CurrentThread::MemCacheManager::commit(bool)
    @          0x748d3e2 std::_Function_handler<void (), starrocks::io::AsyncFlushOutputStream::close()::{lambda()#1}>::_M_invoke(std::_Any_data const&)
    @          0x4f8007d starrocks::PriorityThreadPool::work_thread(int)
    @          0x9ace5bb thread_proxy
    @     0x7f033b9e5ac3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
    @     0x7f033ba76a04 clone
```

* `SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER` commits the cached memory usage to mem_tracker when destructed. However, since `_promise.set_value(_io_status)` has already been called, the query_context will have already been destructed by then.

* When mem_tracker is destructed, manually setting `_promise` to true will make it easier to identify use-after-free issues.

## What I'm doing:

Fix the use-after-free bug in MemTracker within AsyncFlushOutputStream.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Scopes MemTracker/thread context during async file ops and nulls MemTracker consumption on destroy; adds a failpoint and SQL test for async Parquet write.
> 
> - **IO**:
>   - Scope `SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER` and thread context within async tasks; capture `Status` outside to avoid lifetime issues in `AsyncFlushOutputStream::{write,close}` when calling `_file->append()` and `_file->close()`.
>   - Add failpoint `async_flush_output_stream_sleep` and trigger a short sleep in `DeferOp` after buffer release to simulate delayed IO.
> - **Runtime**:
>   - Set `MemTracker::_consumption` to `nullptr` in destructor to prevent use-after-free.
> - **Tests**:
>   - Add SQL test `test_external_file/*/test_async_write_parquet_file` using OSS that enables the failpoint during async Parquet writes and verifies row count, then cleans up.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b690a498f0b34496e847dfe19522d560df4d8a62. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->