### PR TITLE
[Enhancement]  Make query fail fast while lastStartTime of backend has changed

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
@@ -97,6 +97,7 @@ public class FragmentInstanceExecState {
     private final ComputeNode worker;
     private final TNetworkAddress address;
     private final long lastMissingHeartbeatTime;
+    private final long lastStartTime;
 
     private FragmentInstance fragmentInstance;
 
@@ -111,7 +112,7 @@ public class FragmentInstanceExecState {
         profile.addInfoString("Address", String.format("%s:%s", address.hostname, address.port));
         profile.addInfoString("InstanceId", instanceId);
 
-        return new FragmentInstanceExecState(null, null, 0, fragmentInstanceId, 0, null, profile, null, null, -1);
+        return new FragmentInstanceExecState(null, null, 0, fragmentInstanceId, 0, null, profile, null, null, -1, -1);
     }
 
     public static FragmentInstanceExecState createExecution(JobSpec jobSpec,
@@ -131,7 +132,7 @@ public class FragmentInstanceExecState {
                 request.params.getFragment_instance_id(), request.getBackend_num(),
                 request,
                 profile,
-                worker, address, worker.getLastMissingHeartbeatTime());
+                worker, address, worker.getLastMissingHeartbeatTime(), worker.getLastStartTime());
     }
 
     private FragmentInstanceExecState(JobSpec jobSpec,
@@ -143,7 +144,8 @@ public class FragmentInstanceExecState {
                                       RuntimeProfile profile,
                                       ComputeNode worker,
                                       TNetworkAddress address,
-                                      long lastMissingHeartbeatTime) {
+                                      long lastMissingHeartbeatTime,
+                                      long lastStartTime) {
         this.jobSpec = jobSpec;
         // fake fragment instance exec state
         if (jobSpec == null) {
@@ -161,6 +163,7 @@ public class FragmentInstanceExecState {
         this.address = address;
         this.worker = worker;
         this.lastMissingHeartbeatTime = lastMissingHeartbeatTime;
+        this.lastStartTime = lastStartTime;
     }
 
     public void serializeRequest() {
@@ -453,7 +456,13 @@ public class FragmentInstanceExecState {
     }
 
     public boolean isBackendStateHealthy() {
-        if (worker.getLastMissingHeartbeatTime() > lastMissingHeartbeatTime) {
+        // There are two scenarios:
+        // 1. heartbeat is ok, but `lastStartTime` updated, it means the backend is really restarted. we use `lastStartTime`
+        // to detect backend restart while`heartbeat_retry_times` hasn't been exceeded, in which case only checking
+        // `lastMissingHeartbeatTime` is not enough.
+        // 2. heartbeat failed after `heartbeat_retry_times` times, the `lastMissingHeartbeatTime` will be updated for
+        // that backend, we will treat this case as backend un-responsible and make the query fail fast
+        if (worker.getLastStartTime() > lastStartTime || worker.getLastMissingHeartbeatTime() > lastMissingHeartbeatTime) {
             LOG.warn("backend {} is down while joining the coordinator. job id: {}", worker.getId(),
                     jobSpec.getLoadJobId());
             return false;

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -400,6 +400,11 @@ public class ComputeNode implements IComputable, Writable, GsonPostProcessable {
         return lastMissingHeartbeatTime;
     }
 
+    @VisibleForTesting
+    public void setLastMissingHeartbeatTime(long lastMissingHeartbeatTime) {
+        this.lastMissingHeartbeatTime = lastMissingHeartbeatTime;
+    }
+
     public boolean isAlive() {
         return this.isAlive.get();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/DefaultWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/DefaultWorkerProviderTest.java
@@ -48,7 +48,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class DefaultWorkerProviderTest {
+public class    DefaultWorkerProviderTest {
     private final ImmutableMap<Long, ComputeNode> id2Backend = genWorkers(0, 10, Backend::new, false);
     private final ImmutableMap<Long, ComputeNode> id2ComputeNode = genWorkers(10, 15, ComputeNode::new, false);
     private final ImmutableMap<Long, ComputeNode> availableId2Backend = ImmutableMap.of(

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/DefaultWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/DefaultWorkerProviderTest.java
@@ -48,7 +48,7 @@ import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class    DefaultWorkerProviderTest {
+public class DefaultWorkerProviderTest {
     private final ImmutableMap<Long, ComputeNode> id2Backend = genWorkers(0, 10, Backend::new, false);
     private final ImmutableMap<Long, ComputeNode> id2ComputeNode = genWorkers(10, 15, ComputeNode::new, false);
     private final ImmutableMap<Long, ComputeNode> availableId2Backend = ImmutableMap.of(

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/FragmentInstanceExecStateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/FragmentInstanceExecStateTest.java
@@ -1,0 +1,79 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler;
+
+import com.starrocks.qe.scheduler.dag.FragmentInstanceExecState;
+import com.starrocks.qe.scheduler.dag.JobSpec;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.thrift.TExecPlanFragmentParams;
+import com.starrocks.thrift.TPlanFragmentExecParams;
+import com.starrocks.thrift.TUniqueId;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.wildfly.common.Assert;
+
+public class FragmentInstanceExecStateTest {
+    private FragmentInstanceExecState state;
+    private ComputeNode computeNode;
+    private long startTime;
+    private long lastHeartbeatMissTime;
+
+    @Mocked
+    private JobSpec jobSpec;
+
+    @BeforeEach
+    public void setUp() {
+        new Expectations() {
+            {
+                jobSpec.getLoadJobId();
+                result = 1000L;
+            }
+        };
+
+        startTime = System.currentTimeMillis() - 10 * 60 * 60 * 1000;
+        lastHeartbeatMissTime = System.currentTimeMillis() - 3 * 5000;
+
+        computeNode = new ComputeNode(1L, "127.0.0.1", 80);
+        computeNode.setLastStartTime(startTime);
+        computeNode.setLastMissingHeartbeatTime(lastHeartbeatMissTime);
+        TExecPlanFragmentParams request = new TExecPlanFragmentParams();
+        TPlanFragmentExecParams params = new com.starrocks.thrift.TPlanFragmentExecParams();
+        params.fragment_instance_id = new TUniqueId(0x33, 0x0);
+        request.setParams(params);
+
+        state = FragmentInstanceExecState.createExecution(jobSpec, null, 0, request, computeNode);
+    }
+
+    @Test
+    public void testIsBackendStateHealthy() {
+        // everything is ok
+        computeNode.setLastStartTime(startTime);
+        computeNode.setLastMissingHeartbeatTime(lastHeartbeatMissTime);
+        Assert.assertTrue(state.isBackendStateHealthy());
+
+        // mock restart of backend
+        computeNode.setLastStartTime(System.currentTimeMillis());
+        computeNode.setLastMissingHeartbeatTime(lastHeartbeatMissTime);
+        Assert.assertFalse(state.isBackendStateHealthy());
+
+        // mock missing heartbeat
+        computeNode.setLastStartTime(startTime);
+        computeNode.setLastMissingHeartbeatTime(System.currentTimeMillis());
+        state.getWorker().setLastMissingHeartbeatTime(System.currentTimeMillis());
+        Assert.assertFalse(state.isBackendStateHealthy());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

Previously, the coordinator only checked `lastMissingHeartbeatTime` to detect backend failures during query execution. This approach had a critical limitation: when a backend restarts quickly (within seconds), the heartbeat might not exceed the retry threshold (`heartbeat_retry_times`), causing `lastMissingHeartbeatTime` to remain unchanged. 

As a result, queries could hang for a long time (up to query_timeout) without failing fast, even though the backend had already restarted and the query was doomed to fail.


## What I'm doing:

Add an additional check for `lastStartTime` in `isBackendStateHealthy()`:

1. **Capture `lastStartTime` at query start**: Store the backend's `lastStartTime` when creating `FragmentInstanceExecState`
2. **Check for restart during execution**: If `worker.getLastStartTime() > lastStartTime`, it indicates the backend has restarted
3. **Fail fast**: Immediately mark the backend as unhealthy and fail the query


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Track backend lastStartTime in FragmentInstanceExecState and use it with lastMissingHeartbeatTime to detect restarts and fail queries faster; add unit test and a testing setter.
> 
> - **Scheduler/Execution**:
>   - Track `lastStartTime` in `FragmentInstanceExecState`; pass from `ComputeNode` in `createExecution(...)` and store in constructor (also in `createFakeExecution(...)`).
>   - Update `isBackendStateHealthy()` to return unhealthy if `worker.getLastStartTime() > lastStartTime` or `worker.getLastMissingHeartbeatTime() > lastMissingHeartbeatTime`.
> - **System/ComputeNode**:
>   - Add `@VisibleForTesting setLastMissingHeartbeatTime(...)`.
> - **Tests**:
>   - Add `FragmentInstanceExecStateTest` validating healthy case, restart detection via `lastStartTime`, and missing-heartbeat handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 159618c01009c3349ebd6a487154b1d472de29e6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->