### PR TITLE
[BugFix] Fix class cast exception when building scan range

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
@@ -175,8 +175,12 @@ public final class IcebergUtil {
         Map<Integer, MinMaxValue> minMaxValues =
                 parseMinMaxValueBySlots(schema, lowerBounds, upperBounds, nullValueCounts, valueCounts, slots);
         for (SlotDescriptor slot : slots) {
-            int slotId = slot.getId().asInt();
-            MinMaxValue minMaxValue = minMaxValues.get(slotId);
+            Types.NestedField field = schema.findField(slot.getColumn().getName());
+            if (field == null) {
+                continue;
+            }
+            int fieldId = field.fieldId();
+            MinMaxValue minMaxValue = minMaxValues.get(fieldId);
             if (minMaxValue == null) {
                 continue; // No min/max value for this slot
             }


### PR DESCRIPTION
## Why I'm doing:
```
com.starrocks.connector.exception.StarRocksConnectorException: build scan range failed
	at com.starrocks.connector.iceberg.IcebergConnectorScanRangeSource.toScanRanges(IcebergConnectorScanRangeSource.java:151) ~[starrocks-fe.jar:?]
	at com.starrocks.connector.iceberg.IcebergConnectorScanRangeSource.getSourceOutputs(IcebergConnectorScanRangeSource.java:129) ~[starrocks-fe.jar:?]
	at com.starrocks.connector.ConnectorScanRangeSource.getOutputs(ConnectorScanRangeSource.java:27) ~[starrocks-fe.jar:?]
	at com.starrocks.planner.IcebergScanNode.getScanRangeLocations(IcebergScanNode.java:100) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.scheduler.assignment.BackendSelectorFactory.create(BackendSelectorFactory.java:56) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.scheduler.assignment.LocalFragmentAssignmentStrategy.assignScanRangesToWorker(LocalFragmentAssignmentStrategy.java:90) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.scheduler.assignment.LocalFragmentAssignmentStrategy.assignFragmentToWorker(LocalFragmentAssignmentStrategy.java:74) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.CoordinatorPreprocessor.computeFragmentInstances(CoordinatorPreprocessor.java:249) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.CoordinatorPreprocessor.prepareExec(CoordinatorPreprocessor.java:205) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.DefaultCoordinator.prepareExec(DefaultCoordinator.java:517) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.DefaultCoordinator.startScheduling(DefaultCoordinator.java:569) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.scheduler.Coordinator.execWithQueryDeployExecutor(Coordinator.java:112) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.StmtExecutor.handleQueryStmt(StmtExecutor.java:1405) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:713) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.ConnectProcessor.executeQueryAttempt(ConnectProcessor.java:500) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.ConnectProcessor.runWithParserStageRetry(ConnectProcessor.java:399) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:344) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:697) ~[starrocks-fe.jar:?]
	at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:1055) ~[starrocks-fe.jar:?]
	at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:71) ~[starrocks-fe.jar:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
	at java.lang.Thread.run(Thread.java:840) ~[?:?]
Caused by: java.lang.ClassCastException: class java.lang.Long cannot be cast to class java.lang.Integer (java.lang.Long and java.lang.Integer are in module java.base of loader 'bootstrap')
	at com.starrocks.connector.iceberg.IcebergUtil$MinMaxValue.toThrift(IcebergUtil.java:65) ~[starrocks-fe.jar:?]
	at com.starrocks.connector.iceberg.IcebergUtil$MinMaxValue.toThrift(IcebergUtil.java:93) ~[starrocks-fe.jar:?]
	at com.starrocks.connector.iceberg.IcebergUtil.toThriftMinMaxValueBySlots(IcebergUtil.java:172) ~[starrocks-fe.jar:?]
	at com.starrocks.connector.iceberg.IcebergConnectorScanRangeSource.buildScanRange(IcebergConnectorScanRangeSource.java:259) ~[starrocks-fe.jar:?]
	at com.starrocks.connector.iceberg.IcebergConnectorScanRangeSource.buildScanRanges(IcebergConnectorScanRangeSource.java:156) ~[starrocks-fe.jar:?]
	at com.starrocks.connector.iceberg.IcebergConnectorScanRangeSource.toScanRanges(IcebergConnectorScanRangeSource.java:145) ~[starrocks-fe.jar:?]
	... 22 more
```
## What I'm doing:

as title

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects min/max value mapping to use Iceberg field IDs and adds tests for disordered slots and Thrift conversion.
> 
> - **Iceberg Util**:
>   - Update `toThriftMinMaxValueBySlots` to resolve fields via `schema.findField(slot.getColumn().getName())`, skip missing fields, and map using `field.fieldId()` instead of slot ID.
> - **Tests**:
>   - Add `testParseMinMaxValuesFromDisorderedSlots` verifying parsing and `toThriftMinMaxValueBySlots` with disordered slots.
>   - Import `TExprMinMaxValue` and validate generated `min_int_value`/`max_int_value`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad2f863e73dae0fc89b4e262440037a78a19cbf9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->