### PR TITLE
[BugFix] Fix profile collection daemon detection in stop_be.sh

### DIFF
--- a/bin/stop_be.sh
+++ b/bin/stop_be.sh
@@ -93,7 +93,7 @@ if [ -f $profile_pidfile ]; then
     if kill -0 $profile_pid > /dev/null 2>&1; then
         # Check if the process is actually a profile collection daemon
         profile_comm=`ps -p $profile_pid -o comm= 2>/dev/null`
-        if [[ "$profile_comm" == *"collect_be_profile"* ]]; then
+        if [[ "$profile_comm" == *"collect_be_prof"* ]]; then
             kill -9 $profile_pid > /dev/null 2>&1
             rm -f $profile_pidfile
             echo "Profile collection daemon stopped"


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:


The process name check was using "collect_be_profile" but the actual process name returned by `ps -o comm=` is truncated to "collect_be_prof" due to the 15-character limit in the comm field.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
