### PR TITLE
[BugFix] check possible corruption of zonemap min/max

### DIFF
--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -398,6 +398,10 @@ Status ColumnReader::_parse_zone_map(LogicalType type, const ZoneMapPB& zm, Zone
     detail->set_has_null(zm.has_null());
 
     if (zm.has_not_null()) {
+        if (UNLIKELY(!zm.has_min() || !zm.has_max())) {
+            LOG(ERROR) << "Corrupted zone map protobuf detected: " << zm.ShortDebugString();
+            return Status::Corruption("Corrupted zone map data: missing min or max values");
+        }
         RETURN_IF_ERROR(datum_from_string(type_info.get(), &(detail->min_value()), zm.min(), nullptr));
         RETURN_IF_ERROR(datum_from_string(type_info.get(), &(detail->max_value()), zm.max(), nullptr));
     }


### PR DESCRIPTION
* defensive code to detect corrupted zonemap and return errors instead of possibly crash.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a corruption check for zone map min/max in ColumnReader; updates FE slot handling to include all slots; tweaks proc profile test config usage and removes an FE cache test.
> 
> - **Backend (Storage)**
>   - `ColumnReader::_parse_zone_map(...)`: Validate `ZoneMapPB` when `has_not_null` by requiring `min` and `max`; log error and return `Status::Corruption` if missing.
> - **Frontend (Planner)**
>   - `OlapScanNode`: Collect slots without filtering out those with null `getColumn()` in slot-to-column associations and aggregated column slot detection.
> - **Tests**
>   - `proc_profile_e2e_test.cpp`: Use `const char*` and `c_str()` for `config::sys_log_dir` setup/restore.
>   - `QueryCacheTest`: Remove `testQueryCacheWithHeavyExprPushDown`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f35d032da8f5646e2833c424399e80ddeeb40f16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->