### PR TITLE
[Enhancement] Support to load a single orc file in parallel

### DIFF
--- a/be/src/exec/file_scanner/orc_scanner.cpp
+++ b/be/src/exec/file_scanner/orc_scanner.cpp
@@ -20,6 +20,7 @@
 #include "formats/orc/orc_chunk_reader.h"
 #include "formats/orc/orc_input_stream.h"
 #include "fs/fs.h"
+#include "gen_cpp/orc_proto.pb.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/broker_mgr.h"
 #include "runtime/descriptors.h"
@@ -43,6 +44,24 @@ public:
 private:
     std::shared_ptr<RandomAccessFile> _file;
     ScannerCounter* _counter;
+};
+
+// A minimal RowReaderFilter that filters stripes by byte range [start, end).
+class OrcRangeRowReaderFilter : public orc::RowReaderFilter {
+public:
+    OrcRangeRowReaderFilter(uint64_t start, uint64_t end) : _start(start), _end(end) {}
+    ~OrcRangeRowReaderFilter() override = default;
+
+    bool filterOnOpeningStripe(uint64_t /*stripeIndex*/,
+                               const orc::proto::StripeInformation* stripeInformation) override {
+        const uint64_t offset = stripeInformation->offset();
+        // return true to skip this stripe if it is outside [start, end)
+        return !(offset >= _start && offset < _end);
+    }
+
+private:
+    uint64_t _start;
+    uint64_t _end;
 };
 
 ORCScanner::ORCScanner(starrocks::RuntimeState* state, starrocks::RuntimeProfile* profile,
@@ -225,6 +244,9 @@ Status ORCScanner::_open_next_orc_reader() {
         _last_file_size = file_size;
         _orc_reader->set_read_chunk_size(_max_chunk_size);
         _orc_reader->set_current_file_name(file_name);
+        // Attach a byte-range RowReaderFilter to only open stripes within [start_offset, start_offset+size)
+        auto filter = std::make_shared<OrcRangeRowReaderFilter>(range_desc.start_offset, range_desc.size);
+        _orc_reader->set_row_reader_filter(filter);
         auto st = _orc_reader->init(std::move(inStream));
         if (st.is_end_of_file()) {
             LOG(WARNING) << "Failed to init orc reader. filename: " << file_name << ", status: " << st.to_string();

--- a/be/src/exec/file_scanner/orc_scanner.cpp
+++ b/be/src/exec/file_scanner/orc_scanner.cpp
@@ -245,7 +245,7 @@ Status ORCScanner::_open_next_orc_reader() {
         _orc_reader->set_read_chunk_size(_max_chunk_size);
         _orc_reader->set_current_file_name(file_name);
         // Attach a byte-range RowReaderFilter to only open stripes within [start_offset, start_offset+size)
-        auto filter = std::make_shared<OrcRangeRowReaderFilter>(range_desc.start_offset, range_desc.size);
+        auto filter = std::make_shared<OrcRangeRowReaderFilter>(range_desc.start_offset, range_desc.start_offset + range_desc.size);
         _orc_reader->set_row_reader_filter(filter);
         auto st = _orc_reader->init(std::move(inStream));
         if (st.is_end_of_file()) {

--- a/be/src/exec/file_scanner/orc_scanner.cpp
+++ b/be/src/exec/file_scanner/orc_scanner.cpp
@@ -245,9 +245,9 @@ Status ORCScanner::_open_next_orc_reader() {
         _orc_reader->set_read_chunk_size(_max_chunk_size);
         _orc_reader->set_current_file_name(file_name);
 
-        // Attach a byte-range RowReaderFilter to only open stripes within [start_offset, end_offset)
-        int64_t start_offset = range_desc.__isset.start_offset ? range_desc.start_offset : 0;
-        int64_t size = range_desc.__isset.size && range_desc.size >= 0 ? range_desc.size : file_size - start_offset;
+        // Attach a byte-range RowReaderFilter to only open stripes within [start_offset, start_offset + size)
+        int64_t start_offset = std::max<int64_t>(0, range_desc.start_offset);
+        int64_t size = range_desc.size >= 0 ? range_desc.size : file_size - start_offset;
         auto filter = std::make_shared<OrcRangeRowReaderFilter>(start_offset, start_offset + size);
         _orc_reader->set_row_reader_filter(filter);
 

--- a/be/src/exec/file_scanner/orc_scanner.cpp
+++ b/be/src/exec/file_scanner/orc_scanner.cpp
@@ -244,9 +244,13 @@ Status ORCScanner::_open_next_orc_reader() {
         _last_file_size = file_size;
         _orc_reader->set_read_chunk_size(_max_chunk_size);
         _orc_reader->set_current_file_name(file_name);
-        // Attach a byte-range RowReaderFilter to only open stripes within [start_offset, start_offset+size)
-        auto filter = std::make_shared<OrcRangeRowReaderFilter>(range_desc.start_offset, range_desc.start_offset + range_desc.size);
+
+        // Attach a byte-range RowReaderFilter to only open stripes within [start_offset, end_offset)
+        int64_t start_offset = range_desc.__isset.start_offset ? range_desc.start_offset : 0;
+        int64_t size = range_desc.__isset.size && range_desc.size >= 0 ? range_desc.size : file_size - start_offset;
+        auto filter = std::make_shared<OrcRangeRowReaderFilter>(start_offset, start_offset + size);
         _orc_reader->set_row_reader_filter(filter);
+
         auto st = _orc_reader->init(std::move(inStream));
         if (st.is_end_of_file()) {
             LOG(WARNING) << "Failed to init orc reader. filename: " << file_name << ", status: " << st.to_string();

--- a/be/test/exec/file_scanner/orc_scanner_test.cpp
+++ b/be/test/exec/file_scanner/orc_scanner_test.cpp
@@ -16,10 +16,16 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <vector>
+
+#include "glog/logging.h"
+#include "orc/OrcFile.hh"
 #include "runtime/descriptor_helper.h"
 #include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
 #include "testutil/assert.h"
+#include "util/defer_op.h"
 
 namespace starrocks {
 
@@ -44,7 +50,8 @@ public:
 
     std::unique_ptr<ORCScanner> create_orc_scanner(const std::vector<TypeDescriptor>& types,
                                                    const std::vector<std::string>& col_names,
-                                                   const std::vector<TBrokerRangeDesc>& ranges) {
+                                                   const std::vector<TBrokerRangeDesc>& ranges,
+                                                   ScannerCounter* counter = nullptr) {
         /// Init DescriptorTable
         TDescriptorTableBuilder desc_tbl_builder;
         TTupleDescriptorBuilder tuple_desc_builder;
@@ -88,7 +95,12 @@ public:
         TBrokerScanRange* broker_scan_range = _obj_pool.add(new TBrokerScanRange());
         broker_scan_range->params = *params;
         broker_scan_range->ranges = ranges;
-        return std::make_unique<ORCScanner>(_runtime_state.get(), _profile, *broker_scan_range, _counter);
+        ScannerCounter* counter_ptr = counter != nullptr ? counter : _counter;
+        return std::make_unique<ORCScanner>(_runtime_state.get(), _profile, *broker_scan_range, counter_ptr);
+    }
+
+    std::string data_file_path(const std::string& file_name) const {
+        return _test_exec_dir + "/test_data/orc_scanner/" + file_name;
     }
 
     std::shared_ptr<RuntimeState> create_runtime_state() {
@@ -111,6 +123,28 @@ public:
         _counter = _obj_pool.add(new ScannerCounter());
         _profile = _obj_pool.add(new RuntimeProfile("test"));
     }
+
+protected:
+    struct MultiStripeContext {
+        struct StripeInfo {
+            uint64_t offset;
+            uint64_t length;
+            uint64_t rows;
+            size_t row_start;
+        };
+
+        std::string file_path;
+        uint64_t file_length = 0;
+        size_t total_rows = 0;
+        std::vector<StripeInfo> stripes;
+        std::vector<std::string> baseline_rows;
+    };
+
+    Status _init_multi_stripe_context(MultiStripeContext* ctx);
+    Status _scan_multi_stripes(const std::vector<TBrokerRangeDesc>& ranges, std::vector<std::string>* out_rows,
+                               ScannerCounter* out_counter = nullptr);
+    TBrokerRangeDesc _build_range(const std::string& file_path, uint64_t file_length, uint64_t start,
+                                  uint64_t end) const;
 
 private:
     std::string _test_exec_dir;
@@ -176,6 +210,159 @@ TEST_F(ORCScannerTest, implicit_cast) {
     EXPECT_EQ(2, chunk->num_rows());
     EXPECT_EQ("['11', '2020-01-01']", chunk->debug_row(0));
     EXPECT_EQ("['11', '2020-01-02']", chunk->debug_row(1));
+}
+
+Status ORCScannerTest::_init_multi_stripe_context(MultiStripeContext* ctx) {
+    DCHECK(ctx != nullptr);
+    ctx->file_path = data_file_path("multi_stripes.orc");
+
+    try {
+        auto reader = orc::createReader(orc::readLocalFile(ctx->file_path), orc::ReaderOptions{});
+        ctx->file_length = reader->getFileLength();
+        ctx->stripes.clear();
+        size_t row_index = 0;
+        uint64_t stripe_count = reader->getNumberOfStripes();
+        ctx->stripes.reserve(stripe_count);
+        for (uint64_t i = 0; i < stripe_count; ++i) {
+            auto stripe = reader->getStripe(i);
+            MultiStripeContext::StripeInfo info;
+            info.offset = stripe->getOffset();
+            info.length = stripe->getLength();
+            info.rows = stripe->getNumberOfRows();
+            info.row_start = row_index;
+            row_index += static_cast<size_t>(info.rows);
+            ctx->stripes.emplace_back(std::move(info));
+        }
+        ctx->total_rows = row_index;
+        RETURN_IF_ERROR(_scan_multi_stripes({_build_range(ctx->file_path, ctx->file_length, 0, ctx->file_length)},
+                                            &ctx->baseline_rows));
+        return Status::OK();
+    } catch (const std::exception& e) {
+        return Status::InternalError(
+                strings::Substitute("Failed to load ORC metadata for $0: $1", ctx->file_path, e.what()));
+    }
+}
+
+Status ORCScannerTest::_scan_multi_stripes(const std::vector<TBrokerRangeDesc>& ranges,
+                                           std::vector<std::string>* out_rows, ScannerCounter* out_counter) {
+    DCHECK(out_rows != nullptr);
+    out_rows->clear();
+
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TypeDescriptor(TYPE_INT));
+    types.emplace_back(TypeDescriptor::create_varchar_type(1048576));
+    std::vector<std::string> col_names = {"c0", "c1"};
+
+    ScannerCounter local_counter{};
+    ScannerCounter* counter_ptr = &local_counter;
+    if (out_counter != nullptr) {
+        *out_counter = ScannerCounter{};
+        counter_ptr = out_counter;
+    }
+
+    auto scanner = create_orc_scanner(types, col_names, ranges, counter_ptr);
+    RETURN_IF_ERROR(scanner->open());
+    DeferOp close_scanner([&]() { scanner->close(); });
+
+    while (true) {
+        auto result = scanner->get_next();
+        if (result.status().is_end_of_file()) {
+            break;
+        }
+        RETURN_IF_ERROR(result.status());
+        ChunkPtr chunk = result.value();
+        for (size_t i = 0; i < chunk->num_rows(); ++i) {
+            out_rows->emplace_back(chunk->debug_row(i));
+        }
+    }
+    return Status::OK();
+}
+
+TBrokerRangeDesc ORCScannerTest::_build_range(const std::string& file_path, uint64_t file_length, uint64_t start,
+                                              uint64_t end) const {
+    TBrokerRangeDesc range;
+    range.file_type = TFileType::FILE_LOCAL;
+    range.__set_format_type(TFileFormatType::FORMAT_ORC);
+    range.__set_path(file_path);
+    range.start_offset = static_cast<int64_t>(start);
+    range.size = static_cast<int64_t>(end - start);
+    range.__set_splittable(true);
+    range.__set_file_size(static_cast<int64_t>(file_length));
+    return range;
+}
+
+TEST_F(ORCScannerTest, selective_ranges_return_expected_rows) {
+    MultiStripeContext ctx;
+    ASSERT_OK(_init_multi_stripe_context(&ctx));
+    ASSERT_GE(ctx.stripes.size(), 2);
+    const auto& first = ctx.stripes[0];
+    const auto& second = ctx.stripes[1];
+
+    struct {
+        const char* label;
+        uint64_t start;
+        uint64_t end;
+        size_t expected_row_start;
+        size_t expected_row_count;
+    } cases[] = {{"first_stripe", first.offset, first.offset + first.length, first.row_start,
+                  static_cast<size_t>(first.rows)},
+                 {"second_stripe", second.offset, second.offset + second.length, second.row_start,
+                  static_cast<size_t>(second.rows)},
+                 {"interior_start", first.offset + std::max<uint64_t>(uint64_t{1}, first.length / 2),
+                  second.offset + second.length, second.row_start, static_cast<size_t>(second.rows)}};
+
+    for (const auto& c : cases) {
+        SCOPED_TRACE(c.label);
+        std::vector<std::string> actual_rows;
+        ScannerCounter counter;
+        std::vector<TBrokerRangeDesc> ranges = {
+                _build_range(ctx.file_path, ctx.file_length, c.start, c.end),
+        };
+        ASSERT_OK(_scan_multi_stripes(ranges, &actual_rows, &counter));
+
+        std::vector<std::string> expected_rows(ctx.baseline_rows.begin() + c.expected_row_start,
+                                               ctx.baseline_rows.begin() + c.expected_row_start + c.expected_row_count);
+        EXPECT_EQ(expected_rows, actual_rows);
+        EXPECT_EQ(0, counter.num_rows_filtered);
+    }
+    EXPECT_GT(second.offset, first.offset);
+}
+
+TEST_F(ORCScannerTest, zero_length_range_returns_empty_scan) {
+    MultiStripeContext ctx;
+    ASSERT_OK(_init_multi_stripe_context(&ctx));
+    ASSERT_FALSE(ctx.stripes.empty());
+    const auto& first = ctx.stripes.front();
+
+    std::vector<std::string> actual_rows;
+    ScannerCounter counter;
+    std::vector<TBrokerRangeDesc> ranges = {
+            _build_range(ctx.file_path, ctx.file_length, first.offset, first.offset),
+    };
+    ASSERT_OK(_scan_multi_stripes(ranges, &actual_rows, &counter));
+
+    EXPECT_TRUE(actual_rows.empty());
+    EXPECT_EQ(0, counter.num_rows_filtered);
+}
+
+TEST_F(ORCScannerTest, adjacent_ranges_cover_entire_file) {
+    MultiStripeContext ctx;
+    ASSERT_OK(_init_multi_stripe_context(&ctx));
+    ASSERT_GE(ctx.stripes.size(), 2);
+    const auto& first = ctx.stripes[0];
+    const auto& second = ctx.stripes[1];
+
+    std::vector<TBrokerRangeDesc> ranges = {
+            _build_range(ctx.file_path, ctx.file_length, first.offset, first.offset + first.length),
+            _build_range(ctx.file_path, ctx.file_length, second.offset, ctx.file_length),
+    };
+
+    std::vector<std::string> actual_rows;
+    ScannerCounter counter;
+    ASSERT_OK(_scan_multi_stripes(ranges, &actual_rows, &counter));
+
+    EXPECT_EQ(ctx.baseline_rows, actual_rows);
+    EXPECT_EQ(0, counter.num_rows_filtered);
 }
 
 } // namespace starrocks

--- a/be/test/exec/file_scanner/orc_scanner_test.cpp
+++ b/be/test/exec/file_scanner/orc_scanner_test.cpp
@@ -187,8 +187,12 @@ TEST_F(ORCScannerTest, implicit_cast) {
     range.format_type = TFileFormatType::FORMAT_ORC;
     range.file_type = TFileType::FILE_LOCAL;
     range.__set_path(_test_exec_dir + "/test_data/orc_scanner/boolean_type.orc");
+    range.__set_start_offset(0);
+    range.__set_size(-1);
     ranges.push_back(range);
     range.__set_path(_test_exec_dir + "/test_data/orc_scanner/date_type.orc");
+    range.__set_start_offset(0);
+    range.__set_size(-1);
     ranges.push_back(range);
 
     auto scanner = create_orc_scanner(types, {"col_0", "col_1"}, ranges);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
@@ -585,9 +585,8 @@ public class FileScanNode extends LoadScanNode {
             long rangeBytes = 0;
             // The rest of the file belongs to one range
             boolean isEndOfFile = false;
-            if (smallestLocations.second + leftBytes > bytesPerInstance &&
-                    ((formatType == TFileFormatType.FORMAT_CSV_PLAIN || formatType == TFileFormatType.FORMAT_PARQUET)
-                            && fileStatus.isSplitable)) {
+            if (smallestLocations.second + leftBytes > bytesPerInstance && isFileFormatSupportSplit(formatType)
+                            && fileStatus.isSplitable) {
                 rangeBytes = bytesPerInstance - smallestLocations.second;
             } else {
                 rangeBytes = leftBytes;
@@ -616,6 +615,17 @@ public class FileScanNode extends LoadScanNode {
             if (brokerScanRange(locations).isSetRanges()) {
                 locationsList.add(locations);
             }
+        }
+    }
+    
+    private boolean isFileFormatSupportSplit(TFileFormatType format) {
+        switch (format) {
+            case FORMAT_CSV_PLAIN:
+            case FORMAT_PARQUET:
+            case FORMAT_ORC:
+                return true;
+            default:
+                return false;
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/LoadPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/LoadPlannerTest.java
@@ -316,6 +316,7 @@ public class LoadPlannerTest {
         fileStatusesList.add(fileStatusList);
 
         // plan
+        Config.load_parallel_instance_num = 1;
         LoadPlanner planner = new LoadPlanner(jobId, loadId, txnId, db.getId(), table, strictMode,
                 timezone, timeoutS, startTime, partialUpdate, ctx, sessionVariables, loadMemLimit, execMemLimit,
                 brokerDesc, fileGroups, fileStatusesList, 1);
@@ -334,7 +335,7 @@ public class LoadPlannerTest {
         // 2. check scan node column expr
         FileScanNode scanNode = (FileScanNode) planner.getScanNodes().get(0);
         List<TScanRangeLocations> locationsList = scanNode.getScanRangeLocations(0);
-        Assertions.assertEquals(1, locationsList.size());
+        Assertions.assertEquals(2, locationsList.size());
         TScanRangeLocations location = locationsList.get(0);
         TBrokerScanRangeParams params = location.scan_range.broker_scan_range.params;
         Map<Integer, TExpr> exprOfDestSlot = params.expr_of_dest_slot;


### PR DESCRIPTION
## Why I'm doing:
Enable parallel scanning for a large ORC file by making ORC splittable. This reduces single-scanner bottlenecks, improves scan throughput, and aligns ORC with Parquet for range-based reading.

## What I'm doing:
- Backend (ORCScanner): Add `OrcRangeRowReaderFilter` to skip stripes outside a requested byte range and attach it via `_orc_reader->set_row_reader_filter(...)`. Initialize the filter per range before reader init and include `orc_proto.pb.h`.
- Tests: Add multi-stripe tests to validate range-selective scanning (including zero-length ranges and adjacent coverage). Update existing tests to set `start_offset`/`size` explicitly.
- Frontend (FileScanNode): Add ORC to `isFileFormatSupportSplit(...)` so the planner emits split scan ranges for ORC

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds ORC stripe byte-range filtering in BE and teaches FE to split ORC files into ranges, enabling parallel scanning; adds targeted tests.
> 
> - **Backend (BE)**:
>   - **ORC byte-range filtering**: Introduce `OrcRangeRowReaderFilter` and attach via `_orc_reader->set_row_reader_filter(...)` using `range_desc.start_offset`/`size` in `orc_scanner.cpp`.
>   - Include `orc_proto.pb.h` and wire filter prior to reader init in `_open_next_orc_reader`.
> - **Frontend (FE)**:
>   - **Planner splitting**: Add `isFileFormatSupportSplit(...)` and include `FORMAT_ORC` so `FileScanNode` emits split `TBrokerRangeDesc`s for ORC.
> - **Tests**:
>   - Add multi-stripe ORC tests validating selective ranges, zero-length ranges, and adjacent coverage in `orc_scanner_test.cpp`.
>   - Update FE tests (`LoadPlannerTest`, `FileScanNodeTest`) to expect split ranges; set explicit `start_offset`/`size` in ORC tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 042d014926c235c33637c936530742661689ba4f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->