### PR TITLE
[Feature] Support table creation for range distribution

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DistributionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DistributionInfo.java
@@ -46,7 +46,8 @@ public abstract class DistributionInfo implements Writable {
 
     public enum DistributionInfoType {
         HASH,
-        RANDOM
+        RANDOM,
+        RANGE
     }
 
     // for Gson runtime type adaptor

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DistributionInfoBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DistributionInfoBuilder.java
@@ -19,6 +19,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.sql.ast.DistributionDesc;
 import com.starrocks.sql.ast.HashDistributionDesc;
 import com.starrocks.sql.ast.RandomDistributionDesc;
+import com.starrocks.sql.ast.RangeDistributionDesc;
 
 import java.util.List;
 
@@ -31,13 +32,23 @@ public class DistributionInfoBuilder {
      * Build DistributionInfo from a DistributionDesc
      */
     public static DistributionInfo build(DistributionDesc distributionDesc, List<Column> columns) throws DdlException {
-        if (distributionDesc instanceof RandomDistributionDesc) {
+        if (distributionDesc instanceof RangeDistributionDesc) {
+            return buildRangeDistributionInfo((RangeDistributionDesc) distributionDesc, columns);
+        } else if (distributionDesc instanceof RandomDistributionDesc) {
             return buildRandomDistributionInfo((RandomDistributionDesc) distributionDesc, columns);
         } else if (distributionDesc instanceof HashDistributionDesc) {
             return buildHashDistributionInfo((HashDistributionDesc) distributionDesc, columns);
         } else {
             throw new DdlException("Unsupported distribution type: " + distributionDesc.getClass().getSimpleName());
         }
+    }
+
+    /**
+     * Build RangeDistributionInfo from RangeDistributionDesc
+     */
+    public static RangeDistributionInfo buildRangeDistributionInfo(RangeDistributionDesc rangeDistributionDesc,
+                                                                   List<Column> columns) {
+        return new RangeDistributionInfo();
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1223,6 +1223,8 @@ public class OlapTable extends Table {
                 numBucket = CatalogUtils.calPhysicalPartitionBucketNum();
                 info.setBucketNum((int) numBucket);
             }
+        } else if (info.getType() == DistributionInfo.DistributionInfoType.RANGE) {
+            // Range distribution, do nothing
         } else {
             throw new DdlException("Unknown distribution info type: " + info.getType());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RangeDistributionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RangeDistributionInfo.java
@@ -1,0 +1,101 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.base.Objects;
+import com.starrocks.sql.ast.DistributionDesc;
+import com.starrocks.sql.ast.RangeDistributionDesc;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Range distribution.
+ */
+public class RangeDistributionInfo extends DistributionInfo {
+
+    public RangeDistributionInfo() {
+        super(DistributionInfoType.RANGE);
+    }
+
+    /*
+     * Will be changed to true later once colocate is supported.
+     */
+    @Override
+    public boolean supportColocate() {
+        return false;
+    }
+
+    /*
+     * Range distribution doesn't need bucket num, just return 1 to create 1 tablet.
+     */
+    @Override
+    public int getBucketNum() {
+        return 1;
+    }
+
+    /*
+     * Range distribution doesn't need bucket num.
+     */
+    @Override
+    public void setBucketNum(int bucketNum) {
+        // Do nothing
+    }
+
+    @Override
+    public List<ColumnId> getDistributionColumns() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public DistributionDesc toDistributionDesc(Map<ColumnId, Column> schema) {
+        return new RangeDistributionDesc();
+    }
+
+    /*
+     * Range distribution will be the default distribution, no sql needed,
+     * just return empty string.
+     */
+    @Override
+    public String toSql(Map<ColumnId, Column> schema) {
+        return "";
+    }
+
+    @Override
+    public RangeDistributionInfo copy() {
+        return new RangeDistributionInfo();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(type);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+
+        if (!(other instanceof RangeDistributionInfo)) {
+            return false;
+        }
+
+        RangeDistributionInfo rangeDistributionInfo = (RangeDistributionInfo) other;
+
+        return type == rangeDistributionInfo.type;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DynamicPartitionScheduler.java
@@ -46,6 +46,7 @@ import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.RandomDistributionInfo;
+import com.starrocks.catalog.RangeDistributionInfo;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
@@ -72,6 +73,7 @@ import com.starrocks.sql.ast.HashDistributionDesc;
 import com.starrocks.sql.ast.PartitionKeyDesc;
 import com.starrocks.sql.ast.PartitionValue;
 import com.starrocks.sql.ast.RandomDistributionDesc;
+import com.starrocks.sql.ast.RangeDistributionDesc;
 import com.starrocks.sql.ast.SingleRangePartitionDesc;
 import com.starrocks.sql.ast.expression.TimestampArithmeticExpr;
 import com.starrocks.sql.common.MetaUtils;
@@ -273,6 +275,8 @@ public class DynamicPartitionScheduler extends FrontendDaemon {
                         distColumnNames);
         } else if (distributionInfo instanceof RandomDistributionInfo) {
             distributionDesc = new RandomDistributionDesc(dynamicPartitionProperty.getBuckets());
+        } else if (distributionInfo instanceof RangeDistributionInfo) {
+            distributionDesc = new RangeDistributionDesc();
         }
         return distributionDesc;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3955,6 +3955,12 @@ public class Config extends ConfigBase {
     public static long default_statistics_output_row_count = 1L;
 
     /**
+     * Whether enable range distribution.
+     */
+    @ConfField(mutable = true, comment = "Whether enable range distribution.")
+    public static boolean enable_range_distribution = false;
+
+    /**
      * The default scheduler interval for dynamic tablet jobs.
      */
     @ConfField(mutable = false, comment = "The default scheduler interval for dynamic tablet jobs.")

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/PartitionsProcDir.java
@@ -51,7 +51,6 @@ import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.RangePartitionInfo;
-import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
@@ -334,13 +333,18 @@ public class PartitionsProcDir implements ProcDirInterface {
         return partitionInfos;
     }
 
-    public static String distributionKeyAsString(Table table, DistributionInfo distributionInfo) {
+    public static String distributionKeyAsString(OlapTable table, DistributionInfo distributionInfo) {
         if (distributionInfo.getType() == DistributionInfoType.HASH) {
             List<String> columnNames = MetaUtils.getColumnNamesByColumnIds(
                     table.getIdToColumn(), distributionInfo.getDistributionColumns());
             return Joiner.on(", ").join(columnNames);
-        } else {
+        } else if (distributionInfo.getType() == DistributionInfoType.RANDOM) {
             return "ALL KEY";
+        } else if (distributionInfo.getType() == DistributionInfoType.RANGE) {
+            List<String> columnNames = MetaUtils.getRangeDistributionColumnNames(table);
+            return Joiner.on(", ").join(columnNames);
+        } else {
+            throw new RuntimeException("Unsupported distribution type: " + distributionInfo.getType());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
@@ -128,6 +128,7 @@ import com.starrocks.catalog.OdbcCatalogResource;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.RandomDistributionInfo;
+import com.starrocks.catalog.RangeDistributionInfo;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.RecycleListPartitionInfo;
 import com.starrocks.catalog.RecyclePartitionInfoV2;
@@ -256,7 +257,8 @@ public class GsonUtils {
             RuntimeTypeAdapterFactory
                     .of(DistributionInfo.class, "clazz")
                     .registerSubtype(HashDistributionInfo.class, "HashDistributionInfo")
-                    .registerSubtype(RandomDistributionInfo.class, "RandomDistributionInfo");
+                    .registerSubtype(RandomDistributionInfo.class, "RandomDistributionInfo")
+                    .registerSubtype(RangeDistributionInfo.class, "RangeDistributionInfo");
 
     private static final RuntimeTypeAdapterFactory<PartitionInfo> PARTITION_INFO_TYPE_ADAPTER_FACTORY =
             RuntimeTypeAdapterFactory

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2066,7 +2066,8 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
 
         DistributionInfo.DistributionInfoType distributionInfoType = distributionInfo.getType();
         if (distributionInfoType != DistributionInfo.DistributionInfoType.HASH
-                && distributionInfoType != DistributionInfo.DistributionInfoType.RANDOM) {
+                && distributionInfoType != DistributionInfo.DistributionInfoType.RANDOM
+                && distributionInfoType != DistributionInfo.DistributionInfoType.RANGE) {
             throw new DdlException("Unknown distribution type: " + distributionInfoType);
         }
 
@@ -2101,7 +2102,8 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
 
         DistributionInfo.DistributionInfoType distributionInfoType = distributionInfo.getType();
         if (distributionInfoType != DistributionInfo.DistributionInfoType.HASH
-                && distributionInfoType != DistributionInfo.DistributionInfoType.RANDOM) {
+                && distributionInfoType != DistributionInfo.DistributionInfoType.RANDOM
+                && distributionInfoType != DistributionInfo.DistributionInfoType.RANGE) {
             throw new DdlException("Unknown distribution type: " + distributionInfoType);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -201,7 +201,9 @@ public class AstToStringBuilder {
 
             // distribution
             DistributionInfo distributionInfo = olapTable.getDefaultDistributionInfo();
-            sb.append("\n").append(distributionInfo.toSql(table.getIdToColumn()));
+            if (distributionInfo.getType() != DistributionInfo.DistributionInfoType.RANGE) {
+                sb.append("\n").append(distributionInfo.toSql(table.getIdToColumn()));
+            }
 
             // order by
             MaterializedIndexMeta index = olapTable.getIndexMetaByIndexId(olapTable.getBaseIndexId());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -54,6 +54,7 @@ import com.starrocks.sql.ast.OrderByElement;
 import com.starrocks.sql.ast.ParseNode;
 import com.starrocks.sql.ast.PartitionDesc;
 import com.starrocks.sql.ast.RandomDistributionDesc;
+import com.starrocks.sql.ast.RangeDistributionDesc;
 import com.starrocks.sql.ast.RangePartitionDesc;
 import com.starrocks.sql.ast.SingleItemListPartitionDesc;
 import com.starrocks.sql.ast.SingleRangePartitionDesc;
@@ -318,7 +319,7 @@ public class CreateTableAnalyzer {
                         keysColumnNames.add(columnDef.getName());
                     }
                 }
-                keysDesc = new KeysDesc(KeysType.AGG_KEYS, keysColumnNames);
+                keysDesc = new KeysDesc(KeysType.AGG_KEYS, keysColumnNames, true);
             } else {
                 int keyLength = 0;
                 for (ColumnDef columnDef : columnDefs) {
@@ -352,7 +353,7 @@ public class CreateTableAnalyzer {
                 if (keysColumnNames.isEmpty()) {
                     throw new SemanticException("Data type of first column cannot be %s", columnDefs.get(0).getType());
                 }
-                keysDesc = new KeysDesc(KeysType.DUP_KEYS, keysColumnNames);
+                keysDesc = new KeysDesc(KeysType.DUP_KEYS, keysColumnNames, true);
             }
         }
 
@@ -433,7 +434,7 @@ public class CreateTableAnalyzer {
     }
 
     private static void analyzeSortKeys(CreateTableStmt stmt) {
-        if (!stmt.isOlapEngine()) {
+        if (!stmt.isOlapEngine() || stmt.getOrderByElements() == null) {
             return;
         }
 
@@ -443,7 +444,48 @@ public class CreateTableAnalyzer {
         List<ColumnDef> columnDefs = stmt.getColumnDefs();
         List<OrderByElement> orderByElements = stmt.getOrderByElements();
         List<String> columnNames = columnDefs.stream().map(ColumnDef::getName).collect(Collectors.toList());
-        if (orderByElements != null) {
+        if (Config.enable_range_distribution) {
+            // For range distribution, the sort columns must be the same as the key
+            // columns or only in a different order for none duplicate key table
+            if (keysType != KeysType.DUP_KEYS) {
+                List<Integer> sortKeyIdxes = Lists.newArrayList();
+                for (OrderByElement orderByElement : orderByElements) {
+                    String column = orderByElement.castAsSlotRef();
+                    if (column == null) {
+                        throw new SemanticException("Unknown column '%s' in order by clause",
+                                ExprToSql.toSql(orderByElement.getExpr()));
+                    }
+                    int idx = columnNames.indexOf(column);
+                    if (idx == -1) {
+                        throw new SemanticException("Column '%s' does not exist", column);
+                    }
+                    if (keysType == KeysType.PRIMARY_KEYS) {
+                        ColumnDef cd = columnDefs.get(idx);
+                        Type t = cd.getType();
+                        if (!(t.isBoolean() || t.isIntegerType() || t.isLargeint() || t.isVarchar() || t.isBinaryType()
+                                || t.isDate() || t.isDatetime())) {
+                            throw new SemanticException(
+                                    "Sort key column[" + cd.getName() + "] type not supported: " + t.toSql());
+                        }
+                    }
+                    sortKeyIdxes.add(idx);
+                }
+
+                List<Integer> keyColIdxes = Lists.newArrayList();
+                for (String column : keysDesc.getKeysColumnNames()) {
+                    int idx = columnNames.indexOf(column);
+                    if (idx == -1) {
+                        throw new SemanticException("Column '%s' does not exist in key columns", column);
+                    }
+                    keyColIdxes.add(idx);
+                }
+
+                boolean res = new HashSet<>(keyColIdxes).equals(new HashSet<>(sortKeyIdxes));
+                if (!res) {
+                    throw new SemanticException("The sort columns must be same with key columns");
+                }
+            }
+        } else {
             // we should check sort key column type if table is primary key table
             if (keysType == KeysType.PRIMARY_KEYS) {
                 for (OrderByElement orderByElement : orderByElements) {
@@ -633,6 +675,18 @@ public class CreateTableAnalyzer {
             Map<String, String> properties = stmt.getProperties();
             KeysDesc keysDesc = Preconditions.checkNotNull(stmt.getKeysDesc());
 
+            if (Config.enable_range_distribution) {
+                if (distributionDesc == null) {
+                    // For duplicate key table, if both duplicate key and order by are not
+                    // specified, use random distribution, otherwise, use range distribution
+                    if (!(keysDesc.getKeysType() == KeysType.DUP_KEYS
+                            && keysDesc.isKeysColumnsDerived()
+                            && stmt.getOrderByElements() == null)) {
+                        distributionDesc = new RangeDistributionDesc();
+                    }
+                }
+            }
+
             // analyze distribution
             if (distributionDesc == null) {
                 if (properties != null && properties.containsKey("colocate_with")) {
@@ -658,7 +712,7 @@ public class CreateTableAnalyzer {
             }
             if (distributionDesc instanceof RandomDistributionDesc && keysDesc.getKeysType() != KeysType.DUP_KEYS) {
                 throw new SemanticException(keysDesc.getKeysType().toSql()
-                        + " must use hash distribution", distributionDesc.getPos());
+                        + " cannot use random distribution", distributionDesc.getPos());
             }
             if (distributionDesc.getBuckets() > Config.max_bucket_number_per_partition && stmt.isOlapEngine()
                     && stmt.getPartitionDesc() != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DistributionDescAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DistributionDescAnalyzer.java
@@ -17,9 +17,11 @@ package com.starrocks.sql.analyzer;
 import com.starrocks.catalog.DistributionInfo;
 import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.RandomDistributionInfo;
+import com.starrocks.catalog.RangeDistributionInfo;
 import com.starrocks.sql.ast.DistributionDesc;
 import com.starrocks.sql.ast.HashDistributionDesc;
 import com.starrocks.sql.ast.RandomDistributionDesc;
+import com.starrocks.sql.ast.RangeDistributionDesc;
 
 import java.util.Set;
 
@@ -30,6 +32,8 @@ public class DistributionDescAnalyzer {
             analyzeHashDistribution((HashDistributionDesc) distributionDesc, colSet);
         } else if (distributionDesc instanceof RandomDistributionDesc) {
             analyzeRandomDistribution((RandomDistributionDesc) distributionDesc, colSet);
+        } else if (distributionDesc instanceof RangeDistributionDesc) {
+            // Nothing need to be analyzed for range distribution
         }
     }
 
@@ -61,6 +65,8 @@ public class DistributionDescAnalyzer {
         if (distributionDesc instanceof HashDistributionDesc && distributionInfo instanceof HashDistributionInfo) {
             return false;
         } else if (distributionDesc instanceof RandomDistributionDesc && distributionInfo instanceof RandomDistributionInfo) {
+            return false;
+        } else if (distributionDesc instanceof RangeDistributionDesc && distributionInfo instanceof RangeDistributionInfo) {
             return false;
         }
         return true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -85,6 +85,7 @@ import com.starrocks.sql.ast.PartitionRangeDesc;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.RandomDistributionDesc;
+import com.starrocks.sql.ast.RangeDistributionDesc;
 import com.starrocks.sql.ast.RefreshMaterializedViewStatement;
 import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.SetOperationRelation;
@@ -1566,21 +1567,30 @@ public class MaterializedViewAnalyzer {
 
             }
 
-            // If the key type is primary key, the distribution must be hash distribution.
-            if  (KeysType.PRIMARY_KEYS.equals(statement.getKeysType())) {
-                distributionDesc = checkDistributionForPrimaryKey(statement);
-            } else {
-                // for non primary key tables, if user not specify distribution, we use hash distribution
+            if (Config.enable_range_distribution) {
                 if (distributionDesc == null) {
-                    if (connectContext.getSessionVariable().isAllowDefaultPartition()) {
-                        distributionDesc = new HashDistributionDesc(0,
-                                Lists.newArrayList(mvColumnItems.get(0).getName()));
-                    } else {
-                        distributionDesc = new RandomDistributionDesc();
-                    }
+                    // If no distribution specified, use range distribution
+                    distributionDesc = new RangeDistributionDesc();
                     statement.setDistributionDesc(distributionDesc);
                 }
+            } else {
+                // If the key type is primary key, the distribution must be hash distribution.
+                if  (KeysType.PRIMARY_KEYS.equals(statement.getKeysType())) {
+                    distributionDesc = checkDistributionForPrimaryKey(statement);
+                } else {
+                    // for non primary key tables, if user not specify distribution, we use hash distribution
+                    if (distributionDesc == null) {
+                        if (connectContext.getSessionVariable().isAllowDefaultPartition()) {
+                            distributionDesc = new HashDistributionDesc(0,
+                                    Lists.newArrayList(mvColumnItems.get(0).getName()));
+                        } else {
+                            distributionDesc = new RandomDistributionDesc();
+                        }
+                        statement.setDistributionDesc(distributionDesc);
+                    }
+                }
             }
+
             Set<String> columnSet = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
             for (Column columnDef : mvColumnItems) {
                 if (!columnSet.add(columnDef.getName())) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/KeysDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/KeysDesc.java
@@ -24,22 +24,33 @@ import java.util.List;
 public class KeysDesc implements ParseNode {
     private final KeysType type;
     private final List<String> keysColumnNames;
+    private final boolean keysColumnsDerived;
     private final NodePosition pos;
 
     public KeysDesc() {
         pos = NodePosition.ZERO;
         this.type = KeysType.AGG_KEYS;
         this.keysColumnNames = Lists.newArrayList();
+        this.keysColumnsDerived = false;
     }
 
     public KeysDesc(KeysType type, List<String> keysColumnNames) {
-        this(type, keysColumnNames, NodePosition.ZERO);
+        this(type, keysColumnNames, false);
+    }
+
+    public KeysDesc(KeysType type, List<String> keysColumnNames, boolean keysColumnsDerived) {
+        this(type, keysColumnNames, keysColumnsDerived, NodePosition.ZERO);
     }
 
     public KeysDesc(KeysType type, List<String> keysColumnNames, NodePosition pos) {
+        this(type, keysColumnNames, false, pos);
+    }
+
+    public KeysDesc(KeysType type, List<String> keysColumnNames, boolean keysColumnsDerived, NodePosition pos) {
         this.pos = pos;
         this.type = type;
         this.keysColumnNames = keysColumnNames;
+        this.keysColumnsDerived = keysColumnsDerived;
     }
 
     public KeysType getKeysType() {
@@ -52,6 +63,10 @@ public class KeysDesc implements ParseNode {
 
     public boolean containsCol(String colName) {
         return keysColumnNames.stream().anyMatch(e -> StringUtils.equalsIgnoreCase(e, colName));
+    }
+
+    public boolean isKeysColumnsDerived() {
+        return keysColumnsDerived;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/RangeDistributionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/RangeDistributionDesc.java
@@ -1,0 +1,45 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.starrocks.sql.parser.NodePosition;
+
+public class RangeDistributionDesc extends DistributionDesc {
+
+    public RangeDistributionDesc() {
+        this(NodePosition.ZERO);
+    }
+
+    public RangeDistributionDesc(NodePosition pos) {
+        super(pos);
+    }
+
+    /*
+     * Range distribution doesn't need bucket num, just return 1 to create 1 tablet.
+     */
+    @Override
+    public int getBuckets() {
+        return 1;
+    }
+
+    /*
+     * Range distribution will be the default distribution, no sql needed,
+     * just return empty string.
+     */
+    @Override
+    public String toString() {
+        return "";
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnId;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.ExternalOlapTable;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.ErrorCode;
@@ -234,6 +235,24 @@ public class MetaUtils {
             result.put(column.getColumnId(), column);
         }
         return result;
+    }
+
+    public static List<String> getRangeDistributionColumnNames(OlapTable olapTable) {
+        List<String> columnNames = new ArrayList<>();
+        MaterializedIndexMeta baseIndexMeta = olapTable.getIndexMetaByIndexId(olapTable.getBaseIndexId());
+        List<Column> baseSchema = olapTable.getBaseSchema();
+        if (baseIndexMeta.getSortKeyIdxes() != null) {
+            for (Integer i : baseIndexMeta.getSortKeyIdxes()) {
+                columnNames.add(baseSchema.get(i).getName());
+            }
+        } else {
+            for (Column column : baseSchema) {
+                if (column.isKey()) {
+                    columnNames.add(column.getName());
+                }
+            }
+        }
+        return columnNames;
     }
 
     public static List<String> getColumnNamesByColumnIds(Table table, List<ColumnId> columnIds) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -1113,6 +1113,8 @@ public class MvRewritePreprocessor {
             distributionSpec = DistributionSpec.createHashDistributionSpec(hashDistributionDesc);
         } else if (distributionInfo.getType() == DistributionInfoType.RANDOM) {
             distributionSpec = DistributionSpec.createAnyDistributionSpec();
+        } else if (distributionInfo.getType() == DistributionInfoType.RANGE) {
+            distributionSpec = DistributionSpec.createAnyDistributionSpec();
         }
 
         return distributionSpec;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -31,6 +31,8 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.RandomDistributionInfo;
+import com.starrocks.catalog.RangeDistributionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Pair;
@@ -48,6 +50,7 @@ import com.starrocks.sql.ast.ParseNode;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.RandomDistributionDesc;
+import com.starrocks.sql.ast.RangeDistributionDesc;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.expression.BinaryPredicate;
 import com.starrocks.sql.ast.expression.BinaryType;
@@ -1541,8 +1544,12 @@ public class MvUtils {
             List<String> distColumnNames = MetaUtils.getColumnNamesByColumnIds(
                     materializedView.getIdToColumn(), distributionInfo.getDistributionColumns());
             return new HashDistributionDesc(distributionInfo.getBucketNum(), distColumnNames);
-        } else {
+        } else if (distributionInfo instanceof RandomDistributionInfo) {
             return new RandomDistributionDesc();
+        } else if (distributionInfo instanceof RangeDistributionInfo) {
+            return new RangeDistributionDesc();
+        } else {
+            throw new RuntimeException("Unsupported distribution type: " + distributionInfo.getType());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -575,6 +575,8 @@ public class RelationTransformer implements AstVisitorExtendInterface<LogicalPla
             distributionSpec = DistributionSpec.createHashDistributionSpec(hashDistributionDesc);
         } else if (distributionInfo.getType() == DistributionInfoType.RANDOM) {
             distributionSpec = DistributionSpec.createAnyDistributionSpec();
+        } else if (distributionInfo.getType() == DistributionInfoType.RANGE) {
+            distributionSpec = DistributionSpec.createAnyDistributionSpec();
         } else {
             throw new IllegalStateException("Unknown distribution type: " + distributionInfo.getType());
         }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/RangeDistributionInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/RangeDistributionInfoTest.java
@@ -1,0 +1,126 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.starrocks.sql.ast.DistributionDesc;
+import com.starrocks.sql.ast.RangeDistributionDesc;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class RangeDistributionInfoTest {
+
+    @Test
+    public void testConstructor() {
+        RangeDistributionInfo rangeDistributionInfo = new RangeDistributionInfo();
+        Assertions.assertNotNull(rangeDistributionInfo);
+        Assertions.assertEquals(DistributionInfo.DistributionInfoType.RANGE, rangeDistributionInfo.getType());
+    }
+
+    @Test
+    public void testSupportColocate() {
+        RangeDistributionInfo rangeDistributionInfo = new RangeDistributionInfo();
+        Assertions.assertFalse(rangeDistributionInfo.supportColocate());
+    }
+
+    @Test
+    public void testGetBucketNum() {
+        RangeDistributionInfo rangeDistributionInfo = new RangeDistributionInfo();
+        Assertions.assertEquals(1, rangeDistributionInfo.getBucketNum());
+    }
+
+    @Test
+    public void testSetBucketNum() {
+        RangeDistributionInfo rangeDistributionInfo = new RangeDistributionInfo();
+        // setBucketNum should do nothing without throwing exception
+        rangeDistributionInfo.setBucketNum(10);
+        // bucket num should still be 1
+        Assertions.assertEquals(1, rangeDistributionInfo.getBucketNum());
+    }
+
+    @Test
+    public void testGetDistributionColumns() {
+        RangeDistributionInfo rangeDistributionInfo = new RangeDistributionInfo();
+        List<ColumnId> columns = rangeDistributionInfo.getDistributionColumns();
+        Assertions.assertNotNull(columns);
+        Assertions.assertTrue(columns.isEmpty());
+    }
+
+    @Test
+    public void testToDistributionDesc() {
+        RangeDistributionInfo rangeDistributionInfo = new RangeDistributionInfo();
+        Map<ColumnId, Column> schema = new HashMap<>();
+        DistributionDesc desc = rangeDistributionInfo.toDistributionDesc(schema);
+        Assertions.assertNotNull(desc);
+        Assertions.assertTrue(desc instanceof RangeDistributionDesc);
+    }
+
+    @Test
+    public void testToSql() {
+        RangeDistributionInfo rangeDistributionInfo = new RangeDistributionInfo();
+        Map<ColumnId, Column> schema = new HashMap<>();
+        String sql = rangeDistributionInfo.toSql(schema);
+        Assertions.assertNotNull(sql);
+        Assertions.assertEquals("", sql);
+    }
+
+    @Test
+    public void testCopy() {
+        RangeDistributionInfo rangeDistributionInfo = new RangeDistributionInfo();
+        RangeDistributionInfo copy = rangeDistributionInfo.copy();
+        Assertions.assertNotNull(copy);
+        Assertions.assertNotSame(rangeDistributionInfo, copy);
+        Assertions.assertEquals(rangeDistributionInfo, copy);
+        Assertions.assertEquals(rangeDistributionInfo.getType(), copy.getType());
+    }
+
+    @Test
+    public void testHashCode() {
+        RangeDistributionInfo rangeDistributionInfo1 = new RangeDistributionInfo();
+        RangeDistributionInfo rangeDistributionInfo2 = new RangeDistributionInfo();
+        Assertions.assertEquals(rangeDistributionInfo1.hashCode(), rangeDistributionInfo2.hashCode());
+    }
+
+    @Test
+    public void testEquals() {
+        RangeDistributionInfo rangeDistributionInfo1 = new RangeDistributionInfo();
+        RangeDistributionInfo rangeDistributionInfo2 = new RangeDistributionInfo();
+
+        // Test same object
+        Assertions.assertTrue(rangeDistributionInfo1.equals(rangeDistributionInfo1));
+
+        // Test equal objects
+        Assertions.assertTrue(rangeDistributionInfo1.equals(rangeDistributionInfo2));
+        Assertions.assertTrue(rangeDistributionInfo2.equals(rangeDistributionInfo1));
+
+        // Test null
+        Assertions.assertFalse(rangeDistributionInfo1.equals(null));
+
+        // Test different type
+        Assertions.assertFalse(rangeDistributionInfo1.equals(new Object()));
+    }
+
+    @Test
+    public void testGetDistributionKey() {
+        RangeDistributionInfo rangeDistributionInfo = new RangeDistributionInfo();
+        Map<ColumnId, Column> schema = new HashMap<>();
+        String key = rangeDistributionInfo.getDistributionKey(schema);
+        Assertions.assertNotNull(key);
+        Assertions.assertEquals("", key);
+    }
+}

--- a/test/sql/test_create_table/R/test_create_table_with_range_distribution
+++ b/test/sql/test_create_table/R/test_create_table_with_range_distribution
@@ -1,0 +1,75 @@
+-- name: test_create_table_with_range_distribution
+admin set frontend config ("enable_range_distribution" = "true");
+-- result:
+-- !result
+CREATE TABLE dup_table1 (
+    tenant_id varchar(128),
+    created_time datetime,
+    id int, 
+    name varchar(64)
+)
+ORDER BY (tenant_id, created_time, id);
+-- result:
+-- !result
+CREATE TABLE dup_table2 (
+    tenant_id varchar(128),
+    created_time datetime,
+    id int, 
+    name varchar(64)
+)
+DUPLICATE KEY (tenant_id, created_time, id);
+-- result:
+-- !result
+CREATE TABLE dup_table3 (
+    tenant_id varchar(128),
+    created_time datetime,
+    id int, 
+    name varchar(64)
+)
+DUPLICATE KEY (tenant_id)
+ORDER BY (tenant_id, created_time, id);
+-- result:
+-- !result
+CREATE TABLE random_table (
+    tenant_id varchar(128),
+    created_time datetime,
+    id int, 
+    name varchar(64)
+);
+-- result:
+-- !result
+CREATE TABLE pk_table1 (
+    tenant_id varchar(128),
+    created_time datetime,
+    id int, 
+    name varchar(64)
+)
+PRIMARY KEY (tenant_id, created_time, id);
+-- result:
+-- !result
+SHOW PARTITIONS FROM pk_table1;
+CREATE TABLE pk_table2 (
+    tenant_id varchar(128),
+    created_time datetime,
+    id int, 
+    name varchar(64)
+)
+PRIMARY KEY (tenant_id, created_time, id)
+ORDER BY (tenant_id, id, created_time);
+-- result:
+-- !result
+SHOW PARTITIONS FROM pk_table2;
+CREATE TABLE not_supported_pk_table (
+    tenant_id varchar(128),
+    created_time datetime,
+    id int, 
+    name varchar(64)
+)
+PRIMARY KEY (tenant_id, created_time, id)
+ORDER BY (tenant_id);
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: The sort columns must be same with key columns.')
+-- !result
+admin set frontend config ("enable_range_distribution" = "false");
+-- result:
+-- !result

--- a/test/sql/test_create_table/T/test_create_table_case_sensitive
+++ b/test/sql/test_create_table/T/test_create_table_case_sensitive
@@ -1,4 +1,4 @@
 -- name: test_create_table_sensitive
-create table t1(k int) order by (K);
-create table t2(K int) order by (k);
-create table t3 order by (k) as select * from t2;
+create table t1(k int) distributed by random order by (K);
+create table t2(K int) distributed by random order by (k);
+create table t3 distributed by random order by (k) as select * from t2;

--- a/test/sql/test_create_table/T/test_create_table_with_range_distribution
+++ b/test/sql/test_create_table/T/test_create_table_with_range_distribution
@@ -1,0 +1,67 @@
+-- name: test_create_table_with_range_distribution
+
+admin set frontend config ("enable_range_distribution" = "true");
+
+CREATE TABLE dup_table1 (
+    tenant_id varchar(128),
+    created_time datetime,
+    id int, 
+    name varchar(64)
+)
+ORDER BY (tenant_id, created_time, id);
+
+CREATE TABLE dup_table2 (
+    tenant_id varchar(128),
+    created_time datetime,
+    id int, 
+    name varchar(64)
+)
+DUPLICATE KEY (tenant_id, created_time, id);
+
+CREATE TABLE dup_table3 (
+    tenant_id varchar(128),
+    created_time datetime,
+    id int, 
+    name varchar(64)
+)
+DUPLICATE KEY (tenant_id)
+ORDER BY (tenant_id, created_time, id);
+
+CREATE TABLE random_table (
+    tenant_id varchar(128),
+    created_time datetime,
+    id int, 
+    name varchar(64)
+);
+
+CREATE TABLE pk_table1 (
+    tenant_id varchar(128),
+    created_time datetime,
+    id int, 
+    name varchar(64)
+)
+PRIMARY KEY (tenant_id, created_time, id);
+
+SHOW PARTITIONS FROM pk_table1;
+
+CREATE TABLE pk_table2 (
+    tenant_id varchar(128),
+    created_time datetime,
+    id int, 
+    name varchar(64)
+)
+PRIMARY KEY (tenant_id, created_time, id)
+ORDER BY (tenant_id, id, created_time);
+
+SHOW PARTITIONS FROM pk_table2;
+
+CREATE TABLE not_supported_pk_table (
+    tenant_id varchar(128),
+    created_time datetime,
+    id int, 
+    name varchar(64)
+)
+PRIMARY KEY (tenant_id, created_time, id)
+ORDER BY (name);
+
+admin set frontend config ("enable_range_distribution" = "false");


### PR DESCRIPTION
## Why I'm doing:
 Introduce range distribution strategy that creates single tablet per  partition and uses sort keys for range data organization.
 This pr only support table creation for range distribution, data load and query are not supported in this pr.

## What I'm doing:
  - Add RangeDistributionInfo and RangeDistributionDesc
  - Add FE config 'enable_range_distribution' (default: false)
  - Auto-use range distribution by default if enable_range_distribution is true
  - Validate sort columns match key columns for non-DUP tables
  - Colocate not supported yet

Fixes https://github.com/StarRocks/starrocks/issues/64986

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `RANGE` distribution (config-gated), default it for new tables when enabled, and wire through analysis, DDL, runtime, optimizer, serialization, and tests.
> 
> - **Distribution Core**:
>   - Add `RANGE` type (`RangeDistributionInfo`, `RangeDistributionDesc`) with 1 tablet and no bucket config.
>   - Update `DistributionInfoType`, builders, `OlapTable.inferDistribution`, `LocalMetastore` to accept `RANGE`.
> - **Config**:
>   - Add `Config.enable_range_distribution` (default false) to toggle behavior.
> - **Analysis & DDL**:
>   - `CreateTableAnalyzer`: auto-use `RANGE` by default when enabled; enforce sort keys equal key cols for non-`DUP_KEYS`; refine keys derivation (`KeysDesc.keysColumnsDerived`).
>   - `AstToStringBuilder`: omit distribution clause for `RANGE` in SHOW CREATE.
>   - `PartitionsProcDir`: display range distribution key names.
> - **Scheduler & MV**:
>   - `DynamicPartitionScheduler`: generate `RangeDistributionDesc` when applicable.
>   - MV utils/optimizer: treat `RANGE` as `ANY` distribution.
> - **Serialization**:
>   - `GsonUtils`: register `RangeDistributionInfo` subtype.
> - **Utilities**:
>   - `MetaUtils.getRangeDistributionColumnNames` helper.
> - **Tests**:
>   - New UT `RangeDistributionInfoTest` and SQL tests for range distribution creation; adjust case-sensitive create table test.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24a07a6c9038cef2b4849c957f0fde49fc081f42. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->