### PR TITLE
[BugFix] Fix tablet meta load bug on rocksdb iteration timeout

### DIFF
--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -296,28 +296,8 @@ void DataDir::load() {
         }
         return true;
     };
-    Status load_tablet_status =
-            TabletMetaManager::walk_until_timeout(_kv_store, load_tablet_func, config::load_tablet_timeout_seconds);
-    if (load_tablet_status.is_time_out()) {
-        LOG(WARNING) << "load tablets from rocksdb timeout, try to compact meta and retry. path: " << _path;
-        Status s = _kv_store->compact();
-        if (!s.ok()) {
-            // We don't need to make sure compact MUST success. Just ignore the error.
-            LOG(ERROR) << "data dir " << _path << " compact meta before load failed";
-        } else {
-            LOG(WARNING) << "compact meta finished, retry load tablets from rocksdb. path: " << _path;
-        }
-        for (auto tablet_id : tablet_ids) {
-            Status s = _tablet_manager->drop_tablet(tablet_id, kKeepMetaAndFiles);
-            if (!s.ok()) {
-                // Only print log, do not return error. Later load tablet from rocksdb can handle this.
-                LOG(ERROR) << "data dir " << _path << " drop_tablet failed: " << s.message();
-            }
-        }
-        tablet_ids.clear();
-        failed_tablet_ids.clear();
-        load_tablet_status = TabletMetaManager::walk(_kv_store, load_tablet_func);
-    }
+    Status load_tablet_status = TabletMetaManager::walk_with_compact_on_timeout(_kv_store, load_tablet_func,
+                                                                                config::load_tablet_timeout_seconds);
 
     if (failed_tablet_ids.size() != 0) {
         LOG(ERROR) << "load tablets from header failed"

--- a/be/src/storage/kv_store.cpp
+++ b/be/src/storage/kv_store.cpp
@@ -266,6 +266,12 @@ static std::string get_iterate_upper_bound(const std::string& prefix) {
 Status KVStore::iterate(ColumnFamilyIndex column_family_index, const std::string& prefix,
                         std::function<StatusOr<bool>(std::string_view, std::string_view)> const& func,
                         int64_t timeout_sec) {
+    return iterate(column_family_index, prefix, "", func, timeout_sec);
+}
+
+Status KVStore::iterate(ColumnFamilyIndex column_family_index, const std::string& prefix, const std::string& start_key,
+                        std::function<StatusOr<bool>(std::string_view, std::string_view)> const& func,
+                        int64_t timeout_sec) {
     int64_t t_start = MonotonicMillis();
     rocksdb::ColumnFamilyHandle* handle = _handles[column_family_index];
     auto opts = ReadOptions();
@@ -276,11 +282,19 @@ Status KVStore::iterate(ColumnFamilyIndex column_family_index, const std::string
         opts.iterate_upper_bound = &upper_bound_slice;
     }
     std::unique_ptr<Iterator> it(_db->NewIterator(opts, handle));
-    if (prefix.empty()) {
-        it->SeekToFirst();
+    if (start_key.empty()) {
+        if (prefix.empty()) {
+            it->SeekToFirst();
+        } else {
+            it->Seek(prefix);
+        }
     } else {
-        it->Seek(prefix);
+        it->Seek(start_key);
+        if (it->Valid() && it->key() == start_key) {
+            it->Next();
+        }
     }
+
     // if limit time is less than or equal to zero, it means no limit
     if (timeout_sec <= 0) {
         for (; it->Valid(); it->Next()) {
@@ -318,6 +332,30 @@ Status KVStore::iterate(ColumnFamilyIndex column_family_index, const std::string
     }
     LOG_IF(WARNING, !it->status().ok()) << it->status().ToString();
     return to_status(it->status());
+}
+
+Status KVStore::iterate_with_compact_on_timeout(
+        ColumnFamilyIndex column_family_index, const std::string& prefix,
+        std::function<StatusOr<bool>(std::string_view, std::string_view)> const& func, int64_t timeout_sec) {
+    std::string last_key;
+    auto func_wrapper = [&](std::string_view key, std::string_view value) -> StatusOr<bool> {
+        last_key.assign(key.data(), key.size());
+        return func(key, value);
+    };
+
+    Status st = iterate(column_family_index, prefix, func_wrapper, timeout_sec);
+    if (st.is_time_out()) {
+        LOG(WARNING) << "rocksdb iterate timeout, try to compact";
+        Status compact_st = compact();
+        if (!compact_st.ok()) {
+            LOG(ERROR) << "rocksdb compact failed before retry";
+        } else {
+            LOG(INFO) << "rocksdb compact finished, retry iterate from last key";
+        }
+        // retry, but with no timeout
+        return iterate(column_family_index, prefix, last_key, func_wrapper, 0);
+    }
+    return st;
 }
 
 Status KVStore::iterate_range(ColumnFamilyIndex column_family_index, const std::string& lower_bound,

--- a/be/src/storage/kv_store.h
+++ b/be/src/storage/kv_store.h
@@ -75,6 +75,13 @@ public:
                    std::function<StatusOr<bool>(std::string_view, std::string_view)> const& func,
                    int64_t timeout_sec = -1);
 
+    // Iterates through rocksdb with timeout. If the iteration times out,
+    // it triggers a compaction of rocksdb and retries the iteration
+    // from the last processed key without timeout.
+    Status iterate_with_compact_on_timeout(
+            ColumnFamilyIndex column_family_index, const std::string& prefix,
+            std::function<StatusOr<bool>(std::string_view, std::string_view)> const& func, int64_t timeout_sec = -1);
+
     Status iterate_range(ColumnFamilyIndex column_family_index, const std::string& lower_bound,
                          const std::string& upper_bound,
                          std::function<StatusOr<bool>(std::string_view, std::string_view)> const& func);
@@ -104,6 +111,10 @@ public:
 
 private:
     static int64_t calc_rocksdb_write_buffer_size(MemTracker* mem_tracker);
+
+    Status iterate(ColumnFamilyIndex column_family_index, const std::string& prefix, const std::string& start_key,
+                   std::function<StatusOr<bool>(std::string_view, std::string_view)> const& func,
+                   int64_t timeout_sec = -1);
 
 private:
     std::string _root_path;

--- a/be/src/storage/tablet_meta_manager.h
+++ b/be/src/storage/tablet_meta_manager.h
@@ -113,8 +113,17 @@ public:
 
     static Status walk(KVStore* meta, std::function<bool(long, long, std::string_view)> const& func);
 
+    // Iterates through tablet metadata with timeout. If the iteration times out,
+    // returns TIMEOUT status.
     static Status walk_until_timeout(KVStore* meta, std::function<bool(long, long, std::string_view)> const& func,
                                      int64_t limit_time);
+
+    // Iterates through tablet metadata with timeout. If the iteration times out,
+    // it triggers a compaction of the meta KVStore and retries the iteration
+    // from the last processed key without timeout.
+    static Status walk_with_compact_on_timeout(KVStore* meta,
+                                               std::function<bool(long, long, std::string_view)> const& func,
+                                               int64_t limit_time);
 
     static Status load_json_meta(DataDir* store, const std::string& meta_path);
 


### PR DESCRIPTION
## Why I'm doing:

A tablet may be migrated between disks on the same host, if loading tablet metadata times out during BE startup, it may incorrectly load an old tablet, which could result in version loss.

## What I'm doing:

The fix aims to improve the reliability of tablet metadata loading during startup, particularly in scenarios where RocksDB iteration might timeout due to performance issues. In such cases, the system now automatically compacts the database and resumes loading from where it left off, rather than dropping the loaded tablets and reiterate from the beginning.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> On RocksDB iteration timeout, compact and resume iteration from the last key; use this for tablet meta loading and add a unit test.
> 
> - **Storage**:
>   - **KVStore**:
>     - Add `iterate(ColumnFamilyIndex, prefix, start_key, ...)` to support resuming from a specific key.
>     - Implement `iterate_with_compact_on_timeout(...)` to compact on timeout and retry from the last processed key (no timeout on retry).
>     - Adjust iterator seek logic to handle empty/non-empty prefixes and `start_key`.
>   - **TabletMetaManager**:
>     - Add `walk_with_compact_on_timeout(...)` that wraps KVStore's compact-and-resume iteration for `HEADER_PREFIX`.
>   - **DataDir**:
>     - Replace manual timeout handling in `load()` with `TabletMetaManager::walk_with_compact_on_timeout(...)`.
> - **Tests**:
>   - Add `iterate_with_compact_on_timeout_test` validating compaction-and-resume iterates all keys after a forced timeout.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 068f6fbf25f77dd407ad8c0c42b86aa036b53009. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->