### PR TITLE
[Doc] Fix Incorrect MySQL Port in LDAP Authentication Example

### DIFF
--- a/docs/en/administration/user_privs/authentication/ldap_authentication.md
+++ b/docs/en/administration/user_privs/authentication/ldap_authentication.md
@@ -93,7 +93,7 @@ LDAP authentication requires the client to pass on a clear-text password to Star
 Add `--default-auth mysql_clear_password --enable-cleartext-plugin` when executing:
 
 ```sql
-mysql -utom -P8030 -h127.0.0.1 -p --default-auth mysql_clear_password --enable-cleartext-plugin
+mysql -utom -P9030 -h127.0.0.1 -p --default-auth mysql_clear_password --enable-cleartext-plugin
 ```
 
 ### Connect from JDBC/ODBC client with LDAP

--- a/docs/ja/administration/user_privs/authentication/ldap_authentication.md
+++ b/docs/ja/administration/user_privs/authentication/ldap_authentication.md
@@ -93,7 +93,7 @@ LDAP 認証では、クライアントがクリアテキストのパスワード
 実行時に `--default-auth mysql_clear_password --enable-cleartext-plugin` を追加します。
 
 ```sql
-mysql -utom -P8030 -h127.0.0.1 -p --default-auth mysql_clear_password --enable-cleartext-plugin
+mysql -utom -P9030 -h127.0.0.1 -p --default-auth mysql_clear_password --enable-cleartext-plugin
 ```
 
 ### JDBC/ODBC クライアントから LDAP で接続する

--- a/docs/zh/administration/user_privs/authentication/ldap_authentication.md
+++ b/docs/zh/administration/user_privs/authentication/ldap_authentication.md
@@ -93,7 +93,7 @@ LDAP 认证要求客户端将明文密码传递给 StarRocks。有三种方式�
 执行时添加 `--default-auth mysql_clear_password --enable-cleartext-plugin`：
 
 ```sql
-mysql -utom -P8030 -h127.0.0.1 -p --default-auth mysql_clear_password --enable-cleartext-plugin
+mysql -utom -P9030 -h127.0.0.1 -p --default-auth mysql_clear_password --enable-cleartext-plugin
 ```
 
 ### 从 JDBC/ODBC 客户端连接 LDAP


### PR DESCRIPTION
## Description

This PR fixes an **incorrect port number** in the LDAP authentication documentation example. The MySQL client connection command currently shows port `8030`, which is incorrect. The correct port for MySQL protocol connections is `9030`.

**File**: `docs/administration/user_privs/authentication/ldap_authentication.md`

### Issue Summary

**Current (Incorrect)**:
```bash
mysql -utom -P8030 -h127.0.0.1 -p --default-auth mysql_clear_password --enable-cleartext-plugin
```

**Corrected**:
```bash
mysql -utom -P9030 -h127.0.0.1 -p --default-auth mysql_clear_password --enable-cleartext-plugin
```

### Why This Fix Is Important

- Port `8030` is the FE HTTP server port (for web UI and HTTP REST API)
- Port `9030` is the FE MySQL server port (for MySQL protocol connections)
- MySQL client uses the MySQL protocol, therefore must connect to port `9030`
- Users following the current documentation will **fail to connect** with a connection timeout error
- This is the only instance in the documentation where an incorrect port is shown for client connections

## Verification

This fix has been verified against multiple authoritative sources:

1. **StarRocks Official Documentation**: Environment configurations explicitly state port 9030 for MySQL server
2. **JDBC Examples**: All examples use `jdbc:mysql://host:9030/database`
3. **ODBC Examples**: All examples use port 9030
4. **Docker Deployments**: Expose `0.0.0.0:9030->9030/tcp` for MySQL connections
5. **Trino StarRocks Connector**: Documents port 9030 as "metadata default port" for MySQL protocol
6. **Multiple Integration Guides**: Universally specify port 9030 for client connections


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

## Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have signed off my commits using `git commit -s` (DCO sign-off)
- [x] This PR only contains documentation changes
- [x] I have added [Doc] prefix to the PR title
- [ ] I have added test cases for my bug fix or my new feature *(N/A - Documentation fix)*
- [ ] This PR needs user documentation (for new or modified features or behaviors) *(N/A - Documentation fix)*
- [ ] I have added documentation for my new feature or new function *(N/A - Documentation fix)*
- [ ] This is a backport PR *(N/A - Documentation fix)*

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

Signed-off-by: Arvind Kandpal [arvind.kandpal@ksolves.com](mailto:arvind.kandpal@ksolves.com)