### PR TITLE
[Refactor] Decouple expression classes from thrift opcodes by introducing ExprOpcodeRegistry

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PrimitiveType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PrimitiveType.java
@@ -37,55 +37,52 @@ package com.starrocks.catalog;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSetMultimap;
-import com.google.common.collect.Lists;
-import com.starrocks.thrift.TPrimitiveType;
 
 import java.util.Arrays;
-import java.util.List;
 
 public enum PrimitiveType {
-    INVALID_TYPE("INVALID_TYPE", -1, TPrimitiveType.INVALID_TYPE),
+    INVALID_TYPE("INVALID_TYPE", -1),
     // NULL_TYPE - used only in LiteralPredicate and NullLiteral to make NULLs compatible
     // with all other types.
-    NULL_TYPE("NULL_TYPE", 1, TPrimitiveType.NULL_TYPE),
-    BOOLEAN("BOOLEAN", 1, TPrimitiveType.BOOLEAN),
-    TINYINT("TINYINT", 1, TPrimitiveType.TINYINT),
-    SMALLINT("SMALLINT", 2, TPrimitiveType.SMALLINT),
-    INT("INT", 4, TPrimitiveType.INT),
-    BIGINT("BIGINT", 8, TPrimitiveType.BIGINT),
-    LARGEINT("LARGEINT", 16, TPrimitiveType.LARGEINT),
-    FLOAT("FLOAT", 4, TPrimitiveType.FLOAT),
-    DOUBLE("DOUBLE", 8, TPrimitiveType.DOUBLE),
-    DATE("DATE", 16, TPrimitiveType.DATE),
-    DATETIME("DATETIME", 16, TPrimitiveType.DATETIME),
+    NULL_TYPE("NULL_TYPE", 1),
+    BOOLEAN("BOOLEAN", 1),
+    TINYINT("TINYINT", 1),
+    SMALLINT("SMALLINT", 2),
+    INT("INT", 4),
+    BIGINT("BIGINT", 8),
+    LARGEINT("LARGEINT", 16),
+    FLOAT("FLOAT", 4),
+    DOUBLE("DOUBLE", 8),
+    DATE("DATE", 16),
+    DATETIME("DATETIME", 16),
     // Fixed length char array.
-    CHAR("CHAR", 16, TPrimitiveType.CHAR),
+    CHAR("CHAR", 16),
     // 8-byte pointer and 4-byte length indicator (12 bytes total).
     // Aligning to 8 bytes so 16 total.
-    VARCHAR("VARCHAR", 16, TPrimitiveType.VARCHAR),
+    VARCHAR("VARCHAR", 16),
 
-    DECIMALV2("DECIMALV2", 16, TPrimitiveType.DECIMALV2),
+    DECIMALV2("DECIMALV2", 16),
 
-    HLL("HLL", 16, TPrimitiveType.HLL),
-    TIME("TIME", 8, TPrimitiveType.TIME),
+    HLL("HLL", 16),
+    TIME("TIME", 8),
     // we use OBJECT type represent BITMAP type in Backend
-    BITMAP("BITMAP", 16, TPrimitiveType.OBJECT),
-    PERCENTILE("PERCENTILE", 16, TPrimitiveType.PERCENTILE),
-    DECIMAL32("DECIMAL32", 4, TPrimitiveType.DECIMAL32),
-    DECIMAL64("DECIMAL64", 8, TPrimitiveType.DECIMAL64),
-    DECIMAL128("DECIMAL128", 16, TPrimitiveType.DECIMAL128),
-    DECIMAL256("DECIMAL256", 32, TPrimitiveType.DECIMAL256),
+    BITMAP("BITMAP", 16),
+    PERCENTILE("PERCENTILE", 16),
+    DECIMAL32("DECIMAL32", 4),
+    DECIMAL64("DECIMAL64", 8),
+    DECIMAL128("DECIMAL128", 16),
+    DECIMAL256("DECIMAL256", 32),
 
-    JSON("JSON", 16, TPrimitiveType.JSON),
-    VARIANT("VARIANT", 16, TPrimitiveType.VARIANT),
+    JSON("JSON", 16),
+    VARIANT("VARIANT", 16),
 
-    FUNCTION("FUNCTION", 8, TPrimitiveType.FUNCTION),
+    FUNCTION("FUNCTION", 8),
 
-    BINARY("BINARY", -1, TPrimitiveType.BINARY),
-    VARBINARY("VARBINARY", 16, TPrimitiveType.VARBINARY),
+    BINARY("BINARY", -1),
+    VARBINARY("VARBINARY", 16),
 
     // If external table column type is unsupported, it will be converted to UNKNOWN_TYPE
-    UNKNOWN_TYPE("UNKNOWN_TYPE", -1, TPrimitiveType.INVALID_TYPE);
+    UNKNOWN_TYPE("UNKNOWN_TYPE", -1);
 
     private static final int DATE_INDEX_LEN = 3;
     private static final int DATETIME_INDEX_LEN = 8;
@@ -215,12 +212,10 @@ public enum PrimitiveType {
 
     private final String description;
     private final int slotSize;  // size of tuple slot for this type
-    private final TPrimitiveType thriftType;
 
-    PrimitiveType(String description, int slotSize, TPrimitiveType thriftType) {
+    PrimitiveType(String description, int slotSize) {
         this.description = description;
         this.slotSize = slotSize;
-        this.thriftType = thriftType;
     }
 
     public static ImmutableList<PrimitiveType> getIntegerTypeList() {
@@ -233,71 +228,6 @@ public enum PrimitiveType {
             return true;
         }
         return IMPLICIT_CAST_MAP.get(type).contains(target);
-    }
-
-    public static PrimitiveType fromThrift(TPrimitiveType tPrimitiveType) {
-        switch (tPrimitiveType) {
-            case NULL_TYPE:
-                return NULL_TYPE;
-            case BOOLEAN:
-                return BOOLEAN;
-            case TINYINT:
-                return TINYINT;
-            case SMALLINT:
-                return SMALLINT;
-            case INT:
-                return INT;
-            case BIGINT:
-                return BIGINT;
-            case LARGEINT:
-                return LARGEINT;
-            case FLOAT:
-                return FLOAT;
-            case DOUBLE:
-                return DOUBLE;
-            case VARCHAR:
-                return VARCHAR;
-            case CHAR:
-                return CHAR;
-            case HLL:
-                return HLL;
-            case OBJECT:
-                return BITMAP;
-            case PERCENTILE:
-                return PERCENTILE;
-            case DECIMAL32:
-                return DECIMAL32;
-            case DECIMAL64:
-                return DECIMAL64;
-            case DECIMAL128:
-                return DECIMAL128;
-            case DECIMAL256:
-                return DECIMAL256;
-            case DATE:
-                return DATE;
-            case DATETIME:
-                return DATETIME;
-            case TIME:
-                return TIME;
-            case VARBINARY:
-                return VARBINARY;
-            case JSON:
-                return JSON;
-            case FUNCTION:
-                return FUNCTION;
-            case VARIANT:
-                return VARIANT;
-            default:
-                return INVALID_TYPE;
-        }
-    }
-
-    public static List<TPrimitiveType> toThrift(PrimitiveType[] types) {
-        List<TPrimitiveType> result = Lists.newArrayList();
-        for (PrimitiveType t : types) {
-            result.add(t.toThrift());
-        }
-        return result;
     }
 
     public static int getMaxSlotSize() {
@@ -397,10 +327,6 @@ public enum PrimitiveType {
     @Override
     public String toString() {
         return description;
-    }
-
-    public TPrimitiveType toThrift() {
-        return thriftType;
     }
 
     public int getSlotSize() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TypeDeserializer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TypeDeserializer.java
@@ -46,6 +46,64 @@ public class TypeDeserializer {
         return t.first;
     }
 
+    public static PrimitiveType fromThrift(TPrimitiveType tPrimitiveType) {
+        switch (tPrimitiveType) {
+            case NULL_TYPE:
+                return PrimitiveType.NULL_TYPE;
+            case BOOLEAN:
+                return PrimitiveType.BOOLEAN;
+            case TINYINT:
+                return PrimitiveType.TINYINT;
+            case SMALLINT:
+                return PrimitiveType.SMALLINT;
+            case INT:
+                return PrimitiveType.INT;
+            case BIGINT:
+                return PrimitiveType.BIGINT;
+            case LARGEINT:
+                return PrimitiveType.LARGEINT;
+            case FLOAT:
+                return PrimitiveType.FLOAT;
+            case DOUBLE:
+                return PrimitiveType.DOUBLE;
+            case VARCHAR:
+                return PrimitiveType.VARCHAR;
+            case CHAR:
+                return PrimitiveType.CHAR;
+            case HLL:
+                return PrimitiveType.HLL;
+            case OBJECT:
+                return PrimitiveType.BITMAP;
+            case PERCENTILE:
+                return PrimitiveType.PERCENTILE;
+            case DECIMAL32:
+                return PrimitiveType.DECIMAL32;
+            case DECIMAL64:
+                return PrimitiveType.DECIMAL64;
+            case DECIMAL128:
+                return PrimitiveType.DECIMAL128;
+            case DECIMAL256:
+                return PrimitiveType.DECIMAL256;
+            case DATE:
+                return PrimitiveType.DATE;
+            case DATETIME:
+                return PrimitiveType.DATETIME;
+            case TIME:
+                return PrimitiveType.TIME;
+            case VARBINARY:
+                return PrimitiveType.VARBINARY;
+            case JSON:
+                return PrimitiveType.JSON;
+            case FUNCTION:
+                return PrimitiveType.FUNCTION;
+            case VARIANT:
+                return PrimitiveType.VARIANT;
+            case INVALID_TYPE:
+            default:
+                return PrimitiveType.INVALID_TYPE;
+        }
+    }
+
     /**
      * Constructs a Type rooted at the TTypeNode at nodeIdx in TTypeDesc.
      * Returned pair: The resulting Type and the next nodeIdx that is not a child
@@ -124,11 +182,11 @@ public class TypeDeserializer {
                 scalarType.getType() == TPrimitiveType.DECIMAL256) {
             Preconditions.checkState(scalarType.isSetPrecision() && scalarType.isSetScale());
             return ScalarType.createDecimalV3Type(
-                    PrimitiveType.fromThrift(scalarType.getType()),
+                    TypeDeserializer.fromThrift(scalarType.getType()),
                     scalarType.getPrecision(),
                     scalarType.getScale());
         } else {
-            return ScalarType.createType(PrimitiveType.fromThrift(scalarType.getType()));
+            return ScalarType.createType(TypeDeserializer.fromThrift(scalarType.getType()));
         }
     }
 
@@ -200,9 +258,9 @@ public class TypeDeserializer {
             case DECIMAL64:
             case DECIMAL128:
             case DECIMAL256:
-                return ScalarType.createDecimalV3Type(PrimitiveType.fromThrift(tPrimitiveType), ptype.precision, ptype.scale);
+                return ScalarType.createDecimalV3Type(TypeDeserializer.fromThrift(tPrimitiveType), ptype.precision, ptype.scale);
             default:
-                return ScalarType.createType(PrimitiveType.fromThrift(tPrimitiveType));
+                return ScalarType.createType(TypeDeserializer.fromThrift(tPrimitiveType));
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TypeSerializer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TypeSerializer.java
@@ -16,6 +16,7 @@ package com.starrocks.catalog;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.starrocks.thrift.TPrimitiveType;
 import com.starrocks.thrift.TScalarType;
 import com.starrocks.thrift.TStructField;
 import com.starrocks.thrift.TTypeDesc;
@@ -30,6 +31,82 @@ import java.util.ArrayList;
  * For deserialization, see {@link TypeDeserializer}.
  */
 public class TypeSerializer {
+
+    private TypeSerializer() {
+    }
+
+    public static TPrimitiveType toThrift(PrimitiveType primitiveType) {
+        switch (primitiveType) {
+            case INVALID_TYPE:
+                return TPrimitiveType.INVALID_TYPE;
+            case NULL_TYPE:
+                return TPrimitiveType.NULL_TYPE;
+            case BOOLEAN:
+                return TPrimitiveType.BOOLEAN;
+            case TINYINT:
+                return TPrimitiveType.TINYINT;
+            case SMALLINT:
+                return TPrimitiveType.SMALLINT;
+            case INT:
+                return TPrimitiveType.INT;
+            case BIGINT:
+                return TPrimitiveType.BIGINT;
+            case LARGEINT:
+                return TPrimitiveType.LARGEINT;
+            case FLOAT:
+                return TPrimitiveType.FLOAT;
+            case DOUBLE:
+                return TPrimitiveType.DOUBLE;
+            case DATE:
+                return TPrimitiveType.DATE;
+            case DATETIME:
+                return TPrimitiveType.DATETIME;
+            case CHAR:
+                return TPrimitiveType.CHAR;
+            case VARCHAR:
+                return TPrimitiveType.VARCHAR;
+            case DECIMALV2:
+                return TPrimitiveType.DECIMALV2;
+            case HLL:
+                return TPrimitiveType.HLL;
+            case TIME:
+                return TPrimitiveType.TIME;
+            case BITMAP:
+                return TPrimitiveType.OBJECT;
+            case PERCENTILE:
+                return TPrimitiveType.PERCENTILE;
+            case DECIMAL32:
+                return TPrimitiveType.DECIMAL32;
+            case DECIMAL64:
+                return TPrimitiveType.DECIMAL64;
+            case DECIMAL128:
+                return TPrimitiveType.DECIMAL128;
+            case DECIMAL256:
+                return TPrimitiveType.DECIMAL256;
+            case JSON:
+                return TPrimitiveType.JSON;
+            case VARIANT:
+                return TPrimitiveType.VARIANT;
+            case FUNCTION:
+                return TPrimitiveType.FUNCTION;
+            case BINARY:
+                return TPrimitiveType.BINARY;
+            case VARBINARY:
+                return TPrimitiveType.VARBINARY;
+            case UNKNOWN_TYPE:
+                return TPrimitiveType.INVALID_TYPE;
+            default:
+                throw new IllegalArgumentException("Unknown primitive type: " + primitiveType);
+        }
+    }
+
+    public static java.util.List<TPrimitiveType> toThrift(PrimitiveType[] types) {
+        java.util.List<TPrimitiveType> result = Lists.newArrayList();
+        for (PrimitiveType type : types) {
+            result.add(toThrift(type));
+        }
+        return result;
+    }
 
     public static TTypeDesc toThrift(Type type) {
         TTypeDesc container = new TTypeDesc();
@@ -72,7 +149,7 @@ public class TypeSerializer {
             case HLL: {
                 node.setType(TTypeNodeType.SCALAR);
                 TScalarType scalarType = new TScalarType();
-                scalarType.setType(primitiveType.toThrift());
+                scalarType.setType(TypeSerializer.toThrift(primitiveType));
                 scalarType.setLen(type.getLength());
                 node.setScalar_type(scalarType);
                 break;
@@ -84,7 +161,7 @@ public class TypeSerializer {
             case DECIMAL256: {
                 node.setType(TTypeNodeType.SCALAR);
                 TScalarType scalarType = new TScalarType();
-                scalarType.setType(primitiveType.toThrift());
+                scalarType.setType(TypeSerializer.toThrift(primitiveType));
                 scalarType.setScale(type.getScalarScale());
                 scalarType.setPrecision(type.getScalarPrecision());
                 node.setScalar_type(scalarType);
@@ -93,7 +170,7 @@ public class TypeSerializer {
             default: {
                 node.setType(TTypeNodeType.SCALAR);
                 TScalarType scalarType = new TScalarType();
-                scalarType.setType(primitiveType.toThrift());
+                scalarType.setType(TypeSerializer.toThrift(primitiveType));
                 node.setScalar_type(scalarType);
                 break;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/QueryConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/QueryConverter.java
@@ -18,6 +18,7 @@ package com.starrocks.connector.elasticsearch;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.ast.expression.BinaryPredicate;
+import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.ast.expression.BoolLiteral;
 import com.starrocks.sql.ast.expression.CastExpr;
 import com.starrocks.sql.ast.expression.CompoundPredicate;
@@ -33,7 +34,6 @@ import com.starrocks.sql.ast.expression.LikePredicate;
 import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.ast.expression.StringLiteral;
-import com.starrocks.thrift.TExprOpcode;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -124,8 +124,8 @@ public class QueryConverter implements AstVisitorExtendInterface<QueryBuilders.Q
             column = getColumnName(exprWithoutCast(node.getChild(1)));
             value = valueFor(node.getChild(0));
         }
-        TExprOpcode opCode = node.getOpcode();
-        switch (opCode) {
+        BinaryType opType = node.getOp();
+        switch (opType) {
             case EQ:
                 return QueryBuilders.termQuery(column, value);
             case NE:
@@ -139,7 +139,7 @@ public class QueryConverter implements AstVisitorExtendInterface<QueryBuilders.Q
             case LT:
                 return QueryBuilders.rangeQuery(column).lt(value);
             default:
-                throw new StarRocksConnectorException("can not support " + opCode + " in BinaryPredicate");
+                throw new StarRocksConnectorException("can not support " + opType + " in BinaryPredicate");
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
@@ -38,6 +38,7 @@ import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.ast.expression.BinaryPredicate;
+import com.starrocks.sql.ast.expression.ExprOpcodeRegistry;
 import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.JoinOperator;
@@ -120,7 +121,7 @@ public class HashJoinNode extends JoinNode {
             TEqJoinCondition eqJoinCondition = new TEqJoinCondition(
                     ExprToThriftVisitor.treeToThrift(eqJoinPredicate.getChild(0)),
                     ExprToThriftVisitor.treeToThrift(eqJoinPredicate.getChild(1)));
-            eqJoinCondition.setOpcode(eqJoinPredicate.getOp().getOpcode());
+            eqJoinCondition.setOpcode(ExprOpcodeRegistry.getBinaryOpcode(eqJoinPredicate.getOp()));
             msg.hash_join_node.addToEq_join_conjuncts(eqJoinCondition);
             if (sqlJoinPredicatesBuilder.length() > 0) {
                 sqlJoinPredicatesBuilder.append(", ");
@@ -132,7 +133,7 @@ public class HashJoinNode extends JoinNode {
             TAsofJoinCondition asofJoinCondition = new TAsofJoinCondition(
                     ExprToThriftVisitor.treeToThrift(asofJoinConjunct.getChild(0)),
                     ExprToThriftVisitor.treeToThrift(asofJoinConjunct.getChild(1)),
-                    asofJoinConjunct.getOpcode());
+                    ExprOpcodeRegistry.getExprOpcode(asofJoinConjunct));
             msg.hash_join_node.setAsof_join_condition(asofJoinCondition);
             if (!sqlJoinPredicatesBuilder.isEmpty()) {
                 sqlJoinPredicatesBuilder.append(", ");

--- a/fe/fe-core/src/main/java/com/starrocks/planner/MergeJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/MergeJoinNode.java
@@ -36,6 +36,7 @@ package com.starrocks.planner;
 
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.expression.BinaryPredicate;
+import com.starrocks.sql.ast.expression.ExprOpcodeRegistry;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprToThriftVisitor;
 import com.starrocks.sql.ast.expression.JoinOperator;
@@ -69,7 +70,7 @@ public class MergeJoinNode extends JoinNode {
             TEqJoinCondition eqJoinCondition = new TEqJoinCondition(
                     ExprToThriftVisitor.treeToThrift(eqJoinPredicate.getChild(0)),
                     ExprToThriftVisitor.treeToThrift(eqJoinPredicate.getChild(1)));
-            eqJoinCondition.setOpcode(eqJoinPredicate.getOp().getOpcode());
+            eqJoinCondition.setOpcode(ExprOpcodeRegistry.getBinaryOpcode(eqJoinPredicate.getOp()));
             msg.merge_join_node.addToEq_join_conjuncts(eqJoinCondition);
             if (sqlJoinPredicatesBuilder.length() > 0) {
                 sqlJoinPredicatesBuilder.append(", ");

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -63,6 +63,7 @@ import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.Type;
+import com.starrocks.catalog.TypeSerializer;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
@@ -1017,7 +1018,7 @@ public class OlapScanNode extends ScanNode {
                     for (Integer sortKeyIdx : indexMeta.getSortKeyIdxes()) {
                         Column col = indexMeta.getSchema().get(sortKeyIdx);
                         keyColumnNames.add(col.getName());
-                        keyColumnTypes.add(col.getPrimitiveType().toThrift());
+                        keyColumnTypes.add(TypeSerializer.toThrift(col.getPrimitiveType()));
                     }
                 } else {
                     for (Column col : olapTable.getSchemaByIndexId(selectedIndexId)) {
@@ -1026,7 +1027,7 @@ public class OlapScanNode extends ScanNode {
                         }
 
                         keyColumnNames.add(col.getName());
-                        keyColumnTypes.add(col.getPrimitiveType().toThrift());
+                        keyColumnTypes.add(TypeSerializer.toThrift(col.getPrimitiveType()));
                     }
                 }
             }
@@ -1511,7 +1512,7 @@ public class OlapScanNode extends ScanNode {
                     break;
                 }
                 keyColumnNames.add(col.getName());
-                keyColumnTypes.add(col.getPrimitiveType().toThrift());
+                keyColumnTypes.add(TypeSerializer.toThrift(col.getPrimitiveType()));
             }
         }
         scanNode.setKey_column_names(keyColumnNames);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/stream/StreamJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/stream/StreamJoinNode.java
@@ -19,6 +19,7 @@ import com.starrocks.planner.JoinNode;
 import com.starrocks.planner.PlanNode;
 import com.starrocks.planner.PlanNodeId;
 import com.starrocks.sql.ast.expression.BinaryPredicate;
+import com.starrocks.sql.ast.expression.ExprOpcodeRegistry;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprToThriftVisitor;
 import com.starrocks.sql.ast.expression.JoinOperator;
@@ -54,7 +55,7 @@ public class StreamJoinNode extends JoinNode {
                 TEqJoinCondition eqJoinCondition = new TEqJoinCondition(
                         ExprToThriftVisitor.treeToThrift(eqJoinPredicate.getChild(0)),
                         ExprToThriftVisitor.treeToThrift(eqJoinPredicate.getChild(1)));
-                eqJoinCondition.setOpcode(eqJoinPredicate.getOp().getOpcode());
+                eqJoinCondition.setOpcode(ExprOpcodeRegistry.getBinaryOpcode(eqJoinPredicate.getOp()));
                 msg.stream_join_node.addToEq_join_conjuncts(eqJoinCondition);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultSet.java
@@ -36,9 +36,10 @@ package com.starrocks.qe;
 
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
-import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
+import com.starrocks.catalog.TypeDeserializer;
+import com.starrocks.catalog.TypeSerializer;
 import com.starrocks.thrift.TColumnDefinition;
 import com.starrocks.thrift.TColumnType;
 import com.starrocks.thrift.TShowResultSet;
@@ -72,7 +73,7 @@ public class ShowResultSet {
             TColumnDefinition definition = (TColumnDefinition) resultSet.getMetaData().getColumns().get(i);
             columns.add(new Column(
                     definition.getColumnName(),
-                    ScalarType.createType(PrimitiveType.fromThrift(definition.getColumnType().getType())))
+                    ScalarType.createType(TypeDeserializer.fromThrift(definition.getColumnType().getType())))
             );
         }
         this.metaData = new ShowResultSetMetaData(columns);
@@ -144,7 +145,7 @@ public class ShowResultSet {
         if (type instanceof ScalarType) {
             ScalarType scalarType = (ScalarType) type;
             TColumnType thrift = new TColumnType();
-            thrift.type = scalarType.getPrimitiveType().toThrift();
+            thrift.type = TypeSerializer.toThrift(scalarType.getPrimitiveType());
             if (scalarType.getPrimitiveType().isVariableLengthType()) {
                 thrift.setLen(scalarType.getLength());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -65,6 +65,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
+import com.starrocks.catalog.TypeSerializer;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.catalog.system.information.AnalyzeStatusSystemTable;
 import com.starrocks.catalog.system.information.ColumnStatsUsageSystemTable;
@@ -888,7 +889,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         }
         for (Column column : table.getBaseSchema()) {
             final TColumnDesc desc =
-                    new TColumnDesc(column.getName(), column.getPrimitiveType().toThrift());
+                    new TColumnDesc(column.getName(), TypeSerializer.toThrift(column.getPrimitiveType()));
             final Integer precision = column.getType().getPrecision();
             if (precision != null) {
                 desc.setColumnPrecision(precision);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/QueryStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/QueryStatement.java
@@ -20,10 +20,10 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
 import com.starrocks.sql.ast.expression.BinaryPredicate;
+import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.ast.expression.CompoundPredicate;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.SlotRef;
-import com.starrocks.thrift.TExprOpcode;
 
 import java.util.HashMap;
 import java.util.List;
@@ -99,7 +99,7 @@ public class QueryStatement extends StatementBase {
         }
 
         Map<SlotRef, Expr> eqPredicates = new HashMap<>();
-        eqPredicates = getEQBinaryPredicates(eqPredicates, selectRelation.getPredicate(), TExprOpcode.EQ);
+        eqPredicates = getEQBinaryPredicates(eqPredicates, selectRelation.getPredicate(), BinaryType.EQ);
         if (eqPredicates == null) {
             return false;
         }
@@ -121,7 +121,7 @@ public class QueryStatement extends StatementBase {
     }
 
     private static Map<SlotRef, Expr> getEQBinaryPredicates(Map<SlotRef, Expr> result, Expr expr,
-                                                            TExprOpcode eqOpcode) {
+                                                            BinaryType eqType) {
         if (expr == null) {
             return null;
         }
@@ -131,18 +131,18 @@ public class QueryStatement extends StatementBase {
                 return null;
             }
 
-            result = getEQBinaryPredicates(result, compoundPredicate.getChild(0), eqOpcode);
+            result = getEQBinaryPredicates(result, compoundPredicate.getChild(0), eqType);
             if (result == null) {
                 return null;
             }
-            result = getEQBinaryPredicates(result, compoundPredicate.getChild(1), eqOpcode);
+            result = getEQBinaryPredicates(result, compoundPredicate.getChild(1), eqType);
             if (result == null) {
                 return null;
             }
             return result;
         } else if (expr instanceof BinaryPredicate) {
             BinaryPredicate binaryPredicate = (BinaryPredicate) expr;
-            if (binaryPredicate.getOpcode() != eqOpcode) {
+            if (binaryPredicate.getOp() != eqType) {
                 return null;
             }
             Pair<SlotRef, Expr> slotRefExprPair = binaryPredicate.createSlotAndLiteralPair();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/AnalyticExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/AnalyticExpr.java
@@ -417,7 +417,7 @@ public class AnalyticExpr extends Expr {
         // all children information is contained in the group of fnCall, partitionExprs, orderByElements and window,
         // so need to calculate super's hashCode.
         // field window is correlated with field resetWindow, so no need to add resetWindow when calculating hashCode.
-        return Objects.hash(type, opcode, fnCall, partitionExprs, orderByElements, window, partitionHint, skewHint,
+        return Objects.hash(type, fnCall, partitionExprs, orderByElements, window, partitionHint, skewHint,
                 useHashBasedPartition, isSkewed);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ArithmeticExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ArithmeticExpr.java
@@ -49,7 +49,6 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprOpcode;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -439,7 +438,7 @@ public class ArithmeticExpr extends Expr {
         if (!super.equalsWithoutChild(obj)) {
             return false;
         }
-        return ((ArithmeticExpr) obj).opcode == opcode;
+        return op == ((ArithmeticExpr) obj).op;
     }
 
     public static Type getCommonType(Type t1, Type t2) {
@@ -525,35 +524,31 @@ public class ArithmeticExpr extends Expr {
     }
 
     public enum Operator {
-        MULTIPLY("*", "multiply", OperatorPosition.BINARY_INFIX, TExprOpcode.MULTIPLY, true),
-        DIVIDE("/", "divide", OperatorPosition.BINARY_INFIX, TExprOpcode.DIVIDE, true),
-        MOD("%", "mod", OperatorPosition.BINARY_INFIX, TExprOpcode.MOD, false),
-        INT_DIVIDE("DIV", "int_divide", OperatorPosition.BINARY_INFIX, TExprOpcode.INT_DIVIDE, true),
-        ADD("+", "add", OperatorPosition.BINARY_INFIX, TExprOpcode.ADD, true),
-        SUBTRACT("-", "subtract", OperatorPosition.BINARY_INFIX, TExprOpcode.SUBTRACT, true),
-        BITAND("&", "bitand", OperatorPosition.BINARY_INFIX, TExprOpcode.BITAND, false),
-        BITOR("|", "bitor", OperatorPosition.BINARY_INFIX, TExprOpcode.BITOR, false),
-        BITXOR("^", "bitxor", OperatorPosition.BINARY_INFIX, TExprOpcode.BITXOR, false),
-        BITNOT("~", "bitnot", OperatorPosition.UNARY_PREFIX, TExprOpcode.BITNOT, false),
-        FACTORIAL("!", "factorial", OperatorPosition.UNARY_POSTFIX, TExprOpcode.FACTORIAL, true),
-        BIT_SHIFT_LEFT("BITSHIFTLEFT", "bitShiftLeft", OperatorPosition.BINARY_INFIX, TExprOpcode.BIT_SHIFT_LEFT,
-                false),
-        BIT_SHIFT_RIGHT("BITSHIFTRIGHT", "bitShiftRight", OperatorPosition.BINARY_INFIX, TExprOpcode.BIT_SHIFT_RIGHT,
-                false),
+        MULTIPLY("*", "multiply", OperatorPosition.BINARY_INFIX, true),
+        DIVIDE("/", "divide", OperatorPosition.BINARY_INFIX, true),
+        MOD("%", "mod", OperatorPosition.BINARY_INFIX, false),
+        INT_DIVIDE("DIV", "int_divide", OperatorPosition.BINARY_INFIX, true),
+        ADD("+", "add", OperatorPosition.BINARY_INFIX, true),
+        SUBTRACT("-", "subtract", OperatorPosition.BINARY_INFIX, true),
+        BITAND("&", "bitand", OperatorPosition.BINARY_INFIX, false),
+        BITOR("|", "bitor", OperatorPosition.BINARY_INFIX, false),
+        BITXOR("^", "bitxor", OperatorPosition.BINARY_INFIX, false),
+        BITNOT("~", "bitnot", OperatorPosition.UNARY_PREFIX, false),
+        FACTORIAL("!", "factorial", OperatorPosition.UNARY_POSTFIX, true),
+        BIT_SHIFT_LEFT("BITSHIFTLEFT", "bitShiftLeft", OperatorPosition.BINARY_INFIX, false),
+        BIT_SHIFT_RIGHT("BITSHIFTRIGHT", "bitShiftRight", OperatorPosition.BINARY_INFIX, false),
         BIT_SHIFT_RIGHT_LOGICAL("BITSHIFTRIGHTLOGICAL", "bitShiftRightLogical", OperatorPosition.BINARY_INFIX,
-                TExprOpcode.BIT_SHIFT_RIGHT_LOGICAL, false);
+                false);
 
         private final String description;
         private final String name;
         private final OperatorPosition pos;
-        private final TExprOpcode opcode;
         private final boolean monotonic;
 
-        Operator(String description, String name, OperatorPosition pos, TExprOpcode opcode, boolean monotonic) {
+        Operator(String description, String name, OperatorPosition pos, boolean monotonic) {
             this.description = description;
             this.name = name;
             this.pos = pos;
-            this.opcode = opcode;
             this.monotonic = monotonic;
         }
 
@@ -568,10 +563,6 @@ public class ArithmeticExpr extends Expr {
 
         public OperatorPosition getPos() {
             return pos;
-        }
-
-        public TExprOpcode getOpcode() {
-            return opcode;
         }
 
         public boolean isBinary() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/BinaryPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/BinaryPredicate.java
@@ -79,7 +79,6 @@ public class BinaryPredicate extends Predicate implements Writable {
     public BinaryPredicate(BinaryType op, Expr e1, Expr e2, NodePosition pos) {
         super(pos);
         this.op = op;
-        this.opcode = op.getOpcode();
         Preconditions.checkNotNull(e1);
         children.add(e1);
         Preconditions.checkNotNull(e2);
@@ -135,7 +134,7 @@ public class BinaryPredicate extends Predicate implements Writable {
         if (!super.equalsWithoutChild(obj)) {
             return false;
         }
-        return ((BinaryPredicate) obj).opcode == this.opcode;
+        return ((BinaryPredicate) obj).op == this.op;
     }
 
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/BinaryType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/BinaryType.java
@@ -15,18 +15,17 @@
 package com.starrocks.sql.ast.expression;
 
 import com.google.common.collect.ImmutableMap;
-import com.starrocks.thrift.TExprOpcode;
 
 import java.util.Map;
 
 public enum BinaryType {
-    EQ("=", "eq", TExprOpcode.EQ, false),
-    NE("!=", "ne", TExprOpcode.NE, false),
-    LE("<=", "le", TExprOpcode.LE, true),
-    GE(">=", "ge", TExprOpcode.GE, true),
-    LT("<", "lt", TExprOpcode.LT, true),
-    GT(">", "gt", TExprOpcode.GT, true),
-    EQ_FOR_NULL("<=>", "eq_for_null", TExprOpcode.EQ_FOR_NULL, false);
+    EQ("=", "eq", false),
+    NE("!=", "ne", false),
+    LE("<=", "le", true),
+    GE(">=", "ge", true),
+    LT("<", "lt", true),
+    GT(">", "gt", true),
+    EQ_FOR_NULL("<=>", "eq_for_null", false);
 
     private static final Map<BinaryType, BinaryType> BINARY_COMMUTATIVE_MAP =
             ImmutableMap.<BinaryType, BinaryType>builder()
@@ -51,16 +50,13 @@ public enum BinaryType {
 
     private final String type;
     private final String name;
-    private final TExprOpcode opcode;
     private final boolean monotonic;
 
     BinaryType(String description,
                String name,
-               TExprOpcode opcode,
                boolean monotonic) {
         this.type = description;
         this.name = name;
-        this.opcode = opcode;
         this.monotonic = monotonic;
     }
 
@@ -71,10 +67,6 @@ public enum BinaryType {
 
     public String getName() {
         return name;
-    }
-
-    public TExprOpcode getOpcode() {
-        return opcode;
     }
 
     public boolean isEqual() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/CastExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/CastExpr.java
@@ -43,7 +43,6 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprOpcode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -143,7 +142,6 @@ public class CastExpr extends Expr {
             return;
         }
 
-        this.opcode = TExprOpcode.CAST;
         FunctionName fnName = new FunctionName(getFnName(type));
         Function searchDesc = new Function(fnName, collectChildReturnTypes(), Type.INVALID, false);
         if (isImplicit) {
@@ -194,10 +192,6 @@ public class CastExpr extends Expr {
         }
         CastExpr castExpr = (CastExpr) o;
 
-        if (this.opcode != castExpr.opcode) {
-            return false;
-        }
-
         if (targetTypeDef != null) {
             return targetTypeDef.getType().equals(castExpr.getTargetTypeDef().getType());
         }
@@ -206,7 +200,7 @@ public class CastExpr extends Expr {
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), targetTypeDef == null ? null : targetTypeDef.getType(), opcode);
+        return Objects.hash(super.hashCode(), targetTypeDef == null ? null : targetTypeDef.getType());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/Expr.java
@@ -68,7 +68,6 @@ import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.sql.plan.ScalarOperatorToExpr;
-import com.starrocks.thrift.TExprOpcode;
 import org.roaringbitmap.RoaringBitmap;
 
 import java.lang.reflect.Method;
@@ -152,9 +151,6 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
 
     protected boolean isAnalyzed = false;  // true after analyze() has been called
 
-    protected TExprOpcode opcode;  // opcode for this expr
-    protected TExprOpcode vectorOpcode;  // vector opcode for this expr
-
     // estimated probability of a predicate evaluating to true;
     // set during analysis;
     // between 0 and 1 if valid: invalid: -1
@@ -201,8 +197,6 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         pos = NodePosition.ZERO;
         type = Type.INVALID;
         originType = Type.INVALID;
-        opcode = TExprOpcode.INVALID_OPCODE;
-        vectorOpcode = TExprOpcode.INVALID_OPCODE;
         selectivity = -1.0;
         numDistinctValues = -1;
     }
@@ -211,8 +205,6 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         this.pos = pos;
         type = Type.INVALID;
         originType = Type.INVALID;
-        opcode = TExprOpcode.INVALID_OPCODE;
-        vectorOpcode = TExprOpcode.INVALID_OPCODE;
         selectivity = -1.0;
         numDistinctValues = -1;
     }
@@ -226,7 +218,6 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         isAnalyzed = other.isAnalyzed;
         selectivity = other.selectivity;
         numDistinctValues = other.numDistinctValues;
-        opcode = other.opcode;
         isConstant = other.isConstant;
         fn = other.fn;
         printSqlInParens = other.printSqlInParens;
@@ -309,10 +300,6 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         this.originType = originType;
     }
 
-    public TExprOpcode getOpcode() {
-        return opcode;
-    }
-
     public long getNumDistinctValues() {
         return numDistinctValues;
     }
@@ -323,10 +310,6 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
 
     public int getOutputColumn() {
         return outputColumn;
-    }
-
-    public TExprOpcode getVectorOpcode() {
-        return vectorOpcode;
     }
 
     public boolean isFilter() {
@@ -673,7 +656,7 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         // may be null.
         // NOTE that all the types of the related member variables must implement hashCode() and equals().
         if (id == null) {
-            int result = 31 * Objects.hashCode(type) + Objects.hashCode(opcode.getValue());
+            int result = 31 * Objects.hashCode(type);
             for (Expr child : children) {
                 result = 31 * result + Objects.hashCode(child);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ExprOpcodeRegistry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ExprOpcodeRegistry.java
@@ -1,0 +1,106 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast.expression;
+
+import com.starrocks.thrift.TExprOpcode;
+
+import java.util.EnumMap;
+import java.util.Objects;
+
+/**
+ * Central registry that maintains the mapping between front-end expression metadata
+ * and the corresponding thrift {@link TExprOpcode}. This decouples expression
+ * classes from thrift-specific details.
+ */
+public final class ExprOpcodeRegistry {
+    private static final EnumMap<BinaryType, TExprOpcode> BINARY_OPCODES = new EnumMap<>(BinaryType.class);
+    private static final EnumMap<ArithmeticExpr.Operator, TExprOpcode> ARITHMETIC_OPCODES =
+            new EnumMap<>(ArithmeticExpr.Operator.class);
+    private static final EnumMap<MatchExpr.MatchOperator, TExprOpcode> MATCH_OPCODES =
+            new EnumMap<>(MatchExpr.MatchOperator.class);
+
+    static {
+        BINARY_OPCODES.put(BinaryType.EQ, TExprOpcode.EQ);
+        BINARY_OPCODES.put(BinaryType.NE, TExprOpcode.NE);
+        BINARY_OPCODES.put(BinaryType.LE, TExprOpcode.LE);
+        BINARY_OPCODES.put(BinaryType.GE, TExprOpcode.GE);
+        BINARY_OPCODES.put(BinaryType.LT, TExprOpcode.LT);
+        BINARY_OPCODES.put(BinaryType.GT, TExprOpcode.GT);
+        BINARY_OPCODES.put(BinaryType.EQ_FOR_NULL, TExprOpcode.EQ_FOR_NULL);
+
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.MULTIPLY, TExprOpcode.MULTIPLY);
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.DIVIDE, TExprOpcode.DIVIDE);
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.MOD, TExprOpcode.MOD);
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.INT_DIVIDE, TExprOpcode.INT_DIVIDE);
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.ADD, TExprOpcode.ADD);
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.SUBTRACT, TExprOpcode.SUBTRACT);
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.BITAND, TExprOpcode.BITAND);
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.BITOR, TExprOpcode.BITOR);
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.BITXOR, TExprOpcode.BITXOR);
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.BITNOT, TExprOpcode.BITNOT);
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.FACTORIAL, TExprOpcode.FACTORIAL);
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.BIT_SHIFT_LEFT, TExprOpcode.BIT_SHIFT_LEFT);
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.BIT_SHIFT_RIGHT, TExprOpcode.BIT_SHIFT_RIGHT);
+        ARITHMETIC_OPCODES.put(ArithmeticExpr.Operator.BIT_SHIFT_RIGHT_LOGICAL,
+                TExprOpcode.BIT_SHIFT_RIGHT_LOGICAL);
+
+        MATCH_OPCODES.put(MatchExpr.MatchOperator.MATCH, TExprOpcode.MATCH);
+        MATCH_OPCODES.put(MatchExpr.MatchOperator.MATCH_ANY, TExprOpcode.MATCH_ANY);
+        MATCH_OPCODES.put(MatchExpr.MatchOperator.MATCH_ALL, TExprOpcode.MATCH_ALL);
+    }
+
+    private ExprOpcodeRegistry() {
+    }
+
+    public static TExprOpcode getBinaryOpcode(BinaryType type) {
+        return BINARY_OPCODES.getOrDefault(type, TExprOpcode.INVALID_OPCODE);
+    }
+
+    public static TExprOpcode getArithmeticOpcode(ArithmeticExpr.Operator operator) {
+        return ARITHMETIC_OPCODES.getOrDefault(operator, TExprOpcode.INVALID_OPCODE);
+    }
+
+    public static TExprOpcode getMatchOpcode(MatchExpr.MatchOperator operator) {
+        return MATCH_OPCODES.getOrDefault(operator, TExprOpcode.INVALID_OPCODE);
+    }
+
+    public static TExprOpcode getInPredicateOpcode(boolean isNotIn) {
+        return isNotIn ? TExprOpcode.FILTER_NOT_IN : TExprOpcode.FILTER_IN;
+    }
+
+    public static TExprOpcode getCastOpcode() {
+        return TExprOpcode.CAST;
+    }
+
+    /**
+     * Resolve opcode for a specific expression instance. The default value is
+     * {@link TExprOpcode#INVALID_OPCODE} when there is no mapping required.
+     */
+    public static TExprOpcode getExprOpcode(Expr expr) {
+        Objects.requireNonNull(expr, "expr cannot be null");
+        if (expr instanceof BinaryPredicate) {
+            return getBinaryOpcode(((BinaryPredicate) expr).getOp());
+        } else if (expr instanceof InPredicate) {
+            return getInPredicateOpcode(((InPredicate) expr).isNotIn());
+        } else if (expr instanceof ArithmeticExpr) {
+            return getArithmeticOpcode(((ArithmeticExpr) expr).getOp());
+        } else if (expr instanceof CastExpr) {
+            return getCastOpcode();
+        } else if (expr instanceof MatchExpr) {
+            return getMatchOpcode(((MatchExpr) expr).getMatchOperator());
+        }
+        return TExprOpcode.INVALID_OPCODE;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ExprToThriftVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ExprToThriftVisitor.java
@@ -33,6 +33,7 @@ import com.starrocks.thrift.TDictionaryGetExpr;
 import com.starrocks.thrift.TExpr;
 import com.starrocks.thrift.TExprNode;
 import com.starrocks.thrift.TExprNodeType;
+import com.starrocks.thrift.TExprOpcode;
 import com.starrocks.thrift.TFloatLiteral;
 import com.starrocks.thrift.TFunction;
 import com.starrocks.thrift.TInPredicate;
@@ -151,7 +152,7 @@ public class ExprToThriftVisitor implements AstVisitorExtendInterface<Void, TExp
     @Override
     public Void visitArithmeticExpr(ArithmeticExpr node, TExprNode msg) {
         msg.node_type = TExprNodeType.ARITHMETIC_EXPR;
-        msg.setOpcode(node.getOp().getOpcode());
+        msg.setOpcode(ExprOpcodeRegistry.getArithmeticOpcode(node.getOp()));
         msg.setOutput_column(node.getOutputColumn());
         return null;
     }
@@ -223,7 +224,7 @@ public class ExprToThriftVisitor implements AstVisitorExtendInterface<Void, TExp
     public Void visitCaseWhenExpr(CaseExpr node, TExprNode msg) {
         msg.node_type = TExprNodeType.CASE_EXPR;
         msg.case_expr = new TCaseExpr(node.hasCaseExpr(), node.hasElseExpr());
-        msg.setChild_type(node.getChild(0).getType().getPrimitiveType().toThrift());
+        msg.setChild_type(TypeSerializer.toThrift(node.getChild(0).getType().getPrimitiveType()));
         return null;
     }
 
@@ -268,7 +269,7 @@ public class ExprToThriftVisitor implements AstVisitorExtendInterface<Void, TExp
     @Override
     public Void visitMatchExpr(MatchExpr node, TExprNode msg) {
         msg.node_type = TExprNodeType.MATCH_EXPR;
-        msg.setOpcode(node.getMatchOperator().getOpcode());
+        msg.setOpcode(ExprOpcodeRegistry.getMatchOpcode(node.getMatchOperator()));
         return null;
     }
 
@@ -296,12 +297,12 @@ public class ExprToThriftVisitor implements AstVisitorExtendInterface<Void, TExp
     @Override
     public Void visitCastExpr(CastExpr node, TExprNode msg) {
         msg.node_type = TExprNodeType.CAST_EXPR;
-        msg.setOpcode(node.getOpcode());
+        msg.setOpcode(ExprOpcodeRegistry.getCastOpcode());
         msg.setOutput_column(node.getOutputColumn());
         if (node.getChild(0).getType().isComplexType()) {
             msg.setChild_type_desc(TypeSerializer.toThrift(node.getChild(0).getType()));
         } else {
-            msg.setChild_type(node.getChild(0).getType().getPrimitiveType().toThrift());
+            msg.setChild_type(TypeSerializer.toThrift(node.getChild(0).getType().getPrimitiveType()));
         }
         return null;
     }
@@ -335,12 +336,12 @@ public class ExprToThriftVisitor implements AstVisitorExtendInterface<Void, TExp
     @Override
     public Void visitBinaryPredicate(BinaryPredicate node, TExprNode msg) {
         msg.node_type = TExprNodeType.BINARY_PRED;
-        msg.setOpcode(node.getOpcode());
-        msg.setVector_opcode(node.getVectorOpcode());
+        msg.setOpcode(ExprOpcodeRegistry.getBinaryOpcode(node.getOp()));
+        msg.setVector_opcode(TExprOpcode.INVALID_OPCODE);
         if (node.getChild(0).getType().isComplexType()) {
             msg.setChild_type_desc(TypeSerializer.toThrift(node.getChild(0).getType()));
         } else {
-            msg.setChild_type(node.getChild(0).getType().getPrimitiveType().toThrift());
+            msg.setChild_type(TypeSerializer.toThrift(node.getChild(0).getType().getPrimitiveType()));
         }
         return null;
     }
@@ -370,12 +371,12 @@ public class ExprToThriftVisitor implements AstVisitorExtendInterface<Void, TExp
         Preconditions.checkState(!node.contains(Subquery.class));
         msg.in_predicate = new TInPredicate(node.isNotIn());
         msg.node_type = TExprNodeType.IN_PRED;
-        msg.setOpcode(node.getOpcode());
-        msg.setVector_opcode(node.getVectorOpcode());
+        msg.setOpcode(ExprOpcodeRegistry.getInPredicateOpcode(node.isNotIn()));
+        msg.setVector_opcode(TExprOpcode.INVALID_OPCODE);
         if (node.getChild(0).getType().isComplexType()) {
             msg.setChild_type_desc(TypeSerializer.toThrift(node.getChild(0).getType()));
         } else {
-            msg.setChild_type(node.getChild(0).getType().getPrimitiveType().toThrift());
+            msg.setChild_type(TypeSerializer.toThrift(node.getChild(0).getType().getPrimitiveType()));
         }
         return null;
     }
@@ -393,7 +394,7 @@ public class ExprToThriftVisitor implements AstVisitorExtendInterface<Void, TExp
     @Override
     public Void visitTimestampArithmeticExpr(TimestampArithmeticExpr node, TExprNode msg) {
         msg.node_type = TExprNodeType.COMPUTE_FUNCTION_CALL;
-        msg.setOpcode(node.getOpcode());
+        msg.setOpcode(ExprOpcodeRegistry.getExprOpcode(node));
         return null;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/FunctionCallExpr.java
@@ -322,7 +322,7 @@ public class FunctionCallExpr extends Expr {
     @Override
     public int hashCode() {
         // @Note: fnParams is different with children Expr. use children plz.
-        return Objects.hash(super.hashCode(), type, opcode, fnName, nondeterministicId);
+        return Objects.hash(super.hashCode(), type, fnName, nondeterministicId);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/InPredicate.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/InPredicate.java
@@ -40,7 +40,6 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprOpcode;
 
 import java.util.List;
 
@@ -65,13 +64,11 @@ public class InPredicate extends Predicate {
         children.add(compareExpr);
         children.addAll(inList);
         this.isNotIn = isNotIn;
-        this.opcode = isNotIn ? TExprOpcode.FILTER_NOT_IN : TExprOpcode.FILTER_IN;
     }
 
     protected InPredicate(InPredicate other) {
         super(other);
         isNotIn = other.isNotIn();
-        this.opcode = isNotIn ? TExprOpcode.FILTER_NOT_IN : TExprOpcode.FILTER_IN;
     }
 
     public int getInElementNum() {
@@ -96,7 +93,6 @@ public class InPredicate extends Predicate {
         children.add(compareExpr);
         children.add(subquery);
         this.isNotIn = isNotIn;
-        this.opcode = isNotIn ? TExprOpcode.FILTER_NOT_IN : TExprOpcode.FILTER_IN;
     }
 
     /**
@@ -143,10 +139,6 @@ public class InPredicate extends Predicate {
             return isNotIn == expr.isNotIn;
         }
         return false;
-    }
-
-    public void setOpcode(TExprOpcode opcode) {
-        this.opcode = opcode;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/MatchExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/MatchExpr.java
@@ -20,7 +20,6 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TExprOpcode;
 
 import java.util.Objects;
 
@@ -60,24 +59,18 @@ public class MatchExpr extends Expr {
     }
 
     public enum MatchOperator {
-        MATCH("MATCH", TExprOpcode.MATCH),
-        MATCH_ANY("MATCH_ANY", TExprOpcode.MATCH_ANY),
-        MATCH_ALL("MATCH_ALL", TExprOpcode.MATCH_ALL);
+        MATCH("MATCH"),
+        MATCH_ANY("MATCH_ANY"),
+        MATCH_ALL("MATCH_ALL");
 
         private final String name;
-        private final TExprOpcode opcode;
 
-        MatchOperator(String name, TExprOpcode opCode) {
+        MatchOperator(String name) {
             this.name = name;
-            this.opcode = opCode;
         }
 
         public String getName() {
             return name;
-        }
-
-        public TExprOpcode getOpcode() {
-            return opcode;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
@@ -94,7 +94,6 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 import com.starrocks.sql.optimizer.operator.scalar.SubfieldOperator;
 import com.starrocks.sql.optimizer.operator.scalar.SubqueryOperator;
 import com.starrocks.sql.spm.SPMFunctions;
-import com.starrocks.thrift.TExprOpcode;
 import com.starrocks.thrift.TFunctionBinaryType;
 
 import java.time.LocalDateTime;
@@ -338,8 +337,6 @@ public class ScalarOperatorToExpr {
             // @FIXME: support subquery
             InPredicate expr =
                     new InPredicate(buildExpr.build(predicate.getChild(0), context), args, predicate.isNotIn());
-
-            expr.setOpcode(expr.isNotIn() ? TExprOpcode.FILTER_NOT_IN : TExprOpcode.FILTER_IN);
 
             expr.setType(Type.BOOLEAN);
             return expr;

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TypeDeserializerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TypeDeserializerTest.java
@@ -337,7 +337,7 @@ public class TypeDeserializerTest {
             Type type = TypeDeserializer.fromThrift(typeDesc);
 
             Assertions.assertTrue(type.isScalarType());
-            Assertions.assertEquals(PrimitiveType.fromThrift(primitiveType),
+            Assertions.assertEquals(TypeDeserializer.fromThrift(primitiveType),
                     ((ScalarType) type).getPrimitiveType());
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TypeSerializerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TypeSerializerTest.java
@@ -81,7 +81,7 @@ public class TypeSerializerTest {
             TypeSerializer.toThrift(type, container);
 
             Assertions.assertEquals(1, container.types.size());
-            assertScalarTypeNode(container.types.get(0), primitiveType.toThrift());
+            assertScalarTypeNode(container.types.get(0), TypeSerializer.toThrift(primitiveType));
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/ExprToThriftVisitorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/ExprToThriftVisitorTest.java
@@ -33,7 +33,6 @@ import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.thrift.TExpr;
 import com.starrocks.thrift.TExprNode;
 import com.starrocks.thrift.TExprNodeType;
-import com.starrocks.thrift.TExprOpcode;
 import com.starrocks.thrift.TInPredicate;
 import com.starrocks.thrift.TInfoFunc;
 import org.junit.jupiter.api.Assertions;
@@ -382,7 +381,6 @@ public class ExprToThriftVisitorTest {
                                 new IntLiteral(1), "DAY", false);
                 expr.setType(Type.DATE);
                 expr.setOriginType(Type.DATE);
-                expr.opcode = TExprOpcode.ADD;
                 return expr;
             } catch (AnalysisException e) {
                 throw new RuntimeException(e);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This pull request refactors how expression opcodes are handled in the codebase, removing the direct dependency on the `TExprOpcode` enum from most expression classes and replacing it with more abstracted operator types. The main goal is to decouple the expression logic from the Thrift opcode representation, improving maintainability and clarity. The changes also introduce a new registry (`ExprOpcodeRegistry`) to handle opcode conversions where needed.

Key changes include:

**Decoupling from `TExprOpcode` and refactoring operator representations:**

* Removed the `opcode` field and related logic from `BinaryPredicate`, `BinaryType`, and `ArithmeticExpr`, so these classes now use their own operator types instead of Thrift opcodes. (`BinaryPredicate.java`, `BinaryType.java`, `ArithmeticExpr.java`) [[1]](diffhunk://#diff-92d6b335b2e4fffe9515eae4b746927040b74f21a6f65782c495f7148208c2aeL82) [[2]](diffhunk://#diff-92d6b335b2e4fffe9515eae4b746927040b74f21a6f65782c495f7148208c2aeL138-R137) [[3]](diffhunk://#diff-9a0c6e1fe34f0863027f4045325fe95192791632d31a224de6aa5397738c32bcL18-R28) [[4]](diffhunk://#diff-9a0c6e1fe34f0863027f4045325fe95192791632d31a224de6aa5397738c32bcL54-L63) [[5]](diffhunk://#diff-9a0c6e1fe34f0863027f4045325fe95192791632d31a224de6aa5397738c32bcL76-L79) [[6]](diffhunk://#diff-fad75da1b86f53cf6d225eda2ed73a03c22b854b349f2884a55ab7ac31488119L528-L556) [[7]](diffhunk://#diff-fad75da1b86f53cf6d225eda2ed73a03c22b854b349f2884a55ab7ac31488119L573-L576) [[8]](diffhunk://#diff-fad75da1b86f53cf6d225eda2ed73a03c22b854b349f2884a55ab7ac31488119L442-R441)
* Updated the constructors and equality methods in these classes to use the new operator fields. [[1]](diffhunk://#diff-92d6b335b2e4fffe9515eae4b746927040b74f21a6f65782c495f7148208c2aeL82) [[2]](diffhunk://#diff-92d6b335b2e4fffe9515eae4b746927040b74f21a6f65782c495f7148208c2aeL138-R137) [[3]](diffhunk://#diff-fad75da1b86f53cf6d225eda2ed73a03c22b854b349f2884a55ab7ac31488119L442-R441)

**Centralizing opcode conversion logic:**

* Introduced the `ExprOpcodeRegistry` utility to map internal operator types to Thrift opcodes where necessary, such as when serializing to Thrift in planner nodes. (`HashJoinNode.java`, `MergeJoinNode.java`, `StreamJoinNode.java`) [[1]](diffhunk://#diff-328a54dc57dd6701cb82d7bcf0d619d28f8b795c606361075bc385b7b6350066L121-R122) [[2]](diffhunk://#diff-328a54dc57dd6701cb82d7bcf0d619d28f8b795c606361075bc385b7b6350066L131-R132) [[3]](diffhunk://#diff-e3280c67390c5ac3e02ba4089caa546bfaa39b73e591ca9dd413e27480de18c5L70-R71) [[4]](diffhunk://#diff-3b2988874237ca8f77e02b98e71685fd0a81d5fd385ef307a2a79f21b88a640cL55-R56)

**Updating usages throughout the codebase:**

* Replaced all direct usage of `TExprOpcode` with the new operator types (`BinaryType` or `ArithmeticExpr.Operator`) in affected files, including query statements and connectors. [[1]](diffhunk://#diff-cbcee42b13a13fe1907e5e8d3b92d39bcf16121682af794de4ab77b18c7293c0R21) [[2]](diffhunk://#diff-cbcee42b13a13fe1907e5e8d3b92d39bcf16121682af794de4ab77b18c7293c0L36) [[3]](diffhunk://#diff-cbcee42b13a13fe1907e5e8d3b92d39bcf16121682af794de4ab77b18c7293c0L127-R128) [[4]](diffhunk://#diff-cbcee42b13a13fe1907e5e8d3b92d39bcf16121682af794de4ab77b18c7293c0L142-R142) [[5]](diffhunk://#diff-fbde12e3b4cd5fbafb76cc7e5b798913f3c4cfa341d6de59d54869bf206ed277R23-L26) [[6]](diffhunk://#diff-fbde12e3b4cd5fbafb76cc7e5b798913f3c4cfa341d6de59d54869bf206ed277L102-R102) [[7]](diffhunk://#diff-fbde12e3b4cd5fbafb76cc7e5b798913f3c4cfa341d6de59d54869bf206ed277L124-R124) [[8]](diffhunk://#diff-fbde12e3b4cd5fbafb76cc7e5b798913f3c4cfa341d6de59d54869bf206ed277L134-R145) [[9]](diffhunk://#diff-2076bfa66c1a2ca9c28026d25521e89cb41329f0260a39a810249db50c253201L46) [[10]](diffhunk://#diff-2076bfa66c1a2ca9c28026d25521e89cb41329f0260a39a810249db50c253201L146)

**Other minor cleanups:**

* Removed unused imports and fields related to `TExprOpcode` in several classes. [[1]](diffhunk://#diff-cbcee42b13a13fe1907e5e8d3b92d39bcf16121682af794de4ab77b18c7293c0L36) [[2]](diffhunk://#diff-fad75da1b86f53cf6d225eda2ed73a03c22b854b349f2884a55ab7ac31488119L52) [[3]](diffhunk://#diff-2076bfa66c1a2ca9c28026d25521e89cb41329f0260a39a810249db50c253201L46) [[4]](diffhunk://#diff-2076bfa66c1a2ca9c28026d25521e89cb41329f0260a39a810249db50c253201L146) [[5]](diffhunk://#diff-fbde12e3b4cd5fbafb76cc7e5b798913f3c4cfa341d6de59d54869bf206ed277R23-L26)
* Updated hashCode and equals methods to reflect the new operator representations. [[1]](diffhunk://#diff-5d535d5560339d3210890fb544ff48b666a9d3505cbe87de868226758f716ebfL420-R420) [[2]](diffhunk://#diff-92d6b335b2e4fffe9515eae4b746927040b74f21a6f65782c495f7148208c2aeL138-R137) [[3]](diffhunk://#diff-fad75da1b86f53cf6d225eda2ed73a03c22b854b349f2884a55ab7ac31488119L442-R441)

These changes collectively make the expression handling code more modular and easier to maintain by separating internal logic from serialization concerns.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes direct TExprOpcode and PrimitiveType Thrift coupling by introducing ExprOpcodeRegistry and TypeSerializer/TypeDeserializer, updating planners/connectors and tests accordingly.
> 
> - **Expressions/Serialization**:
>   - Introduce `ExprOpcodeRegistry` and refactor `ArithmeticExpr`, `BinaryPredicate`, `BinaryType`, `CastExpr`, `MatchExpr`, `InPredicate`, and base `Expr` to remove direct `TExprOpcode` usage.
>   - Update `ExprToThriftVisitor` to obtain opcodes via `ExprOpcodeRegistry`.
> - **Planner/Connectors**:
>   - Use opcode registry in `HashJoinNode`, `MergeJoinNode`, `StreamJoinNode` and switch to `BinaryType` in `QueryConverter` and `QueryStatement`.
> - **Types**:
>   - Add `TypeSerializer`/`TypeDeserializer`; remove Thrift mapping from `PrimitiveType`; replace all usages with the new utilities (`OlapScanNode`, `ShowResultSet`, `FrontendServiceImpl`).
> - **Tests**:
>   - Add/adjust unit tests for type (de)serialization and Thrift expr conversion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ac71274356f4c6ec550307dfadeeddc4a241e2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->