### PR TITLE
[BugFix] Fix MVPartitionExprResolver column name not matched bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2941,7 +2941,7 @@ public class OlapTable extends Table {
     }
 
     @Override
-    public void onCreate(Database db) {
+    public void onCreate(Database db) throws DdlException {
         super.onCreate(db);
 
         ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -45,6 +45,7 @@ import com.starrocks.alter.AlterMVJobExecutor;
 import com.starrocks.catalog.constraint.ForeignKeyConstraint;
 import com.starrocks.catalog.constraint.UniqueConstraint;
 import com.starrocks.catalog.system.SystemTable;
+import com.starrocks.common.DdlException;
 import com.starrocks.common.MaterializedViewExceptions;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonPostProcessable;
@@ -693,7 +694,13 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
         // Do nothing by default.
     }
 
-    public void onCreate(Database database) {
+    /**
+     * This method is called right after the calling of {@link com.starrocks.server.LocalMetastore#onCreate)}.
+     * If error occurs, DdlException should be thrown to abort the creation of the table.
+     * @param database database where the table is created
+     * @throws DdlException thrown if any error occurs during onCreate
+     */
+    public void onCreate(Database database) throws DdlException  {
         onReload();
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateAsyncMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateAsyncMaterializedViewTest.java
@@ -1,0 +1,47 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.analysis;
+
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Test;
+
+public class CreateAsyncMaterializedViewTest extends MVTestBase {
+    private static final Logger LOG = LogManager.getLogger(CreateAsyncMaterializedViewTest.class);
+
+    @Test
+    public void testCreateMVWithError() throws Exception {
+        starRocksAssert.withTable("create table t1(\n" +
+                "                a date,\n" +
+                "                b string,\n" +
+                "                c int);");
+        starRocksAssert.withTable("create table t3(\n" +
+                "                a date,\n" +
+                "                b string,\n" +
+                "                c int)\n" +
+                "                partition by b,date_trunc(\"day\", a);");
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv1\n" +
+                "                 DISTRIBUTED BY HASH(a) BUCKETS 3\n" +
+                "                 partition by (date_trunc(\"day\", a), b)\n" +
+                "                 REFRESH MANUAL\n" +
+                "                 AS SELECT t3.a, t3.b, sum(t1.c+t3.c) as sum_cnt\n" +
+                "                 FROM t1, t3\n" +
+                "                 where t1.a = t3.a\n" +
+                "                   and t1.b = t3.b\n" +
+                "                 GROUP BY t3.a, t3.b;");
+
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -56,6 +56,7 @@ import com.starrocks.scheduler.persist.TaskRunStatus;
 import com.starrocks.schema.MTable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
+import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.analyzer.AlterSystemStmtAnalyzer;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.MaterializedViewAnalyzer;
@@ -89,6 +90,7 @@ import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
+import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
@@ -100,6 +102,7 @@ import org.junit.jupiter.api.TestInfo;
 import java.lang.reflect.Method;
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -4213,6 +4216,13 @@ public class CreateMaterializedViewTest extends MVTestBase {
             public String getTableIdentifier() {
                 String uuid = UUID.randomUUID().toString();
                 return Joiner.on(":").join("tbl", uuid);
+            }
+        };
+        new MockUp<MetadataMgr>() {
+            @Mock
+            public Optional<Table> getTableWithIdentifier(ConnectContext context, BaseTableInfo baseTableInfo) {
+                DeltaLakeTable mockTable = new DeltaLakeTable();
+                return Optional.of(mockTable);
             }
         };
         starRocksAssert.withMaterializedView("create materialized view mv_deltalake " +


### PR DESCRIPTION
## Why I'm doing:

After pr https://github.com/StarRocks/starrocks/pull/64850, excption may be encountered as below if multi tables' partition expr are not matched and aligned:
```
2025-11-04 13:14:43.723+08:00 ERROR (starrocks-mysql-nio-pool-2|189) [MaterializedView.onReload():1284] reload mv failed: Table [id=10653, name=mv1, type=MATERIALIZED_VIEW]
com.starrocks.sql.analyzer.SemanticException: Getting analyzing error. Detail message: Column '`__generated_partition_column_0`' cannot be resolved.
        at com.starrocks.sql.analyzer.Scope.resolveField(Scope.java:96) ~[fe-core-main.jar:?]
        at com.starrocks.sql.analyzer.Scope.resolveField(Scope.java:90) ~[fe-core-main.jar:?]
        at com.starrocks.sql.analyzer.ExpressionAnalyzer$Visitor.visitSlot(ExpressionAnalyzer.java:437) ~[fe-core-main.jar:?]
        at com.starrocks.sql.analyzer.ExpressionAnalyzer$Visitor.visitSlot(ExpressionAnalyzer.java:379) ~[fe-core-main.jar:?]
        at com.starrocks.sql.ast.expression.SlotRef.accept(SlotRef.java:430) ~[fe-core-main.jar:?]
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:47) ~[fe-parser-main.jar:?]
        at com.starrocks.sql.analyzer.ExpressionAnalyzer.bottomUpAnalyze(ExpressionAnalyzer.java:375) ~[fe-core-main.jar:?]
        at com.starrocks.sql.analyzer.ExpressionAnalyzer.analyze(ExpressionAnalyzer.java:139) ~[fe-core-main.jar:?]
        at com.starrocks.sql.analyzer.ExpressionAnalyzer.analyzeExpression(ExpressionAnalyzer.java:1955) ~[fe-core-main.jar:?]
        at com.starrocks.catalog.MaterializedView.analyzePartitionExpr(MaterializedView.java:2330) ~[fe-core-main.jar:?]
        at com.starrocks.catalog.MaterializedView.analyzePartitionExprs(MaterializedView.java:2191) ~[fe-core-main.jar:?]
        at com.starrocks.catalog.MaterializedView.onReloadImpl(MaterializedView.java:1355) ~[fe-core-main.jar:?]
        at com.starrocks.catalog.MaterializedView.onReload(MaterializedView.java:1278) ~[fe-core-main.jar:?]
        at com.starrocks.catalog.MaterializedView.onReload(MaterializedView.java:1257) ~[fe-core-main.jar:?]
        at com.starrocks.catalog.MaterializedView.onReload(MaterializedView.java:1248) ~[fe-core-main.jar:?]
        at com.starrocks.catalog.Table.onCreate(Table.java:697) ~[fe-core-main.jar:?]
        at com.starrocks.catalog.OlapTable.onCreate(OlapTable.java:2945) ~[fe-core-main.jar:?]
        at com.starrocks.server.LocalMetastore.onCreate(LocalMetastore.java:1989) ~[fe-core-main.jar:?]
        at com.starrocks.server.LocalMetastore.createMaterializedView(LocalMetastore.java:3139) ~[fe-core-main.jar:?]
        at com.starrocks.qe.DDLStmtExecutor$StmtExecutorVisitor.lambda$visitCreateMaterializedViewStatement$12(DDLStmtExecutor.java:379) ~[fe-core-main.jar:?]
        at com.starrocks.common.ErrorReport.wrapWithRuntimeException(ErrorReport.java:118) ~[fe-core-main.jar:?]
        at com.starrocks.qe.DDLStmtExecutor$StmtExecutorVisitor.visitCreateMaterializedViewStatement(DDLStmtExecutor.java:378) ~[fe-core-main.jar:?]
        at com.starrocks.qe.DDLStmtExecutor$StmtExecutorVisitor.visitCreateMaterializedViewStatement(DDLStmtExecutor.java:210) ~[fe-core-main.jar:?]
        at com.starrocks.sql.ast.CreateMaterializedViewStatement.accept(CreateMaterializedViewStatement.java:382) ~[fe-core-main.jar:?]
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:47) ~[fe-parser-main.jar:?]
        at com.starrocks.qe.DDLStmtExecutor.execute(DDLStmtExecutor.java:195) ~[fe-core-main.jar:?]
        at com.starrocks.qe.StmtExecutor.handleDdlStmt(StmtExecutor.java:2244) ~[fe-core-main.jar:?]
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:848) ~[fe-core-main.jar:?]
        at com.starrocks.qe.ConnectProcessor.executeQueryAttempt(ConnectProcessor.java:528) ~[fe-core-main.jar:?]
```

eg:
```
create table t1(
                a date,
                b string,
                c int);
create table t3(
                a date,
                b string,
                c int)
                partition by b,date_trunc("day", a);
CREATE MATERIALIZED VIEW mv1
                 DISTRIBUTED BY HASH(a) BUCKETS 3
                 partition by (date_trunc("day", a), b)
                 REFRESH MANUAL
                 AS SELECT t3.a, t3.b, sum(t1.c+t3.c) as sum_cnt
                 FROM t1, t3
                 where t1.a = t3.a
                   and t1.b = t3.b
                 GROUP BY t3.a, t3.b;
REFRESH MATERIALIZED VIEW mv1 with sync mode;
```
## What I'm doing:
1. fast fail: throw exception if mv partition exprs cannot be analyzed in creating mv.
2. add more validations in resolving mv's partition exprs: checking column name and analyzing.

Fixes https://github.com/StarRocks/StarRocksTest/issues/10524

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
