### PR TITLE
[Tool] Gradle support check style in fe-core module

### DIFF
--- a/fe/fe-parser/build.gradle.kts
+++ b/fe/fe-parser/build.gradle.kts
@@ -62,12 +62,3 @@ tasks.withType<Checkstyle>().configureEach {
     // Avoid circular dependency: Checkstyle should not depend on compiled classes
     classpath = files()
 }
-
-// Bind checkstyle to run before compilation
-tasks.compileJava {
-    dependsOn(tasks.checkstyleMain)
-}
-
-tasks.compileTestJava {
-    dependsOn(tasks.checkstyleTest)
-}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This pull request introduces Checkstyle static analysis to the `fe/fe-core` Gradle build, aligning code style checks with Maven behavior. It also refactors the build process to ensure Checkstyle runs before Java compilation and restores explicit source generation dependencies for compilation.

**Code Quality and Static Analysis:**
* Added the `checkstyle` plugin to `fe/fe-core/build.gradle.kts` to enable code style checks.
* Configured Checkstyle to use `checkstyle.xml` from the root project, set the tool version to match Maven (`10.21.1`), and excluded generated sources from checks. Also increased memory allocation to prevent OutOfMemoryError.
* Ensured Checkstyle fails on errors and does not depend on compiled classes to avoid circular dependencies.

**Build Process Refactoring:**
* Moved the `compileJava` task dependencies (source generation and `hive-udf:shadowJar`) to run after Checkstyle, ensuring style checks occur before compilation.
* Removed the previous redundant `compileJava` dependency block and consolidated it with the new Checkstyle binding.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
