### PR TITLE
[BugFix] Fix IllegalArgumentException in ConnectorAnalyzeTaskQueue init thread pool

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorAnalyzeTaskQueue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/statistics/ConnectorAnalyzeTaskQueue.java
@@ -39,8 +39,8 @@ public class ConnectorAnalyzeTaskQueue {
     private final Map<String, ConnectorAnalyzeTask> runningTasks = Maps.newConcurrentMap();
 
     private final ExecutorService taskRunPool = ThreadPoolManager.newDaemonFixedThreadPool(
-            Config.connector_table_query_trigger_analyze_max_running_task_num,
-            Config.connector_table_query_trigger_analyze_max_running_task_num,
+            Math.max(Config.connector_table_query_trigger_analyze_max_running_task_num, 1),
+            Math.max(Config.connector_table_query_trigger_analyze_max_running_task_num, 1),
             "connector-trigger-analyze-pool", true);
 
     public boolean addPendingTask(String tableUUID, ConnectorAnalyzeTask task) {


### PR DESCRIPTION
## Why I'm doing:
throws IllegalArgumentException when init thread pool with negtive int
## What I'm doing:
at least use one thread
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
