### PR TITLE
[Enhancement] Add FE system metrics

### DIFF
--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -5619,4 +5619,13 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: Whether to prefer string type for fixed length varchar columns in materialized view creation and CTAS operations.
 - Introduced in: v4.0.0
 
+##### enable_collect_system_metrics
+
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether to collect FE system metrics, such as CPU, Memory, IO, Network.
+- Introduced in: v4.1.0
+
 <EditionSpecificFEItem />

--- a/docs/en/administration/management/monitoring/metrics.md
+++ b/docs/en/administration/management/monitoring/metrics.md
@@ -651,7 +651,6 @@ For more information on how to build a monitoring service for your StarRocks clu
 - Type: Instantaneous
 - Description: Indicates the highest Compaction Score on each BE node.
 
-
 ### update_compaction_outputs_total
 
 - Unit: Count
@@ -1794,3 +1793,128 @@ For more information on how to build a monitoring service for your StarRocks clu
 - Unit: ms
 - Type: Cumulative
 - Description: The total time for copy consumed by Clone tasks in the BE node, including both INTER_NODE and INTRA_NODE types.
+
+
+### FE system metrics
+
+These metrics monitor the CPU, memory, IO, and network of the physical machine where the FE is running. These metrics are collected only when you set the FE configuration item `enable_collect_system_metrics` to `true`. For information about how to configure this item, see [enable_collect_system_metrics](../FE_configuration.md#enable_collect_system_metrics).
+
+#### starrocks_fe_cpu
+
+- Unit: -
+- Type: Cumulative
+- Description: CPU time counters by mode, derived from the same kernel counters visualized by `top` (from `/proc/stat`). Labels: `mode` = `user` | `nice` | `system` | `idle` | `iowait` | `irq` | `softirq` | `steal`.
+
+#### starrocks_fe_memory
+
+- Unit: Bytes
+- Type: Instantaneous
+- Description: Physical and swap memory statistics derived from the OS (e.g., `/proc/meminfo`). Labels: `name` = `total` | `used` | `swap_total` | `swap_used`.
+
+#### starrocks_fe_disk_total_capacity
+
+- Unit: Bytes
+- Type: Instantaneous
+- Description: Total capacity of the disk for monitored StarRocks paths (such as `Config.meta_dir` and `Config.sys_log_dir`). Labels: `device` = underlying block device name (for example, `sda`, `nvme0n1`).
+
+#### starrocks_fe_disk_used_capacity
+
+- Unit: Bytes
+- Type: Instantaneous
+- Description: Used capacity of the disk for monitored StarRocks paths (such as `Config.meta_dir` and `Config.sys_log_dir`). Labels: `device` = underlying block device name (for example, `sda`, `nvme0n1`).
+
+#### starrocks_fe_disk_reads_completed
+
+- Unit: Count
+- Type: Cumulative
+- Description: Number of reads completed, derived from Linux disk statistics (`/proc/diskstats`). Labels: `device` = underlying block device name (for example, `sda`, `nvme0n1`).
+
+#### starrocks_fe_disk_bytes_read
+
+- Unit: Bytes
+- Type: Cumulative
+- Description: Total bytes read, from `/proc/diskstats`. Labels: `device` = underlying block device name (for example, `sda`, `nvme0n1`).
+
+#### starrocks_fe_disk_read_time_ms
+
+- Unit: milliseconds
+- Type: Cumulative
+- Description: Cumulative time spent reading, derived from `/proc/diskstats`. Labels: `device` = underlying block device name (for example, `sda`, `nvme0n1`).
+
+#### starrocks_fe_disk_writes_completed
+
+- Unit: Count
+- Type: Cumulative
+- Description: Number of writes completed, derived from Linux disk statistics (`/proc/diskstats`). Labels: `device` = underlying block device name (for example, `sda`, `nvme0n1`).
+
+#### starrocks_fe_disk_bytes_written
+
+- Unit: Bytes
+- Type: Cumulative
+- Description: Total bytes written, from `/proc/diskstats`. Labels: `device` = underlying block device name (for example, `sda`, `nvme0n1`).
+
+#### starrocks_fe_disk_write_time_ms
+
+- Unit: milliseconds
+- Type: Cumulative
+- Description: Cumulative time spent writing, derived from `/proc/diskstats`. Labels: `device` = underlying block device name (for example, `sda`, `nvme0n1`).
+
+#### starrocks_fe_disk_io_time_ms
+
+- Unit: milliseconds
+- Type: Cumulative
+- Description: Cumulative time spent on I/O, derived from `/proc/diskstats`. Labels: `device` = underlying block device name (for example, `sda`, `nvme0n1`).
+
+#### starrocks_fe_disk_io_time_weighted_ms
+
+- Unit: milliseconds
+- Type: Cumulative
+- Description: Weighted cumulative time spent on I/O, derived from `/proc/diskstats`. Labels: `device` = underlying block device name (for example, `sda`, `nvme0n1`).
+
+#### starrocks_fe_network_receive_bytes
+
+- Unit: Bytes
+- Type: Cumulative
+- Description: Total bytes received per network interface, derived from OS NIC statistics (for Linux, typically `/sys/class/net/*/statistics/`). Labels: `device` = network interface name (for example, `eth0`).
+
+#### starrocks_fe_network_receive_packets
+
+- Unit: Count
+- Type: Cumulative
+- Description: Total packets received per network interface, derived from OS NIC statistics (for Linux, typically `/sys/class/net/*/statistics/`). Labels: `device` = network interface name (for example, `eth0`).
+
+#### starrocks_fe_network_receive_errors
+
+- Unit: Count
+- Type: Cumulative
+- Description: Receive errors per network interface, derived from OS NIC statistics (for Linux, typically `/sys/class/net/*/statistics/`). Labels: `device` = network interface name (for example, `eth0`).
+
+#### starrocks_fe_network_receive_dropped
+
+- Unit: Count
+- Type: Cumulative
+- Description: Dropped incoming packets per network interface, derived from OS NIC statistics (for Linux, typically `/sys/class/net/*/statistics/`). Labels: `device` = network interface name (for example, `eth0`).
+
+#### starrocks_fe_network_send_bytes
+
+- Unit: Bytes
+- Type: Cumulative
+- Description: Total bytes sent per network interface, derived from OS NIC statistics (for Linux, typically `/sys/class/net/*/statistics/`). Labels: `device` = network interface name (for example, `eth0`).
+
+#### starrocks_fe_network_send_packets
+
+- Unit: Count
+- Type: Cumulative
+- Description: Total packets sent per network interface, derived from OS NIC statistics (for Linux, typically `/sys/class/net/*/statistics/`). Labels: `device` = network interface name (for example, `eth0`).
+
+#### starrocks_fe_network_send_errors
+
+- Unit: Count
+- Type: Cumulative
+- Description: Send errors per network interface, derived from OS NIC statistics (for Linux, typically `/sys/class/net/*/statistics/`). Labels: `device` = network interface name (for example, `eth0`).
+
+#### starrocks_fe_snmp
+
+- Unit: Count
+- Type: Mixed
+- Description: TCP stack statistics aggregated over IPv4/IPv6, derived from `/proc/net/snmp`. Labels: `name` = `active_opens`, `passive_opens`, `attempts_fails`, `estab_resets`, `curr_estab` (instantaneous), `tcp_in_segs`, `tcp_out_segs`, `tcp_retrans_segs`, `tcp_in_errs`, `tcp_out_rsts` (cumulative).

--- a/docs/ja/administration/management/FE_configuration.md
+++ b/docs/ja/administration/management/FE_configuration.md
@@ -3299,4 +3299,13 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明: マテリアライズドビューの作成とCTAS操作において、固定長のVARCHAR列に対してSTRING型を優先するかどうか。
 - 導入バージョン: v4.0.0
 
+##### enable_collect_system_metrics
+
+- デフォルト: false
+- タイプ: Boolean
+- 単位: -
+- 動的に変更可能か: はい
+- 説明: FEのシステムメトリクス（CPU、メモリ、IO、ネットワークなど）を収集するかどうか。
+- 導入バージョン: v4.1.0
+
 <EditionSpecificFEItem />

--- a/docs/ja/administration/management/monitoring/metrics.md
+++ b/docs/ja/administration/management/monitoring/metrics.md
@@ -1788,3 +1788,127 @@ StarRocks クラスタのモニタリングサービスの構築方法につい�
 - 単位: ms
 - タイプ: Cumulative
 - 説明: BE ノード内のクローンタスクがコピーに消費した合計時間（INTER_NODE タイプと INTRA_NODE タイプの両方を含む）。
+
+### FE システムメトリクス
+
+これらのメトリクスは、FEが実行されている物理マシンのCPU、メモリ、IO、およびネットワークを監視します。これらのメトリクスは、FEの設定項目 `enable_collect_system_metrics` を `true` に設定した場合にのみ収集されます。この項目の設定方法については、[enable_collect_system_metrics](../FE_configuration.md#enable_collect_system_metrics) を参照してください。
+
+#### starrocks_fe_cpu
+
+- 単位: -
+- タイプ: Cumulative
+- 説明: CPU モード別の時間カウンタ。`top` に表示されるカウンタと同一（`/proc/stat` 由来）。ラベル: `mode` = `user` | `nice` | `system` | `idle` | `iowait` | `irq` | `softirq` | `steal`。
+
+#### starrocks_fe_memory
+
+- 単位: Bytes
+- タイプ: Instantaneous
+- 説明: 物理メモリおよびスワップメモリの統計（`/proc/meminfo` 由来）。ラベル: `name` = `total` | `used` | `swap_total` | `swap_used`。
+
+#### starrocks_fe_disk_total_capacity
+
+- 単位: Bytes
+- タイプ: Instantaneous
+- 説明: 監視対象の StarRocks パス（例: `Config.meta_dir`、`Config.sys_log_dir`）が配置されているディスクの総容量。ラベル: `device` = 下位ブロックデバイス名（例: `sda`、`nvme0n1`）。
+
+#### starrocks_fe_disk_used_capacity
+
+- 単位: Bytes
+- タイプ: Instantaneous
+- 説明: 監視対象の StarRocks パス（例: `Config.meta_dir`、`Config.sys_log_dir`）が配置されているディスクの使用容量。ラベル: `device` = 下位ブロックデバイス名（例: `sda`、`nvme0n1`）。
+
+#### starrocks_fe_disk_reads_completed
+
+- 単位: Count
+- タイプ: Cumulative
+- 説明: 読み取り完了回数（`/proc/diskstats` 由来）。ラベル: `device` = 下位ブロックデバイス名（例: `sda`、`nvme0n1`）。
+
+#### starrocks_fe_disk_bytes_read
+
+- 単位: Bytes
+- タイプ: Cumulative
+- 説明: 読み取られた総バイト数（`/proc/diskstats` 由来）。ラベル: `device` = 下位ブロックデバイス名（例: `sda`、`nvme0n1`）。
+
+#### starrocks_fe_disk_read_time_ms
+
+- 単位: ミリ秒
+- タイプ: Cumulative
+- 説明: 読み取りに費やされた累積時間（`/proc/diskstats` 由来）。ラベル: `device` = 下位ブロックデバイス名（例: `sda`、`nvme0n1`）。
+
+#### starrocks_fe_disk_writes_completed
+
+- 単位: Count
+- タイプ: Cumulative
+- 説明: 書き込み完了回数（`/proc/diskstats` 由来）。ラベル: `device` = 下位ブロックデバイス名（例: `sda`、`nvme0n1`）。
+
+#### starrocks_fe_disk_bytes_written
+
+- 単位: Bytes
+- タイプ: Cumulative
+- 説明: 書き込まれた総バイト数（`/proc/diskstats` 由来）。ラベル: `device` = 下位ブロックデバイス名（例: `sda`、`nvme0n1`）。
+
+#### starrocks_fe_disk_write_time_ms
+
+- 単位: ミリ秒
+- タイプ: Cumulative
+- 説明: 書き込みに費やされた累積時間（`/proc/diskstats` 由来）。ラベル: `device` = 下位ブロックデバイス名（例: `sda`、`nvme0n1`）。
+
+#### starrocks_fe_disk_io_time_ms
+
+- 単位: ミリ秒
+- タイプ: Cumulative
+- 説明: I/O に費やされた累積時間（`/proc/diskstats` 由来）。ラベル: `device` = 下位ブロックデバイス名（例: `sda`、`nvme0n1`）。
+
+#### starrocks_fe_disk_io_time_weighted_ms
+
+- 単位: ミリ秒
+- タイプ: Cumulative
+- 説明: I/O に費やされた加重累積時間（`/proc/diskstats` 由来）。ラベル: `device` = 下位ブロックデバイス名（例: `sda`、`nvme0n1`）。
+
+#### starrocks_fe_network_receive_bytes
+
+- 単位: Bytes
+- タイプ: Cumulative
+- 説明: 各ネットワークインターフェースで受信した総バイト数（OS の NIC 統計。Linux は通常 `/sys/class/net/*/statistics/`）。ラベル: `device` = ネットワークインターフェース名（例: `eth0`）。
+
+#### starrocks_fe_network_receive_packets
+
+- 単位: Count
+- タイプ: Cumulative
+- 説明: 各ネットワークインターフェースで受信したパケット総数（OS の NIC 統計。Linux は通常 `/sys/class/net/*/statistics/`）。ラベル: `device` = ネットワークインターフェース名（例: `eth0`）。
+
+#### starrocks_fe_network_receive_errors
+
+- 単位: Count
+- タイプ: Cumulative
+- 説明: 各ネットワークインターフェースの受信エラー総数（OS の NIC 統計。Linux は通常 `/sys/class/net/*/statistics/`）。ラベル: `device` = ネットワークインターフェース名（例: `eth0`）。
+
+#### starrocks_fe_network_receive_dropped
+
+- 単位: Count
+- タイプ: Cumulative
+- 説明: 各ネットワークインターフェースの受信ドロップ総数（OS の NIC 統計。Linux は通常 `/sys/class/net/*/statistics/`）。ラベル: `device` = ネットワークインターフェース名（例: `eth0`）。
+
+#### starrocks_fe_network_send_bytes
+
+- 単位: Bytes
+- タイプ: Cumulative
+- 説明: 各ネットワークインターフェースで送信した総バイト数（OS の NIC 統計。Linux は通常 `/sys/class/net/*/statistics/`）。ラベル: `device` = ネットワークインターフェース名（例: `eth0`）。
+
+#### starrocks_fe_network_send_packets
+
+- 単位: Count
+- タイプ: Cumulative
+- 説明: 各ネットワークインターフェースで送信したパケット総数（OS の NIC 統計。Linux は通常 `/sys/class/net/*/statistics/`）。ラベル: `device` = ネットワークインターフェース名（例: `eth0`）。
+
+#### starrocks_fe_network_send_errors
+
+- 単位: Count
+- タイプ: Cumulative
+- 説明: 各ネットワークインターフェースの送信エラー総数（OS の NIC 統計。Linux は通常 `/sys/class/net/*/statistics/`）。ラベル: `device` = ネットワークインターフェース名（例: `eth0`）。
+
+#### starrocks_fe_snmp
+
+- 単位: Count
+- タイプ: Mixed
+- 説明: IPv4/IPv6 を集約した TCP スタック統計（`/proc/net/snmp` 由来）。ラベル: `name` = `active_opens`、`passive_opens`、`attempts_fails`、`estab_resets`、`curr_estab`（瞬時値）、`tcp_in_segs`、`tcp_out_segs`、`tcp_retrans_segs`、`tcp_in_errs`、`tcp_out_rsts`（累積値）。

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -5541,4 +5541,13 @@ Compaction Score 代表了一个表分区是否值得进行 Compaction 的评分
 - 描述：在物化视图创建和 CTAS 操作中，是否优先对固定长度的 VARCHAR 列使用 STRING 类型。
 - 引入版本：v4.0.0
 
+##### enable_collect_system_metrics
+
+- 默认值：false
+- 类型：Boolean
+- 单位：-
+- 是否可动态修改：是
+- 描述：是否采集 FE 的系统指标，例如 CPU、内存、IO、网络等。
+- 引入版本：v4.1.0
+
 <EditionSpecificFEItem />

--- a/docs/zh/administration/management/monitoring/metrics.md
+++ b/docs/zh/administration/management/monitoring/metrics.md
@@ -1788,3 +1788,127 @@ displayed_sidebar: docs
 - 单位：毫秒
 - 类型：累积值
 - 描述：BE 中 Clone 任务拷贝的总耗时，包括 INTER_NODE 和 INTRA_NODE 两种类型。
+
+### FE 系统指标
+
+该部分监控指标用于监控 FE 节点所在物理机的 CPU、内存、IO 和网络。只有当 FE 参数 `enable_collect_system_metrics` 设置为 `true` 时，StarRocks 才会采集该部分指标。关于如何配置该参数，参见 [enable_collect_system_metrics](../FE_configuration.md#enable_collect_system_metrics)。
+
+#### starrocks_fe_cpu
+
+- 单位：-
+- 类型：累积值
+- 描述：按 CPU 模式统计的时间计数，来源与 `top` 显示一致（来自 `/proc/stat`）。标签：`mode` = `user` | `nice` | `system` | `idle` | `iowait` | `irq` | `softirq` | `steal`。
+
+#### starrocks_fe_memory
+
+- 单位：Byte
+- 类型：瞬时值
+- 描述：物理内存与交换区（swap）统计，来自 `/proc/meminfo`。标签：`name` = `total` | `used` | `swap_total` | `swap_used`。
+
+#### starrocks_fe_disk_total_capacity
+
+- 单位：Byte
+- 类型：瞬时值
+- 描述：与 StarRocks 相关目录（如 `Config.meta_dir`、`Config.sys_log_dir`）所在磁盘的总容量。标签：`device` = 底层块设备名（例如 `sda`、`nvme0n1`）。
+
+#### starrocks_fe_disk_used_capacity
+
+- 单位：Byte
+- 类型：瞬时值
+- 描述：与 StarRocks 相关目录（如 `Config.meta_dir`、`Config.sys_log_dir`）所在磁盘的已用容量。标签：`device` = 底层块设备名（例如 `sda`、`nvme0n1`）。
+
+#### starrocks_fe_disk_reads_completed
+
+- 单位：个
+- 类型：累积值
+- 描述：已完成的读操作次数，来源 `/proc/diskstats`。标签：`device` = 底层块设备名（例如 `sda`、`nvme0n1`）。
+
+#### starrocks_fe_disk_bytes_read
+
+- 单位：Byte
+- 类型：累积值
+- 描述：读取的总字节数，来源 `/proc/diskstats`。标签：`device` = 底层块设备名（例如 `sda`、`nvme0n1`）。
+
+#### starrocks_fe_disk_read_time_ms
+
+- 单位：毫秒
+- 类型：累积值
+- 描述：读取耗费的累计时间，来源 `/proc/diskstats`。标签：`device` = 底层块设备名（例如 `sda`、`nvme0n1`）。
+
+#### starrocks_fe_disk_writes_completed
+
+- 单位：个
+- 类型：累积值
+- 描述：已完成的写操作次数，来源 `/proc/diskstats`。标签：`device` = 底层块设备名（例如 `sda`、`nvme0n1`）。
+
+#### starrocks_fe_disk_bytes_written
+
+- 单位：Byte
+- 类型：累积值
+- 描述：写入的总字节数，来源 `/proc/diskstats`。标签：`device` = 底层块设备名（例如 `sda`、`nvme0n1`）。
+
+#### starrocks_fe_disk_write_time_ms
+
+- 单位：毫秒
+- 类型：累积值
+- 描述：写入耗费的累计时间，来源 `/proc/diskstats`。标签：`device` = 底层块设备名（例如 `sda`、`nvme0n1`）。
+
+#### starrocks_fe_disk_io_time_ms
+
+- 单位：毫秒
+- 类型：累积值
+- 描述：I/O 操作耗费的累计时间，来源 `/proc/diskstats`。标签：`device` = 底层块设备名（例如 `sda`、`nvme0n1`）。
+
+#### starrocks_fe_disk_io_time_weighted_ms
+
+- 单位：毫秒
+- 类型：累积值
+- 描述：I/O 操作耗费的加权累计时间，来源 `/proc/diskstats`。标签：`device` = 底层块设备名（例如 `sda`、`nvme0n1`）。
+
+#### starrocks_fe_network_receive_bytes
+
+- 单位：Byte
+- 类型：累积值
+- 描述：每个网络接口接收的总字节数，来源操作系统网卡统计（Linux 通常位于 `/sys/class/net/*/statistics/`）。标签：`device` = 网络接口名（例如 `eth0`）。
+
+#### starrocks_fe_network_receive_packets
+
+- 单位：个
+- 类型：累积值
+- 描述：每个网络接口接收的数据包总数，来源操作系统网卡统计（Linux 通常位于 `/sys/class/net/*/statistics/`）。标签：`device` = 网络接口名（例如 `eth0`）。
+
+#### starrocks_fe_network_receive_errors
+
+- 单位：个
+- 类型：累积值
+- 描述：每个网络接口接收错误的总次数，来源操作系统网卡统计（Linux 通常位于 `/sys/class/net/*/statistics/`）。标签：`device` = 网络接口名（例如 `eth0`）。
+
+#### starrocks_fe_network_receive_dropped
+
+- 单位：个
+- 类型：累积值
+- 描述：每个网络接口接收丢包的总次数，来源操作系统网卡统计（Linux 通常位于 `/sys/class/net/*/statistics/`）。标签：`device` = 网络接口名（例如 `eth0`）。
+
+#### starrocks_fe_network_send_bytes
+
+- 单位：Byte
+- 类型：累积值
+- 描述：每个网络接口发送的总字节数，来源操作系统网卡统计（Linux 通常位于 `/sys/class/net/*/statistics/`）。标签：`device` = 网络接口名（例如 `eth0`）。
+
+#### starrocks_fe_network_send_packets
+
+- 单位：个
+- 类型：累积值
+- 描述：每个网络接口发送的数据包总数，来源操作系统网卡统计（Linux 通常位于 `/sys/class/net/*/statistics/`）。标签：`device` = 网络接口名（例如 `eth0`）。
+
+#### starrocks_fe_network_send_errors
+
+- 单位：个
+- 类型：累积值
+- 描述：每个网络接口发送错误的总次数，来源操作系统网卡统计（Linux 通常位于 `/sys/class/net/*/statistics/`）。标签：`device` = 网络接口名（例如 `eth0`）。
+
+#### starrocks_fe_snmp
+
+- 单位：个
+- 类型：混合值
+- 描述：聚合 IPv4/IPv6 的 TCP 协议栈统计，来源 `/proc/net/snmp`。标签：`name` = `active_opens`、`passive_opens`、`attempts_fails`、`estab_resets`、`curr_estab`（瞬时值）、`tcp_in_segs`、`tcp_out_segs`、`tcp_retrans_segs`、`tcp_in_errs`、`tcp_out_rsts`（累积值）。

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3969,4 +3969,7 @@ public class Config extends ConfigBase {
     public static int compound_predicate_flatten_threshold = 512;
 
     @ConfField public static int ui_queries_sql_statement_max_length = 128;
+
+    @ConfField(mutable = true, comment = "Whether to collect system metrics, such as CPU, Memory, IO, Network")
+    public static boolean enable_collect_system_metrics = false;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
@@ -170,5 +170,6 @@ public class MetricCalculator extends TimerTask {
         RoutineLoadLagTimeMetricMgr.getInstance().cleanupStaleMetrics();
 
         MetricRepo.GAUGE_SAFE_MODE.setValue(GlobalStateMgr.getCurrentState().isSafeMode() ? 1 : 0);
+        MetricRepo.SYSTEM_METRICS.update();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
@@ -170,6 +170,8 @@ public class MetricCalculator extends TimerTask {
         RoutineLoadLagTimeMetricMgr.getInstance().cleanupStaleMetrics();
 
         MetricRepo.GAUGE_SAFE_MODE.setValue(GlobalStateMgr.getCurrentState().isSafeMode() ? 1 : 0);
-        MetricRepo.SYSTEM_METRICS.update();
+        if (Config.enable_collect_system_metrics) {
+            MetricRepo.SYSTEM_METRICS.update();
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/SystemMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/SystemMetrics.java
@@ -12,111 +12,884 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/metric/SystemMetrics.java
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
 package com.starrocks.metric;
 
-import com.google.common.collect.Maps;
-import com.starrocks.common.FeConstants;
+import com.starrocks.common.Config;
+import com.starrocks.common.Pair;
+import com.starrocks.service.FrontendOptions;
+import org.apache.arrow.util.VisibleForTesting;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import oshi.SystemInfo;
+import oshi.hardware.CentralProcessor;
+import oshi.hardware.GlobalMemory;
+import oshi.hardware.HardwareAbstractionLayer;
+import oshi.hardware.NetworkIF;
+import oshi.hardware.VirtualMemory;
+import oshi.software.os.InternetProtocolStats;
+import oshi.software.os.OSFileStore;
+import oshi.software.os.OperatingSystem;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
+import java.nio.file.FileStore;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
 
 /**
- * Save system metrics such as CPU, MEM, IO, Networks.
- * TODO: Add them gradually
+ * Reports system-level metrics, including CPU, memory, I/O, and network statistics.
+ *
+ * <p><b>Usage Scenario:</b>
+ * This class is used within the StarRocks monitoring framework to provide a snapshot of the host's system health.
+ * The collected metrics can be exposed through a metrics endpoint for observation and alerting.
+ *
+ * <p><b>Implementation Mechanism:</b>
+ * It acts as a facade, aggregating different metric collectors (for CPU, memory, I/O, and network) into a single component.
+ * It initializes and updates these collectors, which in turn use the {@code oshi} library to gather raw system information.
  */
 public class SystemMetrics {
     private static final Logger LOG = LogManager.getLogger(SystemMetrics.class);
 
-    // NOTICE: The following 2 tcp metrics is got from /proc/net/snmp
-    // So they can only be got on Linux system.
-    // All TCP packets retransmitted
-    protected long tcpRetransSegs = 0;
-    // The number of all problematic TCP packets received
-    protected long tcpInErrs = 0;
-    // All received TCP packets
-    protected long tcpInSegs = 0;
-    // All send TCP packets with RST mark
-    protected long tcpOutSegs = 0;
+    private final SystemInfo systemInfo;
+    private final StarRocksMetricRegistry registry;
+    private final CpuMetrics cpuMetrics;
+    private final MemoryMetrics memoryMetrics;
+    private final IOMetrics ioMetrics;
+    private final NetworkMetrics networkMetrics;
 
-    public synchronized void update() {
-        updateSnmpMetrics();
+    /**
+     * Constructs a new {@code SystemMetrics} instance.
+     * This constructor initializes all underlying metric category collectors.
+     */
+    public SystemMetrics() {
+        this.systemInfo = new SystemInfo();
+        this.registry = new StarRocksMetricRegistry();
+        this.cpuMetrics = new CpuMetrics(systemInfo.getHardware().getProcessor());
+        this.memoryMetrics = new MemoryMetrics(systemInfo.getHardware().getMemory());
+        this.ioMetrics = new IOMetrics(systemInfo.getOperatingSystem());
+        this.networkMetrics = new NetworkMetrics(systemInfo.getHardware(), systemInfo.getOperatingSystem());
     }
 
-    private void updateSnmpMetrics() {
-        String procFile = "/proc/net/snmp";
-        if (FeConstants.runningUnitTest) {
-            procFile = getClass().getClassLoader().getResource("data/net_snmp_normal").getFile();
+    public void init() {
+        cpuMetrics.init(registry);
+        memoryMetrics.init(registry);
+        ioMetrics.init(registry);
+        networkMetrics.init(registry);
+    }
+
+    /**
+     * Atomically updates all system metrics by fetching the latest values from the system.
+     */
+    public synchronized void update() {
+        cpuMetrics.update();
+        memoryMetrics.update();
+        ioMetrics.update();
+        networkMetrics.update();
+    }
+
+    public void collect(MetricVisitor visitor) {
+        for (Metric<?> metric : registry.getMetrics()) {
+            visitor.visit(metric);
         }
-        if (Files.notExists(Paths.get(procFile))) {
-            LOG.warn("{} doesn't exist", procFile);
-            return;
+    }
+
+    @VisibleForTesting
+    StarRocksMetricRegistry getRegistry() {
+        return registry;
+    }
+
+    /**
+     * Collects and reports CPU utilization metrics, broken down by various states.
+     *
+     * <p><b>Usage Scenario:</b>
+     * This class is used to monitor the CPU load on the system, providing a detailed breakdown of time spent
+     * in different modes such as user, system, idle, and I/O wait.
+     *
+     * <p><b>Implementation Mechanism:</b>
+     * It leverages {@code oshi}'s {@link CentralProcessor} to get cumulative CPU load ticks for each state
+     * and exposes them as individual gauge metrics.
+     */
+    private static class CpuMetrics {
+        /** The {@code oshi} object for accessing CPU information. */
+        final CentralProcessor centralProcessor;
+        /** Gauge metric for CPU time spent in user mode. */
+        final GaugeMetricImpl<Long> user;
+        /** Gauge metric for CPU time spent in user mode with low priority (nice). */
+        final GaugeMetricImpl<Long> nice;
+        /** Gauge metric for CPU time spent in system/kernel mode. */
+        final GaugeMetricImpl<Long> system;
+        /** Gauge metric for CPU time spent idle. */
+        final GaugeMetricImpl<Long> idle;
+        /** Gauge metric for CPU time spent waiting for I/O to complete. */
+        final GaugeMetricImpl<Long> iowait;
+        /** Gauge metric for CPU time spent servicing hardware interrupts. */
+        final GaugeMetricImpl<Long> irq;
+        /** Gauge metric for CPU time spent servicing software interrupts. */
+        final GaugeMetricImpl<Long> softirq;
+        /** Gauge metric for involuntary wait time, representing time stolen by a virtual machine hypervisor. */
+        final GaugeMetricImpl<Long> steal;
+
+        /**
+         * Constructs a {@code CpuMetrics} instance and initializes all CPU-related gauge metrics.
+         *
+         * @param centralProcessor An {@code oshi} {@link CentralProcessor} instance to query CPU stats from.
+         */
+        public CpuMetrics(CentralProcessor centralProcessor) {
+            this.centralProcessor = centralProcessor;
+            this.user = new GaugeMetricImpl<>(
+                    "cpu", Metric.MetricUnit.NOUNIT, "User CPU time");
+            this.user.addLabel(new MetricLabel("mode", "user"));
+            this.nice = new GaugeMetricImpl<>(
+                    "cpu", Metric.MetricUnit.NOUNIT, "Nice CPU time");
+            this.nice.addLabel(new MetricLabel("mode", "nice"));
+            this.system = new GaugeMetricImpl<>(
+                    "cpu", Metric.MetricUnit.NOUNIT, "System CPU time");
+            this.system.addLabel(new MetricLabel("mode", "system"));
+            this.idle = new GaugeMetricImpl<>(
+                    "cpu", Metric.MetricUnit.NOUNIT, "Idle CPU time");
+            this.idle.addLabel(new MetricLabel("mode", "idle"));
+            this.iowait = new GaugeMetricImpl<>(
+                    "cpu", Metric.MetricUnit.NOUNIT, "IOWait CPU time");
+            this.iowait.addLabel(new MetricLabel("mode", "iowait"));
+            this.irq = new GaugeMetricImpl<>(
+                    "cpu", Metric.MetricUnit.NOUNIT, "IRQ CPU time");
+            this.irq.addLabel(new MetricLabel("mode", "irq"));
+            this.softirq = new GaugeMetricImpl<>(
+                    "cpu", Metric.MetricUnit.NOUNIT, "Softirq CPU time");
+            this.softirq.addLabel(new MetricLabel("mode", "softirq"));
+            this.steal = new GaugeMetricImpl<>(
+                    "cpu", Metric.MetricUnit.NOUNIT, "Steal CPU time");
+            this.steal.addLabel(new MetricLabel("mode", "steal"));
         }
-        try (FileReader fileReader = new FileReader(procFile);
-                BufferedReader br = new BufferedReader(fileReader)) {
-            String line = null;
-            boolean found = false;
-            while ((line = br.readLine()) != null) {
-                if (line.startsWith("Tcp: ")) {
-                    found = true;
-                    break;
+
+        /**
+         * Registers all CPU metrics with the given registry.
+         *
+         * @param registry The metric registry to which the metrics will be added.
+         */
+        public void init(StarRocksMetricRegistry registry) {
+            registry.addMetric(user);
+            registry.addMetric(nice);
+            registry.addMetric(system);
+            registry.addMetric(idle);
+            registry.addMetric(iowait);
+            registry.addMetric(irq);
+            registry.addMetric(softirq);
+            registry.addMetric(steal);
+            LOG.info("init cpu metrics");
+        }
+
+        /**
+         * Fetches the latest CPU tick counters from the system and updates the corresponding gauge metrics.
+         */
+        public void update() {
+            try {
+                long[] ticks = centralProcessor.getSystemCpuLoadTicks();
+                user.setValue(getTicks(ticks, CentralProcessor.TickType.USER));
+                nice.setValue(getTicks(ticks, CentralProcessor.TickType.NICE));
+                system.setValue(getTicks(ticks, CentralProcessor.TickType.SYSTEM));
+                idle.setValue(getTicks(ticks, CentralProcessor.TickType.IDLE));
+                iowait.setValue(getTicks(ticks, CentralProcessor.TickType.IOWAIT));
+                irq.setValue(getTicks(ticks, CentralProcessor.TickType.IRQ));
+                softirq.setValue(getTicks(ticks, CentralProcessor.TickType.SOFTIRQ));
+                steal.setValue(getTicks(ticks, CentralProcessor.TickType.STEAL));
+            } catch (Exception e) {
+                LOG.warn("failed to update cpu metrics", e);
+            }
+        }
+
+        /**
+         * Safely extracts a specific tick value from the ticks array based on its type.
+         *
+         * @param ticks The array of CPU tick counters, where each index corresponds to a {@link CentralProcessor.TickType}.
+         * @param tickType The type of tick to retrieve (e.g., USER, SYSTEM).
+         * @return The corresponding tick value, or 0L if the index is out of bounds for the given array.
+         */
+        private long getTicks(long[] ticks, CentralProcessor.TickType tickType) {
+            int index = tickType.getIndex();
+            return index < ticks.length ? ticks[index] : 0L;
+        }
+    }
+
+    /**
+     * Collects and reports system memory and swap space usage.
+     *
+     * <p><b>Usage Scenario:</b>
+     * This class is used to monitor the physical and virtual memory consumption of the host system,
+     * which is crucial for capacity planning and performance tuning.
+     *
+     * <p><b>Implementation Mechanism:</b>
+     * It uses {@code oshi}'s {@link GlobalMemory} to query total, available, and swap memory statistics
+     * and reports them as gauge metrics.
+     */
+    private static class MemoryMetrics {
+        /** The {@code oshi} object for accessing global memory information. */
+        final GlobalMemory globalMemory;
+        /** Gauge metric for the total amount of physical memory in bytes. */
+        final GaugeMetricImpl<Long> total;
+        /** Gauge metric for the amount of used physical memory in bytes. */
+        final GaugeMetricImpl<Long> used;
+        /** Gauge metric for the total amount of swap space in bytes. */
+        final GaugeMetricImpl<Long> swapTotal;
+        /** Gauge metric for the amount of used swap space in bytes. */
+        final GaugeMetricImpl<Long> swapUsed;
+
+        /**
+         * Constructs a {@code MemoryMetrics} instance and initializes memory-related gauge metrics.
+         *
+         * @param globalMemory An {@code oshi} {@link GlobalMemory} instance for querying memory information.
+         */
+        public MemoryMetrics(GlobalMemory globalMemory) {
+            this.globalMemory = globalMemory;
+            this.total = new GaugeMetricImpl<>(
+                    "memory", Metric.MetricUnit.NOUNIT, "Total memory");
+            this.total.addLabel(new MetricLabel("name", "total"));
+            this.used = new GaugeMetricImpl<>(
+                    "memory", Metric.MetricUnit.NOUNIT, "Used memory");
+            this.used.addLabel(new MetricLabel("name", "used"));
+            this.swapTotal = new GaugeMetricImpl<>(
+                    "memory", Metric.MetricUnit.NOUNIT, "Total swap memory");
+            this.swapTotal.addLabel(new MetricLabel("name", "swap_total"));
+            this.swapUsed = new GaugeMetricImpl<>(
+                    "memory", Metric.MetricUnit.NOUNIT, "Used swap memory");
+            this.swapUsed.addLabel(new MetricLabel("name", "swap_used"));
+        }
+
+        /**
+         * Registers all memory-related metrics with the given registry.
+         *
+         * @param registry The metric registry to which the metrics will be added.
+         */
+        public void init(StarRocksMetricRegistry registry) {
+            registry.addMetric(total);
+            registry.addMetric(used);
+            registry.addMetric(swapTotal);
+            registry.addMetric(swapUsed);
+            LOG.info("init memory metrics");
+        }
+
+        /**
+         * Fetches the latest memory usage statistics from the system and updates the gauge metrics.
+         */
+        public void update() {
+            try {
+                long totalMem = globalMemory.getTotal();
+                long availableMem = globalMemory.getAvailable();
+                long usedMem = totalMem - availableMem;
+
+                total.setValue(totalMem);
+                used.setValue(usedMem);
+
+                VirtualMemory vm = globalMemory.getVirtualMemory();
+                if (vm != null) {
+                    long swapTotalBytes = vm.getSwapTotal();
+                    long swapUsedBytes = vm.getSwapUsed();
+
+                    swapTotal.setValue(swapTotalBytes);
+                    swapUsed.setValue(swapUsedBytes);
+                }
+            } catch (Exception e) {
+                LOG.warn("failed to update memory metrics", e);
+            }
+        }
+    }
+
+    /**
+     * Represents and manages I/O and capacity metrics for a single disk device.
+     *
+     * <p><b>Usage Scenario:</b>
+     * This class is used internally by {@link IOMetrics} to track capacity and I/O statistics for a specific
+     * monitored disk, such as the one hosting metadata or log directories.
+     *
+     * <p><b>Implementation Mechanism:</b>
+     * It holds a set of gauge metrics for a given disk, identified by its device name.
+     * Capacity is read via JDK's {@link FileStore}, while detailed I/O statistics (like read/write counts and times)
+     * are supplied externally from a source like {@code /proc/diskstats}.
+     * 
+     * @note This implementation is Linux-specific due to its reliance on the {@code /proc/diskstats} file.
+     */
+    private static class DiskMetrics {
+        /** The device name of the disk (e.g., "sda"). */
+        final String name;
+        /** The JDK's {@link FileStore} object associated with the disk's mount point. */
+        final FileStore fileStore;
+        /** Gauge for the total capacity of the disk in bytes. */
+        final GaugeMetricImpl<Long> totalCapacity;
+        /** Gauge for the used capacity of the disk in bytes. */
+        final GaugeMetricImpl<Long> usedCapacity;
+        /** Gauge for the total number of reads completed successfully. */
+        final GaugeMetricImpl<Long> readsCompleted;
+        /** Gauge for the total number of bytes read from the disk. */
+        final GaugeMetricImpl<Long> bytesRead;
+        /** Gauge for the cumulative time spent reading from the disk, in milliseconds. */
+        final GaugeMetricImpl<Long> readTimeMs;
+        /** Gauge for the total number of writes completed successfully. */
+        final GaugeMetricImpl<Long> writesCompleted;
+        /** Gauge for the cumulative time spent writing to the disk, in milliseconds. */
+        final GaugeMetricImpl<Long> writeTimeMs;
+        /** Gauge for the total number of bytes written to the disk. */
+        final GaugeMetricImpl<Long> bytesWritten;
+        /** Gauge for the cumulative time spent doing I/Os, in milliseconds. */
+        final GaugeMetricImpl<Long> ioTimeMs;
+        /** Gauge for the weighted cumulative time spent doing I/Os, in milliseconds. */
+        final GaugeMetricImpl<Long> ioTimeWeightedMs;
+        
+        /**
+         * Constructs a {@code DiskMetrics} instance for a specific disk device.
+         *
+         * @param name The device name (e.g., "sda").
+         * @param fileStore The {@link FileStore} associated with a mount point on this device, used to get capacity info.
+         */
+        public DiskMetrics(String name, FileStore fileStore) {
+            this.name = name;
+            this.fileStore = fileStore;
+            this.totalCapacity = new GaugeMetricImpl<>(
+                    "disk_total_capacity", Metric.MetricUnit.BYTES, "Total capacity of the disk");
+            this.totalCapacity.addLabel(new MetricLabel("device", name));
+            this.usedCapacity = new GaugeMetricImpl<>(
+                    "disk_used_capacity", Metric.MetricUnit.BYTES, "Used capacity of the disk");
+            this.usedCapacity.addLabel(new MetricLabel("device", name));
+            this.readsCompleted = new GaugeMetricImpl<>(
+                    "disk_reads_completed", Metric.MetricUnit.NOUNIT, "Reads completed");
+            this.readsCompleted.addLabel(new MetricLabel("device", name));
+            this.bytesRead = new GaugeMetricImpl<>(
+                    "disk_bytes_read", Metric.MetricUnit.BYTES, "Bytes read");
+            this.bytesRead.addLabel(new MetricLabel("device", name));
+            this.readTimeMs = new GaugeMetricImpl<>(
+                    "disk_read_time_ms", Metric.MetricUnit.MILLISECONDS, "Read time in milliseconds");
+            this.readTimeMs.addLabel(new MetricLabel("device", name));
+            this.writesCompleted = new GaugeMetricImpl<>(
+                    "disk_writes_completed", Metric.MetricUnit.NOUNIT, "Writes completed");
+            this.writesCompleted.addLabel(new MetricLabel("device", name));
+            this.bytesWritten = new GaugeMetricImpl<>(
+                    "disk_bytes_written", Metric.MetricUnit.BYTES, "Bytes written");
+            this.bytesWritten.addLabel(new MetricLabel("device", name));
+            this.writeTimeMs = new GaugeMetricImpl<>(
+                    "disk_write_time_ms", Metric.MetricUnit.MILLISECONDS, "Write time in milliseconds");
+            this.writeTimeMs.addLabel(new MetricLabel("device", name));
+            this.ioTimeMs = new GaugeMetricImpl<>(
+                    "disk_io_time_ms", Metric.MetricUnit.MILLISECONDS, "IO time in milliseconds");
+            this.ioTimeMs.addLabel(new MetricLabel("device", name));
+            this.ioTimeWeightedMs = new GaugeMetricImpl<>(
+                    "disk_io_time_weighted_ms", Metric.MetricUnit.MILLISECONDS, "Weighted IO time in milliseconds");
+            this.ioTimeWeightedMs.addLabel(new MetricLabel("device", name));
+        }
+
+        /**
+         * Registers all metrics for this disk with the specified registry.
+         *
+         * @param registry The metric registry to which the metrics will be added.
+         */
+        public void init(StarRocksMetricRegistry registry) {
+            registry.addMetric(totalCapacity);
+            registry.addMetric(usedCapacity);
+            registry.addMetric(readsCompleted);
+            registry.addMetric(bytesRead);
+            registry.addMetric(readTimeMs);
+            registry.addMetric(writesCompleted);
+            registry.addMetric(bytesWritten);
+            registry.addMetric(writeTimeMs);
+            registry.addMetric(ioTimeMs);
+            registry.addMetric(ioTimeWeightedMs);
+            LOG.info("init disk metrics for {}", name);
+        }
+
+        /**
+         * Updates all disk I/O and capacity metrics with the latest values.
+         *
+         * @param readsCompleted The total number of reads completed.
+         * @param bytesRead The total number of bytes read.
+         * @param readTimeMs The cumulative time spent reading, in milliseconds.
+         * @param writesCompleted The total number of writes completed.
+         * @param bytesWritten The total number of bytes written.
+         * @param writeTimeMs The cumulative time spent writing, in milliseconds.
+         * @param ioTimeMs The cumulative time spent doing I/Os, in milliseconds.
+         * @param ioTimeWeightedMs The weighted cumulative time spent doing I/Os, in milliseconds.
+         */
+        public void updateStat(long readsCompleted, long bytesRead, long readTimeMs, long writesCompleted,
+                long bytesWritten, long writeTimeMs, long ioTimeMs, long ioTimeWeightedMs) {
+            try {
+                long total = fileStore.getTotalSpace();
+                long used = total - fileStore.getUnallocatedSpace();
+                totalCapacity.setValue(total);
+                usedCapacity.setValue(used);
+            } catch (Exception e) {
+                LOG.warn("failed to update capacity for disk: {}", name, e);
+            }
+            this.readsCompleted.setValue(readsCompleted);
+            this.bytesRead.setValue(bytesRead);
+            this.readTimeMs.setValue(readTimeMs);
+            this.writesCompleted.setValue(writesCompleted);
+            this.bytesWritten.setValue(bytesWritten);
+            this.writeTimeMs.setValue(writeTimeMs);
+            this.ioTimeMs.setValue(ioTimeMs);
+            this.ioTimeWeightedMs.setValue(ioTimeWeightedMs);
+        }
+    }
+
+    /**
+     * Collects and reports disk I/O and capacity metrics for file systems relevant to StarRocks.
+     *
+     * <p><b>Usage Scenario:</b>
+     * This class is used to monitor the disk I/O activity and storage usage for directories critical to StarRocks operations,
+     * such as the metadata directory ({@code Config.meta_dir}) and the system log directory ({@code Config.sys_log_dir}).
+     *
+     * <p><b>Implementation Mechanism:</b>
+     * It automatically identifies the underlying disk devices for the configured paths. It then parses {@code /proc/diskstats}
+     * to obtain detailed, low-level I/O statistics for these specific devices. Disk capacity is determined using JDK's 
+     * {@link FileStore}.
+     *
+     * @note This implementation is Linux-specific due to its reliance on the {@code /proc/diskstats} file.
+     */
+    private static class IOMetrics {
+
+        // Paths to monitor
+        private static final List<String> MONITOR_PATHS = Arrays.asList(Config.meta_dir, Config.sys_log_dir);
+        
+        private final OperatingSystem operatingSystem;
+        // disk name -> disk metrics
+        private final Map<String, DiskMetrics> metricsForEachDisk;
+
+        /**
+         * Constructs an {@code IOMetrics} instance.
+         *
+         * @param operatingSystem An {@code oshi} {@link OperatingSystem} instance, used for filesystem interactions.
+         */
+        public IOMetrics(OperatingSystem operatingSystem) {
+            this.operatingSystem = operatingSystem;
+            this.metricsForEachDisk = new HashMap<>();
+        }
+
+        /**
+         * Discovers the disks associated with monitored paths and initializes metrics for them.
+         *
+         * <p><b>Implementation Details:</b>
+         * This method first calls {@code getDiskNameAndMounts} to find the physical devices corresponding to the
+         * paths defined in {@code MONITOR_PATHS} (e.g., {@code Config.meta_dir}, {@code Config.sys_log_dir}).
+         * It then creates and initializes a {@link DiskMetrics} object for each unique device discovered.
+         *
+         * @param registry The metric registry to which the disk metrics will be added.
+         */
+        public void init(StarRocksMetricRegistry registry) {
+            try {
+                List<Pair<String, String>> diskNameAndMounts = getDiskNameAndMounts(MONITOR_PATHS);
+                for (Pair<String, String> pair : diskNameAndMounts) {
+                    String name = pair.first;
+                    String mount = pair.second;
+                    FileStore fileStore = Files.getFileStore(Paths.get(mount));
+                    DiskMetrics metrics = new DiskMetrics(name, fileStore);
+                    metricsForEachDisk.put(name, metrics);
+                    metrics.init(registry);
+                }
+                LOG.info("init io metrics");
+            } catch (Exception e) {
+                LOG.warn("failed to init disk metrics", e);
+            }
+        }
+
+        /**
+         * Updates disk I/O metrics by reading and parsing the {@code /proc/diskstats} file.
+         *
+         * <p><b>Implementation Details:</b>
+         * This method reads {@code /proc/diskstats} line by line. Each line contains performance statistics for a
+         * specific block device. If the device name matches one of the monitored disks, the line is parsed, and the
+         * corresponding {@link DiskMetrics} object is updated with the new values.
+         */
+        public void update() {
+            String procFile = "/proc/diskstats";
+            if (Files.notExists(Paths.get(procFile))) {
+                LOG.debug("can't find {}", procFile);
+                return;
+            }
+            try (FileReader fileReader = new FileReader(procFile);
+                    BufferedReader bufferedReader = new BufferedReader(fileReader)) {
+                String line;
+                while ((line = bufferedReader.readLine()) != null) {
+                    line = line.trim();
+                    if (line.isEmpty()) {
+                        continue;
+                    }
+                    // Format (first 14 fields):
+                    // 0:major 1:minor 2:name 3:reads_completed 4:reads_merged 5:sectors_read 6:time_reading_ms
+                    // 7:writes_completed 8:writes_merged 9:sectors_written 10:time_writing_ms
+                    // 11:ios_in_progress 12:io_time_ms 13:io_time_weighted_ms
+                    String[] parts = line.split("\\s+");
+                    if (parts.length < 14) {
+                        continue;
+                    }
+
+                    String device = parts[2];
+                    DiskMetrics metrics = metricsForEachDisk.get(device);
+                    if (metrics == null) {
+                        continue;
+                    }
+
+                    try {
+                        long readsCompleted = Long.parseLong(parts[3]);
+                        long sectorsRead = Long.parseLong(parts[5]);
+                        long readTimeMs = Long.parseLong(parts[6]);
+                        long writesCompleted = Long.parseLong(parts[7]);
+                        long sectorsWritten = Long.parseLong(parts[9]);
+                        long writeTimeMs = Long.parseLong(parts[10]);
+                        long ioTimeMs = Long.parseLong(parts[12]);
+                        long ioTimeWeightedMs = Long.parseLong(parts[13]);
+
+                        // A sector is traditionally 512 bytes.
+                        long bytesRead = sectorsRead << 9; // sectors * 512
+                        long bytesWritten = sectorsWritten << 9; // sectors * 512
+
+                        metrics.updateStat(readsCompleted, bytesRead, readTimeMs,
+                                writesCompleted, bytesWritten, writeTimeMs,
+                                ioTimeMs, ioTimeWeightedMs);
+                    } catch (Exception ie) {
+                        // skip malformed line
+                        LOG.warn("failed to parse /proc/diskstats line for device {}: {}", device, line, ie);
+                    }
+                }
+            } catch (Exception e) {
+                LOG.warn("failed to read disk stat", e);
+            }
+        }
+
+        /**
+         * Identifies the unique disk devices and their corresponding mount points for a list of file paths.
+         *
+         * <p><b>Implementation Details:</b>
+         * For each given path, this method finds the most specific oshi {@link OSFileStore} by searching for the one
+         * with the longest matching mount point prefix against the path. This approach correctly handles nested mounts
+         * and symbolic links. After identifying the file store, it extracts the base device name (e.g., "sda")
+         * from the volume path.
+         *
+         * @param monitorPaths A list of absolute or relative file paths to check.
+         * @return A list of pairs, where each pair contains a disk device name and its associated mount point.
+         */
+        private List<Pair<String, String>> getDiskNameAndMounts(List<String> monitorPaths) {
+            List<OSFileStore> allFileStores = operatingSystem.getFileSystem().getFileStores();
+            Set<OSFileStore> monitorFileStores = Collections.newSetFromMap(new IdentityHashMap<>());
+            for (String path : monitorPaths) {
+                try {
+                    String realPath = Paths.get(path).toAbsolutePath().normalize().toString();
+                    OSFileStore matchedFileStore = null;
+                    for (OSFileStore fileStore : allFileStores) {
+                        String mount = fileStore.getMount();
+                        if (realPath.startsWith(mount) &&
+                                (matchedFileStore == null
+                                        || mount.length() > matchedFileStore.getMount().length())) {
+                            matchedFileStore = fileStore;
+                        }
+                    }
+                    if (matchedFileStore != null) {
+                        monitorFileStores.add(matchedFileStore);
+                        LOG.info("monitor IO for path: {}, disk: {}, mount: {}",
+                                path, matchedFileStore.getVolume(), matchedFileStore.getMount());
+                    }
+                } catch (Exception e) {
+                    LOG.warn("failed to get disk information for path: {}", path, e);
                 }
             }
-            if (!found) {
-                throw new Exception("can not find tcp metrics");
+
+            List<Pair<String, String>> diskNameAndMounts = new ArrayList<>();
+            for (OSFileStore fileStore : monitorFileStores) {
+                String name = Paths.get(fileStore.getVolume()).getFileName().toString();
+                String mount = fileStore.getMount();
+                diskNameAndMounts.add(Pair.create(name, mount));
             }
-
-            // parse the header of TCP
-            String[] headers = line.split(" ");
-            Map<String, Integer> headerMap = Maps.newHashMap();
-            int pos = 0;
-            for (int i = 0; i < headers.length; i++) {
-                headerMap.put(headers[i], pos++);
-            }
-
-            // read the metrics of TCP
-            if ((line = br.readLine()) == null) {
-                throw new Exception("failed to read metrics of TCP");
-            }
-
-            // eg: Tcp: 1 200 120000 -1 38920626 10487279 105581903 300009 305 18079291213 15411998945 11808180 22905 4174570 0
-            String[] parts = line.split(" ");
-            if (parts.length != headerMap.size()) {
-                throw new Exception("invalid tcp metrics: " + line + ". header size: " + headerMap.size());
-            }
-
-            tcpRetransSegs = Long.valueOf(parts[headerMap.get("RetransSegs")]);
-            tcpInErrs = Long.valueOf(parts[headerMap.get("InErrs")]);
-            tcpInSegs = Long.valueOf(parts[headerMap.get("InSegs")]);
-            tcpOutSegs = Long.valueOf(parts[headerMap.get("OutSegs")]);
-
-        } catch (Exception e) {
-            LOG.warn("failed to get /proc/net/snmp", e);
+            return diskNameAndMounts;
         }
     }
 
+    /**
+     * Collects and reports TCP connection statistics derived from the system's protocol stats.
+     *
+     * <p><b>Usage Scenario:</b>
+     * This class provides insights into the state and performance of the TCP network stack, such as connection rates,
+     * failures, resets, and segment traffic. It is useful for diagnosing network-related issues.
+     *
+     * <p><b>Implementation Mechanism:</b>
+     * It uses {@code oshi}'s {@link InternetProtocolStats} to retrieve TCP statistics for both IPv4 and IPv6
+     * (if enabled). The values from both protocol versions are aggregated and exposed as a set of gauge metrics.
+     */
+    private static class TcpMetrics {
+        /** The {@code oshi} object for accessing operating system-level information. */
+        final OperatingSystem operatingSystem;
+        /** The number of times TCP connections have made a direct transition from the CLOSED state to the SYN-SENT state. */
+        final GaugeMetricImpl<Long> activeOpens;
+        /** The number of times TCP connections have made a direct transition from the LISTEN state to the SYN-RCVD state. */
+        final GaugeMetricImpl<Long> passiveOpens;
+        /** The number of failed connection attempts. */
+        final GaugeMetricImpl<Long> attemptsFails;
+        /** The number of established connections that were reset. */
+        final GaugeMetricImpl<Long> estabResets;
+        /** The number of TCP connections currently in the ESTABLISHED or CLOSE-WAIT state. */
+        final GaugeMetricImpl<Long> currEstab;
+        /** The total number of TCP segments received. */
+        final GaugeMetricImpl<Long> tcpInSegs;
+        /** The total number of TCP segments sent. */
+        final GaugeMetricImpl<Long> tcpOutSegs;
+        /** The total number of TCP segments retransmitted. */
+        final GaugeMetricImpl<Long> tcpRetransSegs;
+        /** The number of TCP segments received in error (e.g., bad checksums). */
+        final GaugeMetricImpl<Long> tcpInErrs;
+        /** The number of TCP segments sent containing the RST flag. */
+        final GaugeMetricImpl<Long> tcpOutRsts;
+    
+        /**
+         * Constructs a {@code TcpMetrics} instance.
+         *
+         * @param operatingSystem An {@code oshi} {@link OperatingSystem} instance for querying protocol stats.
+         */
+        public TcpMetrics(OperatingSystem operatingSystem) {
+            this.operatingSystem = operatingSystem;
+            this.activeOpens = new GaugeMetricImpl<>(
+                    "snmp", Metric.MetricUnit.NOUNIT, "The number of active opens");
+            this.activeOpens.addLabel(new MetricLabel("name", "active_opens"));
+            this.passiveOpens = new GaugeMetricImpl<>(
+                    "snmp", Metric.MetricUnit.NOUNIT, "The number of passive opens");
+            this.passiveOpens.addLabel(new MetricLabel("name", "passive_opens"));
+            this.attemptsFails = new GaugeMetricImpl<>(
+                    "snmp", Metric.MetricUnit.NOUNIT, "The number of attempts fails");
+            this.attemptsFails.addLabel(new MetricLabel("name", "attempts_fails"));
+            this.estabResets = new GaugeMetricImpl<>(
+                    "snmp", Metric.MetricUnit.NOUNIT, "The number of estab resets");
+            this.estabResets.addLabel(new MetricLabel("name", "estab_resets"));
+            this.currEstab = new GaugeMetricImpl<>(
+                    "snmp", Metric.MetricUnit.NOUNIT, "The number of current establishes");
+            this.currEstab.addLabel(new MetricLabel("name", "curr_estab"));
+            this.tcpInSegs = new GaugeMetricImpl<>(
+                    "snmp", Metric.MetricUnit.NOUNIT, "The number of all TCP packets received");
+            this.tcpInSegs.addLabel(new MetricLabel("name", "tcp_in_segs"));
+            this.tcpOutSegs = new GaugeMetricImpl<>(
+                    "snmp", Metric.MetricUnit.NOUNIT, "The number of all TCP packets send with RST");
+            this.tcpOutSegs.addLabel(new MetricLabel("name", "tcp_out_segs"));
+            this.tcpRetransSegs = new GaugeMetricImpl<>(
+                    "snmp", Metric.MetricUnit.NOUNIT, "All TCP packets retransmitted");
+            this.tcpRetransSegs.addLabel(new MetricLabel("name", "tcp_retrans_segs"));
+            this.tcpInErrs = new GaugeMetricImpl<>(
+                    "snmp", Metric.MetricUnit.NOUNIT, "The number of all problematic TCP packets received");
+            this.tcpInErrs.addLabel(new MetricLabel("name", "tcp_in_errs"));
+            this.tcpOutRsts = new GaugeMetricImpl<>(
+                    "snmp", Metric.MetricUnit.NOUNIT, "The number of all TCP packets send with RST");
+            this.tcpOutRsts.addLabel(new MetricLabel("name", "tcp_out_rsts"));
+        }
+
+        /**
+         * Registers all TCP-related metrics with the specified registry.
+         *
+         * @param registry The metric registry to which the metrics will be added.
+         */
+        public void init(StarRocksMetricRegistry registry) {
+            registry.addMetric(activeOpens);
+            registry.addMetric(passiveOpens);
+            registry.addMetric(attemptsFails);
+            registry.addMetric(estabResets);
+            registry.addMetric(currEstab);
+            registry.addMetric(tcpInSegs);
+            registry.addMetric(tcpOutSegs);
+            registry.addMetric(tcpRetransSegs);
+            registry.addMetric(tcpInErrs);
+            registry.addMetric(tcpOutRsts);
+            LOG.info("init tcp metrics");
+        }
+
+        /**
+         * Fetches the latest TCP statistics from the system and updates the gauge metrics.
+         */
+        public void update() {
+            try {
+                InternetProtocolStats ipStats = operatingSystem.getInternetProtocolStats();
+                InternetProtocolStats.TcpStats tcpStatsV4 = ipStats.getTCPv4Stats();
+                InternetProtocolStats.TcpStats tcpStatsV6 = FrontendOptions.isBindIPV6() ? ipStats.getTCPv6Stats() : null;
+
+                updateStat(activeOpens, InternetProtocolStats.TcpStats::getConnectionsActive, tcpStatsV4, tcpStatsV6);
+                updateStat(passiveOpens, InternetProtocolStats.TcpStats::getConnectionsPassive, tcpStatsV4, tcpStatsV6);
+                updateStat(attemptsFails, InternetProtocolStats.TcpStats::getConnectionFailures, tcpStatsV4, tcpStatsV6);
+                updateStat(estabResets, InternetProtocolStats.TcpStats::getConnectionsReset, tcpStatsV4, tcpStatsV6);
+                updateStat(currEstab, InternetProtocolStats.TcpStats::getConnectionsEstablished, tcpStatsV4, tcpStatsV6);
+                updateStat(tcpInSegs, InternetProtocolStats.TcpStats::getSegmentsReceived, tcpStatsV4, tcpStatsV6);
+                updateStat(tcpOutSegs, InternetProtocolStats.TcpStats::getSegmentsSent, tcpStatsV4, tcpStatsV6);
+                updateStat(tcpRetransSegs, InternetProtocolStats.TcpStats::getSegmentsRetransmitted, tcpStatsV4, tcpStatsV6);
+                updateStat(tcpInErrs, InternetProtocolStats.TcpStats::getInErrors, tcpStatsV4, tcpStatsV6);
+                updateStat(tcpOutRsts, InternetProtocolStats.TcpStats::getOutResets, tcpStatsV4, tcpStatsV6);
+            } catch (Exception e) {
+                LOG.warn("failed to update tcp metrics", e);
+            }
+        }
+
+        /**
+         * Helper method to update a gauge metric by summing a specific statistic from both IPv4 and IPv6 TCP stats.
+         *
+         * @param metric The gauge metric to update.
+         * @param statSupplier A function that extracts a specific long value from a 
+         *      {@code oshi}'s {@link InternetProtocolStats.TcpStats} object.
+         * @param tcpStatsV4 The TCP statistics for IPv4. Can be null.
+         * @param tcpStatsV6 The TCP statistics for IPv6. Can be null.
+         */
+        private void updateStat(GaugeMetricImpl<Long> metric, Function<InternetProtocolStats.TcpStats, Long> statSupplier,
+                               InternetProtocolStats.TcpStats tcpStatsV4, InternetProtocolStats.TcpStats tcpStatsV6) {
+            long value = (tcpStatsV4 != null ? statSupplier.apply(tcpStatsV4) : 0L);
+            value += (tcpStatsV6 != null ? statSupplier.apply(tcpStatsV6) : 0L);
+            metric.setValue(value);
+        }
+    }
+
+    /**
+     * Collects and reports I/O metrics for a single network interface.
+     *
+     * <p><b>Usage Scenario:</b>
+     * This class is used internally by {@link NetworkMetrics} to track the traffic and error rates for each
+     * active network interface on the system.
+     *
+     * <p><b>Implementation Mechanism:</b>
+     * It holds a set of gauge metrics for a given network interface (e.g., "eth0"). The {@link #update()} method
+     * calls {@link NetworkIF#updateAttributes()} to refresh the underlying statistics before updating the metrics.
+     */
+    private static class NetIfMetrics {
+        /** The {@code oshi} object representing the network interface. */
+        final NetworkIF netIf;
+        /** Gauge for the total number of bytes received on the interface. */
+        final GaugeMetricImpl<Long> receiveBytes;
+        /** Gauge for the total number of packets received on the interface. */
+        final GaugeMetricImpl<Long> receivePackets;
+        /** Gauge for the number of receive errors on the interface. */
+        final GaugeMetricImpl<Long> receiveErrors;
+        /** Gauge for the number of incoming packets that were dropped. */
+        final GaugeMetricImpl<Long> receiveDropped;
+        /** Gauge for the total number of bytes sent from the interface. */
+        final GaugeMetricImpl<Long> sendBytes;
+        /** Gauge for the total number of packets sent from the interface. */
+        final GaugeMetricImpl<Long> sendPackets;
+        /** Gauge for the number of send errors on the interface. */
+        final GaugeMetricImpl<Long> sendErrors;
+
+        /**
+         * Constructs a {@code NetIfMetrics} instance for a specific network interface.
+         *
+         * @param netIf The {@code oshi} {@link NetworkIF} object to monitor.
+         */
+        public NetIfMetrics(NetworkIF netIf) {
+            this.netIf = netIf;
+            this.receiveBytes = new GaugeMetricImpl<>(
+                    "network_receive_bytes", Metric.MetricUnit.BYTES, "Bytes received");
+            this.receiveBytes.addLabel(new MetricLabel("device", netIf.getName()));
+            this.receivePackets = new GaugeMetricImpl<>(
+                    "network_receive_packets", Metric.MetricUnit.NOUNIT, "Packets received");
+            this.receivePackets.addLabel(new MetricLabel("device", netIf.getName()));
+            this.receiveErrors = new GaugeMetricImpl<>(
+                    "network_receive_errors", Metric.MetricUnit.NOUNIT, "Receive errors");
+            this.receiveErrors.addLabel(new MetricLabel("device", netIf.getName()));
+            this.receiveDropped = new GaugeMetricImpl<>(
+                    "network_receive_dropped", Metric.MetricUnit.NOUNIT, "Receive dropped");
+            this.receiveDropped.addLabel(new MetricLabel("device", netIf.getName()));
+            this.sendBytes = new GaugeMetricImpl<>(
+                    "network_send_bytes", Metric.MetricUnit.BYTES, "Bytes sent");
+            this.sendBytes.addLabel(new MetricLabel("device", netIf.getName()));
+            this.sendPackets = new GaugeMetricImpl<>(
+                    "network_send_packets", Metric.MetricUnit.NOUNIT, "Packets sent");
+            this.sendPackets.addLabel(new MetricLabel("device", netIf.getName()));
+            this.sendErrors = new GaugeMetricImpl<>(
+                    "network_send_errors", Metric.MetricUnit.NOUNIT, "Send errors");
+            this.sendErrors.addLabel(new MetricLabel("device", netIf.getName()));
+        }
+
+        /**
+         * Registers all metrics for this network interface with the specified registry.
+         *
+         * @param registry The metric registry to which the metrics will be added.
+         */
+        public void init(StarRocksMetricRegistry registry) {
+            registry.addMetric(receiveBytes);
+            registry.addMetric(receivePackets);
+            registry.addMetric(receiveErrors);
+            registry.addMetric(receiveDropped);
+            registry.addMetric(sendBytes);
+            registry.addMetric(sendPackets);
+            registry.addMetric(sendErrors);
+            LOG.info("init metrics for network interface: {}", netIf.getName());
+        }
+
+        /**
+         * Fetches the latest I/O statistics for the network interface and updates the gauge metrics.
+         */
+        public void update() {
+            try {
+                netIf.updateAttributes();
+                receiveBytes.setValue(netIf.getBytesRecv());
+                receivePackets.setValue(netIf.getPacketsRecv());
+                receiveErrors.setValue(netIf.getInErrors());
+                receiveDropped.setValue(netIf.getInDrops());
+                sendBytes.setValue(netIf.getBytesSent());
+                sendPackets.setValue(netIf.getPacketsSent());
+                sendErrors.setValue(netIf.getOutErrors());
+            } catch (Exception e) {
+                LOG.warn("failed to update metrics for network interface {}", netIf.getName(), e);
+            }
+        }
+    }
+
+    /**
+     * Collects and reports comprehensive network metrics, including per-interface I/O and overall TCP statistics.
+     *
+     * <p><b>Usage Scenario:</b>
+     * This class provides a complete view of the system's network activity. It is used to monitor network traffic,
+     * error rates, and TCP connection behavior to ensure network health and performance.
+     *
+     * <p><b>Implementation Mechanism:</b>
+     * It discovers all active network interfaces (those with an IPv4 or IPv6 address) and creates a {@link NetIfMetrics}
+     * instance for each one. It also instantiates a {@link TcpMetrics} object to gather TCP protocol statistics.
+     * The {@code update} method then triggers updates for all underlying collectors.
+     */
+    private static class NetworkMetrics {
+
+        final HardwareAbstractionLayer hardware;
+        final List<NetIfMetrics> metricsForEachNetIf;
+        final TcpMetrics tcpMetrics;
+
+        /**
+         * Constructs a {@code NetworkMetrics} instance.
+         *
+         * @param hardware The {@code oshi} {@link HardwareAbstractionLayer} for discovering network interfaces.
+         * @param operatingSystem The {@code oshi} {@link OperatingSystem} for querying TCP statistics.
+         */
+        public NetworkMetrics(HardwareAbstractionLayer hardware, OperatingSystem operatingSystem) {
+            this.hardware = hardware;
+            this.metricsForEachNetIf = new ArrayList<>();
+            this.tcpMetrics = new TcpMetrics(operatingSystem);
+        }
+
+        /**
+         * Discovers active network interfaces and initializes metrics for them and for the TCP protocol.
+         *
+         * @param registry The metric registry to which all network metrics will be added.
+         */
+        public void init(StarRocksMetricRegistry registry) {
+            boolean isBindIPV6 = FrontendOptions.isBindIPV6();
+            List<NetworkIF> interfaces = hardware.getNetworkIFs(false).stream()
+                    .filter(netIf -> netIf.getIPv4addr().length > 0 || (isBindIPV6 && netIf.getIPv6addr().length > 0))
+                    .toList();
+            for (NetworkIF netIf : interfaces) {
+                NetIfMetrics metrics = new NetIfMetrics(netIf);
+                metricsForEachNetIf.add(metrics);
+                metrics.init(registry);
+            }
+            tcpMetrics.init(registry);
+            LOG.info("init network metrics");
+        }
+
+        /**
+         * Updates all network-related metrics, including per-interface I/O and TCP statistics.
+         */
+        public void update() {
+            metricsForEachNetIf.forEach(NetIfMetrics::update);
+            tcpMetrics.update();
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/metric/SystemMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/metric/SystemMetricsTest.java
@@ -1,0 +1,389 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.metric;
+
+import com.starrocks.common.Config;
+import com.starrocks.service.FrontendOptions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import oshi.SystemInfo;
+import oshi.hardware.CentralProcessor;
+import oshi.hardware.GlobalMemory;
+import oshi.hardware.HardwareAbstractionLayer;
+import oshi.hardware.NetworkIF;
+import oshi.hardware.VirtualMemory;
+import oshi.software.os.FileSystem;
+import oshi.software.os.InternetProtocolStats;
+import oshi.software.os.OSFileStore;
+import oshi.software.os.OperatingSystem;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SystemMetricsTest {
+
+    // Test-scoped mocks
+    private CentralProcessor cpu;
+    private GlobalMemory memory;
+    private HardwareAbstractionLayer hal;
+    private OperatingSystem os;
+    private FileSystem fs;
+    private OSFileStore storeRoot;
+    private NetworkIF netIf;
+    private InternetProtocolStats ipStats;
+    private InternetProtocolStats.TcpStats v4;
+    private InternetProtocolStats.TcpStats v6;
+    private VirtualMemory vm;
+    private MockedConstruction<SystemInfo> systemInfoConstruction;
+    private SystemMetrics sm;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        cpu = mock(CentralProcessor.class);
+        memory = mock(GlobalMemory.class);
+        hal = mock(HardwareAbstractionLayer.class);
+        os = mock(OperatingSystem.class);
+        fs = mock(FileSystem.class);
+        storeRoot = mock(OSFileStore.class);
+        netIf = mock(NetworkIF.class);
+        ipStats = mock(InternetProtocolStats.class);
+        v4 = mock(InternetProtocolStats.TcpStats.class);
+        v6 = mock(InternetProtocolStats.TcpStats.class);
+        vm = mock(VirtualMemory.class);
+        // Bind new SystemInfo() to mocked HAL/OS; wire HAL to CPU/Memory
+        systemInfoConstruction = Mockito.mockConstruction(SystemInfo.class, (mockSystemInfo, context) -> {
+            when(mockSystemInfo.getHardware()).thenReturn(hal);
+            when(mockSystemInfo.getOperatingSystem()).thenReturn(os);
+        });
+        when(hal.getProcessor()).thenReturn(cpu);
+        when(hal.getMemory()).thenReturn(memory);
+        sm = new SystemMetrics();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception {
+        if (systemInfoConstruction != null) {
+            systemInfoConstruction.close();
+        }
+    }
+
+    @Test
+    public void testInit() {
+        // NetIF discovery stubs
+        when(netIf.getName()).thenReturn("eth0");
+        when(netIf.getIPv4addr()).thenReturn(new String[] {"127.0.0.1"});
+        when(hal.getNetworkIFs(false)).thenReturn(List.of(netIf));
+
+        // Filesystem discovery stubs
+        Config.meta_dir = "/var/starrocks/meta";
+        Config.sys_log_dir = "/var/starrocks/log";
+        when(os.getFileSystem()).thenReturn(fs);
+        when(fs.getFileStores()).thenReturn(List.of(storeRoot));
+        when(storeRoot.getMount()).thenReturn("/");
+        when(storeRoot.getVolume()).thenReturn("/dev/sda");
+
+        sm.init();
+
+        // CPU
+        List<Metric<?>> cpuMetrics = getByName("cpu");
+        assertThat(cpuMetrics).hasSize(8);
+        List<String> modes = new ArrayList<>();
+        for (Metric<?> m : cpuMetrics) {
+            modes.add(m.getLabels().get(0).getValue());
+        }
+        Collections.sort(modes);
+        assertThat(modes).containsExactlyInAnyOrder("user", "nice", "system", "idle", "iowait", "irq", "softirq", "steal");
+
+        // Memory
+        List<Metric<?>> memMetrics = getByName("memory");
+        assertThat(memMetrics).hasSize(4);
+        List<String> memNames = new ArrayList<>();
+        for (Metric<?> m : memMetrics) {
+            memNames.add(m.getLabels().get(0).getValue());
+        }
+        Collections.sort(memNames);
+        assertThat(memNames).containsExactlyInAnyOrder("total", "used", "swap_total", "swap_used");
+
+        // NetIF
+        for (String metricName : List.of(
+                "network_receive_bytes", "network_receive_packets", "network_receive_errors", "network_receive_dropped",
+                "network_send_bytes", "network_send_packets", "network_send_errors")) {
+            List<Metric<?>> ms = getByName(metricName);
+            assertThat(ms).hasSize(1);
+            assertThat(ms.get(0).getLabels().get(0).getValue()).isEqualTo("eth0");
+        }
+
+        // Disk metrics registered for device "sda"
+        List<String> expectedDiskMetricNames = List.of(
+                "disk_total_capacity", "disk_used_capacity",
+                "disk_reads_completed", "disk_bytes_read", "disk_read_time_ms",
+                "disk_writes_completed", "disk_bytes_written", "disk_write_time_ms",
+                "disk_io_time_ms", "disk_io_time_weighted_ms");
+        for (String name : expectedDiskMetricNames) {
+            List<Metric<?>> metrics = getByName(name);
+            assertThat(metrics).hasSize(1);
+            assertThat(metrics.get(0).getLabels().get(0).getValue()).isEqualTo("sda");
+        }
+    }
+
+    @Test
+    public void testUpdateCpuTicksSetsAllModes() {
+        long[] ticks = new long[10];
+        // Order by TickType index used in production code
+        // USER(0), NICE(1), SYSTEM(2), IDLE(3), IOWAIT(4), IRQ(5), SOFTIRQ(6), STEAL(7)
+        for (int i = 0; i < 8; i++) {
+            ticks[i] = 100L + i;
+        }
+
+        when(cpu.getSystemCpuLoadTicks()).thenReturn(ticks);
+        sm.init();
+        sm.update();
+
+        Map<String, Long> modeToValue = new HashMap<>();
+        for (Metric<?> m : getByName("cpu")) {
+            modeToValue.put(m.getLabels().get(0).getValue(), ((GaugeMetricImpl<Long>) m).getValue());
+        }
+        assertThat(modeToValue.get("user")).isEqualTo(100L);
+        assertThat(modeToValue.get("nice")).isEqualTo(101L);
+        assertThat(modeToValue.get("system")).isEqualTo(102L);
+        assertThat(modeToValue.get("idle")).isEqualTo(103L);
+        assertThat(modeToValue.get("iowait")).isEqualTo(104L);
+        assertThat(modeToValue.get("irq")).isEqualTo(105L);
+        assertThat(modeToValue.get("softirq")).isEqualTo(106L);
+        assertThat(modeToValue.get("steal")).isEqualTo(107L);
+    }
+
+    @Test
+    public void testUpdateMemoryAndSwap() {
+        when(memory.getTotal()).thenReturn(1000L);
+        when(memory.getAvailable()).thenReturn(250L);
+        when(memory.getVirtualMemory()).thenReturn(vm);
+        when(vm.getSwapTotal()).thenReturn(2048L);
+        when(vm.getSwapUsed()).thenReturn(512L);
+        sm.init();
+        sm.update();
+
+        Map<String, Long> nameToValue = new HashMap<>();
+        for (Metric<?> m : getByName("memory")) {
+            nameToValue.put(m.getLabels().get(0).getValue(), ((GaugeMetricImpl<Long>) m).getValue());
+        }
+        assertThat(nameToValue.get("total")).isEqualTo(1000L);
+        assertThat(nameToValue.get("used")).isEqualTo(750L);
+        assertThat(nameToValue.get("swap_total")).isEqualTo(2048L);
+        assertThat(nameToValue.get("swap_used")).isEqualTo(512L);
+    }
+
+    @Test
+    public void testUpdateIoSkipsWhenDiskstatsMissing() {
+        // Register a disk so that update has something to try to update
+        Config.meta_dir = "/var/starrocks/meta";
+        Config.sys_log_dir = "/var/starrocks/log";
+        when(os.getFileSystem()).thenReturn(fs);
+        when(fs.getFileStores()).thenReturn(List.of(storeRoot));
+        when(storeRoot.getMount()).thenReturn("/");
+        when(storeRoot.getVolume()).thenReturn("/dev/sda");
+        sm.init();
+
+        try (MockedStatic<Files> filesMock = Mockito.mockStatic(Files.class)) {
+            filesMock.when(() -> Files.notExists(argThat(p -> "/proc/diskstats".equals(p.toString())))).thenReturn(true);
+            filesMock.when(() -> Files.notExists(argThat(p -> !"/proc/diskstats".equals(p.toString())))).thenReturn(false);
+            // Should not throw
+            sm.update();
+        }
+
+        // Disk metrics remain registered; values not asserted here
+        assertThat(getByName("disk_reads_completed")).hasSize(1);
+    }
+
+    @Test
+    public void testUpdateIoParsesValidDiskstatsLine() throws Exception {
+        Config.meta_dir = "/var/starrocks/meta";
+        Config.sys_log_dir = "/var/starrocks/log";
+        when(os.getFileSystem()).thenReturn(fs);
+        when(fs.getFileStores()).thenReturn(List.of(storeRoot));
+        when(storeRoot.getMount()).thenReturn("/");
+        when(storeRoot.getVolume()).thenReturn("/dev/sda");
+        sm.init();
+
+        try (MockedStatic<Files> filesMock = Mockito.mockStatic(Files.class);
+                MockedConstruction<FileReader> frConstruction =
+                        Mockito.mockConstruction(FileReader.class, (mockFr, context) -> {});
+                MockedConstruction<BufferedReader> brConstruction = Mockito.mockConstruction(
+                        BufferedReader.class, (mockBr, context) -> {
+                            when(mockBr.readLine()).thenReturn(
+                                    "   8       0 sda 100 0 200 300 400 0 500 600 0 700 800 900",
+                                    (String) null);
+                        })) {
+            filesMock.when(() -> Files.notExists(any())).thenReturn(false);
+            sm.update();
+        }
+
+        // Validate parsed and shifted values
+        Map<String, Long> diskValues = new HashMap<>();
+        for (Metric<?> m : getByName("disk_reads_completed")) {
+            diskValues.put(m.getLabels().get(0).getValue(), ((GaugeMetricImpl<Long>) m).getValue());
+        }
+        assertThat(diskValues.get("sda")).isEqualTo(100L);
+
+        Map<String, Long> bytesRead = new HashMap<>();
+        for (Metric<?> m : getByName("disk_bytes_read")) {
+            bytesRead.put(m.getLabels().get(0).getValue(), ((GaugeMetricImpl<Long>) m).getValue());
+        }
+        // sectors_read at parts[5] = 200 -> bytes = 200 << 9 = 102400
+        assertThat(bytesRead.get("sda")).isEqualTo(200L << 9);
+
+        Map<String, Long> bytesWritten = new HashMap<>();
+        for (Metric<?> m : getByName("disk_bytes_written")) {
+            bytesWritten.put(m.getLabels().get(0).getValue(), ((GaugeMetricImpl<Long>) m).getValue());
+        }
+        // sectors_written at parts[9] = 500 -> bytes = 500 << 9
+        assertThat(bytesWritten.get("sda")).isEqualTo(500L << 9);
+
+        Map<String, Long> ioTime = new HashMap<>();
+        for (Metric<?> m : getByName("disk_io_time_ms")) {
+            ioTime.put(m.getLabels().get(0).getValue(), ((GaugeMetricImpl<Long>) m).getValue());
+        }
+        assertThat(ioTime.get("sda")).isEqualTo(700L);
+
+        Map<String, Long> ioTimeWeighted = new HashMap<>();
+        for (Metric<?> m : getByName("disk_io_time_weighted_ms")) {
+            ioTimeWeighted.put(m.getLabels().get(0).getValue(), ((GaugeMetricImpl<Long>) m).getValue());
+        }
+        assertThat(ioTimeWeighted.get("sda")).isEqualTo(800L);
+    }
+
+    @Test
+    public void testUpdateNetworkAndTcp() throws Exception {
+        when(os.getInternetProtocolStats()).thenReturn(ipStats);
+        when(ipStats.getTCPv4Stats()).thenReturn(v4);
+        when(ipStats.getTCPv6Stats()).thenReturn(v6);
+
+        when(v4.getConnectionsActive()).thenReturn(1L);
+        when(v6.getConnectionsActive()).thenReturn(10L);
+
+        when(v4.getConnectionsPassive()).thenReturn(2L);
+        when(v6.getConnectionsPassive()).thenReturn(20L);
+
+        when(v4.getConnectionFailures()).thenReturn(3L);
+        when(v6.getConnectionFailures()).thenReturn(30L);
+
+        when(v4.getConnectionsReset()).thenReturn(4L);
+        when(v6.getConnectionsReset()).thenReturn(40L);
+
+        when(v4.getConnectionsEstablished()).thenReturn(5L);
+        when(v6.getConnectionsEstablished()).thenReturn(50L);
+
+        when(v4.getSegmentsReceived()).thenReturn(6L);
+        when(v6.getSegmentsReceived()).thenReturn(60L);
+
+        when(v4.getSegmentsSent()).thenReturn(7L);
+        when(v6.getSegmentsSent()).thenReturn(70L);
+
+        when(v4.getSegmentsRetransmitted()).thenReturn(8L);
+        when(v6.getSegmentsRetransmitted()).thenReturn(80L);
+
+        when(v4.getInErrors()).thenReturn(9L);
+        when(v6.getInErrors()).thenReturn(90L);
+
+        when(v4.getOutResets()).thenReturn(10L);
+        when(v6.getOutResets()).thenReturn(100L);
+
+        // NetIF discovery
+        when(netIf.getName()).thenReturn("eth0");
+        when(netIf.getIPv4addr()).thenReturn(new String[] {"127.0.0.1"});
+        when(hal.getNetworkIFs(false)).thenReturn(List.of(netIf));
+
+        try (MockedStatic<FrontendOptions> fo = Mockito.mockStatic(FrontendOptions.class)) {
+            // IPv4-only
+            fo.when(FrontendOptions::isBindIPV6).thenReturn(false);
+            sm.init();
+
+            when(netIf.getBytesRecv()).thenReturn(1_000L);
+            when(netIf.getPacketsRecv()).thenReturn(200L);
+            when(netIf.getInErrors()).thenReturn(3L);
+            when(netIf.getInDrops()).thenReturn(4L);
+            when(netIf.getBytesSent()).thenReturn(5_000L);
+            when(netIf.getPacketsSent()).thenReturn(600L);
+            when(netIf.getOutErrors()).thenReturn(7L);
+            sm.update();
+            Map<String, Long> v4Values = new HashMap<>();
+            for (Metric<?> m : getByName("snmp")) {
+                v4Values.put(m.getLabels().get(0).getValue(), ((GaugeMetricImpl<Long>) m).getValue());
+            }
+            assertThat(v4Values.get("active_opens")).isEqualTo(1L);
+            assertThat(v4Values.get("passive_opens")).isEqualTo(2L);
+            assertThat(v4Values.get("attempts_fails")).isEqualTo(3L);
+            assertThat(v4Values.get("estab_resets")).isEqualTo(4L);
+            assertThat(v4Values.get("curr_estab")).isEqualTo(5L);
+            assertThat(v4Values.get("tcp_in_segs")).isEqualTo(6L);
+            assertThat(v4Values.get("tcp_out_segs")).isEqualTo(7L);
+            assertThat(v4Values.get("tcp_retrans_segs")).isEqualTo(8L);
+            assertThat(v4Values.get("tcp_in_errs")).isEqualTo(9L);
+            assertThat(v4Values.get("tcp_out_rsts")).isEqualTo(10L);
+            // NetIF metric assertions
+            assertThat(((GaugeMetricImpl<Long>) getByName("network_receive_bytes").get(0)).getValue()).isEqualTo(1_000L);
+            assertThat(((GaugeMetricImpl<Long>) getByName("network_receive_packets").get(0)).getValue()).isEqualTo(200L);
+            assertThat(((GaugeMetricImpl<Long>) getByName("network_receive_errors").get(0)).getValue()).isEqualTo(3L);
+            assertThat(((GaugeMetricImpl<Long>) getByName("network_receive_dropped").get(0)).getValue()).isEqualTo(4L);
+            assertThat(((GaugeMetricImpl<Long>) getByName("network_send_bytes").get(0)).getValue()).isEqualTo(5_000L);
+            assertThat(((GaugeMetricImpl<Long>) getByName("network_send_packets").get(0)).getValue()).isEqualTo(600L);
+            assertThat(((GaugeMetricImpl<Long>) getByName("network_send_errors").get(0)).getValue()).isEqualTo(7L);
+
+            // IPv6 aggregation (v4 + v6)
+            fo.when(FrontendOptions::isBindIPV6).thenReturn(true);
+            sm.update();
+            Map<String, Long> v6AggValues = new HashMap<>();
+            for (Metric<?> m : getByName("snmp")) {
+                v6AggValues.put(m.getLabels().get(0).getValue(), ((GaugeMetricImpl<Long>) m).getValue());
+            }
+            assertThat(v6AggValues.get("active_opens")).isEqualTo(11L);
+            assertThat(v6AggValues.get("passive_opens")).isEqualTo(22L);
+            assertThat(v6AggValues.get("attempts_fails")).isEqualTo(33L);
+            assertThat(v6AggValues.get("estab_resets")).isEqualTo(44L);
+            assertThat(v6AggValues.get("curr_estab")).isEqualTo(55L);
+            assertThat(v6AggValues.get("tcp_in_segs")).isEqualTo(66L);
+            assertThat(v6AggValues.get("tcp_out_segs")).isEqualTo(77L);
+            assertThat(v6AggValues.get("tcp_retrans_segs")).isEqualTo(88L);
+            assertThat(v6AggValues.get("tcp_in_errs")).isEqualTo(99L);
+            assertThat(v6AggValues.get("tcp_out_rsts")).isEqualTo(110L);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Metric<?>> getByName(SystemMetrics sm, String name) {
+        return (List<Metric<?>>) (List<?>) sm.getRegistry().getMetricsByName(name);
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Metric<?>> getByName(String name) {
+        return getByName(sm, name);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
Improve observability and operations by exposing core system-level metrics (CPU, memory, disk I/O, network) from StarRocks FE nodes.

## What I'm doing:
- Add host CPU / Memory / IO / Network metrics . Here we use `oshi` library to fetch os and hardware stats
- Add a configuration `enable_collect_system_metrics` to control whether to collect system metrics, by default `false`. If the user does not deploy 3rd tools, such as node exporter, to monitor system, could turn it on

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce optional FE system metrics (CPU, memory, disk I/O/capacity, network, TCP) via OSHI, gated by new `enable_collect_system_metrics`, integrated into FE metrics pipeline with docs and tests.
> 
> - **FE Core (metrics)**
>   - Add `SystemMetrics` (CPU, memory, disk capacity & I/O via `/proc/diskstats`, NIC I/O, TCP stats aggregated v4/v6 via OSHI).
>   - Integrate into `MetricRepo`/`MetricCalculator`; initialize `SYSTEM_METRICS`, update/collect only when `Config.enable_collect_system_metrics` is `true`.
>   - Remove legacy SNMP init path and periodic `updateMetrics()` call; switch to on-demand, config-gated collection.
>   - New config: `Config.enable_collect_system_metrics` (mutable, default `false`).
> - **Docs**
>   - Add `enable_collect_system_metrics` to FE config (EN/JA/ZH).
>   - Document new FE system metrics (`starrocks_fe_cpu`, `starrocks_fe_memory`, disk, network, TCP SNMP) in EN/JA/ZH metrics guides.
> - **Tests**
>   - Add `SystemMetricsTest` covering init, CPU/memory parsing, diskstats parsing, network/TCP aggregation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6f26fdc4946fdc5741f25bf78aefceb53afca8c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->