### PR TITLE
[Refactor] Remove some unused code of orc reader and orc writer

### DIFF
--- a/be/src/formats/orc/column_reader.cpp
+++ b/be/src/formats/orc/column_reader.cpp
@@ -875,22 +875,20 @@ Status MapColumnReader::_fill_map_column(orc::ColumnVectorBatch* cvb, ColumnPtr&
     copy_array_offset(orc_map->offsets, from, size + 1, offsets);
 
     ColumnPtr& keys = col_map->keys_column();
-    const int keys_from = implicit_cast<int>(orc_map->offsets[from]);
-    const int keys_size = implicit_cast<int>(orc_map->offsets[from + size] - keys_from);
+    const int kv_from = implicit_cast<int>(orc_map->offsets[from]);
+    const int kv_size = implicit_cast<int>(orc_map->offsets[from + size] - kv_from);
 
     if (_child_readers[0] == nullptr) {
-        keys->append_default(keys_size);
+        keys->append_default(kv_size);
     } else {
-        RETURN_IF_ERROR(_child_readers[0]->get_next(orc_map->keys.get(), keys, keys_from, keys_size));
+        RETURN_IF_ERROR(_child_readers[0]->get_next(orc_map->keys.get(), keys, kv_from, kv_size));
     }
 
     ColumnPtr& values = col_map->values_column();
-    const int values_from = implicit_cast<int>(orc_map->offsets[from]);
-    const int values_size = implicit_cast<int>(orc_map->offsets[from + size] - values_from);
     if (_child_readers[1] == nullptr) {
-        values->append_default(values_size);
+        values->append_default(kv_size);
     } else {
-        RETURN_IF_ERROR(_child_readers[1]->get_next(orc_map->elements.get(), values, values_from, values_size));
+        RETURN_IF_ERROR(_child_readers[1]->get_next(orc_map->elements.get(), values, kv_from, kv_size));
     }
     return Status::OK();
 }

--- a/be/src/formats/orc/orc_file_writer.cpp
+++ b/be/src/formats/orc/orc_file_writer.cpp
@@ -29,49 +29,6 @@
 
 namespace starrocks::formats {
 
-OrcOutputStream::OrcOutputStream(std::unique_ptr<starrocks::WritableFile> wfile) : _wfile(std::move(wfile)) {}
-
-OrcOutputStream::~OrcOutputStream() {
-    if (!_is_closed) {
-        close();
-    }
-}
-
-uint64_t OrcOutputStream::getLength() const {
-    return _wfile->size();
-}
-
-uint64_t OrcOutputStream::getNaturalWriteSize() const {
-    return config::vector_chunk_size;
-}
-
-const std::string& OrcOutputStream::getName() const {
-    return _wfile->filename();
-}
-
-void OrcOutputStream::write(const void* buf, size_t length) {
-    if (_is_closed) {
-        throw std::runtime_error("The output stream is closed but there are still inputs");
-    }
-    const char* ch = reinterpret_cast<const char*>(buf);
-    Status st = _wfile->append(Slice(ch, length));
-    if (!st.ok()) {
-        throw std::runtime_error("write to orc failed: " + st.to_string());
-    }
-    return;
-}
-
-void OrcOutputStream::close() {
-    if (_is_closed) {
-        return;
-    }
-    _is_closed = true;
-
-    if (auto st = _wfile->close(); !st.ok()) {
-        throw std::runtime_error("close orc output stream failed: " + st.to_string());
-    }
-}
-
 AsyncOrcOutputStream::AsyncOrcOutputStream(io::AsyncFlushOutputStream* stream) : _stream(stream) {}
 
 uint64_t AsyncOrcOutputStream::getLength() const {

--- a/be/src/formats/orc/orc_file_writer.h
+++ b/be/src/formats/orc/orc_file_writer.h
@@ -23,27 +23,6 @@
 
 namespace starrocks::formats {
 
-class OrcOutputStream : public orc::OutputStream {
-public:
-    OrcOutputStream(std::unique_ptr<starrocks::WritableFile> wfile);
-
-    ~OrcOutputStream() override;
-
-    uint64_t getLength() const override;
-
-    uint64_t getNaturalWriteSize() const override;
-
-    void write(const void* buf, size_t length) override;
-
-    void close() override;
-
-    const std::string& getName() const override;
-
-private:
-    std::unique_ptr<starrocks::WritableFile> _wfile;
-    bool _is_closed = false;
-};
-
 class AsyncOrcOutputStream : public orc::OutputStream {
 public:
     AsyncOrcOutputStream(io::AsyncFlushOutputStream* _stream);

--- a/be/src/runtime/types.h
+++ b/be/src/runtime/types.h
@@ -378,9 +378,12 @@ private:
 
 static const TypeDescriptor TYPE_UNKNOWN_DESC = TypeDescriptor(LogicalType::TYPE_UNKNOWN);
 static const TypeDescriptor TYPE_BOOLEAN_DESC = TypeDescriptor{LogicalType::TYPE_BOOLEAN};
+static const TypeDescriptor TYPE_TINYINT_DESC = TypeDescriptor{LogicalType::TYPE_TINYINT};
 static const TypeDescriptor TYPE_SMALLINT_DESC = TypeDescriptor{LogicalType::TYPE_SMALLINT};
 static const TypeDescriptor TYPE_INT_DESC = TypeDescriptor(LogicalType::TYPE_INT);
 static const TypeDescriptor TYPE_BIGINT_DESC = TypeDescriptor(LogicalType::TYPE_BIGINT);
+static const TypeDescriptor TYPE_FLOAT_DESC = TypeDescriptor(LogicalType::TYPE_FLOAT);
+static const TypeDescriptor TYPE_DOUBLE_DESC = TypeDescriptor(LogicalType::TYPE_DOUBLE);
 static const TypeDescriptor TYPE_TIME_DESC = TypeDescriptor(LogicalType::TYPE_TIME);
 static const TypeDescriptor TYPE_DATE_DESC = TypeDescriptor(LogicalType::TYPE_DATE);
 static const TypeDescriptor TYPE_DATETIME_DESC = TypeDescriptor(LogicalType::TYPE_DATETIME);

--- a/be/src/testutil/column_test_helper.h
+++ b/be/src/testutil/column_test_helper.h
@@ -23,7 +23,15 @@ class ColumnTestHelper {
 public:
     template <class T>
     static MutableColumnPtr build_column(const std::vector<T>& values) {
-        if constexpr (std::is_same_v<T, uint8_t>) {
+        if constexpr (std::is_same_v<T, int8_t>) {
+            auto data = Int8Column::create();
+            data->append_numbers(values.data(), values.size() * sizeof(T));
+            return data;
+        } else if constexpr (std::is_same_v<T, int16_t>) {
+            auto data = Int16Column::create();
+            data->append_numbers(values.data(), values.size() * sizeof(T));
+            return data;
+        } else if constexpr (std::is_same_v<T, uint8_t>) {
             auto data = UInt8Column::create();
             data->append_numbers(values.data(), values.size() * sizeof(T));
             return data;
@@ -39,8 +47,12 @@ public:
             auto data = BinaryColumn::create();
             data->append_strings(values.data(), values.size());
             return data;
+        } else if constexpr (std::is_same_v<T, float>) {
+            auto data = FloatColumn::create();
+            data->append_numbers(values.data(), values.size() * sizeof(T));
+            return data;
         } else if constexpr (std::is_same_v<T, double>) {
-            auto data = DoubleColumn ::create();
+            auto data = DoubleColumn::create();
             data->append_numbers(values.data(), values.size() * sizeof(T));
             return data;
         } else {


### PR DESCRIPTION
## Why I'm doing:

* Remove reduncent `values_from/values_size` from MapColumnReader::_fill_map_column.
* Remove OrcOutputStream.

## What I'm doing:

Remove some unused code of orc reader and orc writer

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies ORC map column offset handling and removes the unused synchronous OrcOutputStream in favor of the async stream.
> 
> - **ORC Reader**:
>   - `MapColumnReader::_fill_map_column`: unify key/value offset computation to `kv_from/kv_size` and use for both keys and values; remove redundant `values_from/values_size`; adjust default appends and child reads accordingly.
> - **ORC Writer**:
>   - Remove unused `OrcOutputStream` class and its implementation; retain `AsyncOrcOutputStream` as the output stream implementation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8fdab9add14c4670284426c5daad695d8e765e67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->