### PR TITLE
[Enhancement] Support hour/minute/second constant evaluation in FE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -1606,5 +1606,28 @@ public class ScalarOperatorFunctions {
         return ConstantOperator.createVarchar(value.getVarchar());
     }
 
+    @ConstantFunction.List(list = {
+            @ConstantFunction(name = "hour", argTypes = {DATETIME}, returnType = TINYINT),
+            @ConstantFunction(name = "hour", argTypes = {DATE}, returnType = TINYINT)
+    })
+    public static ConstantOperator hour(ConstantOperator value) {
+        return ConstantOperator.createTinyInt((byte) value.getDatetime().getHour());
+    }
+
+    @ConstantFunction.List(list = {
+            @ConstantFunction(name = "minute", argTypes = {DATETIME}, returnType = TINYINT),
+            @ConstantFunction(name = "minute", argTypes = {DATE}, returnType = TINYINT)
+    })
+    public static ConstantOperator minute(ConstantOperator value) {
+        return ConstantOperator.createTinyInt((byte) value.getDatetime().getMinute());
+    }
+
+    @ConstantFunction.List(list = {
+            @ConstantFunction(name = "second", argTypes = {DATETIME}, returnType = TINYINT),
+            @ConstantFunction(name = "second", argTypes = {DATE}, returnType = TINYINT)
+    })
+    public static ConstantOperator second(ConstantOperator value) {
+        return ConstantOperator.createTinyInt((byte) value.getDatetime().getSecond());
+    }
 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -1712,4 +1712,17 @@ public class ScalarOperatorFunctionsTest {
         ConstantOperator result = ScalarOperatorFunctions.lastDay(input, unit);
         assertEquals(true, result.isNull());
     }
+
+    @Test
+    public void testHourMinuteSecond() {
+        ConstantOperator v = ConstantOperator.createDatetime(LocalDateTime.of(2022, 11, 11, 11, 10, 9));
+        assertEquals(11, ScalarOperatorFunctions.hour(v).getTinyInt());
+        assertEquals(10, ScalarOperatorFunctions.minute(v).getTinyInt());
+        assertEquals(9, ScalarOperatorFunctions.second(v).getTinyInt());
+
+        v = ConstantOperator.createDate(LocalDate.parse("2022-11-11").atTime(0, 0, 0, 0));
+        assertEquals(0, ScalarOperatorFunctions.hour(v).getTinyInt());
+        assertEquals(0, ScalarOperatorFunctions.minute(v).getTinyInt());
+        assertEquals(0, ScalarOperatorFunctions.second(v).getTinyInt());
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
Support hour/minute/second constant evaluation in FE

## What I'm doing:
Support hour/minute/second constant evaluation in FE

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds constant-evaluable `hour`, `minute`, and `second` functions for `DATE`/`DATETIME` with tests.
> 
> - **Optimizer (FE)**:
>   - Add constant functions `hour`, `minute`, `second` for `DATETIME` and `DATE`, returning `TINYINT` in `ScalarOperatorFunctions`.
> - **Tests**:
>   - Add `testHourMinuteSecond` covering datetime and date inputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b590e4cee2728202da582cb31dbe28807aa19e97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->