### PR TITLE
[BugFix] turn db-level lock to table-level lock in LocalMetastore.truncateTable()

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -179,6 +179,7 @@ import com.starrocks.scheduler.TaskManager;
 import com.starrocks.scheduler.TaskRun;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.Authorizer;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AddPartitionClause;
 import com.starrocks.sql.ast.AdminCheckTabletsStmt;
 import com.starrocks.sql.ast.AdminSetPartitionVersionStmt;
@@ -4471,6 +4472,40 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         }
     }
 
+    /**
+     * Validates that a table exists (by ID), is an OLAP/Cloud Native table, and is in NORMAL state.
+     * This method should be called while holding a lock on the table.
+     * Supports both permanent tables and session-specific temporary tables.
+     *
+     * @param context the connection context (used for session-aware table lookup)
+     * @param db the database containing the table
+     * @param tableId the ID of the table to validate
+     * @param dbTbl the table name (used for lookup and error messages)
+     * @return the validated OlapTable
+     * @throws DdlException if validation fails (table not found, wrong type, wrong state, or table replaced)
+     */
+    private OlapTable validateTableForTruncate(ConnectContext context, Database db, long tableId, TableName dbTbl)
+            throws DdlException {
+        Table table;
+        try {
+            table = MetaUtils.getSessionAwareTable(context, db, dbTbl);
+        } catch (SemanticException exception) {
+            throw new DdlException(exception.getMessage());
+        }
+        // Check if the table has been replaced (dropped and recreated) during truncation
+        if (table.getId() != tableId) {
+            throw new DdlException("Table [" + dbTbl.getTbl() + "] has been modified during truncation, please retry");
+        }
+        if (!table.isOlapOrCloudNativeTable()) {
+            throw new DdlException("Only support truncate OLAP table or LAKE table");
+        }
+        OlapTable olapTable = (OlapTable) table;
+        if (olapTable.getState() != OlapTable.OlapTableState.NORMAL) {
+            throw InvalidOlapTableStateException.of(olapTable.getState(), olapTable.getName());
+        }
+        return olapTable;
+    }
+
     /*
      * Truncate specified table or partitions.
      * The main idea is:
@@ -4502,23 +4537,16 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         TableName dbTbl = new TableName(dbName, tableName);
         boolean truncateEntireTable = tblRef.getPartitionDef() == null;
 
+        // Get the table outside the lock to obtain the tableId for fine-grained locking.
+        // Use session-aware lookup to support temporary tables.
+        long tableId = MetaUtils.getSessionAwareTable(context, db, dbTbl).getId();
         Locker locker = new Locker();
-        locker.lockDatabase(db.getId(), LockType.READ);
+        if (!locker.lockTableAndCheckDbExist(db, tableId, LockType.READ)) {
+            ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
+        }
         try {
-            Table table = MetaUtils.getSessionAwareTable(context, db, dbTbl);
-            if (table == null) {
-                ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_ERROR, dbTbl.getTbl());
-            }
-
-            if (!table.isOlapOrCloudNativeTable()) {
-                throw new DdlException("Only support truncate OLAP table or LAKE table");
-            }
-
-            OlapTable olapTable = (OlapTable) table;
-            if (olapTable.getState() != OlapTable.OlapTableState.NORMAL) {
-                throw InvalidOlapTableStateException.of(olapTable.getState(), olapTable.getName());
-            }
-
+            // Retrieve the table again under the lock, make sure the table still exists.
+            OlapTable olapTable = validateTableForTruncate(context, db, tableId, dbTbl);
             if (!truncateEntireTable) {
                 for (String partName : tblRef.getPartitionDef().getPartitionNames()) {
                     Partition partition = olapTable.getPartition(partName);
@@ -4538,10 +4566,10 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
 
             copiedTbl = AnalyzerUtils.getShadowCopyTable(olapTable);
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.READ);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.READ);
         }
 
-        // 2. use the copied table to create partitions
+        // 2. use the copied table to create partitions outside the lock
         List<Partition> newPartitions = Lists.newArrayListWithCapacity(origPartitions.size());
         // tabletIdSet to save all newly created tablet ids.
         Set<Long> tabletIdSet = Sets.newHashSet();
@@ -4581,18 +4609,14 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
 
         // all partitions are created successfully, try to replace the old partitions.
         // before replacing, we need to check again.
-        // Things may be changed outside the database lock.
-        locker.lockDatabase(db.getId(), LockType.WRITE);
+        if (!locker.lockTableAndCheckDbExist(db, tableId, LockType.WRITE)) {
+            // The db could be dropped during the unlock-READ and lock-WRITE.
+            deleteUselessTablets(tabletIdSet);
+            ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
+        }
         try {
-            OlapTable olapTable = (OlapTable) getTable(db.getId(), copiedTbl.getId());
-            if (olapTable == null) {
-                throw new DdlException("Table[" + copiedTbl.getName() + "] is dropped");
-            }
-
-            if (olapTable.getState() != OlapTable.OlapTableState.NORMAL) {
-                throw InvalidOlapTableStateException.of(olapTable.getState(), olapTable.getName());
-            }
-
+            // The table could also be changed during the unlock-READ and lock-WRITE.
+            OlapTable olapTable = validateTableForTruncate(context, db, tableId, dbTbl);
             // check partitions
             for (Map.Entry<String, Partition> entry : origPartitions.entrySet()) {
                 Partition partition = olapTable.getPartition(entry.getValue().getId());
@@ -4666,7 +4690,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         } catch (MetaNotFoundException e) {
             LOG.warn("Table related materialized view can not be found", e);
         } finally {
-            locker.unLockDatabase(db.getId(), LockType.WRITE);
+            locker.unLockTableWithIntensiveDbLock(db.getId(), tableId, LockType.WRITE);
         }
 
         LOG.info("finished to truncate table {}, partitions: {}",

--- a/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/LocalMetaStoreTest.java
@@ -36,6 +36,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockType;
@@ -46,9 +47,16 @@ import com.starrocks.persist.metablock.SRMetaBlockReader;
 import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.ColumnRenameClause;
+import com.starrocks.sql.ast.QualifiedName;
+import com.starrocks.sql.ast.TableRef;
+import com.starrocks.sql.ast.TruncateTableStmt;
+import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
+import mockit.Invocation;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -56,6 +64,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class LocalMetaStoreTest {
     private static ConnectContext connectContext;
@@ -284,4 +293,50 @@ public class LocalMetaStoreTest {
         Assertions.assertNull(db.getTable(tableName));
     }
 
+    @Test
+    public void testTruncateInTheMiddleOfDatabaseDropped() throws Exception {
+        String dbName = "db_to_be_dropped";
+        starRocksAssert.withDatabase(dbName).useDatabase(dbName)
+                .withTable("CREATE TABLE t1(k1 int, k2 int, k3 int) distributed by " +
+                        "hash(k1) buckets 3 properties('replication_num' = '1');");
+
+        LocalMetastore localMetastore = connectContext.getGlobalStateMgr().getLocalMetastore();
+        Database db = localMetastore.getDb(dbName);
+        long t1TableId = db.getTable("t1").getId();
+        AtomicBoolean writeLockAcquired = new AtomicBoolean(false);
+
+        long tabletsCountBefore = connectContext.getGlobalStateMgr().getTabletInvertedIndex().getTabletCount();
+        new MockUp<Locker>() {
+            @Mock
+            public boolean lockTableAndCheckDbExist(Invocation invocation, Database database, long tableId,
+                                                    LockType lockType)
+                    throws DdlException, MetaNotFoundException {
+                if (lockType == LockType.WRITE && database.getId() == db.getId() && t1TableId == tableId) {
+                    // simulate that the database is dropped after locking the table
+                    localMetastore.dropDb(connectContext, dbName, false);
+                    long tabletCountInMiddle =
+                            connectContext.getGlobalStateMgr().getTabletInvertedIndex().getTabletCount();
+                    // The new partition is ready, but not committed yet, so 3 more tablets are created
+                    Assertions.assertEquals(tabletsCountBefore + 3, tabletCountInMiddle,
+                            "3 new tablets should be created for the new partition during truncate");
+                    writeLockAcquired.set(true);
+                    return false;
+                } else {
+                    return Boolean.TRUE.equals(invocation.proceed(database, tableId, lockType));
+                }
+            }
+        };
+
+
+        List<String> parts = Lists.newArrayList(dbName, "t1");
+        TableRef tableRef = new TableRef(QualifiedName.of(parts), null, NodePosition.ZERO);
+        TruncateTableStmt stmt = new TruncateTableStmt(tableRef);
+        DdlException exception =
+                Assertions.assertThrows(DdlException.class, () -> localMetastore.truncateTable(stmt, connectContext));
+        Assertions.assertEquals("Unknown database 'db_to_be_dropped'", exception.getMessage());
+        long tabletsCountAfter = connectContext.getGlobalStateMgr().getTabletInvertedIndex().getTabletCount();
+        Assertions.assertEquals(tabletsCountBefore, tabletsCountAfter,
+                "Tablets should not be changed when truncate fails");
+        Assertions.assertTrue(writeLockAcquired.get(), "Write lock should be acquired during truncate");
+    }
 }


### PR DESCRIPTION
* reduce lock contention in LocalMetastore.truncateTable() by using db intent lock instead of direct DB read/write lock.

```
    "java.base@11.0.24/jdk.internal.misc.Unsafe.park(Native Method)",
    "java.base@11.0.24/java.util.concurrent.locks.LockSupport.park(LockSupport.java:194)",
    "java.base@11.0.24/java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(AbstractQueuedSynchronizer.java:885)",
    "java.base@11.0.24/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireQueued(AbstractQueuedSynchronizer.java:917)",
    "java.base@11.0.24/java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:1240)",
    "java.base@11.0.24/java.util.concurrent.locks.ReentrantReadWriteLock$WriteLock.lock(ReentrantReadWriteLock.java:959)",
    "app//com.starrocks.catalog.TabletInvertedIndex.writeLock(TabletInvertedIndex.java:120)",
    "app//com.starrocks.catalog.TabletInvertedIndex.deleteTablet(TabletInvertedIndex.java:676)",
    "app//com.starrocks.server.LocalMetastore.truncateTableInternal(LocalMetastore.java:4798)",
    "app//com.starrocks.server.LocalMetastore.truncateTable(LocalMetastore.java:4726)",
    ...
    "java.base@11.0.24/java.lang.Thread.run(Thread.java:829)"
```

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch truncateTable to table-level intent locks with session-aware revalidation and robust failure handling; add UT to cover DB-drop mid-truncate.
> 
> - **Metastore (`LocalMetastore`)**:
>   - Switch truncate flow from DB read/write locks to table-level locks (`lockTableAndCheckDbExist`/`unLockTableWithIntensiveDbLock`).
>   - Add `validateTableForTruncate(...)` to session-aware re-lookup and verify table id/type/state; detect table replacement during truncate.
>   - Obtain `tableId` before locking; create/build new partitions outside locks; re-validate under WRITE lock before replace; improve error paths (DB dropped/table changed) and ensure tablet cleanup on failure.
>   - Minor: import `SemanticException` used by validation.
> - **Tests**:
>   - Add `testTruncateInTheMiddleOfDatabaseDropped` to simulate DB drop during truncate; assert error, tablet cleanup, and lock acquisition.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e022bde9fcfd2cc2136a0ca4a9cfc0aaaafc7c9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->