### PR TITLE
[Enhancement] Estimate IF-based predicate

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculatorTest.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer.statistics;
 
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
@@ -342,7 +343,7 @@ public class PredicateStatisticsCalculatorTest {
     }
 
     @Test
-    public void testEstimateIfPredicate() {
+    public void testEstimateSimpleIfPredicate() {
         ColumnRefOperator columnRef1 = new ColumnRefOperator(1, Type.INT, "c1", true);
         ColumnRefOperator columnRef2 = new ColumnRefOperator(2, Type.INT, "c2", true);
         ColumnRefOperator columnRef3 = new ColumnRefOperator(3, Type.INT, "c3", true);
@@ -353,21 +354,18 @@ public class PredicateStatisticsCalculatorTest {
                 .setDistinctValuesCount(20)
                 .setNullsFraction(0.1)
                 .build();
-
         ColumnStatistic columnStatistic2 = ColumnStatistic.builder()
                 .setMinValue(40)
                 .setMaxValue(80)
                 .setDistinctValuesCount(30)
                 .setNullsFraction(0.2)
                 .build();
-
         ColumnStatistic columnStatistic3 = ColumnStatistic.builder()
                 .setMinValue(10)
                 .setMaxValue(90)
                 .setDistinctValuesCount(50)
                 .setNullsFraction(0.4)
                 .build();
-
         Statistics statistics = Statistics.builder()
                 .setOutputRowCount(1000)
                 .addColumnStatistic(columnRef1, columnStatistic1)
@@ -375,18 +373,213 @@ public class PredicateStatisticsCalculatorTest {
                 .addColumnStatistic(columnRef3, columnStatistic3)
                 .build();
 
+        // IF ( c1 >= 20 , c2 = 50 , c3 = 80 )
         BinaryPredicateOperator condition =
                 new BinaryPredicateOperator(BinaryType.GE, columnRef1, ConstantOperator.createInt(20));
         BinaryPredicateOperator leftPredicate =
                 new BinaryPredicateOperator(BinaryType.EQ, columnRef2, ConstantOperator.createInt(50));
         BinaryPredicateOperator rightPredicate =
                 new BinaryPredicateOperator(BinaryType.EQ, columnRef3, ConstantOperator.createInt(80));
-
         CallOperator ifPredicate =
                 new CallOperator(FunctionSet.IF, Type.BOOLEAN, List.of(condition, leftPredicate, rightPredicate));
 
         Statistics result = PredicateStatisticsCalculator.statisticsCalculate(ifPredicate, statistics);
-
         Assertions.assertEquals(17.0, (int) result.getOutputRowCount());
+    }
+
+    @Test
+    public void testEstimateNestedIfPredicate() {
+        ColumnRefOperator columnRef1 = new ColumnRefOperator(1, Type.INT, "c1", true);
+        ColumnRefOperator columnRef2 = new ColumnRefOperator(2, Type.INT, "c2", true);
+        ColumnRefOperator columnRef3 = new ColumnRefOperator(3, Type.INT, "c3", true);
+
+        ColumnStatistic columnStatistic1 = ColumnStatistic.builder()
+                .setMinValue(10)
+                .setMaxValue(40)
+                .setDistinctValuesCount(20)
+                .setNullsFraction(0.1)
+                .build();
+        ColumnStatistic columnStatistic2 = ColumnStatistic.builder()
+                .setMinValue(40)
+                .setMaxValue(80)
+                .setDistinctValuesCount(30)
+                .setNullsFraction(0.2)
+                .build();
+        ColumnStatistic columnStatistic3 = ColumnStatistic.builder()
+                .setMinValue(10)
+                .setMaxValue(90)
+                .setDistinctValuesCount(50)
+                .setNullsFraction(0.4)
+                .build();
+        Statistics statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(columnRef1, columnStatistic1)
+                .addColumnStatistic(columnRef2, columnStatistic2)
+                .addColumnStatistic(columnRef3, columnStatistic3)
+                .build();
+
+        // IF ( c1 >= 20 , IF ( c1 >= 30 , c2 = 50 , c3 = 80 ) , c3 = 70 )
+        BinaryPredicateOperator c1Ge30Condition =
+                new BinaryPredicateOperator(BinaryType.GE, columnRef1, ConstantOperator.createInt(30));
+        BinaryPredicateOperator c2Eq50Predicate =
+                new BinaryPredicateOperator(BinaryType.EQ, columnRef2, ConstantOperator.createInt(50));
+        BinaryPredicateOperator c3Eq80Predicate =
+                new BinaryPredicateOperator(BinaryType.EQ, columnRef3, ConstantOperator.createInt(80));
+        CallOperator innerIfPredicate =
+                new CallOperator(FunctionSet.IF, Type.BOOLEAN, List.of(c1Ge30Condition, c2Eq50Predicate, c3Eq80Predicate));
+        BinaryPredicateOperator c1Ge20Condition =
+                new BinaryPredicateOperator(BinaryType.GE, columnRef1, ConstantOperator.createInt(20));
+        BinaryPredicateOperator c3Eq70Predicate =
+                new BinaryPredicateOperator(BinaryType.EQ, columnRef3, ConstantOperator.createInt(70));
+        CallOperator outerIfPredicate =
+                new CallOperator(FunctionSet.IF, Type.BOOLEAN, List.of(c1Ge20Condition, innerIfPredicate, c3Eq70Predicate));
+
+        Statistics result = PredicateStatisticsCalculator.statisticsCalculate(outerIfPredicate, statistics);
+        Assertions.assertEquals(14.0, (int) result.getOutputRowCount());
+
+        // IF ( c1 >= 30 , c2 = 50 , IF ( c1 >= 20 , c3 = 80 , c3 = 70 ) )
+        innerIfPredicate =
+                new CallOperator(FunctionSet.IF, Type.BOOLEAN, List.of(c1Ge20Condition, c3Eq80Predicate, c3Eq70Predicate));
+        outerIfPredicate =
+                new CallOperator(FunctionSet.IF, Type.BOOLEAN, List.of(c1Ge30Condition, c2Eq50Predicate, innerIfPredicate));
+
+        result = PredicateStatisticsCalculator.statisticsCalculate(outerIfPredicate, statistics);
+        Assertions.assertEquals(15.0, (int) result.getOutputRowCount());
+
+        // IF ( IF ( c1 >= 20 , c2 >= 50 , c2 <= 70 ) , c3 = 80 , c3 = 70 )
+        BinaryPredicateOperator c1Ge20Predicate =
+                new BinaryPredicateOperator(BinaryType.GE, columnRef1, ConstantOperator.createInt(20));
+        BinaryPredicateOperator c2Ge50Predicate =
+                new BinaryPredicateOperator(BinaryType.GE, columnRef2, ConstantOperator.createInt(50));
+        BinaryPredicateOperator c2Le70Predicate =
+                new BinaryPredicateOperator(BinaryType.LE, columnRef2, ConstantOperator.createInt(70));
+        innerIfPredicate =
+                new CallOperator(FunctionSet.IF, Type.BOOLEAN, List.of(c1Ge20Predicate, c2Ge50Predicate, c2Le70Predicate));
+        outerIfPredicate =
+                new CallOperator(FunctionSet.IF, Type.BOOLEAN, List.of(innerIfPredicate, c3Eq80Predicate, c3Eq70Predicate));
+
+        result = PredicateStatisticsCalculator.statisticsCalculate(outerIfPredicate, statistics);
+        Assertions.assertEquals(11.0, (int) result.getOutputRowCount());
+    }
+
+    @Test
+    public void testEstimateCompoundNestedIfPredicate() {
+        ConnectContext connectContext = new ConnectContext();
+        connectContext.setThreadLocalInfo();
+
+        ColumnRefOperator columnRef1 = new ColumnRefOperator(1, Type.INT, "c1", true);
+        ColumnRefOperator columnRef2 = new ColumnRefOperator(2, Type.INT, "c2", true);
+        ColumnRefOperator columnRef3 = new ColumnRefOperator(3, Type.INT, "c3", true);
+        ColumnRefOperator columnRef4 = new ColumnRefOperator(4, Type.INT, "c4", true);
+
+        ColumnStatistic columnStatistic1 = ColumnStatistic.builder()
+                .setMinValue(10)
+                .setMaxValue(40)
+                .setDistinctValuesCount(20)
+                .setNullsFraction(0.1)
+                .build();
+        ColumnStatistic columnStatistic2 = ColumnStatistic.builder()
+                .setMinValue(40)
+                .setMaxValue(80)
+                .setDistinctValuesCount(30)
+                .setNullsFraction(0.2)
+                .build();
+        ColumnStatistic columnStatistic3 = ColumnStatistic.builder()
+                .setMinValue(10)
+                .setMaxValue(90)
+                .setDistinctValuesCount(50)
+                .setNullsFraction(0.4)
+                .build();
+        ColumnStatistic columnStatistic4 = ColumnStatistic.builder()
+                .setMinValue(0)
+                .setMaxValue(100)
+                .setDistinctValuesCount(70)
+                .setNullsFraction(0.15)
+                .build();
+        Statistics statistics = Statistics.builder()
+                .setOutputRowCount(1000)
+                .addColumnStatistic(columnRef1, columnStatistic1)
+                .addColumnStatistic(columnRef2, columnStatistic2)
+                .addColumnStatistic(columnRef3, columnStatistic3)
+                .addColumnStatistic(columnRef4, columnStatistic4)
+                .build();
+
+        // IF ( c1 >= 20 , NOT IF ( c1 >= 30 , c2 = 50 , c3 = 80 ) , c3 = 70 )
+        BinaryPredicateOperator c1Ge30Condition =
+                new BinaryPredicateOperator(BinaryType.GE, columnRef1, ConstantOperator.createInt(30));
+        BinaryPredicateOperator c2Eq50Predicate =
+                new BinaryPredicateOperator(BinaryType.EQ, columnRef2, ConstantOperator.createInt(50));
+        BinaryPredicateOperator c3Eq80Predicate =
+                new BinaryPredicateOperator(BinaryType.EQ, columnRef3, ConstantOperator.createInt(80));
+        CallOperator innerIfPredicate =
+                new CallOperator(FunctionSet.IF, Type.BOOLEAN, List.of(c1Ge30Condition, c2Eq50Predicate, c3Eq80Predicate));
+        CompoundPredicateOperator compoundInnerIfPredicate =
+                new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.NOT, innerIfPredicate);
+        BinaryPredicateOperator c1Ge20Condition =
+                new BinaryPredicateOperator(BinaryType.GE, columnRef1, ConstantOperator.createInt(20));
+        BinaryPredicateOperator c3Eq70Predicate =
+                new BinaryPredicateOperator(BinaryType.EQ, columnRef3, ConstantOperator.createInt(70));
+        CallOperator outerIfPredicate =
+                new CallOperator(FunctionSet.IF, Type.BOOLEAN,
+                        List.of(c1Ge20Condition, compoundInnerIfPredicate, c3Eq70Predicate));
+
+        Statistics result = PredicateStatisticsCalculator.statisticsCalculate(outerIfPredicate, statistics);
+        Assertions.assertEquals(593.0, (int) result.getOutputRowCount());
+
+        // IF ( c1 >= 20 , c4 = 10 AND IF ( c1 >= 30 , c2 = 50 , c3 = 80 ) , c3 = 70 )
+        BinaryPredicateOperator c4Eq10Predicate =
+                new BinaryPredicateOperator(BinaryType.EQ, columnRef4, ConstantOperator.createInt(10));
+        compoundInnerIfPredicate = new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.AND,
+                c4Eq10Predicate, innerIfPredicate);
+        outerIfPredicate =
+                new CallOperator(FunctionSet.IF, Type.BOOLEAN,
+                        List.of(c1Ge20Condition, compoundInnerIfPredicate, c3Eq70Predicate));
+
+        result = PredicateStatisticsCalculator.statisticsCalculate(outerIfPredicate, statistics);
+        Assertions.assertEquals(4.0, (int) result.getOutputRowCount());
+
+        // IF ( c1 >= 20 , c4 = 10 OR IF ( c1 >= 30 , c2 = 50 , c3 = 80 ) , c3 = 70 )
+        compoundInnerIfPredicate = new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.OR,
+                c4Eq10Predicate, innerIfPredicate);
+        outerIfPredicate = new CallOperator(FunctionSet.IF, Type.BOOLEAN,
+                List.of(c1Ge20Condition, compoundInnerIfPredicate, c3Eq70Predicate));
+
+        result = PredicateStatisticsCalculator.statisticsCalculate(outerIfPredicate, statistics);
+        Assertions.assertEquals(20.0, (int) result.getOutputRowCount());
+
+        // IF ( NOT IF ( c1 >= 20 , c2 >= 50 , c2 <= 70 ) , c3 = 80 , c3 = 70 )
+        BinaryPredicateOperator c1Ge20Predicate =
+                new BinaryPredicateOperator(BinaryType.GE, columnRef1, ConstantOperator.createInt(20));
+        BinaryPredicateOperator c2Ge50Predicate =
+                new BinaryPredicateOperator(BinaryType.GE, columnRef2, ConstantOperator.createInt(50));
+        BinaryPredicateOperator c2Le70Predicate =
+                new BinaryPredicateOperator(BinaryType.LE, columnRef2, ConstantOperator.createInt(70));
+        innerIfPredicate =
+                new CallOperator(FunctionSet.IF, Type.BOOLEAN, List.of(c1Ge20Predicate, c2Ge50Predicate, c2Le70Predicate));
+        compoundInnerIfPredicate =
+                new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.NOT, innerIfPredicate);
+        outerIfPredicate = new CallOperator(FunctionSet.IF, Type.BOOLEAN,
+                List.of(compoundInnerIfPredicate, c3Eq80Predicate, c3Eq70Predicate));
+
+        result = PredicateStatisticsCalculator.statisticsCalculate(outerIfPredicate, statistics);
+        Assertions.assertEquals(11.0, (int) result.getOutputRowCount());
+
+        // IF ( c4 = 10 AND IF ( c1 >= 20 , c2 >= 50 , c2 <= 70 ) , c3 = 80 , c3 = 70 )
+        compoundInnerIfPredicate =
+                new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.AND, c4Eq10Predicate, innerIfPredicate);
+        outerIfPredicate = new CallOperator(FunctionSet.IF, Type.BOOLEAN,
+                List.of(compoundInnerIfPredicate, c3Eq80Predicate, c3Eq70Predicate));
+
+        result = PredicateStatisticsCalculator.statisticsCalculate(outerIfPredicate, statistics);
+        Assertions.assertEquals(11.0, (int) result.getOutputRowCount());
+
+        // IF ( c4 = 10 OR IF ( c1 >= 20 , c2 >= 50 , c2 <= 70 ) , c3 = 80 , c3 = 70 )
+        compoundInnerIfPredicate =
+                new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.OR, c4Eq10Predicate, innerIfPredicate);
+        outerIfPredicate = new CallOperator(FunctionSet.IF, Type.BOOLEAN,
+                List.of(compoundInnerIfPredicate, c3Eq80Predicate, c3Eq70Predicate));
+
+        result = PredicateStatisticsCalculator.statisticsCalculate(outerIfPredicate, statistics);
+        Assertions.assertEquals(11.0, (int) result.getOutputRowCount());
     }
 }


### PR DESCRIPTION
## Why I'm doing:

IF function could be used in predicates to express a conditional predicate. For example:
```
select * from t where IF ( a > 10 , b > 5 , c > 2 ); 
```
However, the optimizer is not able to estimate the selectivity of such a predicate correctly and just uses the default 0.25 selectivity.

## What I'm doing:

This change enables the optimizer to estimate the selectivity of IF predicates by estimating the selectivity of the equivalent predicate with a sequence of AND and OR.
IF:
```
IF ( a > 10 , b > 5 , c > 2 )
```
Equivalent predicate:
```
( a > 10 AND b > 5 ) OR ( ( ( ( a > 10 ) IS NULL ) OR ( NOT ( a > 10 ) ) ) AND c > 2 ) )
```

Result:
- before
```
mysql> explain costs select count(*) from t where IF ( a > 500 , b = 400, b = 600);
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                                                                                                        |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| PLAN COST                                                                                                                                                                                             |
|   CPU: 68000.0                                                                                                                                                                                        |
|   Memory: 8.0                                                                                                                                                                                         |
|                                                                                                                                                                                                       |
| PLAN FRAGMENT 0(F00)                                                                                                                                                                                  |
|   Output Exprs:3: count                                                                                                                                                                               |
|   Input Partition: RANDOM                                                                                                                                                                             |
|   RESULT SINK                                                                                                                                                                                         |
|                                                                                                                                                                                                       |
|   2:AGGREGATE (update finalize)                                                                                                                                                                       |
|   |  aggregate: count[(*); args: ; result: BIGINT; args nullable: false; result nullable: false]                                                                                                      |
|   |  cardinality: 1                                                                                                                                                                                   |
|   |  column statistics:                                                                                                                                                                               |
|   |  * count-->[0.0, 2000.0, 0.0, 8.0, 1.0] ESTIMATE                                                                                                                                                  |
|   |                                                                                                                                                                                                   |
|   1:Project                                                                                                                                                                                           |
|   |  output columns:                                                                                                                                                                                  |
|   |  5 <-> 1                                                                                                                                                                                          |
|   |  cardinality: 2000                                                                                                                                                                                |
|   |  column statistics:                                                                                                                                                                               |
|   |  * auto_fill_col-->[1.0, 1.0, 0.0, 1.0, 1.0] ESTIMATE                                                                                                                                             |
|   |                                                                                                                                                                                                   |
|   0:OlapScanNode                                                                                                                                                                                      |
|      table: t, rollup: t                                                                                                                                                                              |
|      preAggregation: on                                                                                                                                                                               |
|      Predicates: if[([1: a, BIGINT, true] > 500, [2: b, BIGINT, true] = 400, [2: b, BIGINT, true] = 600); args: BOOLEAN,BOOLEAN,BOOLEAN; result: BOOLEAN; args nullable: true; result nullable: true] |
|      partitionsRatio=1/1, tabletsRatio=1/1                                                                                                                                                            |
|      tabletList=10178                                                                                                                                                                                 |
|      actualRows=0, avgRowSize=17.0                                                                                                                                                                    |
|      cardinality: 2000                                                                                                                                                                                |
|      column statistics:                                                                                                                                                                               |
|      * a-->[0.0, 7997.0, 0.0, 8.0, 2000.0] ESTIMATE                                                                                                                                                   |
|      * b-->[0.0, 7999.0, 0.0, 8.0, 2000.0] ESTIMATE                                                                                                                                                   |
|      * auto_fill_col-->[1.0, 1.0, 0.0, 1.0, 1.0] ESTIMATE                                                                                                                                             |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```
- after
```
mysql> explain costs select count(*) from t where IF ( a > 500 , b = 400, b = 600);
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                                                                                                        |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| PLAN COST                                                                                                                                                                                             |
|   CPU: 52.873552398190384                                                                                                                                                                             |
|   Memory: 8.0                                                                                                                                                                                         |
|                                                                                                                                                                                                       |
| PLAN FRAGMENT 0(F00)                                                                                                                                                                                  |
|   Output Exprs:3: count                                                                                                                                                                               |
|   Input Partition: RANDOM                                                                                                                                                                             |
|   RESULT SINK                                                                                                                                                                                         |
|                                                                                                                                                                                                       |
|   2:AGGREGATE (update finalize)                                                                                                                                                                       |
|   |  aggregate: count[(*); args: ; result: BIGINT; args nullable: false; result nullable: false]                                                                                                      |
|   |  cardinality: 1                                                                                                                                                                                   |
|   |  column statistics:                                                                                                                                                                               |
|   |  * count-->[0.0, 1.555104482299717, 0.0, 8.0, 1.0] ESTIMATE                                                                                                                                       |
|   |                                                                                                                                                                                                   |
|   1:Project                                                                                                                                                                                           |
|   |  output columns:                                                                                                                                                                                  |
|   |  5 <-> 1                                                                                                                                                                                          |
|   |  cardinality: 2                                                                                                                                                                                   |
|   |  column statistics:                                                                                                                                                                               |
|   |  * auto_fill_col-->[1.0, 1.0, 0.0, 1.0, 1.0] ESTIMATE                                                                                                                                             |
|   |                                                                                                                                                                                                   |
|   0:OlapScanNode                                                                                                                                                                                      |
|      table: t, rollup: t                                                                                                                                                                              |
|      preAggregation: on                                                                                                                                                                               |
|      Predicates: if[([1: a, BIGINT, true] > 500, [2: b, BIGINT, true] = 400, [2: b, BIGINT, true] = 600); args: BOOLEAN,BOOLEAN,BOOLEAN; result: BOOLEAN; args nullable: true; result nullable: true] |
|      partitionsRatio=1/1, tabletsRatio=1/1                                                                                                                                                            |
|      tabletList=10141                                                                                                                                                                                 |
|      actualRows=8000000, avgRowSize=17.0                                                                                                                                                              |
|      cardinality: 2                                                                                                                                                                                   |
|      column statistics:                                                                                                                                                                               |
|      * a-->[1.0, 7999999.0, 0.0, 8.0, 1.555104482299717] ESTIMATE                                                                                                                                     |
|      * b-->[400.0, 600.0, 0.0, 8.0, 1.555104482299717] ESTIMATE                                                                                                                                       |
|      * auto_fill_col-->[1.0, 1.0, 0.0, 1.0, 1.0] ESTIMATE                                                                                                                                             |
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds boolean IF predicate selectivity estimation by rewriting to equivalent AND/OR predicates, with comprehensive unit tests for simple, nested, and compound cases.
> 
> - **Optimizer/Statistics**:
>   - Handle boolean `CallOperator` for `FunctionSet.IF` in `PredicateStatisticsCalculator`.
>   - Rewrite `IF(cond, a, b)` to equivalent `AND/OR/NOT/IS NULL` compound predicates for stats estimation.
> - **Tests**:
>   - Add unit tests covering simple, nested, and compound `IF` predicates (including NOT/AND/OR combinations) asserting output row counts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a7a90fb647adf7698f57240ffb2b36b51cf8029. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->