### PR TITLE
[BugFix] fix load_id printing, all should be printed with print_id()

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -600,7 +600,7 @@ Status OlapTableSink::_incremental_open_node_channel(const std::vector<TOlapTabl
         });
 
         if (channel->has_intolerable_failure()) {
-            LOG(WARNING) << "Open channel failed. load_id: " << _load_id << ", error: " << err_st.to_string();
+            LOG(WARNING) << "Open channel failed. load_id: " << print_id(_load_id) << ", error: " << err_st.to_string();
             return err_st;
         }
     }

--- a/be/src/exec/tablet_sink_colocate_sender.cpp
+++ b/be/src/exec/tablet_sink_colocate_sender.cpp
@@ -201,7 +201,7 @@ Status TabletSinkColocateSender::open_wait() {
     });
 
     if (_has_intolerable_failure()) {
-        LOG(WARNING) << "Open channel failed. load_id: " << _load_id << ", error: " << err_st.to_string();
+        LOG(WARNING) << "Open channel failed. load_id: " << print_id(_load_id) << ", error: " << err_st.to_string();
         return err_st;
     }
 

--- a/be/src/exec/tablet_sink_sender.cpp
+++ b/be/src/exec/tablet_sink_sender.cpp
@@ -180,7 +180,7 @@ Status TabletSinkSender::open_wait() {
         });
 
         if (index_channel->has_intolerable_failure()) {
-            LOG(WARNING) << "Open channel failed. load_id: " << _load_id << ", error: " << err_st.to_string();
+            LOG(WARNING) << "Open channel failed. load_id: " << print_id(_load_id) << ", error: " << err_st.to_string();
             return err_st;
         }
     }

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -506,13 +506,13 @@ Status LoadChannel::_update_and_serialize_profile(std::string* result, bool prin
     ThriftSerializer ser(false, 4096);
     Status st = ser.serialize(&thrift_profile, &len, &buf);
     if (!st.ok()) {
-        LOG(ERROR) << "Failed to serialize LoadChannel profile, load_id: " << _load_id << ", txn_id: " << _txn_id
-                   << ", status: " << st;
+        LOG(ERROR) << "Failed to serialize LoadChannel profile, load_id: " << print_id(_load_id)
+                   << ", txn_id: " << _txn_id << ", status: " << st;
         return Status::InternalError("Failed to serialize profile, error: " + st.to_string());
     }
     COUNTER_UPDATE(_profile_serialized_size, len);
     result->append((char*)buf, len);
-    VLOG(2) << "report profile, load_id: " << _load_id << ", txn_id: " << _txn_id << ", size: " << len;
+    VLOG(2) << "report profile, load_id: " << print_id(_load_id) << ", txn_id: " << _txn_id << ", size: " << len;
     return Status::OK();
 }
 

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -193,7 +193,7 @@ private:
 };
 
 inline std::ostream& operator<<(std::ostream& os, const LoadChannel& load_channel) {
-    os << "LoadChannel(id=" << load_channel.load_id()
+    os << "LoadChannel(id=" << print_id(load_channel.load_id())
        << ", last_update_time=" << static_cast<uint64_t>(load_channel.last_updated_time()) << ")";
     return os;
 }

--- a/be/src/runtime/load_channel_mgr.cpp
+++ b/be/src/runtime/load_channel_mgr.cpp
@@ -317,7 +317,7 @@ void LoadChannelMgr::load_diagnose(brpc::Controller* cntl, const PLoadDiagnoseRe
         }
     } else {
         std::string remote_ip = butil::ip2str(cntl->remote_side().ip).c_str();
-        LOG(INFO) << "receive load diagnose, load_id: " << load_id << ", txn_id: " << request->txn_id()
+        LOG(INFO) << "receive load diagnose, load_id: " << print_id(load_id) << ", txn_id: " << request->txn_id()
                   << ", remote: " << remote_ip;
         channel->diagnose(remote_ip, request, response);
     }
@@ -371,7 +371,8 @@ void LoadChannelMgr::_start_load_channels_clean() {
     }
     for (auto& channel : timeout_channels) {
         channel->abort();
-        LOG(INFO) << "Deleted timeout channel. load id=" << channel->load_id() << " timeout=" << channel->timeout();
+        LOG(INFO) << "Deleted timeout channel. load id=" << print_id(channel->load_id())
+                  << " timeout=" << channel->timeout();
     }
 
     // clean load in writing data size
@@ -407,7 +408,7 @@ std::shared_ptr<LoadChannel> LoadChannelMgr::remove_load_channel(const UniqueId&
 void LoadChannelMgr::abort_txn(int64_t txn_id) {
     auto channel = _find_load_channel(txn_id);
     if (channel != nullptr) {
-        LOG(INFO) << "Aborting load channel because transaction was aborted. load_id=" << channel->load_id()
+        LOG(INFO) << "Aborting load channel because transaction was aborted. load_id=" << print_id(channel->load_id())
                   << " txn_id=" << txn_id;
         channel->cancel();
         channel->abort();

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -827,7 +827,7 @@ void LocalTabletsChannel::abort() {
     }
     string tablet_id_list_str;
     JoinInts(tablet_ids, ",", &tablet_id_list_str);
-    LOG(INFO) << "cancel LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << _key.id
+    LOG(INFO) << "cancel LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(_key.id)
               << " index_id: " << _key.index_id << " #tablet:" << _delta_writers.size()
               << " tablet_ids:" << tablet_id_list_str;
 }
@@ -842,12 +842,12 @@ void LocalTabletsChannel::abort(const std::vector<int64_t>& tablet_ids, const st
             it->second->abort(abort_with_exception);
         } else {
             LOG(WARNING) << "tablet_id: " << tablet_id << " not found in LocalTabletsChannel txn_id: " << _txn_id
-                         << " load_id: " << _key.id << " index_id: " << _key.index_id;
+                         << " load_id: " << print_id(_key.id) << " index_id: " << _key.index_id;
         }
     }
     string tablet_id_list_str;
     JoinInts(tablet_ids, ",", &tablet_id_list_str);
-    LOG(INFO) << "cancel LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << _key.id
+    LOG(INFO) << "cancel LocalTabletsChannel txn_id: " << _txn_id << " load_id: " << print_id(_key.id)
               << " index_id: " << _key.index_id << " tablet_ids:" << tablet_id_list_str << ", reason: " << reason;
 }
 


### PR DESCRIPTION
* `print_id(load_id): 76ca4b66-b414-11f0-a095-58a2e1a95f4c`
* `load_id.to_string() : 76ca4b66b41411f0-a09558a2e1a95f4c`

## Why I'm doing:

Unified `load_id` format in BE log for easy grep

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces direct load_id output with print_id(load_id) across BE logging to unify ID format.
> 
> - **Logging**:
>   - Replace `load_id` output with `print_id(load_id)` in `tablet_sink.cpp`, `tablet_sink_sender.cpp`, and `tablet_sink_colocate_sender.cpp` (“Open channel failed” warnings).
>   - Use `print_id` in `LoadChannel` profile/log lines and serialization errors in `be/src/runtime/load_channel.cpp`.
>   - Update `operator<<` for `LoadChannel` in `be/src/runtime/load_channel.h` to print `print_id(load_id)`.
>   - Standardize `load_id` printing in `LoadChannelMgr` logs (diagnose receive, timeout deletion, txn abort).
>   - Standardize `load_id` printing in `LocalTabletsChannel` logs (abort paths and related info).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 953400d446b81ff694d322c3d0f4c4c8f0b859a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->