### PR TITLE
[BugFix] When replica enter decommission, transaction will nerver complete. (backport #49349)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -930,8 +930,7 @@ public class DatabaseTransactionMgr {
                                 if (!errorReplicaIds.contains(replica.getId())
                                         && replica.getLastFailedVersion() < 0) {
                                     // if replica not commit yet, skip it. This may happen when it's just create by clone.
-                                    if (!transactionState.tabletCommitInfosContainsReplica(tablet.getId(),
-                                            replica.getBackendId(), replica.getState())) {
+                                    if (transactionState.checkReplicaNeedSkip(tablet, replica, partitionCommitInfo)) {
                                         continue;
                                     }
                                     // this means the replica is a healthy replica,

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
@@ -104,8 +104,7 @@ public class OlapTableTxnLogApplier implements TransactionLogApplier {
                         long lastFailedVersion = replica.getLastFailedVersion();
                         long newVersion = version;
                         long lastSucessVersion = replica.getLastSuccessVersion();
-                        if (!txnState.tabletCommitInfosContainsReplica(tablet.getId(), replica.getBackendId(),
-                                replica.getState())
+                        if (txnState.checkReplicaNeedSkip(tablet, replica, partitionCommitInfo)
                                 || errorReplicaIds.contains(replica.getId())) {
                             // There are 2 cases that we can't update version to visible version and need to 
                             // set lastFailedVersion.


### PR DESCRIPTION
## Why I'm doing:
1. Transaction TA writes to a two-replicas tablet and enters the committed state. The tablet's replica are replicaA, replicaB.
2. replicaA, replicaB generate tasks: PublishVersionTaskA, PublishVersionTaskB. PublishVersionTaskA/PublishVersionTaskB successfully submitted to the beA/beB via RPC.
3. The machine where beB is located hangs and is not recoverable. Therefore PublishVersionTaskA is finished,PublishVersionTaskB is unfinished.
4. FE clone replicaC from replicaA, BE report replicaC info. But transactions must rely on replicaA and replicaB, so TA will block on committed.

## What I'm doing:

Fixes #52769

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

