### PR TITLE
[Enhancement] upgrade gcs hadoop connector to version 3

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -921,6 +921,13 @@ under the License.
             <artifactId>sql-formatter</artifactId>
             <version>2.0.4</version>
         </dependency>
+
+        <!-- https://mvnrepository.com/artifact/com.google.api-client/google-api-client -->
+        <dependency>
+            <groupId>com.google.api-client</groupId>
+            <artifactId>google-api-client</artifactId>
+            <version>2.8.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -52,7 +52,7 @@ under the License.
         <tomcat.version>8.5.70</tomcat.version>
         <parquet.version>1.15.2</parquet.version>
         <hadoop.version>3.4.1</hadoop.version>
-        <gcs.connector.version>hadoop3-2.2.26</gcs.connector.version>
+        <gcs.connector.version>3.0.13</gcs.connector.version>
         <antlr.version>4.9.3</antlr.version>
         <skip.plugin>false</skip.plugin>
         <hudi.version>1.0.2</hudi.version>

--- a/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/gcp/TemporaryGCPAccessTokenProvider.java
+++ b/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/gcp/TemporaryGCPAccessTokenProvider.java
@@ -20,6 +20,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
+import java.time.Instant;
 
 public class TemporaryGCPAccessTokenProvider implements AccessTokenProvider {
     private static final Logger LOG = LogManager.getLogger(TemporaryGCPAccessTokenProvider.class);
@@ -68,7 +69,7 @@ public class TemporaryGCPAccessTokenProvider implements AccessTokenProvider {
             LOG.warn("GCP Access token has expired. Please refresh the token.");
             return null;
         }
-        return new AccessToken(accessToken, expirationTimeMs);
+        return new AccessToken(accessToken, Instant.ofEpochMilli(expirationTimeMs));
     }
 
     @Override

--- a/java-extensions/pom.xml
+++ b/java-extensions/pom.xml
@@ -45,7 +45,7 @@
         <protobuf-java.version>3.25.5</protobuf-java.version>
         <nimbusds.version>9.37.2</nimbusds.version>
         <commons-io.version>2.14.0</commons-io.version>
-        <gcs.connector.version>hadoop3-2.2.26</gcs.connector.version>
+        <gcs.connector.version>3.0.13</gcs.connector.version>
         <slf4j.version>1.7.36</slf4j.version>
         <arrow.version>17.0.0</arrow.version>
         <jackson.version>2.19.1</jackson.version>


### PR DESCRIPTION
## Why I'm doing:
gcs-connector 3.x adds support for non‑GCE environments using Google Cloud Workload Identity Federation (WIF). This allows StarRocks running outside Google Compute Engine to authenticate to GCS using OIDC tokens from a trusted identity provider.
The google-api-client dependency is required by FE.

## What I'm doing:
Fixes https://github.com/StarRocks/starrocks/issues/64341

Bumped gcs-connector version from hadoop3-2.2.26 to 3.0.13 (fe/pom.xml, java-extensions/pom.xml).
Added dependency com.google.api-client:google-api-client:2.8.1 to fe-core/pom.xml.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrade GCS Hadoop connector to 3.0.13, add google-api-client to FE, and adapt GCP access token provider to Instant-based expiry API.
> 
> - **Dependencies**
>   - Upgrade `com.google.cloud.bigdataoss:gcs-connector` to `3.0.13` in `fe/pom.xml` and `java-extensions/pom.xml`.
>   - Add `com.google.api-client:google-api-client:2.8.1` to `fe/fe-core/pom.xml`.
> - **GCP Token Provider**
>   - Update `TemporaryGCPAccessTokenProvider` to use `Instant`-based `AccessToken` expiry (`Instant.ofEpochMilli(expirationTimeMs)`) and add `java.time.Instant` import.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e290a98d1dbbb6e93c19f06c2bd61b3de3a8133. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->