### PR TITLE
[BugFix] BE/CN crashed while executing a query that performs GROUP BY on an expression with large serialized keys

### DIFF
--- a/be/src/exec/aggregate/agg_hash_map.h
+++ b/be/src/exec/aggregate/agg_hash_map.h
@@ -735,13 +735,13 @@ struct AggHashMapWithSerializedKey : public AggHashMapWithKey<HashMap, AggHashMa
                 if (hash_table_size < extra->limits) {
                     _emplace_key(key, pool, allocate_func, (*agg_states)[i], [&]() { hash_table_size++; });
                 } else {
-                    _find_key((*agg_states)[i], (*not_founds)[i], key, caches[i].hashval);
+                    _find_key((*agg_states)[i], (*not_founds)[i], key);
                 }
             } else if constexpr (HTBuildOp::allocate) {
                 _emplace_key(key, pool, allocate_func, (*agg_states)[i],
                              FillNotFounds<HTBuildOp::fill_not_found>(not_founds, i));
             } else if constexpr (HTBuildOp::fill_not_found) {
-                _find_key((*agg_states)[i], (*not_founds)[i], key, caches[i].hashval);
+                _find_key((*agg_states)[i], (*not_founds)[i], key);
             }
         }
     }


### PR DESCRIPTION

## Why I'm doing:
The StarRocks BE/CN process experienced a crash when executing a GROUP BY query with large serialized keys. Core dump analysis revealed that the caches were empty.
```
query_id:3ac68c2b-b535-11f0-be5e-babda0ee6663, fragment_instance:3ac68c2b-b535-11f0-be5e-babda0ee666e
*** Aborted at 1761790068 (unix time) try "date -d @1761790068" if you are using GNU date ***
PC: @          0x564a85e void starrocks::AggHashMapWithSerializedKey<phmap::flat_hash_map<starrocks::Slice, unsigned char*, starrocks::SliceHashWithSeed<(starrocks::PhmapSeed)0>, starrocks::SliceEqual, std::allocator<std::pair<starrocks::Slice const, unsigned char*> > > >::compute@
*** SIGSEGV (@0x10) received by PID 36 (TID 0x7f668e145640) LWP(462) from PID 16; stack trace: ***
    @     0x7f6712270ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @          0xbead914 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f6713646586 PosixSignals::chained_handler(int, siginfo_t*, void*) [clone .part.0]
    @     0x7f6713646ffe JVM_handle_linux_signal
    @     0x7f6712219520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @          0x564a85e void starrocks::AggHashMapWithSerializedKey<phmap::flat_hash_map<starrocks::Slice, unsigned char*, starrocks::SliceHashWithSeed<(starrocks::PhmapSeed)0>, starrocks::SliceEqual, std::allocator<std::pair<starrocks::Slice const, unsigned char*> > > >::compute@
    @          0x56747b4 starrocks::Aggregator::build_hash_map_with_selection(unsigned long)
    @          0x5448ee0 starrocks::pipeline::AggregateStreamingSinkOperator::_push_chunk_by_auto(std::shared_ptr<starrocks::Chunk> const&, unsigned long)
    @          0x544a192 starrocks::pipeline::AggregateStreamingSinkOperator::push_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk> const&)
    @          0x5408909 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0x58aa3b1 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x45fbb7f starrocks::ThreadPool::dispatch_thread()
    @          0x45f2970 starrocks::Thread::supervise_thread(void*)
    @     0x7f671226bac3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
    @     0x7f67122fd8c0 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x1268bf)
[1761790068.485][thread: 140078447089216] je_mallctl execute purge success
```

<img width="3828" height="518" alt="9ed720edcbeaa521126a42f0ef8a5959" src="https://github.com/user-attachments/assets/9b70ffef-cd73-4ca0-9278-c06d74e53904" />

## What I'm doing:

Fixes #64926

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stop passing a precomputed hash to `_find_key` in serialized-key (by-rows) aggregation to prevent crashes with large serialized keys.
> 
> - **Backend/Aggregation**:
>   - **Serialized-key path (`AggHashMapWithSerializedKey`)**:
>     - In `compute_agg_states_by_rows`, remove passing a hash to `_find_key` and use key-only lookup for both limit and fill-not-found branches.
>     - Aligns `_find_key` calls with available data when processing large serialized keys.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d83a341e21569e2f0441f170d98c3572b5cc940. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->