### PR TITLE
[BugFix] Fix crash in ChunkAccumulator when appending chunks with incompatible JSON schemas

### DIFF
--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -490,6 +490,34 @@ void ChunkAccumulator::reset() {
     _accumulate_count = 0;
 }
 
+namespace {
+bool check_json_schema_compatibility(const Chunk* one, const Chunk* two) {
+    if (one->num_columns() != two->num_columns()) {
+        return false;
+    }
+
+    for (size_t i = 0; i < one->num_columns(); i++) {
+        auto& c1 = one->get_column_by_index(i);
+        auto& c2 = two->get_column_by_index(i);
+        const auto* a1 = ColumnHelper::get_data_column(c1.get());
+        const auto* a2 = ColumnHelper::get_data_column(c2.get());
+
+        if (a1->is_json() && a2->is_json()) {
+            auto json1 = down_cast<const JsonColumn*>(a1);
+            if (!json1->is_equallity_schema(a2)) {
+                return false;
+            }
+        } else if (a1->is_json() || a2->is_json()) {
+            // never hit
+            DCHECK_EQ(a1->is_json(), a2->is_json());
+            return false;
+        }
+    }
+
+    return true;
+}
+} // namespace
+
 Status ChunkAccumulator::push(ChunkPtr&& chunk) {
     size_t input_rows = chunk->num_rows();
     // TODO: optimize for zero-copy scenario
@@ -499,7 +527,15 @@ Status ChunkAccumulator::push(ChunkPtr&& chunk) {
         size_t need_rows = 0;
         if (_tmp_chunk) {
             need_rows = std::min(_desired_size - _tmp_chunk->num_rows(), remain_rows);
-            TRY_CATCH_BAD_ALLOC(_tmp_chunk->append(*chunk, start, need_rows));
+            // Check JSON schema compatibility before appending
+            if (!check_json_schema_compatibility(_tmp_chunk.get(), chunk.get())) {
+                // Schema mismatch, output current chunk and create a new one
+                _output.emplace_back(std::move(_tmp_chunk));
+                _tmp_chunk = chunk->clone_empty(_desired_size);
+                TRY_CATCH_BAD_ALLOC(_tmp_chunk->append(*chunk, start, need_rows));
+            } else {
+                TRY_CATCH_BAD_ALLOC(_tmp_chunk->append(*chunk, start, need_rows));
+            }
             RETURN_IF_ERROR(_tmp_chunk->capacity_limit_reached());
         } else {
             need_rows = std::min(_desired_size, remain_rows);
@@ -542,29 +578,7 @@ void ChunkAccumulator::finalize() {
 }
 
 bool ChunkPipelineAccumulator::_check_json_schema_equallity(const Chunk* one, const Chunk* two) {
-    if (one->num_columns() != two->num_columns()) {
-        return false;
-    }
-
-    for (size_t i = 0; i < one->num_columns(); i++) {
-        auto& c1 = one->get_column_by_index(i);
-        auto& c2 = two->get_column_by_index(i);
-        const auto* a1 = ColumnHelper::get_data_column(c1.get());
-        const auto* a2 = ColumnHelper::get_data_column(c2.get());
-
-        if (a1->is_json() && a2->is_json()) {
-            auto json1 = down_cast<const JsonColumn*>(a1);
-            if (!json1->is_equallity_schema(a2)) {
-                return false;
-            }
-        } else if (a1->is_json() || a2->is_json()) {
-            // never hit
-            DCHECK_EQ(a1->is_json(), a2->is_json());
-            return false;
-        }
-    }
-
-    return true;
+    return check_json_schema_compatibility(one, two);
 }
 
 void ChunkPipelineAccumulator::push(const ChunkPtr& chunk) {

--- a/test/sql/test_semi/R/test_flat_json_compatibility
+++ b/test/sql/test_semi/R/test_flat_json_compatibility
@@ -1,0 +1,32 @@
+-- name: test_normal_flat_json_compatibility
+SET enable_runtime_adaptive_dop = true;
+-- result:
+-- !result
+CREATE TABLE t1(c1 int, c2 json);
+-- result:
+-- !result
+INSERT INTO t1 
+SELECT generate_series, json_object('a', generate_series)
+FROM TABLE(generate_series(1, 100000));
+-- result:
+-- !result
+SELECT count(c2) FROM t1;
+-- result:
+100000
+-- !result
+SELECT c2 FROM t1 ORDER BY c1 LIMIT 10;
+-- result:
+{"a": 1}
+{"a": 2}
+{"a": 3}
+{"a": 4}
+{"a": 5}
+{"a": 6}
+{"a": 7}
+{"a": 8}
+{"a": 9}
+{"a": 10}
+-- !result
+SET enable_runtime_adaptive_dop = false;
+-- result:
+-- !result

--- a/test/sql/test_semi/R/test_flat_json_compatibility
+++ b/test/sql/test_semi/R/test_flat_json_compatibility
@@ -1,8 +1,11 @@
--- name: test_normal_flat_json_compatibility
+-- name: test_normal_flat_json_compatibility @sequential
 SET enable_runtime_adaptive_dop = true;
 -- result:
 -- !result
 CREATE TABLE t1(c1 int, c2 json);
+-- result:
+-- !result
+update information_schema.be_configs set value = 'false' where name = 'enable_json_flat';
 -- result:
 -- !result
 INSERT INTO t1 
@@ -10,22 +13,35 @@ SELECT generate_series, json_object('a', generate_series)
 FROM TABLE(generate_series(1, 100000));
 -- result:
 -- !result
+update information_schema.be_configs set value = 'true' where name = 'enable_json_flat';
+-- result:
+-- !result
+INSERT INTO t1 
+SELECT generate_series, json_object('a', generate_series)
+FROM TABLE(generate_series(1, 100000));
+-- result:
+-- !result
+INSERT INTO t1 
+SELECT generate_series, json_object('b', generate_series)
+FROM TABLE(generate_series(1, 100000));
+-- result:
+-- !result
 SELECT count(c2) FROM t1;
 -- result:
-100000
+300000
 -- !result
 SELECT c2 FROM t1 ORDER BY c1 LIMIT 10;
 -- result:
 {"a": 1}
+{"b": 1}
+{"a": 1}
+{"a": 2}
+{"b": 2}
 {"a": 2}
 {"a": 3}
+{"a": 3}
+{"b": 3}
 {"a": 4}
-{"a": 5}
-{"a": 6}
-{"a": 7}
-{"a": 8}
-{"a": 9}
-{"a": 10}
 -- !result
 SET enable_runtime_adaptive_dop = false;
 -- result:

--- a/test/sql/test_semi/T/test_flat_json_compatibility
+++ b/test/sql/test_semi/T/test_flat_json_compatibility
@@ -1,0 +1,15 @@
+-- name: test_normal_flat_json_compatibility
+
+
+-- Test: compatible with adaptive DOP
+SET enable_runtime_adaptive_dop = true;
+CREATE TABLE t1(c1 int, c2 json);
+
+INSERT INTO t1 
+SELECT generate_series, json_object('a', generate_series)
+FROM TABLE(generate_series(1, 100000));
+
+SELECT count(c2) FROM t1;
+SELECT c2 FROM t1 ORDER BY c1 LIMIT 10;
+
+SET enable_runtime_adaptive_dop = false;

--- a/test/sql/test_semi/T/test_flat_json_compatibility
+++ b/test/sql/test_semi/T/test_flat_json_compatibility
@@ -1,12 +1,22 @@
--- name: test_normal_flat_json_compatibility
-
+-- name: test_normal_flat_json_compatibility @sequential
 
 -- Test: compatible with adaptive DOP
 SET enable_runtime_adaptive_dop = true;
 CREATE TABLE t1(c1 int, c2 json);
 
+update information_schema.be_configs set value = 'false' where name = 'enable_json_flat';
+
 INSERT INTO t1 
 SELECT generate_series, json_object('a', generate_series)
+FROM TABLE(generate_series(1, 100000));
+
+update information_schema.be_configs set value = 'true' where name = 'enable_json_flat';
+
+INSERT INTO t1 
+SELECT generate_series, json_object('a', generate_series)
+FROM TABLE(generate_series(1, 100000));
+INSERT INTO t1 
+SELECT generate_series, json_object('b', generate_series)
 FROM TABLE(generate_series(1, 100000));
 
 SELECT count(c2) FROM t1;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

3.5.7, with `set enable_runtime_adaptive_dop=true`:
```
    be/build_Release/src/column/be/src/column/json_column.cpp:376
    @          0x80cbea4 starrocks::JsonColumn::append(starrocks::Column const&, unsigned long, unsigned long)
    @          0x8007854 starrocks::Chunk::append(starrocks::Chunk const&, unsigned long, unsigned long)
    @          0x8024db0 starrocks::ChunkAccumulator::push(std::shared_ptr<starrocks::Chunk>&&)
    @          0xa25372c starrocks::pipeline::RoundRobinState::pull_chunk(int)
    @          0xa253b18 starrocks::pipeline::CollectStatsContext::pull_chunk(int)
    @          0xa25b190 starrocks::pipeline::CollectStatsSourceOperator::pull_chunk(starrocks::RuntimeState*)
    @          0x7ff11b4 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0xb1ed3c0 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0xb64aa44 starrocks::ThreadPool::dispatch_thread()
    @          0xb64102c starrocks::Thread::supervise_thread(void*)
    @     0xfb9280210398 (/usr/lib/aarch64-linux-gnu/libc.so.6+0x80397)
    @     0xfb9280279e9c (/usr/lib/aarch64-linux-gnu/libc.so.6+0xe9e9b)
```

Fix a SIGSEGV crash in JsonColumn::append when ChunkAccumulator attempts to append chunks with incompatible JSON schemas (flat_json vs non-flat_json). The crash occurs at JsonColumn::append line 376 when trying to access flat columns from a non-flat_json source column.

Root cause:
- ChunkAccumulator::push does not check JSON schema compatibility before   calling Chunk::append, which may mix flat_json and non-flat_json columns
- When JsonColumn::append receives incompatible schemas, it tries to access  _flat_columns from a non-flat_json column, leading to null pointer  dereference


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
