### PR TITLE
[BugFix] Add concurrent compaction publish exception checks for PK tables.

### DIFF
--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -46,8 +46,8 @@ public:
     void apply_opwrite(const TxnLogPB_OpWrite& op_write, const std::map<int, FileInfo>& replace_segments,
                        const std::vector<FileMetaPB>& orphan_files);
     void apply_column_mode_partial_update(const TxnLogPB_OpWrite& op_write);
-    void apply_opcompaction(const TxnLogPB_OpCompaction& op_compaction, uint32_t max_compact_input_rowset_id,
-                            int64_t output_rowset_schema_id);
+    Status apply_opcompaction(const TxnLogPB_OpCompaction& op_compaction, uint32_t max_compact_input_rowset_id,
+                              int64_t output_rowset_schema_id);
     void apply_opcompaction_with_conflict(const TxnLogPB_OpCompaction& op_compaction);
 
     // batch processing functions for merging multiple opwrites into one rowset

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -1236,7 +1236,7 @@ Status UpdateManager::light_publish_primary_compaction(const TxnLogPB_OpCompacti
     }
     _index_cache.update_object_size(index_entry, index.memory_usage());
     // 5. update TabletMeta
-    builder->apply_opcompaction(op_compaction, max_rowset_id, tablet_schema->id());
+    RETURN_IF_ERROR(builder->apply_opcompaction(op_compaction, max_rowset_id, tablet_schema->id()));
     RETURN_IF_ERROR(builder->update_num_del_stat(segment_id_to_add_dels));
     RETURN_IF_ERROR(index.apply_opcompaction(metadata, op_compaction));
 
@@ -1259,10 +1259,10 @@ Status UpdateManager::publish_primary_compaction(const TxnLogPB_OpCompaction& op
                                                op_compaction.input_rowsets().end());
         ASSIGN_OR_RETURN(auto tablet_schema, ExecEnv::GetInstance()->lake_tablet_manager()->get_output_rowset_schema(
                                                      input_rowsets_id, &metadata));
-        builder->apply_opcompaction(
+        RETURN_IF_ERROR(builder->apply_opcompaction(
                 op_compaction,
                 *std::max_element(op_compaction.input_rowsets().begin(), op_compaction.input_rowsets().end()),
-                tablet_schema->id());
+                tablet_schema->id()));
         return Status::OK();
     });
     if (CompactionUpdateConflictChecker::conflict_check(op_compaction, txn_id, metadata, builder)) {
@@ -1331,7 +1331,7 @@ Status UpdateManager::publish_primary_compaction(const TxnLogPB_OpCompaction& op
     for (auto&& each : delvecs) {
         builder->append_delvec(each.second, each.first);
     }
-    builder->apply_opcompaction(op_compaction, max_rowset_id, tablet_schema->id());
+    RETURN_IF_ERROR(builder->apply_opcompaction(op_compaction, max_rowset_id, tablet_schema->id()));
     RETURN_IF_ERROR(builder->update_num_del_stat(segment_id_to_add_dels));
 
     RETURN_IF_ERROR(index.apply_opcompaction(metadata, op_compaction));

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -1259,11 +1259,10 @@ Status UpdateManager::publish_primary_compaction(const TxnLogPB_OpCompaction& op
                                                op_compaction.input_rowsets().end());
         ASSIGN_OR_RETURN(auto tablet_schema, ExecEnv::GetInstance()->lake_tablet_manager()->get_output_rowset_schema(
                                                      input_rowsets_id, &metadata));
-        RETURN_IF_ERROR(builder->apply_opcompaction(
+        return builder->apply_opcompaction(
                 op_compaction,
                 *std::max_element(op_compaction.input_rowsets().begin(), op_compaction.input_rowsets().end()),
-                tablet_schema->id()));
-        return Status::OK();
+                tablet_schema->id());
     });
     if (CompactionUpdateConflictChecker::conflict_check(op_compaction, txn_id, metadata, builder)) {
         // conflict happens


### PR DESCRIPTION
## Why I'm doing:
When the FE unexpectedly schedules two compaction tasks at the same time, it can currently cause duplicate primary key errors in PK tables. Therefore, we need to add checks to prevent this situation.

## What I'm doing:
This pull request introduces improvements to the compaction logic in the lake storage engine, focusing on error handling and robustness during the compaction and publish processes. The main changes include updating the `MetaFileBuilder::apply_opcompaction` method to return a status, adding error checks for missing input rowsets, and updating callers to handle errors properly. Additionally, a new test is added to verify concurrent compaction and publish scenarios.

**Compaction error handling and robustness:**

* Changed `MetaFileBuilder::apply_opcompaction` to return a `Status` object instead of `void`, allowing callers to detect and handle errors. (`be/src/storage/lake/meta_file.cpp`, `be/src/storage/lake/meta_file.h`) [[1]](diffhunk://#diff-8da1a78cf605cdb609488453fb2de6df00421063acf7c75a05bc227a91e4271cL288-R288) [[2]](diffhunk://#diff-db3a0688438f74dac5a51a65a8bce51740e6a54b74767275b2fd092f75bca8e1L49-R49)
* Added logic to check if all input rowsets specified in the compaction operation are found and deleted; logs an error and returns an internal error status if any are missing. (`be/src/storage/lake/meta_file.cpp`)
* Updated callers of `apply_opcompaction` in `UpdateManager` to use `RETURN_IF_ERROR`, ensuring that errors from compaction are properly propagated and handled. (`be/src/storage/lake/update_manager.cpp`) [[1]](diffhunk://#diff-ce8ef103b70e198d350635a74a2ce6449e3c2b612231c6de6493359af140ab66L1239-R1239) [[2]](diffhunk://#diff-ce8ef103b70e198d350635a74a2ce6449e3c2b612231c6de6493359af140ab66L1262-R1265) [[3]](diffhunk://#diff-ce8ef103b70e198d350635a74a2ce6449e3c2b612231c6de6493359af140ab66L1334-R1334)

**Testing improvements:**

* Added a new test case `test_concurrent_compaction_and_publish` to verify correct behavior when multiple compaction and publish operations are performed concurrently, including handling of publish failures for conflicting compactions. (`be/test/storage/lake/primary_key_compaction_task_test.cpp`)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
