### PR TITLE
[Enhancement] Add ngram index for the dictionary of inverted index

### DIFF
--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -619,11 +619,6 @@ void LakeDataSource::init_counter(RuntimeState* state) {
     _bi_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "BitmapIndexFilter", segment_init_name);
     _bi_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "BitmapIndexFilterRows", TUnit::UNIT, segment_init_name);
     _bf_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "BloomFilterFilterRows", TUnit::UNIT, segment_init_name);
-    _gin_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinFilterRows", TUnit::UNIT, segment_init_name);
-    _gin_filtered_timer = ADD_CHILD_TIMER(_runtime_profile, "GinFilter", segment_init_name);
-    _gin_prefix_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinPrefixFilter", segment_init_name);
-    _gin_ngram_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinNgramDictFilter", segment_init_name);
-    _gin_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinDictFilter", segment_init_name);
     _seg_zm_filtered_counter =
             ADD_CHILD_COUNTER(_runtime_profile, "SegmentZoneMapFilterRows", TUnit::UNIT, segment_init_name);
     _seg_rt_filtered_counter =
@@ -640,6 +635,17 @@ void LakeDataSource::init_counter(RuntimeState* state) {
     _zone_map_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "ZoneMapIndexFilter", segment_init_name);
     _rows_key_range_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "ShortKeyFilter", segment_init_name);
     _bf_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "BloomFilterFilter", segment_init_name);
+
+    const std::string gin_filter_name = "GinFilter";
+    _gin_filtered_timer = ADD_CHILD_TIMER(_runtime_profile, gin_filter_name, segment_init_name);
+    _gin_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinFilterRows", TUnit::UNIT, gin_filter_name);
+    _gin_prefix_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinPrefixFilter", gin_filter_name);
+    _gin_ngram_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinNgramDictFilter", gin_filter_name);
+    _gin_predicate_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinDictFilter", gin_filter_name);
+    _gin_dict_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinDictNum", TUnit::UNIT, gin_filter_name);
+    _gin_ngram_dict_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinNGramDictNum", TUnit::UNIT, gin_filter_name);
+    _gin_ngram_dict_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinNGramFilteredDictNum", TUnit::UNIT, gin_filter_name);
+    _gin_predicate_dict_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinPredicateFilteredDictNum", TUnit::UNIT, gin_filter_name);
 
     // SegmentRead
     const std::string segment_read_name = "SegmentRead";
@@ -759,12 +765,17 @@ void LakeDataSource::update_counter() {
 
     COUNTER_UPDATE(_bi_filtered_counter, _reader->stats().rows_bitmap_index_filtered);
     COUNTER_UPDATE(_bi_filter_timer, _reader->stats().bitmap_index_filter_timer);
-    COUNTER_UPDATE(_gin_filtered_counter, _reader->stats().rows_gin_filtered);
+    COUNTER_UPDATE(_block_seek_counter, _reader->stats().block_seek_num);
+
     COUNTER_UPDATE(_gin_filtered_timer, _reader->stats().gin_index_filter_ns);
+    COUNTER_UPDATE(_gin_filtered_counter, _reader->stats().rows_gin_filtered);
     COUNTER_UPDATE(_gin_prefix_filter_timer, _reader->stats().gin_prefix_filter_ns);
     COUNTER_UPDATE(_gin_ngram_dict_filter_timer, _reader->stats().gin_ngram_filter_dict_ns);
-    COUNTER_UPDATE(_gin_dict_filter_timer, _reader->stats().gin_filter_dict_ns);
-    COUNTER_UPDATE(_block_seek_counter, _reader->stats().block_seek_num);
+    COUNTER_UPDATE(_gin_predicate_dict_filter_timer, _reader->stats().gin_predicate_filter_dict_ns);
+    COUNTER_UPDATE(_gin_dict_counter, _reader->stats().gin_dict_count);
+    COUNTER_UPDATE(_gin_ngram_dict_counter, _reader->stats().gin_ngram_dict_count);
+    COUNTER_UPDATE(_gin_ngram_dict_filtered_counter, _reader->stats().gin_ngram_dict_filtered);
+    COUNTER_UPDATE(_gin_predicate_dict_filtered_counter, _reader->stats().gin_predicate_dict_filtered);
 
     COUNTER_UPDATE(_rowsets_read_count, _reader->stats().rowsets_read_count);
     COUNTER_UPDATE(_segments_read_count, _reader->stats().segments_read_count);

--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -621,6 +621,9 @@ void LakeDataSource::init_counter(RuntimeState* state) {
     _bf_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "BloomFilterFilterRows", TUnit::UNIT, segment_init_name);
     _gin_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinFilterRows", TUnit::UNIT, segment_init_name);
     _gin_filtered_timer = ADD_CHILD_TIMER(_runtime_profile, "GinFilter", segment_init_name);
+    _gin_prefix_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinPrefixFilter", segment_init_name);
+    _gin_ngram_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinNgramDictFilter", segment_init_name);
+    _gin_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinDictFilter", segment_init_name);
     _seg_zm_filtered_counter =
             ADD_CHILD_COUNTER(_runtime_profile, "SegmentZoneMapFilterRows", TUnit::UNIT, segment_init_name);
     _seg_rt_filtered_counter =
@@ -758,6 +761,9 @@ void LakeDataSource::update_counter() {
     COUNTER_UPDATE(_bi_filter_timer, _reader->stats().bitmap_index_filter_timer);
     COUNTER_UPDATE(_gin_filtered_counter, _reader->stats().rows_gin_filtered);
     COUNTER_UPDATE(_gin_filtered_timer, _reader->stats().gin_index_filter_ns);
+    COUNTER_UPDATE(_gin_prefix_filter_timer, _reader->stats().gin_prefix_filter_ns);
+    COUNTER_UPDATE(_gin_ngram_dict_filter_timer, _reader->stats().gin_ngram_filter_dict_ns);
+    COUNTER_UPDATE(_gin_dict_filter_timer, _reader->stats().gin_filter_dict_ns);
     COUNTER_UPDATE(_block_seek_counter, _reader->stats().block_seek_num);
 
     COUNTER_UPDATE(_rowsets_read_count, _reader->stats().rowsets_read_count);

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -157,6 +157,9 @@ private:
     RuntimeProfile::Counter* _bi_filter_timer = nullptr;
     RuntimeProfile::Counter* _gin_filtered_counter = nullptr;
     RuntimeProfile::Counter* _gin_filtered_timer = nullptr;
+    RuntimeProfile::Counter* _gin_prefix_filter_timer = nullptr;
+    RuntimeProfile::Counter* _gin_ngram_dict_filter_timer = nullptr;
+    RuntimeProfile::Counter* _gin_dict_filter_timer = nullptr;
     RuntimeProfile::Counter* _pushdown_predicates_counter = nullptr;
     RuntimeProfile::Counter* _non_pushdown_predicates_counter = nullptr;
     RuntimeProfile::Counter* _rowsets_read_count = nullptr;

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -155,11 +155,18 @@ private:
     RuntimeProfile::Counter* _block_fetch_timer = nullptr;
     RuntimeProfile::Counter* _bi_filtered_counter = nullptr;
     RuntimeProfile::Counter* _bi_filter_timer = nullptr;
-    RuntimeProfile::Counter* _gin_filtered_counter = nullptr;
+
+    // Gin filter Statistics
     RuntimeProfile::Counter* _gin_filtered_timer = nullptr;
+    RuntimeProfile::Counter* _gin_filtered_counter = nullptr;
     RuntimeProfile::Counter* _gin_prefix_filter_timer = nullptr;
     RuntimeProfile::Counter* _gin_ngram_dict_filter_timer = nullptr;
-    RuntimeProfile::Counter* _gin_dict_filter_timer = nullptr;
+    RuntimeProfile::Counter* _gin_predicate_dict_filter_timer = nullptr;
+    RuntimeProfile::Counter* _gin_dict_counter = nullptr;
+    RuntimeProfile::Counter* _gin_ngram_dict_counter = nullptr;
+    RuntimeProfile::Counter* _gin_ngram_dict_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _gin_predicate_dict_filtered_counter = nullptr;
+
     RuntimeProfile::Counter* _pushdown_predicates_counter = nullptr;
     RuntimeProfile::Counter* _non_pushdown_predicates_counter = nullptr;
     RuntimeProfile::Counter* _rowsets_read_count = nullptr;

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -584,11 +584,18 @@ void OlapScanNode::_init_counter(RuntimeState* state) {
     _bi_filter_timer = ADD_CHILD_TIMER(_scan_profile, "BitmapIndexFilter", "SegmentInit");
     _bi_filtered_counter = ADD_CHILD_COUNTER(_scan_profile, "BitmapIndexFilterRows", TUnit::UNIT, "SegmentInit");
     _bf_filtered_counter = ADD_CHILD_COUNTER(_scan_profile, "BloomFilterFilterRows", TUnit::UNIT, "SegmentInit");
-    _gin_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinFilterRows", TUnit::UNIT, "SegmentInit");
-    _gin_filtered_timer = ADD_CHILD_TIMER(_runtime_profile, "GinFilter", "SegmentInit");
-    _gin_prefix_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinPrefixFilter", "SegmentInit");
-    _gin_ngram_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinNgramDictFilter", "SegmentInit");
-    _gin_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinDictFilter", "SegmentInit");
+
+    const std::string gin_filter_name = "GinFilter";
+    _gin_filtered_timer = ADD_CHILD_TIMER(_runtime_profile, gin_filter_name, "SegmentInit");
+    _gin_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinFilterRows", TUnit::UNIT, gin_filter_name);
+    _gin_prefix_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinPrefixFilter", gin_filter_name);
+    _gin_ngram_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinNgramDictFilter", gin_filter_name);
+    _gin_predicate_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinDictFilter", gin_filter_name);
+    _gin_dict_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinDictNum", TUnit::UNIT, gin_filter_name);
+    _gin_ngram_dict_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinNGramDictNum", TUnit::UNIT, gin_filter_name);
+    _gin_ngram_dict_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinNGramFilteredDictNum", TUnit::UNIT, gin_filter_name);
+    _gin_predicate_dict_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinPredicateFilteredDictNum", TUnit::UNIT, gin_filter_name);
+
     _get_row_ranges_by_vector_index_timer = ADD_CHILD_TIMER(_scan_profile, "GetVectorRowRangesTime", "SegmentInit");
     _vector_search_timer = ADD_CHILD_TIMER(_scan_profile, "VectorSearchTime", "SegmentInit");
     _vector_index_filtered_counter =

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -586,6 +586,9 @@ void OlapScanNode::_init_counter(RuntimeState* state) {
     _bf_filtered_counter = ADD_CHILD_COUNTER(_scan_profile, "BloomFilterFilterRows", TUnit::UNIT, "SegmentInit");
     _gin_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinFilterRows", TUnit::UNIT, "SegmentInit");
     _gin_filtered_timer = ADD_CHILD_TIMER(_runtime_profile, "GinFilter", "SegmentInit");
+    _gin_prefix_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinPrefixFilter", "SegmentInit");
+    _gin_ngram_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinNgramDictFilter", "SegmentInit");
+    _gin_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinDictFilter", "SegmentInit");
     _get_row_ranges_by_vector_index_timer = ADD_CHILD_TIMER(_scan_profile, "GetVectorRowRangesTime", "SegmentInit");
     _vector_search_timer = ADD_CHILD_TIMER(_scan_profile, "VectorSearchTime", "SegmentInit");
     _vector_index_filtered_counter =

--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -248,6 +248,9 @@ private:
     RuntimeProfile::Counter* _bi_filter_timer = nullptr;
     RuntimeProfile::Counter* _gin_filtered_counter = nullptr;
     RuntimeProfile::Counter* _gin_filtered_timer = nullptr;
+    RuntimeProfile::Counter* _gin_prefix_filter_timer = nullptr;
+    RuntimeProfile::Counter* _gin_ngram_dict_filter_timer = nullptr;
+    RuntimeProfile::Counter* _gin_dict_filter_timer = nullptr;
     RuntimeProfile::Counter* _get_row_ranges_by_vector_index_timer = nullptr;
     RuntimeProfile::Counter* _vector_search_timer = nullptr;
     RuntimeProfile::Counter* _vector_index_filtered_counter = nullptr;

--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -246,11 +246,18 @@ private:
     RuntimeProfile::Counter* _cached_pages_num_counter = nullptr;
     RuntimeProfile::Counter* _bi_filtered_counter = nullptr;
     RuntimeProfile::Counter* _bi_filter_timer = nullptr;
-    RuntimeProfile::Counter* _gin_filtered_counter = nullptr;
+
+    // Gin filter Statistics
     RuntimeProfile::Counter* _gin_filtered_timer = nullptr;
+    RuntimeProfile::Counter* _gin_filtered_counter = nullptr;
     RuntimeProfile::Counter* _gin_prefix_filter_timer = nullptr;
     RuntimeProfile::Counter* _gin_ngram_dict_filter_timer = nullptr;
-    RuntimeProfile::Counter* _gin_dict_filter_timer = nullptr;
+    RuntimeProfile::Counter* _gin_predicate_dict_filter_timer = nullptr;
+    RuntimeProfile::Counter* _gin_dict_counter = nullptr;
+    RuntimeProfile::Counter* _gin_ngram_dict_counter = nullptr;
+    RuntimeProfile::Counter* _gin_ngram_dict_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _gin_predicate_dict_filtered_counter = nullptr;
+
     RuntimeProfile::Counter* _get_row_ranges_by_vector_index_timer = nullptr;
     RuntimeProfile::Counter* _vector_search_timer = nullptr;
     RuntimeProfile::Counter* _vector_index_filtered_counter = nullptr;

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -160,11 +160,18 @@ void OlapChunkSource::_init_counter(RuntimeState* state) {
             ADD_CHILD_TIMER(_runtime_profile, "ProcessVectorDistanceAndIdTime", segment_init_name);
     _bi_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "BitmapIndexFilterRows", TUnit::UNIT, segment_init_name);
     _bf_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "BloomFilterFilterRows", TUnit::UNIT, segment_init_name);
-    _gin_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinFilterRows", TUnit::UNIT, segment_init_name);
-    _gin_filtered_timer = ADD_CHILD_TIMER(_runtime_profile, "GinFilter", segment_init_name);
-    _gin_prefix_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinPrefixFilter", segment_init_name);
-    _gin_ngram_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinNgramDictFilter", segment_init_name);
-    _gin_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinDictFilter", segment_init_name);
+
+    const std::string gin_filter_name = "GinFilter";
+    _gin_filtered_timer = ADD_CHILD_TIMER(_runtime_profile, gin_filter_name, segment_init_name);
+    _gin_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinFilterRows", TUnit::UNIT, gin_filter_name);
+    _gin_prefix_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinPrefixFilter", gin_filter_name);
+    _gin_ngram_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinNgramDictFilter", gin_filter_name);
+    _gin_predicate_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinDictFilter", gin_filter_name);
+    _gin_dict_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinDictNum", TUnit::UNIT, gin_filter_name);
+    _gin_ngram_dict_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinNGramDictNum", TUnit::UNIT, gin_filter_name);
+    _gin_ngram_dict_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinNGramFilteredDictNum", TUnit::UNIT, gin_filter_name);
+    _gin_predicate_dict_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinPredicateFilteredDictNum", TUnit::UNIT, gin_filter_name);
+
     _seg_zm_filtered_counter =
             ADD_CHILD_COUNTER_SKIP_MIN_MAX(_runtime_profile, "SegmentZoneMapFilterRows", TUnit::UNIT,
                                            _get_counter_min_max_type("SegmentZoneMapFilterRows"), segment_init_name);
@@ -775,15 +782,20 @@ void OlapChunkSource::_update_counter() {
 
     COUNTER_UPDATE(_bi_filtered_counter, _reader->stats().rows_bitmap_index_filtered);
     COUNTER_UPDATE(_bi_filter_timer, _reader->stats().bitmap_index_filter_timer);
-    COUNTER_UPDATE(_gin_filtered_counter, _reader->stats().rows_gin_filtered);
-    COUNTER_UPDATE(_gin_filtered_timer, _reader->stats().gin_index_filter_ns);
-    COUNTER_UPDATE(_gin_prefix_filter_timer, _reader->stats().gin_prefix_filter_ns);
-    COUNTER_UPDATE(_gin_ngram_dict_filter_timer, _reader->stats().gin_ngram_filter_dict_ns);
-    COUNTER_UPDATE(_gin_dict_filter_timer, _reader->stats().gin_filter_dict_ns);
     COUNTER_UPDATE(_get_row_ranges_by_vector_index_timer, _reader->stats().get_row_ranges_by_vector_index_timer);
     COUNTER_UPDATE(_vector_search_timer, _reader->stats().vector_search_timer);
     COUNTER_UPDATE(_process_vector_distance_and_id_timer, _reader->stats().process_vector_distance_and_id_timer);
     COUNTER_UPDATE(_block_seek_counter, _reader->stats().block_seek_num);
+
+    COUNTER_UPDATE(_gin_filtered_timer, _reader->stats().gin_index_filter_ns);
+    COUNTER_UPDATE(_gin_filtered_counter, _reader->stats().rows_gin_filtered);
+    COUNTER_UPDATE(_gin_prefix_filter_timer, _reader->stats().gin_prefix_filter_ns);
+    COUNTER_UPDATE(_gin_ngram_dict_filter_timer, _reader->stats().gin_ngram_filter_dict_ns);
+    COUNTER_UPDATE(_gin_predicate_dict_filter_timer, _reader->stats().gin_predicate_filter_dict_ns);
+    COUNTER_UPDATE(_gin_dict_counter, _reader->stats().gin_dict_count);
+    COUNTER_UPDATE(_gin_ngram_dict_counter, _reader->stats().gin_ngram_dict_count);
+    COUNTER_UPDATE(_gin_ngram_dict_filtered_counter, _reader->stats().gin_ngram_dict_filtered);
+    COUNTER_UPDATE(_gin_predicate_dict_filtered_counter, _reader->stats().gin_predicate_dict_filtered);
 
     COUNTER_UPDATE(_rowsets_read_count, _reader->stats().rowsets_read_count);
     COUNTER_UPDATE(_segments_read_count, _reader->stats().segments_read_count);

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -162,6 +162,9 @@ void OlapChunkSource::_init_counter(RuntimeState* state) {
     _bf_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "BloomFilterFilterRows", TUnit::UNIT, segment_init_name);
     _gin_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinFilterRows", TUnit::UNIT, segment_init_name);
     _gin_filtered_timer = ADD_CHILD_TIMER(_runtime_profile, "GinFilter", segment_init_name);
+    _gin_prefix_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinPrefixFilter", segment_init_name);
+    _gin_ngram_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinNgramDictFilter", segment_init_name);
+    _gin_dict_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "GinDictFilter", segment_init_name);
     _seg_zm_filtered_counter =
             ADD_CHILD_COUNTER_SKIP_MIN_MAX(_runtime_profile, "SegmentZoneMapFilterRows", TUnit::UNIT,
                                            _get_counter_min_max_type("SegmentZoneMapFilterRows"), segment_init_name);
@@ -774,6 +777,9 @@ void OlapChunkSource::_update_counter() {
     COUNTER_UPDATE(_bi_filter_timer, _reader->stats().bitmap_index_filter_timer);
     COUNTER_UPDATE(_gin_filtered_counter, _reader->stats().rows_gin_filtered);
     COUNTER_UPDATE(_gin_filtered_timer, _reader->stats().gin_index_filter_ns);
+    COUNTER_UPDATE(_gin_prefix_filter_timer, _reader->stats().gin_prefix_filter_ns);
+    COUNTER_UPDATE(_gin_ngram_dict_filter_timer, _reader->stats().gin_ngram_filter_dict_ns);
+    COUNTER_UPDATE(_gin_dict_filter_timer, _reader->stats().gin_filter_dict_ns);
     COUNTER_UPDATE(_get_row_ranges_by_vector_index_timer, _reader->stats().get_row_ranges_by_vector_index_timer);
     COUNTER_UPDATE(_vector_search_timer, _reader->stats().vector_search_timer);
     COUNTER_UPDATE(_process_vector_distance_and_id_timer, _reader->stats().process_vector_distance_and_id_timer);

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -157,6 +157,9 @@ private:
     // GIN (Generalized Inverted Index) filter
     RuntimeProfile::Counter* _gin_filtered_counter = nullptr;
     RuntimeProfile::Counter* _gin_filtered_timer = nullptr;
+    RuntimeProfile::Counter* _gin_prefix_filter_timer = nullptr;
+    RuntimeProfile::Counter* _gin_ngram_dict_filter_timer = nullptr;
+    RuntimeProfile::Counter* _gin_dict_filter_timer = nullptr;
 
     // Rows after skip key filter
     RuntimeProfile::Counter* _rows_after_sk_filtered_counter = nullptr;

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -155,11 +155,15 @@ private:
     RuntimeProfile::Counter* _bi_filter_timer = nullptr;
 
     // GIN (Generalized Inverted Index) filter
-    RuntimeProfile::Counter* _gin_filtered_counter = nullptr;
     RuntimeProfile::Counter* _gin_filtered_timer = nullptr;
+    RuntimeProfile::Counter* _gin_filtered_counter = nullptr;
     RuntimeProfile::Counter* _gin_prefix_filter_timer = nullptr;
     RuntimeProfile::Counter* _gin_ngram_dict_filter_timer = nullptr;
-    RuntimeProfile::Counter* _gin_dict_filter_timer = nullptr;
+    RuntimeProfile::Counter* _gin_predicate_dict_filter_timer = nullptr;
+    RuntimeProfile::Counter* _gin_dict_counter = nullptr;
+    RuntimeProfile::Counter* _gin_ngram_dict_counter = nullptr;
+    RuntimeProfile::Counter* _gin_ngram_dict_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _gin_predicate_dict_filtered_counter = nullptr;
 
     // Rows after skip key filter
     RuntimeProfile::Counter* _rows_after_sk_filtered_counter = nullptr;

--- a/be/src/exec/tablet_scanner.cpp
+++ b/be/src/exec/tablet_scanner.cpp
@@ -368,12 +368,17 @@ void TabletScanner::update_counter() {
 
     COUNTER_UPDATE(_parent->_bi_filtered_counter, _reader->stats().rows_bitmap_index_filtered);
     COUNTER_UPDATE(_parent->_bi_filter_timer, _reader->stats().bitmap_index_filter_timer);
-    COUNTER_UPDATE(_parent->_gin_filtered_counter, _reader->stats().rows_gin_filtered);
+    COUNTER_UPDATE(_parent->_block_seek_counter, _reader->stats().block_seek_num);
+
     COUNTER_UPDATE(_parent->_gin_filtered_timer, _reader->stats().gin_index_filter_ns);
+    COUNTER_UPDATE(_parent->_gin_filtered_counter, _reader->stats().rows_gin_filtered);
     COUNTER_UPDATE(_parent->_gin_prefix_filter_timer, _reader->stats().gin_prefix_filter_ns);
     COUNTER_UPDATE(_parent->_gin_ngram_dict_filter_timer, _reader->stats().gin_ngram_filter_dict_ns);
-    COUNTER_UPDATE(_parent->_gin_dict_filter_timer, _reader->stats().gin_filter_dict_ns);
-    COUNTER_UPDATE(_parent->_block_seek_counter, _reader->stats().block_seek_num);
+    COUNTER_UPDATE(_parent->_gin_predicate_dict_filter_timer, _reader->stats().gin_predicate_filter_dict_ns);
+    COUNTER_UPDATE(_parent->_gin_dict_counter, _reader->stats().gin_dict_count);
+    COUNTER_UPDATE(_parent->_gin_ngram_dict_counter, _reader->stats().gin_ngram_dict_count);
+    COUNTER_UPDATE(_parent->_gin_ngram_dict_filtered_counter, _reader->stats().gin_ngram_dict_filtered);
+    COUNTER_UPDATE(_parent->_gin_predicate_dict_filtered_counter, _reader->stats().gin_predicate_dict_filtered);
 
     COUNTER_UPDATE(_parent->_rowsets_read_count, _reader->stats().rowsets_read_count);
     COUNTER_UPDATE(_parent->_segments_read_count, _reader->stats().segments_read_count);

--- a/be/src/exec/tablet_scanner.cpp
+++ b/be/src/exec/tablet_scanner.cpp
@@ -370,6 +370,9 @@ void TabletScanner::update_counter() {
     COUNTER_UPDATE(_parent->_bi_filter_timer, _reader->stats().bitmap_index_filter_timer);
     COUNTER_UPDATE(_parent->_gin_filtered_counter, _reader->stats().rows_gin_filtered);
     COUNTER_UPDATE(_parent->_gin_filtered_timer, _reader->stats().gin_index_filter_ns);
+    COUNTER_UPDATE(_parent->_gin_prefix_filter_timer, _reader->stats().gin_prefix_filter_ns);
+    COUNTER_UPDATE(_parent->_gin_ngram_dict_filter_timer, _reader->stats().gin_ngram_filter_dict_ns);
+    COUNTER_UPDATE(_parent->_gin_dict_filter_timer, _reader->stats().gin_filter_dict_ns);
     COUNTER_UPDATE(_parent->_block_seek_counter, _reader->stats().block_seek_num);
 
     COUNTER_UPDATE(_parent->_rowsets_read_count, _reader->stats().rowsets_read_count);

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.cpp
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.cpp
@@ -136,9 +136,10 @@ Status BuiltinInvertedIndexIterator::_wildcard_query(const Slice* search_query, 
         last_wildcard_pos = wildcard_pos;
         wildcard_pos = search_query->find('%', last_wildcard_pos);
 
-        auto sub_query = wildcard_pos != -1
-                                 ? Slice(search_query->data + last_wildcard_pos, wildcard_pos - last_wildcard_pos)
-                                 : Slice(search_query->data, search_query->get_size() - last_wildcard_pos);
+        auto sub_query =
+                wildcard_pos != -1
+                        ? Slice(search_query->data + last_wildcard_pos, wildcard_pos - last_wildcard_pos)
+                        : Slice(search_query->data + last_wildcard_pos, search_query->get_size() - last_wildcard_pos);
         keywords.emplace_back(std::make_pair(sub_query, sub_query.build_next()));
         roaring::Roaring tmp;
 
@@ -180,7 +181,7 @@ Status BuiltinInvertedIndexIterator::_wildcard_query(const Slice* search_query, 
     auto predicate = [&keywords](const Slice* dict) -> bool {
         // just need to make sure keywords is in order.
         size_t last_pos = 0;
-        for (const auto& [keyword, next_array]: keywords) {
+        for (const auto& [keyword, next_array] : keywords) {
             last_pos = dict->find(keyword, next_array, last_pos);
             if (last_pos == -1) {
                 return false;

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.cpp
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.cpp
@@ -45,13 +45,6 @@ static std::string get_next_prefix(const Slice& prefix_s) {
     return next_prefix;
 }
 
-Status BuiltinInvertedIndexIterator::close() {
-    if (!_like_context) {
-        return Status::OK();
-    }
-    return LikePredicate::like_close(_like_context.get(), FunctionContext::FunctionStateScope::THREAD_LOCAL);
-}
-
 Status BuiltinInvertedIndexIterator::_equal_query(const Slice* search_query, roaring::Roaring* bit_map) {
     bool exact_match = false;
     Status st = _bitmap_itr->seek_dictionary(search_query, &exact_match);

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.h
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.h
@@ -23,8 +23,10 @@ class FunctionContext;
 class BuiltinInvertedIndexIterator final : public InvertedIndexIterator {
 public:
     BuiltinInvertedIndexIterator(const std::shared_ptr<TabletIndex>& index_meta, InvertedReader* reader,
-                                 std::unique_ptr<BitmapIndexIterator>& bitmap_itr) :
-            InvertedIndexIterator(index_meta, reader), _bitmap_itr(std::move(bitmap_itr)), _like_context(nullptr) {}
+                                 OlapReaderStatistics* stats, std::unique_ptr<BitmapIndexIterator>& bitmap_itr)
+            : InvertedIndexIterator(index_meta, reader, stats),
+              _bitmap_itr(std::move(bitmap_itr)),
+              _like_context(nullptr) {}
 
     ~BuiltinInvertedIndexIterator() override = default;
 
@@ -34,6 +36,7 @@ public:
     Status read_null(const std::string& column_name, roaring::Roaring* bit_map) override;
 
     Status close() override;
+
 private:
     Status _equal_query(const Slice* search_query, roaring::Roaring* bit_map);
 

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.h
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.h
@@ -39,8 +39,6 @@ private:
 
     Status _wildcard_query(const Slice* search_query, roaring::Roaring* bit_map);
 
-    Status _init_like_context(const Slice& s);
-
     std::unique_ptr<BitmapIndexIterator> _bitmap_itr;
     std::unique_ptr<FunctionContext> _like_context;
 };

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.h
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.h
@@ -24,9 +24,7 @@ class BuiltinInvertedIndexIterator final : public InvertedIndexIterator {
 public:
     BuiltinInvertedIndexIterator(const std::shared_ptr<TabletIndex>& index_meta, InvertedReader* reader,
                                  OlapReaderStatistics* stats, std::unique_ptr<BitmapIndexIterator>& bitmap_itr)
-            : InvertedIndexIterator(index_meta, reader, stats),
-              _bitmap_itr(std::move(bitmap_itr)),
-              _like_context(nullptr) {}
+            : InvertedIndexIterator(index_meta, reader, stats), _bitmap_itr(std::move(bitmap_itr)) {}
 
     ~BuiltinInvertedIndexIterator() override = default;
 
@@ -35,15 +33,12 @@ public:
 
     Status read_null(const std::string& column_name, roaring::Roaring* bit_map) override;
 
-    Status close() override;
-
 private:
     Status _equal_query(const Slice* search_query, roaring::Roaring* bit_map);
 
     Status _wildcard_query(const Slice* search_query, roaring::Roaring* bit_map);
 
     std::unique_ptr<BitmapIndexIterator> _bitmap_itr;
-    std::unique_ptr<FunctionContext> _like_context;
 };
 
 } // namespace starrocks

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_reader.cpp
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_reader.cpp
@@ -28,7 +28,7 @@ Status BuiltinInvertedReader::new_iterator(const std::shared_ptr<TabletIndex> in
     RETURN_IF_ERROR(_bitmap_index->new_iterator(index_opt, &iter));
     std::unique_ptr<BitmapIndexIterator> bitmap_itr;
     bitmap_itr.reset(iter);
-    *iterator = new BuiltinInvertedIndexIterator(index_meta, this, bitmap_itr);
+    *iterator = new BuiltinInvertedIndexIterator(index_meta, this, index_opt.stats, bitmap_itr);
     return Status::OK();
 }
 

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_reader.cpp
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_reader.cpp
@@ -23,8 +23,7 @@
 namespace starrocks {
 
 Status BuiltinInvertedReader::new_iterator(const std::shared_ptr<TabletIndex> index_meta,
-                                           InvertedIndexIterator** iterator,
-                                           const IndexReadOptions& index_opt) {
+                                           InvertedIndexIterator** iterator, const IndexReadOptions& index_opt) {
     BitmapIndexIterator* iter;
     RETURN_IF_ERROR(_bitmap_index->new_iterator(index_opt, &iter));
     std::unique_ptr<BitmapIndexIterator> bitmap_itr;
@@ -33,10 +32,11 @@ Status BuiltinInvertedReader::new_iterator(const std::shared_ptr<TabletIndex> in
     return Status::OK();
 }
 
-Status BuiltinInvertedReader::create(const std::shared_ptr<TabletIndex>& tablet_index,
-                                     LogicalType field_type, std::unique_ptr<InvertedReader>* res) {
+Status BuiltinInvertedReader::create(const std::shared_ptr<TabletIndex>& tablet_index, LogicalType field_type,
+                                     std::unique_ptr<InvertedReader>* res) {
     if (is_string_type(field_type)) {
-        *res = std::make_unique<BuiltinInvertedReader>(tablet_index->index_id());
+        const auto gram_num = get_gram_num_from_properties(tablet_index->index_properties());
+        *res = std::make_unique<BuiltinInvertedReader>(tablet_index->index_id(), gram_num);
         return Status::OK();
     } else {
         return Status::InvalidArgument(fmt::format("Not supported type {}", field_type));
@@ -48,7 +48,7 @@ Status BuiltinInvertedReader::load(const IndexReadOptions& opt, void* meta) {
         return Status::InvalidArgument("Invalid argument for loading builtin inverted index");
     }
     const BitmapIndexPB bitmap_index_meta = reinterpret_cast<BuiltinInvertedIndexPB*>(meta)->bitmap_index();
-    _bitmap_index = std::make_unique<BitmapIndexReader>();
+    _bitmap_index = std::make_unique<BitmapIndexReader>(_gram_num);
 
     ASSIGN_OR_RETURN(auto first_load, _bitmap_index->load(opt, bitmap_index_meta));
     if (!first_load) {

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_reader.h
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_reader.h
@@ -31,12 +31,13 @@ class FunctionContext;
 
 class BuiltinInvertedReader : public InvertedReader {
 public:
-    explicit BuiltinInvertedReader(const uint32_t index_id) : InvertedReader("", index_id), _bitmap_index(nullptr) {}
+    explicit BuiltinInvertedReader(const uint32_t index_id, int32_t gram_num)
+            : InvertedReader("", index_id), _gram_num(gram_num), _bitmap_index(nullptr) {}
 
     ~BuiltinInvertedReader() override {}
 
-    static Status create(const std::shared_ptr<TabletIndex>& tablet_index,
-                         LogicalType field_type, std::unique_ptr<InvertedReader>* res);
+    static Status create(const std::shared_ptr<TabletIndex>& tablet_index, LogicalType field_type,
+                         std::unique_ptr<InvertedReader>* res);
 
     Status new_iterator(const std::shared_ptr<TabletIndex> index_meta, InvertedIndexIterator** iterator,
                         const IndexReadOptions& index_opt) override;
@@ -59,6 +60,7 @@ public:
     InvertedIndexReaderType get_inverted_index_reader_type() override { return InvertedIndexReaderType::TEXT; }
 
 private:
+    int32_t _gram_num;
     std::unique_ptr<BitmapIndexReader> _bitmap_index;
 };
 

--- a/be/src/storage/index/inverted/clucene/clucene_inverted_reader.cpp
+++ b/be/src/storage/index/inverted/clucene/clucene_inverted_reader.cpp
@@ -22,6 +22,7 @@
 #include "clucene_inverted_util.h"
 #include "storage/index/index_descriptor.h"
 #include "storage/index/inverted/clucene/match_operator.h"
+#include "storage/rowset/options.h"
 #include "types/logical_type.h"
 #include "util/defer_op.h"
 #include "util/faststring.h"
@@ -29,9 +30,8 @@
 namespace starrocks {
 
 Status CLuceneInvertedReader::new_iterator(const std::shared_ptr<TabletIndex> index_meta,
-                                           InvertedIndexIterator** iterator,
-                                           const IndexReadOptions& index_opt) {
-    *iterator = new InvertedIndexIterator(index_meta, this);
+                                           InvertedIndexIterator** iterator, const IndexReadOptions& index_opt) {
+    *iterator = new InvertedIndexIterator(index_meta, this, index_opt.stats);
     return Status::OK();
 }
 

--- a/be/src/storage/index/inverted/inverted_index_common.h
+++ b/be/src/storage/index/inverted/inverted_index_common.h
@@ -35,6 +35,7 @@ enum class InvertedIndexParserType {
 const std::string INVERTED_IMP_KEY = "imp_lib";
 const std::string TYPE_CLUCENE = "clucene";
 const std::string TYPE_BUILTIN = "builtin";
+
 const std::string INVERTED_INDEX_PARSER_KEY = "parser";
 const std::string INVERTED_INDEX_PARSER_UNKNOWN = "unknown";
 const std::string INVERTED_INDEX_PARSER_NONE = "none";
@@ -42,6 +43,8 @@ const std::string INVERTED_INDEX_PARSER_STANDARD = "standard";
 const std::string INVERTED_INDEX_PARSER_ENGLISH = "english";
 const std::string INVERTED_INDEX_PARSER_CHINESE = "chinese";
 const std::string LIKE_FN_NAME = "like";
+
+const std::string INVERTED_INDEX_DICT_GRAM_NUM_KEY = "dict_gram_num";
 
 const std::string INVERTED_INDEX_TOKENIZED_KEY = "tokenized";
 

--- a/be/src/storage/index/inverted/inverted_index_iterator.h
+++ b/be/src/storage/index/inverted/inverted_index_iterator.h
@@ -26,8 +26,9 @@ enum class InvertedIndexReaderType;
 
 class InvertedIndexIterator {
 public:
-    InvertedIndexIterator(const std::shared_ptr<TabletIndex>& index_meta, InvertedReader* reader)
-            : _index_meta(index_meta), _reader(reader) {
+    InvertedIndexIterator(const std::shared_ptr<TabletIndex>& index_meta, InvertedReader* reader,
+                          OlapReaderStatistics* stats)
+            : _index_meta(index_meta), _stats(stats), _reader(reader) {
         _analyser_type = get_inverted_index_parser_type_from_string(
                 get_parser_string_from_properties(_index_meta->index_properties()));
     }

--- a/be/src/storage/index/inverted/inverted_index_option.cpp
+++ b/be/src/storage/index/inverted/inverted_index_option.cpp
@@ -73,6 +73,14 @@ std::string get_parser_string_from_properties(const std::map<std::string, std::s
     return INVERTED_INDEX_PARSER_NONE;
 }
 
+int32_t get_gram_num_from_properties(const std::map<std::string, std::string>& properties) {
+    if (const auto it = properties.find(INVERTED_INDEX_DICT_GRAM_NUM_KEY); it != properties.end()) {
+        const std::string& gram_num = it->second;
+        return std::stoi(gram_num);
+    }
+    return -1;
+}
+
 bool is_tokenized_from_properties(const std::map<std::string, std::string>& properties) {
     auto tokenized_res = properties.find(INVERTED_INDEX_TOKENIZED_KEY);
     if (tokenized_res != properties.end()) {

--- a/be/src/storage/index/inverted/inverted_index_option.h
+++ b/be/src/storage/index/inverted/inverted_index_option.h
@@ -33,6 +33,8 @@ InvertedIndexParserType get_inverted_index_parser_type_from_string(const std::st
 
 std::string get_parser_string_from_properties(const std::map<std::string, std::string>& properties);
 
+int32_t get_gram_num_from_properties(const std::map<std::string, std::string>& properties);
+
 bool is_tokenized_from_properties(const std::map<std::string, std::string>& properties);
 
 } // namespace starrocks

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -277,12 +277,15 @@ struct OlapReaderStatistics {
 
     int64_t rows_del_vec_filtered = 0;
 
-    int64_t rows_gin_filtered = 0;
     int64_t gin_index_filter_ns = 0;
-
+    int64_t rows_gin_filtered = 0;
     int64_t gin_prefix_filter_ns = 0;
     int64_t gin_ngram_filter_dict_ns = 0;
-    int64_t gin_filter_dict_ns = 0;
+    int64_t gin_predicate_filter_dict_ns = 0;
+    int64_t gin_dict_count = 0;
+    int64_t gin_ngram_dict_count = 0;
+    int64_t gin_ngram_dict_filtered = 0;
+    int64_t gin_predicate_dict_filtered = 0;
 
     int64_t rowsets_read_count = 0;
     int64_t segments_read_count = 0;

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -280,6 +280,10 @@ struct OlapReaderStatistics {
     int64_t rows_gin_filtered = 0;
     int64_t gin_index_filter_ns = 0;
 
+    int64_t gin_prefix_filter_ns = 0;
+    int64_t gin_ngram_filter_dict_ns = 0;
+    int64_t gin_filter_dict_ns = 0;
+
     int64_t rowsets_read_count = 0;
     int64_t segments_read_count = 0;
     int64_t total_columns_data_page_count = 0;

--- a/be/src/storage/rowset/bitmap_index_reader.cpp
+++ b/be/src/storage/rowset/bitmap_index_reader.cpp
@@ -38,6 +38,7 @@
 
 #include <memory>
 
+#include "bitmap_range_iterator.h"
 #include "column/column_helper.h"
 #include "column/column_viewer.h"
 #include "exprs/function_context.h"
@@ -46,12 +47,13 @@
 #include "storage/chunk_helper.h"
 #include "storage/range.h"
 #include "storage/types.h"
+#include "util/utf8.h"
 
 namespace starrocks {
 
 using Roaring = roaring::Roaring;
 
-BitmapIndexReader::BitmapIndexReader() {
+BitmapIndexReader::BitmapIndexReader(int32_t gram_num): _gram_num(gram_num) {
     MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->bitmap_index_mem_tracker(), sizeof(BitmapIndexReader));
 }
 
@@ -88,15 +90,161 @@ Status BitmapIndexReader::_do_load(const IndexReadOptions& opts, const BitmapInd
     _bitmap_column_reader = std::make_unique<IndexedColumnReader>(bitmap_meta);
     RETURN_IF_ERROR(_dict_column_reader->load(opts));
     RETURN_IF_ERROR(_bitmap_column_reader->load(opts));
+    if (meta.has_ngram_dict_column() && meta.has_ngram_bitmap_column()) {
+        const IndexedColumnMetaPB& ngram_dict_meta = meta.ngram_dict_column();
+        const IndexedColumnMetaPB& ngram_bitmap_meta = meta.ngram_bitmap_column();
+        _ngram_dict_column_reader = std::make_unique<IndexedColumnReader>(ngram_dict_meta);
+        _ngram_bitmap_column_reader = std::make_unique<IndexedColumnReader>(ngram_bitmap_meta);
+        RETURN_IF_ERROR(_ngram_dict_column_reader->load(opts));
+        RETURN_IF_ERROR(_ngram_bitmap_column_reader->load(opts));
+    } else {
+        _ngram_dict_column_reader = nullptr;
+        _ngram_bitmap_column_reader = nullptr;
+    }
     return Status::OK();
 }
 
 Status BitmapIndexReader::new_iterator(const IndexReadOptions& opts, BitmapIndexIterator** iterator) {
     std::unique_ptr<IndexedColumnIterator> dict_iter;
     std::unique_ptr<IndexedColumnIterator> bitmap_iter;
+    std::unique_ptr<IndexedColumnIterator> ngram_dict_iter = nullptr;
+    std::unique_ptr<IndexedColumnIterator> ngram_bitmap_iter = nullptr;
     RETURN_IF_ERROR(_dict_column_reader->new_iterator(opts, &dict_iter));
     RETURN_IF_ERROR(_bitmap_column_reader->new_iterator(opts, &bitmap_iter));
-    *iterator = new BitmapIndexIterator(this, std::move(dict_iter), std::move(bitmap_iter), _has_null, bitmap_nums());
+    if (_ngram_dict_column_reader != nullptr && _ngram_bitmap_column_reader != nullptr) {
+        RETURN_IF_ERROR(_ngram_dict_column_reader->new_iterator(opts, &ngram_dict_iter));
+        RETURN_IF_ERROR(_ngram_bitmap_column_reader->new_iterator(opts, &ngram_bitmap_iter));
+    }
+    *iterator = new BitmapIndexIterator(this, std::move(dict_iter), std::move(bitmap_iter), std::move(ngram_dict_iter),
+                                        std::move(ngram_bitmap_iter), _has_null, bitmap_nums());
+    return Status::OK();
+}
+
+Status BitmapIndexIterator::seek_dict_by_ngram(const void* value, roaring::Roaring* roaring) const {
+    if (_reader->gram_num() <= 0) {
+        // _num_bitmap means how many dicts exist. should return all dicts here.
+        roaring->addRange(0, _num_bitmap);
+        return Status::OK();
+    }
+
+    if (_ngram_dict_column_iter == nullptr || _ngram_bitmap_column_iter == nullptr) {
+        return Status::InternalError("ngram bitmap index reader is not opened.");
+    }
+    if (_reader->type_info()->type() != TYPE_VARCHAR && _reader->type_info()->type() != TYPE_CHAR) {
+        return Status::NotSupported("ngram seek for dictionary only support string/char type in bitmap index");
+    }
+
+    const auto gram_num = _reader->gram_num();
+    const auto* slice_val = static_cast<const Slice*>(value);
+    if (slice_val->get_size() < gram_num) {
+        // _num_bitmap means how many dicts exist. should return all dicts here.
+        roaring->addRange(0, _num_bitmap);
+        return Status::OK();
+    }
+
+    std::vector<size_t> index;
+    const size_t slice_gram_num = get_utf8_index(*slice_val, &index);
+
+    bool first = true;
+    for (size_t j = 0; j + gram_num <= slice_gram_num; ++j) {
+        // find next ngram
+        size_t cur_ngram_length =
+                j + gram_num < slice_gram_num ? index[j + gram_num] - index[j] : slice_val->get_size() - index[j];
+        Slice cur_ngram(slice_val->data + index[j], cur_ngram_length);
+
+        bool match = false;
+        RETURN_IF_ERROR(_ngram_dict_column_iter->seek_at_or_after(&cur_ngram, &match));
+        if (!match) {
+            continue;
+        }
+
+        RETURN_IF_ERROR(_ngram_bitmap_column_iter->seek_to_ordinal(_ngram_dict_column_iter->get_current_ordinal()));
+        size_t num_to_read = 1;
+        size_t num_read = num_to_read;
+        auto column = ChunkHelper::column_from_field_type(TYPE_VARCHAR, false);
+        RETURN_IF_ERROR(_ngram_bitmap_column_iter->next_batch(&num_read, column.get()));
+        if (num_to_read != num_read) {
+            return Status::InternalError(fmt::format(
+                    "read ngram bitmap column failed, expect {} rows, but got {} rows.", num_to_read, num_read));
+        }
+
+        ColumnViewer<TYPE_VARCHAR> viewer(std::move(column));
+        const auto str_bitmap = viewer.value(0);
+
+        const auto tmp = Roaring::read(str_bitmap.data, false);
+        if (first) {
+            *roaring |= tmp;
+            first = false;
+        } else {
+            *roaring &= tmp;
+        }
+
+        if (roaring->cardinality() == 0) {
+            // no words match, fast fail
+            return Status::OK();
+        }
+    }
+    return Status::OK();
+}
+
+StatusOr<Buffer<rowid_t>> BitmapIndexIterator::filter_dict_by_predicate(
+        const roaring::Roaring* rowids, const std::function<bool(const Slice*)>& predicate) const {
+    BitmapRangeIterator it(*rowids);
+    uint32_t from, to;
+    const auto max_range = rowids->maximum() - rowids->minimum();
+    Buffer<rowid_t> hit_rowids;
+    while (it.next_range(max_range, &from, &to)) {
+        auto col = ChunkHelper::column_from_field_type(TYPE_VARCHAR, false);
+        RETURN_IF_ERROR(_dict_column_iter->seek_to_ordinal(from));
+        size_t num_to_read = to - from;
+        size_t read = num_to_read;
+        RETURN_IF_ERROR(_dict_column_iter->next_batch(&read, col.get()));
+        if (num_to_read != read) {
+            return Status::InternalError(
+                    fmt::format("read dict column failed, expect {} rows, but got {} rows.", num_to_read, read));
+        }
+
+        ColumnViewer<TYPE_VARCHAR> viewer(std::move(col));
+        for (int i = 0; i < viewer.size(); ++i) {
+            auto value = viewer.value(i);
+            if (predicate(&value)) {
+                hit_rowids.push_back(from + i);
+            }
+        }
+    }
+    return std::move(hit_rowids);
+}
+
+Status BitmapIndexIterator::next_batch_ngram(rowid_t ordinal, size_t* n, Column* column) const {
+    if (_ngram_dict_column_iter != nullptr) {
+        if (!(0 <= ordinal && ordinal < _reader->ngram_bitmap_nums())) {
+            return Status::InvalidArgument("ordinal is out of range while reading ngram bitmap");
+        }
+        RETURN_IF_ERROR(_ngram_dict_column_iter->seek_to_ordinal(ordinal));
+        return _ngram_dict_column_iter->next_batch(n, column);
+    }
+    *n = 0;
+    return Status::OK();
+}
+
+Status BitmapIndexIterator::read_ngram_bitmap(rowid_t ordinal, Roaring* result) const {
+    if (_ngram_bitmap_column_iter != nullptr) {
+        if (!(0 <= ordinal && ordinal < _reader->ngram_bitmap_nums())) {
+            return Status::InvalidArgument("ordinal is out of range while reading ngram bitmap");
+        }
+        auto column = ChunkHelper::column_from_field_type(TYPE_VARCHAR, false);
+        RETURN_IF_ERROR(_ngram_bitmap_column_iter->seek_to_ordinal(ordinal));
+        size_t num_to_read = 1;
+        size_t num_read = num_to_read;
+        RETURN_IF_ERROR(_ngram_bitmap_column_iter->next_batch(&num_read, column.get()));
+        if (num_to_read != num_read) {
+            return Status::InternalError(fmt::format(
+                    "read ngram bitmap column failed, expect {} rows, but got {} rows.", num_to_read, num_read));
+        }
+        const ColumnViewer<TYPE_VARCHAR> viewer(std::move(column));
+        const auto value = viewer.value(0);
+        *result = Roaring::read(value.data, false);
+    }
     return Status::OK();
 }
 
@@ -113,10 +261,11 @@ Status BitmapIndexIterator::next_batch_dictionary(size_t* n, Column* column) {
 }
 
 StatusOr<Buffer<rowid_t>> BitmapIndexIterator::seek_dictionary_by_predicate(const DictPredicate& predicate,
-                                                                            const Slice& from_value, size_t search_size) {
+                                                                            const Slice& from_value,
+                                                                            size_t search_size) {
     if (_reader->type_info()->type() != TYPE_VARCHAR && _reader->type_info()->type() != TYPE_CHAR) {
         return Status::NotSupported("predicate seek for dictionary only support string/char type bitmap index");
-    }                                                                    
+    }
     auto column = ChunkHelper::column_from_field_type(TYPE_VARCHAR, false);
     bool exact_match;
     RETURN_IF_ERROR(seek_dictionary(&from_value, &exact_match));
@@ -132,7 +281,7 @@ StatusOr<Buffer<rowid_t>> BitmapIndexIterator::seek_dictionary_by_predicate(cons
         }
     }
     return hit_rowids;
-} 
+}
 
 Status BitmapIndexIterator::read_bitmap(rowid_t ordinal, Roaring* result) {
     DCHECK(0 <= ordinal && ordinal < _reader->bitmap_nums());

--- a/be/src/storage/rowset/bitmap_index_reader.cpp
+++ b/be/src/storage/rowset/bitmap_index_reader.cpp
@@ -53,7 +53,7 @@ namespace starrocks {
 
 using Roaring = roaring::Roaring;
 
-BitmapIndexReader::BitmapIndexReader(int32_t gram_num): _gram_num(gram_num) {
+BitmapIndexReader::BitmapIndexReader(int32_t gram_num) : _gram_num(gram_num) {
     MEM_TRACKER_SAFE_CONSUME(GlobalEnv::GetInstance()->bitmap_index_mem_tracker(), sizeof(BitmapIndexReader));
 }
 
@@ -163,6 +163,9 @@ Status BitmapIndexIterator::seek_dict_by_ngram(const void* value, roaring::Roari
         bool match = false;
         RETURN_IF_ERROR(_ngram_dict_column_iter->seek_at_or_after(&cur_ngram, &match));
         if (!match) {
+            // Clear rowids bitmap here, otherwise the caller might mistakenly treat the remaining values in the
+            // bitmap as matched rowids.
+            roaring->clear();
             return Status::OK();
         }
 

--- a/be/src/storage/rowset/bitmap_index_reader.h
+++ b/be/src/storage/rowset/bitmap_index_reader.h
@@ -57,7 +57,7 @@ using Roaring = roaring::Roaring;
 
 class BitmapIndexReader {
 public:
-    BitmapIndexReader();
+    BitmapIndexReader(int32_t gram_num = -1);
     ~BitmapIndexReader();
 
     // Load index data into memory.
@@ -77,6 +77,16 @@ public:
     // REQUIRES: the index data has been successfully `load()`ed into memory.
     int64_t bitmap_nums() { return _bitmap_column_reader->num_values(); }
 
+    int32_t gram_num() const { return _gram_num; }
+
+    // REQUIRES: the index data has been successfully `load()`ed into memory.
+    int64_t ngram_bitmap_nums() const {
+        if (_ngram_bitmap_column_reader != nullptr) {
+            return _ngram_bitmap_column_reader->num_values();
+        }
+        return 0;
+    }
+
     const TypeInfoPtr& type_info() { return _typeinfo; }
 
     bool loaded() const { return invoked(_load_once); }
@@ -89,6 +99,12 @@ public:
         if (_bitmap_column_reader != nullptr) {
             size += _bitmap_column_reader->mem_usage();
         }
+        if (_ngram_dict_column_reader != nullptr) {
+            size += _ngram_dict_column_reader->mem_usage();
+        }
+        if (_ngram_bitmap_column_reader != nullptr) {
+            size += _ngram_bitmap_column_reader->mem_usage();
+        }
         return size;
     }
 
@@ -99,10 +115,14 @@ private:
 
     Status _do_load(const IndexReadOptions& opts, const BitmapIndexPB& meta);
 
+    int32_t _gram_num;
+
     OnceFlag _load_once;
     TypeInfoPtr _typeinfo;
     std::unique_ptr<IndexedColumnReader> _dict_column_reader;
     std::unique_ptr<IndexedColumnReader> _bitmap_column_reader;
+    std::unique_ptr<IndexedColumnReader> _ngram_dict_column_reader;
+    std::unique_ptr<IndexedColumnReader> _ngram_bitmap_column_reader;
     bool _has_null = false;
 };
 
@@ -111,14 +131,27 @@ public:
     using DictPredicate = std::function<StatusOr<ColumnPtr>(const Column&)>;
 
     BitmapIndexIterator(BitmapIndexReader* reader, std::unique_ptr<IndexedColumnIterator> dict_iter,
-                        std::unique_ptr<IndexedColumnIterator> bitmap_iter, bool has_null, rowid_t num_bitmap)
+                        std::unique_ptr<IndexedColumnIterator> bitmap_iter,
+                        std::unique_ptr<IndexedColumnIterator> ngram_dict_iter,
+                        std::unique_ptr<IndexedColumnIterator> ngram_bitmap_iter, bool has_null, rowid_t num_bitmap)
             : _reader(reader),
               _dict_column_iter(std::move(dict_iter)),
               _bitmap_column_iter(std::move(bitmap_iter)),
+              _ngram_dict_column_iter(std::move(ngram_dict_iter)),
+              _ngram_bitmap_column_iter(std::move(ngram_bitmap_iter)),
               _has_null(has_null),
               _num_bitmap(num_bitmap) {}
 
     bool has_null_bitmap() const { return _has_null; }
+
+    Status seek_dict_by_ngram(const void* value, roaring::Roaring* roaring) const;
+
+    StatusOr<Buffer<rowid_t>> filter_dict_by_predicate(const roaring::Roaring* rowids,
+                                                       const std::function<bool(const Slice*)>& predicate) const;
+
+    // used for test
+    Status next_batch_ngram(rowid_t ordinal, size_t* n, Column* column) const;
+    Status read_ngram_bitmap(rowid_t ordinal, Roaring* result) const;
 
     // Seek the dictionary to the first value that is >= the given value.
     //
@@ -130,7 +163,8 @@ public:
     // Returns other error status otherwise.
     Status seek_dictionary(const void* value, bool* exact_match);
 
-    StatusOr<Buffer<rowid_t>> seek_dictionary_by_predicate(const DictPredicate& predicate, const Slice& from_value, size_t search_size);
+    StatusOr<Buffer<rowid_t>> seek_dictionary_by_predicate(const DictPredicate& predicate, const Slice& from_value,
+                                                           size_t search_size);
 
     Status next_batch_dictionary(size_t* n, Column* column);
 
@@ -166,6 +200,8 @@ private:
     BitmapIndexReader* _reader;
     std::unique_ptr<IndexedColumnIterator> _dict_column_iter;
     std::unique_ptr<IndexedColumnIterator> _bitmap_column_iter;
+    std::unique_ptr<IndexedColumnIterator> _ngram_dict_column_iter;
+    std::unique_ptr<IndexedColumnIterator> _ngram_bitmap_column_iter;
     bool _has_null;
     rowid_t _num_bitmap;
     rowid_t _current_rowid{0};

--- a/be/src/storage/rowset/bitmap_index_reader.h
+++ b/be/src/storage/rowset/bitmap_index_reader.h
@@ -194,6 +194,13 @@ public:
 
     rowid_t bitmap_nums() const { return _num_bitmap; }
 
+    rowid_t ngram_bitmap_nums() const {
+        if (_reader != nullptr) {
+            return _reader->ngram_bitmap_nums();
+        }
+        return 0;
+    }
+
     rowid_t current_ordinal() const { return _current_rowid; }
 
 private:

--- a/be/src/storage/rowset/bitmap_index_writer.cpp
+++ b/be/src/storage/rowset/bitmap_index_writer.cpp
@@ -307,6 +307,9 @@ public:
                 for (const auto& it : ordered_mem_index) {
                     RETURN_IF_ERROR(_build_ngram(ngram_index, &it.first, offset++));
                 }
+                for (auto& it: ngram_index) {
+                    it.second.flush_pending_adds();
+                }
                 RETURN_IF_ERROR(_write_dictionary(ngram_index, wfile, meta->mutable_ngram_dict_column()));
                 RETURN_IF_ERROR(_write_bitmap(ngram_index, wfile, meta->mutable_ngram_bitmap_column()));
             }

--- a/be/src/storage/rowset/bitmap_index_writer.cpp
+++ b/be/src/storage/rowset/bitmap_index_writer.cpp
@@ -51,6 +51,7 @@
 #include "util/phmap/btree.h"
 #include "util/phmap/phmap.h"
 #include "util/slice.h"
+#include "util/utf8.h"
 #include "util/xxh3.h"
 
 namespace starrocks {
@@ -61,8 +62,12 @@ class BitmapUpdateContext {
     static const size_t estimate_size_threshold = 1024;
 
 public:
-    explicit BitmapUpdateContext(rowid_t rid) : _roaring(Roaring::bitmapOf(1, rid)){ _pending_adds.reserve(_ADD_BATCH_SIZE); };
-    explicit BitmapUpdateContext(rowid_t rid0, rowid_t rid1) : _roaring(Roaring::bitmapOfList({rid0, rid1})){ _pending_adds.reserve(_ADD_BATCH_SIZE); };
+    explicit BitmapUpdateContext(rowid_t rid) : _roaring(Roaring::bitmapOf(1, rid)) {
+        _pending_adds.reserve(_ADD_BATCH_SIZE);
+    };
+    explicit BitmapUpdateContext(rowid_t rid0, rowid_t rid1) : _roaring(Roaring::bitmapOfList({rid0, rid1})) {
+        _pending_adds.reserve(_ADD_BATCH_SIZE);
+    };
 
     Roaring* roaring() { return &_roaring; }
 
@@ -213,7 +218,8 @@ struct BitmapIndexTraits {
 
 template <>
 struct BitmapIndexTraits<Slice> {
-    using UnorderedMemoryIndexType = phmap::flat_hash_map<Slice, BitmapUpdateContextRefOrSingleValue, BitmapIndexSliceHash, std::equal_to<Slice>>;
+    using UnorderedMemoryIndexType = phmap::flat_hash_map<Slice, BitmapUpdateContextRefOrSingleValue,
+                                                          BitmapIndexSliceHash, std::equal_to<Slice>>;
     using OrderedMemoryIndexType = std::map<Slice, BitmapUpdateContextRefOrSingleValue, Slice::Comparator>;
 };
 
@@ -237,7 +243,8 @@ public:
     using UnorderedMemoryIndexType = typename BitmapIndexTraits<CppType>::UnorderedMemoryIndexType;
     using OrderedMemoryIndexType = typename BitmapIndexTraits<CppType>::OrderedMemoryIndexType;
 
-    explicit BitmapIndexWriterImpl(TypeInfoPtr type_info) : _typeinfo(std::move(type_info)) {}
+    explicit BitmapIndexWriterImpl(TypeInfoPtr type_info, int32_t gram_num)
+            : _gram_num(gram_num), _typeinfo(std::move(type_info)) {}
 
     ~BitmapIndexWriterImpl() override = default;
 
@@ -288,76 +295,21 @@ public:
             ordered_mem_index.insert(std::move(p));
         }
 
-        { // write dictionary
-            IndexedColumnWriterOptions options;
-            options.write_ordinal_index = false;
-            options.write_value_index = true;
-            options.encoding = EncodingInfo::get_default_encoding(_typeinfo->type(), true);
-            options.compression = _dictionary_compression;
+        // write dictionary
+        RETURN_IF_ERROR(_write_dictionary(ordered_mem_index, wfile, meta->mutable_dict_column()));
+        // write bitmap
+        RETURN_IF_ERROR(_write_bitmap(ordered_mem_index, wfile, meta->mutable_bitmap_column()));
 
-            IndexedColumnWriter dict_column_writer(options, _typeinfo, wfile);
-            RETURN_IF_ERROR(dict_column_writer.init());
-            for (auto const& it : ordered_mem_index) {
-                RETURN_IF_ERROR(dict_column_writer.add(&(it.first)));
-            }
-            RETURN_IF_ERROR(dict_column_writer.finish(meta->mutable_dict_column()));
-        }
-        { // write bitmaps
-            std::vector<BitmapUpdateContextRefOrSingleValue*> bitmaps;
-            for (auto& it : ordered_mem_index) {
-                bitmaps.push_back(&(it.second));
-            }
-
-            uint32_t max_bitmap_size = 0;
-            std::vector<uint32_t> bitmap_sizes;
-            for (auto& bitmap : bitmaps) {
-                uint32_t bitmap_size = 0;
-                if (bitmap->is_context()) {
-                    bitmap->context()->roaring()->runOptimize();
-                    bitmap_size = bitmap->context()->roaring()->getSizeInBytes(false);
-                    if (max_bitmap_size < bitmap_size) {
-                        max_bitmap_size = bitmap_size;
-                    }
+        if (_gram_num > 0) {
+            if constexpr (field_type == TYPE_VARCHAR || field_type == TYPE_CHAR) {
+                size_t offset = 0;
+                OrderedMemoryIndexType ngram_index;
+                for (const auto& it : ordered_mem_index) {
+                    RETURN_IF_ERROR(_build_ngram(ngram_index, &it.first, offset++));
                 }
-                bitmap_sizes.push_back(bitmap_size);
+                RETURN_IF_ERROR(_write_dictionary(ngram_index, wfile, meta->mutable_ngram_dict_column()));
+                RETURN_IF_ERROR(_write_bitmap(ngram_index, wfile, meta->mutable_ngram_bitmap_column()));
             }
-
-            TypeInfoPtr bitmap_typeinfo = get_type_info(TYPE_OBJECT);
-
-            IndexedColumnWriterOptions options;
-            options.write_ordinal_index = true;
-            options.write_value_index = false;
-            options.encoding = EncodingInfo::get_default_encoding(bitmap_typeinfo->type(), false);
-            // we already store compressed bitmap, use NO_COMPRESSION to save some cpu
-            options.compression = NO_COMPRESSION;
-
-            IndexedColumnWriter bitmap_column_writer(options, bitmap_typeinfo, wfile);
-            RETURN_IF_ERROR(bitmap_column_writer.init());
-
-            faststring buf;
-            buf.reserve(max_bitmap_size);
-            for (size_t i = 0; i < bitmaps.size(); ++i) {
-                if (bitmaps[i]->is_context()) {
-                    buf.resize(bitmap_sizes[i]); // so that buf[0..size) can be read and written
-                    bitmaps[i]->context()->roaring()->write(reinterpret_cast<char*>(buf.data()), false);
-                } else {
-                    Roaring roar({bitmaps[i]->value()});
-                    roar.runOptimize();
-                    auto sz = roar.getSizeInBytes(false);
-                    buf.resize(sz);
-                    roar.write(reinterpret_cast<char*>(buf.data()), false);
-                }
-                Slice buf_slice(buf);
-                RETURN_IF_ERROR(bitmap_column_writer.add(&buf_slice));
-            }
-            if (!_null_bitmap.isEmpty()) {
-                _null_bitmap.runOptimize();
-                buf.resize(_null_bitmap.getSizeInBytes(false)); // so that buf[0..size) can be read and written
-                _null_bitmap.write(reinterpret_cast<char*>(buf.data()), false);
-                Slice buf_slice(buf);
-                RETURN_IF_ERROR(bitmap_column_writer.add(&buf_slice));
-            }
-            RETURN_IF_ERROR(bitmap_column_writer.finish(meta->mutable_bitmap_column()));
         }
         return Status::OK();
     }
@@ -379,6 +331,110 @@ public:
     inline void incre_rowid() override { _rid++; }
 
 private:
+    Status _build_ngram(OrderedMemoryIndexType& ngram_index, const Slice* cur_slice, const size_t offset) {
+        if (_gram_num <= 0) {
+            return Status::InvalidArgument(
+                    "Invalid gram num while building ngram index for inverted index dictionary.");
+        }
+
+        std::vector<size_t> index;
+        const size_t slice_gram_num = get_utf8_index(*cur_slice, &index);
+
+        for (size_t j = 0; j + _gram_num <= slice_gram_num; ++j) {
+            // find next ngram
+            size_t cur_ngram_length =
+                    j + _gram_num < slice_gram_num ? index[j + _gram_num] - index[j] : cur_slice->get_size() - index[j];
+            Slice cur_ngram(cur_slice->data + index[j], cur_ngram_length);
+
+            // add this ngram into set
+            auto it = ngram_index.find(cur_ngram);
+            if (it == ngram_index.end()) {
+                CppType new_value;
+                _typeinfo->deep_copy(&new_value, &cur_ngram, &_pool);
+                ngram_index.emplace(new_value, offset);
+            } else {
+                it->second.add(offset);
+            }
+        }
+        return Status::OK();
+    }
+
+    Status _write_dictionary(OrderedMemoryIndexType& ordered_mem_index, WritableFile* wfile,
+                             IndexedColumnMetaPB* meta) {
+        IndexedColumnWriterOptions options;
+        options.write_ordinal_index = true;
+        options.write_value_index = true;
+        options.encoding = EncodingInfo::get_default_encoding(_typeinfo->type(), true);
+        options.compression = _dictionary_compression;
+
+        IndexedColumnWriter dict_column_writer(options, _typeinfo, wfile);
+        RETURN_IF_ERROR(dict_column_writer.init());
+        for (auto const& it : ordered_mem_index) {
+            RETURN_IF_ERROR(dict_column_writer.add(&(it.first)));
+        }
+        return dict_column_writer.finish(meta);
+    }
+
+    Status _write_bitmap(OrderedMemoryIndexType& ordered_mem_index, WritableFile* wfile, IndexedColumnMetaPB* meta) {
+        std::vector<BitmapUpdateContextRefOrSingleValue*> bitmaps;
+        for (auto& it : ordered_mem_index) {
+            bitmaps.push_back(&(it.second));
+        }
+
+        uint32_t max_bitmap_size = 0;
+        std::vector<uint32_t> bitmap_sizes;
+        for (auto& bitmap : bitmaps) {
+            uint32_t bitmap_size = 0;
+            if (bitmap->is_context()) {
+                bitmap->context()->roaring()->runOptimize();
+                bitmap_size = bitmap->context()->roaring()->getSizeInBytes(false);
+                if (max_bitmap_size < bitmap_size) {
+                    max_bitmap_size = bitmap_size;
+                }
+            }
+            bitmap_sizes.push_back(bitmap_size);
+        }
+
+        TypeInfoPtr bitmap_typeinfo = get_type_info(TYPE_OBJECT);
+
+        IndexedColumnWriterOptions options;
+        options.write_ordinal_index = true;
+        options.write_value_index = false;
+        options.encoding = EncodingInfo::get_default_encoding(bitmap_typeinfo->type(), false);
+        // we already store compressed bitmap, use NO_COMPRESSION to save some cpu
+        options.compression = NO_COMPRESSION;
+
+        IndexedColumnWriter bitmap_column_writer(options, bitmap_typeinfo, wfile);
+        RETURN_IF_ERROR(bitmap_column_writer.init());
+
+        faststring buf;
+        buf.reserve(max_bitmap_size);
+        for (size_t i = 0; i < bitmaps.size(); ++i) {
+            if (bitmaps[i]->is_context()) {
+                buf.resize(bitmap_sizes[i]); // so that buf[0..size) can be read and written
+                bitmaps[i]->context()->roaring()->write(reinterpret_cast<char*>(buf.data()), false);
+            } else {
+                Roaring roar({bitmaps[i]->value()});
+                roar.runOptimize();
+                auto sz = roar.getSizeInBytes(false);
+                buf.resize(sz);
+                roar.write(reinterpret_cast<char*>(buf.data()), false);
+            }
+            Slice buf_slice(buf);
+            RETURN_IF_ERROR(bitmap_column_writer.add(&buf_slice));
+        }
+        if (!_null_bitmap.isEmpty()) {
+            _null_bitmap.runOptimize();
+            buf.resize(_null_bitmap.getSizeInBytes(false)); // so that buf[0..size) can be read and written
+            _null_bitmap.write(reinterpret_cast<char*>(buf.data()), false);
+            Slice buf_slice(buf);
+            RETURN_IF_ERROR(bitmap_column_writer.add(&buf_slice));
+        }
+        return bitmap_column_writer.finish(meta);
+    }
+
+    int32_t _gram_num;
+
     TypeInfoPtr _typeinfo;
     rowid_t _rid = 0;
 
@@ -397,14 +453,15 @@ private:
 
 struct BitmapIndexWriterBuilder {
     template <LogicalType ftype>
-    std::unique_ptr<BitmapIndexWriter> operator()(const TypeInfoPtr& typeinfo) {
-        return std::make_unique<BitmapIndexWriterImpl<ftype>>(typeinfo);
+    std::unique_ptr<BitmapIndexWriter> operator()(const TypeInfoPtr& typeinfo, int32_t gram_num) {
+        return std::make_unique<BitmapIndexWriterImpl<ftype>>(typeinfo, gram_num);
     }
 };
 
-Status BitmapIndexWriter::create(const TypeInfoPtr& typeinfo, std::unique_ptr<BitmapIndexWriter>* res) {
+Status BitmapIndexWriter::create(const TypeInfoPtr& typeinfo, std::unique_ptr<BitmapIndexWriter>* res,
+                                 int32_t gram_num) {
     LogicalType type = typeinfo->type();
-    *res = field_type_dispatch_bitmap_index(type, BitmapIndexWriterBuilder(), typeinfo);
+    *res = field_type_dispatch_bitmap_index(type, BitmapIndexWriterBuilder(), typeinfo, gram_num);
 
     return Status::OK();
 }

--- a/be/src/storage/rowset/bitmap_index_writer.h
+++ b/be/src/storage/rowset/bitmap_index_writer.h
@@ -50,7 +50,7 @@ class WritableFile;
 
 class BitmapIndexWriter {
 public:
-    static Status create(const TypeInfoPtr& type_info, std::unique_ptr<BitmapIndexWriter>* res);
+    static Status create(const TypeInfoPtr& type_info, std::unique_ptr<BitmapIndexWriter>* res, int32_t gram_num = -1);
 
     BitmapIndexWriter() = default;
     virtual ~BitmapIndexWriter() = default;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2506,6 +2506,9 @@ Status SegmentIterator::_apply_inverted_index() {
                 if (res.ok()) {
                     erased_preds.emplace(pred);
                     erased_pred_col_ids.emplace(cid);
+                } else {
+                    LOG(WARNING) << "Failed to seek inverted index for column " << column_name
+                                 << ", reason: " << res.detailed_message();
                 }
             }
         }

--- a/be/src/util/slice.h
+++ b/be/src/util/slice.h
@@ -186,6 +186,82 @@ public:
         return ((size >= x.size) && memequal(data + (size - x.size), x.size, x.data, x.size));
     }
 
+    /**
+     * find character position in this slice.
+     * @param c character need to find in slice
+     * @param offset start position
+     * @return position if found, otherwise -1
+     */
+    int64_t find(const char c, const int64_t offset = 0) const {
+        int64_t pos = offset;
+        while (0 <= pos && pos < size && data[pos] != c) ++pos;
+        if (pos < 0 || pos >= size) return -1;
+        return pos;
+    }
+
+    /**
+     * build next array for KMP algorithm
+     * @return next array
+     */
+    std::vector<size_t> build_next() const {
+        if (size <= 0) return {};
+
+        std::vector<size_t> next(size);
+
+        next[0] = 0;
+        size_t i = 1;
+        size_t j = 0;
+
+        while (i < size) {
+            if (data[i] == data[j]) {
+                next[i++] = ++j;
+            } else {
+                if (j != 0) {
+                    j = next[j - 1];
+                } else {
+                    next[i++] = 0;
+                }
+            }
+        }
+        return next;
+    }
+
+    /**
+     * find sub slice in this slice by KMP algorithm
+     * @param pattern pattern need to find in slice
+     * @param next next array build by pattern.build_next
+     * @param offset start position
+     * @return position if found, otherwise -1
+     */
+    int64_t find(const Slice& pattern, const std::vector<size_t>& next, const int64_t offset = 0) const {
+        if (pattern.size <= 0 || pattern.size > size) return -1;
+        if (offset < 0 || offset > size) return -1;
+        if (next.size() != pattern.size) return -1;
+
+        int64_t pos = offset;
+        int64_t j = 0;
+
+        while (pos < size) {
+            if (data[pos] == pattern[j]) {
+                ++pos;
+                ++j;
+            }
+
+            if (j == pattern.size) {
+                return pos - j;
+            }
+
+            if (pos < size && data[pos] != pattern[j]) {
+                if (j != 0) {
+                    j = next[j - 1];
+                } else {
+                    ++pos;
+                }
+            }
+        }
+        return -1;
+    }
+
     Slice tolower(std::string& buf) {
         // copy this slice into buf
         buf.assign(get_data(), get_size());

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -402,6 +402,7 @@ set(EXEC_FILES
         ./util/byte_stream_split_test.cpp
         ./util/url_coding_test.cpp
         ./util/url_parser_test.cpp
+        ./util/slice_test.cpp
         ./gutil/cpu_test.cc
         ./gutil/sysinfo-test.cc
         ./service/lake_service_test.cpp

--- a/be/test/storage/rowset/binary_prefix_page_test.cpp
+++ b/be/test/storage/rowset/binary_prefix_page_test.cpp
@@ -191,35 +191,4 @@ TEST_F(BinaryPrefixPageTest, TestVectorized) {
     test_vectorized();
 }
 
-TEST_F(BinaryPrefixPageTest, TestFindNonExistentValue) {
-    std::vector<std::string> test_data;
-    test_data.emplace_back("bc");
-    test_data.emplace_back("cd");
-    std::vector<Slice> slices;
-    for (auto& i : test_data) {
-        Slice s(i);
-        slices.emplace_back(s);
-    }
-    // encode
-    PageBuilderOptions options;
-    BinaryPrefixPageBuilder page_builder(options);
-
-    size_t count = slices.size();
-    const Slice* ptr = &slices[0];
-    count = page_builder.add(reinterpret_cast<const uint8_t*>(ptr), count);
-    ASSERT_EQ(2, count);
-
-    OwnedSlice dict_slice = page_builder.finish()->build();
-    auto page_decoder = std::make_unique<BinaryPrefixPageDecoder<TYPE_VARCHAR>>(dict_slice.slice());
-    Status ret = page_decoder->init();
-    ASSERT_TRUE(ret.ok());
-
-    Slice slice("e");
-    bool exact_match;
-    ret = page_decoder->seek_at_or_after_value(&slice, &exact_match);
-    ASSERT_FALSE(ret.ok());
-    ASSERT_TRUE(ret.is_not_found());
-    ASSERT_FALSE(exact_match);
-}
-
 } // namespace starrocks

--- a/be/test/storage/rowset/binary_prefix_page_test.cpp
+++ b/be/test/storage/rowset/binary_prefix_page_test.cpp
@@ -191,4 +191,35 @@ TEST_F(BinaryPrefixPageTest, TestVectorized) {
     test_vectorized();
 }
 
+TEST_F(BinaryPrefixPageTest, TestFindNonExistentValue) {
+    std::vector<std::string> test_data;
+    test_data.emplace_back("bc");
+    test_data.emplace_back("cd");
+    std::vector<Slice> slices;
+    for (auto& i : test_data) {
+        Slice s(i);
+        slices.emplace_back(s);
+    }
+    // encode
+    PageBuilderOptions options;
+    BinaryPrefixPageBuilder page_builder(options);
+
+    size_t count = slices.size();
+    const Slice* ptr = &slices[0];
+    count = page_builder.add(reinterpret_cast<const uint8_t*>(ptr), count);
+    ASSERT_EQ(2, count);
+
+    OwnedSlice dict_slice = page_builder.finish()->build();
+    auto page_decoder = std::make_unique<BinaryPrefixPageDecoder<TYPE_VARCHAR>>(dict_slice.slice());
+    Status ret = page_decoder->init();
+    ASSERT_TRUE(ret.ok());
+
+    Slice slice("e");
+    bool exact_match;
+    ret = page_decoder->seek_at_or_after_value(&slice, &exact_match);
+    ASSERT_FALSE(ret.ok());
+    ASSERT_TRUE(ret.is_not_found());
+    ASSERT_FALSE(exact_match);
+}
+
 } // namespace starrocks

--- a/be/test/storage/rowset/bitmap_index_test.cpp
+++ b/be/test/storage/rowset/bitmap_index_test.cpp
@@ -37,15 +37,18 @@
 #include <string>
 #include <thread>
 
+#include "column/column_viewer.h"
 #include "fs/fs_memory.h"
 #include "runtime/mem_pool.h"
 #include "runtime/mem_tracker.h"
+#include "storage/chunk_helper.h"
 #include "storage/key_coder.h"
 #include "storage/olap_common.h"
 #include "storage/rowset/bitmap_index_reader.h"
 #include "storage/rowset/bitmap_index_writer.h"
 #include "storage/types.h"
 #include "testutil/assert.h"
+#include "util/utf8.h"
 
 namespace starrocks {
 
@@ -66,9 +69,9 @@ protected:
     void TearDown() override {}
 
     void get_bitmap_reader_iter(RandomAccessFile* rfile, const ColumnIndexMetaPB& meta, BitmapIndexReader** reader,
-                                BitmapIndexIterator** iter) {
+                                BitmapIndexIterator** iter, int32_t gram_num = -1) {
         _opts.read_file = rfile;
-        *reader = new BitmapIndexReader();
+        *reader = new BitmapIndexReader(gram_num);
         ASSIGN_OR_ABORT(auto r, (*reader)->load(_opts, meta.bitmap_index()));
         ASSERT_TRUE(r);
         ASSERT_OK((*reader)->new_iterator(_opts, iter));
@@ -89,6 +92,23 @@ protected:
             ASSERT_EQ(BITMAP_INDEX, meta->type());
             ASSERT_TRUE(wfile->close().ok());
         }
+    }
+
+    void write_index_file_use_by_gin(const int32_t gram_num, const std::string& filename,
+                                     const std::vector<std::string>& values, ColumnIndexMetaPB* meta) const {
+        const TypeInfoPtr type_info = get_type_info(TYPE_VARCHAR);
+        ASSIGN_OR_ABORT(const auto wfile, _fs->new_writable_file(filename));
+
+        std::unique_ptr<BitmapIndexWriter> writer;
+        BitmapIndexWriter::create(type_info, &writer, gram_num);
+
+        for (size_t i = 0; i < values.size(); ++i) {
+            Slice tmp(values[i]);
+            writer->add_value_with_current_rowid(&tmp);
+        }
+        ASSERT_TRUE(writer->finish(wfile.get(), meta).ok());
+        ASSERT_EQ(BITMAP_INDEX, meta->type());
+        ASSERT_TRUE(wfile->close().ok());
     }
 
     std::shared_ptr<MemoryFileSystem> _fs = nullptr;
@@ -291,6 +311,75 @@ TEST_F(BitmapIndexTest, test_concurrent_load) {
 
     delete iter;
     delete[] val;
+}
+
+TEST_F(BitmapIndexTest, test_dict_ngram_index) {
+    constexpr int32_t num_keywords = 10;
+    constexpr int32_t gram_num = 3;
+
+    std::set<std::string> ngram;
+    std::vector<std::string> keywords;
+    for (int i = 0; i < num_keywords; ++i) {
+        // slice should be one of hel,ell,llo,low,wor,orl,rld,ld ,d {0,...,9}
+        const std::string keyword = "hello, world " + std::to_string(i);
+
+        std::vector<size_t> index;
+        Slice cur_slice(keyword);
+        const size_t slice_gram_num = get_utf8_index(cur_slice, &index);
+
+        for (size_t j = 0; j + gram_num <= slice_gram_num; ++j) {
+            // find next ngram
+            size_t cur_ngram_length =
+                    j + gram_num < slice_gram_num ? index[j + gram_num] - index[j] : cur_slice.get_size() - index[j];
+            Slice cur_ngram(cur_slice.data + index[j], cur_ngram_length);
+            ngram.emplace(cur_ngram.to_string());
+        }
+
+        keywords.emplace_back(keyword);
+    }
+
+    std::string file_name = kTestDir + "/dict_ngram_index";
+    ColumnIndexMetaPB meta;
+    write_index_file_use_by_gin(3, file_name, keywords, &meta);
+
+    {
+        BitmapIndexReader* reader = nullptr;
+        BitmapIndexIterator* iter = nullptr;
+        ASSIGN_OR_ABORT(const auto rfile, _fs->new_random_access_file(file_name));
+        get_bitmap_reader_iter(rfile.get(), meta, &reader, &iter, 3);
+
+        const size_t dict_num = reader->bitmap_nums();
+        ASSERT_EQ(dict_num, num_keywords);
+
+        size_t to_read = dict_num;
+        const auto col = ChunkHelper::column_from_field_type(TYPE_VARCHAR, false);
+        ASSERT_TRUE(iter->next_batch_ngram(0, &to_read, col.get()).ok());
+        ASSERT_EQ(dict_num, to_read);
+
+        ColumnViewer<TYPE_VARCHAR> viewer(std::move(col));
+        ASSERT_EQ(ngram.size(), viewer.size());
+
+        auto it = ngram.begin();
+        for (int i = 0; i < viewer.size(); ++i) {
+            auto value = viewer.value(i);
+            ASSERT_EQ(*it, value.to_string());
+            ++it;
+        }
+
+        ASSERT_EQ(ngram.size(), reader->ngram_bitmap_nums());
+        for (rowid_t i = 0; i < ngram.size(); ++i) {
+            roaring::Roaring result;
+            ASSERT_TRUE(iter->read_ngram_bitmap(i, &result).ok());
+            if (i < num_keywords) {
+                ASSERT_EQ(1, result.cardinality());
+                ASSERT_EQ(i, result.minimum());
+            } else {
+                ASSERT_EQ(num_keywords, result.cardinality());
+                ASSERT_EQ(0, result.minimum());
+                ASSERT_EQ(num_keywords - 1, result.maximum());
+            }
+        }
+    }
 }
 
 } // namespace starrocks

--- a/be/test/util/slice_test.cpp
+++ b/be/test/util/slice_test.cpp
@@ -1,0 +1,251 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "util/slice.h"
+
+#include <gtest/gtest.h>
+
+namespace starrocks {
+
+class SliceTest : public testing::Test {};
+
+TEST_F(SliceTest, testFindChar) {
+    std::string text("ABCABABCDABCDABD");
+    const Slice slice(text);
+
+    int64_t last_match = 0, cur_match = 0;
+    while (true) {
+        cur_match = text.find('A', last_match);
+        EXPECT_EQ(cur_match, slice.find('A', last_match));
+
+        if (cur_match == -1) break;
+        last_match = cur_match + 1;
+    }
+}
+
+TEST_F(SliceTest, testFindCharEdgeCases) {
+    // Empty slice
+    std::string empty_text("");
+    Slice empty_slice(empty_text);
+    EXPECT_EQ(-1, empty_slice.find('A'));
+
+    // Single character slice - found
+    std::string single_char_text("A");
+    Slice single_char_found(single_char_text);
+    EXPECT_EQ(0, single_char_found.find('A'));
+
+    // Single character slice - not found
+    std::string single_char_not_found_text("B");
+    Slice single_char_not_found(single_char_not_found_text);
+    EXPECT_EQ(-1, single_char_not_found.find('A'));
+
+    // Find with offset
+    std::string muilti_char_text("AAABBBAAA");
+    Slice multi_char(muilti_char_text);
+    EXPECT_EQ(0, multi_char.find('A', 0));  // First A
+    EXPECT_EQ(1, multi_char.find('A', 1));  // Second A
+    EXPECT_EQ(2, multi_char.find('A', 2));  // Third A
+    EXPECT_EQ(3, multi_char.find('B', 3));  // First B
+    EXPECT_EQ(-1, multi_char.find('A', 10)); // Offset beyond size
+    EXPECT_EQ(-1, multi_char.find('X'));     // Character not present
+
+    // Negative offset
+    EXPECT_EQ(-1, multi_char.find('A', -1)); // Should start from 0
+}
+
+TEST_F(SliceTest, testBuildNext) {
+    // Simple case
+    std::string pattern1_text("ABABC");
+    Slice pattern1(pattern1_text);
+    auto next1 = pattern1.build_next();
+    std::vector<size_t> expected1 = {0, 0, 1, 2, 0};
+    EXPECT_EQ(expected1, next1);
+
+    // All same characters
+    std::string pattern2_text("AAAA");
+    Slice pattern2(pattern2_text);
+    auto next2 = pattern2.build_next();
+    std::vector<size_t> expected2 = {0, 1, 2, 3};
+    EXPECT_EQ(expected2, next2);
+
+    // No repetition
+    std::string pattern3_text("ABCD");
+    Slice pattern3(pattern3_text);
+    auto next3 = pattern3.build_next();
+    std::vector<size_t> expected3 = {0, 0, 0, 0};
+    EXPECT_EQ(expected3, next3);
+
+    // Empty slice
+    Slice pattern4("");
+    auto next4 = pattern4.build_next();
+    EXPECT_TRUE(next4.empty());
+}
+
+TEST_F(SliceTest, testFindSlice) {
+    std::string s_text("ABC ABCDAB ABCDABCDABDE");
+    Slice text(s_text);
+    std::string s_pattern("ABCDABD");
+    Slice pattern(s_pattern);
+    auto next = pattern.build_next();
+    std::vector<size_t> expected = {0, 0, 0, 0, 1, 2, 0};
+    EXPECT_EQ(7, next.size());
+    EXPECT_EQ(expected, next);
+
+    // Find pattern in text
+    int64_t pos = text.find(pattern, next);
+    EXPECT_EQ(15, pos);
+
+    // Find with offset before match
+    pos = text.find(pattern, next, 0);
+    EXPECT_EQ(15, pos);
+
+    // Find with offset after match
+    pos = text.find(pattern, next, 16);
+    EXPECT_EQ(-1, pos);
+}
+
+TEST_F(SliceTest, testFindSliceEdgeCases) {
+    // Empty pattern
+    std::string stext1("ABC");
+    Slice text1(stext1);
+    std::string spattern1("");
+    Slice empty_pattern(spattern1);
+    auto next_empty = empty_pattern.build_next();
+    EXPECT_EQ(-1, text1.find(empty_pattern, next_empty));
+
+    // Pattern larger than text
+    std::string stext("ABC");
+    Slice small_text(stext);
+    std::string slarge_pattern("ABCDEFGH");
+    Slice large_pattern(slarge_pattern);
+    auto next_large = large_pattern.build_next();
+    EXPECT_EQ(-1, small_text.find(large_pattern, next_large));
+
+    // Exact match
+    std::string s_exact_text("ABCDEF");
+    Slice exact_text(s_exact_text);
+    std::string s_exact_pattern("ABCDEF");
+    Slice exact_pattern(s_exact_pattern);
+    auto next_exact = exact_pattern.build_next();
+    EXPECT_EQ(0, exact_text.find(exact_pattern, next_exact));
+
+    // No match
+    std::string s_text2("ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+    Slice text2(s_text2);
+    std::string s_pattern2("XYZABC");
+    Slice pattern2(s_pattern2);
+    auto next2 = pattern2.build_next();
+    EXPECT_EQ(-1, text2.find(pattern2, next2));
+
+    // Match at the end
+    std::string s_text3("ABCDEFGHIJKLMNOP");
+    Slice text3(s_text3);
+    std::string s_pattern3("MNOP");
+    Slice pattern3(s_pattern3);
+    auto next3 = pattern3.build_next();
+    EXPECT_EQ(12, text3.find(pattern3, next3));
+
+    // Repeated pattern
+    std::string s_text4("ABABABAB");
+    Slice text4(s_text4);
+    std::string s_pattern4("ABA");
+    Slice pattern4(s_pattern4);
+    auto next4 = pattern4.build_next();
+    EXPECT_EQ(0, text4.find(pattern4, next4, 0));  // First occurrence
+    EXPECT_EQ(2, text4.find(pattern4, next4, 1));  // Second occurrence
+    EXPECT_EQ(4, text4.find(pattern4, next4, 3));  // Third occurrence
+    EXPECT_EQ(-1, text4.find(pattern4, next4, 5));  // Fourth occurrence
+
+    // Invalid offset
+    std::string s_text5("ABCDEF");
+    Slice text5(s_text5);
+    std::string s_pattern5("CDE");
+    Slice pattern5(s_pattern5);
+    auto next5 = pattern5.build_next();
+    EXPECT_EQ(-1, text5.find(pattern5, next5, -1));   // Negative offset
+    EXPECT_EQ(-1, text5.find(pattern5, next5, 100));  // Offset too large
+
+    // Invalid next array size
+    std::string s_text6("ABCDEF");
+    Slice text6(s_text6);
+    std::string s_pattern6("ABC");
+    Slice pattern6(s_pattern6);
+    std::vector<size_t> invalid_next = {0, 1}; // Wrong size
+    EXPECT_EQ(-1, text6.find(pattern6, invalid_next));
+
+    // Empty text
+    std::string s_text7("");
+    Slice empty_text(s_text7);
+    std::string s_pattern7("A");
+    Slice pattern7(s_pattern7);
+    auto next7 = pattern7.build_next();
+    EXPECT_EQ(-1, empty_text.find(pattern7, next7));
+}
+
+TEST_F(SliceTest, testFindSliceAdditionalCases) {
+    // Single character pattern
+    std::string s_text1("ABCDEFGHIJKLMNO");
+    Slice text1(s_text1);
+    std::string s_pattern1("G");
+    Slice pattern1(s_pattern1);
+    auto next1 = pattern1.build_next();
+    EXPECT_EQ(6, text1.find(pattern1, next1));
+
+    // Pattern at the beginning
+    std::string s_text2("ABCDEF");
+    Slice text2(s_text2);
+    std::string s_pattern2("ABC");
+    Slice pattern2(s_pattern2);
+    auto next2 = pattern2.build_next();
+    EXPECT_EQ(0, text2.find(pattern2, next2));
+
+    // Pattern at the end
+    std::string s_text3("ABCDEF");
+    Slice text3(s_text3);
+    std::string s_pattern3("DEF");
+    Slice pattern3(s_pattern3);
+    auto next3 = pattern3.build_next();
+    EXPECT_EQ(3, text3.find(pattern3, next3));
+
+    // All same characters in pattern and text
+    std::string s_text4("AAAAAA");
+    Slice text4(s_text4);
+    std::string s_pattern4("AAA");
+    Slice pattern4(s_pattern4);
+    auto next4 = pattern4.build_next();
+    EXPECT_EQ(0, text4.find(pattern4, next4));
+
+    // Complex KMP backtracking case
+    std::string s_text5("ABABACA");
+    Slice text5(s_text5);
+    std::string s_pattern5("ABABAC");
+    Slice pattern5(s_pattern5);
+    auto next5 = pattern5.build_next();
+    std::vector<size_t> expected_next5 = {0, 0, 1, 2, 3, 0};
+    EXPECT_EQ(expected_next5, next5);
+    EXPECT_EQ(0, text5.find(pattern5, next5));
+
+    // Partial match that fails
+    std::string s_text6("ABABACA");
+    Slice text6(s_text6);
+    std::string s_pattern6("ABABAX");
+    Slice pattern6(s_pattern6);
+    auto next6 = pattern6.build_next();
+    EXPECT_EQ(-1, text6.find(pattern6, next6));
+}
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IndexParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IndexParams.java
@@ -90,6 +90,8 @@ public class IndexParams {
         // index
         register(builder, IndexType.GIN, IndexParamType.INDEX, InvertedIndexParams.IndexParamsKey.PARSER, true, true, "none",
                 null);
+        register(builder, IndexType.GIN, IndexParamType.INDEX, InvertedIndexParams.IndexParamsKey.DICT_GRAM_NUM,
+                false, false, null, null);
         register(builder, IndexType.GIN, IndexParamType.INDEX, InvertedIndexParams.IndexParamsKey.OMIT_TERM_FREQ_AND_POSITION,
                 false, false, null, null);
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/InvertedIndexParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/InvertedIndexParams.java
@@ -51,7 +51,12 @@ public class InvertedIndexParams {
         /**
          * Whether to omit term frequency and term position when indexing
          */
-        OMIT_TERM_FREQ_AND_POSITION("false");
+        OMIT_TERM_FREQ_AND_POSITION("false"),
+
+        /**
+         * Gram num for the dictionary of builtin inverted index.
+         */
+        DICT_GRAM_NUM("-1");
 
         private final String defaultValue;
         private boolean needDefault = false;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/IndexAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/IndexAnalyzer.java
@@ -54,6 +54,7 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import static com.starrocks.common.InvertedIndexParams.CommonIndexParamKey.IMP_LIB;
+import static com.starrocks.common.InvertedIndexParams.IndexParamsKey.DICT_GRAM_NUM;
 import static com.starrocks.common.InvertedIndexParams.IndexParamsKey.PARSER;
 import static com.starrocks.common.InvertedIndexParams.InvertedIndexImpType.BUILTIN;
 import static com.starrocks.common.InvertedIndexParams.InvertedIndexImpType.CLUCENE;
@@ -67,11 +68,15 @@ public class IndexAnalyzer {
     private static final int MAX_INDEX_NAME_LENGTH = 64;
 
     // InvertedIndexUtil constants
+    public static String INVERTED_INDEX_IMP_LIB_KEY = IMP_LIB.name().toLowerCase(Locale.ROOT);
+
     public static String INVERTED_INDEX_PARSER_KEY = PARSER.name().toLowerCase(Locale.ROOT);
     public static String INVERTED_INDEX_PARSER_NONE = "none";
     public static String INVERTED_INDEX_PARSER_STANDARD = "standard";
     public static String INVERTED_INDEX_PARSER_ENGLISH = "english";
     public static String INVERTED_INDEX_PARSER_CHINESE = "chinese";
+
+    public static String INVERTED_INDEX_DICT_GRAM_NUM_KEY = DICT_GRAM_NUM.toString().toLowerCase(Locale.ROOT);
 
     // BloomFilterIndexUtil constants
     public static final String FPP_KEY = NgramBfIndexParamsKey.BLOOM_FILTER_FPP.toString().toLowerCase(Locale.ROOT);
@@ -167,9 +172,8 @@ public class IndexAnalyzer {
                     "The inverted index is disabled, enable it by setting FE config `enable_experimental_gin` to true");
         }
 
-        String impLibKey = IMP_LIB.name().toLowerCase(Locale.ROOT);
-        if (properties.containsKey(impLibKey)) {
-            String impValue = properties.get(impLibKey);
+        if (properties.containsKey(INVERTED_INDEX_IMP_LIB_KEY)) {
+            String impValue = properties.get(INVERTED_INDEX_IMP_LIB_KEY);
             if (!(CLUCENE.name().equalsIgnoreCase(impValue) || BUILTIN.name().equalsIgnoreCase(impValue))) {
                 throw new SemanticException("Only support clucene or builtin implement for now. ");
             }
@@ -187,6 +191,7 @@ public class IndexAnalyzer {
         }
 
         checkInvertedIndexParser(column.getName(), column.getPrimitiveType(), properties);
+        checkInvertedIndexNgram(properties);
 
         // add default properties
         addDefaultProperties(properties);
@@ -212,6 +217,22 @@ public class IndexAnalyzer {
         } else if (!parser.equals(INVERTED_INDEX_PARSER_NONE)) {
             throw new SemanticException("INVERTED index with parser: " + parser
                     + " is not supported for column: " + indexColName + " of type " + colType);
+        }
+    }
+
+    public static void checkInvertedIndexNgram(Map<String, String> properties) {
+        String gramNum = properties == null ? null : properties.get(INVERTED_INDEX_DICT_GRAM_NUM_KEY);
+        if (gramNum == null) {
+            return;
+        }
+
+        if (!StringUtils.isNumeric(gramNum)) {
+            throw new SemanticException("INVERTED index dict gram num " + gramNum + " is a invalid number.");
+        }
+
+        String impValue = properties.get(INVERTED_INDEX_IMP_LIB_KEY);
+        if (!BUILTIN.name().equalsIgnoreCase(impValue)) {
+            throw new SemanticException("INVERTED index with " + impValue + " implement is invalid for dict gram.");
         }
     }
 

--- a/gensrc/proto/segment.proto
+++ b/gensrc/proto/segment.proto
@@ -289,6 +289,10 @@ message BitmapIndexPB {
     optional IndexedColumnMetaPB dict_column = 3;
     // required: meta for bitmaps part
     optional IndexedColumnMetaPB bitmap_column = 4;
+    // options: meta for ngram dictionary part
+    optional IndexedColumnMetaPB ngram_dict_column = 5;
+    // options: meta for ngram bitmaps part
+    optional IndexedColumnMetaPB ngram_bitmap_column = 6;
 }
 
 enum HashStrategyPB {


### PR DESCRIPTION
## Why I'm doing:

When query contains wildcard characters, such as `%keyword%`, the builtin inverted index needs to process each dictionary word one by one. If the dictionary is built with large cardinality, it will damage the speed of initializing segment iterators. 

## What I'm doing:

Add ngram index for the dictionary of builtin inverted index.

Use `amazon_reviews` dataset, with english parser, for query `select count(verified_purchase) from amazon_reviews where review_body match '%awesome%';`, get performance like below:

| | load | query | data size |
| :-: | :-: | :-: | :-: |
| 3-gram | 16min30s | 0.565 s | 58954693891 byte |
| no gram | 17min37s | 1.746 s | 58507088411 byte |

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds n‑gram dictionary indexing for the builtin inverted index, optimizes wildcard/prefix queries, wires new metrics, updates FE params and protobuf, and adds supporting utilities/tests.
> 
> - **Storage/Index (Builtin Inverted Index)**:
>   - Add n‑gram dictionary/bitmap columns to `BitmapIndexPB` and implement write/read (`bitmap_index_writer/reader.*`).
>   - Extend `BitmapIndexIterator` with `seek_dict_by_ngram`, `filter_dict_by_predicate`, `next_batch_ngram`, `read_ngram_bitmap`.
>   - Rework `BuiltinInvertedIndexIterator` wildcard handling: fast prefix scan and n‑gram prefilter + KMP matching; add timers `gin_prefix_filter_ns`, `gin_ngram_filter_dict_ns`, `gin_filter_dict_ns`.
>   - Pass `gram_num` and `stats` through readers/iterators.
> - **Execution/Scan**:
>   - Wire new GIN timers/counters in `lake_connector`, `olap_scan_node`, `olap_chunk_source`, `tablet_scanner`.
>   - Segment iterator: integrate inverted index filtering and add warning on failures.
> - **FE / API**:
>   - Add `DICT_GRAM_NUM` index param, validation, and constants; lower/validate in `IndexParams`/`IndexAnalyzer`.
>   - Update `segment.proto` `BitmapIndexPB` with optional `ngram_dict_column` and `ngram_bitmap_column`.
> - **Utilities/Tests**:
>   - Add `Slice` KMP helpers (`find`, `build_next`) and tests.
>   - Add n‑gram bitmap index tests; include `util/slice_test.cpp` in CMake.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2814118c341f6704059c229e9751a71dd21f53de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->