### PR TITLE
[Tool] Fix mac BE build error with Homebrew-installed protobuf

### DIFF
--- a/build-mac/CMakeLists.txt
+++ b/build-mac/CMakeLists.txt
@@ -356,8 +356,7 @@ if(NOT ZLIB_LIB)
 endif()
 add_library(zlib STATIC IMPORTED GLOBAL)
 set_target_properties(zlib PROPERTIES
-    IMPORTED_LOCATION ${ZLIB_LIB}
-    INTERFACE_INCLUDE_DIRECTORIES ${HOMEBREW_PREFIX}/include)
+    IMPORTED_LOCATION ${ZLIB_LIB})
 message(STATUS "zlib found: ${ZLIB_LIB}")
 
 # Bzip2 library for compression support - use dynamic lookup
@@ -371,8 +370,7 @@ if(NOT BZIP2_LIB)
 endif()
 add_library(bzip2 STATIC IMPORTED GLOBAL)
 set_target_properties(bzip2 PROPERTIES
-    IMPORTED_LOCATION ${BZIP2_LIB}
-    INTERFACE_INCLUDE_DIRECTORIES ${HOMEBREW_PREFIX}/include)
+    IMPORTED_LOCATION ${BZIP2_LIB})
 message(STATUS "bzip2 found: ${BZIP2_LIB}")
 
 # Ryu library for fast float-to-string conversion


### PR DESCRIPTION
## Why I'm doing:

```
/Users/kks/git/starrocks/thirdparty/installed/include/google/protobuf/port_def.inc:92:2: error: PROTOBUF_VERSION was previously
defined
   92 | #error PROTOBUF_VERSION was previously defined
      |  ^
/Users/kks/git/starrocks/thirdparty/installed/include/google/protobuf/port_def.inc:95:2: error: PROTOBUF_VERSION_SUFFIX was
previously defined
   95 | #error PROTOBUF_VERSION_SUFFIX was previously defined
      |  ^
```

```
⏺ Bash(brew list --versions | grep protobuf)
  ⎿  protobuf 32.1
     protobuf@29 29.5_1

⏺ Bash(/Users/kks/git/starrocks/thirdparty/installed/bin/protoc --version)
  ⎿  libprotoc 3.14.0

⏺ Bash(/opt/homebrew/bin/protoc --version)
  ⎿  libprotoc 32.1
  
    - Homebrew: protobuf 32.1 和 protobuf@29 29.5
  - Thirdparty: protobuf 3.14.0
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
