### PR TITLE
[BugFix] Reduce the minimum datacache disk size constraint to avoid datacache is excessively disabled for disk reason

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1345,8 +1345,8 @@ CONF_mInt64(datacache_disk_adjust_interval_seconds, "10");
 CONF_mInt64(datacache_disk_idle_seconds_for_expansion, "7200");
 // The minimum total disk quota bytes to adjust, once the quota to adjust is less than this value,
 // cache quota will be reset to zero to avoid overly frequent population and eviction.
-// Default: 100G
-CONF_mInt64(datacache_min_disk_quota_for_adjustment, "107374182400");
+// Default: 10G
+CONF_mInt64(datacache_min_disk_quota_for_adjustment, "10737418240");
 // The maximum inline cache item count in datacache.
 // When a cache item has a tiny data size, we will try to cache it inline with its metadata
 // to optimize the io performance and reduce disk waste.

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -1959,7 +1959,7 @@ When this value is set to less than `0`, the system uses the product of its abso
 
 ##### datacache_min_disk_quota_for_adjustment
 
-- Default: 107374182400
+- Default: 10737418240
 - Type: Int
 - Unit: Bytes
 - Is mutable: Yes

--- a/docs/ja/administration/management/BE_configuration.md
+++ b/docs/ja/administration/management/BE_configuration.md
@@ -1920,7 +1920,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 ##### datacache_min_disk_quota_for_adjustment
 
-- デフォルト: 107374182400
+- デフォルト: 10737418240
 - タイプ: Int
 - 単位: バイト
 - 可変: はい

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -1918,7 +1918,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 ##### datacache_min_disk_quota_for_adjustment
 
-- 默认值：107374182400
+- 默认值：10737418240
 - 类型：Int
 - 单位：Bytes
 - 是否动态：是


### PR DESCRIPTION
## Why I'm doing:
When using the auto-adjustment of datacache (the default behavior), StarRocks uses the `datacache_min_disk_quota_for_adjustment` parameter to limit the minimum space for datacache, preventing insufficient disk space from causing caching inefficiency and impacting query performance. However, for many test users, this default value is currently too large, resulting in datacache being disabled without the user's awareness, thus significantly impacting the query performance of external tables and cloud native tables.

## What I'm doing:
Reduce the minimum datacache disk size constraint to avoid datacache is excessively disabled for disk reason

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Lowers the default `datacache_min_disk_quota_for_adjustment` from 100G to 10G and updates BE configuration docs (EN/JA/ZH).
> 
> - **Config**:
>   - Update default of `datacache_min_disk_quota_for_adjustment` to `10737418240` (10G) in `be/src/common/config.h`.
> - **Docs**:
>   - Reflect new 10G default for `datacache_min_disk_quota_for_adjustment` in `docs/en/.../BE_configuration.md`, `docs/ja/.../BE_configuration.md`, and `docs/zh/.../BE_configuration.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01509ba48d737031a0e19ea2547d42e06f080997. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->