### PR TITLE
[BugFix]When the PercentileApprox function is wrapped by NullableAggregateFunction, it causes compression to be lost.

### DIFF
--- a/be/src/exprs/agg/percentile_approx.h
+++ b/be/src/exprs/agg/percentile_approx.h
@@ -97,8 +97,6 @@ public:
 // PercentileApproxAggregateFunction: percentile_approx(expr, DOUBLE p[, DOUBLE compression])
 class PercentileApproxAggregateFunction final : public PercentileApproxAggregateFunctionBase {
 public:
-    void create(FunctionContext* ctx, AggDataPtr __restrict ptr) const override { new (ptr) PercentileApproxState(); }
-
     double get_compression_factor(FunctionContext* ctx) const override {
         double compression = DEFAULT_COMPRESSION_FACTOR;
         if (ctx->get_num_args() > 2) {
@@ -169,8 +167,6 @@ public:
 // PercentileApproxWeightedAggregateFunction: percentile_approx_weighted(expr, weight, DOUBLE p[, DOUBLE compression])
 class PercentileApproxWeightedAggregateFunction final : public PercentileApproxAggregateFunctionBase {
 public:
-    void create(FunctionContext* ctx, AggDataPtr __restrict ptr) const override { new (ptr) PercentileApproxState(); }
-
     double get_compression_factor(FunctionContext* ctx) const override {
         double compression = DEFAULT_COMPRESSION_FACTOR;
         if (ctx->get_num_args() > 3) {

--- a/be/src/exprs/agg/percentile_approx.h
+++ b/be/src/exprs/agg/percentile_approx.h
@@ -27,13 +27,23 @@ namespace starrocks {
 struct PercentileApproxState {
 public:
     PercentileApproxState() : percentile(new PercentileValue()) {}
-    explicit PercentileApproxState(double compression) : percentile(new PercentileValue(compression)) {}
+    explicit PercentileApproxState(double compression)
+            : percentile(new PercentileValue(compression)), compression_initialized(true) {}
     ~PercentileApproxState() = default;
+
+    // Reinitialize the PercentileValue with a new compression factor
+    // This is used when the state is already constructed (e.g., as part of NullableAggregateFunctionState)
+    // but we need to apply a different compression factor from FunctionContext
+    void reinit_with_compression(double compression) {
+        percentile.reset(new PercentileValue(compression));
+        compression_initialized = true;
+    }
 
     int64_t mem_usage() const { return percentile->mem_usage(); }
 
     std::unique_ptr<PercentileValue> percentile;
     double targetQuantile = std::numeric_limits<double>::infinity();
+    bool compression_initialized = false; // Flag to track if compression has been initialized from FunctionContext
 };
 
 class PercentileApproxAggregateFunctionBase
@@ -47,12 +57,18 @@ public:
     virtual double get_compression_factor(FunctionContext* ctx) const = 0;
 
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
+        double compression = get_compression_factor(ctx);
+        // Lazy initialization of compression factor on first merge
+        if (UNLIKELY(!data(state).compression_initialized)) {
+            data(state).reinit_with_compression(compression);
+        }
+
         const auto* binary_column = down_cast<const BinaryColumn*>(column);
         Slice src = binary_column->get_slice(row_num);
         double quantile;
         memcpy(&quantile, src.data, sizeof(double));
 
-        PercentileApproxState src_percentile(get_compression_factor(ctx));
+        PercentileApproxState src_percentile(compression);
         src_percentile.targetQuantile = quantile;
         src_percentile.percentile->deserialize((char*)src.data + sizeof(double));
 
@@ -81,10 +97,7 @@ public:
 // PercentileApproxAggregateFunction: percentile_approx(expr, DOUBLE p[, DOUBLE compression])
 class PercentileApproxAggregateFunction final : public PercentileApproxAggregateFunctionBase {
 public:
-    void create(FunctionContext* ctx, AggDataPtr __restrict ptr) const override {
-        double compression = (ctx == nullptr) ? DEFAULT_COMPRESSION_FACTOR : get_compression_factor(ctx);
-        new (ptr) PercentileApproxState(compression);
-    }
+    void create(FunctionContext* ctx, AggDataPtr __restrict ptr) const override { new (ptr) PercentileApproxState(); }
 
     double get_compression_factor(FunctionContext* ctx) const override {
         double compression = DEFAULT_COMPRESSION_FACTOR;
@@ -100,6 +113,12 @@ public:
     }
 
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
+        // Lazy initialization of compression factor on first update
+        if (UNLIKELY(!data(state).compression_initialized)) {
+            double compression = get_compression_factor(ctx);
+            data(state).reinit_with_compression(compression);
+        }
+
         // argument 0
         const auto* data_column = down_cast<const DoubleColumn*>(columns[0]);
         // argument 1
@@ -150,10 +169,7 @@ public:
 // PercentileApproxWeightedAggregateFunction: percentile_approx_weighted(expr, weight, DOUBLE p[, DOUBLE compression])
 class PercentileApproxWeightedAggregateFunction final : public PercentileApproxAggregateFunctionBase {
 public:
-    void create(FunctionContext* ctx, AggDataPtr __restrict ptr) const override {
-        double compression = (ctx == nullptr) ? DEFAULT_COMPRESSION_FACTOR : get_compression_factor(ctx);
-        new (ptr) PercentileApproxState(compression);
-    }
+    void create(FunctionContext* ctx, AggDataPtr __restrict ptr) const override { new (ptr) PercentileApproxState(); }
 
     double get_compression_factor(FunctionContext* ctx) const override {
         double compression = DEFAULT_COMPRESSION_FACTOR;
@@ -169,6 +185,11 @@ public:
     }
 
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
+        // Lazy initialization of compression factor on first update
+        if (UNLIKELY(!data(state).compression_initialized)) {
+            double compression = get_compression_factor(ctx);
+            data(state).reinit_with_compression(compression);
+        }
         // argument 0
         const auto* data_column = down_cast<const DoubleColumn*>(columns[0]);
         // argument 1: weight can be const or int64 column

--- a/test/sql/test_agg_function/R/test_percentile_approx_weighted
+++ b/test/sql/test_agg_function/R/test_percentile_approx_weighted
@@ -47,7 +47,7 @@ E: (1064, "Getting analyzing error. Detail message: percentile_approx requires t
 -- !result
 select cast(percentile_approx_weighted(c1, c1, 0.9, 10000) as int) from t1;
 -- result:
-47434
+47435
 -- !result
 select cast(percentile_approx_weighted(c2, c1, 0.5) as int) from t1;
 -- result:
@@ -99,7 +99,7 @@ select cast(percentile_approx_weighted(c2, 1, 0.9, 8000) as int) from t1;
 -- !result
 select cast(percentile_approx_weighted(c2, c1, 0.9, 10000) as int) from t1;
 -- result:
-47434
+47435
 -- !result
 select cast(percentile_approx_weighted(c3, c1, 0.5) as int) from t1;
 -- result:
@@ -262,7 +262,7 @@ E: (1064, "Getting analyzing error. Detail message: percentile_approx requires t
 -- !result
 select cast(percentile_approx_weighted(c1, c1, 0.9, 10000) as int) from t1;
 -- result:
-47434
+47435
 -- !result
 select cast(percentile_approx_weighted(c2, c1, 0.5) as int) from t1;
 -- result:
@@ -282,7 +282,7 @@ select cast(percentile_approx_weighted(c2, 10, 0.9, 5000) as int) from t1;
 -- !result
 select cast(percentile_approx_weighted(c2, c1, 0.9, 10000) as int) from t1;
 -- result:
-47434
+47435
 -- !result
 select cast(percentile_approx_weighted(c3, c1, 0.5) as int) from t1;
 -- result:


### PR DESCRIPTION
## Why I'm doing:
1.  PercentileApprox function is wrapped by NullableAggregateFunction
2. NullableAggregateFunctionBase only calls AggregateFunctionStateHelper::create, and PercentileApproxAggregateFunction::create is never called.
## What I'm doing:
1. Lazy initialization of compression factor on first merge/update
2. 1000W row Test Data
```
select percentile_approx(c1, 0.9999, 10000) from t1;
+--------------------------------------+
| percentile_approx(c1, 0.9999, 10000) |
+--------------------------------------+
|                              9998901 |
+--------------------------------------+
```
```
select percentile_approx(c1, 0.9999, 2048) from t1;
+-------------------------------------+
| percentile_approx(c1, 0.9999, 2048) |
+-------------------------------------+
|                             9998902 |
+-------------------------------------+
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
