### PR TITLE
[Enhancement] Remove compute node from FE after CN scales in

### DIFF
--- a/docker/dockerfiles/be/cn_prestop.sh
+++ b/docker/dockerfiles/be/cn_prestop.sh
@@ -1,7 +1,79 @@
-#!/bin/bash
+  #!/bin/bash
 
-STARROCKS_ROOT=${STARROCKS_ROOT:-"/opt/starrocks"}
-STARROCKS_HOME=${STARROCKS_ROOT}/cn
+  HOST_TYPE=${HOST_TYPE:-"IP"}
+  FE_QUERY_PORT=${FE_QUERY_PORT:-9030}
+  HEARTBEAT_PORT=9050
+  MY_SELF=
+  MY_IP=`hostname -i`
+  MY_HOSTNAME=`hostname -f`
+  STARROCKS_ROOT=${STARROCKS_ROOT:-"/opt/starrocks"}
+  STARROCKS_HOME=${STARROCKS_ROOT}/cn
+  CN_CONFIG=$STARROCKS_HOME/conf/cn.conf
 
-# graceful stop cn
-$STARROCKS_HOME/bin/stop_cn.sh -g
+  log_stderr()
+  {
+      echo "[`date`] $@" >&2
+  }
+
+  show_compute_nodes(){
+      timeout 15 mysql --connect-timeout 2 -h $svc -P $FE_QUERY_PORT -u root --skip-column-names --batch -e 'SHOW COMPUTE NODES;'
+  }
+
+  parse_confval_from_cn_conf()
+  {
+      local confkey=$1
+      local confvalue=`grep "\<$confkey\>" $CN_CONFIG | grep -v '^\s*#' | sed 's|^\s*'$confkey'\s*=\s*\(.*\)\s*$|\1|g'`
+      echo "$confvalue"
+  }
+
+  collect_env_info()
+  {
+      # heartbeat_port from conf file
+      local heartbeat_port=`parse_confval_from_cn_conf "heartbeat_service_port"`
+      if [[ "x$heartbeat_port" != "x" ]] ; then
+          HEARTBEAT_PORT=$heartbeat_port
+      fi
+
+      if [[ "x$HOST_TYPE" == "xIP" ]] ; then
+          MY_SELF=$MY_IP
+      else
+          MY_SELF=$MY_HOSTNAME
+      fi
+  }
+
+  drop_my_self()
+  {
+      local svc=$1
+      local start=`date +%s`
+      local memlist=
+
+      for ((i=0;i<3;++i))
+      do
+          log_stderr "try to drop myself($MY_SELF) from FE ..."
+          memlist=`show_compute_nodes $svc`
+          ret=$?
+          if [[ $ret -eq 0 ]] ; then
+              selfinfo=`echo "$memlist" | grep -w "\<$MY_SELF\>" | awk '{printf("%s:%s\n", $2, $3);}'`
+              if [[ "x$selfinfo" == "x" ]] ; then
+                  log_stderr "myself is not in fe cluster"
+                  return 0
+              else
+                  log_stderr "drop my self $selfinfo ..."
+                  timeout 15 mysql --connect-timeout 2 -h $svc -P $FE_QUERY_PORT -u root --skip-column-names --batch -e "ALTER SYSTEM DROP COMPUTE NODE \"$selfinfo\";"
+                  break;
+              fi
+          else
+              log_stderr "Got error $ret, sleep and retry ..."
+              sleep $PROBE_INTERVAL
+          fi
+      done
+  }
+
+  # graceful stop cn
+  $STARROCKS_HOME/bin/stop_cn.sh -g
+  # remove myself from FE
+  svc_name=$1
+  if [[ "x$svc_name" != "x" ]] ; then
+      collect_env_info
+      drop_my_self $svc_name
+  fi


### PR DESCRIPTION
## Why I'm doing:
```
2025-11-06 06:33:07.784Z WARN (heartbeat-mgr-pool-5|731) [HeartbeatMgr$BackendHeartbeatHandler.call():333] backend heartbeat got exception, addr: starrocks-cn-1.starrocks-cn-search.wap-starrocks-dev.svc.aiadgen-int-1:9050
2025-11-06 06:33:07.785Z WARN (heartbeat mgr|16) [HeartbeatMgr.runAfterCatalogReady():168] get bad heartbeat response: type: BACKEND, status: BAD, msg: java.net.UnknownHostException: starrocks-cn-1.starrocks-cn-search.wap-starrocks-dev.svc.aiadgen-int-1
```
When CN are dynamically scaled in in Kubernetes, the FE doesn’t automatically remove old CNs from its metadata.
FE keeps trying to calling those  CNs, which is not necessary.

## What I'm doing:

as title

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances `cn_prestop.sh` to gracefully stop CN and remove itself from FE using `SHOW/ALTER SYSTEM` with configurable host identity and ports.
> 
> - **Scripts**:
>   - **`docker/dockerfiles/be/cn_prestop.sh`**:
>     - Adds env/config parsing (`HOST_TYPE`, `FE_QUERY_PORT`, `heartbeat_service_port` from `cn.conf`) and self-identity resolution (IP/hostname).
>     - Implements helpers: `log_stderr`, `show_compute_nodes`, `parse_confval_from_cn_conf`, `collect_env_info`, `drop_my_self`.
>     - On prestop: runs graceful CN stop, then optionally removes this CN from FE via `ALTER SYSTEM DROP COMPUTE NODE` (after `SHOW COMPUTE NODES` lookup) when FE service name is provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cad9459ab84ed2b95e91fd467a2c056a58d8c252. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->