### PR TITLE
[UT] Fix unstable lake batch publish ut

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
@@ -52,6 +52,8 @@ import com.starrocks.warehouse.cngroup.ComputeResource;
 import com.starrocks.warehouse.cngroup.WarehouseComputeResourceProvider;
 import mockit.Mock;
 import mockit.MockUp;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -72,6 +74,8 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class LakePublishBatchTest {
+    private static final Logger LOG = LogManager.getLogger(LakePublishBatchTest.class);
+
     private static ConnectContext connectContext;
     private static StarRocksAssert starRocksAssert;
 
@@ -104,6 +108,16 @@ public class LakePublishBatchTest {
             }
             num++;
         }
+    }
+
+    private void waitTransactionDone(TransactionState transaction) throws InterruptedException {
+        while (!transaction.getTransactionStatus().isFinalStatus()) {
+            LOG.info("transaction {} is running. state: {}", transaction.getTransactionId(),
+                    transaction.getTransactionStatus());
+            Thread.sleep(1000);
+        }
+        LOG.info("transaction {} is done. state: {}", transaction.getTransactionId(),
+                transaction.getTransactionStatus());
     }
 
     @BeforeAll
@@ -235,10 +249,10 @@ public class LakePublishBatchTest {
         PublishVersionDaemon publishVersionDaemon = new PublishVersionDaemon();
         publishVersionDaemon.runAfterCatalogReady();
 
-        Assertions.assertTrue(waiter1.await(10, TimeUnit.SECONDS));
-        Assertions.assertTrue(waiter2.await(10, TimeUnit.SECONDS));
-        Assertions.assertTrue(waiter3.await(10, TimeUnit.SECONDS));
-        Assertions.assertTrue(waiter4.await(10, TimeUnit.SECONDS));
+        Assertions.assertTrue(waiter1.await(100, TimeUnit.SECONDS));
+        Assertions.assertTrue(waiter2.await(100, TimeUnit.SECONDS));
+        Assertions.assertTrue(waiter3.await(100, TimeUnit.SECONDS));
+        Assertions.assertTrue(waiter4.await(100, TimeUnit.SECONDS));
     }
 
     //    @ParameterizedTest
@@ -342,7 +356,9 @@ public class LakePublishBatchTest {
                 getTransactionState(transactionId6);
 
         // wait publish complete
-        Thread.sleep(1000);
+        waitTransactionDone(transactionState1);
+        waitTransactionDone(transactionState2);
+
         assertEquals(transactionState1.getTransactionStatus(), TransactionStatus.ABORTED);
         assertEquals(transactionState2.getTransactionStatus(), TransactionStatus.ABORTED);
     }
@@ -372,8 +388,7 @@ public class LakePublishBatchTest {
                         transactionSource,
                         TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         // commit a transaction
-        VisibleStateWaiter waiter1 = globalTransactionMgr.commitTransaction(db.getId(), transactionId7, transTablets,
-                Lists.newArrayList(), null);
+        globalTransactionMgr.commitTransaction(db.getId(), transactionId7, transTablets, Lists.newArrayList(), null);
 
         long transactionId8 = globalTransactionMgr.
                 beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
@@ -381,8 +396,7 @@ public class LakePublishBatchTest {
                         transactionSource,
                         TransactionState.LoadJobSourceType.FRONTEND, Config.stream_load_default_timeout_second);
         // commit a transaction
-        VisibleStateWaiter waiter2 = globalTransactionMgr.commitTransaction(db.getId(), transactionId8, transTablets,
-                Lists.newArrayList(), null);
+        globalTransactionMgr.commitTransaction(db.getId(), transactionId8, transTablets, Lists.newArrayList(), null);
 
         new MockUp<Database>() {
             @Mock
@@ -394,13 +408,15 @@ public class LakePublishBatchTest {
         PublishVersionDaemon publishVersionDaemon = new PublishVersionDaemon();
         publishVersionDaemon.runAfterCatalogReady();
 
-        Assertions.assertTrue(waiter1.await(1, TimeUnit.MINUTES));
-        Assertions.assertTrue(waiter2.await(1, TimeUnit.MINUTES));
-
         TransactionState transactionState1 = globalTransactionMgr.getDatabaseTransactionMgr(db.getId()).
                 getTransactionState(transactionId7);
         TransactionState transactionState2 = globalTransactionMgr.getDatabaseTransactionMgr(db.getId()).
                 getTransactionState(transactionId8);
+
+        // wait publish complete
+        waitTransactionDone(transactionState1);
+        waitTransactionDone(transactionState2);
+
         assertEquals(transactionState1.getTransactionStatus(), TransactionStatus.VISIBLE);
         assertEquals(transactionState2.getTransactionStatus(), TransactionStatus.VISIBLE);
     }
@@ -455,7 +471,7 @@ public class LakePublishBatchTest {
                 Lists.newArrayList(), null);
 
         publishVersionDaemon.runAfterCatalogReady();
-        Assertions.assertTrue(waiter3.await(10, TimeUnit.SECONDS));
+        Assertions.assertTrue(waiter3.await(100, TimeUnit.SECONDS));
 
         Config.lake_enable_batch_publish_version = true;
     }
@@ -509,13 +525,13 @@ public class LakePublishBatchTest {
 
         Config.lake_enable_batch_publish_version = true;
         publishVersionDaemon.runAfterCatalogReady();
-        Assertions.assertFalse(waiter6.await(10, TimeUnit.SECONDS));
-        Assertions.assertFalse(waiter7.await(10, TimeUnit.SECONDS));
+        Assertions.assertFalse(waiter6.await(100, TimeUnit.SECONDS));
+        Assertions.assertFalse(waiter7.await(100, TimeUnit.SECONDS));
 
         publishVersionDaemon.publishingLakeTransactions.clear();
         publishVersionDaemon.runAfterCatalogReady();
-        Assertions.assertTrue(waiter6.await(10, TimeUnit.SECONDS));
-        Assertions.assertTrue(waiter7.await(10, TimeUnit.SECONDS));
+        Assertions.assertTrue(waiter6.await(100, TimeUnit.SECONDS));
+        Assertions.assertTrue(waiter7.await(100, TimeUnit.SECONDS));
     }
 
     @ParameterizedTest

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
@@ -112,12 +112,10 @@ public class LakePublishBatchTest {
 
     private void waitTransactionDone(TransactionState transaction) throws InterruptedException {
         while (!transaction.getTransactionStatus().isFinalStatus()) {
-            LOG.info("transaction {} is running. state: {}", transaction.getTransactionId(),
-                    transaction.getTransactionStatus());
-            Thread.sleep(1000);
+            LOG.warn("transaction {} is running. state: {}", transaction.getTransactionId(), transaction.getTransactionStatus());
+            Thread.sleep(200);
         }
-        LOG.info("transaction {} is done. state: {}", transaction.getTransactionId(),
-                transaction.getTransactionStatus());
+        LOG.warn("transaction {} is done. state: {}", transaction.getTransactionId(), transaction.getTransactionStatus());
     }
 
     @BeforeAll
@@ -249,10 +247,10 @@ public class LakePublishBatchTest {
         PublishVersionDaemon publishVersionDaemon = new PublishVersionDaemon();
         publishVersionDaemon.runAfterCatalogReady();
 
-        Assertions.assertTrue(waiter1.await(100, TimeUnit.SECONDS));
-        Assertions.assertTrue(waiter2.await(100, TimeUnit.SECONDS));
-        Assertions.assertTrue(waiter3.await(100, TimeUnit.SECONDS));
-        Assertions.assertTrue(waiter4.await(100, TimeUnit.SECONDS));
+        Assertions.assertTrue(waiter1.await(60, TimeUnit.SECONDS));
+        Assertions.assertTrue(waiter2.await(60, TimeUnit.SECONDS));
+        Assertions.assertTrue(waiter3.await(60, TimeUnit.SECONDS));
+        Assertions.assertTrue(waiter4.await(60, TimeUnit.SECONDS));
     }
 
     //    @ParameterizedTest
@@ -454,8 +452,8 @@ public class LakePublishBatchTest {
         PublishVersionDaemon publishVersionDaemon = new PublishVersionDaemon();
         publishVersionDaemon.runAfterCatalogReady();
 
-        Assertions.assertTrue(waiter1.await(10, TimeUnit.SECONDS));
-        Assertions.assertTrue(waiter2.await(10, TimeUnit.SECONDS));
+        Assertions.assertTrue(waiter1.await(60, TimeUnit.SECONDS));
+        Assertions.assertTrue(waiter2.await(60, TimeUnit.SECONDS));
 
         // Ensure publishingLakeTransactionsBatchTableId has been cleared, otherwise the following single publish may fail.
         publishVersionDaemon.publishingLakeTransactionsBatchTableId.clear();
@@ -471,7 +469,7 @@ public class LakePublishBatchTest {
                 Lists.newArrayList(), null);
 
         publishVersionDaemon.runAfterCatalogReady();
-        Assertions.assertTrue(waiter3.await(100, TimeUnit.SECONDS));
+        Assertions.assertTrue(waiter3.await(60, TimeUnit.SECONDS));
 
         Config.lake_enable_batch_publish_version = true;
     }
@@ -499,7 +497,7 @@ public class LakePublishBatchTest {
         Config.lake_enable_batch_publish_version = false;
         PublishVersionDaemon publishVersionDaemon = new PublishVersionDaemon();
         publishVersionDaemon.runAfterCatalogReady();
-        Assertions.assertTrue(waiter5.await(10, TimeUnit.SECONDS));
+        Assertions.assertTrue(waiter5.await(60, TimeUnit.SECONDS));
 
         long transactionId6 = globalTransactionMgr.
                 beginTransaction(db.getId(), Lists.newArrayList(table.getId()),
@@ -525,13 +523,13 @@ public class LakePublishBatchTest {
 
         Config.lake_enable_batch_publish_version = true;
         publishVersionDaemon.runAfterCatalogReady();
-        Assertions.assertFalse(waiter6.await(100, TimeUnit.SECONDS));
-        Assertions.assertFalse(waiter7.await(100, TimeUnit.SECONDS));
+        Assertions.assertFalse(waiter6.await(5, TimeUnit.SECONDS));
+        Assertions.assertFalse(waiter7.await(5, TimeUnit.SECONDS));
 
         publishVersionDaemon.publishingLakeTransactions.clear();
         publishVersionDaemon.runAfterCatalogReady();
-        Assertions.assertTrue(waiter6.await(100, TimeUnit.SECONDS));
-        Assertions.assertTrue(waiter7.await(100, TimeUnit.SECONDS));
+        Assertions.assertTrue(waiter6.await(60, TimeUnit.SECONDS));
+        Assertions.assertTrue(waiter7.await(60, TimeUnit.SECONDS));
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## Why I'm doing:

```
org.opentest4j.AssertionFailedError: expected: <COMMITTED> but was: <ABORTED>
	at com.starrocks.transaction.LakePublishBatchTest.testPublishDbDroped(LakePublishBatchTest.java:346)
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes Lake batch publish unit tests by adding a txn wait helper with logging, extending timeouts, refining mocks for DB/table drop, and clearing state between mode switches.
> 
> - **UT stability: `LakePublishBatchTest`**
>   - Add logging (`Logger`) and a helper `waitTransactionDone()` to poll until txn reaches a final status.
>   - Replace `Thread.sleep`/direct `VisibleStateWaiter` awaits with explicit polling in drop scenarios; mock `LocalMetastore.getDb()` to simulate DB drop and `Database.getTable()` for table drop.
>   - Increase await timeouts from `10s` to `100s` across flaky waits; ensure state cleanup by clearing `publishingLakeTransactionsBatchTableId` before switching batch→single.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4cf2f2bb285b1f49d5450e0b5db1944aad9f47c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->