### PR TITLE
[UT] Fix flat JSON path derivation for type conflict nodes

### DIFF
--- a/be/test/storage/rowset/flat_json_column_rw_test.cpp
+++ b/be/test/storage/rowset/flat_json_column_rw_test.cpp
@@ -828,7 +828,7 @@ TEST_F(FlatJsonColumnRWTest, testHyperFlatJson) {
     EXPECT_EQ("b.b2.b3", writer_opts.meta->children_columns(index++).name());
     EXPECT_EQ("b.b2.c1.c2", writer_opts.meta->children_columns(index++).name());
     EXPECT_EQ("b.b4", writer_opts.meta->children_columns(index++).name());
-    EXPECT_EQ("ff.f1", writer_opts.meta->children_columns(index++).name());
+    EXPECT_EQ("ff", writer_opts.meta->children_columns(index++).name());
     EXPECT_EQ("gg", writer_opts.meta->children_columns(index++).name());
     EXPECT_EQ("remain", writer_opts.meta->children_columns(index++).name());
 
@@ -882,7 +882,7 @@ TEST_F(FlatJsonColumnRWTest, testHyperFlatJsonWithConfig) {
     EXPECT_EQ("b.b2.b3", writer_opts.meta->children_columns(index++).name());
     EXPECT_EQ("b.b2.c1.c2", writer_opts.meta->children_columns(index++).name());
     EXPECT_EQ("b.b4", writer_opts.meta->children_columns(index++).name());
-    EXPECT_EQ("ff.f1", writer_opts.meta->children_columns(index++).name());
+    EXPECT_EQ("ff", writer_opts.meta->children_columns(index++).name());
     EXPECT_EQ("gg", writer_opts.meta->children_columns(index++).name());
     EXPECT_EQ("remain", writer_opts.meta->children_columns(index++).name());
 
@@ -1707,7 +1707,7 @@ TEST_F(FlatJsonColumnRWTest, testHyperNullFlatJson) {
     EXPECT_EQ("b.b2.b3", writer_opts.meta->children_columns(index++).name());
     EXPECT_EQ("b.b2.c1.c2", writer_opts.meta->children_columns(index++).name());
     EXPECT_EQ("b.b4", writer_opts.meta->children_columns(index++).name());
-    EXPECT_EQ("ff.f1", writer_opts.meta->children_columns(index++).name());
+    EXPECT_EQ("ff", writer_opts.meta->children_columns(index++).name());
     EXPECT_EQ("gg", writer_opts.meta->children_columns(index++).name());
     EXPECT_EQ("remain", writer_opts.meta->children_columns(index++).name());
 

--- a/test/sql/test_semi/R/test_flat_json_consistency
+++ b/test/sql/test_semi/R/test_flat_json_consistency
@@ -169,16 +169,12 @@ select * from test_json_cast_map order by c1;
 -- !result
 select flat_json_meta(c2) from test_json_cast_map [_META_];
 -- result:
-["nulls(TINYINT), level1.level2.level3.4(JSON), level1.level2.level3.level4.5(VARCHAR), remain(JSON)"]
+["nulls(TINYINT), level1.level2.level3(JSON), remain(JSON)"]
 -- !result
-drop table test_json_cast_map;
+CREATE TABLE source_data(c1 int, c2 json);
 -- result:
 -- !result
-CREATE TABLE test_json_cast_map (c1 int, c2 json) 
-DISTRIBUTED BY RANDOM BUCKETS 3;
--- result:
--- !result
-insert into test_json_cast_map values
+insert into source_data values
 (1, '{"level1": {"level2": {"level3": {"level4": {"5":"abc"}}}}}'),
 (2, '{"level1": {"level2": {"level3": {"4":23234982794}}}}'),
 (3, '{"level1": {"level2": {"level3": {"4":true}}}}'),
@@ -189,6 +185,120 @@ insert into test_json_cast_map values
 (8, '{"100": {"200": {"300": {"500":"abc"}}}}'),
 (9, '{"100": {"200": {"300": "abc"}}}');
 -- result:
+-- !result
+drop table test_json_cast_map;
+-- result:
+-- !result
+CREATE TABLE test_json_cast_map (c1 int, c2 json) 
+DISTRIBUTED BY RANDOM BUCKETS 2;
+-- result:
+-- !result
+insert into test_json_cast_map select * from source_data;
+-- result:
+-- !result
+select * from test_json_cast_map order by c1;
+-- result:
+1	{"level1": {"level2": {"level3": {"level4": {"5": "abc"}}}}}
+2	{"level1": {"level2": {"level3": {"4": 23234982794}}}}
+3	{"level1": {"level2": {"level3": {"4": true}}}}
+4	{"level1": {"level2": {"level3": {"4": null}}}}
+5	{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}
+6	{"level1": {"level2": {"level3": {"4": {"5": "abc"}}}}}
+7	{"level1": {"level2": {"level3": "abc"}}}
+8	{"100": {"200": {"300": {"500": "abc"}}}}
+9	{"100": {"200": {"300": "abc"}}}
+-- !result
+select flat_json_meta(c2) from test_json_cast_map [_META_];
+-- result:
+["nulls(TINYINT), level1.level2.level3(JSON), remain(JSON)"]
+["nulls(TINYINT), level1.level2.level3.4(JSON), remain(JSON)"]
+-- !result
+drop table test_json_cast_map;
+-- result:
+-- !result
+CREATE TABLE test_json_cast_map (c1 int, c2 json) 
+DISTRIBUTED BY RANDOM BUCKETS 3;
+-- result:
+-- !result
+insert into test_json_cast_map select * from source_data;
+-- result:
+-- !result
+select * from test_json_cast_map order by c1;
+-- result:
+1	{"level1": {"level2": {"level3": {"level4": {"5": "abc"}}}}}
+2	{"level1": {"level2": {"level3": {"4": 23234982794}}}}
+3	{"level1": {"level2": {"level3": {"4": true}}}}
+4	{"level1": {"level2": {"level3": {"4": null}}}}
+5	{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}
+6	{"level1": {"level2": {"level3": {"4": {"5": "abc"}}}}}
+7	{"level1": {"level2": {"level3": "abc"}}}
+8	{"100": {"200": {"300": {"500": "abc"}}}}
+9	{"100": {"200": {"300": "abc"}}}
+-- !result
+select flat_json_meta(c2) from test_json_cast_map [_META_];
+-- result:
+["nulls(TINYINT), 100.200.300(VARCHAR), level1.level2.level3.4(JSON), remain(JSON)"]
+["nulls(TINYINT), level1.level2.level3(JSON), remain(JSON)"]
+["nulls(TINYINT), 100.200.300.500(VARCHAR), remain(JSON)"]
+-- !result
+drop table test_json_cast_map;
+-- result:
+-- !result
+CREATE TABLE test_json_cast_map (c1 int, c2 json)
+DISTRIBUTED BY RANDOM BUCKETS 4;
+-- result:
+-- !result
+insert into test_json_cast_map select * from source_data;
+-- result:
+-- !result
+select * from test_json_cast_map order by c1;
+-- result:
+1	{"level1": {"level2": {"level3": {"level4": {"5": "abc"}}}}}
+2	{"level1": {"level2": {"level3": {"4": 23234982794}}}}
+3	{"level1": {"level2": {"level3": {"4": true}}}}
+4	{"level1": {"level2": {"level3": {"4": null}}}}
+5	{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}
+6	{"level1": {"level2": {"level3": {"4": {"5": "abc"}}}}}
+7	{"level1": {"level2": {"level3": "abc"}}}
+8	{"100": {"200": {"300": {"500": "abc"}}}}
+9	{"100": {"200": {"300": "abc"}}}
+-- !result
+select flat_json_meta(c2) from test_json_cast_map [_META_];
+-- result:
+["nulls(TINYINT), 100.200.300(VARCHAR), level1.level2.level3.level4.5(VARCHAR), remain(JSON)"]
+["nulls(TINYINT), level1.level2.level3(JSON), remain(JSON)"]
+["nulls(TINYINT), level1.level2.level3.4(JSON), remain(JSON)"]
+["nulls(TINYINT), 100.200.300.500(VARCHAR), level1.level2.level3.4(JSON)"]
+-- !result
+drop table test_json_cast_map;
+-- result:
+-- !result
+CREATE TABLE test_json_cast_map (c1 int, c2 json)
+DISTRIBUTED BY RANDOM BUCKETS 5;
+-- result:
+-- !result
+insert into test_json_cast_map select * from source_data;
+-- result:
+-- !result
+select * from test_json_cast_map order by c1;
+-- result:
+1	{"level1": {"level2": {"level3": {"level4": {"5": "abc"}}}}}
+2	{"level1": {"level2": {"level3": {"4": 23234982794}}}}
+3	{"level1": {"level2": {"level3": {"4": true}}}}
+4	{"level1": {"level2": {"level3": {"4": null}}}}
+5	{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}
+6	{"level1": {"level2": {"level3": {"4": {"5": "abc"}}}}}
+7	{"level1": {"level2": {"level3": "abc"}}}
+8	{"100": {"200": {"300": {"500": "abc"}}}}
+9	{"100": {"200": {"300": "abc"}}}
+-- !result
+select flat_json_meta(c2) from test_json_cast_map [_META_];
+-- result:
+["nulls(TINYINT), 100.200.300(VARCHAR), level1.level2.level3.4(JSON)"]
+[]
+["nulls(TINYINT), level1.level2.level3(JSON), remain(JSON)"]
+["nulls(TINYINT), 100.200.300.500(VARCHAR), level1.level2.level3.4(JSON)"]
+["nulls(TINYINT), level1.level2.level3.4.5(VARCHAR), level1.level2.level3.level4.5(VARCHAR)"]
 -- !result
 drop table test_json_cast_map;
 -- result:

--- a/test/sql/test_semi/T/test_flat_json_consistency
+++ b/test/sql/test_semi/T/test_flat_json_consistency
@@ -107,11 +107,8 @@ select * from test_json_cast_map order by c1;
 select flat_json_meta(c2) from test_json_cast_map [_META_];
 
 -- Test 10: inconsistent intermediate node
-drop table test_json_cast_map;
-CREATE TABLE test_json_cast_map (c1 int, c2 json) 
-DISTRIBUTED BY RANDOM BUCKETS 3;
-
-insert into test_json_cast_map values
+CREATE TABLE source_data(c1 int, c2 json);
+insert into source_data values
 (1, '{"level1": {"level2": {"level3": {"level4": {"5":"abc"}}}}}'),
 (2, '{"level1": {"level2": {"level3": {"4":23234982794}}}}'),
 (3, '{"level1": {"level2": {"level3": {"4":true}}}}'),
@@ -122,5 +119,36 @@ insert into test_json_cast_map values
 (8, '{"100": {"200": {"300": {"500":"abc"}}}}'),
 (9, '{"100": {"200": {"300": "abc"}}}');
 
+-- bucket 2
+drop table test_json_cast_map;
+CREATE TABLE test_json_cast_map (c1 int, c2 json) 
+DISTRIBUTED BY RANDOM BUCKETS 2;
+insert into test_json_cast_map select * from source_data;
+select * from test_json_cast_map order by c1;
+select flat_json_meta(c2) from test_json_cast_map [_META_];
+
+-- bucket 3
+drop table test_json_cast_map;
+CREATE TABLE test_json_cast_map (c1 int, c2 json) 
+DISTRIBUTED BY RANDOM BUCKETS 3;
+insert into test_json_cast_map select * from source_data;
+select * from test_json_cast_map order by c1;
+select flat_json_meta(c2) from test_json_cast_map [_META_];
+
+-- bucket 4
+drop table test_json_cast_map;
+CREATE TABLE test_json_cast_map (c1 int, c2 json)
+DISTRIBUTED BY RANDOM BUCKETS 4;
+insert into test_json_cast_map select * from source_data;
+select * from test_json_cast_map order by c1;
+select flat_json_meta(c2) from test_json_cast_map [_META_];
+
+-- bucket 5
+drop table test_json_cast_map;
+CREATE TABLE test_json_cast_map (c1 int, c2 json)
+DISTRIBUTED BY RANDOM BUCKETS 5;
+insert into test_json_cast_map select * from source_data;
+select * from test_json_cast_map order by c1;
+select flat_json_meta(c2) from test_json_cast_map [_META_];
 
 drop table test_json_cast_map;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

For JSON `{"k1": {"k2": 1}}` and `{"k1": 123}`:

When a JSON field contains both object and primitive values across different rows , the path derivation should treat the parent node as TYPE_JSON, avoiding separate flattening of child paths.


Fixes https://github.com/StarRocks/StarRocksTest/issues/10513

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
