### PR TITLE
[Enhancement] Push down heavy exprs involving regexp to storage layer to leverage io threads to evaluate(backport #64727)

### DIFF
--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -314,6 +314,7 @@ public:
     SourceOperatorFactory::AdaptiveState adaptive_initial_state() const override { return AdaptiveState::ACTIVE; }
 
     std::shared_ptr<workgroup::ScanTaskGroup> scan_task_group() const { return _scan_task_group; }
+    ScanNode* scan_node() { return _scan_node; }
 
 protected:
     ScanNode* const _scan_node;

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -146,6 +146,14 @@ public:
         this->_back_pressure_throttle_time_upper_bound = value;
     }
 
+    void set_heavy_expr_slot_ids(std::vector<SlotId>&& slot_ids) { _heavy_expr_slot_ids = std::move(slot_ids); }
+
+    void set_heavy_expr_ctxs(std::vector<ExprContext*>& ctxs) { _heavy_expr_ctxs = std::move(ctxs); }
+
+    std::vector<SlotId>& get_heavy_expr_slot_ids() { return _heavy_expr_slot_ids; }
+
+    std::vector<ExprContext*>& get_heavy_expr_ctxs() { return _heavy_expr_ctxs; }
+
 protected:
     RuntimeProfile::Counter* _bytes_read_counter = nullptr; // # bytes read from the scanner
     // # rows/tuples read from the scanner (including those discarded by eval_conjucts())
@@ -171,6 +179,9 @@ protected:
     size_t _back_pressure_num_rows = 10240;
     int64_t _back_pressure_throttle_time = 500;
     int64_t _back_pressure_throttle_time_upper_bound = 5000;
+
+    std::vector<SlotId> _heavy_expr_slot_ids;
+    std::vector<ExprContext*> _heavy_expr_ctxs;
 };
 
 } // namespace starrocks

--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -3353,6 +3353,12 @@ Status StringFunctions::regexp_replace_prepare(FunctionContext* context, Functio
         }
     }
 
+    state->global_mode = pattern_str.empty() || (!pattern_str.starts_with("^") && !pattern_str.ends_with("$"));
+    if (context->is_notnull_constant_column(2)) {
+        const auto rpl_column = context->get_constant_column(2);
+        const auto rpl_slice = ColumnHelper::get_const_value<TYPE_VARCHAR>(rpl_column);
+        state->opt_const_rpl = rpl_slice.to_string();
+    }
     return Status::OK();
 }
 
@@ -3747,6 +3753,47 @@ static ColumnPtr regexp_replace_general(FunctionContext* context, re2::RE2::Opti
     return result.build(ColumnHelper::is_all_const(columns));
 }
 
+template <bool global_mode>
+static ColumnPtr regexp_replace_const_pattern_and_rpl(re2::RE2* const_re, const Columns& columns,
+                                                      const std::string& rpl) {
+    auto str_viewer = ColumnViewer<TYPE_VARCHAR>(columns[0]);
+    re2::StringPiece rpl_str = re2::StringPiece(rpl);
+    auto size = columns[0]->size();
+    ColumnBuilder<TYPE_VARCHAR> result(size);
+    std::string result_str;
+    for (int row = 0; row < size; ++row) {
+        if (str_viewer.is_null(row)) {
+            result.append_null();
+            continue;
+        }
+
+        auto str_value = str_viewer.value(row);
+        re2::StringPiece str_str = re2::StringPiece(str_value.get_data(), str_value.get_size());
+        result_str.clear();
+#ifdef __APPLE__
+        // macOS RE2 API only supports 3-parameter GlobalReplace
+        result_str = std::string(str_str.data(), str_str.size());
+        if constexpr (global_mode) {
+            re2::RE2::GlobalReplace(&result_str, *const_re, rpl_str);
+        } else {
+            re2::RE2::Replace(&result_str, *const_re, rpl_str);
+        }
+#else
+        // Linux RE2 API supports 4-parameter GlobalReplace
+        if constexpr (global_mode) {
+            re2::RE2::GlobalReplace(str_str, *const_re, rpl_str, result_str);
+        } else {
+            result_str = std::string(str_str.data(), str_str.size());
+            re2::RE2::Replace(&result_str, *const_re, rpl_str);
+        }
+#endif
+        result.append(Slice(result_str.data(), result_str.size()));
+    }
+
+    return result.build(ColumnHelper::is_all_const(columns));
+}
+
+template <bool global_mode>
 static ColumnPtr regexp_replace_const(re2::RE2* const_re, const Columns& columns) {
     auto str_viewer = ColumnViewer<TYPE_VARCHAR>(columns[0]);
     auto rpl_viewer = ColumnViewer<TYPE_VARCHAR>(columns[2]);
@@ -3765,7 +3812,12 @@ static ColumnPtr regexp_replace_const(re2::RE2* const_re, const Columns& columns
         auto str_value = str_viewer.value(row);
         re2::StringPiece str_str = re2::StringPiece(str_value.get_data(), str_value.get_size());
         result_str.clear();
-        re2::RE2::GlobalReplace(str_str, *const_re, rpl_str, result_str);
+        if constexpr (global_mode) {
+            re2::RE2::GlobalReplace(str_str, *const_re, rpl_str, result_str);
+        } else {
+            result_str = std::string(str_str.data(), str_str.size());
+            re2::RE2::Replace(&result_str, *const_re, rpl_str);
+        }
         result.append(Slice(result_str.data(), result_str.size()));
     }
 
@@ -3996,7 +4048,19 @@ StatusOr<ColumnPtr> StringFunctions::regexp_replace(FunctionContext* context, co
             }
         } else {
             re2::RE2* const_re = state->get_or_prepare_regex();
-            return regexp_replace_const(const_re, columns);
+            if (state->opt_const_rpl.has_value()) {
+                if (state->global_mode) {
+                    return regexp_replace_const_pattern_and_rpl<true>(const_re, columns, state->opt_const_rpl.value());
+                } else {
+                    return regexp_replace_const_pattern_and_rpl<false>(const_re, columns, state->opt_const_rpl.value());
+                }
+            } else {
+                if (state->global_mode) {
+                    return regexp_replace_const<true>(const_re, columns);
+                } else {
+                    return regexp_replace_const<false>(const_re, columns);
+                }
+            }
         }
     }
 

--- a/be/src/exprs/string_functions.h
+++ b/be/src/exprs/string_functions.h
@@ -70,6 +70,8 @@ struct StringFunctionsState {
     DriverMap driver_regex_map; // regex for each pipeline_driver, to make it driver-local
 
     bool use_hyperscan = false;
+    std::optional<std::string> opt_const_rpl{};
+    bool global_mode = true;
     int size_of_pattern = -1;
 
     // a pointer to the generated database that responsible for parsed expression.

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ProjectNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ProjectNode.java
@@ -186,17 +186,28 @@ public class ProjectNode extends PlanNode {
     public boolean isTrivial() {
         return slotMap.entrySet().stream().allMatch(
                 e -> e.getValue() instanceof SlotRef && ((SlotRef) e.getValue()).getSlotId().equals(e.getKey())) &&
-                commonSlotMap.isEmpty();
+                commonSlotMap.isEmpty() &&
+                (!(getChild(0) instanceof ScanNode) || ((ScanNode) getChild(0)).getHeavyExprs().isEmpty());
     }
 
     @Override
     protected void toNormalForm(TNormalPlanNode planNode, FragmentNormalizer normalizer) {
         TNormalProjectNode projectNode = new TNormalProjectNode();
+        projectNode.setCse_slot_ids(Lists.newArrayList());
+        projectNode.setCse_exprs(Lists.newArrayList());
+        if ((getChild(0) instanceof ScanNode)) {
+            ScanNode scanNode = (ScanNode) getChild(0);
+            normalizer.addSlotsUseAggColumns(scanNode.getHeavyExprs());
+            Pair<List<Integer>, List<ByteBuffer>> slotIdsAndHeavyExprs =
+                    normalizer.normalizeSlotIdsAndExprs(scanNode.getHeavyExprs());
+            projectNode.getCse_slot_ids().addAll(slotIdsAndHeavyExprs.first);
+            projectNode.getCse_exprs().addAll(slotIdsAndHeavyExprs.second);
+        }
         normalizer.addSlotsUseAggColumns(commonSlotMap);
         normalizer.addSlotsUseAggColumns(slotMap);
         Pair<List<Integer>, List<ByteBuffer>> cseSlotIdsAndExprs = normalizer.normalizeSlotIdsAndExprs(commonSlotMap);
-        projectNode.setCse_slot_ids(cseSlotIdsAndExprs.first);
-        projectNode.setCse_exprs(cseSlotIdsAndExprs.second);
+        projectNode.getCse_slot_ids().addAll(cseSlotIdsAndExprs.first);
+        projectNode.getCse_exprs().addAll(cseSlotIdsAndExprs.second);
 
         Pair<List<Integer>, List<ByteBuffer>> slotIdAndExprs = normalizer.normalizeSlotIdsAndExprs(slotMap);
         projectNode.setSlot_ids(slotIdAndExprs.first);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
@@ -36,8 +36,10 @@ package com.starrocks.planner;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
+import com.google.common.collect.Maps;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.SlotDescriptor;
+import com.starrocks.analysis.SlotId;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.catalog.ColumnAccessPath;
 import com.starrocks.common.StarRocksException;
@@ -77,6 +79,8 @@ public abstract class ScanNode extends PlanNode {
     // NOTE: To avoid trigger a new compute resource creation, set the value when the scan node needs to use it.
     // The compute resource used by this scan node.
     protected ComputeResource computeResource = WarehouseManager.DEFAULT_RESOURCE;
+
+    private Map<SlotId, Expr> heavyExprs = Maps.newHashMap();
 
     public ScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName) {
         super(id, desc.getId().asList(), planNodeName);
@@ -251,5 +255,13 @@ public abstract class ScanNode extends PlanNode {
             output.append("\n");
         }
         return output.toString();
+    }
+
+    public void setHeavyExprs(Map<SlotId, Expr> heavyExprs) {
+        this.heavyExprs = heavyExprs;
+    }
+
+    public Map<SlotId, Expr> getHeavyExprs() {
+        return heavyExprs;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -978,6 +978,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_INSERT_SELECT_EXTERNAL_AUTO_REFRESH = "enable_insert_select_external_auto_refresh";
 
+    public static final String PUSH_DOWN_HEAVY_EXPRS = "push_down_heavy_exprs";
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(MAX_EXECUTION_TIME)
@@ -2008,6 +2010,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_INSERT_SELECT_EXTERNAL_AUTO_REFRESH)
     private boolean enableInsertSelectExternalAutoRefresh = true;
+
+    @VarAttr(name = PUSH_DOWN_HEAVY_EXPRS)
+    private boolean pushDownHeavyExprs = true;
 
     public int getCboPruneJsonSubfieldDepth() {
         return cboPruneJsonSubfieldDepth;
@@ -5423,6 +5428,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableInsertSelectExternalAutoRefresh(boolean enableInsertSelectExternalAutoRefresh) {
         this.enableInsertSelectExternalAutoRefresh = enableInsertSelectExternalAutoRefresh;
+    }
+
+    public void setPushDownHeavyExprs(boolean flag) {
+        this.pushDownHeavyExprs = flag;
+    }
+
+    public boolean isPushDownHeavyExprs() {
+        return this.pushDownHeavyExprs;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -203,9 +203,11 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.LikePredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorUtil;
 import com.starrocks.sql.optimizer.operator.stream.PhysicalStreamAggOperator;
 import com.starrocks.sql.optimizer.operator.stream.PhysicalStreamJoinOperator;
 import com.starrocks.sql.optimizer.operator.stream.PhysicalStreamScanOperator;
+import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rule.tree.prunesubfield.SubfieldAccessPathNormalizer;
 import com.starrocks.sql.optimizer.rule.tree.prunesubfield.SubfieldExpressionCollector;
 import com.starrocks.sql.optimizer.statistics.Statistics;
@@ -234,6 +236,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -514,6 +517,46 @@ public class PlanFragmentBuilder {
             return context.getOptExpression(node.getId().asInt());
         }
 
+        private boolean containsHeavyExpr(ScalarOperator expr) {
+            Predicate<ScalarOperator> isHeavyExpr = e -> {
+                if (e.getChildren().isEmpty() || !(e instanceof CallOperator)) {
+                    return false;
+                }
+                CallOperator call = (CallOperator) e;
+                return call.getFnName().toLowerCase().contains("regexp");
+            };
+            return ScalarOperatorUtil.getStream(expr).anyMatch(isHeavyExpr);
+        }
+
+        public Map<ColumnRefOperator, ScalarOperator> extractHeavyExprs(Projection projection) {
+            Map<ColumnRefOperator, ScalarOperator> commonSubExprs =
+                    Optional.ofNullable(projection.getCommonSubOperatorMap())
+                            .orElse(Collections.emptyMap());
+
+            Map<ColumnRefOperator, ScalarOperator> heavyCommonSubExprs =
+                    commonSubExprs.entrySet().stream().filter(e -> containsHeavyExpr(e.getValue()))
+                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+            Map<ColumnRefOperator, ScalarOperator> exprs =
+                    Optional.ofNullable(projection.getColumnRefMap()).orElse(Collections.emptyMap());
+
+            Map<ColumnRefOperator, ScalarOperator> heavyExprs =
+                    exprs.entrySet().stream().filter(e -> containsHeavyExpr(e.getValue()))
+                            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+            if (heavyCommonSubExprs.isEmpty() && heavyExprs.isEmpty()) {
+                return Collections.emptyMap();
+            }
+
+            commonSubExprs.replaceAll((k, v) -> heavyCommonSubExprs.containsKey(k) ? k : v);
+
+            ReplaceColumnRefRewriter columnRefReplacer = new ReplaceColumnRefRewriter(commonSubExprs);
+            heavyExprs.replaceAll((k, v) -> columnRefReplacer.rewrite(v));
+            exprs.replaceAll((k, v) -> heavyExprs.containsKey(k) ? k : v);
+            heavyExprs.putAll(heavyCommonSubExprs);
+            return heavyExprs;
+        }
+
         @Override
         public PlanFragment visit(OptExpression optExpression, ExecPlan context) {
             PlanFragment fragment = optExpression.getOp().accept(this, optExpression, context);
@@ -686,6 +729,33 @@ public class PlanFragmentBuilder {
             }
 
             Preconditions.checkState(!node.getColumnRefMap().isEmpty());
+
+            // TODO(by satanson): At present we only support OlapTable
+            if (context.getConnectContext().getSessionVariable().isPushDownHeavyExprs() &&
+                    (inputFragment.getPlanRoot() instanceof OlapScanNode)) {
+                Map<ColumnRefOperator, ScalarOperator> heavyExprs = extractHeavyExprs(node);
+                Map<SlotId, Expr> heavyExprMap = Maps.newHashMap();
+                Preconditions.checkArgument(inputFragment.getPlanRoot().getTupleIds().size() == 1);
+                TupleDescriptor tupleDescriptor =
+                        context.getDescTbl().getTupleDesc(inputFragment.getPlanRoot().getTupleIds().get(0));
+                for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : heavyExprs.entrySet()) {
+                    Expr expr = ScalarOperatorToExpr.buildExecExpression(entry.getValue(),
+                            new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr(),
+                                    node.getCommonSubOperatorMap()));
+
+                    heavyExprMap.put(new SlotId(entry.getKey().getId()), expr);
+
+                    SlotDescriptor slotDescriptor =
+                            context.getDescTbl().addSlotDescriptor(tupleDescriptor, new SlotId(entry.getKey().getId()));
+                    slotDescriptor.setIsNullable(expr.isNullable());
+                    slotDescriptor.setIsMaterialized(false);
+                    slotDescriptor.setType(expr.getType());
+                    slotDescriptor.setOriginType(expr.getType());
+                    context.getColRefToExpr()
+                            .put(entry.getKey(), new SlotRef(entry.getKey().toString(), slotDescriptor));
+                }
+                ((OlapScanNode) inputFragment.getPlanRoot()).setHeavyExprs(heavyExprMap);
+            }
 
             TupleDescriptor tupleDescriptor = context.getDescTbl().createTupleDescriptor();
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/PushDownHeavyExprsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/PushDownHeavyExprsTest.java
@@ -1,0 +1,69 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.common.FeConstants;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.util.Utility;
+import com.starrocks.statistic.StatsConstants;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static com.starrocks.sql.optimizer.statistics.CachedStatisticStorageTest.DEFAULT_CREATE_TABLE_TEMPLATE;
+
+public class PushDownHeavyExprsTest {
+    protected static ConnectContext ctx;
+    protected static StarRocksAssert starRocksAssert;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        FeConstants.runningUnitTest = true;
+        UtFrameUtils.createMinStarRocksCluster();
+        ctx = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(ctx);
+        starRocksAssert.withDatabase(StatsConstants.STATISTICS_DB_NAME).useDatabase(StatsConstants.STATISTICS_DB_NAME)
+                .withTable(DEFAULT_CREATE_TABLE_TEMPLATE);
+        starRocksAssert.withDatabase("test").useDatabase("test");
+        Utility.getClickBenchCreateTableSqlList().forEach(createTblSql -> {
+            try {
+                starRocksAssert.withTable(createTblSql);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+    }
+
+    @Test
+    public void test() throws Exception {
+        String q =
+                Utility.getClickBenchQueryList().stream().filter(p -> p.first.equals("Q29")).findFirst().get().second;
+        String plan = UtFrameUtils.getFragmentPlan(ctx, q);
+        Assertions.assertTrue(plan.contains("  0:OlapScanNode\n" +
+                "     TABLE: hits\n" + "     heavy exprs: \n" +
+                "          <slot 106> : regexp_replace(15: Referer, '^https?://(?:www.)?([^/]+)/.*$', '1')"), plan);
+
+        plan = UtFrameUtils.getVerboseFragmentPlan(ctx, q);
+        System.out.println(plan);
+        Assertions.assertTrue(plan.contains("  0:OlapScanNode\n" +
+                "     table: hits, rollup: hits\n" +
+                "     heavy exprs: \n" +
+                "          106 <-> regexp_replace[([15: Referer, VARCHAR(65533), false], " +
+                "'^https?://(?:www.)?([^/]+)/.*$', '1'); args: VARCHAR,VARCHAR,VARCHAR; " +
+                "result: VARCHAR; args nullable: false; result nullable: true]\n"), plan);
+    }
+}

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -1367,7 +1367,11 @@ struct TStreamAggregationNode {
   24: optional i32 agg_func_set_version = 1
 }
 
-
+struct TPlanNodeCommon {
+  // heavy_exprs are extracted from projection and shall be push down to ScanNode and
+  // it is evaluated by ScanNode's ChunkSource in io threads.
+  1: optional map<Types.TSlotId, Exprs.TExpr> heavy_exprs
+}
 // This is essentially a union of all messages corresponding to subclasses
 // of PlanNode.
 struct TPlanNode {
@@ -1384,6 +1388,7 @@ struct TPlanNode {
 
   // Produce data in compact format.
   8: required bool compact_data
+  9: optional TPlanNodeCommon common
 
   // one field per PlanNode subclass
   11: optional THashJoinNode hash_join_node

--- a/test/sql/test_push_down_heavy_exprs/R/test_push_down_heavy_exprs
+++ b/test/sql/test_push_down_heavy_exprs/R/test_push_down_heavy_exprs
@@ -1,0 +1,78 @@
+-- name: test_push_down_heavy_exprs
+create table t0 (
+c0 string
+) properties("replication_num"="1");
+-- result:
+-- !result
+insert into t0 with cte as (
+select i from table(generate_series(1,10000)) t(i)
+)
+select concat(i, ".", "foo", case i%3 when 0 then ".bar" when 1 then ".buzz" else "" end, ".xxxx") c0 
+from cte;
+-- result:
+-- !result
+create table result (
+fp bigint 
+) properties("replication_num"="1");
+-- result:
+-- !result
+insert into result 
+with cte as (
+select distinct regexp_replace(c0, "^\\d+(\\.foo\.b\\w+).*$", "\\1") as c0 from t0 
+)
+select /*+SET_VAR(push_down_heavy_exprs=true)*/sum(murmur_hash3_32(cte.c0)) fp from cte;
+-- result:
+-- !result
+insert into result 
+with cte as (
+select distinct regexp_replace(c0, "^\\d+(\\.foo\.b\\w+).*$", "\\1") as c0 from t0 
+)
+select /*+SET_VAR(push_down_heavy_exprs=false)*/sum(murmur_hash3_32(cte.c0)) fp from cte;
+-- result:
+-- !result
+select assert_true(count(fp)=2 and count(distinct fp)=1) from result;
+-- result:
+1
+-- !result
+truncate table result;
+-- result:
+-- !result
+insert into result 
+with cte as (
+select distinct regexp_replace(c0, "\\d+(\\.foo\.b\\w+).*", "\\1") as c0 from t0 
+)
+select /*+SET_VAR(push_down_heavy_exprs=true)*/sum(murmur_hash3_32(cte.c0)) fp from cte;
+-- result:
+-- !result
+insert into result 
+with cte as (
+select distinct regexp_replace(c0, "\\d+(\\.foo\.b\\w+).*", "\\1") as c0 from t0 
+)
+select /*+SET_VAR(push_down_heavy_exprs=false)*/sum(murmur_hash3_32(cte.c0)) fp from cte;
+-- result:
+-- !result
+select assert_true(count(fp)=2 and count(distinct fp)=1) from result;
+-- result:
+1
+-- !result
+truncate table result;
+-- result:
+-- !result
+insert into result 
+with cte as (
+select distinct regexp_replace(c0, ".*foo.bar*", "deadbeef") as c0 from t0 
+)
+select /*+SET_VAR(push_down_heavy_exprs=true)*/sum(murmur_hash3_32(cte.c0)) fp from cte;
+-- result:
+-- !result
+insert into result 
+with cte as (
+select distinct regexp_replace(c0, ".*foo.bar*", "deadbeef") as c0 from t0 
+)
+select /*+SET_VAR(push_down_heavy_exprs=false)*/sum(murmur_hash3_32(cte.c0)) fp from cte;
+-- result:
+-- !result
+select assert_true(count(fp)=2 and count(distinct fp)=1) from result;
+-- result:
+1
+-- !result

--- a/test/sql/test_push_down_heavy_exprs/T/test_push_down_heavy_exprs
+++ b/test/sql/test_push_down_heavy_exprs/T/test_push_down_heavy_exprs
@@ -1,0 +1,62 @@
+-- name: test_push_down_heavy_exprs
+
+create table t0 (
+c0 string
+) properties("replication_num"="1");
+
+insert into t0 with cte as (
+select i from table(generate_series(1,10000)) t(i)
+)
+select concat(i, ".", "foo", case i%3 when 0 then ".bar" when 1 then ".buzz" else "" end, ".xxxx") c0 
+from cte;
+
+create table result (
+fp bigint 
+) properties("replication_num"="1");
+
+insert into result 
+with cte as (
+select distinct regexp_replace(c0, "^\\d+(\\.foo\.b\\w+).*$", "\\1") as c0 from t0 
+)
+select /*+SET_VAR(push_down_heavy_exprs=true)*/sum(murmur_hash3_32(cte.c0)) fp from cte;
+
+
+insert into result 
+with cte as (
+select distinct regexp_replace(c0, "^\\d+(\\.foo\.b\\w+).*$", "\\1") as c0 from t0 
+)
+select /*+SET_VAR(push_down_heavy_exprs=false)*/sum(murmur_hash3_32(cte.c0)) fp from cte;
+
+select assert_true(count(fp)=2 and count(distinct fp)=1) from result;
+
+truncate table result;
+
+insert into result 
+with cte as (
+select distinct regexp_replace(c0, "\\d+(\\.foo\.b\\w+).*", "\\1") as c0 from t0 
+)
+select /*+SET_VAR(push_down_heavy_exprs=true)*/sum(murmur_hash3_32(cte.c0)) fp from cte;
+
+insert into result 
+with cte as (
+select distinct regexp_replace(c0, "\\d+(\\.foo\.b\\w+).*", "\\1") as c0 from t0 
+)
+select /*+SET_VAR(push_down_heavy_exprs=false)*/sum(murmur_hash3_32(cte.c0)) fp from cte;
+
+select assert_true(count(fp)=2 and count(distinct fp)=1) from result;
+
+truncate table result;
+
+insert into result 
+with cte as (
+select distinct regexp_replace(c0, ".*foo.bar*", "deadbeef") as c0 from t0 
+)
+select /*+SET_VAR(push_down_heavy_exprs=true)*/sum(murmur_hash3_32(cte.c0)) fp from cte;
+
+insert into result 
+with cte as (
+select distinct regexp_replace(c0, ".*foo.bar*", "deadbeef") as c0 from t0 
+)
+select /*+SET_VAR(push_down_heavy_exprs=false)*/sum(murmur_hash3_32(cte.c0)) fp from cte;
+
+select assert_true(count(fp)=2 and count(distinct fp)=1) from result;


### PR DESCRIPTION
cp #64727 

## Why I'm doing:
Two optimizatons as follows:
1. push heavy exprs involving regexp to chunk source to leverage io threads to evaluate, since io dop is 4x or 16x of pipeline dop; 
2. in regexp_replace, if the pattern starts with "^" or ends with "$", then we can use re2::RE2::Replace instead of re2::RE2::GlobalReplace, and if the replacement str is constant str, a new process branch is introduced.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

