### PR TITLE
[Refactor] Merge RC_TEXT and RC_BINARY into RC_FILE in thrift::THdfsFileFormat

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -813,10 +813,12 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
         scanner = new HdfsOrcScanner();
     } else if (format == THdfsFileFormat::TEXT) {
         scanner = new HdfsTextScanner();
-    } else if ((format == THdfsFileFormat::AVRO || format == THdfsFileFormat::RC_BINARY ||
+    } else if ((format == THdfsFileFormat::AVRO || format == THdfsFileFormat::RC_FILE ||
                 format == THdfsFileFormat::RC_TEXT || format == THdfsFileFormat::SEQUENCE_FILE) &&
                (dynamic_cast<const HdfsTableDescriptor*>(_hive_table) != nullptr ||
                 dynamic_cast<const FileTableDescriptor*>(_hive_table) != nullptr)) {
+        // THdfsFileFormat::RC_TEXT is deprecated. RCText and RCBinary are both RC_FILE.
+        // It will be retained here for compatibility when upgrading and will be removed in several versions.
         scanner = create_hive_jni_scanner(jni_scanner_create_options).release();
     } else {
         std::string msg = fmt::format("unsupported hdfs file format: {}", to_string(format));

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -817,8 +817,8 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
                 format == THdfsFileFormat::RC_TEXT || format == THdfsFileFormat::SEQUENCE_FILE) &&
                (dynamic_cast<const HdfsTableDescriptor*>(_hive_table) != nullptr ||
                 dynamic_cast<const FileTableDescriptor*>(_hive_table) != nullptr)) {
-        // THdfsFileFormat::RC_TEXT is deprecated. RCText and RCBinary are both RC_FILE.
-        // It will be retained here for compatibility when upgrading and will be removed in several versions.
+        // THdfsFileFormat::RC_TEXT is deprecated. RCText and RCBinary are both mapped to RC_FILE in the frontend.
+        // The RC_TEXT check is retained here for backward compatibility with older FE versions.
         scanner = create_hive_jni_scanner(jni_scanner_create_options).release();
     } else {
         std::string msg = fmt::format("unsupported hdfs file format: {}", to_string(format));

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveStorageFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveStorageFormat.java
@@ -125,8 +125,7 @@ public enum HiveStorageFormat {
             case ORC -> THdfsFileFormat.ORC;
             case TEXTFILE -> THdfsFileFormat.TEXT;
             case AVRO -> THdfsFileFormat.AVRO;
-            case RCBINARY -> THdfsFileFormat.RC_BINARY;
-            case RCTEXT -> THdfsFileFormat.RC_TEXT;
+            case RCBINARY, RCTEXT -> THdfsFileFormat.RC_FILE;
             case SEQUENCE -> THdfsFileFormat.SEQUENCE_FILE;
             default -> THdfsFileFormat.UNKNOWN;
         };

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/RemoteFileInputFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/RemoteFileInputFormat.java
@@ -77,23 +77,14 @@ public enum RemoteFileInputFormat {
     }
 
     public THdfsFileFormat toThrift() {
-        switch (this) {
-            case PARQUET:
-                return THdfsFileFormat.PARQUET;
-            case ORC:
-                return THdfsFileFormat.ORC;
-            case TEXTFILE:
-                return THdfsFileFormat.TEXT;
-            case AVRO:
-                return THdfsFileFormat.AVRO;
-            case RCBINARY:
-                return THdfsFileFormat.RC_BINARY;
-            case RCTEXT:
-                return THdfsFileFormat.RC_TEXT;
-            case SEQUENCE:
-                return THdfsFileFormat.SEQUENCE_FILE;
-            default:
-                return THdfsFileFormat.UNKNOWN;
-        }
+        return switch (this) {
+            case PARQUET -> THdfsFileFormat.PARQUET;
+            case ORC -> THdfsFileFormat.ORC;
+            case TEXTFILE -> THdfsFileFormat.TEXT;
+            case AVRO -> THdfsFileFormat.AVRO;
+            case RCBINARY, RCTEXT -> THdfsFileFormat.RC_FILE;
+            case SEQUENCE -> THdfsFileFormat.SEQUENCE_FILE;
+            default -> THdfsFileFormat.UNKNOWN;
+        };
     }
 }

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -69,8 +69,10 @@ struct TTupleDescriptor {
 enum THdfsFileFormat {
   TEXT = 0,
   LZO_TEXT = 1,
-  RC_BINARY = 2,
-  RC_TEXT = 3,
+  RC_FILE = 2,
+  // THdfsFileFormat is only used to represent FileFormat, not SerializeFormat,
+  // so there is no need to split it into RC_BINARY and RC_TEXT.
+  RC_TEXT = 3, // Deprecated
   AVRO = 4,
   PARQUET = 5,
   ORC = 6,


### PR DESCRIPTION
## Why I'm doing:

The BE will use `file_format(hive.table.input.format)` and `hive.table.serde.lib` to create the file scanner, so splitting `RC_FILE` into `RC_TEXT` and `RC_BINARY` is unnecessary. This will make the format definition clearer and facilitate adding more formats.

There will be no compatibility problems.

## What I'm doing:

Merge RC_TEXT and RC_BINARY into RC_FILE in thrift::THdfsFileFormat

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates RC_TEXT and RC_BINARY into RC_FILE in THdfsFileFormat and updates FE/BE mappings and scanner selection with backward-compatible RC_TEXT handling.
> 
> - **Thrift**:
>   - Merge `THdfsFileFormat::RC_BINARY` and `RC_TEXT` into `RC_FILE`; keep `RC_TEXT` as deprecated.
> - **Frontend**:
>   - Map `HiveStorageFormat` and `RemoteFileInputFormat` (`RCBINARY`, `RCTEXT`) to `THdfsFileFormat.RC_FILE`.
>   - Simplify `RemoteFileInputFormat.toThrift` using `switch` expression.
> - **Backend**:
>   - In `be/src/connector/hive_connector.cpp`, treat `THdfsFileFormat::RC_FILE` (and deprecated `RC_TEXT`) like other JNI-handled formats; add note on `RC_TEXT` deprecation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2433ad5184149d7697d6934f5101d93ab48b583b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->