### PR TITLE
[Enhancement] Add db info and table info in [transaction] stream load log.

### DIFF
--- a/be/src/runtime/stream_load/stream_load_context.cpp
+++ b/be/src/runtime/stream_load/stream_load_context.cpp
@@ -64,6 +64,12 @@ std::string StreamLoadContext::to_resp_json(const std::string& txn_op, const Sta
     std::string_view msg = st.message();
     writer.Key("Message");
     writer.String(msg.data(), msg.size());
+    // db
+    writer.Key("Db");
+    writer.String(db.c_str());
+    // table
+    writer.Key("Table");
+    writer.String(table.c_str());
 
     if (st.ok()) {
         // label
@@ -144,6 +150,14 @@ std::string StreamLoadContext::to_json() const {
     writer.Key("Label");
     writer.String(label.c_str());
 
+    // db
+    writer.Key("Db");
+    writer.String(db.c_str());
+
+    // table
+    writer.Key("Table");
+    writer.String(table.c_str());
+
     // status
     writer.Key("Status");
     switch (status.code()) {
@@ -216,6 +230,10 @@ std::string StreamLoadContext::to_merge_commit_json() const {
     writer.Int64(txn_id);
     writer.Key("Label");
     writer.String(batch_write_label.c_str());
+    writer.Key("Db");
+    writer.String(db.c_str());
+    writer.Key("Table");
+    writer.String(table.c_str());
 
     writer.Key("Status");
     switch (status.code()) {

--- a/be/test/http/stream_load_test.cpp
+++ b/be/test/http/stream_load_test.cpp
@@ -538,6 +538,8 @@ TEST_F(StreamLoadActionTest, merge_commit_response) {
         ctx.txn_id = 1;
         ctx.batch_write_label = "label1";
         ctx.label = "request_id_1";
+        ctx.db = "test_db1";
+        ctx.table = "test_table1";
         ctx.receive_bytes = 10;
         ctx.load_cost_nanos = 1'200'000'000;
         ctx.mc_read_data_cost_nanos = 10'000'000;
@@ -551,6 +553,8 @@ TEST_F(StreamLoadActionTest, merge_commit_response) {
                 "{\n"
                 "    \"TxnId\": 1,\n"
                 "    \"Label\": \"label1\",\n"
+                "    \"Db\": \"test_db1\",\n"
+                "    \"Table\": \"test_table1\",\n"
                 "    \"Status\": \"Success\",\n"
                 "    \"Message\": \"OK\",\n"
                 "    \"RequestId\": \"request_id_1\",\n"
@@ -574,6 +578,8 @@ TEST_F(StreamLoadActionTest, merge_commit_response) {
         ctx.txn_id = 2;
         ctx.batch_write_label = "label2";
         ctx.label = "request_id_2";
+        ctx.db = "test_db2";
+        ctx.table = "test_table2";
         ctx.receive_bytes = 20;
         ctx.load_cost_nanos = 100'000'000;
         ctx.mc_read_data_cost_nanos = 10'000'000;
@@ -587,6 +593,8 @@ TEST_F(StreamLoadActionTest, merge_commit_response) {
                 "{\n"
                 "    \"TxnId\": 2,\n"
                 "    \"Label\": \"label2\",\n"
+                "    \"Db\": \"test_db2\",\n"
+                "    \"Table\": \"test_table2\",\n"
                 "    \"Status\": \"Fail\",\n"
                 "    \"Message\": \"TestFail\",\n"
                 "    \"RequestId\": \"request_id_2\",\n"


### PR DESCRIPTION


## Why I'm doing:
1.Stream Load client-side logs are more detailed, making it easier to troubleshoot issues.
2.We can collect these logs on the BE side for multi-dimensional analysis, allowing us to analyze Stream Load.

## What I'm doing:
Add db info and table info in [transaction] stream load log.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Include `Db` and `Table` in stream load JSON responses (including merge-commit) and update tests accordingly.
> 
> - **Backend**:
>   - `StreamLoadContext` JSON output now includes `Db` and `Table` in `to_json()` and `to_merge_commit_json()`.
> - **Tests**:
>   - Update `merge_commit_response` to set `ctx.db`/`ctx.table` and assert `"Db"` and `"Table"` in expected JSON.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f91ff892385be6c85353b910371abb02ce6dfa78. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->