### PR TITLE
[BugFix] set forbidden fields unknown column stats

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -682,13 +682,17 @@ public class MetadataMgr {
     }
 
     public Statistics getTableStatisticsFromInternalStatistics(Table table, Map<ColumnRefOperator, Column> columns) {
+        Statistics.Builder statistics = Statistics.builder();
+
         List<ColumnRefOperator> requiredColumnRefs = new ArrayList<>();
         for (ColumnRefOperator colRef : columns.keySet()) {
             if (FeNameFormat.FORBIDDEN_COLUMN_NAMES.contains(colRef.getName())) {
+                statistics.addColumnStatistic(colRef, ColumnStatistic.unknown());
                 continue;
             }
             requiredColumnRefs.add(colRef);
         }
+
         List<String> columnNames = requiredColumnRefs.stream().map(col -> columns.get(col).getName()).collect(
                 Collectors.toList());
         List<ConnectorTableColumnStats> columnStatisticList =
@@ -697,7 +701,6 @@ public class MetadataMgr {
         Map<String, Histogram> histogramStatistics =
                 GlobalStateMgr.getCurrentState().getStatisticStorage().getConnectorHistogramStatistics(table, columnNames);
 
-        Statistics.Builder statistics = Statistics.builder();
         for (int i = 0; i < requiredColumnRefs.size(); ++i) {
             ColumnRefOperator columnRef = requiredColumnRefs.get(i);
             ConnectorTableColumnStats connectorTableColumnStats;


### PR DESCRIPTION
## Why I'm doing:

This bugfix is introduced in this pr https://github.com/StarRocks/starrocks/pull/64849

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/10526

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Marks forbidden columns with unknown stats when building internal table statistics, avoiding metadata fetch for those columns.
> 
> - **Statistics**:
>   - Update `MetadataMgr.getTableStatisticsFromInternalStatistics` to initialize `Statistics.Builder` early and add `ColumnStatistic.unknown()` for columns with forbidden names, excluding them from `requiredColumnRefs` and subsequent stats retrieval.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1579a1ff03940178088e061c5a5455bd2cef8cc8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->