### PR TITLE
[UT] Fix heap-use-after-free in ProcProfileE2ETest

### DIFF
--- a/be/test/http/action/proc_profile_e2e_test.cpp
+++ b/be/test/http/action/proc_profile_e2e_test.cpp
@@ -33,8 +33,8 @@ protected:
         std::filesystem::create_directories(test_dir);
 
         // Set config to use test directory
-        original_sys_log_dir = config::sys_log_dir.c_str();
-        config::sys_log_dir = test_dir.c_str();
+        original_sys_log_dir = config::sys_log_dir;
+        config::sys_log_dir = test_dir;
 
         // Create fake profile files
         create_fake_profile_files();
@@ -92,7 +92,7 @@ protected:
     }
 
     std::string test_dir;
-    const char* original_sys_log_dir;
+    std::string original_sys_log_dir;
 };
 
 TEST_F(ProcProfileE2ETest, TestProcProfilePageDisplay) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fix AddressSanitizer heap-use-after-free error in ProcProfileE2ETest::TearDown(). The issue was caused by storing a pointer to a C-string from config::sys_log_dir.c_str() which becomes invalid after the config is reassigned in SetUp().

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
