### PR TITLE
[Enhancement] Optimize SqlCredentialRedactor redact performance

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/SqlCredentialRedactor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/SqlCredentialRedactor.java
@@ -108,9 +108,9 @@ public class SqlCredentialRedactor {
             CREDENTIAL_KEYS.stream().map(String::length).max(Integer::compareTo).orElse(1);
     // NOTE: MAX_KEY_LENGTH is used to avoid matching too many characters of a long string
     private static final Pattern KEY_VALUE_PATTERN = Pattern.compile(
-            "([\"']?)" +                                    // quote
+            "([\"'])" +                                    // quote
                     "([^\"'=\\s,()]{1," + MAX_KEY_LENGTH + "})" + // key
-                    "([\"']?)" +                                  // quote
+                    "([\"'])" +                                  // quote
                     "\\s*=\\s*" +                                 // =
                     "(?:'((?:[^'\\\\]|\\\\.)*)'|\"((?:[^\"\\\\]|\\\\.)*)\"|([^,()\\n]*))",
             Pattern.DOTALL | Pattern.MULTILINE

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/SqlCredentialRedactor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/SqlCredentialRedactor.java
@@ -104,10 +104,15 @@ public class SqlCredentialRedactor {
     // key'='value
     // key"="value
     // Values can contain spaces and span multiple lines, separated by commas
+    private static final int MAX_KEY_LENGTH =
+            CREDENTIAL_KEYS.stream().map(String::length).max(Integer::compareTo).orElse(1);
+    // NOTE: MAX_KEY_LENGTH is used to avoid matching too many characters of a long string
     private static final Pattern KEY_VALUE_PATTERN = Pattern.compile(
-            "(?:([\"']?)([^\"'=\\s,()]+)([\"']?))\\s*=\\s*" +
-                    "(?:([\"'])((?:[^\\\\]|\\\\.)*?)\\4|([^,()\\n]*?))" +
-            "(?=\\s*,|\\s*$|\\s*\\)|\\s*\\n)",
+            "([\"']?)" +                                    // quote
+                    "([^\"'=\\s,()]{1," + MAX_KEY_LENGTH + "})" + // key
+                    "([\"']?)" +                                  // quote
+                    "\\s*=\\s*" +                                 // =
+                    "(?:'((?:[^'\\\\]|\\\\.)*)'|\"((?:[^\"\\\\]|\\\\.)*)\"|([^,()\\n]*))",
             Pattern.DOTALL | Pattern.MULTILINE
     );
 

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/SqlCredentialRedactorBench.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/SqlCredentialRedactorBench.java
@@ -1,0 +1,170 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+public class SqlCredentialRedactorBench {
+
+    private String sqlWithManyKeys;
+    private String sqlWithFewKeys;
+    private String sqlWithoutCredentials;
+    private Pattern oldPattern;
+
+    public static void main(String[] args) throws Exception {
+        Options opt = new OptionsBuilder()
+                .include(SqlCredentialRedactorBench.class.getSimpleName())
+                .build();
+        new Runner(opt).run();
+    }
+
+    @org.openjdk.jmh.annotations.Setup
+    public void setup() {
+        // Pre-compile the old pattern (simulating old approach with all keys in regex)
+        String[] allKeys = {
+                "aws\\.s3\\.access_key", "aws\\.s3\\.secret_key", "aws\\.s3\\.session_token",
+                "aws\\.glue\\.access_key", "aws\\.glue\\.secret_key", "aws\\.glue\\.session_token",
+                "azure\\.blob\\.shared_key", "azure\\.blob\\.sas_token", "azure\\.blob\\.oauth2_client_secret",
+                "azure\\.adls1\\.oauth2_credential", "azure\\.adls2\\.shared_key", "azure\\.adls2\\.sas_token",
+                "azure\\.adls2\\.oauth2_client_secret", "gcp\\.gcs\\.service_account_private_key",
+                "gcp\\.gcs\\.service_account_private_key_id", "hdfs\\.password",
+                "hadoop\\.security\\.authentication\\.kerberos\\.keytab",
+                "hadoop\\.security\\.authentication\\.kerberos\\.keytab\\.content",
+                "aliyun\\.oss\\.access_key", "aliyun\\.oss\\.secret_key",
+                "tencent\\.cos\\.access_key", "tencent\\.cos\\.secret_key",
+                "fs\\.s3a\\.access\\.key", "fs\\.s3a\\.secret\\.key", "fs\\.ks3\\.access\\.key",
+                "fs\\.ks3\\.secret\\.key",
+                "fs\\.oss\\.access\\.key", "fs\\.oss\\.secret\\.key", "fs\\.cos\\.access\\.key",
+                "fs\\.cos\\.secret\\.key",
+                "fs\\.obs\\.access\\.key", "fs\\.obs\\.secret\\.key", "fs\\.tos\\.access\\.key",
+                "fs\\.tos\\.secret\\.key",
+                "password", "passwd", "pwd", "property\\.sasl\\.password", "broker\\.password"
+        };
+        String keysPattern = String.join("|", allKeys);
+        oldPattern = Pattern.compile(
+                "(?:([\"']?)(" + keysPattern + ")([\"']?))\\s*=\\s*" +
+                        "(?:([\"'])((?:[^\\\\]|\\\\.)*?)\\4|([^,()\\n]*?))" +
+                        "(?=\\s*,|\\s*$|\\s*\\)|\\s*\\n)",
+                Pattern.CASE_INSENSITIVE | Pattern.DOTALL | Pattern.MULTILINE
+        );
+
+        // Build SQL with many key-value pairs (simulates real-world scenario)
+        StringBuilder sqlBuilder = new StringBuilder(10000);
+        sqlBuilder.append("CREATE EXTERNAL CATALOG test_catalog\n");
+        sqlBuilder.append("PROPERTIES (\n");
+
+        // Add many non-sensitive keys
+        for (int i = 0; i < 100; i++) {
+            sqlBuilder.append("    \"property").append(i).append("\" = \"value").append(i).append("\",\n");
+        }
+
+        // Add some sensitive keys
+        sqlBuilder.append("    \"aws.s3.access_key\" = \"AKIAIOSFODNN7EXAMPLE\",\n");
+        sqlBuilder.append("    \"aws.s3.secret_key\" = \"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\",\n");
+        sqlBuilder.append("    \"password\" = \"secret123\",\n");
+        sqlBuilder.append("    \"fs.s3a.access.key\" = \"access_key_value\",\n");
+        sqlBuilder.append("    \"fs.s3a.secret.key\" = \"secret_key_value\"\n");
+        sqlBuilder.append(")");
+
+        sqlWithManyKeys = sqlBuilder.toString();
+
+        // Build SQL with few keys
+        sqlBuilder = new StringBuilder();
+        sqlBuilder.append("CREATE EXTERNAL CATALOG test_catalog\n");
+        sqlBuilder.append("PROPERTIES (\n");
+        sqlBuilder.append("    \"aws.s3.access_key\" = \"AKIAIOSFODNN7EXAMPLE\",\n");
+        sqlBuilder.append("    \"aws.s3.secret_key\" = \"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\"\n");
+        sqlBuilder.append(")");
+        sqlWithFewKeys = sqlBuilder.toString();
+
+        // SQL without credentials
+        sqlWithoutCredentials = "SELECT * FROM table WHERE id = 1";
+    }
+
+    @Benchmark
+    public void benchmarkManyKeys() {
+        SqlCredentialRedactor.redact(sqlWithManyKeys);
+    }
+
+    @Benchmark
+    public void benchmarkFewKeys() {
+        SqlCredentialRedactor.redact(sqlWithFewKeys);
+    }
+
+    @Benchmark
+    public void benchmarkNoCredentials() {
+        SqlCredentialRedactor.redact(sqlWithoutCredentials);
+    }
+
+    @Benchmark
+    public void benchmarkOldVersionManyKeys() {
+        redactOldVersion(sqlWithManyKeys);
+    }
+
+    // Simulate the old version with complex regex pattern containing all keys
+    // This uses alternation with many keys, causing regex backtracking performance issues
+    private String redactOldVersion(String sql) {
+        if (sql == null || sql.isEmpty()) {
+            return sql;
+        }
+
+        Matcher matcher = oldPattern.matcher(sql);
+        StringBuilder result = new StringBuilder(sql.length() + 100);
+
+        int lastEnd = 0;
+        while (matcher.find()) {
+            String keyPrefix = matcher.group(1) != null ? matcher.group(1) : "";
+            String key = matcher.group(2);
+            String keySuffix = matcher.group(3) != null ? matcher.group(3) : "";
+
+            result.append(sql, lastEnd, matcher.start());
+
+            String replacement;
+            if (matcher.group(4) != null && matcher.group(5) != null) {
+                String valueQuote = matcher.group(4);
+                replacement = keyPrefix + key + keySuffix + " = " + valueQuote + "***" + valueQuote;
+            } else {
+                replacement = keyPrefix + key + keySuffix + " = ***";
+            }
+            result.append(replacement);
+            lastEnd = matcher.end();
+        }
+
+        result.append(sql, lastEnd, sql.length());
+        return result.toString();
+    }
+}
+

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/SqlCredentialRedactorBench.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/SqlCredentialRedactorBench.java
@@ -35,13 +35,14 @@ import java.util.regex.Pattern;
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Benchmark)
 @Fork(value = 1)
-@Warmup(iterations = 3)
-@Measurement(iterations = 5)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 3, time = 1)
 public class SqlCredentialRedactorBench {
 
     private String sqlWithManyKeys;
     private String sqlWithFewKeys;
     private String sqlWithoutCredentials;
+    private String sqlLong;
     private Pattern oldPattern;
 
     public static void main(String[] args) throws Exception {
@@ -112,11 +113,25 @@ public class SqlCredentialRedactorBench {
 
         // SQL without credentials
         sqlWithoutCredentials = "SELECT * FROM table WHERE id = 1";
+
+        // long string
+        String longString = "abcdefdhi".repeat(104857);
+        sqlLong = "INSERT INTO t1 VALUES(\"" + longString + "\",)";
     }
 
     @Benchmark
     public void benchmarkManyKeys() {
         SqlCredentialRedactor.redact(sqlWithManyKeys);
+    }
+
+    @Benchmark
+    public void benchmarkLongString() {
+        SqlCredentialRedactor.redact(sqlLong);
+    }
+
+    @Benchmark
+    public void benchmarkOldVersionLongString() {
+        redactOldVersion(sqlLong);
     }
 
     @Benchmark

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/SqlCredentialRedactorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/SqlCredentialRedactorTest.java
@@ -131,10 +131,10 @@ public class SqlCredentialRedactorTest {
         String redacted1 = SqlCredentialRedactor.redact(sql1);
         Assertions.assertFalse(redacted1.contains("AKIAIOSFODNN7EXAMPLE"));
 
-        // Test without quotes on key
+        // Test without quotes on key(not supported)
         String sql2 = "aws.s3.secret_key = \"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\"";
         String redacted2 = SqlCredentialRedactor.redact(sql2);
-        Assertions.assertFalse(redacted2.contains("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"));
+        Assertions.assertTrue(redacted2.contains("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"));
 
         // Test with extra spaces
         String sql3 = "\"aws.s3.access_key\"   =   \"AKIAIOSFODNN7EXAMPLE\"";

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/SqlCredentialRedactorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/SqlCredentialRedactorTest.java
@@ -16,6 +16,7 @@ package com.starrocks.common.util;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 public class SqlCredentialRedactorTest {
 
@@ -189,5 +190,19 @@ public class SqlCredentialRedactorTest {
             index += 3;
         }
         Assertions.assertEquals(2, count, "Should have exactly 2 redacted values");
+    }
+
+    /**
+     * java.regex uses NFA algorithm, it cannot guarantee O(N) complexity, might run into timeout
+     * when the string is very long.
+     * RE2 is O(n)
+     */
+    @Test
+    @Timeout(10)
+    public void testLongString() {
+        String longString = "1234567890".repeat(104857);
+        String longSql = "INSERT INTO t1 VALUES(\"" + longString + "\", 1)";
+        String redacted = SqlCredentialRedactor.redact(longSql);
+        Assertions.assertEquals(longSql, redacted);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

<img width="1056" height="772" alt="image" src="https://github.com/user-attachments/assets/32dc5ea0-59b0-47b9-919f-21363faafbfb" />

**Problem**
The original implementation used a complex regex pattern with 40+ credential keys in alternation, causing massive backtracking and poor performance. This optimization improves performance by:
1. Simplified regex pattern: Match all key-value pairs first, then check  if key is sensitive using HashSet lookup (O(1) instead of regex O(n))
**2. Simplified quote syntax: Property keys and values must always be enclosed in quotes. While a syntax-error SQL might occasionally appear in the log, we consider this a rare occurrence and prioritize performance over addressing it.**

**Performance improvement: ~10x faster** 
> VM version: JDK 17.0.16, OpenJDK 64-Bit Server VM, 17.0.16+8-LTS
```
Benchmark                                                 Mode  Cnt      Score      Error  Units
SqlCredentialRedactorBench.benchmarkLongString            avgt    3   2787.325 ±  127.115  us/op
SqlCredentialRedactorBench.benchmarkManyKeys              avgt    3     40.975 ±   40.143  us/op

SqlCredentialRedactorBench.benchmarkOldVersionLongString  avgt    3  94610.090 ± 6646.028  us/op
SqlCredentialRedactorBench.benchmarkOldVersionManyKeys    avgt    3    450.337 ±  844.340  us/op
```

**full experiments with other optimizations**
- Naive implementation of the key/value regex with `java.util.regex` cannot handle a long string
- `google.re2j` can guarantee O(N) time complexity, which is able to handle the long time even with naive implementation. But it's slower than `java.util.regex` in `benchmarkManyKeys` case
- Limiting the key to `MAX_LENGTH` can improve the performance significantly, otherwise it's slow to match a long string. Example: `[^\"'=\\s,()]+)` VS  `[^\"'=\\s,()]{1,32})`
- Enforce the quote syntax can prune useless matching: `(["']?)` VS  `(["'])`


```
-- java.util.regex
-- timeout on benchmarkLongString

-- google.re2j
Benchmark                                                 Mode  Cnt       Score       Error  Units
SqlCredentialRedactorBench.benchmarkFewKeys               avgt    3      37.130 ±     4.526  us/op
SqlCredentialRedactorBench.benchmarkLongString            avgt    3  127325.670 ±  5558.839  us/op
SqlCredentialRedactorBench.benchmarkManyKeys              avgt    3     821.138 ±   166.228  us/op
SqlCredentialRedactorBench.benchmarkNoCredentials         avgt    3       6.132 ±     3.200  us/op
SqlCredentialRedactorBench.benchmarkOldVersionLongString  avgt    3  103646.069 ± 11400.085  us/op
SqlCredentialRedactorBench.benchmarkOldVersionManyKeys    avgt    3     408.715 ±    15.572  us/op


-- opt(MAX_KEY_LENGTH)
-- java.util.regex
Benchmark                                                 Mode  Cnt       Score       Error  Units
SqlCredentialRedactorBench.benchmarkFewKeys               avgt    3       9.464 ±     2.608  us/op
SqlCredentialRedactorBench.benchmarkLongString            avgt    3  563955.333 ± 89429.125  us/op
SqlCredentialRedactorBench.benchmarkManyKeys              avgt    3      67.462 ±     2.781  us/op
SqlCredentialRedactorBench.benchmarkNoCredentials         avgt    3       2.457 ±     2.079  us/op
SqlCredentialRedactorBench.benchmarkOldVersionLongString  avgt    3   95298.365 ±  3484.496  us/op
SqlCredentialRedactorBench.benchmarkOldVersionManyKeys    avgt    3     410.663 ±   175.296  us/op

-- opt(MAX_KEY_LENGTH)
-- google.re2j
Benchmark                                                 Mode  Cnt       Score        Error  Units
SqlCredentialRedactorBench.benchmarkFewKeys               avgt    3      55.721 ±      2.634  us/op
SqlCredentialRedactorBench.benchmarkLongString            avgt    3  889034.090 ± 429986.434  us/op
SqlCredentialRedactorBench.benchmarkManyKeys              avgt    3    1067.198 ±     20.308  us/op
SqlCredentialRedactorBench.benchmarkNoCredentials         avgt    3       7.169 ±      1.442  us/op
SqlCredentialRedactorBench.benchmarkOldVersionLongString  avgt    3  101724.587 ±   2088.910  us/op
SqlCredentialRedactorBench.benchmarkOldVersionManyKeys    avgt    3     406.102 ±     33.471  us/op

-- opt(MAX_KEY_LENGTH)
-- opt(MUST_QUOTE)
-- java.util.regex
Benchmark                                                 Mode  Cnt      Score      Error  Units
SqlCredentialRedactorBench.benchmarkFewKeys               avgt    3      2.548 ±    0.117  us/op
SqlCredentialRedactorBench.benchmarkLongString            avgt    3   2787.325 ±  127.115  us/op
SqlCredentialRedactorBench.benchmarkManyKeys              avgt    3     40.975 ±   40.143  us/op
SqlCredentialRedactorBench.benchmarkNoCredentials         avgt    3      0.058 ±    0.010  us/op
SqlCredentialRedactorBench.benchmarkOldVersionLongString  avgt    3  94610.090 ± 6646.028  us/op
SqlCredentialRedactorBench.benchmarkOldVersionManyKeys    avgt    3    450.337 ±  844.340  us/op
```


Fixes #https://github.com/StarRocks/StarRocksTest/issues/10546

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
