### PR TITLE
[BugFix] Fix query column names missing bug about Arrow Flight SQL

### DIFF
--- a/be/src/runtime/arrow_result_writer.cpp
+++ b/be/src/runtime/arrow_result_writer.cpp
@@ -110,7 +110,20 @@ void ArrowResultWriter::_prepare_id_to_col_name_map() {
         for (auto slot : slots) {
             int64_t slot_id = slot->id();
             int64_t id = tuple_id << 32 | slot_id;
-            _id_to_col_name.emplace(id, slot->col_name());
+            std::string label = slot->label(); // 使用 label
+            if (label.empty()) {
+                label = slot->col_name(); // 兜底
+            }
+            if (label.empty()) {
+                label = "col_" + std::to_string(slot->id()); // 兜底
+            }
+
+            LOG(INFO) << "[Flight] _prepare_id_to_col_name_map() slot_id = " << slot->id()
+                      << ", slot->label() = " << slot->label()
+                      << ", slot->col_name() = " << slot->col_name()
+                      << ", final label = " << label;
+
+            _id_to_col_name.emplace(id, label);
         }
     }
 }

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -790,6 +790,7 @@ Status DescriptorTbl::create(RuntimeState* state, ObjectPool* pool, const TDescr
 
     for (const auto& tdesc : thrift_tbl.slotDescriptors) {
         SlotDescriptor* slot_d = pool->add(new SlotDescriptor(tdesc));
+        slot_d->set_label(tdesc.colName);
         (*tbl)->_slot_desc_map[tdesc.id] = slot_d;
         if (!slot_d->col_name().empty()) {
             (*tbl)->_slot_with_column_name_map[tdesc.id] = slot_d;

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -93,6 +93,10 @@ public:
     SlotDescriptor(SlotId id, std::string name, TypeDescriptor type);
 
     SlotId id() const { return _id; }
+
+    const std::string& label() const { return _label.empty() ? _col_name : _label; }
+    void set_label(const std::string& label) { _label = label; }
+
     const TypeDescriptor& type() const { return _type; }
     TypeDescriptor& type() { return _type; }
     TupleId parent() const { return _parent; }
@@ -121,6 +125,7 @@ private:
     friend class IcebergDeleteFileMeta;
 
     const SlotId _id;
+    std::string _label;
     TypeDescriptor _type;
     const TupleId _parent;
     const NullIndicatorOffset _null_indicator_offset;

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/JavaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/JavaTest.java
@@ -1,0 +1,48 @@
+package com.starrocks.service.arrow.flight.sql;
+
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.Statement;
+
+public class JavaTest {
+    public static void main(String[] args) {
+
+        String url = "jdbc:arrow-flight-sql://127.0.0.1:9408/testns?useEncryption=false&useSSL=false";
+        String user = "";
+        String password = "";
+
+        String query = "SELECT * FROM INFORMATION_SCHEMA.TABLES;"; // Or any query you like
+        try {
+            // Load Arrow Flight SQL JDBC driver
+            Class.forName("org.apache.arrow.driver.jdbc.ArrowFlightJdbcDriver");
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+
+        try (Connection con = DriverManager.getConnection(url, user, password);
+                Statement stmt = con.createStatement();
+                ResultSet rs = stmt.executeQuery(query)) {
+
+            if (rs.next()) {
+                ResultSetMetaData meta = rs.getMetaData();
+                int colCount = meta.getColumnCount();
+                System.out.println("First row:");
+
+                for (int i = 1; i <= colCount; i++) {
+                    String colName = meta.getColumnName(i);
+                    Object value = rs.getObject(i);
+                    System.out.println(colName + ": " + value);
+                }
+            } else {
+                System.out.println("No results found.");
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/test/arrowtest.py
+++ b/test/arrowtest.py
@@ -1,0 +1,87 @@
+import adbc_driver_manager
+import adbc_driver_flightsql.dbapi as flight_sql
+
+FE_HOST = "127.0.0.1"
+FE_PORT = 9408
+
+conn = flight_sql.connect(
+    uri=f"grpc://{FE_HOST}:{FE_PORT}",
+    db_kwargs={
+        adbc_driver_manager.DatabaseOptions.USERNAME.value: "root",
+        adbc_driver_manager.DatabaseOptions.PASSWORD.value: "",
+    }
+)
+cursor = conn.cursor()
+
+sql1 = "SELECT * FROM default_catalog.testdb.96float_table ORDER BY k0 LIMIT 10"
+
+cursor.execute(sql1)
+df = cursor.fetchallarrow().to_pandas()
+# print(cursor.fetchallarrow().to_pandas())
+# print(df.columns)
+
+cursor.execute("SELECT * FROM default_catalog.testdb.test_flight_sql ORDER BY k0")
+arrow_table = cursor.fetchallarrow()
+print(arrow_table)
+print("Schema column names:", arrow_table.schema.names)
+df = arrow_table.to_pandas()
+print(df)
+
+sql = "SELECT * FROM default_catalog.testdb.96float_table LIMIT 1000"
+
+# cursor.execute(sql)
+# df = cursor.fetch_df()
+# print(df)
+
+# print(cursor.fetchallarrow().to_pandas())
+
+# cursor.execute("DROP DATABASE IF EXISTS sr_arrow_flight_sql FORCE;")
+# print(cursor.fetchallarrow().to_pandas())
+#
+# cursor.execute("create database sr_arrow_flight_sql;")
+# print(cursor.fetchallarrow().to_pandas())
+#
+# cursor.execute("show databases;")
+# print(cursor.fetchallarrow().to_pandas())
+#
+# cursor.execute("use sr_arrow_flight_sql;")
+# print(cursor.fetchallarrow().to_pandas())
+#
+# cursor.execute("""CREATE TABLE sr_arrow_flight_sql
+#     (
+#          k0 INT,
+#          k1 DOUBLE,
+#          K2 varchar(32) NULL DEFAULT "" COMMENT "",
+#          k3 DECIMAL(27,9) DEFAULT "0",
+#          k4 BIGINT NULL DEFAULT '10',
+#          k5 DATE
+#     )
+#     DISTRIBUTED BY HASH(k5) BUCKETS 5
+#     PROPERTIES("replication_num" = "1");""")
+# print(cursor.fetchallarrow().to_pandas())
+#
+# cursor.execute("show create table sr_arrow_flight_sql;")
+# print(cursor.fetchallarrow().to_pandas())
+#
+# cursor.execute("""INSERT INTO sr_arrow_flight_sql VALUES
+#         ('0', 0.1, "ID", 0.0001, 9999999999, '2023-10-21'),
+#         ('1', 0.20, "ID_1", 1.00000001, 0, '2023-10-21'),
+#         ('2', 3.4, "ID_1", 3.1, 123456, '2023-10-22'),
+#         ('3', 4, "ID", 4, 4, '2023-10-22'),
+#         ('4', 122345.54321, "ID", 122345.54321, 5, '2023-10-22');""")
+# print(cursor.fetchallarrow().to_pandas())
+#
+# cursor.execute("select * from sr_arrow_flight_sql order by k0;")
+# print(cursor.fetchallarrow().to_pandas())
+#
+# cursor.execute("SHOW VARIABLES LIKE '%query_mem_limit%';")
+# print(cursor.fetchallarrow().to_pandas())
+#
+# cursor.execute("SET query_mem_limit = 2147483648;")
+# print(cursor.fetchallarrow().to_pandas())
+#
+# cursor.execute("SHOW VARIABLES LIKE '%query_mem_limit%';")
+# print(cursor.fetchallarrow().to_pandas())
+#
+# cursor.execute("select k5, sum(k1), count(1), avg(k3) from sr_arrow_flight_sql group by k5;")
+# print(cursor.fetch_df())

--- a/test/pandas_test.py
+++ b/test/pandas_test.py
@@ -1,0 +1,62 @@
+import pandas as pd
+import adbc_driver_manager
+import adbc_driver_flightsql.dbapi as flight_sql
+
+# ✅ Connect to StarRocks Flight SQL
+conn = flight_sql.connect(
+    uri="grpc://127.0.0.1:9408",
+    db_kwargs={
+        adbc_driver_manager.DatabaseOptions.USERNAME.value: "root",
+        adbc_driver_manager.DatabaseOptions.PASSWORD.value: "",
+    }
+)
+
+# ✅ Create test table
+create_sql = """
+CREATE TABLE IF NOT EXISTS test_flight_sql (
+    id INT,
+    name STRING,
+    score DOUBLE,
+    created_at DATETIME
+) ENGINE=OLAP
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 3
+PROPERTIES("replication_num" = "1");
+"""
+
+# ✅ Insert test data
+insert_sql = """
+INSERT INTO test_flight_sql VALUES
+    (1, 'Alice', 88.5, '2023-10-01 10:00:00'),
+    (2, 'Bob', 92.3, '2023-10-01 10:01:00'),
+    (3, 'Charlie', 79.2, '2023-10-01 10:02:00');
+"""
+
+# ✅ SQL to query data
+query_sql = "SELECT * FROM test_flight_sql ORDER BY id"
+
+# ✅ Run test
+with conn.cursor() as cur:
+    cur.execute("USE pandas_test;")
+    cur.execute(create_sql)
+    cur.execute(insert_sql)
+    cur.execute(query_sql)
+
+    # ✅ Fetch Arrow Table
+    arrow_table = cur.fetchallarrow()
+    print("Arrow Table Schema:", arrow_table.schema)
+
+    # ✅ Convert to Pandas
+    df = arrow_table.to_pandas()
+    # df.columns = ["id", "name", "score", "created_at"]
+
+    print("Pandas DataFrame:")
+    print(df)
+
+    # ✅ Assertions
+    assert df.shape[0] == 3
+    assert "name" in df.columns
+    assert df["score"].dtype in [float, "float64"]
+    assert pd.to_datetime(df["created_at"]).dt.year[0] == 2023
+
+    print("✅ Arrow Flight SQL + Pandas test passed!")

--- a/test/pandastest.py
+++ b/test/pandastest.py
@@ -1,0 +1,88 @@
+import adbc_driver_flightsql.dbapi as flight_sql
+import adbc_driver_manager
+import pandas as pd
+import numpy as np
+import time
+from datetime import datetime
+
+# 连接配置
+conn = flight_sql.connect(
+    uri="grpc://127.0.0.1:9408",
+    db_kwargs={
+        adbc_driver_manager.DatabaseOptions.USERNAME.value: "root",
+        adbc_driver_manager.DatabaseOptions.PASSWORD.value: "",
+    }
+)
+cursor = conn.cursor()
+
+# 创建测试库
+cursor.execute("DROP DATABASE IF EXISTS pandas_test FORCE;")
+cursor.execute("CREATE DATABASE pandas_test;")
+cursor.execute("USE pandas_test;")
+
+# 创建测试表
+cursor.execute("""
+CREATE TABLE pandas_test_table (
+    id INT,
+    name STRING,
+    score DOUBLE,
+    created_at DATE,
+    amount DECIMAL(18,6)
+)
+DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+""")
+
+# 创建 Pandas DataFrame
+df = pd.DataFrame({
+    "id": [1, 2, 3, 4, 5],
+    "name": ["Alice", "Bob", "Charlie", "中文", None],
+    "score": [95.5, 88.0, 92.3, 100.0, np.nan],
+    "created_at": pd.to_datetime(["2023-10-01", "2023-10-02", "2023-10-03", "2023-10-04", "2023-10-05"]),
+    "amount": [100.12, 200.23, 300.34, 400.45, None]
+})
+
+# 打印 DataFrame
+print("✅ Pandas DataFrame:")
+print(df)
+print(df.dtypes)
+
+# 使用 INSERT INTO 方式写入 StarRocks
+print("🚀 INSERT INTO StarRocks")
+for _, row in df.iterrows():
+    sql = f"""
+    INSERT INTO pandas_test_table VALUES (
+        {int(row['id']) if pd.notna(row['id']) else 'NULL'},
+        {f"'{row['name']}'" if pd.notna(row['name']) else 'NULL'},
+        {row['score'] if pd.notna(row['score']) else 'NULL'},
+        {f"'{row['created_at'].date()}'" if pd.notna(row['created_at']) else 'NULL'},
+        {row['amount'] if pd.notna(row['amount']) else 'NULL'}
+    );
+    """
+    cursor.execute(sql)
+
+# 查询并转为 Pandas
+print("🔍 查询并转为 Pandas DataFrame")
+cursor.execute("SELECT * FROM pandas_test_table ORDER BY id;")
+df2 = cursor.fetch_df()
+
+df2.columns = ["id", "name", "score", "created_at", "amount"]
+print("✅ 查询结果:")
+print(df2)
+print(df2.dtypes)
+
+# Pandas 场景测试
+print("🔍 场景测试: 筛选 score > 90")
+print(df2[df2['score'] > 90])
+
+print("🔍 场景测试: 分组聚合")
+print(df2.groupby("created_at").agg({
+    "score": "mean",
+    "amount": "sum"
+}))
+
+# 关闭连接
+cursor.close()
+conn.close()
+print("✅ Pandas 场景测试完成")


### PR DESCRIPTION
## Why I'm doing:
Queries about the system table can now display column names correctly. However, in the end, a small part of the bug regarding DISTINCT syntax fails to map column names correctly. Tomorrow, I need to consult Hawk. Will be fixed in this PR

After the problem is thoroughly resolved, add specific details.
## What I'm doing:

Fixes #64264 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Propagates slot labels from FE to BE to produce correct Arrow Flight SQL column names, with fallbacks and logging, plus new Java/Python test scripts.
> 
> - **Backend (BE)**:
>   - `ArrowResultWriter` now maps `(tuple_id, slot_id)` to column names using `SlotDescriptor::label()` with fallbacks to `col_name` and `col_<id>`, and adds info logs.
>   - `SlotDescriptor` adds `label` field/getter/setter; `DescriptorTbl::create()` sets slot labels from `TSlotDescriptor.colName`.
> - **Frontend (FE)**:
>   - `SlotDescriptor` now maintains `label_`, sets it from column or source expr, and populates `TSlotDescriptor.colName` with fallbacks (`label_`, column name, expr SQL, `col_<id>`); adds debug logs.
> - **Tests/Examples**:
>   - Add Flight SQL examples/tests: `fe/.../JavaTest.java`, `test/arrowtest.py`, `test/pandas_test.py`, `test/pandastest.py` to validate schema/column names and Pandas integration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a353c32f31f9cd06bf65035c0f9178ef8f35e3d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->