### PR TITLE
[Enhancement] Support truncate iceberg table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -295,6 +295,7 @@ public interface ConnectorMetadata {
     }
 
     default void truncateTable(TruncateTableStmt truncateTableStmt, ConnectContext context) throws DdlException {
+        throw new StarRocksConnectorException("This connector doesn't support truncate table");
     }
 
     default void createTableLike(CreateTableLikeStmt stmt) throws DdlException {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -790,7 +790,7 @@ public class DDLStmtExecutor {
         @Override
         public ShowResultSet visitTruncateTableStatement(TruncateTableStmt stmt, ConnectContext context) {
             ErrorReport.wrapWithRuntimeException(() -> {
-                context.getGlobalStateMgr().getLocalMetastore().truncateTable(stmt, context);
+                context.getGlobalStateMgr().getMetadataMgr().truncateTable(context, stmt);
             });
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -77,6 +77,7 @@ import com.starrocks.sql.ast.CreateTemporaryTableStmt;
 import com.starrocks.sql.ast.CreateViewStmt;
 import com.starrocks.sql.ast.DropTableStmt;
 import com.starrocks.sql.ast.DropTemporaryTableStmt;
+import com.starrocks.sql.ast.TruncateTableStmt;
 import com.starrocks.sql.ast.expression.TableName;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -400,6 +401,15 @@ public class MetadataMgr {
 
         if (connectorMetadata.isPresent()) {
             connectorMetadata.get().alterView(context, stmt);
+        }
+    }
+
+    public void truncateTable(ConnectContext context, TruncateTableStmt stmt) throws StarRocksException {
+        String catalogName = stmt.getCatalogName();
+        Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
+
+        if (connectorMetadata.isPresent()) {
+            connectorMetadata.get().truncateTable(stmt, context);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/TruncateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/TruncateTableAnalyzer.java
@@ -19,8 +19,11 @@ import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.PartitionRef;
+import com.starrocks.sql.ast.QualifiedName;
 import com.starrocks.sql.ast.TableRef;
 import com.starrocks.sql.ast.TruncateTableStmt;
+
+import java.util.List;
 
 public class TruncateTableAnalyzer {
 
@@ -30,7 +33,8 @@ public class TruncateTableAnalyzer {
         // Validate catalog
         String catalog = tableRef.getCatalogName();
         if (Strings.isNullOrEmpty(catalog)) {
-            if (Strings.isNullOrEmpty(context.getCurrentCatalog())) {
+            catalog = context.getCurrentCatalog();
+            if (Strings.isNullOrEmpty(catalog)) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_CATALOG_ERROR, catalog);
             }
         }
@@ -61,5 +65,9 @@ public class TruncateTableAnalyzer {
                 throw new SemanticException("there are empty partition name");
             }
         }
+
+        TableRef nomalizedTableRef = new TableRef(QualifiedName.of(List.of(catalog, db, tbl)), partitionRef,
+                tableRef.getPos());
+        statement.setTblRef(nomalizedTableRef);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTruncateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTruncateTableTest.java
@@ -39,7 +39,7 @@ public class AnalyzeTruncateTableTest {
 
         stmt = (TruncateTableStmt) analyzeSuccess("TRUNCATE TABLE tbl PARTITION(p1, p2);");
         Assertions.assertEquals("tbl", stmt.getTblName());
-        Assertions.assertNull(stmt.getDbName());
+        Assertions.assertEquals("test", stmt.getDbName());
         Assertions.assertEquals("[p1, p2]", stmt.getTblRef().getPartitionDef().getPartitionNames().toString());
     }
 

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/TruncateTableStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/TruncateTableStmt.java
@@ -20,7 +20,7 @@ import com.starrocks.sql.parser.NodePosition;
 // TRUNCATE TABLE tbl [PARTITION(p1, p2, ...)]
 public class TruncateTableStmt extends DdlStmt {
 
-    private final TableRef tblRef;
+    private TableRef tblRef;
 
     public TruncateTableStmt(TableRef tblRef) {
         this(tblRef, NodePosition.ZERO);
@@ -33,6 +33,14 @@ public class TruncateTableStmt extends DdlStmt {
 
     public TableRef getTblRef() {
         return tblRef;
+    }
+
+    public void setTblRef(TableRef tblRef) {
+        this.tblRef = tblRef;
+    }
+
+    public String getCatalogName() {
+        return tblRef.getCatalogName();
     }
 
     public String getDbName() {

--- a/test/sql/test_iceberg/R/test_iceberg_truncate
+++ b/test/sql/test_iceberg/R/test_iceberg_truncate
@@ -1,0 +1,77 @@
+-- name: test_iceberg_truncate
+create external catalog iceberg_truncate_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+-- !result
+create database iceberg_truncate_${uuid0}.iceberg_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/iceberg_truncate_${uuid0}/iceberg_db/${uuid0}"
+);
+-- result:
+-- !result
+create external table iceberg_truncate_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} (k1 int);
+-- result:
+-- !result
+insert into iceberg_truncate_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} values(1),(2),(3);
+-- result:
+-- !result
+select * from iceberg_truncate_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} order by k1;
+-- result:
+1
+2
+3
+-- !result
+truncate table iceberg_truncate_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0};
+-- result:
+-- !result
+select * from iceberg_truncate_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} order by k1;
+-- result:
+-- !result
+set catalog iceberg_truncate_${uuid0};
+-- result:
+-- !result
+insert into iceberg_db_${uuid0}.ice_tbl_${uuid0} values(1),(2),(3);
+-- result:
+-- !result
+select * from iceberg_db_${uuid0}.ice_tbl_${uuid0} order by k1;
+-- result:
+1
+2
+3
+-- !result
+truncate table iceberg_db_${uuid0}.ice_tbl_${uuid0};
+-- result:
+-- !result
+select * from iceberg_db_${uuid0}.ice_tbl_${uuid0} order by k1;
+-- result:
+-- !result
+use iceberg_truncate_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+insert into ice_tbl_${uuid0} values(1),(2),(3);
+-- result:
+-- !result
+select * from ice_tbl_${uuid0} order by k1;
+-- result:
+1
+2
+3
+-- !result
+truncate table ice_tbl_${uuid0};
+-- result:
+-- !result
+select * from ice_tbl_${uuid0} order by k1;
+-- result:
+-- !result
+drop table iceberg_truncate_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} force;
+-- result:
+-- !result
+drop database iceberg_truncate_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+drop catalog iceberg_truncate_${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/iceberg_truncate_${uuid0}/iceberg_db/${uuid0} > /dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_truncate
+++ b/test/sql/test_iceberg/T/test_iceberg_truncate
@@ -1,0 +1,32 @@
+-- name: test_iceberg_truncate
+
+create external catalog iceberg_truncate_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+
+create database iceberg_truncate_${uuid0}.iceberg_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/iceberg_truncate_${uuid0}/iceberg_db/${uuid0}"
+);
+
+create external table iceberg_truncate_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} (k1 int);
+
+insert into iceberg_truncate_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} values(1),(2),(3);
+select * from iceberg_truncate_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} order by k1;
+truncate table iceberg_truncate_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0};
+select * from iceberg_truncate_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} order by k1;
+
+set catalog iceberg_truncate_${uuid0};
+insert into iceberg_db_${uuid0}.ice_tbl_${uuid0} values(1),(2),(3);
+select * from iceberg_db_${uuid0}.ice_tbl_${uuid0} order by k1;
+truncate table iceberg_db_${uuid0}.ice_tbl_${uuid0};
+select * from iceberg_db_${uuid0}.ice_tbl_${uuid0} order by k1;
+
+use iceberg_truncate_${uuid0}.iceberg_db_${uuid0};
+insert into ice_tbl_${uuid0} values(1),(2),(3);
+select * from ice_tbl_${uuid0} order by k1;
+truncate table ice_tbl_${uuid0};
+select * from ice_tbl_${uuid0} order by k1;
+
+drop table iceberg_truncate_${uuid0}.iceberg_db_${uuid0}.ice_tbl_${uuid0} force;
+drop database iceberg_truncate_${uuid0}.iceberg_db_${uuid0};
+drop catalog iceberg_truncate_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/iceberg_truncate_${uuid0}/iceberg_db/${uuid0} > /dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
## Why I'm doing:
Support truncate iceberg table
## What I'm doing:

This pull request adds support for the `TRUNCATE TABLE` operation on Iceberg tables in StarRocks, enabling users to remove all data from an Iceberg table via the standard SQL command. The implementation integrates the truncate logic into the metadata management layers, updates the analyzer to normalize table references, and provides comprehensive tests to ensure correctness across various catalog and database contexts.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds TRUNCATE TABLE support for Iceberg tables, routing through MetadataMgr and implementing delete-all in IcebergMetadata with commit metadata; normalizes analyzer behavior and adds tests.
> 
> - **Iceberg Connector**:
>   - Implement `truncateTable` in `IcebergMetadata` by deleting all files via `DeleteFiles.deleteFromRowFilter(Expressions.alwaysTrue())` with robust commit error handling.
>   - Record commit metadata (`engine-name`, `engine-version`, `starrocks_user`).
> - **Execution Flow**:
>   - `DDLStmtExecutor` now routes `TRUNCATE TABLE` to `MetadataMgr.truncateTable`.
>   - `MetadataMgr` delegates truncate to the appropriate `ConnectorMetadata`.
>   - `ConnectorMetadata` default `truncateTable` throws "not supported".
> - **Analyzer/Parser**:
>   - `TruncateTableAnalyzer` normalizes `TableRef` with catalog/db from session; validates inputs.
>   - `TruncateTableStmt` now allows updating `tblRef` and exposes `getCatalogName()`.
> - **Tests**:
>   - Add end-to-end SQL tests for truncating Iceberg tables across fully qualified, set-catalog, and use-db contexts.
>   - Update analyzer UT to expect resolved db and add failure case for empty partition list.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7c5fb5f5d68c26280b9aadfbb5625cbf839e1ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->