### PR TITLE
[BugFix] Fix from_string reads uninitialized buffer

### DIFF
--- a/be/src/storage/types.cpp
+++ b/be/src/storage/types.cpp
@@ -917,7 +917,7 @@ struct ScalarTypeInfoImpl<TYPE_DATETIME_V1> : public ScalarTypeInfoImplBase<TYPE
 template <>
 struct ScalarTypeInfoImpl<TYPE_DATETIME> : public ScalarTypeInfoImplBase<TYPE_DATETIME> {
     static Status from_string(void* buf, const std::string& scan_key) {
-        auto timestamp = unaligned_load<TimestampValue>(buf);
+        TimestampValue timestamp;
         if (!timestamp.from_string(scan_key.data(), scan_key.size())) {
             // Compatible with TYPE_DATETIME_V1
             timestamp.from_string("1400-01-01 00:00:00", sizeof("1400-01-01 00:00:00") - 1);
@@ -952,7 +952,7 @@ struct ScalarTypeInfoImpl<TYPE_CHAR> : public ScalarTypeInfoImplBase<TYPE_CHAR> 
                                                        value_len, get_olap_string_max_length()));
         }
 
-        auto slice = unaligned_load<Slice>(buf);
+        Slice slice;
         memory_copy(slice.data, scan_key.c_str(), value_len);
         if (slice.size < value_len) {
             /*
@@ -1019,7 +1019,7 @@ struct ScalarTypeInfoImpl<TYPE_VARCHAR> : public ScalarTypeInfoImpl<TYPE_CHAR> {
                                                      get_olap_string_max_length()));
         }
 
-        auto slice = unaligned_load<Slice>(buf);
+        Slice slice;
         memory_copy(slice.data, scan_key.c_str(), value_len);
         slice.size = value_len;
         unaligned_store<Slice>(buf, slice);


### PR DESCRIPTION
## Why I'm doing:
```

3.3.19-k-1016-4f84891 RELEASE (build 4f84891 distro centos arch x86_64)
query_id:8c67cfd3-b6d8-11f0-8191-b8e924ddd399, fragment_instance:8c67cfd3-b6d8-11f0-8191-b8e924ddd404
tracker:process consumption: 529026520704
tracker:jemalloc_metadata consumption: 22884829856
tracker:query_pool consumption: 4169992608
tracker:query_pool/connector_scan consumption: 0
tracker:load consumption: 370833960
tracker:metadata consumption: 52467096472
tracker:tablet_metadata consumption: 1638456786
tracker:rowset_metadata consumption: 988632643
tracker:segment_metadata consumption: 3904100988
tracker:column_metadata consumption: 45935906551
tracker:tablet_schema consumption: 16558474
tracker:segment_zonemap consumption: 1017753467
tracker:short_key_index consumption: 2776592215
tracker:column_zonemap_index consumption: 11796395615
tracker:ordinal_index consumption: 27015470688
tracker:bitmap_index consumption: 3754608
tracker:bloom_filter_index consumption: 30392
tracker:compaction consumption: 198617296
tracker:schema_change consumption: 0
tracker:column_pool consumption: 0
tracker:page_cache consumption: 263483125360
tracker:jit_cache consumption: 0
tracker:update consumption: 133424573088
tracker:chunk_allocator consumption: 0
tracker:passthrough consumption: 0
tracker:clone consumption: 0
tracker:consistency consumption: 0
tracker:datacache consumption: 0
tracker:replication consumption: 0
*** Aborted at 1761970163 (unix time) try "date -d @1761970163" if you are using GNU date ***
PC: @          0x627e94b starrocks::ScalarTypeInfoImpl<(starrocks::LogicalType)51>::from_string(void*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator
<char> > const&)
*** SIGSEGV (@0x10600000104) received by PID 120683 (TID 0x147498259640) from PID 260; stack trace: ***
    @     0x147a87c8ee18 __pthread_once_slow
    @          0x7de0f60 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x147a88c2b9b9 os::Linux::chained_handler(int, siginfo_t*, void*)
    @     0x147a88c31c7a JVM_handle_linux_signal
    @     0x147a88c23a4c signalHandler(int, siginfo_t*, void*)
    @     0x147a87c3e6f0 (/usr/lib64/libc.so.6+0x3e6ef)
    @          0x627e94b starrocks::ScalarTypeInfoImpl<(starrocks::LogicalType)51>::from_string(void*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator
<char> > const&)
    @          0x627d9aa starrocks::ScalarTypeInfo::from_string(void*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const
    @          0x403d395 starrocks::datum_from_string(starrocks::TypeInfo*, starrocks::Datum*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >
 const&, starrocks::MemPool*)
    @          0x691a94c starrocks::ColumnReader::_parse_zone_map(starrocks::LogicalType, starrocks::ZoneMapPB const&, starrocks::ZoneMapDetail*) const
    @          0x691b647 starrocks::ColumnReader::_zone_map_filter(std::vector<starrocks::ColumnPredicate const*, std::allocator<starrocks::ColumnPredicate const*> > const&, 
starrocks::ColumnPredicate const*, std::unordered_set<unsigned int, std::hash<unsigned int>, std::equal_to<<D0><DC>^M^S
    @          0x691fbe6 starrocks::ColumnReader::zone_map_filter(std::vector<starrocks::ColumnPredicate const*, std::allocator<starrocks::ColumnPredicate const*> > const&, s
tarrocks::ColumnPredicate const*, std::unordered_set<unsigned int, std::hash<unsigned int>, std::equal_to<u<D0><DC>^M^S
    @          0x6971e0d starrocks::ScalarColumnIterator::get_row_ranges_by_zone_map(std::vector<starrocks::ColumnPredicate const*, std::allocator<starrocks::ColumnPredicate 
const*> > const&, starrocks::ColumnPredicate const*, starrocks::SparseRange<unsigned int>*)
    @          0x62b6aab starrocks::SegmentIterator::_get_row_ranges_by_zone_map()
    @          0x62b771a starrocks::SegmentIterator::_init()
    @          0x62b7e00 starrocks::SegmentIterator::do_get_next(starrocks::Chunk*)
    @          0x6322243 starrocks::ProjectionIterator::do_get_next(starrocks::Chunk*)
    @          0x636cd2c starrocks::UnionIterator::do_get_next(starrocks::Chunk*)
    @          0x6bf1a65 starrocks::SegmentIteratorWrapper::do_get_next(starrocks::Chunk*)
    @          0x69dcf63 starrocks::TimedChunkIterator::do_get_next(starrocks::Chunk*)
    @          0x636cd2c starrocks::UnionIterator::do_get_next(starrocks::Chunk*)
    @          0x6357ba4 starrocks::TabletReader::do_get_next(starrocks::Chunk*)
    @          0x47b1590 starrocks::pipeline::OlapChunkSource::_read_chunk_from_storage(starrocks::RuntimeState*, starrocks::Chunk*)
    @          0x47b1d01 starrocks::pipeline::OlapChunkSource::_read_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*)
    @          0x47a7ef8 starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking(starrocks::RuntimeState*, unsigned long, starrocks::workgroup::WorkGroup const*)
    @          0x447ae6d auto starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}::operator()<starrocks::workgroup::Yiel
dContext>(starrocks::workgroup::YieldContext&) const [clone .constprop.0]
    @          0x4575ddb starrocks::workgroup::ScanExecutor::worker_thread()
    @          0x398fbf3 starrocks::ThreadPool::dispatch_thread()
    @          0x3987276 starrocks::Thread::supervise_thread(void*)
    @     0x147a87c89c02 start_thread
    @     0x147a87d0ec40 __clone3
```
## What I'm doing:
BE will be crashed if `from_string` method tried to read from an uninitialized buffer.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents uninitialized buffer reads in from_string for `TYPE_DATETIME`, `TYPE_CHAR`, and `TYPE_VARCHAR` to avoid crashes.
> 
> - **Storage (types)** in `be/src/storage/types.cpp`:
>   - `TYPE_DATETIME`: parse into a local `TimestampValue` before `unaligned_store`, avoiding `unaligned_load` from `buf`.
>   - `TYPE_CHAR` and `TYPE_VARCHAR`: build a local `Slice` and then `unaligned_store` it, avoiding reading `Slice` from `buf` first.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f648d91de962d537f4528a0aa807cf4cda94b9f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->