### PR TITLE
[BugFix] Actively close connection when client disconnects

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/nio/MySQLReadListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/nio/MySQLReadListener.java
@@ -60,7 +60,7 @@ public class MySQLReadListener implements ChannelListener<ConduitStreamSourceCha
                     if (!ctx.isKilled() && ctx.getState().isRunning()) {
                         ctx.kill(false, "client closed");
                     }
-                    ctx.getMysqlChannel().close();
+                    ctx.cleanup();
                     return;
                 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/nio/MySQLReadListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/nio/MySQLReadListener.java
@@ -60,8 +60,7 @@ public class MySQLReadListener implements ChannelListener<ConduitStreamSourceCha
                     if (!ctx.isKilled() && ctx.getState().isRunning()) {
                         ctx.kill(false, "client closed");
                     }
-                    channel.shutdownReads();
-                    channel.close();
+                    ctx.getMysqlChannel().close();
                     return;
                 }
 


### PR DESCRIPTION
## Why I'm doing:

After this PR #64355, observing with `show proc '/current_queries'` reveals no active queries remain. However, `show processlist` still shows connections present. Calling `channel.close()` does not actually close the connection; it only closes the read channel. We need to call `close stream` to fully terminate the connection.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Inlines SQL/explain rendering into AST nodes (removing ExprToSql) and updates all call sites, fully closes MySQL connections on client disconnect, simplifies Lake/LocalTabletsChannel internals with improved error handling, and fixes zlib/bzip2 include paths.
> 
> - **Frontend (FE)**:
>   - Replace `ExprToSql` with instance methods (`Expr.toSql()`, `explain()`, `toMySql()`); implement `toSql()` across AST nodes and update analyzers, planners, formatters, and tests; adjust error messages accordingly.
>   - Minor API tidying: simplify MV reload flow; remove checked exceptions from `onCreate` signatures.
> - **Backend (BE)**:
>   - MySQL server: actively and fully close client connections via `ctx.getMysqlChannel().close()` when peer disconnects.
>   - Lake/Local tablets channel:
>     - Collapse `DeltaWritersImpl` into a direct `std::unordered_map`, relax `const/static` where needed, and pass `Chunk*` to write context.
>     - Improve missing-tablet handling with warnings and internal errors; tweak profiling helpers and `mem_tracker()` accessors.
> - **Build**:
>   - Add `INTERFACE_INCLUDE_DIRECTORIES` for imported `zlib` and `bzip2` targets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 087df7e39f23bf7e4635f7ceb832cfd4d42e20fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->