### PR TITLE
[Enhancement] Optimize SqlCredentialRedactor redact performance

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/common/util/SqlCredentialRedactorBench.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/SqlCredentialRedactorBench.java
@@ -1,0 +1,170 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+public class SqlCredentialRedactorBench {
+
+    private String sqlWithManyKeys;
+    private String sqlWithFewKeys;
+    private String sqlWithoutCredentials;
+    private Pattern oldPattern;
+
+    public static void main(String[] args) throws Exception {
+        Options opt = new OptionsBuilder()
+                .include(SqlCredentialRedactorBench.class.getSimpleName())
+                .build();
+        new Runner(opt).run();
+    }
+
+    @org.openjdk.jmh.annotations.Setup
+    public void setup() {
+        // Pre-compile the old pattern (simulating old approach with all keys in regex)
+        String[] allKeys = {
+                "aws\\.s3\\.access_key", "aws\\.s3\\.secret_key", "aws\\.s3\\.session_token",
+                "aws\\.glue\\.access_key", "aws\\.glue\\.secret_key", "aws\\.glue\\.session_token",
+                "azure\\.blob\\.shared_key", "azure\\.blob\\.sas_token", "azure\\.blob\\.oauth2_client_secret",
+                "azure\\.adls1\\.oauth2_credential", "azure\\.adls2\\.shared_key", "azure\\.adls2\\.sas_token",
+                "azure\\.adls2\\.oauth2_client_secret", "gcp\\.gcs\\.service_account_private_key",
+                "gcp\\.gcs\\.service_account_private_key_id", "hdfs\\.password",
+                "hadoop\\.security\\.authentication\\.kerberos\\.keytab",
+                "hadoop\\.security\\.authentication\\.kerberos\\.keytab\\.content",
+                "aliyun\\.oss\\.access_key", "aliyun\\.oss\\.secret_key",
+                "tencent\\.cos\\.access_key", "tencent\\.cos\\.secret_key",
+                "fs\\.s3a\\.access\\.key", "fs\\.s3a\\.secret\\.key", "fs\\.ks3\\.access\\.key",
+                "fs\\.ks3\\.secret\\.key",
+                "fs\\.oss\\.access\\.key", "fs\\.oss\\.secret\\.key", "fs\\.cos\\.access\\.key",
+                "fs\\.cos\\.secret\\.key",
+                "fs\\.obs\\.access\\.key", "fs\\.obs\\.secret\\.key", "fs\\.tos\\.access\\.key",
+                "fs\\.tos\\.secret\\.key",
+                "password", "passwd", "pwd", "property\\.sasl\\.password", "broker\\.password"
+        };
+        String keysPattern = String.join("|", allKeys);
+        oldPattern = Pattern.compile(
+                "(?:([\"']?)(" + keysPattern + ")([\"']?))\\s*=\\s*" +
+                        "(?:([\"'])((?:[^\\\\]|\\\\.)*?)\\4|([^,()\\n]*?))" +
+                        "(?=\\s*,|\\s*$|\\s*\\)|\\s*\\n)",
+                Pattern.CASE_INSENSITIVE | Pattern.DOTALL | Pattern.MULTILINE
+        );
+
+        // Build SQL with many key-value pairs (simulates real-world scenario)
+        StringBuilder sqlBuilder = new StringBuilder(10000);
+        sqlBuilder.append("CREATE EXTERNAL CATALOG test_catalog\n");
+        sqlBuilder.append("PROPERTIES (\n");
+
+        // Add many non-sensitive keys
+        for (int i = 0; i < 100; i++) {
+            sqlBuilder.append("    \"property").append(i).append("\" = \"value").append(i).append("\",\n");
+        }
+
+        // Add some sensitive keys
+        sqlBuilder.append("    \"aws.s3.access_key\" = \"AKIAIOSFODNN7EXAMPLE\",\n");
+        sqlBuilder.append("    \"aws.s3.secret_key\" = \"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\",\n");
+        sqlBuilder.append("    \"password\" = \"secret123\",\n");
+        sqlBuilder.append("    \"fs.s3a.access.key\" = \"access_key_value\",\n");
+        sqlBuilder.append("    \"fs.s3a.secret.key\" = \"secret_key_value\"\n");
+        sqlBuilder.append(")");
+
+        sqlWithManyKeys = sqlBuilder.toString();
+
+        // Build SQL with few keys
+        sqlBuilder = new StringBuilder();
+        sqlBuilder.append("CREATE EXTERNAL CATALOG test_catalog\n");
+        sqlBuilder.append("PROPERTIES (\n");
+        sqlBuilder.append("    \"aws.s3.access_key\" = \"AKIAIOSFODNN7EXAMPLE\",\n");
+        sqlBuilder.append("    \"aws.s3.secret_key\" = \"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\"\n");
+        sqlBuilder.append(")");
+        sqlWithFewKeys = sqlBuilder.toString();
+
+        // SQL without credentials
+        sqlWithoutCredentials = "SELECT * FROM table WHERE id = 1";
+    }
+
+    @Benchmark
+    public void benchmarkManyKeys() {
+        SqlCredentialRedactor.redact(sqlWithManyKeys);
+    }
+
+    @Benchmark
+    public void benchmarkFewKeys() {
+        SqlCredentialRedactor.redact(sqlWithFewKeys);
+    }
+
+    @Benchmark
+    public void benchmarkNoCredentials() {
+        SqlCredentialRedactor.redact(sqlWithoutCredentials);
+    }
+
+    @Benchmark
+    public void benchmarkOldVersionManyKeys() {
+        redactOldVersion(sqlWithManyKeys);
+    }
+
+    // Simulate the old version with complex regex pattern containing all keys
+    // This uses alternation with many keys, causing regex backtracking performance issues
+    private String redactOldVersion(String sql) {
+        if (sql == null || sql.isEmpty()) {
+            return sql;
+        }
+
+        Matcher matcher = oldPattern.matcher(sql);
+        StringBuilder result = new StringBuilder(sql.length() + 100);
+
+        int lastEnd = 0;
+        while (matcher.find()) {
+            String keyPrefix = matcher.group(1) != null ? matcher.group(1) : "";
+            String key = matcher.group(2);
+            String keySuffix = matcher.group(3) != null ? matcher.group(3) : "";
+
+            result.append(sql, lastEnd, matcher.start());
+
+            String replacement;
+            if (matcher.group(4) != null && matcher.group(5) != null) {
+                String valueQuote = matcher.group(4);
+                replacement = keyPrefix + key + keySuffix + " = " + valueQuote + "***" + valueQuote;
+            } else {
+                replacement = keyPrefix + key + keySuffix + " = ***";
+            }
+            result.append(replacement);
+            lastEnd = matcher.end();
+        }
+
+        result.append(sql, lastEnd, sql.length());
+        return result.toString();
+    }
+}
+


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

<img width="1056" height="772" alt="image" src="https://github.com/user-attachments/assets/32dc5ea0-59b0-47b9-919f-21363faafbfb" />


The original implementation used a complex regex pattern with 40+ credential keys in alternation, causing massive backtracking and poor performance. This optimization improves performance by:
1. Simplified regex pattern: Match all key-value pairs first, then check  if key is sensitive using HashSet lookup (O(1) instead of regex O(n))
2. Use StringBuilder instead of StringBuffer for better single-threaded   performance
3. Manual string building instead of appendReplacement to reduce overhead

**Performance improvement: ~7.4x faster** 
> VM version: JDK 17.0.16, OpenJDK 64-Bit Server VM, 17.0.16+8-LTS

| Benchmark | Mode | Iterations | Score | Error | Units |
|-----------|------|------------|-------|-------|-------|
| `benchmarkFewKeys` | avgt | 5 | 9.236 | ± 0.306 | us/op |
| `benchmarkManyKeys` | avgt | 5 | 58.036 | ± 1.659 | us/op |
| `benchmarkNoCredentials` | avgt | 5 | 2.134 | ± 0.047 | us/op |
| `benchmarkOldVersionManyKeys` | avgt | 5 | 427.295 | ± 27.053 | us/op |

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Optimizes SQL credential redaction performance and centralizes Iceberg scan metrics reporting with tracer logging, while cleaning up related code/tests and tweaking debugging output; also adds FE scaling guidance in docs.
> 
> - **Performance/Utils**:
>   - Optimized `SqlCredentialRedactor`: simplified key-value regex, case-insensitive key set, manual StringBuilder replacement; adds JMH bench `SqlCredentialRedactorBench`.
> - **Iceberg**:
>   - New `IcebergMetricsReporter` stores `ScanReport`s keyed by table/predicate/snapshot; `IcebergMetadata` now owns the reporter, logs scan metrics via `Tracers`, and clears on `clear()`.
>   - Removed per-table/scan metrics plumbing: deleted reporter field/mutators from `IcebergTable`, `IcebergScanNode`, and `StarRocksIcebergTableScan` now relies on table/reporter context.
> - **Tests**:
>   - Removed obsolete Iceberg scan metrics tests (`IcebergScanMetricsTest`, SQL tests under `test_iceberg_scan_metrics`).
> - **Planner/Optimizer Debug**:
>   - Simplified `DebugOperatorTracer` outputs (explicit predicate/projection fields only); `PruneGroupByKeysRule` uses `Preconditions` for missing keys.
> - **Docs**:
>   - Added FE scaling guidance (typical FE:BE ratios; FE count recommendations) in `docs/*/administration/management/Scale_up_down.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61b59510a5832978cc634a39e7f90fbc51d91ba9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->