### PR TITLE
[Refactor] Update type creation methods to use the new Type class for improved consistency

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -1142,7 +1142,7 @@ public class FunctionSet {
                 Lists.newArrayList(Type.ANY_ELEMENT), Type.VARCHAR, Type.ANY_STRUCT, true,
                 false, false, false));
 
-        for (Type t : Type.getSupportedTypes()) {
+        for (Type t : Type.SUPPORTED_TYPES) {
             if (t.isFunctionType()) {
                 continue;
             }
@@ -1173,7 +1173,7 @@ public class FunctionSet {
                     Lists.newArrayList(t), t, t, true, true, false));
 
             // MAX_BY
-            for (Type t1 : Type.getSupportedTypes()) {
+            for (Type t1 : Type.SUPPORTED_TYPES) {
                 if (t1.isFunctionType() || t1.isNull() || t1.isChar()) {
                     continue;
                 }
@@ -1182,7 +1182,7 @@ public class FunctionSet {
             }
 
             // MIN_BY
-            for (Type t1 : Type.getSupportedTypes()) {
+            for (Type t1 : Type.SUPPORTED_TYPES) {
                 if (t1.isFunctionType() || t1.isNull() || t1.isChar()) {
                     continue;
                 }
@@ -1420,7 +1420,7 @@ public class FunctionSet {
             addBuiltin(AggregateFunction.createAnalyticBuiltin(
                     LEAD, Lists.newArrayList(t, Type.BIGINT), t, t));
         };
-        for (Type t : Type.getSupportedTypes()) {
+        for (Type t : Type.SUPPORTED_TYPES) {
             // null/char/time is handled through type promotion
             // TODO: array/json/pseudo is not supported yet
             if (!t.canBeWindowFunctionArgumentTypes()) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionKey.java
@@ -52,6 +52,7 @@ import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.common.TypeManager;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -103,7 +104,7 @@ public class PartitionKey implements Comparable<PartitionKey>, Writable {
             throws AnalysisException {
         PartitionKey partitionKey = new PartitionKey();
         for (Column column : columns) {
-            partitionKey.keys.add(LiteralExpr.createInfinity(Type.fromPrimitiveType(column.getPrimitiveType()), isMax));
+            partitionKey.keys.add(LiteralExpr.createInfinity(TypeFactory.createType(column.getPrimitiveType()), isMax));
             partitionKey.types.add(column.getPrimitiveType());
         }
         return partitionKey;
@@ -113,7 +114,7 @@ public class PartitionKey implements Comparable<PartitionKey>, Writable {
             throws AnalysisException {
         PartitionKey partitionKey = new PartitionKey();
         for (PrimitiveType type : types) {
-            partitionKey.keys.add(LiteralExpr.createInfinity(Type.fromPrimitiveType(type), isMax));
+            partitionKey.keys.add(LiteralExpr.createInfinity(TypeFactory.createType(type), isMax));
             partitionKey.types.add(type);
         }
         return partitionKey;
@@ -148,13 +149,13 @@ public class PartitionKey implements Comparable<PartitionKey>, Writable {
         int i;
         for (i = 0; i < keys.size(); ++i) {
             partitionKey.keys.add(keys.get(i).getValue(
-                    Type.fromPrimitiveType(columns.get(i).getPrimitiveType())));
+                    TypeFactory.createType(columns.get(i).getPrimitiveType())));
             partitionKey.types.add(columns.get(i).getPrimitiveType());
         }
 
         // fill the vacancy with MIN
         for (; i < columns.size(); ++i) {
-            Type type = Type.fromPrimitiveType(columns.get(i).getPrimitiveType());
+            Type type = TypeFactory.createType(columns.get(i).getPrimitiveType());
             partitionKey.keys.add(LiteralExpr.createInfinity(type, false));
             partitionKey.types.add(columns.get(i).getPrimitiveType());
         }
@@ -276,7 +277,7 @@ public class PartitionKey implements Comparable<PartitionKey>, Writable {
                 final long minValue = -(1L << ((type.getSlotSize() << 3) - 1));
                 long pred = intLiteral.getValue();
                 pred -= pred > minValue ? 1L : 0L;
-                key.pushColumn(new IntLiteral(pred, Type.fromPrimitiveType(type)), type);
+                key.pushColumn(new IntLiteral(pred, TypeFactory.createType(type)), type);
                 return key;
             }
             case LARGEINT: {
@@ -347,7 +348,7 @@ public class PartitionKey implements Comparable<PartitionKey>, Writable {
                 final long maxValue = (1L << ((type.getSlotSize() << 3) - 1)) - 1L;
                 long succ = intLiteral.getValue();
                 succ += succ < maxValue ? 1L : 0L;
-                key.pushColumn(new IntLiteral(succ, Type.fromPrimitiveType(type)), type);
+                key.pushColumn(new IntLiteral(succ, TypeFactory.createType(type)), type);
                 return key;
             }
             case LARGEINT: {
@@ -471,9 +472,9 @@ public class PartitionKey implements Comparable<PartitionKey>, Writable {
         List<PrimitiveType> typeList = Lists.newArrayList();
         for (int index = 0; index < typeArray.length; ++index) {
             PrimitiveType type = PrimitiveType.valueOf(typeArray[index].toUpperCase());
-            LiteralExpr expr = NullLiteral.create(Type.fromPrimitiveType(type));
+            LiteralExpr expr = NullLiteral.create(TypeFactory.createType(type));
             try {
-                expr = LiteralExpr.create(keyArray[index], Type.fromPrimitiveType(type));
+                expr = LiteralExpr.create(keyArray[index], TypeFactory.createType(type));
             } catch (AnalysisException ignored) {
             }
             typeList.add(type);
@@ -550,7 +551,7 @@ public class PartitionKey implements Comparable<PartitionKey>, Writable {
                         throw new IOException("type[" + type.name() + "] not supported: ");
                 }
             }
-            literal.setType(Type.fromPrimitiveType(type));
+            literal.setType(TypeFactory.createType(type));
             keys.add(literal);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergFilesTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergFilesTable.java
@@ -25,6 +25,7 @@ import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
 import com.starrocks.type.MapType;
 import com.starrocks.type.PrimitiveType;
+import com.starrocks.type.Type;
 
 import java.util.List;
 
@@ -32,7 +33,6 @@ import static com.starrocks.connector.metadata.TableMetaMetadata.METADATA_DB_NAM
 import static com.starrocks.type.Type.ARRAY_BIGINT;
 import static com.starrocks.type.Type.ARRAY_INT;
 import static com.starrocks.type.TypeFactory.createType;
-import static com.starrocks.type.TypeFactory.createVarcharType;
 
 public class IcebergFilesTable extends MetadataTable {
     public static final String TABLE_NAME = "iceberg_files_table";
@@ -50,8 +50,8 @@ public class IcebergFilesTable extends MetadataTable {
                 Table.TableType.METADATA,
                 builder()
                         .column("content", createType(PrimitiveType.INT))
-                        .column("file_path", createVarcharType())
-                        .column("file_format", createVarcharType())
+                        .column("file_path", Type.VARCHAR)
+                        .column("file_format", Type.VARCHAR)
                         .column("spec_id", createType(PrimitiveType.INT))
                         .column("record_count", createType(PrimitiveType.BIGINT))
                         .column("file_size_in_bytes", createType(PrimitiveType.BIGINT))
@@ -60,8 +60,8 @@ public class IcebergFilesTable extends MetadataTable {
                         .column("null_value_counts", new MapType(
                                 createType(PrimitiveType.INT), createType(PrimitiveType.BIGINT)))
                         .column("nan_value_counts", new MapType(createType(PrimitiveType.INT), createType(PrimitiveType.BIGINT)))
-                        .column("lower_bounds", new MapType(createType(PrimitiveType.INT), createVarcharType()))
-                        .column("upper_bounds", new MapType(createType(PrimitiveType.INT), createVarcharType()))
+                        .column("lower_bounds", new MapType(createType(PrimitiveType.INT), Type.VARCHAR))
+                        .column("upper_bounds", new MapType(createType(PrimitiveType.INT), Type.VARCHAR))
                         .column("split_offsets", ARRAY_BIGINT)
                         .column("sort_id", createType(PrimitiveType.INT))
                         .column("equality_ids", ARRAY_INT)

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergMetadataLogEntriesTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergMetadataLogEntriesTable.java
@@ -24,6 +24,7 @@ import com.starrocks.thrift.THdfsTable;
 import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
 import com.starrocks.type.PrimitiveType;
+import com.starrocks.type.Type;
 import com.starrocks.type.TypeFactory;
 
 import java.util.List;
@@ -46,7 +47,7 @@ public class IcebergMetadataLogEntriesTable extends MetadataTable {
                 Table.TableType.METADATA,
                 builder()
                         .column("timestamp", TypeFactory.createType(PrimitiveType.DATETIME))
-                        .column("file", TypeFactory.createVarcharType())
+                        .column("file", Type.VARCHAR)
                         .column("latest_snapshot_id", TypeFactory.createType(PrimitiveType.BIGINT))
                         .column("latest_schema_id", TypeFactory.createType(PrimitiveType.INT))
                         .column("latest_sequence_number", TypeFactory.createType(PrimitiveType.BIGINT))

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergRefsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/IcebergRefsTable.java
@@ -24,6 +24,7 @@ import com.starrocks.thrift.THdfsTable;
 import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
 import com.starrocks.type.PrimitiveType;
+import com.starrocks.type.Type;
 import com.starrocks.type.TypeFactory;
 
 import java.util.List;
@@ -44,8 +45,8 @@ public class IcebergRefsTable extends MetadataTable {
                 TABLE_NAME,
                 Table.TableType.METADATA,
                 builder()
-                        .column("name", TypeFactory.createVarcharType())
-                        .column("type", TypeFactory.createVarcharType())
+                        .column("name", Type.VARCHAR)
+                        .column("type", Type.VARCHAR)
                         .column("snapshot_id", TypeFactory.createType(PrimitiveType.BIGINT))
                         .column("max_reference_age_in_ms", TypeFactory.createType(PrimitiveType.BIGINT))
                         .column("min_snapshots_to_keep", TypeFactory.createType(PrimitiveType.INT))

--- a/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/LogicalIcebergMetadataTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/metadata/iceberg/LogicalIcebergMetadataTable.java
@@ -24,6 +24,7 @@ import com.starrocks.thrift.THdfsTable;
 import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
 import com.starrocks.type.PrimitiveType;
+import com.starrocks.type.Type;
 import com.starrocks.type.TypeFactory;
 
 import java.util.List;
@@ -50,8 +51,8 @@ public class LogicalIcebergMetadataTable extends MetadataTable {
                 builder()
                         .columns(PLACEHOLDER_COLUMNS)
                         .column("content", TypeFactory.createType(PrimitiveType.INT))
-                        .column("file_path", TypeFactory.createVarcharType())
-                        .column("file_format", TypeFactory.createVarcharType())
+                        .column("file_path", Type.VARCHAR)
+                        .column("file_format", Type.VARCHAR)
                         .column("spec_id", TypeFactory.createType(PrimitiveType.INT))
                         .column("partition_data", TypeFactory.createType(PrimitiveType.VARBINARY))
                         .column("record_count", TypeFactory.createType(PrimitiveType.BIGINT))

--- a/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheSelectMetrics.java
@@ -23,7 +23,7 @@ import com.starrocks.qe.ShowResultSetMetaData;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
-import com.starrocks.type.TypeFactory;
+import com.starrocks.type.Type;
 
 import java.util.HashMap;
 import java.util.List;
@@ -32,19 +32,19 @@ import java.util.concurrent.TimeUnit;
 
 public class DataCacheSelectMetrics {
     private static final ShowResultSetMetaData SIMPLE_META_DATA = ShowResultSetMetaData.builder()
-            .addColumn(new Column("AVG_READ_CACHE_SIZE", TypeFactory.createVarcharType()))
-            .addColumn(new Column("AVG_WRITE_CACHE_SIZE", TypeFactory.createVarcharType()))
-            .addColumn(new Column("AVG_WRITE_CACHE_TIME", TypeFactory.createVarcharType()))
-            .addColumn(new Column("TOTAL_CACHE_USAGE", TypeFactory.createVarcharType()))
+            .addColumn(new Column("AVG_READ_CACHE_SIZE", Type.VARCHAR))
+            .addColumn(new Column("AVG_WRITE_CACHE_SIZE", Type.VARCHAR))
+            .addColumn(new Column("AVG_WRITE_CACHE_TIME", Type.VARCHAR))
+            .addColumn(new Column("TOTAL_CACHE_USAGE", Type.VARCHAR))
             .build();
 
     private static final ShowResultSetMetaData VERBOSE_META_DATA = ShowResultSetMetaData.builder()
-            .addColumn(new Column("IP", TypeFactory.createVarcharType()))
-            .addColumn(new Column("READ_CACHE_SIZE", TypeFactory.createVarcharType()))
-            .addColumn(new Column("AVG_READ_CACHE_TIME", TypeFactory.createVarcharType()))
-            .addColumn(new Column("WRITE_CACHE_SIZE", TypeFactory.createVarcharType()))
-            .addColumn(new Column("AVG_WRITE_CACHE_TIME", TypeFactory.createVarcharType()))
-            .addColumn(new Column("TOTAL_CACHE_USAGE", TypeFactory.createVarcharType()))
+            .addColumn(new Column("IP", Type.VARCHAR))
+            .addColumn(new Column("READ_CACHE_SIZE", Type.VARCHAR))
+            .addColumn(new Column("AVG_READ_CACHE_TIME", Type.VARCHAR))
+            .addColumn(new Column("WRITE_CACHE_SIZE", Type.VARCHAR))
+            .addColumn(new Column("AVG_WRITE_CACHE_TIME", Type.VARCHAR))
+            .addColumn(new Column("TOTAL_CACHE_USAGE", Type.VARCHAR))
             .build();
 
     private final Map<Long, LoadDataCacheMetrics> beMetrics = new HashMap<>();

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlCodec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlCodec.java
@@ -224,7 +224,7 @@ public class MysqlCodec {
         // Flags: two byte integer
         writeInt2(out, 0);
         // Decimals: one byte integer
-        writeInt1(out, type.getMysqlResultSetFieldDecimals());
+        writeInt1(out, getMysqlResultSetFieldDecimals(type));
         // filler: two byte integer
         writeInt2(out, 0);
 
@@ -360,6 +360,33 @@ public class MysqlCodec {
                 case CHAR, VARCHAR, HLL, BITMAP, LARGEINT, JSON -> CHARSET_UTF8;
                 default -> CHARSET_BINARY;
             };
+        }
+    }
+
+    /**
+     * @return scalar scale if type is decimal
+     * 31 if type is float or double
+     * 0 others
+     * <p>
+     * https://dev.mysql.com/doc/internals/en/com-query-response.html#column-definition
+     * decimals (1) -- max shown decimal digits
+     * 0x00 for integers and static strings
+     * 0x1f for dynamic strings, double, float
+     * 0x00 to 0x51 for decimals
+     */
+    public static int getMysqlResultSetFieldDecimals(Type type) {
+        switch (type.getPrimitiveType()) {
+            case DECIMALV2:
+            case DECIMAL32:
+            case DECIMAL64:
+            case DECIMAL128:
+            case DECIMAL256:
+                return ((ScalarType) type).getScalarScale();
+            case FLOAT:
+            case DOUBLE:
+                return 31;
+            default:
+                return 0;
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RangePartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RangePartitionPruner.java
@@ -49,6 +49,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.ast.expression.NullLiteral;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -92,9 +93,9 @@ public class RangePartitionPruner implements PartitionPruner {
         Column keyColumn = partitionColumns.get(columnIdx);
         PartitionColumnFilter filter = partitionColumnFilters.get(keyColumn.getName());
         if (null == filter) {
-            minKey.pushColumn(LiteralExpr.createInfinity(Type.fromPrimitiveType(keyColumn.getPrimitiveType()), false),
+            minKey.pushColumn(LiteralExpr.createInfinity(TypeFactory.createType(keyColumn.getPrimitiveType()), false),
                     keyColumn.getPrimitiveType());
-            maxKey.pushColumn(LiteralExpr.createInfinity(Type.fromPrimitiveType(keyColumn.getPrimitiveType()), true),
+            maxKey.pushColumn(LiteralExpr.createInfinity(TypeFactory.createType(keyColumn.getPrimitiveType()), true),
                     keyColumn.getPrimitiveType());
             List<Long> result;
             try {
@@ -126,7 +127,7 @@ public class RangePartitionPruner implements PartitionPruner {
                 if (lowerBound instanceof NullLiteral && upperBound instanceof NullLiteral) {
                     // replace Null with min value
                     LiteralExpr minKeyValue = LiteralExpr.createInfinity(
-                            Type.fromPrimitiveType(keyColumn.getPrimitiveType()), false);
+                            TypeFactory.createType(keyColumn.getPrimitiveType()), false);
                     minKey.pushColumn(minKeyValue, keyColumn.getPrimitiveType());
                     maxKey.pushColumn(minKeyValue, keyColumn.getPrimitiveType());
                 } else {
@@ -152,12 +153,12 @@ public class RangePartitionPruner implements PartitionPruner {
                 pushMinCount++;
                 if (filter.lowerBoundInclusive && columnIdx != lastColumnId) {
                     Column column = partitionColumns.get(columnIdx + 1);
-                    Type type = Type.fromPrimitiveType(column.getPrimitiveType());
+                    Type type = TypeFactory.createType(column.getPrimitiveType());
                     minKey.pushColumn(LiteralExpr.createInfinity(type, false), column.getPrimitiveType());
                     pushMinCount++;
                 }
             } else {
-                Type type = Type.fromPrimitiveType(keyColumn.getPrimitiveType());
+                Type type = TypeFactory.createType(keyColumn.getPrimitiveType());
                 minKey.pushColumn(LiteralExpr.createInfinity(type, false), keyColumn.getPrimitiveType());
                 pushMinCount++;
             }
@@ -167,13 +168,13 @@ public class RangePartitionPruner implements PartitionPruner {
                 if (filter.upperBoundInclusive && columnIdx != lastColumnId) {
                     Column column = partitionColumns.get(columnIdx + 1);
                     maxKey.pushColumn(
-                            LiteralExpr.createInfinity(Type.fromPrimitiveType(column.getPrimitiveType()), true),
+                            LiteralExpr.createInfinity(TypeFactory.createType(column.getPrimitiveType()), true),
                             column.getPrimitiveType());
                     pushMaxCount++;
                 }
             } else {
                 maxKey.pushColumn(
-                        LiteralExpr.createInfinity(Type.fromPrimitiveType(keyColumn.getPrimitiveType()), true),
+                        LiteralExpr.createInfinity(TypeFactory.createType(keyColumn.getPrimitiveType()), true),
                         keyColumn.getPrimitiveType());
                 pushMaxCount++;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/TypeDef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/TypeDef.java
@@ -181,7 +181,7 @@ public class TypeDef implements ParseNode {
     }
 
     private void analyzeArrayType(ArrayType type) {
-        Type baseType = Type.getInnermostType(type);
+        Type baseType = getInnermostType(type);
         if (baseType == null) {
             throw new SemanticException("Cannot get innermost type of '" + type + "'");
         }
@@ -189,6 +189,18 @@ public class TypeDef implements ParseNode {
         if (baseType.isHllType() || baseType.isBitmapType() || baseType.isPseudoType() || baseType.isPercentile()) {
             throw new SemanticException("Invalid data type: " + type.toSql());
         }
+    }
+
+    // getInnermostType() is only used for array
+    private static Type getInnermostType(Type type) {
+        if (type.isScalarType() || type.isStructType() || type.isMapType()) {
+            return type;
+        }
+        if (type.isArrayType()) {
+            return getInnermostType(((ArrayType) type).getItemType());
+        }
+
+        return null;
     }
 
     private void analyzeStructType(StructType type) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
@@ -192,8 +192,8 @@ public class TypeManager {
         }
 
 
-        PrimitiveType t1ResultType = t1.getResultType().getPrimitiveType();
-        PrimitiveType t2ResultType = t2.getResultType().getPrimitiveType();
+        PrimitiveType t1ResultType = getResultType(t1).getPrimitiveType();
+        PrimitiveType t2ResultType = getResultType(t2).getPrimitiveType();
         // Following logical is compatible with MySQL.
         if ((t1ResultType == PrimitiveType.VARCHAR && t2ResultType == PrimitiveType.VARCHAR)) {
             return Type.VARCHAR;
@@ -215,6 +215,19 @@ public class TypeManager {
             return Type.LARGEINT;
         }
         return Type.DOUBLE;
+    }
+
+    private static Type getResultType(Type type) {
+        return switch (type.getPrimitiveType()) {
+            case BOOLEAN, TINYINT, SMALLINT, INT, BIGINT -> Type.BIGINT;
+            case LARGEINT -> Type.LARGEINT;
+            case FLOAT, DOUBLE -> Type.DOUBLE;
+            case DATE, DATETIME, TIME, CHAR, VARCHAR, HLL, BITMAP, PERCENTILE, JSON -> Type.VARCHAR;
+            case DECIMALV2 -> Type.DECIMALV2;
+            case DECIMAL32, DECIMAL64, DECIMAL128, DECIMAL256 -> type;
+            case FUNCTION -> Type.FUNCTION;
+            default -> Type.INVALID;
+        };
     }
 
     public static Type getCompatibleTypeForBinary(boolean isRangeCompare, Type type1, Type type2) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -9461,7 +9461,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
                 }
                 return TypeFactory.createDecimalV2Type(precision);
             }
-            return TypeFactory.createDecimalV2Type();
+            return Type.DEFAULT_DECIMALV2;
         } else {
             throw new IllegalArgumentException("Unsupported type " + context.getText());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/type/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/type/Type.java
@@ -40,7 +40,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.starrocks.catalog.combinator.AggStateDesc;
 
-import java.util.List;
 import java.util.stream.Collectors;
 
 /**
@@ -189,7 +188,7 @@ public abstract class Type implements Cloneable {
                     .addAll(DECIMAL_TYPES)
                     .build();
 
-    protected static final ImmutableList<Type> SUPPORTED_TYPES =
+    public static final ImmutableList<Type> SUPPORTED_TYPES =
             ImmutableList.<Type>builder()
                     .add(NULL)
                     .addAll(INTEGER_TYPES)
@@ -233,8 +232,6 @@ public abstract class Type implements Cloneable {
                             .collect(Collectors.toMap(Type::getPrimitiveType, x -> (ScalarType) x)))
                     .put(INVALID.getPrimitiveType(), INVALID)
                     .build();
-
-    // Removed getIntegerTypes() and getNumericTypes(); use INTEGER_TYPES and NUMERIC_TYPES directly.
 
     /**
      * The output of this is stored directly in the hive metastore as the column type.
@@ -370,66 +367,6 @@ public abstract class Type implements Cloneable {
 
     public boolean isValidMapKeyType() {
         return !isComplexType() && !isJsonType() && !isOnlyMetricType() && !isFunctionType();
-    }
-
-    public static List<Type> getSupportedTypes() {
-        return SUPPORTED_TYPES;
-    }
-
-    // TODO(dhc): fix this
-    public static Type fromPrimitiveType(PrimitiveType type) {
-        switch (type) {
-            case BOOLEAN:
-                return Type.BOOLEAN;
-            case TINYINT:
-                return Type.TINYINT;
-            case SMALLINT:
-                return Type.SMALLINT;
-            case INT:
-                return Type.INT;
-            case BIGINT:
-                return Type.BIGINT;
-            case LARGEINT:
-                return Type.LARGEINT;
-            case FLOAT:
-                return Type.FLOAT;
-            case DOUBLE:
-                return Type.DOUBLE;
-            case DATE:
-                return Type.DATE;
-            case DATETIME:
-                return Type.DATETIME;
-            case TIME:
-                return Type.TIME;
-            case DECIMALV2:
-                return Type.DECIMALV2;
-            case CHAR:
-                return Type.CHAR;
-            case VARCHAR:
-                return Type.VARCHAR;
-            case HLL:
-                return Type.HLL;
-            case BITMAP:
-                return Type.BITMAP;
-            case PERCENTILE:
-                return Type.PERCENTILE;
-            case DECIMAL32:
-                return Type.DECIMAL32;
-            case DECIMAL64:
-                return Type.DECIMAL64;
-            case DECIMAL128:
-                return Type.DECIMAL128;
-            case DECIMAL256:
-                return Type.DECIMAL256;
-            case JSON:
-                return Type.JSON;
-            case FUNCTION:
-                return Type.FUNCTION;
-            case VARBINARY:
-                return Type.VARBINARY;
-            default:
-                return null;
-        }
     }
 
     public boolean canApplyToNumeric() {
@@ -867,44 +804,6 @@ public abstract class Type implements Cloneable {
         }
     }
 
-    public Type getResultType() {
-        switch (this.getPrimitiveType()) {
-            case BOOLEAN:
-            case TINYINT:
-            case SMALLINT:
-            case INT:
-            case BIGINT:
-                return BIGINT;
-            case LARGEINT:
-                return LARGEINT;
-            case FLOAT:
-            case DOUBLE:
-                return DOUBLE;
-            case DATE:
-            case DATETIME:
-            case TIME:
-            case CHAR:
-            case VARCHAR:
-            case HLL:
-            case BITMAP:
-            case PERCENTILE:
-            case JSON:
-                return VARCHAR;
-            case DECIMALV2:
-                return DECIMALV2;
-            case DECIMAL32:
-            case DECIMAL64:
-            case DECIMAL128:
-            case DECIMAL256:
-                return this;
-            case FUNCTION:
-                return FUNCTION;
-            default:
-                return INVALID;
-
-        }
-    }
-
     public Type getNumResultType() {
         switch (getPrimitiveType()) {
             case BOOLEAN:
@@ -947,33 +846,6 @@ public abstract class Type implements Cloneable {
         }
     }
 
-    /**
-     * @return scalar scale if type is decimal
-     * 31 if type is float or double
-     * 0 others
-     * <p>
-     * https://dev.mysql.com/doc/internals/en/com-query-response.html#column-definition
-     * decimals (1) -- max shown decimal digits
-     * 0x00 for integers and static strings
-     * 0x1f for dynamic strings, double, float
-     * 0x00 to 0x51 for decimals
-     */
-    public int getMysqlResultSetFieldDecimals() {
-        switch (this.getPrimitiveType()) {
-            case DECIMALV2:
-            case DECIMAL32:
-            case DECIMAL64:
-            case DECIMAL128:
-            case DECIMAL256:
-                return ((ScalarType) this).getScalarScale();
-            case FLOAT:
-            case DOUBLE:
-                return 31;
-            default:
-                return 0;
-        }
-    }
-
     @Override
     public Type clone() {
         try {
@@ -985,18 +857,6 @@ public abstract class Type implements Cloneable {
         } catch (CloneNotSupportedException ex) {
             throw new Error("Something impossible just happened", ex);
         }
-    }
-
-    // getInnermostType() is only used for array
-    public static Type getInnermostType(Type type) {
-        if (type.isScalarType() || type.isStructType() || type.isMapType()) {
-            return type;
-        }
-        if (type.isArrayType()) {
-            return getInnermostType(((ArrayType) type).getItemType());
-        }
-
-        return null;
     }
 
     public String canonicalName() {

--- a/fe/fe-core/src/main/java/com/starrocks/type/TypeFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/type/TypeFactory.java
@@ -32,11 +32,11 @@ public class TypeFactory {
 
     /**
      * Create a scalar type with specified parameters.
-     * 
-     * @param type the primitive type
-     * @param len length for CHAR/VARCHAR types
+     *
+     * @param type      the primitive type
+     * @param len       length for CHAR/VARCHAR types
      * @param precision precision for DECIMAL types
-     * @param scale scale for DECIMAL types
+     * @param scale     scale for DECIMAL types
      * @return the created ScalarType
      */
     public static ScalarType createType(PrimitiveType type, int len, int precision, int scale) {
@@ -61,7 +61,7 @@ public class TypeFactory {
 
     /**
      * Create a scalar type from a primitive type.
-     * 
+     *
      * @param type the primitive type
      * @return the created ScalarType
      */
@@ -73,7 +73,7 @@ public class TypeFactory {
 
     /**
      * Create a scalar type from a string type name.
-     * 
+     *
      * @param type the type name
      * @return the created ScalarType
      */
@@ -85,7 +85,7 @@ public class TypeFactory {
 
     /**
      * Create a CHAR type with specified length.
-     * 
+     *
      * @param len the length of the CHAR type
      * @return the created CHAR type
      */
@@ -103,7 +103,7 @@ public class TypeFactory {
      * Create a unified decimal type with default precision and scale.
      * Unified decimal is used for parser, which creating default decimal from name.
      * For mysql compatibility, uses precision=10, scale=0 as default.
-     * 
+     *
      * @return the created decimal type
      */
     public static ScalarType createUnifiedDecimalType() {
@@ -114,7 +114,7 @@ public class TypeFactory {
     /**
      * Create a unified decimal type with specified precision.
      * For mysql compatibility, uses scale=0 as default.
-     * 
+     *
      * @param precision the precision
      * @return the created decimal type
      */
@@ -126,9 +126,9 @@ public class TypeFactory {
     /**
      * Create a unified decimal type with specified precision and scale.
      * Automatically chooses between DecimalV2 and DecimalV3 based on configuration.
-     * 
+     *
      * @param precision the precision
-     * @param scale the scale
+     * @param scale     the scale
      * @return the created decimal type
      */
     public static ScalarType createUnifiedDecimalType(int precision, int scale) {
@@ -152,17 +152,8 @@ public class TypeFactory {
     }
 
     /**
-     * Create a DecimalV2 type with default precision and scale.
-     * 
-     * @return the default DecimalV2 type
-     */
-    public static ScalarType createDecimalV2Type() {
-        return Type.DEFAULT_DECIMALV2;
-    }
-
-    /**
      * Create a DecimalV2 type with specified precision and default scale.
-     * 
+     *
      * @param precision the precision
      * @return the created DecimalV2 type
      */
@@ -172,9 +163,9 @@ public class TypeFactory {
 
     /**
      * Create a DecimalV2 type with specified precision and scale.
-     * 
+     *
      * @param precision the precision
-     * @param scale the scale
+     * @param scale     the scale
      * @return the created DecimalV2 type
      */
     public static ScalarType createDecimalV2Type(int precision, int scale) {
@@ -186,10 +177,10 @@ public class TypeFactory {
 
     /**
      * Create a DecimalV3 type with specified primitive type, precision and scale.
-     * 
-     * @param type the decimal primitive type (DECIMAL32/64/128/256)
+     *
+     * @param type      the decimal primitive type (DECIMAL32/64/128/256)
      * @param precision the precision
-     * @param scale the scale
+     * @param scale     the scale
      * @return the created DecimalV3 type
      */
     public static ScalarType createDecimalV3Type(PrimitiveType type, int precision, int scale) {
@@ -209,7 +200,7 @@ public class TypeFactory {
         if (precision > maxPrecision) {
             String underlyingType = ConnectContext.get().getSessionVariable().getLargeDecimalUnderlyingType();
             if (underlyingType.equals(SessionVariableConstants.DOUBLE)) {
-                return Type.DOUBLE;
+                return new ScalarType(PrimitiveType.DOUBLE);
             } else {
                 precision = maxPrecision;
                 type = PrimitiveType.DECIMAL256;
@@ -224,7 +215,7 @@ public class TypeFactory {
     /**
      * Create a DecimalV3 type for representing zero with specified scale.
      * The precision is set equal to the scale.
-     * 
+     *
      * @param scale the scale
      * @return the created DecimalV3 type
      */
@@ -248,7 +239,7 @@ public class TypeFactory {
     /**
      * Create a wildcard DecimalV3 type for function matching.
      * Wildcard decimal uses precision=-1 and scale=-1.
-     * 
+     *
      * @param type the decimal primitive type (DECIMAL32/64/128/256)
      * @return the created wildcard DecimalV3 type
      */
@@ -263,8 +254,8 @@ public class TypeFactory {
     /**
      * Create a DecimalV3 type with specified primitive type and precision.
      * Scale is set to the minimum of precision and the default scale for the type.
-     * 
-     * @param type the decimal primitive type (DECIMAL32/64/128/256)
+     *
+     * @param type      the decimal primitive type (DECIMAL32/64/128/256)
      * @param precision the precision
      * @return the created DecimalV3 type
      */
@@ -276,7 +267,7 @@ public class TypeFactory {
     /**
      * Create a DecimalV3 type with specified primitive type.
      * Uses the maximum precision and default scale for the type.
-     * 
+     *
      * @param type the decimal primitive type (DECIMAL32/64/128/256)
      * @return the created DecimalV3 type
      */
@@ -290,9 +281,9 @@ public class TypeFactory {
      * Create the narrowest DecimalV3 type that can hold the specified precision and scale.
      * Chooses the smallest DecimalV3 type (DECIMAL32 -> DECIMAL64 -> DECIMAL128 -> DECIMAL256)
      * that can accommodate the given precision.
-     * 
+     *
      * @param precision the precision
-     * @param scale the scale
+     * @param scale     the scale
      * @return the created narrowest DecimalV3 type
      */
     public static ScalarType createDecimalV3NarrowestType(int precision, int scale) {
@@ -312,15 +303,14 @@ public class TypeFactory {
         } else if (decimal128MaxPrecision < precision && precision <= decimal256MaxPrecision) {
             return createDecimalV3Type(PrimitiveType.DECIMAL256, precision, scale);
         } else {
-            Preconditions.checkState(false,
-                    "Illegal decimal precision(1 to 76): precision=" + precision);
-            return Type.INVALID;
+            Preconditions.checkState(false, "Illegal decimal precision(1 to 76): precision=" + precision);
+            return new ScalarType(PrimitiveType.INVALID_TYPE);
         }
     }
 
     /**
      * Get the maximum varchar length for OLAP tables.
-     * 
+     *
      * @return the maximum varchar length
      */
     public static int getOlapMaxVarcharLength() {
@@ -330,7 +320,7 @@ public class TypeFactory {
     /**
      * Create a default string type.
      * Uses default string length.
-     * 
+     *
      * @return the created string type
      */
     public static ScalarType createDefaultString() {
@@ -341,7 +331,7 @@ public class TypeFactory {
     /**
      * Create a default catalog string type.
      * Uses maximum catalog varchar length for external catalogs like Hive.
-     * 
+     *
      * @return the created catalog string type
      */
     public static ScalarType createDefaultCatalogString() {
@@ -350,7 +340,7 @@ public class TypeFactory {
 
     /**
      * Create a VARCHAR type with maximum OLAP varchar length.
-     * 
+     *
      * @return the created VARCHAR type
      */
     public static ScalarType createOlapMaxVarcharType() {
@@ -360,7 +350,7 @@ public class TypeFactory {
 
     /**
      * Create a VARCHAR type with specified length.
-     * 
+     *
      * @param len the length of the VARCHAR type
      * @return the created VARCHAR type
      */
@@ -374,7 +364,7 @@ public class TypeFactory {
     /**
      * Create a VARCHAR type with specified length.
      * Alias for createVarcharType(int).
-     * 
+     *
      * @param len the length of the VARCHAR type
      * @return the created VARCHAR type
      */
@@ -387,7 +377,7 @@ public class TypeFactory {
 
     /**
      * Create a VARBINARY type with specified length.
-     * 
+     *
      * @param len the length of the VARBINARY type
      * @return the created VARBINARY type
      */
@@ -398,18 +388,9 @@ public class TypeFactory {
     }
 
     /**
-     * Create a VARCHAR type with wildcard length.
-     * 
-     * @return the VARCHAR type with wildcard length
-     */
-    public static ScalarType createVarcharType() {
-        return Type.VARCHAR;
-    }
-
-    /**
      * Create an HLL type.
      * HLL is used for HyperLogLog approximate counting.
-     * 
+     *
      * @return the created HLL type
      */
     public static ScalarType createHllType() {
@@ -421,7 +402,7 @@ public class TypeFactory {
     /**
      * Create an UNKNOWN type.
      * Used for unresolved type references.
-     * 
+     *
      * @return the created UNKNOWN type
      */
     public static ScalarType createUnknownType() {
@@ -430,10 +411,11 @@ public class TypeFactory {
 
     /**
      * Create a JSON type.
-     * 
+     *
      * @return the created JSON type
      */
     public static ScalarType createJsonType() {
         return new ScalarType(PrimitiveType.JSON);
     }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnGsonSerializationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnGsonSerializationTest.java
@@ -43,7 +43,7 @@ import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.type.PrimitiveType;
-import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -86,7 +86,7 @@ public class ColumnGsonSerializationTest {
         file.createNewFile();
         DataOutputStream out = new DataOutputStream(new FileOutputStream(file));
 
-        Column c1 = new Column("c1", Type.fromPrimitiveType(PrimitiveType.BIGINT), true, null, true,
+        Column c1 = new Column("c1", TypeFactory.createType(PrimitiveType.BIGINT), true, null, true,
                 new ColumnDef.DefaultValueDef(true, new StringLiteral("1")), "abc");
 
         String c1Json = GsonUtils.GSON.toJson(c1);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
@@ -241,7 +241,7 @@ public class ColumnTest {
 
         }
 
-        Column decimalv2Column = new Column("user", TypeFactory.createDecimalV2Type(), false, null, true,
+        Column decimalv2Column = new Column("user", Type.DEFAULT_DECIMALV2, false, null, true,
                 new ColumnDef.DefaultValueDef(true, new StringLiteral("0")), "");
         Column decimalColumn3 =
                 new Column("user", TypeFactory.createDecimalV3Type(PrimitiveType.DECIMAL128, 27, 9), false, null, true,

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
@@ -67,113 +67,113 @@ public class TypeTest {
         // tinyint
         ScalarType type = Type.TINYINT;
         Assertions.assertEquals(4, MysqlCodec.getMysqlResultSetFieldLength(type));
-        Assertions.assertEquals(0, type.getMysqlResultSetFieldDecimals());
+        Assertions.assertEquals(0, MysqlCodec.getMysqlResultSetFieldDecimals(type));
         Assertions.assertEquals(63, MysqlCodec.getMysqlResultSetFieldCharsetIndex(type));
 
         // smallint
         type = Type.SMALLINT;
         Assertions.assertEquals(6, MysqlCodec.getMysqlResultSetFieldLength(type));
-        Assertions.assertEquals(0, type.getMysqlResultSetFieldDecimals());
+        Assertions.assertEquals(0, MysqlCodec.getMysqlResultSetFieldDecimals(type));
         Assertions.assertEquals(63, MysqlCodec.getMysqlResultSetFieldCharsetIndex(type));
 
         // int
         type = Type.INT;
         Assertions.assertEquals(11, MysqlCodec.getMysqlResultSetFieldLength(type));
-        Assertions.assertEquals(0, type.getMysqlResultSetFieldDecimals());
+        Assertions.assertEquals(0, MysqlCodec.getMysqlResultSetFieldDecimals(type));
         Assertions.assertEquals(63, MysqlCodec.getMysqlResultSetFieldCharsetIndex(type));
 
         // bigint
         type = Type.BIGINT;
         Assertions.assertEquals(20, MysqlCodec.getMysqlResultSetFieldLength(type));
-        Assertions.assertEquals(0, type.getMysqlResultSetFieldDecimals());
+        Assertions.assertEquals(0, MysqlCodec.getMysqlResultSetFieldDecimals(type));
         Assertions.assertEquals(63, MysqlCodec.getMysqlResultSetFieldCharsetIndex(type));
 
         // largeint
         type = Type.LARGEINT;
         Assertions.assertEquals(40, MysqlCodec.getMysqlResultSetFieldLength(type));
-        Assertions.assertEquals(0, type.getMysqlResultSetFieldDecimals());
+        Assertions.assertEquals(0, MysqlCodec.getMysqlResultSetFieldDecimals(type));
         Assertions.assertEquals(33, MysqlCodec.getMysqlResultSetFieldCharsetIndex(type));
 
         // date
         type = Type.DATE;
         Assertions.assertEquals(10, MysqlCodec.getMysqlResultSetFieldLength(type));
-        Assertions.assertEquals(0, type.getMysqlResultSetFieldDecimals());
+        Assertions.assertEquals(0, MysqlCodec.getMysqlResultSetFieldDecimals(type));
         Assertions.assertEquals(63, MysqlCodec.getMysqlResultSetFieldCharsetIndex(type));
 
         // datetime
         type = Type.DATETIME;
         Assertions.assertEquals(19, MysqlCodec.getMysqlResultSetFieldLength(type));
-        Assertions.assertEquals(0, type.getMysqlResultSetFieldDecimals());
+        Assertions.assertEquals(0, MysqlCodec.getMysqlResultSetFieldDecimals(type));
         Assertions.assertEquals(63, MysqlCodec.getMysqlResultSetFieldCharsetIndex(type));
 
         // float
         type = Type.FLOAT;
         Assertions.assertEquals(12, MysqlCodec.getMysqlResultSetFieldLength(type));
-        Assertions.assertEquals(31, type.getMysqlResultSetFieldDecimals());
+        Assertions.assertEquals(31, MysqlCodec.getMysqlResultSetFieldDecimals(type));
         Assertions.assertEquals(63, MysqlCodec.getMysqlResultSetFieldCharsetIndex(type));
 
         // int
         type = Type.DOUBLE;
         Assertions.assertEquals(22, MysqlCodec.getMysqlResultSetFieldLength(type));
-        Assertions.assertEquals(31, type.getMysqlResultSetFieldDecimals());
+        Assertions.assertEquals(31, MysqlCodec.getMysqlResultSetFieldDecimals(type));
         Assertions.assertEquals(63, MysqlCodec.getMysqlResultSetFieldCharsetIndex(type));
 
         // decimal
         type = TypeFactory.createDecimalV2Type(15, 5);
         Assertions.assertEquals(19, MysqlCodec.getMysqlResultSetFieldLength(type));
-        Assertions.assertEquals(5, type.getMysqlResultSetFieldDecimals());
+        Assertions.assertEquals(5, MysqlCodec.getMysqlResultSetFieldDecimals(type));
         Assertions.assertEquals(63, MysqlCodec.getMysqlResultSetFieldCharsetIndex(type));
 
         // decimalv2
         type = TypeFactory.createDecimalV2Type(15, 0);
         Assertions.assertEquals(18, MysqlCodec.getMysqlResultSetFieldLength(type));
-        Assertions.assertEquals(0, type.getMysqlResultSetFieldDecimals());
+        Assertions.assertEquals(0, MysqlCodec.getMysqlResultSetFieldDecimals(type));
         Assertions.assertEquals(63, MysqlCodec.getMysqlResultSetFieldCharsetIndex(type));
 
         // char
         type = TypeFactory.createCharType(10);
         Assertions.assertEquals(30, MysqlCodec.getMysqlResultSetFieldLength(type));
-        Assertions.assertEquals(0, type.getMysqlResultSetFieldDecimals());
+        Assertions.assertEquals(0, MysqlCodec.getMysqlResultSetFieldDecimals(type));
         Assertions.assertEquals(33, MysqlCodec.getMysqlResultSetFieldCharsetIndex(type));
 
         // varchar
         type = TypeFactory.createVarcharType(11);
         Assertions.assertEquals(33, MysqlCodec.getMysqlResultSetFieldLength(type));
-        Assertions.assertEquals(0, type.getMysqlResultSetFieldDecimals());
+        Assertions.assertEquals(0, MysqlCodec.getMysqlResultSetFieldDecimals(type));
         Assertions.assertEquals(33, MysqlCodec.getMysqlResultSetFieldCharsetIndex(type));
 
         // wildcard varchar
         type = TypeFactory.createVarcharType(-1);
         Assertions.assertEquals(192, MysqlCodec.getMysqlResultSetFieldLength(type));
-        Assertions.assertEquals(0, type.getMysqlResultSetFieldDecimals());
+        Assertions.assertEquals(0, MysqlCodec.getMysqlResultSetFieldDecimals(type));
         Assertions.assertEquals(33, MysqlCodec.getMysqlResultSetFieldCharsetIndex(type));
 
         // bitmap
         type = Type.BITMAP;
         // 20 * 3
         Assertions.assertEquals(192, MysqlCodec.getMysqlResultSetFieldLength(type));
-        Assertions.assertEquals(0, type.getMysqlResultSetFieldDecimals());
+        Assertions.assertEquals(0, MysqlCodec.getMysqlResultSetFieldDecimals(type));
         Assertions.assertEquals(33, MysqlCodec.getMysqlResultSetFieldCharsetIndex(type));
 
         // hll
         type = Type.HLL;
         // MAX_HLL_LENGTH(16385) * 3
         Assertions.assertEquals(49155, MysqlCodec.getMysqlResultSetFieldLength(type));
-        Assertions.assertEquals(0, type.getMysqlResultSetFieldDecimals());
+        Assertions.assertEquals(0, MysqlCodec.getMysqlResultSetFieldDecimals(type));
         Assertions.assertEquals(33, MysqlCodec.getMysqlResultSetFieldCharsetIndex(type));
 
         // hll
         type = Type.JSON;
         // default 20 * 3
         Assertions.assertEquals(60, MysqlCodec.getMysqlResultSetFieldLength(type));
-        Assertions.assertEquals(0, type.getMysqlResultSetFieldDecimals());
+        Assertions.assertEquals(0, MysqlCodec.getMysqlResultSetFieldDecimals(type));
         Assertions.assertEquals(33, MysqlCodec.getMysqlResultSetFieldCharsetIndex(type));
 
         // array
         ArrayType arrayType = new ArrayType(Type.INT);
         // default 20 * 3
         Assertions.assertEquals(60, MysqlCodec.getMysqlResultSetFieldLength(arrayType));
-        Assertions.assertEquals(0, arrayType.getMysqlResultSetFieldDecimals());
+        Assertions.assertEquals(0, MysqlCodec.getMysqlResultSetFieldDecimals(arrayType));
         Assertions.assertEquals(33, MysqlCodec.getMysqlResultSetFieldCharsetIndex(arrayType));
 
         // function (an invisible type for users, just used to express the lambda Functions in high-order functions)
@@ -184,7 +184,7 @@ public class TypeTest {
                 new MapType(TypeFactory.createType(PrimitiveType.INT), TypeFactory.createType(PrimitiveType.INT));
         // default 20 * 3
         Assertions.assertEquals(60, MysqlCodec.getMysqlResultSetFieldLength(mapType));
-        Assertions.assertEquals(0, mapType.getMysqlResultSetFieldDecimals());
+        Assertions.assertEquals(0, MysqlCodec.getMysqlResultSetFieldDecimals(mapType));
         Assertions.assertEquals(33, MysqlCodec.getMysqlResultSetFieldCharsetIndex(mapType));
 
         StructField structField = new StructField("a", TypeFactory.createType(PrimitiveType.INT));
@@ -193,7 +193,7 @@ public class TypeTest {
         StructType structType = new StructType(structFields);
         // default 20 * 3
         Assertions.assertEquals(60, MysqlCodec.getMysqlResultSetFieldLength(structType));
-        Assertions.assertEquals(0, structType.getMysqlResultSetFieldDecimals());
+        Assertions.assertEquals(0, MysqlCodec.getMysqlResultSetFieldDecimals(structType));
         Assertions.assertEquals(33, MysqlCodec.getMysqlResultSetFieldCharsetIndex(structType));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ColumnTypeConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ColumnTypeConverterTest.java
@@ -300,7 +300,7 @@ public class ColumnTypeConverterTest {
         resType = ColumnTypeConverter.fromHiveType(typeStr);
         Assertions.assertNotEquals(resType, varcharType);
 
-        varcharType = TypeFactory.createVarcharType();
+        varcharType = Type.VARCHAR;
         typeStr = "varchar(-1)";
         resType = ColumnTypeConverter.fromHiveType(typeStr);
         Assertions.assertEquals(resType, varcharType);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/PartitionUtilTest.java
@@ -176,8 +176,8 @@ public class PartitionUtilTest {
     public void testHiveTimestampPartitionNames() throws AnalysisException {
         List<String> partitionValues = Lists.newArrayList("2007-01-01 10:35:00.0", "2007-01-01 10:35:00.123");
         List<Column> columns = new ArrayList<>();
-        columns.add(new Column("a", Type.fromPrimitiveType(PrimitiveType.DATETIME)));
-        columns.add(new Column("b", Type.fromPrimitiveType(PrimitiveType.DATETIME)));
+        columns.add(new Column("a", TypeFactory.createType(PrimitiveType.DATETIME)));
+        columns.add(new Column("b", TypeFactory.createType(PrimitiveType.DATETIME)));
 
         PartitionKey partitionKey = PartitionUtil.createPartitionKey(partitionValues, columns, Table.TableType.HIVE);
         List<String> res = PartitionUtil.fromPartitionKey(partitionKey);
@@ -187,9 +187,9 @@ public class PartitionUtilTest {
         partitionValues = Lists.newArrayList("2007-01-01 10:35:00", "2007-01-01 10:35:00.00",
                 "2007-01-01 10:35:00.000");
         columns = new ArrayList<>();
-        columns.add(new Column("a", Type.fromPrimitiveType(PrimitiveType.DATETIME)));
-        columns.add(new Column("b", Type.fromPrimitiveType(PrimitiveType.DATETIME)));
-        columns.add(new Column("c", Type.fromPrimitiveType(PrimitiveType.DATETIME)));
+        columns.add(new Column("a", TypeFactory.createType(PrimitiveType.DATETIME)));
+        columns.add(new Column("b", TypeFactory.createType(PrimitiveType.DATETIME)));
+        columns.add(new Column("c", TypeFactory.createType(PrimitiveType.DATETIME)));
         partitionKey = PartitionUtil.createPartitionKey(partitionValues, columns, Table.TableType.HIVE);
         res = PartitionUtil.fromPartitionKey(partitionKey);
         Assertions.assertEquals("2007-01-01 10:35:00", res.get(0));
@@ -201,8 +201,8 @@ public class PartitionUtilTest {
     public void testHiveIntPartitionNames() throws Exception {
         List<String> partitionValues = Lists.newArrayList("2007-01-01", "01");
         List<Column> columns = new ArrayList<>();
-        columns.add(new Column("a", Type.fromPrimitiveType(PrimitiveType.DATE)));
-        columns.add(new Column("b", Type.fromPrimitiveType(PrimitiveType.INT)));
+        columns.add(new Column("a", TypeFactory.createType(PrimitiveType.DATE)));
+        columns.add(new Column("b", TypeFactory.createType(PrimitiveType.INT)));
 
         PartitionKey partitionKey = PartitionUtil.createPartitionKey(partitionValues, columns, Table.TableType.HIVE);
         List<String> res = PartitionUtil.fromPartitionKey(partitionKey);
@@ -211,8 +211,8 @@ public class PartitionUtilTest {
 
         partitionValues = Lists.newArrayList("125", "0125");
         columns = new ArrayList<>();
-        columns.add(new Column("a", Type.fromPrimitiveType(PrimitiveType.INT)));
-        columns.add(new Column("b", Type.fromPrimitiveType(PrimitiveType.INT)));
+        columns.add(new Column("a", TypeFactory.createType(PrimitiveType.INT)));
+        columns.add(new Column("b", TypeFactory.createType(PrimitiveType.INT)));
 
         partitionKey = PartitionUtil.createPartitionKey(partitionValues, columns, Table.TableType.HIVE);
         res = PartitionUtil.fromPartitionKey(partitionKey);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/FragmentNormalizerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/FragmentNormalizerTest.java
@@ -32,6 +32,7 @@ import com.starrocks.sql.ast.expression.LargeIntLiteral;
 import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -80,7 +81,7 @@ public class FragmentNormalizerTest {
 
     @Test
     public void testToClosedAndOpenRangeForDate() throws AnalysisException {
-        Column partitionColumn = new Column("dt", Type.fromPrimitiveType(PrimitiveType.DATE));
+        Column partitionColumn = new Column("dt", TypeFactory.createType(PrimitiveType.DATE));
         LiteralExpr lower = new DateLiteral(2022, 1, 1);
         LiteralExpr lowerSucc = new DateLiteral(2022, 1, 2);
         LiteralExpr upper = new DateLiteral(2022, 1, 10);
@@ -90,7 +91,7 @@ public class FragmentNormalizerTest {
 
     @Test
     public void testToClosedAndOpenRangeForDatetime() throws AnalysisException {
-        Column partitionColumn = new Column("ts", Type.fromPrimitiveType(PrimitiveType.DATETIME));
+        Column partitionColumn = new Column("ts", TypeFactory.createType(PrimitiveType.DATETIME));
         LiteralExpr lower = new DateLiteral(2022, 1, 1, 11, 23, 59, 0);
         LiteralExpr lowerSucc = new DateLiteral(2022, 1, 1, 11, 24, 0, 0);
         LiteralExpr upper = new DateLiteral(2022, 1, 10, 23, 59, 59, 0);
@@ -108,7 +109,7 @@ public class FragmentNormalizerTest {
                 PrimitiveType.TINYINT,
         };
         for (PrimitiveType ptype : integerPtypes) {
-            Type type = Type.fromPrimitiveType(ptype);
+            Type type = TypeFactory.createType(ptype);
             long secondMaxValue = (1L << (ptype.getTypeSize() * 8 - 1)) - 2;
             Column partitionColumn = new Column("k0", type);
             LiteralExpr lower = new IntLiteral(1, type);
@@ -121,7 +122,7 @@ public class FragmentNormalizerTest {
 
     @Test
     public void testToClosedAndOpenRangeForLargeInt() throws AnalysisException {
-        Column partitionColumn = new Column("k0", Type.fromPrimitiveType(PrimitiveType.LARGEINT));
+        Column partitionColumn = new Column("k0", TypeFactory.createType(PrimitiveType.LARGEINT));
         LiteralExpr lower = new LargeIntLiteral("1");
         LiteralExpr lowerSucc = new LargeIntLiteral("2");
         LiteralExpr upper =

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionUtilsTest.java
@@ -41,6 +41,7 @@ import com.starrocks.sql.common.mv.MVEagerRangePartitionMapper;
 import com.starrocks.sql.common.mv.MVLazyRangePartitionMapper;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
 import com.starrocks.utframe.StarRocksTestBase;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -107,7 +108,7 @@ public class SyncPartitionUtilsTest extends StarRocksTestBase {
         children.add(new StringLiteral(granularity));
         children.add(slotRef);
         FunctionCallExpr functionCallExpr = new FunctionCallExpr("date_trunc", children);
-        functionCallExpr.setType(Type.fromPrimitiveType(type));
+        functionCallExpr.setType(TypeFactory.createType(type));
         return functionCallExpr;
     }
     public static PCellSortedSet toPCellSortedSet(Map<String, Range<PartitionKey>> rangeMap) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This pull request introduces several codebase-wide improvements related to type handling and build configuration. The main changes include standardizing the usage of type factories and constants for type creation, refactoring column type assignments to use `Type.VARCHAR` directly, and adding Checkstyle integration to the Gradle build process to align with Maven. These updates enhance consistency, maintainability, and code quality across the project.

**Type Handling and Refactoring:**

* Replaced calls to `TypeFactory.createVarcharType()` and similar factory methods with direct usage of `Type.VARCHAR` for column definitions in metadata and metrics classes, simplifying type assignments and improving readability. [[1]](diffhunk://#diff-14d2c69a70e2f503a295c7e4b9aa628812cb01d4fd574c6e7ba0a88aea37dfe4L53-R54) [[2]](diffhunk://#diff-14d2c69a70e2f503a295c7e4b9aa628812cb01d4fd574c6e7ba0a88aea37dfe4L63-R64) [[3]](diffhunk://#diff-34df0aa212810d1e6a506ae34c879cb695bf625f235cbfcd1229eadf0c78fe94L49-R50) [[4]](diffhunk://#diff-9b3c41f903d9308f72d88775922b9bf4bf3331884a4605c8da992e3612d02913L47-R49) [[5]](diffhunk://#diff-946ddb357874552ad2883abfc8f2888cd98dcb4e4945bbbeb035c5060549d400L53-R55) [[6]](diffhunk://#diff-7ce33c83757748563449a8c6368794dd9de3aeb1233ec9eef37ffa1ed3ed14edL35-R47)
* Standardized type creation in partition key logic by replacing `Type.fromPrimitiveType()` with `TypeFactory.createType()`, ensuring consistent type instantiation throughout `PartitionKey`. [[1]](diffhunk://#diff-0f43381de31a2293b8bdaf7bd886df0a322990da7d2ab12955345ad49aaa521eL106-R107) [[2]](diffhunk://#diff-0f43381de31a2293b8bdaf7bd886df0a322990da7d2ab12955345ad49aaa521eL116-R117) [[3]](diffhunk://#diff-0f43381de31a2293b8bdaf7bd886df0a322990da7d2ab12955345ad49aaa521eL151-R158) [[4]](diffhunk://#diff-0f43381de31a2293b8bdaf7bd886df0a322990da7d2ab12955345ad49aaa521eL279-R280) [[5]](diffhunk://#diff-0f43381de31a2293b8bdaf7bd886df0a322990da7d2ab12955345ad49aaa521eL350-R351) [[6]](diffhunk://#diff-0f43381de31a2293b8bdaf7bd886df0a322990da7d2ab12955345ad49aaa521eL474-R477) [[7]](diffhunk://#diff-0f43381de31a2293b8bdaf7bd886df0a322990da7d2ab12955345ad49aaa521eL553-R554)
* Updated aggregate function initialization to use `Type.SUPPORTED_TYPES` instead of `Type.getSupportedTypes()`, aligning with current conventions for supported types. [[1]](diffhunk://#diff-cd424a40be160431092cbd337ab6c7354c041b5b0e580b4ff962ff8edd37a855L1145-R1145) [[2]](diffhunk://#diff-cd424a40be160431092cbd337ab6c7354c041b5b0e580b4ff962ff8edd37a855L1176-R1176) [[3]](diffhunk://#diff-cd424a40be160431092cbd337ab6c7354c041b5b0e580b4ff962ff8edd37a855L1185-R1185) [[4]](diffhunk://#diff-cd424a40be160431092cbd337ab6c7354c041b5b0e580b4ff962ff8edd37a855L1423-R1423)

**Build Configuration and Quality Assurance:**

* Added the `checkstyle` plugin to the Gradle build configuration and set up Checkstyle tasks to match Maven behavior, including memory settings and source filtering, to enforce code style and quality standards. [[1]](diffhunk://#diff-7726bddc72ecc2bb67116889b816914f164775c316cec2b8f1ac045cf8da0fdbR21) [[2]](diffhunk://#diff-7726bddc72ecc2bb67116889b816914f164775c316cec2b8f1ac045cf8da0fdbR467-R494)
* Ensured that Checkstyle runs before Java compilation and restored explicit build dependencies for generated sources and plugin artifacts, maintaining proper build order and avoiding circular dependencies. [[1]](diffhunk://#diff-7726bddc72ecc2bb67116889b816914f164775c316cec2b8f1ac045cf8da0fdbL413-L419) [[2]](diffhunk://#diff-7726bddc72ecc2bb67116889b816914f164775c316cec2b8f1ac045cf8da0fdbR467-R494)

These changes collectively improve code consistency, type safety, and build reliability.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
