### PR TITLE
[BugFix] Fix progress calculation when task count > 100 in optimize/merge jobs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/MergePartitionJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/MergePartitionJob.java
@@ -546,7 +546,9 @@ public class MergePartitionJob extends AlterJobV2 implements GsonPostProcessable
 
         // wait insert tasks finished
         boolean allFinished = true;
-        int progress = 0;
+        // Use double to avoid integer division precision loss when task count > 100
+        double progressAcc = 0.0;
+        int taskCount = Math.max(1, rewriteTasks.size());
         TaskRunManager taskRunManager = GlobalStateMgr.getCurrentState().getTaskManager().getTaskRunManager();
         TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
 
@@ -561,14 +563,14 @@ public class MergePartitionJob extends AlterJobV2 implements GsonPostProcessable
         for (OptimizeTask rewriteTask : rewriteTasks) {
             if (rewriteTask.getOptimizeTaskState() == Constants.TaskRunState.FAILED
                         || rewriteTask.getOptimizeTaskState() == Constants.TaskRunState.SUCCESS) {
-                progress += 100 / rewriteTasks.size();
+                progressAcc += 100.0 / taskCount;
                 continue;
             }
 
             TaskRun taskRun = taskRunScheduler.getRunnableTaskRun(rewriteTask.getId());
             if (taskRun != null) {
                 if (taskRun.getStatus() != null) {
-                    progress += taskRun.getStatus().getProgress() / rewriteTasks.size();
+                    progressAcc += (double) taskRun.getStatus().getProgress() / taskCount;
                 }
                 allFinished = false;
                 continue;
@@ -591,12 +593,13 @@ public class MergePartitionJob extends AlterJobV2 implements GsonPostProcessable
                 LOG.warn("optimize task {} failed", rewriteTask.getName());
                 rewriteTask.setOptimizeTaskState(Constants.TaskRunState.FAILED);
             }
-            progress += 100 / rewriteTasks.size();
+            progressAcc += 100.0 / taskCount;
         }
 
         if (!allFinished) {
             LOG.info("wait insert tasks to be finished, merge partition job: {}", jobId);
-            this.progress = progress;
+            // Cap progress at 99 until all tasks are fully finished
+            this.progress = Math.min(99, (int) Math.floor(progressAcc));
             return;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OnlineOptimizeJobV2.java
@@ -340,14 +340,17 @@ public class OnlineOptimizeJobV2 extends AlterJobV2 implements GsonPostProcessab
 
         OlapTable tbl = checkAndGetTable(db, tableId);
 
-        int progress = 0;
+        // Use double to avoid integer division precision loss when task count > 100
+        double progressAcc = 0.0;
+        int taskCount = Math.max(1, rewriteTasks.size());
 
         for (OptimizeTask rewriteTask : rewriteTasks) {
             if (rewriteTask.getOptimizeTaskState() == Constants.TaskRunState.FAILED
                         || rewriteTask.getOptimizeTaskState() == Constants.TaskRunState.SUCCESS) {
-                progress += 100 / rewriteTasks.size();
-                if (this.progress < progress) {
-                    this.progress = progress;
+                progressAcc += 100.0 / taskCount;
+                int current = Math.min(99, (int) Math.floor(progressAcc));
+                if (this.progress < current) {
+                    this.progress = current;
                 }
                 continue;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OptimizeJobV2.java
@@ -334,7 +334,9 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
 
         // wait insert tasks finished
         boolean allFinished = true;
-        int progress = 0;
+        // Use double to avoid integer division precision loss when task count > 100
+        double progressAcc = 0.0;
+        int taskCount = Math.max(1, rewriteTasks.size());
         TaskRunManager taskRunManager = GlobalStateMgr.getCurrentState().getTaskManager().getTaskRunManager();
         TaskRunScheduler taskRunScheduler = taskRunManager.getTaskRunScheduler();
         TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager(); // add: define taskManager
@@ -358,14 +360,14 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
             }
             if (rewriteTask.getOptimizeTaskState() == Constants.TaskRunState.FAILED
                     || rewriteTask.getOptimizeTaskState() == Constants.TaskRunState.SUCCESS) {
-                progress += 100 / rewriteTasks.size();
+                progressAcc += 100.0 / taskCount;
                 continue;
             }
 
             TaskRun taskRun = taskRunScheduler.getRunnableTaskRun(rewriteTask.getId());
             if (taskRun != null) {
                 if (taskRun.getStatus() != null) {
-                    progress += taskRun.getStatus().getProgress() / rewriteTasks.size();
+                    progressAcc += (double) taskRun.getStatus().getProgress() / taskCount;
                 }
                 allFinished = false;
                 continue;
@@ -411,12 +413,13 @@ public class OptimizeJobV2 extends AlterJobV2 implements GsonPostProcessable {
                     rewriteTask.setOptimizeTaskState(Constants.TaskRunState.FAILED);
                 }
             }
-            progress += 100 / rewriteTasks.size();
+            progressAcc += 100.0 / taskCount;
         }
 
         if (!allFinished) {
             LOG.debug("wait insert tasks to be finished, optimize job: {}", jobId);
-            this.progress = progress;
+            // Cap at 99 until all tasks are fully finished to keep previous semantics
+            this.progress = Math.min(99, (int) Math.floor(progressAcc));
             return;
         }
 


### PR DESCRIPTION
Replace integer division with floating-point accumulation to avoid zero increments when rewriteTasks.size() > 100 Guard against divide-by-zero via Math.max(1, taskCount) Cap interim progress at 99 until all tasks complete; set to 100 only on finalization No external behavior change except accurate progress reporting

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use floating-point accumulated progress with 99% cap and divide-by-zero guard across optimize/merge jobs; add pending-task execution and visibility gating in `OptimizeJobV2`.
> 
> - **Progress reporting**
>   - Replace integer division with floating-point accumulation and guard `taskCount` via `Math.max(1, size)`.
>   - Cap in-progress values at `99` until completion, then set to `100`.
>   - Applied in `MergePartitionJob.runRunningJob`, `OptimizeJobV2.runRunningJob`, `OnlineOptimizeJobV2.runRunningJob`.
> - **Optimize task handling** (`OptimizeJobV2`)
>   - Execute tasks still in `PENDING` via `TaskManager.executeTask`.
>   - Gate `SUCCESS` on temp-partition visibility; mark as `FAILED` if committed-but-not-visible.
>   - Minor logging/flow adjustments; maintain finalization path unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de38c31154b6e311680f2bbb4a9c7b2eefd8cdb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->