### PR TITLE
[TEST] test Builtin inverted index

### DIFF
--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -628,6 +628,9 @@ void LakeDataSource::init_counter(RuntimeState* state) {
     _bf_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "BloomFilterFilterRows", TUnit::UNIT, segment_init_name);
     _gin_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinFilterRows", TUnit::UNIT, segment_init_name);
     _gin_filtered_timer = ADD_CHILD_TIMER(_runtime_profile, "GinFilter", segment_init_name);
+    _gin_prefix_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinPrefixFilter", segment_init_name);
+    _gin_ngram_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinNgramDictFilter", segment_init_name);
+    _gin_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinDictFilter", segment_init_name);
     _seg_zm_filtered_counter =
             ADD_CHILD_COUNTER(_runtime_profile, "SegmentZoneMapFilterRows", TUnit::UNIT, segment_init_name);
     _seg_rt_filtered_counter =
@@ -773,6 +776,9 @@ void LakeDataSource::update_counter(RuntimeState* state) {
     COUNTER_UPDATE(_bi_filter_timer, _reader->stats().bitmap_index_filter_timer);
     COUNTER_UPDATE(_gin_filtered_counter, _reader->stats().rows_gin_filtered);
     COUNTER_UPDATE(_gin_filtered_timer, _reader->stats().gin_index_filter_ns);
+    COUNTER_UPDATE(_gin_prefix_filter_timer, _reader->stats().gin_prefix_filter_ns);
+    COUNTER_UPDATE(_gin_ngram_dict_filter_timer, _reader->stats().gin_ngram_filter_dict_ns);
+    COUNTER_UPDATE(_gin_dict_filter_timer, _reader->stats().gin_filter_dict_ns);
     COUNTER_UPDATE(_block_seek_counter, _reader->stats().block_seek_num);
 
     COUNTER_UPDATE(_rowsets_read_count, _reader->stats().rowsets_read_count);

--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -289,6 +289,13 @@ Status LakeDataSource::init_reader_params(const std::vector<OlapScanRange*>& key
     _params.splitted_scan_rows = _provider->get_splitted_scan_rows();
     _params.scan_dop = _provider->get_scan_dop();
 
+    if (thrift_lake_scan_node.__isset.enable_prune_column_after_index_filter) {
+        _params.prune_column_after_index_filter = thrift_lake_scan_node.enable_prune_column_after_index_filter;
+    }
+    if (thrift_lake_scan_node.__isset.enable_gin_filter) {
+        _params.enable_gin_filter = thrift_lake_scan_node.enable_gin_filter;
+    }
+
     ASSIGN_OR_RETURN(auto pred_tree, _conjuncts_manager->get_predicate_tree(parser, _predicate_free_pool));
     _params.enable_join_runtime_filter_pushdown = _runtime_state->enable_join_runtime_filter_pushdown();
     if (_params.enable_join_runtime_filter_pushdown) {

--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -626,6 +626,8 @@ void LakeDataSource::init_counter(RuntimeState* state) {
     _bi_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "BitmapIndexFilter", segment_init_name);
     _bi_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "BitmapIndexFilterRows", TUnit::UNIT, segment_init_name);
     _bf_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "BloomFilterFilterRows", TUnit::UNIT, segment_init_name);
+    _gin_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinFilterRows", TUnit::UNIT, segment_init_name);
+    _gin_filtered_timer = ADD_CHILD_TIMER(_runtime_profile, "GinFilter", segment_init_name);
     _seg_zm_filtered_counter =
             ADD_CHILD_COUNTER(_runtime_profile, "SegmentZoneMapFilterRows", TUnit::UNIT, segment_init_name);
     _seg_rt_filtered_counter =
@@ -769,6 +771,8 @@ void LakeDataSource::update_counter(RuntimeState* state) {
 
     COUNTER_UPDATE(_bi_filtered_counter, _reader->stats().rows_bitmap_index_filtered);
     COUNTER_UPDATE(_bi_filter_timer, _reader->stats().bitmap_index_filter_timer);
+    COUNTER_UPDATE(_gin_filtered_counter, _reader->stats().rows_gin_filtered);
+    COUNTER_UPDATE(_gin_filtered_timer, _reader->stats().gin_index_filter_ns);
     COUNTER_UPDATE(_block_seek_counter, _reader->stats().block_seek_num);
 
     COUNTER_UPDATE(_rowsets_read_count, _reader->stats().rowsets_read_count);

--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -626,11 +626,6 @@ void LakeDataSource::init_counter(RuntimeState* state) {
     _bi_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "BitmapIndexFilter", segment_init_name);
     _bi_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "BitmapIndexFilterRows", TUnit::UNIT, segment_init_name);
     _bf_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "BloomFilterFilterRows", TUnit::UNIT, segment_init_name);
-    _gin_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinFilterRows", TUnit::UNIT, segment_init_name);
-    _gin_filtered_timer = ADD_CHILD_TIMER(_runtime_profile, "GinFilter", segment_init_name);
-    _gin_prefix_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinPrefixFilter", segment_init_name);
-    _gin_ngram_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinNgramDictFilter", segment_init_name);
-    _gin_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinDictFilter", segment_init_name);
     _seg_zm_filtered_counter =
             ADD_CHILD_COUNTER(_runtime_profile, "SegmentZoneMapFilterRows", TUnit::UNIT, segment_init_name);
     _seg_rt_filtered_counter =
@@ -647,6 +642,17 @@ void LakeDataSource::init_counter(RuntimeState* state) {
     _zone_map_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "ZoneMapIndexFilter", segment_init_name);
     _rows_key_range_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "ShortKeyFilter", segment_init_name);
     _bf_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "BloomFilterFilter", segment_init_name);
+
+    const std::string gin_filter_name = "GinFilter";
+    _gin_filtered_timer = ADD_CHILD_TIMER(_runtime_profile, gin_filter_name, segment_init_name);
+    _gin_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinFilterRows", TUnit::UNIT, gin_filter_name);
+    _gin_prefix_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinPrefixFilter", gin_filter_name);
+    _gin_ngram_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinNgramDictFilter", gin_filter_name);
+    _gin_predicate_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinDictFilter", gin_filter_name);
+    _gin_dict_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinDictNum", TUnit::UNIT, gin_filter_name);
+    _gin_ngram_dict_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinNGramDictNum", TUnit::UNIT, gin_filter_name);
+    _gin_ngram_dict_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinNGramFilteredDictNum", TUnit::UNIT, gin_filter_name);
+    _gin_predicate_dict_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinPredicateFilteredDictNum", TUnit::UNIT, gin_filter_name);
 
     // SegmentRead
     const std::string segment_read_name = "SegmentRead";
@@ -774,12 +780,17 @@ void LakeDataSource::update_counter(RuntimeState* state) {
 
     COUNTER_UPDATE(_bi_filtered_counter, _reader->stats().rows_bitmap_index_filtered);
     COUNTER_UPDATE(_bi_filter_timer, _reader->stats().bitmap_index_filter_timer);
-    COUNTER_UPDATE(_gin_filtered_counter, _reader->stats().rows_gin_filtered);
+    COUNTER_UPDATE(_block_seek_counter, _reader->stats().block_seek_num);
+
     COUNTER_UPDATE(_gin_filtered_timer, _reader->stats().gin_index_filter_ns);
+    COUNTER_UPDATE(_gin_filtered_counter, _reader->stats().rows_gin_filtered);
     COUNTER_UPDATE(_gin_prefix_filter_timer, _reader->stats().gin_prefix_filter_ns);
     COUNTER_UPDATE(_gin_ngram_dict_filter_timer, _reader->stats().gin_ngram_filter_dict_ns);
-    COUNTER_UPDATE(_gin_dict_filter_timer, _reader->stats().gin_filter_dict_ns);
-    COUNTER_UPDATE(_block_seek_counter, _reader->stats().block_seek_num);
+    COUNTER_UPDATE(_gin_predicate_dict_filter_timer, _reader->stats().gin_predicate_filter_dict_ns);
+    COUNTER_UPDATE(_gin_dict_counter, _reader->stats().gin_dict_count);
+    COUNTER_UPDATE(_gin_ngram_dict_counter, _reader->stats().gin_ngram_dict_count);
+    COUNTER_UPDATE(_gin_ngram_dict_filtered_counter, _reader->stats().gin_ngram_dict_filtered);
+    COUNTER_UPDATE(_gin_predicate_dict_filtered_counter, _reader->stats().gin_predicate_dict_filtered);
 
     COUNTER_UPDATE(_rowsets_read_count, _reader->stats().rowsets_read_count);
     COUNTER_UPDATE(_segments_read_count, _reader->stats().segments_read_count);

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -158,11 +158,18 @@ private:
     RuntimeProfile::Counter* _block_fetch_timer = nullptr;
     RuntimeProfile::Counter* _bi_filtered_counter = nullptr;
     RuntimeProfile::Counter* _bi_filter_timer = nullptr;
-    RuntimeProfile::Counter* _gin_filtered_counter = nullptr;
+
+    // Gin filter Statistics
     RuntimeProfile::Counter* _gin_filtered_timer = nullptr;
+    RuntimeProfile::Counter* _gin_filtered_counter = nullptr;
     RuntimeProfile::Counter* _gin_prefix_filter_timer = nullptr;
     RuntimeProfile::Counter* _gin_ngram_dict_filter_timer = nullptr;
-    RuntimeProfile::Counter* _gin_dict_filter_timer = nullptr;
+    RuntimeProfile::Counter* _gin_predicate_dict_filter_timer = nullptr;
+    RuntimeProfile::Counter* _gin_dict_counter = nullptr;
+    RuntimeProfile::Counter* _gin_ngram_dict_counter = nullptr;
+    RuntimeProfile::Counter* _gin_ngram_dict_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _gin_predicate_dict_filtered_counter = nullptr;
+
     RuntimeProfile::Counter* _pushdown_predicates_counter = nullptr;
     RuntimeProfile::Counter* _non_pushdown_predicates_counter = nullptr;
     RuntimeProfile::Counter* _rowsets_read_count = nullptr;

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -158,6 +158,8 @@ private:
     RuntimeProfile::Counter* _block_fetch_timer = nullptr;
     RuntimeProfile::Counter* _bi_filtered_counter = nullptr;
     RuntimeProfile::Counter* _bi_filter_timer = nullptr;
+    RuntimeProfile::Counter* _gin_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _gin_filtered_timer = nullptr;
     RuntimeProfile::Counter* _pushdown_predicates_counter = nullptr;
     RuntimeProfile::Counter* _non_pushdown_predicates_counter = nullptr;
     RuntimeProfile::Counter* _rowsets_read_count = nullptr;

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -160,6 +160,9 @@ private:
     RuntimeProfile::Counter* _bi_filter_timer = nullptr;
     RuntimeProfile::Counter* _gin_filtered_counter = nullptr;
     RuntimeProfile::Counter* _gin_filtered_timer = nullptr;
+    RuntimeProfile::Counter* _gin_prefix_filter_timer = nullptr;
+    RuntimeProfile::Counter* _gin_ngram_dict_filter_timer = nullptr;
+    RuntimeProfile::Counter* _gin_dict_filter_timer = nullptr;
     RuntimeProfile::Counter* _pushdown_predicates_counter = nullptr;
     RuntimeProfile::Counter* _non_pushdown_predicates_counter = nullptr;
     RuntimeProfile::Counter* _rowsets_read_count = nullptr;

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -584,11 +584,18 @@ void OlapScanNode::_init_counter(RuntimeState* state) {
     _bi_filter_timer = ADD_CHILD_TIMER(_scan_profile, "BitmapIndexFilter", "SegmentInit");
     _bi_filtered_counter = ADD_CHILD_COUNTER(_scan_profile, "BitmapIndexFilterRows", TUnit::UNIT, "SegmentInit");
     _bf_filtered_counter = ADD_CHILD_COUNTER(_scan_profile, "BloomFilterFilterRows", TUnit::UNIT, "SegmentInit");
-    _gin_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinFilterRows", TUnit::UNIT, "SegmentInit");
-    _gin_filtered_timer = ADD_CHILD_TIMER(_runtime_profile, "GinFilter", "SegmentInit");
-    _gin_prefix_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinPrefixFilter", "SegmentInit");
-    _gin_ngram_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinNgramDictFilter", "SegmentInit");
-    _gin_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinDictFilter", "SegmentInit");
+
+    const std::string gin_filter_name = "GinFilter";
+    _gin_filtered_timer = ADD_CHILD_TIMER(_runtime_profile, gin_filter_name, "SegmentInit");
+    _gin_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinFilterRows", TUnit::UNIT, gin_filter_name);
+    _gin_prefix_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinPrefixFilter", gin_filter_name);
+    _gin_ngram_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinNgramDictFilter", gin_filter_name);
+    _gin_predicate_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinDictFilter", gin_filter_name);
+    _gin_dict_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinDictNum", TUnit::UNIT, gin_filter_name);
+    _gin_ngram_dict_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinNGramDictNum", TUnit::UNIT, gin_filter_name);
+    _gin_ngram_dict_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinNGramFilteredDictNum", TUnit::UNIT, gin_filter_name);
+    _gin_predicate_dict_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinPredicateFilteredDictNum", TUnit::UNIT, gin_filter_name);
+
     _get_row_ranges_by_vector_index_timer = ADD_CHILD_TIMER(_scan_profile, "GetVectorRowRangesTime", "SegmentInit");
     _vector_search_timer = ADD_CHILD_TIMER(_scan_profile, "VectorSearchTime", "SegmentInit");
     _vector_index_filtered_counter =

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -586,6 +586,9 @@ void OlapScanNode::_init_counter(RuntimeState* state) {
     _bf_filtered_counter = ADD_CHILD_COUNTER(_scan_profile, "BloomFilterFilterRows", TUnit::UNIT, "SegmentInit");
     _gin_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinFilterRows", TUnit::UNIT, "SegmentInit");
     _gin_filtered_timer = ADD_CHILD_TIMER(_runtime_profile, "GinFilter", "SegmentInit");
+    _gin_prefix_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinPrefixFilter", "SegmentInit");
+    _gin_ngram_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinNgramDictFilter", "SegmentInit");
+    _gin_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinDictFilter", "SegmentInit");
     _get_row_ranges_by_vector_index_timer = ADD_CHILD_TIMER(_scan_profile, "GetVectorRowRangesTime", "SegmentInit");
     _vector_search_timer = ADD_CHILD_TIMER(_scan_profile, "VectorSearchTime", "SegmentInit");
     _vector_index_filtered_counter =

--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -248,6 +248,9 @@ private:
     RuntimeProfile::Counter* _bi_filter_timer = nullptr;
     RuntimeProfile::Counter* _gin_filtered_counter = nullptr;
     RuntimeProfile::Counter* _gin_filtered_timer = nullptr;
+    RuntimeProfile::Counter* _gin_prefix_filter_timer = nullptr;
+    RuntimeProfile::Counter* _gin_ngram_dict_filter_timer = nullptr;
+    RuntimeProfile::Counter* _gin_dict_filter_timer = nullptr;
     RuntimeProfile::Counter* _get_row_ranges_by_vector_index_timer = nullptr;
     RuntimeProfile::Counter* _vector_search_timer = nullptr;
     RuntimeProfile::Counter* _vector_index_filtered_counter = nullptr;

--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -246,11 +246,18 @@ private:
     RuntimeProfile::Counter* _cached_pages_num_counter = nullptr;
     RuntimeProfile::Counter* _bi_filtered_counter = nullptr;
     RuntimeProfile::Counter* _bi_filter_timer = nullptr;
-    RuntimeProfile::Counter* _gin_filtered_counter = nullptr;
+
+    // Gin filter Statistics
     RuntimeProfile::Counter* _gin_filtered_timer = nullptr;
+    RuntimeProfile::Counter* _gin_filtered_counter = nullptr;
     RuntimeProfile::Counter* _gin_prefix_filter_timer = nullptr;
     RuntimeProfile::Counter* _gin_ngram_dict_filter_timer = nullptr;
-    RuntimeProfile::Counter* _gin_dict_filter_timer = nullptr;
+    RuntimeProfile::Counter* _gin_predicate_dict_filter_timer = nullptr;
+    RuntimeProfile::Counter* _gin_dict_counter = nullptr;
+    RuntimeProfile::Counter* _gin_ngram_dict_counter = nullptr;
+    RuntimeProfile::Counter* _gin_ngram_dict_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _gin_predicate_dict_filtered_counter = nullptr;
+
     RuntimeProfile::Counter* _get_row_ranges_by_vector_index_timer = nullptr;
     RuntimeProfile::Counter* _vector_search_timer = nullptr;
     RuntimeProfile::Counter* _vector_index_filtered_counter = nullptr;

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -166,6 +166,9 @@ void OlapChunkSource::_init_counter(RuntimeState* state) {
     _bf_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "BloomFilterFilterRows", TUnit::UNIT, segment_init_name);
     _gin_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinFilterRows", TUnit::UNIT, segment_init_name);
     _gin_filtered_timer = ADD_CHILD_TIMER(_runtime_profile, "GinFilter", segment_init_name);
+    _gin_prefix_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinPrefixFilter", segment_init_name);
+    _gin_ngram_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinNgramDictFilter", segment_init_name);
+    _gin_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinDictFilter", segment_init_name);
     _seg_zm_filtered_counter =
             ADD_CHILD_COUNTER_SKIP_MIN_MAX(_runtime_profile, "SegmentZoneMapFilterRows", TUnit::UNIT,
                                            _get_counter_min_max_type("SegmentZoneMapFilterRows"), segment_init_name);
@@ -790,6 +793,9 @@ void OlapChunkSource::_update_counter() {
     COUNTER_UPDATE(_bi_filter_timer, _reader->stats().bitmap_index_filter_timer);
     COUNTER_UPDATE(_gin_filtered_counter, _reader->stats().rows_gin_filtered);
     COUNTER_UPDATE(_gin_filtered_timer, _reader->stats().gin_index_filter_ns);
+    COUNTER_UPDATE(_gin_prefix_filter_timer, _reader->stats().gin_prefix_filter_ns);
+    COUNTER_UPDATE(_gin_ngram_dict_filter_timer, _reader->stats().gin_ngram_filter_dict_ns);
+    COUNTER_UPDATE(_gin_dict_filter_timer, _reader->stats().gin_filter_dict_ns);
     COUNTER_UPDATE(_get_row_ranges_by_vector_index_timer, _reader->stats().get_row_ranges_by_vector_index_timer);
     COUNTER_UPDATE(_vector_search_timer, _reader->stats().vector_search_timer);
     COUNTER_UPDATE(_process_vector_distance_and_id_timer, _reader->stats().process_vector_distance_and_id_timer);

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -164,11 +164,18 @@ void OlapChunkSource::_init_counter(RuntimeState* state) {
             ADD_CHILD_TIMER(_runtime_profile, "ProcessVectorDistanceAndIdTime", segment_init_name);
     _bi_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "BitmapIndexFilterRows", TUnit::UNIT, segment_init_name);
     _bf_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "BloomFilterFilterRows", TUnit::UNIT, segment_init_name);
-    _gin_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinFilterRows", TUnit::UNIT, segment_init_name);
-    _gin_filtered_timer = ADD_CHILD_TIMER(_runtime_profile, "GinFilter", segment_init_name);
-    _gin_prefix_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinPrefixFilter", segment_init_name);
-    _gin_ngram_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinNgramDictFilter", segment_init_name);
-    _gin_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinDictFilter", segment_init_name);
+
+    const std::string gin_filter_name = "GinFilter";
+    _gin_filtered_timer = ADD_CHILD_TIMER(_runtime_profile, gin_filter_name, segment_init_name);
+    _gin_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinFilterRows", TUnit::UNIT, gin_filter_name);
+    _gin_prefix_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinPrefixFilter", gin_filter_name);
+    _gin_ngram_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinNgramDictFilter", gin_filter_name);
+    _gin_predicate_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinDictFilter", gin_filter_name);
+    _gin_dict_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinDictNum", TUnit::UNIT, gin_filter_name);
+    _gin_ngram_dict_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinNGramDictNum", TUnit::UNIT, gin_filter_name);
+    _gin_ngram_dict_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinNGramFilteredDictNum", TUnit::UNIT, gin_filter_name);
+    _gin_predicate_dict_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinPredicateFilteredDictNum", TUnit::UNIT, gin_filter_name);
+
     _seg_zm_filtered_counter =
             ADD_CHILD_COUNTER_SKIP_MIN_MAX(_runtime_profile, "SegmentZoneMapFilterRows", TUnit::UNIT,
                                            _get_counter_min_max_type("SegmentZoneMapFilterRows"), segment_init_name);
@@ -791,15 +798,20 @@ void OlapChunkSource::_update_counter() {
 
     COUNTER_UPDATE(_bi_filtered_counter, _reader->stats().rows_bitmap_index_filtered);
     COUNTER_UPDATE(_bi_filter_timer, _reader->stats().bitmap_index_filter_timer);
-    COUNTER_UPDATE(_gin_filtered_counter, _reader->stats().rows_gin_filtered);
-    COUNTER_UPDATE(_gin_filtered_timer, _reader->stats().gin_index_filter_ns);
-    COUNTER_UPDATE(_gin_prefix_filter_timer, _reader->stats().gin_prefix_filter_ns);
-    COUNTER_UPDATE(_gin_ngram_dict_filter_timer, _reader->stats().gin_ngram_filter_dict_ns);
-    COUNTER_UPDATE(_gin_dict_filter_timer, _reader->stats().gin_filter_dict_ns);
     COUNTER_UPDATE(_get_row_ranges_by_vector_index_timer, _reader->stats().get_row_ranges_by_vector_index_timer);
     COUNTER_UPDATE(_vector_search_timer, _reader->stats().vector_search_timer);
     COUNTER_UPDATE(_process_vector_distance_and_id_timer, _reader->stats().process_vector_distance_and_id_timer);
     COUNTER_UPDATE(_block_seek_counter, _reader->stats().block_seek_num);
+
+    COUNTER_UPDATE(_gin_filtered_timer, _reader->stats().gin_index_filter_ns);
+    COUNTER_UPDATE(_gin_filtered_counter, _reader->stats().rows_gin_filtered);
+    COUNTER_UPDATE(_gin_prefix_filter_timer, _reader->stats().gin_prefix_filter_ns);
+    COUNTER_UPDATE(_gin_ngram_dict_filter_timer, _reader->stats().gin_ngram_filter_dict_ns);
+    COUNTER_UPDATE(_gin_predicate_dict_filter_timer, _reader->stats().gin_predicate_filter_dict_ns);
+    COUNTER_UPDATE(_gin_dict_counter, _reader->stats().gin_dict_count);
+    COUNTER_UPDATE(_gin_ngram_dict_counter, _reader->stats().gin_ngram_dict_count);
+    COUNTER_UPDATE(_gin_ngram_dict_filtered_counter, _reader->stats().gin_ngram_dict_filtered);
+    COUNTER_UPDATE(_gin_predicate_dict_filtered_counter, _reader->stats().gin_predicate_dict_filtered);
 
     COUNTER_UPDATE(_rowsets_read_count, _reader->stats().rowsets_read_count);
     COUNTER_UPDATE(_segments_read_count, _reader->stats().segments_read_count);

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -157,6 +157,9 @@ private:
     // GIN (Generalized Inverted Index) filter
     RuntimeProfile::Counter* _gin_filtered_counter = nullptr;
     RuntimeProfile::Counter* _gin_filtered_timer = nullptr;
+    RuntimeProfile::Counter* _gin_prefix_filter_timer = nullptr;
+    RuntimeProfile::Counter* _gin_ngram_dict_filter_timer = nullptr;
+    RuntimeProfile::Counter* _gin_dict_filter_timer = nullptr;
 
     // Rows after skip key filter
     RuntimeProfile::Counter* _rows_after_sk_filtered_counter = nullptr;

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -155,11 +155,15 @@ private:
     RuntimeProfile::Counter* _bi_filter_timer = nullptr;
 
     // GIN (Generalized Inverted Index) filter
-    RuntimeProfile::Counter* _gin_filtered_counter = nullptr;
     RuntimeProfile::Counter* _gin_filtered_timer = nullptr;
+    RuntimeProfile::Counter* _gin_filtered_counter = nullptr;
     RuntimeProfile::Counter* _gin_prefix_filter_timer = nullptr;
     RuntimeProfile::Counter* _gin_ngram_dict_filter_timer = nullptr;
-    RuntimeProfile::Counter* _gin_dict_filter_timer = nullptr;
+    RuntimeProfile::Counter* _gin_predicate_dict_filter_timer = nullptr;
+    RuntimeProfile::Counter* _gin_dict_counter = nullptr;
+    RuntimeProfile::Counter* _gin_ngram_dict_counter = nullptr;
+    RuntimeProfile::Counter* _gin_ngram_dict_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _gin_predicate_dict_filtered_counter = nullptr;
 
     // Rows after skip key filter
     RuntimeProfile::Counter* _rows_after_sk_filtered_counter = nullptr;

--- a/be/src/exec/tablet_scanner.cpp
+++ b/be/src/exec/tablet_scanner.cpp
@@ -368,12 +368,17 @@ void TabletScanner::update_counter() {
 
     COUNTER_UPDATE(_parent->_bi_filtered_counter, _reader->stats().rows_bitmap_index_filtered);
     COUNTER_UPDATE(_parent->_bi_filter_timer, _reader->stats().bitmap_index_filter_timer);
-    COUNTER_UPDATE(_parent->_gin_filtered_counter, _reader->stats().rows_gin_filtered);
+    COUNTER_UPDATE(_parent->_block_seek_counter, _reader->stats().block_seek_num);
+
     COUNTER_UPDATE(_parent->_gin_filtered_timer, _reader->stats().gin_index_filter_ns);
+    COUNTER_UPDATE(_parent->_gin_filtered_counter, _reader->stats().rows_gin_filtered);
     COUNTER_UPDATE(_parent->_gin_prefix_filter_timer, _reader->stats().gin_prefix_filter_ns);
     COUNTER_UPDATE(_parent->_gin_ngram_dict_filter_timer, _reader->stats().gin_ngram_filter_dict_ns);
-    COUNTER_UPDATE(_parent->_gin_dict_filter_timer, _reader->stats().gin_filter_dict_ns);
-    COUNTER_UPDATE(_parent->_block_seek_counter, _reader->stats().block_seek_num);
+    COUNTER_UPDATE(_parent->_gin_predicate_dict_filter_timer, _reader->stats().gin_predicate_filter_dict_ns);
+    COUNTER_UPDATE(_parent->_gin_dict_counter, _reader->stats().gin_dict_count);
+    COUNTER_UPDATE(_parent->_gin_ngram_dict_counter, _reader->stats().gin_ngram_dict_count);
+    COUNTER_UPDATE(_parent->_gin_ngram_dict_filtered_counter, _reader->stats().gin_ngram_dict_filtered);
+    COUNTER_UPDATE(_parent->_gin_predicate_dict_filtered_counter, _reader->stats().gin_predicate_dict_filtered);
 
     COUNTER_UPDATE(_parent->_rowsets_read_count, _reader->stats().rowsets_read_count);
     COUNTER_UPDATE(_parent->_segments_read_count, _reader->stats().segments_read_count);

--- a/be/src/exec/tablet_scanner.cpp
+++ b/be/src/exec/tablet_scanner.cpp
@@ -370,6 +370,9 @@ void TabletScanner::update_counter() {
     COUNTER_UPDATE(_parent->_bi_filter_timer, _reader->stats().bitmap_index_filter_timer);
     COUNTER_UPDATE(_parent->_gin_filtered_counter, _reader->stats().rows_gin_filtered);
     COUNTER_UPDATE(_parent->_gin_filtered_timer, _reader->stats().gin_index_filter_ns);
+    COUNTER_UPDATE(_parent->_gin_prefix_filter_timer, _reader->stats().gin_prefix_filter_ns);
+    COUNTER_UPDATE(_parent->_gin_ngram_dict_filter_timer, _reader->stats().gin_ngram_filter_dict_ns);
+    COUNTER_UPDATE(_parent->_gin_dict_filter_timer, _reader->stats().gin_filter_dict_ns);
     COUNTER_UPDATE(_parent->_block_seek_counter, _reader->stats().block_seek_num);
 
     COUNTER_UPDATE(_parent->_rowsets_read_count, _reader->stats().rowsets_read_count);

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -280,7 +280,12 @@ set(STORAGE_FILES
     index/vector/tenann/tenann_index_builder.cpp
     index/vector/tenann/tenann_index_utils.cpp
     record_predicate/record_predicate_helper.cpp
-    record_predicate/column_hash_is_congruent.cpp)
+    record_predicate/column_hash_is_congruent.cpp
+    index/inverted/builtin/builtin_plugin.cpp
+    index/inverted/builtin/builtin_inverted_writer.cpp
+    index/inverted/builtin/builtin_inverted_reader.cpp
+    index/inverted/builtin/builtin_inverted_index_iterator.cpp
+    index/inverted/builtin/builtin_simple_analyzer.cpp)
 
 if (NOT BUILD_FORMAT_LIB)
     list(APPEND STORAGE_FILES  lake/starlet_location_provider.cpp)

--- a/be/src/storage/column_expr_predicate.cpp
+++ b/be/src/storage/column_expr_predicate.cpp
@@ -337,7 +337,7 @@ Status ColumnExprPredicate::seek_inverted_index(const std::string& column_name, 
     }
     std::string str_v = padded_value.to_string();
     InvertedIndexQueryType query_type = InvertedIndexQueryType::UNKNOWN_QUERY;
-    bool has_wildcard = str_v.find('*') != std::string::npos || str_v.find('%') != std::string::npos;
+    bool has_wildcard = str_v.find('%') != std::string::npos;
 
     // TODO: The logic for determining query_type will be abstracted into a separate method in the future.
     if (valid_match && expr->op() == TExprOpcode::MATCH_ANY) {

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.cpp
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.cpp
@@ -1,0 +1,203 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/index/inverted/builtin/builtin_inverted_index_iterator.h"
+
+#include <CLucene.h>
+
+#include <memory>
+
+#include "exprs/function_context.h"
+#include "exprs/like_predicate.h"
+#include "storage/chunk_helper.h"
+
+namespace starrocks {
+static std::string get_next_prefix(const Slice& prefix_s) {
+    std::string next_prefix = prefix_s.to_string();
+
+    int n = next_prefix.length();
+    int i = n - 1;
+    while (i >= 0) {
+        unsigned char byte_val = static_cast<unsigned char>(next_prefix[i]);
+        if (byte_val == 0xFF) {
+            next_prefix[i] = static_cast<char>(0x00);
+            i--;
+        } else {
+            next_prefix[i] = static_cast<char>(byte_val + 1);
+            break;
+        }
+    }
+    if (i < 0) {
+        next_prefix = std::string(1, static_cast<char>(0x01)) + next_prefix;
+    }
+    return next_prefix;
+}
+
+Status BuiltinInvertedIndexIterator::close() {
+    if (!_like_context) {
+        return Status::OK();
+    }
+    return LikePredicate::like_close(_like_context.get(), FunctionContext::FunctionStateScope::THREAD_LOCAL);
+}
+
+Status BuiltinInvertedIndexIterator::_equal_query(const Slice* search_query, roaring::Roaring* bit_map) {
+    bool exact_match = false;
+    Status st = _bitmap_itr->seek_dictionary(search_query, &exact_match);
+    if (st.ok() && exact_match) {
+        rowid_t ordinal = _bitmap_itr->current_ordinal();
+        RETURN_IF_ERROR(_bitmap_itr->read_bitmap(ordinal, bit_map));
+    } else if (!st.ok() && !st.is_not_found()) {
+        return st;
+    }
+    return Status::OK();
+}
+
+Status BuiltinInvertedIndexIterator::_wildcard_query(const Slice* search_query, roaring::Roaring* bit_map) {
+    auto first_wildcard_pos = search_query->to_string().find('%');
+    if (first_wildcard_pos == std::string::npos) {
+        return Status::InternalError("invalid wildcard query for builtin inverted index");
+    }
+
+    std::pair<rowid_t, std::string> lower = std::make_pair(0, Slice::min_value().to_string());
+    std::pair<rowid_t, std::string> upper = std::make_pair(_bitmap_itr->bitmap_nums(), Slice::max_value().to_string());
+
+    if (first_wildcard_pos != 0) {
+        Slice prefix_s(search_query->data, first_wildcard_pos);
+        std::string next_prefix = get_next_prefix(prefix_s);
+        Slice next_prefix_s(next_prefix);
+
+        auto seek = [&](const Slice& bound) -> StatusOr<std::pair<rowid_t, std::string>> {
+            bool exact_match;
+            auto st = _bitmap_itr->seek_dictionary(&bound, &exact_match);
+            auto cur_ordinal = _bitmap_itr->current_ordinal();
+            if (st.is_not_found()) {
+                // hit the end of dictionary set
+                return std::make_pair(_bitmap_itr->bitmap_nums(), Slice::max_value().to_string());
+            } else if (!st.ok()) {
+                return st;
+            } else {
+                auto column = ChunkHelper::column_from_field_type(TYPE_VARCHAR, false);
+                size_t read_num = 1;
+                RETURN_IF_ERROR(_bitmap_itr->next_batch_dictionary(&read_num, column.get()));
+                Slice s = down_cast<BinaryColumn*>(column.get())->get_data()[0];
+                return std::make_pair(cur_ordinal, s.to_string());
+            }
+        };
+
+        ASSIGN_OR_RETURN(lower, seek(prefix_s));
+        ASSIGN_OR_RETURN(upper, seek(next_prefix_s));
+
+        if (lower.first >= upper.first) {
+            // prefix not found
+            return Status::OK();
+        }
+
+        if (first_wildcard_pos == search_query->size - 1) {
+            // pure prefix query
+            Buffer<rowid_t> hit_rowids(upper.first - lower.first);
+            std::iota(hit_rowids.begin(), hit_rowids.end(), lower.first);
+            RETURN_IF_ERROR(_bitmap_itr->read_union_bitmap(hit_rowids, bit_map));
+            return Status::OK();
+        }
+    }
+
+    RETURN_IF_ERROR(_init_like_context(*search_query));
+    auto predicate = [this](const Column& value_column) -> StatusOr<ColumnPtr> {
+        Columns cols;
+        cols.push_back(&value_column);
+        cols.push_back(this->_like_context->get_constant_column(1));
+        return LikePredicate::like(this->_like_context.get(), cols);
+    };
+    Slice from_value = Slice(lower.second);
+    size_t search_size = upper.first - lower.first;
+    auto res = _bitmap_itr->seek_dictionary_by_predicate(predicate, from_value, search_size);
+    Status st = res.status();
+    if (st.ok()) {
+        auto hit_rowids = std::move(res.value());
+        RETURN_IF_ERROR(_bitmap_itr->read_union_bitmap(hit_rowids, bit_map));
+    } else if (!st.ok() && !st.is_not_found()) {
+        return st;
+    }
+    return Status::OK();
+}
+
+Status BuiltinInvertedIndexIterator::_init_like_context(const Slice& s) {
+    if (_like_context) {
+        RETURN_IF_ERROR(LikePredicate::like_close(_like_context.get(), FunctionContext::FunctionStateScope::THREAD_LOCAL));
+        _like_context.reset(nullptr);
+    }
+
+    _like_context = std::make_unique<FunctionContext>();
+    auto ptr = BinaryColumn::create();
+    ptr->append_datum(Datum(s));
+    ptr->get_data();
+    Columns cols;
+    cols.push_back(nullptr);
+    cols.push_back(std::move(ConstColumn::create(std::move(ptr), 1)));
+    _like_context->set_constant_columns(cols);
+    return LikePredicate::like_prepare(_like_context.get(), FunctionContext::FunctionStateScope::THREAD_LOCAL);
+}
+
+Status BuiltinInvertedIndexIterator::read_from_inverted_index(const std::string& column_name, const void* query_value,
+                                                              InvertedIndexQueryType query_type, roaring::Roaring* bit_map) {
+    const auto* search_query = reinterpret_cast<const Slice*>(query_value);
+    switch (query_type) {
+    case InvertedIndexQueryType::EQUAL_QUERY: {
+        RETURN_IF_ERROR(_equal_query(search_query, bit_map));
+        break;
+    }
+    case InvertedIndexQueryType::MATCH_WILDCARD_QUERY: {
+        RETURN_IF_ERROR(_wildcard_query(search_query, bit_map));
+        break;
+    }
+    case InvertedIndexQueryType::MATCH_ALL_QUERY:
+    case InvertedIndexQueryType::MATCH_ANY_QUERY: {
+        std::string search_query_str = search_query->to_string();
+        std::istringstream iss(search_query_str);
+        std::string cur_predicate;
+        bool first = true;
+        while (iss >> cur_predicate) {
+            Slice s(cur_predicate);
+            roaring::Roaring roaring;
+            if (cur_predicate.find('%') != std::string::npos) {
+                RETURN_IF_ERROR(_wildcard_query(&s, &roaring));
+            } else {
+                RETURN_IF_ERROR(_equal_query(&s, &roaring));
+            }
+
+            if (first) {
+                *bit_map = std::move(roaring);
+                first = false;
+            } else if (query_type == InvertedIndexQueryType::MATCH_ALL_QUERY) {
+                *bit_map &= roaring;
+            } else if (query_type == InvertedIndexQueryType::MATCH_ANY_QUERY) {
+                *bit_map |= roaring;
+            } else {
+                DCHECK(false) << "do not support query type";
+            }
+            cur_predicate.clear();
+        }
+        break;
+    }
+    default:
+        return Status::InvalidArgument("do not support query type");
+    }
+    return Status::OK();
+}
+
+Status BuiltinInvertedIndexIterator::read_null(const std::string& column_name, roaring::Roaring* bit_map) {
+    return Status::InternalError("Unsupported");
+}
+
+} // namespace starrocks

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.cpp
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.cpp
@@ -136,9 +136,10 @@ Status BuiltinInvertedIndexIterator::_wildcard_query(const Slice* search_query, 
         last_wildcard_pos = wildcard_pos;
         wildcard_pos = search_query->find('%', last_wildcard_pos);
 
-        auto sub_query = wildcard_pos != -1
-                                 ? Slice(search_query->data + last_wildcard_pos, wildcard_pos - last_wildcard_pos)
-                                 : Slice(search_query->data, search_query->get_size() - last_wildcard_pos);
+        auto sub_query =
+                wildcard_pos != -1
+                        ? Slice(search_query->data + last_wildcard_pos, wildcard_pos - last_wildcard_pos)
+                        : Slice(search_query->data + last_wildcard_pos, search_query->get_size() - last_wildcard_pos);
         keywords.emplace_back(std::make_pair(sub_query, sub_query.build_next()));
         roaring::Roaring tmp;
 
@@ -180,7 +181,7 @@ Status BuiltinInvertedIndexIterator::_wildcard_query(const Slice* search_query, 
     auto predicate = [&keywords](const Slice* dict) -> bool {
         // just need to make sure keywords is in order.
         size_t last_pos = 0;
-        for (const auto& [keyword, next_array]: keywords) {
+        for (const auto& [keyword, next_array] : keywords) {
             last_pos = dict->find(keyword, next_array, last_pos);
             if (last_pos == -1) {
                 return false;

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.h
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.h
@@ -1,0 +1,48 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "storage/index/inverted/inverted_index_iterator.h"
+#include "storage/rowset/bitmap_index_reader.h"
+
+namespace starrocks {
+class FunctionContext;
+
+class BuiltinInvertedIndexIterator final : public InvertedIndexIterator {
+public:
+    BuiltinInvertedIndexIterator(const std::shared_ptr<TabletIndex>& index_meta, InvertedReader* reader,
+                                 std::unique_ptr<BitmapIndexIterator>& bitmap_itr) :
+            InvertedIndexIterator(index_meta, reader), _bitmap_itr(std::move(bitmap_itr)), _like_context(nullptr) {}
+
+    ~BuiltinInvertedIndexIterator() override = default;
+
+    Status read_from_inverted_index(const std::string& column_name, const void* query_value,
+                                    InvertedIndexQueryType query_type, roaring::Roaring* bit_map) override;
+
+    Status read_null(const std::string& column_name, roaring::Roaring* bit_map) override;
+
+    Status close() override;
+private:
+    Status _equal_query(const Slice* search_query, roaring::Roaring* bit_map);
+
+    Status _wildcard_query(const Slice* search_query, roaring::Roaring* bit_map);
+
+    Status _init_like_context(const Slice& s);
+
+    std::unique_ptr<BitmapIndexIterator> _bitmap_itr;
+    std::unique_ptr<FunctionContext> _like_context;
+};
+
+} // namespace starrocks

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.h
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.h
@@ -23,8 +23,10 @@ class FunctionContext;
 class BuiltinInvertedIndexIterator final : public InvertedIndexIterator {
 public:
     BuiltinInvertedIndexIterator(const std::shared_ptr<TabletIndex>& index_meta, InvertedReader* reader,
-                                 std::unique_ptr<BitmapIndexIterator>& bitmap_itr) :
-            InvertedIndexIterator(index_meta, reader), _bitmap_itr(std::move(bitmap_itr)), _like_context(nullptr) {}
+                                 OlapReaderStatistics* stats, std::unique_ptr<BitmapIndexIterator>& bitmap_itr)
+            : InvertedIndexIterator(index_meta, reader, stats),
+              _bitmap_itr(std::move(bitmap_itr)),
+              _like_context(nullptr) {}
 
     ~BuiltinInvertedIndexIterator() override = default;
 
@@ -34,6 +36,7 @@ public:
     Status read_null(const std::string& column_name, roaring::Roaring* bit_map) override;
 
     Status close() override;
+
 private:
     Status _equal_query(const Slice* search_query, roaring::Roaring* bit_map);
 

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.h
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.h
@@ -39,8 +39,6 @@ private:
 
     Status _wildcard_query(const Slice* search_query, roaring::Roaring* bit_map);
 
-    Status _init_like_context(const Slice& s);
-
     std::unique_ptr<BitmapIndexIterator> _bitmap_itr;
     std::unique_ptr<FunctionContext> _like_context;
 };

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_reader.cpp
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_reader.cpp
@@ -1,0 +1,60 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/index/inverted/builtin/builtin_inverted_reader.h"
+
+#include <fmt/format.h>
+
+#include "storage/index/index_descriptor.h"
+#include "storage/index/inverted/builtin/builtin_inverted_index_iterator.h"
+#include "types/logical_type.h"
+
+namespace starrocks {
+
+Status BuiltinInvertedReader::new_iterator(const std::shared_ptr<TabletIndex> index_meta,
+                                           InvertedIndexIterator** iterator,
+                                           const IndexReadOptions& index_opt) {
+    BitmapIndexIterator* iter;
+    RETURN_IF_ERROR(_bitmap_index->new_iterator(index_opt, &iter));
+    std::unique_ptr<BitmapIndexIterator> bitmap_itr;
+    bitmap_itr.reset(iter);
+    *iterator = new BuiltinInvertedIndexIterator(index_meta, this, bitmap_itr);
+    return Status::OK();
+}
+
+Status BuiltinInvertedReader::create(const std::shared_ptr<TabletIndex>& tablet_index,
+                                     LogicalType field_type, std::unique_ptr<InvertedReader>* res) {
+    if (is_string_type(field_type)) {
+        *res = std::make_unique<BuiltinInvertedReader>(tablet_index->index_id());
+        return Status::OK();
+    } else {
+        return Status::InvalidArgument(fmt::format("Not supported type {}", field_type));
+    }
+}
+
+Status BuiltinInvertedReader::load(const IndexReadOptions& opt, void* meta) {
+    if (meta == nullptr) {
+        return Status::InvalidArgument("Invalid argument for loading builtin inverted index");
+    }
+    const BitmapIndexPB bitmap_index_meta = reinterpret_cast<BuiltinInvertedIndexPB*>(meta)->bitmap_index();
+    _bitmap_index = std::make_unique<BitmapIndexReader>();
+
+    ASSIGN_OR_RETURN(auto first_load, _bitmap_index->load(opt, bitmap_index_meta));
+    if (!first_load) {
+        return Status::InternalError("loading builtin inverted index more than once");
+    }
+    return Status::OK();
+}
+
+} // namespace starrocks

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_reader.cpp
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_reader.cpp
@@ -28,7 +28,7 @@ Status BuiltinInvertedReader::new_iterator(const std::shared_ptr<TabletIndex> in
     RETURN_IF_ERROR(_bitmap_index->new_iterator(index_opt, &iter));
     std::unique_ptr<BitmapIndexIterator> bitmap_itr;
     bitmap_itr.reset(iter);
-    *iterator = new BuiltinInvertedIndexIterator(index_meta, this, bitmap_itr);
+    *iterator = new BuiltinInvertedIndexIterator(index_meta, this, index_opt.stats, bitmap_itr);
     return Status::OK();
 }
 

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_reader.cpp
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_reader.cpp
@@ -23,8 +23,7 @@
 namespace starrocks {
 
 Status BuiltinInvertedReader::new_iterator(const std::shared_ptr<TabletIndex> index_meta,
-                                           InvertedIndexIterator** iterator,
-                                           const IndexReadOptions& index_opt) {
+                                           InvertedIndexIterator** iterator, const IndexReadOptions& index_opt) {
     BitmapIndexIterator* iter;
     RETURN_IF_ERROR(_bitmap_index->new_iterator(index_opt, &iter));
     std::unique_ptr<BitmapIndexIterator> bitmap_itr;
@@ -33,10 +32,11 @@ Status BuiltinInvertedReader::new_iterator(const std::shared_ptr<TabletIndex> in
     return Status::OK();
 }
 
-Status BuiltinInvertedReader::create(const std::shared_ptr<TabletIndex>& tablet_index,
-                                     LogicalType field_type, std::unique_ptr<InvertedReader>* res) {
+Status BuiltinInvertedReader::create(const std::shared_ptr<TabletIndex>& tablet_index, LogicalType field_type,
+                                     std::unique_ptr<InvertedReader>* res) {
     if (is_string_type(field_type)) {
-        *res = std::make_unique<BuiltinInvertedReader>(tablet_index->index_id());
+        const auto gram_num = get_gram_num_from_properties(tablet_index->index_properties());
+        *res = std::make_unique<BuiltinInvertedReader>(tablet_index->index_id(), gram_num);
         return Status::OK();
     } else {
         return Status::InvalidArgument(fmt::format("Not supported type {}", field_type));
@@ -48,7 +48,7 @@ Status BuiltinInvertedReader::load(const IndexReadOptions& opt, void* meta) {
         return Status::InvalidArgument("Invalid argument for loading builtin inverted index");
     }
     const BitmapIndexPB bitmap_index_meta = reinterpret_cast<BuiltinInvertedIndexPB*>(meta)->bitmap_index();
-    _bitmap_index = std::make_unique<BitmapIndexReader>();
+    _bitmap_index = std::make_unique<BitmapIndexReader>(_gram_num);
 
     ASSIGN_OR_RETURN(auto first_load, _bitmap_index->load(opt, bitmap_index_meta));
     if (!first_load) {

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_reader.h
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_reader.h
@@ -1,0 +1,65 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <CLucene.h>
+
+#include <utility>
+
+#include "storage/index/inverted/inverted_reader.h"
+#include "storage/rowset/bitmap_index_reader.h"
+
+namespace starrocks {
+
+class InvertedIndexIterator;
+enum class InvertedIndexQueryType;
+enum class InvertedIndexReaderType;
+class IndexReadOptions;
+class FunctionContext;
+
+class BuiltinInvertedReader : public InvertedReader {
+public:
+    explicit BuiltinInvertedReader(const uint32_t index_id) : InvertedReader("", index_id), _bitmap_index(nullptr) {}
+
+    ~BuiltinInvertedReader() override {}
+
+    static Status create(const std::shared_ptr<TabletIndex>& tablet_index,
+                         LogicalType field_type, std::unique_ptr<InvertedReader>* res);
+
+    Status new_iterator(const std::shared_ptr<TabletIndex> index_meta, InvertedIndexIterator** iterator,
+                        const IndexReadOptions& index_opt) override;
+
+    Status load(const IndexReadOptions& opt, void* meta) override;
+
+    /*
+       Implemented in BuiltinInvertedIndexIterator. For builtin inverted index, we have to define bitmap index iterator in BuiltinInvertedIndexIterator.
+       Because BuiltinInvertedReader may be accessed by multiple threads, and bitmap index iterator is not thread-safe.
+    */
+    Status query(OlapReaderStatistics* stats, const std::string& column_name, const void* query_value,
+                 InvertedIndexQueryType query_type, roaring::Roaring* bit_map) override {
+        return Status::InternalError("Unreachable");
+    }
+
+    Status query_null(OlapReaderStatistics* stats, const std::string& column_name, roaring::Roaring* bit_map) override {
+        return Status::InternalError("Unreachable");
+    }
+
+    InvertedIndexReaderType get_inverted_index_reader_type() override { return InvertedIndexReaderType::TEXT; }
+
+private:
+    std::unique_ptr<BitmapIndexReader> _bitmap_index;
+};
+
+} // namespace starrocks

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_reader.h
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_reader.h
@@ -31,12 +31,13 @@ class FunctionContext;
 
 class BuiltinInvertedReader : public InvertedReader {
 public:
-    explicit BuiltinInvertedReader(const uint32_t index_id) : InvertedReader("", index_id), _bitmap_index(nullptr) {}
+    explicit BuiltinInvertedReader(const uint32_t index_id, int32_t gram_num)
+            : InvertedReader("", index_id), _gram_num(gram_num), _bitmap_index(nullptr) {}
 
     ~BuiltinInvertedReader() override {}
 
-    static Status create(const std::shared_ptr<TabletIndex>& tablet_index,
-                         LogicalType field_type, std::unique_ptr<InvertedReader>* res);
+    static Status create(const std::shared_ptr<TabletIndex>& tablet_index, LogicalType field_type,
+                         std::unique_ptr<InvertedReader>* res);
 
     Status new_iterator(const std::shared_ptr<TabletIndex> index_meta, InvertedIndexIterator** iterator,
                         const IndexReadOptions& index_opt) override;
@@ -59,6 +60,7 @@ public:
     InvertedIndexReaderType get_inverted_index_reader_type() override { return InvertedIndexReaderType::TEXT; }
 
 private:
+    int32_t _gram_num;
     std::unique_ptr<BitmapIndexReader> _bitmap_index;
 };
 

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_writer.cpp
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_writer.cpp
@@ -1,0 +1,157 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/index/inverted/builtin/builtin_inverted_writer.h"
+
+#include <vector>
+
+#include <CLucene.h>
+#include <CLucene/analysis/LanguageBasedAnalyzer.h>
+#include <CLucene/util/Misc.h>
+#include <fmt/format.h>
+
+#include <boost/locale/encoding_utf.hpp>
+
+#include "common/status.h"
+#include "gen_cpp/segment.pb.h"
+#include "storage/index/inverted/builtin/builtin_simple_analyzer.h"
+#include "storage/index/inverted/inverted_index_option.h"
+#include "storage/rowset/bitmap_index_writer.h"
+#include "storage/tablet_index.h"
+#include "storage/type_traits.h"
+#include "types/logical_type.h"
+
+namespace starrocks {
+
+template <LogicalType field_type>
+class BuiltinInvertedWriterImpl : public BuiltinInvertedWriter {
+public:
+    using CppType = typename CppTypeTraits<field_type>::CppType;
+
+    explicit BuiltinInvertedWriterImpl(std::unique_ptr<BitmapIndexWriter>& writer, const TabletIndex* inverted_index)
+            : _builtin_writer(std::move(writer)) {
+        static_assert(field_type == TYPE_CHAR || field_type == TYPE_VARCHAR);
+        _parser_type = get_inverted_index_parser_type_from_string(
+                       get_parser_string_from_properties(inverted_index->index_properties()));
+        DCHECK(_parser_type != InvertedIndexParserType::PARSER_UNKNOWN);
+    }
+
+    Status init() override;
+
+    void add_values(const void* values, size_t count) override;
+
+    void add_nulls(uint32_t count) override { _builtin_writer->add_nulls(count); }
+
+    Status finish(WritableFile* wfile, ColumnMetaPB* meta) override;
+
+    uint64_t size() const override { return _builtin_writer->size(); }
+
+private:
+    std::unique_ptr<BitmapIndexWriter> _builtin_writer;
+    std::unique_ptr<lucene::analysis::Analyzer> _analyzer{};
+    std::unique_ptr<lucene::util::StringReader> _char_string_reader{};
+
+    std::unique_ptr<SimpleAnalyzer> _builtin_analyzer{};
+
+    InvertedIndexParserType _parser_type;
+};
+
+template <LogicalType field_type>
+Status BuiltinInvertedWriterImpl<field_type>::init() {
+    // init tokenizer relative context
+    _char_string_reader = std::make_unique<lucene::util::StringReader>(L"");
+    if (_parser_type == InvertedIndexParserType::PARSER_STANDARD) {
+        _analyzer = std::make_unique<lucene::analysis::standard::StandardAnalyzer>();
+    } else if (_parser_type == InvertedIndexParserType::PARSER_ENGLISH) {
+        _builtin_analyzer = std::make_unique<SimpleAnalyzer>();
+    } else if (_parser_type == InvertedIndexParserType::PARSER_CHINESE) {
+        auto chinese_analyzer = _CLNEW lucene::analysis::LanguageBasedAnalyzer();
+        chinese_analyzer->setLanguage(L"cjk");
+        _analyzer.reset(chinese_analyzer);
+    }
+    return Status::OK();
+}
+
+template <LogicalType field_type>
+void BuiltinInvertedWriterImpl<field_type>::add_values(const void* values, size_t count) {
+    const Slice* val = static_cast<const Slice*>(values);
+    for (int i = 0; i < count; ++i) {
+        const char* s = val->data;
+        size_t size = val->size;
+        if (_parser_type == InvertedIndexParserType::PARSER_NONE) {
+            _builtin_writer->add_value_with_current_rowid((void*) val);
+        } else if (_parser_type == InvertedIndexParserType::PARSER_ENGLISH) {
+            std::string mutable_text(val->data, val->size);
+            std::vector<SliceToken> tokens;
+            _builtin_analyzer->tokenize(mutable_text.data(), mutable_text.length(), tokens);
+            for (const auto& token : tokens) {
+                _builtin_writer->add_value_with_current_rowid((void*) &(token.text));
+            }
+        } else {
+            // For all kinds of CLucene analyzers, we need to process the text as follows:
+            // 1. Convert the text to wstring
+            // 2. Tokenize the wstring
+            // 3. Convert the tokens to string
+            // 4. Add the string to the bitmap index
+            std::wstring tchar = boost::locale::conv::utf_to_utf<TCHAR>(s, s + size);
+    
+            _char_string_reader->init(tchar.c_str(), tchar.size(), false);
+            auto stream = _analyzer->reusableTokenStream(L"", _char_string_reader.get());
+            lucene::analysis::Token token;
+            while (stream->next(&token)) {
+                if (token.termLength() != 0) {
+                    std::string str = boost::locale::conv::utf_to_utf<char>(token.termBuffer(), token.termBuffer() + token.termLength());
+                    Slice s(str);
+                    _builtin_writer->add_value_with_current_rowid((void*) &s);
+                }
+            }
+        }
+
+        ++val;
+        _builtin_writer->incre_rowid();
+    }
+}
+
+template <LogicalType field_type>
+Status BuiltinInvertedWriterImpl<field_type>::finish(WritableFile* wfile, ColumnMetaPB* meta) {
+    ColumnIndexMetaPB* index_meta = meta->add_indexes();
+    index_meta->set_type(BUILTIN_INVERTED_INDEX);
+    BuiltinInvertedIndexPB* inverted_index_meta = index_meta->mutable_builtin_inverted_index();
+    BitmapIndexPB* bitmap_index_meta = inverted_index_meta->mutable_bitmap_index();
+    return _builtin_writer->finish(wfile, bitmap_index_meta);
+}
+
+Status BuiltinInvertedWriter::create(const TypeInfoPtr& typeinfo, TabletIndex* tablet_index, std::unique_ptr<InvertedWriter>* res) {
+    std::unique_ptr<BitmapIndexWriter> writer;
+    RETURN_IF_ERROR(BitmapIndexWriter::create(typeinfo, &writer));
+    writer->set_dictionary_compression(CompressionTypePB::ZSTD);
+
+    LogicalType type = typeinfo->type();
+    switch (type) {
+    case LogicalType::TYPE_CHAR: {
+        *res = std::make_unique<BuiltinInvertedWriterImpl<LogicalType::TYPE_CHAR>>(writer, tablet_index);
+        break;
+    }
+    case LogicalType::TYPE_VARCHAR: {
+        *res = std::make_unique<BuiltinInvertedWriterImpl<LogicalType::TYPE_VARCHAR>>(writer, tablet_index);
+        break;
+    }
+    default:
+        return Status::NotSupported(
+                strings::Substitute("Unsupported type for inverted index: $0", type_to_string_v2(type)));
+    }
+    return Status::OK();
+}
+
+} // namespace starrocks

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_writer.h
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_writer.h
@@ -12,22 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "storage/index/inverted/inverted_plugin_factory.h"
+#pragma once
 
-#include "common/statusor.h"
-#include "storage/index/inverted/clucene/clucene_plugin.h"
-#include "storage/index/inverted/builtin/builtin_plugin.h"
+#include "storage/index/inverted/inverted_writer.h"
+#include "storage/types.h"
 
 namespace starrocks {
-StatusOr<InvertedPlugin*> InvertedPluginFactory::get_plugin(InvertedImplementType imp_type) {
-    switch (imp_type) {
-    case InvertedImplementType::CLUCENE:
-        return &CLucenePlugin::get_instance();
-    case InvertedImplementType::BUILTIN:
-        return &BuiltinPlugin::get_instance();
-    default:
-        return Status::InternalError("Invalid implement of inverted type");
-    }
-}
+class TabletIndex;
+class BuiltinInvertedWriter : public InvertedWriter {
+public:
+    static Status create(const TypeInfoPtr& typeinfo, TabletIndex* tablet_index, std::unique_ptr<InvertedWriter>* res);
+
+    BuiltinInvertedWriter(const BuiltinInvertedWriter&) = delete;
+
+    const BuiltinInvertedWriter& operator=(const BuiltinInvertedWriter&) = delete;
+
+    BuiltinInvertedWriter() = default;
+
+    ~BuiltinInvertedWriter() override = default;
+};
 
 } // namespace starrocks

--- a/be/src/storage/index/inverted/builtin/builtin_plugin.cpp
+++ b/be/src/storage/index/inverted/builtin/builtin_plugin.cpp
@@ -1,0 +1,32 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/index/inverted/builtin/builtin_plugin.h"
+
+#include "storage/index/inverted/builtin/builtin_inverted_reader.h"
+#include "storage/index/inverted/builtin/builtin_inverted_writer.h"
+
+namespace starrocks {
+
+Status BuiltinPlugin::create_inverted_index_writer(TypeInfoPtr typeinfo, std::string field_name, std::string path,
+                                                   TabletIndex* tablet_index, std::unique_ptr<InvertedWriter>* res) {
+    return BuiltinInvertedWriter::create(typeinfo, tablet_index, res);
+}
+
+Status BuiltinPlugin::create_inverted_index_reader(std::string path, const std::shared_ptr<TabletIndex>& tablet_index,
+                                                   LogicalType field_type, std::unique_ptr<InvertedReader>* res) {
+    return BuiltinInvertedReader::create(tablet_index, field_type, res);
+}
+
+} // namespace starrocks

--- a/be/src/storage/index/inverted/builtin/builtin_plugin.h
+++ b/be/src/storage/index/inverted/builtin/builtin_plugin.h
@@ -1,0 +1,41 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "storage/index/inverted/inverted_plugin.h"
+
+namespace starrocks {
+
+class BuiltinPlugin : public InvertedPlugin {
+public:
+    static BuiltinPlugin& get_instance() {
+        static BuiltinPlugin instance;
+        return instance;
+    }
+
+    BuiltinPlugin(BuiltinPlugin const&) = delete;
+    void operator=(BuiltinPlugin const&) = delete;
+
+    Status create_inverted_index_writer(TypeInfoPtr typeinfo, std::string field_name, std::string path,
+                                        TabletIndex* tablet_index, std::unique_ptr<InvertedWriter>* res) override;
+
+    Status create_inverted_index_reader(std::string path, const std::shared_ptr<TabletIndex>& tablet_index,
+                                        LogicalType field_type, std::unique_ptr<InvertedReader>* res) override;
+
+private:
+    BuiltinPlugin() {}
+};
+
+} // namespace starrocks

--- a/be/src/storage/index/inverted/builtin/builtin_simple_analyzer.cpp
+++ b/be/src/storage/index/inverted/builtin/builtin_simple_analyzer.cpp
@@ -1,0 +1,77 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "storage/index/inverted/builtin/builtin_simple_analyzer.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+
+namespace starrocks {
+
+SimpleAnalyzer::SimpleAnalyzer(bool normalize_case) :  _normalize_case(normalize_case) {
+    // Initialize lookup tables based on ASCII character classification
+    for (size_t i = 0; i < LOOKUP_SIZE; ++i) {
+        char c = static_cast<char>(i);
+
+        // Token character table: alphanumeric characters
+        _token_char_table[i] = std::isalnum(static_cast<unsigned char>(c)) != 0;
+
+        // Normalize table: convert uppercase to lowercase
+        _normalize_table[i] = std::tolower(static_cast<unsigned char>(c));
+    }
+}
+
+void SimpleAnalyzer::tokenize(char* mutable_text, size_t text_size, std::vector<SliceToken>& tokens) const {
+    tokens.clear();
+
+    if (mutable_text == nullptr || text_size == 0) {
+        return;
+    }
+    tokens.reserve(text_size);
+
+    size_t offset = 0;
+    size_t position = 0;
+
+    while (offset < text_size) {
+        char c = mutable_text[offset];
+
+        // Skip non-token characters
+        if (!_is_token_char(c)) {
+            ++offset;
+            continue;
+        }
+
+        // Found start of token
+        size_t token_start = offset;
+        size_t token_length = 0;
+
+        // Find end of token
+        while (offset < text_size && _is_token_char(mutable_text[offset])) {
+            ++offset;
+            ++token_length;
+        }
+
+        // Create token if we have content
+        if (token_length > 0) {
+            if (_normalize_case) {
+                for (size_t i = 0; i < token_length; ++i) {
+                    mutable_text[token_start + i] = _normalize(mutable_text[token_start + i]);
+                }
+            }
+            tokens.emplace_back(mutable_text + token_start, token_length, position++);
+        }
+    }
+}
+
+} // namespace starrocks

--- a/be/src/storage/index/inverted/builtin/builtin_simple_analyzer.h
+++ b/be/src/storage/index/inverted/builtin/builtin_simple_analyzer.h
@@ -1,0 +1,106 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <vector>
+#include <memory>
+#include <string>
+#include <string_view>
+
+#include "util/slice.h"
+
+namespace starrocks {
+
+/**
+ * @brief Represents a token extracted from text with its position information.
+ */
+struct SliceToken {
+    Slice text;           // Token text data
+    size_t position;      // Position of this token in the sequence
+
+    SliceToken() : text(), position(0) {}
+
+    // Constructor for raw char buffer
+    SliceToken(const char* data, size_t len, size_t pos)
+        : text(data, len), position(pos) {}
+
+    bool empty() const { return text.empty(); }
+
+    // Get string_view for efficient access
+    std::string_view view() const {
+        return std::string_view(text.data, text.size);
+    }
+
+    // Comparison operators
+    bool operator==(const SliceToken& other) const {
+        return text == other.text;
+    }
+};
+
+/**
+ * @brief Core tokenizer implementation for simple text analysis
+ * Simplified version of CLucene's CharTokenizer using Slice-based tokens
+ */
+class SimpleAnalyzer {
+public:
+    /**
+     * @brief Constructor
+     * @param normalize_case Whether to normalize case (default: false for maximum performance)
+     */
+    SimpleAnalyzer(bool normalize_case = true);
+    ~SimpleAnalyzer() = default;
+
+    /**
+     * @brief Tokenize text and output tokens to provided vector
+     * @param mutable_text Input text buffer (will be modified for case normalization)
+     * @param text_size Size of input text
+     * @param tokens Output vector to store tokens with their positions
+     */
+    void tokenize(char* mutable_text, size_t text_size, std::vector<SliceToken>& tokens) const;
+
+private:
+    static const size_t LOOKUP_SIZE = 256;
+
+    /**
+     * @brief Check if character should be included in token
+     * @param c Character to check
+     * @return true if character is part of token
+     */
+    inline bool _is_token_char(char c) const {
+        size_t index = static_cast<unsigned char>(c);
+        if (index >= LOOKUP_SIZE) {
+            return false; // Non-ASCII characters are not considered token chars
+        }
+        return _token_char_table[index];
+    }
+    
+    /**
+     * @brief Normalize character (e.g., convert to lowercase)
+     * @param c Character to normalize
+     * @return Normalized character
+     */
+    inline char _normalize(char c) const {
+        size_t index = static_cast<unsigned char>(c);
+        if (index >= LOOKUP_SIZE) {
+            return c; // Return unchanged for non-ASCII
+        }
+        return _normalize_table[index];
+    }
+
+    bool _normalize_case;
+    bool _token_char_table[LOOKUP_SIZE];
+    char _normalize_table[LOOKUP_SIZE];
+};
+
+} // namespace starrocks

--- a/be/src/storage/index/inverted/clucene/clucene_inverted_reader.cpp
+++ b/be/src/storage/index/inverted/clucene/clucene_inverted_reader.cpp
@@ -29,7 +29,8 @@
 namespace starrocks {
 
 Status CLuceneInvertedReader::new_iterator(const std::shared_ptr<TabletIndex> index_meta,
-                                           InvertedIndexIterator** iterator) {
+                                           InvertedIndexIterator** iterator,
+                                           const IndexReadOptions& index_opt) {
     *iterator = new InvertedIndexIterator(index_meta, this);
     return Status::OK();
 }

--- a/be/src/storage/index/inverted/clucene/clucene_inverted_reader.cpp
+++ b/be/src/storage/index/inverted/clucene/clucene_inverted_reader.cpp
@@ -22,6 +22,7 @@
 #include "clucene_inverted_util.h"
 #include "storage/index/index_descriptor.h"
 #include "storage/index/inverted/clucene/match_operator.h"
+#include "storage/rowset/options.h"
 #include "types/logical_type.h"
 #include "util/defer_op.h"
 #include "util/faststring.h"
@@ -29,9 +30,8 @@
 namespace starrocks {
 
 Status CLuceneInvertedReader::new_iterator(const std::shared_ptr<TabletIndex> index_meta,
-                                           InvertedIndexIterator** iterator,
-                                           const IndexReadOptions& index_opt) {
-    *iterator = new InvertedIndexIterator(index_meta, this);
+                                           InvertedIndexIterator** iterator, const IndexReadOptions& index_opt) {
+    *iterator = new InvertedIndexIterator(index_meta, this, index_opt.stats);
     return Status::OK();
 }
 

--- a/be/src/storage/index/inverted/clucene/clucene_inverted_reader.h
+++ b/be/src/storage/index/inverted/clucene/clucene_inverted_reader.h
@@ -61,7 +61,8 @@ public:
     static Status create(const std::string& path, const std::shared_ptr<TabletIndex>& tablet_index,
                          LogicalType field_type, std::unique_ptr<InvertedReader>* res);
 
-    Status new_iterator(const std::shared_ptr<TabletIndex> index_meta, InvertedIndexIterator** iterator) override;
+    Status new_iterator(const std::shared_ptr<TabletIndex> index_meta, InvertedIndexIterator** iterator,
+                        const IndexReadOptions& index_opt) override;
 };
 
 class FullTextCLuceneInvertedReader : public CLuceneInvertedReader {

--- a/be/src/storage/index/inverted/clucene/clucene_inverted_writer.cpp
+++ b/be/src/storage/index/inverted/clucene/clucene_inverted_writer.cpp
@@ -51,11 +51,7 @@ public:
         _field_name = std::wstring(field_name.begin(), field_name.end());
     }
 
-    uint64_t size() const override { return _index_writer->numRamDocs(); }
-
-    uint64_t estimate_buffer_size() const override { return _index_writer->ramSizeInBytes(); }
-
-    uint64_t total_mem_footprint() const override { return _index_writer->ramSizeInBytes(); }
+    uint64_t size() const override { return _index_writer->ramSizeInBytes(); }
 
     Status init() override {
         try {
@@ -190,7 +186,7 @@ public:
         }
     }
 
-    Status finish() override {
+    Status finish(WritableFile* wfile, ColumnMetaPB* meta) override {
         lucene::store::Directory* dir = nullptr;
         lucene::store::IndexOutput* null_bitmap_out = nullptr;
         lucene::store::IndexOutput* data_out = nullptr;

--- a/be/src/storage/index/inverted/inverted_index_common.h
+++ b/be/src/storage/index/inverted/inverted_index_common.h
@@ -21,6 +21,7 @@ namespace starrocks {
 enum class InvertedImplementType {
     UNKNOWN = 0,
     CLUCENE = 1,
+    BUILTIN = 2,
 };
 
 enum class InvertedIndexParserType {
@@ -33,6 +34,7 @@ enum class InvertedIndexParserType {
 
 const std::string INVERTED_IMP_KEY = "imp_lib";
 const std::string TYPE_CLUCENE = "clucene";
+const std::string TYPE_BUILTIN = "builtin";
 const std::string INVERTED_INDEX_PARSER_KEY = "parser";
 const std::string INVERTED_INDEX_PARSER_UNKNOWN = "unknown";
 const std::string INVERTED_INDEX_PARSER_NONE = "none";

--- a/be/src/storage/index/inverted/inverted_index_common.h
+++ b/be/src/storage/index/inverted/inverted_index_common.h
@@ -35,6 +35,7 @@ enum class InvertedIndexParserType {
 const std::string INVERTED_IMP_KEY = "imp_lib";
 const std::string TYPE_CLUCENE = "clucene";
 const std::string TYPE_BUILTIN = "builtin";
+
 const std::string INVERTED_INDEX_PARSER_KEY = "parser";
 const std::string INVERTED_INDEX_PARSER_UNKNOWN = "unknown";
 const std::string INVERTED_INDEX_PARSER_NONE = "none";
@@ -42,6 +43,8 @@ const std::string INVERTED_INDEX_PARSER_STANDARD = "standard";
 const std::string INVERTED_INDEX_PARSER_ENGLISH = "english";
 const std::string INVERTED_INDEX_PARSER_CHINESE = "chinese";
 const std::string LIKE_FN_NAME = "like";
+
+const std::string INVERTED_INDEX_DICT_GRAM_NUM_KEY = "dict_gram_num";
 
 const std::string INVERTED_INDEX_TOKENIZED_KEY = "tokenized";
 

--- a/be/src/storage/index/inverted/inverted_index_iterator.h
+++ b/be/src/storage/index/inverted/inverted_index_iterator.h
@@ -32,18 +32,22 @@ public:
                 get_parser_string_from_properties(_index_meta->index_properties()));
     }
 
-    Status read_from_inverted_index(const std::string& column_name, const void* query_value,
-                                    InvertedIndexQueryType query_type, roaring::Roaring* bit_map);
+    virtual ~InvertedIndexIterator() = default;
 
-    Status read_null(const std::string& column_name, roaring::Roaring* bit_map);
+    virtual Status read_from_inverted_index(const std::string& column_name, const void* query_value,
+                                            InvertedIndexQueryType query_type, roaring::Roaring* bit_map);
 
-    InvertedIndexParserType get_inverted_index_analyser_type() const;
+    virtual Status read_null(const std::string& column_name, roaring::Roaring* bit_map);
 
-    InvertedIndexReaderType get_inverted_index_reader_type() const;
+    virtual InvertedIndexParserType get_inverted_index_analyser_type() const;
 
-    bool is_untokenized() const { return _analyser_type == InvertedIndexParserType::PARSER_NONE; }
+    virtual InvertedIndexReaderType get_inverted_index_reader_type() const;
 
-private:
+    virtual bool is_untokenized() const { return _analyser_type == InvertedIndexParserType::PARSER_NONE; }
+
+    virtual Status close() { return Status::OK(); }
+
+protected:
     const std::shared_ptr<TabletIndex> _index_meta;
     OlapReaderStatistics* _stats;
     InvertedReader* _reader;

--- a/be/src/storage/index/inverted/inverted_index_iterator.h
+++ b/be/src/storage/index/inverted/inverted_index_iterator.h
@@ -26,8 +26,9 @@ enum class InvertedIndexReaderType;
 
 class InvertedIndexIterator {
 public:
-    InvertedIndexIterator(const std::shared_ptr<TabletIndex>& index_meta, InvertedReader* reader)
-            : _index_meta(index_meta), _reader(reader) {
+    InvertedIndexIterator(const std::shared_ptr<TabletIndex>& index_meta, InvertedReader* reader,
+                          OlapReaderStatistics* stats)
+            : _index_meta(index_meta), _stats(stats), _reader(reader) {
         _analyser_type = get_inverted_index_parser_type_from_string(
                 get_parser_string_from_properties(_index_meta->index_properties()));
     }

--- a/be/src/storage/index/inverted/inverted_index_option.cpp
+++ b/be/src/storage/index/inverted/inverted_index_option.cpp
@@ -24,6 +24,8 @@ StatusOr<InvertedImplementType> get_inverted_imp_type(const TabletIndex& tablet_
         const auto& imp_type = inverted_imp_prop->second;
         if (boost::algorithm::to_lower_copy(imp_type) == TYPE_CLUCENE) {
             return InvertedImplementType::CLUCENE;
+        } else if (boost::algorithm::to_lower_copy(imp_type) == TYPE_BUILTIN) {
+            return InvertedImplementType::BUILTIN;
         } else {
             return Status::InvalidArgument("Do not support imp_type : " + imp_type);
         }

--- a/be/src/storage/index/inverted/inverted_index_option.cpp
+++ b/be/src/storage/index/inverted/inverted_index_option.cpp
@@ -73,6 +73,14 @@ std::string get_parser_string_from_properties(const std::map<std::string, std::s
     return INVERTED_INDEX_PARSER_NONE;
 }
 
+int32_t get_gram_num_from_properties(const std::map<std::string, std::string>& properties) {
+    if (const auto it = properties.find(INVERTED_INDEX_DICT_GRAM_NUM_KEY); it != properties.end()) {
+        const std::string& gram_num = it->second;
+        return std::stoi(gram_num);
+    }
+    return -1;
+}
+
 bool is_tokenized_from_properties(const std::map<std::string, std::string>& properties) {
     auto tokenized_res = properties.find(INVERTED_INDEX_TOKENIZED_KEY);
     if (tokenized_res != properties.end()) {

--- a/be/src/storage/index/inverted/inverted_index_option.h
+++ b/be/src/storage/index/inverted/inverted_index_option.h
@@ -33,6 +33,8 @@ InvertedIndexParserType get_inverted_index_parser_type_from_string(const std::st
 
 std::string get_parser_string_from_properties(const std::map<std::string, std::string>& properties);
 
+int32_t get_gram_num_from_properties(const std::map<std::string, std::string>& properties);
+
 bool is_tokenized_from_properties(const std::map<std::string, std::string>& properties);
 
 } // namespace starrocks

--- a/be/src/storage/index/inverted/inverted_reader.h
+++ b/be/src/storage/index/inverted/inverted_reader.h
@@ -28,6 +28,7 @@ namespace starrocks {
 class InvertedIndexIterator;
 enum class InvertedIndexReaderType;
 enum class InvertedIndexQueryType;
+class IndexReadOptions;
 
 class InvertedReader {
 public:
@@ -37,7 +38,8 @@ public:
     virtual ~InvertedReader() = default;
 
     // create a new column iterator. Client should delete returned iterator
-    virtual Status new_iterator(const std::shared_ptr<TabletIndex> index_meta, InvertedIndexIterator** iterator) = 0;
+    virtual Status new_iterator(const std::shared_ptr<TabletIndex> index_meta, InvertedIndexIterator** iterator,
+                                const IndexReadOptions& index_opt) = 0;
 
     virtual Status query(OlapReaderStatistics* stats, const std::string& column_name, const void* query_value,
                          InvertedIndexQueryType query_type, roaring::Roaring* bit_map) = 0;
@@ -46,6 +48,8 @@ public:
                               roaring::Roaring* bit_map) = 0;
 
     virtual InvertedIndexReaderType get_inverted_index_reader_type() = 0;
+
+    virtual Status load(const IndexReadOptions& opt, void* meta) { return Status::OK(); }
 
     bool index_exists(const std::string& index_file_path) { return fs::path_exist(index_file_path); }
 

--- a/be/src/storage/index/inverted/inverted_writer.h
+++ b/be/src/storage/index/inverted/inverted_writer.h
@@ -18,6 +18,8 @@
 #include "storage/collection.h"
 
 namespace starrocks {
+class WritableFile;
+class ColumnMetaPB;
 
 class InvertedWriter {
 public:
@@ -33,12 +35,8 @@ public:
 
     virtual void add_nulls(uint32_t count) = 0;
 
-    virtual Status finish() = 0;
+    virtual Status finish(WritableFile* wfile, ColumnMetaPB* meta) = 0;
 
     virtual uint64_t size() const = 0;
-
-    virtual uint64_t estimate_buffer_size() const = 0;
-
-    virtual uint64_t total_mem_footprint() const = 0;
 };
 } // namespace starrocks

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -234,6 +234,8 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
     if (_metadata->has_record_predicate()) {
         ASSIGN_OR_RETURN(seg_options.record_predicate, RecordPredicateHelper::create(_metadata->record_predicate()));
     }
+    seg_options.enable_gin_filter = options.enable_gin_filter;
+    seg_options.has_preaggregation = options.has_preaggregation;
 
     std::unique_ptr<Schema> segment_schema_guard;
     auto* segment_schema = const_cast<Schema*>(&schema);

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -235,6 +235,7 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
         ASSIGN_OR_RETURN(seg_options.record_predicate, RecordPredicateHelper::create(_metadata->record_predicate()));
     }
     seg_options.enable_gin_filter = options.enable_gin_filter;
+    seg_options.prune_column_after_index_filter = options.prune_column_after_index_filter;
     seg_options.has_preaggregation = options.has_preaggregation;
 
     std::unique_ptr<Schema> segment_schema_guard;

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -343,6 +343,8 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     rs_opts.runtime_range_pruner = params.runtime_range_pruner;
     rs_opts.lake_io_opts = params.lake_io_opts;
     rs_opts.enable_join_runtime_filter_pushdown = params.enable_join_runtime_filter_pushdown;
+    rs_opts.prune_column_after_index_filter = params.prune_column_after_index_filter;
+    rs_opts.enable_gin_filter = params.enable_gin_filter;
 
     if (keys_type == KeysType::PRIMARY_KEYS) {
         rs_opts.is_primary_keys = true;

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -277,12 +277,15 @@ struct OlapReaderStatistics {
 
     int64_t rows_del_vec_filtered = 0;
 
-    int64_t rows_gin_filtered = 0;
     int64_t gin_index_filter_ns = 0;
-
+    int64_t rows_gin_filtered = 0;
     int64_t gin_prefix_filter_ns = 0;
     int64_t gin_ngram_filter_dict_ns = 0;
-    int64_t gin_filter_dict_ns = 0;
+    int64_t gin_predicate_filter_dict_ns = 0;
+    int64_t gin_dict_count = 0;
+    int64_t gin_ngram_dict_count = 0;
+    int64_t gin_ngram_dict_filtered = 0;
+    int64_t gin_predicate_dict_filtered = 0;
 
     int64_t rowsets_read_count = 0;
     int64_t segments_read_count = 0;

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -280,6 +280,10 @@ struct OlapReaderStatistics {
     int64_t rows_gin_filtered = 0;
     int64_t gin_index_filter_ns = 0;
 
+    int64_t gin_prefix_filter_ns = 0;
+    int64_t gin_ngram_filter_dict_ns = 0;
+    int64_t gin_filter_dict_ns = 0;
+
     int64_t rowsets_read_count = 0;
     int64_t segments_read_count = 0;
     int64_t total_columns_data_page_count = 0;

--- a/be/src/storage/rowset/bitmap_index_reader.cpp
+++ b/be/src/storage/rowset/bitmap_index_reader.cpp
@@ -281,7 +281,7 @@ StatusOr<Buffer<rowid_t>> BitmapIndexIterator::seek_dictionary_by_predicate(cons
     RETURN_IF_ERROR(next_batch_dictionary(&search_size, column.get()));
     ASSIGN_OR_RETURN(auto ret, predicate(*column));
 
-    auto hit_column = down_cast<BooleanColumn*>(ret.get());
+    const auto* hit_column = down_cast<const BooleanColumn*>(ret.get());
     Buffer<rowid_t> hit_rowids;
     for (int i = 0; i < hit_column->size(); ++i) {
         if (hit_column->get_data()[i]) {

--- a/be/src/storage/rowset/bitmap_index_reader.cpp
+++ b/be/src/storage/rowset/bitmap_index_reader.cpp
@@ -38,6 +38,7 @@
 
 #include <memory>
 
+#include "bitmap_range_iterator.h"
 #include "column/column_helper.h"
 #include "column/column_viewer.h"
 #include "exprs/function_context.h"
@@ -46,12 +47,13 @@
 #include "storage/chunk_helper.h"
 #include "storage/range.h"
 #include "storage/types.h"
+#include "util/utf8.h"
 
 namespace starrocks {
 
 using Roaring = roaring::Roaring;
 
-BitmapIndexReader::BitmapIndexReader() {
+BitmapIndexReader::BitmapIndexReader(int32_t gram_num): _gram_num(gram_num) {
     MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->bitmap_index_mem_tracker(), sizeof(BitmapIndexReader));
 }
 
@@ -88,15 +90,161 @@ Status BitmapIndexReader::_do_load(const IndexReadOptions& opts, const BitmapInd
     _bitmap_column_reader = std::make_unique<IndexedColumnReader>(bitmap_meta);
     RETURN_IF_ERROR(_dict_column_reader->load(opts));
     RETURN_IF_ERROR(_bitmap_column_reader->load(opts));
+    if (meta.has_ngram_dict_column() && meta.has_ngram_bitmap_column()) {
+        const IndexedColumnMetaPB& ngram_dict_meta = meta.ngram_dict_column();
+        const IndexedColumnMetaPB& ngram_bitmap_meta = meta.ngram_bitmap_column();
+        _ngram_dict_column_reader = std::make_unique<IndexedColumnReader>(ngram_dict_meta);
+        _ngram_bitmap_column_reader = std::make_unique<IndexedColumnReader>(ngram_bitmap_meta);
+        RETURN_IF_ERROR(_ngram_dict_column_reader->load(opts));
+        RETURN_IF_ERROR(_ngram_bitmap_column_reader->load(opts));
+    } else {
+        _ngram_dict_column_reader = nullptr;
+        _ngram_bitmap_column_reader = nullptr;
+    }
     return Status::OK();
 }
 
 Status BitmapIndexReader::new_iterator(const IndexReadOptions& opts, BitmapIndexIterator** iterator) {
     std::unique_ptr<IndexedColumnIterator> dict_iter;
     std::unique_ptr<IndexedColumnIterator> bitmap_iter;
+    std::unique_ptr<IndexedColumnIterator> ngram_dict_iter = nullptr;
+    std::unique_ptr<IndexedColumnIterator> ngram_bitmap_iter = nullptr;
     RETURN_IF_ERROR(_dict_column_reader->new_iterator(opts, &dict_iter));
     RETURN_IF_ERROR(_bitmap_column_reader->new_iterator(opts, &bitmap_iter));
-    *iterator = new BitmapIndexIterator(this, std::move(dict_iter), std::move(bitmap_iter), _has_null, bitmap_nums());
+    if (_ngram_dict_column_reader != nullptr && _ngram_bitmap_column_reader != nullptr) {
+        RETURN_IF_ERROR(_ngram_dict_column_reader->new_iterator(opts, &ngram_dict_iter));
+        RETURN_IF_ERROR(_ngram_bitmap_column_reader->new_iterator(opts, &ngram_bitmap_iter));
+    }
+    *iterator = new BitmapIndexIterator(this, std::move(dict_iter), std::move(bitmap_iter), std::move(ngram_dict_iter),
+                                        std::move(ngram_bitmap_iter), _has_null, bitmap_nums());
+    return Status::OK();
+}
+
+Status BitmapIndexIterator::seek_dict_by_ngram(const void* value, roaring::Roaring* roaring) const {
+    if (_reader->gram_num() <= 0) {
+        // _num_bitmap means how many dicts exist. should return all dicts here.
+        roaring->addRange(0, _num_bitmap);
+        return Status::OK();
+    }
+
+    if (_ngram_dict_column_iter == nullptr || _ngram_bitmap_column_iter == nullptr) {
+        return Status::InternalError("ngram bitmap index reader is not opened.");
+    }
+    if (_reader->type_info()->type() != TYPE_VARCHAR && _reader->type_info()->type() != TYPE_CHAR) {
+        return Status::NotSupported("ngram seek for dictionary only support string/char type in bitmap index");
+    }
+
+    const auto gram_num = _reader->gram_num();
+    const auto* slice_val = static_cast<const Slice*>(value);
+    if (slice_val->get_size() < gram_num) {
+        // _num_bitmap means how many dicts exist. should return all dicts here.
+        roaring->addRange(0, _num_bitmap);
+        return Status::OK();
+    }
+
+    std::vector<size_t> index;
+    const size_t slice_gram_num = get_utf8_index(*slice_val, &index);
+
+    bool first = true;
+    for (size_t j = 0; j + gram_num <= slice_gram_num; ++j) {
+        // find next ngram
+        size_t cur_ngram_length =
+                j + gram_num < slice_gram_num ? index[j + gram_num] - index[j] : slice_val->get_size() - index[j];
+        Slice cur_ngram(slice_val->data + index[j], cur_ngram_length);
+
+        bool match = false;
+        RETURN_IF_ERROR(_ngram_dict_column_iter->seek_at_or_after(&cur_ngram, &match));
+        if (!match) {
+            continue;
+        }
+
+        RETURN_IF_ERROR(_ngram_bitmap_column_iter->seek_to_ordinal(_ngram_dict_column_iter->get_current_ordinal()));
+        size_t num_to_read = 1;
+        size_t num_read = num_to_read;
+        auto column = ChunkHelper::column_from_field_type(TYPE_VARCHAR, false);
+        RETURN_IF_ERROR(_ngram_bitmap_column_iter->next_batch(&num_read, column.get()));
+        if (num_to_read != num_read) {
+            return Status::InternalError(fmt::format(
+                    "read ngram bitmap column failed, expect {} rows, but got {} rows.", num_to_read, num_read));
+        }
+
+        ColumnViewer<TYPE_VARCHAR> viewer(std::move(column));
+        const auto str_bitmap = viewer.value(0);
+
+        const auto tmp = Roaring::read(str_bitmap.data, false);
+        if (first) {
+            *roaring |= tmp;
+            first = false;
+        } else {
+            *roaring &= tmp;
+        }
+
+        if (roaring->cardinality() == 0) {
+            // no words match, fast fail
+            return Status::OK();
+        }
+    }
+    return Status::OK();
+}
+
+StatusOr<Buffer<rowid_t>> BitmapIndexIterator::filter_dict_by_predicate(
+        const roaring::Roaring* rowids, const std::function<bool(const Slice*)>& predicate) const {
+    BitmapRangeIterator it(*rowids);
+    uint32_t from, to;
+    const auto max_range = rowids->maximum() - rowids->minimum();
+    Buffer<rowid_t> hit_rowids;
+    while (it.next_range(max_range, &from, &to)) {
+        auto col = ChunkHelper::column_from_field_type(TYPE_VARCHAR, false);
+        RETURN_IF_ERROR(_dict_column_iter->seek_to_ordinal(from));
+        size_t num_to_read = to - from;
+        size_t read = num_to_read;
+        RETURN_IF_ERROR(_dict_column_iter->next_batch(&read, col.get()));
+        if (num_to_read != read) {
+            return Status::InternalError(
+                    fmt::format("read dict column failed, expect {} rows, but got {} rows.", num_to_read, read));
+        }
+
+        ColumnViewer<TYPE_VARCHAR> viewer(std::move(col));
+        for (int i = 0; i < viewer.size(); ++i) {
+            auto value = viewer.value(i);
+            if (predicate(&value)) {
+                hit_rowids.push_back(from + i);
+            }
+        }
+    }
+    return std::move(hit_rowids);
+}
+
+Status BitmapIndexIterator::next_batch_ngram(rowid_t ordinal, size_t* n, Column* column) const {
+    if (_ngram_dict_column_iter != nullptr) {
+        if (!(0 <= ordinal && ordinal < _reader->ngram_bitmap_nums())) {
+            return Status::InvalidArgument("ordinal is out of range while reading ngram bitmap");
+        }
+        RETURN_IF_ERROR(_ngram_dict_column_iter->seek_to_ordinal(ordinal));
+        return _ngram_dict_column_iter->next_batch(n, column);
+    }
+    *n = 0;
+    return Status::OK();
+}
+
+Status BitmapIndexIterator::read_ngram_bitmap(rowid_t ordinal, Roaring* result) const {
+    if (_ngram_bitmap_column_iter != nullptr) {
+        if (!(0 <= ordinal && ordinal < _reader->ngram_bitmap_nums())) {
+            return Status::InvalidArgument("ordinal is out of range while reading ngram bitmap");
+        }
+        auto column = ChunkHelper::column_from_field_type(TYPE_VARCHAR, false);
+        RETURN_IF_ERROR(_ngram_bitmap_column_iter->seek_to_ordinal(ordinal));
+        size_t num_to_read = 1;
+        size_t num_read = num_to_read;
+        RETURN_IF_ERROR(_ngram_bitmap_column_iter->next_batch(&num_read, column.get()));
+        if (num_to_read != num_read) {
+            return Status::InternalError(fmt::format(
+                    "read ngram bitmap column failed, expect {} rows, but got {} rows.", num_to_read, num_read));
+        }
+        const ColumnViewer<TYPE_VARCHAR> viewer(std::move(column));
+        const auto value = viewer.value(0);
+        *result = Roaring::read(value.data, false);
+    }
     return Status::OK();
 }
 
@@ -113,10 +261,11 @@ Status BitmapIndexIterator::next_batch_dictionary(size_t* n, Column* column) {
 }
 
 StatusOr<Buffer<rowid_t>> BitmapIndexIterator::seek_dictionary_by_predicate(const DictPredicate& predicate,
-                                                                            const Slice& from_value, size_t search_size) {
+                                                                            const Slice& from_value,
+                                                                            size_t search_size) {
     if (_reader->type_info()->type() != TYPE_VARCHAR && _reader->type_info()->type() != TYPE_CHAR) {
         return Status::NotSupported("predicate seek for dictionary only support string/char type bitmap index");
-    }                                                                    
+    }
     auto column = ChunkHelper::column_from_field_type(TYPE_VARCHAR, false);
     bool exact_match;
     RETURN_IF_ERROR(seek_dictionary(&from_value, &exact_match));
@@ -132,7 +281,7 @@ StatusOr<Buffer<rowid_t>> BitmapIndexIterator::seek_dictionary_by_predicate(cons
         }
     }
     return hit_rowids;
-} 
+}
 
 Status BitmapIndexIterator::read_bitmap(rowid_t ordinal, Roaring* result) {
     DCHECK(0 <= ordinal && ordinal < _reader->bitmap_nums());

--- a/be/src/storage/rowset/bitmap_index_reader.h
+++ b/be/src/storage/rowset/bitmap_index_reader.h
@@ -36,6 +36,7 @@
 
 #include <roaring/roaring.hh>
 
+#include "column/column_helper.h"
 #include "common/status.h"
 #include "fs/fs.h"
 #include "gen_cpp/segment.pb.h"
@@ -107,6 +108,8 @@ private:
 
 class BitmapIndexIterator {
 public:
+    using DictPredicate = std::function<StatusOr<ColumnPtr>(const Column&)>;
+
     BitmapIndexIterator(BitmapIndexReader* reader, std::unique_ptr<IndexedColumnIterator> dict_iter,
                         std::unique_ptr<IndexedColumnIterator> bitmap_iter, bool has_null, rowid_t num_bitmap)
             : _reader(reader),
@@ -126,6 +129,10 @@ public:
     // Returns NotFound when no such value exists (all values in dictionary < `value`).
     // Returns other error status otherwise.
     Status seek_dictionary(const void* value, bool* exact_match);
+
+    StatusOr<Buffer<rowid_t>> seek_dictionary_by_predicate(const DictPredicate& predicate, const Slice& from_value, size_t search_size);
+
+    Status next_batch_dictionary(size_t* n, Column* column);
 
     // Read bitmap at the given ordinal into `result`.
     Status read_bitmap(rowid_t ordinal, Roaring* result);
@@ -148,6 +155,8 @@ public:
     //     read_union_bitmap(range[i].begin(), range[i].end(), &result);
     // }
     Status read_union_bitmap(const SparseRange<>& range, Roaring* result);
+
+    Status read_union_bitmap(const Buffer<rowid_t>& rowids, Roaring* result);
 
     rowid_t bitmap_nums() const { return _num_bitmap; }
 

--- a/be/src/storage/rowset/bitmap_index_reader.h
+++ b/be/src/storage/rowset/bitmap_index_reader.h
@@ -57,7 +57,7 @@ using Roaring = roaring::Roaring;
 
 class BitmapIndexReader {
 public:
-    BitmapIndexReader();
+    BitmapIndexReader(int32_t gram_num = -1);
     ~BitmapIndexReader();
 
     // Load index data into memory.
@@ -77,6 +77,16 @@ public:
     // REQUIRES: the index data has been successfully `load()`ed into memory.
     int64_t bitmap_nums() { return _bitmap_column_reader->num_values(); }
 
+    int32_t gram_num() const { return _gram_num; }
+
+    // REQUIRES: the index data has been successfully `load()`ed into memory.
+    int64_t ngram_bitmap_nums() const {
+        if (_ngram_bitmap_column_reader != nullptr) {
+            return _ngram_bitmap_column_reader->num_values();
+        }
+        return 0;
+    }
+
     const TypeInfoPtr& type_info() { return _typeinfo; }
 
     bool loaded() const { return invoked(_load_once); }
@@ -89,6 +99,12 @@ public:
         if (_bitmap_column_reader != nullptr) {
             size += _bitmap_column_reader->mem_usage();
         }
+        if (_ngram_dict_column_reader != nullptr) {
+            size += _ngram_dict_column_reader->mem_usage();
+        }
+        if (_ngram_bitmap_column_reader != nullptr) {
+            size += _ngram_bitmap_column_reader->mem_usage();
+        }
         return size;
     }
 
@@ -99,10 +115,14 @@ private:
 
     Status _do_load(const IndexReadOptions& opts, const BitmapIndexPB& meta);
 
+    int32_t _gram_num;
+
     OnceFlag _load_once;
     TypeInfoPtr _typeinfo;
     std::unique_ptr<IndexedColumnReader> _dict_column_reader;
     std::unique_ptr<IndexedColumnReader> _bitmap_column_reader;
+    std::unique_ptr<IndexedColumnReader> _ngram_dict_column_reader;
+    std::unique_ptr<IndexedColumnReader> _ngram_bitmap_column_reader;
     bool _has_null = false;
 };
 
@@ -111,14 +131,27 @@ public:
     using DictPredicate = std::function<StatusOr<ColumnPtr>(const Column&)>;
 
     BitmapIndexIterator(BitmapIndexReader* reader, std::unique_ptr<IndexedColumnIterator> dict_iter,
-                        std::unique_ptr<IndexedColumnIterator> bitmap_iter, bool has_null, rowid_t num_bitmap)
+                        std::unique_ptr<IndexedColumnIterator> bitmap_iter,
+                        std::unique_ptr<IndexedColumnIterator> ngram_dict_iter,
+                        std::unique_ptr<IndexedColumnIterator> ngram_bitmap_iter, bool has_null, rowid_t num_bitmap)
             : _reader(reader),
               _dict_column_iter(std::move(dict_iter)),
               _bitmap_column_iter(std::move(bitmap_iter)),
+              _ngram_dict_column_iter(std::move(ngram_dict_iter)),
+              _ngram_bitmap_column_iter(std::move(ngram_bitmap_iter)),
               _has_null(has_null),
               _num_bitmap(num_bitmap) {}
 
     bool has_null_bitmap() const { return _has_null; }
+
+    Status seek_dict_by_ngram(const void* value, roaring::Roaring* roaring) const;
+
+    StatusOr<Buffer<rowid_t>> filter_dict_by_predicate(const roaring::Roaring* rowids,
+                                                       const std::function<bool(const Slice*)>& predicate) const;
+
+    // used for test
+    Status next_batch_ngram(rowid_t ordinal, size_t* n, Column* column) const;
+    Status read_ngram_bitmap(rowid_t ordinal, Roaring* result) const;
 
     // Seek the dictionary to the first value that is >= the given value.
     //
@@ -130,7 +163,8 @@ public:
     // Returns other error status otherwise.
     Status seek_dictionary(const void* value, bool* exact_match);
 
-    StatusOr<Buffer<rowid_t>> seek_dictionary_by_predicate(const DictPredicate& predicate, const Slice& from_value, size_t search_size);
+    StatusOr<Buffer<rowid_t>> seek_dictionary_by_predicate(const DictPredicate& predicate, const Slice& from_value,
+                                                           size_t search_size);
 
     Status next_batch_dictionary(size_t* n, Column* column);
 
@@ -166,6 +200,8 @@ private:
     BitmapIndexReader* _reader;
     std::unique_ptr<IndexedColumnIterator> _dict_column_iter;
     std::unique_ptr<IndexedColumnIterator> _bitmap_column_iter;
+    std::unique_ptr<IndexedColumnIterator> _ngram_dict_column_iter;
+    std::unique_ptr<IndexedColumnIterator> _ngram_bitmap_column_iter;
     bool _has_null;
     rowid_t _num_bitmap;
     rowid_t _current_rowid{0};

--- a/be/src/storage/rowset/bitmap_index_reader.h
+++ b/be/src/storage/rowset/bitmap_index_reader.h
@@ -194,6 +194,13 @@ public:
 
     rowid_t bitmap_nums() const { return _num_bitmap; }
 
+    rowid_t ngram_bitmap_nums() const {
+        if (_reader != nullptr) {
+            return _reader->ngram_bitmap_nums();
+        }
+        return 0;
+    }
+
     rowid_t current_ordinal() const { return _current_rowid; }
 
 private:

--- a/be/src/storage/rowset/bitmap_index_writer.cpp
+++ b/be/src/storage/rowset/bitmap_index_writer.cpp
@@ -256,7 +256,7 @@ public:
         if (it != _mem_index.end()) {
             it->second.add(_rid);
             if (it->second.update_estimate_size(&_reverted_index_size)) {
-                _late_update_context_vector.push_back(&(it->second));
+                _late_update_context_vector.push_back(it->second.context());
             }
         } else {
             // new value, copy value and insert new key->bitmap pair
@@ -365,7 +365,7 @@ public:
     uint64_t size() const override {
         uint64_t size = 0;
         size += _null_bitmap.getSizeInBytes(false);
-        for (BitmapUpdateContextRefOrSingleValue* update_context : _late_update_context_vector) {
+        for (BitmapUpdateContext* update_context : _late_update_context_vector) {
             update_context->flush_pending_adds();
             update_context->late_update_size(&_reverted_index_size);
         }
@@ -392,7 +392,7 @@ private:
 
     // roaring bitmap size
     mutable uint64_t _reverted_index_size = 0;
-    mutable std::vector<BitmapUpdateContextRefOrSingleValue*> _late_update_context_vector;
+    mutable std::vector<BitmapUpdateContext*> _late_update_context_vector;
 };
 
 struct BitmapIndexWriterBuilder {

--- a/be/src/storage/rowset/bitmap_index_writer.cpp
+++ b/be/src/storage/rowset/bitmap_index_writer.cpp
@@ -48,7 +48,10 @@
 #include "storage/type_traits.h"
 #include "storage/types.h"
 #include "util/faststring.h"
+#include "util/phmap/btree.h"
+#include "util/phmap/phmap.h"
 #include "util/slice.h"
+#include "util/xxh3.h"
 
 namespace starrocks {
 
@@ -58,8 +61,8 @@ class BitmapUpdateContext {
     static const size_t estimate_size_threshold = 1024;
 
 public:
-    explicit BitmapUpdateContext(rowid_t rid) : _roaring(Roaring::bitmapOf(1, rid)){};
-    explicit BitmapUpdateContext(rowid_t rid0, rowid_t rid1) : _roaring(Roaring::bitmapOfList({rid0, rid1})){};
+    explicit BitmapUpdateContext(rowid_t rid) : _roaring(Roaring::bitmapOf(1, rid)){ _pending_adds.reserve(_ADD_BATCH_SIZE); };
+    explicit BitmapUpdateContext(rowid_t rid0, rowid_t rid1) : _roaring(Roaring::bitmapOfList({rid0, rid1})){ _pending_adds.reserve(_ADD_BATCH_SIZE); };
 
     Roaring* roaring() { return &_roaring; }
 
@@ -73,6 +76,20 @@ public:
 
     static void init_estimate_size(uint64_t* reverted_index_size) {
         *reverted_index_size += BitmapUpdateContext::estimate_size(1);
+    }
+
+    void add_and_flush_if_needed(rowid_t rid) {
+        _pending_adds.push_back(rid);
+        if (_pending_adds.size() >= _ADD_BATCH_SIZE) {
+            flush_pending_adds();
+        }
+    }
+
+    void flush_pending_adds() {
+        if (!_pending_adds.empty()) {
+            _roaring.addMany(_pending_adds.size(), _pending_adds.data());
+            _pending_adds.clear();
+        }
     }
 
     // When _element_count is less than estimate_size_threshold, update the estimate size
@@ -114,6 +131,8 @@ private:
     uint64_t _previous_size{0};
     uint32_t _element_count{1};
     bool _size_changed{false};
+    std::vector<uint32_t> _pending_adds;
+    static const size_t _ADD_BATCH_SIZE = 64;
 };
 
 // if last bit is 0 it is std::unique_ptr<BitmapUpdateContext>
@@ -121,6 +140,16 @@ private:
 class BitmapUpdateContextRefOrSingleValue {
 public:
     BitmapUpdateContextRefOrSingleValue(const BitmapUpdateContextRefOrSingleValue& rhs) = delete;
+    BitmapUpdateContextRefOrSingleValue& operator=(const BitmapUpdateContextRefOrSingleValue& rhs) = delete;
+    BitmapUpdateContextRefOrSingleValue(BitmapUpdateContextRefOrSingleValue&& rhs) noexcept {
+        _value = rhs._value;
+        rhs._value = 1; // make sure not delete when rhs is destroyed
+    }
+    BitmapUpdateContextRefOrSingleValue& operator=(BitmapUpdateContextRefOrSingleValue&& rhs) noexcept {
+        this->_value = rhs._value;
+        rhs._value = 1; // make sure not delete when rhs is destroyed
+        return *this;
+    }
     BitmapUpdateContextRefOrSingleValue(uint32_t value) { _value = (value << 1) | 1; }
     ~BitmapUpdateContextRefOrSingleValue() {
         if (is_context()) {
@@ -134,7 +163,7 @@ public:
     }
     void add(rowid_t rid) {
         if (is_context()) {
-            context()->roaring()->add(rid);
+            context()->add_and_flush_if_needed(rid);
         } else {
             auto* context = new BitmapUpdateContext(value(), rid);
             _value = reinterpret_cast<uint64_t>(context); // NOLINT
@@ -162,18 +191,30 @@ public:
         }
     }
 
+    void flush_pending_adds() {
+        if (is_context()) {
+            context()->flush_pending_adds();
+        }
+    }
+
 private:
     uint64_t _value;
 };
 
+struct BitmapIndexSliceHash {
+    inline size_t operator()(const Slice& v) const { return XXH3_64bits(v.data, v.size); }
+};
+
 template <typename CppType>
 struct BitmapIndexTraits {
-    using MemoryIndexType = std::map<CppType, BitmapUpdateContextRefOrSingleValue>;
+    using UnorderedMemoryIndexType = phmap::flat_hash_map<CppType, BitmapUpdateContextRefOrSingleValue>;
+    using OrderedMemoryIndexType = std::map<CppType, BitmapUpdateContextRefOrSingleValue>;
 };
 
 template <>
 struct BitmapIndexTraits<Slice> {
-    using MemoryIndexType = std::map<Slice, BitmapUpdateContextRefOrSingleValue, Slice::Comparator>;
+    using UnorderedMemoryIndexType = phmap::flat_hash_map<Slice, BitmapUpdateContextRefOrSingleValue, BitmapIndexSliceHash, std::equal_to<Slice>>;
+    using OrderedMemoryIndexType = std::map<Slice, BitmapUpdateContextRefOrSingleValue, Slice::Comparator>;
 };
 
 // Builder for bitmap index. Bitmap index is comprised of two parts
@@ -193,7 +234,8 @@ template <LogicalType field_type>
 class BitmapIndexWriterImpl : public BitmapIndexWriter {
 public:
     using CppType = typename CppTypeTraits<field_type>::CppType;
-    using MemoryIndexType = typename BitmapIndexTraits<CppType>::MemoryIndexType;
+    using UnorderedMemoryIndexType = typename BitmapIndexTraits<CppType>::UnorderedMemoryIndexType;
+    using OrderedMemoryIndexType = typename BitmapIndexTraits<CppType>::OrderedMemoryIndexType;
 
     explicit BitmapIndexWriterImpl(TypeInfoPtr type_info) : _typeinfo(std::move(type_info)) {}
 
@@ -202,22 +244,26 @@ public:
     void add_values(const void* values, size_t count) override {
         auto p = reinterpret_cast<const CppType*>(values);
         for (size_t i = 0; i < count; ++i) {
-            const CppType& value = unaligned_load<CppType>(p);
-            auto it = _mem_index.find(value);
-            if (it != _mem_index.end()) {
-                it->second.add(_rid);
-                if (it->second.update_estimate_size(&_reverted_index_size)) {
-                    _late_update_context_vector.push_back(&(it->second));
-                }
-            } else {
-                // new value, copy value and insert new key->bitmap pair
-                CppType new_value;
-                _typeinfo->deep_copy(&new_value, &value, &_pool);
-                _mem_index.emplace(new_value, _rid);
-                BitmapUpdateContext::init_estimate_size(&_reverted_index_size);
-            }
+            add_value_with_current_rowid(p);
             _rid++;
             p++;
+        }
+    }
+
+    inline void add_value_with_current_rowid(const void* vptr) override {
+        const CppType& value = *(reinterpret_cast<const CppType*>(vptr));
+        auto it = _mem_index.find(value);
+        if (it != _mem_index.end()) {
+            it->second.add(_rid);
+            if (it->second.update_estimate_size(&_reverted_index_size)) {
+                _late_update_context_vector.push_back(&(it->second));
+            }
+        } else {
+            // new value, copy value and insert new key->bitmap pair
+            CppType new_value;
+            _typeinfo->deep_copy(&new_value, &value, &_pool);
+            _mem_index.emplace(new_value, _rid);
+            BitmapUpdateContext::init_estimate_size(&_reverted_index_size);
         }
     }
 
@@ -229,27 +275,36 @@ public:
     Status finish(WritableFile* wfile, ColumnIndexMetaPB* index_meta) override {
         index_meta->set_type(BITMAP_INDEX);
         BitmapIndexPB* meta = index_meta->mutable_bitmap_index();
+        return finish(wfile, meta);
+    }
 
+    Status finish(WritableFile* wfile, BitmapIndexPB* meta) override {
         meta->set_bitmap_type(BitmapIndexPB::ROARING_BITMAP);
         meta->set_has_null(!_null_bitmap.isEmpty());
+
+        OrderedMemoryIndexType ordered_mem_index;
+        for (auto& p : _mem_index) {
+            p.second.flush_pending_adds();
+            ordered_mem_index.insert(std::move(p));
+        }
 
         { // write dictionary
             IndexedColumnWriterOptions options;
             options.write_ordinal_index = false;
             options.write_value_index = true;
             options.encoding = EncodingInfo::get_default_encoding(_typeinfo->type(), true);
-            options.compression = CompressionTypePB::LZ4;
+            options.compression = _dictionary_compression;
 
             IndexedColumnWriter dict_column_writer(options, _typeinfo, wfile);
             RETURN_IF_ERROR(dict_column_writer.init());
-            for (auto const& it : _mem_index) {
+            for (auto const& it : ordered_mem_index) {
                 RETURN_IF_ERROR(dict_column_writer.add(&(it.first)));
             }
             RETURN_IF_ERROR(dict_column_writer.finish(meta->mutable_dict_column()));
         }
         { // write bitmaps
             std::vector<BitmapUpdateContextRefOrSingleValue*> bitmaps;
-            for (auto& it : _mem_index) {
+            for (auto& it : ordered_mem_index) {
                 bitmaps.push_back(&(it.second));
             }
 
@@ -311,6 +366,7 @@ public:
         uint64_t size = 0;
         size += _null_bitmap.getSizeInBytes(false);
         for (BitmapUpdateContextRefOrSingleValue* update_context : _late_update_context_vector) {
+            update_context->flush_pending_adds();
             update_context->late_update_size(&_reverted_index_size);
         }
         _late_update_context_vector.clear();
@@ -320,6 +376,8 @@ public:
         return size;
     }
 
+    inline void incre_rowid() override { _rid++; }
+
 private:
     TypeInfoPtr _typeinfo;
     rowid_t _rid = 0;
@@ -327,7 +385,9 @@ private:
     // row id list for null value
     Roaring _null_bitmap;
     // unique value to its row id list
-    MemoryIndexType _mem_index;
+    // Use UnorderedMemoryIndexType during loading and sort it when finish is more efficient than only
+    // use OrderedMemoryIndexType. Especially for the case of built-in inverted index workload.
+    UnorderedMemoryIndexType _mem_index;
     MemPool _pool;
 
     // roaring bitmap size

--- a/be/src/storage/rowset/bitmap_index_writer.cpp
+++ b/be/src/storage/rowset/bitmap_index_writer.cpp
@@ -183,7 +183,7 @@ public:
     }
 
     bool update_estimate_size(uint64_t* reverted_index_size) {
-        if (context()) {
+        if (is_context()) {
             return context()->update_estimate_size(reverted_index_size);
         } else {
             return false;

--- a/be/src/storage/rowset/bitmap_index_writer.cpp
+++ b/be/src/storage/rowset/bitmap_index_writer.cpp
@@ -307,6 +307,9 @@ public:
                 for (const auto& it : ordered_mem_index) {
                     RETURN_IF_ERROR(_build_ngram(ngram_index, &it.first, offset++));
                 }
+                for (auto& it: ngram_index) {
+                    it.second.flush_pending_adds();
+                }
                 RETURN_IF_ERROR(_write_dictionary(ngram_index, wfile, meta->mutable_ngram_dict_column()));
                 RETURN_IF_ERROR(_write_bitmap(ngram_index, wfile, meta->mutable_ngram_bitmap_column()));
             }

--- a/be/src/storage/rowset/bitmap_index_writer.cpp
+++ b/be/src/storage/rowset/bitmap_index_writer.cpp
@@ -84,6 +84,9 @@ public:
     }
 
     void add_and_flush_if_needed(rowid_t rid) {
+        if (!_pending_adds.empty() && _pending_adds.back() == rid) {
+            return;
+        }
         _pending_adds.push_back(rid);
         if (_pending_adds.size() >= _ADD_BATCH_SIZE) {
             flush_pending_adds();
@@ -170,6 +173,9 @@ public:
         if (is_context()) {
             context()->add_and_flush_if_needed(rid);
         } else {
+            if (value() == rid) {
+                return;
+            }
             auto* context = new BitmapUpdateContext(value(), rid);
             _value = reinterpret_cast<uint64_t>(context); // NOLINT
         }

--- a/be/src/storage/rowset/bitmap_index_writer.cpp
+++ b/be/src/storage/rowset/bitmap_index_writer.cpp
@@ -51,6 +51,7 @@
 #include "util/phmap/btree.h"
 #include "util/phmap/phmap.h"
 #include "util/slice.h"
+#include "util/utf8.h"
 #include "util/xxh3.h"
 
 namespace starrocks {
@@ -61,8 +62,12 @@ class BitmapUpdateContext {
     static const size_t estimate_size_threshold = 1024;
 
 public:
-    explicit BitmapUpdateContext(rowid_t rid) : _roaring(Roaring::bitmapOf(1, rid)){ _pending_adds.reserve(_ADD_BATCH_SIZE); };
-    explicit BitmapUpdateContext(rowid_t rid0, rowid_t rid1) : _roaring(Roaring::bitmapOfList({rid0, rid1})){ _pending_adds.reserve(_ADD_BATCH_SIZE); };
+    explicit BitmapUpdateContext(rowid_t rid) : _roaring(Roaring::bitmapOf(1, rid)) {
+        _pending_adds.reserve(_ADD_BATCH_SIZE);
+    };
+    explicit BitmapUpdateContext(rowid_t rid0, rowid_t rid1) : _roaring(Roaring::bitmapOfList({rid0, rid1})) {
+        _pending_adds.reserve(_ADD_BATCH_SIZE);
+    };
 
     Roaring* roaring() { return &_roaring; }
 
@@ -213,7 +218,8 @@ struct BitmapIndexTraits {
 
 template <>
 struct BitmapIndexTraits<Slice> {
-    using UnorderedMemoryIndexType = phmap::flat_hash_map<Slice, BitmapUpdateContextRefOrSingleValue, BitmapIndexSliceHash, std::equal_to<Slice>>;
+    using UnorderedMemoryIndexType = phmap::flat_hash_map<Slice, BitmapUpdateContextRefOrSingleValue,
+                                                          BitmapIndexSliceHash, std::equal_to<Slice>>;
     using OrderedMemoryIndexType = std::map<Slice, BitmapUpdateContextRefOrSingleValue, Slice::Comparator>;
 };
 
@@ -237,7 +243,8 @@ public:
     using UnorderedMemoryIndexType = typename BitmapIndexTraits<CppType>::UnorderedMemoryIndexType;
     using OrderedMemoryIndexType = typename BitmapIndexTraits<CppType>::OrderedMemoryIndexType;
 
-    explicit BitmapIndexWriterImpl(TypeInfoPtr type_info) : _typeinfo(std::move(type_info)) {}
+    explicit BitmapIndexWriterImpl(TypeInfoPtr type_info, int32_t gram_num)
+            : _gram_num(gram_num), _typeinfo(std::move(type_info)) {}
 
     ~BitmapIndexWriterImpl() override = default;
 
@@ -288,76 +295,21 @@ public:
             ordered_mem_index.insert(std::move(p));
         }
 
-        { // write dictionary
-            IndexedColumnWriterOptions options;
-            options.write_ordinal_index = false;
-            options.write_value_index = true;
-            options.encoding = EncodingInfo::get_default_encoding(_typeinfo->type(), true);
-            options.compression = _dictionary_compression;
+        // write dictionary
+        RETURN_IF_ERROR(_write_dictionary(ordered_mem_index, wfile, meta->mutable_dict_column()));
+        // write bitmap
+        RETURN_IF_ERROR(_write_bitmap(ordered_mem_index, wfile, meta->mutable_bitmap_column()));
 
-            IndexedColumnWriter dict_column_writer(options, _typeinfo, wfile);
-            RETURN_IF_ERROR(dict_column_writer.init());
-            for (auto const& it : ordered_mem_index) {
-                RETURN_IF_ERROR(dict_column_writer.add(&(it.first)));
-            }
-            RETURN_IF_ERROR(dict_column_writer.finish(meta->mutable_dict_column()));
-        }
-        { // write bitmaps
-            std::vector<BitmapUpdateContextRefOrSingleValue*> bitmaps;
-            for (auto& it : ordered_mem_index) {
-                bitmaps.push_back(&(it.second));
-            }
-
-            uint32_t max_bitmap_size = 0;
-            std::vector<uint32_t> bitmap_sizes;
-            for (auto& bitmap : bitmaps) {
-                uint32_t bitmap_size = 0;
-                if (bitmap->is_context()) {
-                    bitmap->context()->roaring()->runOptimize();
-                    bitmap_size = bitmap->context()->roaring()->getSizeInBytes(false);
-                    if (max_bitmap_size < bitmap_size) {
-                        max_bitmap_size = bitmap_size;
-                    }
+        if (_gram_num > 0) {
+            if constexpr (field_type == TYPE_VARCHAR || field_type == TYPE_CHAR) {
+                size_t offset = 0;
+                OrderedMemoryIndexType ngram_index;
+                for (const auto& it : ordered_mem_index) {
+                    RETURN_IF_ERROR(_build_ngram(ngram_index, &it.first, offset++));
                 }
-                bitmap_sizes.push_back(bitmap_size);
+                RETURN_IF_ERROR(_write_dictionary(ngram_index, wfile, meta->mutable_ngram_dict_column()));
+                RETURN_IF_ERROR(_write_bitmap(ngram_index, wfile, meta->mutable_ngram_bitmap_column()));
             }
-
-            TypeInfoPtr bitmap_typeinfo = get_type_info(TYPE_OBJECT);
-
-            IndexedColumnWriterOptions options;
-            options.write_ordinal_index = true;
-            options.write_value_index = false;
-            options.encoding = EncodingInfo::get_default_encoding(bitmap_typeinfo->type(), false);
-            // we already store compressed bitmap, use NO_COMPRESSION to save some cpu
-            options.compression = NO_COMPRESSION;
-
-            IndexedColumnWriter bitmap_column_writer(options, bitmap_typeinfo, wfile);
-            RETURN_IF_ERROR(bitmap_column_writer.init());
-
-            faststring buf;
-            buf.reserve(max_bitmap_size);
-            for (size_t i = 0; i < bitmaps.size(); ++i) {
-                if (bitmaps[i]->is_context()) {
-                    buf.resize(bitmap_sizes[i]); // so that buf[0..size) can be read and written
-                    bitmaps[i]->context()->roaring()->write(reinterpret_cast<char*>(buf.data()), false);
-                } else {
-                    Roaring roar({bitmaps[i]->value()});
-                    roar.runOptimize();
-                    auto sz = roar.getSizeInBytes(false);
-                    buf.resize(sz);
-                    roar.write(reinterpret_cast<char*>(buf.data()), false);
-                }
-                Slice buf_slice(buf);
-                RETURN_IF_ERROR(bitmap_column_writer.add(&buf_slice));
-            }
-            if (!_null_bitmap.isEmpty()) {
-                _null_bitmap.runOptimize();
-                buf.resize(_null_bitmap.getSizeInBytes(false)); // so that buf[0..size) can be read and written
-                _null_bitmap.write(reinterpret_cast<char*>(buf.data()), false);
-                Slice buf_slice(buf);
-                RETURN_IF_ERROR(bitmap_column_writer.add(&buf_slice));
-            }
-            RETURN_IF_ERROR(bitmap_column_writer.finish(meta->mutable_bitmap_column()));
         }
         return Status::OK();
     }
@@ -379,6 +331,110 @@ public:
     inline void incre_rowid() override { _rid++; }
 
 private:
+    Status _build_ngram(OrderedMemoryIndexType& ngram_index, const Slice* cur_slice, const size_t offset) {
+        if (_gram_num <= 0) {
+            return Status::InvalidArgument(
+                    "Invalid gram num while building ngram index for inverted index dictionary.");
+        }
+
+        std::vector<size_t> index;
+        const size_t slice_gram_num = get_utf8_index(*cur_slice, &index);
+
+        for (size_t j = 0; j + _gram_num <= slice_gram_num; ++j) {
+            // find next ngram
+            size_t cur_ngram_length =
+                    j + _gram_num < slice_gram_num ? index[j + _gram_num] - index[j] : cur_slice->get_size() - index[j];
+            Slice cur_ngram(cur_slice->data + index[j], cur_ngram_length);
+
+            // add this ngram into set
+            auto it = ngram_index.find(cur_ngram);
+            if (it == ngram_index.end()) {
+                CppType new_value;
+                _typeinfo->deep_copy(&new_value, &cur_ngram, &_pool);
+                ngram_index.emplace(new_value, offset);
+            } else {
+                it->second.add(offset);
+            }
+        }
+        return Status::OK();
+    }
+
+    Status _write_dictionary(OrderedMemoryIndexType& ordered_mem_index, WritableFile* wfile,
+                             IndexedColumnMetaPB* meta) {
+        IndexedColumnWriterOptions options;
+        options.write_ordinal_index = true;
+        options.write_value_index = true;
+        options.encoding = EncodingInfo::get_default_encoding(_typeinfo->type(), true);
+        options.compression = _dictionary_compression;
+
+        IndexedColumnWriter dict_column_writer(options, _typeinfo, wfile);
+        RETURN_IF_ERROR(dict_column_writer.init());
+        for (auto const& it : ordered_mem_index) {
+            RETURN_IF_ERROR(dict_column_writer.add(&(it.first)));
+        }
+        return dict_column_writer.finish(meta);
+    }
+
+    Status _write_bitmap(OrderedMemoryIndexType& ordered_mem_index, WritableFile* wfile, IndexedColumnMetaPB* meta) {
+        std::vector<BitmapUpdateContextRefOrSingleValue*> bitmaps;
+        for (auto& it : ordered_mem_index) {
+            bitmaps.push_back(&(it.second));
+        }
+
+        uint32_t max_bitmap_size = 0;
+        std::vector<uint32_t> bitmap_sizes;
+        for (auto& bitmap : bitmaps) {
+            uint32_t bitmap_size = 0;
+            if (bitmap->is_context()) {
+                bitmap->context()->roaring()->runOptimize();
+                bitmap_size = bitmap->context()->roaring()->getSizeInBytes(false);
+                if (max_bitmap_size < bitmap_size) {
+                    max_bitmap_size = bitmap_size;
+                }
+            }
+            bitmap_sizes.push_back(bitmap_size);
+        }
+
+        TypeInfoPtr bitmap_typeinfo = get_type_info(TYPE_OBJECT);
+
+        IndexedColumnWriterOptions options;
+        options.write_ordinal_index = true;
+        options.write_value_index = false;
+        options.encoding = EncodingInfo::get_default_encoding(bitmap_typeinfo->type(), false);
+        // we already store compressed bitmap, use NO_COMPRESSION to save some cpu
+        options.compression = NO_COMPRESSION;
+
+        IndexedColumnWriter bitmap_column_writer(options, bitmap_typeinfo, wfile);
+        RETURN_IF_ERROR(bitmap_column_writer.init());
+
+        faststring buf;
+        buf.reserve(max_bitmap_size);
+        for (size_t i = 0; i < bitmaps.size(); ++i) {
+            if (bitmaps[i]->is_context()) {
+                buf.resize(bitmap_sizes[i]); // so that buf[0..size) can be read and written
+                bitmaps[i]->context()->roaring()->write(reinterpret_cast<char*>(buf.data()), false);
+            } else {
+                Roaring roar({bitmaps[i]->value()});
+                roar.runOptimize();
+                auto sz = roar.getSizeInBytes(false);
+                buf.resize(sz);
+                roar.write(reinterpret_cast<char*>(buf.data()), false);
+            }
+            Slice buf_slice(buf);
+            RETURN_IF_ERROR(bitmap_column_writer.add(&buf_slice));
+        }
+        if (!_null_bitmap.isEmpty()) {
+            _null_bitmap.runOptimize();
+            buf.resize(_null_bitmap.getSizeInBytes(false)); // so that buf[0..size) can be read and written
+            _null_bitmap.write(reinterpret_cast<char*>(buf.data()), false);
+            Slice buf_slice(buf);
+            RETURN_IF_ERROR(bitmap_column_writer.add(&buf_slice));
+        }
+        return bitmap_column_writer.finish(meta);
+    }
+
+    int32_t _gram_num;
+
     TypeInfoPtr _typeinfo;
     rowid_t _rid = 0;
 
@@ -397,14 +453,15 @@ private:
 
 struct BitmapIndexWriterBuilder {
     template <LogicalType ftype>
-    std::unique_ptr<BitmapIndexWriter> operator()(const TypeInfoPtr& typeinfo) {
-        return std::make_unique<BitmapIndexWriterImpl<ftype>>(typeinfo);
+    std::unique_ptr<BitmapIndexWriter> operator()(const TypeInfoPtr& typeinfo, int32_t gram_num) {
+        return std::make_unique<BitmapIndexWriterImpl<ftype>>(typeinfo, gram_num);
     }
 };
 
-Status BitmapIndexWriter::create(const TypeInfoPtr& typeinfo, std::unique_ptr<BitmapIndexWriter>* res) {
+Status BitmapIndexWriter::create(const TypeInfoPtr& typeinfo, std::unique_ptr<BitmapIndexWriter>* res,
+                                 int32_t gram_num) {
     LogicalType type = typeinfo->type();
-    *res = field_type_dispatch_bitmap_index(type, BitmapIndexWriterBuilder(), typeinfo);
+    *res = field_type_dispatch_bitmap_index(type, BitmapIndexWriterBuilder(), typeinfo, gram_num);
 
     return Status::OK();
 }

--- a/be/src/storage/rowset/bitmap_index_writer.cpp
+++ b/be/src/storage/rowset/bitmap_index_writer.cpp
@@ -309,8 +309,9 @@ public:
             if constexpr (field_type == TYPE_VARCHAR || field_type == TYPE_CHAR) {
                 size_t offset = 0;
                 UnorderedMemoryIndexType ngram_index;
+                std::vector<size_t> index_buffer; // use for ngram index calculation
                 for (const auto& dict : sorted_dicts) {
-                    RETURN_IF_ERROR(_build_ngram(ngram_index, &dict, offset++));
+                    RETURN_IF_ERROR(_build_ngram(ngram_index, &dict, offset++, index_buffer));
                 }
 
                 for (auto& it : ngram_index) {
@@ -349,13 +350,17 @@ public:
     inline void incre_rowid() override { _rid++; }
 
 private:
-    Status _build_ngram(UnorderedMemoryIndexType& ngram_index, const Slice* cur_slice, const size_t offset) {
+    Status _build_ngram(UnorderedMemoryIndexType& ngram_index, const Slice* cur_slice, const size_t offset,
+                        std::vector<size_t>& index) {
         if (_gram_num <= 0) {
             return Status::InvalidArgument(
                     "Invalid gram num while building ngram index for inverted index dictionary.");
         }
 
-        std::vector<size_t> index;
+        index.clear();
+        if (index.capacity() < cur_slice->get_size()) {
+            index.reserve(cur_slice->get_size());
+        }
         const size_t slice_gram_num = get_utf8_index(*cur_slice, &index);
 
         for (size_t j = 0; j + _gram_num <= slice_gram_num; ++j) {
@@ -364,14 +369,13 @@ private:
                     j + _gram_num < slice_gram_num ? index[j + _gram_num] - index[j] : cur_slice->get_size() - index[j];
             Slice cur_ngram(cur_slice->data + index[j], cur_ngram_length);
 
-            // add this ngram into set
-            auto it = ngram_index.find(cur_ngram);
-            if (it == ngram_index.end()) {
-                CppType new_value;
-                _typeinfo->deep_copy(&new_value, &cur_ngram, &_pool);
-                ngram_index.emplace(new_value, offset);
-            } else {
-                it->second.add(offset);
+            // Use Slice pointing into dictionary memory as key; dictionary values are already deep-copied
+            // into `_pool` when building `_mem_index`, so this Slice remains valid for the lifetime of
+            // the bitmap index writer. This avoids an extra deep copy per distinct ngram.
+            auto [it, inserted] =
+                    ngram_index.try_emplace(cur_ngram, static_cast<uint32_t>(offset));
+            if (!inserted) {
+                it->second.add(static_cast<uint32_t>(offset));
             }
         }
         return Status::OK();
@@ -395,6 +399,7 @@ private:
     Status _write_bitmap(UnorderedMemoryIndexType& ordered_mem_index, const std::vector<CppType>& sorted_dicts,
                          WritableFile* wfile, IndexedColumnMetaPB* meta) {
         std::vector<BitmapUpdateContextRefOrSingleValue*> bitmaps;
+        bitmaps.reserve(sorted_dicts.size());
         for (const auto& dict : sorted_dicts) {
             auto it = ordered_mem_index.find(dict);
             if (it == ordered_mem_index.end()) {
@@ -406,6 +411,7 @@ private:
 
         uint32_t max_bitmap_size = 0;
         std::vector<uint32_t> bitmap_sizes;
+        bitmap_sizes.reserve(bitmaps.size());
         for (auto& bitmap : bitmaps) {
             uint32_t bitmap_size = 0;
             if (bitmap->is_context()) {

--- a/be/src/storage/rowset/bitmap_index_writer.h
+++ b/be/src/storage/rowset/bitmap_index_writer.h
@@ -55,15 +55,26 @@ public:
     BitmapIndexWriter() = default;
     virtual ~BitmapIndexWriter() = default;
 
+    virtual void add_value_with_current_rowid(const void* vptr) = 0;
+
     virtual void add_values(const void* values, size_t count) = 0;
 
     virtual void add_nulls(uint32_t count) = 0;
 
     virtual Status finish(WritableFile* file, ColumnIndexMetaPB* index_meta) = 0;
+    virtual Status finish(WritableFile* file, BitmapIndexPB* meta) = 0;
 
     virtual uint64_t size() const = 0;
 
+    virtual void incre_rowid() = 0;
+
+    void set_dictionary_compression(CompressionTypePB compression) { _dictionary_compression = compression; }
+
+protected:
+    CompressionTypePB _dictionary_compression = LZ4;
+
 private:
+
     BitmapIndexWriter(const BitmapIndexWriter&) = delete;
     const BitmapIndexWriter& operator=(const BitmapIndexWriter&) = delete;
 };

--- a/be/src/storage/rowset/bitmap_index_writer.h
+++ b/be/src/storage/rowset/bitmap_index_writer.h
@@ -50,7 +50,7 @@ class WritableFile;
 
 class BitmapIndexWriter {
 public:
-    static Status create(const TypeInfoPtr& type_info, std::unique_ptr<BitmapIndexWriter>* res);
+    static Status create(const TypeInfoPtr& type_info, std::unique_ptr<BitmapIndexWriter>* res, int32_t gram_num = -1);
 
     BitmapIndexWriter() = default;
     virtual ~BitmapIndexWriter() = default;

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -119,6 +119,9 @@ ColumnReader::~ColumnReader() {
                                  _bloom_filter_index_meta->SpaceUsedLong());
         _bloom_filter_index_meta.reset(nullptr);
     }
+    if (_builtin_inverted_index_meta != nullptr) {
+        _builtin_inverted_index_meta.reset(nullptr);
+    }
     MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->column_metadata_mem_tracker(), sizeof(ColumnReader));
 }
 
@@ -201,6 +204,9 @@ Status ColumnReader::_init(ColumnMetaPB* meta, const TabletColumn* column) {
                                          _bloom_filter_index_meta->SpaceUsedLong());
                 _meta_mem_usage.fetch_add(_bloom_filter_index_meta->SpaceUsedLong(), std::memory_order_relaxed);
                 _bloom_filter_index = std::make_unique<BloomFilterIndexReader>();
+                break;
+            case BUILTIN_INVERTED_INDEX:
+                _builtin_inverted_index_meta.reset(index_meta->release_builtin_inverted_index());
                 break;
             case UNKNOWN_INDEX_TYPE:
                 return Status::Corruption(fmt::format("Bad file {}: unknown index type", file_name()));
@@ -531,16 +537,16 @@ Status ColumnReader::_load_bloom_filter_index(const IndexReadOptions& opts) {
 }
 
 Status ColumnReader::new_inverted_index_iterator(const std::shared_ptr<TabletIndex>& index_meta,
-                                                 InvertedIndexIterator** iterator, const SegmentReadOptions& opts) {
-    RETURN_IF_ERROR(_load_inverted_index(index_meta, opts));
-    RETURN_IF_ERROR(_inverted_index->new_iterator(index_meta, iterator));
+                                                 InvertedIndexIterator** iterator, const SegmentReadOptions& opts,
+                                                 const IndexReadOptions& index_opt) {
+    RETURN_IF_ERROR(_load_inverted_index(index_meta, opts, index_opt));
+    RETURN_IF_ERROR(_inverted_index->new_iterator(index_meta, iterator, index_opt));
     return Status::OK();
 }
 
 Status ColumnReader::_load_inverted_index(const std::shared_ptr<TabletIndex>& index_meta,
-                                          const SegmentReadOptions& opts) {
-    if (_inverted_index && index_meta && _inverted_index->get_index_id() == index_meta->index_id() &&
-        _inverted_index_loaded()) {
+                                          const SegmentReadOptions& opts, const IndexReadOptions& index_opt) {
+    if (index_meta == nullptr || _inverted_index_loaded()) {
         return Status::OK();
     }
 
@@ -562,7 +568,10 @@ Status ColumnReader::_load_inverted_index(const std::shared_ptr<TabletIndex>& in
                             ASSIGN_OR_RETURN(auto inverted_plugin, InvertedPluginFactory::get_plugin(imp_type));
                             RETURN_IF_ERROR(inverted_plugin->create_inverted_index_reader(index_path, index_meta, type,
                                                                                           &_inverted_index));
-
+                            RETURN_IF_ERROR(_inverted_index->load(index_opt, _builtin_inverted_index_meta.get()));
+                            if (_builtin_inverted_index_meta != nullptr) {
+                                _builtin_inverted_index_meta.reset();
+                            }
                             return Status::OK();
                         })
             .status();

--- a/be/src/storage/rowset/column_reader.h
+++ b/be/src/storage/rowset/column_reader.h
@@ -188,7 +188,7 @@ public:
     Status load_ordinal_index(const IndexReadOptions& opts);
 
     Status new_inverted_index_iterator(const std::shared_ptr<TabletIndex>& index_meta, InvertedIndexIterator** iterator,
-                                       const SegmentReadOptions& opts);
+                                       const SegmentReadOptions& opts, const IndexReadOptions& index_opt);
 
     uint32_t num_rows() const { return _segment->num_rows(); }
 
@@ -241,7 +241,8 @@ private:
                             std::unordered_set<uint32_t>* del_partial_filtered_pages, std::vector<uint32_t>* pages,
                             const Range<>* src_range);
 
-    Status _load_inverted_index(const std::shared_ptr<TabletIndex>& index_meta, const SegmentReadOptions& opts);
+    Status _load_inverted_index(const std::shared_ptr<TabletIndex>& index_meta, const SegmentReadOptions& opts,
+                                const IndexReadOptions& index_opt);
 
     NgramBloomFilterReaderOptions _get_reader_options_for_ngram() const;
 
@@ -269,6 +270,7 @@ private:
     std::unique_ptr<OrdinalIndexPB> _ordinal_index_meta;
     std::unique_ptr<BitmapIndexPB> _bitmap_index_meta;
     std::unique_ptr<BloomFilterIndexPB> _bloom_filter_index_meta;
+    std::unique_ptr<BuiltinInvertedIndexPB> _builtin_inverted_index_meta;
 
     std::unique_ptr<ZoneMapIndexReader> _zonemap_index;
     std::unique_ptr<OrdinalIndexReader> _ordinal_index;

--- a/be/src/storage/rowset/column_writer.cpp
+++ b/be/src/storage/rowset/column_writer.cpp
@@ -577,7 +577,7 @@ Status ScalarColumnWriter::write_bloom_filter_index() {
 Status ScalarColumnWriter::write_inverted_index() {
 #ifndef __APPLE__
     if (_inverted_index_builder != nullptr) {
-        return _inverted_index_builder->finish();
+        return _inverted_index_builder->finish(_wfile, _opts.meta);
     }
 #endif
     return Status::OK();

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -348,14 +348,15 @@ StatusOr<ChunkIteratorPtr> Segment::new_iterator(const Schema& schema, const Seg
 }
 
 Status Segment::new_inverted_index_iterator(uint32_t ucid, InvertedIndexIterator** iter,
-                                            const SegmentReadOptions& opts) {
+                                            const SegmentReadOptions& opts, const IndexReadOptions& index_opt) {
     auto column_reader_iter = _column_readers.find(ucid);
 
     if (column_reader_iter != _column_readers.end()) {
         std::shared_ptr<TabletIndex> index_meta;
         RETURN_IF_ERROR(_tablet_schema->get_indexes_for_column(ucid, GIN, index_meta));
         if (index_meta.get() != nullptr) {
-            return column_reader_iter->second->new_inverted_index_iterator(index_meta, iter, std::move(opts));
+            return column_reader_iter->second->new_inverted_index_iterator(index_meta, iter, std::move(opts),
+                                                                           index_opt);
         }
     }
     return Status::OK();

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -200,7 +200,8 @@ public:
     Status load_index(const LakeIOOptions& lake_io_opts = {});
     bool has_loaded_index() const;
 
-    Status new_inverted_index_iterator(uint32_t cid, InvertedIndexIterator** iter, const SegmentReadOptions& opts);
+    Status new_inverted_index_iterator(uint32_t cid, InvertedIndexIterator** iter, const SegmentReadOptions& opts,
+                                       const IndexReadOptions& index_opt);
 
     const ShortKeyIndexDecoder* decoder() const { return _sk_index_decoder.get(); }
 

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2459,9 +2459,16 @@ Status SegmentIterator::_init_inverted_index_iterators() {
         ColumnId cid = pair.first;
         ColumnUID ucid = cid_2_ucid[cid];
 
+        IndexReadOptions index_opts;
+        index_opts.use_page_cache = !_opts.temporary_data && _opts.use_page_cache &&
+                                    !config::disable_storage_page_cache;
+        index_opts.lake_io_opts = _opts.lake_io_opts;
+        index_opts.read_file = _column_files[cid].get();
+        index_opts.stats = _opts.stats;
+
         if (_inverted_index_ctx->inverted_index_iterators[cid] == nullptr) {
             RETURN_IF_ERROR(_segment->new_inverted_index_iterator(
-                    ucid, &_inverted_index_ctx->inverted_index_iterators[cid], _opts));
+                    ucid, &_inverted_index_ctx->inverted_index_iterators[cid], _opts, index_opts));
             _inverted_index_ctx->has_inverted_index |= (_inverted_index_ctx->inverted_index_iterators[cid] != nullptr);
         }
     }
@@ -2525,6 +2532,12 @@ Status SegmentIterator::_apply_inverted_index() {
                 // inverted index filtering.These columns may can be pruned.
                 _inverted_index_ctx->prune_cols_candidate_by_inverted_index.insert(cid);
             }
+        }
+    }
+
+    for (auto* iter : _inverted_index_ctx->inverted_index_iterators) {
+        if (iter != nullptr) {
+            RETURN_IF_ERROR(iter->close());
         }
     }
 

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2512,6 +2512,9 @@ Status SegmentIterator::_apply_inverted_index() {
                 if (res.ok()) {
                     erased_preds.emplace(pred);
                     erased_pred_col_ids.emplace(cid);
+                } else {
+                    LOG(WARNING) << "Failed to seek inverted index for column " << column_name
+                                 << ", reason: " << res.detailed_message();
                 }
             }
         }

--- a/be/src/util/slice.h
+++ b/be/src/util/slice.h
@@ -186,6 +186,82 @@ public:
         return ((size >= x.size) && memequal(data + (size - x.size), x.size, x.data, x.size));
     }
 
+    /**
+     * find character position in this slice.
+     * @param c character need to find in slice
+     * @param offset start position
+     * @return position if found, otherwise -1
+     */
+    int64_t find(const char c, const int64_t offset = 0) const {
+        int64_t pos = offset;
+        while (0 <= pos && pos < size && data[pos] != c) ++pos;
+        if (pos < 0 || pos >= size) return -1;
+        return pos;
+    }
+
+    /**
+     * build next array for KMP algorithm
+     * @return next array
+     */
+    std::vector<size_t> build_next() const {
+        if (size <= 0) return {};
+
+        std::vector<size_t> next(size);
+
+        next[0] = 0;
+        size_t i = 1;
+        size_t j = 0;
+
+        while (i < size) {
+            if (data[i] == data[j]) {
+                next[i++] = ++j;
+            } else {
+                if (j != 0) {
+                    j = next[j - 1];
+                } else {
+                    next[i++] = 0;
+                }
+            }
+        }
+        return next;
+    }
+
+    /**
+     * find sub slice in this slice by KMP algorithm
+     * @param pattern pattern need to find in slice
+     * @param next next array build by pattern.build_next
+     * @param offset start position
+     * @return position if found, otherwise -1
+     */
+    int64_t find(const Slice& pattern, const std::vector<size_t>& next, const int64_t offset = 0) const {
+        if (pattern.size <= 0 || pattern.size > size) return -1;
+        if (offset < 0 || offset > size) return -1;
+        if (next.size() != pattern.size) return -1;
+
+        int64_t pos = offset;
+        int64_t j = 0;
+
+        while (pos < size) {
+            if (data[pos] == pattern[j]) {
+                ++pos;
+                ++j;
+            }
+
+            if (j == pattern.size) {
+                return pos - j;
+            }
+
+            if (pos < size && data[pos] != pattern[j]) {
+                if (j != 0) {
+                    j = next[j - 1];
+                } else {
+                    ++pos;
+                }
+            }
+        }
+        return -1;
+    }
+
     Slice tolower(std::string& buf) {
         // copy this slice into buf
         buf.assign(get_data(), get_size());

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -414,6 +414,7 @@ set(EXEC_FILES
         ./util/byte_stream_split_test.cpp
         ./util/url_coding_test.cpp
         ./util/url_parser_test.cpp
+        ./util/slice_test.cpp
         ./gutil/cpu_test.cc
         ./gutil/sysinfo-test.cc
         service/backend_base_test.cpp

--- a/be/test/storage/rowset/binary_prefix_page_test.cpp
+++ b/be/test/storage/rowset/binary_prefix_page_test.cpp
@@ -191,35 +191,4 @@ TEST_F(BinaryPrefixPageTest, TestVectorized) {
     test_vectorized();
 }
 
-TEST_F(BinaryPrefixPageTest, TestFindNonExistentValue) {
-    std::vector<std::string> test_data;
-    test_data.emplace_back("bc");
-    test_data.emplace_back("cd");
-    std::vector<Slice> slices;
-    for (auto& i : test_data) {
-        Slice s(i);
-        slices.emplace_back(s);
-    }
-    // encode
-    PageBuilderOptions options;
-    BinaryPrefixPageBuilder page_builder(options);
-
-    size_t count = slices.size();
-    const Slice* ptr = &slices[0];
-    count = page_builder.add(reinterpret_cast<const uint8_t*>(ptr), count);
-    ASSERT_EQ(2, count);
-
-    OwnedSlice dict_slice = page_builder.finish()->build();
-    auto page_decoder = std::make_unique<BinaryPrefixPageDecoder<TYPE_VARCHAR>>(dict_slice.slice());
-    Status ret = page_decoder->init();
-    ASSERT_TRUE(ret.ok());
-
-    Slice slice("e");
-    bool exact_match;
-    ret = page_decoder->seek_at_or_after_value(&slice, &exact_match);
-    ASSERT_FALSE(ret.ok());
-    ASSERT_TRUE(ret.is_not_found());
-    ASSERT_FALSE(exact_match);
-}
-
 } // namespace starrocks

--- a/be/test/storage/rowset/binary_prefix_page_test.cpp
+++ b/be/test/storage/rowset/binary_prefix_page_test.cpp
@@ -191,4 +191,35 @@ TEST_F(BinaryPrefixPageTest, TestVectorized) {
     test_vectorized();
 }
 
+TEST_F(BinaryPrefixPageTest, TestFindNonExistentValue) {
+    std::vector<std::string> test_data;
+    test_data.emplace_back("bc");
+    test_data.emplace_back("cd");
+    std::vector<Slice> slices;
+    for (auto& i : test_data) {
+        Slice s(i);
+        slices.emplace_back(s);
+    }
+    // encode
+    PageBuilderOptions options;
+    BinaryPrefixPageBuilder page_builder(options);
+
+    size_t count = slices.size();
+    const Slice* ptr = &slices[0];
+    count = page_builder.add(reinterpret_cast<const uint8_t*>(ptr), count);
+    ASSERT_EQ(2, count);
+
+    OwnedSlice dict_slice = page_builder.finish()->build();
+    auto page_decoder = std::make_unique<BinaryPrefixPageDecoder<TYPE_VARCHAR>>(dict_slice.slice());
+    Status ret = page_decoder->init();
+    ASSERT_TRUE(ret.ok());
+
+    Slice slice("e");
+    bool exact_match;
+    ret = page_decoder->seek_at_or_after_value(&slice, &exact_match);
+    ASSERT_FALSE(ret.ok());
+    ASSERT_TRUE(ret.is_not_found());
+    ASSERT_FALSE(exact_match);
+}
+
 } // namespace starrocks

--- a/be/test/storage/rowset/bitmap_index_test.cpp
+++ b/be/test/storage/rowset/bitmap_index_test.cpp
@@ -37,15 +37,18 @@
 #include <string>
 #include <thread>
 
+#include "column/column_viewer.h"
 #include "fs/fs_memory.h"
 #include "runtime/mem_pool.h"
 #include "runtime/mem_tracker.h"
+#include "storage/chunk_helper.h"
 #include "storage/key_coder.h"
 #include "storage/olap_common.h"
 #include "storage/rowset/bitmap_index_reader.h"
 #include "storage/rowset/bitmap_index_writer.h"
 #include "storage/types.h"
 #include "testutil/assert.h"
+#include "util/utf8.h"
 
 namespace starrocks {
 
@@ -66,9 +69,9 @@ protected:
     void TearDown() override {}
 
     void get_bitmap_reader_iter(RandomAccessFile* rfile, const ColumnIndexMetaPB& meta, BitmapIndexReader** reader,
-                                BitmapIndexIterator** iter) {
+                                BitmapIndexIterator** iter, int32_t gram_num = -1) {
         _opts.read_file = rfile;
-        *reader = new BitmapIndexReader();
+        *reader = new BitmapIndexReader(gram_num);
         ASSIGN_OR_ABORT(auto r, (*reader)->load(_opts, meta.bitmap_index()));
         ASSERT_TRUE(r);
         ASSERT_OK((*reader)->new_iterator(_opts, iter));
@@ -89,6 +92,23 @@ protected:
             ASSERT_EQ(BITMAP_INDEX, meta->type());
             ASSERT_TRUE(wfile->close().ok());
         }
+    }
+
+    void write_index_file_use_by_gin(const int32_t gram_num, const std::string& filename,
+                                     const std::vector<std::string>& values, ColumnIndexMetaPB* meta) const {
+        const TypeInfoPtr type_info = get_type_info(TYPE_VARCHAR);
+        ASSIGN_OR_ABORT(const auto wfile, _fs->new_writable_file(filename));
+
+        std::unique_ptr<BitmapIndexWriter> writer;
+        BitmapIndexWriter::create(type_info, &writer, gram_num);
+
+        for (size_t i = 0; i < values.size(); ++i) {
+            Slice tmp(values[i]);
+            writer->add_value_with_current_rowid(&tmp);
+        }
+        ASSERT_TRUE(writer->finish(wfile.get(), meta).ok());
+        ASSERT_EQ(BITMAP_INDEX, meta->type());
+        ASSERT_TRUE(wfile->close().ok());
     }
 
     std::shared_ptr<MemoryFileSystem> _fs = nullptr;
@@ -291,6 +311,75 @@ TEST_F(BitmapIndexTest, test_concurrent_load) {
 
     delete iter;
     delete[] val;
+}
+
+TEST_F(BitmapIndexTest, test_dict_ngram_index) {
+    constexpr int32_t num_keywords = 10;
+    constexpr int32_t gram_num = 3;
+
+    std::set<std::string> ngram;
+    std::vector<std::string> keywords;
+    for (int i = 0; i < num_keywords; ++i) {
+        // slice should be one of hel,ell,llo,low,wor,orl,rld,ld ,d {0,...,9}
+        const std::string keyword = "hello, world " + std::to_string(i);
+
+        std::vector<size_t> index;
+        Slice cur_slice(keyword);
+        const size_t slice_gram_num = get_utf8_index(cur_slice, &index);
+
+        for (size_t j = 0; j + gram_num <= slice_gram_num; ++j) {
+            // find next ngram
+            size_t cur_ngram_length =
+                    j + gram_num < slice_gram_num ? index[j + gram_num] - index[j] : cur_slice.get_size() - index[j];
+            Slice cur_ngram(cur_slice.data + index[j], cur_ngram_length);
+            ngram.emplace(cur_ngram.to_string());
+        }
+
+        keywords.emplace_back(keyword);
+    }
+
+    std::string file_name = kTestDir + "/dict_ngram_index";
+    ColumnIndexMetaPB meta;
+    write_index_file_use_by_gin(3, file_name, keywords, &meta);
+
+    {
+        BitmapIndexReader* reader = nullptr;
+        BitmapIndexIterator* iter = nullptr;
+        ASSIGN_OR_ABORT(const auto rfile, _fs->new_random_access_file(file_name));
+        get_bitmap_reader_iter(rfile.get(), meta, &reader, &iter, 3);
+
+        const size_t dict_num = reader->bitmap_nums();
+        ASSERT_EQ(dict_num, num_keywords);
+
+        size_t to_read = dict_num;
+        const auto col = ChunkHelper::column_from_field_type(TYPE_VARCHAR, false);
+        ASSERT_TRUE(iter->next_batch_ngram(0, &to_read, col.get()).ok());
+        ASSERT_EQ(dict_num, to_read);
+
+        ColumnViewer<TYPE_VARCHAR> viewer(std::move(col));
+        ASSERT_EQ(ngram.size(), viewer.size());
+
+        auto it = ngram.begin();
+        for (int i = 0; i < viewer.size(); ++i) {
+            auto value = viewer.value(i);
+            ASSERT_EQ(*it, value.to_string());
+            ++it;
+        }
+
+        ASSERT_EQ(ngram.size(), reader->ngram_bitmap_nums());
+        for (rowid_t i = 0; i < ngram.size(); ++i) {
+            roaring::Roaring result;
+            ASSERT_TRUE(iter->read_ngram_bitmap(i, &result).ok());
+            if (i < num_keywords) {
+                ASSERT_EQ(1, result.cardinality());
+                ASSERT_EQ(i, result.minimum());
+            } else {
+                ASSERT_EQ(num_keywords, result.cardinality());
+                ASSERT_EQ(0, result.minimum());
+                ASSERT_EQ(num_keywords - 1, result.maximum());
+            }
+        }
+    }
 }
 
 } // namespace starrocks

--- a/be/test/util/slice_test.cpp
+++ b/be/test/util/slice_test.cpp
@@ -1,0 +1,251 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "util/slice.h"
+
+#include <gtest/gtest.h>
+
+namespace starrocks {
+
+class SliceTest : public testing::Test {};
+
+TEST_F(SliceTest, testFindChar) {
+    std::string text("ABCABABCDABCDABD");
+    const Slice slice(text);
+
+    int64_t last_match = 0, cur_match = 0;
+    while (true) {
+        cur_match = text.find('A', last_match);
+        EXPECT_EQ(cur_match, slice.find('A', last_match));
+
+        if (cur_match == -1) break;
+        last_match = cur_match + 1;
+    }
+}
+
+TEST_F(SliceTest, testFindCharEdgeCases) {
+    // Empty slice
+    std::string empty_text("");
+    Slice empty_slice(empty_text);
+    EXPECT_EQ(-1, empty_slice.find('A'));
+
+    // Single character slice - found
+    std::string single_char_text("A");
+    Slice single_char_found(single_char_text);
+    EXPECT_EQ(0, single_char_found.find('A'));
+
+    // Single character slice - not found
+    std::string single_char_not_found_text("B");
+    Slice single_char_not_found(single_char_not_found_text);
+    EXPECT_EQ(-1, single_char_not_found.find('A'));
+
+    // Find with offset
+    std::string muilti_char_text("AAABBBAAA");
+    Slice multi_char(muilti_char_text);
+    EXPECT_EQ(0, multi_char.find('A', 0));  // First A
+    EXPECT_EQ(1, multi_char.find('A', 1));  // Second A
+    EXPECT_EQ(2, multi_char.find('A', 2));  // Third A
+    EXPECT_EQ(3, multi_char.find('B', 3));  // First B
+    EXPECT_EQ(-1, multi_char.find('A', 10)); // Offset beyond size
+    EXPECT_EQ(-1, multi_char.find('X'));     // Character not present
+
+    // Negative offset
+    EXPECT_EQ(-1, multi_char.find('A', -1)); // Should start from 0
+}
+
+TEST_F(SliceTest, testBuildNext) {
+    // Simple case
+    std::string pattern1_text("ABABC");
+    Slice pattern1(pattern1_text);
+    auto next1 = pattern1.build_next();
+    std::vector<size_t> expected1 = {0, 0, 1, 2, 0};
+    EXPECT_EQ(expected1, next1);
+
+    // All same characters
+    std::string pattern2_text("AAAA");
+    Slice pattern2(pattern2_text);
+    auto next2 = pattern2.build_next();
+    std::vector<size_t> expected2 = {0, 1, 2, 3};
+    EXPECT_EQ(expected2, next2);
+
+    // No repetition
+    std::string pattern3_text("ABCD");
+    Slice pattern3(pattern3_text);
+    auto next3 = pattern3.build_next();
+    std::vector<size_t> expected3 = {0, 0, 0, 0};
+    EXPECT_EQ(expected3, next3);
+
+    // Empty slice
+    Slice pattern4("");
+    auto next4 = pattern4.build_next();
+    EXPECT_TRUE(next4.empty());
+}
+
+TEST_F(SliceTest, testFindSlice) {
+    std::string s_text("ABC ABCDAB ABCDABCDABDE");
+    Slice text(s_text);
+    std::string s_pattern("ABCDABD");
+    Slice pattern(s_pattern);
+    auto next = pattern.build_next();
+    std::vector<size_t> expected = {0, 0, 0, 0, 1, 2, 0};
+    EXPECT_EQ(7, next.size());
+    EXPECT_EQ(expected, next);
+
+    // Find pattern in text
+    int64_t pos = text.find(pattern, next);
+    EXPECT_EQ(15, pos);
+
+    // Find with offset before match
+    pos = text.find(pattern, next, 0);
+    EXPECT_EQ(15, pos);
+
+    // Find with offset after match
+    pos = text.find(pattern, next, 16);
+    EXPECT_EQ(-1, pos);
+}
+
+TEST_F(SliceTest, testFindSliceEdgeCases) {
+    // Empty pattern
+    std::string stext1("ABC");
+    Slice text1(stext1);
+    std::string spattern1("");
+    Slice empty_pattern(spattern1);
+    auto next_empty = empty_pattern.build_next();
+    EXPECT_EQ(-1, text1.find(empty_pattern, next_empty));
+
+    // Pattern larger than text
+    std::string stext("ABC");
+    Slice small_text(stext);
+    std::string slarge_pattern("ABCDEFGH");
+    Slice large_pattern(slarge_pattern);
+    auto next_large = large_pattern.build_next();
+    EXPECT_EQ(-1, small_text.find(large_pattern, next_large));
+
+    // Exact match
+    std::string s_exact_text("ABCDEF");
+    Slice exact_text(s_exact_text);
+    std::string s_exact_pattern("ABCDEF");
+    Slice exact_pattern(s_exact_pattern);
+    auto next_exact = exact_pattern.build_next();
+    EXPECT_EQ(0, exact_text.find(exact_pattern, next_exact));
+
+    // No match
+    std::string s_text2("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+    Slice text2(s_text2);
+    std::string s_pattern2("XYZABC");
+    Slice pattern2(s_pattern2);
+    auto next2 = pattern2.build_next();
+    EXPECT_EQ(-1, text2.find(pattern2, next2));
+
+    // Match at the end
+    std::string s_text3("ABCDEFGHIJKLMNOP");
+    Slice text3(s_text3);
+    std::string s_pattern3("MNOP");
+    Slice pattern3(s_pattern3);
+    auto next3 = pattern3.build_next();
+    EXPECT_EQ(12, text3.find(pattern3, next3));
+
+    // Repeated pattern
+    std::string s_text4("ABABABAB");
+    Slice text4(s_text4);
+    std::string s_pattern4("ABA");
+    Slice pattern4(s_pattern4);
+    auto next4 = pattern4.build_next();
+    EXPECT_EQ(0, text4.find(pattern4, next4, 0));  // First occurrence
+    EXPECT_EQ(2, text4.find(pattern4, next4, 1));  // Second occurrence
+    EXPECT_EQ(4, text4.find(pattern4, next4, 3));  // Third occurrence
+    EXPECT_EQ(-1, text4.find(pattern4, next4, 5));  // Fourth occurrence
+
+    // Invalid offset
+    std::string s_text5("ABCDEF");
+    Slice text5(s_text5);
+    std::string s_pattern5("CDE");
+    Slice pattern5(s_pattern5);
+    auto next5 = pattern5.build_next();
+    EXPECT_EQ(-1, text5.find(pattern5, next5, -1));   // Negative offset
+    EXPECT_EQ(-1, text5.find(pattern5, next5, 100));  // Offset too large
+
+    // Invalid next array size
+    std::string s_text6("ABCDEF");
+    Slice text6(s_text6);
+    std::string s_pattern6("ABC");
+    Slice pattern6(s_pattern6);
+    std::vector<size_t> invalid_next = {0, 1}; // Wrong size
+    EXPECT_EQ(-1, text6.find(pattern6, invalid_next));
+
+    // Empty text
+    std::string s_text7("");
+    Slice empty_text(s_text7);
+    std::string s_pattern7("A");
+    Slice pattern7(s_pattern7);
+    auto next7 = pattern7.build_next();
+    EXPECT_EQ(-1, empty_text.find(pattern7, next7));
+}
+
+TEST_F(SliceTest, testFindSliceAdditionalCases) {
+    // Single character pattern
+    std::string s_text1("ABCDEFGHIJKLMNO");
+    Slice text1(s_text1);
+    std::string s_pattern1("G");
+    Slice pattern1(s_pattern1);
+    auto next1 = pattern1.build_next();
+    EXPECT_EQ(6, text1.find(pattern1, next1));
+
+    // Pattern at the beginning
+    std::string s_text2("ABCDEF");
+    Slice text2(s_text2);
+    std::string s_pattern2("ABC");
+    Slice pattern2(s_pattern2);
+    auto next2 = pattern2.build_next();
+    EXPECT_EQ(0, text2.find(pattern2, next2));
+
+    // Pattern at the end
+    std::string s_text3("ABCDEF");
+    Slice text3(s_text3);
+    std::string s_pattern3("DEF");
+    Slice pattern3(s_pattern3);
+    auto next3 = pattern3.build_next();
+    EXPECT_EQ(3, text3.find(pattern3, next3));
+
+    // All same characters in pattern and text
+    std::string s_text4("AAAAAA");
+    Slice text4(s_text4);
+    std::string s_pattern4("AAA");
+    Slice pattern4(s_pattern4);
+    auto next4 = pattern4.build_next();
+    EXPECT_EQ(0, text4.find(pattern4, next4));
+
+    // Complex KMP backtracking case
+    std::string s_text5("ABABACA");
+    Slice text5(s_text5);
+    std::string s_pattern5("ABABAC");
+    Slice pattern5(s_pattern5);
+    auto next5 = pattern5.build_next();
+    std::vector<size_t> expected_next5 = {0, 0, 1, 2, 3, 0};
+    EXPECT_EQ(expected_next5, next5);
+    EXPECT_EQ(0, text5.find(pattern5, next5));
+
+    // Partial match that fails
+    std::string s_text6("ABABACA");
+    Slice text6(s_text6);
+    std::string s_pattern6("ABABAX");
+    Slice pattern6(s_pattern6);
+    auto next6 = pattern6.build_next();
+    EXPECT_EQ(-1, text6.find(pattern6, next6));
+}
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2874,7 +2874,7 @@ public class SchemaChangeHandler extends AlterHandler {
         IndexDef indexDef = alterClause.getIndexDef();
         Index newIndex;
         // Only assign meaningful indexId for OlapTable
-        if (olapTable.isOlapTableOrMaterializedView()) {
+        if (olapTable.isOlapTableOrMaterializedView() || olapTable.isCloudNativeTableOrMaterializedView()) {
             long indexId = IndexDef.IndexType.isCompatibleIndex(indexDef.getIndexType()) ? 
                     olapTable.incAndGetMaxIndexId() : -1;
             newIndex = new Index(indexId, indexDef.getIndexName(),

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IndexParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IndexParams.java
@@ -90,6 +90,8 @@ public class IndexParams {
         // index
         register(builder, IndexType.GIN, IndexParamType.INDEX, InvertedIndexParams.IndexParamsKey.PARSER, true, true, "none",
                 null);
+        register(builder, IndexType.GIN, IndexParamType.INDEX, InvertedIndexParams.IndexParamsKey.DICT_GRAM_NUM,
+                false, false, null, null);
         register(builder, IndexType.GIN, IndexParamType.INDEX, InvertedIndexParams.IndexParamsKey.OMIT_TERM_FREQ_AND_POSITION,
                 false, false, null, null);
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/InvertedIndexParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/InvertedIndexParams.java
@@ -30,7 +30,8 @@ public class InvertedIndexParams {
             .collect(Collectors.toSet());
 
     public enum InvertedIndexImpType {
-        CLUCENE
+        CLUCENE,
+        BUILTIN,
     }
 
     public enum CommonIndexParamKey implements ParamsKey {

--- a/fe/fe-core/src/main/java/com/starrocks/common/InvertedIndexParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/InvertedIndexParams.java
@@ -51,7 +51,12 @@ public class InvertedIndexParams {
         /**
          * Whether to omit term frequency and term position when indexing
          */
-        OMIT_TERM_FREQ_AND_POSITION("false");
+        OMIT_TERM_FREQ_AND_POSITION("false"),
+
+        /**
+         * Gram num for the dictionary of builtin inverted index.
+         */
+        DICT_GRAM_NUM("-1");
 
         private final String defaultValue;
         private boolean needDefault = false;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -1108,6 +1108,10 @@ public class OlapScanNode extends ScanNode {
             if (ConnectContext.get() != null) {
                 msg.lake_scan_node.setEnable_column_expr_predicate(
                         ConnectContext.get().getSessionVariable().isEnableColumnExprPredicate());
+                msg.lake_scan_node.setEnable_prune_column_after_index_filter(
+                        ConnectContext.get().getSessionVariable().isEnablePruneColumnAfterIndexFilter());
+                msg.lake_scan_node.setEnable_gin_filter(
+                        ConnectContext.get().getSessionVariable().isEnableGinFilter());
             }
             msg.lake_scan_node.setDict_string_id_to_int_ids(dictStringIdToIntIds);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/IndexAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/IndexAnalyzer.java
@@ -54,6 +54,7 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import static com.starrocks.common.InvertedIndexParams.CommonIndexParamKey.IMP_LIB;
+import static com.starrocks.common.InvertedIndexParams.IndexParamsKey.DICT_GRAM_NUM;
 import static com.starrocks.common.InvertedIndexParams.IndexParamsKey.PARSER;
 import static com.starrocks.common.InvertedIndexParams.InvertedIndexImpType.BUILTIN;
 import static com.starrocks.common.InvertedIndexParams.InvertedIndexImpType.CLUCENE;
@@ -67,11 +68,15 @@ public class IndexAnalyzer {
     private static final int MAX_INDEX_NAME_LENGTH = 64;
 
     // InvertedIndexUtil constants
+    public static String INVERTED_INDEX_IMP_LIB_KEY = IMP_LIB.name().toLowerCase(Locale.ROOT);
+
     public static String INVERTED_INDEX_PARSER_KEY = PARSER.name().toLowerCase(Locale.ROOT);
     public static String INVERTED_INDEX_PARSER_NONE = "none";
     public static String INVERTED_INDEX_PARSER_STANDARD = "standard";
     public static String INVERTED_INDEX_PARSER_ENGLISH = "english";
     public static String INVERTED_INDEX_PARSER_CHINESE = "chinese";
+
+    public static String INVERTED_INDEX_DICT_GRAM_NUM_KEY = DICT_GRAM_NUM.toString().toLowerCase(Locale.ROOT);
 
     // BloomFilterIndexUtil constants
     public static final String FPP_KEY = NgramBfIndexParamsKey.BLOOM_FILTER_FPP.toString().toLowerCase(Locale.ROOT);
@@ -167,9 +172,8 @@ public class IndexAnalyzer {
                     "The inverted index is disabled, enable it by setting FE config `enable_experimental_gin` to true");
         }
 
-        String impLibKey = IMP_LIB.name().toLowerCase(Locale.ROOT);
-        if (properties.containsKey(impLibKey)) {
-            String impValue = properties.get(impLibKey);
+        if (properties.containsKey(INVERTED_INDEX_IMP_LIB_KEY)) {
+            String impValue = properties.get(INVERTED_INDEX_IMP_LIB_KEY);
             if (!(CLUCENE.name().equalsIgnoreCase(impValue) || BUILTIN.name().equalsIgnoreCase(impValue))) {
                 throw new SemanticException("Only support clucene or builtin implement for now. ");
             }
@@ -187,6 +191,7 @@ public class IndexAnalyzer {
         }
 
         checkInvertedIndexParser(column.getName(), column.getPrimitiveType(), properties);
+        checkInvertedIndexNgram(properties);
 
         // add default properties
         addDefaultProperties(properties);
@@ -212,6 +217,22 @@ public class IndexAnalyzer {
         } else if (!parser.equals(INVERTED_INDEX_PARSER_NONE)) {
             throw new SemanticException("INVERTED index with parser: " + parser
                     + " is not supported for column: " + indexColName + " of type " + colType);
+        }
+    }
+
+    public static void checkInvertedIndexNgram(Map<String, String> properties) {
+        String gramNum = properties == null ? null : properties.get(INVERTED_INDEX_DICT_GRAM_NUM_KEY);
+        if (gramNum == null) {
+            return;
+        }
+
+        if (!StringUtils.isNumeric(gramNum)) {
+            throw new SemanticException("INVERTED index dict gram num " + gramNum + " is a invalid number.");
+        }
+
+        String impValue = properties.get(INVERTED_INDEX_IMP_LIB_KEY);
+        if (!BUILTIN.name().equalsIgnoreCase(impValue)) {
+            throw new SemanticException("INVERTED index with " + impValue + " implement is invalid for dict gram.");
         }
     }
 

--- a/gensrc/proto/segment.proto
+++ b/gensrc/proto/segment.proto
@@ -250,6 +250,7 @@ enum ColumnIndexTypePB {
     ZONE_MAP_INDEX = 2;
     BITMAP_INDEX = 3;
     BLOOM_FILTER_INDEX = 4;
+    BUILTIN_INVERTED_INDEX = 5;
 }
 
 message ColumnIndexMetaPB {
@@ -258,6 +259,7 @@ message ColumnIndexMetaPB {
     optional ZoneMapIndexPB zone_map_index = 8;
     optional BitmapIndexPB bitmap_index = 9;
     optional BloomFilterIndexPB bloom_filter_index = 10;
+    optional BuiltinInvertedIndexPB builtin_inverted_index = 11;
 }
 
 message OrdinalIndexPB {
@@ -304,4 +306,8 @@ message BloomFilterIndexPB {
     optional BloomFilterAlgorithmPB algorithm = 2;
     // required: meta for bloom filters
     optional IndexedColumnMetaPB bloom_filter = 3;
+}
+
+message BuiltinInvertedIndexPB {
+    optional BitmapIndexPB bitmap_index = 1;
 }

--- a/gensrc/proto/segment.proto
+++ b/gensrc/proto/segment.proto
@@ -289,6 +289,10 @@ message BitmapIndexPB {
     optional IndexedColumnMetaPB dict_column = 3;
     // required: meta for bitmaps part
     optional IndexedColumnMetaPB bitmap_column = 4;
+    // options: meta for ngram dictionary part
+    optional IndexedColumnMetaPB ngram_dict_column = 5;
+    // options: meta for ngram bitmaps part
+    optional IndexedColumnMetaPB ngram_bitmap_column = 6;
 }
 
 enum HashStrategyPB {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -695,6 +695,9 @@ struct TLakeScanNode {
   42: optional i64 back_pressure_num_rows
 
   43: optional TTableSchemaMeta schema_meta
+  // inverted index
+  44: optional bool enable_prune_column_after_index_filter
+  45: optional bool enable_gin_filter
 }
 
 struct TEqJoinCondition {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a built-in inverted index using bitmap+ngram dictionaries and wires it into scans with GIN filtering, profiling, FE params, and tests.
> 
> - **Storage/Indexing**:
>   - **Built-in Inverted Index**: Implement `builtin_inverted_{writer,reader,iterator}` and plugin; register in `inverted_plugin_factory`.
>   - **Bitmap Index**: Extend reader/writer for n-gram dictionaries, new seek/filter APIs, union by rowids; protobuf adds `BUILTIN_INVERTED_INDEX` and n-gram fields.
> - **Query/Scan Integration**:
>   - **GIN Filter**: Add scan options `enable_gin_filter` and `prune_column_after_index_filter`; load iterators via `IndexReadOptions`; close iterators after use.
>   - **Profiling**: Add GIN timers/counters (prefix/ngram/predicate/dict stats) across lake/olap scan paths.
> - **FE Changes**:
>   - Allow GIN `imp_lib` = `builtin` and `dict_gram_num`; enable index id for cloud-native; planner passes `enable_prune_column_after_index_filter` and `enable_gin_filter`.
> - **Utilities**:
>   - Enhance `Slice` with char find and KMP-based substring search helpers.
> - **Build & Tests**:
>   - Add new storage sources to CMake; add `slice_test` and bitmap n-gram tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf66085dd305720a628e6eae3dbab891af774206. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->