### PR TITLE
[Enhancement] Do not add default compression type when create iceberg table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -445,31 +445,32 @@ public class IcebergApiConverter {
         ImmutableMap.Builder<String, String> tableProperties = ImmutableMap.builder();
         createProperties.entrySet().forEach(tableProperties::put);
         String fileFormat = createProperties.getOrDefault(FILE_FORMAT, TableProperties.DEFAULT_FILE_FORMAT_DEFAULT);
-        String compressionCodec = null;
+        String compressionCodec = createProperties.get(COMPRESSION_CODEC);
 
         if ("parquet".equalsIgnoreCase(fileFormat)) {
             tableProperties.put(TableProperties.DEFAULT_FILE_FORMAT, "parquet");
-            compressionCodec =
-                    createProperties.getOrDefault(COMPRESSION_CODEC, TableProperties.PARQUET_COMPRESSION_DEFAULT);
-            tableProperties.put(TableProperties.PARQUET_COMPRESSION, compressionCodec);
+            if (compressionCodec != null) {
+                tableProperties.put(TableProperties.PARQUET_COMPRESSION, compressionCodec);
+            }
         } else if ("avro".equalsIgnoreCase(fileFormat)) {
             tableProperties.put(TableProperties.DEFAULT_FILE_FORMAT, "avro");
-            compressionCodec =
-                    createProperties.getOrDefault(COMPRESSION_CODEC, TableProperties.AVRO_COMPRESSION_DEFAULT);
-            tableProperties.put(TableProperties.AVRO_COMPRESSION, compressionCodec);
+            if (compressionCodec != null) {
+                tableProperties.put(TableProperties.AVRO_COMPRESSION, compressionCodec);
+            }
         } else if ("orc".equalsIgnoreCase(fileFormat)) {
             tableProperties.put(TableProperties.DEFAULT_FILE_FORMAT, "orc");
-            compressionCodec =
-                    createProperties.getOrDefault(COMPRESSION_CODEC, TableProperties.ORC_COMPRESSION_DEFAULT);
-            tableProperties.put(TableProperties.ORC_COMPRESSION, compressionCodec);
+            if (compressionCodec != null) {
+                tableProperties.put(TableProperties.ORC_COMPRESSION, compressionCodec);
+            }
         } else if (fileFormat != null) {
             throw new IllegalArgumentException("Unsupported format in USING: " + fileFormat);
         }
 
-        if (!PARQUET_COMPRESSION_TYPE_MAP.containsKey(compressionCodec.toLowerCase(Locale.ROOT))) {
+        if (!Strings.isNullOrEmpty(compressionCodec) &&
+                !PARQUET_COMPRESSION_TYPE_MAP.containsKey(compressionCodec.toLowerCase(Locale.ROOT))) {
             throw new IllegalArgumentException("Unsupported compression codec in USING: " + compressionCodec);
         }
-        tableProperties.put(TableProperties.FORMAT_VERSION, "1");
+        tableProperties.put(TableProperties.FORMAT_VERSION, "2");
 
         return tableProperties.build();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -79,7 +79,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -98,7 +97,6 @@ import static com.starrocks.connector.iceberg.IcebergCatalogProperties.ICEBERG_C
 import static com.starrocks.connector.iceberg.IcebergMetadata.COMPRESSION_CODEC;
 import static com.starrocks.connector.iceberg.IcebergMetadata.FILE_FORMAT;
 import static com.starrocks.server.CatalogMgr.ResourceMappingCatalog.toResourceName;
-import static com.starrocks.sql.ast.OutFileClause.PARQUET_COMPRESSION_TYPE_MAP;
 import static java.lang.String.format;
 import static org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap.copyOf;
 import static org.apache.iceberg.view.ViewProperties.COMMENT;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -465,11 +465,6 @@ public class IcebergApiConverter {
         } else if (fileFormat != null) {
             throw new IllegalArgumentException("Unsupported format in USING: " + fileFormat);
         }
-
-        if (!Strings.isNullOrEmpty(compressionCodec) &&
-                !PARQUET_COMPRESSION_TYPE_MAP.containsKey(compressionCodec.toLowerCase(Locale.ROOT))) {
-            throw new IllegalArgumentException("Unsupported compression codec in USING: " + compressionCodec);
-        }
         tableProperties.put(TableProperties.FORMAT_VERSION, "2");
 
         return tableProperties.build();


### PR DESCRIPTION
## Why I'm doing:
add these default table properties, starrocks  canot create iceberg table at unity catalog 
## What I'm do
This pull request refines the logic for handling table properties when creating Iceberg tables, focusing on how compression codecs and format versions are set. The main improvements ensure that compression codecs are only applied and validated when provided, and the default format version is updated.

**Improvements to table property handling:**

* Compression codec properties for `parquet`, `avro`, and `orc` formats are now only set if a codec is explicitly provided in `createProperties`, avoiding unnecessary defaults.
* Validation for the compression codec now only occurs if a codec is specified, preventing null pointer issues and unnecessary validation.

**Default version update:**

* The default `FORMAT_VERSION` property for new tables is changed from `"1"` to `"2"`.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Only set/validate compression codec for Iceberg tables when provided and change default format version to 2.
> 
> - **Iceberg table creation (`IcebergApiConverter.rebuildCreateTableProperties`)**:
>   - Only set `PARQUET_COMPRESSION`/`AVRO_COMPRESSION`/`ORC_COMPRESSION` when `COMPRESSION_CODEC` is provided in `createProperties`.
>   - Validate compression codec only if non-empty.
>   - Keep setting `DEFAULT_FILE_FORMAT` based on `FILE_FORMAT` and reject unsupported formats.
>   - Change `TableProperties.FORMAT_VERSION` default from `"1"` to `"2"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e16deaff7f0eb83274e0febfc5ad9b89e2c451f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->