### PR TITLE
[Feature] Introduce range metadata for range distribution

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/BoolVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/BoolVariant.java
@@ -1,0 +1,80 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.type.BooleanType;
+
+import java.util.Objects;
+
+/*
+ * BoolVariant is for type BOOLEAN
+ */
+public class BoolVariant extends Variant {
+
+    @SerializedName(value = "value")
+    protected final boolean value;
+
+    public BoolVariant(boolean value) {
+        super(BooleanType.BOOLEAN);
+        this.value = value;
+    }
+
+    public BoolVariant(String value) {
+        super(BooleanType.BOOLEAN);
+        if (value.trim().equalsIgnoreCase("true") || value.trim().equals("1")) {
+            this.value = true;
+        } else if (value.trim().equalsIgnoreCase("false") || value.trim().equals("0")) {
+            this.value = false;
+        } else {
+            throw new RuntimeException("Invalid boolean value: " + value);
+        }
+    }
+
+    @Override
+    public long getLongValue() {
+        return value ? 1 : 0;
+    }
+
+    @Override
+    public String getStringValue() {
+        return value ? "TRUE" : "FALSE";
+    }
+
+    @Override
+    public int compareTo(Variant other) {
+        if (other instanceof LargeIntVariant) {
+            return -other.compareTo(this);
+        }
+        return Long.compare(this.getLongValue(), other.getLongValue());
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || !(object instanceof BoolVariant)) {
+            return false;
+        }
+        BoolVariant other = (BoolVariant) object;
+        return this.value == other.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DateVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DateVariant.java
@@ -1,0 +1,86 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.util.DateUtils;
+import com.starrocks.type.Type;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.Objects;
+
+/*
+ * DateVariant is for type DATE, DATETIME and TIME
+ */
+public class DateVariant extends Variant {
+
+    @SerializedName(value = "seconds")
+    protected final long seconds;
+
+    @SerializedName(value = "nanos")
+    protected final long nanos;
+
+    public DateVariant(Type type, String value) {
+        this(type, DateUtils.parseStrictDateTime(value).toInstant(ZoneOffset.UTC));
+    }
+
+    public DateVariant(Type type, Instant value) {
+        super(type);
+        this.seconds = value.getEpochSecond();
+        this.nanos = value.getNano();
+    }
+
+    @Override
+    public long getLongValue() {
+        // Micro seconds
+        return seconds * 1000000 + (nanos / 1000);
+    }
+
+    @Override
+    public String getStringValue() {
+        return Instant.ofEpochSecond(seconds, nanos).toString();
+    }
+
+    @Override
+    public int compareTo(Variant other) {
+        Preconditions.checkArgument(other instanceof DateVariant, other);
+        DateVariant otherDateTime = (DateVariant) other;
+
+        int result = Long.compare(this.seconds, otherDateTime.seconds);
+        if (result != 0) {
+            return result;
+        }
+        return Long.compare(this.nanos, otherDateTime.nanos);
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || !(object instanceof DateVariant)) {
+            return false;
+        }
+        DateVariant other = (DateVariant) object;
+        return this.seconds == other.seconds && this.nanos == other.nanos;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(seconds, nanos);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IntVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IntVariant.java
@@ -1,0 +1,98 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.type.Type;
+
+import java.util.Objects;
+
+/*
+ * IntVariant is for type TINYINT, SMALLINT, INT and BIGINT
+ */
+public class IntVariant extends Variant {
+
+    @SerializedName(value = "value")
+    protected final long value;
+
+    static long parseLong(String value) {
+        try {
+            return Long.parseLong(value);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid int value: " + value, e);
+        }
+    }
+
+    public IntVariant(Type type, long value) {
+        super(type);
+        this.value = value;
+        Preconditions.checkArgument(checkNumberRange(), "Number out of range, type: " + type + ", value: " + value);
+    }
+
+    public IntVariant(Type type, String value) {
+        this(type, IntVariant.parseLong(value));
+    }
+
+    @Override
+    public long getLongValue() {
+        return value;
+    }
+
+    @Override
+    public String getStringValue() {
+        return String.valueOf(value);
+    }
+
+    @Override
+    public int compareTo(Variant other) {
+        if (other instanceof LargeIntVariant) {
+            return -other.compareTo(this);
+        }
+        return Long.compare(this.getLongValue(), other.getLongValue());
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || !(object instanceof IntVariant)) {
+            return false;
+        }
+        IntVariant other = (IntVariant) object;
+        return this.value == other.value;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value);
+    }
+
+    private boolean checkNumberRange() {
+        switch (type.getPrimitiveType()) {
+            case TINYINT:
+                return (this.value >= Byte.MIN_VALUE && this.value <= Byte.MAX_VALUE);
+            case SMALLINT:
+                return (this.value >= Short.MIN_VALUE && this.value <= Short.MAX_VALUE);
+            case INT:
+                return (this.value >= Integer.MIN_VALUE && this.value <= Integer.MAX_VALUE);
+            case BIGINT:
+                return true;
+            default:
+                throw new IllegalArgumentException("Invalid type: " + type);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LargeIntVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LargeIntVariant.java
@@ -1,0 +1,87 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.Int128;
+import com.starrocks.type.IntegerType;
+
+import java.math.BigInteger;
+
+/*
+ * LargeIntVariant is for type LARGEINT
+ */
+public class LargeIntVariant extends Variant {
+
+    @SerializedName(value = "value")
+    protected final Int128 value;
+
+    public LargeIntVariant(Int128 value) {
+        super(IntegerType.LARGEINT);
+        this.value = value;
+    }
+
+    public LargeIntVariant(long value) {
+        this(Int128.of(value));
+    }
+
+    public LargeIntVariant(String value) {
+        this(Int128.of(value));
+    }
+
+    public LargeIntVariant(BigInteger value) {
+        this(Int128.of(value));
+    }
+
+    @Override
+    public long getLongValue() {
+        return value.toLong();
+    }
+
+    @Override
+    public String getStringValue() {
+        return value.toString();
+    }
+
+    public BigInteger toBigInteger() {
+        return value.toBigInteger();
+    }
+
+    @Override
+    public int compareTo(Variant other) {
+        if (other instanceof LargeIntVariant) {
+            return this.value.compareTo(((LargeIntVariant) other).value);
+        } else {
+            return this.value.compareTo(Int128.of(other.getLongValue()));
+        }
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || !(object instanceof LargeIntVariant)) {
+            return false;
+        }
+        LargeIntVariant other = (LargeIntVariant) object;
+        return this.value.equals(other.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StringVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StringVariant.java
@@ -1,0 +1,66 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.util.StringUtils;
+import com.starrocks.type.Type;
+
+/*
+ * StringVariant is for type CHAR, VARCHAR, BINARY, VARBINARY and HLL
+ */
+public class StringVariant extends Variant {
+
+    @SerializedName(value = "value")
+    protected final String value;
+
+    public StringVariant(Type type, String value) {
+        super(type);
+        this.value = value;
+    }
+
+    @Override
+    public long getLongValue() {
+        return IntVariant.parseLong(value);
+    }
+
+    @Override
+    public String getStringValue() {
+        return value;
+    }
+
+    @Override
+    public int compareTo(Variant other) {
+        // compare string with utf-8 byte array, same with DM,BE,StorageEngine
+        return StringUtils.compareStringWithUTF8ByteArray(value, other.getStringValue());
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || !(object instanceof StringVariant)) {
+            return false;
+        }
+        StringVariant other = (StringVariant) object;
+        return this.value.equals(other.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Tablet.java
@@ -16,6 +16,7 @@
 package com.starrocks.catalog;
 
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.Range;
 import com.starrocks.common.io.Writable;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 
@@ -31,12 +32,32 @@ public abstract class Tablet extends MetaObject implements Writable {
     @SerializedName(value = JSON_KEY_ID)
     protected long id;
 
+    /*
+     * Add the serialization when the feature is almost finished
+     * @SerializedName(value = "range")
+     */
+    protected Range<Tuple> range;
+
     public Tablet(long id) {
         this.id = id;
+        this.range = Range.all();
+    }
+
+    public Tablet(long id, Range<Tuple> range) {
+        this.id = id;
+        this.range = range;
     }
 
     public long getId() {
         return id;
+    }
+
+    public Range<Tuple> getRange() {
+        return range;
+    }
+
+    public void setRange(Range<Tuple> range) {
+        this.range = range;
     }
 
     public abstract long getDataSize(boolean singleReplica);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Tuple.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Tuple.java
@@ -1,0 +1,55 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+public class Tuple implements Comparable<Tuple> {
+
+    @SerializedName(value = "values")
+    private final List<Variant> values;
+
+    public Tuple(List<Variant> values) {
+        this.values = values;
+    }
+
+    public List<Variant> getValues() {
+        return this.values;
+    }
+
+    @Override
+    public int compareTo(Tuple other) {
+        return Variant.compatibleCompare(this.values, other.values);
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || !(object instanceof Tuple)) {
+            return false;
+        }
+        Tuple other = (Tuple) object;
+        return this.values.equals(other.values);
+    }
+
+    @Override
+    public int hashCode() {
+        return values.hashCode();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Variant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Variant.java
@@ -1,0 +1,107 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.sql.common.TypeManager;
+import com.starrocks.type.Type;
+
+import java.util.List;
+
+/*
+ * Variant is used to store a value ​​of various types,
+ * currently supporting type: BOOLEAN, INT (TINYINT, SMALLINT, INT, BIGINT and LARGEINT),
+ * DATETIME (DATE, DATETIME and TIME), STRING (CHAR, VARCHAR, BINARY, VARBINARY and HLL)
+ */
+public abstract class Variant implements Comparable<Variant> {
+
+    @SerializedName(value = "type")
+    protected final Type type;
+
+    public Variant(Type type) {
+        this.type = type;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public abstract long getLongValue();
+
+    public abstract String getStringValue();
+
+    // public abstract TVariant toThrift();
+
+    // public abstract VariantPB toProto();
+
+    public static Variant of(Type type, String value) {
+        Preconditions.checkArgument(type.isValid());
+        switch (type.getPrimitiveType()) {
+            case BOOLEAN:
+                return new BoolVariant(value);
+            case TINYINT:
+            case SMALLINT:
+            case INT:
+            case BIGINT:
+                return new IntVariant(type, value);
+            case LARGEINT:
+                return new LargeIntVariant(value);
+            case CHAR:
+            case VARCHAR:
+            case BINARY:
+            case VARBINARY:
+            case HLL:
+                return new StringVariant(type, value);
+            case DATE:
+            case DATETIME:
+            case TIME:
+                return new DateVariant(type, value);
+            default:
+                throw new IllegalArgumentException("Type[" + type.toSql() + "] not supported.");
+        }
+    }
+
+    public static int compatibleCompare(Variant key1, Variant key2) {
+        if (key1.getClass() == key2.getClass()) {
+            return key1.compareTo(key2);
+        }
+
+        Type destType = TypeManager.getAssignmentCompatibleType(key1.getType(), key2.getType(), false);
+        Preconditions.checkArgument(destType.isValid());
+        Variant newKey1 = key1;
+        if (key1.getType() != destType) {
+            newKey1 = Variant.of(destType, key1.getStringValue());
+        }
+        Variant newKey2 = key2;
+        if (key2.getType() != destType) {
+            newKey2 = Variant.of(destType, key2.getStringValue());
+        }
+        return newKey1.compareTo(newKey2);
+    }
+
+    public static int compatibleCompare(List<Variant> key1, List<Variant> key2) {
+        int key1Length = key1.size();
+        int key2Length = key2.size();
+        int minLength = Math.min(key1Length, key2Length);
+        for (int i = 0; i < minLength; ++i) {
+            int ret = Variant.compatibleCompare(key1.get(i), key2.get(i));
+            if (0 != ret) {
+                return ret;
+            }
+        }
+        return Integer.compare(key1Length, key2Length);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/common/Int128.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Int128.java
@@ -1,0 +1,140 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.annotations.SerializedName;
+
+import java.math.BigInteger;
+import java.util.Objects;
+
+public class Int128 implements Comparable<Int128> {
+
+    @SerializedName(value = "high")
+    protected final long high;
+
+    @SerializedName(value = "low")
+    protected final long low;
+
+    public static Int128 of(BigInteger value) {
+        Preconditions.checkArgument(value.bitLength() < 128,
+                "Value out of signed 128-bit range: " + value);
+
+        long high = value.shiftRight(64).longValue();
+        long low = value.longValue();
+        return new Int128(high, low);
+    }
+
+    public static Int128 of(String value) {
+        return Int128.of(new BigInteger(value));
+    }
+
+    public static Int128 of(long value) {
+        return new Int128(value);
+    }
+
+    private Int128(long high, long low) {
+        this.high = high;
+        this.low = low;
+    }
+
+    private Int128(long value) {
+        this(value >> 63, value);
+    }
+
+    public long getHigh() {
+        return high;
+    }
+
+    public long getLow() {
+        return low;
+    }
+
+    public boolean isInLong() {
+        return high == (low >> 63);
+    }
+
+    // For numbers outside long range, returns the low 64 bits
+    public long toLong() {
+        return low;
+    }
+
+    public byte[] toByteArray() {
+        return new byte[] {
+                (byte) ((high >> 56) & 0xFFL),
+                (byte) ((high >> 48) & 0xFFL),
+                (byte) ((high >> 40) & 0xFFL),
+                (byte) ((high >> 32) & 0xFFL),
+                (byte) ((high >> 24) & 0xFFL),
+                (byte) ((high >> 16) & 0xFFL),
+                (byte) ((high >> 8) & 0xFFL),
+                (byte) ((high) & 0xFFL),
+                (byte) ((low >> 56) & 0xFFL),
+                (byte) ((low >> 48) & 0xFFL),
+                (byte) ((low >> 40) & 0xFFL),
+                (byte) ((low >> 32) & 0xFFL),
+                (byte) ((low >> 24) & 0xFFL),
+                (byte) ((low >> 16) & 0xFFL),
+                (byte) ((low >> 8) & 0xFFL),
+                (byte) ((low) & 0xFFL) };
+    }
+
+    public BigInteger toBigInteger() {
+        if (isInLong()) {
+            return BigInteger.valueOf(low);
+        }
+
+        return new BigInteger(toByteArray());
+    }
+
+    @Override
+    public String toString() {
+        if (high == 0L) {
+            return Long.toUnsignedString(low);
+        }
+
+        if (isInLong()) {
+            return Long.toString(low);
+        }
+
+        return toBigInteger().toString();
+    }
+
+    @Override
+    public int compareTo(Int128 other) {
+        int result = Long.compare(this.high, other.high);
+        if (result != 0) {
+            return result;
+        }
+        return Long.compareUnsigned(this.low, other.low);
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (!(object instanceof Int128)) {
+            return false;
+        }
+        Int128 other = (Int128) object;
+        return this.high == other.high && this.low == other.low;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(high, low);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/common/Range.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Range.java
@@ -1,0 +1,790 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common;
+
+import com.google.common.base.Preconditions;
+
+import java.util.Objects;
+
+/**
+ * An abstract class representing a range with lower and upper bounds and supporting gson serialization.
+ * Bounds can be inclusive or exclusive, and null bounds represent infinity.
+ *
+ * <p>Note: The {@link #compareTo(Range)} method is used for ordering ranges
+ * and may return 0 for overlapping ranges that are not equal. This is intentional
+ * for range sorting purposes. Do not rely on {@code compareTo(x) == 0} to test equality;
+ * use {@link #equals(Object)} instead.
+ *
+ * @param <T> the type of the range bounds, must be Comparable
+ */
+public abstract class Range<T extends Comparable<T>> implements Comparable<Range<T>> {
+
+    /**
+     * Factory method to create a Range instance based on bounds and inclusiveness.
+     *
+     * @param lowerBound the lower bound, or null for negative infinity
+     * @param upperBound the upper bound, or null for positive infinity
+     * @param lowerBoundIncluded true if the lower bound should be included
+     * @param upperBoundIncluded true if the upper bound should be included
+     * @param <T> the type of the range bounds
+     * @return an appropriate Range implementation
+     */
+    public static <T extends Comparable<T>> Range<T> of(T lowerBound, T upperBound,
+                                                         boolean lowerBoundIncluded,
+                                                         boolean upperBoundIncluded) {
+        // Case 1: Both bounds are null - represents all values (-∞, +∞)
+        if (lowerBound == null && upperBound == null) {
+            Preconditions.checkArgument(lowerBoundIncluded == false && upperBoundIncluded == false);
+            return AllRange.getInstance();
+        }
+
+        // Case 2: Only lower bound is null - represents (-∞, upperBound) or (-∞, upperBound]
+        if (lowerBound == null) {
+            Preconditions.checkArgument(lowerBoundIncluded == false);
+            if (upperBoundIncluded) {
+                return new LERange<>(upperBound);  // (-∞, upperBound]
+            } else {
+                return new LTRange<>(upperBound);  // (-∞, upperBound)
+            }
+        }
+
+        // Case 3: Only upper bound is null - represents (lowerBound, +∞) or [lowerBound, +∞)
+        if (upperBound == null) {
+            Preconditions.checkArgument(upperBoundIncluded == false);
+            if (lowerBoundIncluded) {
+                return new GERange<>(lowerBound);  // [lowerBound, +∞)
+            } else {
+                return new GTRange<>(lowerBound);  // (lowerBound, +∞)
+            }
+        }
+
+        // Case 4: Both bounds are non-null - represents bounded ranges
+        if (lowerBoundIncluded && upperBoundIncluded) {
+            return new GELERange<>(lowerBound, upperBound);  // [lowerBound, upperBound]
+        } else if (lowerBoundIncluded && !upperBoundIncluded) {
+            return new GELTRange<>(lowerBound, upperBound);  // [lowerBound, upperBound)
+        } else if (!lowerBoundIncluded && upperBoundIncluded) {
+            return new GTLERange<>(lowerBound, upperBound);  // (lowerBound, upperBound]
+        } else {
+            return new GTLTRange<>(lowerBound, upperBound);  // (lowerBound, upperBound)
+        }
+    }
+
+    /**
+     * Creates an AllRange representing all possible values (-∞, +∞).
+     *
+     * @param <T> the type of the range bounds
+     * @return an AllRange instance
+     */
+    public static <T extends Comparable<T>> Range<T> all() {
+        return AllRange.getInstance();
+    }
+
+    /**
+     * Creates a LTRange representing values less than the upper bound: (-∞, upperBound).
+     *
+     * @param upperBound the upper bound (excluded)
+     * @param <T> the type of the range bounds
+     * @return a LTRange instance
+     */
+    public static <T extends Comparable<T>> Range<T> lt(T upperBound) {
+        return new LTRange<>(upperBound);
+    }
+
+    /**
+     * Creates a LERange representing values less than or equal to the upper bound: (-∞, upperBound].
+     *
+     * @param upperBound the upper bound (included)
+     * @param <T> the type of the range bounds
+     * @return a LERange instance
+     */
+    public static <T extends Comparable<T>> Range<T> le(T upperBound) {
+        return new LERange<>(upperBound);
+    }
+
+    /**
+     * Creates a GTRange representing values greater than the lower bound: (lowerBound, +∞).
+     *
+     * @param lowerBound the lower bound (excluded)
+     * @param <T> the type of the range bounds
+     * @return a GTRange instance
+     */
+    public static <T extends Comparable<T>> Range<T> gt(T lowerBound) {
+        return new GTRange<>(lowerBound);
+    }
+
+    /**
+     * Creates a GERange representing values greater than or equal to the lower bound: [lowerBound, +∞).
+     *
+     * @param lowerBound the lower bound (included)
+     * @param <T> the type of the range bounds
+     * @return a GERange instance
+     */
+    public static <T extends Comparable<T>> Range<T> ge(T lowerBound) {
+        return new GERange<>(lowerBound);
+    }
+
+    /**
+     * Creates a GTLTRange representing an open interval: (lowerBound, upperBound).
+     * Both bounds are excluded.
+     *
+     * @param lowerBound the lower bound (excluded)
+     * @param upperBound the upper bound (excluded)
+     * @param <T> the type of the range bounds
+     * @return a GTLTRange instance
+     */
+    public static <T extends Comparable<T>> Range<T> gtlt(T lowerBound, T upperBound) {
+        return new GTLTRange<>(lowerBound, upperBound);
+    }
+
+    /**
+     * Creates a GELTRange representing a half-open interval: [lowerBound, upperBound).
+     * Lower bound is included, upper bound is excluded.
+     *
+     * @param lowerBound the lower bound (included)
+     * @param upperBound the upper bound (excluded)
+     * @param <T> the type of the range bounds
+     * @return a GELTRange instance
+     */
+    public static <T extends Comparable<T>> Range<T> gelt(T lowerBound, T upperBound) {
+        return new GELTRange<>(lowerBound, upperBound);
+    }
+
+    /**
+     * Creates a GTLERange representing a half-open interval: (lowerBound, upperBound].
+     * Lower bound is excluded, upper bound is included.
+     *
+     * @param lowerBound the lower bound (excluded)
+     * @param upperBound the upper bound (included)
+     * @param <T> the type of the range bounds
+     * @return a GTLERange instance
+     */
+    public static <T extends Comparable<T>> Range<T> gtle(T lowerBound, T upperBound) {
+        return new GTLERange<>(lowerBound, upperBound);
+    }
+
+    /**
+     * Creates a GELERange representing a closed interval: [lowerBound, upperBound].
+     * Both bounds are included.
+     *
+     * @param lowerBound the lower bound (included)
+     * @param upperBound the upper bound (included)
+     * @param <T> the type of the range bounds
+     * @return a GELERange instance
+     */
+    public static <T extends Comparable<T>> Range<T> gele(T lowerBound, T upperBound) {
+        return new GELERange<>(lowerBound, upperBound);
+    }
+
+    /**
+     * @return the lower bound of the range, or null if the range extends to negative infinity
+     */
+    public abstract T getLowerBound();
+
+    /**
+     * @return the upper bound of the range, or null if the range extends to positive infinity
+     */
+    public abstract T getUpperBound();
+
+    /**
+     * @return true if the lower bound is included in the range (closed), false if excluded (open)
+     */
+    public abstract boolean isLowerBoundIncluded();
+
+    /**
+     * @return true if the upper bound is included in the range (closed), false if excluded (open)
+     */
+    public abstract boolean isUpperBoundIncluded();
+
+    /**
+     * @return true if the lower bound is excluded from the range (open), false if included (closed)
+     */
+    public boolean isLowerBoundExcluded() {
+        return !isLowerBoundIncluded();
+    }
+
+    /**
+     * @return true if the upper bound is excluded from the range (open), false if included (closed)
+     */
+    public boolean isUpperBoundExcluded() {
+        return !isUpperBoundIncluded();
+    }
+
+    /**
+     * @return true if the lower bound is negative infinity (null)
+     */
+    public boolean isMinimum() {
+        return getLowerBound() == null;
+    }
+
+    /**
+     * @return true if the upper bound is positive infinity (null)
+     */
+    public boolean isMaximum() {
+        return getUpperBound() == null;
+    }
+
+    /**
+     * @return true if this range represents all possible values (-∞, +∞)
+     */
+    public boolean isAll() {
+        return isMinimum() && isMaximum();
+    }
+
+    /**
+     * Checks if this range represents a single point (e.g., [5, 5]).
+     *
+     * @return true if both bounds are equal and included
+     */
+    public boolean isIdentical() {
+        return isLowerBoundIncluded() && isUpperBoundIncluded() && Objects.equals(getLowerBound(), getUpperBound());
+    }
+
+    /**
+     * Checks if this range is entirely less than the given element.
+     *
+     * @param e the element to compare, must not be null
+     * @return true if all values in this range are less than e
+     * @throws NullPointerException if e is null
+     */
+    public boolean isLessThan(T e) {
+        Objects.requireNonNull(e, "Element must not be null");
+
+        if (isMaximum()) {
+            return false;
+        }
+
+        int result = getUpperBound().compareTo(e);
+        return result < 0 || (result == 0 && isUpperBoundExcluded());
+    }
+
+    /**
+     * Checks if this range is entirely greater than the given element.
+     *
+     * @param e the element to compare, must not be null
+     * @return true if all values in this range are greater than e
+     * @throws NullPointerException if e is null
+     */
+    public boolean isGreaterThan(T e) {
+        Objects.requireNonNull(e, "Element must not be null");
+
+        if (isMinimum()) {
+            return false;
+        }
+
+        int result = getLowerBound().compareTo(e);
+        return result > 0 || (result == 0 && isLowerBoundExcluded());
+    }
+
+    /**
+     * Checks if this range contains the given element.
+     *
+     * @param e the element to check, must not be null
+     * @return true if e is within this range
+     * @throws NullPointerException if e is null
+     */
+    public boolean contains(T e) {
+        return !(isLessThan(e) || isGreaterThan(e));
+    }
+
+    /**
+     * Checks if this range is entirely less than another range.
+     *
+     * @param other the range to compare, must not be null
+     * @return true if all values in this range are less than all values in the other range
+     * @throws NullPointerException if other is null
+     */
+    public boolean isLessThan(Range<T> other) {
+        Objects.requireNonNull(other, "Range must not be null");
+
+        if (isMaximum() || other.isMinimum()) {
+            return false;
+        }
+
+        int result = getUpperBound().compareTo(other.getLowerBound());
+        return result < 0 || (result == 0 && (isUpperBoundExcluded() || other.isLowerBoundExcluded()));
+    }
+
+    /**
+     * Checks if this range is entirely greater than another range.
+     *
+     * @param other the range to compare, must not be null
+     * @return true if all values in this range are greater than all values in the other range
+     * @throws NullPointerException if other is null
+     */
+    public boolean isGreaterThan(Range<T> other) {
+        Objects.requireNonNull(other, "Range must not be null");
+
+        if (isMinimum() || other.isMaximum()) {
+            return false;
+        }
+
+        int result = getLowerBound().compareTo(other.getUpperBound());
+        return result > 0 || (result == 0 && (isLowerBoundExcluded() || other.isUpperBoundExcluded()));
+    }
+
+    /**
+     * Checks if this range overlaps with another range.
+     *
+     * @param other the range to check for overlap, must not be null
+     * @return true if the two ranges have any values in common
+     * @throws NullPointerException if other is null
+     */
+    public boolean isOverlapping(Range<T> other) {
+        return !(isLessThan(other) || isGreaterThan(other));
+    }
+
+    /**
+     * Compares this range with another for ordering.
+     *
+     * <p>Note: This method may return 0 for overlapping ranges that are not equal.
+     * It is designed for range ordering, not equality testing. Use {@link #equals(Object)}
+     * to test for equality.
+     *
+     * @param other the range to compare to
+     * @return a negative integer, zero, or a positive integer as this range is less than,
+     *         overlapping with, or greater than the specified range
+     */
+    @Override
+    public int compareTo(Range<T> other) {
+        if (isLessThan(other)) {
+            return -1;
+        }
+        if (isGreaterThan(other)) {
+            return 1;
+        }
+        return 0;
+    }
+
+    /**
+     * Checks if this range is equal to another object.
+     *
+     * <p>Two ranges are equal if they have the same bounds (or both null) and
+     * the same inclusiveness for both lower and upper bounds.
+     *
+     * @param object the object to compare with
+     * @return true if the ranges are equal
+     */
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (object == null || !(object instanceof Range)) {
+            return false;
+        }
+        Range<?> other = (Range<?>) object;
+        return Objects.equals(getLowerBound(), other.getLowerBound())
+                && Objects.equals(getUpperBound(), other.getUpperBound())
+                && isLowerBoundIncluded() == other.isLowerBoundIncluded()
+                && isUpperBoundIncluded() == other.isUpperBoundIncluded();
+    }
+
+    /**
+     * Returns the hash code for this range.
+     *
+     * @return the hash code value
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(getLowerBound(), getUpperBound(),
+                isLowerBoundIncluded(), isUpperBoundIncluded());
+    }
+
+
+    /**
+     * A range implementation representing all possible values (-∞, +∞).
+     * Both bounds are null (infinite) and excluded.
+     *
+     * <p>This class uses a singleton pattern to ensure all instances share the same object.
+     *
+     * @param <T> the type of the range bounds
+     */
+    private static class AllRange<T extends Comparable<T>> extends Range<T> {
+
+        private static final AllRange<?> INSTANCE = new AllRange<>();
+
+        /**
+         * Private constructor to prevent external instantiation.
+         * Use {@link #getInstance()} to obtain the singleton instance.
+         */
+        private AllRange() {
+        }
+
+        /**
+         * Returns the singleton instance of AllRange.
+         *
+         * @param <T> the type of the range bounds
+         * @return the singleton AllRange instance
+         */
+        @SuppressWarnings("unchecked")
+        public static <T extends Comparable<T>> AllRange<T> getInstance() {
+            return (AllRange<T>) INSTANCE;
+        }
+
+        @Override
+        public T getLowerBound() {
+            return null;
+        }
+
+        @Override
+        public T getUpperBound() {
+            return null;
+        }
+
+        @Override
+        public boolean isLowerBoundIncluded() {
+            return false;
+        }
+
+        @Override
+        public boolean isUpperBoundIncluded() {
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "(-∞, +∞)";
+        }
+    }
+
+    /**
+     * A range implementation representing values less than an upper bound: (-∞, upperBound).
+     * Lower bound is null (negative infinity) and upper bound is excluded.
+     *
+     * @param <T> the type of the range bounds
+     */
+    private static class LTRange<T extends Comparable<T>> extends Range<T> {
+
+        private final T upperBound;
+
+        public LTRange(T upperBound) {
+            this.upperBound = Objects.requireNonNull(upperBound, "Upper bound must not be null");
+        }
+
+        @Override
+        public T getLowerBound() {
+            return null;
+        }
+
+        @Override
+        public T getUpperBound() {
+            return upperBound;
+        }
+
+        @Override
+        public boolean isLowerBoundIncluded() {
+            return false;
+        }
+
+        @Override
+        public boolean isUpperBoundIncluded() {
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "(-∞, " + upperBound + ")";
+        }
+    }
+
+    /**
+     * A range implementation representing values less than or equal to an upper bound: (-∞, upperBound].
+     * Lower bound is null (negative infinity) and upper bound is included.
+     *
+     * @param <T> the type of the range bounds
+     */
+    private static class LERange<T extends Comparable<T>> extends Range<T> {
+
+        private final T upperBound;
+
+        public LERange(T upperBound) {
+            this.upperBound = Objects.requireNonNull(upperBound, "Upper bound must not be null");
+        }
+
+        @Override
+        public T getLowerBound() {
+            return null;
+        }
+
+        @Override
+        public T getUpperBound() {
+            return upperBound;
+        }
+
+        @Override
+        public boolean isLowerBoundIncluded() {
+            return false;
+        }
+
+        @Override
+        public boolean isUpperBoundIncluded() {
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return "(-∞, " + upperBound + "]";
+        }
+    }
+
+    /**
+     * A range implementation representing values greater than a lower bound: (lowerBound, +∞).
+     * Lower bound is excluded and upper bound is null (positive infinity).
+     *
+     * @param <T> the type of the range bounds
+     */
+    private static class GTRange<T extends Comparable<T>> extends Range<T> {
+
+        private final T lowerBound;
+
+        public GTRange(T lowerBound) {
+            this.lowerBound = Objects.requireNonNull(lowerBound, "Lower bound must not be null");
+        }
+
+        @Override
+        public T getLowerBound() {
+            return lowerBound;
+        }
+
+        @Override
+        public T getUpperBound() {
+            return null;
+        }
+
+        @Override
+        public boolean isLowerBoundIncluded() {
+            return false;
+        }
+
+        @Override
+        public boolean isUpperBoundIncluded() {
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "(" + lowerBound + ", +∞)";
+        }
+    }
+
+    /**
+     * A range implementation representing values greater than or equal to a lower bound: [lowerBound, +∞).
+     * Lower bound is included and upper bound is null (positive infinity).
+     *
+     * @param <T> the type of the range bounds
+     */
+    private static class GERange<T extends Comparable<T>> extends Range<T> {
+
+        private final T lowerBound;
+
+        public GERange(T lowerBound) {
+            this.lowerBound = Objects.requireNonNull(lowerBound, "Lower bound must not be null");
+        }
+
+        @Override
+        public T getLowerBound() {
+            return lowerBound;
+        }
+
+        @Override
+        public T getUpperBound() {
+            return null;
+        }
+
+        @Override
+        public boolean isLowerBoundIncluded() {
+            return true;
+        }
+
+        @Override
+        public boolean isUpperBoundIncluded() {
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "[" + lowerBound + ", +∞)";
+        }
+    }
+
+    /**
+     * A range implementation representing values between two bounds: (lowerBound, upperBound).
+     * Both bounds are excluded (open interval).
+     *
+     * @param <T> the type of the range bounds
+     */
+    private static class GTLTRange<T extends Comparable<T>> extends Range<T> {
+
+        private final T lowerBound;
+        private final T upperBound;
+
+        public GTLTRange(T lowerBound, T upperBound) {
+            this.lowerBound = Objects.requireNonNull(lowerBound, "Lower bound must not be null");
+            this.upperBound = Objects.requireNonNull(upperBound, "Upper bound must not be null");
+        }
+
+        @Override
+        public T getLowerBound() {
+            return lowerBound;
+        }
+
+        @Override
+        public T getUpperBound() {
+            return upperBound;
+        }
+
+        @Override
+        public boolean isLowerBoundIncluded() {
+            return false;
+        }
+
+        @Override
+        public boolean isUpperBoundIncluded() {
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "(" + lowerBound + ", " + upperBound + ")";
+        }
+    }
+
+    /**
+     * A range implementation representing values between two bounds: [lowerBound, upperBound).
+     * Lower bound is included, upper bound is excluded (half-open interval).
+     *
+     * @param <T> the type of the range bounds
+     */
+    private static class GELTRange<T extends Comparable<T>> extends Range<T> {
+
+        private final T lowerBound;
+        private final T upperBound;
+
+        public GELTRange(T lowerBound, T upperBound) {
+            this.lowerBound = Objects.requireNonNull(lowerBound, "Lower bound must not be null");
+            this.upperBound = Objects.requireNonNull(upperBound, "Upper bound must not be null");
+        }
+
+        @Override
+        public T getLowerBound() {
+            return lowerBound;
+        }
+
+        @Override
+        public T getUpperBound() {
+            return upperBound;
+        }
+
+        @Override
+        public boolean isLowerBoundIncluded() {
+            return true;
+        }
+
+        @Override
+        public boolean isUpperBoundIncluded() {
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "[" + lowerBound + ", " + upperBound + ")";
+        }
+    }
+
+    /**
+     * A range implementation representing values between two bounds: (lowerBound, upperBound].
+     * Lower bound is excluded, upper bound is included (half-open interval).
+     *
+     * @param <T> the type of the range bounds
+     */
+    private static class GTLERange<T extends Comparable<T>> extends Range<T> {
+
+        private final T lowerBound;
+        private final T upperBound;
+
+        public GTLERange(T lowerBound, T upperBound) {
+            this.lowerBound = Objects.requireNonNull(lowerBound, "Lower bound must not be null");
+            this.upperBound = Objects.requireNonNull(upperBound, "Upper bound must not be null");
+        }
+
+        @Override
+        public T getLowerBound() {
+            return lowerBound;
+        }
+
+        @Override
+        public T getUpperBound() {
+            return upperBound;
+        }
+
+        @Override
+        public boolean isLowerBoundIncluded() {
+            return false;
+        }
+
+        @Override
+        public boolean isUpperBoundIncluded() {
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return "(" + lowerBound + ", " + upperBound + "]";
+        }
+    }
+
+    /**
+     * A range implementation representing values between two bounds: [lowerBound, upperBound].
+     * Both bounds are included (closed interval).
+     *
+     * @param <T> the type of the range bounds
+     */
+    private static class GELERange<T extends Comparable<T>> extends Range<T> {
+
+        private final T lowerBound;
+        private final T upperBound;
+
+        public GELERange(T lowerBound, T upperBound) {
+            this.lowerBound = Objects.requireNonNull(lowerBound, "Lower bound must not be null");
+            this.upperBound = Objects.requireNonNull(upperBound, "Upper bound must not be null");
+        }
+
+        @Override
+        public T getLowerBound() {
+            return lowerBound;
+        }
+
+        @Override
+        public T getUpperBound() {
+            return upperBound;
+        }
+
+        @Override
+        public boolean isLowerBoundIncluded() {
+            return true;
+        }
+
+        @Override
+        public boolean isUpperBoundIncluded() {
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return "[" + lowerBound + ", " + upperBound + "]";
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/StringUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/StringUtils.java
@@ -36,6 +36,7 @@ package com.starrocks.common.util;
 
 import com.starrocks.catalog.Table;
 
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 
 public class StringUtils {
@@ -79,5 +80,38 @@ public class StringUtils {
         }
 
         return columName.equalsIgnoreCase(toCheck);
+    }
+
+    /*
+     * Compare string with utf-8 byte array, same with DM,BE,StorageEngine
+     */
+    public static int compareStringWithUTF8ByteArray(String s1, String s2) {
+        byte[] s1Bytes = s1.getBytes(StandardCharsets.UTF_8);
+        byte[] s2Bytes = s2.getBytes(StandardCharsets.UTF_8);
+
+        int minLength = Math.min(s1Bytes.length, s2Bytes.length);
+        int i;
+        for (i = 0; i < minLength; i++) {
+            if (s1Bytes[i] < s2Bytes[i]) {
+                return -1;
+            } else if (s1Bytes[i] > s2Bytes[i]) {
+                return 1;
+            }
+        }
+        if (s1Bytes.length > s2Bytes.length) {
+            if (s1Bytes[i] == 0x00) {
+                return 0;
+            } else {
+                return 1;
+            }
+        } else if (s1Bytes.length < s2Bytes.length) {
+            if (s2Bytes[i] == 0x00) {
+                return 0;
+            } else {
+                return -1;
+            }
+        } else {
+            return 0;
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
@@ -103,7 +103,9 @@ import com.starrocks.backup.BackupJob;
 import com.starrocks.backup.RestoreJob;
 import com.starrocks.backup.SnapshotInfo;
 import com.starrocks.catalog.AggregateFunction;
+import com.starrocks.catalog.BoolVariant;
 import com.starrocks.catalog.ColumnId;
+import com.starrocks.catalog.DateVariant;
 import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.EsTable;
 import com.starrocks.catalog.ExpressionRangePartitionInfo;
@@ -118,8 +120,10 @@ import com.starrocks.catalog.HudiResource;
 import com.starrocks.catalog.HudiTable;
 import com.starrocks.catalog.IcebergResource;
 import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.IntVariant;
 import com.starrocks.catalog.JDBCResource;
 import com.starrocks.catalog.JDBCTable;
+import com.starrocks.catalog.LargeIntVariant;
 import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedView;
@@ -138,10 +142,13 @@ import com.starrocks.catalog.Resource;
 import com.starrocks.catalog.ScalarFunction;
 import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.SparkResource;
+import com.starrocks.catalog.StringVariant;
 import com.starrocks.catalog.TableFunction;
 import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.Variant;
 import com.starrocks.catalog.View;
 import com.starrocks.common.Config;
+import com.starrocks.common.Range;
 import com.starrocks.common.tvr.TvrTableDelta;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersionRange;
@@ -446,6 +453,14 @@ public class GsonUtils {
                     .registerSubtype(SplittingTablet.class, "SplittingTablet")
                     .registerSubtype(MergingTablet.class, "MergingTablet")
                     .registerSubtype(IdenticalTablet.class, "IdenticalTablet");
+    
+    public static final RuntimeTypeAdapterFactory<Variant> VARIANT_RUNTIME_TYPE_ADAPTER_FACTORY =
+            RuntimeTypeAdapterFactory.of(Variant.class, "clazz")
+                    .registerSubtype(BoolVariant.class, "BoolVariant")
+                    .registerSubtype(IntVariant.class, "IntVariant")
+                    .registerSubtype(LargeIntVariant.class, "LargeIntVariant")
+                    .registerSubtype(StringVariant.class, "StringVariant")
+                    .registerSubtype(DateVariant.class, "DateVariant");
 
     public static final RuntimeTypeAdapterFactory<TvrVersionRange> TVR_DELTA_RUNTIME_TYPE_ADAPTER_FACTORY =
             RuntimeTypeAdapterFactory.of(TvrVersionRange.class, "clazz")
@@ -487,6 +502,7 @@ public class GsonUtils {
                 .registerTypeHierarchyAdapter(Table.class, new GuavaTableAdapter())
                 .registerTypeHierarchyAdapter(Multimap.class, new GuavaMultimapAdapter())
                 .registerTypeHierarchyAdapter(ColumnId.class, new ColumnIdAdapter())
+                .registerTypeHierarchyAdapter(Range.class, new RangeAdapter())
                 .registerTypeAdapterFactory(new ProcessHookTypeAdapterFactory())
                 // For call constructor with selectedFields
                 .registerTypeAdapter(MapType.class, new MapTypeDeserializer())
@@ -519,6 +535,7 @@ public class GsonUtils {
                 .registerTypeAdapterFactory(COMPUTE_RESOURCE_RUNTIME_TYPE_ADAPTER_FACTORY)
                 .registerTypeAdapterFactory(DYNAMIC_TABLET_RUNTIME_TYPE_ADAPTER_FACTORY)
                 .registerTypeAdapterFactory(TVR_DELTA_RUNTIME_TYPE_ADAPTER_FACTORY)
+                .registerTypeAdapterFactory(VARIANT_RUNTIME_TYPE_ADAPTER_FACTORY)
                 .registerTypeAdapter(LocalDateTime.class, LOCAL_DATE_TIME_TYPE_SERIALIZER)
                 .registerTypeAdapter(LocalDateTime.class, LOCAL_DATE_TIME_TYPE_DESERIALIZER)
                 .registerTypeAdapter(QueryDumpInfo.class, DUMP_INFO_SERIALIZER)
@@ -745,6 +762,77 @@ public class GsonUtils {
         @Override
         public JsonElement serialize(ColumnId src, Type typeOfSrc, JsonSerializationContext context) {
             return new JsonPrimitive(src.getId());
+        }
+    }
+
+    /*
+     * The json adapter for Range with generic type support.
+     */
+    private static class RangeAdapter<T extends Comparable<T>>
+            implements JsonSerializer<Range<T>>, JsonDeserializer<Range<T>> {
+
+        @Override
+        public JsonElement serialize(Range<T> src, Type typeOfSrc, JsonSerializationContext context) {
+            JsonObject jsonObject = new JsonObject();
+
+            // Serialize bounds using context to preserve generic type
+            if (src.getLowerBound() != null) {
+                jsonObject.add("lowerBound", context.serialize(src.getLowerBound()));
+            }
+            if (src.getUpperBound() != null) {
+                jsonObject.add("upperBound", context.serialize(src.getUpperBound()));
+            }
+            if (src.isLowerBoundIncluded()) {
+                jsonObject.add("lowerBoundIncluded", new JsonPrimitive(true));
+            }
+            if (src.isUpperBoundIncluded()) {
+                jsonObject.add("upperBoundIncluded", new JsonPrimitive(true));
+            }
+
+            return jsonObject;
+        }
+
+        @Override
+        public Range<T> deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
+                throws JsonParseException {
+            JsonObject jsonObject = json.getAsJsonObject();
+
+            // Extract generic type information
+            Type elementType;
+            if (typeOfT instanceof ParameterizedType) {
+                ParameterizedType parameterizedType = (ParameterizedType) typeOfT;
+                Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
+                elementType = actualTypeArguments[0];
+            } else {
+                // Cannot deserialize Range without generic type information
+                throw new JsonParseException("Cannot deserialize Range without generic type information.");
+            }
+
+            T lowerBound = null;
+            JsonElement lowerBoundElement = jsonObject.get("lowerBound");
+            if (lowerBoundElement != null) {
+                lowerBound = context.deserialize(lowerBoundElement, elementType);
+            }
+
+            T upperBound = null;
+            JsonElement upperBoundElement = jsonObject.get("upperBound");
+            if (upperBoundElement != null) {
+                upperBound = context.deserialize(upperBoundElement, elementType);
+            }
+
+            boolean lowerBoundIncluded = false;
+            JsonElement lowerBoundIncludedElement = jsonObject.get("lowerBoundIncluded");
+            if (lowerBoundIncludedElement != null) {
+                lowerBoundIncluded = lowerBoundIncludedElement.getAsBoolean();
+            }
+
+            boolean upperBoundIncluded = false;
+            JsonElement upperBoundIncludedElement = jsonObject.get("upperBoundIncluded");
+            if (upperBoundIncludedElement != null) {
+                upperBoundIncluded = upperBoundIncludedElement.getAsBoolean();
+            }
+
+            return Range.of(lowerBound, upperBound, lowerBoundIncluded, upperBoundIncluded);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TupleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TupleTest.java
@@ -1,0 +1,706 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.type.DateType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class TupleTest {
+
+    // ==================== Basic Tuple Tests ====================
+
+    @Test
+    public void testTupleCreation() {
+        List<Variant> values = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new StringVariant(VarcharType.VARCHAR, "hello"),
+                new BoolVariant(true));
+
+        Tuple tuple = new Tuple(values);
+        Assertions.assertNotNull(tuple.getValues());
+        Assertions.assertEquals(3, tuple.getValues().size());
+        Assertions.assertEquals(1L, tuple.getValues().get(0).getLongValue());
+        Assertions.assertEquals("hello", tuple.getValues().get(1).getStringValue());
+        Assertions.assertEquals(1L, tuple.getValues().get(2).getLongValue());
+    }
+
+    @Test
+    public void testEmptyTuple() {
+        List<Variant> emptyValues = Collections.emptyList();
+        Tuple tuple = new Tuple(emptyValues);
+
+        Assertions.assertNotNull(tuple.getValues());
+        Assertions.assertEquals(0, tuple.getValues().size());
+    }
+
+    @Test
+    public void testSingleElementTuple() {
+        List<Variant> singleValue = Collections.singletonList(
+                new IntVariant(IntegerType.INT, 42));
+
+        Tuple tuple = new Tuple(singleValue);
+        Assertions.assertEquals(1, tuple.getValues().size());
+        Assertions.assertEquals(42L, tuple.getValues().get(0).getLongValue());
+    }
+
+    // ==================== Tuple Comparison Tests ====================
+
+    @Test
+    public void testTupleCompareToEqual() {
+        List<Variant> values1 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new IntVariant(IntegerType.INT, 2),
+                new IntVariant(IntegerType.INT, 3));
+
+        List<Variant> values2 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new IntVariant(IntegerType.INT, 2),
+                new IntVariant(IntegerType.INT, 3));
+
+        Tuple tuple1 = new Tuple(values1);
+        Tuple tuple2 = new Tuple(values2);
+
+        Assertions.assertEquals(0, tuple1.compareTo(tuple2));
+        Assertions.assertEquals(0, tuple2.compareTo(tuple1));
+    }
+
+    @Test
+    public void testTupleCompareToLessThan() {
+        List<Variant> values1 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new IntVariant(IntegerType.INT, 2));
+
+        List<Variant> values2 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new IntVariant(IntegerType.INT, 3));
+
+        Tuple tuple1 = new Tuple(values1);
+        Tuple tuple2 = new Tuple(values2);
+
+        Assertions.assertTrue(tuple1.compareTo(tuple2) < 0);
+        Assertions.assertTrue(tuple2.compareTo(tuple1) > 0);
+    }
+
+    @Test
+    public void testTupleCompareToGreaterThan() {
+        List<Variant> values1 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 2),
+                new IntVariant(IntegerType.INT, 1));
+
+        List<Variant> values2 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new IntVariant(IntegerType.INT, 10));
+
+        Tuple tuple1 = new Tuple(values1);
+        Tuple tuple2 = new Tuple(values2);
+
+        Assertions.assertTrue(tuple1.compareTo(tuple2) > 0);
+        Assertions.assertTrue(tuple2.compareTo(tuple1) < 0);
+    }
+
+    @Test
+    public void testTupleCompareDifferentLengths() {
+        // Shorter tuple should be less than longer tuple when all common elements are
+        // equal
+        List<Variant> values1 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new IntVariant(IntegerType.INT, 2));
+
+        List<Variant> values2 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new IntVariant(IntegerType.INT, 2),
+                new IntVariant(IntegerType.INT, 3));
+
+        Tuple tuple1 = new Tuple(values1);
+        Tuple tuple2 = new Tuple(values2);
+
+        Assertions.assertTrue(tuple1.compareTo(tuple2) < 0);
+        Assertions.assertTrue(tuple2.compareTo(tuple1) > 0);
+    }
+
+    @Test
+    public void testTupleCompareEmptyTuples() {
+        Tuple tuple1 = new Tuple(Collections.emptyList());
+        Tuple tuple2 = new Tuple(Collections.emptyList());
+
+        Assertions.assertEquals(0, tuple1.compareTo(tuple2));
+    }
+
+    @Test
+    public void testTupleCompareEmptyWithNonEmpty() {
+        Tuple emptyTuple = new Tuple(Collections.emptyList());
+        Tuple nonEmptyTuple = new Tuple(Collections.singletonList(
+                new IntVariant(IntegerType.INT, 1)));
+
+        Assertions.assertTrue(emptyTuple.compareTo(nonEmptyTuple) < 0);
+        Assertions.assertTrue(nonEmptyTuple.compareTo(emptyTuple) > 0);
+    }
+
+    // ==================== Mixed Type Tuple Tests ====================
+
+    @Test
+    public void testMixedTypeTuple() {
+        List<Variant> mixedValues = Arrays.asList(
+                new IntVariant(IntegerType.INT, 100),
+                new StringVariant(VarcharType.VARCHAR, "test"),
+                new BoolVariant(false),
+                new LargeIntVariant("12345678901234567890"));
+
+        Tuple tuple = new Tuple(mixedValues);
+
+        Assertions.assertEquals(4, tuple.getValues().size());
+        Assertions.assertEquals(100L, tuple.getValues().get(0).getLongValue());
+        Assertions.assertEquals("test", tuple.getValues().get(1).getStringValue());
+        Assertions.assertEquals(0L, tuple.getValues().get(2).getLongValue());
+        Assertions.assertEquals("12345678901234567890", tuple.getValues().get(3).getStringValue());
+    }
+
+    @Test
+    public void testMixedTypeTupleComparison() {
+        List<Variant> values1 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new StringVariant(VarcharType.VARCHAR, "abc"));
+
+        List<Variant> values2 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new StringVariant(VarcharType.VARCHAR, "abd"));
+
+        Tuple tuple1 = new Tuple(values1);
+        Tuple tuple2 = new Tuple(values2);
+
+        Assertions.assertTrue(tuple1.compareTo(tuple2) < 0);
+    }
+
+    // ==================== Tuple with Different Integer Types ====================
+
+    @Test
+    public void testTupleWithDifferentIntTypes() {
+        List<Variant> values = Arrays.asList(
+                new IntVariant(IntegerType.TINYINT, 10),
+                new IntVariant(IntegerType.SMALLINT, 1000),
+                new IntVariant(IntegerType.INT, 100000),
+                new IntVariant(IntegerType.BIGINT, 10000000000L));
+
+        Tuple tuple = new Tuple(values);
+
+        Assertions.assertEquals(4, tuple.getValues().size());
+        Assertions.assertEquals(10L, tuple.getValues().get(0).getLongValue());
+        Assertions.assertEquals(1000L, tuple.getValues().get(1).getLongValue());
+        Assertions.assertEquals(100000L, tuple.getValues().get(2).getLongValue());
+        Assertions.assertEquals(10000000000L, tuple.getValues().get(3).getLongValue());
+    }
+
+    @Test
+    public void testTupleComparisonWithCompatibleTypes() {
+        // INT and BIGINT with same value should compare equal
+        List<Variant> values1 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 100),
+                new IntVariant(IntegerType.INT, 200));
+
+        List<Variant> values2 = Arrays.asList(
+                new IntVariant(IntegerType.BIGINT, 100),
+                new IntVariant(IntegerType.BIGINT, 200));
+
+        Tuple tuple1 = new Tuple(values1);
+        Tuple tuple2 = new Tuple(values2);
+
+        Assertions.assertEquals(0, tuple1.compareTo(tuple2));
+    }
+
+    // ==================== Large Tuple Tests ====================
+
+    @Test
+    public void testLargeTuple() {
+        // Create a tuple with many elements
+        List<Variant> values = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new IntVariant(IntegerType.INT, 2),
+                new IntVariant(IntegerType.INT, 3),
+                new IntVariant(IntegerType.INT, 4),
+                new IntVariant(IntegerType.INT, 5),
+                new IntVariant(IntegerType.INT, 6),
+                new IntVariant(IntegerType.INT, 7),
+                new IntVariant(IntegerType.INT, 8),
+                new IntVariant(IntegerType.INT, 9),
+                new IntVariant(IntegerType.INT, 10));
+
+        Tuple tuple = new Tuple(values);
+        Assertions.assertEquals(10, tuple.getValues().size());
+    }
+
+    @Test
+    public void testLargeTupleComparison() {
+        List<Variant> values1 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new IntVariant(IntegerType.INT, 2),
+                new IntVariant(IntegerType.INT, 3),
+                new IntVariant(IntegerType.INT, 4),
+                new IntVariant(IntegerType.INT, 5));
+
+        List<Variant> values2 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new IntVariant(IntegerType.INT, 2),
+                new IntVariant(IntegerType.INT, 3),
+                new IntVariant(IntegerType.INT, 4),
+                new IntVariant(IntegerType.INT, 6) // Different in last element
+        );
+
+        Tuple tuple1 = new Tuple(values1);
+        Tuple tuple2 = new Tuple(values2);
+
+        Assertions.assertTrue(tuple1.compareTo(tuple2) < 0);
+    }
+
+    // ==================== Tuple with DateTime Tests ====================
+
+    @Test
+    public void testTupleWithDateTime() {
+        List<Variant> values = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new DateVariant(DateType.DATETIME, "2024-01-15T10:30:00"));
+
+        Tuple tuple = new Tuple(values);
+
+        Assertions.assertEquals(2, tuple.getValues().size());
+        Assertions.assertEquals(1L, tuple.getValues().get(0).getLongValue());
+        Assertions.assertTrue(tuple.getValues().get(1) instanceof DateVariant);
+    }
+
+    @Test
+    public void testTupleComparisonWithDateTime() {
+        List<Variant> values1 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new DateVariant(DateType.DATETIME, "2024-01-15T10:30:00"));
+
+        List<Variant> values2 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new DateVariant(DateType.DATETIME, "2024-01-15T10:30:01"));
+
+        Tuple tuple1 = new Tuple(values1);
+        Tuple tuple2 = new Tuple(values2);
+
+        Assertions.assertTrue(tuple1.compareTo(tuple2) < 0);
+    }
+
+    // ==================== Tuple Serialization Tests ====================
+
+    @Test
+    public void testTupleSerialization() {
+        List<Variant> values = Arrays.asList(
+                new IntVariant(IntegerType.INT, 100),
+                new StringVariant(VarcharType.VARCHAR, "test"));
+
+        Tuple originalTuple = new Tuple(values);
+
+        // Serialize
+        String json = GsonUtils.GSON.toJson(originalTuple);
+        Assertions.assertNotNull(json);
+        Assertions.assertTrue(json.length() > 0);
+
+        // Deserialize
+        Tuple deserializedTuple = GsonUtils.GSON.fromJson(json, Tuple.class);
+        Assertions.assertNotNull(deserializedTuple);
+        Assertions.assertEquals(2, deserializedTuple.getValues().size());
+
+        // Note: After deserialization, we need to verify the values
+        Assertions.assertEquals(0, originalTuple.compareTo(deserializedTuple));
+    }
+
+    @Test
+    public void testTupleSerializationWithMixedTypes() {
+        List<Variant> values = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new BoolVariant(true),
+                new StringVariant(VarcharType.VARCHAR, "hello"),
+                new LargeIntVariant("12345678901234567890"));
+
+        Tuple originalTuple = new Tuple(values);
+
+        // Serialize and deserialize
+        String json = GsonUtils.GSON.toJson(originalTuple);
+        Tuple deserializedTuple = GsonUtils.GSON.fromJson(json, Tuple.class);
+
+        Assertions.assertNotNull(deserializedTuple);
+        Assertions.assertEquals(4, deserializedTuple.getValues().size());
+        Assertions.assertEquals(0, originalTuple.compareTo(deserializedTuple));
+    }
+
+    @Test
+    public void testEmptyTupleSerialization() {
+        Tuple emptyTuple = new Tuple(Collections.emptyList());
+
+        String json = GsonUtils.GSON.toJson(emptyTuple);
+        Tuple deserializedTuple = GsonUtils.GSON.fromJson(json, Tuple.class);
+
+        Assertions.assertNotNull(deserializedTuple);
+        Assertions.assertEquals(0, deserializedTuple.getValues().size());
+    }
+
+    // ==================== Edge Cases ====================
+
+    @Test
+    public void testTupleWithNegativeValues() {
+        List<Variant> values = Arrays.asList(
+                new IntVariant(IntegerType.INT, -100),
+                new IntVariant(IntegerType.INT, -200),
+                new LargeIntVariant("-12345678901234567890"));
+
+        Tuple tuple = new Tuple(values);
+
+        Assertions.assertEquals(3, tuple.getValues().size());
+        Assertions.assertEquals(-100L, tuple.getValues().get(0).getLongValue());
+        Assertions.assertEquals(-200L, tuple.getValues().get(1).getLongValue());
+        Assertions.assertEquals("-12345678901234567890", tuple.getValues().get(2).getStringValue());
+    }
+
+    @Test
+    public void testTupleComparisonNegativeValues() {
+        List<Variant> values1 = Arrays.asList(
+                new IntVariant(IntegerType.INT, -100),
+                new IntVariant(IntegerType.INT, 50));
+
+        List<Variant> values2 = Arrays.asList(
+                new IntVariant(IntegerType.INT, -50),
+                new IntVariant(IntegerType.INT, 100));
+
+        Tuple tuple1 = new Tuple(values1);
+        Tuple tuple2 = new Tuple(values2);
+
+        // -100 < -50, so tuple1 < tuple2
+        Assertions.assertTrue(tuple1.compareTo(tuple2) < 0);
+    }
+
+    @Test
+    public void testTupleWithZeroValues() {
+        List<Variant> values = Arrays.asList(
+                new IntVariant(IntegerType.INT, 0),
+                new BoolVariant(false),
+                new LargeIntVariant("0"));
+
+        Tuple tuple = new Tuple(values);
+
+        Assertions.assertEquals(3, tuple.getValues().size());
+        Assertions.assertEquals(0L, tuple.getValues().get(0).getLongValue());
+        Assertions.assertEquals(0L, tuple.getValues().get(1).getLongValue());
+        Assertions.assertEquals(0L, tuple.getValues().get(2).getLongValue());
+    }
+
+    @Test
+    public void testTupleWithMaxMinValues() {
+        List<Variant> values = Arrays.asList(
+                new IntVariant(IntegerType.INT, Integer.MAX_VALUE),
+                new IntVariant(IntegerType.INT, Integer.MIN_VALUE),
+                new IntVariant(IntegerType.BIGINT, Long.MAX_VALUE),
+                new IntVariant(IntegerType.BIGINT, Long.MIN_VALUE));
+
+        Tuple tuple = new Tuple(values);
+
+        Assertions.assertEquals(4, tuple.getValues().size());
+        Assertions.assertEquals((long) Integer.MAX_VALUE, tuple.getValues().get(0).getLongValue());
+        Assertions.assertEquals((long) Integer.MIN_VALUE, tuple.getValues().get(1).getLongValue());
+        Assertions.assertEquals(Long.MAX_VALUE, tuple.getValues().get(2).getLongValue());
+        Assertions.assertEquals(Long.MIN_VALUE, tuple.getValues().get(3).getLongValue());
+    }
+
+    @Test
+    public void testTupleComparisonWithFirstElementDifferent() {
+        // When first elements differ, comparison should stop there
+        List<Variant> values1 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new IntVariant(IntegerType.INT, 999));
+
+        List<Variant> values2 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 2),
+                new IntVariant(IntegerType.INT, 1));
+
+        Tuple tuple1 = new Tuple(values1);
+        Tuple tuple2 = new Tuple(values2);
+
+        Assertions.assertTrue(tuple1.compareTo(tuple2) < 0);
+    }
+
+    @Test
+    public void testTupleSelfComparison() {
+        List<Variant> values = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new StringVariant(VarcharType.VARCHAR, "test"));
+
+        Tuple tuple = new Tuple(values);
+
+        Assertions.assertEquals(0, tuple.compareTo(tuple));
+    }
+
+    // ==================== Tuple equals() Tests ====================
+
+    @Test
+    public void testTupleEqualsReflexive() {
+        // Test reflexive property: x.equals(x) should return true
+        List<Variant> values = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new StringVariant(VarcharType.VARCHAR, "test"));
+        Tuple tuple = new Tuple(values);
+
+        Assertions.assertTrue(tuple.equals(tuple));
+    }
+
+    @Test
+    public void testTupleEqualsSymmetric() {
+        // Test symmetric property: x.equals(y) == y.equals(x)
+        List<Variant> values1 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 100),
+                new BoolVariant(true));
+        List<Variant> values2 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 100),
+                new BoolVariant(true));
+
+        Tuple tuple1 = new Tuple(values1);
+        Tuple tuple2 = new Tuple(values2);
+
+        Assertions.assertTrue(tuple1.equals(tuple2));
+        Assertions.assertTrue(tuple2.equals(tuple1));
+    }
+
+    @Test
+    public void testTupleEqualsTransitive() {
+        // Test transitive property: if x.equals(y) and y.equals(z), then x.equals(z)
+        List<Variant> values1 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new IntVariant(IntegerType.INT, 2));
+        List<Variant> values2 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new IntVariant(IntegerType.INT, 2));
+        List<Variant> values3 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new IntVariant(IntegerType.INT, 2));
+
+        Tuple tuple1 = new Tuple(values1);
+        Tuple tuple2 = new Tuple(values2);
+        Tuple tuple3 = new Tuple(values3);
+
+        Assertions.assertTrue(tuple1.equals(tuple2));
+        Assertions.assertTrue(tuple2.equals(tuple3));
+        Assertions.assertTrue(tuple1.equals(tuple3));
+    }
+
+    @Test
+    public void testTupleEqualsNull() {
+        // Test that equals(null) returns false
+        List<Variant> values = Arrays.asList(new IntVariant(IntegerType.INT, 1));
+        Tuple tuple = new Tuple(values);
+
+        Assertions.assertFalse(tuple.equals(null));
+    }
+
+    @Test
+    public void testTupleEqualsDifferentClass() {
+        // Test that equals returns false for different class
+        List<Variant> values = Arrays.asList(new IntVariant(IntegerType.INT, 1));
+        Tuple tuple = new Tuple(values);
+
+        Assertions.assertFalse(tuple.equals("not a tuple"));
+        Assertions.assertFalse(tuple.equals(Integer.valueOf(1)));
+    }
+
+    @Test
+    public void testTupleEqualsSameValues() {
+        // Tuples with same values should be equal
+        List<Variant> values1 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 42),
+                new StringVariant(VarcharType.VARCHAR, "hello"),
+                new BoolVariant(true));
+        List<Variant> values2 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 42),
+                new StringVariant(VarcharType.VARCHAR, "hello"),
+                new BoolVariant(true));
+
+        Tuple tuple1 = new Tuple(values1);
+        Tuple tuple2 = new Tuple(values2);
+
+        Assertions.assertTrue(tuple1.equals(tuple2));
+        Assertions.assertTrue(tuple2.equals(tuple1));
+    }
+
+    @Test
+    public void testTupleEqualsDifferentValues() {
+        // Tuples with different values should not be equal
+        List<Variant> values1 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new IntVariant(IntegerType.INT, 2));
+        List<Variant> values2 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new IntVariant(IntegerType.INT, 3));
+
+        Tuple tuple1 = new Tuple(values1);
+        Tuple tuple2 = new Tuple(values2);
+
+        Assertions.assertFalse(tuple1.equals(tuple2));
+        Assertions.assertFalse(tuple2.equals(tuple1));
+    }
+
+    @Test
+    public void testTupleEqualsDifferentLengths() {
+        // Tuples with different lengths should not be equal
+        List<Variant> values1 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new IntVariant(IntegerType.INT, 2));
+        List<Variant> values2 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new IntVariant(IntegerType.INT, 2),
+                new IntVariant(IntegerType.INT, 3));
+
+        Tuple tuple1 = new Tuple(values1);
+        Tuple tuple2 = new Tuple(values2);
+
+        Assertions.assertFalse(tuple1.equals(tuple2));
+        Assertions.assertFalse(tuple2.equals(tuple1));
+    }
+
+    @Test
+    public void testTupleEqualsEmptyTuples() {
+        // Empty tuples should be equal
+        Tuple tuple1 = new Tuple(Collections.emptyList());
+        Tuple tuple2 = new Tuple(Collections.emptyList());
+
+        Assertions.assertTrue(tuple1.equals(tuple2));
+    }
+
+    @Test
+    public void testTupleEqualsMixedTypes() {
+        // Tuples with mixed types and same values should be equal
+        List<Variant> values1 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 100),
+                new StringVariant(VarcharType.VARCHAR, "test"),
+                new BoolVariant(false),
+                new LargeIntVariant("999"));
+        List<Variant> values2 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 100),
+                new StringVariant(VarcharType.VARCHAR, "test"),
+                new BoolVariant(false),
+                new LargeIntVariant("999"));
+
+        Tuple tuple1 = new Tuple(values1);
+        Tuple tuple2 = new Tuple(values2);
+
+        Assertions.assertTrue(tuple1.equals(tuple2));
+    }
+
+    // ==================== Tuple hashCode() Tests ====================
+
+    @Test
+    public void testTupleHashCodeConsistency() {
+        // hashCode should return the same value when called multiple times
+        List<Variant> values = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new StringVariant(VarcharType.VARCHAR, "test"));
+        Tuple tuple = new Tuple(values);
+
+        int hash1 = tuple.hashCode();
+        int hash2 = tuple.hashCode();
+        int hash3 = tuple.hashCode();
+
+        Assertions.assertEquals(hash1, hash2);
+        Assertions.assertEquals(hash2, hash3);
+    }
+
+    @Test
+    public void testTupleHashCodeEqualObjects() {
+        // Equal objects must have equal hash codes
+        List<Variant> values1 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 42),
+                new StringVariant(VarcharType.VARCHAR, "hello"));
+        List<Variant> values2 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 42),
+                new StringVariant(VarcharType.VARCHAR, "hello"));
+
+        Tuple tuple1 = new Tuple(values1);
+        Tuple tuple2 = new Tuple(values2);
+
+        Assertions.assertTrue(tuple1.equals(tuple2));
+        Assertions.assertEquals(tuple1.hashCode(), tuple2.hashCode());
+    }
+
+    @Test
+    public void testTupleHashCodeDifferentObjects() {
+        // Different objects may have different hash codes (not required, but desirable)
+        List<Variant> values1 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new IntVariant(IntegerType.INT, 2));
+        List<Variant> values2 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 3),
+                new IntVariant(IntegerType.INT, 4));
+
+        Tuple tuple1 = new Tuple(values1);
+        Tuple tuple2 = new Tuple(values2);
+
+        Assertions.assertFalse(tuple1.equals(tuple2));
+        // Note: Different objects CAN have the same hash code (collision),
+        // but we expect them to be different in most cases
+    }
+
+    @Test
+    public void testTupleHashCodeEmptyTuples() {
+        // Empty tuples should have the same hash code
+        Tuple tuple1 = new Tuple(Collections.emptyList());
+        Tuple tuple2 = new Tuple(Collections.emptyList());
+
+        Assertions.assertEquals(tuple1.hashCode(), tuple2.hashCode());
+    }
+
+    @Test
+    public void testTupleHashCodeWithMixedTypes() {
+        // Tuples with mixed types should have consistent hash codes
+        List<Variant> values1 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 100),
+                new BoolVariant(true),
+                new StringVariant(VarcharType.VARCHAR, "data"),
+                new LargeIntVariant("12345"));
+        List<Variant> values2 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 100),
+                new BoolVariant(true),
+                new StringVariant(VarcharType.VARCHAR, "data"),
+                new LargeIntVariant("12345"));
+
+        Tuple tuple1 = new Tuple(values1);
+        Tuple tuple2 = new Tuple(values2);
+
+        Assertions.assertTrue(tuple1.equals(tuple2));
+        Assertions.assertEquals(tuple1.hashCode(), tuple2.hashCode());
+    }
+
+    @Test
+    public void testTupleHashCodeDifferentOrder() {
+        // Tuples with same values in different order should have different hash codes
+        List<Variant> values1 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new IntVariant(IntegerType.INT, 2));
+        List<Variant> values2 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 2),
+                new IntVariant(IntegerType.INT, 1));
+
+        Tuple tuple1 = new Tuple(values1);
+        Tuple tuple2 = new Tuple(values2);
+
+        Assertions.assertFalse(tuple1.equals(tuple2));
+        // Hash codes will likely be different (but not guaranteed)
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/VariantTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/VariantTest.java
@@ -1,0 +1,875 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.starrocks.type.BooleanType;
+import com.starrocks.type.CharType;
+import com.starrocks.type.DateType;
+import com.starrocks.type.FloatType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+
+public class VariantTest {
+
+    // ==================== BoolVariant Tests ====================
+
+    @Test
+    public void testBoolVariantFromBoolean() {
+        BoolVariant trueVariant = new BoolVariant(true);
+        Assertions.assertEquals(1L, trueVariant.getLongValue());
+        Assertions.assertEquals("TRUE", trueVariant.getStringValue());
+        Assertions.assertEquals(BooleanType.BOOLEAN, trueVariant.getType());
+
+        BoolVariant falseVariant = new BoolVariant(false);
+        Assertions.assertEquals(0L, falseVariant.getLongValue());
+        Assertions.assertEquals("FALSE", falseVariant.getStringValue());
+    }
+
+    @Test
+    public void testBoolVariantFromString() {
+        BoolVariant v1 = new BoolVariant("true");
+        Assertions.assertEquals(1L, v1.getLongValue());
+
+        BoolVariant v2 = new BoolVariant("TRUE");
+        Assertions.assertEquals(1L, v2.getLongValue());
+
+        BoolVariant v3 = new BoolVariant("1");
+        Assertions.assertEquals(1L, v3.getLongValue());
+
+        BoolVariant v4 = new BoolVariant("false");
+        Assertions.assertEquals(0L, v4.getLongValue());
+
+        BoolVariant v5 = new BoolVariant("FALSE");
+        Assertions.assertEquals(0L, v5.getLongValue());
+
+        BoolVariant v6 = new BoolVariant("0");
+        Assertions.assertEquals(0L, v6.getLongValue());
+
+        // Test with whitespace
+        BoolVariant v7 = new BoolVariant("  true  ");
+        Assertions.assertEquals(1L, v7.getLongValue());
+    }
+
+    @Test
+    public void testBoolVariantInvalidString() {
+        Assertions.assertThrows(RuntimeException.class, () -> new BoolVariant("invalid"));
+        Assertions.assertThrows(RuntimeException.class, () -> new BoolVariant("2"));
+    }
+
+    @Test
+    public void testBoolVariantCompareTo() {
+        BoolVariant trueVar = new BoolVariant(true);
+        BoolVariant falseVar = new BoolVariant(false);
+
+        Assertions.assertTrue(trueVar.compareTo(falseVar) > 0);
+        Assertions.assertTrue(falseVar.compareTo(trueVar) < 0);
+        Assertions.assertEquals(0, trueVar.compareTo(new BoolVariant(true)));
+    }
+
+    // ==================== IntVariant Tests ====================
+
+    @Test
+    public void testIntVariantTinyInt() {
+        IntVariant v1 = new IntVariant(IntegerType.TINYINT, (byte) 127);
+        Assertions.assertEquals(127L, v1.getLongValue());
+        Assertions.assertEquals("127", v1.getStringValue());
+
+        IntVariant v2 = new IntVariant(IntegerType.TINYINT, (byte) -128);
+        Assertions.assertEquals(-128L, v2.getLongValue());
+
+        // Out of range
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new IntVariant(IntegerType.TINYINT, 128));
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new IntVariant(IntegerType.TINYINT, -129));
+    }
+
+    @Test
+    public void testIntVariantSmallInt() {
+        IntVariant v1 = new IntVariant(IntegerType.SMALLINT, (short) 32767);
+        Assertions.assertEquals(32767L, v1.getLongValue());
+
+        IntVariant v2 = new IntVariant(IntegerType.SMALLINT, (short) -32768);
+        Assertions.assertEquals(-32768L, v2.getLongValue());
+
+        // Out of range
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new IntVariant(IntegerType.SMALLINT, 32768));
+    }
+
+    @Test
+    public void testIntVariantInt() {
+        IntVariant v1 = new IntVariant(IntegerType.INT, Integer.MAX_VALUE);
+        Assertions.assertEquals((long) Integer.MAX_VALUE, v1.getLongValue());
+
+        IntVariant v2 = new IntVariant(IntegerType.INT, Integer.MIN_VALUE);
+        Assertions.assertEquals((long) Integer.MIN_VALUE, v2.getLongValue());
+
+        // Out of range
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new IntVariant(IntegerType.INT, (long) Integer.MAX_VALUE + 1));
+    }
+
+    @Test
+    public void testIntVariantBigInt() {
+        IntVariant v1 = new IntVariant(IntegerType.BIGINT, Long.MAX_VALUE);
+        Assertions.assertEquals(Long.MAX_VALUE, v1.getLongValue());
+
+        IntVariant v2 = new IntVariant(IntegerType.BIGINT, Long.MIN_VALUE);
+        Assertions.assertEquals(Long.MIN_VALUE, v2.getLongValue());
+    }
+
+    @Test
+    public void testIntVariantFromString() {
+        IntVariant v1 = new IntVariant(IntegerType.INT, "12345");
+        Assertions.assertEquals(12345L, v1.getLongValue());
+
+        IntVariant v2 = new IntVariant(IntegerType.BIGINT, "-9876543210");
+        Assertions.assertEquals(-9876543210L, v2.getLongValue());
+
+        Assertions.assertThrows(RuntimeException.class,
+                () -> new IntVariant(IntegerType.INT, "not a number"));
+    }
+
+    @Test
+    public void testIntVariantCompareTo() {
+        IntVariant v1 = new IntVariant(IntegerType.INT, 100);
+        IntVariant v2 = new IntVariant(IntegerType.INT, 200);
+        IntVariant v3 = new IntVariant(IntegerType.BIGINT, 100);
+
+        Assertions.assertTrue(v1.compareTo(v2) < 0);
+        Assertions.assertTrue(v2.compareTo(v1) > 0);
+        Assertions.assertEquals(0, v1.compareTo(v3));
+    }
+
+    // ==================== LargeIntVariant Tests ====================
+
+    @Test
+    public void testLargeIntVariantFromString() {
+        LargeIntVariant v1 = new LargeIntVariant("12345678901234567890");
+        Assertions.assertEquals("12345678901234567890", v1.getStringValue());
+
+        LargeIntVariant v2 = new LargeIntVariant("-98765432109876543210");
+        Assertions.assertEquals("-98765432109876543210", v2.getStringValue());
+    }
+
+    @Test
+    public void testLargeIntVariantFromBigInteger() {
+        BigInteger value = new BigInteger("170141183460469231731687303715884105727"); // 2^127 - 1
+        LargeIntVariant v = new LargeIntVariant(value);
+        Assertions.assertEquals(value.toString(), v.getStringValue());
+    }
+
+    @Test
+    public void testLargeIntVariantSmallValues() {
+        // When high == 0, should use optimized path
+        LargeIntVariant v1 = new LargeIntVariant("100");
+        Assertions.assertEquals(100L, v1.getLongValue());
+        Assertions.assertEquals("100", v1.getStringValue());
+
+        LargeIntVariant v2 = new LargeIntVariant("0");
+        Assertions.assertEquals(0L, v2.getLongValue());
+    }
+
+    @Test
+    public void testLargeIntVariantOutOfRange() {
+        // 2^127 should be out of range
+        BigInteger outOfRange = BigInteger.ONE.shiftLeft(127);
+        Assertions.assertThrows(IllegalArgumentException.class,
+                () -> new LargeIntVariant(outOfRange));
+    }
+
+    @Test
+    public void testLargeIntVariantCompareTo() {
+        LargeIntVariant v1 = new LargeIntVariant("100");
+        LargeIntVariant v2 = new LargeIntVariant("200");
+        LargeIntVariant v3 = new LargeIntVariant("12345678901234567890");
+
+        Assertions.assertTrue(v1.compareTo(v2) < 0);
+        Assertions.assertTrue(v2.compareTo(v1) > 0);
+        Assertions.assertTrue(v3.compareTo(v2) > 0);
+
+        // Compare with IntVariant
+        IntVariant intVar = new IntVariant(IntegerType.BIGINT, 100);
+        Assertions.assertEquals(0, v1.compareTo(intVar));
+    }
+
+    // ==================== StringVariant Tests ====================
+
+    @Test
+    public void testStringVariantBasic() {
+        StringVariant v1 = new StringVariant(VarcharType.VARCHAR, "hello");
+        Assertions.assertEquals("hello", v1.getStringValue());
+        Assertions.assertEquals(VarcharType.VARCHAR, v1.getType());
+    }
+
+    @Test
+    public void testStringVariantGetLongValue() {
+        StringVariant v1 = new StringVariant(VarcharType.VARCHAR, "12345");
+        Assertions.assertEquals(12345L, v1.getLongValue());
+
+        StringVariant v2 = new StringVariant(VarcharType.VARCHAR, "not a number");
+        Assertions.assertThrows(RuntimeException.class, v2::getLongValue);
+    }
+
+    @Test
+    public void testStringVariantCompareTo() {
+        StringVariant v1 = new StringVariant(VarcharType.VARCHAR, "abc");
+        StringVariant v2 = new StringVariant(VarcharType.VARCHAR, "abd");
+        StringVariant v3 = new StringVariant(VarcharType.VARCHAR, "abc");
+
+        Assertions.assertTrue(v1.compareTo(v2) < 0);
+        Assertions.assertTrue(v2.compareTo(v1) > 0);
+        Assertions.assertEquals(0, v1.compareTo(v3));
+    }
+
+    @Test
+    public void testStringVariantCompareDifferentLengths() {
+        StringVariant v1 = new StringVariant(VarcharType.VARCHAR, "abc");
+        StringVariant v2 = new StringVariant(VarcharType.VARCHAR, "abcd");
+
+        Assertions.assertTrue(v1.compareTo(v2) < 0);
+        Assertions.assertTrue(v2.compareTo(v1) > 0);
+    }
+
+    @Test
+    public void testStringVariantCompareWithNullBytes() {
+        StringVariant v1 = new StringVariant(VarcharType.VARCHAR, "abc\0");
+        StringVariant v2 = new StringVariant(VarcharType.VARCHAR, "abc");
+
+        // When one string has null byte at the end, they should be equal
+        Assertions.assertEquals(0, v1.compareTo(v2));
+    }
+
+    @Test
+    public void testStringVariantEmpty() {
+        StringVariant v1 = new StringVariant(VarcharType.VARCHAR, "");
+        Assertions.assertEquals("", v1.getStringValue());
+
+        StringVariant v2 = new StringVariant(VarcharType.VARCHAR, "a");
+        Assertions.assertTrue(v1.compareTo(v2) < 0);
+    }
+
+    // ==================== DateVariant Tests ====================
+
+    @Test
+    public void testDateTimeVariantFromString() {
+        DateVariant v1 = new DateVariant(DateType.DATETIME, "2024-01-15T10:30:00");
+        Assertions.assertNotNull(v1.getStringValue());
+        Assertions.assertTrue(v1.getLongValue() > 0);
+    }
+
+    @Test
+    public void testDateTimeVariantFromInstant() {
+        Instant instant = Instant.parse("2024-01-15T10:30:00Z");
+        DateVariant v1 = new DateVariant(DateType.DATETIME, instant);
+
+        Assertions.assertNotNull(v1.getStringValue());
+        Assertions.assertEquals(instant.getEpochSecond() * 1000000 + instant.getNano() / 1000,
+                v1.getLongValue());
+    }
+
+    @Test
+    public void testDateTimeVariantCompareTo() {
+        DateVariant v1 = new DateVariant(DateType.DATETIME, "2024-01-15T10:30:00");
+        DateVariant v2 = new DateVariant(DateType.DATETIME, "2024-01-15T10:30:01");
+        DateVariant v3 = new DateVariant(DateType.DATETIME, "2024-01-15T10:30:00");
+
+        Assertions.assertTrue(v1.compareTo(v2) < 0);
+        Assertions.assertTrue(v2.compareTo(v1) > 0);
+        Assertions.assertEquals(0, v1.compareTo(v3));
+    }
+
+    @Test
+    public void testDateTimeVariantWithNanos() {
+        Instant instant1 = Instant.ofEpochSecond(1000, 123456789);
+        Instant instant2 = Instant.ofEpochSecond(1000, 123456790);
+
+        DateVariant v1 = new DateVariant(DateType.DATETIME, instant1);
+        DateVariant v2 = new DateVariant(DateType.DATETIME, instant2);
+
+        Assertions.assertTrue(v1.compareTo(v2) < 0);
+    }
+
+    // ==================== Variant.of() Factory Method Tests ====================
+
+    @Test
+    public void testVariantOfBoolean() {
+        Variant v1 = Variant.of(BooleanType.BOOLEAN, "true");
+        Assertions.assertTrue(v1 instanceof BoolVariant);
+        Assertions.assertEquals(1L, v1.getLongValue());
+
+        Variant v2 = Variant.of(BooleanType.BOOLEAN, "false");
+        Assertions.assertEquals(0L, v2.getLongValue());
+    }
+
+    @Test
+    public void testVariantOfIntTypes() {
+        Variant v1 = Variant.of(IntegerType.TINYINT, "100");
+        Assertions.assertTrue(v1 instanceof IntVariant);
+        Assertions.assertEquals(100L, v1.getLongValue());
+
+        Variant v2 = Variant.of(IntegerType.SMALLINT, "1000");
+        Assertions.assertTrue(v2 instanceof IntVariant);
+
+        Variant v3 = Variant.of(IntegerType.INT, "100000");
+        Assertions.assertTrue(v3 instanceof IntVariant);
+
+        Variant v4 = Variant.of(IntegerType.BIGINT, "10000000000");
+        Assertions.assertTrue(v4 instanceof IntVariant);
+    }
+
+    @Test
+    public void testVariantOfLargeInt() {
+        Variant v = Variant.of(IntegerType.LARGEINT, "12345678901234567890");
+        Assertions.assertTrue(v instanceof LargeIntVariant);
+        Assertions.assertEquals("12345678901234567890", v.getStringValue());
+    }
+
+    @Test
+    public void testVariantOfStringTypes() {
+        Variant v1 = Variant.of(VarcharType.VARCHAR, "test");
+        Assertions.assertTrue(v1 instanceof StringVariant);
+        Assertions.assertEquals("test", v1.getStringValue());
+
+        Variant v2 = Variant.of(CharType.CHAR, "char");
+        Assertions.assertTrue(v2 instanceof StringVariant);
+    }
+
+    @Test
+    public void testVariantOfDateTime() {
+        Variant v1 = Variant.of(DateType.DATETIME, "2024-01-15T10:30:00");
+        Assertions.assertTrue(v1 instanceof DateVariant);
+
+        Variant v2 = Variant.of(DateType.DATE, "2024-01-15T00:00:00");
+        Assertions.assertTrue(v2 instanceof DateVariant);
+    }
+
+    @Test
+    public void testVariantOfUnsupportedType() {
+        Assertions.assertThrows(RuntimeException.class,
+                () -> Variant.of(FloatType.FLOAT, "1.23"));
+    }
+
+    // ==================== Variant.compatibleCompare() Tests ====================
+
+    @Test
+    public void testCompatibleCompareSameType() {
+        Variant v1 = new IntVariant(IntegerType.INT, 100);
+        Variant v2 = new IntVariant(IntegerType.INT, 200);
+
+        Assertions.assertTrue(Variant.compatibleCompare(v1, v2) < 0);
+        Assertions.assertTrue(Variant.compatibleCompare(v2, v1) > 0);
+        Assertions.assertEquals(0, Variant.compatibleCompare(v1, v1));
+    }
+
+    @Test
+    public void testCompatibleCompareDifferentTypes() {
+        {
+            Variant v1 = new IntVariant(IntegerType.INT, 100);
+            Variant v2 = new IntVariant(IntegerType.BIGINT, 100);
+
+            // Should be equal after type conversion
+            Assertions.assertEquals(0, Variant.compatibleCompare(v1, v2));
+        }
+
+        {
+            Variant v1 = new IntVariant(IntegerType.BIGINT, 100);
+            Variant v2 = new LargeIntVariant(100);
+
+            // Should be equal after type conversion
+            Assertions.assertEquals(0, Variant.compatibleCompare(v1, v2));
+        }
+    }
+
+    @Test
+    public void testCompatibleCompareList() {
+        List<Variant> list1 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new IntVariant(IntegerType.INT, 2),
+                new IntVariant(IntegerType.INT, 3));
+
+        List<Variant> list2 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new IntVariant(IntegerType.INT, 2),
+                new IntVariant(IntegerType.INT, 4));
+
+        Assertions.assertTrue(Variant.compatibleCompare(list1, list2) < 0);
+        Assertions.assertTrue(Variant.compatibleCompare(list2, list1) > 0);
+        Assertions.assertEquals(0, Variant.compatibleCompare(list1, list1));
+    }
+
+    @Test
+    public void testCompatibleCompareListDifferentLengths() {
+        List<Variant> list1 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new IntVariant(IntegerType.INT, 2));
+
+        List<Variant> list2 = Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new IntVariant(IntegerType.INT, 2),
+                new IntVariant(IntegerType.INT, 3));
+
+        Assertions.assertTrue(Variant.compatibleCompare(list1, list2) < 0);
+        Assertions.assertTrue(Variant.compatibleCompare(list2, list1) > 0);
+    }
+
+    @Test
+    public void testCompatibleCompareEmptyList() {
+        List<Variant> empty = Arrays.asList();
+        List<Variant> nonEmpty = Arrays.asList(new IntVariant(IntegerType.INT, 1));
+
+        Assertions.assertTrue(Variant.compatibleCompare(empty, nonEmpty) < 0);
+        Assertions.assertTrue(Variant.compatibleCompare(nonEmpty, empty) > 0);
+        Assertions.assertEquals(0, Variant.compatibleCompare(empty, empty));
+    }
+
+    // ==================== Cross-type Comparison Tests ====================
+
+    @Test
+    public void testBoolVariantCompareWithLargeInt() {
+        BoolVariant boolVar = new BoolVariant(true);
+        IntVariant intVar = new IntVariant(IntegerType.INT, 1);
+        LargeIntVariant largeIntVar = new LargeIntVariant("1");
+
+        Assertions.assertEquals(0, boolVar.compareTo(intVar));
+        Assertions.assertEquals(0, intVar.compareTo(boolVar));
+        Assertions.assertEquals(0, boolVar.compareTo(largeIntVar));
+        Assertions.assertEquals(0, largeIntVar.compareTo(boolVar));
+    }
+
+    @Test
+    public void testIntVariantCompareWithLargeInt() {
+        IntVariant intVar = new IntVariant(IntegerType.BIGINT, 12345);
+        LargeIntVariant largeIntVar = new LargeIntVariant("12345");
+
+        Assertions.assertEquals(0, intVar.compareTo(largeIntVar));
+        Assertions.assertEquals(0, largeIntVar.compareTo(intVar));
+    }
+
+    // ==================== Edge Cases ====================
+
+    @Test
+    public void testZeroValues() {
+        BoolVariant boolZero = new BoolVariant(false);
+        IntVariant intZero = new IntVariant(IntegerType.INT, 0);
+        LargeIntVariant largeIntZero = new LargeIntVariant("0");
+
+        Assertions.assertEquals(0L, boolZero.getLongValue());
+        Assertions.assertEquals(0L, intZero.getLongValue());
+        Assertions.assertEquals(0L, largeIntZero.getLongValue());
+    }
+
+    @Test
+    public void testNegativeValues() {
+        IntVariant v1 = new IntVariant(IntegerType.INT, -100);
+        Assertions.assertEquals(-100L, v1.getLongValue());
+        Assertions.assertEquals("-100", v1.getStringValue());
+
+        LargeIntVariant v2 = new LargeIntVariant("-12345678901234567890");
+        Assertions.assertEquals("-12345678901234567890", v2.getStringValue());
+    }
+
+    // ==================== BoolVariant equals() and hashCode() Tests ====================
+
+    @Test
+    public void testBoolVariantEqualsReflexive() {
+        BoolVariant v = new BoolVariant(true);
+        Assertions.assertTrue(v.equals(v));
+    }
+
+    @Test
+    public void testBoolVariantEqualsSymmetric() {
+        BoolVariant v1 = new BoolVariant(true);
+        BoolVariant v2 = new BoolVariant(true);
+        Assertions.assertTrue(v1.equals(v2));
+        Assertions.assertTrue(v2.equals(v1));
+    }
+
+    @Test
+    public void testBoolVariantEqualsNull() {
+        BoolVariant v = new BoolVariant(true);
+        Assertions.assertFalse(v.equals(null));
+    }
+
+    @Test
+    public void testBoolVariantEqualsDifferentClass() {
+        BoolVariant v = new BoolVariant(true);
+        Assertions.assertFalse(v.equals("true"));
+        Assertions.assertFalse(v.equals(Integer.valueOf(1)));
+    }
+
+    @Test
+    public void testBoolVariantEqualsSameValue() {
+        BoolVariant v1 = new BoolVariant(true);
+        BoolVariant v2 = new BoolVariant(true);
+        Assertions.assertTrue(v1.equals(v2));
+
+        BoolVariant v3 = new BoolVariant(false);
+        BoolVariant v4 = new BoolVariant(false);
+        Assertions.assertTrue(v3.equals(v4));
+    }
+
+    @Test
+    public void testBoolVariantEqualsDifferentValue() {
+        BoolVariant v1 = new BoolVariant(true);
+        BoolVariant v2 = new BoolVariant(false);
+        Assertions.assertFalse(v1.equals(v2));
+        Assertions.assertFalse(v2.equals(v1));
+    }
+
+    @Test
+    public void testBoolVariantHashCodeConsistency() {
+        BoolVariant v = new BoolVariant(true);
+        int hash1 = v.hashCode();
+        int hash2 = v.hashCode();
+        Assertions.assertEquals(hash1, hash2);
+    }
+
+    @Test
+    public void testBoolVariantHashCodeEqualObjects() {
+        BoolVariant v1 = new BoolVariant(true);
+        BoolVariant v2 = new BoolVariant(true);
+        Assertions.assertTrue(v1.equals(v2));
+        Assertions.assertEquals(v1.hashCode(), v2.hashCode());
+
+        BoolVariant v3 = new BoolVariant(false);
+        BoolVariant v4 = new BoolVariant(false);
+        Assertions.assertTrue(v3.equals(v4));
+        Assertions.assertEquals(v3.hashCode(), v4.hashCode());
+    }
+
+    // ==================== IntVariant equals() and hashCode() Tests ====================
+
+    @Test
+    public void testIntVariantEqualsReflexive() {
+        IntVariant v = new IntVariant(IntegerType.INT, 100);
+        Assertions.assertTrue(v.equals(v));
+    }
+
+    @Test
+    public void testIntVariantEqualsSymmetric() {
+        IntVariant v1 = new IntVariant(IntegerType.INT, 100);
+        IntVariant v2 = new IntVariant(IntegerType.INT, 100);
+        Assertions.assertTrue(v1.equals(v2));
+        Assertions.assertTrue(v2.equals(v1));
+    }
+
+    @Test
+    public void testIntVariantEqualsNull() {
+        IntVariant v = new IntVariant(IntegerType.INT, 100);
+        Assertions.assertFalse(v.equals(null));
+    }
+
+    @Test
+    public void testIntVariantEqualsDifferentClass() {
+        IntVariant v = new IntVariant(IntegerType.INT, 100);
+        Assertions.assertFalse(v.equals("100"));
+        Assertions.assertFalse(v.equals(Integer.valueOf(100)));
+        // IntVariant should not equal LargeIntVariant even with same value
+        Assertions.assertFalse(v.equals(new LargeIntVariant(100)));
+    }
+
+    @Test
+    public void testIntVariantEqualsSameValue() {
+        IntVariant v1 = new IntVariant(IntegerType.INT, 12345);
+        IntVariant v2 = new IntVariant(IntegerType.INT, 12345);
+        Assertions.assertTrue(v1.equals(v2));
+    }
+
+    @Test
+    public void testIntVariantEqualsDifferentValue() {
+        IntVariant v1 = new IntVariant(IntegerType.INT, 100);
+        IntVariant v2 = new IntVariant(IntegerType.INT, 200);
+        Assertions.assertFalse(v1.equals(v2));
+    }
+
+    @Test
+    public void testIntVariantEqualsDifferentTypes() {
+        // Different integer types with same value should still be equal
+        IntVariant v1 = new IntVariant(IntegerType.INT, 100);
+        IntVariant v2 = new IntVariant(IntegerType.BIGINT, 100);
+        Assertions.assertTrue(v1.equals(v2));
+    }
+
+    @Test
+    public void testIntVariantHashCodeConsistency() {
+        IntVariant v = new IntVariant(IntegerType.INT, 12345);
+        int hash1 = v.hashCode();
+        int hash2 = v.hashCode();
+        Assertions.assertEquals(hash1, hash2);
+    }
+
+    @Test
+    public void testIntVariantHashCodeEqualObjects() {
+        IntVariant v1 = new IntVariant(IntegerType.INT, 12345);
+        IntVariant v2 = new IntVariant(IntegerType.INT, 12345);
+        Assertions.assertTrue(v1.equals(v2));
+        Assertions.assertEquals(v1.hashCode(), v2.hashCode());
+    }
+
+    @Test
+    public void testIntVariantHashCodeNegativeValues() {
+        IntVariant v1 = new IntVariant(IntegerType.INT, -100);
+        IntVariant v2 = new IntVariant(IntegerType.INT, -100);
+        Assertions.assertTrue(v1.equals(v2));
+        Assertions.assertEquals(v1.hashCode(), v2.hashCode());
+    }
+
+    // ==================== LargeIntVariant equals() and hashCode() Tests ====================
+
+    @Test
+    public void testLargeIntVariantEqualsReflexive() {
+        LargeIntVariant v = new LargeIntVariant("12345678901234567890");
+        Assertions.assertTrue(v.equals(v));
+    }
+
+    @Test
+    public void testLargeIntVariantEqualsSymmetric() {
+        LargeIntVariant v1 = new LargeIntVariant("12345678901234567890");
+        LargeIntVariant v2 = new LargeIntVariant("12345678901234567890");
+        Assertions.assertTrue(v1.equals(v2));
+        Assertions.assertTrue(v2.equals(v1));
+    }
+
+    @Test
+    public void testLargeIntVariantEqualsNull() {
+        LargeIntVariant v = new LargeIntVariant("12345678901234567890");
+        Assertions.assertFalse(v.equals(null));
+    }
+
+    @Test
+    public void testLargeIntVariantEqualsDifferentClass() {
+        LargeIntVariant v = new LargeIntVariant("12345678901234567890");
+        Assertions.assertFalse(v.equals("12345678901234567890"));
+        Assertions.assertFalse(v.equals(new IntVariant(IntegerType.BIGINT, 100)));
+    }
+
+    @Test
+    public void testLargeIntVariantEqualsSameValue() {
+        LargeIntVariant v1 = new LargeIntVariant("12345678901234567890");
+        LargeIntVariant v2 = new LargeIntVariant("12345678901234567890");
+        Assertions.assertTrue(v1.equals(v2));
+    }
+
+    @Test
+    public void testLargeIntVariantEqualsDifferentValue() {
+        LargeIntVariant v1 = new LargeIntVariant("12345678901234567890");
+        LargeIntVariant v2 = new LargeIntVariant("98765432109876543210");
+        Assertions.assertFalse(v1.equals(v2));
+    }
+
+    @Test
+    public void testLargeIntVariantEqualsSmallValues() {
+        LargeIntVariant v1 = new LargeIntVariant(100);
+        LargeIntVariant v2 = new LargeIntVariant("100");
+        Assertions.assertTrue(v1.equals(v2));
+    }
+
+    @Test
+    public void testLargeIntVariantEqualsNegativeValues() {
+        LargeIntVariant v1 = new LargeIntVariant("-12345678901234567890");
+        LargeIntVariant v2 = new LargeIntVariant("-12345678901234567890");
+        Assertions.assertTrue(v1.equals(v2));
+    }
+
+    @Test
+    public void testLargeIntVariantHashCodeConsistency() {
+        LargeIntVariant v = new LargeIntVariant("12345678901234567890");
+        int hash1 = v.hashCode();
+        int hash2 = v.hashCode();
+        Assertions.assertEquals(hash1, hash2);
+    }
+
+    @Test
+    public void testLargeIntVariantHashCodeEqualObjects() {
+        LargeIntVariant v1 = new LargeIntVariant("12345678901234567890");
+        LargeIntVariant v2 = new LargeIntVariant("12345678901234567890");
+        Assertions.assertTrue(v1.equals(v2));
+        Assertions.assertEquals(v1.hashCode(), v2.hashCode());
+    }
+
+    // ==================== StringVariant equals() and hashCode() Tests ====================
+
+    @Test
+    public void testStringVariantEqualsReflexive() {
+        StringVariant v = new StringVariant(VarcharType.VARCHAR, "hello");
+        Assertions.assertTrue(v.equals(v));
+    }
+
+    @Test
+    public void testStringVariantEqualsSymmetric() {
+        StringVariant v1 = new StringVariant(VarcharType.VARCHAR, "hello");
+        StringVariant v2 = new StringVariant(VarcharType.VARCHAR, "hello");
+        Assertions.assertTrue(v1.equals(v2));
+        Assertions.assertTrue(v2.equals(v1));
+    }
+
+    @Test
+    public void testStringVariantEqualsNull() {
+        StringVariant v = new StringVariant(VarcharType.VARCHAR, "hello");
+        Assertions.assertFalse(v.equals(null));
+    }
+
+    @Test
+    public void testStringVariantEqualsDifferentClass() {
+        StringVariant v = new StringVariant(VarcharType.VARCHAR, "hello");
+        Assertions.assertFalse(v.equals("hello"));
+        Assertions.assertFalse(v.equals(new IntVariant(IntegerType.INT, 100)));
+    }
+
+    @Test
+    public void testStringVariantEqualsSameValue() {
+        StringVariant v1 = new StringVariant(VarcharType.VARCHAR, "test string");
+        StringVariant v2 = new StringVariant(VarcharType.VARCHAR, "test string");
+        Assertions.assertTrue(v1.equals(v2));
+    }
+
+    @Test
+    public void testStringVariantEqualsDifferentValue() {
+        StringVariant v1 = new StringVariant(VarcharType.VARCHAR, "hello");
+        StringVariant v2 = new StringVariant(VarcharType.VARCHAR, "world");
+        Assertions.assertFalse(v1.equals(v2));
+    }
+
+    @Test
+    public void testStringVariantEqualsEmptyString() {
+        StringVariant v1 = new StringVariant(VarcharType.VARCHAR, "");
+        StringVariant v2 = new StringVariant(VarcharType.VARCHAR, "");
+        Assertions.assertTrue(v1.equals(v2));
+    }
+
+    @Test
+    public void testStringVariantEqualsCaseSensitive() {
+        StringVariant v1 = new StringVariant(VarcharType.VARCHAR, "Hello");
+        StringVariant v2 = new StringVariant(VarcharType.VARCHAR, "hello");
+        Assertions.assertFalse(v1.equals(v2));
+    }
+
+    @Test
+    public void testStringVariantHashCodeConsistency() {
+        StringVariant v = new StringVariant(VarcharType.VARCHAR, "hello");
+        int hash1 = v.hashCode();
+        int hash2 = v.hashCode();
+        Assertions.assertEquals(hash1, hash2);
+    }
+
+    @Test
+    public void testStringVariantHashCodeEqualObjects() {
+        StringVariant v1 = new StringVariant(VarcharType.VARCHAR, "test");
+        StringVariant v2 = new StringVariant(VarcharType.VARCHAR, "test");
+        Assertions.assertTrue(v1.equals(v2));
+        Assertions.assertEquals(v1.hashCode(), v2.hashCode());
+    }
+
+    // ==================== DateVariant equals() and hashCode() Tests ====================
+
+    @Test
+    public void testDateTimeVariantEqualsReflexive() {
+        DateVariant v = new DateVariant(DateType.DATETIME, "2024-01-15T10:30:00");
+        Assertions.assertTrue(v.equals(v));
+    }
+
+    @Test
+    public void testDateTimeVariantEqualsSymmetric() {
+        DateVariant v1 = new DateVariant(DateType.DATETIME, "2024-01-15T10:30:00");
+        DateVariant v2 = new DateVariant(DateType.DATETIME, "2024-01-15T10:30:00");
+        Assertions.assertTrue(v1.equals(v2));
+        Assertions.assertTrue(v2.equals(v1));
+    }
+
+    @Test
+    public void testDateTimeVariantEqualsNull() {
+        DateVariant v = new DateVariant(DateType.DATETIME, "2024-01-15T10:30:00");
+        Assertions.assertFalse(v.equals(null));
+    }
+
+    @Test
+    public void testDateTimeVariantEqualsDifferentClass() {
+        DateVariant v = new DateVariant(DateType.DATETIME, "2024-01-15T10:30:00");
+        Assertions.assertFalse(v.equals("2024-01-15T10:30:00"));
+        Assertions.assertFalse(v.equals(new IntVariant(IntegerType.INT, 100)));
+    }
+
+    @Test
+    public void testDateTimeVariantEqualsSameValue() {
+        Instant instant = Instant.parse("2024-01-15T10:30:00Z");
+        DateVariant v1 = new DateVariant(DateType.DATETIME, instant);
+        DateVariant v2 = new DateVariant(DateType.DATETIME, instant);
+        Assertions.assertTrue(v1.equals(v2));
+    }
+
+    @Test
+    public void testDateTimeVariantEqualsDifferentValue() {
+        DateVariant v1 = new DateVariant(DateType.DATETIME, "2024-01-15T10:30:00");
+        DateVariant v2 = new DateVariant(DateType.DATETIME, "2024-01-15T10:30:01");
+        Assertions.assertFalse(v1.equals(v2));
+    }
+
+    @Test
+    public void testDateTimeVariantEqualsWithNanos() {
+        Instant instant1 = Instant.ofEpochSecond(1000, 123456789);
+        Instant instant2 = Instant.ofEpochSecond(1000, 123456789);
+        Instant instant3 = Instant.ofEpochSecond(1000, 123456790);
+
+        DateVariant v1 = new DateVariant(DateType.DATETIME, instant1);
+        DateVariant v2 = new DateVariant(DateType.DATETIME, instant2);
+        DateVariant v3 = new DateVariant(DateType.DATETIME, instant3);
+
+        Assertions.assertTrue(v1.equals(v2));
+        Assertions.assertFalse(v1.equals(v3));
+    }
+
+    @Test
+    public void testDateTimeVariantHashCodeConsistency() {
+        DateVariant v = new DateVariant(DateType.DATETIME, "2024-01-15T10:30:00");
+        int hash1 = v.hashCode();
+        int hash2 = v.hashCode();
+        Assertions.assertEquals(hash1, hash2);
+    }
+
+    @Test
+    public void testDateTimeVariantHashCodeEqualObjects() {
+        DateVariant v1 = new DateVariant(DateType.DATETIME, "2024-01-15T10:30:00");
+        DateVariant v2 = new DateVariant(DateType.DATETIME, "2024-01-15T10:30:00");
+        Assertions.assertTrue(v1.equals(v2));
+        Assertions.assertEquals(v1.hashCode(), v2.hashCode());
+    }
+
+    // ==================== Cross-Variant equals() Tests ====================
+
+    @Test
+    public void testCrossVariantEquals() {
+        // Different types should not be equal via equals()
+        BoolVariant boolVar = new BoolVariant(true);
+        IntVariant intVar = new IntVariant(IntegerType.INT, 1);
+        LargeIntVariant largeIntVar = new LargeIntVariant("1");
+        StringVariant stringVar = new StringVariant(VarcharType.VARCHAR, "1");
+
+        Assertions.assertFalse(boolVar.equals(intVar));
+        Assertions.assertFalse(boolVar.equals(largeIntVar));
+        Assertions.assertFalse(boolVar.equals(stringVar));
+        Assertions.assertFalse(intVar.equals(largeIntVar));
+        Assertions.assertFalse(intVar.equals(stringVar));
+        Assertions.assertFalse(largeIntVar.equals(stringVar));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/common/Int128Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/Int128Test.java
@@ -1,0 +1,455 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+
+public class Int128Test {
+
+    @Test
+    public void testOfLong() {
+        // Test zero
+        Int128 zero = Int128.of(0L);
+        Assertions.assertEquals(0L, zero.getHigh());
+        Assertions.assertEquals(0L, zero.getLow());
+        Assertions.assertTrue(zero.isInLong());
+        Assertions.assertEquals("0", zero.toString());
+
+        // Test positive number
+        Int128 positive = Int128.of(12345L);
+        Assertions.assertEquals(0L, positive.getHigh());
+        Assertions.assertEquals(12345L, positive.getLow());
+        Assertions.assertTrue(positive.isInLong());
+        Assertions.assertEquals("12345", positive.toString());
+
+        // Test negative number
+        Int128 negative = Int128.of(-12345L);
+        Assertions.assertEquals(-1L, negative.getHigh());
+        Assertions.assertEquals(-12345L, negative.getLow());
+        Assertions.assertTrue(negative.isInLong());
+        Assertions.assertEquals("-12345", negative.toString());
+
+        // Test Long.MAX_VALUE
+        Int128 maxLong = Int128.of(Long.MAX_VALUE);
+        Assertions.assertEquals(0L, maxLong.getHigh());
+        Assertions.assertEquals(Long.MAX_VALUE, maxLong.getLow());
+        Assertions.assertTrue(maxLong.isInLong());
+        Assertions.assertEquals(String.valueOf(Long.MAX_VALUE), maxLong.toString());
+
+        // Test Long.MIN_VALUE
+        Int128 minLong = Int128.of(Long.MIN_VALUE);
+        Assertions.assertEquals(-1L, minLong.getHigh());
+        Assertions.assertEquals(Long.MIN_VALUE, minLong.getLow());
+        Assertions.assertTrue(minLong.isInLong());
+        Assertions.assertEquals(String.valueOf(Long.MIN_VALUE), minLong.toString());
+    }
+
+    @Test
+    public void testOfString() {
+        // Test zero
+        Int128 zero = Int128.of("0");
+        Assertions.assertEquals(0L, zero.getHigh());
+        Assertions.assertEquals(0L, zero.getLow());
+        Assertions.assertEquals("0", zero.toString());
+
+        // Test positive number
+        Int128 positive = Int128.of("123456789012345678901234567890");
+        Assertions.assertEquals("123456789012345678901234567890", positive.toString());
+
+        // Test negative number
+        Int128 negative = Int128.of("-123456789012345678901234567890");
+        Assertions.assertEquals("-123456789012345678901234567890", negative.toString());
+
+        // Test large positive number close to max
+        String maxValue = "170141183460469231731687303715884105727"; // 2^127 - 1
+        Int128 max = Int128.of(maxValue);
+        Assertions.assertEquals(maxValue, max.toString());
+        Assertions.assertEquals(Long.MAX_VALUE, max.getHigh());
+        Assertions.assertEquals(-1L, max.getLow());
+
+        // Test large negative number close to min
+        String minValue = "-170141183460469231731687303715884105728"; // -2^127
+        Int128 min = Int128.of(minValue);
+        Assertions.assertEquals(minValue, min.toString());
+        Assertions.assertEquals(Long.MIN_VALUE, min.getHigh());
+        Assertions.assertEquals(0L, min.getLow());
+    }
+
+    @Test
+    public void testOfBigInteger() {
+        // Test zero
+        Int128 zero = Int128.of(BigInteger.ZERO);
+        Assertions.assertEquals(0L, zero.getHigh());
+        Assertions.assertEquals(0L, zero.getLow());
+
+        // Test BigInteger.ONE
+        Int128 one = Int128.of(BigInteger.ONE);
+        Assertions.assertEquals(0L, one.getHigh());
+        Assertions.assertEquals(1L, one.getLow());
+
+        // Test large positive BigInteger
+        BigInteger largePositive = new BigInteger("123456789012345678901234567890");
+        Int128 intLargePositive = Int128.of(largePositive);
+        Assertions.assertEquals(largePositive, intLargePositive.toBigInteger());
+
+        // Test large negative BigInteger
+        BigInteger largeNegative = new BigInteger("-123456789012345678901234567890");
+        Int128 intLargeNegative = Int128.of(largeNegative);
+        Assertions.assertEquals(largeNegative, intLargeNegative.toBigInteger());
+
+        // Test max value
+        BigInteger maxValue = BigInteger.ONE.shiftLeft(127).subtract(BigInteger.ONE);
+        Int128 max = Int128.of(maxValue);
+        Assertions.assertEquals(maxValue, max.toBigInteger());
+
+        // Test min value
+        BigInteger minValue = BigInteger.ONE.shiftLeft(127).negate();
+        Int128 min = Int128.of(minValue);
+        Assertions.assertEquals(minValue, min.toBigInteger());
+    }
+
+    @Test
+    public void testOfBigIntegerOverflowPositive() {
+        // Test overflow: 2^127 (too large)
+        BigInteger overflow = BigInteger.ONE.shiftLeft(127);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Int128.of(overflow));
+    }
+
+    @Test
+    public void testOfBigIntegerOverflowNegative() {
+        // Test overflow: -2^127 - 1 (too small)
+        BigInteger overflow = BigInteger.ONE.shiftLeft(127).negate().subtract(BigInteger.ONE);
+        Assertions.assertThrows(IllegalArgumentException.class, () -> Int128.of(overflow));
+    }
+
+    @Test
+    public void testIsInLong() {
+        // Numbers that fit in long
+        Assertions.assertTrue(Int128.of(0L).isInLong());
+        Assertions.assertTrue(Int128.of(1L).isInLong());
+        Assertions.assertTrue(Int128.of(-1L).isInLong());
+        Assertions.assertTrue(Int128.of(Long.MAX_VALUE).isInLong());
+        Assertions.assertTrue(Int128.of(Long.MIN_VALUE).isInLong());
+
+        // Numbers that don't fit in long
+        BigInteger largeThanLongMax = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+        Assertions.assertFalse(Int128.of(largeThanLongMax).isInLong());
+
+        BigInteger smallerThanLongMin = BigInteger.valueOf(Long.MIN_VALUE).subtract(BigInteger.ONE);
+        Assertions.assertFalse(Int128.of(smallerThanLongMin).isInLong());
+
+        // Edge case: exactly 2^64 - 1 (unsigned max of low, but doesn't fit in long)
+        BigInteger unsignedLongMax = BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE);
+        Assertions.assertFalse(Int128.of(unsignedLongMax).isInLong());
+    }
+
+    @Test
+    public void testToLong() {
+        Assertions.assertEquals(0L, Int128.of(0L).toLong());
+        Assertions.assertEquals(12345L, Int128.of(12345L).toLong());
+        Assertions.assertEquals(-12345L, Int128.of(-12345L).toLong());
+        Assertions.assertEquals(Long.MAX_VALUE, Int128.of(Long.MAX_VALUE).toLong());
+        Assertions.assertEquals(Long.MIN_VALUE, Int128.of(Long.MIN_VALUE).toLong());
+
+        // For numbers outside long range, toLong() returns the low 64 bits
+        BigInteger large = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+        Int128 largeInt128 = Int128.of(large);
+        Assertions.assertEquals(Long.MIN_VALUE, largeInt128.toLong());
+    }
+
+    @Test
+    public void testToBigInteger() {
+        // Test zero
+        Assertions.assertEquals(BigInteger.ZERO, Int128.of(0L).toBigInteger());
+
+        // Test positive numbers
+        Assertions.assertEquals(BigInteger.valueOf(12345L), Int128.of(12345L).toBigInteger());
+        Assertions.assertEquals(BigInteger.valueOf(Long.MAX_VALUE), Int128.of(Long.MAX_VALUE).toBigInteger());
+
+        // Test negative numbers
+        Assertions.assertEquals(BigInteger.valueOf(-12345L), Int128.of(-12345L).toBigInteger());
+        Assertions.assertEquals(BigInteger.valueOf(Long.MIN_VALUE), Int128.of(Long.MIN_VALUE).toBigInteger());
+
+        // Test large numbers
+        BigInteger large = new BigInteger("123456789012345678901234567890");
+        Assertions.assertEquals(large, Int128.of(large).toBigInteger());
+
+        BigInteger negLarge = new BigInteger("-123456789012345678901234567890");
+        Assertions.assertEquals(negLarge, Int128.of(negLarge).toBigInteger());
+
+        // Test max and min values
+        BigInteger maxValue = BigInteger.ONE.shiftLeft(127).subtract(BigInteger.ONE);
+        Assertions.assertEquals(maxValue, Int128.of(maxValue).toBigInteger());
+
+        BigInteger minValue = BigInteger.ONE.shiftLeft(127).negate();
+        Assertions.assertEquals(minValue, Int128.of(minValue).toBigInteger());
+    }
+
+    @Test
+    public void testToByteArray() {
+        // Test zero
+        Int128 zero = Int128.of(0L);
+        byte[] zeroBytes = zero.toByteArray();
+        Assertions.assertEquals(16, zeroBytes.length);
+        for (byte b : zeroBytes) {
+            Assertions.assertEquals(0, b);
+        }
+
+        // Test positive number
+        Int128 positive = Int128.of(0x123456789ABCDEF0L);
+        byte[] positiveBytes = positive.toByteArray();
+        Assertions.assertEquals(16, positiveBytes.length);
+        // Check high bytes are 0
+        for (int i = 0; i < 8; i++) {
+            Assertions.assertEquals(0, positiveBytes[i]);
+        }
+        // Check low bytes
+        Assertions.assertEquals((byte) 0x12, positiveBytes[8]);
+        Assertions.assertEquals((byte) 0x34, positiveBytes[9]);
+        Assertions.assertEquals((byte) 0x56, positiveBytes[10]);
+        Assertions.assertEquals((byte) 0x78, positiveBytes[11]);
+        Assertions.assertEquals((byte) 0x9A, positiveBytes[12]);
+        Assertions.assertEquals((byte) 0xBC, positiveBytes[13]);
+        Assertions.assertEquals((byte) 0xDE, positiveBytes[14]);
+        Assertions.assertEquals((byte) 0xF0, positiveBytes[15]);
+
+        // Test -1 (all bits set)
+        Int128 negOne = Int128.of(-1L);
+        byte[] negOneBytes = negOne.toByteArray();
+        Assertions.assertEquals(16, negOneBytes.length);
+        for (byte b : negOneBytes) {
+            Assertions.assertEquals((byte) 0xFF, b);
+        }
+
+        // Test roundtrip with BigInteger
+        BigInteger original = new BigInteger("123456789012345678901234567890");
+        Int128 int128 = Int128.of(original);
+        BigInteger restored = new BigInteger(int128.toByteArray());
+        Assertions.assertEquals(original, restored);
+    }
+
+    @Test
+    public void testToString() {
+        // Test zero
+        Assertions.assertEquals("0", Int128.of(0L).toString());
+
+        // Test positive numbers
+        Assertions.assertEquals("1", Int128.of(1L).toString());
+        Assertions.assertEquals("12345", Int128.of(12345L).toString());
+        Assertions.assertEquals(String.valueOf(Long.MAX_VALUE), Int128.of(Long.MAX_VALUE).toString());
+
+        // Test negative numbers
+        Assertions.assertEquals("-1", Int128.of(-1L).toString());
+        Assertions.assertEquals("-12345", Int128.of(-12345L).toString());
+        Assertions.assertEquals(String.valueOf(Long.MIN_VALUE), Int128.of(Long.MIN_VALUE).toString());
+
+        // Test large positive number
+        String largePositive = "123456789012345678901234567890";
+        Assertions.assertEquals(largePositive, Int128.of(largePositive).toString());
+
+        // Test large negative number
+        String largeNegative = "-123456789012345678901234567890";
+        Assertions.assertEquals(largeNegative, Int128.of(largeNegative).toString());
+
+        // Test max value
+        String maxValue = "170141183460469231731687303715884105727";
+        Assertions.assertEquals(maxValue, Int128.of(maxValue).toString());
+
+        // Test min value
+        String minValue = "-170141183460469231731687303715884105728";
+        Assertions.assertEquals(minValue, Int128.of(minValue).toString());
+
+        // Test unsigned long max (2^64 - 1)
+        BigInteger unsignedLongMax = BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE);
+        Assertions.assertEquals("18446744073709551615", Int128.of(unsignedLongMax).toString());
+    }
+
+    @Test
+    public void testCompareTo() {
+        // Test equality
+        Assertions.assertEquals(0, Int128.of(0L).compareTo(Int128.of(0L)));
+        Assertions.assertEquals(0, Int128.of(12345L).compareTo(Int128.of(12345L)));
+        Assertions.assertEquals(0, Int128.of(-12345L).compareTo(Int128.of(-12345L)));
+
+        // Test less than
+        Assertions.assertTrue(Int128.of(0L).compareTo(Int128.of(1L)) < 0);
+        Assertions.assertTrue(Int128.of(-1L).compareTo(Int128.of(0L)) < 0);
+        Assertions.assertTrue(Int128.of(-12345L).compareTo(Int128.of(-12344L)) < 0);
+        Assertions.assertTrue(Int128.of(Long.MIN_VALUE).compareTo(Int128.of(Long.MAX_VALUE)) < 0);
+
+        // Test greater than
+        Assertions.assertTrue(Int128.of(1L).compareTo(Int128.of(0L)) > 0);
+        Assertions.assertTrue(Int128.of(0L).compareTo(Int128.of(-1L)) > 0);
+        Assertions.assertTrue(Int128.of(-12344L).compareTo(Int128.of(-12345L)) > 0);
+        Assertions.assertTrue(Int128.of(Long.MAX_VALUE).compareTo(Int128.of(Long.MIN_VALUE)) > 0);
+
+        // Test large numbers
+        BigInteger large1 = new BigInteger("123456789012345678901234567890");
+        BigInteger large2 = new BigInteger("123456789012345678901234567891");
+        Assertions.assertTrue(Int128.of(large1).compareTo(Int128.of(large2)) < 0);
+        Assertions.assertTrue(Int128.of(large2).compareTo(Int128.of(large1)) > 0);
+
+        // Test negative large numbers
+        BigInteger negLarge1 = new BigInteger("-123456789012345678901234567890");
+        BigInteger negLarge2 = new BigInteger("-123456789012345678901234567891");
+        Assertions.assertTrue(Int128.of(negLarge1).compareTo(Int128.of(negLarge2)) > 0);
+        Assertions.assertTrue(Int128.of(negLarge2).compareTo(Int128.of(negLarge1)) < 0);
+
+        // Test max and min values
+        BigInteger maxValue = BigInteger.ONE.shiftLeft(127).subtract(BigInteger.ONE);
+        BigInteger minValue = BigInteger.ONE.shiftLeft(127).negate();
+        Assertions.assertTrue(Int128.of(minValue).compareTo(Int128.of(maxValue)) < 0);
+        Assertions.assertTrue(Int128.of(maxValue).compareTo(Int128.of(minValue)) > 0);
+
+        // Test comparison with different high values
+        BigInteger val1 = BigInteger.valueOf(Long.MAX_VALUE);
+        BigInteger val2 = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+        Assertions.assertTrue(Int128.of(val1).compareTo(Int128.of(val2)) < 0);
+
+        // Test unsigned comparison of low when high is equal
+        Int128 a = Int128.of(BigInteger.ONE.shiftLeft(64)); // high=1, low=0
+        Int128 b = Int128.of(BigInteger.ONE.shiftLeft(64).add(BigInteger.ONE)); // high=1, low=1
+        Assertions.assertTrue(a.compareTo(b) < 0);
+    }
+
+    @Test
+    public void testEquals() {
+        // Test equality with same values
+        Int128 a = Int128.of(12345L);
+        Int128 b = Int128.of(12345L);
+        Assertions.assertEquals(a, b);
+        Assertions.assertEquals(b, a);
+
+        // Test equality with zero
+        Assertions.assertEquals(Int128.of(0L), Int128.of(0L));
+
+        // Test equality with negative numbers
+        Assertions.assertEquals(Int128.of(-12345L), Int128.of(-12345L));
+
+        // Test equality with large numbers
+        BigInteger large = new BigInteger("123456789012345678901234567890");
+        Assertions.assertEquals(Int128.of(large), Int128.of(large));
+
+        // Test inequality
+        Assertions.assertNotEquals(Int128.of(0L), Int128.of(1L));
+        Assertions.assertNotEquals(Int128.of(-1L), Int128.of(1L));
+        Assertions.assertNotEquals(Int128.of(12345L), Int128.of(12346L));
+
+        // Test inequality with large numbers
+        BigInteger large1 = new BigInteger("123456789012345678901234567890");
+        BigInteger large2 = new BigInteger("123456789012345678901234567891");
+        Assertions.assertNotEquals(Int128.of(large1), Int128.of(large2));
+
+        // Test with null
+        Assertions.assertNotEquals(Int128.of(0L), null);
+
+        // Test with different type
+        Assertions.assertNotEquals(Int128.of(0L), BigInteger.ZERO);
+    }
+
+    @Test
+    public void testHashCode() {
+        // Test same values have same hash code
+        Int128 a = Int128.of(12345L);
+        Int128 b = Int128.of(12345L);
+        Assertions.assertEquals(a.hashCode(), b.hashCode());
+
+        // Test zero
+        Int128 zero1 = Int128.of(0L);
+        Int128 zero2 = Int128.of(0L);
+        Assertions.assertEquals(zero1.hashCode(), zero2.hashCode());
+
+        // Test large numbers
+        BigInteger large = new BigInteger("123456789012345678901234567890");
+        Int128 large1 = Int128.of(large);
+        Int128 large2 = Int128.of(large);
+        Assertions.assertEquals(large1.hashCode(), large2.hashCode());
+
+        // Note: Different values may have different hash codes (not guaranteed, but
+        // likely)
+        // This is not a strict requirement, but good practice
+        Int128 val1 = Int128.of(1L);
+        Int128 val2 = Int128.of(2L);
+        // We don't assert inequality here because hash collisions are allowed
+    }
+
+    @Test
+    public void testEdgeCases() {
+        // Test boundary between positive and negative in low word
+        BigInteger justAboveLongMax = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+        Int128 val = Int128.of(justAboveLongMax);
+        Assertions.assertEquals(0L, val.getHigh());
+        Assertions.assertEquals(Long.MIN_VALUE, val.getLow());
+        Assertions.assertFalse(val.isInLong());
+
+        // Test 2^64 - 1 (max unsigned long, but positive Int128)
+        BigInteger unsignedLongMax = BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE);
+        Int128 val2 = Int128.of(unsignedLongMax);
+        Assertions.assertEquals(0L, val2.getHigh());
+        Assertions.assertEquals(-1L, val2.getLow());
+        Assertions.assertFalse(val2.isInLong());
+        Assertions.assertEquals("18446744073709551615", val2.toString());
+
+        // Test 2^64 (requires high word)
+        BigInteger twoToThe64 = BigInteger.ONE.shiftLeft(64);
+        Int128 val3 = Int128.of(twoToThe64);
+        Assertions.assertEquals(1L, val3.getHigh());
+        Assertions.assertEquals(0L, val3.getLow());
+        Assertions.assertFalse(val3.isInLong());
+
+        // Test -2^64
+        BigInteger negTwoToThe64 = BigInteger.ONE.shiftLeft(64).negate();
+        Int128 val4 = Int128.of(negTwoToThe64);
+        Assertions.assertEquals(-1L, val4.getHigh());
+        Assertions.assertEquals(0L, val4.getLow());
+        Assertions.assertFalse(val4.isInLong());
+    }
+
+    @Test
+    public void testRoundTrip() {
+        // Test round-trip: long -> Int128 -> long
+        long[] longValues = { 0L, 1L, -1L, Long.MAX_VALUE, Long.MIN_VALUE, 12345L, -67890L };
+        for (long val : longValues) {
+            Int128 int128 = Int128.of(val);
+            Assertions.assertEquals(val, int128.toLong());
+        }
+
+        // Test round-trip: BigInteger -> Int128 -> BigInteger (for values in range)
+        String[] stringValues = {
+                "0",
+                "1",
+                "-1",
+                "123456789012345678901234567890",
+                "-123456789012345678901234567890",
+                "170141183460469231731687303715884105727", // max
+                "-170141183460469231731687303715884105728" // min
+        };
+        for (String strVal : stringValues) {
+            BigInteger big = new BigInteger(strVal);
+            Int128 int128 = Int128.of(big);
+            Assertions.assertEquals(big, int128.toBigInteger());
+            Assertions.assertEquals(strVal, int128.toString());
+        }
+
+        // Test round-trip: String -> Int128 -> String
+        for (String strVal : stringValues) {
+            Int128 int128 = Int128.of(strVal);
+            Assertions.assertEquals(strVal, int128.toString());
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/common/RangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/RangeTest.java
@@ -1,0 +1,871 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common;
+
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import com.starrocks.persist.gson.GsonUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class RangeTest {
+
+    // Test class that contains Range as a member variable
+    public static class RangeContainer {
+        @SerializedName(value = "id")
+        private int id;
+
+        @SerializedName(value = "name")
+        private String name;
+
+        @SerializedName(value = "valueRange")
+        private Range<Integer> valueRange;
+
+        @SerializedName(value = "nameRange")
+        private Range<String> nameRange;
+
+        public RangeContainer(int id, String name, Range<Integer> valueRange, Range<String> nameRange) {
+            this.id = id;
+            this.name = name;
+            this.valueRange = valueRange;
+            this.nameRange = nameRange;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Range<Integer> getValueRange() {
+            return valueRange;
+        }
+
+        public Range<String> getNameRange() {
+            return nameRange;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            RangeContainer that = (RangeContainer) obj;
+            return id == that.id &&
+                    name.equals(that.name) &&
+                    valueRange.equals(that.valueRange) &&
+                    nameRange.equals(that.nameRange);
+        }
+    }
+
+    // ==================== Factory Method Tests ====================
+
+    @Test
+    public void testOfMethodWithAllNull() {
+        Range<Integer> range = Range.of(null, null, false, false);
+        Assertions.assertNull(range.getLowerBound());
+        Assertions.assertNull(range.getUpperBound());
+        Assertions.assertFalse(range.isLowerBoundIncluded());
+        Assertions.assertFalse(range.isUpperBoundIncluded());
+        Assertions.assertTrue(range.isAll());
+    }
+
+    @Test
+    public void testOfMethodWithLowerBoundNull() {
+        Range<Integer> rangeLT = Range.of(null, 10, false, false);
+        Assertions.assertNull(rangeLT.getLowerBound());
+        Assertions.assertEquals(10, rangeLT.getUpperBound());
+        Assertions.assertFalse(rangeLT.isUpperBoundIncluded());
+
+        Range<Integer> rangeLE = Range.of(null, 10, false, true);
+        Assertions.assertNull(rangeLE.getLowerBound());
+        Assertions.assertEquals(10, rangeLE.getUpperBound());
+        Assertions.assertTrue(rangeLE.isUpperBoundIncluded());
+    }
+
+    @Test
+    public void testOfMethodWithUpperBoundNull() {
+        Range<Integer> rangeGT = Range.of(5, null, false, false);
+        Assertions.assertEquals(5, rangeGT.getLowerBound());
+        Assertions.assertNull(rangeGT.getUpperBound());
+        Assertions.assertFalse(rangeGT.isLowerBoundIncluded());
+
+        Range<Integer> rangeGE = Range.of(5, null, true, false);
+        Assertions.assertEquals(5, rangeGE.getLowerBound());
+        Assertions.assertNull(rangeGE.getUpperBound());
+        Assertions.assertTrue(rangeGE.isLowerBoundIncluded());
+    }
+
+    @Test
+    public void testOfMethodWithBothBounds() {
+        Range<Integer> openRange = Range.of(1, 10, false, false);
+        Assertions.assertEquals(1, openRange.getLowerBound());
+        Assertions.assertEquals(10, openRange.getUpperBound());
+        Assertions.assertFalse(openRange.isLowerBoundIncluded());
+        Assertions.assertFalse(openRange.isUpperBoundIncluded());
+
+        Range<Integer> closedRange = Range.of(1, 10, true, true);
+        Assertions.assertEquals(1, closedRange.getLowerBound());
+        Assertions.assertEquals(10, closedRange.getUpperBound());
+        Assertions.assertTrue(closedRange.isLowerBoundIncluded());
+        Assertions.assertTrue(closedRange.isUpperBoundIncluded());
+
+        Range<Integer> closedOpen = Range.of(1, 10, true, false);
+        Assertions.assertEquals(1, closedOpen.getLowerBound());
+        Assertions.assertEquals(10, closedOpen.getUpperBound());
+        Assertions.assertTrue(closedOpen.isLowerBoundIncluded());
+        Assertions.assertFalse(closedOpen.isUpperBoundIncluded());
+
+        Range<Integer> openClosed = Range.of(1, 10, false, true);
+        Assertions.assertEquals(1, openClosed.getLowerBound());
+        Assertions.assertEquals(10, openClosed.getUpperBound());
+        Assertions.assertFalse(openClosed.isLowerBoundIncluded());
+        Assertions.assertTrue(openClosed.isUpperBoundIncluded());
+    }
+
+    @Test
+    public void testAllFactoryMethod() {
+        Range<Integer> range = Range.all();
+        Assertions.assertNull(range.getLowerBound());
+        Assertions.assertNull(range.getUpperBound());
+        Assertions.assertFalse(range.isLowerBoundIncluded());
+        Assertions.assertFalse(range.isUpperBoundIncluded());
+        Assertions.assertTrue(range.isAll());
+        Assertions.assertEquals("(-∞, +∞)", range.toString());
+    }
+
+    @Test
+    public void testLTFactoryMethod() {
+        Range<Integer> range = Range.lt(100);
+        Assertions.assertNull(range.getLowerBound());
+        Assertions.assertEquals(100, range.getUpperBound());
+        Assertions.assertFalse(range.isLowerBoundIncluded());
+        Assertions.assertFalse(range.isUpperBoundIncluded());
+        Assertions.assertEquals("(-∞, 100)", range.toString());
+    }
+
+    @Test
+    public void testLEFactoryMethod() {
+        Range<Integer> range = Range.le(50);
+        Assertions.assertNull(range.getLowerBound());
+        Assertions.assertEquals(50, range.getUpperBound());
+        Assertions.assertFalse(range.isLowerBoundIncluded());
+        Assertions.assertTrue(range.isUpperBoundIncluded());
+        Assertions.assertEquals("(-∞, 50]", range.toString());
+    }
+
+    @Test
+    public void testGTFactoryMethod() {
+        Range<Integer> range = Range.gt(20);
+        Assertions.assertEquals(20, range.getLowerBound());
+        Assertions.assertNull(range.getUpperBound());
+        Assertions.assertFalse(range.isLowerBoundIncluded());
+        Assertions.assertFalse(range.isUpperBoundIncluded());
+        Assertions.assertEquals("(20, +∞)", range.toString());
+    }
+
+    @Test
+    public void testGEFactoryMethod() {
+        Range<Integer> range = Range.ge(30);
+        Assertions.assertEquals(30, range.getLowerBound());
+        Assertions.assertNull(range.getUpperBound());
+        Assertions.assertTrue(range.isLowerBoundIncluded());
+        Assertions.assertFalse(range.isUpperBoundIncluded());
+        Assertions.assertEquals("[30, +∞)", range.toString());
+    }
+
+    @Test
+    public void testGTLTFactoryMethod() {
+        Range<Integer> range = Range.gtlt(10, 20);
+        Assertions.assertEquals(10, range.getLowerBound());
+        Assertions.assertEquals(20, range.getUpperBound());
+        Assertions.assertFalse(range.isLowerBoundIncluded());
+        Assertions.assertFalse(range.isUpperBoundIncluded());
+        Assertions.assertEquals("(10, 20)", range.toString());
+    }
+
+    @Test
+    public void testGELTFactoryMethod() {
+        Range<Integer> range = Range.gelt(5, 15);
+        Assertions.assertEquals(5, range.getLowerBound());
+        Assertions.assertEquals(15, range.getUpperBound());
+        Assertions.assertTrue(range.isLowerBoundIncluded());
+        Assertions.assertFalse(range.isUpperBoundIncluded());
+        Assertions.assertEquals("[5, 15)", range.toString());
+    }
+
+    @Test
+    public void testGTLEFactoryMethod() {
+        Range<Integer> range = Range.gtle(3, 13);
+        Assertions.assertEquals(3, range.getLowerBound());
+        Assertions.assertEquals(13, range.getUpperBound());
+        Assertions.assertFalse(range.isLowerBoundIncluded());
+        Assertions.assertTrue(range.isUpperBoundIncluded());
+        Assertions.assertEquals("(3, 13]", range.toString());
+    }
+
+    @Test
+    public void testGELEFactoryMethod() {
+        Range<Integer> range = Range.gele(7, 17);
+        Assertions.assertEquals(7, range.getLowerBound());
+        Assertions.assertEquals(17, range.getUpperBound());
+        Assertions.assertTrue(range.isLowerBoundIncluded());
+        Assertions.assertTrue(range.isUpperBoundIncluded());
+        Assertions.assertEquals("[7, 17]", range.toString());
+    }
+
+    @Test
+    public void testFactoryMethodsWithStringType() {
+        Range<String> ltRange = Range.lt("z");
+        Assertions.assertTrue(ltRange.contains("a"));
+        Assertions.assertFalse(ltRange.contains("z"));
+
+        Range<String> geRange = Range.ge("m");
+        Assertions.assertTrue(geRange.contains("m"));
+        Assertions.assertTrue(geRange.contains("z"));
+        Assertions.assertFalse(geRange.contains("a"));
+
+        Range<String> geleRange = Range.gele("d", "w");
+        Assertions.assertTrue(geleRange.contains("d"));
+        Assertions.assertTrue(geleRange.contains("m"));
+        Assertions.assertTrue(geleRange.contains("w"));
+        Assertions.assertFalse(geleRange.contains("a"));
+        Assertions.assertFalse(geleRange.contains("z"));
+    }
+
+    @Test
+    public void testFactoryMethodEquivalentToOf() {
+        // Verify that factory methods create equivalent ranges to Range.of
+        Assertions.assertEquals(Range.of(null, null, false, false), Range.all());
+        Assertions.assertEquals(Range.of(null, 10, false, false), Range.lt(10));
+        Assertions.assertEquals(Range.of(null, 10, false, true), Range.le(10));
+        Assertions.assertEquals(Range.of(5, null, false, false), Range.gt(5));
+        Assertions.assertEquals(Range.of(5, null, true, false), Range.ge(5));
+        Assertions.assertEquals(Range.of(1, 10, false, false), Range.gtlt(1, 10));
+        Assertions.assertEquals(Range.of(1, 10, true, false), Range.gelt(1, 10));
+        Assertions.assertEquals(Range.of(1, 10, false, true), Range.gtle(1, 10));
+        Assertions.assertEquals(Range.of(1, 10, true, true), Range.gele(1, 10));
+    }
+
+    // ==================== AllRange Singleton Tests ====================
+
+    @Test
+    public void testAllRangeSingleton() {
+        Range<Integer> instance1 = Range.of(null, null, false, false);
+        Range<Integer> instance2 = Range.of(null, null, false, false);
+        Range<String> instance3 = Range.of(null, null, false, false);
+
+        Assertions.assertSame(instance1, instance2);
+        Assertions.assertSame(instance1, instance3); // Same singleton regardless of type parameter
+    }
+
+    @Test
+    public void testAllRangeProperties() {
+        Range<Integer> allRange = Range.of(null, null, false, false);
+        Assertions.assertTrue(allRange.isAll());
+        Assertions.assertTrue(allRange.isMinimum());
+        Assertions.assertTrue(allRange.isMaximum());
+        Assertions.assertFalse(allRange.isIdentical());
+    }
+
+    // ==================== Individual Range Type Tests ====================
+
+    @Test
+    public void testLTRange() {
+        Range<Integer> range = Range.of(null, 10, false, false);
+        Assertions.assertNull(range.getLowerBound());
+        Assertions.assertEquals(10, range.getUpperBound());
+        Assertions.assertFalse(range.isLowerBoundIncluded());
+        Assertions.assertFalse(range.isUpperBoundIncluded());
+        Assertions.assertEquals("(-∞, 10)", range.toString());
+    }
+
+    @Test
+    public void testLERange() {
+        Range<Integer> range = Range.of(null, 10, false, true);
+        Assertions.assertNull(range.getLowerBound());
+        Assertions.assertEquals(10, range.getUpperBound());
+        Assertions.assertFalse(range.isLowerBoundIncluded());
+        Assertions.assertTrue(range.isUpperBoundIncluded());
+        Assertions.assertEquals("(-∞, 10]", range.toString());
+    }
+
+    @Test
+    public void testGTRange() {
+        Range<Integer> range = Range.of(5, null, false, false);
+        Assertions.assertEquals(5, range.getLowerBound());
+        Assertions.assertNull(range.getUpperBound());
+        Assertions.assertFalse(range.isLowerBoundIncluded());
+        Assertions.assertFalse(range.isUpperBoundIncluded());
+        Assertions.assertEquals("(5, +∞)", range.toString());
+    }
+
+    @Test
+    public void testGERange() {
+        Range<Integer> range = Range.of(5, null, true, false);
+        Assertions.assertEquals(5, range.getLowerBound());
+        Assertions.assertNull(range.getUpperBound());
+        Assertions.assertTrue(range.isLowerBoundIncluded());
+        Assertions.assertFalse(range.isUpperBoundIncluded());
+        Assertions.assertEquals("[5, +∞)", range.toString());
+    }
+
+    @Test
+    public void testGTLTRange() {
+        Range<Integer> range = Range.of(1, 10, false, false);
+        Assertions.assertEquals(1, range.getLowerBound());
+        Assertions.assertEquals(10, range.getUpperBound());
+        Assertions.assertFalse(range.isLowerBoundIncluded());
+        Assertions.assertFalse(range.isUpperBoundIncluded());
+        Assertions.assertEquals("(1, 10)", range.toString());
+    }
+
+    @Test
+    public void testGELTRange() {
+        Range<Integer> range = Range.of(1, 10, true, false);
+        Assertions.assertEquals(1, range.getLowerBound());
+        Assertions.assertEquals(10, range.getUpperBound());
+        Assertions.assertTrue(range.isLowerBoundIncluded());
+        Assertions.assertFalse(range.isUpperBoundIncluded());
+        Assertions.assertEquals("[1, 10)", range.toString());
+    }
+
+    @Test
+    public void testGTLERange() {
+        Range<Integer> range = Range.of(1, 10, false, true);
+        Assertions.assertEquals(1, range.getLowerBound());
+        Assertions.assertEquals(10, range.getUpperBound());
+        Assertions.assertFalse(range.isLowerBoundIncluded());
+        Assertions.assertTrue(range.isUpperBoundIncluded());
+        Assertions.assertEquals("(1, 10]", range.toString());
+    }
+
+    @Test
+    public void testGELERange() {
+        Range<Integer> range = Range.of(1, 10, true, true);
+        Assertions.assertEquals(1, range.getLowerBound());
+        Assertions.assertEquals(10, range.getUpperBound());
+        Assertions.assertTrue(range.isLowerBoundIncluded());
+        Assertions.assertTrue(range.isUpperBoundIncluded());
+        Assertions.assertEquals("[1, 10]", range.toString());
+    }
+
+    // ==================== Contains Element Tests ====================
+
+    @Test
+    public void testContainsElement() {
+        Range<Integer> closedRange = Range.of(1, 10, true, true);
+        Assertions.assertTrue(closedRange.contains(1));
+        Assertions.assertTrue(closedRange.contains(5));
+        Assertions.assertTrue(closedRange.contains(10));
+        Assertions.assertFalse(closedRange.contains(0));
+        Assertions.assertFalse(closedRange.contains(11));
+
+        Range<Integer> openRange = Range.of(1, 10, false, false);
+        Assertions.assertFalse(openRange.contains(1));
+        Assertions.assertTrue(openRange.contains(5));
+        Assertions.assertFalse(openRange.contains(10));
+        Assertions.assertFalse(openRange.contains(0));
+        Assertions.assertFalse(openRange.contains(11));
+    }
+
+    @Test
+    public void testContainsElementWithInfiniteRange() {
+        Range<Integer> allRange = Range.of(null, null, false, false);
+        Assertions.assertTrue(allRange.contains(Integer.MIN_VALUE));
+        Assertions.assertTrue(allRange.contains(0));
+        Assertions.assertTrue(allRange.contains(Integer.MAX_VALUE));
+    }
+
+    // ==================== IsLessThan/IsGreaterThan Element Tests ====================
+
+    @Test
+    public void testIsLessThanElement() {
+        Range<Integer> range = Range.of(1, 5, true, true);
+        Assertions.assertTrue(range.isLessThan(10));
+        Assertions.assertFalse(range.isLessThan(5));
+        Assertions.assertFalse(range.isLessThan(3));
+
+        Range<Integer> openRange = Range.of(1, 5, false, false);
+        Assertions.assertTrue(openRange.isLessThan(5));
+        Assertions.assertFalse(openRange.isLessThan(4));
+    }
+
+    @Test
+    public void testIsGreaterThanElement() {
+        Range<Integer> range = Range.of(5, 10, true, true);
+        Assertions.assertTrue(range.isGreaterThan(3));
+        Assertions.assertFalse(range.isGreaterThan(5));
+        Assertions.assertFalse(range.isGreaterThan(7));
+
+        Range<Integer> openRange = Range.of(5, 10, false, false);
+        Assertions.assertTrue(openRange.isGreaterThan(5));
+        Assertions.assertFalse(openRange.isGreaterThan(6));
+    }
+
+    // ==================== IsLessThan/IsGreaterThan Range Tests ====================
+
+    @Test
+    public void testIsLessThanRange() {
+        Range<Integer> range1 = Range.of(1, 5, true, true);
+        Range<Integer> range2 = Range.of(6, 10, true, true);
+        Assertions.assertTrue(range1.isLessThan(range2));
+        Assertions.assertFalse(range2.isLessThan(range1));
+
+        Range<Integer> range3 = Range.of(5, 10, true, true);
+        Assertions.assertFalse(range1.isLessThan(range3)); // They touch at 5
+    }
+
+    @Test
+    public void testIsGreaterThanRange() {
+        Range<Integer> range1 = Range.of(6, 10, true, true);
+        Range<Integer> range2 = Range.of(1, 5, true, true);
+        Assertions.assertTrue(range1.isGreaterThan(range2));
+        Assertions.assertFalse(range2.isGreaterThan(range1));
+    }
+
+    @Test
+    public void testRangeTouchingAtBoundary() {
+        Range<Integer> range1 = Range.of(1, 5, true, false); // [1, 5)
+        Range<Integer> range2 = Range.of(5, 10, true, false); // [5, 10)
+        Assertions.assertTrue(range1.isLessThan(range2));
+        Assertions.assertTrue(range2.isGreaterThan(range1));
+        Assertions.assertFalse(range1.isOverlapping(range2));
+    }
+
+    // ==================== IsOverlapping Tests ====================
+
+    @Test
+    public void testIsOverlapping() {
+        Range<Integer> range1 = Range.of(1, 10, true, true);
+        Range<Integer> range2 = Range.of(5, 15, true, true);
+        Assertions.assertTrue(range1.isOverlapping(range2));
+        Assertions.assertTrue(range2.isOverlapping(range1));
+
+        Range<Integer> range3 = Range.of(20, 30, true, true);
+        Assertions.assertFalse(range1.isOverlapping(range3));
+        Assertions.assertFalse(range3.isOverlapping(range1));
+    }
+
+    @Test
+    public void testIsOverlappingWithContainedRange() {
+        Range<Integer> outer = Range.of(1, 10, true, true);
+        Range<Integer> inner = Range.of(3, 7, true, true);
+        Assertions.assertTrue(outer.isOverlapping(inner));
+        Assertions.assertTrue(inner.isOverlapping(outer));
+    }
+
+    // ==================== CompareTo Tests ====================
+
+    @Test
+    public void testCompareTo() {
+        Range<Integer> range1 = Range.of(1, 5, true, true);
+        Range<Integer> range2 = Range.of(6, 10, true, true);
+        Range<Integer> range3 = Range.of(3, 8, true, true);
+
+        Assertions.assertTrue(range1.compareTo(range2) < 0);
+        Assertions.assertTrue(range2.compareTo(range1) > 0);
+        Assertions.assertEquals(0, range1.compareTo(range3)); // Overlapping ranges
+    }
+
+    // ==================== Equals and HashCode Tests ====================
+
+    @Test
+    public void testEquals() {
+        Range<Integer> range1 = Range.of(1, 10, true, true);
+        Range<Integer> range2 = Range.of(1, 10, true, true);
+        Range<Integer> range3 = Range.of(1, 11, true, true);
+        Range<Integer> range4 = Range.of(1, 10, true, false); // Different inclusiveness
+
+        Assertions.assertEquals(range1, range2);
+        Assertions.assertNotEquals(range1, range3);
+        Assertions.assertNotEquals(range1, range4);
+        Assertions.assertNotEquals(range1, null);
+        Assertions.assertNotEquals(range1, "not a range");
+    }
+
+    @Test
+    public void testHashCode() {
+        Range<Integer> range1 = Range.of(1, 10, true, true);
+        Range<Integer> range2 = Range.of(1, 10, true, true);
+        Range<Integer> range3 = Range.of(1, 11, true, true);
+
+        Assertions.assertEquals(range1.hashCode(), range2.hashCode());
+        // Not guaranteed to be different, but likely
+        Assertions.assertNotEquals(range1.hashCode(), range3.hashCode());
+    }
+
+    @Test
+    public void testEqualsSameInstance() {
+        Range<Integer> range = Range.of(1, 10, true, true);
+        Assertions.assertEquals(range, range);
+    }
+
+    // ==================== IsIdentical Tests ====================
+
+    @Test
+    public void testIsIdentical() {
+        Range<Integer> pointRange = Range.of(5, 5, true, true);
+        Assertions.assertTrue(pointRange.isIdentical());
+
+        Range<Integer> normalRange = Range.of(1, 10, true, true);
+        Assertions.assertFalse(normalRange.isIdentical());
+
+        Range<Integer> openPoint = Range.of(5, 5, false, false);
+        Assertions.assertFalse(openPoint.isIdentical()); // Not included
+    }
+
+    // ==================== Boundary Condition Tests ====================
+
+    @Test
+    public void testBoundaryExcluded() {
+        Range<Integer> range = Range.of(1, 10, true, true);
+        Assertions.assertTrue(range.isLowerBoundIncluded());
+        Assertions.assertTrue(range.isUpperBoundIncluded());
+        Assertions.assertFalse(range.isLowerBoundExcluded());
+        Assertions.assertFalse(range.isUpperBoundExcluded());
+    }
+
+    @Test
+    public void testMinimumMaximum() {
+        Range<Integer> ltRange = Range.of(null, 10, false, false);
+        Assertions.assertTrue(ltRange.isMinimum());
+        Assertions.assertFalse(ltRange.isMaximum());
+
+        Range<Integer> gtRange = Range.of(5, null, false, false);
+        Assertions.assertFalse(gtRange.isMinimum());
+        Assertions.assertTrue(gtRange.isMaximum());
+
+        Range<Integer> normalRange = Range.of(1, 10, true, true);
+        Assertions.assertFalse(normalRange.isMinimum());
+        Assertions.assertFalse(normalRange.isMaximum());
+    }
+
+    // ==================== Null Parameter Tests ====================
+
+    @Test
+    public void testNullParameterInContains() {
+        Range<Integer> range = Range.of(1, 10, true, true);
+        Assertions.assertThrows(NullPointerException.class, () -> range.contains(null));
+    }
+
+    @Test
+    public void testNullParameterInIsLessThan() {
+        Range<Integer> range = Range.of(1, 10, true, true);
+        Assertions.assertThrows(NullPointerException.class, () -> range.isLessThan((Integer) null));
+    }
+
+    @Test
+    public void testNullParameterInIsGreaterThan() {
+        Range<Integer> range = Range.of(1, 10, true, true);
+        Assertions.assertThrows(NullPointerException.class, () -> range.isGreaterThan((Integer) null));
+    }
+
+    @Test
+    public void testNullParameterInRangeComparison() {
+        Range<Integer> range = Range.of(1, 10, true, true);
+        Assertions.assertThrows(NullPointerException.class, () -> range.isLessThan((Range<Integer>) null));
+        Assertions.assertThrows(NullPointerException.class, () -> range.isGreaterThan((Range<Integer>) null));
+        Assertions.assertThrows(NullPointerException.class, () -> range.isOverlapping(null));
+    }
+
+    @Test
+    public void testValidRangeWithEqualBounds() {
+        // Equal bounds should be allowed (point ranges)
+        Range<Integer> pointOpen = Range.of(5, 5, false, false); // (5, 5) - empty range
+        Assertions.assertNotNull(pointOpen);
+        Assertions.assertFalse(pointOpen.contains(5));
+        Assertions.assertFalse(pointOpen.isIdentical());
+
+        Range<Integer> pointClosed = Range.of(5, 5, true, true); // [5, 5] - point range
+        Assertions.assertNotNull(pointClosed);
+        Assertions.assertTrue(pointClosed.contains(5));
+        Assertions.assertTrue(pointClosed.isIdentical());
+
+        Range<Integer> halfOpen1 = Range.of(5, 5, true, false); // [5, 5)
+        Assertions.assertNotNull(halfOpen1);
+        Assertions.assertFalse(halfOpen1.contains(5));
+
+        Range<Integer> halfOpen2 = Range.of(5, 5, false, true); // (5, 5]
+        Assertions.assertNotNull(halfOpen2);
+        Assertions.assertFalse(halfOpen2.contains(5));
+    }
+
+    // ==================== ToString Tests ====================
+
+    @Test
+    public void testToString() {
+        Assertions.assertEquals("(-∞, +∞)", Range.of(null, null, false, false).toString());
+        Assertions.assertEquals("(-∞, 10)", Range.of(null, 10, false, false).toString());
+        Assertions.assertEquals("(-∞, 10]", Range.of(null, 10, false, true).toString());
+        Assertions.assertEquals("(5, +∞)", Range.of(5, null, false, false).toString());
+        Assertions.assertEquals("[5, +∞)", Range.of(5, null, true, false).toString());
+        Assertions.assertEquals("(1, 10)", Range.of(1, 10, false, false).toString());
+        Assertions.assertEquals("[1, 10)", Range.of(1, 10, true, false).toString());
+        Assertions.assertEquals("(1, 10]", Range.of(1, 10, false, true).toString());
+        Assertions.assertEquals("[1, 10]", Range.of(1, 10, true, true).toString());
+    }
+
+    // ==================== String Range Tests ====================
+
+    @Test
+    public void testStringRange() {
+        Range<String> range = Range.of("a", "z", true, true);
+        Assertions.assertTrue(range.contains("m"));
+        Assertions.assertTrue(range.contains("a"));
+        Assertions.assertTrue(range.contains("z"));
+        Assertions.assertFalse(range.contains("A"));
+        Assertions.assertTrue(range.isLessThan("zz"));
+        Assertions.assertTrue(range.isGreaterThan("A"));
+    }
+
+    // ==================== Gson Serialization Tests ====================
+    // Note: All serialization tests use TypeToken to preserve generic type information.
+    // Without TypeToken, JSON numbers would be deserialized as Double instead of Integer.
+
+    @Test
+    public void testAllRangeSerialization() {
+        Range<Integer> original = Range.of(null, null, false, false);
+        String json = GsonUtils.GSON.toJson(original);
+        Range<Integer> deserialized = GsonUtils.GSON.fromJson(json,
+                new TypeToken<Range<Integer>>(){}.getType());
+
+        Assertions.assertEquals(original, deserialized);
+        Assertions.assertSame(original, deserialized); // Singleton should be preserved
+    }
+
+    @Test
+    public void testLTRangeSerialization() {
+        Range<Integer> original = Range.of(null, 100, false, false);
+        String json = GsonUtils.GSON.toJson(original);
+        Range<Integer> deserialized = GsonUtils.GSON.fromJson(json,
+                new TypeToken<Range<Integer>>(){}.getType());
+
+        Assertions.assertEquals(original, deserialized);
+        Assertions.assertEquals(100, deserialized.getUpperBound());
+        Assertions.assertNull(deserialized.getLowerBound());
+        Assertions.assertFalse(deserialized.isUpperBoundIncluded());
+    }
+
+    @Test
+    public void testLERangeSerialization() {
+        Range<Integer> original = Range.of(null, 50, false, true);
+        String json = GsonUtils.GSON.toJson(original);
+        Range<Integer> deserialized = GsonUtils.GSON.fromJson(json,
+                new TypeToken<Range<Integer>>(){}.getType());
+
+        Assertions.assertEquals(original, deserialized);
+        Assertions.assertEquals(50, deserialized.getUpperBound());
+        Assertions.assertTrue(deserialized.isUpperBoundIncluded());
+    }
+
+    @Test
+    public void testGTRangeSerialization() {
+        Range<Integer> original = Range.of(20, null, false, false);
+        String json = GsonUtils.GSON.toJson(original);
+        Range<Integer> deserialized = GsonUtils.GSON.fromJson(json,
+                new TypeToken<Range<Integer>>(){}.getType());
+
+        Assertions.assertEquals(original, deserialized);
+        Assertions.assertEquals(20, deserialized.getLowerBound());
+        Assertions.assertFalse(deserialized.isLowerBoundIncluded());
+    }
+
+    @Test
+    public void testGERangeSerialization() {
+        Range<Integer> original = Range.of(30, null, true, false);
+        String json = GsonUtils.GSON.toJson(original);
+        Range<Integer> deserialized = GsonUtils.GSON.fromJson(json,
+                new TypeToken<Range<Integer>>(){}.getType());
+
+        Assertions.assertEquals(original, deserialized);
+        Assertions.assertEquals(30, deserialized.getLowerBound());
+        Assertions.assertTrue(deserialized.isLowerBoundIncluded());
+    }
+
+    @Test
+    public void testGTLTRangeSerialization() {
+        Range<Integer> original = Range.of(10, 20, false, false);
+        String json = GsonUtils.GSON.toJson(original);
+        Range<Integer> deserialized = GsonUtils.GSON.fromJson(json,
+                new TypeToken<Range<Integer>>(){}.getType());
+
+        Assertions.assertEquals(original, deserialized);
+        Assertions.assertEquals(10, deserialized.getLowerBound());
+        Assertions.assertEquals(20, deserialized.getUpperBound());
+        Assertions.assertFalse(deserialized.isLowerBoundIncluded());
+        Assertions.assertFalse(deserialized.isUpperBoundIncluded());
+    }
+
+    @Test
+    public void testGELTRangeSerialization() {
+        Range<Integer> original = Range.of(5, 15, true, false);
+        String json = GsonUtils.GSON.toJson(original);
+        Range<Integer> deserialized = GsonUtils.GSON.fromJson(json,
+                new TypeToken<Range<Integer>>(){}.getType());
+
+        Assertions.assertEquals(original, deserialized);
+        Assertions.assertEquals(5, deserialized.getLowerBound());
+        Assertions.assertEquals(15, deserialized.getUpperBound());
+        Assertions.assertTrue(deserialized.isLowerBoundIncluded());
+        Assertions.assertFalse(deserialized.isUpperBoundIncluded());
+    }
+
+    @Test
+    public void testGTLERangeSerialization() {
+        Range<Integer> original = Range.of(3, 13, false, true);
+        String json = GsonUtils.GSON.toJson(original);
+        Range<Integer> deserialized = GsonUtils.GSON.fromJson(json,
+                new TypeToken<Range<Integer>>(){}.getType());
+
+        Assertions.assertEquals(original, deserialized);
+        Assertions.assertEquals(3, deserialized.getLowerBound());
+        Assertions.assertEquals(13, deserialized.getUpperBound());
+        Assertions.assertFalse(deserialized.isLowerBoundIncluded());
+        Assertions.assertTrue(deserialized.isUpperBoundIncluded());
+    }
+
+    @Test
+    public void testGELERangeSerialization() {
+        Range<Integer> original = Range.of(7, 17, true, true);
+        String json = GsonUtils.GSON.toJson(original);
+        Range<Integer> deserialized = GsonUtils.GSON.fromJson(json,
+                new TypeToken<Range<Integer>>(){}.getType());
+
+        Assertions.assertEquals(original, deserialized);
+        Assertions.assertEquals(7, deserialized.getLowerBound());
+        Assertions.assertEquals(17, deserialized.getUpperBound());
+        Assertions.assertTrue(deserialized.isLowerBoundIncluded());
+        Assertions.assertTrue(deserialized.isUpperBoundIncluded());
+    }
+
+    @Test
+    public void testStringRangeSerialization() {
+        Range<String> original = Range.of("apple", "orange", true, true);
+        String json = GsonUtils.GSON.toJson(original);
+        Range<String> deserialized = GsonUtils.GSON.fromJson(json,
+                new TypeToken<Range<String>>(){}.getType());
+
+        Assertions.assertEquals(original, deserialized);
+        Assertions.assertEquals("apple", deserialized.getLowerBound());
+        Assertions.assertEquals("orange", deserialized.getUpperBound());
+    }
+
+    @Test
+    public void testSerializedRangeOperations() {
+        // Serialize and deserialize a range, then test operations
+        Range<Integer> original = Range.of(10, 20, true, true);
+        String json = GsonUtils.GSON.toJson(original);
+        Range<Integer> deserialized = GsonUtils.GSON.fromJson(json,
+                new TypeToken<Range<Integer>>(){}.getType());
+
+        // Test operations on deserialized range
+        Assertions.assertTrue(deserialized.contains(15));
+        Assertions.assertFalse(deserialized.contains(25));
+        Assertions.assertTrue(deserialized.isLessThan(30));
+        Assertions.assertTrue(deserialized.isGreaterThan(5));
+
+        Range<Integer> other = Range.of(25, 35, true, true);
+        Assertions.assertFalse(deserialized.isOverlapping(other));
+    }
+
+    @Test
+    public void testRangeContainerSerialization() {
+        // Create a container with different types of ranges
+        Range<Integer> valueRange = Range.of(1, 100, true, true);
+        Range<String> nameRange = Range.of("Alice", "Zoe", true, false);
+        RangeContainer original = new RangeContainer(1001, "TestContainer", valueRange, nameRange);
+
+        // Serialize
+        String json = GsonUtils.GSON.toJson(original);
+        Assertions.assertNotNull(json);
+        Assertions.assertTrue(json.contains("\"id\":1001"));
+        Assertions.assertTrue(json.contains("\"name\":\"TestContainer\""));
+        Assertions.assertTrue(json.contains("\"valueRange\""));
+        Assertions.assertTrue(json.contains("\"nameRange\""));
+
+        // Deserialize
+        RangeContainer deserialized = GsonUtils.GSON.fromJson(json, RangeContainer.class);
+
+        // Verify container properties
+        Assertions.assertNotNull(deserialized);
+        Assertions.assertEquals(1001, deserialized.getId());
+        Assertions.assertEquals("TestContainer", deserialized.getName());
+
+        // Verify value range
+        Assertions.assertNotNull(deserialized.getValueRange());
+        Assertions.assertEquals(valueRange, deserialized.getValueRange());
+        Assertions.assertTrue(deserialized.getValueRange().contains(50));
+        Assertions.assertFalse(deserialized.getValueRange().contains(150));
+
+        // Verify name range
+        Assertions.assertNotNull(deserialized.getNameRange());
+        Assertions.assertEquals(nameRange, deserialized.getNameRange());
+        Assertions.assertTrue(deserialized.getNameRange().contains("Bob"));
+        Assertions.assertFalse(deserialized.getNameRange().contains("Adam"));
+
+        // Verify complete equality
+        Assertions.assertEquals(original, deserialized);
+    }
+
+    @Test
+    public void testRangeContainerWithAllRange() {
+        // Test container with AllRange singleton
+        Range<Integer> allRange = Range.of(null, null, false, false);
+        Range<String> stringRange = Range.of("M", null, false, false);
+        RangeContainer original = new RangeContainer(2002, "AllRangeContainer", allRange, stringRange);
+
+        // Serialize and deserialize
+        String json = GsonUtils.GSON.toJson(original);
+        RangeContainer deserialized = GsonUtils.GSON.fromJson(json, RangeContainer.class);
+
+        // Verify AllRange singleton is preserved
+        Assertions.assertNotNull(deserialized.getValueRange());
+        Assertions.assertSame(Range.of(null, null, false, false), deserialized.getValueRange());
+
+        // Verify string range
+        Assertions.assertEquals("M", deserialized.getNameRange().getLowerBound());
+        Assertions.assertTrue(deserialized.getNameRange().contains("Tom"));
+        Assertions.assertFalse(deserialized.getNameRange().contains("Alice"));
+    }
+
+    @Test
+    public void testRangeContainerWithVariousRangeTypes() {
+        // Test with different range types
+        Range<Integer> ltRange = Range.of(null, 100, false, false);
+        Range<String> geRange = Range.of("G", null, true, false);
+        RangeContainer container1 = new RangeContainer(3001, "Container1", ltRange, geRange);
+
+        String json1 = GsonUtils.GSON.toJson(container1);
+        RangeContainer deserialized1 = GsonUtils.GSON.fromJson(json1, RangeContainer.class);
+
+        Assertions.assertEquals(container1, deserialized1);
+
+        // Test with another combination
+        Range<Integer> gtRange = Range.of(0, null, false, false);
+        Range<String> leRange = Range.of(null, "Z", false, true);
+        RangeContainer container2 = new RangeContainer(3002, "Container2", gtRange, leRange);
+
+        String json2 = GsonUtils.GSON.toJson(container2);
+        RangeContainer deserialized2 = GsonUtils.GSON.fromJson(json2, RangeContainer.class);
+
+        Assertions.assertEquals(container2, deserialized2);
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
  This commit introduces a comprehensive range metadata infrastructure for
  range-based data distribution in StarRocks. It provides type-safe abstractions
  for representing ranges, tuples, and variant values with full serialization
  support.

## What I'm doing:

  ### 1. Core Range Infrastructure (790 lines)
  - **Range.java**: Abstract range class with 9 specialized implementations
    - AllRange: (-∞, +∞)
    - LTRange/LERange: (-∞, bound)
    - GTRange/GERange: (bound, +∞)
    - GELERange/GELTRange/GTLERange/GTLTRange: Bounded ranges
  - Factory methods for creating ranges with various bound types
  - Comprehensive comparison and overlap detection logic
  - Full Gson serialization support

  ### 2. Variant Type System
  Abstract Variant class with 5 concrete implementations:
  - **BoolVariant**: Boolean values with string parsing
  - **IntVariant**: TINYINT/SMALLINT/INT/BIGINT with range validation
  - **LargeIntVariant**: 128-bit integers using Int128
  - **StringVariant**: VARCHAR/CHAR with byte-level comparison
  - **DateVariant**: DATE/DATETIME/TIME with nanosecond precision

  Features:
  - Type-safe value representation
  - Compatible comparison across different types
  - Gson serialization/deserialization support
  - Factory method `Variant.of(Type, String)` for dynamic creation

  ### 3. Tuple and Int128 Support
  - **Tuple.java**: Immutable tuple of Variant values with lexicographic comparison
  - **Int128.java**: 128-bit signed integer implementation
    - BigInteger conversion support
    - Optimized for values fitting in long
    - Proper signed comparison logic

  ### 4. Gson Utilities
  - **GsonUtils.java**: Centralized Gson configuration with RuntimeTypeAdapterFactory
  - Automatic polymorphic serialization for Variant and Range hierarchies

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce generic Range, Variant (bool/int/largeint/string/date), Tuple, and Int128 types with full Gson serialization; wire ranges into Tablet and unify UTF-8 string comparison; add extensive tests.
> 
> - **Core types**:
>   - Add `com.starrocks.common.Range<T>` with inclusive/exclusive bounds, ordering/overlap ops, and JSON (Gson) serialization.
>   - Add `com.starrocks.catalog.Variant` system with `BoolVariant`, `IntVariant`, `LargeIntVariant` (via `Int128`), `StringVariant`, and `DateVariant` plus factory and compatible comparison.
>   - Add `Tuple` (lexicographic compare of `Variant` lists) and `Int128` (signed 128-bit int).
> - **Metadata integration**:
>   - Extend `Tablet` with `Range<Tuple>` field (default `Range.all()`), getters/setters.
> - **Serialization**:
>   - Update `GsonUtils` with `RuntimeTypeAdapterFactory` for `Variant` and a generic `Range` adapter; register both.
> - **String comparison**:
>   - Add `StringUtils.compareStringWithUTF8ByteArray` and use it in `StringLiteral` and `VarBinaryLiteral` comparisons.
> - **Tests**:
>   - Add comprehensive unit tests for `Range`, `Int128`, `Variant`, and `Tuple` including serialization and comparisons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3745b8909980d2838afeab473d6cb40e1a100ee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->