### PR TITLE
[BugFix] Reduce the minimum datacache disk size constraint to avoid datacache is excessively disabled for disk reasons (backport #64909)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1298,8 +1298,8 @@ CONF_mInt64(datacache_disk_adjust_interval_seconds, "10");
 CONF_mInt64(datacache_disk_idle_seconds_for_expansion, "7200");
 // The minimum total disk quota bytes to adjust, once the quota to adjust is less than this value,
 // cache quota will be reset to zero to avoid overly frequent population and eviction.
-// Default: 100G
-CONF_mInt64(datacache_min_disk_quota_for_adjustment, "107374182400");
+// Default: 10G
+CONF_mInt64(datacache_min_disk_quota_for_adjustment, "10737418240");
 // The maxmum inline cache item count in datacache.
 // When a cache item has a really small data size, we will try to cache it inline with its metadata
 // to optimize the io performance and reduce disk waste.

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -4079,7 +4079,7 @@ When this value is set to less than `0`, the system uses the product of its abso
 
 ##### datacache_min_disk_quota_for_adjustment
 
-- Default: 107374182400
+- Default: 10737418240
 - Type: Int
 - Unit: Bytes
 - Is mutable: Yes

--- a/docs/ja/administration/management/BE_configuration.md
+++ b/docs/ja/administration/management/BE_configuration.md
@@ -1935,7 +1935,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 ##### datacache_min_disk_quota_for_adjustment
 
-- デフォルト: 107374182400
+- デフォルト: 10737418240
 - タイプ: Int
 - 単位: バイト
 - 可変: はい

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -4038,7 +4038,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 ##### datacache_min_disk_quota_for_adjustment
 
-- 默认值：107374182400
+- 默认值：10737418240
 - 类型：Int
 - 单位：Bytes
 - 是否动态：是


### PR DESCRIPTION
## Why I'm doing:
When using the auto-adjustment of datacache (the default behavior), StarRocks uses the datacache_min_disk_quota_for_adjustment parameter to limit the minimum space for datacache, preventing insufficient disk space from causing caching inefficiency and impacting query performance. However, for many test users, this default value is currently too large, resulting in datacache being disabled without the user's awareness, thus significantly impacting the query performance of external tables and cloud native tables.

## What I'm doing:
Reduce the minimum datacache disk size constraint to avoid datacache is excessively disabled for disk reason

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3