### PR TITLE
[BugFix] Avoid merging two-phase non-group-by aggregation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneAggregateNodeRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneAggregateNodeRule.java
@@ -127,6 +127,13 @@ public class PruneAggregateNodeRule implements TreeRewriteRule {
                 return null;
             }
 
+            // Do not merge the two-phase non-group-by aggregation into a single phase. For non-group-by aggregation, a blocking
+            // aggregation can only be computed by a single `AggregationOperator`, whereas a streaming aggregation can be computed
+            // by multiple `AggregationOperator`s.
+            if (globalAgg.getGroupBys().isEmpty()) {
+                return null;
+            }
+
             Map<ColumnRefOperator, CallOperator> newAggregationMap = Maps.newHashMap();
             for (Map.Entry<ColumnRefOperator, CallOperator> entry : globalAgg.getAggregations().entrySet()) {
                 ColumnRefOperator globalColumn = entry.getKey();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -3213,4 +3213,17 @@ public class AggregateTest extends PlanTestBase {
             FeConstants.runningUnitTest = false;
         }
     }
+
+    @Test
+    public void testAvoidMergeNonGroupByAgg() throws Exception {
+        String plan = getFragmentPlan("SELECT /*+SET_VAR(disable_join_reorder=true)*/ COUNT(*) " +
+                "FROM t0 RIGHT JOIN t1 ON v1 < v4");
+        assertContains(plan, "  7:AGGREGATE (merge finalize)\n" +
+                "  |  output: count(7: count)\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  6:AGGREGATE (update serialize)\n" +
+                "  |  output: count(*)\n" +
+                "  |  group by: ");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

Do not merge the two-phase non-group-by aggregation into a single phase. For non-group-by aggregation, a blocking aggregation can only be computed by a single `AggregationOperator`, whereas a streaming aggregation can be computed by multiple `AggregationOperator`s.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
