### PR TITLE
[Enhancement] avoid collecting `__count__` this derivated column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -67,6 +67,7 @@ import com.starrocks.connector.metadata.MetadataTable;
 import com.starrocks.connector.metadata.MetadataTableType;
 import com.starrocks.connector.statistics.ConnectorTableColumnStats;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.analyzer.FeNameFormat;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.AlterViewStmt;
 import com.starrocks.sql.ast.CallProcedureStatement;
@@ -671,7 +672,13 @@ public class MetadataMgr {
     }
 
     public Statistics getTableStatisticsFromInternalStatistics(Table table, Map<ColumnRefOperator, Column> columns) {
-        List<ColumnRefOperator> requiredColumnRefs = new ArrayList<>(columns.keySet());
+        List<ColumnRefOperator> requiredColumnRefs = new ArrayList<>();
+        for (ColumnRefOperator colRef : columns.keySet()) {
+            if (FeNameFormat.FORBIDDEN_COLUMN_NAMES.contains(colRef.getName())) {
+                continue;
+            }
+            requiredColumnRefs.add(colRef);
+        }
         List<String> columnNames = requiredColumnRefs.stream().map(col -> columns.get(col).getName()).collect(
                 Collectors.toList());
         List<ConnectorTableColumnStats> columnStatisticList =


### PR DESCRIPTION
## Why I'm doing:

Optimization on `select count(1)` will generate a derivated column `__count__`. 

But this column can not be handled by column stats collector, and we will get error like

```
2025-11-02 01:59:54.307Z WARN (stats-cache-refresher-3|1254) [CachedStatisticStorage.lambda$getConnectorTableStatistics$7():224] Get connector table column statistics filed, exception: 
 java.util.concurrent.CompletionException: com.starrocks.sql.analyzer.SemanticException: Getting analyzing error. Detail message: Unknown column '___count___' in 'store_sales'.
        at com.starrocks.connector.statistics.ConnectorColumnStatsCacheLoader.lambda$asyncLoadAll$1(ConnectorColumnStatsCacheLoader.java:103)
        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:840)
```

## What I'm doing:

Remove those derivated and forbidden columns when doing collecting column stats.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Filters out forbidden/derived columns (e.g., `__count__`) when collecting internal column statistics to avoid errors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b205a58a57663c93c3fe38327204458b3db2391. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->