### PR TITLE
[BugFix] Fix transaction stream load not update load rows state

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
@@ -42,6 +42,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TUniqueId;
+import com.starrocks.transaction.TxnCommitAttachment;
 import com.starrocks.warehouse.WarehouseLoadInfoBuilder;
 import com.starrocks.warehouse.WarehouseLoadStatusInfo;
 import com.starrocks.warehouse.cngroup.ComputeResource;
@@ -579,6 +580,13 @@ public class StreamLoadMgr implements MemoryTrackable {
 
     public StreamLoadTask getSyncSteamLoadTaskByTxnId(long txnId) {
         return txnIdToSyncStreamLoadTasks.getOrDefault(txnId, null);
+    }
+
+    public void setSyncStreamLoadState(long txnId, TxnCommitAttachment attachment, String errorMsg) {
+        StreamLoadTask task = getSyncSteamLoadTaskByTxnId(txnId);
+        if (task != null && attachment != null) {
+            task.setLoadState(attachment, errorMsg);
+        }
     }
 
     // put history task in the end

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -118,13 +118,11 @@ import com.starrocks.load.batchwrite.RequestLoadResult;
 import com.starrocks.load.batchwrite.TableId;
 import com.starrocks.load.loadv2.LoadJob;
 import com.starrocks.load.loadv2.LoadMgr;
-import com.starrocks.load.loadv2.ManualLoadTxnCommitAttachment;
 import com.starrocks.load.pipe.Pipe;
 import com.starrocks.load.pipe.PipeFileRecord;
 import com.starrocks.load.pipe.PipeId;
 import com.starrocks.load.pipe.PipeManager;
 import com.starrocks.load.pipe.filelist.RepoAccessor;
-import com.starrocks.load.routineload.RLTaskTxnCommitAttachment;
 import com.starrocks.load.routineload.RoutineLoadJob;
 import com.starrocks.load.routineload.RoutineLoadMgr;
 import com.starrocks.load.streamload.AbstractStreamLoadTask;
@@ -1281,33 +1279,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         if (null == tbl) {
             return;
         }
-        StreamLoadTask streamLoadtask = GlobalStateMgr.getCurrentState().getStreamLoadMgr().
-                getSyncSteamLoadTaskByTxnId(request.getTxnId());
-
-        switch (request.txnCommitAttachment.getLoadType()) {
-            case ROUTINE_LOAD:
-                if (!(attachment instanceof RLTaskTxnCommitAttachment)) {
-                    break;
-                }
-
-                if (streamLoadtask != null) {
-                    streamLoadtask.setLoadState(attachment, "");
-                }
-
-                break;
-            case MANUAL_LOAD:
-                if (!(attachment instanceof ManualLoadTxnCommitAttachment)) {
-                    break;
-                }
-
-                if (streamLoadtask != null) {
-                    streamLoadtask.setLoadState(attachment, "");
-                }
-
-                break;
-            default:
-                break;
-        }
+        GlobalStateMgr.getCurrentState().getStreamLoadMgr().setSyncStreamLoadState(request.getTxnId(), attachment, "");
     }
 
     @Override
@@ -1407,7 +1379,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                 TabletCommitInfo.fromThrift(request.getCommitInfos()),
                 TabletFailInfo.fromThrift(request.getFailInfos()),
                 attachment);
-
+        GlobalStateMgr.getCurrentState().getStreamLoadMgr().setSyncStreamLoadState(request.getTxnId(), attachment, "");
     }
 
     @Override
@@ -1468,36 +1440,8 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                 TxnCommitAttachment.fromThrift(request.getTxnCommitAttachment()));
 
         TxnCommitAttachment attachment = TxnCommitAttachment.fromThrift(request.txnCommitAttachment);
-        StreamLoadTask streamLoadtask = GlobalStateMgr.getCurrentState().getStreamLoadMgr().
-                getSyncSteamLoadTaskByTxnId(request.getTxnId());
-
-        switch (request.txnCommitAttachment.getLoadType()) {
-            case ROUTINE_LOAD:
-                if (!(attachment instanceof RLTaskTxnCommitAttachment)) {
-                    break;
-                }
-                RLTaskTxnCommitAttachment routineAttachment = (RLTaskTxnCommitAttachment) attachment;
-
-                if (streamLoadtask != null) {
-                    streamLoadtask.setLoadState(routineAttachment, request.getReason());
-
-                }
-
-                break;
-            case MANUAL_LOAD:
-                if (!(attachment instanceof ManualLoadTxnCommitAttachment)) {
-                    break;
-                }
-                ManualLoadTxnCommitAttachment streamAttachment = (ManualLoadTxnCommitAttachment) attachment;
-
-                if (streamLoadtask != null) {
-                    streamLoadtask.setLoadState(streamAttachment, request.getReason());
-                }
-
-                break;
-            default:
-                break;
-        }
+        GlobalStateMgr.getCurrentState().getStreamLoadMgr()
+                .setSyncStreamLoadState(request.getTxnId(), attachment, request.getReason());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -1433,13 +1433,11 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             throw new MetaNotFoundException("db " + dbName + " does not exist");
         }
         long dbId = db.getId();
+        TxnCommitAttachment attachment = TxnCommitAttachment.fromThrift(request.getTxnCommitAttachment());
         GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(dbId, request.getTxnId(),
                 request.isSetReason() ? request.getReason() : "system cancel",
                 TabletCommitInfo.fromThrift(request.getCommitInfos()),
-                TabletFailInfo.fromThrift(request.getFailInfos()),
-                TxnCommitAttachment.fromThrift(request.getTxnCommitAttachment()));
-
-        TxnCommitAttachment attachment = TxnCommitAttachment.fromThrift(request.txnCommitAttachment);
+                TabletFailInfo.fromThrift(request.getFailInfos()), attachment);
         GlobalStateMgr.getCurrentState().getStreamLoadMgr()
                 .setSyncStreamLoadState(request.getTxnId(), attachment, request.getReason());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -19,6 +19,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.ExpressionRangePartitionInfo;
+import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
@@ -37,6 +38,7 @@ import com.starrocks.load.batchwrite.BatchWriteMgr;
 import com.starrocks.load.batchwrite.RequestLoadResult;
 import com.starrocks.load.batchwrite.TableId;
 import com.starrocks.load.streamload.StreamLoadKvParams;
+import com.starrocks.load.streamload.StreamLoadTask;
 import com.starrocks.planner.StreamLoadPlanner;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DDLStmtExecutor;
@@ -75,6 +77,8 @@ import com.starrocks.thrift.TLoadTxnBeginRequest;
 import com.starrocks.thrift.TLoadTxnBeginResult;
 import com.starrocks.thrift.TLoadTxnCommitRequest;
 import com.starrocks.thrift.TLoadTxnCommitResult;
+import com.starrocks.thrift.TLoadType;
+import com.starrocks.thrift.TManualLoadTxnCommitAttachment;
 import com.starrocks.thrift.TMergeCommitRequest;
 import com.starrocks.thrift.TMergeCommitResult;
 import com.starrocks.thrift.TNetworkAddress;
@@ -92,7 +96,9 @@ import com.starrocks.thrift.TStreamLoadPutResult;
 import com.starrocks.thrift.TTableInfo;
 import com.starrocks.thrift.TTableStatus;
 import com.starrocks.thrift.TTableType;
+import com.starrocks.thrift.TTabletCommitInfo;
 import com.starrocks.thrift.TTransactionStatus;
+import com.starrocks.thrift.TTxnCommitAttachment;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.thrift.TUpdateResourceUsageRequest;
 import com.starrocks.thrift.TUserIdentity;
@@ -117,6 +123,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -124,9 +131,11 @@ import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_BATCH_WRIT
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_BATCH_WRITE_INTERVAL_MS;
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_BATCH_WRITE_PARALLEL;
 import static com.starrocks.load.streamload.StreamLoadHttpHeader.HTTP_ENABLE_BATCH_WRITE;
+import static com.starrocks.thrift.TFileType.FILE_STREAM;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 
@@ -299,6 +308,12 @@ public class FrontendServiceImplTest {
                                 "PROPERTIES (\n" +
                                 "\"replication_num\" = \"1\"\n" +
                                 ");")
+                    .withTable("CREATE TABLE test_load (\n" +
+                                "    id INT\n" +
+                                ")\n" +
+                                "DUPLICATE KEY(id)\n" +
+                                "DISTRIBUTED BY HASH(id) BUCKETS 1\n" +
+                                "PROPERTIES(\"replication_num\" = \"1\");")
                     .withView("create view v as select * from site_access_empty")
                     .withView("create view v1 as select current_role()")
                     .withView("create view v2 as select current_user()")
@@ -1185,6 +1200,68 @@ public class FrontendServiceImplTest {
         List<List<String>> configs = Config.getConfigInfo(matcher);
         Assertions.assertEquals("98", configs.get(0).get(2));
         Assertions.assertEquals(98, Config.adaptive_choose_instances_threshold);
+    }
+
+    @Test
+    public void testLoadTxnPrepare() throws TException {
+        FrontendServiceImpl impl = spy(new FrontendServiceImpl(exeEnv));
+        TNetworkAddress address = new TNetworkAddress();
+        address.setHostname("127.0.0.1");
+        address.setPort(9030);
+        doReturn(address).when(impl).getClientAddr();
+        String db = "test";
+        String table = "test_load";
+
+        TLoadTxnBeginRequest beginRequest = new TLoadTxnBeginRequest();
+        beginRequest.setLabel(UUID.randomUUID().toString());
+        beginRequest.setDb(db);
+        beginRequest.setTbl(table);
+        beginRequest.setUser("root");
+        beginRequest.setPasswd("");
+        TLoadTxnBeginResult beginResult = impl.loadTxnBegin(beginRequest);
+        assertEquals(TStatusCode.OK, beginResult.getStatus().getStatus_code());
+
+        TUniqueId loadId = UUIDUtil.genTUniqueId();
+        TStreamLoadPutRequest putRequest = new TStreamLoadPutRequest();
+        putRequest.setDb(db);
+        putRequest.setTbl(table);
+        putRequest.setTxnId(beginResult.getTxnId());
+        putRequest.setLoadId(loadId);
+        putRequest.setFileType(FILE_STREAM);
+        putRequest.setAuth_code(100);
+        TStreamLoadPutResult putResult = impl.streamLoadPut(putRequest);
+        assertEquals(TStatusCode.OK, putResult.getStatus().status_code);
+
+        TLoadTxnCommitRequest prepareRequest = new TLoadTxnCommitRequest();
+        prepareRequest.setDb(db);
+        prepareRequest.setTbl(table);
+        prepareRequest.setTxnId(beginResult.getTxnId());
+        List<TTabletCommitInfo> commitInfos = new ArrayList<>();
+        OlapTable tbl = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db, table);
+        tbl.getAllPhysicalPartitions().stream().map(PhysicalPartition::getBaseIndex)
+                .map(MaterializedIndex::getTablets).flatMap(List::stream).forEach(tablet -> {
+                    TTabletCommitInfo commitInfo = new TTabletCommitInfo();
+                    commitInfo.setTabletId(tablet.getId());
+                    commitInfo.setBackendId(tablet.getBackendIds().iterator().next());
+                    commitInfos.add(commitInfo);
+                });
+        prepareRequest.setCommitInfos(commitInfos);
+        TManualLoadTxnCommitAttachment loadAttachment = new TManualLoadTxnCommitAttachment();
+        loadAttachment.setLoadedRows(2);
+        loadAttachment.setFilteredRows(1);
+        TTxnCommitAttachment txnAttachment = new TTxnCommitAttachment();
+        txnAttachment.setLoadType(TLoadType.MANUAL_LOAD);
+        txnAttachment.setManualLoadTxnCommitAttachment(loadAttachment);
+        prepareRequest.setTxnCommitAttachment(txnAttachment);
+        prepareRequest.setAuth_code(100);
+        TLoadTxnCommitResult prepareResult = impl.loadTxnPrepare(prepareRequest);
+        assertEquals(TStatusCode.OK, prepareResult.getStatus().status_code);
+
+        StreamLoadTask streamLoadTask =
+                GlobalStateMgr.getCurrentState().getStreamLoadMgr().getSyncSteamLoadTaskByTxnId(beginResult.getTxnId());
+        Assertions.assertNotNull(streamLoadTask);
+        Assertions.assertEquals("2", streamLoadTask.getShowInfo().get(0).get(11));
+        Assertions.assertEquals("1", streamLoadTask.getShowInfo().get(0).get(12));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/FrontendServiceImplTest.java
@@ -807,7 +807,7 @@ public class FrontendServiceImplTest {
         params.setCurrent_user_ident(tUserIdentity);
 
         TGetTablesResult result = impl.getTableNames(params);
-        Assertions.assertEquals(17, result.tables.size());
+        Assertions.assertEquals(18, result.tables.size());
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
`StreamLoadTask` for transaction stream load wasn’t consistently updated during txn prepare, causing incorrect client-visible results (e.g., missing loadedRows/filteredRows) in `information_schema.loads`

## What I'm doing:
* Centralize `StreamLoadTask` state updates in StreamLoadMgr#setSyncStreamLoadState(txnId, attachment, errorMsg).
* Refactor FrontendServiceImpl to call the centralized method from loadTxnPrepare, loadTxnCommit, and loadTxnRollback.

Fixes #issue

## What type of PR is this:
- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 4.0
  - [X] 3.5
  - [X] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes StreamLoadTask state updates via StreamLoadMgr.setSyncStreamLoadState and hooks it into loadTxnPrepare/Commit/Rollback, with tests verifying loaded/filtered rows propagation.
> 
> - **Stream Load Management**:
>   - Add `StreamLoadMgr#setSyncStreamLoadState(txnId, attachment, errorMsg)` to update sync `StreamLoadTask` state.
>   - Wire state updates into `FrontendServiceImpl`: `loadTxnPrepare`, `loadTxnCommit`, and `loadTxnRollback` now call the centralized method (remove attachment-type-specific handling).
> - **Tests**:
>   - Add unit tests for txn prepare/commit/rollback ensuring `loadedRows`/`filteredRows` and `error_msg` are reflected in `StreamLoadTask` (`toThrift`).
>   - Introduce test table `test_load` and adjust expectations (e.g., table count from `17` to `18`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e464daf76d58b139dce759d23950c8d6592c9997. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->