### PR TITLE
[Enhancement] Support distinct aggregation over window without sliding frames

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyticAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyticAnalyzer.java
@@ -58,7 +58,7 @@ public class AnalyticAnalyzer {
         }
 
         FunctionCallExpr analyticFunction = analyticExpr.getFnCall();
-        if (analyticFunction.getParams().isDistinct()) {
+        if (analyticFunction.getParams().isDistinct() && !analyticExpr.isUnboundedWindowWithoutSlidingFrame()) {
             throw new SemanticException("DISTINCT not allowed in analytic function: " + ExprToSql.toSql(analyticFunction),
                     analyticExpr.getPos());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -36,6 +36,7 @@ import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTreeAnchorOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalViewScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalWindowOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
 import com.starrocks.sql.optimizer.rule.RuleSet;
 import com.starrocks.sql.optimizer.rule.join.JoinReorderFactory;
@@ -46,6 +47,7 @@ import com.starrocks.sql.optimizer.rule.transformation.ArrayDistinctAfterAggRule
 import com.starrocks.sql.optimizer.rule.transformation.CTEProduceAddProjectionRule;
 import com.starrocks.sql.optimizer.rule.transformation.ConvertToEqualForNullRule;
 import com.starrocks.sql.optimizer.rule.transformation.DeriveRangeJoinPredicateRule;
+import com.starrocks.sql.optimizer.rule.transformation.DistinctAggregationOverWindowRule;
 import com.starrocks.sql.optimizer.rule.transformation.EliminateAggFunctionRule;
 import com.starrocks.sql.optimizer.rule.transformation.EliminateAggRule;
 import com.starrocks.sql.optimizer.rule.transformation.EliminateConstantCTERule;
@@ -134,6 +136,7 @@ import com.starrocks.sql.optimizer.task.TaskContext;
 import com.starrocks.sql.optimizer.task.TaskScheduler;
 import com.starrocks.sql.optimizer.validate.MVRewriteValidator;
 import com.starrocks.sql.optimizer.validate.OptExpressionValidator;
+import com.starrocks.sql.util.Util;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -512,6 +515,7 @@ public class QueryOptimizer extends Optimizer {
         SessionVariable sessionVariable = rootTaskContext.getOptimizerContext().getSessionVariable();
         CTEContext cteContext = context.getCteContext();
 
+        tree = convertDistinctAggOverWindowToNullSafeEqualJoin(tree, rootTaskContext);
         // see JoinPredicatePushdown
         if (sessionVariable.isEnableRboTablePrune()) {
             context.setEnableJoinEquivalenceDerive(false);
@@ -904,6 +908,22 @@ public class QueryOptimizer extends Optimizer {
             scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.PRUNE_COLUMNS_RULES);
         }
         scheduler.rewriteOnce(tree, rootTaskContext, new PruneSubfieldRule());
+        deriveLogicalProperty(tree);
+        return tree;
+    }
+
+    private OptExpression convertDistinctAggOverWindowToNullSafeEqualJoin(OptExpression tree,
+                                                                          TaskContext rootTaskContext) {
+        if (Util.getStream(tree).noneMatch(op -> op instanceof LogicalWindowOperator)) {
+            return tree;
+        }
+        scheduler.rewriteIterative(tree, rootTaskContext, new MergeTwoProjectRule());
+        scheduler.rewriteIterative(tree, rootTaskContext, new MergeProjectWithChildRule(false));
+        deriveLogicalProperty(tree);
+        DistinctAggregationOverWindowRule rule = new DistinctAggregationOverWindowRule();
+        tree = rule.rewrite(tree, rootTaskContext);
+        deriveLogicalProperty(tree);
+        tree = new SeparateProjectRule().rewrite(tree, rootTaskContext);
         deriveLogicalProperty(tree);
         return tree;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/BinaryPredicateOperator.java
@@ -130,6 +130,10 @@ public class BinaryPredicateOperator extends PredicateOperator {
         return new BinaryPredicateOperator(BinaryType.EQ, lhs, rhs);
     }
 
+    public static BinaryPredicateOperator null_safe_eq(ScalarOperator lhs, ScalarOperator rhs) {
+        return new BinaryPredicateOperator(BinaryType.EQ_FOR_NULL, lhs, rhs);
+    }
+
     public static BinaryPredicateOperator ge(ScalarOperator lhs, ScalarOperator rhs) {
         return new BinaryPredicateOperator(BinaryType.GE, lhs, rhs);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/DistinctAggregationOverWindowRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/DistinctAggregationOverWindowRule.java
@@ -1,0 +1,192 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation;
+
+import com.google.common.base.Functions;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.sql.ast.expression.JoinOperator;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptExpressionVisitor;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.operator.AggType;
+import com.starrocks.sql.optimizer.operator.Projection;
+import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalCTEAnchorOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalCTEConsumeOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalCTEProduceOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalWindowOperator;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
+import com.starrocks.sql.optimizer.rule.tree.TreeRewriteRule;
+import com.starrocks.sql.optimizer.task.TaskContext;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+/*
+Rewrite count(distinct) over window without sliding frames into null-safe-equal join + aggregation
+for an example:
+
+select v1,v2,v3,count(distinct v3) over(partition by v1,v2) from t;
+can be rewritten into
+
+with cte as(
+  select v1, v2, count(distinct v3) cd
+  from t0
+  group by v1,v2
+)
+select t0.v1, t0.v2, t0.v3, cte.cd
+from t0 inner join cte on t0.v1 <=> cte.v1 and t0.v2 <=> cte.v2;
+
+*/
+
+public class DistinctAggregationOverWindowRule implements TreeRewriteRule {
+    @Override
+    public OptExpression rewrite(OptExpression root, TaskContext taskContext) {
+        return INSTANCE.process(root, taskContext).orElse(root);
+    }
+
+    private static final Visitor INSTANCE = new Visitor();
+
+    private static class Visitor extends OptExpressionVisitor<Optional<OptExpression>, TaskContext> {
+        @Override
+        public Optional<OptExpression> visit(OptExpression optExpression, TaskContext context) {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<OptExpression> visitLogicalWindow(OptExpression optExpression, TaskContext context) {
+            LogicalWindowOperator windowOp = optExpression.getOp().cast();
+
+            boolean isWindowWithSlidingFrame = windowOp.getAnalyticWindow() != null &&
+                    !(windowOp.getAnalyticWindow().getRightBoundary().getType().isAbsolutePos() &&
+                            windowOp.getAnalyticWindow().getLeftBoundary().getType().isAbsolutePos());
+
+            if (isWindowWithSlidingFrame || !windowOp.getOrderByElements().isEmpty()) {
+                return Optional.empty();
+            }
+            Set<String> funcNames = ImmutableSet.of(FunctionSet.SUM, FunctionSet.COUNT, FunctionSet.AVG);
+            java.util.function.Function<Map.Entry<ColumnRefOperator, CallOperator>, Integer> classify = e -> {
+                if (FunctionSet.onlyAnalyticUsedFunctions.contains(e.getValue().getFnName())) {
+                    return 0;
+                } else if (e.getValue().isDistinct() && funcNames.contains(e.getValue().getFnName())) {
+                    return 1;
+                } else {
+                    return 2;
+                }
+            };
+            Map<Integer, Map<ColumnRefOperator, CallOperator>> windowCallGroups =
+                    windowOp.getWindowCall().entrySet().stream().collect(
+                            Collectors.groupingBy(classify, Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+            Map<ColumnRefOperator, CallOperator> analyticCalls = windowCallGroups.getOrDefault(0, Maps.newHashMap());
+            Map<ColumnRefOperator, CallOperator> distinctAggCalls = windowCallGroups.getOrDefault(1, Maps.newHashMap());
+            Map<ColumnRefOperator, CallOperator> aggCalls = windowCallGroups.getOrDefault(2, Maps.newHashMap());
+            if (distinctAggCalls.isEmpty()) {
+                return Optional.empty();
+            }
+            aggCalls.putAll(distinctAggCalls);
+            List<ColumnRefOperator> groupBy = Optional.ofNullable(windowOp.getPartitionExpressions())
+                    .map(exprs -> exprs.stream().map(e -> (ColumnRefOperator) e).collect(Collectors.toList()))
+                    .orElse(List.of());
+
+            OptExpression child = optExpression.inputAt(0);
+            int cteId = context.getOptimizerContext().getCteContext().getNextCteId();
+            List<ColumnRefOperator> inputColumnRefs = child.getRowOutputInfo().getOutputColRefs();
+            java.util.function.Function<ColumnRefOperator, ColumnRefOperator> forkColumnRef =
+                    colRef -> context.getOptimizerContext().getColumnRefFactory()
+                            .create(colRef.getName(), colRef.getType(), colRef.isNullable());
+
+            Map<ColumnRefOperator, ColumnRefOperator> cteOutputColumnRefMap =
+                    inputColumnRefs.stream().collect(Collectors.toMap(forkColumnRef, Functions.identity()));
+            Map<ColumnRefOperator, ColumnRefOperator> joinLhsCteOutputColumnRefMap =
+                    inputColumnRefs.stream().collect(Collectors.toMap(Function.identity(), Function.identity()));
+
+            LogicalCTEAnchorOperator cteAnchorOp = new LogicalCTEAnchorOperator(cteId);
+            LogicalCTEProduceOperator cteProduceOp = new LogicalCTEProduceOperator(cteId);
+            LogicalCTEConsumeOperator cteConsumeOp = new LogicalCTEConsumeOperator(cteId, cteOutputColumnRefMap);
+
+            LogicalCTEConsumeOperator joinLhsCteConsumeOp =
+                    new LogicalCTEConsumeOperator(cteId, joinLhsCteOutputColumnRefMap);
+
+            Map<ColumnRefOperator, ScalarOperator> replaceMap = cteOutputColumnRefMap.entrySet().stream()
+                    .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+
+            ReplaceColumnRefRewriter replaceRewriter = new ReplaceColumnRefRewriter(replaceMap, false);
+            groupBy = groupBy.stream().map(expr -> (ColumnRefOperator) replaceRewriter.rewrite(expr))
+                    .collect(Collectors.toList());
+            aggCalls = aggCalls.entrySet().stream().collect(
+                    Collectors.toMap(Map.Entry::getKey, e -> (CallOperator) replaceRewriter.rewrite(e.getValue())));
+
+            LogicalAggregationOperator aggOp = new LogicalAggregationOperator(AggType.GLOBAL, groupBy, aggCalls);
+            Map<ColumnRefOperator, ScalarOperator> aggColRefMap =
+                    Stream.concat(groupBy.stream(), aggCalls.keySet().stream())
+                            .collect(Collectors.toMap(Function.identity(), Function.identity()));
+            aggOp.setProjection(new Projection(aggColRefMap));
+
+            LogicalJoinOperator joinOp;
+            if (groupBy.isEmpty()) {
+                joinOp = new LogicalJoinOperator(JoinOperator.CROSS_JOIN, null);
+            } else {
+                List<ScalarOperator> eqConjuncts = groupBy.stream()
+                        .map(expr -> BinaryPredicateOperator.null_safe_eq(expr, cteOutputColumnRefMap.get(expr)))
+                        .collect(Collectors.toList());
+
+                joinOp = new LogicalJoinOperator(JoinOperator.INNER_JOIN, Utils.compoundAnd(eqConjuncts));
+            }
+
+            Map<ColumnRefOperator, ScalarOperator> joinColRefMap =
+                    Stream.concat(joinLhsCteOutputColumnRefMap.keySet().stream(), aggCalls.keySet().stream())
+                            .collect(Collectors.toMap(Function.identity(), Function.identity()));
+
+            if (analyticCalls.isEmpty() && windowOp.getProjection() != null) {
+                joinOp.setProjection(windowOp.getProjection());
+            } else {
+                joinOp.setProjection(new Projection(joinColRefMap));
+            }
+            OptExpression cteProduceOptExpr = OptExpression.create(cteProduceOp, child);
+            OptExpression aggOptExpr = OptExpression.create(aggOp, OptExpression.create(cteConsumeOp));
+            OptExpression joinLhsOptExpr = OptExpression.create(joinLhsCteConsumeOp);
+            OptExpression joinOptExpr = OptExpression.create(joinOp, joinLhsOptExpr, aggOptExpr);
+            OptExpression cteAnchorOptExpr = OptExpression.create(cteAnchorOp, cteProduceOptExpr, joinOptExpr);
+
+            if (analyticCalls.isEmpty()) {
+                return Optional.of(cteAnchorOptExpr);
+            }
+
+            LogicalWindowOperator newWindowOp =
+                    LogicalWindowOperator.builder().withOperator(windowOp).setWindowCall(analyticCalls).build();
+            OptExpression windowOptExpr = OptExpression.create(newWindowOp, cteAnchorOptExpr);
+            return Optional.of(windowOptExpr);
+        }
+
+        private Optional<OptExpression> process(OptExpression opt, TaskContext context) {
+            for (int i = 0; i < opt.getInputs().size(); ++i) {
+                OptExpression input = opt.inputAt(i);
+                opt.setChild(i, process(input, context).orElse(input));
+            }
+            return opt.getOp().accept(this, opt, context);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAnalyticTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAnalyticTest.java
@@ -33,7 +33,6 @@ public class AnalyzeAnalyticTest {    // use a unique dir so that it won't be co
     public void testSingle() {
         analyzeFail("select sum(v1) over(partition by v2 rows between 1 preceding and 2 following) from t0",
                 "Windowing clause requires ORDER BY clause");
-        analyzeFail("select count(distinct v1) over() from t0", "DISTINCT not allowed in analytic function");
 
         analyzeFail("select abs(v1) over() from t0", "not supported with OVER clause");
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistinctAggregationOverWindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistinctAggregationOverWindowTest.java
@@ -1,0 +1,334 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.utframe.StarRocksAssert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+public class DistinctAggregationOverWindowTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withTable("CREATE TABLE `s1` (    \n" +
+                "  `v1` bigint(20) NULL COMMENT \"\",    \n" +
+                "  `v2` int(11) NULL COMMENT \"\",    \n" +
+                "  `a1` array<varchar(65533)> NULL COMMENT \"\",    \n" +
+                "  `a2` array<varchar(65533)> NULL COMMENT \"\"    \n" +
+                ") ENGINE=OLAP    \n" +
+                "DUPLICATE KEY(`v1`)    \n" +
+                "COMMENT \"OLAP\"    \n" +
+                "DISTRIBUTED BY HASH(`v1`) BUCKETS 10    \n" +
+                "PROPERTIES (    \n" +
+                "\"replication_num\" = \"1\",       \n" +
+                "\"in_memory\" = \"false\",    \n" +
+                "\"enable_persistent_index\" = \"true\",    \n" +
+                "\"replicated_storage\" = \"false\",    \n" +
+                "\"light_schema_change\" = \"true\",    \n" +
+                "\"compression\" = \"LZ4\"    \n" +
+                ");");
+    }
+
+    @Test
+    public void testCountDistinctWithPartition() throws Exception {
+
+        String sql = "select v1,v2,v3,\n" +
+                "      count (distinct v3) \n" +
+                "      \tover(partition by v1, v2)\n" +
+                "from t0;";
+
+        String plan = getFragmentPlan(sql);
+        assertCContains(plan, "  10:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 <=> 5: v1\n" +
+                "  |  equal join conjunct: 2: v2 <=> 6: v2\n" +
+                "  |  \n" +
+                "  |----9:AGGREGATE (update finalize)\n" +
+                "  |    |  output: count(7: v3)\n" +
+                "  |    |  group by: 5: v1, 6: v2\n" +
+                "  |    |  \n" +
+                "  |    8:AGGREGATE (merge serialize)\n" +
+                "  |    |  group by: 5: v1, 6: v2, 7: v3\n" +
+                "  |    |  \n" +
+                "  |    7:EXCHANGE\n");
+
+        assertCContains(plan, "  MultiCastDataSinks\n" +
+                "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 01\n" +
+                "    RANDOM\n" +
+                "  STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 04\n" +
+                "    RANDOM\n" +
+                "\n" +
+                "  0:OlapScanNode\n" +
+                "     TABLE: t0");
+    }
+
+    @Test
+    public void testMultiDistinctAggregationsWithPartition() throws Exception {
+
+        String sql = "select \n" +
+                "v1, v2, v3, \n" +
+                "count(distinct v3) over(partition by v1, v2) cnt,\n" +
+                "sum(distinct v3) over(partition by v1, v2) sum,\n" +
+                "avg(distinct v3) over(partition by v1, v2) avg\n" +
+                "from t0";
+
+        String plan = getFragmentPlan(sql);
+        assertCContains(plan, "  11:Project\n" +
+                "  |  <slot 1> : 1: v1\n" +
+                "  |  <slot 2> : 2: v2\n" +
+                "  |  <slot 3> : 3: v3\n" +
+                "  |  <slot 4> : 4: count(distinct 3: v3)\n" +
+                "  |  <slot 5> : 5: sum(distinct 3: v3)\n" +
+                "  |  <slot 6> : 6: avg(distinct 3: v3)\n" +
+                "  |  \n" +
+                "  10:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 7: v1 <=> 1: v1\n" +
+                "  |  equal join conjunct: 8: v2 <=> 2: v2");
+
+        assertCContains(plan, "  6:AGGREGATE (update finalize)\n" +
+                "  |  output: count(9: v3), sum(9: v3), avg(9: v3)\n" +
+                "  |  group by: 7: v1, 8: v2\n" +
+                "  |  \n" +
+                "  5:AGGREGATE (merge serialize)\n" +
+                "  |  group by: 7: v1, 8: v2, 9: v3");
+    }
+
+    @Test
+    public void testMultiDistinctAggregationsMixedWithOthersWithPartition() throws Exception {
+        String sql = "select \n" +
+                "v1, v2, v3, \n" +
+                "count(distinct v3) over(partition by v1, v2) cnt,\n" +
+                "sum(distinct v3) over(partition by v1, v2) sum,\n" +
+                "avg(distinct v3) over(partition by v1, v2) avg,\n" +
+                "count(v3) over(partition by v1, v2) cnt1,\n" +
+                "sum(v3) over(partition by v1, v2) sum1,\n" +
+                "avg(v3) over(partition by v1, v2) avg1,\n" +
+                "rank() over(partition by v1, v2) r\n" +
+                "from t0;";
+        String plan = getFragmentPlan(sql);
+        assertCContains(plan, "  13:ANALYTIC\n" +
+                "  |  functions: [, rank(), ]\n" +
+                "  |  partition by: 1: v1, 2: v2\n" +
+                "  |  \n" +
+                "  12:SORT\n" +
+                "  |  order by: <slot 1> 1: v1 ASC, <slot 2> 2: v2 ASC\n" +
+                "  |  analytic partition by: 1: v1, 2: v2\n" +
+                "  |  offset: 0\n" +
+                "  |  \n" +
+                "  11:Project\n" +
+                "  |  <slot 1> : 1: v1\n" +
+                "  |  <slot 2> : 2: v2\n" +
+                "  |  <slot 3> : 3: v3\n" +
+                "  |  <slot 4> : 4: count(distinct 3: v3)\n" +
+                "  |  <slot 5> : 5: sum(distinct 3: v3)\n" +
+                "  |  <slot 6> : 6: avg(distinct 3: v3)\n" +
+                "  |  <slot 7> : 7: count(3: v3)\n" +
+                "  |  <slot 8> : 8: sum(3: v3)\n" +
+                "  |  <slot 9> : 9: avg(3: v3)\n" +
+                "  |  \n" +
+                "  10:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 11: v1 <=> 1: v1\n" +
+                "  |  equal join conjunct: 12: v2 <=> 2: v2");
+        assertCContains(plan, "  6:AGGREGATE (update finalize)\n" +
+                "  |  output: count(13: v3), sum(13: v3), avg(13: v3), count(7: count(3: v3)), " +
+                "sum(8: sum(3: v3)), avg(9: avg(3: v3))\n" +
+                "  |  group by: 11: v1, 12: v2\n" +
+                "  |  \n" +
+                "  5:AGGREGATE (merge serialize)\n" +
+                "  |  output: count(7: count(3: v3)), sum(8: sum(3: v3)), avg(9: avg(3: v3))\n" +
+                "  |  group by: 11: v1, 12: v2, 13: v3");
+    }
+
+    @Test
+    public void testMultiDistinctAggregationsMixedWithOthersWithMultiPartition() throws Exception {
+        String sql = "select \n" +
+                "v1, v2, v3, \n" +
+                "count(distinct v3) over(partition by v1, v2) cnt,\n" +
+                "sum(distinct v2) over(partition by v1, v3) sum,\n" +
+                "avg(distinct v1) over(partition by v3, v2) avg,\n" +
+                "count(v1) over(partition by v2, v3) cnt1,\n" +
+                "sum(v2) over(partition by v3, v1) sum1,\n" +
+                "avg(v3) over(partition by v2, v1) avg1,\n" +
+                "rank() over(partition by v1, v2) r \n" +
+                "from t0;";
+        String plan = getFragmentPlan(sql);
+        long numJoins = Arrays.stream(plan.split("\n")).filter(ln -> ln.contains("HASH JOIN")).count();
+        Assertions.assertEquals(3, numJoins);
+        long numAnalytics = Arrays.stream(plan.split("\n")).filter(ln -> ln.contains("ANALYTIC")).count();
+        Assertions.assertEquals(1, numAnalytics);
+
+        assertCContains(plan, "  34:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 3: v3 <=> 22: v3\n" +
+                "  |  equal join conjunct: 2: v2 <=> 21: v2");
+
+        assertCContains(plan, "  23:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 <=> 14: v1\n" +
+                "  |  equal join conjunct: 3: v3 <=> 16: v3\n" +
+                "  |  \n" +
+                "  |----22:AGGREGATE (update finalize)\n" +
+                "  |    |  output: sum(15: v2), sum(8: sum(2: v2))\n" +
+                "  |    |  group by: 14: v1, 16: v3");
+        assertCContains(plan, "  10:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 11: v1 <=> 1: v1\n" +
+                "  |  equal join conjunct: 12: v2 <=> 2: v2\n" +
+                "  |  \n" +
+                "  |----9:EXCHANGE\n" +
+                "  |    \n" +
+                "  6:AGGREGATE (update finalize)\n" +
+                "  |  output: count(13: v3), avg(5: avg(3: v3))\n" +
+                "  |  group by: 11: v1, 12: v2");
+    }
+
+    @Test
+    public void testCountDistinctWithoutPartition() throws Exception {
+
+        String sql = "select v1,v2,v3,\n" +
+                "      count (distinct v3) \n" +
+                "      \tover()\n" +
+                "from t0;";
+
+        String plan = getFragmentPlan(sql);
+        assertCContains(plan, "  12:NESTLOOP JOIN\n" +
+                "  |  join op: CROSS JOIN");
+        assertCContains(plan, "  8:AGGREGATE (update serialize)\n" +
+                "  |  output: count(7: v3)\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  7:AGGREGATE (merge serialize)\n" +
+                "  |  group by: 7: v3");
+    }
+
+    @Test
+    public void testMultiDistinctAggregationsWithoutPartition() throws Exception {
+
+        String sql = "select \n" +
+                "v1, v2, v3, \n" +
+                "count(distinct v3) over() cnt,\n" +
+                "sum(distinct v3) over() sum,\n" +
+                "avg(distinct v3) over() avg\n" +
+                "from t0";
+
+        String plan = getFragmentPlan(sql);
+        assertCContains(plan, "  12:NESTLOOP JOIN\n" +
+                "  |  join op: CROSS JOIN");
+        assertCContains(plan, "  10:AGGREGATE (merge finalize)\n" +
+                "  |  output: count(4: count(distinct 3: v3)), " +
+                "sum(5: sum(distinct 3: v3)), " +
+                "avg(6: avg(distinct 3: v3))\n" +
+                "  |  group by: ");
+    }
+
+    @Test
+    public void testMultiDistinctAggregationsMixedWithOthersWithoutPartition() throws Exception {
+        String sql = "select \n" +
+                "v1, v2, v3, \n" +
+                "count(distinct v3) over() cnt,\n" +
+                "sum(distinct v3) over() sum,\n" +
+                "avg(distinct v3) over() avg,\n" +
+                "count(v3) over() cnt1,\n" +
+                "sum(v3) over() sum1,\n" +
+                "avg(v3) over() avg1,\n" +
+                "rank() over() r \n" +
+                "from t0";
+        String plan = getFragmentPlan(sql);
+        assertCContains(plan, "  13:ANALYTIC\n" +
+                "  |  functions: [, rank(), ]\n" +
+                "  |  \n" +
+                "  12:NESTLOOP JOIN\n" +
+                "  |  join op: CROSS JOIN\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  \n" +
+                "  |----11:EXCHANGE\n" +
+                "  |    \n" +
+                "  8:AGGREGATE (merge finalize)\n" +
+                "  |  output: count(4: count(distinct 3: v3)), sum(5: sum(distinct 3: v3)), " +
+                "avg(6: avg(distinct 3: v3)), count(7: count(3: v3)), sum(8: sum(3: v3)), avg(9: avg(3: v3))\n" +
+                "  |  group by: \n");
+    }
+
+    @Test
+    public void testCountDistinctWithCte() throws Exception {
+        String sql = "select v1, v2, v3, cnt\n" +
+                "from (select v1, v2, v3, count(distinct v3) over(partition by v1, v2) cnt\n" +
+                "from t0) t\n" +
+                "order by cnt\n" +
+                "limit 10;";
+        String plan = getFragmentPlan(sql);
+        assertCContains(plan, "  12:TOP-N\n" +
+                "  |  order by: <slot 4> 4: count(distinct 3: v3) ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  limit: 10\n" +
+                "  |  \n" +
+                "  11:Project\n" +
+                "  |  <slot 1> : 1: v1\n" +
+                "  |  <slot 2> : 2: v2\n" +
+                "  |  <slot 3> : 3: v3\n" +
+                "  |  <slot 4> : 4: count(distinct 3: v3)\n" +
+                "  |  \n" +
+                "  10:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 1: v1 <=> 5: v1\n" +
+                "  |  equal join conjunct: 2: v2 <=> 6: v2");
+    }
+
+    @Test
+    public void testDistinctAggAsSubquery() throws Exception {
+        String sql = "select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+" +
+                "murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(cnt,0))+murmur_hash3_32(ifnull(sum,0))+" +
+                "murmur_hash3_32(ifnull(avg,0)))) as fingerprint from (select\n" +
+                "v1,v2,v3,\n" +
+                "count(distinct v3) over(partition by v1,v2) cnt,\n" +
+                "sum(distinct v3) over(partition by v1,v2) sum,\n" +
+                "avg(distinct v3) over(partition by v1,v2) avg\n" +
+                "from t0) as t;";
+        String plan = getFragmentPlan(sql);
+        assertCContains(plan, "  12:AGGREGATE (update serialize)\n" +
+                "  |  output: sum(7: expr)\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  11:Project\n" +
+                "  |  <slot 7> : CAST(murmur_hash3_32(CAST(ifnull(1: v1, 0) AS VARCHAR)) AS BIGINT) + " +
+                "CAST(murmur_hash3_32(CAST(ifnull(2: v2, 0) AS VARCHAR)) AS BIGINT) + " +
+                "CAST(murmur_hash3_32(CAST(ifnull(3: v3, 0) AS VARCHAR)) AS BIGINT) + " +
+                "CAST(murmur_hash3_32(CAST(ifnull(4: count(distinct 3: v3), 0) AS VARCHAR)) AS BIGINT) + " +
+                "CAST(murmur_hash3_32(CAST(ifnull(5: sum(distinct 3: v3), 0) AS VARCHAR)) AS BIGINT) + " +
+                "CAST(murmur_hash3_32(CAST(ifnull(6: avg(distinct 3: v3), 0.0) AS VARCHAR)) AS BIGINT)\n" +
+                "  |  \n" +
+                "  10:HASH JOIN\n" +
+                "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 9: v1 <=> 1: v1\n" +
+                "  |  equal join conjunct: 10: v2 <=> 2: v2");
+    }
+}

--- a/test/sql/test_distinct_aggregation_over_window_without_sliding_frame/R/test_distinct_aggregation_over_window_without_sliding_frame
+++ b/test/sql/test_distinct_aggregation_over_window_without_sliding_frame/R/test_distinct_aggregation_over_window_without_sliding_frame
@@ -1,0 +1,97 @@
+-- name: test_distinct_aggregation_over_window_without_sliding_frame
+create table t0 (
+v1 int,
+v2 int,
+v3 int
+) properties("replication_num"="1");
+-- result:
+-- !result
+insert into t0 select i%13 as v1, i%17 as v2, i % 37 as v3 from table(generate_series(1,100000)) t(i);
+-- result:
+-- !result
+select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(cnt,0))+murmur_hash3_32(ifnull(sum,0))+murmur_hash3_32(ifnull(avg,0)))) as fingerprint from (select
+v1,v2,v3,
+count(distinct v3) over(partition by v1,v2) cnt,
+sum(distinct v3) over(partition by v1,v2) sum,
+avg(distinct v3) over(partition by v1,v2) avg
+from t0) as t;
+-- result:
+183166953401109
+-- !result
+select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(cnt,0))+murmur_hash3_32(ifnull(sum,0))+murmur_hash3_32(ifnull(avg,0)))) as fingerprint from (select
+v1,v2,v3,
+count(distinct v3) over() cnt,
+sum(distinct v3) over() sum,
+avg(distinct v3) over() avg
+from t0) as t;
+-- result:
+183166953401109
+-- !result
+select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(cnt,0))+murmur_hash3_32(ifnull(sum,0))+murmur_hash3_32(ifnull(avg,0))+murmur_hash3_32(ifnull(cnt1,0))+murmur_hash3_32(ifnull(sum1,0))+murmur_hash3_32(ifnull(avg1,0))+murmur_hash3_32(ifnull(r,0)))) as fingerprint from (select
+v1,v2,v3,
+count(distinct v3) over(partition by v1,v2) cnt,
+sum(distinct v3) over(partition by v1,v2) sum,
+avg(distinct v3) over(partition by v1,v2) avg,
+count(v3) over(partition by v1,v2) cnt1,
+sum(v3) over(partition by v1,v2) sum1,
+avg(v3) over(partition by v1,v2) avg1,
+rank() over(partition by v1,v2) r
+from t0) as t;
+-- result:
+-35895600093467
+-- !result
+select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(cnt,0))+murmur_hash3_32(ifnull(sum,0))+murmur_hash3_32(ifnull(avg,0))+murmur_hash3_32(ifnull(cnt1,0))+murmur_hash3_32(ifnull(sum1,0))+murmur_hash3_32(ifnull(avg1,0))+murmur_hash3_32(ifnull(r,0)))) as fingerprint from (select
+v1,v2,v3,
+count(distinct v3) over() cnt,
+sum(distinct v3) over() sum,
+avg(distinct v3) over() avg,
+count(v3) over() cnt1,
+sum(v3) over() sum1,
+avg(v3) over() avg1,
+rank() over() r
+from t0) as t;
+-- result:
+-239925849598891
+-- !result
+select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(cnt,0))+murmur_hash3_32(ifnull(sum,0))+murmur_hash3_32(ifnull(avg,0))+murmur_hash3_32(ifnull(cnt1,0))+murmur_hash3_32(ifnull(sum1,0))+murmur_hash3_32(ifnull(avg1,0))+murmur_hash3_32(ifnull(r,0)))) as fingerprint from (select
+v1,v2,v3,
+count(distinct v3) over(partition by v1,v2) cnt,
+sum(distinct v2) over(partition by v1,v3) sum,
+avg(distinct v1) over(partition by v3,v2) avg,
+count(v1) over(partition by v2,v3) cnt1,
+sum(v2) over(partition by v3,v1) sum1,
+avg(v3) over(partition by v2,v1) avg1,
+rank() over(partition by v1,v2) r
+from t0) as t;
+-- result:
+95237749130791
+-- !result
+with cte1 as(
+select
+v1, v2,
+count(distinct v3) over(partition by v1, v2) cnt,
+sum(distinct v3) over(partition by v1, v2) sum,
+avg(distinct v3) over(partition by v1, v2) avg
+from t0
+),
+cte2 as (
+select distinct v1, v2, cnt, sum,avg
+from cte1
+),
+cte3 as (
+select sum(murmur_hash3_32(v1,v2,cnt,sum,avg)) fp
+from cte2
+),
+cte4 as (
+select v1, v2, count(distinct v3) cnt, sum(distinct v3) sum, avg(distinct v3) avg
+from t0
+group by v1,v2
+),
+cte5 as (
+select sum(murmur_hash3_32(v1,v2,cnt,sum,avg)) fp
+from cte4
+)
+select assert_true(a.fp = b.fp) from cte5 a,cte3 b;
+-- result:
+1
+-- !result

--- a/test/sql/test_distinct_aggregation_over_window_without_sliding_frame/T/test_distinct_aggregation_over_window_without_sliding_frame
+++ b/test/sql/test_distinct_aggregation_over_window_without_sliding_frame/T/test_distinct_aggregation_over_window_without_sliding_frame
@@ -1,0 +1,75 @@
+-- name: test_distinct_aggregation_over_window_without_sliding_frame
+create table t0 (
+v1 int,
+v2 int,
+v3 int
+) properties("replication_num"="1");
+insert into t0 select i%13 as v1, i%17 as v2, i % 37 as v3 from table(generate_series(1,100000)) t(i);
+select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(cnt,0))+murmur_hash3_32(ifnull(sum,0))+murmur_hash3_32(ifnull(avg,0)))) as fingerprint from (select
+v1,v2,v3,
+count(distinct v3) over(partition by v1,v2) cnt,
+sum(distinct v3) over(partition by v1,v2) sum,
+avg(distinct v3) over(partition by v1,v2) avg
+from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(cnt,0))+murmur_hash3_32(ifnull(sum,0))+murmur_hash3_32(ifnull(avg,0)))) as fingerprint from (select
+v1,v2,v3,
+count(distinct v3) over() cnt,
+sum(distinct v3) over() sum,
+avg(distinct v3) over() avg
+from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(cnt,0))+murmur_hash3_32(ifnull(sum,0))+murmur_hash3_32(ifnull(avg,0))+murmur_hash3_32(ifnull(cnt1,0))+murmur_hash3_32(ifnull(sum1,0))+murmur_hash3_32(ifnull(avg1,0))+murmur_hash3_32(ifnull(r,0)))) as fingerprint from (select
+v1,v2,v3,
+count(distinct v3) over(partition by v1,v2) cnt,
+sum(distinct v3) over(partition by v1,v2) sum,
+avg(distinct v3) over(partition by v1,v2) avg,
+count(v3) over(partition by v1,v2) cnt1,
+sum(v3) over(partition by v1,v2) sum1,
+avg(v3) over(partition by v1,v2) avg1,
+rank() over(partition by v1,v2) r
+from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(cnt,0))+murmur_hash3_32(ifnull(sum,0))+murmur_hash3_32(ifnull(avg,0))+murmur_hash3_32(ifnull(cnt1,0))+murmur_hash3_32(ifnull(sum1,0))+murmur_hash3_32(ifnull(avg1,0))+murmur_hash3_32(ifnull(r,0)))) as fingerprint from (select
+v1,v2,v3,
+count(distinct v3) over() cnt,
+sum(distinct v3) over() sum,
+avg(distinct v3) over() avg,
+count(v3) over() cnt1,
+sum(v3) over() sum1,
+avg(v3) over() avg1,
+rank() over() r
+from t0) as t;
+select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(cnt,0))+murmur_hash3_32(ifnull(sum,0))+murmur_hash3_32(ifnull(avg,0))+murmur_hash3_32(ifnull(cnt1,0))+murmur_hash3_32(ifnull(sum1,0))+murmur_hash3_32(ifnull(avg1,0))+murmur_hash3_32(ifnull(r,0)))) as fingerprint from (select
+v1,v2,v3,
+count(distinct v3) over(partition by v1,v2) cnt,
+sum(distinct v2) over(partition by v1,v3) sum,
+avg(distinct v1) over(partition by v3,v2) avg,
+count(v1) over(partition by v2,v3) cnt1,
+sum(v2) over(partition by v3,v1) sum1,
+avg(v3) over(partition by v2,v1) avg1,
+rank() over(partition by v1,v2) r
+from t0) as t;
+with cte1 as(
+select
+v1, v2,
+count(distinct v3) over(partition by v1, v2) cnt,
+sum(distinct v3) over(partition by v1, v2) sum,
+avg(distinct v3) over(partition by v1, v2) avg
+from t0
+),
+cte2 as (
+select distinct v1, v2, cnt, sum,avg
+from cte1
+),
+cte3 as (
+select sum(murmur_hash3_32(v1,v2,cnt,sum,avg)) fp
+from cte2
+),
+cte4 as (
+select v1, v2, count(distinct v3) cnt, sum(distinct v3) sum, avg(distinct v3) avg
+from t0
+group by v1,v2
+),
+cte5 as (
+select sum(murmur_hash3_32(v1,v2,cnt,sum,avg)) fp
+from cte4
+)
+select assert_true(a.fp = b.fp) from cte5 a,cte3 b;


### PR DESCRIPTION
## Why I'm doing:
Rewrite count(distinct) over window without sliding frames into null-safe-equal join + aggregation
for an exmaple:

```sql
select v1,v2,v3,count(distinct v3) over(partition by v1,v2)
from t;
```

can be rewritten into 
```sql
with cte as(
select v1, v2, count(distinct v3) cd
from t0
group by v1,v2
)
select t0.v1, t0.v2, t0.v3, cte.cd
from t0 inner join cte on t0.v1 <=> cte.v1 and t0.v2 <=> cte.v2;
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
