### PR TITLE
[BugFix] increase tablet_map_shard_size to 1024 to favor a large size of BE

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -791,8 +791,14 @@ CONF_mBool(brpc_load_ignore_overcrowded, "true");
 CONF_mInt64(max_runnings_transactions_per_txn_map, "100");
 
 // The tablet map shard size, the value must be power of two.
-// this is an enhancement for better performance to manage tablet.
-CONF_Int32(tablet_map_shard_size, "32");
+//
+// It is the total number of slots pre-allocated by TabletManager in shared-nothing mode.
+// All the tablets hosted on the backend will be hashed and put into the corresponding slots.
+// Tablets in the same slots shares the single mutex for R/W ops from TabletManager.
+// Increasing this number would greatly reduce the lock contention between tablets in the same slot.
+// Recommended setting:
+//   tablet_map_shard_size = total_num_of_tablets_in_BE / 512
+CONF_Int32(tablet_map_shard_size, "1024");
 // The value must be power of two.
 CONF_Int32(pk_index_map_shard_size, "4096");
 

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -738,7 +738,11 @@ void StorageEngine::compaction_check() {
 // Compaction checker will check whether to schedule base compaction for tablets
 size_t StorageEngine::_compaction_check_one_round() {
     size_t batch_size = _compaction_manager->max_task_num();
+#ifdef BE_TEST
+    int batch_sleep_time_ms = 1; // 1ms
+#else
     int batch_sleep_time_ms = 1000;
+#endif
     std::vector<TabletSharedPtr> tablets;
     tablets.reserve(batch_size);
     size_t tablets_num_checked = 0;

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -1667,7 +1667,7 @@ When this value is set to less than `0`, the system uses the product of its abso
 
 ##### tablet_map_shard_size
 
-- Default: 32
+- Default: 1024
 - Type: Int
 - Unit: -
 - Is mutable: No

--- a/docs/ja/administration/management/BE_configuration.md
+++ b/docs/ja/administration/management/BE_configuration.md
@@ -1646,7 +1646,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 ##### tablet_map_shard_size
 
-- デフォルト: 32
+- デフォルト: 1024
 - タイプ: Int
 - 単位: -
 - 可変: いいえ

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -1626,7 +1626,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 ##### tablet_map_shard_size
 
-- 默认值：32
+- 默认值：1024
 - 类型：Int
 - 单位：-
 - 是否动态：否


### PR DESCRIPTION
* increase `tablet_map_shard_size` to 1024 so that the BE can still have moderate performance in a large scale of backend node hosting 100k+ tablets in shared-nothing mode.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase `tablet_map_shard_size` default to 1024 with guidance; make compaction checker sleep 1ms under tests; update docs (en/ja/zh).
> 
> - **Config/Storage**:
>   - Increase default `tablet_map_shard_size` from `32` to `1024` and add guidance/comments on sizing and contention in `be/src/common/config.h`.
>   - Under `BE_TEST`, reduce compaction checker batch sleep from `1000ms` to `1ms` in `be/src/storage/storage_engine.cpp`.
> - **Docs**:
>   - Update default for `tablet_map_shard_size` to `1024` in `docs/*/administration/management/BE_configuration.md` (en/ja/zh).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 613f4724b84b182ad733022fc6858dca70d41531. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->