### PR TITLE
[Enhancement] Introduce max committed txn version to physical partition snapshot info

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotInfo.java
@@ -37,7 +37,7 @@ public class ClusterSnapshotInfo {
         if (physicalPartInfo == null) {
             return 0;
         }
-        return physicalPartInfo.version;
+        return physicalPartInfo.visibleVersion;
     }
 
     public List<Long> getCommittedVersionsAfterVisible(long dbId, long tableId, long partId, long physicalPartId) {
@@ -46,9 +46,9 @@ public class ClusterSnapshotInfo {
         if (physicalPartInfo == null) {
             return committedVersions;
         }
-        long visibleVersion = physicalPartInfo.version;
-        long maxCommittedVersion = physicalPartInfo.maxCommittedVersion;
-        for (long version = visibleVersion + 1; version <= maxCommittedVersion; version++) {
+        long visibleVersion = physicalPartInfo.visibleVersion;
+        long committedVersion = physicalPartInfo.committedVersion;
+        for (long version = visibleVersion + 1; version <= committedVersion; version++) {
             committedVersions.add(version);
         }
         return committedVersions;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotInfo.java
@@ -14,8 +14,10 @@
 
 package com.starrocks.lake.snapshot;
 
+import com.google.common.collect.Lists;
 import com.google.gson.annotations.SerializedName;
 
+import java.util.List;
 import java.util.Map;
 
 public class ClusterSnapshotInfo {
@@ -36,6 +38,20 @@ public class ClusterSnapshotInfo {
             return 0;
         }
         return physicalPartInfo.version;
+    }
+
+    public List<Long> getCommittedVersionsAfterVisible(long dbId, long tableId, long partId, long physicalPartId) {
+        List<Long> commitVersions = Lists.newArrayList();
+        PhysicalPartitionSnapshotInfo physicalPartInfo = getPhysicalPartitionInfo(dbId, tableId, partId, physicalPartId);
+        if (physicalPartInfo == null) {
+            return commitVersions;
+        }
+        long visibleVersion = physicalPartInfo.version;
+        long maxCommittedVersion = physicalPartInfo.maxCommittedVersion;
+        for (long version = visibleVersion + 1; version <= maxCommittedVersion; version++) {
+            commitVersions.add(version);
+        }
+        return commitVersions;
     }
 
     public boolean containsDb(long dbId) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotInfo.java
@@ -41,17 +41,17 @@ public class ClusterSnapshotInfo {
     }
 
     public List<Long> getCommittedVersionsAfterVisible(long dbId, long tableId, long partId, long physicalPartId) {
-        List<Long> commitVersions = Lists.newArrayList();
+        List<Long> committedVersions = Lists.newArrayList();
         PhysicalPartitionSnapshotInfo physicalPartInfo = getPhysicalPartitionInfo(dbId, tableId, partId, physicalPartId);
         if (physicalPartInfo == null) {
-            return commitVersions;
+            return committedVersions;
         }
         long visibleVersion = physicalPartInfo.version;
         long maxCommittedVersion = physicalPartInfo.maxCommittedVersion;
         for (long version = visibleVersion + 1; version <= maxCommittedVersion; version++) {
-            commitVersions.add(version);
+            committedVersions.add(version);
         }
-        return commitVersions;
+        return committedVersions;
     }
 
     public boolean containsDb(long dbId) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/PhysicalPartitionSnapshotInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/PhysicalPartitionSnapshotInfo.java
@@ -23,10 +23,10 @@ public class PhysicalPartitionSnapshotInfo {
     public final long physicalPartitionId;
     @SerializedName(value = "version")
     public final long visibleVersion;
-    @SerializedName(value = "indexInfos")
-    public final Map<Long, MaterializedIndexSnapshotInfo> indexInfos;
     @SerializedName(value = "committedVersion")
     public final long committedVersion;
+    @SerializedName(value = "indexInfos")
+    public final Map<Long, MaterializedIndexSnapshotInfo> indexInfos;
 
     public PhysicalPartitionSnapshotInfo(long physicalPartId, long visibleVersion, long committedVersion,
                                          Map<Long, MaterializedIndexSnapshotInfo> indexInfos) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/PhysicalPartitionSnapshotInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/PhysicalPartitionSnapshotInfo.java
@@ -25,11 +25,14 @@ public class PhysicalPartitionSnapshotInfo {
     public final long version;
     @SerializedName(value = "indexInfos")
     public final Map<Long, MaterializedIndexSnapshotInfo> indexInfos;
+    @SerializedName(value = "maxCommittedVersion")
+    public final long maxCommittedVersion;
 
     public PhysicalPartitionSnapshotInfo(long physicalPartId, long visibleVersion,
-                                         Map<Long, MaterializedIndexSnapshotInfo> indexInfos) {
+                                         Map<Long, MaterializedIndexSnapshotInfo> indexInfos, long maxCommittedVersion) {
         this.physicalPartitionId = physicalPartId;
         this.version = visibleVersion;
         this.indexInfos = indexInfos;
+        this.maxCommittedVersion = maxCommittedVersion;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/PhysicalPartitionSnapshotInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/PhysicalPartitionSnapshotInfo.java
@@ -28,11 +28,11 @@ public class PhysicalPartitionSnapshotInfo {
     @SerializedName(value = "committedVersion")
     public final long committedVersion;
 
-    public PhysicalPartitionSnapshotInfo(long physicalPartId, long visibleVersion,
-                                         Map<Long, MaterializedIndexSnapshotInfo> indexInfos, long committedVersion) {
+    public PhysicalPartitionSnapshotInfo(long physicalPartId, long visibleVersion, long committedVersion,
+                                         Map<Long, MaterializedIndexSnapshotInfo> indexInfos) {
         this.physicalPartitionId = physicalPartId;
         this.visibleVersion = visibleVersion;
-        this.indexInfos = indexInfos;
         this.committedVersion = committedVersion;
+        this.indexInfos = indexInfos;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/PhysicalPartitionSnapshotInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/PhysicalPartitionSnapshotInfo.java
@@ -22,17 +22,17 @@ public class PhysicalPartitionSnapshotInfo {
     @SerializedName(value = "physicalPartitionId")
     public final long physicalPartitionId;
     @SerializedName(value = "version")
-    public final long version;
+    public final long visibleVersion;
     @SerializedName(value = "indexInfos")
     public final Map<Long, MaterializedIndexSnapshotInfo> indexInfos;
-    @SerializedName(value = "maxCommittedVersion")
-    public final long maxCommittedVersion;
+    @SerializedName(value = "committedVersion")
+    public final long committedVersion;
 
     public PhysicalPartitionSnapshotInfo(long physicalPartId, long visibleVersion,
-                                         Map<Long, MaterializedIndexSnapshotInfo> indexInfos, long maxCommittedVersion) {
+                                         Map<Long, MaterializedIndexSnapshotInfo> indexInfos, long committedVersion) {
         this.physicalPartitionId = physicalPartId;
-        this.version = visibleVersion;
+        this.visibleVersion = visibleVersion;
         this.indexInfos = indexInfos;
-        this.maxCommittedVersion = maxCommittedVersion;
+        this.committedVersion = committedVersion;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/SnapshotInfoHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/SnapshotInfoHelper.java
@@ -67,7 +67,7 @@ public class SnapshotInfoHelper {
             indexInfos.put(index.getId(), SnapshotInfoHelper.buildMaterializedIndexSnapshotInfo(index));
         }
         return new PhysicalPartitionSnapshotInfo(
-                physicalPart.getId(), physicalPart.getVisibleVersion(), indexInfos, physicalPart.getCommittedVersion());
+                physicalPart.getId(), physicalPart.getVisibleVersion(), physicalPart.getCommittedVersion(), indexInfos);
     }
 
     public static MaterializedIndexSnapshotInfo buildMaterializedIndexSnapshotInfo(MaterializedIndex index) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/SnapshotInfoHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/SnapshotInfoHelper.java
@@ -67,7 +67,7 @@ public class SnapshotInfoHelper {
             indexInfos.put(index.getId(), SnapshotInfoHelper.buildMaterializedIndexSnapshotInfo(index));
         }
         return new PhysicalPartitionSnapshotInfo(
-                physicalPart.getId(), physicalPart.getVisibleVersion(), indexInfos);
+                physicalPart.getId(), physicalPart.getVisibleVersion(), indexInfos, physicalPart.getCommittedVersion());
     }
 
     public static MaterializedIndexSnapshotInfo buildMaterializedIndexSnapshotInfo(MaterializedIndex index) {

--- a/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/snapshot/ClusterSnapshotInfoTest.java
@@ -40,6 +40,182 @@ public class ClusterSnapshotInfoTest {
     }
 
     @Test
+    public void testCommittedVersionsAfterVisible() {
+        long testDbId = 0;
+        List<Long> dbIds = GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIds();
+        for (Long dbId : dbIds) {
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
+            if (db != null && !db.isSystemDatabase()) {
+                testDbId = dbId;
+                break;
+            }
+        }
+        Database sourceDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(testDbId);
+        final Database dbTest = new Database(sourceDb.getId(), sourceDb.getFullName());
+        for (Table tbl : sourceDb.getTables()) {
+            if (tbl.isOlapTable()) {
+                dbTest.registerTableUnlocked(tbl);
+            }
+        }
+
+        new MockUp<Table>() {
+            @Mock
+            public boolean isCloudNativeTableOrMaterializedView() {
+                return true;
+            }
+        };
+
+        new MockUp<LocalMetastore>() {
+            @Mock
+            public List<Database> getAllDbs() {
+                return Lists.newArrayList(dbTest);
+            }
+        };
+
+        ClusterSnapshotInfo clusterSnapshotInfo =
+                SnapshotInfoHelper.buildClusterSnapshotInfo(
+                        GlobalStateMgr.getCurrentState().getLocalMetastore().getAllDbs());
+        Assertions.assertTrue(!clusterSnapshotInfo.isEmpty());
+
+        for (Table tbl : dbTest.getTables()) {
+            OlapTable olapTable = (OlapTable) tbl;
+            for (PhysicalPartition part : olapTable.getPhysicalPartitions()) {
+                long dbId = dbTest.getId();
+                long tableId = olapTable.getId();
+                long parentPartId = part.getParentId();
+                long physicalPartId = part.getId();
+
+                List<Long> committedAfterVisible = clusterSnapshotInfo.getCommittedVersionsAfterVisible(
+                        dbId, tableId, parentPartId, physicalPartId);
+
+                long visibleVersion = part.getVisibleVersion();
+                long committedVersion = part.getCommittedVersion();
+                long expectedSize = Math.max(0L, committedVersion - visibleVersion);
+
+                Assertions.assertEquals(expectedSize, committedAfterVisible.size());
+                if (expectedSize > 0) {
+                    Assertions.assertEquals(visibleVersion + 1, committedAfterVisible.get(0).longValue());
+                    Assertions.assertEquals(committedVersion,
+                            committedAfterVisible.get(committedAfterVisible.size() - 1).longValue());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testCommittedVersionsAfterVisibleWithInvalidIds() {
+        long testDbId = 0;
+        List<Long> dbIds = GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIds();
+        for (Long dbId : dbIds) {
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
+            if (db != null && !db.isSystemDatabase()) {
+                testDbId = dbId;
+                break;
+            }
+        }
+        Database sourceDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(testDbId);
+        final Database dbTest = new Database(sourceDb.getId(), sourceDb.getFullName());
+        for (Table tbl : sourceDb.getTables()) {
+            if (tbl.isOlapTable()) {
+                dbTest.registerTableUnlocked(tbl);
+            }
+        }
+
+        new MockUp<Table>() {
+            @Mock
+            public boolean isCloudNativeTableOrMaterializedView() {
+                return true;
+            }
+        };
+
+        new MockUp<LocalMetastore>() {
+            @Mock
+            public List<Database> getAllDbs() {
+                return Lists.newArrayList(dbTest);
+            }
+        };
+
+        ClusterSnapshotInfo clusterSnapshotInfo =
+                SnapshotInfoHelper.buildClusterSnapshotInfo(
+                        GlobalStateMgr.getCurrentState().getLocalMetastore().getAllDbs());
+        Assertions.assertTrue(!clusterSnapshotInfo.isEmpty());
+
+        // Non-existent identifiers should return an empty list
+        List<Long> res = clusterSnapshotInfo.getCommittedVersionsAfterVisible(0L, 0L, 0L, 0L);
+        Assertions.assertTrue(res.isEmpty());
+    }
+
+    @Test
+    public void testCommittedVersionsAfterVisibleWithManualBump() {
+        long testDbId = 0;
+        List<Long> dbIds = GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIds();
+        for (Long dbId : dbIds) {
+            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
+            if (db != null && !db.isSystemDatabase()) {
+                testDbId = dbId;
+                break;
+            }
+        }
+        Database sourceDb = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(testDbId);
+        final Database dbTest = new Database(sourceDb.getId(), sourceDb.getFullName());
+        for (Table tbl : sourceDb.getTables()) {
+            if (tbl.isOlapTable()) {
+                dbTest.registerTableUnlocked(tbl);
+            }
+        }
+
+        new MockUp<Table>() {
+            @Mock
+            public boolean isCloudNativeTableOrMaterializedView() {
+                return true;
+            }
+        };
+
+        new MockUp<LocalMetastore>() {
+            @Mock
+            public List<Database> getAllDbs() {
+                return Lists.newArrayList(dbTest);
+            }
+        };
+
+        // Pick the first available physical partition and manually bump nextVersion
+        PhysicalPartition targetPart = null;
+        OlapTable targetTable = null;
+        outer:
+        for (Table tbl : dbTest.getTables()) {
+            OlapTable olapTable = (OlapTable) tbl;
+            for (PhysicalPartition part : olapTable.getPhysicalPartitions()) {
+                targetPart = part;
+                targetTable = olapTable;
+                break outer;
+            }
+        }
+        Assertions.assertNotNull(targetPart);
+        Assertions.assertNotNull(targetTable);
+
+        long originalNext = targetPart.getNextVersion();
+        long visible = targetPart.getVisibleVersion();
+        long bump = 3L; // expect versions (visible+1 .. visible+3)
+        try {
+            targetPart.setNextVersion(visible + bump + 1);
+
+            ClusterSnapshotInfo clusterSnapshotInfo =
+                    SnapshotInfoHelper.buildClusterSnapshotInfo(
+                            GlobalStateMgr.getCurrentState().getLocalMetastore().getAllDbs());
+
+            List<Long> committedAfterVisible = clusterSnapshotInfo.getCommittedVersionsAfterVisible(
+                    dbTest.getId(), targetTable.getId(), targetPart.getParentId(), targetPart.getId());
+
+            Assertions.assertEquals(bump, committedAfterVisible.size());
+            Assertions.assertEquals(visible + 1, committedAfterVisible.get(0).longValue());
+            Assertions.assertEquals(visible + bump, committedAfterVisible.get((int) bump - 1).longValue());
+        } finally {
+            // restore state
+            targetPart.setNextVersion(originalNext);
+        }
+    }
+
+    @Test
     public void testClusterSnapshotInfoBasic() {
         // 1. test get version info function
         long testDbId = 0;


### PR DESCRIPTION
## Why I'm doing:
In current implementation, cluster snapshot info know nothing about the committed txn information
even the snapshot image contains the committed txn.
To support GC control for such txn files within the snapshot, we need to introduce max committed txn version
get the more accurate version information for each physical partition.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Track committed txn version per physical partition, rename `version` to `visibleVersion`, add API to list versions committed after visible, and add tests.
> 
> - **Snapshot model updates**:
>   - Rename `version` to `visibleVersion` in `PhysicalPartitionSnapshotInfo` and add `committedVersion`.
>   - Update `SnapshotInfoHelper.buildPhysicalPartitionSnapshotInfo` to populate `committedVersion` from `PhysicalPartition`.
> - **APIs**:
>   - `ClusterSnapshotInfo.getVersion(...)` now returns `visibleVersion`.
>   - Add `ClusterSnapshotInfo.getCommittedVersionsAfterVisible(...)` to list versions `(visibleVersion+1 .. committedVersion)`.
> - **Tests**:
>   - Add tests covering normal, invalid-id, and manual-bump cases for `getCommittedVersionsAfterVisible`.
>   - Adjust existing basic snapshot test to expect `visibleVersion`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acb076cee90bea58715370f3e90a76ef7f3aeaa9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->