### PR TITLE
[BugFix] Fix creating mv bug with generated partition column 

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -96,9 +96,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
-import org.junit.jupiter.api.io.TempDir;
 
-import java.io.File;
 import java.lang.reflect.Method;
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -5908,5 +5906,103 @@ public class CreateMaterializedViewTest extends MVTestBase {
                 ") \n" +
                 "as select 'This is a test',123,v1.date, v1.id from iceberg0.partitioned_db.t2 as v1; ";
         starRocksAssert.withMaterializedView(sql);
+    }
+
+    @Test
+    public void testCreateMVWithGeneratedColumn() throws Exception {
+        starRocksAssert.withTable("\n" +
+                "CREATE TABLE `user_events` (\n" +
+                "  `user_id` varchar(128) NULL COMMENT \"\",\n" +
+                "  `event_ts` bigint(20) NULL COMMENT \"\",\n" +
+                "  `event_name` varchar(128) NULL COMMENT \"\",\n" +
+                "  `session_id` varchar(128) NULL COMMENT \"\",\n" +
+                "  `event_type` varchar(64) NULL COMMENT \"\",\n" +
+                "  `event_level` varchar(64) NULL COMMENT \"\",\n" +
+                "  `properties` json NULL COMMENT \"\",\n" +
+                "  `dt` datetime NULL AS date_trunc('day', from_unixtime(`event_ts` / 1000)) COMMENT \"\"\n" +
+                ") ENGINE=OLAP \n" +
+                "DUPLICATE KEY(`user_id`, `event_ts`, `event_name`)\n" +
+                "COMMENT \"OLAP\"\n" +
+                "PARTITION BY (`dt`)\n" +
+                "DISTRIBUTED BY HASH(`user_id`) BUCKETS 10 \n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");");
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW `test`.`user_events_agg_mv`\n" +
+                "PARTITION BY dt\n" +
+                "REFRESH ASYNC EVERY(INTERVAL 1 DAY)\n" +
+                "PROPERTIES (\n" +
+                "  \"partition_refresh_number\" = \"1\",\n" +
+                "  \"partition_ttl\" = \"100 DAY\"\n" +
+                ")\n" +
+                "AS\n" +
+                "WITH filtered_events AS (\n" +
+                "  SELECT\n" +
+                "    dt,\n" +
+                "    user_id,\n" +
+                "    session_id,\n" +
+                "    event_ts,\n" +
+                "    properties,\n" +
+                "    CAST(properties->'$.category_id' AS VARCHAR) as category_id,\n" +
+                "    CAST(properties->'$.product_id' AS VARCHAR) as product_id,\n" +
+                "    CAST(properties->'$.resource_id' AS VARCHAR) as resource_id,\n" +
+                "    properties->'$.resource_type' as resource_type_code,\n" +
+                "    CASE \n" +
+                "      WHEN resource_type_code IN (1, '1', 'category') THEN 'category'\n" +
+                "      WHEN resource_type_code IN (2, '2', 'product') THEN 'product'\n" +
+                "      WHEN resource_type_code IN (3, '3', 'brand') THEN 'brand'\n" +
+                "      ELSE NULL\n" +
+                "    END as resource_type\n" +
+                "  FROM user_events\n" +
+                "  WHERE dt >= CURRENT_DATE - INTERVAL 90 DAY\n" +
+                "    AND event_level IN ('click', 'view')\n" +
+                "    AND event_name != 'page_exit'\n" +
+                "),\n" +
+                "resource_interests AS (\n" +
+                "  SELECT\n" +
+                "    dt,\n" +
+                "    user_id,\n" +
+                "    session_id,\n" +
+                "    event_ts,\n" +
+                "    'category' as resource_type,\n" +
+                "    category_id as resource_id\n" +
+                "  FROM filtered_events\n" +
+                "  WHERE category_id IS NOT NULL\n" +
+                "\n" +
+                "  UNION ALL\n" +
+                "\n" +
+                "  SELECT\n" +
+                "    dt,\n" +
+                "    user_id,\n" +
+                "    session_id,\n" +
+                "    event_ts,\n" +
+                "    'product' as resource_type,\n" +
+                "    product_id as resource_id\n" +
+                "  FROM filtered_events\n" +
+                "  WHERE product_id IS NOT NULL\n" +
+                "\n" +
+                "  UNION ALL\n" +
+                "\n" +
+                "  SELECT\n" +
+                "    dt,\n" +
+                "    user_id,\n" +
+                "    session_id,\n" +
+                "    event_ts,\n" +
+                "    resource_type,\n" +
+                "    resource_id\n" +
+                "  FROM filtered_events\n" +
+                "  WHERE resource_type IS NOT NULL AND resource_id IS NOT NULL\n" +
+                ")\n" +
+                "\n" +
+                "SELECT\n" +
+                "  dt,\n" +
+                "  user_id,\n" +
+                "  resource_type,\n" +
+                "  resource_id,\n" +
+                "  COUNT(DISTINCT session_id) AS session_count,\n" +
+                "  COUNT(*) AS event_count\n" +
+                "FROM resource_interests\n" +
+                "WHERE user_id IS NOT NULL AND user_id != ''\n" +
+                "GROUP BY dt, user_id, resource_type, resource_id;");
     }
 }

--- a/test/sql/test_create_materialized_view/R/test_create_mv_with_generate_column
+++ b/test/sql/test_create_materialized_view/R/test_create_mv_with_generate_column
@@ -1,0 +1,173 @@
+-- name: test_create_mv_with_generate_column
+CREATE TABLE `user_events` (
+  `user_id` varchar(128) NULL COMMENT "",
+  `event_ts` bigint(20) NULL COMMENT "",
+  `event_name` varchar(128) NULL COMMENT "",
+  `session_id` varchar(128) NULL COMMENT "",
+  `event_type` varchar(64) NULL COMMENT "",
+  `event_level` varchar(64) NULL COMMENT "",
+  `properties` json NULL COMMENT "",
+  `dt` datetime NULL AS date_trunc('day', from_unixtime(`event_ts` / 1000)) COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`user_id`, `event_ts`, `event_name`)
+COMMENT "OLAP"
+PARTITION BY (`dt`)
+DISTRIBUTED BY HASH(`user_id`) BUCKETS 10 
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO user_events (user_id, event_ts, event_name, session_id, event_type, event_level, properties) VALUES
+('user_001', unix_timestamp(now() - INTERVAL 1 DAY) * 1000, 'product_view', 'session_001', 'view_event', 'view', 
+ '{"category_id": "cat_101", "product_id": "prod_201"}'),
+('user_001', unix_timestamp(now() - INTERVAL 1 DAY) * 1000 + 1000, 'product_click', 'session_001', 'click_event', 'click',
+ '{"category_id": "cat_101", "product_id": "prod_202"}'),
+('user_002', unix_timestamp(now() - INTERVAL 2 DAY) * 1000, 'category_view', 'session_002', 'view_event', 'view',
+ '{"category_id": "cat_102"}'),
+('user_002', unix_timestamp(now() - INTERVAL 2 DAY) * 1000 + 2000, 'product_click', 'session_002', 'click_event', 'click',
+ '{"category_id": "cat_102", "product_id": "prod_203"}');
+-- result:
+-- !result
+INSERT INTO user_events (user_id, event_ts, event_name, session_id, event_type, event_level, properties) VALUES
+('user_003', unix_timestamp(now() - INTERVAL 3 DAY) * 1000, 'product_view', 'session_003', 'view_event', 'view',
+ '{"product_id": "prod_301", "resource_id": "res_401", "resource_type": "1"}'),
+('user_003', unix_timestamp(now() - INTERVAL 3 DAY) * 1000 + 3000, 'product_click', 'session_004', 'click_event', 'click',
+ '{"product_id": "prod_302", "resource_id": "res_402", "resource_type": "category"}'),
+('user_004', unix_timestamp(now() - INTERVAL 5 DAY) * 1000, 'item_view', 'session_005', 'view_event', 'view',
+ '{"product_id": "prod_303"}');
+-- result:
+-- !result
+INSERT INTO user_events (user_id, event_ts, event_name, session_id, event_type, event_level, properties) VALUES
+('user_005', unix_timestamp(now() - INTERVAL 7 DAY) * 1000, 'brand_view', 'session_006', 'view_event', 'view',
+ '{"resource_id": "brand_501", "resource_type": "3"}'),
+('user_005', unix_timestamp(now() - INTERVAL 7 DAY) * 1000 + 5000, 'brand_click', 'session_006', 'click_event', 'click',
+ '{"resource_id": "brand_502", "resource_type": "brand"}'),
+('user_006', unix_timestamp(now() - INTERVAL 10 DAY) * 1000, 'product_view', 'session_007', 'view_event', 'view',
+ '{"resource_id": "prod_601", "resource_type": "2", "category_id": "cat_201"}');
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1
+PARTITION BY dt
+REFRESH ASYNC EVERY(INTERVAL 1 DAY)
+PROPERTIES (
+  "partition_refresh_number" = "1"
+)
+AS
+WITH filtered_events AS (
+  SELECT
+    dt,
+    user_id,
+    session_id,
+    event_ts,
+    properties,
+    CAST(properties->'$.category_id' AS VARCHAR) as category_id,
+    CAST(properties->'$.product_id' AS VARCHAR) as product_id,
+    CAST(properties->'$.resource_id' AS VARCHAR) as resource_id,
+    properties->'$.resource_type' as resource_type_code,
+    CASE 
+      WHEN resource_type_code IN (1, '1', 'category') THEN 'category'
+      WHEN resource_type_code IN (2, '2', 'product') THEN 'product'
+      WHEN resource_type_code IN (3, '3', 'brand') THEN 'brand'
+      ELSE NULL
+    END as resource_type
+  FROM user_events
+),
+resource_interests AS (
+  SELECT
+    dt,
+    user_id,
+    session_id,
+    event_ts,
+    'category' as resource_type,
+    category_id as resource_id
+  FROM filtered_events
+
+  UNION ALL
+
+  SELECT
+    dt,
+    user_id,
+    session_id,
+    event_ts,
+    'product' as resource_type,
+    product_id as resource_id
+  FROM filtered_events
+
+  UNION ALL
+
+  SELECT
+    dt,
+    user_id,
+    session_id,
+    event_ts,
+    resource_type,
+    resource_id
+  FROM filtered_events
+)
+SELECT
+  dt,
+  user_id,
+  resource_type,
+  resource_id,
+  COUNT(DISTINCT session_id) AS session_count,
+  COUNT(*) AS event_count
+FROM resource_interests
+GROUP BY dt, user_id, resource_type, resource_id;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT COUNT(1) FROM test_mv1;
+-- result:
+23
+-- !result
+SELECT * FROM test_mv1 ORDER BY 1,2,3,4,5,6 LIMIT 5;
+-- result:
+2025-10-24 00:00:00	user_006	category	cat_201	1	1
+2025-10-24 00:00:00	user_006	product	None	1	1
+2025-10-24 00:00:00	user_006	product	prod_601	1	1
+2025-10-27 00:00:00	user_005	brand	brand_501	1	1
+2025-10-27 00:00:00	user_005	brand	brand_502	1	1
+-- !result
+INSERT INTO user_events (user_id, event_ts, event_name, session_id, event_type, event_level, properties) VALUES
+('user_001', unix_timestamp(now() - INTERVAL 15 DAY) * 1000, 'category_click', 'session_008', 'click_event', 'click',
+ '{"category_id": "cat_103", "resource_type": "category"}'),
+('user_001', unix_timestamp(now() - INTERVAL 15 DAY) * 1000 + 10000, 'product_view', 'session_009', 'view_event', 'view',
+ '{"category_id": "cat_103", "product_id": "prod_204"}'),
+('user_001', unix_timestamp(now() - INTERVAL 20 DAY) * 1000, 'product_click', 'session_010', 'click_event', 'click',
+ '{"product_id": "prod_205", "resource_id": "res_403", "resource_type": "product"}');
+-- result:
+-- !result
+INSERT INTO user_events (user_id, event_ts, event_name, session_id, event_type, event_level, properties) VALUES
+('user_007', unix_timestamp(now() - INTERVAL 1 DAY) * 1000, 'page_exit', 'session_011', 'exit_event', 'view',
+ '{"category_id": "cat_104"}'),
+('user_008', unix_timestamp(now() - INTERVAL 1 DAY) * 1000, 'product_view', 'session_012', 'view_event', 'impression',
+ '{"product_id": "prod_401"}'),
+('user_009', unix_timestamp(now() - INTERVAL 100 DAY) * 1000, 'product_click', 'session_013', 'click_event', 'click',
+ '{"category_id": "cat_105", "product_id": "prod_501"}'),
+('', unix_timestamp(now() - INTERVAL 1 DAY) * 1000, 'product_view', 'session_014', 'view_event', 'view',
+ '{"category_id": "cat_106"}');
+-- result:
+-- !result
+INSERT INTO user_events (user_id, event_ts, event_name, session_id, event_type, event_level, properties) VALUES
+('user_010', unix_timestamp(now() - INTERVAL 25 DAY) * 1000, 'category_browse', 'session_015', 'browse_event', 'view',
+ '{"category_id": "cat_107", "product_id": "prod_601", "resource_id": "res_501", "resource_type": "1"}'),
+('user_010', unix_timestamp(now() - INTERVAL 25 DAY) * 1000 + 15000, 'product_detail_view', 'session_015', 'detail_event', 'view',
+ '{"category_id": "cat_107", "product_id": "prod_602"}'),
+('user_010', unix_timestamp(now() - INTERVAL 25 DAY) * 1000 + 30000, 'add_to_cart_click', 'session_016', 'cart_event', 'click',
+ '{"product_id": "prod_602", "resource_type": "product", "resource_id": "prod_602"}');
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT COUNT(1) FROM test_mv1;
+-- result:
+49
+-- !result
+SELECT * FROM test_mv1 ORDER BY 1,2,3,4,5,6 LIMIT 5;
+-- result:
+2025-07-26 00:00:00	user_009	None	None	1	1
+2025-07-26 00:00:00	user_009	category	cat_105	1	1
+2025-07-26 00:00:00	user_009	product	prod_501	1	1
+2025-10-09 00:00:00	user_010	None	None	1	1
+2025-10-09 00:00:00	user_010	category	None	1	1
+-- !result

--- a/test/sql/test_create_materialized_view/T/test_create_mv_with_generate_column
+++ b/test/sql/test_create_materialized_view/T/test_create_mv_with_generate_column
@@ -1,0 +1,147 @@
+-- name: test_create_mv_with_generate_column
+
+CREATE TABLE `user_events` (
+  `user_id` varchar(128) NULL COMMENT "",
+  `event_ts` bigint(20) NULL COMMENT "",
+  `event_name` varchar(128) NULL COMMENT "",
+  `session_id` varchar(128) NULL COMMENT "",
+  `event_type` varchar(64) NULL COMMENT "",
+  `event_level` varchar(64) NULL COMMENT "",
+  `properties` json NULL COMMENT "",
+  `dt` datetime NULL AS date_trunc('day', from_unixtime(`event_ts` / 1000)) COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`user_id`, `event_ts`, `event_name`)
+COMMENT "OLAP"
+PARTITION BY (`dt`)
+DISTRIBUTED BY HASH(`user_id`) BUCKETS 10 
+PROPERTIES (
+"replication_num" = "1"
+);
+
+INSERT INTO user_events (user_id, event_ts, event_name, session_id, event_type, event_level, properties) VALUES
+('user_001', unix_timestamp(now() - INTERVAL 1 DAY) * 1000, 'product_view', 'session_001', 'view_event', 'view', 
+ '{"category_id": "cat_101", "product_id": "prod_201"}'),
+('user_001', unix_timestamp(now() - INTERVAL 1 DAY) * 1000 + 1000, 'product_click', 'session_001', 'click_event', 'click',
+ '{"category_id": "cat_101", "product_id": "prod_202"}'),
+('user_002', unix_timestamp(now() - INTERVAL 2 DAY) * 1000, 'category_view', 'session_002', 'view_event', 'view',
+ '{"category_id": "cat_102"}'),
+('user_002', unix_timestamp(now() - INTERVAL 2 DAY) * 1000 + 2000, 'product_click', 'session_002', 'click_event', 'click',
+ '{"category_id": "cat_102", "product_id": "prod_203"}');
+
+INSERT INTO user_events (user_id, event_ts, event_name, session_id, event_type, event_level, properties) VALUES
+('user_003', unix_timestamp(now() - INTERVAL 3 DAY) * 1000, 'product_view', 'session_003', 'view_event', 'view',
+ '{"product_id": "prod_301", "resource_id": "res_401", "resource_type": "1"}'),
+('user_003', unix_timestamp(now() - INTERVAL 3 DAY) * 1000 + 3000, 'product_click', 'session_004', 'click_event', 'click',
+ '{"product_id": "prod_302", "resource_id": "res_402", "resource_type": "category"}'),
+('user_004', unix_timestamp(now() - INTERVAL 5 DAY) * 1000, 'item_view', 'session_005', 'view_event', 'view',
+ '{"product_id": "prod_303"}');
+
+INSERT INTO user_events (user_id, event_ts, event_name, session_id, event_type, event_level, properties) VALUES
+('user_005', unix_timestamp(now() - INTERVAL 7 DAY) * 1000, 'brand_view', 'session_006', 'view_event', 'view',
+ '{"resource_id": "brand_501", "resource_type": "3"}'),
+('user_005', unix_timestamp(now() - INTERVAL 7 DAY) * 1000 + 5000, 'brand_click', 'session_006', 'click_event', 'click',
+ '{"resource_id": "brand_502", "resource_type": "brand"}'),
+('user_006', unix_timestamp(now() - INTERVAL 10 DAY) * 1000, 'product_view', 'session_007', 'view_event', 'view',
+ '{"resource_id": "prod_601", "resource_type": "2", "category_id": "cat_201"}');
+
+CREATE MATERIALIZED VIEW test_mv1
+PARTITION BY dt
+REFRESH ASYNC EVERY(INTERVAL 1 DAY)
+PROPERTIES (
+  "partition_refresh_number" = "1"
+)
+AS
+WITH filtered_events AS (
+  SELECT
+    dt,
+    user_id,
+    session_id,
+    event_ts,
+    properties,
+    CAST(properties->'$.category_id' AS VARCHAR) as category_id,
+    CAST(properties->'$.product_id' AS VARCHAR) as product_id,
+    CAST(properties->'$.resource_id' AS VARCHAR) as resource_id,
+    properties->'$.resource_type' as resource_type_code,
+    CASE 
+      WHEN resource_type_code IN (1, '1', 'category') THEN 'category'
+      WHEN resource_type_code IN (2, '2', 'product') THEN 'product'
+      WHEN resource_type_code IN (3, '3', 'brand') THEN 'brand'
+      ELSE NULL
+    END as resource_type
+  FROM user_events
+),
+resource_interests AS (
+  SELECT
+    dt,
+    user_id,
+    session_id,
+    event_ts,
+    'category' as resource_type,
+    category_id as resource_id
+  FROM filtered_events
+
+  UNION ALL
+
+  SELECT
+    dt,
+    user_id,
+    session_id,
+    event_ts,
+    'product' as resource_type,
+    product_id as resource_id
+  FROM filtered_events
+
+  UNION ALL
+
+  SELECT
+    dt,
+    user_id,
+    session_id,
+    event_ts,
+    resource_type,
+    resource_id
+  FROM filtered_events
+)
+SELECT
+  dt,
+  user_id,
+  resource_type,
+  resource_id,
+  COUNT(DISTINCT session_id) AS session_count,
+  COUNT(*) AS event_count
+FROM resource_interests
+GROUP BY dt, user_id, resource_type, resource_id;
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT COUNT(1) FROM test_mv1;
+SELECT * FROM test_mv1 ORDER BY 1,2,3,4,5,6 LIMIT 5;
+
+INSERT INTO user_events (user_id, event_ts, event_name, session_id, event_type, event_level, properties) VALUES
+('user_001', unix_timestamp(now() - INTERVAL 15 DAY) * 1000, 'category_click', 'session_008', 'click_event', 'click',
+ '{"category_id": "cat_103", "resource_type": "category"}'),
+('user_001', unix_timestamp(now() - INTERVAL 15 DAY) * 1000 + 10000, 'product_view', 'session_009', 'view_event', 'view',
+ '{"category_id": "cat_103", "product_id": "prod_204"}'),
+('user_001', unix_timestamp(now() - INTERVAL 20 DAY) * 1000, 'product_click', 'session_010', 'click_event', 'click',
+ '{"product_id": "prod_205", "resource_id": "res_403", "resource_type": "product"}');
+
+INSERT INTO user_events (user_id, event_ts, event_name, session_id, event_type, event_level, properties) VALUES
+('user_007', unix_timestamp(now() - INTERVAL 1 DAY) * 1000, 'page_exit', 'session_011', 'exit_event', 'view',
+ '{"category_id": "cat_104"}'),
+('user_008', unix_timestamp(now() - INTERVAL 1 DAY) * 1000, 'product_view', 'session_012', 'view_event', 'impression',
+ '{"product_id": "prod_401"}'),
+('user_009', unix_timestamp(now() - INTERVAL 100 DAY) * 1000, 'product_click', 'session_013', 'click_event', 'click',
+ '{"category_id": "cat_105", "product_id": "prod_501"}'),
+('', unix_timestamp(now() - INTERVAL 1 DAY) * 1000, 'product_view', 'session_014', 'view_event', 'view',
+ '{"category_id": "cat_106"}');
+
+INSERT INTO user_events (user_id, event_ts, event_name, session_id, event_type, event_level, properties) VALUES
+('user_010', unix_timestamp(now() - INTERVAL 25 DAY) * 1000, 'category_browse', 'session_015', 'browse_event', 'view',
+ '{"category_id": "cat_107", "product_id": "prod_601", "resource_id": "res_501", "resource_type": "1"}'),
+('user_010', unix_timestamp(now() - INTERVAL 25 DAY) * 1000 + 15000, 'product_detail_view', 'session_015', 'detail_event', 'view',
+ '{"category_id": "cat_107", "product_id": "prod_602"}'),
+('user_010', unix_timestamp(now() - INTERVAL 25 DAY) * 1000 + 30000, 'add_to_cart_click', 'session_016', 'cart_event', 'click',
+ '{"product_id": "prod_602", "resource_type": "product", "resource_id": "prod_602"}');
+
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+SELECT COUNT(1) FROM test_mv1;
+SELECT * FROM test_mv1 ORDER BY 1,2,3,4,5,6 LIMIT 5;


### PR DESCRIPTION
## Why I'm doing:

Fix NPE in creating mv with `generated partition columns`:
```
GROUP BY __generated_partition_column_0, device_id, entity_type, entity_id) process failed.
 java.lang.NullPointerException: Cannot invoke "java.util.List.isEmpty()" because "refPartitionExprs" is null
        at com.starrocks.mv.analyzer.MVPartitionExprResolver.getMVPartitionExprsChecked(MVPartitionExprResolver.java:581)
        at com.starrocks.server.LocalMetastore.createMaterializedView(LocalMetastore.java:3123)
        at com.starrocks.qe.DDLStmtExecutor$StmtExecutorVisitor.lambda$visitCreateMaterializedViewStatement$12(DDLStmtExecutor.java:379)
        at com.starrocks.common.ErrorReport.wrapWithRuntimeException(ErrorReport.java:118)
        at com.starrocks.qe.DDLStmtExecutor$StmtExecutorVisitor.visitCreateMaterializedViewStatement(DDLStmtExecutor.java:378)
        at com.starrocks.qe.DDLStmtExecutor$StmtExecutorVisitor.visitCreateMaterializedViewStatement(DDLStmtExecutor.java:210)
        at com.starrocks.sql.ast.CreateMaterializedViewStatement.accept(CreateMaterializedViewStatement.java:392)
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:47)
        at com.starrocks.qe.DDLStmtExecutor.execute(DDLStmtExecutor.java:195)
        at com.starrocks.qe.StmtExecutor.handleDdlStmt(StmtExecutor.java:2239)
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:848)
        at com.starrocks.qe.ConnectProcessor.executeQueryAttempt(ConnectProcessor.java:528)
        at com.starrocks.qe.ConnectProcessor.runWithParserStageRetry(ConnectProcessor.java:423)
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:368)
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:725)
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:1073)
        at com.starrocks.mysql.nio.MySQLReadListener.handleRequest(MySQLReadListener.java:90)
        at com.starrocks.mysql.nio.MySQLReadListener.lambda$handleEvent$0(MySQLReadListener.java:76)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)

```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
