### PR TITLE
[BugFix] Change connector_table_query_trigger_analyze_max_running_task_num to immutable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2362,7 +2362,7 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static long connector_table_query_trigger_analyze_large_table_interval = 12 * 3600; // unit: second, default 12h
 
-    @ConfField(mutable = true)
+    @ConfField
     public static int connector_table_query_trigger_analyze_max_running_task_num = 2;
 
     @ConfField(mutable = true)


### PR DESCRIPTION
## Why I'm doing:
Fix checkpoint failure
```
Oct 30, 2025 @ 00:23:45.839 +08:00	starrocks-marketwatch-001	java.lang.IllegalArgumentException: null
	at java.util.concurrent.LinkedBlockingQueue.<init>(LinkedBlockingQueue.java:254) ~[?:?]
	at com.starrocks.common.ThreadPoolManager.newDaemonFixedThreadPool(ThreadPoolManager.java:136) ~[starrocks-fe.jar:?]
	at com.starrocks.connector.statistics.ConnectorAnalyzeTaskQueue.<init>(ConnectorAnalyzeTaskQueue.java:41) ~[starrocks-fe.jar:?]
	at com.starrocks.connector.statistics.ConnectorTableTriggerAnalyzeMgr.<init>(ConnectorTableTriggerAnalyzeMgr.java:38) ~[starrocks-fe.jar:?]
	at com.starrocks.server.GlobalStateMgr.<init>(GlobalStateMgr.java:738) ~[starrocks-fe.jar:?]
	at com.starrocks.server.GlobalStateMgr.<init>(GlobalStateMgr.java:624) ~[starrocks-fe.jar:?]
	at com.starrocks.server.GlobalStateMgr.getCurrentState(GlobalStateMgr.java:847) ~[starrocks-fe.jar:?]
	at com.starrocks.journal.GlobalStateCheckpointWorker.doCheckpoint(GlobalStateCheckpointWorker.java:33) ~[starrocks-fe.jar:?]
	at com.starrocks.journal.CheckpointWorker.createImage(CheckpointWorker.java:100) ~[starrocks-fe.jar:?]
	at com.starrocks.journal.CheckpointWorker.runAfterCatalogReady(CheckpointWorker.java:86) ~[starrocks-fe.jar:?]
	at com.starrocks.common.util.FrontendDaemon.runOneCycle(FrontendDaemon.java:72) ~[starrocks-fe.jar:?]
	at com.starrocks.common.util.Daemon.run(Daemon.java:98) ~[starrocks-fe.jar:?]	 - 	trace
Oct 30, 2025 @ 00:23:45.839 +08:00	starrocks-marketwatch-001	2025-10-29 16:23:45.839Z WARN (global_state_checkpoint_worker|149) [CheckpointWorker.createImage():102] create image failed	 - 	trace
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
