### PR TITLE
[BugFix] fix comment typo of ColumnExprPredicate

### DIFF
--- a/be/src/storage/column_expr_predicate.h
+++ b/be/src/storage/column_expr_predicate.h
@@ -19,7 +19,7 @@ namespace starrocks {
 
 class Column;
 
-// This class is a bridge to connect ColumnPredicatew which is used in scan/storage layer, and ExprContext which is
+// This class is a bridge to connect ColumnPredicate which is used in scan/storage layer, and ExprContext which is
 // used in computation layer. By bridging that, we can push more predicates from computation layer onto storage layer,
 // hopefully to scan less data and boost performance.
 


### PR DESCRIPTION
## Why I'm doing:
This pull request makes a minor correction to a comment in the `column_expr_predicate.h` file, fixing a typo in the class description. No functional code changes were made.

## What I'm doing:
* Fixed a typo in the class comment, correcting "ColumnPredicatew" to "ColumnPredicate" to improve documentation clarity.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
