### PR TITLE
[Tool] Remove unused nio config param

### DIFF
--- a/conf/fe.conf
+++ b/conf/fe.conf
@@ -41,7 +41,6 @@ http_port = 8030
 rpc_port = 9020
 query_port = 9030
 edit_log_port = 9010
-mysql_service_nio_enabled = true
 
 # Enable jaeger tracing by setting jaeger_grpc_endpoint
 # jaeger_grpc_endpoint = http://localhost:14250


### PR DESCRIPTION
## Why I'm doing:
Just a clean up of a parameter that is no longer being used.
mysql_service_nio_enabled = true

## What I'm doing:
Removed parameter from fe.conf to avoid confusion and to keep it tidy.

Fixes #65103 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
