### PR TITLE
[BugFix] Fix bugs for Arrow Flight SQL

### DIFF
--- a/be/src/runtime/arrow_result_writer.cpp
+++ b/be/src/runtime/arrow_result_writer.cpp
@@ -75,10 +75,7 @@ Status ArrowResultWriter::append_chunk(Chunk* chunk) {
 }
 
 Status ArrowResultWriter::close() {
-    LOG(INFO) << "[Flight] ArrowResultWriter::close() called";
-    if (_sinker != nullptr) {
-        return _sinker->close(Status::OK());
-    }
+    VLOG_ROW << "[Flight] ArrowResultWriter::close() called";
     return Status::OK();
 }
 

--- a/be/src/runtime/buffer_control_result_writer.cpp
+++ b/be/src/runtime/buffer_control_result_writer.cpp
@@ -41,7 +41,6 @@ Status BufferControlResultWriter::add_to_write_buffer(Chunk* chunk) {
         LOG(WARNING) << "Append result batch to sink failed: status=" << status.to_string();
     }
     return status;
-    return Status::OK();
 }
 
 void BufferControlResultWriter::cancel() {

--- a/be/src/runtime/result_buffer_mgr.cpp
+++ b/be/src/runtime/result_buffer_mgr.cpp
@@ -128,12 +128,13 @@ Status ResultBufferMgr::fetch_arrow_data(const TUniqueId& query_id, std::shared_
 }
 
 void ResultBufferMgr::set_arrow_schema(const TUniqueId& query_id, const std::shared_ptr<arrow::Schema>& arrow_schema) {
+    std::lock_guard<std::mutex> l(_lock);
     _arrow_schema_map.insert(std::make_pair(query_id, arrow_schema));
 }
 
 std::shared_ptr<arrow::Schema> ResultBufferMgr::get_arrow_schema(const TUniqueId& query_id) {
-    auto iter = _arrow_schema_map.find(query_id);
-    if (_arrow_schema_map.end() != iter) {
+    std::lock_guard<std::mutex> l(_lock);
+    if (auto iter = _arrow_schema_map.find(query_id); _arrow_schema_map.end() != iter) {
         return iter->second;
     }
     return nullptr;
@@ -141,12 +142,13 @@ std::shared_ptr<arrow::Schema> ResultBufferMgr::get_arrow_schema(const TUniqueId
 
 Status ResultBufferMgr::cancel(const TUniqueId& query_id) {
     std::lock_guard<std::mutex> l(_lock);
-    auto iter = _buffer_map.find(query_id);
 
-    if (_buffer_map.end() != iter) {
+    if (auto iter = _buffer_map.find(query_id); _buffer_map.end() != iter) {
         iter->second->cancel();
         _buffer_map.erase(iter);
     }
+
+    _arrow_schema_map.erase(query_id);
 
     return Status::OK();
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -909,7 +909,7 @@ public class StmtExecutor {
             String sql = originStmt != null ? originStmt.originStmt : "";
             String truncatedSql = sql.length() > 200 ? sql.substring(0, 200) + "..." : sql;
             LOG.error("LargeInPredicate optimization failed, sql: {}, error: {}. Will retry with" +
-                            " enable_large_in_predicate=false.", truncatedSql, e.getMessage());
+                    " enable_large_in_predicate=false.", truncatedSql, e.getMessage());
             throw e;
         } catch (StarRocksException e) {
             String sql = originStmt != null ? originStmt.originStmt : "";
@@ -1512,6 +1512,11 @@ public class StmtExecutor {
 
         if (context instanceof ArrowFlightSqlConnectContext) {
             coord.join(context.getSessionVariable().getQueryTimeoutS());
+            if (!isOutfileQuery) {
+                context.getState().setEof();
+            }
+            // TODO(liuzihe): process query statistics for Arrow Flight SQL. For now query statistics is passed by the final
+            //  batch, so we need to change the implementation to support Arrow Flight SQL.
         }
 
         processQueryStatisticsFromResult(batch, execPlan, isOutfileQuery);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1511,7 +1511,7 @@ public class StmtExecutor {
         }
 
         if (context instanceof ArrowFlightSqlConnectContext) {
-            coord.join(0);
+            coord.join(context.getSessionVariable().getQueryTimeoutS());
         }
 
         processQueryStatisticsFromResult(batch, execPlan, isOutfileQuery);

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
@@ -462,18 +462,16 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
 
                     ctx.setDeploymentFinished(null);
                     processorFinished.complete(null);
-                } catch (Exception e) {
-                    processorFinished.completeExceptionally(e);
                 } catch (Throwable t) {
                     processorFinished.completeExceptionally(t);
                 }
             });
 
-            processorFinished.get();
             // ------------------------------------------------------------------------------------
             // FE task will return FE as endpoint.
             // ------------------------------------------------------------------------------------
             if (ctx.returnFromFE() || ctx.isFromFECoordinator()) {
+                processorFinished.get();
                 if (ctx.getState().isError()) {
                     throw new RuntimeException(String.format("failed to process query [queryID=%s] [error=%s]",
                             DebugUtil.printId(ctx.getExecutionId()),

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
@@ -467,10 +467,14 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
                 }
             });
 
+            // Wait util deployment finished or ArrowFlightSqlConnectProcessor finished.
+            SessionVariable sv = ctx.getSessionVariable();
+            Coordinator coordinator = ctx.waitForDeploymentFinished(sv.getQueryTimeoutS() * 1000L);
+
             // ------------------------------------------------------------------------------------
             // FE task will return FE as endpoint.
             // ------------------------------------------------------------------------------------
-            if (ctx.returnFromFE() || ctx.isFromFECoordinator()) {
+            if (ctx.returnFromFE()) {
                 processorFinished.get();
                 if (ctx.getState().isError()) {
                     throw new RuntimeException(String.format("failed to process query [queryID=%s] [error=%s]",
@@ -491,8 +495,6 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
             // ------------------------------------------------------------------------------------
             // Query task will wait until deployment to BE is finished and return BE as endpoint.
             // ------------------------------------------------------------------------------------
-            SessionVariable sv = ctx.getSessionVariable();
-            Coordinator coordinator = ctx.waitForDeploymentFinished(sv.getQueryTimeoutS() * 1000L);
             if (coordinator == null || ctx.getState().isError()) {
                 throw new RuntimeException(String.format("failed to process query [queryID=%s] [error=%s]",
                         DebugUtil.printId(ctx.getExecutionId()),

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
@@ -119,7 +119,6 @@ public class ArrowFlightSqlServiceImplTest {
         mockCallContext = mock(FlightProducer.CallContext.class);
         when(mockCallContext.peerIdentity()).thenReturn("token123");
         when(sessionManager.validateAndGetConnectContext("token123")).thenReturn(mockContext);
-        when(mockContext.getSessionVariable()).thenReturn(new SessionVariable());
         when(mockContext.getQuery()).thenReturn("SELECT 1");
         when(mockContext.getState()).thenReturn(mock(QueryState.class));
         when(mockContext.getResult(anyString())).thenReturn(mock(VectorSchemaRoot.class));
@@ -127,6 +126,12 @@ public class ArrowFlightSqlServiceImplTest {
         when(mockContext.returnFromFE()).thenReturn(true);
         when(mockContext.isFromFECoordinator()).thenReturn(true);
         when(mockContext.getArrowFlightSqlToken()).thenReturn("token123");
+
+        SessionVariable mockSessionVariable = mock(SessionVariable.class);
+        when(mockContext.getSessionVariable()).thenReturn(mockSessionVariable);
+        when(mockSessionVariable.getQueryTimeoutS()).thenReturn(10);
+        when(mockSessionVariable.getQueryDeliveryTimeoutS()).thenReturn(10);
+        when(mockSessionVariable.getSqlDialect()).thenReturn("mysql");
 
         CallHeaders mockHeaders = mock(CallHeaders.class);
         when(mockHeaders.get("database")).thenReturn("test_db");
@@ -218,20 +223,6 @@ public class ArrowFlightSqlServiceImplTest {
                 .getFlightInfoStatement(command, mockCallContext, FlightDescriptor.command("SELECT 1".getBytes()));
         assertNotNull(beInfo);
         assertEquals(mockFlightInfo, beInfo);
-    }
-    @Test
-    public void testGetFlightInfoPreparedStatement() {
-        SessionVariable mockSessionVariable = mock(SessionVariable.class);
-        when(mockContext.getSessionVariable()).thenReturn(mockSessionVariable);
-        when(mockSessionVariable.getQueryTimeoutS()).thenReturn(10);
-        when(mockSessionVariable.getQueryDeliveryTimeoutS()).thenReturn(10);
-        when(mockSessionVariable.getSqlDialect()).thenReturn("mysql");
-
-        FlightSql.CommandPreparedStatementQuery command = FlightSql.CommandPreparedStatementQuery.newBuilder()
-                .setPreparedStatementHandle(ByteString.copyFromUtf8("token123")).build();
-        FlightInfo info = service
-                .getFlightInfoPreparedStatement(command, mockCallContext, FlightDescriptor.command("SELECT 1".getBytes()));
-        assertNotNull(info);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
@@ -221,6 +221,12 @@ public class ArrowFlightSqlServiceImplTest {
     }
     @Test
     public void testGetFlightInfoPreparedStatement() {
+        SessionVariable mockSessionVariable = mock(SessionVariable.class);
+        when(mockContext.getSessionVariable()).thenReturn(mockSessionVariable);
+        when(mockSessionVariable.getQueryTimeoutS()).thenReturn(10);
+        when(mockSessionVariable.getQueryDeliveryTimeoutS()).thenReturn(10);
+        when(mockSessionVariable.getSqlDialect()).thenReturn("mysql");
+
         FlightSql.CommandPreparedStatementQuery command = FlightSql.CommandPreparedStatementQuery.newBuilder()
                 .setPreparedStatementHandle(ByteString.copyFromUtf8("token123")).build();
         FlightInfo info = service


### PR DESCRIPTION
## Why I'm doing:

**Issues for error empty result**

`ResultSinkOperator::close` first calls `_writer->close()`. If this is the final `ResultSinkOperator::close`, it then calls `_sender->close()`. Calling `_sender->close()` marks the sender as closed and it will no longer accept new chunks.

Arrow Flight SQL mistakenly invokes `_sender->close()` inside `_writer->close()`. As a result, if one `ResultSinkOperator::close` runs before another `ResultSinkOperator::push_chunk`, that `push_chunk` is discarded.


**Issues with `_arrow_schema_map`:**
- Reads and writes are not synchronized (no locking).
- Schemas for queries that have already closed are not cleaned up.

**Issues on the FE side:**
- The query’s terminal state is not set.
- The FE deregisters the query before waiting for the BE to finish (i.e., before all fragment instances report their profiles).

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Harden Arrow Flight SQL end-to-end: thread-safe schema map and cleanup, correct FE coordination/timeouts with EOF, implement BE Arrow record writing, and adjust tests.
> 
> - **Backend (BE)**:
>   - Implement Arrow conversion path in `ArrowResultWriter::process_chunk` to write `arrow::RecordBatch` via `_sinker->add_arrow_batch`.
>   - Tweak `ArrowResultWriter::close()` logging and avoid closing the sinker here.
>   - Make `ResultBufferMgr` Arrow schema map thread-safe with locking; remove schema on `cancel()`.
> - **Frontend (FE)**:
>   - In `StmtExecutor`, for `ArrowFlightSqlConnectContext` use session `queryTimeoutS` in `coord.join(...)` and set terminal `EOF` when not OUTFILE.
>   - In `ArrowFlightSqlServiceImpl`, wait for deployment completion with timeout, only block on processor when returning from FE, and streamline error handling.
> - **Tests**:
>   - Update `ArrowFlightSqlServiceImplTest` to mock session variables/timeouts and validate FE/BE ticket flows; remove obsolete prepared statement test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bca1d81ff02313d4758f45a2f17f5f2e59f98f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->