### PR TITLE
[BugFix] Correct database ID handling in resetMVIdsForRestore method for materialized views

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -870,18 +870,19 @@ public class RestoreJob extends AbstractJob {
 
     public Status resetMVIdsForRestore(GlobalStateMgr globalStateMgr,
                                        MaterializedView remoteOlapTbl,
-                                       Database db, int restoreReplicationNum,
+                                       Database db,
+                                       int restoreReplicationNum,
                                        MvRestoreContext mvRestoreContext) {
         // change db_id to new restore id
-        MvId oldMvId = new MvId(dbId, remoteOlapTbl.getId());
+        MvId oldMvId = new MvId(remoteOlapTbl.getDbId(), remoteOlapTbl.getId());
 
-        this.dbId = db.getId();
+        remoteOlapTbl.setDbId(db.getId());
         Status status = resetIdsForRestore(globalStateMgr, remoteOlapTbl, db, restoreReplicationNum, mvRestoreContext);
         if (!status.ok()) {
             return status;
         }
         // store new mvId to for old mvId
-        MvId newMvId = new MvId(dbId, remoteOlapTbl.getId());
+        MvId newMvId = new MvId(db.getId(), remoteOlapTbl.getId());
         MvBackupInfo mvBackupInfo = mvRestoreContext.getMvIdToTableNameMap()
                 .computeIfAbsent(oldMvId, x -> new MvBackupInfo(db.getFullName(), remoteOlapTbl.getName()));
         mvBackupInfo.setLocalMvId(newMvId);

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
@@ -51,6 +51,8 @@ import com.starrocks.catalog.Function;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
@@ -1060,5 +1062,131 @@ public class RestoreJobTest {
         localBackupHandler.replayAddJob(job3);
         Config.history_job_keep_max_second = oldVal;
         Assertions.assertTrue(localBackupHandler.getJob(db.getId() + 999).isDone());
+    }
+
+    @Test
+    public void testResetMVIdsForRestore() {
+        // Test case: Verify that resetMVIdsForRestore correctly handles database ID mapping
+        // for materialized views during restore operations
+        
+        // This test validates the fix for the bug where resetMVIdsForRestore was incorrectly
+        // using the RestoreJob's dbId field instead of remoteOlapTbl.getDbId() and db.getId()
+        
+        // Setup: Define test IDs
+        long oldDbId = 10000L;
+        long oldTableId = 20000L;
+        long newDbId = db.getId();
+        
+        // Track the dbId values that are accessed
+        final long[] capturedOldDbId = {0};
+        final long[] capturedNewDbId = {0};
+        final boolean[] setDbIdCalled = {false};
+        
+        // Create a MaterializedView with mocked behavior to track dbId operations
+        new MockUp<MaterializedView>() {
+            private long mvDbId = oldDbId;
+            private long mvTableId = oldTableId;
+            
+            @Mock
+            public long getDbId() {
+                capturedOldDbId[0] = mvDbId;
+                return mvDbId;
+            }
+            
+            @Mock
+            public void setDbId(long newDbId) {
+                setDbIdCalled[0] = true;
+                capturedNewDbId[0] = newDbId;
+                this.mvDbId = newDbId;
+            }
+            
+            @Mock
+            public long getId() {
+                return mvTableId;
+            }
+            
+            @Mock
+            public void setId(long newId) {
+                this.mvTableId = newId;
+            }
+            
+            @Mock
+            public String getName() {
+                return "test_mv";
+            }
+            
+            @Mock
+            public Map<String, Long> getIndexNameToId() {
+                return Maps.newHashMap();
+            }
+            
+            @Mock
+            public com.starrocks.catalog.PartitionInfo getPartitionInfo() {
+                // Return a minimal mock to avoid NullPointerException
+                return new com.starrocks.catalog.SinglePartitionInfo();
+            }
+            
+            @Mock
+            public Map<Long, Partition> getIdToPartition() {
+                return Maps.newHashMap();
+            }
+            
+            @Mock
+            public Map<Long, Long> getPhysicalPartitionIdToPartitionId() {
+                return Maps.newHashMap();
+            }
+            
+            @Mock
+            public Map<String, Long> getPhysicalPartitionNameToPartitionId() {
+                return Maps.newHashMap();
+            }
+        };
+        
+        // Create the MaterializedView instance after MockUp is set up
+        MaterializedView testMv = new MaterializedView();
+        
+        // Setup MvRestoreContext to track ID mappings
+        MvRestoreContext mvRestoreContext = new MvRestoreContext();
+        
+        // Create RestoreJob instance
+        RestoreJob restoreJob = new RestoreJob(label, "2018-01-01 01:01:01", newDbId, db.getFullName(),
+                new BackupJobInfo(), false, 3, 100000,
+                globalStateMgr, repo.getId(), backupMeta, mvRestoreContext);
+        
+        // Create the old MvId based on the initial state
+        // This is the key test: oldMvId should use remoteOlapTbl.getDbId(), not this.dbId
+        MvId oldMvIdObj = new MvId(oldDbId, testMv.getId());
+        
+        // Execute: Call resetMVIdsForRestore
+        Status result = restoreJob.resetMVIdsForRestore(globalStateMgr, testMv, db, 3, mvRestoreContext);
+        
+        // Verify: Check the result is OK
+        Assertions.assertTrue(result.ok(), "resetMVIdsForRestore should return OK status");
+        
+        // Verify: setDbId was called with the new database ID
+        Assertions.assertTrue(setDbIdCalled[0], "setDbId should be called on the MaterializedView");
+        Assertions.assertEquals(newDbId, capturedNewDbId[0], 
+                "setDbId should be called with the new database ID");
+        
+        // Verify: getDbId was called and captured the old database ID
+        Assertions.assertEquals(oldDbId, capturedOldDbId[0], 
+                "getDbId should return the old database ID from the table");
+        
+        // Verify: Check that MvRestoreContext contains the correct ID mapping
+        // The key verification: oldMvIdObj (created with oldDbId) should be in the map
+        com.starrocks.backup.mv.MvBackupInfo mvBackupInfo = 
+                mvRestoreContext.getMvIdToTableNameMap().get(oldMvIdObj);
+        Assertions.assertNotNull(mvBackupInfo, 
+                "MvBackupInfo should be stored in MvRestoreContext with old MvId as key");
+        
+        // Verify: Check that the local MvId in MvBackupInfo has the new database ID
+        MvId newMvIdObj = mvBackupInfo.getLocalMvId();
+        Assertions.assertNotNull(newMvIdObj, "Local MvId should be set in MvBackupInfo");
+        Assertions.assertEquals(newDbId, newMvIdObj.getDbId(), 
+                "Local MvId should have the new database ID from target database");
+        
+        // Additional verification: The new MvId should have a different table ID
+        Assertions.assertNotEquals(oldTableId, newMvIdObj.getId(), 
+                "MaterializedView table ID should be updated to a new ID");
     }
 }


### PR DESCRIPTION
## Why I'm doing:
Fixes [#issue](https://github.com/StarRocks/StarRocksTest/issues/10515) 
fix : https://github.com/StarRocks/starrocks/pull/64711
## What I'm doing:
This pull request addresses a bug in the restore logic for materialized views, ensuring that database ID mappings are handled correctly during restore operations. The main fix corrects how old and new materialized view IDs are constructed, and a comprehensive unit test is added to verify this behavior.

**Bug Fixes:**

* Fixed `resetMVIdsForRestore` in `RestoreJob` to use the correct database IDs when constructing `MvId` objects for materialized views, ensuring the old and new IDs are mapped accurately during restore. Previously, the method incorrectly used the job's `dbId` instead of the actual IDs from the involved objects.

**Testing Improvements:**

* Added a thorough unit test `testResetMVIdsForRestore` in `RestoreJobTest` that mocks a `MaterializedView` and validates that `resetMVIdsForRestore` correctly handles database ID mapping, calls `setDbId` appropriately, and updates the restore context with the correct ID mapping.
* Added necessary imports for `MaterializedView` and `MvId` in the test file to support the new test.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
