### PR TITLE
[Tool] Fix mac thirdparty build error

### DIFF
--- a/be/src/storage/sstable/format.cpp
+++ b/be/src/storage/sstable/format.cpp
@@ -4,9 +4,6 @@
 
 #include "storage/sstable/format.h"
 
-#include <snappy/snappy-sinksource.h>
-#include <snappy/snappy.h>
-
 #include <string>
 
 #include "common/status.h"
@@ -14,6 +11,7 @@
 #include "runtime/exec_env.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/sstable/coding.h"
+#include "util/compression/compression_headers.h"
 #include "util/crc32c.h"
 
 namespace starrocks::sstable {

--- a/be/src/storage/sstable/table_builder.cpp
+++ b/be/src/storage/sstable/table_builder.cpp
@@ -4,9 +4,6 @@
 
 #include "storage/sstable/table_builder.h"
 
-#include <snappy/snappy-sinksource.h>
-#include <snappy/snappy.h>
-
 #include "common/status.h"
 #include "fs/fs.h"
 #include "storage/sstable/block_builder.h"
@@ -16,6 +13,7 @@
 #include "storage/sstable/filter_policy.h"
 #include "storage/sstable/format.h"
 #include "testutil/sync_point.h"
+#include "util/compression/compression_headers.h"
 #include "util/crc32c.h"
 #include "util/slice.h"
 

--- a/be/src/util/compression/block_compression.cpp
+++ b/be/src/util/compression/block_compression.cpp
@@ -39,8 +39,6 @@
 #ifdef __x86_64__
 #include <libdeflate.h>
 #endif
-#include <snappy/snappy-sinksource.h>
-#include <snappy/snappy.h>
 #include <zlib.h>
 
 #include "gutil/endian.h"

--- a/be/src/util/compression/compression_headers.h
+++ b/be/src/util/compression/compression_headers.h
@@ -23,6 +23,8 @@
 #include <lz4.h>
 #include <lz4frame.h>
 #include <lz4hc.h>
+#include <snappy-sinksource.h>
+#include <snappy.h>
 #include <zstd.h>
 #include <zstd_errors.h>
 #else
@@ -30,6 +32,8 @@
 #include <lz4/lz4.h>
 #include <lz4/lz4frame.h>
 #include <lz4/lz4hc.h>
+#include <snappy/snappy-sinksource.h>
+#include <snappy/snappy.h>
 #include <zstd/zstd.h>
 #include <zstd/zstd_errors.h>
 #endif

--- a/be/src/util/compression/stream_compression.cpp
+++ b/be/src/util/compression/stream_compression.cpp
@@ -35,7 +35,6 @@
 #include "util/compression/stream_compression.h"
 
 #include <bzlib.h>
-#include <snappy/snappy.h>
 #include <zlib.h>
 
 #include <memory>


### PR DESCRIPTION
## Why I'm doing:

for https://github.com/StarRocks/starrocks/issues/64775
#64777
#64778

## What I'm doing:

- Fix brpc compile error with Homebrew protobuf
- Fix Fix BUILD filename conflicts
- Fix CFLAGS: unbound variable error

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes macOS third-party builds by standardizing CMake build dirs, fixing brpc to use local protobuf toolchain, auto-detecting Boost for vectorscan, and restoring env after ICU.
> 
> - **Build system (macOS thirdparty script)**:
>   - Standardize CMake out-of-source directory to `cmake_build` across multiple deps (`gflags`, `glog`, `brpc`, `rocksdb`, `velocypack`, `vectorscan`, `simdutf`, `fmt`, `croaringbitmap`).
> - **brpc build fixes**:
>   - Force C++17 in `CMakeLists.txt`.
>   - Ensure local `protoc` 3.14.0 is used: prepend `$INSTALL_DIR/bin` to `PATH`, set `CPLUS_INCLUDE_PATH`/`C_INCLUDE_PATH`, and log selected `protoc`.
>   - Prepend include flags and pass `CMAKE_PREFIX_PATH`, `CMAKE_[C|CXX]_FLAGS`; wire up `-Dgflags_DIR`, `-DProtobuf_DIR`, `-Dglog_DIR`, `-DGLOG_*`.
> - **vectorscan**:
>   - Rebuild in `cmake_build`; dynamically detect Homebrew Boost version and set `BOOST_ROOT`/`Boost_DIR`; adjust compile flags.
> - **ICU**:
>   - Restore `CFLAGS`/`CXXFLAGS`/`CPPFLAGS` after subshell build to avoid leaking unset flags into subsequent builds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdebe1ddc972f9d723c0129a261e826f5e4a29c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->