### PR TITLE
[BugFix] Fix the bug of hash join spill crash when set finishing task failed

### DIFF
--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -18,7 +18,6 @@
 #include <memory>
 
 #include "column/column_helper.h"
-#include "column/vectorized_fwd.h"
 #include "common/statusor.h"
 #include "exec/hash_join_components.h"
 #include "exec/hash_join_node.h"
@@ -33,10 +32,12 @@
 #include "gen_cpp/InternalService_types.h"
 #include "gen_cpp/PlanNodes_types.h"
 #include "runtime/runtime_state.h"
-#include "util/bit_util.h"
 #include "util/defer_op.h"
+#include "util/failpoint/fail_point.h"
 
 namespace starrocks::pipeline {
+
+DEFINE_FAIL_POINT(spill_flush_set_invalid_status);
 
 Status SpillableHashJoinBuildOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(HashJoinBuildOperator::prepare(state));
@@ -106,6 +107,10 @@ Status SpillableHashJoinBuildOperator::set_finishing(RuntimeState* state) {
                 [this]() {
                     _is_finished = true;
                     _join_builder->enter_probe_phase();
+                    FAIL_POINT_TRIGGER_EXECUTE(spill_flush_set_invalid_status, {
+                        _join_builder->spiller()->update_spilled_task_status(
+                                Status::InternalError("spill flush failed"));
+                    });
                     return Status::OK();
                 },
                 state, TRACKER_WITH_SPILLER_GUARD(state, spiller));

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -18,19 +18,16 @@
 #include <memory>
 #include <mutex>
 #include <numeric>
-#include <optional>
 
 #include "common/config.h"
 #include "exec/hash_joiner.h"
 #include "exec/pipeline/hashjoin/hash_join_probe_operator.h"
 #include "exec/pipeline/hashjoin/hash_joiner_factory.h"
-#include "exec/pipeline/query_context.h"
 #include "exec/spill/executor.h"
 #include "exec/spill/partition.h"
 #include "exec/spill/spill_components.h"
 #include "exec/spill/spiller.h"
 #include "exec/spill/spiller.hpp"
-#include "gen_cpp/PlanNodes_types.h"
 #include "gutil/casts.h"
 #include "runtime/current_thread.h"
 #include "runtime/runtime_state.h"
@@ -345,6 +342,9 @@ void SpillableHashJoinProbeOperator::_update_status(Status&& status) const {
 }
 
 Status SpillableHashJoinProbeOperator::_status() const {
+    if (!_join_builder->spiller()->task_status().ok()) {
+        return _join_builder->spiller()->task_status();
+    }
     std::lock_guard guard(_mutex);
     return _operator_status;
 }

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -342,9 +342,7 @@ void SpillableHashJoinProbeOperator::_update_status(Status&& status) const {
 }
 
 Status SpillableHashJoinProbeOperator::_status() const {
-    if (!_join_builder->spiller()->task_status().ok()) {
-        return _join_builder->spiller()->task_status();
-    }
+    RETURN_IF_ERROR(_join_builder->spiller()->task_status());
     std::lock_guard guard(_mutex);
     return _operator_status;
 }

--- a/test/sql/test_spill/R/test_spill_hash_join_set_finishing_failed
+++ b/test/sql/test_spill/R/test_spill_hash_join_set_finishing_failed
@@ -1,0 +1,32 @@
+-- name: test_spill_hash_join_set_finishing_failed @sequential
+set enable_spill=true;
+-- result:
+-- !result
+set spill_mode="force";
+-- result:
+-- !result
+set pipeline_dop = 1;
+-- result:
+-- !result
+create table t1(c1 int, c2 int) properties("replication_num"="1");
+-- result:
+-- !result
+create table t2(c1 int, c2 int) properties("replication_num"="1");
+-- result:
+-- !result
+insert into t1 select generate_series,generate_series from table(generate_series(0,2000));
+-- result:
+-- !result
+insert into t2 select generate_series,generate_series from table(generate_series(0,2000));
+-- result:
+-- !result
+admin enable failpoint 'spill_flush_set_invalid_status';
+-- result:
+-- !result
+select sum(t1.c1), sum(t2.c2) from t1 join t2 on t1.c1=t2.c2;
+-- result:
+[REGEX] .*spill flush failed.*
+-- !result
+admin disable failpoint 'spill_flush_set_invalid_status';
+-- result:
+-- !result

--- a/test/sql/test_spill/T/test_spill_hash_join_set_finishing_failed
+++ b/test/sql/test_spill/T/test_spill_hash_join_set_finishing_failed
@@ -1,0 +1,16 @@
+-- name: test_spill_hash_join_set_finishing_failed @sequential
+set enable_spill=true;
+set spill_mode="force";
+set pipeline_dop = 1;
+
+create table t1(c1 int, c2 int) properties("replication_num"="1");
+create table t2(c1 int, c2 int) properties("replication_num"="1");
+
+insert into t1 select generate_series,generate_series from table(generate_series(0,2000));
+insert into t2 select generate_series,generate_series from table(generate_series(0,2000));
+
+admin enable failpoint 'spill_flush_set_invalid_status';
+
+select sum(t1.c1), sum(t2.c2) from t1 join t2 on t1.c1=t2.c2;
+
+admin disable failpoint 'spill_flush_set_invalid_status';


### PR DESCRIPTION
## Why I'm doing:

The `SpillableHashJoinBuildOperator::set_finishing` method submits an asynchronous task. If the task fails, it will set the status of the spiller and `set_finishing` will return success. Then, the `SpillableHashJoinProbeOperator` will continue running, which may trigger issues such as crashes or dead loops.

Build set finishing task run failed: 
```
W20251102 11:45:06.830918 139803200026176 stack_util.cpp:353] 2025-11-02 11:45:06.830888, query_id=00000000-0000-0000-0000-000000000000, fragment_instance_id=00000000-0000-0000-0000-000000000000 throws exception: std::bad_alloc, trace:
     @          0x6357510  __wrap___cxa_throw
    @          0xe44bf5a  operator new(unsigned long) [clone .cold]
    @          0x5052edb  std::vector<unsigned char, starrocks::raw::RawAllocator<unsigned char, 16ul, std::allocator<unsigned char> > >::_M_default_append(unsigned long)
    @          0x507660b  starrocks::BinaryColumnBase<unsigned int>::append_selective(starrocks::Column const&, unsigned int const*, unsigned int, unsigned int)
    @          0x5092b0d  starrocks::NullableColumn::append_selective(starrocks::Column const&, unsigned int const*, unsigned int, unsigned int)
    @          0x4fecca9  starrocks::Chunk::append_selective(starrocks::Chunk const&, unsigned int const*, unsigned int, unsigned int)
    @          0x5502cee  starrocks::spill::UnorderedMemTable::append_selective(starrocks::Chunk const&, unsigned int const*, unsigned int, unsigned int)
    @          0x54fae1d  starrocks::spill::PartitionedSpillerWriter::_split_partition(starrocks::workgroup::YieldContext&, starrocks::spill::SerdeContext&, starrocks::spill::SpillerReader*, starrocks::spill::SpilledPartition*, starrocks::spill::SpilledPartition*, starrocks::spill:jE
    @          0x54fb89e  starrocks::spill::PartitionedSpillerWriter::_split_input_partitions(starrocks::workgroup::YieldContext&, starrocks::spill::SerdeContext&, std::vector<starrocks::spill::SpilledPartition*, std::allocator<starrocks::spill::SpilledPartition*> > const&)
    @          0x54fc1d1  starrocks::spill::PartitionedSpillerWriter::yieldable_flush_task(starrocks::workgroup::YieldContext&, std::vector<starrocks::spill::SpilledPartition*, std::allocator<starrocks::spill::SpilledPartition*> > const&, std::vector<starrocks::spill::SpilledPartitjE
    @          0x54ca0eb  auto starrocks::spill::PartitionedSpillerWriter::flush<starrocks::spill::IOTaskExecutor, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptr<starrocks::spill::Spiller> >&>(starrocks::RuntimeState*, booljE
    @          0x54ca47d  std::_Function_handler<void (starrocks::workgroup::YieldContext&), starrocks::spill::PartitionedSpillerWriter::flush<starrocks::spill::IOTaskExecutor, starrocks::spill::ResourceMemTrackerGuard<std::weak_ptr<starrocks::pipeline::QueryContext>, std::weak_ptrjE
    @          0x4fbaede  starrocks::workgroup::ScanExecutor::worker_thread()
    @          0x87563fe  starrocks::ThreadPool::dispatch_thread()
    @          0x874ce19  starrocks::Thread::supervise_thread(void*)
```

Probe crash
```
*** SIGSEGV (@0x0) received by PID 25 (TID 0x7f2676133640) from PID 0; stack trace: ***
    @     0x7f27de726ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @          0x9b0fc69 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f27df5ba526 os::Linux::chained_handler(int, siginfo_t*, void*)
    @     0x7f27df5c021b JVM_handle_linux_signal
    @     0x7f27df5b307c signalHandler(int, siginfo_t*, void*)
    @     0x7f27de6cf520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @          0x506ba30 void std::vector<unsigned char, starrocks::raw::RawAllocator<unsigned char, 16ul, std::allocator<unsigned char> > >::_M_range_insert<unsigned char const*>(__gnu_cxx::__normal_iterator<unsigned char*, std::vector<unsigned char, starrocks::raw::RawAllocator<}K
    @          0x506e803 starrocks::BinaryColumnBase<unsigned int>::append(starrocks::Column const&, unsigned long, unsigned long)
    @          0x5092e16 starrocks::NullableColumn::append(starrocks::Column const&, unsigned long, unsigned long)
    @          0x7283cd6 starrocks::JoinHashTable::append_chunk(std::shared_ptr<starrocks::Chunk> const&, std::vector<std::shared_ptr<starrocks::Column>, std::allocator<std::shared_ptr<starrocks::Column> > > const&)
    @          0x726a2af starrocks::HashJoinBuilder::append_chunk(std::shared_ptr<starrocks::Chunk> const&)
    @          0x724f9fa starrocks::pipeline::SpillableHashJoinProbeOperator::_load_partition_build_side(starrocks::workgroup::YieldContext&, starrocks::RuntimeState*, std::shared_ptr<starrocks::spill::SpillerReader> const&, unsigned long)
    @          0x724fc78 std::_Function_handler<void (starrocks::workgroup::YieldContext&), starrocks::pipeline::SpillableHashJoinProbeOperator::_load_all_partition_build_side(starrocks::RuntimeState*)::{lambda(auto:1&)#1}>::_M_invoke(std::_Any_data const&, starrocks::workgroup::Y}K
    @          0x4fbaede starrocks::workgroup::ScanExecutor::worker_thread()
    @          0x87563fe starrocks::ThreadPool::dispatch_thread()
    @          0x874ce19 starrocks::Thread::supervise_thread(void*)
    @     0x7f27de721ac3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
    @     0x7f27de7b2a74 clone
```

## What I'm doing:

[BugFix] Fix the bug of hash join spill crash when set finishing task failed

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
