### PR TITLE
[Enhancement] ORC writer support map type

### DIFF
--- a/be/src/formats/orc/orc_file_writer.h
+++ b/be/src/formats/orc/orc_file_writer.h
@@ -116,6 +116,8 @@ private:
 
     Status _write_datetime(orc::ColumnVectorBatch& orc_column, ColumnPtr& column);
 
+    Status _write_map(const TypeDescriptor& type, orc::ColumnVectorBatch& orc_column, ColumnPtr& column);
+
     inline static const std::string STARROCKS_ORC_WRITER_VERSION_KEY = "starrocks.writer.version";
 
     const std::string _location;

--- a/be/test/formats/orc/orc_file_writer_test.cpp
+++ b/be/test/formats/orc/orc_file_writer_test.cpp
@@ -932,7 +932,7 @@ TEST_F(OrcFileWriterTest, TestWriteMapNullable) {
     auto writer = std::make_unique<formats::ORCFileWriter>(_file_path, std::move(output_stream), column_names,
                                                            type_descs, std::move(column_evaluators),
                                                            TCompressionType::NO_COMPRESSION, writer_options, []() {});
-    ASSERT_ERROR(writer->init());
+    ASSERT_OK(writer->init());
 }
 
 TEST_F(OrcFileWriterTest, TestWriteMapNotNull) {
@@ -954,7 +954,7 @@ TEST_F(OrcFileWriterTest, TestWriteMapNotNull) {
     auto writer = std::make_unique<formats::ORCFileWriter>(_file_path, std::move(output_stream), column_names,
                                                            type_descs, std::move(column_evaluators),
                                                            TCompressionType::NO_COMPRESSION, writer_options, []() {});
-    ASSERT_ERROR(writer->init());
+    ASSERT_OK(writer->init());
 }
 
 TEST_F(OrcFileWriterTest, TestWriteArrayNullable) {

--- a/test/sql/test_hive/R/test_write_orc_file
+++ b/test/sql/test_hive/R/test_write_orc_file
@@ -1,0 +1,53 @@
+-- name: test_write_orc_file
+create external catalog hive_sink_test_${uuid0} PROPERTIES ("type"="hive", "hive.metastore.uris"="${hive_metastore_uris}");
+-- result:
+-- !result
+set catalog hive_sink_test_${uuid0};
+-- result:
+-- !result
+create database hive_db_${uuid0};
+-- result:
+-- !result
+use hive_db_${uuid0};
+-- result:
+-- !result
+create table t1(c1 int, c2 map<int, string>) properties("file_format"="orc");
+-- result:
+-- !result
+insert into t1 values (1, null), (2, map{22:"v22", 222:"v222"}), (3, map{33:"v33"}), (4, map{44:null, 444:"v444"});
+-- result:
+-- !result
+select * from t1;
+-- result:
+1	None
+2	{22:"v22",222:"v222"}
+3	{33:"v33"}
+4	{44:null,444:"v444"}
+-- !result
+drop table t1 force;
+-- result:
+-- !result
+create table t2(c1 int, c2 map<int, map<int, string>>) properties("file_format"="orc");
+-- result:
+-- !result
+insert into t2 values (1, null), (2, map{22: map{"222": "v222"}}), (3, map{33: map{"333": null}});
+-- result:
+-- !result
+select * from t2;
+-- result:
+1	None
+2	{22:{222:"v222"}}
+3	{33:{333:null}}
+-- !result
+drop table t2 force;
+-- result:
+-- !result
+drop database hive_db_${uuid0};
+-- result:
+-- !result
+drop catalog hive_sink_test_${uuid0};
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result

--- a/test/sql/test_hive/T/test_write_orc_file
+++ b/test/sql/test_hive/T/test_write_orc_file
@@ -1,0 +1,22 @@
+-- name: test_write_orc_file
+
+create external catalog hive_sink_test_${uuid0} PROPERTIES ("type"="hive", "hive.metastore.uris"="${hive_metastore_uris}");
+set catalog hive_sink_test_${uuid0};
+create database hive_db_${uuid0};
+use hive_db_${uuid0};
+
+-- test write map type: level 1 map
+create table t1(c1 int, c2 map<int, string>) properties("file_format"="orc");
+insert into t1 values (1, null), (2, map{22:"v22", 222:"v222"}), (3, map{33:"v33"}), (4, map{44:null, 444:"v444"});
+select * from t1;
+drop table t1 force;
+
+-- test write map type: level 2 map
+create table t2(c1 int, c2 map<int, map<int, string>>) properties("file_format"="orc");
+insert into t2 values (1, null), (2, map{22: map{"222": "v222"}}), (3, map{33: map{"333": null}});
+select * from t2;
+drop table t2 force;
+
+drop database hive_db_${uuid0};
+drop catalog hive_sink_test_${uuid0};
+set catalog default_catalog;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

ORC writer support map type

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable writing `TYPE_MAP` columns to ORC, including schema generation and serialization, with unit and Hive SQL tests.
> 
> - **ORC Writer**:
>   - Add `_write_map` to serialize `TYPE_MAP` (populate offsets, keys, values, and nulls).
>   - Extend `_write_column` to dispatch `TYPE_MAP` and `_make_schema_node` to build ORC map types.
> - **Tests**:
>   - Update unit tests to expect successful init for map types (`TestWriteMapNullable`, `TestWriteMapNotNull`).
>   - Add Hive SQL tests to write/read ORC tables with `map<int,string>` and nested `map<int,map<int,string>>`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1b5bc2d7e31425dc80b994cddc8b69f0e116da1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->