### PR TITLE
[Refactor] Eliminate runtime CPU checks in hash functions

### DIFF
--- a/be/src/util/hash_util.cpp
+++ b/be/src/util/hash_util.cpp
@@ -14,9 +14,56 @@
 
 #include "util/hash_util.hpp"
 
+#ifdef __SSE4_2__
+#include <nmmintrin.h>
+#endif
+
+#include "util/cpu_info.h"
+#include "util/murmur_hash3.h"
 #include "util/xxh3.h"
 
 namespace starrocks {
+
+// Static member definitions
+HashUtil::Hash32Func HashUtil::g_hash32_func = nullptr;
+HashUtil::Hash64Func HashUtil::g_hash64_func = nullptr;
+#ifdef __SSE4_2__
+HashUtil::Crc32Func HashUtil::g_crc32_func = nullptr;
+HashUtil::Crc64Func HashUtil::g_crc64_func = nullptr;
+#endif
+
+// Initialize function pointers at program startup based on CPU capabilities.
+// This avoids runtime CPU checks in the hot path (hash(), hash64(), crc_hash(), crc_hash64() functions).
+// The constructor attribute ensures this runs before main(), but after CpuInfo::init()
+// is called in Daemon::init(). If CpuInfo hasn't been initialized yet, we initialize it here.
+__attribute__((constructor)) void SelectHashFunctions() {
+    // Ensure CpuInfo is initialized
+    CpuInfo::init();
+
+#ifdef __SSE4_2__
+    if (CpuInfo::is_supported(CpuInfo::SSE4_2)) {
+        HashUtil::g_hash32_func = HashUtil::crc_hash_sse42;
+        HashUtil::g_hash64_func = HashUtil::crc_hash64_sse42;
+        HashUtil::g_crc32_func = HashUtil::crc_hash_sse42;
+        HashUtil::g_crc64_func = HashUtil::crc_hash64_sse42;
+    } else {
+        HashUtil::g_hash32_func = HashUtil::fnv_hash;
+        HashUtil::g_hash64_func = HashUtil::hash64_fallback;
+        HashUtil::g_crc32_func = HashUtil::zlib_crc_hash;
+        HashUtil::g_crc64_func = [](const void* data, int32_t bytes, uint64_t hash) -> uint64_t {
+            // For 64-bit fallback, use zlib_crc_hash on both halves
+            uint32_t h1 = hash >> 32;
+            uint32_t h2 = (hash << 32) >> 32;
+            h1 = HashUtil::zlib_crc_hash(data, bytes, h1);
+            h2 = HashUtil::zlib_crc_hash(data, bytes, h2);
+            return ((uint64_t)h1 << 32) | h2;
+        };
+    }
+#else
+    HashUtil::g_hash32_func = HashUtil::fnv_hash;
+    HashUtil::g_hash64_func = HashUtil::hash64_fallback;
+#endif
+}
 
 uint64_t HashUtil::xx_hash3_64(const void* key, int32_t len, uint64_t seed) {
     return XXH3_64bits_withSeed(key, len, seed);
@@ -25,5 +72,71 @@ uint64_t HashUtil::xx_hash3_64(const void* key, int32_t len, uint64_t seed) {
 uint64_t HashUtil::xx_hash64(const void* key, int32_t len, uint64_t seed) {
     return XXH64(key, len, seed);
 }
+
+uint64_t HashUtil::hash64_fallback(const void* data, int32_t bytes, uint64_t seed) {
+    uint64_t hash = 0;
+    murmur_hash3_x64_64(data, bytes, seed, &hash);
+    return hash;
+}
+
+#ifdef __SSE4_2__
+uint32_t HashUtil::crc_hash_sse42(const void* data, int32_t bytes, uint32_t hash) {
+    uint32_t words = bytes / sizeof(uint32_t);
+    bytes = bytes % sizeof(uint32_t);
+
+    const uint32_t* p = reinterpret_cast<const uint32_t*>(data);
+
+    while (words--) {
+        hash = _mm_crc32_u32(hash, *p);
+        ++p;
+    }
+
+    const uint8_t* s = reinterpret_cast<const uint8_t*>(p);
+
+    while (bytes--) {
+        hash = _mm_crc32_u8(hash, *s);
+        ++s;
+    }
+
+    // The lower half of the CRC hash has has poor uniformity, so swap the halves
+    // for anyone who only uses the first several bits of the hash.
+    hash = (hash << 16) | (hash >> 16);
+    return hash;
+}
+
+uint64_t HashUtil::crc_hash64_sse42(const void* data, int32_t bytes, uint64_t hash) {
+    uint32_t words = bytes / sizeof(uint32_t);
+    bytes = bytes % sizeof(uint32_t);
+
+    uint32_t h1 = hash >> 32;
+    uint32_t h2 = (hash << 32) >> 32;
+
+    const uint32_t* p = reinterpret_cast<const uint32_t*>(data);
+    while (words--) {
+        (words & 1) ? (h1 = _mm_crc32_u32(h1, *p)) : (h2 = _mm_crc32_u32(h2, *p));
+        ++p;
+    }
+
+    const uint8_t* s = reinterpret_cast<const uint8_t*>(p);
+    while (bytes--) {
+        (bytes & 1) ? (h1 = _mm_crc32_u8(h1, *s)) : (h2 = _mm_crc32_u8(h2, *s));
+        ++s;
+    }
+
+    h1 = (h1 << 16) | (h1 >> 16);
+    h2 = (h2 << 16) | (h2 >> 16);
+    ((uint32_t*)(&hash))[0] = h1;
+    ((uint32_t*)(&hash))[1] = h2;
+    return hash;
+}
+
+uint32_t HashUtil::crc_hash(const void* data, int32_t bytes, uint32_t hash) {
+    return g_crc32_func(data, bytes, hash);
+}
+
+uint64_t HashUtil::crc_hash64(const void* data, int32_t bytes, uint64_t hash) {
+    return g_crc64_func(data, bytes, hash);
+}
+#endif
 
 } // namespace starrocks

--- a/be/src/util/hash_util.cpp
+++ b/be/src/util/hash_util.cpp
@@ -98,7 +98,7 @@ uint32_t HashUtil::crc_hash_sse42(const void* data, int32_t bytes, uint32_t hash
         ++s;
     }
 
-    // The lower half of the CRC hash has has poor uniformity, so swap the halves
+    // The lower half of the CRC hash has poor uniformity, so swap the halves
     // for anyone who only uses the first several bits of the hash.
     hash = (hash << 16) | (hash >> 16);
     return hash;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Optimize HashUtil hash functions by leveraging CPU-specific implementations determined at program startup, eliminating the need for repeated CPU capability checks during each function call. This approach minimizes runtime overhead in performance-critical paths.

- Utilize function pointers initialized with `__attribute__((constructor))` to select the most efficient hash implementation based on CPU features during startup.
- Eliminate runtime checks such as `CpuInfo::is_supported()` from functions like `hash()`, `hash64()`, `crc_hash()`, and `crc_hash64()`.
- Relocate `crc_hash_sse42()` and `crc_hash64_sse42()` implementations from header files to source files to streamline compilation.
- Perform CPU feature detection once at program startup, initializing function pointers to avoid repeated checks in high-frequency hash operations.

This enhancement significantly reduces the overhead of CPU capability detection, improving performance for intensive hash operations, particularly in query execution scenarios.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Initialize function pointers at startup to pick SSE4.2/zlib/murmur paths and route HashUtil hash/CRC APIs through them, moving SSE code to .cpp and eliminating per-call CPU checks.
> 
> - **Hash dispatch refactor**:
>   - Initialize function pointers in `select_hash_functions()` (constructor) based on `CpuInfo` to select SSE4.2 or fallback implementations.
>   - Route `HashUtil::hash()`, `hash64()`, `crc_hash()`, `crc_hash64()` via these pointers (no per-call CPU checks).
> - **Implementations**:
>   - Add `hash64_fallback()` using `murmur_hash3_x64_64`.
>   - Define SSE4.2 `crc_hash_sse42()` and `crc_hash64_sse42()` in `hash_util.cpp`.
>   - Provide 64-bit CRC fallback by applying `zlib_crc_hash` to both 32-bit halves.
> - **Header cleanup**:
>   - Remove inline SSE4.2 CRC implementations and runtime checks; replace with declarations.
>   - Drop `CpuInfo`/`murmur_hash3` includes from header; add needed includes to `.cpp`.
>   - Update comments to reflect new initialization and dispatch model.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb27b1880ddd6d62e493b638b7ed01c5612fc9d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->