### PR TITLE
[BugFix] introduces checksum for pk table's delete vector

### DIFF
--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -24,6 +24,7 @@
 #include "storage/lake/update_manager.h"
 #include "storage/protobuf_file.h"
 #include "util/coding.h"
+#include "util/crc32c.h"
 #include "util/defer_op.h"
 #include "util/raw_container.h"
 #include "util/starrocks_metrics.h"
@@ -50,6 +51,7 @@ void MetaFileBuilder::append_delvec(const DelVectorPtr& delvec, uint32_t segment
         const uint64_t size = _buf.size() - offset;
         _delvecs[segment_id].set_offset(offset);
         _delvecs[segment_id].set_size(size);
+        _delvecs[segment_id].set_crc32c(crc32c::Mask(crc32c::Value(delvec_str.data(), delvec_str.size())));
         _segmentid_to_delvec[segment_id] = delvec;
     }
 }
@@ -489,6 +491,7 @@ Status MetaFileBuilder::_finalize_delvec(int64_t version, int64_t txn_id) {
             each_delvec.second.set_version(version);
             each_delvec.second.set_offset(iter->second.offset());
             each_delvec.second.set_size(iter->second.size());
+            each_delvec.second.set_crc32c(iter->second.crc32c());
             // record from cache key to segment id, so we can fill up cache later
             _cache_key_to_segment_id[delvec_cache_key(_tablet_meta->id(), each_delvec.second)] = iter->first;
             _delvecs.erase(iter);
@@ -505,6 +508,7 @@ Status MetaFileBuilder::_finalize_delvec(int64_t version, int64_t txn_id) {
 
     // 3. write to delvec file
     if (_buf.size() > 0) {
+        TEST_SYNC_POINT_CALLBACK("MetaFileBuilder::_finalize_delvec", &_buf);
         auto delvec_file_name = gen_delvec_filename(txn_id);
         auto delvec_file_path = _tablet.delvec_location(delvec_file_name);
         // keep delete vector file name in tablet meta
@@ -515,7 +519,7 @@ Status MetaFileBuilder::_finalize_delvec(int64_t version, int64_t txn_id) {
         ASSIGN_OR_RETURN(auto writer_file, fs::new_writable_file(options, delvec_file_path));
         RETURN_IF_ERROR(writer_file->append(Slice(_buf.data(), _buf.size())));
         RETURN_IF_ERROR(writer_file->close());
-        TRACE("end write delvel");
+        TRACE("end write delvec");
     }
 
     // 4. clear delvec file record in version_to_file if it's not refered any more
@@ -652,6 +656,17 @@ Status get_del_vec(TabletManager* tablet_mgr, const TabletMetadata& metadata, co
         ASSIGN_OR_RETURN(rf, fs::new_random_access_file(opts, tablet_mgr->delvec_location(metadata.id(), delvec_name)));
     }
     RETURN_IF_ERROR(rf->read_at_fully(delvec_page.offset(), buf.data(), delvec_page.size()));
+    // check crc32c
+    uint32_t crc32c = crc32c::Value(buf.data(), delvec_page.size());
+    if (delvec_page.has_crc32c() && crc32c != crc32c::Unmask(delvec_page.crc32c())) {
+        LOG(ERROR) << fmt::format(
+                "delvec crc32c mismatch, tabletid {}, delvecfile {}, offset {}, size {}, expect crc32c {}, actual "
+                "crc32c {}",
+                metadata.id(), delvec_name, delvec_page.offset(), delvec_page.size(),
+                crc32c::Unmask(delvec_page.crc32c()), crc32c);
+        return Status::Corruption(fmt::format("delvec crc32c mismatch. expect crc32c {}, actual {}",
+                                              crc32c::Unmask(delvec_page.crc32c()), crc32c));
+    }
     // parse delvec
     RETURN_IF_ERROR(delvec->load(delvec_page.version(), buf.data(), delvec_page.size()));
     // put in cache

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -325,7 +325,7 @@ Status MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compa
     }
     if (deleted_input_rowset_cnt != op_compaction.input_rowsets_size()) {
         LOG(ERROR) << fmt::format(
-                "MetaFileBuilder apply_opcompaction failed to find all input rowsets, tablet_id:{} "
+                "MetaFileBuilder apply_opcompaction failed to find all input rowsets, tablet_id : {} "
                 "expected_input_rowsets : {} "
                 "deleted_input_rowsets : {} "
                 "op_compaction : {} "

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -33,6 +33,7 @@ message DelvecPagePB {
     // position in file
     optional uint64 offset = 2;
     optional uint64 size = 3;
+    optional uint32 crc32c = 4;
 }
 
 message PersistentIndexSstablePB {


### PR DESCRIPTION
## Why I'm doing:
Delete vector in PK table could be corrupted because of all kinds of reason. In current implementation, we lack mechanism to detect such issues. It will lead to unexpected result.

## What I'm doing:
This pull request introduces CRC32C checksum support for delete vector (delvec) files in the Lake storage engine, improving data integrity and error detection. It also updates related tests to validate the new corruption detection logic and makes minor code and test refactors for consistency and correctness.

**Data Integrity Improvements:**

* Added CRC32C checksum calculation and storage for each delvec in `MetaFileBuilder::append_delvec`, and included the checksum in the `DelvecPagePB` protobuf message. [[1]](diffhunk://#diff-8da1a78cf605cdb609488453fb2de6df00421063acf7c75a05bc227a91e4271cR27) [[2]](diffhunk://#diff-8da1a78cf605cdb609488453fb2de6df00421063acf7c75a05bc227a91e4271cR54) [[3]](diffhunk://#diff-524472dda097de9a69e07b8558f378af45c235da4d9af913e284ecc73cbb1d95R36)
* When reading delvec data, now verifies the CRC32C checksum and returns an error if there is a mismatch, ensuring corrupted delvec files are detected. [[1]](diffhunk://#diff-8da1a78cf605cdb609488453fb2de6df00421063acf7c75a05bc227a91e4271cR644-R654) [[2]](diffhunk://#diff-8da1a78cf605cdb609488453fb2de6df00421063acf7c75a05bc227a91e4271cR479)

**Testing Enhancements:**

* Added a new test case `test_write_with_delvec_corrupt` in `primary_key_publish_test.cpp` to simulate and verify behavior when a delvec file is corrupted; uses sync point callback to intentionally corrupt the buffer and checks that the read operation fails as expected.

**Minor Code and Test Refactors:**

* Changed the return type of the `read` method in the test from `ChunkPtr` to `StatusOr<ChunkPtr>` to better handle error cases, and updated related usages. [[1]](diffhunk://#diff-4f36256904a1ebe4735a4adba8e8781396c2298a21a776fac27005d5b38d60f0L138-R138) [[2]](diffhunk://#diff-4f36256904a1ebe4735a4adba8e8781396c2298a21a776fac27005d5b38d60f0L150-R160) [[3]](diffhunk://#diff-4f36256904a1ebe4735a4adba8e8781396c2298a21a776fac27005d5b38d60f0L641-R644)
* Fixed a typo in a trace log message from "delvel" to "delvec".
* Inserted a test sync point callback in `MetaFileBuilder::_finalize_delvec` to facilitate corruption testing.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
