### PR TITLE
[UT] fix unstable sql test about floating-point precision

### DIFF
--- a/test/sql/test_join/R/test_large_in_predicate_to_join.sql
+++ b/test/sql/test_join/R/test_large_in_predicate_to_join.sql
@@ -440,9 +440,9 @@ select id, int_col from t_int where id in (
 4	4000
 5	5000
 -- !result
-select id, int_col, (
+select id, int_col, round((
     select avg(score) from t_large where category_id in (1, 2, 3, 4, 5)
-) as avg_score from t_int where id <= 5 order by id;
+), 2) as avg_score from t_int where id <= 5 order by id;
 -- result:
 1	1000	80.35
 2	2000	80.35

--- a/test/sql/test_join/T/test_large_in_predicate_to_join.sql
+++ b/test/sql/test_join/T/test_large_in_predicate_to_join.sql
@@ -289,9 +289,11 @@ select id, int_col from t_int where id in (
 ) order by id;
 
 -- Test 24: Scalar subquery with LargeInPredicate
-select id, int_col, (
+-- Note: Use ROUND() to avoid floating-point precision issues from different execution orders
+-- (LargeInPredicate rewrite to JOIN may cause different accumulation order for AVG)
+select id, int_col, round((
     select avg(score) from t_large where category_id in (1, 2, 3, 4, 5)
-) as avg_score from t_int where id <= 5 order by id;
+), 2) as avg_score from t_int where id <= 5 order by id;
 
 -- Test 25: Subquery with DISTINCT and LargeInPredicate
 select id, int_col from t_int where id in (


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wrap the AVG(score) scalar subquery with ROUND(..., 2) in LargeInPredicate test to avoid floating-point precision instability and update the corresponding expected SQL.
> 
> - **Tests**:
>   - Update `test/sql/test_join/T/test_large_in_predicate_to_join.sql`:
>     - In Test 24, wrap `avg(score)` with `round(..., 2)` and add a note explaining precision differences due to JOIN rewrite order.
>   - Update expected query in `test/sql/test_join/R/test_large_in_predicate_to_join.sql` to match the `ROUND` change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64abfd8fe6afaddc2ff012799575c7efd22ad052. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->