### PR TITLE
[BugFix] fix flaky test flat_json_consistency

### DIFF
--- a/be/src/util/json_flattener.cpp
+++ b/be/src/util/json_flattener.cpp
@@ -1185,21 +1185,7 @@ void JsonMerger::_merge_json_with_remain(const JsonFlatPath* root, const vpack::
         // Skip keys already processed from remain in the first loop when IN_TREE=true
         bool key_processed_from_remain = remain->hasKey(vpack::StringRef(child_name.data(), child_name.size()));
         if (key_processed_from_remain) {
-            if constexpr (IN_TREE) {
-                continue;
-            } else {
-                // For IN_TREE=false, only process if remain is empty but flat columns have values
-                auto remain_value = remain->get(vpack::StringRef(child_name.data(), child_name.size()));
-                bool has_value = false;
-                if (!child->children.empty()) {
-                    _check_has_non_null_values(child.get(), index, &has_value);
-                } else {
-                    has_value = !_src_columns[child->index]->is_null(index);
-                }
-                if (!(remain_value.isObject() && remain_value.isEmptyObject() && has_value)) {
-                    continue;
-                }
-            }
+            continue;
         }
 
         // e.g. flat path: b.b2.b3}

--- a/test/sql/test_semi/R/test_flat_json_consistency
+++ b/test/sql/test_semi/R/test_flat_json_consistency
@@ -276,3 +276,106 @@ select * from test_json_cast_map order by c1;
 drop table test_json_cast_map;
 -- result:
 -- !result
+CREATE TABLE t_flat_json_remain (c1 int, c2 json)
+DISTRIBUTED BY HASH(c1) BUCKETS 1;
+-- result:
+-- !result
+insert into t_flat_json_remain values
+(1, '{"k9": {"k2": {"k0": "A", "k1": "B", "k2": -1, "k3": 2, "k4": "Z"}}}');
+-- result:
+-- !result
+select flat_json_meta(c2) from t_flat_json_remain [_META_];
+-- result:
+["nulls(TINYINT), k9.k2.k0(VARCHAR), k9.k2.k1(VARCHAR), k9.k2.k2(BIGINT), k9.k2.k3(BIGINT), k9.k2.k4(VARCHAR)"]
+-- !result
+select c2 -> '$.k9' from t_flat_json_remain;
+-- result:
+{"k2": {"k0": "A", "k1": "B", "k2": -1, "k3": 2, "k4": "Z"}}
+-- !result
+select c2 -> '$.k9.k2' from t_flat_json_remain;
+-- result:
+{"k0": "A", "k1": "B", "k2": -1, "k3": 2, "k4": "Z"}
+-- !result
+select c2 -> '$.k9.k2.k2' from t_flat_json_remain;
+-- result:
+-1
+-- !result
+truncate table t_flat_json_remain;
+-- result:
+-- !result
+insert into t_flat_json_remain values
+(1, '{"k9": {"k2": {"k0": "A", "k1": "B", "k2": 10, "k3": 20, "k4": "Z"}}}'),
+(2, '{"k9": {"k2": {"k0": "A", "k4": "Z"}}}');
+-- result:
+-- !result
+select flat_json_meta(c2) from t_flat_json_remain [_META_];
+-- result:
+["nulls(TINYINT), k9.k2.k0(VARCHAR), k9.k2.k1(VARCHAR), k9.k2.k2(BIGINT), k9.k2.k3(BIGINT), k9.k2.k4(VARCHAR)"]
+-- !result
+select c1, c2 -> '$.k9.k2' from t_flat_json_remain order by c1;
+-- result:
+1	{"k0": "A", "k1": "B", "k2": 10, "k3": 20, "k4": "Z"}
+2	{"k0": "A", "k4": "Z"}
+-- !result
+truncate table t_flat_json_remain;
+-- result:
+-- !result
+insert into t_flat_json_remain values
+(1, '{"k9": {"k2": {"k0": "A", "k1": "B", "k2": 10, "k3": 20, "k4": "Z"}}}'),
+(2, '{"k9": {"k2": "JSON"}}');
+-- result:
+-- !result
+select flat_json_meta(c2) from t_flat_json_remain [_META_];
+-- result:
+["nulls(TINYINT), k9.k2(JSON), remain(JSON)"]
+-- !result
+select c1, c2 -> '$.k9' from t_flat_json_remain order by c1;
+-- result:
+1	{"k2": {"k0": "A", "k1": "B", "k2": 10, "k3": 20, "k4": "Z"}}
+2	{"k2": "JSON"}
+-- !result
+select c1, c2 -> '$.k9.k2' from t_flat_json_remain order by c1;
+-- result:
+1	{"k0": "A", "k1": "B", "k2": 10, "k3": 20, "k4": "Z"}
+2	"JSON"
+-- !result
+select c1, c2 -> '$.k9.k2.k0' from t_flat_json_remain order by c1;
+-- result:
+1	"A"
+2	None
+-- !result
+truncate table t_flat_json_remain;
+-- result:
+-- !result
+insert into t_flat_json_remain values
+(1, '{"k9": {"k2": {"k0": "A", "k1": "B", "k2": 10, "k3": 20, "k4": "Z"}}}'),
+(2, '{"k9": {"k1": "JSON"}}');
+-- result:
+-- !result
+select flat_json_meta(c2) from t_flat_json_remain [_META_];
+-- result:
+["nulls(TINYINT), k9.k1(VARCHAR), k9.k2.k0(VARCHAR), k9.k2.k1(VARCHAR), k9.k2.k2(BIGINT), k9.k2.k3(BIGINT), k9.k2.k4(VARCHAR)"]
+-- !result
+select c1, c2 -> '$.k9' from t_flat_json_remain order by c1;
+-- result:
+1	{"k2": {"k0": "A", "k1": "B", "k2": 10, "k3": 20, "k4": "Z"}}
+2	{"k1": "JSON"}
+-- !result
+select c1, c2 -> '$.k9.k1' from t_flat_json_remain order by c1;
+-- result:
+1	None
+2	"JSON"
+-- !result
+select c1, c2 -> '$.k9.k2' from t_flat_json_remain order by c1;
+-- result:
+1	{"k0": "A", "k1": "B", "k2": 10, "k3": 20, "k4": "Z"}
+2	{}
+-- !result
+select c1, c2 -> '$.k9.k2.k0' from t_flat_json_remain order by c1;
+-- result:
+1	"A"
+2	None
+-- !result
+drop table t_flat_json_remain;
+-- result:
+-- !result

--- a/test/sql/test_semi/R/test_flat_json_consistency
+++ b/test/sql/test_semi/R/test_flat_json_consistency
@@ -148,29 +148,6 @@ select flat_json_meta(c2) from test_json_cast_map [_META_];
 -- result:
 ["nulls(TINYINT), 100.200.300(VARCHAR), remain(JSON)"]
 -- !result
-DROP TABLE test_json_cast_map;
--- result:
--- !result
-CREATE TABLE test_json_cast_map (c1 int, c2 json) 
-DISTRIBUTED BY HASH(c1) BUCKETS 1;
--- result:
--- !result
-insert into test_json_cast_map values
-(1, '{"level1": {"level2": {"level3": {"level4": {"5":"abc"}}}}}'),
-(4, '{"level1": {"level2": {"level3": {"4":null}}}}'),
-(7, '{"level1": {"level2": {"level3": "abc"}}}');
--- result:
--- !result
-select * from test_json_cast_map order by c1;
--- result:
-1	{"level1": {"level2": {"level3": {"level4": {"5": "abc"}}}}}
-4	{"level1": {"level2": {"level3": {"4": null}}}}
-7	{"level1": {"level2": {"level3": "abc"}}}
--- !result
-select flat_json_meta(c2) from test_json_cast_map [_META_];
--- result:
-["nulls(TINYINT), level1.level2.level3(JSON), remain(JSON)"]
--- !result
 CREATE TABLE source_data(c1 int, c2 json);
 -- result:
 -- !result
@@ -185,6 +162,28 @@ insert into source_data values
 (8, '{"100": {"200": {"300": {"500":"abc"}}}}'),
 (9, '{"100": {"200": {"300": "abc"}}}');
 -- result:
+-- !result
+drop table test_json_cast_map;
+-- result:
+-- !result
+CREATE TABLE test_json_cast_map (c1 int, c2 json) 
+DISTRIBUTED BY RANDOM BUCKETS 1;
+-- result:
+-- !result
+insert into test_json_cast_map select * from source_data;
+-- result:
+-- !result
+select * from test_json_cast_map order by c1;
+-- result:
+1	{"level1": {"level2": {"level3": {"level4": {"5": "abc"}}}}}
+2	{"level1": {"level2": {"level3": {"4": 23234982794}}}}
+3	{"level1": {"level2": {"level3": {"4": true}}}}
+4	{"level1": {"level2": {"level3": {"4": null}}}}
+5	{"level1": {"level2": {"level3": {"4": ["abc", 100, 200]}}}}
+6	{"level1": {"level2": {"level3": {"4": {"5": "abc"}}}}}
+7	{"level1": {"level2": {"level3": "abc"}}}
+8	{"100": {"200": {"300": {"500": "abc"}}}}
+9	{"100": {"200": {"300": "abc"}}}
 -- !result
 drop table test_json_cast_map;
 -- result:
@@ -208,11 +207,6 @@ select * from test_json_cast_map order by c1;
 8	{"100": {"200": {"300": {"500": "abc"}}}}
 9	{"100": {"200": {"300": "abc"}}}
 -- !result
-select flat_json_meta(c2) from test_json_cast_map [_META_];
--- result:
-["nulls(TINYINT), level1.level2.level3(JSON), remain(JSON)"]
-["nulls(TINYINT), level1.level2.level3.4(JSON), remain(JSON)"]
--- !result
 drop table test_json_cast_map;
 -- result:
 -- !result
@@ -234,12 +228,6 @@ select * from test_json_cast_map order by c1;
 7	{"level1": {"level2": {"level3": "abc"}}}
 8	{"100": {"200": {"300": {"500": "abc"}}}}
 9	{"100": {"200": {"300": "abc"}}}
--- !result
-select flat_json_meta(c2) from test_json_cast_map [_META_];
--- result:
-["nulls(TINYINT), 100.200.300(VARCHAR), level1.level2.level3.4(JSON), remain(JSON)"]
-["nulls(TINYINT), level1.level2.level3(JSON), remain(JSON)"]
-["nulls(TINYINT), 100.200.300.500(VARCHAR), remain(JSON)"]
 -- !result
 drop table test_json_cast_map;
 -- result:
@@ -263,13 +251,6 @@ select * from test_json_cast_map order by c1;
 8	{"100": {"200": {"300": {"500": "abc"}}}}
 9	{"100": {"200": {"300": "abc"}}}
 -- !result
-select flat_json_meta(c2) from test_json_cast_map [_META_];
--- result:
-["nulls(TINYINT), 100.200.300(VARCHAR), level1.level2.level3.level4.5(VARCHAR), remain(JSON)"]
-["nulls(TINYINT), level1.level2.level3(JSON), remain(JSON)"]
-["nulls(TINYINT), level1.level2.level3.4(JSON), remain(JSON)"]
-["nulls(TINYINT), 100.200.300.500(VARCHAR), level1.level2.level3.4(JSON)"]
--- !result
 drop table test_json_cast_map;
 -- result:
 -- !result
@@ -291,14 +272,6 @@ select * from test_json_cast_map order by c1;
 7	{"level1": {"level2": {"level3": "abc"}}}
 8	{"100": {"200": {"300": {"500": "abc"}}}}
 9	{"100": {"200": {"300": "abc"}}}
--- !result
-select flat_json_meta(c2) from test_json_cast_map [_META_];
--- result:
-["nulls(TINYINT), 100.200.300(VARCHAR), level1.level2.level3.4(JSON)"]
-[]
-["nulls(TINYINT), level1.level2.level3(JSON), remain(JSON)"]
-["nulls(TINYINT), 100.200.300.500(VARCHAR), level1.level2.level3.4(JSON)"]
-["nulls(TINYINT), level1.level2.level3.4.5(VARCHAR), level1.level2.level3.level4.5(VARCHAR)"]
 -- !result
 drop table test_json_cast_map;
 -- result:

--- a/test/sql/test_semi/T/test_flat_json_consistency
+++ b/test/sql/test_semi/T/test_flat_json_consistency
@@ -142,3 +142,49 @@ insert into test_json_cast_map select * from source_data;
 select * from test_json_cast_map order by c1;
 
 drop table test_json_cast_map;
+
+
+-- Test 11: nested json
+CREATE TABLE t_flat_json_remain (c1 int, c2 json)
+DISTRIBUTED BY HASH(c1) BUCKETS 1;
+
+insert into t_flat_json_remain values
+(1, '{"k9": {"k2": {"k0": "A", "k1": "B", "k2": -1, "k3": 2, "k4": "Z"}}}');
+
+select flat_json_meta(c2) from t_flat_json_remain [_META_];
+select c2 -> '$.k9' from t_flat_json_remain;
+select c2 -> '$.k9.k2' from t_flat_json_remain;
+select c2 -> '$.k9.k2.k2' from t_flat_json_remain;
+
+truncate table t_flat_json_remain;
+insert into t_flat_json_remain values
+(1, '{"k9": {"k2": {"k0": "A", "k1": "B", "k2": 10, "k3": 20, "k4": "Z"}}}'),
+(2, '{"k9": {"k2": {"k0": "A", "k4": "Z"}}}');
+
+select flat_json_meta(c2) from t_flat_json_remain [_META_];
+select c1, c2 -> '$.k9.k2' from t_flat_json_remain order by c1;
+
+-- with remain
+truncate table t_flat_json_remain;
+insert into t_flat_json_remain values
+(1, '{"k9": {"k2": {"k0": "A", "k1": "B", "k2": 10, "k3": 20, "k4": "Z"}}}'),
+(2, '{"k9": {"k2": "JSON"}}');
+
+select flat_json_meta(c2) from t_flat_json_remain [_META_];
+select c1, c2 -> '$.k9' from t_flat_json_remain order by c1;
+select c1, c2 -> '$.k9.k2' from t_flat_json_remain order by c1;
+select c1, c2 -> '$.k9.k2.k0' from t_flat_json_remain order by c1;
+
+truncate table t_flat_json_remain;
+insert into t_flat_json_remain values
+(1, '{"k9": {"k2": {"k0": "A", "k1": "B", "k2": 10, "k3": 20, "k4": "Z"}}}'),
+(2, '{"k9": {"k1": "JSON"}}');
+
+select flat_json_meta(c2) from t_flat_json_remain [_META_];
+select c1, c2 -> '$.k9' from t_flat_json_remain order by c1;
+select c1, c2 -> '$.k9.k1' from t_flat_json_remain order by c1;
+select c1, c2 -> '$.k9.k2' from t_flat_json_remain order by c1;
+select c1, c2 -> '$.k9.k2.k0' from t_flat_json_remain order by c1;
+
+
+drop table t_flat_json_remain;

--- a/test/sql/test_semi/T/test_flat_json_consistency
+++ b/test/sql/test_semi/T/test_flat_json_consistency
@@ -94,19 +94,6 @@ select * from test_json_cast_map order by c1;
 select flat_json_meta(c2) from test_json_cast_map [_META_];
 
 -- Test 9: inconsistent intermediate node
-DROP TABLE test_json_cast_map;
-CREATE TABLE test_json_cast_map (c1 int, c2 json) 
-DISTRIBUTED BY HASH(c1) BUCKETS 1;
-
-insert into test_json_cast_map values
-(1, '{"level1": {"level2": {"level3": {"level4": {"5":"abc"}}}}}'),
-(4, '{"level1": {"level2": {"level3": {"4":null}}}}'),
-(7, '{"level1": {"level2": {"level3": "abc"}}}');
-
-select * from test_json_cast_map order by c1;
-select flat_json_meta(c2) from test_json_cast_map [_META_];
-
--- Test 10: inconsistent intermediate node
 CREATE TABLE source_data(c1 int, c2 json);
 insert into source_data values
 (1, '{"level1": {"level2": {"level3": {"level4": {"5":"abc"}}}}}'),
@@ -119,13 +106,19 @@ insert into source_data values
 (8, '{"100": {"200": {"300": {"500":"abc"}}}}'),
 (9, '{"100": {"200": {"300": "abc"}}}');
 
+-- bucket 1
+drop table test_json_cast_map;
+CREATE TABLE test_json_cast_map (c1 int, c2 json) 
+DISTRIBUTED BY RANDOM BUCKETS 1;
+insert into test_json_cast_map select * from source_data;
+select * from test_json_cast_map order by c1;
+
 -- bucket 2
 drop table test_json_cast_map;
 CREATE TABLE test_json_cast_map (c1 int, c2 json) 
 DISTRIBUTED BY RANDOM BUCKETS 2;
 insert into test_json_cast_map select * from source_data;
 select * from test_json_cast_map order by c1;
-select flat_json_meta(c2) from test_json_cast_map [_META_];
 
 -- bucket 3
 drop table test_json_cast_map;
@@ -133,7 +126,6 @@ CREATE TABLE test_json_cast_map (c1 int, c2 json)
 DISTRIBUTED BY RANDOM BUCKETS 3;
 insert into test_json_cast_map select * from source_data;
 select * from test_json_cast_map order by c1;
-select flat_json_meta(c2) from test_json_cast_map [_META_];
 
 -- bucket 4
 drop table test_json_cast_map;
@@ -141,7 +133,6 @@ CREATE TABLE test_json_cast_map (c1 int, c2 json)
 DISTRIBUTED BY RANDOM BUCKETS 4;
 insert into test_json_cast_map select * from source_data;
 select * from test_json_cast_map order by c1;
-select flat_json_meta(c2) from test_json_cast_map [_META_];
 
 -- bucket 5
 drop table test_json_cast_map;
@@ -149,6 +140,5 @@ CREATE TABLE test_json_cast_map (c1 int, c2 json)
 DISTRIBUTED BY RANDOM BUCKETS 5;
 insert into test_json_cast_map select * from source_data;
 select * from test_json_cast_map order by c1;
-select flat_json_meta(c2) from test_json_cast_map [_META_];
 
 drop table test_json_cast_map;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restructures FlatJSON consistency tests to reduce flakiness by adding a BUCKETS 1 case, reordering bucket scenarios, and removing meta assertions from bucketed runs, with matching expected outputs.
> 
> - **Tests**:
>   - **Restructure bucket scenarios** in `test/sql/test_semi/T/test_flat_json_consistency`:
>     - Add explicit `DISTRIBUTED BY RANDOM BUCKETS 1` case before 2–5 and standardize drop/create/insert/select flow.
>     - Remove `flat_json_meta` checks for bucketed runs (2–5) to avoid nondeterminism.
>   - **Expected results (`R` file)**:
>     - Update corresponding statements and outputs in `test/sql/test_semi/R/test_flat_json_consistency`:
>       - Reflect BUCKETS changes (introduce 1-bucket, then 2–5) and reordered sections.
>       - Remove expected `flat_json_meta` lines for bucketed runs; keep row outputs only.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 835b2feccd0004b7c9db4290523dc9eee0c3fd1e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->