### PR TITLE
[Refactor] Remove virtual bucket and simplify data distribution and bucket pruning

### DIFF
--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -291,14 +291,6 @@ Status OlapTablePartitionParam::init(RuntimeState* state) {
                       return lhs.index_id < rhs.index_id;
                   });
 
-        // If virtual buckets is not set, set its value with tablets.
-        // This may happen during cluster upgrading, when BE is upgraded to the new version but FE is still on the old version.
-        for (auto& index : part->indexes) {
-            if (!index.__isset.virtual_buckets) {
-                index.__set_virtual_buckets(index.tablets);
-            }
-        }
-
         // check index
         for (int j = 0; j < num_indexes; ++j) {
             const auto& index_tablets = part->indexes[j];
@@ -512,14 +504,6 @@ Status OlapTablePartitionParam::add_partitions(const std::vector<TOlapTableParti
                   [](const OlapTableIndexTablets& lhs, const OlapTableIndexTablets& rhs) {
                       return lhs.index_id < rhs.index_id;
                   });
-
-        // If virtual buckets is not set, set its value with tablets.
-        // This may happen during cluster upgrading, when BE is upgraded to the new version but FE is still on the old version.
-        for (auto& index : part->indexes) {
-            if (!index.__isset.virtual_buckets) {
-                index.__set_virtual_buckets(index.tablets);
-            }
-        }
 
         // check index
         // If an add_partition operation is executed during the ALTER process, the ALTER operation will be canceled first.

--- a/be/src/exec/tablet_sink_colocate_sender.cpp
+++ b/be/src/exec/tablet_sink_colocate_sender.cpp
@@ -61,8 +61,8 @@ Status TabletSinkColocateSender::send_chunk(const OlapTableSchemaParam* schema,
                 uint16_t selection = validate_select_idx[j];
                 const auto* partition = partitions[selection];
                 index_id_partition_id[index->index_id].emplace(partition->id);
-                const auto& virtual_buckets = partition->indexes[i].virtual_buckets;
-                _index_tablet_ids[i][selection] = virtual_buckets[record_hashes[selection] % virtual_buckets.size()];
+                const auto& tablets = partition->indexes[i].tablets;
+                _index_tablet_ids[i][selection] = tablets[record_hashes[selection] % tablets.size()];
             }
         }
         return _send_chunks(schema, chunk, _index_tablet_ids, validate_select_idx);
@@ -75,8 +75,8 @@ Status TabletSinkColocateSender::send_chunk(const OlapTableSchemaParam* schema,
             for (size_t j = 0; j < num_rows; ++j) {
                 const auto* partition = partitions[j];
                 index_id_partition_id[index->index_id].emplace(partition->id);
-                const auto& virtual_buckets = partition->indexes[i].virtual_buckets;
-                _index_tablet_ids[i][j] = virtual_buckets[record_hashes[j] % virtual_buckets.size()];
+                const auto& tablets = partition->indexes[i].tablets;
+                _index_tablet_ids[i][j] = tablets[record_hashes[j] % tablets.size()];
             }
         }
         return _send_chunks(schema, chunk, _index_tablet_ids, validate_select_idx);

--- a/be/src/exec/tablet_sink_sender.cpp
+++ b/be/src/exec/tablet_sink_sender.cpp
@@ -60,8 +60,8 @@ Status TabletSinkSender::send_chunk(const OlapTableSchemaParam* schema,
                 uint16_t selection = validate_select_idx[j];
                 const auto* partition = partitions[selection];
                 index_id_partition_id[index->index_id].emplace(partition->id);
-                const auto& virtual_buckets = partition->indexes[i].virtual_buckets;
-                _tablet_ids[selection] = virtual_buckets[record_hashes[selection] % virtual_buckets.size()];
+                const auto& tablets = partition->indexes[i].tablets;
+                _tablet_ids[selection] = tablets[record_hashes[selection] % tablets.size()];
             }
             RETURN_IF_ERROR(_send_chunk_by_node(chunk, _channels[i], validate_select_idx));
         }
@@ -72,8 +72,8 @@ Status TabletSinkSender::send_chunk(const OlapTableSchemaParam* schema,
             for (size_t j = 0; j < num_rows; ++j) {
                 const auto* partition = partitions[j];
                 index_id_partition_id[index->index_id].emplace(partition->id);
-                const auto& virtual_buckets = partition->indexes[i].virtual_buckets;
-                _tablet_ids[j] = virtual_buckets[record_hashes[j] % virtual_buckets.size()];
+                const auto& tablets = partition->indexes[i].tablets;
+                _tablet_ids[j] = tablets[record_hashes[j] % tablets.size()];
             }
             RETURN_IF_ERROR(_send_chunk_by_node(chunk, _channels[i], validate_select_idx));
         }

--- a/be/src/storage/table_reader.cpp
+++ b/be/src/storage/table_reader.cpp
@@ -134,8 +134,8 @@ Status TableReader::multi_get(Chunk& keys, const std::vector<std::string>& value
     for (size_t i = 0; i < selected_size; ++i) {
         size_t key_index = validate_select_idx[i];
         const auto* partition = partitions[key_index];
-        const auto& virtual_buckets = partition->indexes[0].virtual_buckets;
-        int64_t tablet_id = virtual_buckets[record_hashes[key_index] % virtual_buckets.size()];
+        const auto& tablets = partition->indexes[0].tablets;
+        int64_t tablet_id = tablets[record_hashes[key_index] % tablets.size()];
         auto iter = multi_gets_by_tablet.find(tablet_id);
         TabletMultiGet* multi_get = nullptr;
         if (iter == multi_gets_by_tablet.end()) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterJobV2Builder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterJobV2Builder.java
@@ -31,7 +31,6 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -96,19 +95,13 @@ public class LakeTableAlterJobV2Builder extends AlterJobV2Builder {
                         new TabletMeta(dbId, tableId, physicalPartitionId, shadowIndexId, medium, true);
                 MaterializedIndex shadowIndex =
                         new MaterializedIndex(shadowIndexId, MaterializedIndex.IndexState.SHADOW, shardGroupId);
-                Map<Long, Long> tabletIdMap = new HashMap<>();
                 for (int i = 0; i < originTablets.size(); i++) {
                     Tablet originTablet = originTablets.get(i);
                     Tablet shadowTablet = new LakeTablet(shadowTabletIds.get(i));
                     shadowIndex.addTablet(shadowTablet, shadowTabletMeta);
                     schemaChangeJob
                             .addTabletIdMap(physicalPartitionId, shadowIndexId, shadowTablet.getId(), originTablet.getId());
-                    tabletIdMap.put(originTablet.getId(), shadowTablet.getId());
                 }
-
-                List<Long> virtualBuckets = new ArrayList<>(originIndex.getVirtualBuckets());
-                virtualBuckets.replaceAll(tabletId -> tabletIdMap.get(tabletId));
-                shadowIndex.setVirtualBuckets(virtualBuckets);
 
                 schemaChangeJob.addPartitionShadowIndex(physicalPartitionId, shadowIndexId, shadowIndex);
             } // end for physicalPartition

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableRollupBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableRollupBuilder.java
@@ -34,7 +34,6 @@ import com.starrocks.warehouse.Warehouse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -105,18 +104,12 @@ public class LakeTableRollupBuilder extends AlterJobV2Builder {
 
                 TabletMeta shadowTabletMeta =
                         new TabletMeta(dbId, olapTable.getId(), physicalPartitionId, rollupIndexId, medium, true);
-                Map<Long, Long> tabletIdMap = new HashMap<>();
                 for (int i = 0; i < originTablets.size(); i++) {
                     Tablet originTablet = originTablets.get(i);
                     Tablet shadowTablet = new LakeTablet(shadowTabletIds.get(i));
                     mvIndex.addTablet(shadowTablet, shadowTabletMeta);
                     mvJob.addTabletIdMap(physicalPartitionId, shadowTablet.getId(), originTablet.getId());
-                    tabletIdMap.put(originTablet.getId(), shadowTablet.getId());
                 }
-
-                List<Long> virtualBuckets = new ArrayList<>(baseIndex.getVirtualBuckets());
-                virtualBuckets.replaceAll(tabletId -> tabletIdMap.get(tabletId));
-                mvIndex.setVirtualBuckets(virtualBuckets);
 
                 mvJob.addMVIndex(physicalPartitionId, mvIndex);
                 LOG.debug("create materialized view index {} based on index {} in partition {}:{}",

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableAlterJobV2Builder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableAlterJobV2Builder.java
@@ -35,8 +35,6 @@ import com.starrocks.thrift.TStorageMedium;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -97,7 +95,6 @@ public class OlapTableAlterJobV2Builder extends AlterJobV2Builder {
                 MaterializedIndex originIndex = partition.getIndex(originIndexId);
                 TabletMeta shadowTabletMeta = new TabletMeta(
                         dbId, tableId, physicalPartitionId, shadowIndexId, medium);
-                Map<Long, Long> tabletIdMap = new HashMap<>();
                 for (Tablet originTablet : originIndex.getTablets()) {
                     long originTabletId = originTablet.getId();
                     long shadowTabletId = globalStateMgr.getNextId();
@@ -107,7 +104,6 @@ public class OlapTableAlterJobV2Builder extends AlterJobV2Builder {
                     addedTablets.add(shadowTablet);
 
                     schemaChangeJob.addTabletIdMap(physicalPartitionId, shadowIndexId, shadowTabletId, originTabletId);
-                    tabletIdMap.put(originTabletId, shadowTabletId);
                     List<Replica> originReplicas = ((LocalTablet) originTablet).getImmutableReplicas();
 
                     int healthyReplicaNum = 0;
@@ -152,10 +148,6 @@ public class OlapTableAlterJobV2Builder extends AlterJobV2Builder {
                                 "tablet " + originTabletId + " has few healthy replica: " + healthyReplicaNum);
                     }
                 }
-
-                List<Long> virtualBuckets = new ArrayList<>(originIndex.getVirtualBuckets());
-                virtualBuckets.replaceAll(tabletId -> tabletIdMap.get(tabletId));
-                shadowIndex.setVirtualBuckets(virtualBuckets);
 
                 schemaChangeJob.addPartitionShadowIndex(physicalPartitionId, shadowIndexId, shadowIndex);
             } // end for partition

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableRollupJobBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableRollupJobBuilder.java
@@ -32,10 +32,7 @@ import com.starrocks.thrift.TStorageMedium;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class OlapTableRollupJobBuilder extends AlterJobV2Builder {
     private static final Logger LOG = LogManager.getLogger(OlapTableRollupJobBuilder.class);
@@ -72,7 +69,6 @@ public class OlapTableRollupJobBuilder extends AlterJobV2Builder {
                 MaterializedIndex baseIndex = physicalPartition.getIndex(baseIndexId);
                 TabletMeta mvTabletMeta = new TabletMeta(dbId, olapTable.getId(),
                         physicalPartitionId, rollupIndexId, medium);
-                Map<Long, Long> tabletIdMap = new HashMap<>();
                 for (Tablet baseTablet : baseIndex.getTablets()) {
                     long baseTabletId = baseTablet.getId();
                     long mvTabletId = globalStateMgr.getNextId();
@@ -83,7 +79,6 @@ public class OlapTableRollupJobBuilder extends AlterJobV2Builder {
                     addedTablets.add(newTablet);
 
                     mvJob.addTabletIdMap(physicalPartitionId, mvTabletId, baseTabletId);
-                    tabletIdMap.put(baseTabletId, mvTabletId);
 
                     List<Replica> baseReplicas = ((LocalTablet) baseTablet).getImmutableReplicas();
 
@@ -127,10 +122,6 @@ public class OlapTableRollupJobBuilder extends AlterJobV2Builder {
                         throw new DdlException("tablet " + baseTabletId + " has few healthy replica: " + healthyReplicaNum);
                     }
                 } // end for baseTablets
-
-                List<Long> virtualBuckets = new ArrayList<>(baseIndex.getVirtualBuckets());
-                virtualBuckets.replaceAll(tabletId -> tabletIdMap.get(tabletId));
-                mvIndex.setVirtualBuckets(virtualBuckets);
 
                 mvJob.addMVIndex(physicalPartitionId, mvIndex);
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/SplitTabletJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/SplitTabletJobFactory.java
@@ -295,7 +295,7 @@ public class SplitTabletJobFactory implements DynamicTabletJobFactory {
             newIndex.addTablet(tablet, null, false);
         }
 
-        newIndex.setVirtualBuckets(dynamicTablets.calcNewVirtualBuckets(oldIndex.getVirtualBuckets()));
+        // newIndex.setVirtualBuckets(dynamicTablets.calcNewVirtualBuckets(oldIndex.getVirtualBuckets()));
         return newIndex;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MetadataViewer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MetadataViewer.java
@@ -389,7 +389,6 @@ public class MetadataViewer {
                             row.add(partition.getName());
                             row.add(String.valueOf(physicalPartition.getId()));
                             row.add(olapTable.getIndexNameById(index.getId()));
-                            row.add(index.getVirtualBucketsByTabletId(tablets.get(i).getId()).toString());
                             row.add(String.valueOf(rowCountStatistics.get(i)));
                             row.add(totalRowCount == 0L ? "0.00 %"
                                     : df.format((double) rowCountStatistics.get(i) / totalRowCount));

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1955,7 +1955,7 @@ public class OlapTable extends Table {
 
             short replicationNum = partitionInfo.getReplicationNum(partition.getId());
             MaterializedIndex baseIdx = physicalPartition.getBaseIndex();
-            for (Long tabletId : baseIdx.getTabletIds()) {
+            for (Long tabletId : baseIdx.getTabletIdsInOrder()) {
                 LocalTablet tablet = (LocalTablet) baseIdx.getTablet(tabletId);
                 List<Long> replicaBackendIds = tablet.getNormalReplicaBackendIds();
                 if (replicaBackendIds.size() < replicationNum) {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -801,7 +801,7 @@ public class ColocateTableBalancer extends FrontendDaemon {
                         BalanceStat balanceStat = BalanceStat.BALANCED_STAT;
 
                         int idx = 0;
-                        for (Long tabletId : index.getTabletIds()) {
+                        for (Long tabletId : index.getTabletIdsInOrder()) {
                             LocalTablet tablet = (LocalTablet) index.getTablet(tabletId);
                             Set<Long> bucketSeq = backendBucketsSeq.get(idx);
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/IndicesProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/IndicesProcDir.java
@@ -59,7 +59,7 @@ import java.util.List;
 public class IndicesProcDir implements ProcDirInterface {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("IndexId").add("IndexName").add("State").add("LastConsistencyCheckTime")
-            .add("TabletBalanceStat").add("VirtualBuckets").add("Tablets")
+            .add("TabletBalanceStat").add("Tablets")
             .build();
 
     private Database db;
@@ -91,7 +91,6 @@ public class IndicesProcDir implements ProcDirInterface {
                 indexInfo.add(materializedIndex.getState());
                 indexInfo.add(TimeUtils.longToTimeString(materializedIndex.getLastCheckTime()));
                 indexInfo.add(materializedIndex.getBalanceStat().toString());
-                indexInfo.add(materializedIndex.getVirtualBuckets().size());
                 indexInfo.add(materializedIndex.getTablets().size());
 
                 indexInfos.add(indexInfo);

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/LakeTabletsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/LakeTabletsProcDir.java
@@ -44,7 +44,7 @@ import java.util.List;
 public class LakeTabletsProcDir implements ProcDirInterface {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("TabletId").add("BackendId").add("DataSize").add("RowCount")
-            .add("MinVersion").add("VirtualBuckets")
+            .add("MinVersion")
             .build();
 
     private final Database db;
@@ -86,7 +86,6 @@ public class LakeTabletsProcDir implements ProcDirInterface {
                 tabletInfo.add(new ByteSizeValue(lakeTablet.getDataSize(true)));
                 tabletInfo.add(lakeTablet.getRowCount(0L));
                 tabletInfo.add(lakeTablet.getMinVersion());
-                tabletInfo.add(index.getVirtualBucketsByTabletId(lakeTablet.getId()).toString());
                 tabletInfos.add(tabletInfo);
             }
         } finally {
@@ -144,7 +143,7 @@ public class LakeTabletsProcDir implements ProcDirInterface {
                 throw new AnalysisException("Can't find tablet id: " + tabletIdStr);
             }
             Preconditions.checkState(tablet instanceof LakeTablet);
-            return new LakeTabletProcNode(index, (LakeTablet) tablet);
+            return new LakeTabletProcNode((LakeTablet) tablet);
         } finally {
             locker.unLockDatabase(db.getId(), LockType.READ);
         }
@@ -152,11 +151,9 @@ public class LakeTabletsProcDir implements ProcDirInterface {
 
     // Handle showing single tablet info
     public static class LakeTabletProcNode implements ProcNodeInterface {
-        private final MaterializedIndex index;
         private final LakeTablet tablet;
 
-        public LakeTabletProcNode(MaterializedIndex index, LakeTablet tablet) {
-            this.index = index;
+        public LakeTabletProcNode(LakeTablet tablet) {
             this.tablet = tablet;
         }
 
@@ -172,8 +169,7 @@ public class LakeTabletsProcDir implements ProcDirInterface {
                     new Gson().toJson(tablet.getBackendIds(computeResource)),
                     new ByteSizeValue(tablet.getDataSize(true)).toString(),
                     String.valueOf(tablet.getRowCount(0L)),
-                    String.valueOf(tablet.getMinVersion()),
-                    index.getVirtualBucketsByTabletId(tablet.getId()).toString()
+                    String.valueOf(tablet.getMinVersion())
             );
             result.addRow(row);
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -423,8 +423,7 @@ public class OlapScanNode extends ScanNode {
         DistributionPruner distributionPruner;
         if (DistributionInfo.DistributionInfoType.HASH == distributionInfo.getType()) {
             HashDistributionInfo info = (HashDistributionInfo) distributionInfo;
-            distributionPruner = new HashDistributionPruner(index.getVirtualBuckets(),
-                    index.getTabletIds(),
+            distributionPruner = new HashDistributionPruner(index.getTabletIdsInOrder(),
                     MetaUtils.getColumnsByColumnIds(olapTable, info.getDistributionColumns()),
                     columnFilters);
             return distributionPruner.prune();
@@ -769,7 +768,7 @@ public class OlapScanNode extends ScanNode {
                 final Collection<Long> tabletIds = distributionPrune(selectedIndex, partition.getDistributionInfo());
                 LOG.debug("distribution prune tablets: {}", tabletIds);
 
-                List<Long> allTabletIds = selectedIndex.getTabletIds();
+                List<Long> allTabletIds = selectedIndex.getTabletIdsInOrder();
                 if (tabletIds != null) {
                     for (Long id : tabletIds) {
                         tablets.add(selectedIndex.getTablet(id));
@@ -1577,7 +1576,7 @@ public class OlapScanNode extends ScanNode {
             Partition partition = olapTable.getPartition(partitionId);
             for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
                 MaterializedIndex materializedIndex = physicalPartition.getIndex(selectedIndexId);
-                for (long tabletId : materializedIndex.getTabletIds()) {
+                for (long tabletId : materializedIndex.getTabletIdsInOrder()) {
                     tabletToPartitionMap.put(tabletId, physicalPartition.getId());
                 }
                 partitionToTabletMap.put(physicalPartition.getId(), Lists.newArrayList());

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -758,8 +758,7 @@ public class OlapTableSink extends DataSink {
 
     private static void setMaterializedIndexes(PhysicalPartition partition, TOlapTablePartition tPartition) {
         for (MaterializedIndex index : partition.getMaterializedIndices(IndexExtState.ALL)) {
-            TOlapTableIndexTablets tIndex = new TOlapTableIndexTablets(index.getId(), index.getTabletIds());
-            tIndex.setVirtual_buckets(Lists.newArrayList(index.getVirtualBuckets()));
+            TOlapTableIndexTablets tIndex = new TOlapTableIndexTablets(index.getId(), index.getTabletIdsInOrder());
             tPartition.addToIndexes(tIndex);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultMetaFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultMetaFactory.java
@@ -1007,7 +1007,6 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
                 .addColumn(new Column("PartitionName", TypeFactory.createVarchar(30)))
                 .addColumn(new Column("SubPartitionId", TypeFactory.createVarchar(30)))
                 .addColumn(new Column("MaterializedIndexName", TypeFactory.createVarchar(30)))
-                .addColumn(new Column("VirtualBuckets", TypeFactory.createVarchar(30)))
                 .addColumn(new Column("RowCount", TypeFactory.createVarchar(30)))
                 .addColumn(new Column("RowCount%", TypeFactory.createVarchar(10)))
                 .addColumn(new Column("DataSize", TypeFactory.createVarchar(30)))

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -2040,8 +2040,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             }
         }
         for (MaterializedIndex index : physicalPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
-            TOlapTableIndexTablets tIndex = new TOlapTableIndexTablets(index.getId(), index.getTabletIds());
-            tIndex.setVirtual_buckets(Lists.newArrayList(index.getVirtualBuckets()));
+            TOlapTableIndexTablets tIndex = new TOlapTableIndexTablets(index.getId(), index.getTabletIdsInOrder());
             tPartition.addToIndexes(tIndex);
         }
         partitions.add(tPartition);
@@ -2466,8 +2465,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         }
         for (MaterializedIndex index : partition.getDefaultPhysicalPartition()
                 .getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
-            TOlapTableIndexTablets tIndex = new TOlapTableIndexTablets(index.getId(), index.getTabletIds());
-            tIndex.setVirtual_buckets(Lists.newArrayList(index.getVirtualBuckets()));
+            TOlapTableIndexTablets tIndex = new TOlapTableIndexTablets(index.getId(), index.getTabletIdsInOrder());
             tPartition.addToIndexes(tIndex);
         }
         partitions.add(tPartition);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -1072,7 +1072,7 @@ public class MvRewritePreprocessor {
                 selectedPartitionNames.add(p.getName());
                 for (PhysicalPartition physicalPartition : p.getSubPartitions()) {
                     MaterializedIndex materializedIndex = physicalPartition.getIndex(mv.getBaseIndexId());
-                    selectTabletIds.addAll(materializedIndex.getTabletIds());
+                    selectTabletIds.addAll(materializedIndex.getTabletIdsInOrder());
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptDistributionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptDistributionPruner.java
@@ -74,8 +74,7 @@ public class OptDistributionPruner {
                 } else {
                     filters = operator.getColumnFilters();
                 }
-                distributionPruner = new HashDistributionPruner(index.getVirtualBuckets(),
-                        index.getTabletIds(),
+                distributionPruner = new HashDistributionPruner(index.getTabletIdsInOrder(),
                         MetaUtils.getColumnsByColumnIds(idToColumn, info.getDistributionColumns()),
                         filters);
                 return distributionPruner.prune();
@@ -84,6 +83,6 @@ public class OptDistributionPruner {
             LOG.warn("distribution prune failed. ", e);
         }
 
-        return index.getTabletIds();
+        return index.getTabletIdsInOrder();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -987,7 +987,7 @@ public class PlanFragmentBuilder {
                         Preconditions.checkState(selectTabletIds != null && !selectTabletIds.isEmpty());
                         final MaterializedIndex selectedIndex = physicalPartition.getIndex(selectedIndexId);
                         totalTabletsNum += selectedIndex.getTablets().size();
-                        List<Long> allTabletIds = selectedIndex.getTabletIds();
+                        List<Long> allTabletIds = selectedIndex.getTabletIdsInOrder();
                         for (int i = 0; i < allTabletIds.size(); i++) {
                             tabletId2BucketSeq.put(allTabletIds.get(i), i);
                         }

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/IndicesProcDirTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/IndicesProcDirTest.java
@@ -76,7 +76,6 @@ public class IndicesProcDirTest {
                 "{\"maxTabletNum\":9,\"minTabletNum\":1,\"maxBeId\":1,\"minBeId\":2," +
                         "\"type\":\"INTER_NODE_TABLET_DISTRIBUTION\",\"balanced\":false}",
                 row.get(4)); // tablet balance stat
-        Assertions.assertEquals("2", row.get(5)); // virtual buckets
-        Assertions.assertEquals("2", row.get(6)); // tablets
+        Assertions.assertEquals("2", row.get(5)); // tablets
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/HashDistributionPrunerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/HashDistributionPrunerTest.java
@@ -55,8 +55,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class HashDistributionPrunerTest extends PlanTestBase {
 
@@ -113,9 +111,7 @@ public class HashDistributionPrunerTest extends PlanTestBase {
         filters.put("channel", channelFilter);
         filters.put("shop_type", shopTypeFilter);
 
-        HashDistributionPruner pruner = new HashDistributionPruner(
-                Stream.concat(tabletIds.stream(), tabletIds.stream()).collect(Collectors.toList()),
-                tabletIds, columns, filters);
+        HashDistributionPruner pruner = new HashDistributionPruner(tabletIds, columns, filters);
 
         Collection<Long> results = pruner.prune();
         // 20 = 1 * 5 * 2 * 2 * 1 (element num of each filter)
@@ -194,9 +190,7 @@ public class HashDistributionPrunerTest extends PlanTestBase {
         Map<String, PartitionColumnFilter> filters = Maps.newHashMap();
         filters.put("main_brand_id", mainBrandFilter);
 
-        HashDistributionPruner pruner = new HashDistributionPruner(
-                Stream.concat(tabletIds.stream(), tabletIds.stream()).collect(Collectors.toList()),
-                tabletIds, columns, filters);
+        HashDistributionPruner pruner = new HashDistributionPruner(tabletIds, columns, filters);
 
         Collection<Long> results = pruner.prune();
         Assertions.assertEquals(tabletIds.size(), results.size());

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
@@ -141,7 +141,7 @@ public class CoordinatorTest extends PlanTestBase {
         OlapTable olapTable = getOlapTable("t0");
         List<Long> olapTableTabletIds =
                 olapTable.getAllPartitions().stream().flatMap(x -> x.getDefaultPhysicalPartition().getBaseIndex()
-                                .getTabletIds().stream())
+                                .getTabletIdsInOrder().stream())
                         .collect(Collectors.toList());
         Assertions.assertFalse(olapTableTabletIds.isEmpty());
         tupleDesc.setTable(olapTable);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowStmtMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowStmtMetaTest.java
@@ -942,15 +942,14 @@ public class ShowStmtMetaTest {
         TableRef tableRef = new TableRef(QualifiedName.of(List.of("test_db", "test_table")), null, NodePosition.ZERO);
         ShowDataDistributionStmt stmt = new ShowDataDistributionStmt(tableRef);
         ShowResultSetMetaData metaData = new ShowResultMetaFactory().getMetadata(stmt);
-        Assertions.assertEquals(8, metaData.getColumnCount());
+        Assertions.assertEquals(7, metaData.getColumnCount());
         Assertions.assertEquals("PartitionName", metaData.getColumn(0).getName());
         Assertions.assertEquals("SubPartitionId", metaData.getColumn(1).getName());
         Assertions.assertEquals("MaterializedIndexName", metaData.getColumn(2).getName());
-        Assertions.assertEquals("VirtualBuckets", metaData.getColumn(3).getName());
-        Assertions.assertEquals("RowCount", metaData.getColumn(4).getName());
-        Assertions.assertEquals("RowCount%", metaData.getColumn(5).getName());
-        Assertions.assertEquals("DataSize", metaData.getColumn(6).getName());
-        Assertions.assertEquals("DataSize%", metaData.getColumn(7).getName());
+        Assertions.assertEquals("RowCount", metaData.getColumn(3).getName());
+        Assertions.assertEquals("RowCount%", metaData.getColumn(4).getName());
+        Assertions.assertEquals("DataSize", metaData.getColumn(5).getName());
+        Assertions.assertEquals("DataSize%", metaData.getColumn(6).getName());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/server/ConcurrentDDLTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/ConcurrentDDLTest.java
@@ -121,7 +121,7 @@ public class ConcurrentDDLTest {
         for (long threadId : threadIds) {
             table = GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getFullName(), "test_tbl_" + threadId);
             List<Long> tablets = table.getPartitions().stream().findFirst().get().getDefaultPhysicalPartition()
-                    .getBaseIndex().getTabletIds();
+                    .getBaseIndex().getTabletIdsInOrder();
             List<Long> backendIdList = tablets.stream()
                         .map(id -> GlobalStateMgr.getCurrentState().getTabletInvertedIndex().getReplicasByTabletId(id))
                         .map(replicaList -> replicaList.get(0).getBackendId())

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/DistributionPrunerRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/DistributionPrunerRuleTest.java
@@ -50,7 +50,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -178,10 +177,7 @@ public class DistributionPrunerRuleTest {
                 partition.getDistributionInfo();
                 result = distributionInfo;
 
-                index.getVirtualBuckets();
-                result = Stream.concat(tabletIds.stream(), tabletIds.stream()).collect(Collectors.toList());
-
-                index.getTabletIds();
+                index.getTabletIdsInOrder();
                 result = tabletIds;
 
                 distributionInfo.getDistributionColumns();

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakeAggregatePublishTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakeAggregatePublishTest.java
@@ -97,7 +97,7 @@ public class LakeAggregatePublishTest {
 
         for (Partition partition : table.getPartitions()) {
             MaterializedIndex baseIndex = partition.getDefaultPhysicalPartition().getBaseIndex();
-            for (Long tabletId : baseIndex.getTabletIds()) {
+            for (Long tabletId : baseIndex.getTabletIdsInOrder()) {
                 for (Long backendId : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds()) {
                     TabletCommitInfo tabletCommitInfo = new TabletCommitInfo(tabletId, backendId);
                     transTablets1.add(tabletCommitInfo);

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
@@ -95,7 +95,7 @@ public class LakePublishBatchTest {
         int num = 0;
         for (Partition partition : table.getPartitions()) {
             MaterializedIndex baseIndex = partition.getDefaultPhysicalPartition().getBaseIndex();
-            for (Long tabletId : baseIndex.getTabletIds()) {
+            for (Long tabletId : baseIndex.getTabletIdsInOrder()) {
                 for (Long backendId : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds()) {
                     TabletCommitInfo tabletCommitInfo = new TabletCommitInfo(tabletId, backendId);
                     if (num % 2 == 0) {
@@ -262,7 +262,7 @@ public class LakePublishBatchTest {
 
         for (Partition partition : table.getPartitions()) {
             MaterializedIndex baseIndex = partition.getDefaultPhysicalPartition().getBaseIndex();
-            for (Long tabletId : baseIndex.getTabletIds()) {
+            for (Long tabletId : baseIndex.getTabletIdsInOrder()) {
                 for (Long backendId : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds()) {
                     TabletCommitInfo tabletCommitInfo = new TabletCommitInfo(tabletId, backendId);
                     transTablets.add(tabletCommitInfo);
@@ -309,7 +309,7 @@ public class LakePublishBatchTest {
         List<TabletCommitInfo> transTablets = Lists.newArrayList();
         for (Partition partition : table.getPartitions()) {
             MaterializedIndex baseIndex = partition.getDefaultPhysicalPartition().getBaseIndex();
-            for (Long tabletId : baseIndex.getTabletIds()) {
+            for (Long tabletId : baseIndex.getTabletIdsInOrder()) {
                 for (Long backendId : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds()) {
                     TabletCommitInfo tabletCommitInfo = new TabletCommitInfo(tabletId, backendId);
                     transTablets.add(tabletCommitInfo);
@@ -369,7 +369,7 @@ public class LakePublishBatchTest {
         List<TabletCommitInfo> transTablets = Lists.newArrayList();
         for (Partition partition : table.getPartitions()) {
             MaterializedIndex baseIndex = partition.getDefaultPhysicalPartition().getBaseIndex();
-            for (Long tabletId : baseIndex.getTabletIds()) {
+            for (Long tabletId : baseIndex.getTabletIdsInOrder()) {
                 for (Long backendId : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds()) {
                     TabletCommitInfo tabletCommitInfo = new TabletCommitInfo(tabletId, backendId);
                     transTablets.add(tabletCommitInfo);
@@ -540,7 +540,7 @@ public class LakePublishBatchTest {
         List<TabletCommitInfo> transTablets = Lists.newArrayList();
         for (Partition partition : table.getPartitions()) {
             MaterializedIndex baseIndex = partition.getDefaultPhysicalPartition().getBaseIndex();
-            for (Long tabletId : baseIndex.getTabletIds()) {
+            for (Long tabletId : baseIndex.getTabletIdsInOrder()) {
                 for (Long backendId : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds()) {
                     TabletCommitInfo tabletCommitInfo = new TabletCommitInfo(tabletId, backendId);
                     transTablets.add(tabletCommitInfo);
@@ -621,7 +621,7 @@ public class LakePublishBatchTest {
                 physicalPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE);
         assertEquals(1, normalIndices.size());
         MaterializedIndex normalIndex = normalIndices.get(0);
-        assertEquals(1, normalIndex.getTabletIds().size());
+        assertEquals(1, normalIndex.getTablets().size());
         LakeTablet normalTablet = (LakeTablet) normalIndex.getTablets().get(0);
 
         GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
@@ -650,7 +650,7 @@ public class LakePublishBatchTest {
                 physicalPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.SHADOW);
         assertEquals(1, shadowIndices.size());
         MaterializedIndex shadowIndex = shadowIndices.get(0);
-        assertEquals(1, shadowIndex.getTabletIds().size());
+        assertEquals(1, shadowIndex.getTablets().size());
         LakeTablet shadowTablet = (LakeTablet) shadowIndex.getTablets().get(0);
 
         // txn2 includes tablets of both base index and shadow index

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -246,10 +246,6 @@ struct TColumn {
 struct TOlapTableIndexTablets {
     1: required i64 index_id
     2: required list<i64> tablets
-
-    // Virtual buckets. There is a tablet id for each virtual bucket,
-    // which means this virtual bucket's data is stored in this tablet.
-    3: optional list<i64> virtual_buckets
 }
 
 // its a closed-open range


### PR DESCRIPTION
## Why I'm doing:
Virtual bucket is no longer needed, so remove it. 
Kernel compatibility is maintained.

## What I'm doing:
  - Remove virtual bucket fields and methods from MaterializedIndex
  - Update BE tablet sink/reader to use tablets directly
  - Simplify FE hash distribution pruning logic
  - Rename getTabletIds() to getTabletIdsInOrder() for clarity
  - Remove virtual bucket info from system views and Thrift interfaces

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes virtual buckets across BE/FE and Thrift, shifting hashing, routing, and displays to use ordered tablet IDs with simplified distribution pruning.
> 
> - **Core Refactor**
>   - Remove all `virtual_buckets` usage/fields and related logic; rely on ordered `tablets` only.
>   - Rename `MaterializedIndex.getTabletIds()` to `getTabletIdsInOrder()` and update callers.
> - **Backend (BE)**
>   - Tablet routing in `tablet_sink_*` and `table_reader` now hashes directly to `indexes[i].tablets`.
>   - Drop upgrade fallback and virtual bucket handling in `tablet_info.cpp`.
> - **Frontend (FE)**
>   - Simplify hash distribution pruning: `HashDistributionPruner` now takes ordered tablet IDs; remove virtual bucket parameters/logic.
>   - Update planners/scanners/sinks (`OlapScanNode`, `PlanFragmentBuilder`, `OlapTableSink`, optimizer rules) to use `getTabletIdsInOrder()`.
>   - Remove virtual bucket metadata from `MaterializedIndex` (fields, methods, equality/hash, toString, postProcess); adjust `MetadataViewer`, proc dirs, and builders.
>   - Lake/OLAP alter/rollup builders stop constructing or mapping virtual buckets; dynamic tablet split no longer sets them.
> - **Thrift/API**
>   - `TOlapTableIndexTablets`: remove optional `virtual_buckets` field; FE population switched to ordered `tablets` only.
> - **UI/Proc outputs**
>   - Remove "VirtualBuckets" columns/values from SHOW/PROC outputs (`IndicesProcDir`, `LakeTabletsProcDir`, `ShowResultMetaFactory`).
> - **Tests**
>   - Adjust unit tests to new APIs and outputs; remove virtual bucket expectations; update mocks to `getTabletIdsInOrder()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c6c47162963b40906623d5ae413a897f2713a1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->