### PR TITLE
[BugFix] Fix JSON flatten losing data when path tree expects object but actual value is primitive

### DIFF
--- a/be/src/util/json_flattener.cpp
+++ b/be/src/util/json_flattener.cpp
@@ -671,6 +671,15 @@ uint32_t JsonPathDeriver::_dfs_finalize(JsonFlatPath* node, const std::string& a
             // Node was marked as remain because it was empty in some row(s)
             // Keep it as remain even if all children are flattened
         }
+        // IMPORTANT: If a node has children in path tree (expects object), but actual data
+        // might have primitive value at this level, we need remain to preserve it.
+        // This is a conservative approach: if path tree expects object, enable remain
+        // to handle cases where actual data has primitive instead of object.
+        if (!node->children.empty() && !absolute_path.empty()) {
+            // Path tree expects this node to be an object, but actual data might have primitive
+            // Mark as remain to preserve the actual data structure
+            node->remain = true;
+        }
         return 1;
     }
 }

--- a/be/src/util/json_flattener.cpp
+++ b/be/src/util/json_flattener.cpp
@@ -199,6 +199,7 @@ using JsonFlatExtractFunc = void (*)(const vpack::Slice* json, NullableColumn* r
 using JsonFlatMergeFunc = void (*)(vpack::Builder* builder, const std::string_view& name, const Column* src, size_t idx);
 static const uint8_t JSON_BASE_TYPE_BITS = 0;   // least flat to JSON type
 static const uint8_t JSON_BIGINT_TYPE_BITS = 7; // bigint compatible type
+static const uint8_t JSON_NULL_TYPE_BITS = 31;  // JSON_NULL_TYPE_BITS, initial value for JsonFlatDesc::type
 
 // bool will flatting as string, because it's need save string-literal(true/false)
 // int & string compatible type is json, because int cast to string will add double quote, it's different with json
@@ -614,10 +615,21 @@ void JsonPathDeriver::_visit_json_paths(const vpack::Slice& value, JsonFlatPath*
         if (v.isObject()) {
             // Accumulate remain status: if node is ever empty in any row, mark as remain
             child->remain |= v.isEmptyObject();
+            // If this node was previously visited as primitive (desc->type != JSON_BASE_TYPE_BITS and != initial value),
+            // but now we see an object, this indicates a type mismatch.
+            // Mark the parent node as remain to preserve the actual data structure.
+            if (desc->type != flat_json::JSON_BASE_TYPE_BITS && desc->type != flat_json::JSON_NULL_TYPE_BITS) {
+                root->remain = true;
+            }
             desc->type = flat_json::JSON_BASE_TYPE_BITS;
             _visit_json_paths(v, child, mark_row);
         } else {
-            auto desc = &_derived_maps[child];
+            // If this node has children (was previously visited as object), but now we see a primitive,
+            // this indicates a type mismatch: path tree expects object but actual data has primitive.
+            // Mark the parent node as remain to preserve the actual data structure.
+            if (!child->children.empty()) {
+                root->remain = true;
+            }
             vpack::ValueType json_type = v.type();
             desc->type = flat_json::get_compatibility_type(json_type, desc->type);
             desc->base_type_count += flat_json::JSON_BASE_TYPE.count(json_type);
@@ -670,15 +682,6 @@ uint32_t JsonPathDeriver::_dfs_finalize(JsonFlatPath* node, const std::string& a
         } else if (!absolute_path.empty() && node->remain) {
             // Node was marked as remain because it was empty in some row(s)
             // Keep it as remain even if all children are flattened
-        }
-        // IMPORTANT: If a node has children in path tree (expects object), but actual data
-        // might have primitive value at this level, we need remain to preserve it.
-        // This is a conservative approach: if path tree expects object, enable remain
-        // to handle cases where actual data has primitive instead of object.
-        if (!node->children.empty() && !absolute_path.empty()) {
-            // Path tree expects this node to be an object, but actual data might have primitive
-            // Mark as remain to preserve the actual data structure
-            node->remain = true;
         }
         return 1;
     }

--- a/test/sql/test_semi/R/test_flat_json_consistency
+++ b/test/sql/test_semi/R/test_flat_json_consistency
@@ -53,7 +53,7 @@ select * from test_json_cast_map order by c1;
 -- !result
 select flat_json_meta(c2) from test_json_cast_map [_META_];
 -- result:
-["nulls(TINYINT), 100.200.300(VARCHAR), level1.level2.level3.level4.5(VARCHAR), remain(JSON)"]
+["nulls(TINYINT), 100.200.300(VARCHAR), level1.level2.level3.level4.5(VARCHAR)"]
 -- !result
 truncate table test_json_cast_map;
 -- result:
@@ -72,7 +72,7 @@ select * from test_json_cast_map order by c1;
 -- !result
 select flat_json_meta(c2) from test_json_cast_map [_META_];
 -- result:
-["nulls(TINYINT), level1.level2.level3.level4.5(VARCHAR), level1.level2.level3.level4.6(VARCHAR), remain(JSON)"]
+["nulls(TINYINT), level1.level2.level3.level4.5(VARCHAR), level1.level2.level3.level4.6(VARCHAR)"]
 -- !result
 truncate table test_json_cast_map;
 -- result:

--- a/test/sql/test_semi/R/test_flat_json_consistency
+++ b/test/sql/test_semi/R/test_flat_json_consistency
@@ -53,7 +53,7 @@ select * from test_json_cast_map order by c1;
 -- !result
 select flat_json_meta(c2) from test_json_cast_map [_META_];
 -- result:
-["nulls(TINYINT), 100.200.300(VARCHAR), level1.level2.level3.level4.5(VARCHAR)"]
+["nulls(TINYINT), 100.200.300(VARCHAR), level1.level2.level3.level4.5(VARCHAR), remain(JSON)"]
 -- !result
 truncate table test_json_cast_map;
 -- result:
@@ -72,7 +72,7 @@ select * from test_json_cast_map order by c1;
 -- !result
 select flat_json_meta(c2) from test_json_cast_map [_META_];
 -- result:
-["nulls(TINYINT), level1.level2.level3.level4.5(VARCHAR), level1.level2.level3.level4.6(VARCHAR)"]
+["nulls(TINYINT), level1.level2.level3.level4.5(VARCHAR), level1.level2.level3.level4.6(VARCHAR), remain(JSON)"]
 -- !result
 truncate table test_json_cast_map;
 -- result:
@@ -147,6 +147,48 @@ select * from test_json_cast_map order by c1;
 select flat_json_meta(c2) from test_json_cast_map [_META_];
 -- result:
 ["nulls(TINYINT), 100.200.300(VARCHAR), remain(JSON)"]
+-- !result
+DROP TABLE test_json_cast_map;
+-- result:
+-- !result
+CREATE TABLE test_json_cast_map (c1 int, c2 json) 
+DISTRIBUTED BY HASH(c1) BUCKETS 1;
+-- result:
+-- !result
+insert into test_json_cast_map values
+(1, '{"level1": {"level2": {"level3": {"level4": {"5":"abc"}}}}}'),
+(4, '{"level1": {"level2": {"level3": {"4":null}}}}'),
+(7, '{"level1": {"level2": {"level3": "abc"}}}');
+-- result:
+-- !result
+select * from test_json_cast_map order by c1;
+-- result:
+1	{"level1": {"level2": {"level3": {"level4": {"5": "abc"}}}}}
+4	{"level1": {"level2": {"level3": {"4": null}}}}
+7	{"level1": {"level2": {"level3": "abc"}}}
+-- !result
+select flat_json_meta(c2) from test_json_cast_map [_META_];
+-- result:
+["nulls(TINYINT), level1.level2.level3.4(JSON), level1.level2.level3.level4.5(VARCHAR), remain(JSON)"]
+-- !result
+drop table test_json_cast_map;
+-- result:
+-- !result
+CREATE TABLE test_json_cast_map (c1 int, c2 json) 
+DISTRIBUTED BY RANDOM BUCKETS 3;
+-- result:
+-- !result
+insert into test_json_cast_map values
+(1, '{"level1": {"level2": {"level3": {"level4": {"5":"abc"}}}}}'),
+(2, '{"level1": {"level2": {"level3": {"4":23234982794}}}}'),
+(3, '{"level1": {"level2": {"level3": {"4":true}}}}'),
+(4, '{"level1": {"level2": {"level3": {"4":null}}}}'),
+(5, '{"level1": {"level2": {"level3": {"4":["abc", 100, 200]}}}}'),
+(6, '{"level1": {"level2": {"level3": {"4":{"5": "abc"}}}}}'),
+(7, '{"level1": {"level2": {"level3": "abc"}}}'),
+(8, '{"100": {"200": {"300": {"500":"abc"}}}}'),
+(9, '{"100": {"200": {"300": "abc"}}}');
+-- result:
 -- !result
 drop table test_json_cast_map;
 -- result:

--- a/test/sql/test_semi/T/test_flat_json_consistency
+++ b/test/sql/test_semi/T/test_flat_json_consistency
@@ -93,5 +93,34 @@ insert into test_json_cast_map values
 select * from test_json_cast_map order by c1;
 select flat_json_meta(c2) from test_json_cast_map [_META_];
 
+-- Test 9: inconsistent intermediate node
+DROP TABLE test_json_cast_map;
+CREATE TABLE test_json_cast_map (c1 int, c2 json) 
+DISTRIBUTED BY HASH(c1) BUCKETS 1;
+
+insert into test_json_cast_map values
+(1, '{"level1": {"level2": {"level3": {"level4": {"5":"abc"}}}}}'),
+(4, '{"level1": {"level2": {"level3": {"4":null}}}}'),
+(7, '{"level1": {"level2": {"level3": "abc"}}}');
+
+select * from test_json_cast_map order by c1;
+select flat_json_meta(c2) from test_json_cast_map [_META_];
+
+-- Test 10: inconsistent intermediate node
+drop table test_json_cast_map;
+CREATE TABLE test_json_cast_map (c1 int, c2 json) 
+DISTRIBUTED BY RANDOM BUCKETS 3;
+
+insert into test_json_cast_map values
+(1, '{"level1": {"level2": {"level3": {"level4": {"5":"abc"}}}}}'),
+(2, '{"level1": {"level2": {"level3": {"4":23234982794}}}}'),
+(3, '{"level1": {"level2": {"level3": {"4":true}}}}'),
+(4, '{"level1": {"level2": {"level3": {"4":null}}}}'),
+(5, '{"level1": {"level2": {"level3": {"4":["abc", 100, 200]}}}}'),
+(6, '{"level1": {"level2": {"level3": {"4":{"5": "abc"}}}}}'),
+(7, '{"level1": {"level2": {"level3": "abc"}}}'),
+(8, '{"100": {"200": {"300": {"500":"abc"}}}}'),
+(9, '{"100": {"200": {"300": "abc"}}}');
+
 
 drop table test_json_cast_map;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:


When flattening JSON data, if some rows have a node as an object (e.g., {"level1": {"level2": {"level3": {"level4": {...}}}}}) but other rows have the same node as a primitive (e.g., {"level1": {"level2": {"level3": "abc"}}}), the primitive value was being lost during flattening because the node was not marked as remain.

Fixes #https://github.com/StarRocks/StarRocksTest/issues/10513

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
