### PR TITLE
[Enhancement] Support truncate hive table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -38,6 +38,13 @@ import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.IcebergPartitionUtils;
 import com.starrocks.planner.PartitionColumnFilter;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.analyzer.AnalyzeState;
+import com.starrocks.sql.analyzer.ExpressionAnalyzer;
+import com.starrocks.sql.analyzer.Field;
+import com.starrocks.sql.analyzer.RelationFields;
+import com.starrocks.sql.analyzer.RelationId;
+import com.starrocks.sql.analyzer.Scope;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.expression.BoolLiteral;
 import com.starrocks.sql.ast.expression.DateLiteral;
@@ -48,6 +55,7 @@ import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.ast.expression.MaxLiteral;
 import com.starrocks.sql.ast.expression.NullLiteral;
 import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.sql.ast.expression.TableName;
 import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.common.PCellSortedSet;
 import com.starrocks.sql.common.PCellWithName;
@@ -57,6 +65,16 @@ import com.starrocks.sql.common.PartitionDiff;
 import com.starrocks.sql.common.RangePartitionDiffer;
 import com.starrocks.sql.common.SyncPartitionUtils;
 import com.starrocks.sql.common.UnsupportedException;
+import com.starrocks.sql.optimizer.OptimizerFactory;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.ScanOperatorPredicates;
+import com.starrocks.sql.optimizer.operator.logical.LogicalHiveScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.OptExternalPartitionPruner;
+import com.starrocks.sql.optimizer.transformer.ExpressionMapping;
+import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.Type;
 import org.apache.hadoop.fs.Path;
@@ -76,10 +94,12 @@ import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -946,5 +966,104 @@ public class PartitionUtil {
 
     public static String getPathWithSlash(String path) {
         return path.endsWith("/") ? path : path + "/";
+    }
+
+    /**
+     * Get filtered partition keys based on partition predicate using Hive partition pruning
+     * Reuses key logic from OptExternalPartitionPruner
+     *
+     * @param context         The ConnectContext
+     * @param sourceHiveTable The source Hive table
+     * @return List of filtered partition keys, or null if no filtering is needed
+     */
+    public static List<PartitionKey> getFilteredPartitionKeys(ConnectContext context,
+                                                              com.starrocks.catalog.Table sourceHiveTable,
+                                                              Expr partitionFilter) {
+        try {
+            List<Column> partitionColumns = sourceHiveTable.getPartitionColumns();
+
+            if (partitionColumns.isEmpty()) {
+                LOG.info("Source table is not partitioned, partition filter will be ignored");
+                return null;
+            }
+            if (partitionFilter == null) {
+                LOG.info("No partition filter provided, no partition pruning will be applied");
+                return null;
+            }
+
+            // Create column reference mappings for reusing OptExternalPartitionPruner logic
+            ColumnRefFactory columnRefFactory = new ColumnRefFactory();
+            Map<Column, ColumnRefOperator> columnToColRefMap = new HashMap<>();
+            Map<ColumnRefOperator, Column> colRefToColumnMap = new HashMap<>();
+
+            // Create a simple mock operator that provides the necessary interface
+            LogicalHiveScanOperator hiveScanOperator = makeSourceTableHiveScanOperator(sourceHiveTable, columnToColRefMap,
+                    colRefToColumnMap, columnRefFactory, partitionFilter, context);
+
+            OptExternalPartitionPruner.prunePartitions(OptimizerFactory.initContext(context, columnRefFactory),
+                    hiveScanOperator);
+
+            ScanOperatorPredicates scanOperatorPredicates = hiveScanOperator.getScanOperatorPredicates();
+            if (!scanOperatorPredicates.getNonPartitionConjuncts().isEmpty() ||
+                    !scanOperatorPredicates.getNoEvalPartitionConjuncts().isEmpty()) {
+                LOG.warn("Partition filter contains non-partition predicates or can not eval predicates, " +
+                                "non-partition predicates: {}, no-eval partition predicates: {}. ",
+                        Joiner.on(", ").join(scanOperatorPredicates.getNonPartitionConjuncts()),
+                        Joiner.on(", ").join(scanOperatorPredicates.getNoEvalPartitionConjuncts()));
+                throw new StarRocksConnectorException("Partition filter contains non-partition predicates or can not eval " +
+                        "predicates, only simple partition predicates are supported for partition pruning. " +
+                        "Non-partition predicates: %s, no-eval partition predicates: %s",
+                        Joiner.on(", ").join(scanOperatorPredicates.getNonPartitionConjuncts()),
+                        Joiner.on(", ").join(scanOperatorPredicates.getNoEvalPartitionConjuncts()));
+            }
+
+            List<PartitionKey> partitionKeys = Lists.newArrayList();
+            scanOperatorPredicates.getSelectedPartitionIds().stream()
+                    .map(id -> scanOperatorPredicates.getIdToPartitionKey().get(id))
+                    .filter(Objects::nonNull)
+                    .forEach(partitionKeys::add);
+            LOG.info("Partition pruning selected {} partitions, select partitions : {}", partitionKeys.size(),
+                    Joiner.on(", ").join(partitionKeys));
+
+            return partitionKeys;
+        } catch (Exception e) {
+            LOG.warn("Failed to perform partition pruning, Error: {}", e.getMessage());
+            throw new StarRocksConnectorException("Failed to perform partition pruning: %s", e.getMessage(), e);
+        }
+    }
+
+    private static LogicalHiveScanOperator makeSourceTableHiveScanOperator(com.starrocks.catalog.Table sourceTable,
+                                                                           Map<Column, ColumnRefOperator> columnToColRefMap,
+                                                                           Map<ColumnRefOperator, Column> colRefToColumnMap,
+                                                                           ColumnRefFactory columnRefFactory,
+                                                                           Expr whereExpr, ConnectContext context) {
+        List<ColumnRefOperator> columnRefOperators = new ArrayList<>();
+        for (Column column : sourceTable.getBaseSchema()) {
+            ColumnRefOperator columnRef = columnRefFactory.create(column.getName(),
+                    column.getType(), column.isAllowNull());
+            colRefToColumnMap.put(columnRef, column);
+            columnToColRefMap.put(column, columnRef);
+            columnRefOperators.add(columnRef);
+        }
+
+        ScalarOperator scalarOperator = null;
+        if (whereExpr != null) {
+            // Create scope with table columns for expression analysis
+            TableName sourceTableName = new TableName(sourceTable.getCatalogName(),
+                    sourceTable.getCatalogDBName(), sourceTable.getCatalogTableName());
+            Scope scope = new Scope(RelationId.anonymous(), new RelationFields(columnRefOperators.stream()
+                    .map(col -> new Field(col.getName(), col.getType(), sourceTableName, null))
+                    .collect(Collectors.toList())));
+            // Analyze the WHERE expression
+            ExpressionAnalyzer.analyzeExpression(whereExpr, new AnalyzeState(), scope, context);
+
+            // Create expression mapping for conversion
+            ExpressionMapping expressionMapping = new ExpressionMapping(scope, columnRefOperators);
+
+            // Convert Expr to ScalarOperator
+            scalarOperator = SqlToScalarOperatorTranslator.translate(whereExpr, expressionMapping, columnRefFactory);
+        }
+        return new LogicalHiveScanOperator(sourceTable, colRefToColumnMap, columnToColRefMap,
+                Operator.DEFAULT_LIMIT, scalarOperator);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -986,10 +986,6 @@ public class PartitionUtil {
                 LOG.info("Source table is not partitioned, partition filter will be ignored");
                 return null;
             }
-            if (partitionFilter == null) {
-                LOG.info("No partition filter provided, no partition pruning will be applied");
-                return null;
-            }
 
             // Create column reference mappings for reusing OptExternalPartitionPruner logic
             ColumnRefFactory columnRefFactory = new ColumnRefFactory();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/RemoteFileOperations.java
@@ -310,6 +310,23 @@ public class RemoteFileOperations {
         return HiveWriteUtils.deleteIfExists(path, recursive, conf);
     }
 
+    public void truncateLocations(List<String> paths) {
+        for (String location : paths) {
+            try {
+                Path path = new Path(location);
+                if (!deleteIfExists(path, true)) {
+                    throw new StarRocksConnectorException("Failed to delete path : %s", location);
+                }
+                HiveWriteUtils.createDirectoryIfNotExists(path, conf);
+                LOG.info("Truncate data in partition location: {}", location);
+            } catch (Exception e) {
+                LOG.error("Failed to truncate data in location: {}", location, e);
+                throw new StarRocksConnectorException("Failed to truncate data in location: %s. msg: %s",
+                        location, e.getMessage());
+            }
+        }
+    }
+
     public FileStatus[] listStatus(Path path) {
         try {
             FileSystem fileSystem = FileSystem.get(path.toUri(), conf);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -38,6 +38,7 @@ import com.starrocks.connector.ConnectorProperties;
 import com.starrocks.connector.GetRemoteFilesParams;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.PartitionInfo;
+import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.RemoteFileInfoSource;
 import com.starrocks.connector.RemoteFileOperations;
@@ -55,6 +56,14 @@ import com.starrocks.sql.ast.CreateTableLikeStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.DropTableStmt;
 import com.starrocks.sql.ast.SingleItemListPartitionDesc;
+import com.starrocks.sql.ast.TruncateTablePartitionStmt;
+import com.starrocks.sql.ast.TruncateTableStmt;
+import com.starrocks.sql.ast.expression.BinaryPredicate;
+import com.starrocks.sql.ast.expression.BinaryType;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.ExprUtils;
+import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.sql.ast.expression.TableName;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
@@ -165,6 +174,82 @@ public class HiveMetadata implements ConnectorMetadata {
     @Override
     public void createTableLike(CreateTableLikeStmt stmt) throws DdlException {
         hmsOps.createTableLike(stmt);
+    }
+
+    @Override
+    public void truncateTable(TruncateTableStmt truncateTableStmt, ConnectContext context) throws DdlException {
+        String dbName = truncateTableStmt.getDbName();
+        String tableName = truncateTableStmt.getTblName();
+
+        Table table = getTable(context, dbName, tableName);
+        if (table == null) {
+            throw new DdlException("Table [" + tableName + "] does not exist");
+        }
+
+        if (!(table instanceof HiveTable hiveTable)) {
+            throw new DdlException("Table [" + tableName + "] is not a Hive table");
+        }
+
+        if (hiveTable.getHiveTableType() != HiveTable.HiveTableType.MANAGED_TABLE) {
+            throw new StarRocksConnectorException("Only managed Hive table support truncate operation, table type is %s",
+                    hiveTable.getHiveTableType());
+        }
+
+        List<String> locations = Lists.newArrayList();
+        if (truncateTableStmt instanceof TruncateTablePartitionStmt truncateTablePartitionStmt) {
+            // truncate partitions data
+            locations.addAll(filterTruncatePartitions(truncateTablePartitionStmt, hiveTable, context));
+        } else if (hiveTable.isUnPartitioned()) {
+            // truncate whole unpartitioned table data
+            String tableLocation = hiveTable.getTableLocation();
+            locations.add(tableLocation);
+        } else {
+            // truncate whole partitioned table data
+            List<String> partitionNames = hmsOps.getPartitionKeys(dbName, tableName);
+            hmsOps.getPartitionByNames(hiveTable, partitionNames).values().forEach(partition -> {
+                locations.add(partition.getFullPath());
+            });
+        }
+
+        fileOps.truncateLocations(locations);
+        refreshTable(dbName, hiveTable, null, true);
+    }
+
+    private List<String> filterTruncatePartitions(TruncateTablePartitionStmt stmt, HiveTable table,
+                                                  ConnectContext context) throws DdlException {
+
+        if (table.isUnPartitioned()) {
+            throw new StarRocksConnectorException("Table [" + table.getName() + "] is not partitioned, " +
+                    "cannot truncate partitions");
+        }
+
+        List<String> partitionColNames = stmt.getKeyPartitionRef().getPartitionColNames();
+        if (partitionColNames.stream().anyMatch(p -> !table.getPartitionColumnNames().contains(p))) {
+            throw new DdlException("partition names in partition spec do not match table partition columns");
+        }
+
+        List<Expr> predicates = Lists.newArrayList();
+        for (int index = 0; index < partitionColNames.size(); index++) {
+            String partitionColName = partitionColNames.get(index);
+            Expr partitionColValueExpr = stmt.getKeyPartitionRef().getPartitionColValues().get(index);
+            BinaryPredicate eqPredicate = new BinaryPredicate(BinaryType.EQ,
+                    new SlotRef(new TableName(stmt.getCatalogName(), stmt.getDbName(), stmt.getTblName()), partitionColName),
+                    partitionColValueExpr);
+            predicates.add(eqPredicate);
+        }
+        Expr partitionFilter = ExprUtils.compoundAnd(predicates);
+
+        List<PartitionKey> partitionKeys = PartitionUtil.getFilteredPartitionKeys(context, table, partitionFilter);
+        if (partitionKeys == null || partitionKeys.isEmpty()) {
+            throw new StarRocksConnectorException("No partitions matched the partition filter");
+        }
+
+        List<String> partitionLocations = Lists.newArrayList();
+        hmsOps.getPartitionByPartitionKeys(table, partitionKeys).values().forEach(partition -> {
+            partitionLocations.add(partition.getFullPath());
+        });
+
+        return partitionLocations;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -239,7 +239,8 @@ public class HiveMetadata implements ConnectorMetadata {
         }
         Expr partitionFilter = ExprUtils.compoundAnd(predicates);
 
-        List<PartitionKey> partitionKeys = PartitionUtil.getFilteredPartitionKeys(context, table, partitionFilter);
+        List<PartitionKey> partitionKeys = partitionFilter != null ?
+                PartitionUtil.getFilteredPartitionKeys(context, table, partitionFilter) : null;
         if (partitionKeys == null || partitionKeys.isEmpty()) {
             throw new StarRocksConnectorException("No partitions matched the partition filter");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveWriteUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveWriteUtils.java
@@ -148,4 +148,17 @@ public class HiveWriteUtils {
         return false;
     }
 
+    public static boolean createDirectoryIfNotExists(Path path, Configuration conf) {
+        try {
+            FileSystem fileSystem = FileSystem.get(path.toUri(), conf);
+            if (fileSystem.exists(path)) {
+                return false;
+            }
+            return fileSystem.mkdirs(path);
+        } catch (IOException e) {
+            LOG.error("Failed to create remote path {}", path, e);
+            throw new StarRocksConnectorException("Failed to create remote path: " + path);
+        }
+    }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -78,6 +78,7 @@ import com.starrocks.sql.ast.CreateViewStmt;
 import com.starrocks.sql.ast.DropTableStmt;
 import com.starrocks.sql.ast.ListPartitionDesc;
 import com.starrocks.sql.ast.PartitionDesc;
+import com.starrocks.sql.ast.TruncateTablePartitionStmt;
 import com.starrocks.sql.ast.TruncateTableStmt;
 import com.starrocks.sql.ast.expression.TableName;
 import com.starrocks.sql.optimizer.OptimizerContext;
@@ -389,6 +390,11 @@ public class IcebergMetadata implements ConnectorMetadata {
         if (table == null) {
             throw new StarRocksConnectorException(
                     "Failed to load iceberg table: " + truncateTableStmt.getTblRef().toString());
+        }
+
+        if (truncateTableStmt instanceof TruncateTablePartitionStmt) {
+            throw new StarRocksConnectorException("Iceberg table partition truncate is not supported: %s.%s",
+                    dbName, tableName);
         }
 
         DeleteFiles deleteFiles = table.newDelete().deleteFromRowFilter(Expressions.alwaysTrue());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/TruncateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/TruncateTableAnalyzer.java
@@ -15,21 +15,66 @@
 package com.starrocks.sql.analyzer;
 
 import com.google.common.base.Strings;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.KeyPartitionRef;
 import com.starrocks.sql.ast.PartitionRef;
 import com.starrocks.sql.ast.QualifiedName;
 import com.starrocks.sql.ast.TableRef;
+import com.starrocks.sql.ast.TruncateTablePartitionStmt;
 import com.starrocks.sql.ast.TruncateTableStmt;
+import com.starrocks.sql.ast.expression.Expr;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class TruncateTableAnalyzer {
 
     public static void analyze(TruncateTableStmt statement, ConnectContext context) {
-        TableRef tableRef = statement.getTblRef();
-        
+        TableRef tableRef = normalizedTableRef(statement.getTblRef(), context);
+
+        // Validate partition reference if present
+        PartitionRef partitionRef = tableRef.getPartitionDef();
+        if (partitionRef != null) {
+            if (partitionRef.isTemp()) {
+                throw new SemanticException("Not support truncate temp partitions");
+            }
+            // Check if partition name is not empty string
+            if (partitionRef.getPartitionNames().stream().anyMatch(Strings::isNullOrEmpty)) {
+                throw new SemanticException("there are empty partition name");
+            }
+        }
+        statement.setTblRef(tableRef);
+
+        if (statement instanceof TruncateTablePartitionStmt) {
+            analyzeKeyPartitions((TruncateTablePartitionStmt) statement);
+        }
+    }
+
+    public static void analyzeKeyPartitions(TruncateTablePartitionStmt statement) {
+        KeyPartitionRef partitionRef = statement.getKeyPartitionRef();
+        if (partitionRef == null) {
+            throw new SemanticException("KeyPartitionRef in TruncateTablePartitionStmt is null");
+        }
+
+        List<String> partitionColNames = partitionRef.getPartitionColNames();
+        List<Expr> partitionColValues = partitionRef.getPartitionColValues();
+        if (partitionColNames.size() != partitionColValues.size()) {
+            throw new SemanticException("The size of partition columns and values do not match");
+        }
+
+        // Check for duplicate partition column names
+        Set<String> uniqueColNames = new HashSet<>(partitionColNames);
+        if (uniqueColNames.size() != partitionColNames.size()) {
+            throw new SemanticException("Duplicate partition column names are not allowed");
+        }
+    }
+
+    private static TableRef normalizedTableRef(TableRef tableRef, ConnectContext context) {
         // Validate catalog
         String catalog = tableRef.getCatalogName();
         if (Strings.isNullOrEmpty(catalog)) {
@@ -54,20 +99,11 @@ public class TruncateTableAnalyzer {
             throw new SemanticException("Table name is null");
         }
 
-        // Validate partition reference if present
-        PartitionRef partitionRef = tableRef.getPartitionDef();
-        if (partitionRef != null) {
-            if (partitionRef.isTemp()) {
-                throw new SemanticException("Not support truncate temp partitions");
-            }
-            // Check if partition name is not empty string
-            if (partitionRef.getPartitionNames().stream().anyMatch(Strings::isNullOrEmpty)) {
-                throw new SemanticException("there are empty partition name");
-            }
+        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(context, catalog, db, tbl);
+        if (table == null) {
+            throw new SemanticException("Table %s.%s.%s does not exist", catalog, db, tbl);
         }
 
-        TableRef nomalizedTableRef = new TableRef(QualifiedName.of(List.of(catalog, db, tbl)), partitionRef,
-                tableRef.getPos());
-        statement.setTblRef(nomalizedTableRef);
+        return new TableRef(QualifiedName.of(List.of(catalog, db, tbl)), tableRef.getPartitionDef(), tableRef.getPos());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/TruncateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/TruncateTableAnalyzer.java
@@ -15,11 +15,9 @@
 package com.starrocks.sql.analyzer;
 
 import com.google.common.base.Strings;
-import com.starrocks.catalog.Table;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.KeyPartitionRef;
 import com.starrocks.sql.ast.PartitionRef;
 import com.starrocks.sql.ast.QualifiedName;
@@ -97,11 +95,6 @@ public class TruncateTableAnalyzer {
         String tbl = tableRef.getTableName();
         if (Strings.isNullOrEmpty(tbl)) {
             throw new SemanticException("Table name is null");
-        }
-
-        Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(context, catalog, db, tbl);
-        if (table == null) {
-            throw new SemanticException("Table %s.%s.%s does not exist", catalog, db, tbl);
         }
 
         return new TableRef(QualifiedName.of(List.of(catalog, db, tbl)), tableRef.getPartitionDef(), tableRef.getPos());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
@@ -260,7 +260,7 @@ public class InsertStmt extends DmlStmt {
     }
 
     public boolean isSpecifyPartitionNames() {
-        return targetPartitionNames != null && !targetPartitionNames.isStaticKeyPartitionInsert();
+        return targetPartitionNames != null && !targetPartitionNames.isKeyPartitionNames();
     }
 
     public void setTargetColumnNames(List<String> targetColumnNames) {
@@ -317,7 +317,7 @@ public class InsertStmt extends DmlStmt {
     }
 
     public boolean isStaticKeyPartitionInsert() {
-        return targetPartitionNames != null && targetPartitionNames.isStaticKeyPartitionInsert();
+        return targetPartitionNames != null && targetPartitionNames.isKeyPartitionNames();
     }
 
     public boolean isPartitionNotSpecifiedInOverwrite() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/KeyPartitionRef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/KeyPartitionRef.java
@@ -1,0 +1,45 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.parser.NodePosition;
+
+import java.util.List;
+
+public class KeyPartitionRef implements ParseNode {
+    private final List<String> partitionColNames;
+    private final List<Expr> partitionColValues;
+    private final NodePosition pos;
+
+    public KeyPartitionRef(List<String> partitionColNames, List<Expr> partitionColValues, NodePosition pos) {
+        this.partitionColNames = partitionColNames;
+        this.partitionColValues = partitionColValues;
+        this.pos = pos;
+    }
+
+    public List<String> getPartitionColNames() {
+        return partitionColNames;
+    }
+
+    public List<Expr> getPartitionColValues() {
+        return partitionColValues;
+    }
+
+    @Override
+    public NodePosition getPos() {
+        return pos;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/PartitionNames.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/PartitionNames.java
@@ -106,7 +106,7 @@ public class PartitionNames implements ParseNode {
         return pos;
     }
 
-    public boolean isStaticKeyPartitionInsert() {
+    public boolean isKeyPartitionNames() {
         return !partitionColValues.isEmpty();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/TruncateTablePartitionStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/TruncateTablePartitionStmt.java
@@ -1,0 +1,28 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+public class TruncateTablePartitionStmt extends TruncateTableStmt {
+    private final KeyPartitionRef partitionRef;
+
+    public TruncateTablePartitionStmt(TableRef tableRef, KeyPartitionRef partitionRef) {
+        super(tableRef);
+        this.partitionRef = partitionRef;
+    }
+
+    public KeyPartitionRef getKeyPartitionRef() {
+        return partitionRef;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTruncateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeTruncateTableTest.java
@@ -14,8 +14,14 @@
 
 package com.starrocks.sql.analyzer;
 
+import com.starrocks.catalog.Table;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.ast.TruncateTableStmt;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -32,7 +38,14 @@ public class AnalyzeTruncateTableTest {
     }
 
     @Test
-    public void normalTest() {
+    public void normalTest(@Mocked Table mockTable) {
+        new MockUp<MetadataMgr>() {
+            @Mock
+            public Table getTable(ConnectContext context, String catalogName, String dbName, String tblName) {
+                return mockTable;
+            }
+        };
+
         TruncateTableStmt stmt = (TruncateTableStmt) analyzeSuccess("TRUNCATE TABLE example_db.tbl;");
         Assertions.assertEquals("tbl", stmt.getTblName());
         Assertions.assertEquals("example_db", stmt.getDbName());

--- a/test/sql/test_hive/R/test_hive_truncate
+++ b/test/sql/test_hive/R/test_hive_truncate
@@ -1,0 +1,137 @@
+-- name: test_hive_truncate
+create external catalog hive_truncate_${uuid0} PROPERTIES ("type"="hive",
+    "hive.metastore.uris"="${hive_metastore_uris}",
+    "aws.s3.access_key"="${oss_ak}",
+    "aws.s3.secret_key"="${oss_sk}",
+    "aws.s3.endpoint"="${oss_endpoint}"
+);
+-- result:
+-- !result
+create database hive_truncate_${uuid0}.hive_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/hive_truncate_${uuid0}/hive_db/${uuid0}"
+);
+-- result:
+-- !result
+create table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} (k1 int);
+-- result:
+-- !result
+insert into hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} values (1),(2),(3);
+-- result:
+-- !result
+select * from hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} order by k1;
+-- result:
+1
+2
+3
+-- !result
+truncate table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0};
+-- result:
+-- !result
+select * from hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} order by k1;
+-- result:
+-- !result
+drop table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} force;
+-- result:
+-- !result
+create table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} (k1 int, k2 date) partition by (k2);
+-- result:
+-- !result
+insert into hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} values (1,'2020-01-01'),(2,'2020-01-01'),(3,'2020-01-02');
+-- result:
+-- !result
+select * from hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} order by k1;
+-- result:
+1	2020-01-01
+2	2020-01-01
+3	2020-01-02
+-- !result
+truncate table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0};
+-- result:
+-- !result
+select * from hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} order by k1;
+-- result:
+-- !result
+drop table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} force;
+-- result:
+-- !result
+create table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} (k1 int, k2 date, k3 string) partition by (k2,k3);
+-- result:
+-- !result
+insert into hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} values (1,'2020-01-01','a'),(2,'2020-01-01','b'),(3,'2020-01-02','a');
+-- result:
+-- !result
+select * from hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} order by k1;
+-- result:
+1	2020-01-01	a
+2	2020-01-01	b
+3	2020-01-02	a
+-- !result
+truncate table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0};
+-- result:
+-- !result
+select * from hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} order by k1;
+-- result:
+-- !result
+drop table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} force;
+-- result:
+-- !result
+create table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_par${uuid0} (k1 int, k2 date, k3 string) partition by (k2,k3);
+-- result:
+-- !result
+insert into hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_par${uuid0} values (1,'2020-01-01','a'),(2,'2020-01-01','b'),(3,'2020-01-02','a');
+-- result:
+-- !result
+select * from hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_par${uuid0} order by k1;
+-- result:
+1	2020-01-01	a
+2	2020-01-01	b
+3	2020-01-02	a
+-- !result
+truncate table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_par${uuid0} partition (k2='2020-01-01');
+-- result:
+-- !result
+select * from hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_par${uuid0} order by k1;
+-- result:
+3	2020-01-02	a
+-- !result
+insert into hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_par${uuid0} values (4,'2020-01-02','b'),(5,'2020-01-02','c'),(6,'2020-01-02','d');
+-- result:
+-- !result
+select * from hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_par${uuid0} order by k1;
+-- result:
+3	2020-01-02	a
+4	2020-01-02	b
+5	2020-01-02	c
+6	2020-01-02	d
+-- !result
+truncate table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_par${uuid0} partition (k2='2020-01-02',k3='b');
+-- result:
+-- !result
+select * from hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_par${uuid0} order by k1;
+-- result:
+3	2020-01-02	a
+5	2020-01-02	c
+6	2020-01-02	d
+-- !result
+truncate table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_par${uuid0} partition (k3='c');
+-- result:
+-- !result
+select * from hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_par${uuid0} order by k1;
+-- result:
+3	2020-01-02	a
+6	2020-01-02	d
+-- !result
+drop table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_par${uuid0} force;
+-- result:
+-- !result
+drop database hive_truncate_${uuid0}.hive_db_${uuid0};
+-- result:
+-- !result
+drop catalog hive_truncate_${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/hive_truncate_${uuid0}/hive_db/${uuid0} > /dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_hive/T/test_hive_truncate
+++ b/test/sql/test_hive/T/test_hive_truncate
@@ -1,0 +1,55 @@
+-- name: test_hive_truncate
+
+create external catalog hive_truncate_${uuid0} PROPERTIES ("type"="hive",
+    "hive.metastore.uris"="${hive_metastore_uris}",
+    "aws.s3.access_key"="${oss_ak}",
+    "aws.s3.secret_key"="${oss_sk}",
+    "aws.s3.endpoint"="${oss_endpoint}"
+);
+
+create database hive_truncate_${uuid0}.hive_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/hive_truncate_${uuid0}/hive_db/${uuid0}"
+);
+
+-- test truncate unpartitioned table
+create table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} (k1 int);
+insert into hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} values (1),(2),(3);
+select * from hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} order by k1;
+truncate table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0};
+select * from hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} order by k1;
+drop table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} force;
+
+-- test truncate single partitioned table and truncate all partitions
+create table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} (k1 int, k2 date) partition by (k2);
+insert into hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} values (1,'2020-01-01'),(2,'2020-01-01'),(3,'2020-01-02');
+select * from hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} order by k1;
+truncate table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0};
+select * from hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} order by k1;
+drop table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} force;
+
+-- test truncate multi-partitioned table and truncate all partitions
+create table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} (k1 int, k2 date, k3 string) partition by (k2,k3);
+insert into hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} values (1,'2020-01-01','a'),(2,'2020-01-01','b'),(3,'2020-01-02','a');
+select * from hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} order by k1;
+truncate table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0};
+select * from hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} order by k1;
+drop table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_${uuid0} force;
+
+-- test truncate partitioned table and truncate specify partition
+create table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_par${uuid0} (k1 int, k2 date, k3 string) partition by (k2,k3);
+insert into hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_par${uuid0} values (1,'2020-01-01','a'),(2,'2020-01-01','b'),(3,'2020-01-02','a');
+select * from hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_par${uuid0} order by k1;
+truncate table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_par${uuid0} partition (k2='2020-01-01');
+select * from hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_par${uuid0} order by k1;
+insert into hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_par${uuid0} values (4,'2020-01-02','b'),(5,'2020-01-02','c'),(6,'2020-01-02','d');
+select * from hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_par${uuid0} order by k1;
+truncate table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_par${uuid0} partition (k2='2020-01-02',k3='b');
+select * from hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_par${uuid0} order by k1;
+truncate table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_par${uuid0} partition (k3='c');
+select * from hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_par${uuid0} order by k1;
+drop table hive_truncate_${uuid0}.hive_db_${uuid0}.hive_tbl_par${uuid0} force;
+
+drop database hive_truncate_${uuid0}.hive_db_${uuid0};
+drop catalog hive_truncate_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/hive_truncate_${uuid0}/hive_db/${uuid0} > /dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
## Why I'm doing:
support truncate hive table 
## What I'm doing:
This pull request introduces support for the `TRUNCATE TABLE` and `TRUNCATE TABLE PARTITION` operations for Hive tables in StarRocks, including partition pruning and improved error handling. It adds new APIs and refactors code to reuse partition pruning logic, ensuring only managed Hive tables are supported for truncation. Additionally, it improves directory management after truncation and provides clear user feedback for unsupported operations on Iceberg tables.

### Hive table truncate and partition prune support

* Added `truncateTable` and `truncateTablePartition` support for Hive tables in `HiveMetadata`, including logic to validate table type, partition specs, and to prune partitions using predicates. Only managed Hive tables are allowed for truncation.
* Implemented `PartitionUtil.getFilteredPartitionKeys`, which uses partition predicates to efficiently prune Hive table partitions by reusing optimizer logic.
* Refactored partition pruning usage in Iceberg add-files procedure to use the new `PartitionUtil.getFilteredPartitionKeys` method for consistency.

### Filesystem and directory management

* Added `truncateLocations` method to `RemoteFileOperations` to delete and recreate directories for truncated partitions or tables, ensuring data is properly removed and structure is maintained.
* Added `createDirectoryIfNotExists` utility to `HiveWriteUtils` for robust directory creation after truncation.

### Iceberg table error handling

* Added explicit error handling for unsupported partition truncation on Iceberg tables, providing clear feedback to users.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements Hive TRUNCATE TABLE and TRUNCATE TABLE PARTITION using optimizer-based partition pruning, adds parser/analyzer nodes and FS helpers, refactors related code, and disallows Iceberg partition truncation.
> 
> - **Hive**:
>   - **Truncate Support**: Implement `TRUNCATE TABLE` and `TRUNCATE TABLE PARTITION` for managed Hive tables in `HiveMetadata`, including validation, table/partition location cleanup, and cache refresh.
>   - **Partition Pruning**: Add `PartitionUtil.getFilteredPartitionKeys` reusing optimizer pruning logic.
>   - **FS Ops**: Add `RemoteFileOperations.truncateLocations` and `HiveWriteUtils.createDirectoryIfNotExists` for delete-and-recreate paths.
> - **SQL Parser/Analyzer**:
>   - Add `KeyPartitionRef`, `TruncateTablePartitionStmt`, analyzer checks in `TruncateTableAnalyzer`, and parsing in `AstBuilder`.
>   - Tweak `InsertStmt`/`PartitionNames` (`isKeyPartitionNames`).
> - **Iceberg**:
>   - Forbid partition truncation in `IcebergMetadata.truncateTable`.
>   - Refactor `AddFilesProcedure` to use `PartitionUtil.getFilteredPartitionKeys`.
> - **Tests**:
>   - Add UTs for Hive truncate flows and analyzer, plus SQL tests under `test_hive_truncate`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2c02891ee1e4067e6de61d306cbbb50faaf8be6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->