### PR TITLE
[Refactor] Update type creation methods to use TypeFactory for consistency

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -101,8 +101,8 @@ import com.starrocks.thrift.TTabletSchema;
 import com.starrocks.thrift.TTabletType;
 import com.starrocks.thrift.TTaskType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import io.opentelemetry.api.trace.StatusCode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -545,7 +545,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
 
         Expr whereExpr = null;
         if (whereClause != null) {
-            Type type = ScalarType.createType(PrimitiveType.BOOLEAN);
+            Type type = TypeFactory.createType(PrimitiveType.BOOLEAN);
             whereExpr = analyzeExpr(visitor, type, CreateMaterializedViewStmt.WHERE_PREDICATE_COLUMN_NAME,
                     whereClause, slotDescByName);
             List<SlotRef> slots = Lists.newArrayList();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
@@ -21,7 +21,7 @@ import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.thrift.TWorkGroup;
 import com.starrocks.thrift.TWorkGroupType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import java.text.DecimalFormat;
 import java.util.Collections;
@@ -86,44 +86,44 @@ public class ResourceGroup {
 
     private static final List<ColumnMeta> COLUMN_METAS = ImmutableList.of(
             new ColumnMeta(
-                    new Column("name", ScalarType.createVarchar(100)),
+                    new Column("name", TypeFactory.createVarchar(100)),
                     (rg, classifier) -> rg.getName()),
             new ColumnMeta(
-                    new Column("id", ScalarType.createVarchar(200)),
+                    new Column("id", TypeFactory.createVarchar(200)),
                     (rg, classifier) -> "" + rg.getId()),
             new ColumnMeta(
-                    new Column(CPU_WEIGHT, ScalarType.createVarchar(200)),
+                    new Column(CPU_WEIGHT, TypeFactory.createVarchar(200)),
                     (rg, classifier) -> "" + rg.geNormalizedCpuWeight()),
             new ColumnMeta(
-                    new Column(EXCLUSIVE_CPU_CORES, ScalarType.createVarchar(200)),
+                    new Column(EXCLUSIVE_CPU_CORES, TypeFactory.createVarchar(200)),
                     (rg, classifier) -> "" + rg.getNormalizedExclusiveCpuCores()),
             new ColumnMeta(
-                    new Column(MEM_LIMIT, ScalarType.createVarchar(200)),
+                    new Column(MEM_LIMIT, TypeFactory.createVarchar(200)),
                     (rg, classifier) -> (rg.getMemLimit() * 100) + "%"),
             new ColumnMeta(
-                    new Column(MAX_CPU_CORES, ScalarType.createVarchar(200)),
+                    new Column(MAX_CPU_CORES, TypeFactory.createVarchar(200)),
                     (rg, classifier) -> "" + rg.getMaxCpuCores(), false),
             new ColumnMeta(
-                    new Column(BIG_QUERY_CPU_SECOND_LIMIT, ScalarType.createVarchar(200)),
+                    new Column(BIG_QUERY_CPU_SECOND_LIMIT, TypeFactory.createVarchar(200)),
                     (rg, classifier) -> "" + Objects.requireNonNullElse(rg.getBigQueryCpuSecondLimit(), 0)),
             new ColumnMeta(
-                    new Column(BIG_QUERY_SCAN_ROWS_LIMIT, ScalarType.createVarchar(200)),
+                    new Column(BIG_QUERY_SCAN_ROWS_LIMIT, TypeFactory.createVarchar(200)),
                     (rg, classifier) -> "" + Objects.requireNonNullElse(rg.getBigQueryScanRowsLimit(), 0)),
             new ColumnMeta(
-                    new Column(BIG_QUERY_MEM_LIMIT, ScalarType.createVarchar(200)),
+                    new Column(BIG_QUERY_MEM_LIMIT, TypeFactory.createVarchar(200)),
                     (rg, classifier) -> "" + Objects.requireNonNullElse(rg.getBigQueryMemLimit(), 0)),
             new ColumnMeta(
-                    new Column(CONCURRENCY_LIMIT, ScalarType.createVarchar(200)),
+                    new Column(CONCURRENCY_LIMIT, TypeFactory.createVarchar(200)),
                     (rg, classifier) -> "" + rg.getConcurrencyLimit()),
             new ColumnMeta(
-                    new Column(SPILL_MEM_LIMIT_THRESHOLD, ScalarType.createVarchar(200)),
+                    new Column(SPILL_MEM_LIMIT_THRESHOLD, TypeFactory.createVarchar(200)),
                     (rg, classifier) -> new DecimalFormat("#.##").format(
                             Objects.requireNonNullElse(rg.getSpillMemLimitThreshold(), 1.0) * 100) + "%"),
             new ColumnMeta(
-                    new Column(GROUP_TYPE, ScalarType.createVarchar(200)),
+                    new Column(GROUP_TYPE, TypeFactory.createVarchar(200)),
                     (rg, classifier) -> rg.getResourceGroupType().name().substring("WG_".length()), false),
             new ColumnMeta(
-                    new Column("classifiers", ScalarType.createVarchar(1024)),
+                    new Column("classifiers", TypeFactory.createVarchar(1024)),
                     (rg, classifier) -> classifier.toString())
     );
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -58,9 +58,9 @@ import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableFunctionTable;
 import com.starrocks.thrift.TTableType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
 import com.starrocks.type.TypeDeserializer;
+import com.starrocks.type.TypeFactory;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.logging.log4j.LogManager;
@@ -701,7 +701,7 @@ public class TableFunctionTable extends Table {
     private List<Column> getSchemaFromPath() {
         List<Column> columns = new ArrayList<>();
         for (String colName : columnsFromPath) {
-            columns.add(new Column(colName, ScalarType.createDefaultString(), true));
+            columns.add(new Column(colName, TypeFactory.createDefaultString(), true));
         }
         return columns;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/SystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/SystemTable.java
@@ -48,6 +48,7 @@ import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.thrift.protocol.TType;
@@ -278,6 +279,6 @@ public class SystemTable extends Table {
     }
 
     public static ScalarType createNameType() {
-        return ScalarType.createVarchar(NAME_CHAR_LEN);
+        return TypeFactory.createVarchar(NAME_CHAR_LEN);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/AnalyzeStatusSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/AnalyzeStatusSystemTable.java
@@ -34,7 +34,7 @@ import com.starrocks.thrift.TAnalyzeStatusItem;
 import com.starrocks.thrift.TAnalyzeStatusReq;
 import com.starrocks.thrift.TAnalyzeStatusRes;
 import com.starrocks.thrift.TSchemaTableType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -54,17 +54,17 @@ public class AnalyzeStatusSystemTable extends SystemTable {
 
     public static final ShowResultSetMetaData META_DATA =
             ShowResultSetMetaData.builder()
-                    .addColumn(new Column("Id", ScalarType.createVarchar(60)))
-                    .addColumn(new Column("Database", ScalarType.createVarchar(60)))
-                    .addColumn(new Column("Table", ScalarType.createVarchar(60)))
-                    .addColumn(new Column("Columns", ScalarType.createVarchar(200)))
-                    .addColumn(new Column("Type", ScalarType.createVarchar(20)))
-                    .addColumn(new Column("Schedule", ScalarType.createVarchar(20)))
-                    .addColumn(new Column("Status", ScalarType.createVarchar(20)))
-                    .addColumn(new Column("StartTime", ScalarType.createVarchar(60)))
-                    .addColumn(new Column("EndTime", ScalarType.createVarchar(60)))
-                    .addColumn(new Column("Properties", ScalarType.createVarchar(200)))
-                    .addColumn(new Column("Reason", ScalarType.createVarchar(100)))
+                    .addColumn(new Column("Id", TypeFactory.createVarchar(60)))
+                    .addColumn(new Column("Database", TypeFactory.createVarchar(60)))
+                    .addColumn(new Column("Table", TypeFactory.createVarchar(60)))
+                    .addColumn(new Column("Columns", TypeFactory.createVarchar(200)))
+                    .addColumn(new Column("Type", TypeFactory.createVarchar(20)))
+                    .addColumn(new Column("Schedule", TypeFactory.createVarchar(20)))
+                    .addColumn(new Column("Status", TypeFactory.createVarchar(20)))
+                    .addColumn(new Column("StartTime", TypeFactory.createVarchar(60)))
+                    .addColumn(new Column("EndTime", TypeFactory.createVarchar(60)))
+                    .addColumn(new Column("Properties", TypeFactory.createVarchar(200)))
+                    .addColumn(new Column("Reason", TypeFactory.createVarchar(100)))
                     .build();
     static {
         COLUMNS = Lists.newArrayList(META_DATA.getColumns());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ApplicableRolesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ApplicableRolesSystemTable.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.builder;
 
@@ -30,15 +30,15 @@ public class ApplicableRolesSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("USER", ScalarType.createVarchar(97))
-                        .column("HOST", ScalarType.createVarchar(256))
-                        .column("GRANTEE", ScalarType.createVarchar(97))
-                        .column("GRANTEE_HOST", ScalarType.createVarchar(256))
-                        .column("ROLE_NAME", ScalarType.createVarchar(255))
-                        .column("ROLE_HOST", ScalarType.createVarchar(256))
-                        .column("IS_GRANTABLE", ScalarType.createVarchar(3))
-                        .column("IS_DEFAULT", ScalarType.createVarchar(3))
-                        .column("IS_MANDATORY", ScalarType.createVarchar(3))
+                        .column("USER", TypeFactory.createVarchar(97))
+                        .column("HOST", TypeFactory.createVarchar(256))
+                        .column("GRANTEE", TypeFactory.createVarchar(97))
+                        .column("GRANTEE_HOST", TypeFactory.createVarchar(256))
+                        .column("ROLE_NAME", TypeFactory.createVarchar(255))
+                        .column("ROLE_HOST", TypeFactory.createVarchar(256))
+                        .column("IS_GRANTABLE", TypeFactory.createVarchar(3))
+                        .column("IS_DEFAULT", TypeFactory.createVarchar(3))
+                        .column("IS_MANDATORY", TypeFactory.createVarchar(3))
                         .build(),
                 TSchemaTableType.SCH_APPLICABLE_ROLES);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeBvarsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeBvarsSystemTable.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
@@ -31,9 +31,9 @@ public class BeBvarsSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT), false)
-                        .column("NAME", ScalarType.createVarchar(NAME_CHAR_LEN), false)
-                        .column("VALUE", ScalarType.createVarchar(NAME_CHAR_LEN), false)
+                        .column("BE_ID", TypeFactory.createType(PrimitiveType.BIGINT), false)
+                        .column("NAME", TypeFactory.createVarchar(NAME_CHAR_LEN), false)
+                        .column("VALUE", TypeFactory.createVarchar(NAME_CHAR_LEN), false)
                         .build(), TSchemaTableType.SCH_BE_BVARS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeCloudNativeCompactionsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeCloudNativeCompactionsSystemTable.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.builder;
 
@@ -30,17 +30,17 @@ public class BeCloudNativeCompactionsSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("TXN_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("TABLET_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("VERSION", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("SKIPPED", ScalarType.createType(PrimitiveType.BOOLEAN))
-                        .column("RUNS", ScalarType.createType(PrimitiveType.INT))
-                        .column("START_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("FINISH_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("PROGRESS", ScalarType.createType(PrimitiveType.INT))
-                        .column("STATUS", ScalarType.createType(PrimitiveType.VARCHAR))
-                        .column("PROFILE", ScalarType.createType(PrimitiveType.VARCHAR))
+                        .column("BE_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("TXN_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("TABLET_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("VERSION", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("SKIPPED", TypeFactory.createType(PrimitiveType.BOOLEAN))
+                        .column("RUNS", TypeFactory.createType(PrimitiveType.INT))
+                        .column("START_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("FINISH_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("PROGRESS", TypeFactory.createType(PrimitiveType.INT))
+                        .column("STATUS", TypeFactory.createType(PrimitiveType.VARCHAR))
+                        .column("PROFILE", TypeFactory.createType(PrimitiveType.VARCHAR))
                         .build(), TSchemaTableType.SCH_BE_CLOUD_NATIVE_COMPACTIONS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeCompactionsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeCompactionsSystemTable.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.builder;
 
@@ -30,14 +30,14 @@ public class BeCompactionsSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("CANDIDATES_NUM", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("BASE_COMPACTION_CONCURRENCY", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("CUMULATIVE_COMPACTION_CONCURRENCY", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("LATEST_COMPACTION_SCORE", ScalarType.createType(PrimitiveType.DOUBLE))
-                        .column("CANDIDATE_MAX_SCORE", ScalarType.createType(PrimitiveType.DOUBLE))
-                        .column("MANUAL_COMPACTION_CONCURRENCY", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("MANUAL_COMPACTION_CANDIDATES_NUM", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("BE_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("CANDIDATES_NUM", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("BASE_COMPACTION_CONCURRENCY", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("CUMULATIVE_COMPACTION_CONCURRENCY", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("LATEST_COMPACTION_SCORE", TypeFactory.createType(PrimitiveType.DOUBLE))
+                        .column("CANDIDATE_MAX_SCORE", TypeFactory.createType(PrimitiveType.DOUBLE))
+                        .column("MANUAL_COMPACTION_CONCURRENCY", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("MANUAL_COMPACTION_CANDIDATES_NUM", TypeFactory.createType(PrimitiveType.BIGINT))
                         .build(), TSchemaTableType.SCH_BE_COMPACTIONS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeConfigsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeConfigsSystemTable.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
@@ -31,12 +31,12 @@ public class BeConfigsSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("VALUE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("DEFAULT", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("MUTABLE", ScalarType.createType(PrimitiveType.BOOLEAN))
+                        .column("BE_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("VALUE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TYPE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("DEFAULT", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("MUTABLE", TypeFactory.createType(PrimitiveType.BOOLEAN))
                         .build(), TSchemaTableType.SCH_BE_CONFIGS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeDataCacheMetricsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeDataCacheMetricsTable.java
@@ -21,9 +21,9 @@ import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.MapType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
+import com.starrocks.type.TypeFactory;
 
 import java.util.ArrayList;
 
@@ -35,23 +35,23 @@ public class BeDataCacheMetricsTable {
 
     public static SystemTable create() {
         ArrayList<StructField> dirSpacesFields = new ArrayList<>();
-        dirSpacesFields.add(new StructField("path", ScalarType.createVarcharType(MAX_FIELD_VARCHAR_LENGTH)));
-        dirSpacesFields.add(new StructField("quota_bytes", ScalarType.createType(PrimitiveType.BIGINT)));
+        dirSpacesFields.add(new StructField("path", TypeFactory.createVarcharType(MAX_FIELD_VARCHAR_LENGTH)));
+        dirSpacesFields.add(new StructField("quota_bytes", TypeFactory.createType(PrimitiveType.BIGINT)));
         StructType dirSpacesType = new StructType(dirSpacesFields);
         ArrayType dirSpacesArrayType = new ArrayType(dirSpacesType);
 
         MapType usedBytesDetailType =
-                new MapType(ScalarType.createType(PrimitiveType.INT), ScalarType.createType(PrimitiveType.BIGINT));
+                new MapType(TypeFactory.createType(PrimitiveType.INT), TypeFactory.createType(PrimitiveType.BIGINT));
 
         return new SystemTable(SystemId.BE_DATACACHE_METRICS, NAME, Table.TableType.SCHEMA,
                 SystemTable.builder()
-                        .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("STATUS", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("DISK_QUOTA_BYTES", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("DISK_USED_BYTES", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("MEM_QUOTA_BYTES", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("MEM_USED_BYTES", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("META_USED_BYTES", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("BE_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("STATUS", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("DISK_QUOTA_BYTES", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("DISK_USED_BYTES", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("MEM_QUOTA_BYTES", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("MEM_USED_BYTES", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("META_USED_BYTES", TypeFactory.createType(PrimitiveType.BIGINT))
                         .column("DIR_SPACES", dirSpacesArrayType)
                         .column("USED_BYTES_DETAIL", usedBytesDetailType)
                         .build(),

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeLogsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeLogsSystemTable.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
@@ -31,11 +31,11 @@ public class BeLogsSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("LEVEL", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TIMESTAMP", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("TID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("LOG", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("BE_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("LEVEL", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TIMESTAMP", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("TID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("LOG", TypeFactory.createVarchar(NAME_CHAR_LEN))
                         .build(), TSchemaTableType.SCH_BE_LOGS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeMetricsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeMetricsSystemTable.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
@@ -31,10 +31,10 @@ public class BeMetricsSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("LABELS", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("VALUE", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("BE_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("LABELS", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("VALUE", TypeFactory.createType(PrimitiveType.BIGINT))
                         .build(), TSchemaTableType.SCH_BE_METRICS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeTabletsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeTabletsSystemTable.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
@@ -31,26 +31,26 @@ public class BeTabletsSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("TABLE_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("PARTITION_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("TABLET_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("NUM_VERSION", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("MAX_VERSION", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("MIN_VERSION", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("NUM_ROWSET", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("NUM_ROW", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("DATA_SIZE", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("INDEX_MEM", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("CREATE_TIME", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("STATE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("DATA_DIR", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("SHARD_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("SCHEMA_HASH", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("INDEX_DISK", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("MEDIUM_TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("NUM_SEGMENT", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("BE_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("TABLE_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("PARTITION_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("TABLET_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("NUM_VERSION", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("MAX_VERSION", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("MIN_VERSION", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("NUM_ROWSET", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("NUM_ROW", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("DATA_SIZE", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("INDEX_MEM", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("CREATE_TIME", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("STATE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TYPE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("DATA_DIR", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("SHARD_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("SCHEMA_HASH", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("INDEX_DISK", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("MEDIUM_TYPE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("NUM_SEGMENT", TypeFactory.createType(PrimitiveType.BIGINT))
                         .build(), TSchemaTableType.SCH_BE_TABLETS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeThreadsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeThreadsSystemTable.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
@@ -31,14 +31,14 @@ public class BeThreadsSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("GROUP", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("PTHREAD_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("TID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("IDLE", ScalarType.createType(PrimitiveType.BOOLEAN))
-                        .column("FINISHED_TASKS", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("BOUND_CPUS", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("BE_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("GROUP", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("PTHREAD_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("TID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("IDLE", TypeFactory.createType(PrimitiveType.BOOLEAN))
+                        .column("FINISHED_TASKS", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("BOUND_CPUS", TypeFactory.createType(PrimitiveType.BIGINT))
                         .build(), TSchemaTableType.SCH_BE_THREADS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeTxnsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeTxnsSystemTable.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
@@ -31,20 +31,20 @@ public class BeTxnsSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("BE_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("LOAD_ID", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TXN_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("PARTITION_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("TABLET_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("CREATE_TIME", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("COMMIT_TIME", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("PUBLISH_TIME", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("ROWSET_ID", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("NUM_SEGMENT", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("NUM_DELFILE", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("NUM_ROW", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("DATA_SIZE", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("VERSION", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("BE_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("LOAD_ID", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TXN_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("PARTITION_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("TABLET_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("CREATE_TIME", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("COMMIT_TIME", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("PUBLISH_TIME", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("ROWSET_ID", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("NUM_SEGMENT", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("NUM_DELFILE", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("NUM_ROW", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("DATA_SIZE", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("VERSION", TypeFactory.createType(PrimitiveType.BIGINT))
                         .build(), TSchemaTableType.SCH_BE_TXNS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/CharacterSetsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/CharacterSetsSystemTable.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.builder;
 
@@ -32,10 +32,10 @@ public class CharacterSetsSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("CHARACTER_SET_NAME", ScalarType.createVarchar(512))
-                        .column("DEFAULT_COLLATE_NAME", ScalarType.createVarchar(64))
-                        .column("DESCRIPTION", ScalarType.createVarchar(64))
-                        .column("MAXLEN", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("CHARACTER_SET_NAME", TypeFactory.createVarchar(512))
+                        .column("DEFAULT_COLLATE_NAME", TypeFactory.createVarchar(64))
+                        .column("DESCRIPTION", TypeFactory.createVarchar(64))
+                        .column("MAXLEN", TypeFactory.createType(PrimitiveType.BIGINT))
                         .build(), TSchemaTableType.SCH_CHARSETS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ClusterSnapshotJobsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ClusterSnapshotJobsTable.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
@@ -31,13 +31,13 @@ public class ClusterSnapshotJobsTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("SNAPSHOT_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("JOB_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("CREATED_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("FINISHED_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("STATE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("DETAIL_INFO", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("ERROR_MESSAGE", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("SNAPSHOT_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("JOB_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("CREATED_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("FINISHED_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("STATE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("DETAIL_INFO", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("ERROR_MESSAGE", TypeFactory.createVarchar(NAME_CHAR_LEN))
                         .build(), TSchemaTableType.SCH_CLUSTER_SNAPSHOT_JOBS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ClusterSnapshotsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ClusterSnapshotsTable.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
@@ -31,14 +31,14 @@ public class ClusterSnapshotsTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("SNAPSHOT_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("SNAPSHOT_TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("CREATED_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("FE_JOURNAL_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("STARMGR_JOURNAL_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("PROPERTIES", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("STORAGE_VOLUME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("STORAGE_PATH", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("SNAPSHOT_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("SNAPSHOT_TYPE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("CREATED_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("FE_JOURNAL_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("STARMGR_JOURNAL_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("PROPERTIES", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("STORAGE_VOLUME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("STORAGE_PATH", TypeFactory.createVarchar(NAME_CHAR_LEN))
                         .build(), TSchemaTableType.SCH_CLUSTER_SNAPSHOTS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/CollationsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/CollationsSystemTable.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.builder;
 
@@ -32,12 +32,12 @@ public class CollationsSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("COLLATION_NAME", ScalarType.createVarchar(512))
-                        .column("CHARACTER_SET_NAME", ScalarType.createVarchar(64))
-                        .column("ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("IS_DEFAULT", ScalarType.createVarchar(64))
-                        .column("IS_COMPILED", ScalarType.createVarchar(64))
-                        .column("SORTLEN", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("COLLATION_NAME", TypeFactory.createVarchar(512))
+                        .column("CHARACTER_SET_NAME", TypeFactory.createVarchar(64))
+                        .column("ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("IS_DEFAULT", TypeFactory.createVarchar(64))
+                        .column("IS_COMPILED", TypeFactory.createVarchar(64))
+                        .column("SORTLEN", TypeFactory.createType(PrimitiveType.BIGINT))
                         .build(), TSchemaTableType.SCH_COLLATIONS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ColumnPrivilegesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ColumnPrivilegesSystemTable.java
@@ -17,7 +17,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
@@ -32,13 +32,13 @@ public class ColumnPrivilegesSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("GRANTEE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TABLE_CATALOG", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TABLE_SCHEMA", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TABLE_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("COLUMN_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("PRIVILEGE_TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("IS_GRANTABLE", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("GRANTEE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TABLE_CATALOG", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TABLE_SCHEMA", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TABLE_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("COLUMN_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("PRIVILEGE_TYPE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("IS_GRANTABLE", TypeFactory.createVarchar(NAME_CHAR_LEN))
                         .build(), TSchemaTableType.SCH_COLUMN_PRIVILEGES);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ColumnsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ColumnsSystemTable.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.builder;
 
@@ -32,32 +32,32 @@ public class ColumnsSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("TABLE_CATALOG", ScalarType.createVarchar(512))
-                        .column("TABLE_SCHEMA", ScalarType.createVarchar(64))
-                        .column("TABLE_NAME", ScalarType.createVarchar(64))
-                        .column("COLUMN_NAME", ScalarType.createVarchar(64))
-                        .column("ORDINAL_POSITION", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("COLUMN_DEFAULT", ScalarType.createVarchar(1024))
-                        .column("IS_NULLABLE", ScalarType.createVarchar(3))
-                        .column("DATA_TYPE", ScalarType.createVarchar(64))
+                        .column("TABLE_CATALOG", TypeFactory.createVarchar(512))
+                        .column("TABLE_SCHEMA", TypeFactory.createVarchar(64))
+                        .column("TABLE_NAME", TypeFactory.createVarchar(64))
+                        .column("COLUMN_NAME", TypeFactory.createVarchar(64))
+                        .column("ORDINAL_POSITION", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("COLUMN_DEFAULT", TypeFactory.createVarchar(1024))
+                        .column("IS_NULLABLE", TypeFactory.createVarchar(3))
+                        .column("DATA_TYPE", TypeFactory.createVarchar(64))
                         .column("CHARACTER_MAXIMUM_LENGTH",
-                                ScalarType.createType(PrimitiveType.BIGINT))
+                                TypeFactory.createType(PrimitiveType.BIGINT))
                         .column("CHARACTER_OCTET_LENGTH",
-                                ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("NUMERIC_PRECISION", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("NUMERIC_SCALE", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("DATETIME_PRECISION", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("CHARACTER_SET_NAME", ScalarType.createVarchar(32))
-                        .column("COLLATION_NAME", ScalarType.createVarchar(32))
-                        .column("COLUMN_TYPE", ScalarType.createVarchar(32))
-                        .column("COLUMN_KEY", ScalarType.createVarchar(3))
-                        .column("EXTRA", ScalarType.createVarchar(27))
-                        .column("PRIVILEGES", ScalarType.createVarchar(80))
-                        .column("COLUMN_COMMENT", ScalarType.createVarchar(255))
-                        .column("COLUMN_SIZE", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("DECIMAL_DIGITS", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("GENERATION_EXPRESSION", ScalarType.createVarchar(64))
-                        .column("SRS_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                                TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("NUMERIC_PRECISION", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("NUMERIC_SCALE", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("DATETIME_PRECISION", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("CHARACTER_SET_NAME", TypeFactory.createVarchar(32))
+                        .column("COLLATION_NAME", TypeFactory.createVarchar(32))
+                        .column("COLUMN_TYPE", TypeFactory.createVarchar(32))
+                        .column("COLUMN_KEY", TypeFactory.createVarchar(3))
+                        .column("EXTRA", TypeFactory.createVarchar(27))
+                        .column("PRIVILEGES", TypeFactory.createVarchar(80))
+                        .column("COLUMN_COMMENT", TypeFactory.createVarchar(255))
+                        .column("COLUMN_SIZE", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("DECIMAL_DIGITS", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("GENERATION_EXPRESSION", TypeFactory.createVarchar(64))
+                        .column("SRS_ID", TypeFactory.createType(PrimitiveType.BIGINT))
                         .build(), TSchemaTableType.SCH_COLUMNS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/DynamicTabletJobsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/DynamicTabletJobsTable.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
@@ -31,19 +31,19 @@ public class DynamicTabletJobsTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("JOB_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("DB_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("DB_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TABLE_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("TABLE_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("JOB_TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("JOB_STATE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TRANSACTION_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("PARALLEL_PARTITIONS", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("PARALLEL_TABLETS", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("CREATED_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("FINISHED_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("ERROR_MESSAGE", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("JOB_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("DB_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("DB_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TABLE_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("TABLE_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("JOB_TYPE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("JOB_STATE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TRANSACTION_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("PARALLEL_PARTITIONS", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("PARALLEL_TABLETS", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("CREATED_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("FINISHED_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("ERROR_MESSAGE", TypeFactory.createVarchar(NAME_CHAR_LEN))
                         .build(), TSchemaTableType.SCH_DYNAMIC_TABLET_JOBS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/EnginesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/EnginesSystemTable.java
@@ -17,7 +17,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.builder;
 
@@ -31,12 +31,12 @@ public class EnginesSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("ENGINE", ScalarType.createVarchar(64))
-                        .column("SUPPORT", ScalarType.createVarchar(8))
-                        .column("COMMENT", ScalarType.createVarchar(80))
-                        .column("TRANSACTIONS", ScalarType.createVarchar(3))
-                        .column("XA", ScalarType.createVarchar(3))
-                        .column("SAVEPOINTS", ScalarType.createVarchar(3))
+                        .column("ENGINE", TypeFactory.createVarchar(64))
+                        .column("SUPPORT", TypeFactory.createVarchar(8))
+                        .column("COMMENT", TypeFactory.createVarchar(80))
+                        .column("TRANSACTIONS", TypeFactory.createVarchar(3))
+                        .column("XA", TypeFactory.createVarchar(3))
+                        .column("SAVEPOINTS", TypeFactory.createVarchar(3))
                         .build(), TSchemaTableType.SCH_ENGINES);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/EventsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/EventsSystemTable.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.MAX_FIELD_VARCHAR_LENGTH;
 import static com.starrocks.catalog.system.SystemTable.builder;
@@ -33,32 +33,32 @@ public class EventsSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("EVENT_CATALOG", ScalarType.createVarchar(64))
-                        .column("EVENT_SCHEMA", ScalarType.createVarchar(64))
-                        .column("EVENT_NAME", ScalarType.createVarchar(64))
-                        .column("DEFINER", ScalarType.createVarchar(77))
-                        .column("TIME_ZONE", ScalarType.createVarchar(64))
-                        .column("EVENT_BODY", ScalarType.createVarchar(8))
+                        .column("EVENT_CATALOG", TypeFactory.createVarchar(64))
+                        .column("EVENT_SCHEMA", TypeFactory.createVarchar(64))
+                        .column("EVENT_NAME", TypeFactory.createVarchar(64))
+                        .column("DEFINER", TypeFactory.createVarchar(77))
+                        .column("TIME_ZONE", TypeFactory.createVarchar(64))
+                        .column("EVENT_BODY", TypeFactory.createVarchar(8))
                         // TODO: Type for EVENT_DEFINITION should be `longtext`, but `varchar(65535)` was set at this stage.
                         .column("EVENT_DEFINITION",
-                                ScalarType.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
-                        .column("EVENT_TYPE", ScalarType.createVarchar(9))
-                        .column("EXECUTE_AT", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("INTERVAL_VALUE", ScalarType.createVarchar(256))
-                        .column("INTERVAL_FIELD", ScalarType.createVarchar(18))
-                        .column("SQL_MODE", ScalarType.createVarchar(8192))
-                        .column("STARTS", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("ENDS", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("STATUS", ScalarType.createVarchar(18))
-                        .column("ON_COMPLETION", ScalarType.createVarchar(12))
-                        .column("CREATED", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("LAST_ALTERED", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("LAST_EXECUTED", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("EVENT_COMMENT", ScalarType.createVarchar(64))
-                        .column("ORIGINATOR", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("CHARACTER_SET_CLIENT", ScalarType.createVarchar(32))
-                        .column("COLLATION_CONNECTION", ScalarType.createVarchar(32))
-                        .column("DATABASE_COLLATION", ScalarType.createVarchar(32))
+                                TypeFactory.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
+                        .column("EVENT_TYPE", TypeFactory.createVarchar(9))
+                        .column("EXECUTE_AT", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("INTERVAL_VALUE", TypeFactory.createVarchar(256))
+                        .column("INTERVAL_FIELD", TypeFactory.createVarchar(18))
+                        .column("SQL_MODE", TypeFactory.createVarchar(8192))
+                        .column("STARTS", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("ENDS", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("STATUS", TypeFactory.createVarchar(18))
+                        .column("ON_COMPLETION", TypeFactory.createVarchar(12))
+                        .column("CREATED", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("LAST_ALTERED", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("LAST_EXECUTED", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("EVENT_COMMENT", TypeFactory.createVarchar(64))
+                        .column("ORIGINATOR", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("CHARACTER_SET_CLIENT", TypeFactory.createVarchar(32))
+                        .column("COLLATION_CONNECTION", TypeFactory.createVarchar(32))
+                        .column("DATABASE_COLLATION", TypeFactory.createVarchar(32))
                         .build(), TSchemaTableType.SCH_EVENTS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/FeMetricsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/FeMetricsSystemTable.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
@@ -31,10 +31,10 @@ public class FeMetricsSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("FE_ID", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("LABELS", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("VALUE", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("FE_ID", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("LABELS", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("VALUE", TypeFactory.createType(PrimitiveType.BIGINT))
                         .build(), TSchemaTableType.SCH_FE_METRICS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/FeTabletSchedulesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/FeTabletSchedulesSystemTable.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
@@ -31,32 +31,32 @@ public class FeTabletSchedulesSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("TABLET_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("TABLE_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("PARTITION_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("STATE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("SCHEDULE_REASON", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("MEDIUM", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("PRIORITY", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("ORIG_PRIORITY", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("LAST_PRIORITY_ADJUST_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("VISIBLE_VERSION", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("COMMITTED_VERSION", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("SRC_BE_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("SRC_PATH", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("DEST_BE_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("DEST_PATH", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TIMEOUT", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("CREATE_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("SCHEDULE_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("FINISH_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("CLONE_BYTES", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("CLONE_DURATION", ScalarType.createType(PrimitiveType.DOUBLE))
-                        .column("CLONE_RATE", ScalarType.createType(PrimitiveType.DOUBLE))
-                        .column("FAILED_SCHEDULE_COUNT", ScalarType.createType(PrimitiveType.INT))
-                        .column("FAILED_RUNNING_COUNT", ScalarType.createType(PrimitiveType.INT))
-                        .column("MSG", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("TABLET_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("TABLE_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("PARTITION_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("TYPE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("STATE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("SCHEDULE_REASON", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("MEDIUM", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("PRIORITY", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("ORIG_PRIORITY", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("LAST_PRIORITY_ADJUST_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("VISIBLE_VERSION", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("COMMITTED_VERSION", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("SRC_BE_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("SRC_PATH", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("DEST_BE_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("DEST_PATH", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TIMEOUT", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("CREATE_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("SCHEDULE_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("FINISH_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("CLONE_BYTES", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("CLONE_DURATION", TypeFactory.createType(PrimitiveType.DOUBLE))
+                        .column("CLONE_RATE", TypeFactory.createType(PrimitiveType.DOUBLE))
+                        .column("FAILED_SCHEDULE_COUNT", TypeFactory.createType(PrimitiveType.INT))
+                        .column("FAILED_RUNNING_COUNT", TypeFactory.createType(PrimitiveType.INT))
+                        .column("MSG", TypeFactory.createVarchar(NAME_CHAR_LEN))
                         .build(), TSchemaTableType.SCH_FE_TABLET_SCHEDULES);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/GlobalVariablesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/GlobalVariablesSystemTable.java
@@ -17,7 +17,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.builder;
 
@@ -29,8 +29,8 @@ public class GlobalVariablesSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("VARIABLE_NAME", ScalarType.createVarchar(64))
-                        .column("VARIABLE_VALUE", ScalarType.createVarchar(1024))
+                        .column("VARIABLE_NAME", TypeFactory.createVarchar(64))
+                        .column("VARIABLE_VALUE", TypeFactory.createVarchar(1024))
                         .build(), TSchemaTableType.SCH_GLOBAL_VARIABLES);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/KeyColumnUsageSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/KeyColumnUsageSystemTable.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
@@ -33,19 +33,19 @@ public class KeyColumnUsageSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("CONSTRAINT_CATALOG", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("CONSTRAINT_SCHEMA", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("CONSTRAINT_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TABLE_CATALOG", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TABLE_SCHEMA", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TABLE_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("COLUMN_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("ORDINAL_POSITION", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("CONSTRAINT_CATALOG", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("CONSTRAINT_SCHEMA", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("CONSTRAINT_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TABLE_CATALOG", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TABLE_SCHEMA", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TABLE_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("COLUMN_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("ORDINAL_POSITION", TypeFactory.createType(PrimitiveType.BIGINT))
                         .column("POSITION_IN_UNIQUE_CONSTRAINT",
-                                ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("REFERENCED_TABLE_SCHEMA", ScalarType.createVarchar(64))
-                        .column("REFERENCED_TABLE_NAME", ScalarType.createVarchar(64))
-                        .column("REFERENCED_COLUMN_NAME", ScalarType.createVarchar(64))
+                                TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("REFERENCED_TABLE_SCHEMA", TypeFactory.createVarchar(64))
+                        .column("REFERENCED_TABLE_NAME", TypeFactory.createVarchar(64))
+                        .column("REFERENCED_COLUMN_NAME", TypeFactory.createVarchar(64))
                         .build(), TSchemaTableType.SCH_KEY_COLUMN_USAGE);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/KeywordsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/KeywordsSystemTable.java
@@ -19,7 +19,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.builder;
 
@@ -31,8 +31,8 @@ public class KeywordsSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("WORD", ScalarType.createVarchar(128))
-                        .column("RESERVED", ScalarType.createType(PrimitiveType.BOOLEAN))
+                        .column("WORD", TypeFactory.createVarchar(128))
+                        .column("RESERVED", TypeFactory.createType(PrimitiveType.BOOLEAN))
                         .build(),
                 TSchemaTableType.SCH_KEYWORDS);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/LoadTrackingLogsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/LoadTrackingLogsSystemTable.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.MAX_FIELD_VARCHAR_LENGTH;
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
@@ -32,12 +32,12 @@ public class LoadTrackingLogsSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("JOB_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("LABEL", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("DATABASE_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TRACKING_LOG", ScalarType.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
-                        .column("TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("JOB_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("LABEL", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("DATABASE_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TRACKING_LOG", TypeFactory.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
+                        .column("TYPE", TypeFactory.createVarchar(NAME_CHAR_LEN))
                         .build(), TSchemaTableType.SCH_LOAD_TRACKING_LOGS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/LoadsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/LoadsSystemTable.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
@@ -31,32 +31,32 @@ public class LoadsSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("LABEL", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("PROFILE_ID", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("DB_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TABLE_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("USER", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("WAREHOUSE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("STATE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("PROGRESS", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("PRIORITY", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("SCAN_ROWS", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("SCAN_BYTES", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("FILTERED_ROWS", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("UNSELECTED_ROWS", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("SINK_ROWS", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("RUNTIME_DETAILS", ScalarType.createJsonType())
-                        .column("CREATE_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("LOAD_START_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("LOAD_COMMIT_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("LOAD_FINISH_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("PROPERTIES", ScalarType.createJsonType())
-                        .column("ERROR_MSG", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TRACKING_SQL", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("REJECTED_RECORD_PATH", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("JOB_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("LABEL", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("PROFILE_ID", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("DB_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TABLE_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("USER", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("WAREHOUSE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("STATE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("PROGRESS", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TYPE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("PRIORITY", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("SCAN_ROWS", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("SCAN_BYTES", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("FILTERED_ROWS", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("UNSELECTED_ROWS", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("SINK_ROWS", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("RUNTIME_DETAILS", TypeFactory.createJsonType())
+                        .column("CREATE_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("LOAD_START_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("LOAD_COMMIT_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("LOAD_FINISH_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("PROPERTIES", TypeFactory.createJsonType())
+                        .column("ERROR_MSG", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TRACKING_SQL", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("REJECTED_RECORD_PATH", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("JOB_ID", TypeFactory.createType(PrimitiveType.BIGINT))
                         .build(), TSchemaTableType.SCH_LOADS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/MaterializedViewsSystemTable.java
@@ -45,8 +45,8 @@ import com.starrocks.thrift.TMaterializedViewStatus;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.thrift.TUserIdentity;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -74,34 +74,34 @@ public class MaterializedViewsSystemTable extends SystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("MATERIALIZED_VIEW_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("TABLE_SCHEMA", ScalarType.createVarchar(20))
-                        .column("TABLE_NAME", ScalarType.createVarchar(50))
-                        .column("REFRESH_TYPE", ScalarType.createVarchar(20))
-                        .column("IS_ACTIVE", ScalarType.createVarchar(10))
-                        .column("INACTIVE_REASON", ScalarType.createVarcharType(1024))
-                        .column("PARTITION_TYPE", ScalarType.createVarchar(16))
-                        .column("TASK_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("TASK_NAME", ScalarType.createVarchar(50))
-                        .column("LAST_REFRESH_START_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("LAST_REFRESH_FINISHED_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("LAST_REFRESH_DURATION", ScalarType.createType(PrimitiveType.DOUBLE))
-                        .column("LAST_REFRESH_STATE", ScalarType.createVarchar(20))
-                        .column("LAST_REFRESH_FORCE_REFRESH", ScalarType.createVarchar(8))
-                        .column("LAST_REFRESH_START_PARTITION", ScalarType.createVarchar(1024))
-                        .column("LAST_REFRESH_END_PARTITION", ScalarType.createVarchar(1024))
-                        .column("LAST_REFRESH_BASE_REFRESH_PARTITIONS", ScalarType.createVarchar(1024))
-                        .column("LAST_REFRESH_MV_REFRESH_PARTITIONS", ScalarType.createVarchar(1024))
-                        .column("LAST_REFRESH_ERROR_CODE", ScalarType.createVarchar(20))
-                        .column("LAST_REFRESH_ERROR_MESSAGE", ScalarType.createVarchar(1024))
-                        .column("TABLE_ROWS", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("MATERIALIZED_VIEW_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("TABLE_SCHEMA", TypeFactory.createVarchar(20))
+                        .column("TABLE_NAME", TypeFactory.createVarchar(50))
+                        .column("REFRESH_TYPE", TypeFactory.createVarchar(20))
+                        .column("IS_ACTIVE", TypeFactory.createVarchar(10))
+                        .column("INACTIVE_REASON", TypeFactory.createVarcharType(1024))
+                        .column("PARTITION_TYPE", TypeFactory.createVarchar(16))
+                        .column("TASK_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("TASK_NAME", TypeFactory.createVarchar(50))
+                        .column("LAST_REFRESH_START_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("LAST_REFRESH_FINISHED_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("LAST_REFRESH_DURATION", TypeFactory.createType(PrimitiveType.DOUBLE))
+                        .column("LAST_REFRESH_STATE", TypeFactory.createVarchar(20))
+                        .column("LAST_REFRESH_FORCE_REFRESH", TypeFactory.createVarchar(8))
+                        .column("LAST_REFRESH_START_PARTITION", TypeFactory.createVarchar(1024))
+                        .column("LAST_REFRESH_END_PARTITION", TypeFactory.createVarchar(1024))
+                        .column("LAST_REFRESH_BASE_REFRESH_PARTITIONS", TypeFactory.createVarchar(1024))
+                        .column("LAST_REFRESH_MV_REFRESH_PARTITIONS", TypeFactory.createVarchar(1024))
+                        .column("LAST_REFRESH_ERROR_CODE", TypeFactory.createVarchar(20))
+                        .column("LAST_REFRESH_ERROR_MESSAGE", TypeFactory.createVarchar(1024))
+                        .column("TABLE_ROWS", TypeFactory.createType(PrimitiveType.BIGINT))
                         .column("MATERIALIZED_VIEW_DEFINITION",
-                                ScalarType.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
-                        .column("EXTRA_MESSAGE", ScalarType.createVarchar(1024))
-                        .column("QUERY_REWRITE_STATUS", ScalarType.createVarcharType(64))
-                        .column("CREATOR", ScalarType.createVarchar(64))
-                        .column("LAST_REFRESH_PROCESS_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("LAST_REFRESH_JOB_ID", ScalarType.createVarchar(64))
+                                TypeFactory.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
+                        .column("EXTRA_MESSAGE", TypeFactory.createVarchar(1024))
+                        .column("QUERY_REWRITE_STATUS", TypeFactory.createVarcharType(64))
+                        .column("CREATOR", TypeFactory.createVarchar(64))
+                        .column("LAST_REFRESH_PROCESS_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("LAST_REFRESH_JOB_ID", TypeFactory.createVarchar(64))
                         .build(), TSchemaTableType.SCH_MATERIALIZED_VIEWS);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PartitionsMetaSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PartitionsMetaSystemTable.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
@@ -31,39 +31,39 @@ public class PartitionsMetaSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("DB_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TABLE_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("PARTITION_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("PARTITION_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("COMPACT_VERSION", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("VISIBLE_VERSION", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("VISIBLE_VERSION_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("NEXT_VERSION", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("DATA_VERSION", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("VERSION_EPOCH", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("VERSION_TXN_TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("PARTITION_KEY", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("DB_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TABLE_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("PARTITION_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("PARTITION_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("COMPACT_VERSION", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("VISIBLE_VERSION", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("VISIBLE_VERSION_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("NEXT_VERSION", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("DATA_VERSION", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("VERSION_EPOCH", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("VERSION_TXN_TYPE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("PARTITION_KEY", TypeFactory.createVarchar(NAME_CHAR_LEN))
                         // corresponding to `Range` or `List` in `SHOW PARTITIONS FROM XXX`
-                        .column("PARTITION_VALUE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("DISTRIBUTION_KEY", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("BUCKETS", ScalarType.createType(PrimitiveType.INT))
-                        .column("REPLICATION_NUM", ScalarType.createType(PrimitiveType.INT))
-                        .column("STORAGE_MEDIUM", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("COOLDOWN_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("LAST_CONSISTENCY_CHECK_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("IS_IN_MEMORY", ScalarType.createType(PrimitiveType.BOOLEAN))
-                        .column("IS_TEMP", ScalarType.createType(PrimitiveType.BOOLEAN))
-                        .column("DATA_SIZE", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("ROW_COUNT", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("ENABLE_DATACACHE", ScalarType.createType(PrimitiveType.BOOLEAN))
-                        .column("AVG_CS", ScalarType.createType(PrimitiveType.DOUBLE))
-                        .column("P50_CS", ScalarType.createType(PrimitiveType.DOUBLE))
-                        .column("MAX_CS", ScalarType.createType(PrimitiveType.DOUBLE))
-                        .column("STORAGE_PATH", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("STORAGE_SIZE", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("TABLET_BALANCED", ScalarType.createType(PrimitiveType.BOOLEAN))
-                        .column("METADATA_SWITCH_VERSION", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("PATH_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("PARTITION_VALUE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("DISTRIBUTION_KEY", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("BUCKETS", TypeFactory.createType(PrimitiveType.INT))
+                        .column("REPLICATION_NUM", TypeFactory.createType(PrimitiveType.INT))
+                        .column("STORAGE_MEDIUM", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("COOLDOWN_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("LAST_CONSISTENCY_CHECK_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("IS_IN_MEMORY", TypeFactory.createType(PrimitiveType.BOOLEAN))
+                        .column("IS_TEMP", TypeFactory.createType(PrimitiveType.BOOLEAN))
+                        .column("DATA_SIZE", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("ROW_COUNT", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("ENABLE_DATACACHE", TypeFactory.createType(PrimitiveType.BOOLEAN))
+                        .column("AVG_CS", TypeFactory.createType(PrimitiveType.DOUBLE))
+                        .column("P50_CS", TypeFactory.createType(PrimitiveType.DOUBLE))
+                        .column("MAX_CS", TypeFactory.createType(PrimitiveType.DOUBLE))
+                        .column("STORAGE_PATH", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("STORAGE_SIZE", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("TABLET_BALANCED", TypeFactory.createType(PrimitiveType.BOOLEAN))
+                        .column("METADATA_SWITCH_VERSION", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("PATH_ID", TypeFactory.createType(PrimitiveType.BIGINT))
                         .build(), TSchemaTableType.SCH_PARTITIONS_META);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PartitionsSystemTableSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PartitionsSystemTableSystemTable.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.FN_REFLEN;
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
@@ -34,31 +34,31 @@ public class PartitionsSystemTableSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("TABLE_CATALOG", ScalarType.createVarchar(FN_REFLEN))
-                        .column("TABLE_SCHEMA", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TABLE_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("PARTITION_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("SUBPARTITION_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("PARTITION_ORDINAL_POSITION", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("PARTITION_METHOD", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("SUBPARTITION_METHOD", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("PARTITION_EXPRESSION", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("SUBPARTITION_EXPRESSION", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("PARTITION_DESCRIPTION", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TABLE_ROWS", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("AVG_ROW_LENGTH", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("DATA_LENGTH", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("MAX_DATA_LENGTH", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("INDEX_LENGTH", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("DATA_FREE", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("CREATE_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("UPDATE_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("CHECK_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("CHECKSUM", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("PARTITION_COMMENT", ScalarType.createVarchar(2048))
-                        .column("NODEGROUP", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TABLESPACE_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("SUBPARTITION_ORDINAL_POSITION", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("TABLE_CATALOG", TypeFactory.createVarchar(FN_REFLEN))
+                        .column("TABLE_SCHEMA", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TABLE_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("PARTITION_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("SUBPARTITION_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("PARTITION_ORDINAL_POSITION", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("PARTITION_METHOD", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("SUBPARTITION_METHOD", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("PARTITION_EXPRESSION", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("SUBPARTITION_EXPRESSION", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("PARTITION_DESCRIPTION", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TABLE_ROWS", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("AVG_ROW_LENGTH", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("DATA_LENGTH", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("MAX_DATA_LENGTH", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("INDEX_LENGTH", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("DATA_FREE", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("CREATE_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("UPDATE_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("CHECK_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("CHECKSUM", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("PARTITION_COMMENT", TypeFactory.createVarchar(2048))
+                        .column("NODEGROUP", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TABLESPACE_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("SUBPARTITION_ORDINAL_POSITION", TypeFactory.createType(PrimitiveType.BIGINT))
                         .build(), TSchemaTableType.SCH_PARTITIONS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PipeFileSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PipeFileSystemTable.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 public class PipeFileSystemTable {
     public static final String NAME = "pipe_files";
@@ -27,23 +28,23 @@ public class PipeFileSystemTable {
     public static SystemTable create() {
         return new SystemTable(SystemId.PIPE_FILES_ID, NAME, Table.TableType.SCHEMA,
                 SystemTable.builder()
-                        .column("DATABASE_NAME", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
+                        .column("DATABASE_NAME", TypeFactory.createVarcharType(SystemTable.NAME_CHAR_LEN))
                         .column("PIPE_ID", ScalarType.BIGINT)
-                        .column("PIPE_NAME", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
+                        .column("PIPE_NAME", TypeFactory.createVarcharType(SystemTable.NAME_CHAR_LEN))
 
-                        .column("FILE_NAME", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
-                        .column("FILE_VERSION", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
+                        .column("FILE_NAME", TypeFactory.createVarcharType(SystemTable.NAME_CHAR_LEN))
+                        .column("FILE_VERSION", TypeFactory.createVarcharType(SystemTable.NAME_CHAR_LEN))
                         // TODO
                         // .column("FILE_ROWS", ScalarType.BIGINT)
                         .column("FILE_SIZE", ScalarType.BIGINT)
-                        .column("LAST_MODIFIED", ScalarType.createVarcharType(16))
+                        .column("LAST_MODIFIED", TypeFactory.createVarcharType(16))
 
-                        .column("LOAD_STATE", ScalarType.createVarcharType(8))
-                        .column("STAGED_TIME", ScalarType.createVarcharType(16))
-                        .column("START_LOAD_TIME", ScalarType.createVarcharType(16))
-                        .column("FINISH_LOAD_TIME", ScalarType.createVarcharType(16))
+                        .column("LOAD_STATE", TypeFactory.createVarcharType(8))
+                        .column("STAGED_TIME", TypeFactory.createVarcharType(16))
+                        .column("START_LOAD_TIME", TypeFactory.createVarcharType(16))
+                        .column("FINISH_LOAD_TIME", TypeFactory.createVarcharType(16))
 
-                        .column("ERROR_MSG", ScalarType.createVarcharType(512))
+                        .column("ERROR_MSG", TypeFactory.createVarcharType(512))
                         // TODO
                         // .column("ERROR_COUNT", ScalarType.BIGINT)
                         // .column("ERROR_LINE", ScalarType.BIGINT)

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PipesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/PipesSystemTable.java
@@ -19,6 +19,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 public class PipesSystemTable {
     public static final String NAME = "pipes";
@@ -26,14 +27,14 @@ public class PipesSystemTable {
     public static SystemTable create() {
         return new SystemTable(SystemId.PIPES_ID, NAME, Table.TableType.SCHEMA,
                 SystemTable.builder()
-                        .column("DATABASE_NAME", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
+                        .column("DATABASE_NAME", TypeFactory.createVarcharType(SystemTable.NAME_CHAR_LEN))
                         .column("PIPE_ID", ScalarType.BIGINT)
-                        .column("PIPE_NAME", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
-                        .column("PROPERTIES", ScalarType.createVarcharType(1024))
-                        .column("STATE", ScalarType.createVarcharType(8))
-                        .column("TABLE_NAME", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
-                        .column("LOAD_STATUS", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
-                        .column("LAST_ERROR", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
+                        .column("PIPE_NAME", TypeFactory.createVarcharType(SystemTable.NAME_CHAR_LEN))
+                        .column("PROPERTIES", TypeFactory.createVarcharType(1024))
+                        .column("STATE", TypeFactory.createVarcharType(8))
+                        .column("TABLE_NAME", TypeFactory.createVarcharType(SystemTable.NAME_CHAR_LEN))
+                        .column("LOAD_STATUS", TypeFactory.createVarcharType(SystemTable.NAME_CHAR_LEN))
+                        .column("LAST_ERROR", TypeFactory.createVarcharType(SystemTable.NAME_CHAR_LEN))
                         .column("CREATED_TIME", ScalarType.DATETIME)
                         .build(),
                 TSchemaTableType.SCH_PIPES);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/RecycleBinCatalogsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/RecycleBinCatalogsTable.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 public class RecycleBinCatalogsTable {
     public static final String NAME = "recyclebin_catalogs";
@@ -27,8 +28,8 @@ public class RecycleBinCatalogsTable {
     public static SystemTable create() {
         return new SystemTable(SystemId.RECYCLEBIN_CATALOGS, NAME, Table.TableType.SCHEMA,
                 SystemTable.builder()
-                        .column("TYPE", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
-                        .column("NAME", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
+                        .column("TYPE", TypeFactory.createVarcharType(SystemTable.NAME_CHAR_LEN))
+                        .column("NAME", TypeFactory.createVarcharType(SystemTable.NAME_CHAR_LEN))
                         .column("DB_ID", ScalarType.BIGINT)
                         .column("TABLE_ID", ScalarType.BIGINT)
                         .column("PARTITION_ID", ScalarType.BIGINT)

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ReferentialConstraintsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ReferentialConstraintsSystemTable.java
@@ -17,7 +17,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
@@ -32,17 +32,17 @@ public class ReferentialConstraintsSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("CONSTRAINT_CATALOG", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("CONSTRAINT_SCHEMA", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("CONSTRAINT_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("UNIQUE_CONSTRAINT_CATALOG", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("UNIQUE_CONSTRAINT_SCHEMA", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("UNIQUE_CONSTRAINT_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("MATCH_OPTION", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("UPDATE_RULE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("DELETE_RULE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TABLE_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("REFERENCED_TABLE_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("CONSTRAINT_CATALOG", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("CONSTRAINT_SCHEMA", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("CONSTRAINT_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("UNIQUE_CONSTRAINT_CATALOG", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("UNIQUE_CONSTRAINT_SCHEMA", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("UNIQUE_CONSTRAINT_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("MATCH_OPTION", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("UPDATE_RULE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("DELETE_RULE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TABLE_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("REFERENCED_TABLE_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
                         .build(), TSchemaTableType.SCH_REFERENTIAL_CONSTRAINTS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/RoutineLoadJobsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/RoutineLoadJobsSystemTable.java
@@ -19,7 +19,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
@@ -32,28 +32,28 @@ public class RoutineLoadJobsSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("CREATE_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("PAUSE_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("END_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("DB_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TABLE_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("STATE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("DATA_SOURCE_TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("CURRENT_TASK_NUM", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("JOB_PROPERTIES", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("DATA_SOURCE_PROPERTIES", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("CUSTOM_PROPERTIES", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("STATISTICS", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("PROGRESS", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("REASONS_OF_STATE_CHANGED", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("ERROR_LOG_URLS", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TRACKING_SQL", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("OTHER_MSG", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("LATEST_SOURCE_POSITION", ScalarType.createJsonType())
-                        .column("OFFSET_LAG", ScalarType.createJsonType())
-                        .column("TIMESTAMP_PROGRESS", ScalarType.createJsonType())
+                        .column("ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("CREATE_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("PAUSE_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("END_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("DB_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TABLE_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("STATE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("DATA_SOURCE_TYPE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("CURRENT_TASK_NUM", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("JOB_PROPERTIES", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("DATA_SOURCE_PROPERTIES", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("CUSTOM_PROPERTIES", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("STATISTICS", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("PROGRESS", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("REASONS_OF_STATE_CHANGED", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("ERROR_LOG_URLS", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TRACKING_SQL", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("OTHER_MSG", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("LATEST_SOURCE_POSITION", TypeFactory.createJsonType())
+                        .column("OFFSET_LAG", TypeFactory.createJsonType())
+                        .column("TIMESTAMP_PROGRESS", TypeFactory.createJsonType())
                         .build(), TSchemaTableType.SCH_ROUTINE_LOAD_JOBS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/RoutinesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/RoutinesSystemTable.java
@@ -17,7 +17,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
@@ -33,29 +33,29 @@ public class RoutinesSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("SPECIFIC_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("ROUTINE_CATALOG", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("ROUTINE_SCHEMA", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("ROUTINE_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("ROUTINE_TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("DTD_IDENTIFIER", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("ROUTINE_BODY", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("ROUTINE_DEFINITION", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("EXTERNAL_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("EXTERNAL_LANGUAGE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("PARAMETER_STYLE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("IS_DETERMINISTIC", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("SQL_DATA_ACCESS", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("SQL_PATH", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("SECURITY_TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("CREATED", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("LAST_ALTERED", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("SQL_MODE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("ROUTINE_COMMENT", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("DEFINER", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("CHARACTER_SET_CLIENT", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("COLLATION_CONNECTION", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("DATABASE_COLLATION", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("SPECIFIC_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("ROUTINE_CATALOG", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("ROUTINE_SCHEMA", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("ROUTINE_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("ROUTINE_TYPE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("DTD_IDENTIFIER", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("ROUTINE_BODY", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("ROUTINE_DEFINITION", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("EXTERNAL_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("EXTERNAL_LANGUAGE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("PARAMETER_STYLE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("IS_DETERMINISTIC", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("SQL_DATA_ACCESS", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("SQL_PATH", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("SECURITY_TYPE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("CREATED", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("LAST_ALTERED", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("SQL_MODE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("ROUTINE_COMMENT", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("DEFINER", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("CHARACTER_SET_CLIENT", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("COLLATION_CONNECTION", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("DATABASE_COLLATION", TypeFactory.createVarchar(NAME_CHAR_LEN))
                         .build(), SCH_PROCEDURES);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/SchemaPrivilegesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/SchemaPrivilegesSystemTable.java
@@ -17,7 +17,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.FN_REFLEN;
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
@@ -33,11 +33,11 @@ public class SchemaPrivilegesSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("GRANTEE", ScalarType.createVarchar(81))
-                        .column("TABLE_CATALOG", ScalarType.createVarchar(FN_REFLEN))
-                        .column("TABLE_SCHEMA", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("PRIVILEGE_TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("IS_GRANTABLE", ScalarType.createVarchar(3))
+                        .column("GRANTEE", TypeFactory.createVarchar(81))
+                        .column("TABLE_CATALOG", TypeFactory.createVarchar(FN_REFLEN))
+                        .column("TABLE_SCHEMA", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("PRIVILEGE_TYPE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("IS_GRANTABLE", TypeFactory.createVarchar(3))
                         .build(), TSchemaTableType.SCH_SCHEMA_PRIVILEGES);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/SchemataSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/SchemataSystemTable.java
@@ -17,7 +17,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.builder;
 
@@ -31,11 +31,11 @@ public class SchemataSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("CATALOG_NAME", ScalarType.createVarchar(512))
-                        .column("SCHEMA_NAME", ScalarType.createVarchar(32))
-                        .column("DEFAULT_CHARACTER_SET_NAME", ScalarType.createVarchar(32))
-                        .column("DEFAULT_COLLATION_NAME", ScalarType.createVarchar(32))
-                        .column("SQL_PATH", ScalarType.createVarchar(512))
+                        .column("CATALOG_NAME", TypeFactory.createVarchar(512))
+                        .column("SCHEMA_NAME", TypeFactory.createVarchar(32))
+                        .column("DEFAULT_CHARACTER_SET_NAME", TypeFactory.createVarchar(32))
+                        .column("DEFAULT_COLLATION_NAME", TypeFactory.createVarchar(32))
+                        .column("SQL_PATH", TypeFactory.createVarchar(512))
                         .build(), TSchemaTableType.SCH_SCHEMATA);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/SessionVariablesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/SessionVariablesSystemTable.java
@@ -17,7 +17,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.builder;
 
@@ -29,8 +29,8 @@ public class SessionVariablesSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("VARIABLE_NAME", ScalarType.createVarchar(64))
-                        .column("VARIABLE_VALUE", ScalarType.createVarchar(1024))
+                        .column("VARIABLE_NAME", TypeFactory.createVarchar(64))
+                        .column("VARIABLE_VALUE", TypeFactory.createVarchar(1024))
                         .build(), TSchemaTableType.SCH_SESSION_VARIABLES);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/StatisticsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/StatisticsSystemTable.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.MAX_FIELD_VARCHAR_LENGTH;
 import static com.starrocks.catalog.system.SystemTable.builder;
@@ -33,23 +33,23 @@ public class StatisticsSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("TABLE_CATALOG", ScalarType.createVarchar(512))
-                        .column("TABLE_SCHEMA", ScalarType.createVarchar(64))
-                        .column("TABLE_NAME", ScalarType.createVarchar(64))
-                        .column("NON_UNIQUE", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("INDEX_SCHEMA", ScalarType.createVarchar(64))
-                        .column("INDEX_NAME", ScalarType.createVarchar(64))
-                        .column("SEQ_IN_INDEX", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("COLUMN_NAME", ScalarType.createVarchar(64))
-                        .column("COLLATION", ScalarType.createVarchar(1))
-                        .column("CARDINALITY", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("SUB_PART", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("PACKED", ScalarType.createVarchar(10))
-                        .column("NULLABLE", ScalarType.createVarchar(3))
-                        .column("INDEX_TYPE", ScalarType.createVarchar(16))
-                        .column("COMMENT", ScalarType.createVarchar(16))
-                        .column("INDEX_COMMENT", ScalarType.createVarchar(1024))
-                        .column("EXPRESSION", ScalarType.createVarcharType(MAX_FIELD_VARCHAR_LENGTH))
+                        .column("TABLE_CATALOG", TypeFactory.createVarchar(512))
+                        .column("TABLE_SCHEMA", TypeFactory.createVarchar(64))
+                        .column("TABLE_NAME", TypeFactory.createVarchar(64))
+                        .column("NON_UNIQUE", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("INDEX_SCHEMA", TypeFactory.createVarchar(64))
+                        .column("INDEX_NAME", TypeFactory.createVarchar(64))
+                        .column("SEQ_IN_INDEX", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("COLUMN_NAME", TypeFactory.createVarchar(64))
+                        .column("COLLATION", TypeFactory.createVarchar(1))
+                        .column("CARDINALITY", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("SUB_PART", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("PACKED", TypeFactory.createVarchar(10))
+                        .column("NULLABLE", TypeFactory.createVarchar(3))
+                        .column("INDEX_TYPE", TypeFactory.createVarchar(16))
+                        .column("COMMENT", TypeFactory.createVarchar(16))
+                        .column("INDEX_COMMENT", TypeFactory.createVarchar(1024))
+                        .column("EXPRESSION", TypeFactory.createVarcharType(MAX_FIELD_VARCHAR_LENGTH))
                         .build(), TSchemaTableType.SCH_STATISTICS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/StreamLoadsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/StreamLoadsSystemTable.java
@@ -19,7 +19,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
@@ -32,31 +32,31 @@ public class StreamLoadsSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("LABEL", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("LOAD_ID", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TXN_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("DB_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TABLE_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("STATE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("ERROR_MSG", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TRACKING_URL", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("CHANNEL_NUM", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("PREPARED_CHANNEL_NUM", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("NUM_ROWS_NORMAL", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("NUM_ROWS_AB_NORMAL", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("NUM_ROWS_UNSELECTED", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("NUM_LOAD_BYTES", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("TIMEOUT_SECOND", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("CREATE_TIME_MS", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("BEFORE_LOAD_TIME_MS", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("START_LOADING_TIME_MS", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("START_PREPARING_TIME_MS", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("FINISH_PREPARING_TIME_MS", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("END_TIME_MS", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("CHANNEL_STATE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TRACKING_SQL", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("LABEL", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("LOAD_ID", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TXN_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("DB_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TABLE_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("STATE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("ERROR_MSG", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TRACKING_URL", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("CHANNEL_NUM", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("PREPARED_CHANNEL_NUM", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("NUM_ROWS_NORMAL", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("NUM_ROWS_AB_NORMAL", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("NUM_ROWS_UNSELECTED", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("NUM_LOAD_BYTES", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("TIMEOUT_SECOND", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("CREATE_TIME_MS", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("BEFORE_LOAD_TIME_MS", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("START_LOADING_TIME_MS", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("START_PREPARING_TIME_MS", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("FINISH_PREPARING_TIME_MS", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("END_TIME_MS", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("CHANNEL_STATE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TYPE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TRACKING_SQL", TypeFactory.createVarchar(NAME_CHAR_LEN))
                         .build(), TSchemaTableType.SCH_STREAM_LOADS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TableConstraintsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TableConstraintsSystemTable.java
@@ -17,7 +17,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.builder;
 
@@ -31,13 +31,13 @@ public class TableConstraintsSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("CONSTRAINT_CATALOG", ScalarType.createVarchar(512))
-                        .column("CONSTRAINT_SCHEMA", ScalarType.createVarchar(64))
-                        .column("CONSTRAINT_NAME", ScalarType.createVarchar(64))
-                        .column("TABLE_SCHEMA", ScalarType.createVarchar(64))
-                        .column("TABLE_NAME", ScalarType.createVarchar(64))
-                        .column("CONSTRAINT_TYPE", ScalarType.createVarchar(64))
-                        .column("ENFORCED", ScalarType.createVarcharType(3))
+                        .column("CONSTRAINT_CATALOG", TypeFactory.createVarchar(512))
+                        .column("CONSTRAINT_SCHEMA", TypeFactory.createVarchar(64))
+                        .column("CONSTRAINT_NAME", TypeFactory.createVarchar(64))
+                        .column("TABLE_SCHEMA", TypeFactory.createVarchar(64))
+                        .column("TABLE_NAME", TypeFactory.createVarchar(64))
+                        .column("CONSTRAINT_TYPE", TypeFactory.createVarchar(64))
+                        .column("ENFORCED", TypeFactory.createVarcharType(3))
                         .build(), TSchemaTableType.SCH_TABLE_CONSTRAINTS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablePrivilegesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablePrivilegesSystemTable.java
@@ -17,7 +17,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
 import static com.starrocks.catalog.system.SystemTable.builder;
@@ -32,12 +32,12 @@ public class TablePrivilegesSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("GRANTEE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TABLE_CATALOG", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TABLE_SCHEMA", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TABLE_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("PRIVILEGE_TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("IS_GRANTABLE", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("GRANTEE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TABLE_CATALOG", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TABLE_SCHEMA", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TABLE_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("PRIVILEGE_TYPE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("IS_GRANTABLE", TypeFactory.createVarchar(NAME_CHAR_LEN))
                         .build(), TSchemaTableType.SCH_TABLE_PRIVILEGES);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablesConfigSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablesConfigSystemTable.java
@@ -19,6 +19,7 @@ import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.MAX_FIELD_VARCHAR_LENGTH;
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
@@ -32,17 +33,17 @@ public class TablesConfigSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("TABLE_SCHEMA", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TABLE_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TABLE_ENGINE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TABLE_MODEL", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("PRIMARY_KEY", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("PARTITION_KEY", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("DISTRIBUTE_KEY", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("DISTRIBUTE_TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("TABLE_SCHEMA", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TABLE_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TABLE_ENGINE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TABLE_MODEL", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("PRIMARY_KEY", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("PARTITION_KEY", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("DISTRIBUTE_KEY", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("DISTRIBUTE_TYPE", TypeFactory.createVarchar(NAME_CHAR_LEN))
                         .column("DISTRIBUTE_BUCKET", ScalarType.INT)
-                        .column("SORT_KEY", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("PROPERTIES", ScalarType.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
+                        .column("SORT_KEY", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("PROPERTIES", TypeFactory.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
                         .column("TABLE_ID", Type.BIGINT)
                         .build(), TSchemaTableType.SCH_TABLES_CONFIG);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablesSystemTable.java
@@ -35,8 +35,8 @@ import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.thrift.TTableInfo;
 import com.starrocks.thrift.TUserIdentity;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -57,27 +57,27 @@ public class TablesSystemTable extends SystemTable {
 
     public TablesSystemTable(String catalogName) {
         super(catalogName, SystemId.TABLES_ID, NAME, Table.TableType.SCHEMA, builder()
-                .column("TABLE_CATALOG", ScalarType.createVarchar(FN_REFLEN))
-                .column("TABLE_SCHEMA", ScalarType.createVarchar(NAME_CHAR_LEN))
-                .column("TABLE_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                .column("TABLE_TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                .column("ENGINE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                .column("VERSION", ScalarType.createType(PrimitiveType.BIGINT))
-                .column("ROW_FORMAT", ScalarType.createVarchar(10))
-                .column("TABLE_ROWS", ScalarType.createType(PrimitiveType.BIGINT))
-                .column("AVG_ROW_LENGTH", ScalarType.createType(PrimitiveType.BIGINT))
-                .column("DATA_LENGTH", ScalarType.createType(PrimitiveType.BIGINT))
-                .column("MAX_DATA_LENGTH", ScalarType.createType(PrimitiveType.BIGINT))
-                .column("INDEX_LENGTH", ScalarType.createType(PrimitiveType.BIGINT))
-                .column("DATA_FREE", ScalarType.createType(PrimitiveType.BIGINT))
-                .column("AUTO_INCREMENT", ScalarType.createType(PrimitiveType.BIGINT))
-                .column("CREATE_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                .column("UPDATE_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                .column("CHECK_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                .column("TABLE_COLLATION", ScalarType.createVarchar(MY_CS_NAME_SIZE))
-                .column("CHECKSUM", ScalarType.createType(PrimitiveType.BIGINT))
-                .column("CREATE_OPTIONS", ScalarType.createVarchar(255))
-                .column("TABLE_COMMENT", ScalarType.createVarchar(2048))
+                .column("TABLE_CATALOG", TypeFactory.createVarchar(FN_REFLEN))
+                .column("TABLE_SCHEMA", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                .column("TABLE_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                .column("TABLE_TYPE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                .column("ENGINE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                .column("VERSION", TypeFactory.createType(PrimitiveType.BIGINT))
+                .column("ROW_FORMAT", TypeFactory.createVarchar(10))
+                .column("TABLE_ROWS", TypeFactory.createType(PrimitiveType.BIGINT))
+                .column("AVG_ROW_LENGTH", TypeFactory.createType(PrimitiveType.BIGINT))
+                .column("DATA_LENGTH", TypeFactory.createType(PrimitiveType.BIGINT))
+                .column("MAX_DATA_LENGTH", TypeFactory.createType(PrimitiveType.BIGINT))
+                .column("INDEX_LENGTH", TypeFactory.createType(PrimitiveType.BIGINT))
+                .column("DATA_FREE", TypeFactory.createType(PrimitiveType.BIGINT))
+                .column("AUTO_INCREMENT", TypeFactory.createType(PrimitiveType.BIGINT))
+                .column("CREATE_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                .column("UPDATE_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                .column("CHECK_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                .column("TABLE_COLLATION", TypeFactory.createVarchar(MY_CS_NAME_SIZE))
+                .column("CHECKSUM", TypeFactory.createType(PrimitiveType.BIGINT))
+                .column("CREATE_OPTIONS", TypeFactory.createVarchar(255))
+                .column("TABLE_COMMENT", TypeFactory.createVarchar(2048))
                 .build(), TSchemaTableType.SCH_TABLES);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TaskRunsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TaskRunsSystemTable.java
@@ -43,8 +43,8 @@ import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.thrift.TTaskRunInfo;
 import com.starrocks.thrift.TUserIdentity;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -73,22 +73,22 @@ public class TaskRunsSystemTable extends SystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("QUERY_ID", ScalarType.createVarchar(64))
-                        .column("TASK_NAME", ScalarType.createVarchar(64))
-                        .column("CREATE_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("FINISH_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("STATE", ScalarType.createVarchar(16))
-                        .column("CATALOG", ScalarType.createVarchar(64))
-                        .column("DATABASE", ScalarType.createVarchar(64))
-                        .column("DEFINITION", ScalarType.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
-                        .column("EXPIRE_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("ERROR_CODE", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("ERROR_MESSAGE", ScalarType.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
-                        .column("PROGRESS", ScalarType.createVarchar(64))
-                        .column("EXTRA_MESSAGE", ScalarType.createVarchar(8192))
-                        .column("PROPERTIES", ScalarType.createVarcharType(512))
-                        .column("JOB_ID", ScalarType.createVarcharType(64))
-                        .column("PROCESS_TIME", ScalarType.createType(PrimitiveType.DATETIME))
+                        .column("QUERY_ID", TypeFactory.createVarchar(64))
+                        .column("TASK_NAME", TypeFactory.createVarchar(64))
+                        .column("CREATE_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("FINISH_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("STATE", TypeFactory.createVarchar(16))
+                        .column("CATALOG", TypeFactory.createVarchar(64))
+                        .column("DATABASE", TypeFactory.createVarchar(64))
+                        .column("DEFINITION", TypeFactory.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
+                        .column("EXPIRE_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("ERROR_CODE", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("ERROR_MESSAGE", TypeFactory.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
+                        .column("PROGRESS", TypeFactory.createVarchar(64))
+                        .column("EXTRA_MESSAGE", TypeFactory.createVarchar(8192))
+                        .column("PROPERTIES", TypeFactory.createVarcharType(512))
+                        .column("JOB_ID", TypeFactory.createVarcharType(64))
+                        .column("PROCESS_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
                         .build(), TSchemaTableType.SCH_TASK_RUNS);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TasksSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TasksSystemTable.java
@@ -34,7 +34,7 @@ import com.starrocks.thrift.TGetTasksParams;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.thrift.TTaskInfo;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -53,15 +53,15 @@ public class TasksSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("TASK_NAME", ScalarType.createVarchar(64))
-                        .column("CREATE_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("SCHEDULE", ScalarType.createVarchar(64))
-                        .column("CATALOG", ScalarType.createVarchar(64))
-                        .column("DATABASE", ScalarType.createVarchar(64))
-                        .column("DEFINITION", ScalarType.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
-                        .column("EXPIRE_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("PROPERTIES", ScalarType.createVarcharType(MAX_FIELD_VARCHAR_LENGTH))
-                        .column("CREATOR", ScalarType.createVarchar(64))
+                        .column("TASK_NAME", TypeFactory.createVarchar(64))
+                        .column("CREATE_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("SCHEDULE", TypeFactory.createVarchar(64))
+                        .column("CATALOG", TypeFactory.createVarchar(64))
+                        .column("DATABASE", TypeFactory.createVarchar(64))
+                        .column("DEFINITION", TypeFactory.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
+                        .column("EXPIRE_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("PROPERTIES", TypeFactory.createVarcharType(MAX_FIELD_VARCHAR_LENGTH))
+                        .column("CREATOR", TypeFactory.createVarchar(64))
                         .build(), TSchemaTableType.SCH_TASKS);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TemporaryTablesTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TemporaryTablesTable.java
@@ -19,7 +19,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.FN_REFLEN;
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
@@ -31,29 +31,29 @@ public class TemporaryTablesTable {
 
     public static SystemTable create() {
         return new SystemTable(SystemId.TEMP_TABLES_ID, NAME, Table.TableType.SCHEMA, builder()
-                .column("TABLE_CATALOG", ScalarType.createVarchar(FN_REFLEN))
-                .column("TABLE_SCHEMA", ScalarType.createVarchar(NAME_CHAR_LEN))
-                .column("TABLE_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                .column("TABLE_TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                .column("ENGINE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                .column("VERSION", ScalarType.createType(PrimitiveType.BIGINT))
-                .column("ROW_FORMAT", ScalarType.createVarchar(10))
-                .column("TABLE_ROWS", ScalarType.createType(PrimitiveType.BIGINT))
-                .column("AVG_ROW_LENGTH", ScalarType.createType(PrimitiveType.BIGINT))
-                .column("DATA_LENGTH", ScalarType.createType(PrimitiveType.BIGINT))
-                .column("MAX_DATA_LENGTH", ScalarType.createType(PrimitiveType.BIGINT))
-                .column("INDEX_LENGTH", ScalarType.createType(PrimitiveType.BIGINT))
-                .column("DATA_FREE", ScalarType.createType(PrimitiveType.BIGINT))
-                .column("AUTO_INCREMENT", ScalarType.createType(PrimitiveType.BIGINT))
-                .column("CREATE_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                .column("UPDATE_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                .column("CHECK_TIME", ScalarType.createType(PrimitiveType.DATETIME))
-                .column("TABLE_COLLATION", ScalarType.createVarchar(MY_CS_NAME_SIZE))
-                .column("CHECKSUM", ScalarType.createType(PrimitiveType.BIGINT))
-                .column("CREATE_OPTIONS", ScalarType.createVarchar(255))
-                .column("TABLE_COMMENT", ScalarType.createVarchar(2048))
-                .column("SESSION", ScalarType.createVarchar(128))
-                .column("TABLE_ID", ScalarType.createType(PrimitiveType.BIGINT))
+                .column("TABLE_CATALOG", TypeFactory.createVarchar(FN_REFLEN))
+                .column("TABLE_SCHEMA", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                .column("TABLE_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                .column("TABLE_TYPE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                .column("ENGINE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                .column("VERSION", TypeFactory.createType(PrimitiveType.BIGINT))
+                .column("ROW_FORMAT", TypeFactory.createVarchar(10))
+                .column("TABLE_ROWS", TypeFactory.createType(PrimitiveType.BIGINT))
+                .column("AVG_ROW_LENGTH", TypeFactory.createType(PrimitiveType.BIGINT))
+                .column("DATA_LENGTH", TypeFactory.createType(PrimitiveType.BIGINT))
+                .column("MAX_DATA_LENGTH", TypeFactory.createType(PrimitiveType.BIGINT))
+                .column("INDEX_LENGTH", TypeFactory.createType(PrimitiveType.BIGINT))
+                .column("DATA_FREE", TypeFactory.createType(PrimitiveType.BIGINT))
+                .column("AUTO_INCREMENT", TypeFactory.createType(PrimitiveType.BIGINT))
+                .column("CREATE_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                .column("UPDATE_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                .column("CHECK_TIME", TypeFactory.createType(PrimitiveType.DATETIME))
+                .column("TABLE_COLLATION", TypeFactory.createVarchar(MY_CS_NAME_SIZE))
+                .column("CHECKSUM", TypeFactory.createType(PrimitiveType.BIGINT))
+                .column("CREATE_OPTIONS", TypeFactory.createVarchar(255))
+                .column("TABLE_COMMENT", TypeFactory.createVarchar(2048))
+                .column("SESSION", TypeFactory.createVarchar(128))
+                .column("TABLE_ID", TypeFactory.createType(PrimitiveType.BIGINT))
                 .build(), TSchemaTableType.SCH_TEMP_TABLES);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TriggersSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TriggersSystemTable.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.MAX_FIELD_VARCHAR_LENGTH;
 import static com.starrocks.catalog.system.SystemTable.builder;
@@ -33,31 +33,31 @@ public class TriggersSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("TRIGGER_CATALOG", ScalarType.createVarchar(512))
-                        .column("TRIGGER_SCHEMA", ScalarType.createVarchar(64))
-                        .column("TRIGGER_NAME", ScalarType.createVarchar(64))
-                        .column("EVENT_MANIPULATION", ScalarType.createVarchar(6))
-                        .column("EVENT_OBJECT_CATALOG", ScalarType.createVarchar(512))
-                        .column("EVENT_OBJECT_SCHEMA", ScalarType.createVarchar(64))
-                        .column("EVENT_OBJECT_TABLE", ScalarType.createVarchar(64))
-                        .column("ACTION_ORDER", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("TRIGGER_CATALOG", TypeFactory.createVarchar(512))
+                        .column("TRIGGER_SCHEMA", TypeFactory.createVarchar(64))
+                        .column("TRIGGER_NAME", TypeFactory.createVarchar(64))
+                        .column("EVENT_MANIPULATION", TypeFactory.createVarchar(6))
+                        .column("EVENT_OBJECT_CATALOG", TypeFactory.createVarchar(512))
+                        .column("EVENT_OBJECT_SCHEMA", TypeFactory.createVarchar(64))
+                        .column("EVENT_OBJECT_TABLE", TypeFactory.createVarchar(64))
+                        .column("ACTION_ORDER", TypeFactory.createType(PrimitiveType.BIGINT))
                         // TODO: Type for ACTION_CONDITION && ACTION_STATEMENT should be `longtext`, but `varchar(65535)` was set at this stage.
                         .column("ACTION_CONDITION",
-                                ScalarType.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
+                                TypeFactory.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
                         .column("ACTION_STATEMENT",
-                                ScalarType.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
-                        .column("ACTION_ORIENTATION", ScalarType.createVarchar(9))
-                        .column("ACTION_TIMING", ScalarType.createVarchar(6))
-                        .column("ACTION_REFERENCE_OLD_TABLE", ScalarType.createVarchar(64))
-                        .column("ACTION_REFERENCE_NEW_TABLE", ScalarType.createVarchar(64))
-                        .column("ACTION_REFERENCE_OLD_ROW", ScalarType.createVarchar(3))
-                        .column("ACTION_REFERENCE_NEW_ROW", ScalarType.createVarchar(3))
-                        .column("CREATED", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("SQL_MODE", ScalarType.createVarchar(8192))
-                        .column("DEFINER", ScalarType.createVarchar(77))
-                        .column("CHARACTER_SET_CLIENT", ScalarType.createVarchar(32))
-                        .column("COLLATION_CONNECTION", ScalarType.createVarchar(32))
-                        .column("DATABASE_COLLATION", ScalarType.createVarchar(32))
+                                TypeFactory.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
+                        .column("ACTION_ORIENTATION", TypeFactory.createVarchar(9))
+                        .column("ACTION_TIMING", TypeFactory.createVarchar(6))
+                        .column("ACTION_REFERENCE_OLD_TABLE", TypeFactory.createVarchar(64))
+                        .column("ACTION_REFERENCE_NEW_TABLE", TypeFactory.createVarchar(64))
+                        .column("ACTION_REFERENCE_OLD_ROW", TypeFactory.createVarchar(3))
+                        .column("ACTION_REFERENCE_NEW_ROW", TypeFactory.createVarchar(3))
+                        .column("CREATED", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("SQL_MODE", TypeFactory.createVarchar(8192))
+                        .column("DEFINER", TypeFactory.createVarchar(77))
+                        .column("CHARACTER_SET_CLIENT", TypeFactory.createVarchar(32))
+                        .column("COLLATION_CONNECTION", TypeFactory.createVarchar(32))
+                        .column("DATABASE_COLLATION", TypeFactory.createVarchar(32))
                         .build(), TSchemaTableType.SCH_TRIGGERS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/UserPrivilegesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/UserPrivilegesSystemTable.java
@@ -17,7 +17,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.FN_REFLEN;
 import static com.starrocks.catalog.system.SystemTable.NAME_CHAR_LEN;
@@ -33,10 +33,10 @@ public class UserPrivilegesSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("GRANTEE", ScalarType.createVarchar(81))
-                        .column("TABLE_CATALOG", ScalarType.createVarchar(FN_REFLEN))
-                        .column("PRIVILEGE_TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("IS_GRANTABLE", ScalarType.createVarchar(3))
+                        .column("GRANTEE", TypeFactory.createVarchar(81))
+                        .column("TABLE_CATALOG", TypeFactory.createVarchar(FN_REFLEN))
+                        .column("PRIVILEGE_TYPE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("IS_GRANTABLE", TypeFactory.createVarchar(3))
                         .build(), TSchemaTableType.SCH_USER_PRIVILEGES);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/VerboseSessionVariablesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/VerboseSessionVariablesSystemTable.java
@@ -18,7 +18,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import static com.starrocks.catalog.system.SystemTable.builder;
 
@@ -30,10 +30,10 @@ public class VerboseSessionVariablesSystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("VARIABLE_NAME", ScalarType.createVarchar(64))
-                        .column("VARIABLE_VALUE", ScalarType.createVarchar(1024))
-                        .column("DEFAULT_VALUE", ScalarType.createVarchar(1024))
-                        .column("IS_CHANGED", ScalarType.createType(PrimitiveType.BOOLEAN))
+                        .column("VARIABLE_NAME", TypeFactory.createVarchar(64))
+                        .column("VARIABLE_VALUE", TypeFactory.createVarchar(1024))
+                        .column("DEFAULT_VALUE", TypeFactory.createVarchar(1024))
+                        .column("IS_CHANGED", TypeFactory.createType(PrimitiveType.BOOLEAN))
                         .build(), TSchemaTableType.SCH_VERBOSE_SESSION_VARIABLES);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ViewsSystemTable.java
@@ -48,8 +48,8 @@ import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.thrift.TTableStatus;
 import com.starrocks.thrift.TTableType;
 import com.starrocks.thrift.TUserIdentity;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -78,18 +78,18 @@ public class ViewsSystemTable extends SystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("TABLE_CATALOG", ScalarType.createVarchar(512))
-                        .column("TABLE_SCHEMA", ScalarType.createVarchar(64))
-                        .column("TABLE_NAME", ScalarType.createVarchar(64))
+                        .column("TABLE_CATALOG", TypeFactory.createVarchar(512))
+                        .column("TABLE_SCHEMA", TypeFactory.createVarchar(64))
+                        .column("TABLE_NAME", TypeFactory.createVarchar(64))
                         // TODO: Type for EVENT_DEFINITION should be `longtext`, but `varchar(65535)` was set at this stage.
                         .column("VIEW_DEFINITION",
-                                ScalarType.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
-                        .column("CHECK_OPTION", ScalarType.createVarchar(8))
-                        .column("IS_UPDATABLE", ScalarType.createVarchar(3))
-                        .column("DEFINER", ScalarType.createVarchar(77))
-                        .column("SECURITY_TYPE", ScalarType.createVarchar(7))
-                        .column("CHARACTER_SET_CLIENT", ScalarType.createVarchar(32))
-                        .column("COLLATION_CONNECTION", ScalarType.createVarchar(32))
+                                TypeFactory.createVarchar(MAX_FIELD_VARCHAR_LENGTH))
+                        .column("CHECK_OPTION", TypeFactory.createVarchar(8))
+                        .column("IS_UPDATABLE", TypeFactory.createVarchar(3))
+                        .column("DEFINER", TypeFactory.createVarchar(77))
+                        .column("SECURITY_TYPE", TypeFactory.createVarchar(7))
+                        .column("CHARACTER_SET_CLIENT", TypeFactory.createVarchar(32))
+                        .column("COLLATION_CONNECTION", TypeFactory.createVarchar(32))
                         .build(), TSchemaTableType.SCH_VIEWS);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/WarehouseMetricsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/WarehouseMetricsSystemTable.java
@@ -29,7 +29,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.warehouse.Warehouse;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.NotImplementedException;
@@ -50,18 +50,18 @@ public class WarehouseMetricsSystemTable extends SystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("WAREHOUSE_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("WAREHOUSE_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("QUEUE_PENDING_LENGTH", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("QUEUE_RUNNING_LENGTH", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("MAX_PENDING_LENGTH", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("MAX_PENDING_TIME_SECOND", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("EARLIEST_QUERY_WAIT_TIME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("MAX_REQUIRED_SLOTS", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("SUM_REQUIRED_SLOTS", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("REMAIN_SLOTS", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("MAX_SLOTS", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("EXTRA_MESSAGE", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("WAREHOUSE_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("WAREHOUSE_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("QUEUE_PENDING_LENGTH", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("QUEUE_RUNNING_LENGTH", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("MAX_PENDING_LENGTH", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("MAX_PENDING_TIME_SECOND", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("EARLIEST_QUERY_WAIT_TIME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("MAX_REQUIRED_SLOTS", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("SUM_REQUIRED_SLOTS", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("REMAIN_SLOTS", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("MAX_SLOTS", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("EXTRA_MESSAGE", TypeFactory.createVarchar(NAME_CHAR_LEN))
                         .build(), TSchemaTableType.SCH_WAREHOUSE_METRICS);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/WarehouseQueriesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/WarehouseQueriesSystemTable.java
@@ -29,7 +29,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.warehouse.Warehouse;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.NotImplementedException;
@@ -48,18 +48,18 @@ public class WarehouseQueriesSystemTable extends SystemTable {
                 NAME,
                 Table.TableType.SCHEMA,
                 builder()
-                        .column("WAREHOUSE_ID", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("WAREHOUSE_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("QUERY_ID", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("STATE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("EST_COSTS_SLOTS", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("ALLOCATE_SLOTS", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("QUEUED_WAIT_SECONDS", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("QUERY", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("QUERY_START_TIME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("QUERY_END_TIME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("QUERY_DURATION", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("EXTRA_MESSAGE", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("WAREHOUSE_ID", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("WAREHOUSE_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("QUERY_ID", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("STATE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("EST_COSTS_SLOTS", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("ALLOCATE_SLOTS", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("QUEUED_WAIT_SECONDS", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("QUERY", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("QUERY_START_TIME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("QUERY_END_TIME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("QUERY_DURATION", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("EXTRA_MESSAGE", TypeFactory.createVarchar(NAME_CHAR_LEN))
                         .build(), TSchemaTableType.SCH_WAREHOUSE_QUERIES);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/GrantsTo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/GrantsTo.java
@@ -55,7 +55,7 @@ import com.starrocks.thrift.TGetGrantsToRolesOrUserRequest;
 import com.starrocks.thrift.TGetGrantsToRolesOrUserResponse;
 import com.starrocks.thrift.TGrantsToType;
 import com.starrocks.thrift.TSchemaTableType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.warehouse.Warehouse;
 
 import java.util.ArrayList;
@@ -76,13 +76,13 @@ public class GrantsTo {
     public static SystemTable createGrantsToRoles() {
         return new SystemTable(SystemId.GRANTS_TO_ROLES_ID, GRANTS_TO_ROLES, Table.TableType.SCHEMA,
                 builder()
-                        .column("GRANTEE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("OBJECT_CATALOG", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("OBJECT_DATABASE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("OBJECT_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("OBJECT_TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("PRIVILEGE_TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("IS_GRANTABLE", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("GRANTEE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("OBJECT_CATALOG", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("OBJECT_DATABASE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("OBJECT_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("OBJECT_TYPE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("PRIVILEGE_TYPE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("IS_GRANTABLE", TypeFactory.createVarchar(NAME_CHAR_LEN))
                         .build(),
                 TSchemaTableType.STARROCKS_GRANT_TO_ROLES);
     }
@@ -90,13 +90,13 @@ public class GrantsTo {
     public static SystemTable createGrantsToUsers() {
         return new SystemTable(SystemId.GRANTS_TO_USERS_ID, GRANTS_TO_USERS, Table.TableType.SCHEMA,
                 builder()
-                        .column("GRANTEE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("OBJECT_CATALOG", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("OBJECT_DATABASE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("OBJECT_NAME", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("OBJECT_TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("PRIVILEGE_TYPE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("IS_GRANTABLE", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("GRANTEE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("OBJECT_CATALOG", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("OBJECT_DATABASE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("OBJECT_NAME", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("OBJECT_TYPE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("PRIVILEGE_TYPE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("IS_GRANTABLE", TypeFactory.createVarchar(NAME_CHAR_LEN))
                         .build(),
                 TSchemaTableType.STARROCKS_GRANT_TO_USERS);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/RoleEdges.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/RoleEdges.java
@@ -25,7 +25,7 @@ import com.starrocks.thrift.TGetRoleEdgesItem;
 import com.starrocks.thrift.TGetRoleEdgesRequest;
 import com.starrocks.thrift.TGetRoleEdgesResponse;
 import com.starrocks.thrift.TSchemaTableType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import java.util.List;
 import java.util.Set;
@@ -39,9 +39,9 @@ public class RoleEdges {
     public static SystemTable create() {
         return new SystemTable(SystemId.ROLE_EDGES_ID, NAME, Table.TableType.SCHEMA,
                 builder()
-                        .column("FROM_ROLE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TO_ROLE", ScalarType.createVarchar(NAME_CHAR_LEN))
-                        .column("TO_USER", ScalarType.createVarchar(NAME_CHAR_LEN))
+                        .column("FROM_ROLE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TO_ROLE", TypeFactory.createVarchar(NAME_CHAR_LEN))
+                        .column("TO_USER", TypeFactory.createVarchar(NAME_CHAR_LEN))
                         .build(),
                 TSchemaTableType.STARROCKS_ROLE_EDGES);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysFeLocks.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysFeLocks.java
@@ -40,7 +40,7 @@ import com.starrocks.thrift.TFeLocksReq;
 import com.starrocks.thrift.TFeLocksRes;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.SetUtils;
 import org.apache.thrift.TException;
@@ -58,14 +58,14 @@ public class SysFeLocks {
         return new SystemTable(SystemId.FE_LOCKS_ID, NAME,
                 Table.TableType.SCHEMA,
                 SystemTable.builder()
-                        .column("lock_type", ScalarType.createVarcharType(64))
-                        .column("lock_object", ScalarType.createVarcharType(64))
-                        .column("lock_mode", ScalarType.createVarcharType(64))
-                        .column("start_time", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("hold_time_ms", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("thread_info", ScalarType.createVarcharType(64))
-                        .column("granted", ScalarType.createType(PrimitiveType.BOOLEAN))
-                        .column("waiter_list", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
+                        .column("lock_type", TypeFactory.createVarcharType(64))
+                        .column("lock_object", TypeFactory.createVarcharType(64))
+                        .column("lock_mode", TypeFactory.createVarcharType(64))
+                        .column("start_time", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("hold_time_ms", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("thread_info", TypeFactory.createVarcharType(64))
+                        .column("granted", TypeFactory.createType(PrimitiveType.BOOLEAN))
+                        .column("waiter_list", TypeFactory.createVarcharType(SystemTable.NAME_CHAR_LEN))
                         .build(),
                 TSchemaTableType.SYS_FE_LOCKS);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysFeMemoryUsage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysFeMemoryUsage.java
@@ -29,7 +29,7 @@ import com.starrocks.thrift.TFeMemoryReq;
 import com.starrocks.thrift.TFeMemoryRes;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import org.apache.thrift.TException;
 
 
@@ -40,11 +40,11 @@ public class SysFeMemoryUsage {
         return new SystemTable(SystemId.MEMORY_USAGE_ID, NAME,
                 Table.TableType.SCHEMA,
                 SystemTable.builder()
-                        .column("module_name", ScalarType.createVarcharType(256))
-                        .column("class_name", ScalarType.createVarcharType(256))
-                        .column("current_consumption", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("peak_consumption", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("counter_info", ScalarType.createVarcharType(65532))
+                        .column("module_name", TypeFactory.createVarcharType(256))
+                        .column("class_name", TypeFactory.createVarcharType(256))
+                        .column("current_consumption", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("peak_consumption", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("counter_info", TypeFactory.createVarcharType(65532))
                         .build(),
                 TSchemaTableType.SYS_FE_MEMORY_USAGE);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysObjectDependencies.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysObjectDependencies.java
@@ -35,6 +35,7 @@ import com.starrocks.thrift.TObjectDependencyReq;
 import com.starrocks.thrift.TObjectDependencyRes;
 import com.starrocks.thrift.TSchemaTableType;
 import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -51,16 +52,16 @@ public class SysObjectDependencies {
         return new SystemTable(SystemId.OBJECT_DEPENDENCIES, NAME, Table.TableType.SCHEMA,
                 SystemTable.builder()
                         .column("object_id", ScalarType.BIGINT)
-                        .column("object_name", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
-                        .column("object_database", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
-                        .column("object_catalog", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
-                        .column("object_type", ScalarType.createVarcharType(64))
+                        .column("object_name", TypeFactory.createVarcharType(SystemTable.NAME_CHAR_LEN))
+                        .column("object_database", TypeFactory.createVarcharType(SystemTable.NAME_CHAR_LEN))
+                        .column("object_catalog", TypeFactory.createVarcharType(SystemTable.NAME_CHAR_LEN))
+                        .column("object_type", TypeFactory.createVarcharType(64))
 
                         .column("ref_object_id", ScalarType.BIGINT)
-                        .column("ref_object_name", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
-                        .column("ref_object_database", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
-                        .column("ref_object_catalog", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
-                        .column("ref_object_type", ScalarType.createVarcharType(64))
+                        .column("ref_object_name", TypeFactory.createVarcharType(SystemTable.NAME_CHAR_LEN))
+                        .column("ref_object_database", TypeFactory.createVarcharType(SystemTable.NAME_CHAR_LEN))
+                        .column("ref_object_catalog", TypeFactory.createVarcharType(SystemTable.NAME_CHAR_LEN))
+                        .column("ref_object_type", TypeFactory.createVarcharType(64))
                         .build(),
                 TSchemaTableType.STARROCKS_OBJECT_DEPENDENCIES);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
@@ -22,10 +22,10 @@ import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.MapType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import io.delta.kernel.internal.util.ColumnMapping;
 import io.delta.kernel.types.DataType;
 import org.apache.avro.LogicalType;
@@ -140,11 +140,11 @@ public class ColumnTypeConverter {
                 primitiveType = PrimitiveType.DATE;
                 break;
             case "STRING":
-                return ScalarType.createDefaultCatalogString();
+                return TypeFactory.createDefaultCatalogString();
             case "VARCHAR":
-                return ScalarType.createVarcharType(getVarcharLength(hiveType));
+                return TypeFactory.createVarcharType(getVarcharLength(hiveType));
             case "CHAR":
-                return ScalarType.createCharType(getCharLength(hiveType));
+                return TypeFactory.createCharType(getCharLength(hiveType));
             case "BINARY":
                 return Type.VARBINARY;
             case "BOOLEAN":
@@ -177,10 +177,10 @@ public class ColumnTypeConverter {
         }
 
         if (primitiveType != PrimitiveType.DECIMAL32) {
-            return ScalarType.createType(primitiveType);
+            return TypeFactory.createType(primitiveType);
         } else {
             int[] parts = getPrecisionAndScale(hiveType);
-            return ScalarType.createUnifiedDecimalType(parts[0], parts[1]);
+            return TypeFactory.createUnifiedDecimalType(parts[0], parts[1]);
         }
     }
 
@@ -285,7 +285,7 @@ public class ColumnTypeConverter {
                 primitiveType = PrimitiveType.DOUBLE;
                 break;
             case STRING:
-                return ScalarType.createDefaultCatalogString();
+                return TypeFactory.createDefaultCatalogString();
             case ARRAY:
                 Type type = new ArrayType(fromHudiType(avroSchema.getElementType()));
                 if (type.isArrayType()) {
@@ -299,7 +299,7 @@ public class ColumnTypeConverter {
                 if (logicalType instanceof LogicalTypes.Decimal) {
                     int precision = ((LogicalTypes.Decimal) logicalType).getPrecision();
                     int scale = ((LogicalTypes.Decimal) logicalType).getScale();
-                    return ScalarType.createUnifiedDecimalType(precision, scale);
+                    return TypeFactory.createUnifiedDecimalType(precision, scale);
                 } else {
                     primitiveType = PrimitiveType.VARCHAR;
                     break;
@@ -333,7 +333,7 @@ public class ColumnTypeConverter {
 
                 if (!isConvertedFailed) {
                     // Hudi map's key must be string
-                    return new MapType(ScalarType.createDefaultCatalogString(), valueType);
+                    return new MapType(TypeFactory.createDefaultCatalogString(), valueType);
                 }
                 break;
             case UNION:
@@ -357,7 +357,7 @@ public class ColumnTypeConverter {
             primitiveType = PrimitiveType.UNKNOWN_TYPE;
         }
 
-        return ScalarType.createType(primitiveType);
+        return TypeFactory.createType(primitiveType);
     }
 
     // used for HUDI MOR reader only
@@ -468,11 +468,11 @@ public class ColumnTypeConverter {
                 primitiveType = PrimitiveType.DATETIME;
                 break;
             case STRING:
-                return ScalarType.createDefaultCatalogString();
+                return TypeFactory.createDefaultCatalogString();
             case DECIMAL:
                 int precision = ((io.delta.kernel.types.DecimalType) dataType).getPrecision();
                 int scale = ((io.delta.kernel.types.DecimalType) dataType).getScale();
-                return ScalarType.createUnifiedDecimalType(precision, scale);
+                return TypeFactory.createUnifiedDecimalType(precision, scale);
             case BINARY:
                 primitiveType = PrimitiveType.VARBINARY;
                 break;
@@ -485,7 +485,7 @@ public class ColumnTypeConverter {
             default:
                 primitiveType = PrimitiveType.UNKNOWN_TYPE;
         }
-        return ScalarType.createType(primitiveType);
+        return TypeFactory.createType(primitiveType);
     }
 
     public static Type fromPaimonType(org.apache.paimon.types.DataType type) {
@@ -497,67 +497,67 @@ public class ColumnTypeConverter {
         private static final PaimonToHiveTypeVisitor INSTANCE = new PaimonToHiveTypeVisitor();
 
         public Type visit(BinaryType binaryType) {
-            return ScalarType.createType(PrimitiveType.VARBINARY);
+            return TypeFactory.createType(PrimitiveType.VARBINARY);
         }
 
         public Type visit(VarBinaryType varBinaryType) {
-            return ScalarType.createType(PrimitiveType.VARBINARY);
+            return TypeFactory.createType(PrimitiveType.VARBINARY);
         }
 
         public Type visit(CharType charType) {
-            return ScalarType.createCharType(charType.getLength());
+            return TypeFactory.createCharType(charType.getLength());
         }
 
         public Type visit(VarCharType varCharType) {
-            return ScalarType.createDefaultCatalogString();
+            return TypeFactory.createDefaultCatalogString();
         }
 
         public Type visit(BooleanType booleanType) {
-            return ScalarType.createType(PrimitiveType.BOOLEAN);
+            return TypeFactory.createType(PrimitiveType.BOOLEAN);
         }
 
         public Type visit(DecimalType decimalType) {
-            return ScalarType.createUnifiedDecimalType(decimalType.getPrecision(), decimalType.getScale());
+            return TypeFactory.createUnifiedDecimalType(decimalType.getPrecision(), decimalType.getScale());
         }
 
         public Type visit(TinyIntType tinyIntType) {
-            return ScalarType.createType(PrimitiveType.TINYINT);
+            return TypeFactory.createType(PrimitiveType.TINYINT);
         }
 
         public Type visit(SmallIntType smallIntType) {
-            return ScalarType.createType(PrimitiveType.SMALLINT);
+            return TypeFactory.createType(PrimitiveType.SMALLINT);
         }
 
         public Type visit(IntType intType) {
-            return ScalarType.createType(PrimitiveType.INT);
+            return TypeFactory.createType(PrimitiveType.INT);
         }
 
         public Type visit(BigIntType bigIntType) {
-            return ScalarType.createType(PrimitiveType.BIGINT);
+            return TypeFactory.createType(PrimitiveType.BIGINT);
         }
 
         public Type visit(FloatType floatType) {
-            return ScalarType.createType(PrimitiveType.FLOAT);
+            return TypeFactory.createType(PrimitiveType.FLOAT);
         }
 
         public Type visit(DoubleType doubleType) {
-            return ScalarType.createType(PrimitiveType.DOUBLE);
+            return TypeFactory.createType(PrimitiveType.DOUBLE);
         }
 
         public Type visit(DateType dateType) {
-            return ScalarType.createType(PrimitiveType.DATE);
+            return TypeFactory.createType(PrimitiveType.DATE);
         }
 
         public Type visit(TimeType timeType) {
-            return ScalarType.createType(PrimitiveType.TIME);
+            return TypeFactory.createType(PrimitiveType.TIME);
         }
 
         public Type visit(TimestampType timestampType) {
-            return ScalarType.createType(PrimitiveType.DATETIME);
+            return TypeFactory.createType(PrimitiveType.DATETIME);
         }
 
         public Type visit(LocalZonedTimestampType timestampType) {
-            return ScalarType.createType(PrimitiveType.DATETIME);
+            return TypeFactory.createType(PrimitiveType.DATETIME);
         }
 
         public Type visit(org.apache.paimon.types.ArrayType arrayType) {
@@ -581,7 +581,7 @@ public class ColumnTypeConverter {
 
         @Override
         protected Type defaultMethod(org.apache.paimon.types.DataType dataType) {
-            return ScalarType.createType(PrimitiveType.UNKNOWN_TYPE);
+            return TypeFactory.createType(PrimitiveType.UNKNOWN_TYPE);
         }
     }
 
@@ -622,20 +622,20 @@ public class ColumnTypeConverter {
                 primitiveType = PrimitiveType.DATETIME;
                 break;
             case STRING:
-                return ScalarType.createDefaultCatalogString();
+                return TypeFactory.createDefaultCatalogString();
             case VARCHAR:
-                return ScalarType.createVarcharType(columnSchema.getTypeAttributes().getLength());
+                return TypeFactory.createVarcharType(columnSchema.getTypeAttributes().getLength());
             case DECIMAL:
                 ColumnTypeAttributes typeAttributes = columnSchema.getTypeAttributes();
                 int precision = typeAttributes.getPrecision();
                 int scale = typeAttributes.getScale();
-                return ScalarType.createUnifiedDecimalType(precision, scale);
+                return TypeFactory.createUnifiedDecimalType(precision, scale);
             case BINARY:
                 return Type.VARBINARY;
             default:
                 primitiveType = PrimitiveType.UNKNOWN_TYPE;
         }
-        return ScalarType.createType(primitiveType);
+        return TypeFactory.createType(primitiveType);
     }
 
     public static Type fromIcebergType(org.apache.iceberg.types.Type icebergType) {
@@ -668,16 +668,16 @@ public class ColumnTypeConverter {
                 primitiveType = PrimitiveType.DATETIME;
                 break;
             case STRING:
-                return ScalarType.createDefaultCatalogString();
+                return TypeFactory.createDefaultCatalogString();
             case DECIMAL:
                 int precision = ((Types.DecimalType) icebergType).precision();
                 int scale = ((Types.DecimalType) icebergType).scale();
                 if (precision <= 9) {
-                    return ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, precision, scale);
+                    return TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, precision, scale);
                 } else if (precision <= 18) {
-                    return ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, precision, scale);
+                    return TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, precision, scale);
                 } else {
-                    return ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, precision, scale);
+                    return TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, precision, scale);
                 }
             case LIST:
                 Type type = convertToArrayTypeForIceberg(icebergType);
@@ -717,7 +717,7 @@ public class ColumnTypeConverter {
             default:
                 primitiveType = PrimitiveType.UNKNOWN_TYPE;
         }
-        return ScalarType.createType(primitiveType);
+        return TypeFactory.createType(primitiveType);
     }
 
     private static ArrayType convertToArrayTypeForIceberg(org.apache.iceberg.types.Type icebergType) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsUtil.java
@@ -44,8 +44,8 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.DistributionDesc;
 import com.starrocks.sql.ast.PartitionDesc;
 import com.starrocks.sql.ast.RangePartitionDesc;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -163,7 +163,7 @@ public class EsUtil {
             case "text":
             case "ip":
             default:
-                return ScalarType.createDefaultCatalogString();
+                return TypeFactory.createDefaultCatalogString();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
@@ -36,6 +36,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 import com.starrocks.sql.optimizer.operator.scalar.SubfieldOperator;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Binder;
 import org.apache.iceberg.expressions.Expression;
@@ -368,7 +369,7 @@ public class ScalarOperatorToIcebergExpr {
                     // num usually don't need cast, and num and string has different comparator
                     // cast is dangerous.
                 case DECIMAL:
-                    res = operator.castTo(ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 9, 0));
+                    res = operator.castTo(TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 9, 0));
                     break;
                 case INTEGER:
                 case LONG:

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolver.java
@@ -17,8 +17,8 @@ package com.starrocks.connector.jdbc;
 import com.google.common.collect.ImmutableSet;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -118,7 +118,7 @@ public class ClickhouseSchemaResolver extends JDBCSchemaResolver {
                 primitiveType = PrimitiveType.BOOLEAN;
                 break;
             case Types.VARCHAR:
-                return ScalarType.createVarcharType(65533);
+                return TypeFactory.createVarcharType(65533);
             case Types.DATE:
                 primitiveType = PrimitiveType.DATE;
                 break;
@@ -141,13 +141,13 @@ public class ClickhouseSchemaResolver extends JDBCSchemaResolver {
                 } else {
                     int precision = Integer.parseInt(precisionAndScale[0]);
                     int scale = Integer.parseInt(precisionAndScale[1]);
-                    return ScalarType.createUnifiedDecimalType(precision, scale);
+                    return TypeFactory.createUnifiedDecimalType(precision, scale);
                 }
             default:
                 primitiveType = PrimitiveType.UNKNOWN_TYPE;
                 break;
         }
-        return ScalarType.createType(primitiveType);
+        return TypeFactory.createType(primitiveType);
     }
 
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
@@ -22,8 +22,8 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.jetbrains.annotations.NotNull;
 
 import java.sql.Connection;
@@ -133,10 +133,10 @@ public class MysqlSchemaResolver extends JDBCSchemaResolver {
                 primitiveType = PrimitiveType.DECIMAL32;
                 break;
             case Types.CHAR:
-                return ScalarType.createCharType(columnSize);
+                return TypeFactory.createCharType(columnSize);
             case Types.VARCHAR:
             case Types.LONGVARCHAR: //text type in mysql
-                return ScalarType.createVarcharType(columnSize);
+                return TypeFactory.createVarcharType(columnSize);
             case Types.DATE:
                 primitiveType = PrimitiveType.DATE;
                 break;
@@ -152,14 +152,14 @@ public class MysqlSchemaResolver extends JDBCSchemaResolver {
                 // so it will be converted to Types.Other. Here, in order to handle JSON, for the Types.Other,
                 // it is uniformly converted to Types.LONGVARCHAR(1073741824).
                 // If later mariadb-java-client support json, this code can be reverted.
-                return ScalarType.createVarcharType(1073741824);
+                return TypeFactory.createVarcharType(1073741824);
         }
 
         if (primitiveType != PrimitiveType.DECIMAL32) {
-            return ScalarType.createType(primitiveType);
+            return TypeFactory.createType(primitiveType);
         } else {
             int precision = columnSize + max(-digits, 0);
-            return ScalarType.createUnifiedDecimalType(precision, max(digits, 0));
+            return TypeFactory.createUnifiedDecimalType(precision, max(digits, 0));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/OracleSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/OracleSchemaResolver.java
@@ -26,6 +26,7 @@ import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -106,29 +107,29 @@ public class OracleSchemaResolver extends JDBCSchemaResolver {
                 break;
             case Types.CHAR:
             case Types.NCHAR:
-                return ScalarType.createCharType(columnSize);
+                return TypeFactory.createCharType(columnSize);
             case Types.VARCHAR:
             // NVARCHAR2
             case Types.NVARCHAR:
                 if (columnSize > 0) {
-                    return ScalarType.createVarcharType(columnSize);
+                    return TypeFactory.createVarcharType(columnSize);
                 } else {
-                    return ScalarType.createVarcharType(ScalarType.CATALOG_MAX_VARCHAR_LENGTH);
+                    return TypeFactory.createVarcharType(ScalarType.CATALOG_MAX_VARCHAR_LENGTH);
                 }
             case Types.CLOB:
             case Types.NCLOB:
             // LONG
             case Types.LONGVARCHAR:
-                return ScalarType.createVarcharType(ScalarType.CATALOG_MAX_VARCHAR_LENGTH);
+                return TypeFactory.createVarcharType(ScalarType.CATALOG_MAX_VARCHAR_LENGTH);
             case Types.BLOB:
             case Types.BINARY:
             case Types.VARBINARY:
             // raw
             case 23:
                 if (columnSize > 0) {
-                    return ScalarType.createVarbinary(columnSize);
+                    return TypeFactory.createVarbinary(columnSize);
                 } else {
-                    return ScalarType.createVarbinary(ScalarType.CATALOG_MAX_VARCHAR_LENGTH);
+                    return TypeFactory.createVarbinary(ScalarType.CATALOG_MAX_VARCHAR_LENGTH);
                 }
             case Types.DATE:
                 primitiveType = PrimitiveType.DATE;
@@ -139,22 +140,22 @@ public class OracleSchemaResolver extends JDBCSchemaResolver {
             case -102:
             // TIMESTAMP WITH TIME ZONE
             case -101:
-                return ScalarType.createVarcharType(ScalarType.CATALOG_MAX_VARCHAR_LENGTH);
+                return TypeFactory.createVarcharType(ScalarType.CATALOG_MAX_VARCHAR_LENGTH);
             default:
                 primitiveType = PrimitiveType.UNKNOWN_TYPE;
                 break;
         }
 
         if (primitiveType != PrimitiveType.DECIMAL32) {
-            return ScalarType.createType(primitiveType);
+            return TypeFactory.createType(primitiveType);
         } else {
             int precision = columnSize + max(-digits, 0);
             // if user not specify numeric precision and scale, the default value is 0,
             // we can't defer the precision and scale, can only deal it as string.
             if (precision == 0) {
-                return ScalarType.createVarcharType(ScalarType.CATALOG_MAX_VARCHAR_LENGTH);
+                return TypeFactory.createVarcharType(ScalarType.CATALOG_MAX_VARCHAR_LENGTH);
             }
-            return ScalarType.createUnifiedDecimalType(precision, max(digits, 0));
+            return TypeFactory.createUnifiedDecimalType(precision, max(digits, 0));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
@@ -25,6 +25,7 @@ import com.starrocks.common.util.TimeUtils;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -109,18 +110,18 @@ public class PostgresSchemaResolver extends JDBCSchemaResolver {
                 primitiveType = PrimitiveType.DECIMAL32;
                 break;
             case Types.CHAR:
-                return ScalarType.createCharType(columnSize);
+                return TypeFactory.createCharType(columnSize);
             case Types.VARCHAR:
                 if (typeName.equalsIgnoreCase("varchar")) {
-                    return ScalarType.createVarcharType(columnSize);
+                    return TypeFactory.createVarcharType(columnSize);
                 } else if (typeName.equalsIgnoreCase("text")) {
-                    return ScalarType.createVarcharType(ScalarType.getOlapMaxVarcharLength());
+                    return TypeFactory.createVarcharType(TypeFactory.getOlapMaxVarcharLength());
                 }
                 primitiveType = PrimitiveType.UNKNOWN_TYPE;
                 break;
             case Types.BINARY:
             case Types.VARBINARY:
-                return ScalarType.createVarbinary(ScalarType.CATALOG_MAX_VARCHAR_LENGTH);
+                return TypeFactory.createVarbinary(ScalarType.CATALOG_MAX_VARCHAR_LENGTH);
             case Types.DATE:
                 primitiveType = PrimitiveType.DATE;
                 break;
@@ -133,19 +134,19 @@ public class PostgresSchemaResolver extends JDBCSchemaResolver {
         }
 
         if (typeName.equalsIgnoreCase("uuid")) {
-            return ScalarType.createVarbinary(columnSize);
+            return TypeFactory.createVarbinary(columnSize);
         }
 
         if (primitiveType != PrimitiveType.DECIMAL32) {
-            return ScalarType.createType(primitiveType);
+            return TypeFactory.createType(primitiveType);
         } else {
             int precision = columnSize + max(-digits, 0);
             // if user not specify numeric precision and scale, the default value is 0,
             // we can't defer the precision and scale, can only deal it as string.
             if (precision == 0) {
-                return ScalarType.createVarcharType(ScalarType.getOlapMaxVarcharLength());
+                return TypeFactory.createVarcharType(TypeFactory.getOlapMaxVarcharLength());
             }
-            return ScalarType.createUnifiedDecimalType(precision, max(digits, 0));
+            return TypeFactory.createUnifiedDecimalType(precision, max(digits, 0));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/SqlServerSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/SqlServerSchemaResolver.java
@@ -21,6 +21,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -94,13 +95,13 @@ public class SqlServerSchemaResolver extends JDBCSchemaResolver {
             // UNIQUEIDENTIFIER
             case Types.CHAR:
             case Types.NCHAR:
-                return ScalarType.createCharType(columnSize);
+                return TypeFactory.createCharType(columnSize);
             case Types.VARCHAR:
             case Types.NVARCHAR:
                 if (columnSize > 0) {
-                    return ScalarType.createVarcharType(columnSize);
+                    return TypeFactory.createVarcharType(columnSize);
                 } else {
-                    return ScalarType.createVarcharType(ScalarType.getOlapMaxVarcharLength());
+                    return TypeFactory.createVarcharType(TypeFactory.getOlapMaxVarcharLength());
                 }
             // DATETIMEOFFSET
             case -155:
@@ -110,9 +111,9 @@ public class SqlServerSchemaResolver extends JDBCSchemaResolver {
             case Types.LONGNVARCHAR:
                 if (typeName.equalsIgnoreCase("text") || typeName.equalsIgnoreCase("ntext") ||
                         typeName.equalsIgnoreCase("xml")) {
-                    return ScalarType.createVarcharType(ScalarType.getOlapMaxVarcharLength());
+                    return TypeFactory.createVarcharType(TypeFactory.getOlapMaxVarcharLength());
                 } else if (typeName.equalsIgnoreCase("datetimeoffset")) {
-                    return ScalarType.createVarcharType(columnSize);
+                    return TypeFactory.createVarcharType(columnSize);
                 }
                 primitiveType = PrimitiveType.UNKNOWN_TYPE;
                 break;
@@ -121,9 +122,9 @@ public class SqlServerSchemaResolver extends JDBCSchemaResolver {
             case Types.BINARY:
             case Types.VARBINARY:
                 if (columnSize > 0) {
-                    return ScalarType.createVarbinary(columnSize);
+                    return TypeFactory.createVarbinary(columnSize);
                 } else {
-                    return ScalarType.createVarbinary(ScalarType.CATALOG_MAX_VARCHAR_LENGTH);
+                    return TypeFactory.createVarbinary(ScalarType.CATALOG_MAX_VARCHAR_LENGTH);
                 }
             case Types.DATE:
                 primitiveType = PrimitiveType.DATE;
@@ -141,16 +142,16 @@ public class SqlServerSchemaResolver extends JDBCSchemaResolver {
         }
 
         if (primitiveType != PrimitiveType.DECIMAL32) {
-            ScalarType scalarType = ScalarType.createType(primitiveType);
+            ScalarType scalarType = TypeFactory.createType(primitiveType);
             return scalarType;
         } else {
             int precision = columnSize + max(-digits, 0);
             // if user not specify numeric precision and scale, the default value is 0,
             // we can't defer the precision and scale, can only deal it as string.
             if (precision == 0) {
-                return ScalarType.createVarcharType(ScalarType.CATALOG_MAX_VARCHAR_LENGTH);
+                return TypeFactory.createVarcharType(ScalarType.CATALOG_MAX_VARCHAR_LENGTH);
             }
-            return ScalarType.createUnifiedDecimalType(precision, max(digits, 0));
+            return TypeFactory.createUnifiedDecimalType(precision, max(digits, 0));
 
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergFilesTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergFilesTable.java
@@ -29,10 +29,10 @@ import com.starrocks.type.PrimitiveType;
 import java.util.List;
 
 import static com.starrocks.connector.metadata.TableMetaMetadata.METADATA_DB_NAME;
-import static com.starrocks.type.ScalarType.createType;
-import static com.starrocks.type.ScalarType.createVarcharType;
 import static com.starrocks.type.Type.ARRAY_BIGINT;
 import static com.starrocks.type.Type.ARRAY_INT;
+import static com.starrocks.type.TypeFactory.createType;
+import static com.starrocks.type.TypeFactory.createVarcharType;
 
 public class IcebergFilesTable extends MetadataTable {
     public static final String TABLE_NAME = "iceberg_files_table";

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergHistoryTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergHistoryTable.java
@@ -24,7 +24,7 @@ import com.starrocks.thrift.THdfsTable;
 import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import java.util.List;
 
@@ -44,10 +44,10 @@ public class IcebergHistoryTable extends MetadataTable {
                 TABLE_NAME,
                 Table.TableType.METADATA,
                 builder()
-                        .column("made_current_at", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("snapshot_id", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("parent_id", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("is_current_ancestor", ScalarType.createType(PrimitiveType.VARCHAR))
+                        .column("made_current_at", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("snapshot_id", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("parent_id", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("is_current_ancestor", TypeFactory.createType(PrimitiveType.VARCHAR))
                         .build(),
                 originDb,
                 originTable,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergManifestsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergManifestsTable.java
@@ -26,9 +26,9 @@ import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
+import com.starrocks.type.TypeFactory;
 
 import java.util.List;
 
@@ -48,22 +48,22 @@ public class IcebergManifestsTable extends MetadataTable {
                 TABLE_NAME,
                 Table.TableType.METADATA,
                 builder()
-                        .column("path", ScalarType.createType(PrimitiveType.VARCHAR))
-                        .column("length", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("partition_spec_id", ScalarType.createType(PrimitiveType.INT))
-                        .column("added_snapshot_id", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("added_data_files_count", ScalarType.createType(PrimitiveType.INT))
-                        .column("added_rows_count", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("existing_data_files_count", ScalarType.createType(PrimitiveType.INT))
-                        .column("existing_rows_count", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("deleted_data_files_count", ScalarType.createType(PrimitiveType.INT))
-                        .column("deleted_rows_count", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("path", TypeFactory.createType(PrimitiveType.VARCHAR))
+                        .column("length", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("partition_spec_id", TypeFactory.createType(PrimitiveType.INT))
+                        .column("added_snapshot_id", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("added_data_files_count", TypeFactory.createType(PrimitiveType.INT))
+                        .column("added_rows_count", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("existing_data_files_count", TypeFactory.createType(PrimitiveType.INT))
+                        .column("existing_rows_count", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("deleted_data_files_count", TypeFactory.createType(PrimitiveType.INT))
+                        .column("deleted_rows_count", TypeFactory.createType(PrimitiveType.BIGINT))
                         .column("partitions", new ArrayType(
                                 new StructType(Lists.newArrayList(
-                                        new StructField("contains_null", ScalarType.createType(PrimitiveType.VARCHAR)),
-                                        new StructField("contains_nan", ScalarType.createType(PrimitiveType.VARCHAR)),
-                                        new StructField("lower_bound", ScalarType.createType(PrimitiveType.VARCHAR)),
-                                        new StructField("upper_bound", ScalarType.createType(PrimitiveType.VARCHAR)))))
+                                        new StructField("contains_null", TypeFactory.createType(PrimitiveType.VARCHAR)),
+                                        new StructField("contains_nan", TypeFactory.createType(PrimitiveType.VARCHAR)),
+                                        new StructField("lower_bound", TypeFactory.createType(PrimitiveType.VARCHAR)),
+                                        new StructField("upper_bound", TypeFactory.createType(PrimitiveType.VARCHAR)))))
                         )
                         .build(),
                 originDb,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergMetadataLogEntriesTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergMetadataLogEntriesTable.java
@@ -24,7 +24,7 @@ import com.starrocks.thrift.THdfsTable;
 import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import java.util.List;
 
@@ -45,11 +45,11 @@ public class IcebergMetadataLogEntriesTable extends MetadataTable {
                 TABLE_NAME,
                 Table.TableType.METADATA,
                 builder()
-                        .column("timestamp", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("file", ScalarType.createVarcharType())
-                        .column("latest_snapshot_id", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("latest_schema_id", ScalarType.createType(PrimitiveType.INT))
-                        .column("latest_sequence_number", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("timestamp", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("file", TypeFactory.createVarcharType())
+                        .column("latest_snapshot_id", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("latest_schema_id", TypeFactory.createType(PrimitiveType.INT))
+                        .column("latest_sequence_number", TypeFactory.createType(PrimitiveType.BIGINT))
                         .build(),
                 originDb,
                 originTable,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergPartitionsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergPartitionsTable.java
@@ -37,7 +37,7 @@ import org.apache.iceberg.PartitionField;
 import java.util.List;
 
 import static com.starrocks.connector.metadata.TableMetaMetadata.METADATA_DB_NAME;
-import static com.starrocks.type.ScalarType.createType;
+import static com.starrocks.type.TypeFactory.createType;
 
 public class IcebergPartitionsTable extends MetadataTable {
     public static final String TABLE_NAME = "iceberg_partitions_table";

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergRefsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergRefsTable.java
@@ -24,7 +24,7 @@ import com.starrocks.thrift.THdfsTable;
 import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import java.util.List;
 
@@ -44,12 +44,12 @@ public class IcebergRefsTable extends MetadataTable {
                 TABLE_NAME,
                 Table.TableType.METADATA,
                 builder()
-                        .column("name", ScalarType.createVarcharType())
-                        .column("type", ScalarType.createVarcharType())
-                        .column("snapshot_id", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("max_reference_age_in_ms", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("min_snapshots_to_keep", ScalarType.createType(PrimitiveType.INT))
-                        .column("max_snapshot_age_in_ms", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("name", TypeFactory.createVarcharType())
+                        .column("type", TypeFactory.createVarcharType())
+                        .column("snapshot_id", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("max_reference_age_in_ms", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("min_snapshots_to_keep", TypeFactory.createType(PrimitiveType.INT))
+                        .column("max_snapshot_age_in_ms", TypeFactory.createType(PrimitiveType.BIGINT))
                         .build(),
                 originDb,
                 originTable,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergSnapshotsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergSnapshotsTable.java
@@ -25,7 +25,7 @@ import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
 import com.starrocks.type.MapType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import java.util.List;
 
@@ -45,13 +45,13 @@ public class IcebergSnapshotsTable extends MetadataTable {
                 TABLE_NAME,
                 Table.TableType.METADATA,
                 builder()
-                        .column("committed_at", ScalarType.createType(PrimitiveType.DATETIME))
-                        .column("snapshot_id", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("parent_id", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("operation", ScalarType.createType(PrimitiveType.VARCHAR))
-                        .column("manifest_list", ScalarType.createType(PrimitiveType.VARCHAR))
+                        .column("committed_at", TypeFactory.createType(PrimitiveType.DATETIME))
+                        .column("snapshot_id", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("parent_id", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("operation", TypeFactory.createType(PrimitiveType.VARCHAR))
+                        .column("manifest_list", TypeFactory.createType(PrimitiveType.VARCHAR))
                         .column("summary", new MapType(
-                                ScalarType.createType(PrimitiveType.VARCHAR), ScalarType.createType(PrimitiveType.VARCHAR)))
+                                TypeFactory.createType(PrimitiveType.VARCHAR), TypeFactory.createType(PrimitiveType.VARCHAR)))
                         .build(),
                 originDb,
                 originTable,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/LogicalIcebergMetadataTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/LogicalIcebergMetadataTable.java
@@ -24,7 +24,7 @@ import com.starrocks.thrift.THdfsTable;
 import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -49,20 +49,20 @@ public class LogicalIcebergMetadataTable extends MetadataTable {
                 Table.TableType.METADATA,
                 builder()
                         .columns(PLACEHOLDER_COLUMNS)
-                        .column("content", ScalarType.createType(PrimitiveType.INT))
-                        .column("file_path", ScalarType.createVarcharType())
-                        .column("file_format", ScalarType.createVarcharType())
-                        .column("spec_id", ScalarType.createType(PrimitiveType.INT))
-                        .column("partition_data", ScalarType.createType(PrimitiveType.VARBINARY))
-                        .column("record_count", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("file_size_in_bytes", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("content", TypeFactory.createType(PrimitiveType.INT))
+                        .column("file_path", TypeFactory.createVarcharType())
+                        .column("file_format", TypeFactory.createVarcharType())
+                        .column("spec_id", TypeFactory.createType(PrimitiveType.INT))
+                        .column("partition_data", TypeFactory.createType(PrimitiveType.VARBINARY))
+                        .column("record_count", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("file_size_in_bytes", TypeFactory.createType(PrimitiveType.BIGINT))
                         .column("split_offsets", ARRAY_BIGINT)
-                        .column("sort_id", ScalarType.createType(PrimitiveType.INT))
+                        .column("sort_id", TypeFactory.createType(PrimitiveType.INT))
                         .column("equality_ids", ARRAY_INT)
-                        .column("file_sequence_number", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("data_sequence_number", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("column_stats", ScalarType.createType(PrimitiveType.VARBINARY))
-                        .column("key_metadata", ScalarType.createType(PrimitiveType.VARBINARY))
+                        .column("file_sequence_number", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("data_sequence_number", TypeFactory.createType(PrimitiveType.BIGINT))
+                        .column("column_stats", TypeFactory.createType(PrimitiveType.VARBINARY))
+                        .column("key_metadata", TypeFactory.createType(PrimitiveType.VARBINARY))
                         .build(),
                 originDb,
                 originTable,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/odps/EntityConvertUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/odps/EntityConvertUtils.java
@@ -25,9 +25,9 @@ import com.aliyun.odps.type.VarcharTypeInfo;
 import com.starrocks.catalog.Column;
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.MapType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -52,20 +52,20 @@ public class EntityConvertUtils {
                 //In odps 2.0, the maximum length of decimal is 38, while in 1.0 it is 54. You need to convert it to String type for processing.
                 //https://help.aliyun.com/zh/maxcompute/user-guide/maxcompute-v2-0-data-type-edition?spm=a2c4g.11186623.help-menu-27797.d_2_15_0_2.1c01123dDL8rEV
                 if (decimalTypeInfo.getPrecision() > 38) {
-                    return ScalarType.createDefaultCatalogString();
+                    return TypeFactory.createDefaultCatalogString();
                 }
-                return ScalarType.createUnifiedDecimalType(decimalTypeInfo.getPrecision(), decimalTypeInfo.getScale());
+                return TypeFactory.createUnifiedDecimalType(decimalTypeInfo.getPrecision(), decimalTypeInfo.getScale());
             case DOUBLE:
                 return Type.DOUBLE;
             case CHAR:
                 CharTypeInfo charTypeInfo = (CharTypeInfo) typeInfo;
-                return ScalarType.createCharType(charTypeInfo.getLength());
+                return TypeFactory.createCharType(charTypeInfo.getLength());
             case VARCHAR:
                 VarcharTypeInfo varcharTypeInfo = (VarcharTypeInfo) typeInfo;
-                return ScalarType.createVarcharType(varcharTypeInfo.getLength());
+                return TypeFactory.createVarcharType(varcharTypeInfo.getLength());
             case STRING:
             case JSON:
-                return ScalarType.createDefaultCatalogString();
+                return TypeFactory.createDefaultCatalogString();
             case BINARY:
                 return Type.VARBINARY;
             case BOOLEAN:

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
@@ -96,6 +96,7 @@ import com.starrocks.type.ScalarType;
 import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import io.trino.sql.tree.AliasedRelation;
 import io.trino.sql.tree.AllColumns;
 import io.trino.sql.tree.ArithmeticBinaryExpression;
@@ -1345,9 +1346,9 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
         } else if (dataType instanceof DateTimeDataType) {
             DateTimeDataType dateTimeType = (DateTimeDataType) dataType;
             if (dateTimeType.getType() == DateTimeDataType.Type.TIME) {
-                return ScalarType.createType(PrimitiveType.TIME);
+                return TypeFactory.createType(PrimitiveType.TIME);
             } else {
-                return ScalarType.createType(PrimitiveType.DATETIME);
+                return TypeFactory.createType(PrimitiveType.DATETIME);
             }
         } else if (dataType instanceof RowDataType) {
             RowDataType rowDataType = (RowDataType) dataType;
@@ -1379,29 +1380,29 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
             }
         }
         if (typeName.equals("varchar")) {
-            ScalarType type = ScalarType.createVarcharType(length);
+            ScalarType type = TypeFactory.createVarcharType(length);
             return type;
         } else if (typeName.equals("char")) {
-            ScalarType type = ScalarType.createCharType(length);
+            ScalarType type = TypeFactory.createCharType(length);
             return type;
         } else if (typeName.equals("decimal")) {
             if (precision != -1) {
                 if (scale != -1) {
-                    return ScalarType.createUnifiedDecimalType(precision, scale);
+                    return TypeFactory.createUnifiedDecimalType(precision, scale);
                 }
-                return ScalarType.createUnifiedDecimalType(precision, 0);
+                return TypeFactory.createUnifiedDecimalType(precision, 0);
             }
-            return ScalarType.createUnifiedDecimalType(38, 0);
+            return TypeFactory.createUnifiedDecimalType(38, 0);
         } else if (typeName.contains("decimal")) {
             throw new ParsingException("Unknown type: %s", typeName);
         } else if (typeName.equals("real")) {
-            return ScalarType.createType(PrimitiveType.FLOAT);
+            return TypeFactory.createType(PrimitiveType.FLOAT);
         } else if (typeName.equals("array")) {
             TypeParameter typeParam = (TypeParameter) dataType.getArguments().get(0);
             return new ArrayType(getType(typeParam.getValue()));
         } else {
             // this contains datetime/date/numeric type
-            return ScalarType.createType(typeName);
+            return TypeFactory.createType(typeName);
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/trino/TrinoViewColumnTypeConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/trino/TrinoViewColumnTypeConverter.java
@@ -18,10 +18,10 @@ import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.MapType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -82,17 +82,17 @@ public class TrinoViewColumnTypeConverter {
                 primitiveType = PrimitiveType.DATE;
                 break;
             case "STRING":
-                return ScalarType.createDefaultCatalogString();
+                return TypeFactory.createDefaultCatalogString();
             case "VARCHAR":
                 int length = 0;
                 try {
                     length = getVarcharLength(trinoType);
                 } catch (StarRocksConnectorException e) {
-                    return ScalarType.createDefaultCatalogString();
+                    return TypeFactory.createDefaultCatalogString();
                 }
-                return ScalarType.createVarcharType(length);
+                return TypeFactory.createVarcharType(length);
             case "CHAR":
-                return ScalarType.createCharType(getCharLength(trinoType));
+                return TypeFactory.createCharType(getCharLength(trinoType));
             case "BINARY":
             case "VARBINARY":
                 return Type.VARBINARY;
@@ -126,10 +126,10 @@ public class TrinoViewColumnTypeConverter {
         }
 
         if (primitiveType != PrimitiveType.DECIMAL32) {
-            return ScalarType.createType(primitiveType);
+            return TypeFactory.createType(primitiveType);
         } else {
             int[] parts = getPrecisionAndScale(trinoType);
-            return ScalarType.createUnifiedDecimalType(parts[0], parts[1]);
+            return TypeFactory.createUnifiedDecimalType(parts[0], parts[1]);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectMetrics.java
@@ -23,7 +23,7 @@ import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import java.util.HashMap;
 import java.util.List;
@@ -32,19 +32,19 @@ import java.util.concurrent.TimeUnit;
 
 public class DataCacheSelectMetrics {
     private static final ShowResultSetMetaData SIMPLE_META_DATA = ShowResultSetMetaData.builder()
-            .addColumn(new Column("AVG_READ_CACHE_SIZE", ScalarType.createVarcharType()))
-            .addColumn(new Column("AVG_WRITE_CACHE_SIZE", ScalarType.createVarcharType()))
-            .addColumn(new Column("AVG_WRITE_CACHE_TIME", ScalarType.createVarcharType()))
-            .addColumn(new Column("TOTAL_CACHE_USAGE", ScalarType.createVarcharType()))
+            .addColumn(new Column("AVG_READ_CACHE_SIZE", TypeFactory.createVarcharType()))
+            .addColumn(new Column("AVG_WRITE_CACHE_SIZE", TypeFactory.createVarcharType()))
+            .addColumn(new Column("AVG_WRITE_CACHE_TIME", TypeFactory.createVarcharType()))
+            .addColumn(new Column("TOTAL_CACHE_USAGE", TypeFactory.createVarcharType()))
             .build();
 
     private static final ShowResultSetMetaData VERBOSE_META_DATA = ShowResultSetMetaData.builder()
-            .addColumn(new Column("IP", ScalarType.createVarcharType()))
-            .addColumn(new Column("READ_CACHE_SIZE", ScalarType.createVarcharType()))
-            .addColumn(new Column("AVG_READ_CACHE_TIME", ScalarType.createVarcharType()))
-            .addColumn(new Column("WRITE_CACHE_SIZE", ScalarType.createVarcharType()))
-            .addColumn(new Column("AVG_WRITE_CACHE_TIME", ScalarType.createVarcharType()))
-            .addColumn(new Column("TOTAL_CACHE_USAGE", ScalarType.createVarcharType()))
+            .addColumn(new Column("IP", TypeFactory.createVarcharType()))
+            .addColumn(new Column("READ_CACHE_SIZE", TypeFactory.createVarcharType()))
+            .addColumn(new Column("AVG_READ_CACHE_TIME", TypeFactory.createVarcharType()))
+            .addColumn(new Column("WRITE_CACHE_SIZE", TypeFactory.createVarcharType()))
+            .addColumn(new Column("AVG_WRITE_CACHE_TIME", TypeFactory.createVarcharType()))
+            .addColumn(new Column("TOTAL_CACHE_USAGE", TypeFactory.createVarcharType()))
             .build();
 
     private final Map<Long, LoadDataCacheMetrics> beMetrics = new HashMap<>();

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadJob.java
@@ -119,8 +119,8 @@ import com.starrocks.transaction.TransactionState.LoadJobSourceType;
 import com.starrocks.transaction.TransactionState.TxnCoordinator;
 import com.starrocks.transaction.TransactionState.TxnSourceType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.warehouse.WarehouseIdleChecker;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -1043,7 +1043,7 @@ public class SparkLoadJob extends BulkLoadJob {
                 Type type = column.getType();
                 if (type.isLargeIntType() || type.isBoolean() || type.isBitmapType() || type.isHllType()) {
                     // largeint, boolean, bitmap, hll type using varchar in spark dpp parquet file
-                    srcSlotDesc.setType(ScalarType.createType(PrimitiveType.VARCHAR));
+                    srcSlotDesc.setType(TypeFactory.createType(PrimitiveType.VARCHAR));
                     srcSlotDesc.setColumn(new Column(column.getName(), Type.VARCHAR));
                 } else {
                     srcSlotDesc.setType(type);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SlotDescriptor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SlotDescriptor.java
@@ -46,6 +46,7 @@ import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.thrift.TSlotDescriptor;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.type.TypeSerializer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -164,14 +165,14 @@ public class SlotDescriptor {
         if (this.originType.isScalarType()) {
             ScalarType scalarType = (ScalarType) this.originType;
             if (this.originType.isDecimalV3()) {
-                this.type = ScalarType.createDecimalV3Type(
+                this.type = TypeFactory.createDecimalV3Type(
                         scalarType.getPrimitiveType(),
                         scalarType.getScalarPrecision(),
                         scalarType.getScalarScale());
             } else if (this.originType.isVarchar() && FeConstants.setLengthForVarchar) {
-                this.type = ScalarType.createVarcharType(scalarType.getLength());
+                this.type = TypeFactory.createVarcharType(scalarType.getLength());
             } else {
-                this.type = ScalarType.createType(this.originType.getPrimitiveType());
+                this.type = TypeFactory.createType(this.originType.getPrimitiveType());
             }
         } else {
             this.type = this.originType.clone();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -263,7 +263,7 @@ import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TTableInfo;
 import com.starrocks.transaction.GlobalTransactionMgr;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.warehouse.Warehouse;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
@@ -443,8 +443,8 @@ public class ShowExecutor {
         @Override
         public ShowResultSet visitHelpStatement(HelpStmt statement, ConnectContext context) {
             ShowResultSetMetaData metaData = ShowResultSetMetaData.builder()
-                    .addColumn(new Column("name", ScalarType.createVarchar(64)))
-                    .addColumn(new Column("is_it_category", ScalarType.createVarchar(1)))
+                    .addColumn(new Column("name", TypeFactory.createVarchar(64)))
+                    .addColumn(new Column("is_it_category", TypeFactory.createVarchar(1)))
                     .build();
             return new ShowResultSet(metaData, EMPTY_SET);
         }
@@ -758,8 +758,8 @@ public class ShowExecutor {
                                         }
 
                                         ShowResultSetMetaData showResultSetMetaData = ShowResultSetMetaData.builder()
-                                                .addColumn(new Column("Materialized View", ScalarType.createVarchar(20)))
-                                                .addColumn(new Column("Create Materialized View", ScalarType.createVarchar(30)))
+                                                .addColumn(new Column("Materialized View", TypeFactory.createVarchar(20)))
+                                                .addColumn(new Column("Create Materialized View", TypeFactory.createVarchar(30)))
                                                 .build();
                                         return new ShowResultSet(showResultSetMetaData, rows);
                                     }
@@ -784,10 +784,10 @@ public class ShowExecutor {
                     rows.add(Lists.newArrayList(table.getName(), createTableStmt.get(0), "utf8", "utf8_general_ci"));
 
                     ShowResultSetMetaData showViewResultSetMeta = ShowResultSetMetaData.builder()
-                            .addColumn(new Column("View", ScalarType.createVarchar(20)))
-                            .addColumn(new Column("Create View", ScalarType.createVarchar(30)))
-                            .addColumn(new Column("character_set_client", ScalarType.createVarchar(30)))
-                            .addColumn(new Column("collation_connection", ScalarType.createVarchar(30)))
+                            .addColumn(new Column("View", TypeFactory.createVarchar(20)))
+                            .addColumn(new Column("Create View", TypeFactory.createVarchar(30)))
+                            .addColumn(new Column("character_set_client", TypeFactory.createVarchar(30)))
+                            .addColumn(new Column("collation_connection", TypeFactory.createVarchar(30)))
                             .build();
                     return new ShowResultSet(showViewResultSetMeta, rows);
                 } else if (table instanceof MaterializedView) {
@@ -799,17 +799,17 @@ public class ShowExecutor {
                         rows.add(Lists.newArrayList(table.getName(), sb, "utf8", "utf8_general_ci"));
 
                         ShowResultSetMetaData showViewResultSetMeta = ShowResultSetMetaData.builder()
-                                .addColumn(new Column("View", ScalarType.createVarchar(20)))
-                                .addColumn(new Column("Create View", ScalarType.createVarchar(30)))
-                                .addColumn(new Column("character_set_client", ScalarType.createVarchar(30)))
-                                .addColumn(new Column("collation_connection", ScalarType.createVarchar(30)))
+                                .addColumn(new Column("View", TypeFactory.createVarchar(20)))
+                                .addColumn(new Column("Create View", TypeFactory.createVarchar(30)))
+                                .addColumn(new Column("character_set_client", TypeFactory.createVarchar(30)))
+                                .addColumn(new Column("collation_connection", TypeFactory.createVarchar(30)))
                                 .build();
                         return new ShowResultSet(showViewResultSetMeta, rows);
                     } else {
                         rows.add(Lists.newArrayList(table.getName(), createTableStmt.get(0)));
                         ShowResultSetMetaData showResultSetMetaData = ShowResultSetMetaData.builder()
-                                .addColumn(new Column("Materialized View", ScalarType.createVarchar(20)))
-                                .addColumn(new Column("Create Materialized View", ScalarType.createVarchar(30)))
+                                .addColumn(new Column("Materialized View", TypeFactory.createVarchar(20)))
+                                .addColumn(new Column("Create Materialized View", TypeFactory.createVarchar(30)))
                                 .build();
                         return new ShowResultSet(showResultSetMetaData, rows);
                     }
@@ -846,8 +846,8 @@ public class ShowExecutor {
                 rows.add(Lists.newArrayList(tableName, createViewSql));
 
                 ShowResultSetMetaData showResultSetMetaData = ShowResultSetMetaData.builder()
-                        .addColumn(new Column("View", ScalarType.createVarchar(20)))
-                        .addColumn(new Column("Create View", ScalarType.createVarchar(30)))
+                        .addColumn(new Column("View", TypeFactory.createVarchar(20)))
+                        .addColumn(new Column("Create View", TypeFactory.createVarchar(30)))
                         .build();
                 return new ShowResultSet(showResultSetMetaData, rows);
             } else {
@@ -1059,7 +1059,7 @@ public class ShowExecutor {
             // Only success
             ShowResultSetMetaData showMetaData = statement.getIsVerbose() ? showResultMetaFactory.getMetadata(statement) :
                     ShowResultSetMetaData.builder()
-                            .addColumn(new Column("Function Name", ScalarType.createVarchar(256))).build();
+                            .addColumn(new Column("Function Name", TypeFactory.createVarchar(256))).build();
             return new ShowResultSet(showMetaData, resultRowSet);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultMetaFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultMetaFactory.java
@@ -128,6 +128,7 @@ import com.starrocks.sql.ast.warehouse.ShowNodesStmt;
 import com.starrocks.sql.ast.warehouse.ShowWarehousesStmt;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import java.util.List;
 
@@ -145,7 +146,7 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     public ShowResultSetMetaData visitShowLoadStatement(ShowLoadStmt statement, Void context) {
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
         for (String title : LoadProcDir.TITLE_NAMES) {
-            builder.addColumn(new Column(title, ScalarType.createVarchar(30)));
+            builder.addColumn(new Column(title, TypeFactory.createVarchar(30)));
         }
         return builder.build();
     }
@@ -153,17 +154,17 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     @Override
     public ShowResultSetMetaData visitShowAnalyzeJobStatement(ShowAnalyzeJobStmt statement, Void context) {
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder()
-                .addColumn(new Column("Id", ScalarType.createVarchar(60)))
-                .addColumn(new Column("Catalog", ScalarType.createVarchar(60)))
-                .addColumn(new Column("Database", ScalarType.createVarchar(60)))
-                .addColumn(new Column("Table", ScalarType.createVarchar(60)))
-                .addColumn(new Column("Columns", ScalarType.createVarchar(200)))
-                .addColumn(new Column("Type", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Schedule", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Properties", ScalarType.createVarchar(200)))
-                .addColumn(new Column("Status", ScalarType.createVarchar(20)))
-                .addColumn(new Column("LastWorkTime", ScalarType.createVarchar(60)))
-                .addColumn(new Column("Reason", ScalarType.createVarchar(100)));
+                .addColumn(new Column("Id", TypeFactory.createVarchar(60)))
+                .addColumn(new Column("Catalog", TypeFactory.createVarchar(60)))
+                .addColumn(new Column("Database", TypeFactory.createVarchar(60)))
+                .addColumn(new Column("Table", TypeFactory.createVarchar(60)))
+                .addColumn(new Column("Columns", TypeFactory.createVarchar(200)))
+                .addColumn(new Column("Type", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Schedule", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Properties", TypeFactory.createVarchar(200)))
+                .addColumn(new Column("Status", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("LastWorkTime", TypeFactory.createVarchar(60)))
+                .addColumn(new Column("Reason", TypeFactory.createVarchar(100)));
         return builder.build();
     }
 
@@ -171,7 +172,7 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     public ShowResultSetMetaData visitShowDeleteStatement(ShowDeleteStmt statement, Void context) {
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
         for (String title : DeleteInfoProcDir.TITLE_NAMES) {
-            builder.addColumn(new Column(title, ScalarType.createVarchar(30)));
+            builder.addColumn(new Column(title, TypeFactory.createVarchar(30)));
         }
         return builder.build();
     }
@@ -179,45 +180,45 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     @Override
     public ShowResultSetMetaData visitShowEnginesStatement(ShowEnginesStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Engine", ScalarType.createVarchar(64)))
-                .addColumn(new Column("Support", ScalarType.createVarchar(8)))
-                .addColumn(new Column("Comment", ScalarType.createVarchar(80)))
-                .addColumn(new Column("Transactions", ScalarType.createVarchar(3)))
-                .addColumn(new Column("XA", ScalarType.createVarchar(3)))
-                .addColumn(new Column("Savepoints", ScalarType.createVarchar(3)))
+                .addColumn(new Column("Engine", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("Support", TypeFactory.createVarchar(8)))
+                .addColumn(new Column("Comment", TypeFactory.createVarchar(80)))
+                .addColumn(new Column("Transactions", TypeFactory.createVarchar(3)))
+                .addColumn(new Column("XA", TypeFactory.createVarchar(3)))
+                .addColumn(new Column("Savepoints", TypeFactory.createVarchar(3)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowEventStatement(ShowEventsStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Db", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Name", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Definer", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Time", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Type", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Execute at", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Interval value", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Interval field", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Status", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Ends", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Status", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Originator", ScalarType.createVarchar(30)))
-                .addColumn(new Column("character_set_client", ScalarType.createVarchar(30)))
-                .addColumn(new Column("collation_connection", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Database Collation", ScalarType.createVarchar(30)))
+                .addColumn(new Column("Db", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Name", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Definer", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Time", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Type", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Execute at", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Interval value", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Interval field", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Status", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Ends", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Status", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Originator", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("character_set_client", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("collation_connection", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Database Collation", TypeFactory.createVarchar(30)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowHistogramStatsMetaStatement(ShowHistogramStatsMetaStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Database", ScalarType.createVarchar(60)))
-                .addColumn(new Column("Table", ScalarType.createVarchar(60)))
-                .addColumn(new Column("Column", ScalarType.createVarchar(60)))
-                .addColumn(new Column("Type", ScalarType.createVarchar(20)))
-                .addColumn(new Column("UpdateTime", ScalarType.createVarchar(60)))
-                .addColumn(new Column("Properties", ScalarType.createVarchar(200)))
+                .addColumn(new Column("Database", TypeFactory.createVarchar(60)))
+                .addColumn(new Column("Table", TypeFactory.createVarchar(60)))
+                .addColumn(new Column("Column", TypeFactory.createVarchar(60)))
+                .addColumn(new Column("Type", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("UpdateTime", TypeFactory.createVarchar(60)))
+                .addColumn(new Column("Properties", TypeFactory.createVarchar(200)))
                 .build();
     }
 
@@ -233,7 +234,7 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
         }
 
         for (String col : result.getColumnNames()) {
-            builder.addColumn(new Column(col, ScalarType.createVarchar(30)));
+            builder.addColumn(new Column(col, TypeFactory.createVarchar(30)));
         }
         return builder.build();
     }
@@ -241,34 +242,34 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     @Override
     public ShowResultSetMetaData visitShowCreateDbStatement(ShowCreateDbStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Database", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Create Database", ScalarType.createVarchar(30)))
+                .addColumn(new Column("Database", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Create Database", TypeFactory.createVarchar(30)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowBasicStatsMetaStatement(ShowBasicStatsMetaStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Database", ScalarType.createVarchar(60)))
-                .addColumn(new Column("Table", ScalarType.createVarchar(60)))
-                .addColumn(new Column("Columns", ScalarType.createVarchar(200)))
-                .addColumn(new Column("Type", ScalarType.createVarchar(20)))
-                .addColumn(new Column("UpdateTime", ScalarType.createVarchar(60)))
-                .addColumn(new Column("Properties", ScalarType.createVarchar(200)))
-                .addColumn(new Column("Healthy", ScalarType.createVarchar(5)))
-                .addColumn(new Column("ColumnStats", ScalarType.createVarcharType(128)))
-                .addColumn(new Column("TabletStatsReportTime", ScalarType.createVarcharType(60)))
-                .addColumn(new Column("TableHealthyMetrics", ScalarType.createVarcharType(128)))
-                .addColumn(new Column("TableUpdateTime", ScalarType.createVarcharType(60)))
+                .addColumn(new Column("Database", TypeFactory.createVarchar(60)))
+                .addColumn(new Column("Table", TypeFactory.createVarchar(60)))
+                .addColumn(new Column("Columns", TypeFactory.createVarchar(200)))
+                .addColumn(new Column("Type", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("UpdateTime", TypeFactory.createVarchar(60)))
+                .addColumn(new Column("Properties", TypeFactory.createVarchar(200)))
+                .addColumn(new Column("Healthy", TypeFactory.createVarchar(5)))
+                .addColumn(new Column("ColumnStats", TypeFactory.createVarcharType(128)))
+                .addColumn(new Column("TabletStatsReportTime", TypeFactory.createVarcharType(60)))
+                .addColumn(new Column("TableHealthyMetrics", TypeFactory.createVarcharType(128)))
+                .addColumn(new Column("TableUpdateTime", TypeFactory.createVarcharType(60)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowAuthorStatement(ShowAuthorStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Name", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Location", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Comment", ScalarType.createVarchar(30)))
+                .addColumn(new Column("Name", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Location", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Comment", TypeFactory.createVarchar(30)))
                 .build();
     }
 
@@ -276,7 +277,7 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     public ShowResultSetMetaData visitShowDictionaryStatement(ShowDictionaryStmt statement, Void context) {
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
         for (String title : ShowDictionaryStmt.TITLE_NAMES) {
-            builder.addColumn(new Column(title, ScalarType.createVarchar(30)));
+            builder.addColumn(new Column(title, TypeFactory.createVarchar(30)));
         }
         return builder.build();
     }
@@ -284,21 +285,21 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     @Override
     public ShowResultSetMetaData visitShowWhiteListStatement(ShowWhiteListStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("user_name", ScalarType.createVarchar(20)))
-                .addColumn(new Column("white_list", ScalarType.createVarchar(1000)))
+                .addColumn(new Column("user_name", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("white_list", TypeFactory.createVarchar(1000)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowSmallFilesStatement(ShowSmallFilesStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Id", ScalarType.createVarchar(32)))
-                .addColumn(new Column("DbName", ScalarType.createVarchar(256)))
-                .addColumn(new Column("GlobalStateMgr", ScalarType.createVarchar(32)))
-                .addColumn(new Column("FileName", ScalarType.createVarchar(16)))
-                .addColumn(new Column("FileSize", ScalarType.createVarchar(16)))
-                .addColumn(new Column("IsContent", ScalarType.createVarchar(16)))
-                .addColumn(new Column("MD5", ScalarType.createVarchar(16)))
+                .addColumn(new Column("Id", TypeFactory.createVarchar(32)))
+                .addColumn(new Column("DbName", TypeFactory.createVarchar(256)))
+                .addColumn(new Column("GlobalStateMgr", TypeFactory.createVarchar(32)))
+                .addColumn(new Column("FileName", TypeFactory.createVarchar(16)))
+                .addColumn(new Column("FileSize", TypeFactory.createVarchar(16)))
+                .addColumn(new Column("IsContent", TypeFactory.createVarchar(16)))
+                .addColumn(new Column("MD5", TypeFactory.createVarchar(16)))
                 .build();
     }
 
@@ -306,7 +307,7 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     public ShowResultSetMetaData visitShowRoutineLoadTaskStatement(ShowRoutineLoadTaskStmt statement, Void context) {
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
         for (String title : ShowRoutineLoadTaskStmt.TITLE_NAMES) {
-            builder.addColumn(new Column(title, ScalarType.createVarchar(30)));
+            builder.addColumn(new Column(title, TypeFactory.createVarchar(30)));
         }
         return builder.build();
     }
@@ -316,11 +317,11 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
         if (!Strings.isNullOrEmpty(statement.getSnapshotName()) && !Strings.isNullOrEmpty(statement.getTimestamp())) {
             for (String title : ShowSnapshotStmt.SNAPSHOT_DETAIL) {
-                builder.addColumn(new Column(title, ScalarType.createVarchar(30)));
+                builder.addColumn(new Column(title, TypeFactory.createVarchar(30)));
             }
         } else {
             for (String title : ShowSnapshotStmt.SNAPSHOT_ALL) {
-                builder.addColumn(new Column(title, ScalarType.createVarchar(30)));
+                builder.addColumn(new Column(title, TypeFactory.createVarchar(30)));
             }
         }
         return builder.build();
@@ -329,68 +330,68 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     @Override
     public ShowResultSetMetaData visitShowAuthenticationStatement(ShowAuthenticationStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("UserIdentity", ScalarType.createVarchar(100)))
-                .addColumn(new Column("Password", ScalarType.createVarchar(20)))
-                .addColumn(new Column("AuthPlugin", ScalarType.createVarchar(100)))
-                .addColumn(new Column("UserForAuthPlugin", ScalarType.createVarchar(100)))
+                .addColumn(new Column("UserIdentity", TypeFactory.createVarchar(100)))
+                .addColumn(new Column("Password", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("AuthPlugin", TypeFactory.createVarchar(100)))
+                .addColumn(new Column("UserForAuthPlugin", TypeFactory.createVarchar(100)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowProfilelistStatement(ShowProfilelistStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("QueryId", ScalarType.createVarchar(48)))
-                .addColumn(new Column("StartTime", ScalarType.createVarchar(16)))
-                .addColumn(new Column("Time", ScalarType.createVarchar(16)))
-                .addColumn(new Column("State", ScalarType.createVarchar(16)))
-                .addColumn(new Column("Statement", ScalarType.createVarchar(128)))
+                .addColumn(new Column("QueryId", TypeFactory.createVarchar(48)))
+                .addColumn(new Column("StartTime", TypeFactory.createVarchar(16)))
+                .addColumn(new Column("Time", TypeFactory.createVarchar(16)))
+                .addColumn(new Column("State", TypeFactory.createVarchar(16)))
+                .addColumn(new Column("Statement", TypeFactory.createVarchar(128)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowSqlBlackListStatement(ShowSqlBlackListStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Id", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Forbidden SQL", ScalarType.createVarchar(100)))
+                .addColumn(new Column("Id", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Forbidden SQL", TypeFactory.createVarchar(100)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitAdminShowReplicaStatusStatement(AdminShowReplicaStatusStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("TabletId", ScalarType.createVarchar(30)))
-                .addColumn(new Column("ReplicaId", ScalarType.createVarchar(30)))
-                .addColumn(new Column("BackendId", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Version", ScalarType.createVarchar(30)))
-                .addColumn(new Column("LastFailedVersion", ScalarType.createVarchar(30)))
-                .addColumn(new Column("LastSuccessVersion", ScalarType.createVarchar(30)))
-                .addColumn(new Column("CommittedVersion", ScalarType.createVarchar(30)))
-                .addColumn(new Column("SchemaHash", ScalarType.createVarchar(30)))
-                .addColumn(new Column("VersionNum", ScalarType.createVarchar(30)))
-                .addColumn(new Column("IsBad", ScalarType.createVarchar(30)))
-                .addColumn(new Column("IsSetBadForce", ScalarType.createVarchar(30)))
-                .addColumn(new Column("State", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Status", ScalarType.createVarchar(30)))
+                .addColumn(new Column("TabletId", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("ReplicaId", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("BackendId", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Version", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("LastFailedVersion", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("LastSuccessVersion", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("CommittedVersion", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("SchemaHash", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("VersionNum", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("IsBad", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("IsSetBadForce", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("State", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Status", TypeFactory.createVarchar(30)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitHelpStatement(HelpStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("name", ScalarType.createVarchar(64)))
-                .addColumn(new Column("description", ScalarType.createVarchar(1000)))
-                .addColumn(new Column("example", ScalarType.createVarchar(1000)))
+                .addColumn(new Column("name", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("description", TypeFactory.createVarchar(1000)))
+                .addColumn(new Column("example", TypeFactory.createVarchar(1000)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowBackendBlackListStatement(ShowBackendBlackListStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("BackendId", ScalarType.createVarchar(20)))
-                .addColumn(new Column("AddBlackListType", ScalarType.createVarchar(20)))
-                .addColumn(new Column("LostConnectionTime", ScalarType.createVarchar(20)))
-                .addColumn(new Column("LostConnectionNumberInPeriod", ScalarType.createVarchar(10)))
-                .addColumn(new Column("CheckTimePeriod(s)", ScalarType.createVarchar(10)))
+                .addColumn(new Column("BackendId", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("AddBlackListType", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("LostConnectionTime", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("LostConnectionNumberInPeriod", TypeFactory.createVarchar(10)))
+                .addColumn(new Column("CheckTimePeriod(s)", TypeFactory.createVarchar(10)))
                 .build();
     }
 
@@ -398,9 +399,9 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     public ShowResultSetMetaData visitShowTableStatement(ShowTableStmt statement, Void context) {
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
         builder.addColumn(
-                new Column("Tables_in_" + statement.getDb(), ScalarType.createVarchar(20)));
+                new Column("Tables_in_" + statement.getDb(), TypeFactory.createVarchar(20)));
         if (statement.isVerbose()) {
-            builder.addColumn(new Column("Table_type", ScalarType.createVarchar(20)));
+            builder.addColumn(new Column("Table_type", TypeFactory.createVarchar(20)));
         }
         return builder.build();
     }
@@ -413,11 +414,11 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     @Override
     public ShowResultSetMetaData visitShowComputeNodeBlackListStatement(ShowComputeNodeBlackListStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("ComputeNodeId", ScalarType.createVarchar(20)))
-                .addColumn(new Column("AddBlackListType", ScalarType.createVarchar(20)))
-                .addColumn(new Column("LostConnectionTime", ScalarType.createVarchar(20)))
-                .addColumn(new Column("LostConnectionNumberInPeriod", ScalarType.createVarchar(10)))
-                .addColumn(new Column("CheckTimePeriod(s)", ScalarType.createVarchar(10)))
+                .addColumn(new Column("ComputeNodeId", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("AddBlackListType", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("LostConnectionTime", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("LostConnectionNumberInPeriod", TypeFactory.createVarchar(10)))
+                .addColumn(new Column("CheckTimePeriod(s)", TypeFactory.createVarchar(10)))
                 .build();
     }
 
@@ -425,7 +426,7 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     public ShowResultSetMetaData visitShowFrontendsStatement(ShowFrontendsStmt statement, Void context) {
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
         for (String title : FrontendsProcNode.TITLE_NAMES) {
-            builder.addColumn(new Column(title, ScalarType.createVarchar(30)));
+            builder.addColumn(new Column(title, TypeFactory.createVarchar(30)));
         }
         return builder.build();
     }
@@ -433,9 +434,9 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     @Override
     public ShowResultSetMetaData visitShowLoadWarningsStatement(ShowLoadWarningsStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("JobId", ScalarType.createVarchar(15)))
-                .addColumn(new Column("Label", ScalarType.createVarchar(15)))
-                .addColumn(new Column("ErrorMsgDetail", ScalarType.createVarchar(100)))
+                .addColumn(new Column("JobId", TypeFactory.createVarchar(15)))
+                .addColumn(new Column("Label", TypeFactory.createVarchar(15)))
+                .addColumn(new Column("ErrorMsgDetail", TypeFactory.createVarchar(100)))
                 .build();
     }
 
@@ -443,7 +444,7 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     public ShowResultSetMetaData visitShowBackendsStatement(ShowBackendsStmt statement, Void context) {
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
         for (String title : BackendsProcDir.getMetadata()) {
-            builder.addColumn(new Column(title, ScalarType.createVarchar(30)));
+            builder.addColumn(new Column(title, TypeFactory.createVarchar(30)));
         }
         return builder.build();
     }
@@ -451,21 +452,21 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     @Override
     public ShowResultSetMetaData visitShowDataCacheRulesStatement(ShowDataCacheRulesStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Rule Id", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Catalog", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Database", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Table", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Priority", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Predicates", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Properties", ScalarType.createVarchar(30)))
+                .addColumn(new Column("Rule Id", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Catalog", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Database", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Table", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Priority", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Predicates", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Properties", TypeFactory.createVarchar(30)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowCreateTableStatement(ShowCreateTableStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Table", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Create Table", ScalarType.createVarchar(30)))
+                .addColumn(new Column("Table", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Create Table", TypeFactory.createVarchar(30)))
                 .build();
     }
 
@@ -473,7 +474,7 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     public ShowResultSetMetaData visitShowRepositoriesStatement(ShowRepositoriesStmt statement, Void context) {
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
         for (String title : ShowRepositoriesStmt.TITLE_NAMES) {
-            builder.addColumn(new Column(title, ScalarType.createVarchar(30)));
+            builder.addColumn(new Column(title, TypeFactory.createVarchar(30)));
         }
         return builder.build();
     }
@@ -482,7 +483,7 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     public ShowResultSetMetaData visitShowExportStatement(ShowExportStmt statement, Void context) {
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
         for (String title : ExportProcNode.TITLE_NAMES) {
-            builder.addColumn(new Column(title, ScalarType.createVarchar(30)));
+            builder.addColumn(new Column(title, TypeFactory.createVarchar(30)));
         }
         return builder.build();
     }
@@ -491,24 +492,24 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     public ShowResultSetMetaData visitShowColumnStatement(ShowColumnStmt statement, Void context) {
         if (statement.isVerbose()) {
             return ShowResultSetMetaData.builder()
-                    .addColumn(new Column("Field", ScalarType.createVarchar(20)))
-                    .addColumn(new Column("Type", ScalarType.createVarchar(20)))
-                    .addColumn(new Column("Collation", ScalarType.createVarchar(20)))
-                    .addColumn(new Column("Null", ScalarType.createVarchar(20)))
-                    .addColumn(new Column("Key", ScalarType.createVarchar(20)))
-                    .addColumn(new Column("Default", ScalarType.createVarchar(20)))
-                    .addColumn(new Column("Extra", ScalarType.createVarchar(20)))
-                    .addColumn(new Column("Privileges", ScalarType.createVarchar(80)))
-                    .addColumn(new Column("Comment", ScalarType.createVarchar(20)))
+                    .addColumn(new Column("Field", TypeFactory.createVarchar(20)))
+                    .addColumn(new Column("Type", TypeFactory.createVarchar(20)))
+                    .addColumn(new Column("Collation", TypeFactory.createVarchar(20)))
+                    .addColumn(new Column("Null", TypeFactory.createVarchar(20)))
+                    .addColumn(new Column("Key", TypeFactory.createVarchar(20)))
+                    .addColumn(new Column("Default", TypeFactory.createVarchar(20)))
+                    .addColumn(new Column("Extra", TypeFactory.createVarchar(20)))
+                    .addColumn(new Column("Privileges", TypeFactory.createVarchar(80)))
+                    .addColumn(new Column("Comment", TypeFactory.createVarchar(20)))
                     .build();
         } else {
             return ShowResultSetMetaData.builder()
-                    .addColumn(new Column("Field", ScalarType.createVarchar(20)))
-                    .addColumn(new Column("Type", ScalarType.createVarchar(20)))
-                    .addColumn(new Column("Null", ScalarType.createVarchar(20)))
-                    .addColumn(new Column("Key", ScalarType.createVarchar(20)))
-                    .addColumn(new Column("Default", ScalarType.createVarchar(20)))
-                    .addColumn(new Column("Extra", ScalarType.createVarchar(20)))
+                    .addColumn(new Column("Field", TypeFactory.createVarchar(20)))
+                    .addColumn(new Column("Type", TypeFactory.createVarchar(20)))
+                    .addColumn(new Column("Null", TypeFactory.createVarchar(20)))
+                    .addColumn(new Column("Key", TypeFactory.createVarchar(20)))
+                    .addColumn(new Column("Default", TypeFactory.createVarchar(20)))
+                    .addColumn(new Column("Extra", TypeFactory.createVarchar(20)))
                     .build();
         }
     }
@@ -516,55 +517,55 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     @Override
     public ShowResultSetMetaData visitShowDynamicPartitionStatement(ShowDynamicPartitionStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("TableName", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Enable", ScalarType.createVarchar(20)))
-                .addColumn(new Column("TimeUnit", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Start", ScalarType.createVarchar(20)))
-                .addColumn(new Column("End", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Prefix", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Buckets", ScalarType.createVarchar(20)))
-                .addColumn(new Column("ReplicationNum", ScalarType.createVarchar(20)))
-                .addColumn(new Column("StartOf", ScalarType.createVarchar(20)))
-                .addColumn(new Column("LastUpdateTime", ScalarType.createVarchar(20)))
-                .addColumn(new Column("LastSchedulerTime", ScalarType.createVarchar(20)))
-                .addColumn(new Column("State", ScalarType.createVarchar(20)))
-                .addColumn(new Column("LastCreatePartitionMsg", ScalarType.createVarchar(20)))
-                .addColumn(new Column("LastDropPartitionMsg", ScalarType.createVarchar(20)))
-                .addColumn(new Column("InScheduler", ScalarType.createVarchar(20)))
+                .addColumn(new Column("TableName", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Enable", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("TimeUnit", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Start", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("End", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Prefix", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Buckets", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("ReplicationNum", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("StartOf", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("LastUpdateTime", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("LastSchedulerTime", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("State", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("LastCreatePartitionMsg", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("LastDropPartitionMsg", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("InScheduler", TypeFactory.createVarchar(20)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowAnalyzeStatusStatement(ShowAnalyzeStatusStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Id", ScalarType.createVarchar(60)))
-                .addColumn(new Column("Database", ScalarType.createVarchar(60)))
-                .addColumn(new Column("Table", ScalarType.createVarchar(60)))
-                .addColumn(new Column("Columns", ScalarType.createVarchar(200)))
-                .addColumn(new Column("Type", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Schedule", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Status", ScalarType.createVarchar(20)))
-                .addColumn(new Column("StartTime", ScalarType.createVarchar(60)))
-                .addColumn(new Column("EndTime", ScalarType.createVarchar(60)))
-                .addColumn(new Column("Properties", ScalarType.createVarchar(200)))
-                .addColumn(new Column("Reason", ScalarType.createVarchar(100)))
+                .addColumn(new Column("Id", TypeFactory.createVarchar(60)))
+                .addColumn(new Column("Database", TypeFactory.createVarchar(60)))
+                .addColumn(new Column("Table", TypeFactory.createVarchar(60)))
+                .addColumn(new Column("Columns", TypeFactory.createVarchar(200)))
+                .addColumn(new Column("Type", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Schedule", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Status", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("StartTime", TypeFactory.createVarchar(60)))
+                .addColumn(new Column("EndTime", TypeFactory.createVarchar(60)))
+                .addColumn(new Column("Properties", TypeFactory.createVarchar(200)))
+                .addColumn(new Column("Reason", TypeFactory.createVarchar(100)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowProcedureStatement(ShowProcedureStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Db", ScalarType.createVarchar(64)))
-                .addColumn(new Column("Name", ScalarType.createVarchar(10)))
-                .addColumn(new Column("Type", ScalarType.createVarchar(80)))
-                .addColumn(new Column("Definer", ScalarType.createVarchar(64)))
-                .addColumn(new Column("Modified", ScalarType.createVarchar(80)))
-                .addColumn(new Column("Created", ScalarType.createVarchar(80)))
-                .addColumn(new Column("Security_type", ScalarType.createVarchar(80)))
-                .addColumn(new Column("Comment", ScalarType.createVarchar(80)))
-                .addColumn(new Column("character_set_client", ScalarType.createVarchar(80)))
-                .addColumn(new Column("collation_connection", ScalarType.createVarchar(80)))
-                .addColumn(new Column("Database Collation", ScalarType.createVarchar(80)))
+                .addColumn(new Column("Db", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("Name", TypeFactory.createVarchar(10)))
+                .addColumn(new Column("Type", TypeFactory.createVarchar(80)))
+                .addColumn(new Column("Definer", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("Modified", TypeFactory.createVarchar(80)))
+                .addColumn(new Column("Created", TypeFactory.createVarchar(80)))
+                .addColumn(new Column("Security_type", TypeFactory.createVarchar(80)))
+                .addColumn(new Column("Comment", TypeFactory.createVarchar(80)))
+                .addColumn(new Column("character_set_client", TypeFactory.createVarchar(80)))
+                .addColumn(new Column("collation_connection", TypeFactory.createVarchar(80)))
+                .addColumn(new Column("Database Collation", TypeFactory.createVarchar(80)))
                 .build();
     }
 
@@ -572,7 +573,7 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     public ShowResultSetMetaData visitShowResourceStatement(ShowResourcesStmt statement, Void context) {
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
         for (String title : ResourceMgr.RESOURCE_PROC_NODE_TITLE_NAMES) {
-            builder.addColumn(new Column(title, ScalarType.createVarchar(30)));
+            builder.addColumn(new Column(title, TypeFactory.createVarchar(30)));
         }
         return builder.build();
     }
@@ -581,15 +582,15 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     public ShowResultSetMetaData visitShowVariablesStatement(ShowVariablesStmt statement, Void context) {
         if (statement.getType() != SetType.VERBOSE) {
             return ShowResultSetMetaData.builder()
-                    .addColumn(new Column("Variable_name", ScalarType.createVarchar(20)))
-                    .addColumn(new Column("Value", ScalarType.createVarchar(20)))
+                    .addColumn(new Column("Variable_name", TypeFactory.createVarchar(20)))
+                    .addColumn(new Column("Value", TypeFactory.createVarchar(20)))
                     .build();
         } else {
             return ShowResultSetMetaData.builder()
-                    .addColumn(new Column("Variable_name", ScalarType.createVarchar(20)))
-                    .addColumn(new Column("Value", ScalarType.createVarchar(20)))
-                    .addColumn(new Column("Default_value", ScalarType.createVarchar(20)))
-                    .addColumn(new Column("Is_changed", ScalarType.createType(PrimitiveType.BOOLEAN)))
+                    .addColumn(new Column("Variable_name", TypeFactory.createVarchar(20)))
+                    .addColumn(new Column("Value", TypeFactory.createVarchar(20)))
+                    .addColumn(new Column("Default_value", TypeFactory.createVarchar(20)))
+                    .addColumn(new Column("Is_changed", TypeFactory.createType(PrimitiveType.BOOLEAN)))
                     .build();
         }
     }
@@ -597,10 +598,10 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     @Override
     public ShowResultSetMetaData visitShowCharsetStatement(ShowCharsetStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Charset", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Description", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Default collation", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Maxlen", ScalarType.createVarchar(20)))
+                .addColumn(new Column("Charset", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Description", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Default collation", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Maxlen", TypeFactory.createVarchar(20)))
                 .build();
     }
 
@@ -609,25 +610,25 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
         return ShowResultSetMetaData.builder()
                 .addColumn(new Column("DATABASE_ID", ScalarType.BIGINT))
                 .addColumn(new Column("ID", ScalarType.BIGINT))
-                .addColumn(new Column("NAME", ScalarType.createVarchar(64)))
-                .addColumn(new Column("TYPE", ScalarType.createVarchar(8)))
-                .addColumn(new Column("TABLE_NAME", ScalarType.createVarchar(64)))
-                .addColumn(new Column("SOURCE", ScalarType.createVarcharType(128)))
-                .addColumn(new Column("SQL", ScalarType.createVarcharType(128)))
-                .addColumn(new Column("PROPERTIES", ScalarType.createVarchar(512)))
+                .addColumn(new Column("NAME", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("TYPE", TypeFactory.createVarchar(8)))
+                .addColumn(new Column("TABLE_NAME", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("SOURCE", TypeFactory.createVarcharType(128)))
+                .addColumn(new Column("SQL", TypeFactory.createVarcharType(128)))
+                .addColumn(new Column("PROPERTIES", TypeFactory.createVarchar(512)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowPipeStatement(ShowPipeStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("DATABASE_NAME", ScalarType.createVarchar(64)))
+                .addColumn(new Column("DATABASE_NAME", TypeFactory.createVarchar(64)))
                 .addColumn(new Column("PIPE_ID", ScalarType.BIGINT))
-                .addColumn(new Column("PIPE_NAME", ScalarType.createVarchar(64)))
-                .addColumn(new Column("STATE", ScalarType.createVarcharType(8)))
-                .addColumn(new Column("TABLE_NAME", ScalarType.createVarchar(64)))
-                .addColumn(new Column("LOAD_STATUS", ScalarType.createVarchar(512)))
-                .addColumn(new Column("LAST_ERROR", ScalarType.createVarchar(1024)))
+                .addColumn(new Column("PIPE_NAME", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("STATE", TypeFactory.createVarcharType(8)))
+                .addColumn(new Column("TABLE_NAME", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("LOAD_STATUS", TypeFactory.createVarchar(512)))
+                .addColumn(new Column("LAST_ERROR", TypeFactory.createVarchar(1024)))
                 .addColumn(new Column("CREATED_TIME", ScalarType.DATETIME))
                 .build();
     }
@@ -635,9 +636,9 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     @Override
     public ShowResultSetMetaData visitShowWarningStatement(ShowWarningStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Level", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Code", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Message", ScalarType.createVarchar(20)))
+                .addColumn(new Column("Level", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Code", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Message", TypeFactory.createVarchar(20)))
                 .build();
     }
 
@@ -645,17 +646,17 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     public ShowResultSetMetaData visitShowDataStatement(ShowDataStmt statement, Void context) {
         if (statement.getTableName() != null) {
             return ShowResultSetMetaData.builder()
-                    .addColumn(new Column("TableName", ScalarType.createVarchar(20)))
-                    .addColumn(new Column("IndexName", ScalarType.createVarchar(20)))
-                    .addColumn(new Column("Size", ScalarType.createVarchar(30)))
-                    .addColumn(new Column("ReplicaCount", ScalarType.createVarchar(20)))
-                    .addColumn(new Column("RowCount", ScalarType.createVarchar(20)))
+                    .addColumn(new Column("TableName", TypeFactory.createVarchar(20)))
+                    .addColumn(new Column("IndexName", TypeFactory.createVarchar(20)))
+                    .addColumn(new Column("Size", TypeFactory.createVarchar(30)))
+                    .addColumn(new Column("ReplicaCount", TypeFactory.createVarchar(20)))
+                    .addColumn(new Column("RowCount", TypeFactory.createVarchar(20)))
                     .build();
         } else {
             return ShowResultSetMetaData.builder()
-                    .addColumn(new Column("TableName", ScalarType.createVarchar(20)))
-                    .addColumn(new Column("Size", ScalarType.createVarchar(30)))
-                    .addColumn(new Column("ReplicaCount", ScalarType.createVarchar(20)))
+                    .addColumn(new Column("TableName", TypeFactory.createVarchar(20)))
+                    .addColumn(new Column("Size", TypeFactory.createVarchar(30)))
+                    .addColumn(new Column("ReplicaCount", TypeFactory.createVarchar(20)))
                     .build();
         }
     }
@@ -663,39 +664,39 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     @Override
     public ShowResultSetMetaData visitShowResourceGroupUsageStatement(ShowResourceGroupUsageStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Name", ScalarType.createVarchar(64)))
-                .addColumn(new Column("Id", ScalarType.createVarchar(64)))
-                .addColumn(new Column("Backend", ScalarType.createVarchar(64)))
-                .addColumn(new Column("BEInUseCpuCores", ScalarType.createVarchar(64)))
-                .addColumn(new Column("BEInUseMemBytes", ScalarType.createVarchar(64)))
-                .addColumn(new Column("BERunningQueries", ScalarType.createVarchar(64)))
+                .addColumn(new Column("Name", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("Id", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("Backend", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("BEInUseCpuCores", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("BEInUseMemBytes", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("BERunningQueries", TypeFactory.createVarchar(64)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowUserStatement(ShowUserStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("User", ScalarType.createVarchar(50)))
+                .addColumn(new Column("User", TypeFactory.createVarchar(50)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowWarehousesStatement(ShowWarehousesStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Id", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Name", ScalarType.createVarchar(256)))
-                .addColumn(new Column("State", ScalarType.createVarchar(20)))
-                .addColumn(new Column("NodeCount", ScalarType.createVarchar(20)))
-                .addColumn(new Column("CurrentClusterCount", ScalarType.createVarchar(20)))
-                .addColumn(new Column("MaxClusterCount", ScalarType.createVarchar(20)))
-                .addColumn(new Column("StartedClusters", ScalarType.createVarchar(20)))
-                .addColumn(new Column("RunningSql", ScalarType.createVarchar(20)))
-                .addColumn(new Column("QueuedSql", ScalarType.createVarchar(20)))
-                .addColumn(new Column("CreatedOn", ScalarType.createVarchar(20)))
-                .addColumn(new Column("ResumedOn", ScalarType.createVarchar(20)))
-                .addColumn(new Column("UpdatedOn", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Property", ScalarType.createVarchar(256)))
-                .addColumn(new Column("Comment", ScalarType.createVarchar(256)))
+                .addColumn(new Column("Id", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Name", TypeFactory.createVarchar(256)))
+                .addColumn(new Column("State", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("NodeCount", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("CurrentClusterCount", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("MaxClusterCount", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("StartedClusters", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("RunningSql", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("QueuedSql", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("CreatedOn", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("ResumedOn", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("UpdatedOn", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Property", TypeFactory.createVarchar(256)))
+                .addColumn(new Column("Comment", TypeFactory.createVarchar(256)))
                 .build();
     }
 
@@ -703,7 +704,7 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     public ShowResultSetMetaData visitShowBrokerStatement(ShowBrokerStmt statement, Void context) {
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
         for (String title : BrokerProcNode.BROKER_PROC_NODE_TITLE_NAMES) {
-            builder.addColumn(new Column(title, ScalarType.createVarchar(30)));
+            builder.addColumn(new Column(title, TypeFactory.createVarchar(30)));
         }
         return builder.build();
     }
@@ -711,100 +712,100 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     @Override
     public ShowResultSetMetaData visitShowRunningQueriesStatement(ShowRunningQueriesStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("QueryId", ScalarType.createVarchar(64)))
-                .addColumn(new Column("WarehouseId", ScalarType.createVarchar(64)))
-                .addColumn(new Column("ResourceGroupId", ScalarType.createVarchar(64)))
-                .addColumn(new Column("StartTime", ScalarType.createVarchar(64)))
-                .addColumn(new Column("PendingTimeout", ScalarType.createVarchar(64)))
-                .addColumn(new Column("QueryTimeout", ScalarType.createVarchar(64)))
-                .addColumn(new Column("State", ScalarType.createVarchar(64)))
-                .addColumn(new Column("Slots", ScalarType.createVarchar(64)))
-                .addColumn(new Column("Fragments", ScalarType.createVarchar(64)))
-                .addColumn(new Column("DOP", ScalarType.createVarchar(64)))
-                .addColumn(new Column("Frontend", ScalarType.createVarchar(64)))
-                .addColumn(new Column("FeStartTime", ScalarType.createVarchar(64)))
+                .addColumn(new Column("QueryId", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("WarehouseId", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("ResourceGroupId", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("StartTime", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("PendingTimeout", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("QueryTimeout", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("State", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("Slots", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("Fragments", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("DOP", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("Frontend", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("FeStartTime", TypeFactory.createVarchar(64)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowCreateRoutineLoadStatement(ShowCreateRoutineLoadStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Job", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Create Job", ScalarType.createVarchar(30)))
+                .addColumn(new Column("Job", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Create Job", TypeFactory.createVarchar(30)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitAdminShowConfigStatement(AdminShowConfigStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Key", ScalarType.createVarchar(30)))
-                .addColumn(new Column("AliasNames", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Value", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Type", ScalarType.createVarchar(30)))
-                .addColumn(new Column("IsMutable", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Comment", ScalarType.createVarchar(30)))
+                .addColumn(new Column("Key", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("AliasNames", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Value", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Type", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("IsMutable", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Comment", TypeFactory.createVarchar(30)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowPluginsStatement(ShowPluginsStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Name", ScalarType.createVarchar(64)))
-                .addColumn(new Column("Type", ScalarType.createVarchar(10)))
-                .addColumn(new Column("Description", ScalarType.createVarchar(200)))
-                .addColumn(new Column("Version", ScalarType.createVarchar(20)))
-                .addColumn(new Column("JavaVersion", ScalarType.createVarchar(20)))
-                .addColumn(new Column("ClassName", ScalarType.createVarchar(64)))
-                .addColumn(new Column("SoName", ScalarType.createVarchar(64)))
-                .addColumn(new Column("Sources", ScalarType.createVarchar(200)))
-                .addColumn(new Column("Status", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Properties", ScalarType.createVarchar(250)))
+                .addColumn(new Column("Name", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("Type", TypeFactory.createVarchar(10)))
+                .addColumn(new Column("Description", TypeFactory.createVarchar(200)))
+                .addColumn(new Column("Version", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("JavaVersion", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("ClassName", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("SoName", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("Sources", TypeFactory.createVarchar(200)))
+                .addColumn(new Column("Status", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Properties", TypeFactory.createVarchar(250)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitDescStorageVolumeStatement(DescStorageVolumeStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Name", ScalarType.createVarchar(256)))
-                .addColumn(new Column("Type", ScalarType.createVarchar(20)))
-                .addColumn(new Column("IsDefault", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Location", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Params", ScalarType.createVarchar(256)))
-                .addColumn(new Column("Enabled", ScalarType.createVarchar(256)))
-                .addColumn(new Column("Comment", ScalarType.createVarchar(20)))
+                .addColumn(new Column("Name", TypeFactory.createVarchar(256)))
+                .addColumn(new Column("Type", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("IsDefault", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Location", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Params", TypeFactory.createVarchar(256)))
+                .addColumn(new Column("Enabled", TypeFactory.createVarchar(256)))
+                .addColumn(new Column("Comment", TypeFactory.createVarchar(20)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowMaterializedViewStatement(ShowMaterializedViewsStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .column("id", ScalarType.createType(PrimitiveType.BIGINT))
-                .column("database_name", ScalarType.createVarchar(20))
-                .column("name", ScalarType.createVarchar(50))
-                .column("refresh_type", ScalarType.createVarchar(10))
-                .column("is_active", ScalarType.createVarchar(10))
-                .column("inactive_reason", ScalarType.createVarcharType(64))
-                .column("partition_type", ScalarType.createVarchar(16))
-                .column("task_id", ScalarType.createType(PrimitiveType.BIGINT))
-                .column("task_name", ScalarType.createVarchar(50))
-                .column("last_refresh_start_time", ScalarType.createType(PrimitiveType.DATETIME))
-                .column("last_refresh_finished_time", ScalarType.createType(PrimitiveType.DATETIME))
-                .column("last_refresh_duration", ScalarType.createType(PrimitiveType.DOUBLE))
-                .column("last_refresh_state", ScalarType.createVarchar(20))
-                .column("last_refresh_force_refresh", ScalarType.createVarchar(8))
-                .column("last_refresh_start_partition", ScalarType.createVarchar(1024))
-                .column("last_refresh_end_partition", ScalarType.createVarchar(1024))
-                .column("last_refresh_base_refresh_partitions", ScalarType.createVarchar(1024))
-                .column("last_refresh_mv_refresh_partitions", ScalarType.createVarchar(1024))
-                .column("last_refresh_error_code", ScalarType.createVarchar(20))
-                .column("last_refresh_error_message", ScalarType.createVarchar(1024))
-                .column("rows", ScalarType.createType(PrimitiveType.BIGINT))
-                .column("text", ScalarType.createVarchar(1024))
-                .column("extra_message", ScalarType.createVarchar(1024))
-                .column("query_rewrite_status", ScalarType.createVarchar(64))
-                .column("creator", ScalarType.createVarchar(64))
-                .column("last_refresh_process_time", ScalarType.createType(PrimitiveType.DATETIME))
-                .column("last_refresh_job_id", ScalarType.createVarchar(64))
+                .column("id", TypeFactory.createType(PrimitiveType.BIGINT))
+                .column("database_name", TypeFactory.createVarchar(20))
+                .column("name", TypeFactory.createVarchar(50))
+                .column("refresh_type", TypeFactory.createVarchar(10))
+                .column("is_active", TypeFactory.createVarchar(10))
+                .column("inactive_reason", TypeFactory.createVarcharType(64))
+                .column("partition_type", TypeFactory.createVarchar(16))
+                .column("task_id", TypeFactory.createType(PrimitiveType.BIGINT))
+                .column("task_name", TypeFactory.createVarchar(50))
+                .column("last_refresh_start_time", TypeFactory.createType(PrimitiveType.DATETIME))
+                .column("last_refresh_finished_time", TypeFactory.createType(PrimitiveType.DATETIME))
+                .column("last_refresh_duration", TypeFactory.createType(PrimitiveType.DOUBLE))
+                .column("last_refresh_state", TypeFactory.createVarchar(20))
+                .column("last_refresh_force_refresh", TypeFactory.createVarchar(8))
+                .column("last_refresh_start_partition", TypeFactory.createVarchar(1024))
+                .column("last_refresh_end_partition", TypeFactory.createVarchar(1024))
+                .column("last_refresh_base_refresh_partitions", TypeFactory.createVarchar(1024))
+                .column("last_refresh_mv_refresh_partitions", TypeFactory.createVarchar(1024))
+                .column("last_refresh_error_code", TypeFactory.createVarchar(20))
+                .column("last_refresh_error_message", TypeFactory.createVarchar(1024))
+                .column("rows", TypeFactory.createType(PrimitiveType.BIGINT))
+                .column("text", TypeFactory.createVarchar(1024))
+                .column("extra_message", TypeFactory.createVarchar(1024))
+                .column("query_rewrite_status", TypeFactory.createVarchar(64))
+                .column("creator", TypeFactory.createVarchar(64))
+                .column("last_refresh_process_time", TypeFactory.createType(PrimitiveType.DATETIME))
+                .column("last_refresh_job_id", TypeFactory.createVarchar(64))
                 .build();
     }
 
@@ -814,7 +815,7 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
         try {
             ProcResult result = statement.getNode().fetchResult();
             for (String col : result.getColumnNames()) {
-                builder.addColumn(new Column(col, ScalarType.createVarchar(30)));
+                builder.addColumn(new Column(col, TypeFactory.createVarchar(30)));
             }
         } catch (AnalysisException e) {
             // Return empty builder if fetch fails
@@ -825,31 +826,31 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     @Override
     public ShowResultSetMetaData visitShowDatabasesStatement(ShowDbStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Database", ScalarType.createVarchar(64)))
+                .addColumn(new Column("Database", TypeFactory.createVarchar(64)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowTableStatusStatement(ShowTableStatusStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Name", ScalarType.createVarchar(64)))
-                .addColumn(new Column("Engine", ScalarType.createVarchar(10)))
-                .addColumn(new Column("Version", ScalarType.createType(PrimitiveType.BIGINT)))
-                .addColumn(new Column("Row_format", ScalarType.createVarchar(64)))
-                .addColumn(new Column("Rows", ScalarType.createType(PrimitiveType.BIGINT)))
-                .addColumn(new Column("Avg_row_length", ScalarType.createType(PrimitiveType.BIGINT)))
-                .addColumn(new Column("Data_length", ScalarType.createType(PrimitiveType.BIGINT)))
-                .addColumn(new Column("Max_data_length", ScalarType.createType(PrimitiveType.BIGINT)))
-                .addColumn(new Column("Index_length", ScalarType.createType(PrimitiveType.BIGINT)))
-                .addColumn(new Column("Data_free", ScalarType.createType(PrimitiveType.BIGINT)))
-                .addColumn(new Column("Auto_increment", ScalarType.createType(PrimitiveType.BIGINT)))
-                .addColumn(new Column("Create_time", ScalarType.createType(PrimitiveType.DATETIME)))
-                .addColumn(new Column("Update_time", ScalarType.createType(PrimitiveType.DATETIME)))
-                .addColumn(new Column("Check_time", ScalarType.createType(PrimitiveType.DATETIME)))
-                .addColumn(new Column("Collation", ScalarType.createVarchar(64)))
-                .addColumn(new Column("Checksum", ScalarType.createType(PrimitiveType.BIGINT)))
-                .addColumn(new Column("Create_options", ScalarType.createVarchar(64)))
-                .addColumn(new Column("Comment", ScalarType.createVarchar(64)))
+                .addColumn(new Column("Name", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("Engine", TypeFactory.createVarchar(10)))
+                .addColumn(new Column("Version", TypeFactory.createType(PrimitiveType.BIGINT)))
+                .addColumn(new Column("Row_format", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("Rows", TypeFactory.createType(PrimitiveType.BIGINT)))
+                .addColumn(new Column("Avg_row_length", TypeFactory.createType(PrimitiveType.BIGINT)))
+                .addColumn(new Column("Data_length", TypeFactory.createType(PrimitiveType.BIGINT)))
+                .addColumn(new Column("Max_data_length", TypeFactory.createType(PrimitiveType.BIGINT)))
+                .addColumn(new Column("Index_length", TypeFactory.createType(PrimitiveType.BIGINT)))
+                .addColumn(new Column("Data_free", TypeFactory.createType(PrimitiveType.BIGINT)))
+                .addColumn(new Column("Auto_increment", TypeFactory.createType(PrimitiveType.BIGINT)))
+                .addColumn(new Column("Create_time", TypeFactory.createType(PrimitiveType.DATETIME)))
+                .addColumn(new Column("Update_time", TypeFactory.createType(PrimitiveType.DATETIME)))
+                .addColumn(new Column("Check_time", TypeFactory.createType(PrimitiveType.DATETIME)))
+                .addColumn(new Column("Collation", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("Checksum", TypeFactory.createType(PrimitiveType.BIGINT)))
+                .addColumn(new Column("Create_options", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("Comment", TypeFactory.createVarchar(64)))
                 .build();
     }
 
@@ -857,28 +858,28 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     public ShowResultSetMetaData visitDescTableStmt(DescribeStmt statement, Void context) {
         if (statement.isTableFunctionTable()) {
             return ShowResultSetMetaData.builder()
-                    .addColumn(new Column("Field", ScalarType.createVarchar(20)))
-                    .addColumn(new Column("Type", ScalarType.createVarchar(20)))
-                    .addColumn(new Column("Null", ScalarType.createVarchar(10)))
+                    .addColumn(new Column("Field", TypeFactory.createVarchar(20)))
+                    .addColumn(new Column("Type", TypeFactory.createVarchar(20)))
+                    .addColumn(new Column("Null", TypeFactory.createVarchar(10)))
                     .build();
         }
 
         if (!statement.isAllTables()) {
             if (statement.isMaterializedView()) {
                 return ShowResultSetMetaData.builder()
-                        .addColumn(new Column("Field", ScalarType.createVarchar(20)))
-                        .addColumn(new Column("Type", ScalarType.createVarchar(20)))
-                        .addColumn(new Column("Null", ScalarType.createVarchar(10)))
-                        .addColumn(new Column("Key", ScalarType.createVarchar(10)))
-                        .addColumn(new Column("Default", ScalarType.createVarchar(30)))
-                        .addColumn(new Column("Extra", ScalarType.createVarchar(30)))
+                        .addColumn(new Column("Field", TypeFactory.createVarchar(20)))
+                        .addColumn(new Column("Type", TypeFactory.createVarchar(20)))
+                        .addColumn(new Column("Null", TypeFactory.createVarchar(10)))
+                        .addColumn(new Column("Key", TypeFactory.createVarchar(10)))
+                        .addColumn(new Column("Default", TypeFactory.createVarchar(30)))
+                        .addColumn(new Column("Extra", TypeFactory.createVarchar(30)))
                         .build();
             } else {
                 ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
                 try {
                     ProcResult result = statement.getNode().fetchResult();
                     for (String col : result.getColumnNames()) {
-                        builder.addColumn(new Column(col, ScalarType.createVarchar(30)));
+                        builder.addColumn(new Column(col, TypeFactory.createVarchar(30)));
                     }
                 } catch (AnalysisException e) {
                     // Return empty builder if fetch fails
@@ -888,32 +889,32 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
         } else {
             if (statement.isOlapTable()) {
                 return ShowResultSetMetaData.builder()
-                        .addColumn(new Column("IndexName", ScalarType.createVarchar(20)))
-                        .addColumn(new Column("IndexKeysType", ScalarType.createVarchar(20)))
-                        .addColumn(new Column("Field", ScalarType.createVarchar(20)))
-                        .addColumn(new Column("Type", ScalarType.createVarchar(20)))
-                        .addColumn(new Column("Null", ScalarType.createVarchar(10)))
-                        .addColumn(new Column("Key", ScalarType.createVarchar(10)))
-                        .addColumn(new Column("Default", ScalarType.createVarchar(30)))
-                        .addColumn(new Column("Extra", ScalarType.createVarchar(30)))
+                        .addColumn(new Column("IndexName", TypeFactory.createVarchar(20)))
+                        .addColumn(new Column("IndexKeysType", TypeFactory.createVarchar(20)))
+                        .addColumn(new Column("Field", TypeFactory.createVarchar(20)))
+                        .addColumn(new Column("Type", TypeFactory.createVarchar(20)))
+                        .addColumn(new Column("Null", TypeFactory.createVarchar(10)))
+                        .addColumn(new Column("Key", TypeFactory.createVarchar(10)))
+                        .addColumn(new Column("Default", TypeFactory.createVarchar(30)))
+                        .addColumn(new Column("Extra", TypeFactory.createVarchar(30)))
                         .build();
             } else if (statement.isMaterializedView()) {
                 return ShowResultSetMetaData.builder()
-                        .addColumn(new Column("Field", ScalarType.createVarchar(20)))
-                        .addColumn(new Column("Type", ScalarType.createVarchar(20)))
-                        .addColumn(new Column("Null", ScalarType.createVarchar(10)))
-                        .addColumn(new Column("Key", ScalarType.createVarchar(10)))
-                        .addColumn(new Column("Default", ScalarType.createVarchar(30)))
-                        .addColumn(new Column("Extra", ScalarType.createVarchar(30)))
+                        .addColumn(new Column("Field", TypeFactory.createVarchar(20)))
+                        .addColumn(new Column("Type", TypeFactory.createVarchar(20)))
+                        .addColumn(new Column("Null", TypeFactory.createVarchar(10)))
+                        .addColumn(new Column("Key", TypeFactory.createVarchar(10)))
+                        .addColumn(new Column("Default", TypeFactory.createVarchar(30)))
+                        .addColumn(new Column("Extra", TypeFactory.createVarchar(30)))
                         .build();
             } else {
                 return ShowResultSetMetaData.builder()
-                        .addColumn(new Column("Host", ScalarType.createVarchar(30)))
-                        .addColumn(new Column("Port", ScalarType.createVarchar(10)))
-                        .addColumn(new Column("User", ScalarType.createVarchar(30)))
-                        .addColumn(new Column("Password", ScalarType.createVarchar(30)))
-                        .addColumn(new Column("Database", ScalarType.createVarchar(30)))
-                        .addColumn(new Column("Table", ScalarType.createVarchar(30)))
+                        .addColumn(new Column("Host", TypeFactory.createVarchar(30)))
+                        .addColumn(new Column("Port", TypeFactory.createVarchar(10)))
+                        .addColumn(new Column("User", TypeFactory.createVarchar(30)))
+                        .addColumn(new Column("Password", TypeFactory.createVarchar(30)))
+                        .addColumn(new Column("Database", TypeFactory.createVarchar(30)))
+                        .addColumn(new Column("Table", TypeFactory.createVarchar(30)))
                         .build();
             }
         }
@@ -922,32 +923,32 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     @Override
     public ShowResultSetMetaData visitShowProcesslistStatement(ShowProcesslistStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("ServerName", ScalarType.createVarchar(64)))
-                .addColumn(new Column("Id", ScalarType.createType(PrimitiveType.BIGINT)))
-                .addColumn(new Column("User", ScalarType.createVarchar(16)))
-                .addColumn(new Column("Host", ScalarType.createVarchar(16)))
-                .addColumn(new Column("Db", ScalarType.createVarchar(16)))
-                .addColumn(new Column("Command", ScalarType.createVarchar(16)))
-                .addColumn(new Column("ConnectionStartTime", ScalarType.createVarchar(16)))
-                .addColumn(new Column("Time", ScalarType.createType(PrimitiveType.INT)))
-                .addColumn(new Column("State", ScalarType.createVarchar(64)))
-                .addColumn(new Column("Info", ScalarType.createVarchar(32 * 1024)))
-                .addColumn(new Column("IsPending", ScalarType.createVarchar(16)))
-                .addColumn(new Column("Warehouse", ScalarType.createVarchar(20)))
-                .addColumn(new Column("CNGroup", ScalarType.createVarchar(64)))
-                .addColumn(new Column("Catalog", ScalarType.createVarchar(64)))
-                .addColumn(new Column("QueryId", ScalarType.createVarchar(64)))
+                .addColumn(new Column("ServerName", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("Id", TypeFactory.createType(PrimitiveType.BIGINT)))
+                .addColumn(new Column("User", TypeFactory.createVarchar(16)))
+                .addColumn(new Column("Host", TypeFactory.createVarchar(16)))
+                .addColumn(new Column("Db", TypeFactory.createVarchar(16)))
+                .addColumn(new Column("Command", TypeFactory.createVarchar(16)))
+                .addColumn(new Column("ConnectionStartTime", TypeFactory.createVarchar(16)))
+                .addColumn(new Column("Time", TypeFactory.createType(PrimitiveType.INT)))
+                .addColumn(new Column("State", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("Info", TypeFactory.createVarchar(32 * 1024)))
+                .addColumn(new Column("IsPending", TypeFactory.createVarchar(16)))
+                .addColumn(new Column("Warehouse", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("CNGroup", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("Catalog", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("QueryId", TypeFactory.createVarchar(64)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowFunctionsStatement(ShowFunctionsStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Signature", ScalarType.createVarchar(256)))
-                .addColumn(new Column("Return Type", ScalarType.createVarchar(32)))
-                .addColumn(new Column("Function Type", ScalarType.createVarchar(16)))
-                .addColumn(new Column("Intermediate Type", ScalarType.createVarchar(16)))
-                .addColumn(new Column("Properties", ScalarType.createVarchar(16)))
+                .addColumn(new Column("Signature", TypeFactory.createVarchar(256)))
+                .addColumn(new Column("Return Type", TypeFactory.createVarchar(32)))
+                .addColumn(new Column("Function Type", TypeFactory.createVarchar(16)))
+                .addColumn(new Column("Intermediate Type", TypeFactory.createVarchar(16)))
+                .addColumn(new Column("Properties", TypeFactory.createVarchar(16)))
                 .build();
     }
 
@@ -956,7 +957,7 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
 
         for (String title : ShowRoutineLoadStmt.TITLE_NAMES) {
-            builder.addColumn(new Column(title, ScalarType.createVarchar(30)));
+            builder.addColumn(new Column(title, TypeFactory.createVarchar(30)));
         }
         return builder.build();
     }
@@ -966,7 +967,7 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
 
         for (String title : ShowStreamLoadStmt.TITLE_NAMES) {
-            builder.addColumn(new Column(title, ScalarType.createVarchar(30)));
+            builder.addColumn(new Column(title, TypeFactory.createVarchar(30)));
         }
         return builder.build();
     }
@@ -986,7 +987,7 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
         }
 
         for (String title : titleNames) {
-            builder.addColumn(new Column(title, ScalarType.createVarchar(30)));
+            builder.addColumn(new Column(title, TypeFactory.createVarchar(30)));
         }
 
         return builder.build();
@@ -995,34 +996,34 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     @Override
     public ShowResultSetMetaData visitShowUserPropertyStatement(ShowUserPropertyStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Key", ScalarType.createVarchar(64)))
-                .addColumn(new Column("Value", ScalarType.createVarchar(64)))
+                .addColumn(new Column("Key", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("Value", TypeFactory.createVarchar(64)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowDataDistributionStatement(ShowDataDistributionStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("PartitionName", ScalarType.createVarchar(30)))
-                .addColumn(new Column("SubPartitionId", ScalarType.createVarchar(30)))
-                .addColumn(new Column("MaterializedIndexName", ScalarType.createVarchar(30)))
-                .addColumn(new Column("VirtualBuckets", ScalarType.createVarchar(30)))
-                .addColumn(new Column("RowCount", ScalarType.createVarchar(30)))
-                .addColumn(new Column("RowCount%", ScalarType.createVarchar(10)))
-                .addColumn(new Column("DataSize", ScalarType.createVarchar(30)))
-                .addColumn(new Column("DataSize%", ScalarType.createVarchar(10)))
+                .addColumn(new Column("PartitionName", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("SubPartitionId", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("MaterializedIndexName", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("VirtualBuckets", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("RowCount", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("RowCount%", TypeFactory.createVarchar(10)))
+                .addColumn(new Column("DataSize", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("DataSize%", TypeFactory.createVarchar(10)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowCollationStatement(ShowCollationStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Collation", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Charset", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Id", ScalarType.createType(PrimitiveType.BIGINT)))
-                .addColumn(new Column("Default", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Compiled", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Sortlen", ScalarType.createType(PrimitiveType.BIGINT)))
+                .addColumn(new Column("Collation", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Charset", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Id", TypeFactory.createType(PrimitiveType.BIGINT)))
+                .addColumn(new Column("Default", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Compiled", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Sortlen", TypeFactory.createType(PrimitiveType.BIGINT)))
                 .build();
     }
 
@@ -1032,7 +1033,7 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
 
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
         for (String title : titleNames) {
-            builder.addColumn(new Column(title, ScalarType.createVarchar(30)));
+            builder.addColumn(new Column(title, TypeFactory.createVarchar(30)));
         }
         return builder.build();
     }
@@ -1040,71 +1041,71 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     @Override
     public ShowResultSetMetaData visitShowBackupStatement(ShowBackupStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("JobId", ScalarType.createVarchar(30)))
-                .addColumn(new Column("SnapshotName", ScalarType.createVarchar(30)))
-                .addColumn(new Column("DbName", ScalarType.createVarchar(30)))
-                .addColumn(new Column("State", ScalarType.createVarchar(30)))
-                .addColumn(new Column("BackupObjs", ScalarType.createVarchar(30)))
-                .addColumn(new Column("CreateTime", ScalarType.createVarchar(30)))
-                .addColumn(new Column("SnapshotFinishedTime", ScalarType.createVarchar(30)))
-                .addColumn(new Column("UploadFinishedTime", ScalarType.createVarchar(30)))
-                .addColumn(new Column("FinishedTime", ScalarType.createVarchar(30)))
-                .addColumn(new Column("UnfinishedTasks", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Progress", ScalarType.createVarchar(30)))
-                .addColumn(new Column("TaskErrMsg", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Status", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Timeout", ScalarType.createVarchar(30)))
+                .addColumn(new Column("JobId", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("SnapshotName", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("DbName", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("State", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("BackupObjs", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("CreateTime", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("SnapshotFinishedTime", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("UploadFinishedTime", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("FinishedTime", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("UnfinishedTasks", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Progress", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("TaskErrMsg", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Status", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Timeout", TypeFactory.createVarchar(30)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowRestoreStatement(ShowRestoreStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("JobId", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Label", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Timestamp", ScalarType.createVarchar(30)))
-                .addColumn(new Column("DbName", ScalarType.createVarchar(30)))
-                .addColumn(new Column("State", ScalarType.createVarchar(30)))
-                .addColumn(new Column("AllowLoad", ScalarType.createVarchar(30)))
-                .addColumn(new Column("ReplicationNum", ScalarType.createVarchar(30)))
-                .addColumn(new Column("RestoreObjs", ScalarType.createVarchar(30)))
-                .addColumn(new Column("CreateTime", ScalarType.createVarchar(30)))
-                .addColumn(new Column("MetaPreparedTime", ScalarType.createVarchar(30)))
-                .addColumn(new Column("SnapshotFinishedTime", ScalarType.createVarchar(30)))
-                .addColumn(new Column("DownloadFinishedTime", ScalarType.createVarchar(30)))
-                .addColumn(new Column("FinishedTime", ScalarType.createVarchar(30)))
-                .addColumn(new Column("UnfinishedTasks", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Progress", ScalarType.createVarchar(30)))
-                .addColumn(new Column("TaskErrMsg", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Status", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Timeout", ScalarType.createVarchar(30)))
+                .addColumn(new Column("JobId", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Label", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Timestamp", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("DbName", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("State", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("AllowLoad", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("ReplicationNum", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("RestoreObjs", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("CreateTime", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("MetaPreparedTime", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("SnapshotFinishedTime", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("DownloadFinishedTime", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("FinishedTime", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("UnfinishedTasks", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Progress", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("TaskErrMsg", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Status", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Timeout", TypeFactory.createVarchar(30)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowGrantsStatement(ShowGrantsStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("UserIdentity", ScalarType.createVarchar(100)))
-                .addColumn(new Column("Catalog", ScalarType.createVarchar(400)))
-                .addColumn(new Column("Grants", ScalarType.createVarchar(400)))
+                .addColumn(new Column("UserIdentity", TypeFactory.createVarchar(100)))
+                .addColumn(new Column("Catalog", TypeFactory.createVarchar(400)))
+                .addColumn(new Column("Grants", TypeFactory.createVarchar(400)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowRolesStatement(ShowRolesStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Name", ScalarType.createVarchar(100)))
-                .addColumn(new Column("Builtin", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Comment", ScalarType.createVarchar(300)))
+                .addColumn(new Column("Name", TypeFactory.createVarchar(100)))
+                .addColumn(new Column("Builtin", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Comment", TypeFactory.createVarchar(300)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowSecurityIntegrationStatement(ShowSecurityIntegrationStatement statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Name", ScalarType.createVarchar(100)))
-                .addColumn(new Column("Type", ScalarType.createVarchar(100)))
-                .addColumn(new Column("Comment", ScalarType.createVarchar(300)))
+                .addColumn(new Column("Name", TypeFactory.createVarchar(100)))
+                .addColumn(new Column("Type", TypeFactory.createVarchar(100)))
+                .addColumn(new Column("Comment", TypeFactory.createVarchar(300)))
                 .build();
     }
 
@@ -1112,25 +1113,25 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     public ShowResultSetMetaData visitShowCreateSecurityIntegrationStatement(
             com.starrocks.sql.ast.integration.ShowCreateSecurityIntegrationStatement statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Security Integration", ScalarType.createVarchar(60)))
-                .addColumn(new Column("Create Security Integration", ScalarType.createVarchar(500)))
+                .addColumn(new Column("Security Integration", TypeFactory.createVarchar(60)))
+                .addColumn(new Column("Create Security Integration", TypeFactory.createVarchar(500)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowGroupProvidersStatement(ShowGroupProvidersStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Name", ScalarType.createVarchar(100)))
-                .addColumn(new Column("Type", ScalarType.createVarchar(100)))
-                .addColumn(new Column("Comment", ScalarType.createVarchar(300)))
+                .addColumn(new Column("Name", TypeFactory.createVarchar(100)))
+                .addColumn(new Column("Type", TypeFactory.createVarchar(100)))
+                .addColumn(new Column("Comment", TypeFactory.createVarchar(300)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowCreateGroupProviderStatement(ShowCreateGroupProviderStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Group Provider", ScalarType.createVarchar(60)))
-                .addColumn(new Column("Create Group Provider", ScalarType.createVarchar(500)))
+                .addColumn(new Column("Group Provider", TypeFactory.createVarchar(60)))
+                .addColumn(new Column("Create Group Provider", TypeFactory.createVarchar(500)))
                 .build();
     }
 
@@ -1138,28 +1139,28 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     public ShowResultSetMetaData visitAdminShowReplicaDistributionStatement(AdminShowReplicaDistributionStmt statement,
                                                                             Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("BackendId", ScalarType.createVarchar(30)))
-                .addColumn(new Column("ReplicaNum", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Graph", ScalarType.createVarchar(30)))
-                .addColumn(new Column("Percent", ScalarType.createVarchar(30)))
+                .addColumn(new Column("BackendId", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("ReplicaNum", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Graph", TypeFactory.createVarchar(30)))
+                .addColumn(new Column("Percent", TypeFactory.createVarchar(30)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowIndexStatement(ShowIndexStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Table", ScalarType.createVarchar(64)))
-                .addColumn(new Column("Non_unique", ScalarType.createVarchar(10)))
-                .addColumn(new Column("Key_name", ScalarType.createVarchar(80)))
-                .addColumn(new Column("Seq_in_index", ScalarType.createVarchar(64)))
-                .addColumn(new Column("Column_name", ScalarType.createVarchar(80)))
-                .addColumn(new Column("Collation", ScalarType.createVarchar(80)))
-                .addColumn(new Column("Cardinality", ScalarType.createVarchar(80)))
-                .addColumn(new Column("Sub_part", ScalarType.createVarchar(80)))
-                .addColumn(new Column("Packed", ScalarType.createVarchar(80)))
-                .addColumn(new Column("Null", ScalarType.createVarchar(80)))
-                .addColumn(new Column("Index_type", ScalarType.createVarchar(80)))
-                .addColumn(new Column("Comment", ScalarType.createVarchar(80)))
+                .addColumn(new Column("Table", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("Non_unique", TypeFactory.createVarchar(10)))
+                .addColumn(new Column("Key_name", TypeFactory.createVarchar(80)))
+                .addColumn(new Column("Seq_in_index", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("Column_name", TypeFactory.createVarchar(80)))
+                .addColumn(new Column("Collation", TypeFactory.createVarchar(80)))
+                .addColumn(new Column("Cardinality", TypeFactory.createVarchar(80)))
+                .addColumn(new Column("Sub_part", TypeFactory.createVarchar(80)))
+                .addColumn(new Column("Packed", TypeFactory.createVarchar(80)))
+                .addColumn(new Column("Null", TypeFactory.createVarchar(80)))
+                .addColumn(new Column("Index_type", TypeFactory.createVarchar(80)))
+                .addColumn(new Column("Comment", TypeFactory.createVarchar(80)))
                 .build();
     }
 
@@ -1167,7 +1168,7 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     public ShowResultSetMetaData visitShowTransactionStatement(ShowTransactionStmt statement, Void context) {
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
         for (String title : TransProcDir.TITLE_NAMES) {
-            builder.addColumn(new Column(title, ScalarType.createVarchar(30)));
+            builder.addColumn(new Column(title, TypeFactory.createVarchar(30)));
         }
         return builder.build();
     }
@@ -1175,30 +1176,30 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     @Override
     public ShowResultSetMetaData visitShowMultiColumnsStatsMetaStatement(ShowMultiColumnStatsMetaStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Database", ScalarType.createVarchar(60)))
-                .addColumn(new Column("Table", ScalarType.createVarchar(60)))
-                .addColumn(new Column("Columns", ScalarType.createVarchar(200)))
-                .addColumn(new Column("Type", ScalarType.createVarchar(20)))
-                .addColumn(new Column("StatisticsTypes", ScalarType.createVarchar(200)))
-                .addColumn(new Column("UpdateTime", ScalarType.createVarchar(60)))
-                .addColumn(new Column("Properties", ScalarType.createVarchar(200)))
+                .addColumn(new Column("Database", TypeFactory.createVarchar(60)))
+                .addColumn(new Column("Table", TypeFactory.createVarchar(60)))
+                .addColumn(new Column("Columns", TypeFactory.createVarchar(200)))
+                .addColumn(new Column("Type", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("StatisticsTypes", TypeFactory.createVarchar(200)))
+                .addColumn(new Column("UpdateTime", TypeFactory.createVarchar(60)))
+                .addColumn(new Column("Properties", TypeFactory.createVarchar(200)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowBaselinePlanStatement(ShowBaselinePlanStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Id", ScalarType.createVarchar(60)))
-                .addColumn(new Column("global", ScalarType.createVarchar(10)))
-                .addColumn(new Column("enable", ScalarType.createVarchar(10)))
-                .addColumn(new Column("bindSQLDigest", ScalarType.createVarchar(65535)))
-                .addColumn(new Column("bindSQLHash", ScalarType.createVarchar(60)))
-                .addColumn(new Column("bindSQL", ScalarType.createVarchar(65535)))
-                .addColumn(new Column("planSQL", ScalarType.createVarchar(65535)))
-                .addColumn(new Column("costs", ScalarType.createVarchar(60)))
-                .addColumn(new Column("queryMs", ScalarType.createVarchar(60)))
-                .addColumn(new Column("source", ScalarType.createVarchar(60)))
-                .addColumn(new Column("updateTime", ScalarType.createVarchar(60)))
+                .addColumn(new Column("Id", TypeFactory.createVarchar(60)))
+                .addColumn(new Column("global", TypeFactory.createVarchar(10)))
+                .addColumn(new Column("enable", TypeFactory.createVarchar(10)))
+                .addColumn(new Column("bindSQLDigest", TypeFactory.createVarchar(65535)))
+                .addColumn(new Column("bindSQLHash", TypeFactory.createVarchar(60)))
+                .addColumn(new Column("bindSQL", TypeFactory.createVarchar(65535)))
+                .addColumn(new Column("planSQL", TypeFactory.createVarchar(65535)))
+                .addColumn(new Column("costs", TypeFactory.createVarchar(60)))
+                .addColumn(new Column("queryMs", TypeFactory.createVarchar(60)))
+                .addColumn(new Column("source", TypeFactory.createVarchar(60)))
+                .addColumn(new Column("updateTime", TypeFactory.createVarchar(60)))
                 .build();
     }
 
@@ -1213,132 +1214,132 @@ public class ShowResultMetaFactory implements AstVisitorExtendInterface<ShowResu
     @Override
     public ShowResultSetMetaData visitShowCatalogsStatement(ShowCatalogsStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Catalog", ScalarType.createVarchar(256)))
-                .addColumn(new Column("Type", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Comment", ScalarType.createVarchar(30)))
+                .addColumn(new Column("Catalog", TypeFactory.createVarchar(256)))
+                .addColumn(new Column("Type", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Comment", TypeFactory.createVarchar(30)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowCreateExternalCatalogStatement(ShowCreateExternalCatalogStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Catalog", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Create Catalog", ScalarType.createVarchar(30)))
+                .addColumn(new Column("Catalog", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Create Catalog", TypeFactory.createVarchar(30)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowStorageVolumesStatement(ShowStorageVolumesStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Storage Volume", ScalarType.createVarchar(256)))
+                .addColumn(new Column("Storage Volume", TypeFactory.createVarchar(256)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowFailPointStatement(ShowFailPointStatement statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Name", ScalarType.createVarchar(256)))
-                .addColumn(new Column("TriggerMode", ScalarType.createVarchar(32)))
-                .addColumn(new Column("Times/Probability", ScalarType.createVarchar(16)))
-                .addColumn(new Column("Host", ScalarType.createVarchar(64)))
+                .addColumn(new Column("Name", TypeFactory.createVarchar(256)))
+                .addColumn(new Column("TriggerMode", TypeFactory.createVarchar(32)))
+                .addColumn(new Column("Times/Probability", TypeFactory.createVarchar(16)))
+                .addColumn(new Column("Host", TypeFactory.createVarchar(64)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowNodesStatement(ShowNodesStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("WarehouseName", ScalarType.createVarchar(256)))
-                .addColumn(new Column("CNGroupId", ScalarType.createVarchar(20)))
-                .addColumn(new Column("WorkerGroupId", ScalarType.createVarchar(20)))
-                .addColumn(new Column("NodeId", ScalarType.createVarchar(20)))
-                .addColumn(new Column("WorkerId", ScalarType.createVarchar(20)))
-                .addColumn(new Column("IP", ScalarType.createVarchar(256)))
-                .addColumn(new Column("HeartbeatPort", ScalarType.createVarchar(20)))
-                .addColumn(new Column("BePort", ScalarType.createVarchar(20)))
-                .addColumn(new Column("HttpPort", ScalarType.createVarchar(20)))
-                .addColumn(new Column("BrpcPort", ScalarType.createVarchar(20)))
-                .addColumn(new Column("StarletPort", ScalarType.createVarchar(20)))
-                .addColumn(new Column("LastStartTime", ScalarType.createVarchar(256)))
-                .addColumn(new Column("LastUpdateMs", ScalarType.createVarchar(256)))
-                .addColumn(new Column("Alive", ScalarType.createVarchar(20)))
-                .addColumn(new Column("ErrMsg", ScalarType.createVarchar(256)))
-                .addColumn(new Column("Version", ScalarType.createVarchar(20)))
-                .addColumn(new Column("NumRunningQueries", ScalarType.createVarchar(20)))
-                .addColumn(new Column("CpuCores", ScalarType.createVarchar(20)))
-                .addColumn(new Column("MemUsedPct", ScalarType.createVarchar(20)))
-                .addColumn(new Column("CpuUsedPct", ScalarType.createVarchar(20)))
-                .addColumn(new Column("CNGroupName", ScalarType.createVarchar(256)))
+                .addColumn(new Column("WarehouseName", TypeFactory.createVarchar(256)))
+                .addColumn(new Column("CNGroupId", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("WorkerGroupId", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("NodeId", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("WorkerId", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("IP", TypeFactory.createVarchar(256)))
+                .addColumn(new Column("HeartbeatPort", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("BePort", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("HttpPort", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("BrpcPort", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("StarletPort", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("LastStartTime", TypeFactory.createVarchar(256)))
+                .addColumn(new Column("LastUpdateMs", TypeFactory.createVarchar(256)))
+                .addColumn(new Column("Alive", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("ErrMsg", TypeFactory.createVarchar(256)))
+                .addColumn(new Column("Version", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("NumRunningQueries", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("CpuCores", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("MemUsedPct", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("CpuUsedPct", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("CNGroupName", TypeFactory.createVarchar(256)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowClusterStatement(ShowClustersStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("CNGroupId", ScalarType.createVarchar(20)))
-                .addColumn(new Column("CNGroupName", ScalarType.createVarchar(256)))
-                .addColumn(new Column("WorkerGroupId", ScalarType.createVarchar(20)))
-                .addColumn(new Column("ComputeNodeIds", ScalarType.createVarchar(4096)))
-                .addColumn(new Column("Pending", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Running", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Enabled", ScalarType.createVarchar(10)))
-                .addColumn(new Column("Properties", ScalarType.createVarchar(1024)))
+                .addColumn(new Column("CNGroupId", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("CNGroupName", TypeFactory.createVarchar(256)))
+                .addColumn(new Column("WorkerGroupId", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("ComputeNodeIds", TypeFactory.createVarchar(4096)))
+                .addColumn(new Column("Pending", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Running", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Enabled", TypeFactory.createVarchar(10)))
+                .addColumn(new Column("Properties", TypeFactory.createVarchar(1024)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowOpenTableStatement(ShowOpenTableStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Database", ScalarType.createVarchar(64)))
-                .addColumn(new Column("Table", ScalarType.createVarchar(10)))
-                .addColumn(new Column("In_use", ScalarType.createVarchar(80)))
-                .addColumn(new Column("Name_locked", ScalarType.createVarchar(64)))
+                .addColumn(new Column("Database", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("Table", TypeFactory.createVarchar(10)))
+                .addColumn(new Column("In_use", TypeFactory.createVarchar(80)))
+                .addColumn(new Column("Name_locked", TypeFactory.createVarchar(64)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowPrivilegeStatement(ShowPrivilegesStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Privilege", ScalarType.createVarchar(64)))
-                .addColumn(new Column("Context", ScalarType.createVarchar(64)))
-                .addColumn(new Column("Comment", ScalarType.createVarchar(200)))
+                .addColumn(new Column("Privilege", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("Context", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("Comment", TypeFactory.createVarchar(200)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowStatusStatement(ShowStatusStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Variable_name", ScalarType.createVarchar(20)))
-                .addColumn(new Column("Value", ScalarType.createVarchar(20)))
+                .addColumn(new Column("Variable_name", TypeFactory.createVarchar(20)))
+                .addColumn(new Column("Value", TypeFactory.createVarchar(20)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowTriggersStatement(ShowTriggersStmt statement, Void context) {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("Trigger", ScalarType.createVarchar(64)))
-                .addColumn(new Column("Event", ScalarType.createVarchar(10)))
-                .addColumn(new Column("Table", ScalarType.createVarchar(80)))
-                .addColumn(new Column("Statement", ScalarType.createVarchar(64)))
-                .addColumn(new Column("Timing", ScalarType.createVarchar(80)))
-                .addColumn(new Column("Created", ScalarType.createVarchar(80)))
-                .addColumn(new Column("sql_mode", ScalarType.createVarchar(80)))
-                .addColumn(new Column("Definer", ScalarType.createVarchar(80)))
-                .addColumn(new Column("character_set_client", ScalarType.createVarchar(80)))
-                .addColumn(new Column("collation_connection", ScalarType.createVarchar(80)))
-                .addColumn(new Column("Database Collation", ScalarType.createVarchar(80)))
+                .addColumn(new Column("Trigger", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("Event", TypeFactory.createVarchar(10)))
+                .addColumn(new Column("Table", TypeFactory.createVarchar(80)))
+                .addColumn(new Column("Statement", TypeFactory.createVarchar(64)))
+                .addColumn(new Column("Timing", TypeFactory.createVarchar(80)))
+                .addColumn(new Column("Created", TypeFactory.createVarchar(80)))
+                .addColumn(new Column("sql_mode", TypeFactory.createVarchar(80)))
+                .addColumn(new Column("Definer", TypeFactory.createVarchar(80)))
+                .addColumn(new Column("character_set_client", TypeFactory.createVarchar(80)))
+                .addColumn(new Column("collation_connection", TypeFactory.createVarchar(80)))
+                .addColumn(new Column("Database Collation", TypeFactory.createVarchar(80)))
                 .build();
     }
 
     @Override
     public ShowResultSetMetaData visitRefreshMaterializedViewStatement(RefreshMaterializedViewStatement statement, Void context) {
-        return ShowResultSetMetaData.builder().addColumn(new Column("QUERY_ID", ScalarType.createVarchar(60))).build();
+        return ShowResultSetMetaData.builder().addColumn(new Column("QUERY_ID", TypeFactory.createVarchar(60))).build();
     }
 
     @Override
     public ShowResultSetMetaData visitShowComputeNodes(ShowComputeNodesStmt statement, Void context) {
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
         for (String title : ComputeNodeProcDir.getMetadata()) {
-            builder.addColumn(new Column(title, ScalarType.createVarchar(30)));
+            builder.addColumn(new Column(title, TypeFactory.createVarchar(30)));
         }
         return builder.build();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowResultSet.java
@@ -43,6 +43,7 @@ import com.starrocks.thrift.TShowResultSetMetaData;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
 import com.starrocks.type.TypeDeserializer;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.type.TypeSerializer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -73,7 +74,7 @@ public class ShowResultSet {
             TColumnDefinition definition = (TColumnDefinition) resultSet.getMetaData().getColumns().get(i);
             columns.add(new Column(
                     definition.getColumnName(),
-                    ScalarType.createType(TypeDeserializer.fromThrift(definition.getColumnType().getType())))
+                    TypeFactory.createType(TypeDeserializer.fromThrift(definition.getColumnType().getType())))
             );
         }
         this.metaData = new ShowResultSetMetaData(columns);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -254,7 +254,7 @@ import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TransactionStatus;
 import com.starrocks.transaction.TransactionStmtExecutor;
 import com.starrocks.transaction.VisibleStateWaiter;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.warehouse.WarehouseIdleChecker;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
@@ -2171,7 +2171,7 @@ public class StmtExecutor {
 
         ShowResultSetMetaData metaData =
                 ShowResultSetMetaData.builder()
-                        .addColumn(new Column("Explain String", ScalarType.createVarchar(20)))
+                        .addColumn(new Column("Explain String", TypeFactory.createVarchar(20)))
                         .build();
         sendMetaData(metaData);
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -55,7 +55,7 @@ import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TGetTasksParams;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.logging.log4j.LogManager;
@@ -759,8 +759,8 @@ public class TaskManager implements MemoryTrackable {
         }
 
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
-        builder.addColumn(new Column("TaskName", ScalarType.createVarchar(40)));
-        builder.addColumn(new Column("Status", ScalarType.createVarchar(10)));
+        builder.addColumn(new Column("TaskName", TypeFactory.createVarchar(40)));
+        builder.addColumn(new Column("Status", TypeFactory.createVarchar(10)));
         List<String> item = ImmutableList.of(taskName, submitResult.getStatus().toString());
         List<List<String>> result = ImmutableList.of(item);
         return new ShowResultSet(builder.build(), result);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -125,6 +125,7 @@ import com.starrocks.type.ScalarType;
 import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -1274,33 +1275,33 @@ public class AnalyzerUtils {
             if (PrimitiveType.VARCHAR == srcType.getPrimitiveType() ||
                     PrimitiveType.CHAR == srcType.getPrimitiveType() ||
                     PrimitiveType.NULL_TYPE == srcType.getPrimitiveType()) {
-                int len = ScalarType.getOlapMaxVarcharLength();
+                int len = TypeFactory.getOlapMaxVarcharLength();
                 if (srcType instanceof ScalarType) {
                     ScalarType scalarType = (ScalarType) srcType;
                     if (Config.transform_type_prefer_string_for_varchar) {
                         // always use max varchar length for varchar type if transform_type_prefer_string_for_varchar is set.
-                        len = ScalarType.getOlapMaxVarcharLength();
+                        len = TypeFactory.getOlapMaxVarcharLength();
                     } else {
                         if (scalarType.getLength() > 0) {
                             // Catalog's varchar length may larger than olap's max varchar length
-                            len = Integer.min(scalarType.getLength(), ScalarType.getOlapMaxVarcharLength());
+                            len = Integer.min(scalarType.getLength(), TypeFactory.getOlapMaxVarcharLength());
                         }
                     }
                 }
-                newType = ScalarType.createVarcharType(len);
+                newType = TypeFactory.createVarcharType(len);
             } else if (PrimitiveType.FLOAT == srcType.getPrimitiveType() ||
                     PrimitiveType.DOUBLE == srcType.getPrimitiveType()) {
                 if (convertDouble) {
-                    newType = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 9);
+                    newType = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 9);
                 }
             } else if (PrimitiveType.DECIMAL256 == srcType.getPrimitiveType() ||
                     PrimitiveType.DECIMAL128 == srcType.getPrimitiveType() ||
                     PrimitiveType.DECIMAL64 == srcType.getPrimitiveType() ||
                     PrimitiveType.DECIMAL32 == srcType.getPrimitiveType()) {
-                newType = ScalarType.createDecimalV3Type(srcType.getPrimitiveType(),
+                newType = TypeFactory.createDecimalV3Type(srcType.getPrimitiveType(),
                         srcType.getPrecision(), srcType.getDecimalDigits());
             } else {
-                newType = ScalarType.createType(srcType.getPrimitiveType());
+                newType = TypeFactory.createType(srcType.getPrimitiveType());
             }
         } else if (srcType.isArrayType()) {
             newType = new ArrayType(transformTableColumnType(((ArrayType) srcType).getItemType(), convertDouble));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ColumnDefAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ColumnDefAnalyzer.java
@@ -37,6 +37,7 @@ import com.starrocks.sql.ast.expression.TypeDef;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 
 import java.util.Set;
 
@@ -192,7 +193,7 @@ public class ColumnDefAnalyzer {
         }
 
         if (type.isDecimalV3()) {
-            return ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, ((ScalarType) type).getScalarScale());
+            return TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, ((ScalarType) type).getScalarScale());
         }
         return type;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateFunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateFunctionAnalyzer.java
@@ -38,6 +38,7 @@ import com.starrocks.type.MapType;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang.StringUtils;
 
@@ -310,7 +311,7 @@ public class CreateFunctionAnalyzer {
         FunctionArgsDef argsDef = stmt.getArgsDef();
         TypeDef returnType = stmt.getReturnType();
         String objectFile = stmt.getProperties().get(CreateFunctionStmt.FILE_KEY);
-        TypeDef intermediateType = TypeDef.createVarchar(ScalarType.getOlapMaxVarcharLength());
+        TypeDef intermediateType = TypeDef.createVarchar(TypeFactory.getOlapMaxVarcharLength());
         ;
         Map<String, String> properties = stmt.getProperties();
         boolean isAnalyticFn = "true".equalsIgnoreCase(properties.get(CreateFunctionStmt.IS_ANALYTIC_NAME));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -69,6 +69,7 @@ import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -538,9 +539,9 @@ public class CreateTableAnalyzer {
                 if (type.isScalarType()) {
                     ScalarType scalarType = (ScalarType) type;
                     if (scalarType.isWildcardChar()) {
-                        type = ScalarType.createCharType(ScalarType.getOlapMaxVarcharLength());
+                        type = TypeFactory.createCharType(TypeFactory.getOlapMaxVarcharLength());
                     } else if (scalarType.isWildcardVarchar()) {
-                        type = ScalarType.createVarcharType(ScalarType.getOlapMaxVarcharLength());
+                        type = TypeFactory.createVarcharType(TypeFactory.getOlapMaxVarcharLength());
                     }
                 }
                 TypeDef typeDef = new TypeDef(type);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -103,10 +103,10 @@ import com.starrocks.thrift.TFunctionBinaryType;
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.MapType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -1736,7 +1736,7 @@ public class ExpressionAnalyzer {
             List<Type> expectTypes = new ArrayList<>();
             expectTypes.add(Type.VARCHAR);
             for (Column keyColumn : keyColumns) {
-                expectTypes.add(ScalarType.createType(keyColumn.getType().getPrimitiveType()));
+                expectTypes.add(TypeFactory.createType(keyColumn.getType().getPrimitiveType()));
             }
             if (valueColumnIdx >= 0) {
                 expectTypes.add(Type.VARCHAR);
@@ -1746,7 +1746,7 @@ public class ExpressionAnalyzer {
             }
 
             List<Type> actualTypes = node.getChildren().stream()
-                    .map(expr -> ScalarType.createType(expr.getType().getPrimitiveType())).collect(Collectors.toList());
+                    .map(expr -> TypeFactory.createType(expr.getType().getPrimitiveType())).collect(Collectors.toList());
             if (!Objects.equals(expectTypes, actualTypes)) {
                 List<String> expectTypeNames = new ArrayList<>();
                 expectTypeNames.add("VARCHAR dict_table");
@@ -1775,7 +1775,7 @@ public class ExpressionAnalyzer {
                 }
             }
 
-            Type valueType = ScalarType.createType(valueColumn.getType().getPrimitiveType());
+            Type valueType = TypeFactory.createType(valueColumn.getType().getPrimitiveType());
 
             final TDictQueryExpr dictQueryExpr = new TDictQueryExpr();
             dictQueryExpr.setDb_name(tableName.getDb());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -125,6 +125,7 @@ import com.starrocks.sql.plan.PlanFragmentBuilder;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.apache.commons.collections.map.CaseInsensitiveMap;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.iceberg.PartitionField;
@@ -1825,9 +1826,9 @@ public class MaterializedViewAnalyzer {
         if (type.isScalarType()) {
             ScalarType scalarType = (ScalarType) type;
             if (scalarType.isWildcardChar()) {
-                type = ScalarType.createCharType(ScalarType.getOlapMaxVarcharLength());
+                type = TypeFactory.createCharType(TypeFactory.getOlapMaxVarcharLength());
             } else if (scalarType.isWildcardVarchar()) {
-                type = ScalarType.createVarcharType(ScalarType.getOlapMaxVarcharLength());
+                type = TypeFactory.createVarcharType(TypeFactory.getOlapMaxVarcharLength());
             }
         }
         String columnName = FeConstants.GENERATED_PARTITION_COLUMN_PREFIX + placeHolderSlotId;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowResourceGroupUsageStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowResourceGroupUsageStmt.java
@@ -19,7 +19,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.common.Pair;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.system.ComputeNode;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Comparator;
@@ -30,17 +30,17 @@ import java.util.stream.Collectors;
 public class ShowResourceGroupUsageStmt extends ShowStmt {
     private static final List<Pair<Column, Function<ShowItem, String>>> META_DATA =
             ImmutableList.of(
-                    Pair.create(new Column("Name", ScalarType.createVarchar(64)),
+                    Pair.create(new Column("Name", TypeFactory.createVarchar(64)),
                             item -> item.usage.getGroup().getName()),
-                    Pair.create(new Column("Id", ScalarType.createVarchar(64)),
+                    Pair.create(new Column("Id", TypeFactory.createVarchar(64)),
                             item -> Long.toString(item.usage.getGroup().getId())),
-                    Pair.create(new Column("Backend", ScalarType.createVarchar(64)),
+                    Pair.create(new Column("Backend", TypeFactory.createVarchar(64)),
                             item -> item.worker.getHost()),
-                    Pair.create(new Column("BEInUseCpuCores", ScalarType.createVarchar(64)),
+                    Pair.create(new Column("BEInUseCpuCores", TypeFactory.createVarchar(64)),
                             item -> Double.toString(item.usage.getCpuCoreUsagePermille() / 1000.0D)),
-                    Pair.create(new Column("BEInUseMemBytes", ScalarType.createVarchar(64)),
+                    Pair.create(new Column("BEInUseMemBytes", TypeFactory.createVarchar(64)),
                             item -> Long.toString(item.usage.getMemUsageBytes())),
-                    Pair.create(new Column("BERunningQueries", ScalarType.createVarchar(64)),
+                    Pair.create(new Column("BERunningQueries", TypeFactory.createVarchar(64)),
                             item -> Integer.toString(item.usage.getNumRunningQueries()))
             );
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowRunningQueriesStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowRunningQueriesStmt.java
@@ -22,7 +22,7 @@ import com.starrocks.common.util.TimeUtils;
 import com.starrocks.qe.scheduler.slot.LogicalSlot;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import java.util.List;
 import java.util.function.Function;
@@ -34,30 +34,30 @@ import java.util.stream.Collectors;
  */
 public class ShowRunningQueriesStmt extends ShowStmt {
     private static final List<Pair<Column, Function<LogicalSlot, String>>> META_DATA = ImmutableList.of(
-            Pair.create(new Column("QueryId", ScalarType.createVarchar(64)),
+            Pair.create(new Column("QueryId", TypeFactory.createVarchar(64)),
                     slot -> DebugUtil.printId(slot.getSlotId())),
-            Pair.create(new Column("WarehouseId", ScalarType.createVarchar(64)),
+            Pair.create(new Column("WarehouseId", TypeFactory.createVarchar(64)),
                     slot -> slot.getWarehouseId() == WarehouseManager.DEFAULT_WAREHOUSE_ID  ? "-" :
                             Long.toString(slot.getWarehouseId())),
-            Pair.create(new Column("ResourceGroupId", ScalarType.createVarchar(64)),
+            Pair.create(new Column("ResourceGroupId", TypeFactory.createVarchar(64)),
                     slot -> slot.getGroupId() == LogicalSlot.ABSENT_GROUP_ID ? "-" : Long.toString(slot.getGroupId())),
-            Pair.create(new Column("StartTime", ScalarType.createVarchar(64)),
+            Pair.create(new Column("StartTime", TypeFactory.createVarchar(64)),
                     slot -> TimeUtils.longToTimeString(slot.getStartTimeMs())),
-            Pair.create(new Column("PendingTimeout", ScalarType.createVarchar(64)),
+            Pair.create(new Column("PendingTimeout", TypeFactory.createVarchar(64)),
                     slot -> TimeUtils.longToTimeString(slot.getExpiredPendingTimeMs())),
-            Pair.create(new Column("QueryTimeout", ScalarType.createVarchar(64)),
+            Pair.create(new Column("QueryTimeout", TypeFactory.createVarchar(64)),
                     slot -> TimeUtils.longToTimeString(slot.getExpiredAllocatedTimeMs())),
-            Pair.create(new Column("State", ScalarType.createVarchar(64)),
+            Pair.create(new Column("State", TypeFactory.createVarchar(64)),
                     slot -> slot.getState().toQueryStateString()),
-            Pair.create(new Column("Slots", ScalarType.createVarchar(64)),
+            Pair.create(new Column("Slots", TypeFactory.createVarchar(64)),
                     slot -> Integer.toString(slot.getNumPhysicalSlots())),
-            Pair.create(new Column("Fragments", ScalarType.createVarchar(64)),
+            Pair.create(new Column("Fragments", TypeFactory.createVarchar(64)),
                     slot -> Integer.toString(slot.getNumFragments())),
-            Pair.create(new Column("DOP", ScalarType.createVarchar(64)),
+            Pair.create(new Column("DOP", TypeFactory.createVarchar(64)),
                     slot -> Integer.toString(slot.getPipelineDop())),
-            Pair.create(new Column("Frontend", ScalarType.createVarchar(64)),
+            Pair.create(new Column("Frontend", TypeFactory.createVarchar(64)),
                     LogicalSlot::getRequestFeName),
-            Pair.create(new Column("FeStartTime", ScalarType.createVarchar(64)),
+            Pair.create(new Column("FeStartTime", TypeFactory.createVarchar(64)),
                     slot -> TimeUtils.longToTimeString(slot.getFeStartTimeMs()))
     );
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ArithmeticExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ArithmeticExpr.java
@@ -49,6 +49,7 @@ import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -228,9 +229,9 @@ public class ArithmeticExpr extends Expr {
         decimalType = PrimitiveType.getWiderDecimalV3Type(decimalType, lhsType.getPrimitiveType());
         decimalType = PrimitiveType.getWiderDecimalV3Type(decimalType, rhsType.getPrimitiveType());
 
-        triple.lhsTargetType = ScalarType.createDecimalV3Type(decimalType, retPrecision, lhsScale);
-        triple.rhsTargetType = ScalarType.createDecimalV3Type(decimalType, retPrecision, rhsScale);
-        triple.returnType = ScalarType.createDecimalV3Type(decimalType, retPrecision, retScale);
+        triple.lhsTargetType = TypeFactory.createDecimalV3Type(decimalType, retPrecision, lhsScale);
+        triple.rhsTargetType = TypeFactory.createDecimalV3Type(decimalType, retPrecision, rhsScale);
+        triple.returnType = TypeFactory.createDecimalV3Type(decimalType, retPrecision, retScale);
     }
 
     public static TypeTriple getReturnTypeOfDecimal(Operator op, ScalarType lhsType, ScalarType rhsType)
@@ -251,8 +252,8 @@ public class ArithmeticExpr extends Expr {
         int maxPrecision = PrimitiveType.getMaxPrecisionOfDecimal(widerType);
 
         TypeTriple result = new TypeTriple();
-        result.lhsTargetType = ScalarType.createDecimalV3Type(widerType, maxPrecision, lhsScale);
-        result.rhsTargetType = ScalarType.createDecimalV3Type(widerType, maxPrecision, rhsScale);
+        result.lhsTargetType = TypeFactory.createDecimalV3Type(widerType, maxPrecision, lhsScale);
+        result.rhsTargetType = TypeFactory.createDecimalV3Type(widerType, maxPrecision, rhsScale);
         int returnScale = 0;
         int returnPrecision = 0;
         switch (op) {
@@ -278,7 +279,7 @@ public class ArithmeticExpr extends Expr {
                     // decimal32(4,3) * decimal32(4,3) => decimal32(8,6);
                     // decimal64(15,3) * decimal32(9,4) => decimal128(24,7).
                     PrimitiveType commonPtype =
-                            ScalarType.createDecimalV3NarrowestType(returnPrecision, returnScale).getPrimitiveType();
+                            TypeFactory.createDecimalV3NarrowestType(returnPrecision, returnScale).getPrimitiveType();
                     // TODO(stephen): support auto scale up decimal precision
                     if (defaultMaxDecimalType == PrimitiveType.DECIMAL128 && commonPtype == PrimitiveType.DECIMAL256) {
                         commonPtype = PrimitiveType.DECIMAL128;
@@ -287,9 +288,9 @@ public class ArithmeticExpr extends Expr {
                     // a common type shall never be narrower than type of lhs and rhs
                     commonPtype = PrimitiveType.getWiderDecimalV3Type(commonPtype, lhsPtype);
                     commonPtype = PrimitiveType.getWiderDecimalV3Type(commonPtype, rhsPtype);
-                    result.returnType = ScalarType.createDecimalV3Type(commonPtype, returnPrecision, returnScale);
-                    result.lhsTargetType = ScalarType.createDecimalV3Type(commonPtype, lhsPrecision, lhsScale);
-                    result.rhsTargetType = ScalarType.createDecimalV3Type(commonPtype, rhsPrecision, rhsScale);
+                    result.returnType = TypeFactory.createDecimalV3Type(commonPtype, returnPrecision, returnScale);
+                    result.lhsTargetType = TypeFactory.createDecimalV3Type(commonPtype, lhsPrecision, lhsScale);
+                    result.rhsTargetType = TypeFactory.createDecimalV3Type(commonPtype, rhsPrecision, rhsScale);
                     return result;
                 } else if (returnScale <= maxDecimalPrecision) {
                     ConnectContext connectContext = ConnectContext.get();
@@ -308,11 +309,11 @@ public class ArithmeticExpr extends Expr {
                     // decimal128(23,5) * decimal64(18,4) => decimal128(38, 9).
                     // TODO(stephen): support auto scale up decimal precision
                     result.returnType =
-                            ScalarType.createDecimalV3Type(defaultMaxDecimalType, maxDecimalPrecision, returnScale);
+                            TypeFactory.createDecimalV3Type(defaultMaxDecimalType, maxDecimalPrecision, returnScale);
                     result.lhsTargetType =
-                            ScalarType.createDecimalV3Type(defaultMaxDecimalType, lhsPrecision, lhsScale);
+                            TypeFactory.createDecimalV3Type(defaultMaxDecimalType, lhsPrecision, lhsScale);
                     result.rhsTargetType =
-                            ScalarType.createDecimalV3Type(defaultMaxDecimalType, rhsPrecision, rhsScale);
+                            TypeFactory.createDecimalV3Type(defaultMaxDecimalType, rhsPrecision, rhsScale);
                     return result;
                 } else {
                     // returnScale > 38, so it is cannot be represented as decimal.
@@ -338,8 +339,8 @@ public class ArithmeticExpr extends Expr {
                 }
 
                 maxPrecision = PrimitiveType.getMaxPrecisionOfDecimal(widerType);
-                result.lhsTargetType = ScalarType.createDecimalV3Type(widerType, maxPrecision, lhsScale);
-                result.rhsTargetType = ScalarType.createDecimalV3Type(widerType, maxPrecision, rhsScale);
+                result.lhsTargetType = TypeFactory.createDecimalV3Type(widerType, maxPrecision, lhsScale);
+                result.rhsTargetType = TypeFactory.createDecimalV3Type(widerType, maxPrecision, rhsScale);
                 int adjustedScale = returnScale + rhsScale;
                 if (adjustedScale > maxPrecision) {
                     throw new SemanticException(
@@ -363,7 +364,7 @@ public class ArithmeticExpr extends Expr {
                 Preconditions.checkState(false, "DecimalV3 only support operators: +-*/%&|^");
         }
         result.returnType = op == Operator.INT_DIVIDE ? ScalarType.BIGINT :
-                ScalarType.createDecimalV3Type(widerType, maxPrecision, returnScale);
+                TypeFactory.createDecimalV3Type(widerType, maxPrecision, returnScale);
         return result;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/DateLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/DateLiteral.java
@@ -42,8 +42,8 @@ import com.starrocks.sql.ast.AstVisitorExtendInterface;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -478,7 +478,7 @@ public class DateLiteral extends LiteralExpr {
                 if (len > 7) {
                     microsecond = data.getInt();
                     // choose the highest scale to keep microsecond value
-                    type = ScalarType.createDecimalV2Type(6);
+                    type = TypeFactory.createDecimalV2Type(6);
                 }
             } else {
                 copy(MIN_DATETIME);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/DecimalLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/DecimalLiteral.java
@@ -47,6 +47,7 @@ import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -163,7 +164,7 @@ public class DecimalLiteral extends LiteralExpr {
             scale = Math.min(maxIntegerPartWidth - integerPartWidth, scale);
             precision = integerPartWidth + scale;
             this.value = this.value.setScale(scale, RoundingMode.HALF_UP);
-            type = ScalarType.createDecimalV3NarrowestType(precision, scale);
+            type = TypeFactory.createDecimalV3NarrowestType(precision, scale);
         }
     }
 
@@ -189,7 +190,7 @@ public class DecimalLiteral extends LiteralExpr {
             realPrecision = realIntegerPartWidth + realScale;
             // round
             this.value = this.value.setScale(realScale, RoundingMode.HALF_UP);
-            this.type = ScalarType.createDecimalV3NarrowestType(realPrecision, realScale);
+            this.type = TypeFactory.createDecimalV3NarrowestType(realPrecision, realScale);
         } else {
             this.type = type;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/TypeDef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/TypeDef.java
@@ -44,6 +44,7 @@ import com.starrocks.type.ScalarType;
 import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 
 import java.util.List;
 
@@ -66,19 +67,19 @@ public class TypeDef implements ParseNode {
     }
 
     public static TypeDef create(PrimitiveType type) {
-        return new TypeDef(ScalarType.createType(type));
+        return new TypeDef(TypeFactory.createType(type));
     }
 
     public static TypeDef createDecimal(int precision, int scale) {
-        return new TypeDef(ScalarType.createDecimalV2Type(precision, scale));
+        return new TypeDef(TypeFactory.createDecimalV2Type(precision, scale));
     }
 
     public static TypeDef createVarchar(int len) {
-        return new TypeDef(ScalarType.createVarchar(len));
+        return new TypeDef(TypeFactory.createVarchar(len));
     }
 
     public static TypeDef createChar(int len) {
-        return new TypeDef(ScalarType.createCharType(len));
+        return new TypeDef(TypeFactory.createCharType(len));
     }
 
     public void analyze() {
@@ -122,7 +123,7 @@ public class TypeDef implements ParseNode {
                 int maxLen;
                 if (type == PrimitiveType.VARCHAR) {
                     name = "Varchar";
-                    maxLen = ScalarType.getOlapMaxVarcharLength();
+                    maxLen = TypeFactory.getOlapMaxVarcharLength();
                 } else {
                     name = "Char";
                     maxLen = ScalarType.MAX_CHAR_LENGTH;
@@ -141,7 +142,7 @@ public class TypeDef implements ParseNode {
             }
             case VARBINARY: {
                 String name = "VARBINARY";
-                int maxLen = ScalarType.getOlapMaxVarcharLength();
+                int maxLen = TypeFactory.getOlapMaxVarcharLength();
                 int len = scalarType.getLength();
                 // len is decided by child, when it is -1.
                 if (scalarType.getLength() > maxLen) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
@@ -28,6 +28,7 @@ import com.starrocks.type.ScalarType;
 import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -322,7 +323,7 @@ public class TypeManager {
             ScalarType resultType = (ScalarType) compatibleType;
             // If result type is varchar with length, it may cause the case when result type is not compatible.
             if (isContainVarcharWithoutLength && resultType.getLength() > 0) {
-                return ScalarType.createVarcharType(ScalarType.getOlapMaxVarcharLength());
+                return TypeFactory.createVarcharType(TypeFactory.getOlapMaxVarcharLength());
             } else {
                 return compatibleType;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperatorUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperatorUtil.java
@@ -25,6 +25,7 @@ import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 
 import java.util.stream.Stream;
 
@@ -73,7 +74,7 @@ public class ScalarOperatorUtil {
         Function newFn = sumFn.copy();
         if (argTypes[0].isDecimalV3()) {
             newFn.setArgsType(argTypes);
-            newFn.setRetType(ScalarType.createDecimalV3NarrowestType(38,
+            newFn.setRetType(TypeFactory.createDecimalV3NarrowestType(38,
                     ((ScalarType) argTypes[0]).getScalarScale()));
         }
         return newFn;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluator.java
@@ -35,8 +35,8 @@ import com.starrocks.sql.optimizer.operator.scalar.CastOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.logging.log4j.LogManager;
@@ -99,10 +99,10 @@ public enum ScalarOperatorEvaluator {
                                   Method method, ConstantFunction annotation) {
         if (annotation != null) {
             String name = annotation.name().toUpperCase();
-            Type returnType = ScalarType.createType(annotation.returnType());
+            Type returnType = TypeFactory.createType(annotation.returnType());
             List<Type> argTypes = new ArrayList<>();
             for (PrimitiveType type : annotation.argTypes()) {
-                argTypes.add(ScalarType.createType(type));
+                argTypes.add(TypeFactory.createType(type));
             }
 
             FunctionSignature signature = new FunctionSignature(name, argTypes, returnType);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -49,6 +49,7 @@ import com.starrocks.sql.ast.expression.DecimalLiteral;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import net.openhft.hashing.LongHashFunction;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.NameValuePair;
@@ -1518,7 +1519,7 @@ public class ScalarOperatorFunctions {
         } else {
             int precision = DecimalLiteral.getRealPrecision(result);
             int scale = DecimalLiteral.getRealScale(result);
-            type = ScalarType.createDecimalV3NarrowestType(precision, scale);
+            type = TypeFactory.createDecimalV3NarrowestType(precision, scale);
         }
 
         return ConstantOperator.createDecimal(result, type);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/FoldConstantsRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/FoldConstantsRule.java
@@ -43,6 +43,7 @@ import com.starrocks.type.ArrayType;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -228,10 +229,10 @@ public class FoldConstantsRule extends BottomUpScalarOperatorRewriteRule {
         if (call.getType().isDecimalV3()) {
             Preconditions.checkArgument(sum.getType().isDecimalV3());
             ScalarType sumType = (ScalarType) sum.getType();
-            sumType = ScalarType.createDecimalV3Type(call.getType().getPrimitiveType(), sumType.getScalarPrecision(),
+            sumType = TypeFactory.createDecimalV3Type(call.getType().getPrimitiveType(), sumType.getScalarPrecision(),
                     sumType.getScalarScale());
             int precision = PrimitiveType.getMaxPrecisionOfDecimal(call.getType().getPrimitiveType());
-            ScalarType countType = ScalarType.createDecimalV3Type(call.getType().getPrimitiveType(), precision, 0);
+            ScalarType countType = TypeFactory.createDecimalV3Type(call.getType().getPrimitiveType(), precision, 0);
             fn = new ScalarFunction(fn.getFunctionName(), new Type[] {sumType, countType}, call.getType(),
                     fn.hasVarArgs());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MultiDistinctByCTERewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MultiDistinctByCTERewriter.java
@@ -50,6 +50,7 @@ import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.sql.optimizer.rewrite.scalar.ImplicitCastRule;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -287,9 +288,9 @@ public class MultiDistinctByCTERewriter {
                     // TODO(stephen): support auto scale up decimal precision
                     ScalarType decimalType;
                     if (avgCallOperatorType.isDecimal256()) {
-                        decimalType = ScalarType.createDecimalV3NarrowestType(76, 0);
+                        decimalType = TypeFactory.createDecimalV3NarrowestType(76, 0);
                     } else {
-                        decimalType = ScalarType.createDecimalV3NarrowestType(38, 0);
+                        decimalType = TypeFactory.createDecimalV3NarrowestType(38, 0);
                     }
                     distinctAvgCallOperator.getChildren().set(
                             1, new CastOperator(decimalType, distinctAvgCallOperator.getChild(1), true));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MultiDistinctByMultiFuncRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MultiDistinctByMultiFuncRewriter.java
@@ -35,6 +35,7 @@ import com.starrocks.sql.optimizer.rewrite.scalar.ImplicitCastRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ScalarOperatorRewriteRule;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 
 import java.util.HashMap;
 import java.util.List;
@@ -122,9 +123,9 @@ public class MultiDistinctByMultiFuncRewriter {
                     // TODO(stephen): support auto scale up decimal precision
                     ScalarType decimalType;
                     if (multiAvg.getType().isDecimal256()) {
-                        decimalType = ScalarType.createDecimalV3NarrowestType(76, 0);
+                        decimalType = TypeFactory.createDecimalV3NarrowestType(76, 0);
                     } else {
-                        decimalType = ScalarType.createDecimalV3NarrowestType(38, 0);
+                        decimalType = TypeFactory.createDecimalV3NarrowestType(38, 0);
                     }
                     multiAvg.getChildren().set(
                             1, new CastOperator(decimalType, multiAvg.getChild(1), true));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSumByAssociativeRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSumByAssociativeRule.java
@@ -39,6 +39,7 @@ import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -330,11 +331,11 @@ public class RewriteSumByAssociativeRule extends TransformationRule {
                 switch (primitiveType) {
                     case DECIMAL128:
                         countOperator = new CastOperator(
-                                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 18, 0),
+                                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 18, 0),
                                 newAggRef, false);
                         int precision = ((ScalarType) arg0.getType()).getScalarPrecision();
                         int scale = ((ScalarType) arg0.getType()).getScalarScale();
-                        Type constType = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, precision, scale);
+                        Type constType = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, precision, scale);
                         constOperator = arg0.isConstantNull() ? ConstantOperator.createNull(constType) :
                                 ConstantOperator.createDecimal(new BigDecimal(arg0.toString()), constType);
                         break;
@@ -379,7 +380,7 @@ public class RewriteSumByAssociativeRule extends TransformationRule {
                 if (returnType.isDecimalV3()) {
                     // for decimal type, we should keep the result's scale same as the input's scale
                     int argScale = ((ScalarType) arg0.getType()).getScalarScale();
-                    sumFunctionType = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, argScale);
+                    sumFunctionType = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, argScale);
                 }
 
                 AggregateFunction sumFunction = AggregateFunction.createBuiltin(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/common/AggregatePushDownUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/common/AggregatePushDownUtils.java
@@ -41,6 +41,7 @@ import com.starrocks.sql.optimizer.rule.transformation.materialization.Predicate
 import com.starrocks.sql.optimizer.rule.tree.pdagg.AggregatePushDownContext;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 
 import java.util.List;
 import java.util.Map;
@@ -362,7 +363,7 @@ public class AggregatePushDownUtils {
         if (argType.isDecimalV3()) {
             // There is not need to apply ImplicitCastRule to divide operator of decimal types.
             // but we should cast BIGINT-typed countColRef into DECIMAL(38,0).
-            ScalarType decimal128p38s0 = ScalarType.createDecimalV3NarrowestType(38, 0);
+            ScalarType decimal128p38s0 = TypeFactory.createDecimalV3NarrowestType(38, 0);
             newAvg.getChildren().set(1, new CastOperator(decimal128p38s0, newAvg.getChild(1), true));
         } else {
             final ScalarOperatorRewriter scalarRewriter = new ScalarOperatorRewriter();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -533,6 +533,7 @@ import com.starrocks.type.ScalarType;
 import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.RuleContext;
 import org.antlr.v4.runtime.Token;
@@ -9396,24 +9397,24 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             length = Integer.parseInt(context.typeParameter().INTEGER_VALUE().toString());
         }
         if (context.STRING() != null || context.TEXT() != null) {
-            ScalarType type = ScalarType.createVarcharType(ScalarType.DEFAULT_STRING_LENGTH);
+            ScalarType type = TypeFactory.createVarcharType(ScalarType.DEFAULT_STRING_LENGTH);
             return type;
         } else if (context.VARCHAR() != null) {
-            ScalarType type = ScalarType.createVarcharType(length);
+            ScalarType type = TypeFactory.createVarcharType(length);
             return type;
         } else if (context.CHAR() != null) {
-            ScalarType type = ScalarType.createCharType(length);
+            ScalarType type = TypeFactory.createCharType(length);
             return type;
         } else if (context.SIGNED() != null) {
             return Type.INT;
         } else if (context.HLL() != null) {
-            ScalarType type = ScalarType.createHllType();
+            ScalarType type = TypeFactory.createHllType();
             return type;
         } else if (context.BINARY() != null || context.VARBINARY() != null) {
-            ScalarType type = ScalarType.createVarbinary(length);
+            ScalarType type = TypeFactory.createVarbinary(length);
             return type;
         } else {
-            return ScalarType.createType(context.getChild(0).getText());
+            return TypeFactory.createType(context.getChild(0).getText());
         }
     }
 
@@ -9429,11 +9430,11 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         if (context.DECIMAL() != null || context.NUMBER() != null || context.NUMERIC() != null) {
             if (precision != null) {
                 if (scale != null) {
-                    return ScalarType.createUnifiedDecimalType(precision, scale);
+                    return TypeFactory.createUnifiedDecimalType(precision, scale);
                 }
-                return ScalarType.createUnifiedDecimalType(precision);
+                return TypeFactory.createUnifiedDecimalType(precision);
             }
-            return ScalarType.createUnifiedDecimalType(10, 0);
+            return TypeFactory.createUnifiedDecimalType(10, 0);
         } else if (context.DECIMAL32() != null || context.DECIMAL64() != null || context.DECIMAL128() != null) {
             if (!Config.enable_decimal_v3) {
                 throw new SemanticException("Config field enable_decimal_v3 is false now, " +
@@ -9444,19 +9445,19 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             final PrimitiveType primitiveType = PrimitiveType.valueOf(context.children.get(0).getText().toUpperCase());
             if (precision != null) {
                 if (scale != null) {
-                    return ScalarType.createDecimalV3Type(primitiveType, precision, scale);
+                    return TypeFactory.createDecimalV3Type(primitiveType, precision, scale);
                 }
-                return ScalarType.createDecimalV3Type(primitiveType, precision);
+                return TypeFactory.createDecimalV3Type(primitiveType, precision);
             }
-            return ScalarType.createDecimalV3Type(primitiveType);
+            return TypeFactory.createDecimalV3Type(primitiveType);
         } else if (context.DECIMALV2() != null) {
             if (precision != null) {
                 if (scale != null) {
-                    return ScalarType.createDecimalV2Type(precision, scale);
+                    return TypeFactory.createDecimalV2Type(precision, scale);
                 }
-                return ScalarType.createDecimalV2Type(precision);
+                return TypeFactory.createDecimalV2Type(precision);
             }
-            return ScalarType.createDecimalV2Type();
+            return TypeFactory.createDecimalV2Type();
         } else {
             throw new IllegalArgumentException("Unsupported type " + context.getText());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/util/TypePlus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/util/TypePlus.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.util;
 
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 
 import java.util.Objects;
 
@@ -58,7 +59,7 @@ public class TypePlus {
         if (rectifiedType == null) {
             if (type instanceof ScalarType) {
                 ScalarType scalarType = (ScalarType) type;
-                rectifiedType = ScalarType.createType(scalarType.getPrimitiveType(), len, precision, scale);
+                rectifiedType = TypeFactory.createType(scalarType.getPrimitiveType(), len, precision, scale);
             } else {
                 rectifiedType = type;
             }
@@ -70,7 +71,7 @@ public class TypePlus {
         if (decayedType == null) {
             if (type instanceof ScalarType) {
                 ScalarType scalarType = (ScalarType) type;
-                decayedType = ScalarType.createType(scalarType.getPrimitiveType());
+                decayedType = TypeFactory.createType(scalarType.getPrimitiveType());
             } else {
                 decayedType = type;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeStatus.java
@@ -19,7 +19,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.qe.ShowResultSetMetaData;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -28,10 +28,10 @@ import java.util.Map;
 public interface AnalyzeStatus {
 
     ShowResultSetMetaData META_DATA = ShowResultSetMetaData.builder()
-            .addColumn(new Column("Table", ScalarType.createVarchar(20)))
-            .addColumn(new Column("Op", ScalarType.createVarchar(20)))
-            .addColumn(new Column("Msg_type", ScalarType.createVarchar(20)))
-            .addColumn(new Column("Msg_text", ScalarType.createVarchar(200)))
+            .addColumn(new Column("Table", TypeFactory.createVarchar(20)))
+            .addColumn(new Column("Op", TypeFactory.createVarchar(20)))
+            .addColumn(new Column("Msg_type", TypeFactory.createVarchar(20)))
+            .addColumn(new Column("Msg_text", TypeFactory.createVarchar(200)))
             .build();
 
     long getId();

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -61,6 +61,7 @@ import com.starrocks.type.ScalarType;
 import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.warehouse.Warehouse;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -313,48 +314,48 @@ public class StatisticUtils {
     }
 
     public static List<ColumnDef> buildStatsColumnDef(String tableName) {
-        ScalarType columnNameType = ScalarType.createVarcharType(65530);
-        ScalarType tableNameType = ScalarType.createVarcharType(65530);
-        ScalarType tableUUIDType = ScalarType.createVarcharType(65530);
-        ScalarType partitionNameType = ScalarType.createVarcharType(65530);
-        ScalarType dbNameType = ScalarType.createVarcharType(65530);
-        ScalarType maxType = ScalarType.createOlapMaxVarcharType();
-        ScalarType minType = ScalarType.createOlapMaxVarcharType();
-        ScalarType bucketsType = ScalarType.createOlapMaxVarcharType();
-        ScalarType mostCommonValueType = ScalarType.createOlapMaxVarcharType();
-        ScalarType catalogNameType = ScalarType.createVarcharType(65530);
+        ScalarType columnNameType = TypeFactory.createVarcharType(65530);
+        ScalarType tableNameType = TypeFactory.createVarcharType(65530);
+        ScalarType tableUUIDType = TypeFactory.createVarcharType(65530);
+        ScalarType partitionNameType = TypeFactory.createVarcharType(65530);
+        ScalarType dbNameType = TypeFactory.createVarcharType(65530);
+        ScalarType maxType = TypeFactory.createOlapMaxVarcharType();
+        ScalarType minType = TypeFactory.createOlapMaxVarcharType();
+        ScalarType bucketsType = TypeFactory.createOlapMaxVarcharType();
+        ScalarType mostCommonValueType = TypeFactory.createOlapMaxVarcharType();
+        ScalarType catalogNameType = TypeFactory.createVarcharType(65530);
 
         if (tableName.equals(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME)) {
             return ImmutableList.of(
-                    new ColumnDef("table_id", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
+                    new ColumnDef("table_id", new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT))),
                     new ColumnDef("column_name", new TypeDef(columnNameType)),
-                    new ColumnDef("db_id", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
+                    new ColumnDef("db_id", new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT))),
                     new ColumnDef("table_name", new TypeDef(tableNameType)),
                     new ColumnDef("db_name", new TypeDef(dbNameType)),
-                    new ColumnDef("row_count", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
-                    new ColumnDef("data_size", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
-                    new ColumnDef("distinct_count", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
-                    new ColumnDef("null_count", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
+                    new ColumnDef("row_count", new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT))),
+                    new ColumnDef("data_size", new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT))),
+                    new ColumnDef("distinct_count", new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT))),
+                    new ColumnDef("null_count", new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT))),
                     new ColumnDef("max", new TypeDef(maxType)),
                     new ColumnDef("min", new TypeDef(minType)),
-                    new ColumnDef("update_time", new TypeDef(ScalarType.createType(PrimitiveType.DATETIME)))
+                    new ColumnDef("update_time", new TypeDef(TypeFactory.createType(PrimitiveType.DATETIME)))
             );
         } else if (tableName.equals(StatsConstants.FULL_STATISTICS_TABLE_NAME)) {
             return ImmutableList.of(
-                    new ColumnDef("table_id", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
-                    new ColumnDef("partition_id", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
+                    new ColumnDef("table_id", new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT))),
+                    new ColumnDef("partition_id", new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT))),
                     new ColumnDef("column_name", new TypeDef(columnNameType)),
-                    new ColumnDef("db_id", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
+                    new ColumnDef("db_id", new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT))),
                     new ColumnDef("table_name", new TypeDef(tableNameType)),
                     new ColumnDef("partition_name", new TypeDef(partitionNameType)),
-                    new ColumnDef("row_count", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
-                    new ColumnDef("data_size", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
-                    new ColumnDef("ndv", new TypeDef(ScalarType.createType(PrimitiveType.HLL))),
-                    new ColumnDef("null_count", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
+                    new ColumnDef("row_count", new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT))),
+                    new ColumnDef("data_size", new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT))),
+                    new ColumnDef("ndv", new TypeDef(TypeFactory.createType(PrimitiveType.HLL))),
+                    new ColumnDef("null_count", new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT))),
                     new ColumnDef("max", new TypeDef(maxType)),
                     new ColumnDef("min", new TypeDef(minType)),
-                    new ColumnDef("update_time", new TypeDef(ScalarType.createType(PrimitiveType.DATETIME))),
-                    new ColumnDef("collection_size", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT)), false, null,
+                    new ColumnDef("update_time", new TypeDef(TypeFactory.createType(PrimitiveType.DATETIME))),
+                    new ColumnDef("collection_size", new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT)), false, null,
                             null, true, new ColumnDef.DefaultValueDef(true, new StringLiteral("-1")), "")
             );
         } else if (tableName.equals(StatsConstants.EXTERNAL_FULL_STATISTICS_TABLE_NAME)) {
@@ -365,25 +366,25 @@ public class StatisticUtils {
                     new ColumnDef("catalog_name", new TypeDef(catalogNameType)),
                     new ColumnDef("db_name", new TypeDef(dbNameType)),
                     new ColumnDef("table_name", new TypeDef(tableNameType)),
-                    new ColumnDef("row_count", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
-                    new ColumnDef("data_size", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
-                    new ColumnDef("ndv", new TypeDef(ScalarType.createType(PrimitiveType.HLL))),
-                    new ColumnDef("null_count", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
+                    new ColumnDef("row_count", new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT))),
+                    new ColumnDef("data_size", new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT))),
+                    new ColumnDef("ndv", new TypeDef(TypeFactory.createType(PrimitiveType.HLL))),
+                    new ColumnDef("null_count", new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT))),
                     new ColumnDef("max", new TypeDef(maxType)),
                     new ColumnDef("min", new TypeDef(minType)),
-                    new ColumnDef("update_time", new TypeDef(ScalarType.createType(PrimitiveType.DATETIME)))
+                    new ColumnDef("update_time", new TypeDef(TypeFactory.createType(PrimitiveType.DATETIME)))
             );
         } else if (tableName.equals(StatsConstants.HISTOGRAM_STATISTICS_TABLE_NAME)) {
             return ImmutableList.of(
-                    new ColumnDef("table_id", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
+                    new ColumnDef("table_id", new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT))),
                     new ColumnDef("column_name", new TypeDef(columnNameType)),
-                    new ColumnDef("db_id", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
+                    new ColumnDef("db_id", new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT))),
                     new ColumnDef("table_name", new TypeDef(tableNameType)),
                     new ColumnDef("buckets", new TypeDef(bucketsType), false, null, null,
                             true, ColumnDef.DefaultValueDef.NOT_SET, ""),
                     new ColumnDef("mcv", new TypeDef(mostCommonValueType), false, null, null,
                             true, ColumnDef.DefaultValueDef.NOT_SET, ""),
-                    new ColumnDef("update_time", new TypeDef(ScalarType.createType(PrimitiveType.DATETIME)))
+                    new ColumnDef("update_time", new TypeDef(TypeFactory.createType(PrimitiveType.DATETIME)))
             );
         } else if (tableName.equals(StatsConstants.EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME)) {
             return ImmutableList.of(
@@ -396,17 +397,17 @@ public class StatisticUtils {
                             true, ColumnDef.DefaultValueDef.NOT_SET, ""),
                     new ColumnDef("mcv", new TypeDef(mostCommonValueType), false, null, null,
                             true, ColumnDef.DefaultValueDef.NOT_SET, ""),
-                    new ColumnDef("update_time", new TypeDef(ScalarType.createType(PrimitiveType.DATETIME)))
+                    new ColumnDef("update_time", new TypeDef(TypeFactory.createType(PrimitiveType.DATETIME)))
             );
         } else if (tableName.equals(StatsConstants.MULTI_COLUMN_STATISTICS_TABLE_NAME)) {
             return ImmutableList.of(
-                    new ColumnDef("table_id", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
-                    new ColumnDef("column_ids", new TypeDef(ScalarType.createVarcharType(65530))),
-                    new ColumnDef("db_id", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
+                    new ColumnDef("table_id", new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT))),
+                    new ColumnDef("column_ids", new TypeDef(TypeFactory.createVarcharType(65530))),
+                    new ColumnDef("db_id", new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT))),
                     new ColumnDef("table_name", new TypeDef(tableNameType)),
                     new ColumnDef("column_names", new TypeDef(columnNameType)),
-                    new ColumnDef("ndv",  new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
-                    new ColumnDef("update_time", new TypeDef(ScalarType.createType(PrimitiveType.DATETIME)))
+                    new ColumnDef("ndv",  new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT))),
+                    new ColumnDef("update_time", new TypeDef(TypeFactory.createType(PrimitiveType.DATETIME)))
             );
         } else {
             throw new StarRocksPlannerException("Not support stats table " + tableName, ErrorType.INTERNAL_ERROR);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -47,7 +47,7 @@ import com.starrocks.sql.common.EngineType;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -347,16 +347,16 @@ public class StatisticsMetaManager extends FrontendDaemon {
         Map<String, String> properties = Maps.newHashMap();
         try {
             List<ColumnDef> columns = ImmutableList.of(
-                    new ColumnDef("id", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
-                    new ColumnDef("is_enable", new TypeDef(ScalarType.createType(PrimitiveType.BOOLEAN))),
-                    new ColumnDef("bind_sql", new TypeDef(ScalarType.createVarcharType(65530))),
-                    new ColumnDef("bind_sql_digest", new TypeDef(ScalarType.createVarcharType(65530))),
-                    new ColumnDef("bind_sql_hash", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
-                    new ColumnDef("plan_sql", new TypeDef(ScalarType.createVarcharType(65530))),
-                    new ColumnDef("costs", new TypeDef(ScalarType.createType(PrimitiveType.DOUBLE))),
-                    new ColumnDef("query_ms", new TypeDef(ScalarType.createType(PrimitiveType.DOUBLE))),
-                    new ColumnDef("source", new TypeDef(ScalarType.createVarcharType(100))),
-                    new ColumnDef("update_time", new TypeDef(ScalarType.createType(PrimitiveType.DATETIME)))
+                    new ColumnDef("id", new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT))),
+                    new ColumnDef("is_enable", new TypeDef(TypeFactory.createType(PrimitiveType.BOOLEAN))),
+                    new ColumnDef("bind_sql", new TypeDef(TypeFactory.createVarcharType(65530))),
+                    new ColumnDef("bind_sql_digest", new TypeDef(TypeFactory.createVarcharType(65530))),
+                    new ColumnDef("bind_sql_hash", new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT))),
+                    new ColumnDef("plan_sql", new TypeDef(TypeFactory.createVarcharType(65530))),
+                    new ColumnDef("costs", new TypeDef(TypeFactory.createType(PrimitiveType.DOUBLE))),
+                    new ColumnDef("query_ms", new TypeDef(TypeFactory.createType(PrimitiveType.DOUBLE))),
+                    new ColumnDef("source", new TypeDef(TypeFactory.createVarcharType(100))),
+                    new ColumnDef("update_time", new TypeDef(TypeFactory.createType(PrimitiveType.DATETIME)))
             );
 
             int defaultReplicationNum = AutoInferUtil.calDefaultReplicationNum();
@@ -384,15 +384,15 @@ public class StatisticsMetaManager extends FrontendDaemon {
         Map<String, String> properties = Maps.newHashMap();
         try {
             List<ColumnDef> columns = ImmutableList.of(
-                    new ColumnDef("dt", new TypeDef(ScalarType.createType(PrimitiveType.DATETIME))),
-                    new ColumnDef("frontend", new TypeDef(ScalarType.createVarcharType(65530))),
-                    new ColumnDef("db", new TypeDef(ScalarType.createVarcharType(65530))),
-                    new ColumnDef("sql_digest", new TypeDef(ScalarType.createVarcharType(65530))),
-                    new ColumnDef("sql", new TypeDef(ScalarType.createVarcharType(65530))),
-                    new ColumnDef("plan", new TypeDef(ScalarType.createVarcharType(65530))),
-                    new ColumnDef("plan_costs", new TypeDef(ScalarType.createType(PrimitiveType.DOUBLE))),
-                    new ColumnDef("query_ms", new TypeDef(ScalarType.createType(PrimitiveType.DOUBLE))),
-                    new ColumnDef("other", new TypeDef(ScalarType.createType(PrimitiveType.JSON)))
+                    new ColumnDef("dt", new TypeDef(TypeFactory.createType(PrimitiveType.DATETIME))),
+                    new ColumnDef("frontend", new TypeDef(TypeFactory.createVarcharType(65530))),
+                    new ColumnDef("db", new TypeDef(TypeFactory.createVarcharType(65530))),
+                    new ColumnDef("sql_digest", new TypeDef(TypeFactory.createVarcharType(65530))),
+                    new ColumnDef("sql", new TypeDef(TypeFactory.createVarcharType(65530))),
+                    new ColumnDef("plan", new TypeDef(TypeFactory.createVarcharType(65530))),
+                    new ColumnDef("plan_costs", new TypeDef(TypeFactory.createType(PrimitiveType.DOUBLE))),
+                    new ColumnDef("query_ms", new TypeDef(TypeFactory.createType(PrimitiveType.DOUBLE))),
+                    new ColumnDef("other", new TypeDef(TypeFactory.createType(PrimitiveType.JSON)))
             );
 
             int defaultReplicationNum = AutoInferUtil.calDefaultReplicationNum();
@@ -478,7 +478,7 @@ public class StatisticsMetaManager extends FrontendDaemon {
             if (table.getColumn(columnName) == null) {
                 if (columnName.equalsIgnoreCase("collection_size")) {
                     ColumnDef.DefaultValueDef defaultValueDef = new ColumnDef.DefaultValueDef(true, new StringLiteral("-1"));
-                    ColumnDef columnDef = new ColumnDef(columnName, new TypeDef(ScalarType.createType(PrimitiveType.BIGINT)),
+                    ColumnDef columnDef = new ColumnDef(columnName, new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT)),
                             false, null, null, true, defaultValueDef, "");
                     AddColumnClause addColumnClause = new AddColumnClause(columnDef, null, null, new HashMap<>());
                     AlterTableStmt alterTableStmt = new AlterTableStmt(

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -93,7 +93,7 @@ import com.starrocks.system.Backend.BackendState;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TResourceGroupUsage;
 import com.starrocks.thrift.TStatusCode;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.warehouse.Warehouse;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import com.starrocks.warehouse.cngroup.ComputeResourceProvider;
@@ -389,7 +389,7 @@ public class SystemInfoService implements GsonPostProcessable {
             opMessage = String.format(formatSb.toString(), willBeModifiedHost, backend.getHeartbeatPort(), fqdn);
         }
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
-        builder.addColumn(new Column("Message", ScalarType.createVarchar(1024)));
+        builder.addColumn(new Column("Message", TypeFactory.createVarchar(1024)));
         List<List<String>> messageResult = new ArrayList<>();
         messageResult.add(Collections.singletonList(opMessage));
         return new ShowResultSet(builder.build(), messageResult);
@@ -407,7 +407,7 @@ public class SystemInfoService implements GsonPostProcessable {
         }
 
         ShowResultSetMetaData.Builder builder = ShowResultSetMetaData.builder();
-        builder.addColumn(new Column("Message", ScalarType.createVarchar(1024)));
+        builder.addColumn(new Column("Message", TypeFactory.createVarchar(1024)));
         List<List<String>> messageResult = new ArrayList<>();
 
         // update backend based on properties

--- a/fe/fe-core/src/main/java/com/starrocks/type/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/type/Type.java
@@ -101,44 +101,44 @@ public abstract class Type implements Cloneable {
     public static final ScalarType DATE = new ScalarType(PrimitiveType.DATE);
     public static final ScalarType DATETIME = new ScalarType(PrimitiveType.DATETIME);
     public static final ScalarType TIME = new ScalarType(PrimitiveType.TIME);
-    public static final ScalarType DEFAULT_DECIMALV2 = ScalarType.createDecimalV2Type(ScalarType.DEFAULT_PRECISION,
+    public static final ScalarType DEFAULT_DECIMALV2 = TypeFactory.createDecimalV2Type(ScalarType.DEFAULT_PRECISION,
             ScalarType.DEFAULT_SCALE);
     public static final ScalarType DEFAULT_DECIMAL32 =
-            ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 3);
+            TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 3);
     public static final ScalarType DEFAULT_DECIMAL64 =
-            ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 6);
+            TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 6);
     public static final ScalarType DEFAULT_DECIMAL128 =
-            ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 9);
+            TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 9);
     public static final ScalarType DEFAULT_DECIMAL256 =
-            ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL256, 76, 12);
+            TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL256, 76, 12);
 
     public static final ScalarType DECIMALV2 = DEFAULT_DECIMALV2;
 
-    public static final ScalarType DECIMAL32 = ScalarType.createWildcardDecimalV3Type(PrimitiveType.DECIMAL32);
-    public static final ScalarType DECIMAL64 = ScalarType.createWildcardDecimalV3Type(PrimitiveType.DECIMAL64);
-    public static final ScalarType DECIMAL128 = ScalarType.createWildcardDecimalV3Type(PrimitiveType.DECIMAL128);
-    public static final ScalarType DECIMAL256 = ScalarType.createWildcardDecimalV3Type(PrimitiveType.DECIMAL256);
+    public static final ScalarType DECIMAL32 = TypeFactory.createWildcardDecimalV3Type(PrimitiveType.DECIMAL32);
+    public static final ScalarType DECIMAL64 = TypeFactory.createWildcardDecimalV3Type(PrimitiveType.DECIMAL64);
+    public static final ScalarType DECIMAL128 = TypeFactory.createWildcardDecimalV3Type(PrimitiveType.DECIMAL128);
+    public static final ScalarType DECIMAL256 = TypeFactory.createWildcardDecimalV3Type(PrimitiveType.DECIMAL256);
 
     // DECIMAL64_INT and DECIMAL128_INT for integer casting to decimal
     public static final ScalarType DECIMAL_ZERO =
-            ScalarType.createDecimalV3TypeForZero(0);
+            TypeFactory.createDecimalV3TypeForZero(0);
     public static final ScalarType DECIMAL32_INT =
-            ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 9, 0);
+            TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 9, 0);
     public static final ScalarType DECIMAL64_INT =
-            ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 0);
+            TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 0);
     public static final ScalarType DECIMAL128_INT =
-            ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 0);
+            TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 0);
 
-    public static final ScalarType VARCHAR = ScalarType.createVarcharType(-1);
-    public static final ScalarType STRING = ScalarType.createVarcharType(ScalarType.getOlapMaxVarcharLength());
-    public static final ScalarType DEFAULT_STRING = ScalarType.createDefaultString();
-    public static final ScalarType HLL = ScalarType.createHllType();
-    public static final ScalarType CHAR = ScalarType.createCharType(-1);
+    public static final ScalarType VARCHAR = TypeFactory.createVarcharType(-1);
+    public static final ScalarType STRING = TypeFactory.createVarcharType(TypeFactory.getOlapMaxVarcharLength());
+    public static final ScalarType DEFAULT_STRING = TypeFactory.createDefaultString();
+    public static final ScalarType HLL = TypeFactory.createHllType();
+    public static final ScalarType CHAR = TypeFactory.createCharType(-1);
     public static final ScalarType BITMAP = new ScalarType(PrimitiveType.BITMAP);
     public static final ScalarType PERCENTILE = new ScalarType(PrimitiveType.PERCENTILE);
     public static final ScalarType JSON = new ScalarType(PrimitiveType.JSON);
     public static final ScalarType VARIANT = new ScalarType(PrimitiveType.VARIANT);
-    public static final ScalarType UNKNOWN_TYPE = ScalarType.createUnknownType();
+    public static final ScalarType UNKNOWN_TYPE = TypeFactory.createUnknownType();
     public static final ScalarType FUNCTION = new ScalarType(PrimitiveType.FUNCTION);
     public static final ScalarType VARBINARY = new ScalarType(PrimitiveType.VARBINARY);
 

--- a/fe/fe-core/src/main/java/com/starrocks/type/TypeCompatibilityMatrix.java
+++ b/fe/fe-core/src/main/java/com/starrocks/type/TypeCompatibilityMatrix.java
@@ -322,11 +322,11 @@ public class TypeCompatibilityMatrix {
 
         // JSON
         for (PrimitiveType type : PrimitiveType.JSON_COMPATIBLE_TYPE) {
-            ScalarType scalar = ScalarType.createType(type);
+            ScalarType scalar = TypeFactory.createType(type);
             COMPATIBILITY_MATRIX[scalar.ordinal()][Type.JSON.ordinal()] = type;
         }
         for (PrimitiveType type : PrimitiveType.JSON_UNCOMPATIBLE_TYPE) {
-            ScalarType scalar = ScalarType.createType(type);
+            ScalarType scalar = TypeFactory.createType(type);
             COMPATIBILITY_MATRIX[scalar.ordinal()][Type.JSON.ordinal()] = PrimitiveType.INVALID_TYPE;
         }
 
@@ -342,11 +342,11 @@ public class TypeCompatibilityMatrix {
 
         // VARIANT
         for (PrimitiveType type : PrimitiveType.VARIANT_COMPATIBLE_TYPE) {
-            ScalarType scalar = ScalarType.createType(type);
+            ScalarType scalar = TypeFactory.createType(type);
             COMPATIBILITY_MATRIX[scalar.ordinal()][Type.VARIANT.ordinal()] = PrimitiveType.VARIANT;
         }
         for (PrimitiveType type : PrimitiveType.VARIANT_INCOMPATIBLE_TYPES) {
-            ScalarType scalar = ScalarType.createType(type);
+            ScalarType scalar = TypeFactory.createType(type);
             COMPATIBILITY_MATRIX[scalar.ordinal()][Type.VARIANT.ordinal()] = PrimitiveType.INVALID_TYPE;
         }
         COMPATIBILITY_MATRIX[Type.VARIANT.ordinal()][Type.DATE.ordinal()] = PrimitiveType.INVALID_TYPE;
@@ -370,7 +370,7 @@ public class TypeCompatibilityMatrix {
 
         // binary type
         for (PrimitiveType type : PrimitiveType.BINARY_INCOMPATIBLE_TYPE_LIST) {
-            ScalarType scalar = ScalarType.createType(type);
+            ScalarType scalar = TypeFactory.createType(type);
             COMPATIBILITY_MATRIX[scalar.ordinal()][Type.VARBINARY.ordinal()] = PrimitiveType.INVALID_TYPE;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/type/TypeDeserializer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/type/TypeDeserializer.java
@@ -162,31 +162,31 @@ public class TypeDeserializer {
         
         if (scalarType.getType() == TPrimitiveType.CHAR) {
             Preconditions.checkState(scalarType.isSetLen());
-            return ScalarType.createCharType(scalarType.getLen());
+            return TypeFactory.createCharType(scalarType.getLen());
         } else if (scalarType.getType() == TPrimitiveType.VARCHAR) {
             Preconditions.checkState(scalarType.isSetLen());
-            return ScalarType.createVarcharType(scalarType.getLen());
+            return TypeFactory.createVarcharType(scalarType.getLen());
         } else if (scalarType.getType() == TPrimitiveType.VARBINARY) {
-            return ScalarType.createVarbinary(scalarType.getLen());
+            return TypeFactory.createVarbinary(scalarType.getLen());
         } else if (scalarType.getType() == TPrimitiveType.HLL) {
-            return ScalarType.createHllType();
+            return TypeFactory.createHllType();
         } else if (scalarType.getType() == TPrimitiveType.DECIMAL) {
             Preconditions.checkState(scalarType.isSetPrecision() && scalarType.isSetScale());
-            return ScalarType.createDecimalV2Type(scalarType.getPrecision(), scalarType.getScale());
+            return TypeFactory.createDecimalV2Type(scalarType.getPrecision(), scalarType.getScale());
         } else if (scalarType.getType() == TPrimitiveType.DECIMALV2) {
             Preconditions.checkState(scalarType.isSetPrecision() && scalarType.isSetScale());
-            return ScalarType.createDecimalV2Type(scalarType.getPrecision(), scalarType.getScale());
+            return TypeFactory.createDecimalV2Type(scalarType.getPrecision(), scalarType.getScale());
         } else if (scalarType.getType() == TPrimitiveType.DECIMAL32 ||
                 scalarType.getType() == TPrimitiveType.DECIMAL64 ||
                 scalarType.getType() == TPrimitiveType.DECIMAL128 ||
                 scalarType.getType() == TPrimitiveType.DECIMAL256) {
             Preconditions.checkState(scalarType.isSetPrecision() && scalarType.isSetScale());
-            return ScalarType.createDecimalV3Type(
+            return TypeFactory.createDecimalV3Type(
                     TypeDeserializer.fromThrift(scalarType.getType()),
                     scalarType.getPrecision(),
                     scalarType.getScale());
         } else {
-            return ScalarType.createType(TypeDeserializer.fromThrift(scalarType.getType()));
+            return TypeFactory.createType(TypeDeserializer.fromThrift(scalarType.getType()));
         }
     }
 
@@ -247,20 +247,20 @@ public class TypeDeserializer {
 
         switch (tPrimitiveType) {
             case CHAR:
-                return ScalarType.createCharType(ptype.len);
+                return TypeFactory.createCharType(ptype.len);
             case VARCHAR:
-                return ScalarType.createVarcharType(ptype.len);
+                return TypeFactory.createVarcharType(ptype.len);
             case VARBINARY:
-                return ScalarType.createVarbinary(ptype.len);
+                return TypeFactory.createVarbinary(ptype.len);
             case DECIMALV2:
-                return ScalarType.createDecimalV2Type(ptype.precision, ptype.precision);
+                return TypeFactory.createDecimalV2Type(ptype.precision, ptype.precision);
             case DECIMAL32:
             case DECIMAL64:
             case DECIMAL128:
             case DECIMAL256:
-                return ScalarType.createDecimalV3Type(TypeDeserializer.fromThrift(tPrimitiveType), ptype.precision, ptype.scale);
+                return TypeFactory.createDecimalV3Type(TypeDeserializer.fromThrift(tPrimitiveType), ptype.precision, ptype.scale);
             default:
-                return ScalarType.createType(TypeDeserializer.fromThrift(tPrimitiveType));
+                return TypeFactory.createType(TypeDeserializer.fromThrift(tPrimitiveType));
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/type/TypeFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/type/TypeFactory.java
@@ -1,0 +1,439 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.type;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.common.Config;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariableConstants;
+
+/**
+ * Factory class for creating Type instances.
+ * This class centralizes all type creation logic that was previously scattered
+ * across Type and ScalarType classes, following the Factory pattern.
+ */
+public class TypeFactory {
+
+    private TypeFactory() {
+        // Private constructor to prevent instantiation
+    }
+
+    /**
+     * Create a scalar type with specified parameters.
+     * 
+     * @param type the primitive type
+     * @param len length for CHAR/VARCHAR types
+     * @param precision precision for DECIMAL types
+     * @param scale scale for DECIMAL types
+     * @return the created ScalarType
+     */
+    public static ScalarType createType(PrimitiveType type, int len, int precision, int scale) {
+        switch (type) {
+            case CHAR:
+                return createCharType(len);
+            case VARCHAR:
+                return createVarcharType(len);
+            case VARBINARY:
+                return createVarbinary(len);
+            case DECIMALV2:
+                return createDecimalV2Type(precision, scale);
+            case DECIMAL32:
+            case DECIMAL64:
+            case DECIMAL128:
+            case DECIMAL256:
+                return createDecimalV3Type(type, precision, scale);
+            default:
+                return createType(type);
+        }
+    }
+
+    /**
+     * Create a scalar type from a primitive type.
+     * 
+     * @param type the primitive type
+     * @return the created ScalarType
+     */
+    public static ScalarType createType(PrimitiveType type) {
+        ScalarType res = Type.PRIMITIVE_TYPE_SCALAR_TYPE_MAP.get(type);
+        Preconditions.checkNotNull(res, "unknown type " + type);
+        return res;
+    }
+
+    /**
+     * Create a scalar type from a string type name.
+     * 
+     * @param type the type name
+     * @return the created ScalarType
+     */
+    public static ScalarType createType(String type) {
+        ScalarType res = Type.STATIC_TYPE_MAP.get(type);
+        Preconditions.checkNotNull(res, "unknown type " + type);
+        return res;
+    }
+
+    /**
+     * Create a CHAR type with specified length.
+     * 
+     * @param len the length of the CHAR type
+     * @return the created CHAR type
+     */
+    public static ScalarType createCharType(int len) {
+        ScalarType type = new ScalarType(PrimitiveType.CHAR);
+        type.setLength(len);
+        return type;
+    }
+
+    private static boolean isDecimalV3Enabled() {
+        return Config.enable_decimal_v3;
+    }
+
+    /**
+     * Create a unified decimal type with default precision and scale.
+     * Unified decimal is used for parser, which creating default decimal from name.
+     * For mysql compatibility, uses precision=10, scale=0 as default.
+     * 
+     * @return the created decimal type
+     */
+    public static ScalarType createUnifiedDecimalType() {
+        // for mysql compatibility
+        return createUnifiedDecimalType(10, 0);
+    }
+
+    /**
+     * Create a unified decimal type with specified precision.
+     * For mysql compatibility, uses scale=0 as default.
+     * 
+     * @param precision the precision
+     * @return the created decimal type
+     */
+    public static ScalarType createUnifiedDecimalType(int precision) {
+        // for mysql compatibility
+        return createUnifiedDecimalType(precision, 0);
+    }
+
+    /**
+     * Create a unified decimal type with specified precision and scale.
+     * Automatically chooses between DecimalV2 and DecimalV3 based on configuration.
+     * 
+     * @param precision the precision
+     * @param scale the scale
+     * @return the created decimal type
+     */
+    public static ScalarType createUnifiedDecimalType(int precision, int scale) {
+        if (isDecimalV3Enabled()) {
+            // use decimal64 even if precision <= 9, because decimal32 is vulnerable to overflow
+            // and casted to decimal64 before expression evaluations are performed on it in BE, so
+            // decimal32 has a performance penalty.
+            PrimitiveType pt;
+            if (precision <= 18) {
+                pt = PrimitiveType.DECIMAL64;
+            } else if (precision <= 38) {
+                pt = PrimitiveType.DECIMAL128;
+            } else {
+                pt = PrimitiveType.DECIMAL256;
+            }
+
+            return createDecimalV3Type(pt, precision, scale);
+        } else {
+            return createDecimalV2Type(precision, scale);
+        }
+    }
+
+    /**
+     * Create a DecimalV2 type with default precision and scale.
+     * 
+     * @return the default DecimalV2 type
+     */
+    public static ScalarType createDecimalV2Type() {
+        return Type.DEFAULT_DECIMALV2;
+    }
+
+    /**
+     * Create a DecimalV2 type with specified precision and default scale.
+     * 
+     * @param precision the precision
+     * @return the created DecimalV2 type
+     */
+    public static ScalarType createDecimalV2Type(int precision) {
+        return createDecimalV2Type(precision, ScalarType.DEFAULT_SCALE);
+    }
+
+    /**
+     * Create a DecimalV2 type with specified precision and scale.
+     * 
+     * @param precision the precision
+     * @param scale the scale
+     * @return the created DecimalV2 type
+     */
+    public static ScalarType createDecimalV2Type(int precision, int scale) {
+        ScalarType type = new ScalarType(PrimitiveType.DECIMALV2);
+        type.setPrecision(precision);
+        type.setScale(scale);
+        return type;
+    }
+
+    /**
+     * Create a DecimalV3 type with specified primitive type, precision and scale.
+     * 
+     * @param type the decimal primitive type (DECIMAL32/64/128/256)
+     * @param precision the precision
+     * @param scale the scale
+     * @return the created DecimalV3 type
+     */
+    public static ScalarType createDecimalV3Type(PrimitiveType type, int precision, int scale) {
+        int maxPrecision = PrimitiveType.getMaxPrecisionOfDecimal(PrimitiveType.DECIMAL256);
+        ConnectContext ctx = ConnectContext.get();
+        if (ctx == null ||
+                ctx.getSessionVariable() == null ||
+                ctx.getSessionVariable().getLargeDecimalUnderlyingType() == null ||
+                ctx.getSessionVariable().getLargeDecimalUnderlyingType().equals(SessionVariableConstants.PANIC)) {
+            Preconditions.checkArgument(0 <= precision &&
+                            precision <= PrimitiveType.getMaxPrecisionOfDecimal(type),
+                    "DECIMAL's precision should range from 1 to %s",
+                    PrimitiveType.getMaxPrecisionOfDecimal(type));
+            Preconditions.checkArgument(0 <= scale && scale <= precision,
+                    "DECIMAL(P[,S]) type P must be greater than or equal to the value of S");
+        }
+        if (precision > maxPrecision) {
+            String underlyingType = ConnectContext.get().getSessionVariable().getLargeDecimalUnderlyingType();
+            if (underlyingType.equals(SessionVariableConstants.DOUBLE)) {
+                return Type.DOUBLE;
+            } else {
+                precision = maxPrecision;
+                type = PrimitiveType.DECIMAL256;
+            }
+        }
+        ScalarType scalarType = new ScalarType(type);
+        scalarType.setPrecision(Math.max(precision, 1));
+        scalarType.setScale(scale);
+        return scalarType;
+    }
+
+    /**
+     * Create a DecimalV3 type for representing zero with specified scale.
+     * The precision is set equal to the scale.
+     * 
+     * @param scale the scale
+     * @return the created DecimalV3 type
+     */
+    public static ScalarType createDecimalV3TypeForZero(int scale) {
+        final ScalarType scalarType;
+        if (scale <= PrimitiveType.getMaxPrecisionOfDecimal(PrimitiveType.DECIMAL32)) {
+            scalarType = new ScalarType(PrimitiveType.DECIMAL32);
+        } else if (scale <= PrimitiveType.getDefaultScaleOfDecimal(PrimitiveType.DECIMAL64)) {
+            scalarType = new ScalarType(PrimitiveType.DECIMAL64);
+        } else if (scale <= PrimitiveType.getDefaultScaleOfDecimal(PrimitiveType.DECIMAL128)) {
+            scalarType = new ScalarType(PrimitiveType.DECIMAL128);
+        } else {
+            scalarType = new ScalarType(PrimitiveType.DECIMAL256);
+            scale = PrimitiveType.getDefaultScaleOfDecimal(PrimitiveType.DECIMAL256);
+        }
+        scalarType.setPrecision(scale);
+        scalarType.setScale(scale);
+        return scalarType;
+    }
+
+    /**
+     * Create a wildcard DecimalV3 type for function matching.
+     * Wildcard decimal uses precision=-1 and scale=-1.
+     * 
+     * @param type the decimal primitive type (DECIMAL32/64/128/256)
+     * @return the created wildcard DecimalV3 type
+     */
+    public static ScalarType createWildcardDecimalV3Type(PrimitiveType type) {
+        Preconditions.checkArgument(type.isDecimalV3Type());
+        ScalarType scalarType = new ScalarType(type);
+        scalarType.setPrecision(-1);
+        scalarType.setScale(-1);
+        return scalarType;
+    }
+
+    /**
+     * Create a DecimalV3 type with specified primitive type and precision.
+     * Scale is set to the minimum of precision and the default scale for the type.
+     * 
+     * @param type the decimal primitive type (DECIMAL32/64/128/256)
+     * @param precision the precision
+     * @return the created DecimalV3 type
+     */
+    public static ScalarType createDecimalV3Type(PrimitiveType type, int precision) {
+        int defaultScale = PrimitiveType.getDefaultScaleOfDecimal(type);
+        return createDecimalV3Type(type, precision, Math.min(precision, defaultScale));
+    }
+
+    /**
+     * Create a DecimalV3 type with specified primitive type.
+     * Uses the maximum precision and default scale for the type.
+     * 
+     * @param type the decimal primitive type (DECIMAL32/64/128/256)
+     * @return the created DecimalV3 type
+     */
+    public static ScalarType createDecimalV3Type(PrimitiveType type) {
+        int maxPrecision = PrimitiveType.getMaxPrecisionOfDecimal(type);
+        int defaultScale = PrimitiveType.getDefaultScaleOfDecimal(type);
+        return createDecimalV3Type(type, maxPrecision, defaultScale);
+    }
+
+    /**
+     * Create the narrowest DecimalV3 type that can hold the specified precision and scale.
+     * Chooses the smallest DecimalV3 type (DECIMAL32 -> DECIMAL64 -> DECIMAL128 -> DECIMAL256)
+     * that can accommodate the given precision.
+     * 
+     * @param precision the precision
+     * @param scale the scale
+     * @return the created narrowest DecimalV3 type
+     */
+    public static ScalarType createDecimalV3NarrowestType(int precision, int scale) {
+        if (precision == 0 && scale == 0) {
+            return createDecimalV3TypeForZero(0);
+        }
+        final int decimal32MaxPrecision = PrimitiveType.getMaxPrecisionOfDecimal(PrimitiveType.DECIMAL32);
+        final int decimal64MaxPrecision = PrimitiveType.getMaxPrecisionOfDecimal(PrimitiveType.DECIMAL64);
+        final int decimal128MaxPrecision = PrimitiveType.getMaxPrecisionOfDecimal(PrimitiveType.DECIMAL128);
+        final int decimal256MaxPrecision = PrimitiveType.getMaxPrecisionOfDecimal(PrimitiveType.DECIMAL256);
+        if (0 < precision && precision <= decimal32MaxPrecision) {
+            return createDecimalV3Type(PrimitiveType.DECIMAL32, precision, scale);
+        } else if (decimal32MaxPrecision < precision && precision <= decimal64MaxPrecision) {
+            return createDecimalV3Type(PrimitiveType.DECIMAL64, precision, scale);
+        } else if (decimal64MaxPrecision < precision && precision <= decimal128MaxPrecision) {
+            return createDecimalV3Type(PrimitiveType.DECIMAL128, precision, scale);
+        } else if (decimal128MaxPrecision < precision && precision <= decimal256MaxPrecision) {
+            return createDecimalV3Type(PrimitiveType.DECIMAL256, precision, scale);
+        } else {
+            Preconditions.checkState(false,
+                    "Illegal decimal precision(1 to 76): precision=" + precision);
+            return Type.INVALID;
+        }
+    }
+
+    /**
+     * Get the maximum varchar length for OLAP tables.
+     * 
+     * @return the maximum varchar length
+     */
+    public static int getOlapMaxVarcharLength() {
+        return Config.max_varchar_length;
+    }
+
+    /**
+     * Create a default string type.
+     * Uses default string length.
+     * 
+     * @return the created string type
+     */
+    public static ScalarType createDefaultString() {
+        ScalarType stringType = createVarcharType(ScalarType.DEFAULT_STRING_LENGTH);
+        return stringType;
+    }
+
+    /**
+     * Create a default catalog string type.
+     * Uses maximum catalog varchar length for external catalogs like Hive.
+     * 
+     * @return the created catalog string type
+     */
+    public static ScalarType createDefaultCatalogString() {
+        return createVarcharType(ScalarType.CATALOG_MAX_VARCHAR_LENGTH);
+    }
+
+    /**
+     * Create a VARCHAR type with maximum OLAP varchar length.
+     * 
+     * @return the created VARCHAR type
+     */
+    public static ScalarType createOlapMaxVarcharType() {
+        ScalarType stringType = createVarcharType(getOlapMaxVarcharLength());
+        return stringType;
+    }
+
+    /**
+     * Create a VARCHAR type with specified length.
+     * 
+     * @param len the length of the VARCHAR type
+     * @return the created VARCHAR type
+     */
+    public static ScalarType createVarcharType(int len) {
+        // length checked in analysis
+        ScalarType type = new ScalarType(PrimitiveType.VARCHAR);
+        type.setLength(len);
+        return type;
+    }
+
+    /**
+     * Create a VARCHAR type with specified length.
+     * Alias for createVarcharType(int).
+     * 
+     * @param len the length of the VARCHAR type
+     * @return the created VARCHAR type
+     */
+    public static ScalarType createVarchar(int len) {
+        // length checked in analysis
+        ScalarType type = new ScalarType(PrimitiveType.VARCHAR);
+        type.setLength(len);
+        return type;
+    }
+
+    /**
+     * Create a VARBINARY type with specified length.
+     * 
+     * @param len the length of the VARBINARY type
+     * @return the created VARBINARY type
+     */
+    public static ScalarType createVarbinary(int len) {
+        ScalarType type = new ScalarType(PrimitiveType.VARBINARY);
+        type.setLength(len);
+        return type;
+    }
+
+    /**
+     * Create a VARCHAR type with wildcard length.
+     * 
+     * @return the VARCHAR type with wildcard length
+     */
+    public static ScalarType createVarcharType() {
+        return Type.VARCHAR;
+    }
+
+    /**
+     * Create an HLL type.
+     * HLL is used for HyperLogLog approximate counting.
+     * 
+     * @return the created HLL type
+     */
+    public static ScalarType createHllType() {
+        ScalarType type = new ScalarType(PrimitiveType.HLL);
+        type.setLength(ScalarType.MAX_HLL_LENGTH);
+        return type;
+    }
+
+    /**
+     * Create an UNKNOWN type.
+     * Used for unresolved type references.
+     * 
+     * @return the created UNKNOWN type
+     */
+    public static ScalarType createUnknownType() {
+        return new ScalarType(PrimitiveType.UNKNOWN_TYPE);
+    }
+
+    /**
+     * Create a JSON type.
+     * 
+     * @return the created JSON type
+     */
+    public static ScalarType createJsonType() {
+        return new ScalarType(PrimitiveType.JSON);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ArithmeticExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ArithmeticExprTest.java
@@ -10,6 +10,7 @@ import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.ast.expression.TableName;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -22,12 +23,12 @@ public class ArithmeticExprTest {
         UtFrameUtils.createDefaultCtx();
         Expr lhsExpr = new SlotRef(new TableName("foo_db", "bar_table"), "c0");
         Expr rhsExpr = new SlotRef(new TableName("foo_db", "bar_table"), "c1");
-        ScalarType decimal32p9s2 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 2);
+        ScalarType decimal32p9s2 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 2);
         lhsExpr.setType(decimal32p9s2);
         rhsExpr.setType(decimal32p9s2);
         ArithmeticExpr addExpr = new ArithmeticExpr(
                 ArithmeticExpr.Operator.ADD, lhsExpr, rhsExpr);
-        ScalarType decimal64p10s2 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 2);
+        ScalarType decimal64p10s2 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 2);
         ExpressionAnalyzer.analyzeExpressionIgnoreSlot(addExpr, ConnectContext.get());
         Assertions.assertEquals(addExpr.getType(), decimal64p10s2);
         Assertions.assertNotNull(addExpr.getFn());
@@ -49,7 +50,7 @@ public class ArithmeticExprTest {
                 pType = PrimitiveType.DECIMAL128;
                 break;
         }
-        return ScalarType.createDecimalV3Type(pType, precision, scale);
+        return TypeFactory.createDecimalV3Type(pType, precision, scale);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ColumnDefTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ColumnDefTest.java
@@ -51,8 +51,8 @@ import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.ast.expression.TypeDef;
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -69,11 +69,11 @@ public class ColumnDefTest {
 
     @BeforeEach
     public void setUp() {
-        intCol = new TypeDef(ScalarType.createType(PrimitiveType.INT));
-        BigIntCol = new TypeDef(ScalarType.createType(PrimitiveType.BIGINT));
-        stringCol = new TypeDef(ScalarType.createCharType(10));
-        floatCol = new TypeDef(ScalarType.createType(PrimitiveType.FLOAT));
-        booleanCol = new TypeDef(ScalarType.createType(PrimitiveType.BOOLEAN));
+        intCol = new TypeDef(TypeFactory.createType(PrimitiveType.INT));
+        BigIntCol = new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT));
+        stringCol = new TypeDef(TypeFactory.createCharType(10));
+        floatCol = new TypeDef(TypeFactory.createType(PrimitiveType.FLOAT));
+        booleanCol = new TypeDef(TypeFactory.createType(PrimitiveType.BOOLEAN));
         arrayIntCol = new TypeDef(new ArrayType(Type.INT));
     }
 
@@ -320,7 +320,7 @@ public class ColumnDefTest {
     @Test
     public void testInvalidVarcharInsideArray() {
         assertThrows(SemanticException.class, () -> {
-            Type tooLongVarchar = ScalarType.createVarchar(ScalarType.getOlapMaxVarcharLength() + 1);
+            Type tooLongVarchar = TypeFactory.createVarchar(TypeFactory.getOlapMaxVarcharLength() + 1);
             ColumnDef column = new ColumnDef("col", new TypeDef(new ArrayType(tooLongVarchar)), false, null, null, true,
                     DefaultValueDef.NOT_SET, "");
             ColumnDefAnalyzer.analyze(column, true);
@@ -330,7 +330,7 @@ public class ColumnDefTest {
     @Test
     public void testInvalidDecimalInsideArray() {
         assertThrows(SemanticException.class, () -> {
-            Type invalidDecimal = ScalarType.createDecimalV2Type(100, -1);
+            Type invalidDecimal = TypeFactory.createDecimalV2Type(100, -1);
             ColumnDef column = new ColumnDef("col", new TypeDef(new ArrayType(invalidDecimal)), false, null, null, true,
                     DefaultValueDef.NOT_SET, "");
             ColumnDefAnalyzer.analyze(column, true);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DecimalLiteralTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DecimalLiteralTest.java
@@ -44,6 +44,7 @@ import com.starrocks.sql.ast.expression.NullLiteral;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -95,7 +96,7 @@ public class DecimalLiteralTest {
         for (String tc : testCases) {
             DecimalLiteral decimalLiteral = new DecimalLiteral(tc);
             ByteBuffer a = decimalLiteral.getHashValue(Type.DECIMALV2);
-            ByteBuffer b = decimalLiteral.getHashValue(ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 27, 9));
+            ByteBuffer b = decimalLiteral.getHashValue(TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 27, 9));
             Assertions.assertEquals(a.limit(), 12);
             Assertions.assertEquals(a.limit(), b.limit());
             Assertions.assertEquals(a.getLong(), b.getLong());
@@ -127,7 +128,7 @@ public class DecimalLiteralTest {
             LargeIntLiteral largeIntLiteral = new LargeIntLiteral(bigInt.toString());
             ByteBuffer a = largeIntLiteral.getHashValue(Type.LARGEINT);
             ByteBuffer b =
-                    decimalLiteral.getHashValue(ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 30, 10));
+                    decimalLiteral.getHashValue(TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 30, 10));
             Assertions.assertEquals(a.limit(), 16);
             Assertions.assertEquals(a.limit(), b.limit());
             Assertions.assertEquals(a.getLong(), b.getLong());
@@ -158,7 +159,7 @@ public class DecimalLiteralTest {
             long bigInt = decimalLiteral.getValue().multiply(scaleFactor).longValue();
             IntLiteral largeIntLiteral = new IntLiteral(bigInt);
             ByteBuffer a = largeIntLiteral.getHashValue(Type.BIGINT);
-            ByteBuffer b = decimalLiteral.getHashValue(ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 15, 5));
+            ByteBuffer b = decimalLiteral.getHashValue(TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 15, 5));
             Assertions.assertEquals(a.limit(), 8);
             Assertions.assertEquals(a.limit(), b.limit());
             Assertions.assertEquals(a.getLong(), b.getLong());
@@ -188,7 +189,7 @@ public class DecimalLiteralTest {
             long bigInt = decimalLiteral.getValue().multiply(scaleFactor).intValue();
             IntLiteral intLiteral = new IntLiteral(bigInt);
             ByteBuffer a = intLiteral.getHashValue(Type.INT);
-            ByteBuffer b = decimalLiteral.getHashValue(ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 7, 2));
+            ByteBuffer b = decimalLiteral.getHashValue(TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 7, 2));
             Assertions.assertEquals(a.limit(), 4);
             Assertions.assertEquals(a.limit(), b.limit());
             Assertions.assertEquals(a.getInt(), b.getInt());
@@ -201,34 +202,34 @@ public class DecimalLiteralTest {
         DecimalLiteral decimalLiteral;
         Type type;
         decimalLiteral = new DecimalLiteral(Strings.repeat("9", 38));
-        Assertions.assertEquals(decimalLiteral.getType(), ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 0));
+        Assertions.assertEquals(decimalLiteral.getType(), TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 0));
 
         decimalLiteral = new DecimalLiteral("123456789012345678901234567890.1234567890");
-        Assertions.assertEquals(decimalLiteral.getType(), ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL256, 40, 10));
+        Assertions.assertEquals(decimalLiteral.getType(), TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL256, 40, 10));
         Assertions.assertEquals("123456789012345678901234567890.1234567890", decimalLiteral.getStringValue());
 
         decimalLiteral = new DecimalLiteral("1234567890123456789012345678901234567890123456789012345678901234567890.1234567890");
-        Assertions.assertEquals(decimalLiteral.getType(), ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL256, 76, 6));
+        Assertions.assertEquals(decimalLiteral.getType(), TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL256, 76, 6));
         Assertions.assertEquals("1234567890123456789012345678901234567890123456789012345678901234567890.123457",
                 decimalLiteral.getStringValue());
 
         decimalLiteral = new DecimalLiteral(new BigDecimal("12345678901234567890.12345678901234567890"));
-        Assertions.assertEquals(decimalLiteral.getType(), ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL256, 40, 20));
+        Assertions.assertEquals(decimalLiteral.getType(), TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL256, 40, 20));
         Assertions.assertEquals("12345678901234567890.12345678901234567890", decimalLiteral.getStringValue());
 
-        type = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4);
+        type = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4);
         decimalLiteral = new DecimalLiteral("12345678.90", type);
-        Assertions.assertEquals(decimalLiteral.getType(), ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 2));
+        Assertions.assertEquals(decimalLiteral.getType(), TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 2));
         decimalLiteral = (DecimalLiteral) decimalLiteral.uncheckedCastTo(type);
         Assertions.assertEquals(decimalLiteral.getType(), type);
 
-        type = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 6);
+        type = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 6);
         decimalLiteral = new DecimalLiteral("12345678.1234567890123", type);
-        Assertions.assertEquals(decimalLiteral.getType(), ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 14, 6));
+        Assertions.assertEquals(decimalLiteral.getType(), TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 14, 6));
         decimalLiteral = (DecimalLiteral) decimalLiteral.uncheckedCastTo(type);
         Assertions.assertEquals(decimalLiteral.getType(), type);
         Assertions.assertEquals(decimalLiteral.getStringValue(), "12345678.123457");
-        type = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 17, 5);
+        type = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 17, 5);
         decimalLiteral = (DecimalLiteral) decimalLiteral.uncheckedCastTo(type);
         Assertions.assertEquals(decimalLiteral.getType(), type);
         Assertions.assertEquals(decimalLiteral.getStringValue(), "12345678.12346");
@@ -252,7 +253,7 @@ public class DecimalLiteralTest {
     @Test
     public void testDealWithSingularDecimalLiteralAbnormal2() {
         assertThrows(Throwable.class, () -> {
-            Type type = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 9, 2);
+            Type type = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 9, 2);
             DecimalLiteral decimalLiteral = new DecimalLiteral("1234567890.1235", type);
         });
     }
@@ -260,7 +261,7 @@ public class DecimalLiteralTest {
     @Test
     public void testDealWithSingularDecimalLiteralAbnormal3() {
         assertThrows(Throwable.class, () -> {
-            Type type = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 9, 2);
+            Type type = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 9, 2);
             DecimalLiteral decimalLiteral = new DecimalLiteral("92233720368547758.08");
             decimalLiteral.uncheckedCastTo(type);
         });
@@ -274,7 +275,7 @@ public class DecimalLiteralTest {
                 new BigDecimal("2147483.648"),
                 new BigDecimal("-2147483.649"),
         };
-        ScalarType decimal32p4s3 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 4, 3);
+        ScalarType decimal32p4s3 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 4, 3);
         for (BigDecimal dec32 : decimal32Values) {
             try {
                 DecimalLiteral.checkLiteralOverflowInBinaryStyle(dec32, decimal32p4s3);
@@ -289,7 +290,7 @@ public class DecimalLiteralTest {
                 new BigDecimal("-9223372036854.775809"),
                 new BigDecimal("-9223372036854.7758086"),
         };
-        ScalarType decimal64p10s6 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 6);
+        ScalarType decimal64p10s6 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 6);
         for (BigDecimal dec64 : decimal64Values) {
             try {
                 DecimalLiteral.checkLiteralOverflowInBinaryStyle(dec64, decimal64p10s6);
@@ -304,7 +305,7 @@ public class DecimalLiteralTest {
                 new BigDecimal("-1701411834604692317316873037.15884105729"),
                 new BigDecimal("-1701411834604692317316873037.158841057286"),
         };
-        ScalarType decimal128p36s11 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 36, 11);
+        ScalarType decimal128p36s11 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 36, 11);
         for (BigDecimal dec128 : decimal128Values) {
             try {
                 DecimalLiteral.checkLiteralOverflowInBinaryStyle(dec128, decimal128p36s11);
@@ -328,7 +329,7 @@ public class DecimalLiteralTest {
                 new BigDecimal("-2147483.6475"),
                 new BigDecimal("-0.0001"),
         };
-        ScalarType decimal32p4s3 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 4, 3);
+        ScalarType decimal32p4s3 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 4, 3);
         for (BigDecimal dec32 : decimal32Values) {
             try {
                 DecimalLiteral.checkLiteralOverflowInBinaryStyle(dec32, decimal32p4s3);
@@ -348,7 +349,7 @@ public class DecimalLiteralTest {
                 new BigDecimal("0.000001"),
                 new BigDecimal("0.0"),
         };
-        ScalarType decimal64p10s6 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 6);
+        ScalarType decimal64p10s6 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 6);
         for (BigDecimal dec64 : decimal64Values) {
             try {
                 DecimalLiteral.checkLiteralOverflowInBinaryStyle(dec64, decimal64p10s6);
@@ -368,7 +369,7 @@ public class DecimalLiteralTest {
                 new BigDecimal("0.00000000001"),
                 new BigDecimal("0.0"),
         };
-        ScalarType decimal128p36s11 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 36, 11);
+        ScalarType decimal128p36s11 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 36, 11);
         for (BigDecimal dec128 : decimal128Values) {
             try {
                 DecimalLiteral.checkLiteralOverflowInBinaryStyle(dec128, decimal128p36s11);
@@ -386,7 +387,7 @@ public class DecimalLiteralTest {
                 new BigDecimal("-100000.0000"),
                 new BigDecimal("-99999.99995"),
         };
-        ScalarType decimal32p9s4 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 4);
+        ScalarType decimal32p9s4 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 4);
         for (BigDecimal dec32 : decimal32Values) {
             Assertions.assertFalse(DecimalLiteral.checkLiteralOverflowInDecimalStyle(dec32, decimal32p9s4));
         }
@@ -397,7 +398,7 @@ public class DecimalLiteralTest {
                 new BigDecimal("-1000000000000.000000"),
                 new BigDecimal("-999999999999.9999995"),
         };
-        ScalarType decimal64p18s6 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 6);
+        ScalarType decimal64p18s6 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 6);
         for (BigDecimal dec64 : decimal64Values) {
             Assertions.assertFalse(DecimalLiteral.checkLiteralOverflowInDecimalStyle(dec64, decimal64p18s6));
         }
@@ -408,7 +409,7 @@ public class DecimalLiteralTest {
                 new BigDecimal("-1000000000000000000000000000.00000000000"),
                 new BigDecimal("-999999999999999999999999999.999999999995"),
         };
-        ScalarType decimal128p38s11 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 11);
+        ScalarType decimal128p38s11 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 11);
         for (BigDecimal dec128 : decimal128Values) {
             Assertions.assertFalse(DecimalLiteral.checkLiteralOverflowInDecimalStyle(dec128, decimal128p38s11));
         }
@@ -427,7 +428,7 @@ public class DecimalLiteralTest {
                 new BigDecimal("0.0"),
                 new BigDecimal("-0.0001"),
         };
-        ScalarType decimal32p9s4 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 4);
+        ScalarType decimal32p9s4 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 4);
         for (BigDecimal dec32 : decimal32Values) {
             Assertions.assertTrue(DecimalLiteral.checkLiteralOverflowInDecimalStyle(dec32, decimal32p9s4));
         }
@@ -443,7 +444,7 @@ public class DecimalLiteralTest {
                 new BigDecimal("0.000001"),
                 new BigDecimal("0.0"),
         };
-        ScalarType decimal64p18s6 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 6);
+        ScalarType decimal64p18s6 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 6);
         for (BigDecimal dec64 : decimal64Values) {
             Assertions.assertTrue(DecimalLiteral.checkLiteralOverflowInDecimalStyle(dec64, decimal64p18s6));
         }
@@ -459,7 +460,7 @@ public class DecimalLiteralTest {
                 new BigDecimal("0.00000000001"),
                 new BigDecimal("0.0"),
         };
-        ScalarType decimal128p38s11 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 11);
+        ScalarType decimal128p38s11 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 11);
         for (BigDecimal dec128 : decimal128Values) {
             Assertions.assertTrue(DecimalLiteral.checkLiteralOverflowInDecimalStyle(dec128, decimal128p38s11));
         }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/InsertIntoValuesDecimalV3Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/InsertIntoValuesDecimalV3Test.java
@@ -26,7 +26,7 @@ import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
@@ -95,7 +95,7 @@ public class InsertIntoValuesDecimalV3Test {
         for (List<Expr> exprs : ((ValuesRelation) selectStmt.getQueryRelation()).getRows()) {
             Assertions.assertEquals(
                     exprs.get(1).getType(),
-                    ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 20, 9));
+                    TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 20, 9));
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/LiteralExprCompareTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/LiteralExprCompareTest.java
@@ -30,6 +30,7 @@ import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -274,10 +275,10 @@ public class LiteralExprCompareTest {
 
     @Test
     public void intTest() throws AnalysisException {
-        intTestInternal(ScalarType.createType(PrimitiveType.TINYINT));
-        intTestInternal(ScalarType.createType(PrimitiveType.SMALLINT));
-        intTestInternal(ScalarType.createType(PrimitiveType.INT));
-        intTestInternal(ScalarType.createType(PrimitiveType.BIGINT));
+        intTestInternal(TypeFactory.createType(PrimitiveType.TINYINT));
+        intTestInternal(TypeFactory.createType(PrimitiveType.SMALLINT));
+        intTestInternal(TypeFactory.createType(PrimitiveType.INT));
+        intTestInternal(TypeFactory.createType(PrimitiveType.BIGINT));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/VariableExprTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/VariableExprTest.java
@@ -22,7 +22,7 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.SetType;
 import com.starrocks.sql.ast.expression.VariableExpr;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -37,7 +37,7 @@ public class VariableExprTest {
         ExpressionAnalyzer.analyzeExpressionIgnoreSlot(desc, UtFrameUtils.createDefaultCtx());
         Assertions.assertEquals(SetType.SESSION, desc.getSetType());
         Assertions.assertEquals("version_comment", desc.getName());
-        Assertions.assertEquals(ScalarType.createType(PrimitiveType.VARCHAR), desc.getType());
+        Assertions.assertEquals(TypeFactory.createType(PrimitiveType.VARCHAR), desc.getType());
         Assertions.assertEquals(SetType.SESSION, desc.getSetType());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/backup/CatalogMocker.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/CatalogMocker.java
@@ -76,7 +76,7 @@ import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import mockit.Expectations;
 
 import java.util.List;
@@ -197,14 +197,14 @@ public class CatalogMocker {
     public static List<Column> TEST_ROLLUP_SCHEMA = Lists.newArrayList();
 
     static {
-        Column k1 = new Column("k1", ScalarType.createType(PrimitiveType.TINYINT), true, null, "", "key1");
-        Column k2 = new Column("k2", ScalarType.createType(PrimitiveType.SMALLINT), true, null, "", "key2");
-        Column k3 = new Column("k3", ScalarType.createType(PrimitiveType.INT), true, null, "", "key3");
-        Column k4 = new Column("k4", ScalarType.createType(PrimitiveType.BIGINT), true, null, "", "key4");
-        Column k5 = new Column("k5", ScalarType.createType(PrimitiveType.LARGEINT), true, null, "", "key5");
-        Column k6 = new Column("k6", ScalarType.createType(PrimitiveType.DATE), true, null, "", "key6");
-        Column k7 = new Column("k7", ScalarType.createType(PrimitiveType.DATETIME), true, null, "", "key7");
-        Column k8 = new Column("k8", ScalarType.createDecimalV2Type(10, 3), true, null, "", "key8");
+        Column k1 = new Column("k1", TypeFactory.createType(PrimitiveType.TINYINT), true, null, "", "key1");
+        Column k2 = new Column("k2", TypeFactory.createType(PrimitiveType.SMALLINT), true, null, "", "key2");
+        Column k3 = new Column("k3", TypeFactory.createType(PrimitiveType.INT), true, null, "", "key3");
+        Column k4 = new Column("k4", TypeFactory.createType(PrimitiveType.BIGINT), true, null, "", "key4");
+        Column k5 = new Column("k5", TypeFactory.createType(PrimitiveType.LARGEINT), true, null, "", "key5");
+        Column k6 = new Column("k6", TypeFactory.createType(PrimitiveType.DATE), true, null, "", "key6");
+        Column k7 = new Column("k7", TypeFactory.createType(PrimitiveType.DATETIME), true, null, "", "key7");
+        Column k8 = new Column("k8", TypeFactory.createDecimalV2Type(10, 3), true, null, "", "key8");
         k1.setIsKey(true);
         k2.setIsKey(true);
         k3.setIsKey(true);
@@ -215,13 +215,13 @@ public class CatalogMocker {
         k8.setIsKey(true);
 
         Column v1 = new Column("v1",
-                ScalarType.createCharType(10), false, AggregateType.REPLACE, "none", " value1");
+                TypeFactory.createCharType(10), false, AggregateType.REPLACE, "none", " value1");
         Column v2 = new Column("v2",
-                ScalarType.createType(PrimitiveType.FLOAT), false, AggregateType.MAX, "none", " value2");
+                TypeFactory.createType(PrimitiveType.FLOAT), false, AggregateType.MAX, "none", " value2");
         Column v3 = new Column("v3",
-                ScalarType.createType(PrimitiveType.DOUBLE), false, AggregateType.MIN, "none", " value3");
+                TypeFactory.createType(PrimitiveType.DOUBLE), false, AggregateType.MIN, "none", " value3");
         Column v4 = new Column("v4",
-                ScalarType.createType(PrimitiveType.INT), false, AggregateType.SUM, "", " value4");
+                TypeFactory.createType(PrimitiveType.INT), false, AggregateType.SUM, "", " value4");
 
         TEST_TBL_BASE_SCHEMA.add(k1);
         TEST_TBL_BASE_SCHEMA.add(k2);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogRecycleBinTest.java
@@ -32,8 +32,8 @@ import com.starrocks.sql.ast.PartitionValue;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TTabletType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
@@ -154,7 +154,7 @@ public class CatalogRecycleBinTest {
         FakeEditLog fakeEditLog = new FakeEditLog();
 
         CatalogRecycleBin bin = new CatalogRecycleBin();
-        List<Column> columns = Lists.newArrayList(new Column("k1", ScalarType.createVarcharType(10)));
+        List<Column> columns = Lists.newArrayList(new Column("k1", TypeFactory.createVarcharType(10)));
         Range<PartitionKey> range =
                 Range.range(PartitionKey.createPartitionKey(Lists.newArrayList(new PartitionValue("1")), columns),
                         BoundType.CLOSED,
@@ -179,7 +179,7 @@ public class CatalogRecycleBinTest {
     @Test
     public void testGetPhysicalPartition() throws Exception {
         CatalogRecycleBin bin = new CatalogRecycleBin();
-        List<Column> columns = Lists.newArrayList(new Column("k1", ScalarType.createVarcharType(10)));
+        List<Column> columns = Lists.newArrayList(new Column("k1", TypeFactory.createVarcharType(10)));
         Range<PartitionKey> range =
                 Range.range(PartitionKey.createPartitionKey(Lists.newArrayList(new PartitionValue("1")), columns),
                         BoundType.CLOSED,

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
@@ -46,8 +46,8 @@ import com.starrocks.sql.ast.expression.NullLiteral;
 import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.thrift.TColumn;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -78,9 +78,9 @@ public class ColumnTest {
 
     @Test
     public void testSchemaChangeNotAllow() throws DdlException {
-        Column oldColumn = new Column("user", ScalarType.createType(PrimitiveType.JSON), false, null, false,
+        Column oldColumn = new Column("user", TypeFactory.createType(PrimitiveType.JSON), false, null, false,
                 NULL_DEFAULT_VALUE, "");
-        Column newColumn = new Column("user", ScalarType.createVarcharType(1), true, null, false,
+        Column newColumn = new Column("user", TypeFactory.createVarcharType(1), true, null, false,
                 NULL_DEFAULT_VALUE, "");
         try {
             oldColumn.checkSchemaChangeAllowed(newColumn);
@@ -89,28 +89,28 @@ public class ColumnTest {
             Assertions.assertTrue(e.getMessage().contains("JSON needs minimum length of "));
         }
 
-        Column largeColumn = new Column("user", ScalarType.createVarcharType(1025), true, null, false,
+        Column largeColumn = new Column("user", TypeFactory.createVarcharType(1025), true, null, false,
                 NULL_DEFAULT_VALUE, "");
         oldColumn.checkSchemaChangeAllowed(largeColumn);
     }
 
     @Test
     public void testSchemaChangeAllowNormal() throws DdlException {
-        Column oldColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+        Column oldColumn = new Column("user", TypeFactory.createType(PrimitiveType.INT), true, null, false,
                 NULL_DEFAULT_VALUE, "");
-        Column newColumn = new Column("user", ScalarType.createType(PrimitiveType.VARCHAR), true, null, false,
+        Column newColumn = new Column("user", TypeFactory.createType(PrimitiveType.VARCHAR), true, null, false,
                 NULL_DEFAULT_VALUE, "");
         oldColumn.checkSchemaChangeAllowed(newColumn);
 
-        oldColumn = new Column("user", ScalarType.createType(PrimitiveType.VARCHAR), true, null, false,
+        oldColumn = new Column("user", TypeFactory.createType(PrimitiveType.VARCHAR), true, null, false,
                 new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
-        newColumn = new Column("user", ScalarType.createType(PrimitiveType.VARCHAR), true, null, false,
+        newColumn = new Column("user", TypeFactory.createType(PrimitiveType.VARCHAR), true, null, false,
                 new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
         oldColumn.checkSchemaChangeAllowed(newColumn);
 
-        oldColumn = new Column("user", ScalarType.createType(PrimitiveType.DATETIME), true, null, false,
+        oldColumn = new Column("user", TypeFactory.createType(PrimitiveType.DATETIME), true, null, false,
                 CURRENT_TIMESTAMP_VALUE, "");
-        newColumn = new Column("user", ScalarType.createType(PrimitiveType.DATETIME), true, null, false,
+        newColumn = new Column("user", TypeFactory.createType(PrimitiveType.DATETIME), true, null, false,
                 CURRENT_TIMESTAMP_VALUE, "");
         oldColumn.checkSchemaChangeAllowed(newColumn);
     }
@@ -118,9 +118,9 @@ public class ColumnTest {
     @Test
     public void testSchemaChangeAllowedDefaultValue() {
         try {
-            Column oldColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+            Column oldColumn = new Column("user", TypeFactory.createType(PrimitiveType.INT), true, null, false,
                     new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
-            Column newColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+            Column newColumn = new Column("user", TypeFactory.createType(PrimitiveType.INT), true, null, false,
                     NOT_SET, "");
             oldColumn.checkSchemaChangeAllowed(newColumn);
             Assertions.fail("No exception throws.");
@@ -128,9 +128,9 @@ public class ColumnTest {
         }
 
         try {
-            Column oldColumn = new Column("dt", ScalarType.createType(PrimitiveType.DATETIME), true, null, false,
+            Column oldColumn = new Column("dt", TypeFactory.createType(PrimitiveType.DATETIME), true, null, false,
                     CURRENT_TIMESTAMP_VALUE, "");
-            Column newColumn = new Column("dt", ScalarType.createType(PrimitiveType.DATETIME), true, null, false,
+            Column newColumn = new Column("dt", TypeFactory.createType(PrimitiveType.DATETIME), true, null, false,
                     NOT_SET, "");
             oldColumn.checkSchemaChangeAllowed(newColumn);
             Assertions.fail("No exception throws.");
@@ -138,9 +138,9 @@ public class ColumnTest {
         }
 
         try {
-            Column oldColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+            Column oldColumn = new Column("user", TypeFactory.createType(PrimitiveType.INT), true, null, false,
                     NOT_SET, "");
-            Column newColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+            Column newColumn = new Column("user", TypeFactory.createType(PrimitiveType.INT), true, null, false,
                     new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
             oldColumn.checkSchemaChangeAllowed(newColumn);
             Assertions.fail("No exception throws.");
@@ -148,19 +148,9 @@ public class ColumnTest {
         }
 
         try {
-            Column oldColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+            Column oldColumn = new Column("user", TypeFactory.createType(PrimitiveType.INT), true, null, false,
                     NOT_SET, "");
-            Column newColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
-                    CURRENT_TIMESTAMP_VALUE, "");
-            oldColumn.checkSchemaChangeAllowed(newColumn);
-            Assertions.fail("No exception throws.");
-        } catch (DdlException ex) {
-        }
-
-        try {
-            Column oldColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
-                    new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
-            Column newColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+            Column newColumn = new Column("user", TypeFactory.createType(PrimitiveType.INT), true, null, false,
                     CURRENT_TIMESTAMP_VALUE, "");
             oldColumn.checkSchemaChangeAllowed(newColumn);
             Assertions.fail("No exception throws.");
@@ -168,9 +158,19 @@ public class ColumnTest {
         }
 
         try {
-            Column oldColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+            Column oldColumn = new Column("user", TypeFactory.createType(PrimitiveType.INT), true, null, false,
                     new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
-            Column newColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+            Column newColumn = new Column("user", TypeFactory.createType(PrimitiveType.INT), true, null, false,
+                    CURRENT_TIMESTAMP_VALUE, "");
+            oldColumn.checkSchemaChangeAllowed(newColumn);
+            Assertions.fail("No exception throws.");
+        } catch (DdlException ex) {
+        }
+
+        try {
+            Column oldColumn = new Column("user", TypeFactory.createType(PrimitiveType.INT), true, null, false,
+                    new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
+            Column newColumn = new Column("user", TypeFactory.createType(PrimitiveType.INT), true, null, false,
                     new ColumnDef.DefaultValueDef(true, new StringLiteral("1")), "");
             oldColumn.checkSchemaChangeAllowed(newColumn);
             Assertions.fail("No exception throws.");
@@ -178,9 +178,9 @@ public class ColumnTest {
         }
 
         try {
-            Column oldColumn = new Column("dt", ScalarType.createType(PrimitiveType.DATETIME), true, null, false,
+            Column oldColumn = new Column("dt", TypeFactory.createType(PrimitiveType.DATETIME), true, null, false,
                     CURRENT_TIMESTAMP_VALUE, "");
-            Column newColumn = new Column("dt", ScalarType.createType(PrimitiveType.DATETIME), true, null, false,
+            Column newColumn = new Column("dt", TypeFactory.createType(PrimitiveType.DATETIME), true, null, false,
                     new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
             oldColumn.checkSchemaChangeAllowed(newColumn);
             Assertions.fail("No exception throws.");
@@ -192,9 +192,9 @@ public class ColumnTest {
     @Test
     public void testSchemaChangeAllowedNullToNonNull() {
         assertThrows(DdlException.class, () -> {
-            Column oldColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, true,
+            Column oldColumn = new Column("user", TypeFactory.createType(PrimitiveType.INT), true, null, true,
                     new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
-            Column newColumn = new Column("user", ScalarType.createType(PrimitiveType.INT), true, null, false,
+            Column newColumn = new Column("user", TypeFactory.createType(PrimitiveType.INT), true, null, false,
                     new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
             oldColumn.checkSchemaChangeAllowed(newColumn);
             Assertions.fail("No exception throws.");
@@ -203,7 +203,7 @@ public class ColumnTest {
 
     @Test
     public void testAutoIncrement() {
-        Column col = new Column("col", ScalarType.createType(PrimitiveType.BIGINT), true, null, Boolean.FALSE,
+        Column col = new Column("col", TypeFactory.createType(PrimitiveType.BIGINT), true, null, Boolean.FALSE,
                 ColumnDef.DefaultValueDef.NOT_SET, "");
         col.setIsAutoIncrement(true);
         Assertions.assertTrue(col.isAutoIncrement() == true);
@@ -212,15 +212,15 @@ public class ColumnTest {
     @Test
     public void testSchemaChangeAllowedInvolvingDecimalv3() throws DdlException {
         Column decimalColumn =
-                new Column("user", ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 15, 3), false, null, true,
+                new Column("user", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 15, 3), false, null, true,
                         new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
 
-        Column varcharColumn1 = new Column("user", ScalarType.createVarchar(50), false, null, true,
+        Column varcharColumn1 = new Column("user", TypeFactory.createVarchar(50), false, null, true,
                 new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
         varcharColumn1.checkSchemaChangeAllowed(decimalColumn);
         decimalColumn.checkSchemaChangeAllowed(varcharColumn1);
 
-        Column varcharColumn2 = new Column("user", ScalarType.createVarchar(10), false, null, true,
+        Column varcharColumn2 = new Column("user", TypeFactory.createVarchar(10), false, null, true,
                 new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
         varcharColumn2.checkSchemaChangeAllowed(decimalColumn);
         try {
@@ -230,7 +230,7 @@ public class ColumnTest {
         }
 
         Column decimalColumn2 =
-                new Column("user", ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 20, 4), false, null, true,
+                new Column("user", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 20, 4), false, null, true,
                         new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
         decimalColumn.checkSchemaChangeAllowed(decimalColumn2);
 
@@ -241,10 +241,10 @@ public class ColumnTest {
 
         }
 
-        Column decimalv2Column = new Column("user", ScalarType.createDecimalV2Type(), false, null, true,
+        Column decimalv2Column = new Column("user", TypeFactory.createDecimalV2Type(), false, null, true,
                 new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
         Column decimalColumn3 =
-                new Column("user", ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 27, 9), false, null, true,
+                new Column("user", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 27, 9), false, null, true,
                         new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
         decimalv2Column.checkSchemaChangeAllowed(decimalColumn3);
 
@@ -256,7 +256,7 @@ public class ColumnTest {
         }
 
         Column decimalColumn4 =
-                new Column("user", ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 13), false, null, true,
+                new Column("user", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 13), false, null, true,
                         new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
         try {
             decimalv2Column.checkSchemaChangeAllowed(decimalColumn4);
@@ -306,7 +306,7 @@ public class ColumnTest {
     @Test
     public void testToSqlWithoutAggregateTypeName() {
         String comment = "{\"id\":\"0\",\"value\":\"1\"}";
-        Column column = new Column("col", ScalarType.createType(PrimitiveType.JSON), false, null, true, null, comment);
+        Column column = new Column("col", TypeFactory.createType(PrimitiveType.JSON), false, null, true, null, comment);
         String toSql = column.toSqlWithoutAggregateTypeName(null);
 
         Assertions.assertEquals("`col` json NULL COMMENT \"{\\\"id\\\":\\\"0\\\",\\\"value\\\":\\\"1\\\"}\"", toSql);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/HudiTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/HudiTableTest.java
@@ -36,8 +36,8 @@ import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.MapType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
@@ -202,27 +202,27 @@ public class HudiTableTest {
     @Test
     public void testColumnTypeConvert() {
         Assertions.assertEquals(ColumnTypeConverter.fromHudiType(Schema.create(Schema.Type.BOOLEAN)),
-                ScalarType.createType(PrimitiveType.BOOLEAN));
+                TypeFactory.createType(PrimitiveType.BOOLEAN));
         Assertions.assertEquals(ColumnTypeConverter.fromHudiType(Schema.create(Schema.Type.INT)),
-                ScalarType.createType(PrimitiveType.INT));
+                TypeFactory.createType(PrimitiveType.INT));
         Assertions.assertEquals(ColumnTypeConverter.fromHudiType(Schema.create(Schema.Type.FLOAT)),
-                ScalarType.createType(PrimitiveType.FLOAT));
+                TypeFactory.createType(PrimitiveType.FLOAT));
         Assertions.assertEquals(ColumnTypeConverter.fromHudiType(Schema.create(Schema.Type.DOUBLE)),
-                ScalarType.createType(PrimitiveType.DOUBLE));
+                TypeFactory.createType(PrimitiveType.DOUBLE));
         Assertions.assertEquals(ColumnTypeConverter.fromHudiType(Schema.create(Schema.Type.STRING)),
-                ScalarType.createDefaultCatalogString());
+                TypeFactory.createDefaultCatalogString());
         Assertions.assertEquals(ColumnTypeConverter.fromHudiType(
                         Schema.createArray(Schema.create(Schema.Type.INT))),
-                new ArrayType(ScalarType.createType(PrimitiveType.INT)));
+                new ArrayType(TypeFactory.createType(PrimitiveType.INT)));
         Assertions.assertEquals(ColumnTypeConverter.fromHudiType(
                         Schema.createFixed("FIXED", "FIXED", "F", 1)),
-                ScalarType.createType(PrimitiveType.VARCHAR));
+                TypeFactory.createType(PrimitiveType.VARCHAR));
         Assertions.assertEquals(ColumnTypeConverter.fromHudiType(
                         Schema.createMap(Schema.create(Schema.Type.INT))),
-                new MapType(ScalarType.createDefaultCatalogString(), ScalarType.createType(PrimitiveType.INT)));
+                new MapType(TypeFactory.createDefaultCatalogString(), TypeFactory.createType(PrimitiveType.INT)));
         Assertions.assertEquals(ColumnTypeConverter.fromHudiType(
                         Schema.createUnion(Schema.create(Schema.Type.INT))),
-                ScalarType.createType(PrimitiveType.INT));
+                TypeFactory.createType(PrimitiveType.INT));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ListPartitionInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ListPartitionInfoTest.java
@@ -33,8 +33,8 @@ import com.starrocks.sql.ast.TruncateTableStmt;
 import com.starrocks.thrift.TDataSink;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.thrift.TWriteQuorumType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
@@ -118,11 +118,11 @@ public class ListPartitionInfoTest {
 
         // k2
         SlotDescriptor k2 = descTable.addSlotDescriptor(tuple);
-        k2.setColumn(new Column("k2", ScalarType.createVarchar(25)));
+        k2.setColumn(new Column("k2", TypeFactory.createVarchar(25)));
         k2.setIsMaterialized(true);
         // v1
         SlotDescriptor v1 = descTable.addSlotDescriptor(tuple);
-        v1.setColumn(new Column("v1", ScalarType.createVarchar(25)));
+        v1.setColumn(new Column("v1", TypeFactory.createVarchar(25)));
         v1.setIsMaterialized(true);
         // v2
         SlotDescriptor v2 = descTable.addSlotDescriptor(tuple);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedIndexTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedIndexTest.java
@@ -38,7 +38,7 @@ import com.starrocks.catalog.MaterializedIndex.IndexState;
 import com.starrocks.common.FeConstants;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,9 +63,9 @@ public class MaterializedIndexTest {
         indexId = 10000;
 
         columns = new LinkedList<Column>();
-        columns.add(new Column("k1", ScalarType.createType(PrimitiveType.TINYINT), true, null, "", ""));
-        columns.add(new Column("k2", ScalarType.createType(PrimitiveType.SMALLINT), true, null, "", ""));
-        columns.add(new Column("v1", ScalarType.createType(PrimitiveType.INT), false, AggregateType.REPLACE, "", ""));
+        columns.add(new Column("k1", TypeFactory.createType(PrimitiveType.TINYINT), true, null, "", ""));
+        columns.add(new Column("k2", TypeFactory.createType(PrimitiveType.SMALLINT), true, null, "", ""));
+        columns.add(new Column("v1", TypeFactory.createType(PrimitiveType.INT), false, AggregateType.REPLACE, "", ""));
         index = new MaterializedIndex(indexId, IndexState.NORMAL);
 
         fakeGlobalStateMgr = new FakeGlobalStateMgr();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -50,7 +50,7 @@ import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
 import com.starrocks.thrift.TTabletType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.StarRocksTestBase;
 import com.starrocks.utframe.UtFrameUtils;
@@ -85,9 +85,9 @@ public class MaterializedViewTest extends StarRocksTestBase {
 
         UtFrameUtils.createMinStarRocksCluster();
 
-        columns.add(new Column("k1", ScalarType.createType(PrimitiveType.TINYINT), true, null, "", ""));
-        columns.add(new Column("k2", ScalarType.createType(PrimitiveType.SMALLINT), true, null, "", ""));
-        columns.add(new Column("v1", ScalarType.createType(PrimitiveType.INT), false, AggregateType.SUM, "", ""));
+        columns.add(new Column("k1", TypeFactory.createType(PrimitiveType.TINYINT), true, null, "", ""));
+        columns.add(new Column("k2", TypeFactory.createType(PrimitiveType.SMALLINT), true, null, "", ""));
+        columns.add(new Column("v1", TypeFactory.createType(PrimitiveType.INT), false, AggregateType.SUM, "", ""));
 
         super.before();
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ScalarTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ScalarTypeTest.java
@@ -21,6 +21,7 @@ import com.starrocks.common.Config;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -30,58 +31,58 @@ public class ScalarTypeTest {
 
     @Test
     public void createUnifiedDecimalTypeWithoutPrecisionAndScale() throws AnalysisException {
-        ScalarType.createUnifiedDecimalType();
+        TypeFactory.createUnifiedDecimalType();
     }
 
     @Test
     public void testCreateUnifiedDecimalTypeWithoutScale() throws AnalysisException {
-        ScalarType.createUnifiedDecimalType(18);
+        TypeFactory.createUnifiedDecimalType(18);
     }
 
     @Test
     public void testCreateUnifiedDecimalType() {
         Config.enable_decimal_v3 = false;
         Assertions.assertEquals(
-                ScalarType.createUnifiedDecimalType(27, 3),
-                ScalarType.createDecimalV2Type(27, 3));
+                TypeFactory.createUnifiedDecimalType(27, 3),
+                TypeFactory.createDecimalV2Type(27, 3));
         Assertions.assertEquals(
-                ScalarType.createUnifiedDecimalType(28, 9),
-                ScalarType.createDecimalV2Type(28, 9));
+                TypeFactory.createUnifiedDecimalType(28, 9),
+                TypeFactory.createDecimalV2Type(28, 9));
         Assertions.assertEquals(
-                ScalarType.createUnifiedDecimalType(18, 10),
-                ScalarType.createUnifiedDecimalType(18, 10));
+                TypeFactory.createUnifiedDecimalType(18, 10),
+                TypeFactory.createUnifiedDecimalType(18, 10));
 
         Config.enable_decimal_v3 = true;
         Assertions.assertEquals(
-                ScalarType.createUnifiedDecimalType(9, 3),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 9, 3));
+                TypeFactory.createUnifiedDecimalType(9, 3),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 9, 3));
 
         Assertions.assertEquals(
-                ScalarType.createUnifiedDecimalType(18, 15),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 15));
+                TypeFactory.createUnifiedDecimalType(18, 15),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 15));
 
         Assertions.assertEquals(
-                ScalarType.createUnifiedDecimalType(19, 15),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 19, 15));
+                TypeFactory.createUnifiedDecimalType(19, 15),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 19, 15));
 
         Assertions.assertEquals(
-                ScalarType.createUnifiedDecimalType(27, 15),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 27, 15));
+                TypeFactory.createUnifiedDecimalType(27, 15),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 27, 15));
 
         Assertions.assertEquals(
-                ScalarType.createUnifiedDecimalType(28, 28),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 28, 28));
+                TypeFactory.createUnifiedDecimalType(28, 28),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 28, 28));
 
         Assertions.assertEquals(
-                ScalarType.createUnifiedDecimalType(38, 0),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 0));
+                TypeFactory.createUnifiedDecimalType(38, 0),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 0));
 
         Assertions.assertEquals(
-                ScalarType.createUnifiedDecimalType(38, 38),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 38));
+                TypeFactory.createUnifiedDecimalType(38, 38),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 38));
 
-        Assertions.assertThrows(Throwable.class, () -> ScalarType.createUnifiedDecimalType(79, 38));
-        Assertions.assertThrows(Throwable.class, () -> ScalarType.createUnifiedDecimalType(10, 11));
+        Assertions.assertThrows(Throwable.class, () -> TypeFactory.createUnifiedDecimalType(79, 38));
+        Assertions.assertThrows(Throwable.class, () -> TypeFactory.createUnifiedDecimalType(10, 11));
     }
 
     @Test
@@ -89,49 +90,49 @@ public class ScalarTypeTest {
 
         ScalarType[][] testCases = {
                 {
-                        ScalarType.createDecimalV3NarrowestType(9, 9),
-                        ScalarType.createDecimalV3NarrowestType(0, 0),
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 9),
+                        TypeFactory.createDecimalV3NarrowestType(9, 9),
+                        TypeFactory.createDecimalV3NarrowestType(0, 0),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 9),
                 },
                 {
-                        ScalarType.createDecimalV3NarrowestType(9, 9),
-                        ScalarType.createDecimalV3NarrowestType(3, 2),
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 9),
+                        TypeFactory.createDecimalV3NarrowestType(9, 9),
+                        TypeFactory.createDecimalV3NarrowestType(3, 2),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 9),
                 },
                 {
-                        ScalarType.createDecimalV3NarrowestType(9, 9),
-                        ScalarType.createDecimalV3NarrowestType(3, 3),
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 9),
+                        TypeFactory.createDecimalV3NarrowestType(9, 9),
+                        TypeFactory.createDecimalV3NarrowestType(3, 3),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 9),
                 },
                 {
-                        ScalarType.createDecimalV3NarrowestType(18, 9),
-                        ScalarType.createDecimalV3NarrowestType(11, 10),
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 19, 10),
+                        TypeFactory.createDecimalV3NarrowestType(18, 9),
+                        TypeFactory.createDecimalV3NarrowestType(11, 10),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 19, 10),
                 },
                 {
-                        ScalarType.createDecimalV3NarrowestType(35, 4),
-                        ScalarType.createDecimalV3NarrowestType(18, 6),
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 37, 6),
+                        TypeFactory.createDecimalV3NarrowestType(35, 4),
+                        TypeFactory.createDecimalV3NarrowestType(18, 6),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 37, 6),
                 },
                 {
-                        ScalarType.createDecimalV3NarrowestType(38, 4),
-                        ScalarType.createDecimalV3NarrowestType(18, 10),
+                        TypeFactory.createDecimalV3NarrowestType(38, 4),
+                        TypeFactory.createDecimalV3NarrowestType(18, 10),
                         ScalarType.DOUBLE,
                 },
                 {
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 7, 4),
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 3, 0),
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 7, 4),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 7, 4),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 3, 0),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 7, 4),
                 },
                 {
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 15, 11),
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 15, 11),
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 15, 11),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 15, 11),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 15, 11),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 15, 11),
                 },
                 {
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 9, 4),
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 4),
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 9, 4),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 9, 4),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 4),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 9, 4),
                 },
         };
 
@@ -169,18 +170,18 @@ public class ScalarTypeTest {
                 ScalarType.LARGEINT
         );
         List<ScalarType> stringTypes = Lists.newArrayList(
-                ScalarType.createCharType(-1),
-                ScalarType.createVarcharType(-1)
+                TypeFactory.createCharType(-1),
+                TypeFactory.createVarcharType(-1)
         );
         List<ScalarType> decimalTypes = Lists.newArrayList(
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 3, 0),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 6, 2),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 4),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 12, 8),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 15, 10),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 12),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 21, 14),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 24, 16)
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 3, 0),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 6, 2),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 4),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 12, 8),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 15, 10),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 12),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 21, 14),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 24, 16)
         );
 
         // integer to integer

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/SchemaChangeTypeCompatibilityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/SchemaChangeTypeCompatibilityTest.java
@@ -16,6 +16,7 @@ package com.starrocks.catalog;
 
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.junit.jupiter.api.Test;
 
 import static com.starrocks.catalog.SchemaChangeTypeCompatibility.canReuseZonemapIndex;
@@ -77,12 +78,12 @@ public class SchemaChangeTypeCompatibilityTest {
 
         assertTrue(canReuseZonemapIndex(Type.DATETIME, Type.DATETIME));
 
-        ScalarType char10 = ScalarType.createCharType(10);
-        ScalarType varchar20 = ScalarType.createVarcharType(20);
+        ScalarType char10 = TypeFactory.createCharType(10);
+        ScalarType varchar20 = TypeFactory.createVarcharType(20);
         assertTrue(canReuseZonemapIndex(char10, char10));
         assertTrue(canReuseZonemapIndex(char10, varchar20));
 
-        ScalarType varchar30 = ScalarType.createVarcharType(30);
+        ScalarType varchar30 = TypeFactory.createVarcharType(30);
         assertTrue(canReuseZonemapIndex(varchar20, varchar30));
     }
 
@@ -104,8 +105,8 @@ public class SchemaChangeTypeCompatibilityTest {
         assertFalse(canReuseZonemapIndex(Type.DATETIME, Type.DATE));
 
         // varchar to char not allowed by reuse matrix
-        ScalarType varchar20 = ScalarType.createVarcharType(20);
-        ScalarType char10 = ScalarType.createCharType(10);
+        ScalarType varchar20 = TypeFactory.createVarcharType(20);
+        ScalarType char10 = TypeFactory.createCharType(10);
         assertFalse(canReuseZonemapIndex(varchar20, char10));
 
         // string <-> int not allowed

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/StructTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/StructTypeTest.java
@@ -18,10 +18,10 @@ import com.google.common.collect.Lists;
 import com.starrocks.type.AnyMapType;
 import com.starrocks.type.MapType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -77,11 +77,11 @@ public class StructTypeTest {
     public void testStructMatchType() throws Exception {
         // "struct<struct_test:int,c1:struct<c1:int,cc1:string>>"
         StructType c1 = new StructType(Lists.newArrayList(
-                new StructField("c1", ScalarType.createType(PrimitiveType.INT)),
-                new StructField("cc1", ScalarType.createDefaultCatalogString())
+                new StructField("c1", TypeFactory.createType(PrimitiveType.INT)),
+                new StructField("cc1", TypeFactory.createDefaultCatalogString())
         ));
         StructType root = new StructType(Lists.newArrayList(
-                new StructField("struct_test", ScalarType.createType(PrimitiveType.INT)),
+                new StructField("struct_test", TypeFactory.createType(PrimitiveType.INT)),
                 new StructField("c1", c1)
         ));
 
@@ -90,50 +90,50 @@ public class StructTypeTest {
         Assertions.assertFalse(root.matchesType(t));
 
         // MapType
-        Type keyType = ScalarType.createType(PrimitiveType.INT);
-        Type valueType = ScalarType.createCharType(10);
+        Type keyType = TypeFactory.createType(PrimitiveType.INT);
+        Type valueType = TypeFactory.createCharType(10);
         Type mapType = new MapType(keyType, valueType);
 
         Assertions.assertFalse(root.matchesType(mapType));
 
         // Different fields length
         StructType c = new StructType(Lists.newArrayList(
-                new StructField("c1", ScalarType.createType(PrimitiveType.INT))));
+                new StructField("c1", TypeFactory.createType(PrimitiveType.INT))));
         Assertions.assertFalse(root.matchesType(c));
 
         // Types will match with different field names
         StructType diffName = new StructType(Lists.newArrayList(
-                new StructField("st", ScalarType.createType(PrimitiveType.INT)),
+                new StructField("st", TypeFactory.createType(PrimitiveType.INT)),
                 new StructField("cc", c1)
         ));
         Assertions.assertFalse(root.matchesType(diffName));
 
         // Different field type
         StructType diffType = new StructType(Lists.newArrayList(
-                new StructField("struct_test", ScalarType.createType(PrimitiveType.INT)),
-                new StructField("c1", ScalarType.createType(PrimitiveType.INT))
+                new StructField("struct_test", TypeFactory.createType(PrimitiveType.INT)),
+                new StructField("c1", TypeFactory.createType(PrimitiveType.INT))
         ));
         Assertions.assertFalse(root.matchesType(diffType));
 
         // matched
         StructType mc1 = new StructType(Lists.newArrayList(
-                new StructField("c1", ScalarType.createType(PrimitiveType.INT)),
-                new StructField("cc1", ScalarType.createDefaultCatalogString())
+                new StructField("c1", TypeFactory.createType(PrimitiveType.INT)),
+                new StructField("cc1", TypeFactory.createDefaultCatalogString())
         ));
         StructType matched = new StructType(Lists.newArrayList(
-                new StructField("struct_test", ScalarType.createType(PrimitiveType.INT)),
+                new StructField("struct_test", TypeFactory.createType(PrimitiveType.INT)),
                 new StructField("c1", mc1)
         ));
         Assertions.assertTrue(root.matchesType(matched));
 
         // Won't match with different subfield order
         StructType mc2 = new StructType(Lists.newArrayList(
-                new StructField("cc1", ScalarType.createDefaultCatalogString()),
-                new StructField("c1", ScalarType.createType(PrimitiveType.INT))
+                new StructField("cc1", TypeFactory.createDefaultCatalogString()),
+                new StructField("c1", TypeFactory.createType(PrimitiveType.INT))
         ));
         StructType matchedDiffOrder = new StructType(Lists.newArrayList(
                 new StructField("c1", mc2),
-                new StructField("struct_test", ScalarType.createType(PrimitiveType.INT))
+                new StructField("struct_test", TypeFactory.createType(PrimitiveType.INT))
         ));
         Assertions.assertFalse(root.matchesType(matchedDiffOrder));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
@@ -31,8 +31,8 @@ import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.system.Backend;
 import com.starrocks.system.SystemInfoService;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -74,9 +74,9 @@ public class TableFunctionTableTest {
             Assertions.assertEquals(5, schema.size());
             Assertions.assertEquals(new Column("col_int", Type.INT), schema.get(0));
             Assertions.assertEquals(new Column("col_string", Type.VARCHAR), schema.get(1));
-            Assertions.assertEquals(new Column("col_path1", ScalarType.createDefaultString(), true), schema.get(2));
-            Assertions.assertEquals(new Column("col_path2", ScalarType.createDefaultString(), true), schema.get(3));
-            Assertions.assertEquals(new Column("col_path3", ScalarType.createDefaultString(), true), schema.get(4));
+            Assertions.assertEquals(new Column("col_path1", TypeFactory.createDefaultString(), true), schema.get(2));
+            Assertions.assertEquals(new Column("col_path2", TypeFactory.createDefaultString(), true), schema.get(3));
+            Assertions.assertEquals(new Column("col_path3", TypeFactory.createDefaultString(), true), schema.get(4));
         });
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TypeDeserializerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TypeDeserializerTest.java
@@ -33,6 +33,7 @@ import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
 import com.starrocks.type.TypeDeserializer;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.type.TypeSerializer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -601,7 +602,7 @@ public class TypeDeserializerTest {
             Type type = TypeDeserializer.fromProtobuf(typeDesc);
 
             Assertions.assertTrue(type.isScalarType());
-            // Note: ScalarType.createType(PScalarType) method handles the conversion
+            // Note: TypeFactory.createType(PScalarType) method handles the conversion
         }
     }
 
@@ -750,16 +751,16 @@ public class TypeDeserializerTest {
                 Type.INT,
                 Type.BIGINT,
                 Type.DOUBLE,
-                ScalarType.createVarcharType(255), // Use explicit length for VARCHAR
-                ScalarType.createCharType(10),
-                ScalarType.createVarcharType(255),
-                ScalarType.createDecimalV2Type(10, 4),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 6),
+                TypeFactory.createVarcharType(255), // Use explicit length for VARCHAR
+                TypeFactory.createCharType(10),
+                TypeFactory.createVarcharType(255),
+                TypeFactory.createDecimalV2Type(10, 4),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 6),
                 new ArrayType(Type.INT),
-                new MapType(ScalarType.createVarcharType(100), Type.BIGINT), // Use explicit length for VARCHAR key
+                new MapType(TypeFactory.createVarcharType(100), Type.BIGINT), // Use explicit length for VARCHAR key
                 new StructType(Lists.newArrayList(
                         new StructField("f1", Type.INT),
-                        new StructField("f2", ScalarType.createVarcharType(200), "test comment") // Use explicit length
+                        new StructField("f2", TypeFactory.createVarcharType(200), "test comment") // Use explicit length
                 ))
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TypeSerializerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TypeSerializerTest.java
@@ -28,6 +28,7 @@ import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
 import com.starrocks.type.TypeDeserializer;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.type.TypeSerializer;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -65,7 +66,7 @@ public class TypeSerializerTest {
     @Test
     public void testSerializeBasicScalarTypes() {
         // Test all basic primitive types without special length/precision handling
-        // Note: BINARY type is not supported by ScalarType.createType()
+        // Note: BINARY type is not supported by TypeFactory.createType()
         PrimitiveType[] primitiveTypes = {
                 PrimitiveType.BOOLEAN,
                 PrimitiveType.TINYINT,
@@ -87,7 +88,7 @@ public class TypeSerializerTest {
             TTypeDesc container = new TTypeDesc();
             container.types = new ArrayList<>();
 
-            Type type = ScalarType.createType(primitiveType);
+            Type type = TypeFactory.createType(primitiveType);
             TypeSerializer.toThrift(type, container);
 
             Assertions.assertEquals(1, container.types.size());
@@ -100,7 +101,7 @@ public class TypeSerializerTest {
         TTypeDesc container = new TTypeDesc();
         container.types = new ArrayList<>();
 
-        Type nullType = ScalarType.createType(PrimitiveType.NULL_TYPE);
+        Type nullType = TypeFactory.createType(PrimitiveType.NULL_TYPE);
         TypeSerializer.toThrift(nullType, container);
 
         Assertions.assertEquals(1, container.types.size());
@@ -114,7 +115,7 @@ public class TypeSerializerTest {
         TTypeDesc container = new TTypeDesc();
         container.types = new ArrayList<>();
 
-        ScalarType charType = ScalarType.createCharType(10);
+        ScalarType charType = TypeFactory.createCharType(10);
         TypeSerializer.toThrift(charType, container);
 
         Assertions.assertEquals(1, container.types.size());
@@ -126,7 +127,7 @@ public class TypeSerializerTest {
         TTypeDesc container = new TTypeDesc();
         container.types = new ArrayList<>();
 
-        ScalarType charType = ScalarType.createCharType(ScalarType.MAX_CHAR_LENGTH);
+        ScalarType charType = TypeFactory.createCharType(ScalarType.MAX_CHAR_LENGTH);
         TypeSerializer.toThrift(charType, container);
 
         Assertions.assertEquals(1, container.types.size());
@@ -139,7 +140,7 @@ public class TypeSerializerTest {
         TTypeDesc container = new TTypeDesc();
         container.types = new ArrayList<>();
 
-        ScalarType varcharType = ScalarType.createVarcharType(255);
+        ScalarType varcharType = TypeFactory.createVarcharType(255);
         TypeSerializer.toThrift(varcharType, container);
 
         Assertions.assertEquals(1, container.types.size());
@@ -151,7 +152,7 @@ public class TypeSerializerTest {
         TTypeDesc container = new TTypeDesc();
         container.types = new ArrayList<>();
 
-        ScalarType varcharType = ScalarType.createVarcharType(ScalarType.DEFAULT_STRING_LENGTH);
+        ScalarType varcharType = TypeFactory.createVarcharType(ScalarType.DEFAULT_STRING_LENGTH);
         TypeSerializer.toThrift(varcharType, container);
 
         Assertions.assertEquals(1, container.types.size());
@@ -165,7 +166,7 @@ public class TypeSerializerTest {
         container.types = new ArrayList<>();
 
         // Use a large length value
-        ScalarType varcharType = ScalarType.createVarcharType(1048576);
+        ScalarType varcharType = TypeFactory.createVarcharType(1048576);
         TypeSerializer.toThrift(varcharType, container);
 
         Assertions.assertEquals(1, container.types.size());
@@ -177,7 +178,7 @@ public class TypeSerializerTest {
         TTypeDesc container = new TTypeDesc();
         container.types = new ArrayList<>();
 
-        ScalarType varbinaryType = ScalarType.createVarbinary(1024);
+        ScalarType varbinaryType = TypeFactory.createVarbinary(1024);
         TypeSerializer.toThrift(varbinaryType, container);
 
         Assertions.assertEquals(1, container.types.size());
@@ -190,7 +191,7 @@ public class TypeSerializerTest {
         container.types = new ArrayList<>();
 
         // Use a large length value
-        ScalarType varbinaryType = ScalarType.createVarbinary(1048576);
+        ScalarType varbinaryType = TypeFactory.createVarbinary(1048576);
         TypeSerializer.toThrift(varbinaryType, container);
 
         Assertions.assertEquals(1, container.types.size());
@@ -204,7 +205,7 @@ public class TypeSerializerTest {
         TTypeDesc container = new TTypeDesc();
         container.types = new ArrayList<>();
 
-        ScalarType hllType = ScalarType.createHllType();
+        ScalarType hllType = TypeFactory.createHllType();
         TypeSerializer.toThrift(hllType, container);
 
         Assertions.assertEquals(1, container.types.size());
@@ -219,7 +220,7 @@ public class TypeSerializerTest {
         TTypeDesc container = new TTypeDesc();
         container.types = new ArrayList<>();
 
-        ScalarType decimalType = ScalarType.createDecimalV2Type(10, 4);
+        ScalarType decimalType = TypeFactory.createDecimalV2Type(10, 4);
         TypeSerializer.toThrift(decimalType, container);
 
         Assertions.assertEquals(1, container.types.size());
@@ -232,7 +233,7 @@ public class TypeSerializerTest {
         container.types = new ArrayList<>();
 
         // DecimalV2 max precision is 27, max scale is 9
-        ScalarType decimalType = ScalarType.createDecimalV2Type(27, 9);
+        ScalarType decimalType = TypeFactory.createDecimalV2Type(27, 9);
         TypeSerializer.toThrift(decimalType, container);
 
         Assertions.assertEquals(1, container.types.size());
@@ -244,7 +245,7 @@ public class TypeSerializerTest {
         TTypeDesc container = new TTypeDesc();
         container.types = new ArrayList<>();
 
-        ScalarType decimal32Type = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 2);
+        ScalarType decimal32Type = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 2);
         TypeSerializer.toThrift(decimal32Type, container);
 
         Assertions.assertEquals(1, container.types.size());
@@ -256,7 +257,7 @@ public class TypeSerializerTest {
         TTypeDesc container = new TTypeDesc();
         container.types = new ArrayList<>();
 
-        ScalarType decimal64Type = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 6);
+        ScalarType decimal64Type = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 6);
         TypeSerializer.toThrift(decimal64Type, container);
 
         Assertions.assertEquals(1, container.types.size());
@@ -268,7 +269,7 @@ public class TypeSerializerTest {
         TTypeDesc container = new TTypeDesc();
         container.types = new ArrayList<>();
 
-        ScalarType decimal128Type = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 10);
+        ScalarType decimal128Type = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 10);
         TypeSerializer.toThrift(decimal128Type, container);
 
         Assertions.assertEquals(1, container.types.size());
@@ -280,7 +281,7 @@ public class TypeSerializerTest {
         TTypeDesc container = new TTypeDesc();
         container.types = new ArrayList<>();
 
-        ScalarType decimal256Type = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL256, 76, 20);
+        ScalarType decimal256Type = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL256, 76, 20);
         TypeSerializer.toThrift(decimal256Type, container);
 
         Assertions.assertEquals(1, container.types.size());
@@ -293,7 +294,7 @@ public class TypeSerializerTest {
         TTypeDesc container = new TTypeDesc();
         container.types = new ArrayList<>();
 
-        ScalarType decimalType = ScalarType.createDecimalV2Type(10, 0);
+        ScalarType decimalType = TypeFactory.createDecimalV2Type(10, 0);
         TypeSerializer.toThrift(decimalType, container);
 
         Assertions.assertEquals(1, container.types.size());
@@ -320,7 +321,7 @@ public class TypeSerializerTest {
         TTypeDesc container = new TTypeDesc();
         container.types = new ArrayList<>();
 
-        ArrayType arrayType = new ArrayType(ScalarType.createVarcharType(100));
+        ArrayType arrayType = new ArrayType(TypeFactory.createVarcharType(100));
         TypeSerializer.toThrift(arrayType, container);
 
         Assertions.assertEquals(2, container.types.size());
@@ -333,7 +334,7 @@ public class TypeSerializerTest {
         TTypeDesc container = new TTypeDesc();
         container.types = new ArrayList<>();
 
-        ArrayType arrayType = new ArrayType(ScalarType.createDecimalV2Type(10, 2));
+        ArrayType arrayType = new ArrayType(TypeFactory.createDecimalV2Type(10, 2));
         TypeSerializer.toThrift(arrayType, container);
 
         Assertions.assertEquals(2, container.types.size());
@@ -364,7 +365,7 @@ public class TypeSerializerTest {
         TTypeDesc container = new TTypeDesc();
         container.types = new ArrayList<>();
 
-        MapType mapType = new MapType(Type.INT, ScalarType.createVarcharType(255));
+        MapType mapType = new MapType(Type.INT, TypeFactory.createVarcharType(255));
         TypeSerializer.toThrift(mapType, container);
 
         Assertions.assertEquals(3, container.types.size());
@@ -378,7 +379,7 @@ public class TypeSerializerTest {
         TTypeDesc container = new TTypeDesc();
         container.types = new ArrayList<>();
 
-        MapType mapType = new MapType(ScalarType.createVarcharType(50), Type.DOUBLE);
+        MapType mapType = new MapType(TypeFactory.createVarcharType(50), Type.DOUBLE);
         TypeSerializer.toThrift(mapType, container);
 
         Assertions.assertEquals(3, container.types.size());
@@ -393,8 +394,8 @@ public class TypeSerializerTest {
         container.types = new ArrayList<>();
 
         MapType mapType = new MapType(
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4),
-                ScalarType.createDecimalV2Type(10, 2)
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4),
+                TypeFactory.createDecimalV2Type(10, 2)
         );
         TypeSerializer.toThrift(mapType, container);
 
@@ -410,7 +411,7 @@ public class TypeSerializerTest {
         container.types = new ArrayList<>();
 
         // ARRAY<MAP<INT, VARCHAR>>
-        MapType mapType = new MapType(Type.INT, ScalarType.createVarcharType(100));
+        MapType mapType = new MapType(Type.INT, TypeFactory.createVarcharType(100));
         ArrayType arrayType = new ArrayType(mapType);
         TypeSerializer.toThrift(arrayType, container);
 
@@ -430,7 +431,7 @@ public class TypeSerializerTest {
 
         StructType structType = new StructType(Lists.newArrayList(
                 new StructField("field1", Type.INT),
-                new StructField("field2", ScalarType.createVarcharType(50))
+                new StructField("field2", TypeFactory.createVarcharType(50))
         ));
         TypeSerializer.toThrift(structType, container);
 
@@ -456,7 +457,7 @@ public class TypeSerializerTest {
 
         StructType structType = new StructType(Lists.newArrayList(
                 new StructField("id", Type.BIGINT, "User ID"),
-                new StructField("name", ScalarType.createVarcharType(100), "User name"),
+                new StructField("name", TypeFactory.createVarcharType(100), "User name"),
                 new StructField("score", Type.DOUBLE)
         ));
         TypeSerializer.toThrift(structType, container);
@@ -484,8 +485,8 @@ public class TypeSerializerTest {
         container.types = new ArrayList<>();
 
         StructType structType = new StructType(Lists.newArrayList(
-                new StructField("price", ScalarType.createDecimalV2Type(10, 2)),
-                new StructField("quantity", ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4))
+                new StructField("price", TypeFactory.createDecimalV2Type(10, 2)),
+                new StructField("quantity", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4))
         ));
         TypeSerializer.toThrift(structType, container);
 
@@ -542,7 +543,7 @@ public class TypeSerializerTest {
 
         // Use constructor with fieldId parameter
         StructField field1 = new StructField("id", 1, Type.INT, null);
-        StructField field2 = new StructField("name", 2, ScalarType.createVarcharType(100), null);
+        StructField field2 = new StructField("name", 2, TypeFactory.createVarcharType(100), null);
 
         StructType structType = new StructType(Lists.newArrayList(field1, field2));
         TypeSerializer.toThrift(structType, container);
@@ -622,7 +623,7 @@ public class TypeSerializerTest {
                 new StructField("value", Type.DOUBLE)
         ));
 
-        MapType mapType = new MapType(ScalarType.createVarcharType(50), structType);
+        MapType mapType = new MapType(TypeFactory.createVarcharType(50), structType);
         ArrayType arrayType = new ArrayType(mapType);
 
         TypeSerializer.toThrift(arrayType, container);
@@ -644,7 +645,7 @@ public class TypeSerializerTest {
 
         // STRUCT<users:ARRAY<STRUCT<name:VARCHAR, age:INT>>, count:BIGINT>
         StructType userStruct = new StructType(Lists.newArrayList(
-                new StructField("name", ScalarType.createVarcharType(100)),
+                new StructField("name", TypeFactory.createVarcharType(100)),
                 new StructField("age", Type.INT)
         ));
 
@@ -674,7 +675,7 @@ public class TypeSerializerTest {
         container.types = new ArrayList<>();
 
         // MAP<INT, ARRAY<VARCHAR>>
-        ArrayType arrayType = new ArrayType(ScalarType.createVarcharType(200));
+        ArrayType arrayType = new ArrayType(TypeFactory.createVarcharType(200));
         MapType mapType = new MapType(Type.INT, arrayType);
 
         TypeSerializer.toThrift(mapType, container);
@@ -692,7 +693,7 @@ public class TypeSerializerTest {
         container.types = new ArrayList<>();
 
         // ARRAY<MAP<VARCHAR, BIGINT>>
-        MapType mapType = new MapType(ScalarType.createVarcharType(50), Type.BIGINT);
+        MapType mapType = new MapType(TypeFactory.createVarcharType(50), Type.BIGINT);
         ArrayType arrayType = new ArrayType(mapType);
 
         TypeSerializer.toThrift(arrayType, container);
@@ -764,20 +765,20 @@ public class TypeSerializerTest {
                 Type.DOUBLE,
                 Type.DATE,
                 Type.DATETIME,
-                ScalarType.createCharType(10),
-                ScalarType.createVarcharType(255),
-                ScalarType.createVarbinary(1024),
-                ScalarType.createHllType(),
-                ScalarType.createDecimalV2Type(10, 4),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 2),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 6),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 10),
+                TypeFactory.createCharType(10),
+                TypeFactory.createVarcharType(255),
+                TypeFactory.createVarbinary(1024),
+                TypeFactory.createHllType(),
+                TypeFactory.createDecimalV2Type(10, 4),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 2),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 6),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 10),
                 new ArrayType(Type.INT),
-                new ArrayType(ScalarType.createVarcharType(100)),
-                new MapType(Type.INT, ScalarType.createVarcharType(200)),
+                new ArrayType(TypeFactory.createVarcharType(100)),
+                new MapType(Type.INT, TypeFactory.createVarcharType(200)),
                 new StructType(Lists.newArrayList(
                         new StructField("f1", Type.INT),
-                        new StructField("f2", ScalarType.createVarcharType(50), "comment")
+                        new StructField("f2", TypeFactory.createVarcharType(50), "comment")
                 ))
         };
 
@@ -804,7 +805,7 @@ public class TypeSerializerTest {
                 new StructField("y", Type.DOUBLE)
         ));
 
-        MapType mapType = new MapType(ScalarType.createVarcharType(50), innerStruct);
+        MapType mapType = new MapType(TypeFactory.createVarcharType(50), innerStruct);
         ArrayType arrayType = new ArrayType(mapType);
 
         StructType outerStruct = new StructType(Lists.newArrayList(

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
@@ -52,6 +52,7 @@ import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
 import com.starrocks.type.TypeDeserializer;
+import com.starrocks.type.TypeFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -117,31 +118,31 @@ public class TypeTest {
         Assertions.assertEquals(63, MysqlCodec.getMysqlResultSetFieldCharsetIndex(type));
 
         // decimal
-        type = ScalarType.createDecimalV2Type(15, 5);
+        type = TypeFactory.createDecimalV2Type(15, 5);
         Assertions.assertEquals(19, MysqlCodec.getMysqlResultSetFieldLength(type));
         Assertions.assertEquals(5, type.getMysqlResultSetFieldDecimals());
         Assertions.assertEquals(63, MysqlCodec.getMysqlResultSetFieldCharsetIndex(type));
 
         // decimalv2
-        type = ScalarType.createDecimalV2Type(15, 0);
+        type = TypeFactory.createDecimalV2Type(15, 0);
         Assertions.assertEquals(18, MysqlCodec.getMysqlResultSetFieldLength(type));
         Assertions.assertEquals(0, type.getMysqlResultSetFieldDecimals());
         Assertions.assertEquals(63, MysqlCodec.getMysqlResultSetFieldCharsetIndex(type));
 
         // char
-        type = ScalarType.createCharType(10);
+        type = TypeFactory.createCharType(10);
         Assertions.assertEquals(30, MysqlCodec.getMysqlResultSetFieldLength(type));
         Assertions.assertEquals(0, type.getMysqlResultSetFieldDecimals());
         Assertions.assertEquals(33, MysqlCodec.getMysqlResultSetFieldCharsetIndex(type));
 
         // varchar
-        type = ScalarType.createVarcharType(11);
+        type = TypeFactory.createVarcharType(11);
         Assertions.assertEquals(33, MysqlCodec.getMysqlResultSetFieldLength(type));
         Assertions.assertEquals(0, type.getMysqlResultSetFieldDecimals());
         Assertions.assertEquals(33, MysqlCodec.getMysqlResultSetFieldCharsetIndex(type));
 
         // wildcard varchar
-        type = ScalarType.createVarcharType(-1);
+        type = TypeFactory.createVarcharType(-1);
         Assertions.assertEquals(192, MysqlCodec.getMysqlResultSetFieldLength(type));
         Assertions.assertEquals(0, type.getMysqlResultSetFieldDecimals());
         Assertions.assertEquals(33, MysqlCodec.getMysqlResultSetFieldCharsetIndex(type));
@@ -179,13 +180,13 @@ public class TypeTest {
         Assertions.assertEquals(60, MysqlCodec.getMysqlResultSetFieldLength(type));
 
         MapType mapType =
-                new MapType(ScalarType.createType(PrimitiveType.INT), ScalarType.createType(PrimitiveType.INT));
+                new MapType(TypeFactory.createType(PrimitiveType.INT), TypeFactory.createType(PrimitiveType.INT));
         // default 20 * 3
         Assertions.assertEquals(60, MysqlCodec.getMysqlResultSetFieldLength(mapType));
         Assertions.assertEquals(0, mapType.getMysqlResultSetFieldDecimals());
         Assertions.assertEquals(33, MysqlCodec.getMysqlResultSetFieldCharsetIndex(mapType));
 
-        StructField structField = new StructField("a", ScalarType.createType(PrimitiveType.INT));
+        StructField structField = new StructField("a", TypeFactory.createType(PrimitiveType.INT));
         ArrayList<StructField> structFields = new ArrayList<>();
         structFields.add(structField);
         StructType structType = new StructType(structFields);
@@ -198,13 +199,13 @@ public class TypeTest {
     @Test
     public void testCanonicalName() {
         Object[][] testCases = new Object[][] {
-                {ScalarType.createDecimalV3NarrowestType(9, 2), "DECIMAL(9,2)"},
-                {ScalarType.createDecimalV3NarrowestType(18, 4), "DECIMAL(18,4)"},
-                {ScalarType.createDecimalV3NarrowestType(38, 6), "DECIMAL(38,6)"},
-                {ScalarType.createVarchar(16), "VARCHAR(16)"},
-                {ScalarType.createCharType(16), "CHAR(16)"},
-                {ScalarType.createType(PrimitiveType.INT), "INT"},
-                {ScalarType.createType(PrimitiveType.FLOAT), "FLOAT"},
+                {TypeFactory.createDecimalV3NarrowestType(9, 2), "DECIMAL(9,2)"},
+                {TypeFactory.createDecimalV3NarrowestType(18, 4), "DECIMAL(18,4)"},
+                {TypeFactory.createDecimalV3NarrowestType(38, 6), "DECIMAL(38,6)"},
+                {TypeFactory.createVarchar(16), "VARCHAR(16)"},
+                {TypeFactory.createCharType(16), "CHAR(16)"},
+                {TypeFactory.createType(PrimitiveType.INT), "INT"},
+                {TypeFactory.createType(PrimitiveType.FLOAT), "FLOAT"},
         };
 
         for (Object[] tc : testCases) {
@@ -217,9 +218,9 @@ public class TypeTest {
     @Test
     public void testMysqlDataType() {
         Object[][] testCases = new Object[][] {
-                {ScalarType.createType(PrimitiveType.BOOLEAN), "tinyint"},
-                {ScalarType.createType(PrimitiveType.LARGEINT), "bigint unsigned"},
-                {ScalarType.createDecimalV3NarrowestType(18, 4), "decimal"},
+                {TypeFactory.createType(PrimitiveType.BOOLEAN), "tinyint"},
+                {TypeFactory.createType(PrimitiveType.LARGEINT), "bigint unsigned"},
+                {TypeFactory.createDecimalV3NarrowestType(18, 4), "decimal"},
                 {new ArrayType(Type.INT), "array"},
                 {new MapType(Type.INT, Type.INT), "map"},
                 {new StructType(Lists.newArrayList(Type.INT)), "struct"},
@@ -235,9 +236,9 @@ public class TypeTest {
     @Test
     public void testMysqlColumnType() {
         Object[][] testCases = new Object[][] {
-                {ScalarType.createType(PrimitiveType.BOOLEAN), "tinyint(1)"},
-                {ScalarType.createType(PrimitiveType.LARGEINT), "bigint(20) unsigned"},
-                {ScalarType.createDecimalV3NarrowestType(18, 4), "decimal(18, 4)"},
+                {TypeFactory.createType(PrimitiveType.BOOLEAN), "tinyint(1)"},
+                {TypeFactory.createType(PrimitiveType.LARGEINT), "bigint(20) unsigned"},
+                {TypeFactory.createDecimalV3NarrowestType(18, 4), "decimal(18, 4)"},
                 {new ArrayType(Type.INT), "array<int(11)>"},
                 {new MapType(Type.INT, Type.INT), "map<int(11),int(11)>"},
                 {new StructType(Lists.newArrayList(Type.INT)), "struct<col1 int(11)>"},
@@ -254,11 +255,11 @@ public class TypeTest {
     public void testMapSerialAndDeser() {
         // map<int,struct<c1:int,cc1:string>>
         StructType c1 = new StructType(Lists.newArrayList(
-                new StructField("c1", ScalarType.createType(PrimitiveType.INT)),
-                new StructField("cc1", ScalarType.createDefaultCatalogString())
+                new StructField("c1", TypeFactory.createType(PrimitiveType.INT)),
+                new StructField("cc1", TypeFactory.createDefaultCatalogString())
         ));
         MapType mapType =
-                new MapType(ScalarType.createType(PrimitiveType.INT), c1);
+                new MapType(TypeFactory.createType(PrimitiveType.INT), c1);
         String json = GsonUtils.GSON.toJson(mapType);
         Type deType = GsonUtils.GSON.fromJson(json, Type.class);
         Assertions.assertTrue(deType.isMapType());
@@ -272,11 +273,11 @@ public class TypeTest {
     public void testStructSerialAndDeser() {
         // "struct<struct_test:int,c1:struct<c1:int,cc1:string>>"
         StructType c1 = new StructType(Lists.newArrayList(
-                new StructField("c1", ScalarType.createType(PrimitiveType.INT)),
-                new StructField("cc1", ScalarType.createDefaultCatalogString())
+                new StructField("c1", TypeFactory.createType(PrimitiveType.INT)),
+                new StructField("cc1", TypeFactory.createDefaultCatalogString())
         ));
         StructType root = new StructType(Lists.newArrayList(
-                new StructField("struct_test", ScalarType.createType(PrimitiveType.INT), "comment test"),
+                new StructField("struct_test", TypeFactory.createType(PrimitiveType.INT), "comment test"),
                 new StructField("c1", c1)
         ));
         String json = GsonUtils.GSON.toJson(root);
@@ -402,7 +403,7 @@ public class TypeTest {
 
     @Test
     public void testExtendedPrecision() {
-        ScalarType type = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 10, 4);
+        ScalarType type = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 10, 4);
         Assertions.assertSame(type, ColumnDefAnalyzer.extendedPrecision(type, true));
         Assertions.assertNotSame(type, ColumnDefAnalyzer.extendedPrecision(type, false));
     }
@@ -446,8 +447,8 @@ public class TypeTest {
         Assertions.assertTrue(Type.DECIMAL64.supportZoneMap());
         Assertions.assertTrue(Type.DECIMAL128.supportZoneMap());
         Assertions.assertTrue(Type.DECIMAL256.supportZoneMap());
-        Assertions.assertTrue(ScalarType.createVarcharType(10).supportZoneMap());
-        Assertions.assertTrue(ScalarType.createCharType(5).supportZoneMap());
+        Assertions.assertTrue(TypeFactory.createVarcharType(10).supportZoneMap());
+        Assertions.assertTrue(TypeFactory.createCharType(5).supportZoneMap());
 
         // Negative cases: Non-scalar types or scalar types that are not numeric, date, or string
         Assertions.assertFalse(Type.NULL.supportZoneMap());

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/combinator/AggStateCombinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/combinator/AggStateCombinatorTest.java
@@ -42,9 +42,9 @@ import com.starrocks.type.AnyMapType;
 import com.starrocks.type.AnyStructType;
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.MapType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.assertj.core.util.Sets;
@@ -115,11 +115,11 @@ public class AggStateCombinatorTest extends MVTestBase {
 
     private Type mockType(Type type) {
         if (type.isDecimalOfAnyVersion()) {
-            return ScalarType.createDecimalV3NarrowestType(10, 2);
+            return TypeFactory.createDecimalV3NarrowestType(10, 2);
         } else if (type.isChar()) {
-            return ScalarType.createCharType(100);
+            return TypeFactory.createCharType(100);
         } else if (type.isVarchar()) {
-            return ScalarType.createVarcharType(100);
+            return TypeFactory.createVarcharType(100);
         } else if (type instanceof AnyElementType) {
             return Type.STRING;
         } else if (type instanceof AnyArrayType) {

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedCtxTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedCtxTest.java
@@ -48,7 +48,7 @@ import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TTabletSchedule;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -68,7 +68,7 @@ public class TabletSchedCtxTest {
     private static int PH_PART_ID = 6;
 
     private static String TB_NAME = "test";
-    private static List<Column> TB_BASE_SCHEMA = Lists.newArrayList(new Column("k1", ScalarType
+    private static List<Column> TB_BASE_SCHEMA = Lists.newArrayList(new Column("k1", TypeFactory
             .createType(PrimitiveType.TINYINT), true, null, "", "key1"));
 
     private static int TABLET_ID_1 = 50000;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ColumnTypeConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ColumnTypeConverterTest.java
@@ -26,6 +26,7 @@ import com.starrocks.type.ScalarType;
 import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.apache.avro.Schema;
 import org.apache.hadoop.hive.common.type.HiveVarchar;
 import org.junit.jupiter.api.Assertions;
@@ -43,8 +44,8 @@ import static com.starrocks.connector.ColumnTypeConverter.fromPaimonType;
 import static com.starrocks.connector.ColumnTypeConverter.getPrecisionAndScale;
 import static com.starrocks.connector.ColumnTypeConverter.toHiveType;
 import static com.starrocks.type.ScalarType.CATALOG_MAX_VARCHAR_LENGTH;
-import static com.starrocks.type.ScalarType.getOlapMaxVarcharLength;
 import static com.starrocks.type.Type.UNKNOWN_TYPE;
+import static com.starrocks.type.TypeFactory.getOlapMaxVarcharLength;
 
 
 public class ColumnTypeConverterTest {
@@ -109,101 +110,101 @@ public class ColumnTypeConverterTest {
 
     @Test
     public void testArrayString() {
-        ScalarType itemType = ScalarType.createType(PrimitiveType.DATE);
+        ScalarType itemType = TypeFactory.createType(PrimitiveType.DATE);
         ArrayType arrayType = new ArrayType(new ArrayType(itemType));
         String typeStr = "Array<Array<date>>";
         Type resType = fromHiveTypeToArrayType(typeStr);
         Assertions.assertEquals(arrayType, resType);
 
-        itemType = ScalarType.createDefaultCatalogString();
+        itemType = TypeFactory.createDefaultCatalogString();
         arrayType = new ArrayType(itemType);
         typeStr = "Array<string>";
         resType = fromHiveTypeToArrayType(typeStr);
         Assertions.assertEquals(arrayType, resType);
 
-        itemType = ScalarType.createType(PrimitiveType.INT);
+        itemType = TypeFactory.createType(PrimitiveType.INT);
         arrayType = new ArrayType(new ArrayType(new ArrayType(itemType)));
         typeStr = "array<Array<Array<int>>>";
         resType = fromHiveTypeToArrayType(typeStr);
         Assertions.assertEquals(arrayType, resType);
 
-        itemType = ScalarType.createType(PrimitiveType.BIGINT);
+        itemType = TypeFactory.createType(PrimitiveType.BIGINT);
         arrayType = new ArrayType(new ArrayType(new ArrayType(itemType)));
         typeStr = "array<Array<Array<bigint>>>";
         resType = fromHiveTypeToArrayType(typeStr);
         Assertions.assertEquals(arrayType, resType);
 
-        itemType = ScalarType.createUnifiedDecimalType(4, 2);
+        itemType = TypeFactory.createUnifiedDecimalType(4, 2);
         Assertions.assertEquals(new ArrayType(new ArrayType(itemType)),
                 fromHiveTypeToArrayType("array<Array<decimal(4, 2)>>"));
 
-        itemType = ScalarType.createType(PrimitiveType.VARBINARY);
+        itemType = TypeFactory.createType(PrimitiveType.VARBINARY);
         Assertions.assertEquals(new ArrayType(itemType),
                 fromHiveTypeToArrayType("array<BINARY>"));
     }
 
     @Test
     public void testMapString() {
-        ScalarType keyType = ScalarType.createType(PrimitiveType.TINYINT);
-        ScalarType valueType = ScalarType.createType(PrimitiveType.SMALLINT);
+        ScalarType keyType = TypeFactory.createType(PrimitiveType.TINYINT);
+        ScalarType valueType = TypeFactory.createType(PrimitiveType.SMALLINT);
         MapType mapType = new MapType(keyType, valueType);
         String typeStr = "map<tinyint,smallint>";
         Type resType = fromHiveTypeToMapType(typeStr);
         Assertions.assertEquals(mapType, resType);
 
-        keyType = ScalarType.createType(PrimitiveType.INT);
-        valueType = ScalarType.createType(PrimitiveType.INT);
+        keyType = TypeFactory.createType(PrimitiveType.INT);
+        valueType = TypeFactory.createType(PrimitiveType.INT);
         mapType = new MapType(keyType, valueType);
         typeStr = "Map<INT,INTEGER>";
         resType = fromHiveTypeToMapType(typeStr);
         Assertions.assertEquals(mapType, resType);
 
-        keyType = ScalarType.createType(PrimitiveType.FLOAT);
-        valueType = ScalarType.createType(PrimitiveType.DOUBLE);
+        keyType = TypeFactory.createType(PrimitiveType.FLOAT);
+        valueType = TypeFactory.createType(PrimitiveType.DOUBLE);
         mapType = new MapType(keyType, valueType);
         typeStr = "map<float,double>";
         resType = fromHiveTypeToMapType(typeStr);
         Assertions.assertEquals(mapType, resType);
 
-        keyType = ScalarType.createUnifiedDecimalType(10, 7);
-        valueType = ScalarType.createType(PrimitiveType.DATETIME);
+        keyType = TypeFactory.createUnifiedDecimalType(10, 7);
+        valueType = TypeFactory.createType(PrimitiveType.DATETIME);
         mapType = new MapType(keyType, valueType);
         typeStr = "map<decimal(10,7),timestamp>";
         resType = fromHiveTypeToMapType(typeStr);
         Assertions.assertEquals(mapType, resType);
 
-        keyType = ScalarType.createType(PrimitiveType.DATE);
-        valueType = ScalarType.createDefaultCatalogString();
+        keyType = TypeFactory.createType(PrimitiveType.DATE);
+        valueType = TypeFactory.createDefaultCatalogString();
         mapType = new MapType(keyType, valueType);
         typeStr = "map<date,string>";
         resType = fromHiveTypeToMapType(typeStr);
         Assertions.assertEquals(mapType, resType);
 
-        keyType = ScalarType.createVarcharType(10);
-        valueType = ScalarType.createCharType(5);
+        keyType = TypeFactory.createVarcharType(10);
+        valueType = TypeFactory.createCharType(5);
         mapType = new MapType(keyType, valueType);
         typeStr = "map<varchar(10),char(5)>";
         resType = fromHiveTypeToMapType(typeStr);
         Assertions.assertEquals(mapType, resType);
 
-        keyType = ScalarType.createType(PrimitiveType.BOOLEAN);
-        valueType = ScalarType.createVarcharType(10);
+        keyType = TypeFactory.createType(PrimitiveType.BOOLEAN);
+        valueType = TypeFactory.createVarcharType(10);
         mapType = new MapType(keyType, valueType);
         typeStr = "map<boolean,varchar(10)>";
         resType = fromHiveTypeToMapType(typeStr);
         Assertions.assertEquals(mapType, resType);
 
-        keyType = ScalarType.createCharType(10);
-        ScalarType itemType = ScalarType.createType(PrimitiveType.INT);
+        keyType = TypeFactory.createCharType(10);
+        ScalarType itemType = TypeFactory.createType(PrimitiveType.INT);
         ArrayType vType = new ArrayType(itemType);
         mapType = new MapType(keyType, vType);
         typeStr = "map<char(10),array<int>>";
         resType = fromHiveTypeToMapType(typeStr);
         Assertions.assertEquals(mapType, resType);
 
-        keyType = ScalarType.createCharType(10);
-        ScalarType inKeyType = ScalarType.createType(PrimitiveType.INT);
-        itemType = ScalarType.createType(PrimitiveType.DATETIME);
+        keyType = TypeFactory.createCharType(10);
+        ScalarType inKeyType = TypeFactory.createType(PrimitiveType.INT);
+        itemType = TypeFactory.createType(PrimitiveType.DATETIME);
         ArrayType inValueType = new ArrayType(itemType);
         MapType mValueType = new MapType(inKeyType, inValueType);
         mapType = new MapType(keyType, mValueType);
@@ -216,11 +217,11 @@ public class ColumnTypeConverterTest {
     public void testStructString() {
         {
             String typeStr = "struct<a:struct<aa:date>,b:int>";
-            StructField aa = new StructField("aa", ScalarType.createType(PrimitiveType.DATE));
+            StructField aa = new StructField("aa", TypeFactory.createType(PrimitiveType.DATE));
 
             StructType innerStruct = new StructType(Lists.newArrayList(aa));
             StructField a = new StructField("a", innerStruct);
-            StructField b = new StructField("b", ScalarType.createType(PrimitiveType.INT));
+            StructField b = new StructField("b", TypeFactory.createType(PrimitiveType.INT));
             StructType outerStruct = new StructType(Lists.newArrayList(a, b));
 
             Type resType = ColumnTypeConverter.fromHiveType(typeStr);
@@ -230,8 +231,8 @@ public class ColumnTypeConverterTest {
         {
             String typeStr = "array<struct<a:int,b:map<int,int>>>";
             MapType map =
-                    new MapType(ScalarType.createType(PrimitiveType.INT), ScalarType.createType(PrimitiveType.INT));
-            StructField a = new StructField("a", ScalarType.createType(PrimitiveType.INT));
+                    new MapType(TypeFactory.createType(PrimitiveType.INT), TypeFactory.createType(PrimitiveType.INT));
+            StructField a = new StructField("a", TypeFactory.createType(PrimitiveType.INT));
             StructField b = new StructField("b", map);
             StructType structType = new StructType(Lists.newArrayList(a, b));
             ArrayType arrayType = new ArrayType(structType);
@@ -243,11 +244,11 @@ public class ColumnTypeConverterTest {
         {
             String typeStr = "struct<struct_test:int,c1:struct<c1:int,cc1:string>>";
             StructType c1 = new StructType(Lists.newArrayList(
-                    new StructField("c1", ScalarType.createType(PrimitiveType.INT)),
-                    new StructField("cc1", ScalarType.createDefaultCatalogString())
+                    new StructField("c1", TypeFactory.createType(PrimitiveType.INT)),
+                    new StructField("cc1", TypeFactory.createDefaultCatalogString())
             ));
             StructType root = new StructType(Lists.newArrayList(
-                    new StructField("struct_test", ScalarType.createType(PrimitiveType.INT)),
+                    new StructField("struct_test", TypeFactory.createType(PrimitiveType.INT)),
                     new StructField("c1", c1)
             ));
 
@@ -278,7 +279,7 @@ public class ColumnTypeConverterTest {
 
     @Test
     public void testCharString() {
-        Type charType = ScalarType.createCharType(100);
+        Type charType = TypeFactory.createCharType(100);
         String typeStr = "char(100)";
         Type resType = ColumnTypeConverter.fromHiveType(typeStr);
         Assertions.assertEquals(resType, charType);
@@ -290,7 +291,7 @@ public class ColumnTypeConverterTest {
 
     @Test
     public void testVarcharString() {
-        Type varcharType = ScalarType.createVarcharType(100);
+        Type varcharType = TypeFactory.createVarcharType(100);
         String typeStr = "varchar(100)";
         Type resType = ColumnTypeConverter.fromHiveType(typeStr);
         Assertions.assertEquals(resType, varcharType);
@@ -299,20 +300,20 @@ public class ColumnTypeConverterTest {
         resType = ColumnTypeConverter.fromHiveType(typeStr);
         Assertions.assertNotEquals(resType, varcharType);
 
-        varcharType = ScalarType.createVarcharType();
+        varcharType = TypeFactory.createVarcharType();
         typeStr = "varchar(-1)";
         resType = ColumnTypeConverter.fromHiveType(typeStr);
         Assertions.assertEquals(resType, varcharType);
 
-        Type stringType = ScalarType.createDefaultCatalogString();
+        Type stringType = TypeFactory.createDefaultCatalogString();
         typeStr = "string";
         resType = ColumnTypeConverter.fromHiveType(typeStr);
         Assertions.assertEquals(resType, stringType);
 
-        Assertions.assertEquals("varchar(65535)", toHiveType(ScalarType.createVarchar(HiveVarchar.MAX_VARCHAR_LENGTH)));
-        Assertions.assertEquals("varchar(65534)", toHiveType(ScalarType.createVarchar(HiveVarchar.MAX_VARCHAR_LENGTH - 1)));
-        Assertions.assertEquals("string", toHiveType(ScalarType.createVarchar(getOlapMaxVarcharLength())));
-        Assertions.assertEquals("string", toHiveType(ScalarType.createVarchar(CATALOG_MAX_VARCHAR_LENGTH)));
+        Assertions.assertEquals("varchar(65535)", toHiveType(TypeFactory.createVarchar(HiveVarchar.MAX_VARCHAR_LENGTH)));
+        Assertions.assertEquals("varchar(65534)", toHiveType(TypeFactory.createVarchar(HiveVarchar.MAX_VARCHAR_LENGTH - 1)));
+        Assertions.assertEquals("string", toHiveType(TypeFactory.createVarchar(getOlapMaxVarcharLength())));
+        Assertions.assertEquals("string", toHiveType(TypeFactory.createVarchar(CATALOG_MAX_VARCHAR_LENGTH)));
     }
 
     @Test
@@ -321,30 +322,30 @@ public class ColumnTypeConverterTest {
         Schema arraySchema;
 
         unionSchema = Schema.createUnion(Schema.create(Schema.Type.INT));
-        Assertions.assertEquals(fromHudiType(unionSchema), ScalarType.createType(PrimitiveType.INT));
+        Assertions.assertEquals(fromHudiType(unionSchema), TypeFactory.createType(PrimitiveType.INT));
 
         unionSchema = Schema.createUnion(Schema.create(Schema.Type.INT));
         arraySchema = Schema.createArray(unionSchema);
         Schema.createArray(unionSchema);
-        Assertions.assertEquals(fromHudiType(arraySchema), new ArrayType(ScalarType.createType(PrimitiveType.INT)));
+        Assertions.assertEquals(fromHudiType(arraySchema), new ArrayType(TypeFactory.createType(PrimitiveType.INT)));
 
         unionSchema = Schema.createUnion(Schema.create(Schema.Type.BOOLEAN));
         arraySchema = Schema.createArray(unionSchema);
-        Assertions.assertEquals(fromHudiType(arraySchema), new ArrayType(ScalarType.createType(PrimitiveType.BOOLEAN)));
+        Assertions.assertEquals(fromHudiType(arraySchema), new ArrayType(TypeFactory.createType(PrimitiveType.BOOLEAN)));
 
         unionSchema = Schema.createUnion(Schema.create(Schema.Type.STRING));
         arraySchema = Schema.createArray(unionSchema);
-        Assertions.assertEquals(fromHudiType(arraySchema), new ArrayType(ScalarType.createDefaultCatalogString()));
+        Assertions.assertEquals(fromHudiType(arraySchema), new ArrayType(TypeFactory.createDefaultCatalogString()));
 
         unionSchema = Schema.createUnion(Schema.create(Schema.Type.BYTES));
         arraySchema = Schema.createArray(unionSchema);
-        Assertions.assertEquals(fromHudiType(arraySchema), new ArrayType(ScalarType.createType(PrimitiveType.VARCHAR)));
+        Assertions.assertEquals(fromHudiType(arraySchema), new ArrayType(TypeFactory.createType(PrimitiveType.VARCHAR)));
     }
 
     @Test
     public void testPaimonSchema() {
         org.apache.paimon.types.TimeType type = new org.apache.paimon.types.TimeType(3);
-        Assertions.assertEquals(ScalarType.createType(PrimitiveType.TIME), fromPaimonType(type));
+        Assertions.assertEquals(TypeFactory.createType(PrimitiveType.TIME), fromPaimonType(type));
     }
 
     @Test
@@ -356,8 +357,8 @@ public class ColumnTypeConverterTest {
         fields.add(field2);
         Schema structSchema = Schema.createRecord(fields);
 
-        StructField structField1 = new StructField("field1", ScalarType.createType(PrimitiveType.INT));
-        StructField structField2 = new StructField("field2", ScalarType.createDefaultCatalogString());
+        StructField structField1 = new StructField("field1", TypeFactory.createType(PrimitiveType.INT));
+        StructField structField2 = new StructField("field2", TypeFactory.createDefaultCatalogString());
         ArrayList<StructField> structFields = new ArrayList<>();
         structFields.add(structField1);
         structFields.add(structField2);
@@ -380,14 +381,14 @@ public class ColumnTypeConverterTest {
 
         Schema mapSchema = Schema.createMap(structSchema);
 
-        StructField structField1 = new StructField("field1", ScalarType.createType(PrimitiveType.INT));
-        StructField structField2 = new StructField("field2", ScalarType.createDefaultCatalogString());
+        StructField structField1 = new StructField("field1", TypeFactory.createType(PrimitiveType.INT));
+        StructField structField2 = new StructField("field2", TypeFactory.createDefaultCatalogString());
         ArrayList<StructField> structFields = new ArrayList<>();
         structFields.add(structField1);
         structFields.add(structField2);
         StructType structType = new StructType(structFields);
 
-        MapType mapType = new MapType(ScalarType.createDefaultCatalogString(), structType);
+        MapType mapType = new MapType(TypeFactory.createDefaultCatalogString(), structType);
 
         Assertions.assertEquals(mapType, fromHudiType(mapSchema));
 
@@ -409,16 +410,16 @@ public class ColumnTypeConverterTest {
         other = new Column("k1", Type.STRING, false);
         Assertions.assertFalse(columnEquals(base, other));
 
-        base = new Column("k1", ScalarType.createCharType(5), false);
-        other = new Column("k1", ScalarType.createCharType(10), false);
+        base = new Column("k1", TypeFactory.createCharType(5), false);
+        other = new Column("k1", TypeFactory.createCharType(10), false);
         Assertions.assertFalse(columnEquals(base, other));
 
-        base = new Column("k1", ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 5, 5), false);
-        other = new Column("k1", ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 6, 5), false);
+        base = new Column("k1", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 5, 5), false);
+        other = new Column("k1", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 6, 5), false);
         Assertions.assertFalse(columnEquals(base, other));
 
-        base = new Column("k1", ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 5, 5), false);
-        other = new Column("k1", ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 5, 4), false);
+        base = new Column("k1", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 5, 5), false);
+        other = new Column("k1", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 5, 4), false);
         Assertions.assertFalse(columnEquals(base, other));
     }
 
@@ -435,32 +436,32 @@ public class ColumnTypeConverterTest {
         Assertions.assertEquals("date", toHiveType(Type.DATE));
         Assertions.assertEquals("timestamp", toHiveType(Type.DATETIME));
 
-        Assertions.assertEquals("char(10)", toHiveType(ScalarType.createCharType(10)));
+        Assertions.assertEquals("char(10)", toHiveType(TypeFactory.createCharType(10)));
         ExceptionChecker.expectThrowsWithMsg(StarRocksConnectorException.class,
                 "Unsupported Hive type: CHAR(10000). Supported CHAR types: CHAR(<=255)",
-                () -> toHiveType(ScalarType.createCharType(10000)));
+                () -> toHiveType(TypeFactory.createCharType(10000)));
 
-        Assertions.assertEquals("varchar(100)", toHiveType(ScalarType.createVarchar(100)));
-        Assertions.assertEquals("string", toHiveType(ScalarType.createVarcharType(200000)));
+        Assertions.assertEquals("varchar(100)", toHiveType(TypeFactory.createVarchar(100)));
+        Assertions.assertEquals("string", toHiveType(TypeFactory.createVarcharType(200000)));
 
-        Assertions.assertEquals("string", toHiveType(ScalarType.createVarchar(getOlapMaxVarcharLength())));
+        Assertions.assertEquals("string", toHiveType(TypeFactory.createVarchar(getOlapMaxVarcharLength())));
 
-        ScalarType itemType = ScalarType.createType(PrimitiveType.DATE);
+        ScalarType itemType = TypeFactory.createType(PrimitiveType.DATE);
         ArrayType arrayType = new ArrayType(new ArrayType(itemType));
         Assertions.assertEquals("array<array<date>>", toHiveType(arrayType));
 
-        ScalarType keyType = ScalarType.createType(PrimitiveType.TINYINT);
-        ScalarType valueType = ScalarType.createType(PrimitiveType.SMALLINT);
+        ScalarType keyType = TypeFactory.createType(PrimitiveType.TINYINT);
+        ScalarType valueType = TypeFactory.createType(PrimitiveType.SMALLINT);
         MapType mapType = new MapType(keyType, valueType);
         String typeStr = "map<tinyint,smallint>";
         Assertions.assertEquals(typeStr, toHiveType(mapType));
 
         typeStr = "struct<a:struct<aa:date>,b:int>";
-        StructField aa = new StructField("aa", ScalarType.createType(PrimitiveType.DATE));
+        StructField aa = new StructField("aa", TypeFactory.createType(PrimitiveType.DATE));
 
         StructType innerStruct = new StructType(Lists.newArrayList(aa));
         StructField a = new StructField("a", innerStruct);
-        StructField b = new StructField("b", ScalarType.createType(PrimitiveType.INT));
+        StructField b = new StructField("b", TypeFactory.createType(PrimitiveType.INT));
         StructType outerStruct = new StructType(Lists.newArrayList(a, b));
         Assertions.assertEquals(typeStr, toHiveType(outerStruct));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorPartitionTraitsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorPartitionTraitsTest.java
@@ -34,7 +34,7 @@ import com.starrocks.connector.partitiontraits.OdpsPartitionTraits;
 import com.starrocks.connector.partitiontraits.OlapPartitionTraits;
 import com.starrocks.connector.partitiontraits.PaimonPartitionTraits;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
@@ -126,9 +126,9 @@ public class ConnectorPartitionTraitsTest {
         Assertions.assertEquals(connectorPartitionTraits.getTableName(), "icebergTable");
         try {
             PartitionKey key = connectorPartitionTraits.createPartitionKeyWithType(Lists.newArrayList("123.3"), 
-                    Lists.newArrayList(ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 6)));
+                    Lists.newArrayList(TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 6)));
             Assertions.assertEquals(key.getKeys().get(0).getType(), 
-                    ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 6));
+                    TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 6));
         } catch (Exception e) {
             throw new RuntimeException("createPartitionKeyWithType failed", e);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
@@ -36,8 +36,8 @@ import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.common.PCellSortedSet;
 import com.starrocks.sql.common.PRangeCell;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -59,7 +59,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class PartitionUtilTest {
     private final List<Column> partColumns = Lists.newArrayList(new Column("k1", Type.INT),
-            new Column("k2", ScalarType.createVarcharType(10)),
+            new Column("k2", TypeFactory.createVarcharType(10)),
             new Column("k3", Type.DOUBLE),
             new Column("k4", Type.INT));
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeApiConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/delta/DeltaLakeApiConverterTest.java
@@ -18,9 +18,9 @@ import com.google.common.collect.ImmutableList;
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.MapType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import io.delta.kernel.types.BinaryType;
 import io.delta.kernel.types.DataType;
 import io.delta.kernel.types.IntegerType;
@@ -43,7 +43,7 @@ public class DeltaLakeApiConverterTest {
         );
 
         Type srType = fromDeltaLakeType(deltaType, COLUMN_MAPPING_MODE_NONE);
-        Assertions.assertEquals(srType, new ArrayType(ScalarType.createType(PrimitiveType.INT)));
+        Assertions.assertEquals(srType, new ArrayType(TypeFactory.createType(PrimitiveType.INT)));
     }
 
     @Test
@@ -74,7 +74,7 @@ public class DeltaLakeApiConverterTest {
 
         Type srType = fromDeltaLakeType(deltaType, COLUMN_MAPPING_MODE_NONE);
         Assertions.assertEquals(srType,
-                new MapType(ScalarType.createType(PrimitiveType.INT), ScalarType.createType(PrimitiveType.VARBINARY)));
+                new MapType(TypeFactory.createType(PrimitiveType.INT), TypeFactory.createType(PrimitiveType.VARBINARY)));
     }
 
     @Test
@@ -87,7 +87,7 @@ public class DeltaLakeApiConverterTest {
 
         Type srType = fromDeltaLakeType(deltaType, COLUMN_MAPPING_MODE_NONE);
         Assertions.assertEquals(srType, new StructType(ImmutableList.of(
-                ScalarType.createType(PrimitiveType.INT),
-                ScalarType.createDefaultCatalogString())));
+                TypeFactory.createType(PrimitiveType.INT),
+                TypeFactory.createDefaultCatalogString())));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
@@ -30,9 +30,9 @@ import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.MapType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionSpec;
@@ -85,16 +85,16 @@ public class IcebergApiConverterTest {
         int scale = 5;
         org.apache.iceberg.types.Type icebergType = Types.DecimalType.of(precision, scale);
         Type resType = fromIcebergType(icebergType);
-        assertEquals(resType, ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, scale));
+        assertEquals(resType, TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, scale));
         resType = fromIcebergType(Types.DecimalType.of(10, scale));
-        assertEquals(resType, ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, scale));
+        assertEquals(resType, TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, scale));
         resType = fromIcebergType(Types.DecimalType.of(19, scale));
-        assertEquals(resType, ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 19, scale));
+        assertEquals(resType, TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 19, scale));
     }
 
     @Test
     public void testString() {
-        Type stringType = ScalarType.createDefaultCatalogString();
+        Type stringType = TypeFactory.createDefaultCatalogString();
         org.apache.iceberg.types.Type icebergType = Types.StringType.get();
         Type resType = fromIcebergType(icebergType);
         assertEquals(resType, stringType);
@@ -110,17 +110,17 @@ public class IcebergApiConverterTest {
     @Test
     public void testArray() {
         assertEquals(fromIcebergType(Types.ListType.ofRequired(136, Types.IntegerType.get())),
-                new ArrayType(ScalarType.createType(PrimitiveType.INT)));
+                new ArrayType(TypeFactory.createType(PrimitiveType.INT)));
         assertEquals(fromIcebergType(Types.ListType.ofRequired(136,
                         Types.ListType.ofRequired(136, Types.IntegerType.get()))),
-                new ArrayType(new ArrayType(ScalarType.createType(PrimitiveType.INT))));
+                new ArrayType(new ArrayType(TypeFactory.createType(PrimitiveType.INT))));
     }
 
     @Test
     public void testVariant() {
         Type variantType = fromIcebergType(Types.VariantType.get());
         Assertions.assertTrue(variantType.isVariantType());
-        Assertions.assertEquals(ScalarType.createType(PrimitiveType.VARIANT), variantType);
+        Assertions.assertEquals(TypeFactory.createType(PrimitiveType.VARIANT), variantType);
     }
 
     @Test
@@ -154,7 +154,7 @@ public class IcebergApiConverterTest {
                 Types.StringType.get(), Types.IntegerType.get());
         Type resType = fromIcebergType(icebergType);
         assertEquals(resType,
-                new MapType(ScalarType.createDefaultCatalogString(), ScalarType.createType(PrimitiveType.INT)));
+                new MapType(TypeFactory.createDefaultCatalogString(), TypeFactory.createType(PrimitiveType.INT)));
     }
 
     @Test
@@ -326,7 +326,7 @@ public class IcebergApiConverterTest {
 
     @Test
     public void testTime() {
-        Type timeType = ScalarType.createType(PrimitiveType.TIME);
+        Type timeType = TypeFactory.createType(PrimitiveType.TIME);
         org.apache.iceberg.types.Type icebergType = Types.TimeType.get();
         Type resType = fromIcebergType(icebergType);
         assertEquals(resType, timeType);
@@ -542,29 +542,29 @@ public class IcebergApiConverterTest {
     @Test
     public void testIcebergColumnType() {
         org.apache.iceberg.types.Type type;
-        type = IcebergApiConverter.toIcebergColumnType(ScalarType.createType(PrimitiveType.INT));
+        type = IcebergApiConverter.toIcebergColumnType(TypeFactory.createType(PrimitiveType.INT));
         assertEquals(org.apache.iceberg.types.Type.TypeID.INTEGER, type.typeId());
-        type = IcebergApiConverter.toIcebergColumnType(ScalarType.createType(PrimitiveType.BOOLEAN));
+        type = IcebergApiConverter.toIcebergColumnType(TypeFactory.createType(PrimitiveType.BOOLEAN));
         assertEquals(org.apache.iceberg.types.Type.TypeID.BOOLEAN, type.typeId());
-        type = IcebergApiConverter.toIcebergColumnType(ScalarType.createType(PrimitiveType.TINYINT));
+        type = IcebergApiConverter.toIcebergColumnType(TypeFactory.createType(PrimitiveType.TINYINT));
         assertEquals(org.apache.iceberg.types.Type.TypeID.INTEGER, type.typeId());
-        type = IcebergApiConverter.toIcebergColumnType(ScalarType.createType(PrimitiveType.DECIMAL64));
+        type = IcebergApiConverter.toIcebergColumnType(TypeFactory.createType(PrimitiveType.DECIMAL64));
         assertEquals(org.apache.iceberg.types.Type.TypeID.DECIMAL, type.typeId());
-        type = IcebergApiConverter.toIcebergColumnType(ScalarType.createType(PrimitiveType.BIGINT));
+        type = IcebergApiConverter.toIcebergColumnType(TypeFactory.createType(PrimitiveType.BIGINT));
         assertEquals(org.apache.iceberg.types.Type.TypeID.LONG, type.typeId());
-        type = IcebergApiConverter.toIcebergColumnType(ScalarType.createType(PrimitiveType.DOUBLE));
+        type = IcebergApiConverter.toIcebergColumnType(TypeFactory.createType(PrimitiveType.DOUBLE));
         assertEquals(org.apache.iceberg.types.Type.TypeID.DOUBLE, type.typeId());
-        type = IcebergApiConverter.toIcebergColumnType(ScalarType.createType(PrimitiveType.FLOAT));
+        type = IcebergApiConverter.toIcebergColumnType(TypeFactory.createType(PrimitiveType.FLOAT));
         assertEquals(org.apache.iceberg.types.Type.TypeID.FLOAT, type.typeId());
-        type = IcebergApiConverter.toIcebergColumnType(ScalarType.createType(PrimitiveType.DATE));
+        type = IcebergApiConverter.toIcebergColumnType(TypeFactory.createType(PrimitiveType.DATE));
         assertEquals(org.apache.iceberg.types.Type.TypeID.DATE, type.typeId());
-        type = IcebergApiConverter.toIcebergColumnType(ScalarType.createType(PrimitiveType.DATETIME));
+        type = IcebergApiConverter.toIcebergColumnType(TypeFactory.createType(PrimitiveType.DATETIME));
         assertEquals(org.apache.iceberg.types.Type.TypeID.TIMESTAMP, type.typeId());
-        type = IcebergApiConverter.toIcebergColumnType(ScalarType.createType(PrimitiveType.TIME));
+        type = IcebergApiConverter.toIcebergColumnType(TypeFactory.createType(PrimitiveType.TIME));
         assertEquals(org.apache.iceberg.types.Type.TypeID.TIME, type.typeId());
-        type = IcebergApiConverter.toIcebergColumnType(ScalarType.createType(PrimitiveType.VARCHAR));
+        type = IcebergApiConverter.toIcebergColumnType(TypeFactory.createType(PrimitiveType.VARCHAR));
         assertEquals(org.apache.iceberg.types.Type.TypeID.STRING, type.typeId());
-        type = IcebergApiConverter.toIcebergColumnType(ScalarType.createType(PrimitiveType.VARBINARY));
+        type = IcebergApiConverter.toIcebergColumnType(TypeFactory.createType(PrimitiveType.VARBINARY));
         assertEquals(org.apache.iceberg.types.Type.TypeID.BINARY, type.typeId());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
@@ -23,7 +23,7 @@ import com.starrocks.catalog.JDBCTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import com.zaxxer.hikari.HikariDataSource;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -205,21 +205,21 @@ public class JDBCMetadataTest {
         Table table = jdbcMetadata.getTable(new ConnectContext(), "test", "tbl1");
         List<Column> columns = table.getColumns();
         Assertions.assertEquals(columns.size(), columnResult.getRowCount());
-        Assertions.assertTrue(columns.get(0).getType().equals(ScalarType.createType(PrimitiveType.INT)));
-        Assertions.assertTrue(columns.get(1).getType().equals(ScalarType.createUnifiedDecimalType(10, 2)));
-        Assertions.assertTrue(columns.get(2).getType().equals(ScalarType.createCharType(10)));
-        Assertions.assertTrue(columns.get(3).getType().equals(ScalarType.createVarcharType(10)));
-        Assertions.assertTrue(columns.get(4).getType().equals(ScalarType.createType(PrimitiveType.SMALLINT)));
-        Assertions.assertTrue(columns.get(5).getType().equals(ScalarType.createType(PrimitiveType.INT)));
-        Assertions.assertTrue(columns.get(6).getType().equals(ScalarType.createType(PrimitiveType.BIGINT)));
-        Assertions.assertTrue(columns.get(7).getType().equals(ScalarType.createType(PrimitiveType.LARGEINT)));
-        Assertions.assertTrue(columns.get(8).getType().equals(ScalarType.createType(PrimitiveType.TINYINT)));
-        Assertions.assertTrue(columns.get(9).getType().equals(ScalarType.createType(PrimitiveType.SMALLINT)));
-        Assertions.assertTrue(columns.get(10).getType().equals(ScalarType.createType(PrimitiveType.INT)));
-        Assertions.assertTrue(columns.get(11).getType().equals(ScalarType.createType(PrimitiveType.BIGINT)));
-        Assertions.assertTrue(columns.get(12).getType().equals(ScalarType.createType(PrimitiveType.DATE)));
-        Assertions.assertTrue(columns.get(13).getType().equals(ScalarType.createType(PrimitiveType.TIME)));
-        Assertions.assertTrue(columns.get(14).getType().equals(ScalarType.createType(PrimitiveType.DATETIME)));
+        Assertions.assertTrue(columns.get(0).getType().equals(TypeFactory.createType(PrimitiveType.INT)));
+        Assertions.assertTrue(columns.get(1).getType().equals(TypeFactory.createUnifiedDecimalType(10, 2)));
+        Assertions.assertTrue(columns.get(2).getType().equals(TypeFactory.createCharType(10)));
+        Assertions.assertTrue(columns.get(3).getType().equals(TypeFactory.createVarcharType(10)));
+        Assertions.assertTrue(columns.get(4).getType().equals(TypeFactory.createType(PrimitiveType.SMALLINT)));
+        Assertions.assertTrue(columns.get(5).getType().equals(TypeFactory.createType(PrimitiveType.INT)));
+        Assertions.assertTrue(columns.get(6).getType().equals(TypeFactory.createType(PrimitiveType.BIGINT)));
+        Assertions.assertTrue(columns.get(7).getType().equals(TypeFactory.createType(PrimitiveType.LARGEINT)));
+        Assertions.assertTrue(columns.get(8).getType().equals(TypeFactory.createType(PrimitiveType.TINYINT)));
+        Assertions.assertTrue(columns.get(9).getType().equals(TypeFactory.createType(PrimitiveType.SMALLINT)));
+        Assertions.assertTrue(columns.get(10).getType().equals(TypeFactory.createType(PrimitiveType.INT)));
+        Assertions.assertTrue(columns.get(11).getType().equals(TypeFactory.createType(PrimitiveType.BIGINT)));
+        Assertions.assertTrue(columns.get(12).getType().equals(TypeFactory.createType(PrimitiveType.DATE)));
+        Assertions.assertTrue(columns.get(13).getType().equals(TypeFactory.createType(PrimitiveType.TIME)));
+        Assertions.assertTrue(columns.get(14).getType().equals(TypeFactory.createType(PrimitiveType.DATETIME)));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/kudu/KuduColumnConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/kudu/KuduColumnConverterTest.java
@@ -16,8 +16,8 @@ package com.starrocks.connector.kudu;
 
 import com.starrocks.connector.ColumnTypeConverter;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.apache.kudu.ColumnSchema;
 import org.apache.kudu.ColumnTypeAttributes;
 import org.junit.jupiter.api.Assertions;
@@ -95,7 +95,7 @@ public class KuduColumnConverterTest {
     public void testConvertString() {
         ColumnSchema columnSchema = genColumnSchema("test", org.apache.kudu.Type.STRING);
         Type result = ColumnTypeConverter.fromKuduType(columnSchema);
-        Assertions.assertEquals(result, ScalarType.createVarcharType(CATALOG_MAX_VARCHAR_LENGTH));
+        Assertions.assertEquals(result, TypeFactory.createVarcharType(CATALOG_MAX_VARCHAR_LENGTH));
     }
 
     @Test
@@ -105,7 +105,7 @@ public class KuduColumnConverterTest {
                         .typeAttributes(new ColumnTypeAttributes.ColumnTypeAttributesBuilder().length(len).build())
                         .build();
         Type result = ColumnTypeConverter.fromKuduType(columnSchema);
-        Assertions.assertEquals(result, ScalarType.createVarcharType(len));
+        Assertions.assertEquals(result, TypeFactory.createVarcharType(len));
     }
 
     @Test
@@ -123,6 +123,6 @@ public class KuduColumnConverterTest {
                 .typeAttributes(new ColumnTypeAttributes.ColumnTypeAttributesBuilder().precision(p).scale(s).build())
                 .build();
         Type result = ColumnTypeConverter.fromKuduType(columnSchema);
-        Assertions.assertEquals(result, ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, p, s));
+        Assertions.assertEquals(result, TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, p, s));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/kudu/KuduMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/kudu/KuduMetadataTest.java
@@ -24,6 +24,7 @@ import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.apache.kudu.Schema;
@@ -106,7 +107,7 @@ public class KuduMetadataTest {
         Assertions.assertEquals(0, kuduTable.getPartitionColumnNames().size());
         Assertions.assertEquals(ScalarType.INT, kuduTable.getColumns().get(0).getType());
         Assertions.assertTrue(kuduTable.getBaseSchema().get(0).isAllowNull());
-        Assertions.assertEquals(ScalarType.createVarcharType(CATALOG_MAX_VARCHAR_LENGTH),
+        Assertions.assertEquals(TypeFactory.createVarcharType(CATALOG_MAX_VARCHAR_LENGTH),
                 kuduTable.getBaseSchema().get(1).getType());
         Assertions.assertTrue(kuduTable.getBaseSchema().get(1).isAllowNull());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/odps/EntityConvertUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/odps/EntityConvertUtilsTest.java
@@ -27,9 +27,9 @@ import com.starrocks.catalog.Column;
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.MapType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -77,7 +77,7 @@ public class EntityConvertUtilsTest {
     public void testConvertTypeCaseDecimalLessThanOrEqualMaxDecimal32Precision() {
         DecimalTypeInfo decimalTypeInfo = TypeInfoFactory.getDecimalTypeInfo(5, 2);
         Type result = EntityConvertUtils.convertType(decimalTypeInfo);
-        Type expectedType = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 5, 2);
+        Type expectedType = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 5, 2);
         assertEquals(expectedType, result);
     }
 
@@ -85,7 +85,7 @@ public class EntityConvertUtilsTest {
     public void testConvertTypeCaseDecimalLessThanOrEqualMaxDecimal64Precision() {
         DecimalTypeInfo decimalTypeInfo = TypeInfoFactory.getDecimalTypeInfo(12, 4);
         Type result = EntityConvertUtils.convertType(decimalTypeInfo);
-        Type expectedType = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 12, 4);
+        Type expectedType = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 12, 4);
         assertEquals(expectedType, result);
     }
 
@@ -93,7 +93,7 @@ public class EntityConvertUtilsTest {
     public void testConvertTypeCaseDecimalGreaterThanMaxDecimal64Precision() {
         DecimalTypeInfo decimalTypeInfo = TypeInfoFactory.getDecimalTypeInfo(20, 6);
         Type result = EntityConvertUtils.convertType(decimalTypeInfo);
-        Type expectedType = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 20, 6);
+        Type expectedType = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 20, 6);
         assertEquals(expectedType, result);
     }
 
@@ -108,7 +108,7 @@ public class EntityConvertUtilsTest {
     public void testConvertTypeCaseChar() {
         CharTypeInfo charTypeInfo = TypeInfoFactory.getCharTypeInfo(10);
         Type result = EntityConvertUtils.convertType(charTypeInfo);
-        Type expectedType = ScalarType.createCharType(10);
+        Type expectedType = TypeFactory.createCharType(10);
         assertEquals(expectedType, result);
     }
 
@@ -116,7 +116,7 @@ public class EntityConvertUtilsTest {
     public void testConvertTypeCaseVarchar() {
         VarcharTypeInfo varcharTypeInfo = TypeInfoFactory.getVarcharTypeInfo(20);
         Type result = EntityConvertUtils.convertType(varcharTypeInfo);
-        Type expectedType = ScalarType.createVarcharType(20);
+        Type expectedType = TypeFactory.createVarcharType(20);
         assertEquals(expectedType, result);
     }
 
@@ -124,7 +124,7 @@ public class EntityConvertUtilsTest {
     public void testConvertTypeCaseStringAndJson() {
         TypeInfo typeInfo = TypeInfoFactory.STRING;
         Type result = EntityConvertUtils.convertType(typeInfo);
-        Type expectedType = ScalarType.createDefaultCatalogString();
+        Type expectedType = TypeFactory.createDefaultCatalogString();
         assertEquals(expectedType, result);
     }
 
@@ -162,7 +162,7 @@ public class EntityConvertUtilsTest {
         TypeInfo valueTypeInfo = TypeInfoFactory.INT;
         MapTypeInfo mapTypeInfo = TypeInfoFactory.getMapTypeInfo(keyTypeInfo, valueTypeInfo);
         Type result = EntityConvertUtils.convertType(mapTypeInfo);
-        Type expectedType = new MapType(ScalarType.createDefaultCatalogString(), Type.INT);
+        Type expectedType = new MapType(TypeFactory.createDefaultCatalogString(), Type.INT);
         assertEquals(expectedType, result);
     }
 
@@ -183,7 +183,7 @@ public class EntityConvertUtilsTest {
                 TypeInfoFactory.getStructTypeInfo(ImmutableList.of("fieldTypeInfo1", "fieldTypeInfo2"),
                         ImmutableList.of(fieldTypeInfo1, fieldTypeInfo2));
         Type result = EntityConvertUtils.convertType(structTypeInfo);
-        Type expectedType1 = ScalarType.createDefaultCatalogString();
+        Type expectedType1 = TypeFactory.createDefaultCatalogString();
         Type expectedType2 = Type.INT;
         Type expectedType = new StructType(ImmutableList.of(expectedType1, expectedType2));
         assertEquals(expectedType, result);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/odps/EntityConvertUtilsTests.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/odps/EntityConvertUtilsTests.java
@@ -27,9 +27,9 @@ import com.starrocks.catalog.Column;
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.MapType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -77,7 +77,7 @@ public class EntityConvertUtilsTests {
     public void testConvertTypeCaseDecimalLessThanOrEqualMaxDecimal32Precision() {
         DecimalTypeInfo decimalTypeInfo = TypeInfoFactory.getDecimalTypeInfo(5, 2);
         Type result = EntityConvertUtils.convertType(decimalTypeInfo);
-        Type expectedType = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 5, 2);
+        Type expectedType = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 5, 2);
         assertEquals(expectedType, result);
     }
 
@@ -85,7 +85,7 @@ public class EntityConvertUtilsTests {
     public void testConvertTypeCaseDecimalLessThanOrEqualMaxDecimal64Precision() {
         DecimalTypeInfo decimalTypeInfo = TypeInfoFactory.getDecimalTypeInfo(12, 4);
         Type result = EntityConvertUtils.convertType(decimalTypeInfo);
-        Type expectedType = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 12, 4);
+        Type expectedType = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 12, 4);
         assertEquals(expectedType, result);
     }
 
@@ -93,7 +93,7 @@ public class EntityConvertUtilsTests {
     public void testConvertTypeCaseDecimalGreaterThanMaxDecimal64Precision() {
         DecimalTypeInfo decimalTypeInfo = TypeInfoFactory.getDecimalTypeInfo(20, 6);
         Type result = EntityConvertUtils.convertType(decimalTypeInfo);
-        Type expectedType = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 20, 6);
+        Type expectedType = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 20, 6);
         assertEquals(expectedType, result);
     }
 
@@ -108,7 +108,7 @@ public class EntityConvertUtilsTests {
     public void testConvertTypeCaseChar() {
         CharTypeInfo charTypeInfo = TypeInfoFactory.getCharTypeInfo(10);
         Type result = EntityConvertUtils.convertType(charTypeInfo);
-        Type expectedType = ScalarType.createCharType(10);
+        Type expectedType = TypeFactory.createCharType(10);
         assertEquals(expectedType, result);
     }
 
@@ -116,7 +116,7 @@ public class EntityConvertUtilsTests {
     public void testConvertTypeCaseVarchar() {
         VarcharTypeInfo varcharTypeInfo = TypeInfoFactory.getVarcharTypeInfo(20);
         Type result = EntityConvertUtils.convertType(varcharTypeInfo);
-        Type expectedType = ScalarType.createVarcharType(20);
+        Type expectedType = TypeFactory.createVarcharType(20);
         assertEquals(expectedType, result);
     }
 
@@ -124,7 +124,7 @@ public class EntityConvertUtilsTests {
     public void testConvertTypeCaseStringAndJson() {
         TypeInfo typeInfo = TypeInfoFactory.STRING;
         Type result = EntityConvertUtils.convertType(typeInfo);
-        Type expectedType = ScalarType.createDefaultCatalogString();
+        Type expectedType = TypeFactory.createDefaultCatalogString();
         assertEquals(expectedType, result);
     }
 
@@ -164,7 +164,7 @@ public class EntityConvertUtilsTests {
         TypeInfo valueTypeInfo = TypeInfoFactory.INT;
         MapTypeInfo mapTypeInfo = TypeInfoFactory.getMapTypeInfo(keyTypeInfo, valueTypeInfo);
         Type result = EntityConvertUtils.convertType(mapTypeInfo);
-        Type expectedType = new MapType(ScalarType.createDefaultCatalogString(), Type.INT);
+        Type expectedType = new MapType(TypeFactory.createDefaultCatalogString(), Type.INT);
         assertEquals(expectedType, result);
     }
 
@@ -185,7 +185,7 @@ public class EntityConvertUtilsTests {
                 TypeInfoFactory.getStructTypeInfo(ImmutableList.of("fieldTypeInfo1", "fieldTypeInfo2"),
                         ImmutableList.of(fieldTypeInfo1, fieldTypeInfo2));
         Type result = EntityConvertUtils.convertType(structTypeInfo);
-        Type expectedType1 = ScalarType.createDefaultCatalogString();
+        Type expectedType1 = TypeFactory.createDefaultCatalogString();
         Type expectedType2 = Type.INT;
         Type expectedType = new StructType(ImmutableList.of(expectedType1, expectedType2));
         assertEquals(expectedType, result);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonColumnConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonColumnConverterTest.java
@@ -15,9 +15,9 @@
 package com.starrocks.connector.paimon;
 
 import com.starrocks.connector.ColumnTypeConverter;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.apache.paimon.types.ArrayType;
 import org.apache.paimon.types.BigIntType;
 import org.apache.paimon.types.BinaryType;
@@ -63,7 +63,7 @@ public class PaimonColumnConverterTest {
     public void testConvertChar() {
         CharType paimonType = new CharType(10);
         Type result = ColumnTypeConverter.fromPaimonType(paimonType);
-        Type srType = ScalarType.createCharType(10);
+        Type srType = TypeFactory.createCharType(10);
         Assertions.assertEquals(result, srType);
     }
 
@@ -71,7 +71,7 @@ public class PaimonColumnConverterTest {
     public void testConvertVarchar() {
         VarCharType paimonType = new VarCharType();
         Type result = ColumnTypeConverter.fromPaimonType(paimonType);
-        Type srType = ScalarType.createDefaultCatalogString();
+        Type srType = TypeFactory.createDefaultCatalogString();
         Assertions.assertEquals(result, srType);
     }
 
@@ -88,7 +88,7 @@ public class PaimonColumnConverterTest {
         int scale = 5;
         DecimalType paimonType = new DecimalType(precision, scale);
         Type result = ColumnTypeConverter.fromPaimonType(paimonType);
-        Type srType = ScalarType.createUnifiedDecimalType(precision, scale);
+        Type srType = TypeFactory.createUnifiedDecimalType(precision, scale);
         Assertions.assertEquals(result, srType);
     }
 
@@ -170,7 +170,7 @@ public class PaimonColumnConverterTest {
         Type result = ColumnTypeConverter.fromPaimonType(paimonType);
         Assertions.assertTrue(result instanceof com.starrocks.type.MapType);
         com.starrocks.type.MapType srType = (com.starrocks.type.MapType) result;
-        Assertions.assertEquals(ScalarType.createDefaultCatalogString(), srType.getKeyType());
+        Assertions.assertEquals(TypeFactory.createDefaultCatalogString(), srType.getKeyType());
         Assertions.assertEquals(Type.DATETIME, srType.getValueType());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/trino/TrinoViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/trino/TrinoViewTest.java
@@ -22,6 +22,7 @@ import com.starrocks.type.MapType;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
+import com.starrocks.type.TypeFactory;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.apache.hadoop.hive.metastore.api.Table;
@@ -88,7 +89,7 @@ public class TrinoViewTest {
         Assertions.assertEquals(hiveView.getFullSchema().get(2).getName(), "salary");
         Assertions.assertEquals(hiveView.getFullSchema().get(2).getType(), ScalarType.DOUBLE);
         Assertions.assertEquals(hiveView.getFullSchema().get(3).getName(), "new_col");
-        Assertions.assertEquals(hiveView.getFullSchema().get(3).getType(), ScalarType.createDefaultCatalogString());
+        Assertions.assertEquals(hiveView.getFullSchema().get(3).getType(), TypeFactory.createDefaultCatalogString());
     }
 
     @Test
@@ -131,7 +132,7 @@ public class TrinoViewTest {
         Assertions.assertEquals(hiveView.getFullSchema().get(5).getName(), "double_col");
         Assertions.assertEquals(hiveView.getFullSchema().get(5).getType(), ScalarType.DOUBLE);
         Assertions.assertEquals(hiveView.getFullSchema().get(9).getName(), "varchar_col");
-        Assertions.assertEquals(hiveView.getFullSchema().get(9).getType(), ScalarType.createVarcharType(20));
+        Assertions.assertEquals(hiveView.getFullSchema().get(9).getType(), TypeFactory.createVarcharType(20));
         Assertions.assertEquals(hiveView.getFullSchema().get(10).getName(), "binary_col");
         Assertions.assertEquals(hiveView.getFullSchema().get(10).getType(), ScalarType.VARBINARY);
         Assertions.assertEquals(hiveView.getFullSchema().get(13).getName(), "timestamp_col");
@@ -140,11 +141,11 @@ public class TrinoViewTest {
         Assertions.assertEquals(hiveView.getFullSchema().get(14).getType(), ScalarType.ARRAY_INT);
         Assertions.assertEquals(hiveView.getFullSchema().get(15).getName(), "map_col");
         Assertions.assertEquals(hiveView.getFullSchema().get(15).getType(),
-                new MapType(ScalarType.createDefaultCatalogString(), ScalarType.INT));
+                new MapType(TypeFactory.createDefaultCatalogString(), ScalarType.INT));
         Assertions.assertEquals(hiveView.getFullSchema().get(16).getName(), "struct_col");
         ArrayList<StructField> structFields = new ArrayList<>();
         structFields.add(new StructField("field1", ScalarType.INT));
-        structFields.add(new StructField("field2", ScalarType.createDefaultCatalogString()));
+        structFields.add(new StructField("field2", TypeFactory.createDefaultCatalogString()));
         Assertions.assertEquals(hiveView.getFullSchema().get(16).getType(), new StructType(structFields));
     }
 
@@ -177,18 +178,18 @@ public class TrinoViewTest {
         Assertions.assertEquals(columnList.get(3).getType(), ScalarType.BIGINT);
         Assertions.assertEquals(columnList.get(4).getType(), ScalarType.FLOAT);
         Assertions.assertEquals(columnList.get(5).getType(), ScalarType.DOUBLE);
-        Assertions.assertEquals(columnList.get(6).getType(), ScalarType.createDecimalV3NarrowestType(10, 2));
-        Assertions.assertEquals(columnList.get(7).getType(), ScalarType.createVarcharType(20));
-        Assertions.assertEquals(columnList.get(8).getType(), ScalarType.createCharType(10));
-        Assertions.assertEquals(columnList.get(9).getType(), ScalarType.createDefaultCatalogString());
+        Assertions.assertEquals(columnList.get(6).getType(), TypeFactory.createDecimalV3NarrowestType(10, 2));
+        Assertions.assertEquals(columnList.get(7).getType(), TypeFactory.createVarcharType(20));
+        Assertions.assertEquals(columnList.get(8).getType(), TypeFactory.createCharType(10));
+        Assertions.assertEquals(columnList.get(9).getType(), TypeFactory.createDefaultCatalogString());
         Assertions.assertEquals(columnList.get(10).getType(), ScalarType.BOOLEAN);
         Assertions.assertEquals(columnList.get(11).getType(), ScalarType.DATETIME);
         Assertions.assertEquals(columnList.get(12).getType(), ScalarType.ARRAY_INT);
         Assertions.assertEquals(columnList.get(13).getType(),
-                new MapType(ScalarType.createDefaultCatalogString(), ScalarType.INT));
+                new MapType(TypeFactory.createDefaultCatalogString(), ScalarType.INT));
         ArrayList<StructField> structFields = new ArrayList<>();
         structFields.add(new StructField("field1", ScalarType.INT));
-        structFields.add(new StructField("field2", ScalarType.createDefaultCatalogString()));
+        structFields.add(new StructField("field2", TypeFactory.createDefaultCatalogString()));
         Assertions.assertEquals(columnList.get(14).getType(), new StructType(structFields));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/TablePartitionActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/TablePartitionActionTest.java
@@ -56,8 +56,8 @@ import com.starrocks.sql.ast.PartitionValue;
 import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import mockit.Expectations;
 import okhttp3.Request;
@@ -125,7 +125,7 @@ public class TablePartitionActionTest extends StarRocksHttpTestCase {
         Column c1 = new Column("c1", Type.DATETIME, true, null, null, false, null, "cc1", 2);
         Column c2 = new Column("c2", Type.VARCHAR, true, null, null, false, null, "cc2", 3);
         Column c3 = new Column("c3",
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 8),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 8),
                 false, null, null, true, new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "cc3", 4
         );
         List<Column> columns = Lists.newArrayList(c0, c1, c2, c3);
@@ -167,7 +167,7 @@ public class TablePartitionActionTest extends StarRocksHttpTestCase {
         Column c1 = new Column("c1", Type.DATETIME, true, null, null, false, null, "cc1", 2);
         Column c2 = new Column("c2", Type.VARCHAR, true, null, null, false, null, "cc2", 3);
         Column c3 = new Column("c3",
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 8),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 8),
                 false, null, null, true, new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "cc3", 4
         );
         List<Column> columns = Lists.newArrayList(c0, c1, c2, c3);
@@ -331,7 +331,7 @@ public class TablePartitionActionTest extends StarRocksHttpTestCase {
         Column c1 = new Column("c1", Type.DATETIME, true, null, null, false, null, "cc1", 2);
         Column c2 = new Column("c2", Type.VARCHAR, true, null, null, false, null, "cc2", 3);
         Column c3 = new Column("c3",
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 8),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 8),
                 false, null, null, true, new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "cc3", 4
         );
         List<Column> columns = Lists.newArrayList(c0, c1, c2, c3);

--- a/fe/fe-core/src/test/java/com/starrocks/load/LoadPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/LoadPlannerTest.java
@@ -61,8 +61,8 @@ import com.starrocks.thrift.TPlanNodeType;
 import com.starrocks.thrift.TPrimitiveType;
 import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.thrift.TUniqueId;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
 import mockit.Injectable;
@@ -246,7 +246,7 @@ public class LoadPlannerTest {
         List<Column> columns = Lists.newArrayList();
         columns.add(new Column("k1", Type.TINYINT, true, null, true, null, ""));
         columns.add(new Column("k2", Type.INT, true, null, false, null, ""));
-        columns.add(new Column("k3", ScalarType.createVarchar(50), true, null, true, null, ""));
+        columns.add(new Column("k3", TypeFactory.createVarchar(50), true, null, true, null, ""));
         columns.add(new Column("v", Type.BIGINT, false, AggregateType.SUM, false, null, ""));
 
         Function f1 = new Function(new FunctionName(FunctionSet.SUBSTR), new Type[] {Type.VARCHAR, Type.INT, Type.INT},
@@ -380,7 +380,7 @@ public class LoadPlannerTest {
         List<Column> columns = Lists.newArrayList();
         columns.add(new Column("k1", Type.TINYINT, true, null, true, null, ""));
         columns.add(new Column("k2", Type.INT, true, null, false, null, ""));
-        columns.add(new Column("k3", ScalarType.createVarchar(50), true, null, true, null, ""));
+        columns.add(new Column("k3", TypeFactory.createVarchar(50), true, null, true, null, ""));
         columns.add(new Column("v", Type.BIGINT, false, AggregateType.SUM, false, null, ""));
 
         Function f1 = new Function(new FunctionName(FunctionSet.SUBSTR), new Type[] {Type.VARCHAR, Type.INT, Type.INT},
@@ -538,7 +538,7 @@ public class LoadPlannerTest {
         List<Column> columns = Lists.newArrayList();
         columns.add(new Column("pk", Type.BIGINT, true, null, false, null, ""));
         columns.add(new Column("v1", Type.INT, false, null, false, null, ""));
-        columns.add(new Column("v2", ScalarType.createVarchar(50), false, null, true, null, ""));
+        columns.add(new Column("v2", TypeFactory.createVarchar(50), false, null, true, null, ""));
 
         new Expectations() {
             {
@@ -627,7 +627,7 @@ public class LoadPlannerTest {
         List<Column> columns = Lists.newArrayList();
         columns.add(new Column("pk", Type.BIGINT, true, null, false, null, ""));
         columns.add(new Column("v1", Type.INT, false, null, false, null, ""));
-        columns.add(new Column("v2", ScalarType.createVarchar(50), false, null, true, null, ""));
+        columns.add(new Column("v2", TypeFactory.createVarchar(50), false, null, true, null, ""));
 
         new Expectations() {
             {
@@ -718,7 +718,7 @@ public class LoadPlannerTest {
         List<Column> columns = Lists.newArrayList();
         columns.add(new Column("pk", Type.BIGINT, true, null, false, null, ""));
         columns.add(new Column("v1", Type.INT, false, null, false, null, ""));
-        columns.add(new Column("v2", ScalarType.createVarchar(50), false, null, true, null, ""));
+        columns.add(new Column("v2", TypeFactory.createVarchar(50), false, null, true, null, ""));
 
         Function f1 = new Function(new FunctionName("casttobigint"), new Type[] {Type.VARCHAR},
                 Type.BIGINT, true);
@@ -829,7 +829,7 @@ public class LoadPlannerTest {
                 new ColumnDef.DefaultValueDef(true, new StringLiteral("123")), ""));
         columns.add(new Column("v1", Type.INT, false, null, false,
                 new ColumnDef.DefaultValueDef(true, new StringLiteral("231")), ""));
-        columns.add(new Column("v2", ScalarType.createVarchar(50), false, null, true,
+        columns.add(new Column("v2", TypeFactory.createVarchar(50), false, null, true,
                 new ColumnDef.DefaultValueDef(true, new StringLiteral("asdf")), ""));
 
         Function f1 = new Function(new FunctionName("casttobigint"), new Type[] {Type.VARCHAR},
@@ -924,7 +924,7 @@ public class LoadPlannerTest {
         List<Column> columns = Lists.newArrayList();
         columns.add(new Column("k1", Type.TINYINT, true, null, true, null, ""));
         columns.add(new Column("k2", Type.INT, true, null, false, null, ""));
-        columns.add(new Column("k3", ScalarType.createVarchar(50), true, null, true, null, ""));
+        columns.add(new Column("k3", TypeFactory.createVarchar(50), true, null, true, null, ""));
         columns.add(new Column("v", Type.BIGINT, false, AggregateType.SUM, false, null, ""));
 
         List<Column> keyColumns = Lists.newArrayList();
@@ -1038,7 +1038,7 @@ public class LoadPlannerTest {
         List<Column> columns = Lists.newArrayList();
         columns.add(new Column("k1", Type.TINYINT, true, null, true, null, ""));
         columns.add(new Column("k2", Type.INT, true, null, false, null, ""));
-        columns.add(new Column("k3", ScalarType.createVarchar(50), true, null, true, null, ""));
+        columns.add(new Column("k3", TypeFactory.createVarchar(50), true, null, true, null, ""));
         columns.add(new Column("v", Type.BIGINT, false, AggregateType.REPLACE, false, null, ""));
 
         List<Column> keyColumns = Lists.newArrayList();

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/SparkLoadPendingTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/SparkLoadPendingTaskTest.java
@@ -72,8 +72,8 @@ import com.starrocks.sql.ast.PartitionValue;
 import com.starrocks.sql.ast.SingleRangePartitionDesc;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
 import com.starrocks.sql.common.MetaUtils;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import mockit.Expectations;
 import mockit.Injectable;
 import mockit.Mock;
@@ -244,7 +244,7 @@ public class SparkLoadPendingTaskTest {
         // c1 is partition column, c2 is distribution column
         List<Column> columns = Lists.newArrayList();
         columns.add(new Column("c1", Type.INT, true, null, false, null, ""));
-        columns.add(new Column("c2", ScalarType.createVarchar(10), true, null, false, null, ""));
+        columns.add(new Column("c2", TypeFactory.createVarchar(10), true, null, false, null, ""));
         columns.add(new Column("c3", Type.INT, false, AggregateType.SUM, false, null, ""));
 
         Map<ColumnId, Column> idToColumn = Maps.newTreeMap(ColumnId.CASE_INSENSITIVE_ORDER);

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlColDefTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/MysqlColDefTest.java
@@ -24,7 +24,7 @@ public class MysqlColDefTest {
     @Test
     public void testCreate() {
         //        Expr expr = EasyMock.createMock(Expr.class);
-        //        EasyMock.expect(expr.getType()).andReturn(ScalarType.createType(PrimitiveType.BIGINT)).anyTimes();
+        //        EasyMock.expect(expr.getType()).andReturn(TypeFactory.createType(PrimitiveType.BIGINT)).anyTimes();
         //        EasyMock.replay(expr);
         //
         //        MysqlColDef def = MysqlColDef.fromExpr(expr, "col1");
@@ -50,7 +50,7 @@ public class MysqlColDefTest {
     @Test
     public void testCreateFromName() {
         //        Expr expr = EasyMock.createMock(Expr.class);
-        //        EasyMock.expect(expr.getType()).andReturn(ScalarType.createType(PrimitiveType.BIGINT)).anyTimes();
+        //        EasyMock.expect(expr.getType()).andReturn(TypeFactory.createType(PrimitiveType.BIGINT)).anyTimes();
         //        EasyMock.replay(expr);
         //
         //        MysqlColDef def = MysqlColDef.fromName("col1");

--- a/fe/fe-core/src/test/java/com/starrocks/persist/ChangeMaterializedViewRefreshSchemeLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/ChangeMaterializedViewRefreshSchemeLogTest.java
@@ -34,7 +34,7 @@ import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TTabletType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import mockit.Expectations;
 import mockit.Injectable;
 import mockit.Mocked;
@@ -71,9 +71,9 @@ public class ChangeMaterializedViewRefreshSchemeLogTest {
         DataOutputStream out = new DataOutputStream(Files.newOutputStream(file.toPath()));
 
         List<Column> columns = new LinkedList<Column>();
-        columns.add(new Column("k1", ScalarType.createType(PrimitiveType.TINYINT), true, null, "", ""));
-        columns.add(new Column("k2", ScalarType.createType(PrimitiveType.SMALLINT), true, null, "", ""));
-        columns.add(new Column("v1", ScalarType.createType(PrimitiveType.INT), false, AggregateType.SUM, "", ""));
+        columns.add(new Column("k1", TypeFactory.createType(PrimitiveType.TINYINT), true, null, "", ""));
+        columns.add(new Column("k2", TypeFactory.createType(PrimitiveType.SMALLINT), true, null, "", ""));
+        columns.add(new Column("v1", TypeFactory.createType(PrimitiveType.INT), false, AggregateType.SUM, "", ""));
         RandomDistributionInfo distributionInfo = new RandomDistributionInfo(10);
         PartitionInfo partitionInfo = new SinglePartitionInfo();
         partitionInfo.setDataProperty(1, DataProperty.DEFAULT_DATA_PROPERTY);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
@@ -47,6 +47,7 @@ import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.thrift.TSinkCommitInfo;
 import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -346,7 +347,7 @@ public class IcebergScanNodeTest {
 
 
         List<Column> schemaColumns = new ArrayList<>();
-        schemaColumns.add(new Column("col1", ScalarType.createVarchar(20)));
+        schemaColumns.add(new Column("col1", TypeFactory.createVarchar(20)));
 
         IcebergTable icebergTable = new IcebergTable.Builder()
                 .setId(1234)

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -67,8 +67,8 @@ import com.starrocks.thrift.TTabletLocation;
 import com.starrocks.thrift.TTabletType;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.thrift.TWriteQuorumType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.utframe.MockedWarehouseManager;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
@@ -106,11 +106,11 @@ public class OlapTableSinkTest {
 
         // k2
         SlotDescriptor k2 = descTable.addSlotDescriptor(tuple);
-        k2.setColumn(new Column("k2", ScalarType.createVarchar(25)));
+        k2.setColumn(new Column("k2", TypeFactory.createVarchar(25)));
         k2.setIsMaterialized(true);
         // v1
         SlotDescriptor v1 = descTable.addSlotDescriptor(tuple);
-        v1.setColumn(new Column("v1", ScalarType.createVarchar(25)));
+        v1.setColumn(new Column("v1", TypeFactory.createVarchar(25)));
         v1.setIsMaterialized(true);
         // v2
         SlotDescriptor v2 = descTable.addSlotDescriptor(tuple);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/StreamLoadScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/StreamLoadScanNodeTest.java
@@ -65,8 +65,8 @@ import com.starrocks.thrift.TPrimitiveType;
 import com.starrocks.thrift.TSlotDescriptor;
 import com.starrocks.thrift.TStreamLoadPutRequest;
 import com.starrocks.thrift.TTypeNode;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import mockit.Expectations;
 import mockit.Injectable;
 import mockit.Mock;
@@ -118,7 +118,7 @@ public class StreamLoadScanNodeTest {
         k1.setIsAllowNull(false);
         columns.add(k1);
 
-        Column k2 = new Column("k2", ScalarType.createVarchar(25));
+        Column k2 = new Column("k2", TypeFactory.createVarchar(25));
         k2.setIsKey(true);
         k2.setIsAllowNull(true);
         columns.add(k2);
@@ -130,7 +130,7 @@ public class StreamLoadScanNodeTest {
 
         columns.add(v1);
 
-        Column v2 = new Column("v2", ScalarType.createVarchar(25));
+        Column v2 = new Column("v2", TypeFactory.createVarchar(25));
         v2.setIsKey(false);
         v2.setAggregationType(AggregateType.REPLACE, false);
         v2.setIsAllowNull(false);
@@ -801,7 +801,7 @@ public class StreamLoadScanNodeTest {
         assertThrows(DdlException.class, () -> {
             List<Column> columns = Lists.newArrayList();
             columns.add(new Column("c1", Type.INT, true, null, false, null, ""));
-            columns.add(new Column("c2", ScalarType.createVarchar(10), true, null, false, null, ""));
+            columns.add(new Column("c2", TypeFactory.createVarchar(10), true, null, false, null, ""));
             Table table = new Table(1L, "table0", TableType.OLAP, columns);
             List<ImportColumnDesc> columnExprs = Lists.newArrayList();
             columnExprs.add(new ImportColumnDesc("c3", new FunctionCallExpr("func", Lists.newArrayList())));

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SetExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SetExecutorTest.java
@@ -43,8 +43,8 @@ import com.starrocks.sql.ast.expression.NullLiteral;
 import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.thrift.TExplainLevel;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
@@ -164,7 +164,7 @@ public class SetExecutorTest {
         testUserVariableImp(new DecimalLiteral("1", Type.DECIMAL32_INT), Type.DECIMAL32_INT);
         testUserVariableImp(new DecimalLiteral("1", Type.DECIMAL64_INT), Type.DECIMAL64_INT);
         testUserVariableImp(new DecimalLiteral("1", Type.DECIMAL128_INT), Type.DECIMAL128_INT);
-        testUserVariableImp(new StringLiteral("xxx"), ScalarType.createVarcharType(10));
+        testUserVariableImp(new StringLiteral("xxx"), TypeFactory.createVarcharType(10));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowResultTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowResultTest.java
@@ -27,6 +27,7 @@ import com.starrocks.thrift.TShowResultSet;
 import com.starrocks.thrift.TShowResultSetMetaData;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -44,19 +45,19 @@ public class ShowResultTest {
 
     private ShowResultSetMetaData createTestMetaData() {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("string_col", ScalarType.createType(PrimitiveType.VARCHAR)))
-                .addColumn(new Column("int_col", ScalarType.createType(PrimitiveType.INT)))
-                .addColumn(new Column("long_col", ScalarType.createType(PrimitiveType.BIGINT)))
-                .addColumn(new Column("short_col", ScalarType.createType(PrimitiveType.SMALLINT)))
-                .addColumn(new Column("byte_col", ScalarType.createType(PrimitiveType.TINYINT)))
+                .addColumn(new Column("string_col", TypeFactory.createType(PrimitiveType.VARCHAR)))
+                .addColumn(new Column("int_col", TypeFactory.createType(PrimitiveType.INT)))
+                .addColumn(new Column("long_col", TypeFactory.createType(PrimitiveType.BIGINT)))
+                .addColumn(new Column("short_col", TypeFactory.createType(PrimitiveType.SMALLINT)))
+                .addColumn(new Column("byte_col", TypeFactory.createType(PrimitiveType.TINYINT)))
                 .build();
     }
 
     private ShowResultSetMetaData createDecimalMetaData() {
         return ShowResultSetMetaData.builder()
-                .addColumn(new Column("decimal_col", ScalarType.createDecimalV2Type(10, 2)))
-                .addColumn(new Column("char_col", ScalarType.createCharType(5)))
-                .addColumn(new Column("varchar_col", ScalarType.createVarcharType(255)))
+                .addColumn(new Column("decimal_col", TypeFactory.createDecimalV2Type(10, 2)))
+                .addColumn(new Column("char_col", TypeFactory.createCharType(5)))
+                .addColumn(new Column("varchar_col", TypeFactory.createVarcharType(255)))
                 .build();
     }
 
@@ -72,8 +73,8 @@ public class ShowResultTest {
     @Test
     public void testMetaDataBasicCreation() {
         ShowResultSetMetaData metaData = ShowResultSetMetaData.builder()
-                .addColumn(new Column("col1", ScalarType.createType(PrimitiveType.INT)))
-                .addColumn(new Column("col2", ScalarType.createType(PrimitiveType.VARCHAR)))
+                .addColumn(new Column("col1", TypeFactory.createType(PrimitiveType.INT)))
+                .addColumn(new Column("col2", TypeFactory.createType(PrimitiveType.VARCHAR)))
                 .build();
 
         Assertions.assertEquals(2, metaData.getColumnCount());
@@ -94,9 +95,9 @@ public class ShowResultTest {
     @Test
     public void testMetaDataBuilderWithColumn() {
         ShowResultSetMetaData metaData = ShowResultSetMetaData.builder()
-                .column("test_col", ScalarType.createType(PrimitiveType.BIGINT))
-                .column("varchar_col", ScalarType.createVarcharType(255))
-                .column("decimal_col", ScalarType.createDecimalV2Type(10, 2))
+                .column("test_col", TypeFactory.createType(PrimitiveType.BIGINT))
+                .column("varchar_col", TypeFactory.createVarcharType(255))
+                .column("decimal_col", TypeFactory.createDecimalV2Type(10, 2))
                 .build();
 
         Assertions.assertEquals(3, metaData.getColumnCount());
@@ -112,8 +113,8 @@ public class ShowResultTest {
     @Test
     public void testMetaDataGetColumns() {
         ShowResultSetMetaData metaData = ShowResultSetMetaData.builder()
-                .addColumn(new Column("col1", ScalarType.createType(PrimitiveType.INT)))
-                .addColumn(new Column("col2", ScalarType.createType(PrimitiveType.VARCHAR)))
+                .addColumn(new Column("col1", TypeFactory.createType(PrimitiveType.INT)))
+                .addColumn(new Column("col2", TypeFactory.createType(PrimitiveType.VARCHAR)))
                 .build();
 
         List<Column> columns = metaData.getColumns();
@@ -125,9 +126,9 @@ public class ShowResultTest {
     @Test
     public void testMetaDataGetColumnIdx() {
         ShowResultSetMetaData metaData = ShowResultSetMetaData.builder()
-                .addColumn(new Column("FirstColumn", ScalarType.createType(PrimitiveType.INT)))
-                .addColumn(new Column("SecondColumn", ScalarType.createType(PrimitiveType.VARCHAR)))
-                .addColumn(new Column("ThirdColumn", ScalarType.createType(PrimitiveType.DOUBLE)))
+                .addColumn(new Column("FirstColumn", TypeFactory.createType(PrimitiveType.INT)))
+                .addColumn(new Column("SecondColumn", TypeFactory.createType(PrimitiveType.VARCHAR)))
+                .addColumn(new Column("ThirdColumn", TypeFactory.createType(PrimitiveType.DOUBLE)))
                 .build();
 
         // Test exact case match
@@ -144,8 +145,8 @@ public class ShowResultTest {
     @Test
     public void testMetaDataGetColumnIdxNotFound() {
         ShowResultSetMetaData metaData = ShowResultSetMetaData.builder()
-                .addColumn(new Column("col1", ScalarType.createType(PrimitiveType.INT)))
-                .addColumn(new Column("col2", ScalarType.createType(PrimitiveType.VARCHAR)))
+                .addColumn(new Column("col1", TypeFactory.createType(PrimitiveType.INT)))
+                .addColumn(new Column("col2", TypeFactory.createType(PrimitiveType.VARCHAR)))
                 .build();
 
         assertThrows(StarRocksPlannerException.class, () -> {
@@ -156,7 +157,7 @@ public class ShowResultTest {
     @Test
     public void testMetaDataGetColumnIdxEmptyName() {
         ShowResultSetMetaData metaData = ShowResultSetMetaData.builder()
-                .addColumn(new Column("col1", ScalarType.createType(PrimitiveType.INT)))
+                .addColumn(new Column("col1", TypeFactory.createType(PrimitiveType.INT)))
                 .build();
 
         assertThrows(StarRocksPlannerException.class, () -> {
@@ -167,7 +168,7 @@ public class ShowResultTest {
     @Test
     public void testMetaDataGetColumnIdxNullName() {
         ShowResultSetMetaData metaData = ShowResultSetMetaData.builder()
-                .addColumn(new Column("col1", ScalarType.createType(PrimitiveType.INT)))
+                .addColumn(new Column("col1", TypeFactory.createType(PrimitiveType.INT)))
                 .build();
 
         assertThrows(StarRocksPlannerException.class, () -> {
@@ -178,10 +179,10 @@ public class ShowResultTest {
     @Test
     public void testMetaDataMixedBuilderMethods() {
         ShowResultSetMetaData metaData = ShowResultSetMetaData.builder()
-                .addColumn(new Column("explicit_col", ScalarType.createType(PrimitiveType.INT)))
-                .column("builder_col", ScalarType.createType(PrimitiveType.VARCHAR))
-                .addColumn(new Column("another_explicit", ScalarType.createCharType(10)))
-                .column("final_col", ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4))
+                .addColumn(new Column("explicit_col", TypeFactory.createType(PrimitiveType.INT)))
+                .column("builder_col", TypeFactory.createType(PrimitiveType.VARCHAR))
+                .addColumn(new Column("another_explicit", TypeFactory.createCharType(10)))
+                .column("final_col", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4))
                 .build();
 
         Assertions.assertEquals(4, metaData.getColumnCount());
@@ -200,13 +201,13 @@ public class ShowResultTest {
     @Test
     public void testMetaDataSpecialColumnNames() {
         ShowResultSetMetaData metaData = ShowResultSetMetaData.builder()
-                .column("", ScalarType.createType(PrimitiveType.INT)) // Empty name
-                .column("Column With Spaces", ScalarType.createType(PrimitiveType.VARCHAR))
-                .column("column_with_underscores", ScalarType.createType(PrimitiveType.DOUBLE))
-                .column("UPPERCASE", ScalarType.createType(PrimitiveType.BOOLEAN))
-                .column("MiXeDcAsE", ScalarType.createType(PrimitiveType.DATE))
-                .column("123numeric", ScalarType.createType(PrimitiveType.TIME))
-                .column("special@#$%chars", ScalarType.createType(PrimitiveType.DATETIME))
+                .column("", TypeFactory.createType(PrimitiveType.INT)) // Empty name
+                .column("Column With Spaces", TypeFactory.createType(PrimitiveType.VARCHAR))
+                .column("column_with_underscores", TypeFactory.createType(PrimitiveType.DOUBLE))
+                .column("UPPERCASE", TypeFactory.createType(PrimitiveType.BOOLEAN))
+                .column("MiXeDcAsE", TypeFactory.createType(PrimitiveType.DATE))
+                .column("123numeric", TypeFactory.createType(PrimitiveType.TIME))
+                .column("special@#$%chars", TypeFactory.createType(PrimitiveType.DATETIME))
                 .build();
 
         Assertions.assertEquals(7, metaData.getColumnCount());
@@ -230,24 +231,24 @@ public class ShowResultTest {
     @Test
     public void testMetaDataAllScalarTypes() {
         ShowResultSetMetaData metaData = ShowResultSetMetaData.builder()
-                .column("boolean_col", ScalarType.createType(PrimitiveType.BOOLEAN))
-                .column("tinyint_col", ScalarType.createType(PrimitiveType.TINYINT))
-                .column("smallint_col", ScalarType.createType(PrimitiveType.SMALLINT))
-                .column("int_col", ScalarType.createType(PrimitiveType.INT))
-                .column("bigint_col", ScalarType.createType(PrimitiveType.BIGINT))
-                .column("largeint_col", ScalarType.createType(PrimitiveType.LARGEINT))
-                .column("float_col", ScalarType.createType(PrimitiveType.FLOAT))
-                .column("double_col", ScalarType.createType(PrimitiveType.DOUBLE))
-                .column("date_col", ScalarType.createType(PrimitiveType.DATE))
-                .column("datetime_col", ScalarType.createType(PrimitiveType.DATETIME))
-                .column("time_col", ScalarType.createType(PrimitiveType.TIME))
-                .column("char_col", ScalarType.createCharType(10))
-                .column("varchar_col", ScalarType.createVarcharType(255))
-                .column("varbinary_col", ScalarType.createVarbinary(1024))
-                .column("hll_col", ScalarType.createHllType())
-                .column("bitmap_col", ScalarType.createType(PrimitiveType.BITMAP))
-                .column("percentile_col", ScalarType.createType(PrimitiveType.PERCENTILE))
-                .column("json_col", ScalarType.createType(PrimitiveType.JSON))
+                .column("boolean_col", TypeFactory.createType(PrimitiveType.BOOLEAN))
+                .column("tinyint_col", TypeFactory.createType(PrimitiveType.TINYINT))
+                .column("smallint_col", TypeFactory.createType(PrimitiveType.SMALLINT))
+                .column("int_col", TypeFactory.createType(PrimitiveType.INT))
+                .column("bigint_col", TypeFactory.createType(PrimitiveType.BIGINT))
+                .column("largeint_col", TypeFactory.createType(PrimitiveType.LARGEINT))
+                .column("float_col", TypeFactory.createType(PrimitiveType.FLOAT))
+                .column("double_col", TypeFactory.createType(PrimitiveType.DOUBLE))
+                .column("date_col", TypeFactory.createType(PrimitiveType.DATE))
+                .column("datetime_col", TypeFactory.createType(PrimitiveType.DATETIME))
+                .column("time_col", TypeFactory.createType(PrimitiveType.TIME))
+                .column("char_col", TypeFactory.createCharType(10))
+                .column("varchar_col", TypeFactory.createVarcharType(255))
+                .column("varbinary_col", TypeFactory.createVarbinary(1024))
+                .column("hll_col", TypeFactory.createHllType())
+                .column("bitmap_col", TypeFactory.createType(PrimitiveType.BITMAP))
+                .column("percentile_col", TypeFactory.createType(PrimitiveType.PERCENTILE))
+                .column("json_col", TypeFactory.createType(PrimitiveType.JSON))
                 .build();
 
         Assertions.assertEquals(18, metaData.getColumnCount());
@@ -276,11 +277,11 @@ public class ShowResultTest {
     @Test
     public void testMetaDataDecimalTypes() {
         ShowResultSetMetaData metaData = ShowResultSetMetaData.builder()
-                .column("decimalv2_col", ScalarType.createDecimalV2Type(10, 2))
-                .column("decimal32_col", ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 2))
-                .column("decimal64_col", ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4))
-                .column("decimal128_col", ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 8))
-                .column("decimal256_col", ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL256, 76, 16))
+                .column("decimalv2_col", TypeFactory.createDecimalV2Type(10, 2))
+                .column("decimal32_col", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 2))
+                .column("decimal64_col", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4))
+                .column("decimal128_col", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 8))
+                .column("decimal256_col", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL256, 76, 16))
                 .build();
 
         Assertions.assertEquals(5, metaData.getColumnCount());
@@ -318,15 +319,15 @@ public class ShowResultTest {
         
         // Create first metadata with 2 columns
         ShowResultSetMetaData metaData1 = builder
-                .column("col1", ScalarType.createType(PrimitiveType.INT))
-                .column("col2", ScalarType.createType(PrimitiveType.VARCHAR))
+                .column("col1", TypeFactory.createType(PrimitiveType.INT))
+                .column("col2", TypeFactory.createType(PrimitiveType.VARCHAR))
                 .build();
         
         // Create new builder for second metadata
         ShowResultSetMetaData metaData2 = ShowResultSetMetaData.builder()
-                .column("col1", ScalarType.createType(PrimitiveType.INT))
-                .column("col2", ScalarType.createType(PrimitiveType.VARCHAR))
-                .column("col3", ScalarType.createType(PrimitiveType.DOUBLE))
+                .column("col1", TypeFactory.createType(PrimitiveType.INT))
+                .column("col2", TypeFactory.createType(PrimitiveType.VARCHAR))
+                .column("col3", TypeFactory.createType(PrimitiveType.DOUBLE))
                 .build();
         
         // First metadata should have 2 columns
@@ -344,9 +345,9 @@ public class ShowResultTest {
     @Test
     public void testMetaDataDuplicateColumnNames() {
         ShowResultSetMetaData metaData = ShowResultSetMetaData.builder()
-                .column("duplicate", ScalarType.createType(PrimitiveType.INT))
-                .column("Duplicate", ScalarType.createType(PrimitiveType.VARCHAR))  // Different case
-                .column("duplicate", ScalarType.createType(PrimitiveType.DOUBLE))   // Exact duplicate
+                .column("duplicate", TypeFactory.createType(PrimitiveType.INT))
+                .column("Duplicate", TypeFactory.createType(PrimitiveType.VARCHAR))  // Different case
+                .column("duplicate", TypeFactory.createType(PrimitiveType.DOUBLE))   // Exact duplicate
                 .build();
 
         Assertions.assertEquals(3, metaData.getColumnCount());
@@ -636,9 +637,9 @@ public class ShowResultTest {
     @Test
     public void testResultSetToThriftWithDecimalV3Types() {
         ShowResultSetMetaData metaData = ShowResultSetMetaData.builder()
-                .addColumn(new Column("decimal32_col", ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 2)))
-                .addColumn(new Column("decimal64_col", ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4)))
-                .addColumn(new Column("decimal128_col", ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 8)))
+                .addColumn(new Column("decimal32_col", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 2)))
+                .addColumn(new Column("decimal64_col", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 4)))
+                .addColumn(new Column("decimal128_col", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 8)))
                 .build();
         
         List<List<String>> rows = Lists.newArrayList();

--- a/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
@@ -50,7 +50,7 @@ import com.starrocks.sql.ast.expression.IntLiteral;
 import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.ast.expression.VariableExpr;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.utframe.UtFrameUtils;
 import com.starrocks.utframe.UtFrameUtils.PseudoImage;
 import mockit.Expectations;
@@ -331,7 +331,7 @@ public class VariableMgrTest {
         ExpressionAnalyzer.analyzeExpressionIgnoreSlot(desc, UtFrameUtils.createDefaultCtx());
 
         Assertions.assertEquals("autocommit", desc.getName());
-        Assertions.assertEquals(ScalarType.createType(PrimitiveType.BIGINT), desc.getType());
+        Assertions.assertEquals(TypeFactory.createType(PrimitiveType.BIGINT), desc.getType());
         Assertions.assertEquals((long) desc.getValue(), 1);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectContextTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectContextTest.java
@@ -25,7 +25,7 @@ import com.starrocks.qe.StmtExecutor;
 import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.service.ExecuteEnv;
 import com.starrocks.sql.ast.StatementBase;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
@@ -111,7 +111,7 @@ public class ArrowFlightSqlConnectContextTest {
     public void testAddShowResultAndGetResult() {
         String queryId = "query-2";
 
-        Column column = new Column("col1", ScalarType.createVarchar(20));
+        Column column = new Column("col1", TypeFactory.createVarchar(20));
         ShowResultSetMetaData metaData = new ShowResultSetMetaData(Collections.singletonList(column));
         ShowResultSet showResultSet = new ShowResultSet(metaData, List.of(Collections.singletonList("value1")));
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDecimalV3Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeDecimalV3Test.java
@@ -34,6 +34,7 @@ import com.starrocks.sql.optimizer.transformer.RelationTransformer;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
@@ -108,7 +109,7 @@ public class AnalyzeDecimalV3Test {
         List<Expr> items = ((SelectRelation) queryRelation).getOutputExpression();
         Assertions.assertTrue(items.size() == 2 && items.get(1) != null);
         Type type = items.get(1).getType();
-        Assertions.assertEquals(type, ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 2));
+        Assertions.assertEquals(type, TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 2));
     }
 
     @Test
@@ -143,7 +144,7 @@ public class AnalyzeDecimalV3Test {
 
         Assertions.assertTrue(items.size() == 1 && items.get(0) != null);
         Type type = items.get(0).getType();
-        Assertions.assertEquals(type, ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 2));
+        Assertions.assertEquals(type, TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 2));
     }
 
     @Test
@@ -160,7 +161,7 @@ public class AnalyzeDecimalV3Test {
 
         Assertions.assertTrue(items.size() == 1 && items.get(0) != null);
         Type type = items.get(0).getType();
-        Assertions.assertEquals(type, ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 2));
+        Assertions.assertEquals(type, TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 2));
     }
 
     @Test
@@ -182,9 +183,9 @@ public class AnalyzeDecimalV3Test {
         List<Expr> items = ((SelectRelation) queryRelation).getOutputExpression();
 
         Type[] expectTypes = Arrays.asList(
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 4),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 15, 10),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30)
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 4),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 15, 10),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30)
         ).toArray(new Type[0]);
         Assertions.assertTrue(items.size() == 6);
         Assertions.assertTrue(expectTypes.length == 3);
@@ -226,15 +227,15 @@ public class AnalyzeDecimalV3Test {
         List<Expr> items = ((SelectRelation) queryRelation).getOutputExpression();
 
         Type[] expectArgTypes = Arrays.asList(
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 4),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 15, 10),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 18)
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 4),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 15, 10),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 18)
         ).toArray(new Type[0]);
 
         Type[] expectReturnTypes = Arrays.asList(
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 4),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 10),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 18)
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 4),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 10),
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 18)
         ).toArray(new Type[0]);
         Assertions.assertTrue(items.size() == 9);
         Assertions.assertTrue(expectArgTypes.length == 3);
@@ -345,11 +346,11 @@ public class AnalyzeDecimalV3Test {
         QueryRelation queryRelation = analyzeSuccess(sql1);
         List<Expr> items = ((SelectRelation) queryRelation).getOutputExpression();
 
-        ScalarType targetDecimal32Type = ScalarType.createDecimalV3Type(
+        ScalarType targetDecimal32Type = TypeFactory.createDecimalV3Type(
                 PrimitiveType.DECIMAL32, 7, 4);
-        ScalarType targetDecimal64Type = ScalarType.createDecimalV3Type(
+        ScalarType targetDecimal64Type = TypeFactory.createDecimalV3Type(
                 PrimitiveType.DECIMAL64, 18, 16);
-        ScalarType targetDecimal128Type = ScalarType.createDecimalV3Type(
+        ScalarType targetDecimal128Type = TypeFactory.createDecimalV3Type(
                 PrimitiveType.DECIMAL128, 30, 7);
         Assertions.assertEquals(items.get(0).getType(), targetDecimal32Type);
         Assertions.assertEquals(items.get(1).getType(), targetDecimal64Type);
@@ -396,42 +397,42 @@ public class AnalyzeDecimalV3Test {
     @Test
     public void testDecimal128TypedBetweenPredicatePushDown() throws Exception {
         String predicate = "col_decimal_p38s30 between -999.99 and 999.99";
-        Type decimal128p38s30 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30);
+        Type decimal128p38s30 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30);
         testDecimalTypedPredicatePushDownHelper(predicate, decimal128p38s30);
     }
 
     @Test
     public void testDecimal64TypedBetweenPredicatePushDown() throws Exception {
         String predicate = "col_decimal_p15s10 between -999.99 and 999.99";
-        Type decimal64p15s10 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 15, 10);
+        Type decimal64p15s10 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 15, 10);
         testDecimalTypedPredicatePushDownHelper(predicate, decimal64p15s10);
     }
 
     @Test
     public void testDecimal32TypedBetweenPredicatePushDown() throws Exception {
         String predicate = "col_decimal_p9s4 between -999.99 and 999.99";
-        Type decimal32p9s4 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 4);
+        Type decimal32p9s4 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 4);
         testDecimalTypedPredicatePushDownHelper(predicate, decimal32p9s4);
     }
 
     @Test
     public void testDecimal128TypedCompoundPredicatePushDown() throws Exception {
         String predicate = "-999.99 < col_decimal_p38s30 and 999.99 > col_decimal_p38s30";
-        Type decimal128p38s30 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30);
+        Type decimal128p38s30 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30);
         testDecimalTypedPredicatePushDownHelper(predicate, decimal128p38s30);
     }
 
     @Test
     public void testDecimal64TypedCompoundPredicatePushDown() throws Exception {
         String predicate = "col_decimal_p15s10 <= -999.99 or col_decimal_p15s10 >= 999.99";
-        Type decimal64p15s10 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 15, 10);
+        Type decimal64p15s10 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 15, 10);
         testDecimalTypedPredicatePushDownHelper(predicate, decimal64p15s10);
     }
 
     @Test
     public void testDecimal32TypedCompoundPredicatePushDown() throws Exception {
         String predicate = "col_decimal_p9s4 != -999.99 and  col_decimal_p9s4 is NULL";
-        Type decimal32p9s4 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 4);
+        Type decimal32p9s4 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 4);
         testDecimalTypedPredicatePushDownHelper(predicate, decimal32p9s4);
     }
 
@@ -459,21 +460,21 @@ public class AnalyzeDecimalV3Test {
     @Test
     public void testDecimal128TypedInPredicatePushDown() throws Exception {
         String predicate = "col_decimal_p38s30 in (999.999, -999.999, -1, 0, +1)";
-        Type decimal128p38s30 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30);
+        Type decimal128p38s30 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30);
         testDecimalTypedInPredicatePushDownHelper(predicate, 5, decimal128p38s30);
     }
 
     @Test
     public void testDecimal64TypedInPredicatePushDown() throws Exception {
         String predicate = "col_decimal_p15s10 not in (0, 1)";
-        Type decimal64p15s10 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 15, 10);
+        Type decimal64p15s10 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 15, 10);
         testDecimalTypedInPredicatePushDownHelper(predicate, 2, decimal64p15s10);
     }
 
     @Test
     public void testDecimal32TypedIntPredicatePushDown() throws Exception {
         String predicate = "col_decimal_p9s4 not in (2, 4)";
-        Type decimal32p9s4 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 4);
+        Type decimal32p9s4 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 4);
         testDecimalTypedInPredicatePushDownHelper(predicate, 2, decimal32p9s4);
     }
 
@@ -502,14 +503,14 @@ public class AnalyzeDecimalV3Test {
     public void testSmallIntDivDecimal32p9s2() throws Exception {
         testDecimalArithmeticHelper(
                 "col0_smallint/col0_decimal_p9s2",
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 6));
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 6));
     }
 
     @Test
     public void testDecimal32p9s2DivDecimal32p9s2() throws Exception {
         testDecimalArithmeticHelper(
                 "col1_decimal_p9s2/col0_decimal_p9s2",
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 8));
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 8));
     }
 
     @Test
@@ -523,35 +524,35 @@ public class AnalyzeDecimalV3Test {
     public void testDecimalv2DivDecimal32p9s2() throws Exception {
         testDecimalArithmeticHelper(
                 "col_decimal/col0_decimal_p9s2",
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 12));
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 12));
     }
 
     @Test
     public void testDecimal128p38s3DivDecimal32p9s2() throws Exception {
         testDecimalArithmeticHelper(
                 "col0_nullable_decimal_p38s3/col0_decimal_p9s2",
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 9));
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 9));
     }
 
     @Test
     public void testDecimal128p38s30DivDecimal32p9s2() throws Exception {
         testDecimalArithmeticHelper(
                 "col_decimal_p38s30/col0_decimal_p9s2",
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30));
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30));
     }
 
     @Test
     public void testDecimal128p38s3DivDecimal128p38s3() throws Exception {
         testDecimalArithmeticHelper(
                 "col_decimal_p38s30/col1_nullable_decimal_p38s3",
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30));
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30));
     }
 
     @Test
     public void testDecimal64p15s10DivDecimal64p15s10() throws Exception {
         testDecimalArithmeticHelper(
                 "col_nullable_decimal_p15s10/col_decimal_p15s10",
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 12));
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 12));
     }
 
     @Test
@@ -559,7 +560,7 @@ public class AnalyzeDecimalV3Test {
         assertThrows(SemanticException.class, () -> {
             testDecimalArithmeticHelper(
                     "col_decimal_p38s30/col_nullable_decimal_p15s10",
-                    ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30));
+                    TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30));
             Assertions.fail("should not reach here");
         });
     }
@@ -569,7 +570,7 @@ public class AnalyzeDecimalV3Test {
         assertThrows(SemanticException.class, () -> {
             testDecimalArithmeticHelper(
                     "col_decimal_p38s30/col_decimal_p38s30",
-                    ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30));
+                    TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30));
             Assertions.fail("should not reach here");
         });
     }
@@ -579,7 +580,7 @@ public class AnalyzeDecimalV3Test {
         assertThrows(SemanticException.class, () -> {
             testDecimalArithmeticHelper(
                     "col_decimal_p38s30/col_decimal_p9s9",
-                    ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30));
+                    TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30));
             Assertions.fail("should not reach here");
         });
     }
@@ -589,7 +590,7 @@ public class AnalyzeDecimalV3Test {
     public void testDecimal32p9s2ModDecimal32p9s2() throws Exception {
         testDecimalArithmeticHelper(
                 "col1_decimal_p9s2%col0_decimal_p9s2",
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2));
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 2));
     }
 
     public void testDoubleModDecimal32p9s2() throws Exception {
@@ -602,56 +603,56 @@ public class AnalyzeDecimalV3Test {
     public void testDecimalv2ModDecimal32p9s2() throws Exception {
         testDecimalArithmeticHelper(
                 "col_decimal%col0_decimal_p9s2",
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 9));
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 9));
     }
 
     @Test
     public void testDecimal128p38s3ModDecimal32p9s2() throws Exception {
         testDecimalArithmeticHelper(
                 "col0_nullable_decimal_p38s3%col0_decimal_p9s2",
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 3));
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 3));
     }
 
     @Test
     public void testDecimal128p38s30ModDecimal32p9s2() throws Exception {
         testDecimalArithmeticHelper(
                 "col_decimal_p38s30%col0_decimal_p9s2",
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30));
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30));
     }
 
     @Test
     public void testDecimal128p38s3ModDecimal128p38s3() throws Exception {
         testDecimalArithmeticHelper(
                 "col_decimal_p38s30%col1_nullable_decimal_p38s3",
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30));
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30));
     }
 
     @Test
     public void testDecimal64p15s10ModDecimal64p15s10() throws Exception {
         testDecimalArithmeticHelper(
                 "col_nullable_decimal_p15s10%col_decimal_p15s10",
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 10));
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 10));
     }
 
     @Test
     public void testDecimal128p38s30ModDecimal64p15s10() throws Exception {
         testDecimalArithmeticHelper(
                 "col_decimal_p38s30%col_nullable_decimal_p15s10",
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30));
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30));
     }
 
     @Test
     public void testDecimal128p38s30ModDecimal128p38s30() throws Exception {
         testDecimalArithmeticHelper(
                 "col_decimal_p38s30%col_decimal_p38s30",
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30));
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30));
     }
 
     @Test
     public void testDecimal128p38s30ModDecimal32p9s9() throws Exception {
         testDecimalArithmeticHelper(
                 "col_decimal_p38s30%col_decimal_p9s9",
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30));
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30));
     }
 
     @Test
@@ -697,7 +698,7 @@ public class AnalyzeDecimalV3Test {
                     ((LogicalProjectOperator) logicalPlan.getRoot().getOp()).getColumnRefMap()
                             .get(logicalPlan.getOutputColumn().get(0));
 
-            Type decimal128p38s5 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 24, 12);
+            Type decimal128p38s5 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 24, 12);
             Assertions.assertEquals(op.getChild(0).getType(), decimal128p38s5);
             Assertions.assertEquals(op.getChild(1).getType(), decimal128p38s5);
         }
@@ -721,8 +722,8 @@ public class AnalyzeDecimalV3Test {
         {
             SelectRelation queryRelation = (SelectRelation) analyzeSuccess(sql);
             Expr expr = queryRelation.getOutputExpression().get(0);
-            Type decimal128p38s8 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 8);
-            Type decimal32p9s2 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 2);
+            Type decimal128p38s8 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 8);
+            Type decimal32p9s2 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 2);
             Assertions.assertEquals(expr.getType(), decimal128p38s8);
             Assertions.assertEquals(expr.getChild(0).getType(), decimal32p9s2);
         }
@@ -740,8 +741,8 @@ public class AnalyzeDecimalV3Test {
         {
             SelectRelation queryRelation = (SelectRelation) analyzeSuccess(sql);
             Expr expr = queryRelation.getOutputExpression().get(0);
-            Type decimal128p38s12 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 12);
-            Type decimal64p15s10 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 15, 10);
+            Type decimal128p38s12 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 12);
+            Type decimal64p15s10 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 15, 10);
             Assertions.assertEquals(expr.getType(), decimal128p38s12);
             Assertions.assertEquals(expr.getChild(0).getType(), decimal64p15s10);
         }
@@ -759,8 +760,8 @@ public class AnalyzeDecimalV3Test {
         {
             SelectRelation queryRelation = (SelectRelation) analyzeSuccess(sql);
             Expr expr = queryRelation.getOutputExpression().get(0);
-            Type decimal128p38s18 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 18);
-            Type decimal128p38s30 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30);
+            Type decimal128p38s18 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 18);
+            Type decimal128p38s30 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30);
             Assertions.assertEquals(decimal128p38s18, expr.getType());
             Assertions.assertEquals(decimal128p38s30, expr.getChild(0).getType());
         }
@@ -833,7 +834,7 @@ public class AnalyzeDecimalV3Test {
                     ((LogicalProjectOperator) logicalPlan.getRoot().getOp()).getColumnRefMap()
                             .get(logicalPlan.getOutputColumn().get(0));
 
-            Type decimal64p9s3 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 3);
+            Type decimal64p9s3 = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 3);
             Assertions.assertEquals(op.getType(), decimal64p9s3);
             Assertions.assertEquals(op.getChild(0).getType(), decimal64p9s3);
             Assertions.assertEquals(op.getChild(1).getType(), decimal64p9s3);
@@ -871,12 +872,12 @@ public class AnalyzeDecimalV3Test {
         {
             SelectRelation queryRelation = (SelectRelation) analyzeSuccess(sql);
             List<Expr> items = ((SelectRelation) queryRelation).getOutputExpression();
-            Assertions.assertEquals(items.get(0).getType(), ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 9));
+            Assertions.assertEquals(items.get(0).getType(), TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 9));
             Assertions.assertEquals(items.get(1).getType(),
-                    ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 15, 10));
+                    TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 15, 10));
             Assertions.assertEquals(items.get(2).getType(), ScalarType.DOUBLE);
             Assertions.assertEquals(items.get(3).getType(),
-                    ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30));
+                    TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 30));
         }
     }
 
@@ -897,10 +898,10 @@ public class AnalyzeDecimalV3Test {
             List<Expr> items = queryRelation.getOutputExpression();
             Assertions.assertEquals(items.get(0).getType(), ScalarType.DOUBLE);
             Assertions.assertEquals(items.get(1).getType(),
-                    ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 0));
+                    TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 0));
             Assertions.assertEquals(items.get(2).getType(), ScalarType.FLOAT);
-            Assertions.assertEquals(items.get(3).getType(), ScalarType.createDecimalV3NarrowestType(3, 2));
-            Assertions.assertEquals(items.get(4).getType(), ScalarType.createDecimalV3TypeForZero(1));
+            Assertions.assertEquals(items.get(3).getType(), TypeFactory.createDecimalV3NarrowestType(3, 2));
+            Assertions.assertEquals(items.get(4).getType(), TypeFactory.createDecimalV3TypeForZero(1));
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzerUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzerUtilsTest.java
@@ -31,6 +31,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
@@ -90,9 +91,9 @@ public class AnalyzerUtilsTest {
 
     @Test
     public void testConvertCatalogMaxStringToOlapMaxString() {
-        ScalarType catalogString = ScalarType.createDefaultCatalogString();
+        ScalarType catalogString = TypeFactory.createDefaultCatalogString();
         ScalarType convertedString = (ScalarType) AnalyzerUtils.transformTableColumnType(catalogString);
-        Assertions.assertEquals(ScalarType.getOlapMaxVarcharLength(), convertedString.getLength());
+        Assertions.assertEquals(TypeFactory.getOlapMaxVarcharLength(), convertedString.getLength());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzerTest.java
@@ -32,6 +32,7 @@ import com.starrocks.sql.ast.expression.TableName;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -69,7 +70,7 @@ public class DecimalV3FunctionAnalyzerTest {
         FunctionCallExpr node = new FunctionCallExpr(FunctionSet.TRUNCATE, params);
 
         List<Type> paramTypes = Lists.newArrayList();
-        paramTypes.add(ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 7, 2));
+        paramTypes.add(TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 7, 2));
         paramTypes.add(Type.TINYINT);
 
         Function function = ExprUtils.getBuiltinFunction(FunctionSet.TRUNCATE, paramTypes.toArray(new Type[0]),
@@ -91,7 +92,7 @@ public class DecimalV3FunctionAnalyzerTest {
         FunctionCallExpr node = new FunctionCallExpr(FunctionSet.TRUNCATE, params);
 
         List<Type> paramTypes = Lists.newArrayList();
-        paramTypes.add(ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 7, 2));
+        paramTypes.add(TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 7, 2));
         paramTypes.add(Type.TINYINT);
 
         Function function = ExprUtils.getBuiltinFunction(FunctionSet.TRUNCATE, paramTypes.toArray(new Type[0]),
@@ -111,7 +112,7 @@ public class DecimalV3FunctionAnalyzerTest {
         FunctionCallExpr node = new FunctionCallExpr(FunctionSet.TRUNCATE, params);
 
         List<Type> paramTypes = Lists.newArrayList();
-        paramTypes.add(ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 7, 2));
+        paramTypes.add(TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 7, 2));
         paramTypes.add(Type.TINYINT);
 
         Function function = ExprUtils.getBuiltinFunction(FunctionSet.TRUNCATE, paramTypes.toArray(new Type[0]),
@@ -142,7 +143,7 @@ public class DecimalV3FunctionAnalyzerTest {
                     (AggregateFunction) ExprUtils.getBuiltinFunction(funcName, paramTypes.toArray(new Type[0]),
                             Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
             Assertions.assertNotNull(function);
-            Type argType = ScalarType.createWildcardDecimalV3Type(PrimitiveType.DECIMAL128);
+            Type argType = TypeFactory.createWildcardDecimalV3Type(PrimitiveType.DECIMAL128);
             Type retType = Type.DOUBLE;
             AggregateFunction aggFunc =
                     DecimalV3FunctionAnalyzer.rectifyAggregationFunction(function, argType, retType);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/ExpressionAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/ExpressionAnalyzerTest.java
@@ -32,8 +32,8 @@ import com.starrocks.thrift.TExprNodeType;
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.MapType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -53,8 +53,8 @@ public class ExpressionAnalyzerTest extends PlanTestBase {
     public void testMapElementAnalyzer() {
         ExpressionAnalyzer.Visitor visitor = new ExpressionAnalyzer.Visitor(new AnalyzeState(), new ConnectContext());
         SlotRef slot = new SlotRef(null, "col", "col");
-        Type keyType = ScalarType.createType(PrimitiveType.INT);
-        Type valueType = ScalarType.createCharType(10);
+        Type keyType = TypeFactory.createType(PrimitiveType.INT);
+        Type valueType = TypeFactory.createCharType(10);
         Type mapType = new MapType(keyType, valueType);
         slot.setType(mapType);
 
@@ -83,8 +83,8 @@ public class ExpressionAnalyzerTest extends PlanTestBase {
                 () -> visitor.visitCollectionElementExpr(collectionElementExpr2,
                         new Scope(RelationId.anonymous(), new RelationFields())));
 
-        Type keyTypeChar = ScalarType.createCharType(10);
-        Type valueTypeInt = ScalarType.createType(PrimitiveType.INT);
+        Type keyTypeChar = TypeFactory.createCharType(10);
+        Type valueTypeInt = TypeFactory.createType(PrimitiveType.INT);
         mapType = new MapType(keyTypeChar, valueTypeInt);
         slot.setType(mapType);
         StringLiteral subString = new StringLiteral("aaa");
@@ -105,7 +105,7 @@ public class ExpressionAnalyzerTest extends PlanTestBase {
     public void testArraySubscriptAnalyzer() {
         ExpressionAnalyzer.Visitor visitor = new ExpressionAnalyzer.Visitor(new AnalyzeState(), new ConnectContext());
         SlotRef slot = new SlotRef(null, "col", "col");
-        Type elementType = ScalarType.createCharType(10);
+        Type elementType = TypeFactory.createCharType(10);
         Type arrayType = new ArrayType(elementType);
         slot.setType(arrayType);
 
@@ -140,7 +140,7 @@ public class ExpressionAnalyzerTest extends PlanTestBase {
     public void testNoSubscriptAnalyzer() {
         ExpressionAnalyzer.Visitor visitor = new ExpressionAnalyzer.Visitor(new AnalyzeState(), new ConnectContext());
         SlotRef slot = new SlotRef(null, "col", "col");
-        slot.setType(ScalarType.createType(PrimitiveType.INT));
+        slot.setType(TypeFactory.createType(PrimitiveType.INT));
 
         IntLiteral sub = new IntLiteral(10);
 
@@ -152,8 +152,8 @@ public class ExpressionAnalyzerTest extends PlanTestBase {
 
     @Test
     public void testMapFunctionsAnalyzer() {
-        Type keyType = ScalarType.createType(PrimitiveType.INT);
-        Type valueType = ScalarType.createCharType(10);
+        Type keyType = TypeFactory.createType(PrimitiveType.INT);
+        Type valueType = TypeFactory.createCharType(10);
         Type mapType = new MapType(keyType, valueType);
 
         String mapKeys = "map_keys";
@@ -201,8 +201,8 @@ public class ExpressionAnalyzerTest extends PlanTestBase {
 
     @Test
     public void testDateCoalesceAnalyzer() {
-        Type dateType = ScalarType.createType(PrimitiveType.DATE);
-        Type dateTimeType = ScalarType.createType(PrimitiveType.DATETIME);
+        Type dateType = TypeFactory.createType(PrimitiveType.DATE);
+        Type dateTimeType = TypeFactory.createType(PrimitiveType.DATETIME);
 
         {
             Type[] argumentTypes = {dateType, dateTimeType};

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/IndexAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/IndexAnalyzerTest.java
@@ -22,7 +22,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.sql.ast.IndexDef;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -125,7 +125,7 @@ public class IndexAnalyzerTest {
     public void testCheckColumn() {
         // Create a test column
         Column column =
-                new Column("test_col", ScalarType.createType(PrimitiveType.INT), false, null, true, NULL_DEFAULT_VALUE, "");
+                new Column("test_col", TypeFactory.createType(PrimitiveType.INT), false, null, true, NULL_DEFAULT_VALUE, "");
         Map<String, String> properties = new HashMap<>();
 
         // Test BITMAP index with valid column

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerWithPaimonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerWithPaimonTest.java
@@ -23,7 +23,7 @@ import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.optimizer.MaterializedViewOptimizer;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
@@ -109,7 +109,7 @@ public class MaterializedViewAnalyzerWithPaimonTest {
                     result = "dt";
 
                     table.getColumn("dt");
-                    result = new Column("dt", ScalarType.createType(PrimitiveType.DATE));
+                    result = new Column("dt", TypeFactory.createType(PrimitiveType.DATE));
                 }
             };
             try {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/StructFieldDescTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/StructFieldDescTest.java
@@ -19,10 +19,10 @@ import com.starrocks.catalog.Column;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.sql.ast.expression.TypeDef;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -45,7 +45,7 @@ public class StructFieldDescTest {
 
         Column structCol1 = new Column("structCol1", type);
 
-        Type addType = ScalarType.createType(PrimitiveType.INT);
+        Type addType = TypeFactory.createType(PrimitiveType.INT);
         TypeDef addTypeDef = new TypeDef(addType);
         Column intCol1 = new Column("intCol1", addType);
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/ExprToThriftVisitorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/ExprToThriftVisitorTest.java
@@ -35,6 +35,7 @@ import com.starrocks.type.MapType;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -97,7 +98,7 @@ public class ExprToThriftVisitorTest {
             cases.add(nodeCase("DecimalLiteral", ExprCaseFactory::buildDecimalLiteral,
                     TExprNodeType.DECIMAL_LITERAL));
             cases.add(nodeCase("StringLiteral", () -> withType(new StringLiteral("starrocks"),
-                    ScalarType.createVarchar(16)), TExprNodeType.STRING_LITERAL));
+                    TypeFactory.createVarchar(16)), TExprNodeType.STRING_LITERAL));
             cases.add(nodeCase("BoolLiteral", () -> withType(new BoolLiteral(true), Type.BOOLEAN),
                     TExprNodeType.BOOL_LITERAL));
             cases.add(nodeCase("VarBinaryLiteral", () -> withType(new VarBinaryLiteral(new byte[] {1, 2}),
@@ -216,7 +217,7 @@ public class ExprToThriftVisitorTest {
         private static Expr buildDecimalLiteral() {
             try {
                 DecimalLiteral literal = new DecimalLiteral("1.23");
-                ScalarType type = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 6, 2);
+                ScalarType type = TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 6, 2);
                 literal.setType(type);
                 literal.setOriginType(type);
                 return literal;
@@ -265,11 +266,11 @@ public class ExprToThriftVisitorTest {
 
         private static Expr buildMapExpr() {
             List<Expr> children = List.of(
-                    withType(new StringLiteral("k"), ScalarType.createVarchar(8)),
+                    withType(new StringLiteral("k"), TypeFactory.createVarchar(8)),
                     withType(new IntLiteral(1), Type.INT),
-                    withType(new StringLiteral("k2"), ScalarType.createVarchar(8)),
+                    withType(new StringLiteral("k2"), TypeFactory.createVarchar(8)),
                     withType(new IntLiteral(2), Type.INT));
-            MapExpr mapExpr = new MapExpr(new MapType(ScalarType.createVarchar(8), Type.INT), children);
+            MapExpr mapExpr = new MapExpr(new MapType(TypeFactory.createVarchar(8), Type.INT), children);
             mapExpr.setOriginType(mapExpr.getType());
             return mapExpr;
         }
@@ -278,7 +279,7 @@ public class ExprToThriftVisitorTest {
             MapExpr mapExpr = (MapExpr) buildMapExpr();
             CollectionElementExpr expr =
                     new CollectionElementExpr(Type.INT, mapExpr, withType(new StringLiteral("k"),
-                            ScalarType.createVarchar(8)), true);
+                            TypeFactory.createVarchar(8)), true);
             expr.setOriginType(Type.INT);
             return expr;
         }
@@ -309,8 +310,8 @@ public class ExprToThriftVisitorTest {
 
         private static Expr buildDictMappingExpr() {
             DictMappingExpr expr = new DictMappingExpr(buildSlotRef(), withType(new StringLiteral("expr"),
-                    ScalarType.createVarchar(16)));
-            expr.setType(ScalarType.createVarchar(16));
+                    TypeFactory.createVarchar(16)));
+            expr.setType(TypeFactory.createVarchar(16));
             expr.setOriginType(expr.getType());
             return expr;
         }
@@ -327,7 +328,7 @@ public class ExprToThriftVisitorTest {
             CaseExpr expr = new CaseExpr(new IntLiteral(1),
                     List.of(new CaseWhenClause(new IntLiteral(1), new StringLiteral("x"))),
                     new StringLiteral("y"));
-            expr.setType(ScalarType.createVarchar(8));
+            expr.setType(TypeFactory.createVarchar(8));
             expr.setOriginType(expr.getType());
             return expr;
         }
@@ -368,7 +369,7 @@ public class ExprToThriftVisitorTest {
 
         private static Expr buildInformationFunction() {
             InformationFunction infoFunction = new InformationFunction("CURRENT_CATALOG", "cluster", 11);
-            infoFunction.setType(ScalarType.createVarchar(16));
+            infoFunction.setType(TypeFactory.createVarchar(16));
             infoFunction.setOriginType(infoFunction.getType());
             return infoFunction;
         }
@@ -518,7 +519,7 @@ public class ExprToThriftVisitorTest {
 
         private static Expr buildArrowExpr() {
             ArrowExpr arrowExpr = new ArrowExpr(new StringLiteral("k"), new StringLiteral("v"));
-            ScalarType varchar = ScalarType.createVarchar(8);
+            ScalarType varchar = TypeFactory.createVarchar(8);
             arrowExpr.setType(varchar);
             arrowExpr.setOriginType(varchar);
             return arrowExpr;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -22,8 +22,8 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -99,17 +99,17 @@ public class ScalarOperatorFunctionsTest {
         O_LI_NEG_100 = ConstantOperator.createLargeInt(new BigInteger("-100"));
         O_DECIMAL_100 = ConstantOperator.createDecimal(new BigDecimal(100), Type.DECIMALV2);
         O_DECIMAL32P7S2_100 = ConstantOperator.createDecimal(new BigDecimal(100),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 7, 2));
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 7, 2));
         O_DECIMAL32P9S0_100 = ConstantOperator.createDecimal(new BigDecimal(100),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 0));
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 0));
         O_DECIMAL64P15S10_100 = ConstantOperator.createDecimal(new BigDecimal(100),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 15, 10));
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 15, 10));
         O_DECIMAL64P18S15_100 = ConstantOperator.createDecimal(new BigDecimal(100),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 15));
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 15));
         O_DECIMAL128P38S20_100 = ConstantOperator.createDecimal(new BigDecimal(100),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 20));
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 20));
         O_DECIMAL128P30S2_100 = ConstantOperator.createDecimal(new BigDecimal(100),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 30, 2));
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 30, 2));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/FoldConstantsRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/FoldConstantsRuleTest.java
@@ -30,8 +30,8 @@ import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import mockit.Expectations;
 import org.junit.jupiter.api.Test;
 
@@ -148,9 +148,9 @@ public class FoldConstantsRuleTest {
         CastOperator cast6 = new CastOperator(Type.BIGINT, ConstantOperator.createDate(LocalDateTime.of(2020, 2, 12, 0, 0, 0)));
         assertEquals(ConstantOperator.createBigint(20200212), rule.apply(cast6, null));
 
-        CastOperator cast7 = new CastOperator(ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 1, 1),
+        CastOperator cast7 = new CastOperator(TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 1, 1),
                 ConstantOperator.createDecimal(BigDecimal.valueOf(0.00008),
-                ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 6, 6))
+                TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 6, 6))
         );
         assertEquals("0.0", rule.apply(cast7, null).toString());
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/scalar/ReduceCastRuleTest.java
@@ -23,8 +23,8 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -178,11 +178,11 @@ public class ReduceCastRuleTest {
     @Test
     public void testBinaryPredicateInvolvingDecimalSuccess() {
         Type[][] typeListList = new Type[][] {
-                {Type.TINYINT, Type.SMALLINT, ScalarType.createDecimalV3NarrowestType(16, 9)},
-                {Type.TINYINT, Type.SMALLINT, ScalarType.createDecimalV3NarrowestType(9, 0)},
-                {ScalarType.createDecimalV3NarrowestType(4, 0), Type.SMALLINT, Type.BIGINT},
-                {ScalarType.createDecimalV3NarrowestType(18, 0), Type.BIGINT, Type.LARGEINT},
-                {ScalarType.createDecimalV3NarrowestType(2, 0), Type.TINYINT, Type.INT},
+                {Type.TINYINT, Type.SMALLINT, TypeFactory.createDecimalV3NarrowestType(16, 9)},
+                {Type.TINYINT, Type.SMALLINT, TypeFactory.createDecimalV3NarrowestType(9, 0)},
+                {TypeFactory.createDecimalV3NarrowestType(4, 0), Type.SMALLINT, Type.BIGINT},
+                {TypeFactory.createDecimalV3NarrowestType(18, 0), Type.BIGINT, Type.LARGEINT},
+                {TypeFactory.createDecimalV3NarrowestType(2, 0), Type.TINYINT, Type.INT},
         };
 
         ScalarOperatorRewriteRule reduceCastRule = new ReduceCastRule();
@@ -202,8 +202,8 @@ public class ReduceCastRuleTest {
     @Test
     public void testBinaryPredicateInvolvingDecimalFail() {
         Type[][] typeListList = new Type[][] {
-                {Type.TINYINT, Type.SMALLINT, ScalarType.createDecimalV3NarrowestType(13, 9)},
-                {Type.INT, Type.SMALLINT, ScalarType.createDecimalV3NarrowestType(9, 0)},
+                {Type.TINYINT, Type.SMALLINT, TypeFactory.createDecimalV3NarrowestType(13, 9)},
+                {Type.INT, Type.SMALLINT, TypeFactory.createDecimalV3NarrowestType(9, 0)},
         };
 
         ScalarOperatorRewriteRule reduceCastRule = new ReduceCastRule();
@@ -220,9 +220,9 @@ public class ReduceCastRuleTest {
         }
 
         typeListList = new Type[][] {
-                {ScalarType.createDecimalV3NarrowestType(6, 0), Type.SMALLINT, Type.BIGINT},
-                {ScalarType.createDecimalV3NarrowestType(19, 0), Type.BIGINT, Type.LARGEINT},
-                {ScalarType.createDecimalV3NarrowestType(10, 0), Type.TINYINT, Type.INT},
+                {TypeFactory.createDecimalV3NarrowestType(6, 0), Type.SMALLINT, Type.BIGINT},
+                {TypeFactory.createDecimalV3NarrowestType(19, 0), Type.BIGINT, Type.LARGEINT},
+                {TypeFactory.createDecimalV3NarrowestType(10, 0), Type.TINYINT, Type.INT},
         };
 
         for (Type[] types : typeListList) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/PruneSubfieldsForComplexTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/tree/PruneSubfieldsForComplexTypeTest.java
@@ -22,10 +22,10 @@ import com.starrocks.type.ComplexTypeAccessPath;
 import com.starrocks.type.ComplexTypeAccessPathType;
 import com.starrocks.type.MapType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,11 +39,11 @@ public class PruneSubfieldsForComplexTypeTest {
 
     @BeforeEach
     public void setup() {
-        Type keyType = ScalarType.createType(PrimitiveType.INT);
-        Type valueType = ScalarType.createCharType(10);
+        Type keyType = TypeFactory.createType(PrimitiveType.INT);
+        Type valueType = TypeFactory.createCharType(10);
         mapType = new MapType(keyType, valueType);
         Type arrayType = new ArrayType(mapType);
-        Type keyTypeOuter = ScalarType.createType(PrimitiveType.INT);
+        Type keyTypeOuter = TypeFactory.createType(PrimitiveType.INT);
         typeMapArrayMap = new MapType(keyTypeOuter, arrayType);
     }
 
@@ -165,10 +165,10 @@ public class PruneSubfieldsForComplexTypeTest {
 
     @Test
     public void testStructSubfield() {
-        Type field1 = ScalarType.createType(PrimitiveType.INT);
+        Type field1 = TypeFactory.createType(PrimitiveType.INT);
         Type field2Map =
-                new MapType(ScalarType.createType(PrimitiveType.INT), ScalarType.createType(PrimitiveType.VARCHAR));
-        Type field2Str = ScalarType.createType(PrimitiveType.VARCHAR);
+                new MapType(TypeFactory.createType(PrimitiveType.INT), TypeFactory.createType(PrimitiveType.VARCHAR));
+        Type field2Str = TypeFactory.createType(PrimitiveType.VARCHAR);
         StructField structField1 = new StructField("subfield1", field2Map);
         StructField structField2 = new StructField("subfield2", field2Str);
         ArrayList<StructField> list1 = new ArrayList<>();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
@@ -36,8 +36,8 @@ import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
 import com.starrocks.sql.ast.expression.JoinOperator;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.utframe.UtFrameUtils;
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.CharStreams;
@@ -235,7 +235,7 @@ class ParserTest {
             QueryStatement stmt = (QueryStatement) SqlParser.parse(sql, sessionVariable).get(0);
             Analyzer.analyze(stmt, ctx);
             Type type = stmt.getQueryRelation().getOutputExpression().get(0).getType();
-            Assertions.assertEquals(type, ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL256, 76, 0));
+            Assertions.assertEquals(type, TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL256, 76, 0));
         } catch (Throwable err) {
             Assertions.fail(err.getMessage());
         }
@@ -246,7 +246,7 @@ class ParserTest {
             QueryStatement stmt = (QueryStatement) SqlParser.parse(sql, sessionVariable).get(0);
             Analyzer.analyze(stmt, ctx);
             Type type = stmt.getQueryRelation().getOutputExpression().get(0).getType();
-            Assertions.assertEquals(type, ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL256, 76, 0));
+            Assertions.assertEquals(type, TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL256, 76, 0));
         } catch (Throwable err) {
             Assertions.fail(err.getMessage());
         }
@@ -270,8 +270,8 @@ class ParserTest {
         Analyzer.analyze(stmt, ctx);
         Type type1 = stmt.getQueryRelation().getOutputExpression().get(0).getType();
         Type type2 = stmt.getQueryRelation().getOutputExpression().get(1).getType();
-        Assertions.assertEquals(type1, ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL256, 65, 0));
-        Assertions.assertEquals(type2, ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 0));
+        Assertions.assertEquals(type1, TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL256, 65, 0));
+        Assertions.assertEquals(type2, TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 10, 0));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsMetaMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsMetaMgrTest.java
@@ -30,7 +30,7 @@ import com.starrocks.sql.ast.expression.TypeDef;
 import com.starrocks.sql.common.EngineType;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -55,11 +55,11 @@ public class StatisticsMetaMgrTest extends PlanTestBase  {
         CreateTableStmt stmt = new CreateTableStmt(false, false,
                 tableName,
                 ImmutableList.of(
-                        new ColumnDef("table_id", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
-                        new ColumnDef("partition_id", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
-                        new ColumnDef("column_name", new TypeDef(ScalarType.createVarcharType(65530))),
-                        new ColumnDef("db_id", new TypeDef(ScalarType.createType(PrimitiveType.BIGINT))),
-                        new ColumnDef("table_name", new TypeDef(ScalarType.createVarcharType(65530)))),
+                        new ColumnDef("table_id", new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT))),
+                        new ColumnDef("partition_id", new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT))),
+                        new ColumnDef("column_name", new TypeDef(TypeFactory.createVarcharType(65530))),
+                        new ColumnDef("db_id", new TypeDef(TypeFactory.createType(PrimitiveType.BIGINT))),
+                        new ColumnDef("table_name", new TypeDef(TypeFactory.createVarcharType(65530)))),
                 EngineType.defaultEngine().name(),
                 new KeysDesc(KeysType.UNIQUE_KEYS, ImmutableList.of("table_id", "partition_id", "column_name")),
                 null,

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
@@ -35,8 +35,8 @@ import com.starrocks.statistic.sample.SampleInfo;
 import com.starrocks.statistic.sample.TabletSampleManager;
 import com.starrocks.type.MapType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -366,14 +366,14 @@ public class StatisticsSQLTest extends PlanTestBase {
 
         sql = StatisticSQLBuilder.buildQueryFullStatisticsSQL(2L,
                 Lists.newArrayList("col1", "col2", "col3", "col4", "col5", "col6", "col7"),
-                Lists.newArrayList(ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 4, 3),
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 4, 3),
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 5, 2),
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 14, 3),
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 8, 3),
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 21, 6),
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 22, 7),
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 23, 8)));
+                Lists.newArrayList(TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 4, 3),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 4, 3),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 5, 2),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 14, 3),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 8, 3),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 21, 6),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 22, 7),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 23, 8)));
         assertContains(sql, "table_id = 2 and column_name in (\"col1\", \"col2\")");
         Assertions.assertEquals(5, StringUtils.countMatches(sql, "UNION ALL"));
     }
@@ -404,14 +404,14 @@ public class StatisticsSQLTest extends PlanTestBase {
 
         sql = StatisticSQLBuilder.buildQueryExternalFullStatisticsSQL("a",
                 Lists.newArrayList("col1", "col2", "col3", "col4", "col5", "col6", "col7"),
-                Lists.newArrayList(ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 4, 3),
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 4, 3),
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 5, 2),
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 14, 3),
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 8, 3),
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 21, 6),
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 22, 7),
-                        ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 23, 8)));
+                Lists.newArrayList(TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 4, 3),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 4, 3),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL32, 5, 2),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 14, 3),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL64, 8, 3),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 21, 6),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 22, 7),
+                        TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 23, 8)));
         assertContains(sql, "column_name in (\"col1\", \"col2\")");
         Assertions.assertEquals(5, StringUtils.countMatches(sql, "UNION ALL"));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/AgentTaskTest.java
@@ -59,7 +59,7 @@ import com.starrocks.thrift.TTabletSchema;
 import com.starrocks.thrift.TTabletType;
 import com.starrocks.thrift.TTaskType;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.ScalarType;
+import com.starrocks.type.TypeFactory;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
@@ -116,8 +116,8 @@ public class AgentTaskTest {
         agentBatchTask = new AgentBatchTask();
 
         columns = new LinkedList<Column>();
-        columns.add(new Column("k1", ScalarType.createType(PrimitiveType.INT), false, null, "1", ""));
-        columns.add(new Column("v1", ScalarType.createType(PrimitiveType.INT), false, AggregateType.SUM, "1", ""));
+        columns.add(new Column("k1", TypeFactory.createType(PrimitiveType.INT), false, null, "1", ""));
+        columns.add(new Column("v1", TypeFactory.createType(PrimitiveType.INT), false, AggregateType.SUM, "1", ""));
 
         PartitionKey pk1 = PartitionKey.createInfinityPartitionKey(Arrays.asList(columns.get(0)), false);
         PartitionKey pk2 =


### PR DESCRIPTION
# Why I'm doing:

## What I'm doing:

This pull request refactors the way column types are created throughout the codebase by replacing direct usage of `ScalarType`'s static methods with equivalent methods from the new `TypeFactory` class. This change standardizes type creation, making the code more maintainable and consistent.

**Refactoring type creation across the codebase:**

* Replaced all usages of `ScalarType.createVarchar`, `ScalarType.createDefaultString`, and `ScalarType.createType` with `TypeFactory.createVarchar`, `TypeFactory.createDefaultString`, and `TypeFactory.createType` respectively in system tables, resource group metadata, and table functions. This affects files such as `ResourceGroup.java`, `SystemTable.java`, and multiple files in the `system/information` package. [[1]](diffhunk://#diff-0854a5a412a27516fdca0a59063ef3e47a02977c03b3d6ac52294e09ba477059L89-R126) [[2]](diffhunk://#diff-a73037112e375ee90bbd2d67118783d7b59f89ca380841318ff497ea60eba151L281-R282) [[3]](diffhunk://#diff-db493aefbc35950da749dbbf427d8fd8887b15f7c976c0f13601e4af7b3ef87cL57-R67) [[4]](diffhunk://#diff-92e113c09337f7656dc9be9076655a3b0e949df97110038fd46043b8b3451446L33-R41) [[5]](diffhunk://#diff-0a896f4d3196b10146124acb2c67ac7c7cec36b01c80254f0fd32e4b5fac8ea9L34-R36) [[6]](diffhunk://#diff-75ba98a04033323e35c89cf7d0e66a558f8ba73a9a2289cc6583ba631ad82c71L33-R43) [[7]](diffhunk://#diff-3c622dda839e6b3d1e4e88f731a67d1cd600682d69201f6261db08aec63a8b7aL33-R40) [[8]](diffhunk://#diff-0d05913a4db0383bcf70b89bffab2b0bb2c3659b88fc3f6c4338d22444472f4eL34-R39) [[9]](diffhunk://#diff-5e49effa0d11dc4037e3c47143e421459e7cf411ae3a94aefb02d4edb5f4e17dL704-R704)

* Updated import statements to use `TypeFactory` instead of `ScalarType` where appropriate. [[1]](diffhunk://#diff-373bd2cfff2d32a6888f75de28c7ae7bab5bd54ddb6501db6a10bf59c623a1e3L104-R105) [[2]](diffhunk://#diff-0854a5a412a27516fdca0a59063ef3e47a02977c03b3d6ac52294e09ba477059L24-R24) [[3]](diffhunk://#diff-5e49effa0d11dc4037e3c47143e421459e7cf411ae3a94aefb02d4edb5f4e17dL61-R63) [[4]](diffhunk://#diff-a73037112e375ee90bbd2d67118783d7b59f89ca380841318ff497ea60eba151R51) [[5]](diffhunk://#diff-db493aefbc35950da749dbbf427d8fd8887b15f7c976c0f13601e4af7b3ef87cL37-R37) [[6]](diffhunk://#diff-92e113c09337f7656dc9be9076655a3b0e949df97110038fd46043b8b3451446L21-R21) [[7]](diffhunk://#diff-0a896f4d3196b10146124acb2c67ac7c7cec36b01c80254f0fd32e4b5fac8ea9L21-R21) [[8]](diffhunk://#diff-75ba98a04033323e35c89cf7d0e66a558f8ba73a9a2289cc6583ba631ad82c71L21-R21) [[9]](diffhunk://#diff-3c622dda839e6b3d1e4e88f731a67d1cd600682d69201f6261db08aec63a8b7aL21-R21) [[10]](diffhunk://#diff-0d05913a4db0383bcf70b89bffab2b0bb2c3659b88fc3f6c4338d22444472f4eL21-R21)

**Ensuring consistency in expression analysis and schema generation:**

* Changed the creation of boolean types in expression analysis from `ScalarType.createType(PrimitiveType.BOOLEAN)` to `TypeFactory.createType(PrimitiveType.BOOLEAN)` in `RollupJobV2.java`.

* Updated schema generation in table functions to use `TypeFactory.createDefaultString()` instead of `ScalarType.createDefaultString()`.

These changes help unify the way types are instantiated, paving the way for easier future modifications and improved code clarity.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
