### PR TITLE
[Enhancement] Retain partition for a while after insert overwrite happened

### DIFF
--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -1842,7 +1842,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Unit: Seconds
 - Is mutable: Yes
 - Description: The metadata retention time for the partition that is dropped by INSERT OVERWRITE or materialized view refresh operations. Note that such metadata cannot be recovered by executing [RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md).
-- Introduced in: 3.5.8
+- Introduced in: v3.5.8
 
 ##### check_consistency_default_timeout_second
 

--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -1842,7 +1842,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Unit: Seconds
 - Is mutable: Yes
 - Description: The metadata retention time for the partition that is dropped by INSERT OVERWRITE or materialized view refresh operations. Note that such metadata cannot be recovered by executing [RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md).
-- Introduced in: -
+- Introduced in: 3.5.8
 
 ##### check_consistency_default_timeout_second
 

--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -1842,7 +1842,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Unit: Seconds
 - Is mutable: Yes
 - Description: The metadata retention time for the partition that is dropped by INSERT OVERWRITE or materialized view refresh operations. Note that such metadata cannot be recovered by executing [RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md).
-- Introduced in: v3.5.8
+- Introduced in: v3.5.9
 
 ##### check_consistency_default_timeout_second
 

--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -1841,7 +1841,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Type: Long
 - Unit: Seconds
 - Is mutable: Yes
-- Description: The retention time for partition dropped by insert overwrite/mv rewrite etc. Partitions retained with this config cannot be recovered through the [RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md) command.
+- Description: The metadata retention time for the partition that is dropped by INSERT OVERWRITE or materialized view refresh operations. Note that such metadata cannot be recovered by executing [RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md).
 - Introduced in: -
 
 ##### check_consistency_default_timeout_second

--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -1835,6 +1835,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: The longest duration the metadata can be retained after a database, table, or partition is dropped. If this duration expires, the data will be deleted and cannot be recovered through the [RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md) command.
 - Introduced in: -
 
+##### partition_recycle_retention_period_secs
+
+- Default: 1800
+- Type: Long
+- Unit: Seconds
+- Is mutable: Yes
+- Description: The retention time for partition dropped by insert overwrite/mv rewrite etc. Partitions retained with this config cannot be recovered through the [RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md) command.
+- Introduced in: -
+
 ##### check_consistency_default_timeout_second
 
 - Default: 600

--- a/docs/ja/administration/management/FE_configuration.md
+++ b/docs/ja/administration/management/FE_configuration.md
@@ -1770,6 +1770,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明: データベース、テーブル、またはパーティションが削除された後にメタデータが保持される最長期間。この期間が経過すると、データは削除され、[RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md) コマンドを使用して回復することはできません。
 - 導入バージョン: -
 
+##### partition_recycle_retention_period_secs
+
+- デフォルト: 1800
+- イプ: Long
+- 単位: 秒
+- 変更可能: はい
+- 説明: INSERT OVERWRITE またはマテリアライズドビューのリフレッシュ操作によって削除されるパーティションのメタデータ保持期間。このようなメタデータは、[RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md) を実行しても復元できないことに注意してください。
+- 導入バージョン: -
+
 ##### check_consistency_default_timeout_second
 
 - デフォルト: 600

--- a/docs/ja/administration/management/FE_configuration.md
+++ b/docs/ja/administration/management/FE_configuration.md
@@ -1777,7 +1777,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 単位: 秒
 - 変更可能: はい
 - 説明: INSERT OVERWRITE またはマテリアライズドビューのリフレッシュ操作によって削除されるパーティションのメタデータ保持期間。このようなメタデータは、[RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md) を実行しても復元できないことに注意してください。
-- 導入バージョン: -
+- 導入バージョン: v3.5.8
 
 ##### check_consistency_default_timeout_second
 

--- a/docs/ja/administration/management/FE_configuration.md
+++ b/docs/ja/administration/management/FE_configuration.md
@@ -1777,7 +1777,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 単位: 秒
 - 変更可能: はい
 - 説明: INSERT OVERWRITE またはマテリアライズドビューのリフレッシュ操作によって削除されるパーティションのメタデータ保持期間。このようなメタデータは、[RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md) を実行しても復元できないことに注意してください。
-- 導入バージョン: v3.5.8
+- 導入バージョン: v3.5.9
 
 ##### check_consistency_default_timeout_second
 

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -1807,7 +1807,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 单位：Seconds
 - 是否动态：是
 - 描述：因 INSERT OVERWRITE 或物化视图刷新操作而被删除的分区的元数据保留时间。请注意，此类元数据无法通过执行 [RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md) 命令恢复。
-- 引入版本：-
+- 引入版本：3.5.8
 
 ##### check_consistency_default_timeout_second
 

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -1807,7 +1807,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 单位：Seconds
 - 是否动态：是
 - 描述：因 INSERT OVERWRITE 或物化视图刷新操作而被删除的分区的元数据保留时间。请注意，此类元数据无法通过执行 [RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md) 命令恢复。
-- 引入版本：3.5.8
+- 引入版本：v3.5.8
 
 ##### check_consistency_default_timeout_second
 

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -1806,7 +1806,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 类型：Long
 - 单位：Seconds
 - 是否动态：是
-- 描述：通过insert overwrite、MV刷新等方式替换旧分区后将旧分区的元数据移动到回收站中。该参数控制旧分区元数据在回收站中保留的时长。注意，这些元数据不支持通过[RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md) 语句恢复。
+- 描述：因 INSERT OVERWRITE 或物化视图刷新操作而被删除的分区的元数据保留时间。请注意，此类元数据无法通过执行 [RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md) 命令恢复。
 - 引入版本：-
 
 ##### check_consistency_default_timeout_second

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -1807,7 +1807,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 单位：Seconds
 - 是否动态：是
 - 描述：因 INSERT OVERWRITE 或物化视图刷新操作而被删除的分区的元数据保留时间。请注意，此类元数据无法通过执行 [RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md) 命令恢复。
-- 引入版本：v3.5.8
+- 引入版本：v3.5.9
 
 ##### check_consistency_default_timeout_second
 

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -1800,6 +1800,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述：删除表/数据库之后，元数据在回收站中保留的时长，超过这个时长，数据就不可以通过[RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md) 语句恢复。
 - 引入版本：-
 
+##### partition_recycle_retention_period_secs
+
+- 默认值：1800
+- 类型：Long
+- 单位：Seconds
+- 是否动态：是
+- 描述：通过insert overwrite、MV刷新等方式替换旧分区后将旧分区的元数据移动到回收站中。该参数控制旧分区元数据在回收站中保留的时长。注意，这些元数据不支持通过[RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md) 语句恢复。
+- 引入版本：-
+
 ##### check_consistency_default_timeout_second
 
 - 默认值：600

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -350,6 +350,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
             RecyclePartitionInfo recyclePartitionInfo = idToPartition.get(id);
             if (recyclePartitionInfo.getRetentionPeriod() > 0) {
                 // retain the partition alive for `tabletReservePeriod` seconds
+                // `catalog_trash_expire_second` will not take effect while retention period is set
                 expireMs = max(recyclePartitionInfo.getRetentionPeriod() * 1000, MIN_ERASE_LATENCY);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -322,7 +322,12 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
 
         RecyclePartitionInfo partitionInfo = idToPartition.get(id);
         if (partitionInfo != null && !partitionInfo.isRecoverable()) {
-            return 0;
+            if (partitionInfo.getRetentionPeriod() > 0) {
+                // partition retention period is set, return the original recycle timestamp
+                return idToRecycleTime.get(id);
+            } else {
+                return 0;
+            }
         }
 
         RecycleDatabaseInfo databaseInfo = idToDatabase.get(id);
@@ -340,6 +345,14 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
     private synchronized boolean timeExpired(long id, long currentTimeMs) {
         long latencyMs = currentTimeMs - getAdjustedRecycleTimestamp(id);
         long expireMs = max(Config.catalog_trash_expire_second * 1000L, MIN_ERASE_LATENCY);
+        // customize expireMs for partition that need to be retained for a configurable period
+        if (idToPartition.containsKey(id)) {
+            RecyclePartitionInfo recyclePartitionInfo = idToPartition.get(id);
+            if (recyclePartitionInfo.getRetentionPeriod() > 0) {
+                // retain the partition alive for `tabletReservePeriod` seconds
+                expireMs = max(recyclePartitionInfo.getRetentionPeriod() * 1000, MIN_ERASE_LATENCY);
+            }
+        }
         if (enableEraseLater.contains(id)) {
             // if enableEraseLater is set, extend the timeout by LATE_RECYCLE_INTERVAL_SECONDS
             expireMs += LATE_RECYCLE_INTERVAL_SECONDS * 1000L;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -350,7 +350,8 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
             RecyclePartitionInfo recyclePartitionInfo = idToPartition.get(id);
             if (recyclePartitionInfo.getRetentionPeriod() > 0) {
                 // retain the partition alive for `tabletReservePeriod` seconds
-                // `catalog_trash_expire_second` will not take effect while retention period is set
+                // while retention period is set, `catalog_trash_expire_second` will not take effect and the partition
+                // is assumed to have been set un-recoverable (i.e. partition is not recoverable)
                 expireMs = max(recyclePartitionInfo.getRetentionPeriod() * 1000, MIN_ERASE_LATENCY);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RecyclePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RecyclePartitionInfo.java
@@ -38,6 +38,12 @@ public abstract class RecyclePartitionInfo extends JsonWriter {
     @SerializedName(value = "recoverable")
     protected boolean recoverable;
 
+    /**
+     * partition retention period in `second` unit
+     */
+    @SerializedName(value = "retentionPeriod")
+    protected long retentionPeriod = 0L;
+
     public RecyclePartitionInfo() {
         recoverable = true;
     }
@@ -88,6 +94,14 @@ public abstract class RecyclePartitionInfo extends JsonWriter {
 
     public void setRecoverable(boolean recoverable) {
         this.recoverable = recoverable;
+    }
+
+    public void setRetentionPeriod(long retentionPeriod) {
+        this.retentionPeriod = retentionPeriod;
+    }
+
+    public long getRetentionPeriod() {
+        return retentionPeriod;
     }
 
     public boolean delete() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RecyclePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RecyclePartitionInfo.java
@@ -58,6 +58,7 @@ public abstract class RecyclePartitionInfo extends JsonWriter {
         this.replicationNum = replicationNum;
         this.isInMemory = isInMemory;
         this.recoverable = true;
+        this.retentionPeriod = 0L;
     }
 
     public long getDbId() {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1283,7 +1283,7 @@ public class Config extends ConfigBase {
      * The retention time for partition dropped by insert overwrite/mv rewrite etc.
      */
     @ConfField(mutable = true)
-    public static long partition_retention_period_before_drop = 30 * 60L; // 30mins
+    public static long partition_recycle_retention_period_secs = 30 * 60L; // 30mins
 
     /**
      * Parallel load fragment instance num in single host

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1280,6 +1280,12 @@ public class Config extends ConfigBase {
     public static long catalog_trash_expire_second = 86400L; // 1day
 
     /**
+     * The retention time for partition dropped by insert overwrite/mv rewrite etc.
+     */
+    @ConfField(mutable = true)
+    public static long partition_retention_period_before_drop = 30 * 60L; // 30mins
+
+    /**
      * Parallel load fragment instance num in single host
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
@@ -1056,4 +1056,92 @@ public class CatalogRecycleBinTest {
         String actual = rowsToString(recyclebininfo);
         Assertions.assertTrue(actual.contains("222"));          
     }
+
+    @Test
+    public void testTimeExpiredWithRetentionPeriod(@Mocked GlobalStateMgr globalStateMgr, @Mocked EditLog editLog) {
+        ClusterSnapshotMgr clusterSnapshotMgr = new ClusterSnapshotMgr();
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                minTimes = 0;
+                result = globalStateMgr;
+
+                globalStateMgr.getClusterSnapshotMgr();
+                result = clusterSnapshotMgr;
+
+                globalStateMgr.getEditLog();
+                minTimes = 0;
+                result = editLog;
+
+                editLog.logErasePartition(anyLong);
+                minTimes = 0;
+            }
+        };
+
+        long dbId = 1;
+        long tableId = 2;
+        DataProperty dataProperty = new DataProperty(TStorageMedium.HDD);
+        CatalogRecycleBin recycleBin = new CatalogRecycleBin();
+
+        // Create non-recoverable partition with retention period = 7200 seconds (2 hours)
+        Partition p1 = new Partition(101, 102, "p1", null, null);
+        RecycleRangePartitionInfo info1 =
+                new RecycleRangePartitionInfo(dbId, tableId, p1, null, dataProperty, (short) 2, false, null);
+        info1.setRecoverable(false);
+        info1.setRetentionPeriod(7200);
+        recycleBin.recyclePartition(info1);
+
+        // Used to check that `catalog_trash_expire_second` will not take effect while retention period is set
+        long defaultTrashExpireSecond = Config.catalog_trash_expire_second;
+        Config.catalog_trash_expire_second = 3600; // default 1 hour
+        long now = System.currentTimeMillis();
+
+        // Case 1: should not expire after 1.5 hours (less than retention period)
+        long recycleTime1 = now - 5400 * 1000L; // 1.5 hours ago
+        recycleBin.idToRecycleTime.put(p1.getId(), recycleTime1);
+        recycleBin.erasePartition(now);
+        // time not expired
+        Assertions.assertNotNull(recycleBin.getPartition(p1.getId()));
+
+        // Case 2: should expire after 2.5 hours (exceeds retention period)
+        long recycleTime2 = now - 9000 * 1000L; // 2.5 hours ago
+        recycleBin.idToRecycleTime.put(p1.getId(), recycleTime2);
+        recycleBin.erasePartition(now);
+        waitPartitionClearFinished(recycleBin, p1.getId(), now);
+        Assertions.assertNull(recycleBin.getPartition(p1.getId()));
+
+        // reset default trash expire second
+        Config.catalog_trash_expire_second = defaultTrashExpireSecond;
+    }
+
+    @Test
+    public void testGetAdjustedRecycleTimestampWithRetentionPeriod() {
+        CatalogRecycleBin recycleBin = new CatalogRecycleBin();
+        long dbId = 1;
+        long tableId = 2;
+        DataProperty dataProperty = new DataProperty(TStorageMedium.HDD);
+
+        // Non-recoverable partition with retention period
+        Partition p1 = new Partition(201, 202, "p1", null, null);
+        RecycleRangePartitionInfo info1 =
+                new RecycleRangePartitionInfo(dbId, tableId, p1, null, dataProperty, (short) 2, false, null);
+        info1.setRecoverable(false);
+        info1.setRetentionPeriod(3600);
+        recycleBin.recyclePartition(info1);
+        
+        // Non-recoverable partition without retention period
+        Partition p2 = new Partition(301, 302, "p2", null, null);
+        RecycleRangePartitionInfo info2 =
+                new RecycleRangePartitionInfo(dbId, tableId, p2, null, dataProperty, (short) 2, false, null);
+        info2.setRecoverable(false);
+        recycleBin.recyclePartition(info2);
+
+        // With retention period: should return original recycle timestamp
+        long adjustedTime1 = Deencapsulation.invoke(recycleBin, "getAdjustedRecycleTimestamp", p1.getId());
+        Assertions.assertEquals(recycleBin.idToRecycleTime.get(p1.getId()), adjustedTime1);
+
+        // Without retention period: should return 0 for non-recoverable partition
+        long adjustedTime2 = Deencapsulation.invoke(recycleBin, "getAdjustedRecycleTimestamp", p2.getId());
+        Assertions.assertEquals(0, adjustedTime2);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TempPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TempPartitionTest.java
@@ -80,7 +80,9 @@ public class TempPartitionTest extends StarRocksTestBase {
         ctx = UtFrameUtils.createDefaultCtx();
         Config.alter_scheduler_interval_millisecond = 100;
         starRocksAssert = new StarRocksAssert(ctx);
-        // temporarily disable partition duration to prevent blocking ut progress
+
+        // temporarily disable partition duration to prevent CatalogRecycleBin waiting too long time
+        // and blocking ut progress
         defaultRetentionPeriod = Config.partition_recycle_retention_period_secs;
         Config.partition_recycle_retention_period_secs = 0;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TempPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TempPartitionTest.java
@@ -72,16 +72,23 @@ public class TempPartitionTest extends StarRocksTestBase {
     private static ConnectContext ctx;
     private static StarRocksAssert starRocksAssert;
 
+    private static long defaultRetentionPeriod;
+
     @BeforeAll
     public static void setup() throws Exception {
         UtFrameUtils.createMinStarRocksCluster();
         ctx = UtFrameUtils.createDefaultCtx();
         Config.alter_scheduler_interval_millisecond = 100;
         starRocksAssert = new StarRocksAssert(ctx);
+        // temporarily disable partition duration to prevent blocking ut progress
+        defaultRetentionPeriod = Config.partition_recycle_retention_period_secs;
+        Config.partition_recycle_retention_period_secs = 0;
     }
 
     @AfterAll
     public static void tearDown() {
+        Config.partition_recycle_retention_period_secs = defaultRetentionPeriod;
+
         File file2 = new File(tempPartitionFile);
         file2.delete();
         File file3 = new File(tblFile);


### PR DESCRIPTION
## Why I'm doing:

When `insert overwrite` happend to a partition, the old partition will be dropped and tablet will be delete by recycle bin imediately in most cases. This can be a big problem if some query is running on that partition, which will fail with shard not existed error in shared-data clusters.

## What I'm doing:

Introduce a FE config to delay the deletion of partition's tablet data

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a retention period for partitions dropped by INSERT OVERWRITE/MV refresh via new FE config, updates recycle bin behavior and integrates it into partition replacement paths, with docs and tests.
> 
> - **Core (FE)**:
>   - `OlapTable`:
>     - Add `dropPartitionWithRetention(dbId, partitionName, period)` and refactor inner removal (`removePartitionFromInnerState`).
>     - Use retention when replacing/dropping partitions (`replaceMatchPartitions`, `replaceTempPartitions`, unpartitioned `replacePartition`).
>   - `CatalogRecycleBin`:
>     - Support per-partition `retentionPeriod` for non-recoverable partitions: keep original recycle timestamp and compute expiry based on retention instead of `catalog_trash_expire_second`.
>   - `RecyclePartitionInfo`:
>     - Add serialized `retentionPeriod` field with getters/setters.
>   - `Config`:
>     - Add `partition_recycle_retention_period_secs` (default 30m).
> - **Docs**:
>   - Add `partition_recycle_retention_period_secs` to FE configuration (en/ja/zh).
> - **Tests**:
>   - New tests covering retention timestamp/expiry and `dropPartitionWithRetention`; adjust temp partition tests to disable retention during UT.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da39c97837cf0cb37676e7c0d6e42bc73ea91fe0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->