### PR TITLE
[BugFix] Fix global RF race condition in event scheduler

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -933,6 +933,8 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     FAIL_POINT_TRIGGER_EXECUTE(fragment_prepare_sleep, { sleep(2); });
 
     RETURN_IF_ERROR(_query_ctx->fragment_mgr()->register_ctx(request.fragment_instance_id(), _fragment_ctx));
+    auto* runtime_state = _fragment_ctx->runtime_state();
+    runtime_state->set_fragment_prepared(true);
     _query_ctx->mark_prepared();
     prepare_success = true;
 

--- a/be/src/exprs/runtime_filter_bank.cpp
+++ b/be/src/exprs/runtime_filter_bank.cpp
@@ -38,9 +38,12 @@
 #include "simd/simd.h"
 #include "types/logical_type.h"
 #include "types/logical_type_infra.h"
+#include "util/failpoint/fail_point.h"
 #include "util/time.h"
 
 namespace starrocks {
+DEFINE_FAIL_POINT(global_runtime_filter_sync_B);
+
 RuntimeFilter* RuntimeFilterHelper::transmit_to_runtime_empty_filter(ObjectPool* pool, RuntimeFilter* rf) {
     const auto* min_max_filter = rf->get_min_max_filter();
     const auto* membership_filter = rf->get_membership_filter();
@@ -590,6 +593,7 @@ Status RuntimeFilterProbeDescriptor::init(int32_t filter_id, ExprContext* probe_
 }
 
 Status RuntimeFilterProbeDescriptor::prepare(RuntimeState* state, RuntimeProfile* p) {
+    _runtime_state = state;
     if (_probe_expr_ctx != nullptr) {
         RETURN_IF_ERROR(_probe_expr_ctx->prepare(state));
     }
@@ -1090,7 +1094,12 @@ void RuntimeFilterProbeCollector::wait(bool on_scan_node) {
 }
 
 void RuntimeFilterProbeDescriptor::set_runtime_filter(const RuntimeFilter* rf) {
-    auto notify = DeferOp([this]() { _observable.notify_source_observers(); });
+    auto notify = DeferOp([this]() {
+        FAIL_POINT_TRIGGER_EXECUTE(global_runtime_filter_sync_B, { this->barrier.arrive_B(); });
+        if (_runtime_state && _runtime_state->fragment_prepared()) {
+            _observable.notify_source_observers();
+        }
+    });
     const RuntimeFilter* expected = nullptr;
     _runtime_filter.compare_exchange_strong(expected, rf, std::memory_order_seq_cst, std::memory_order_seq_cst);
     if (_ready_timestamp == 0 && rf != nullptr && _latency_timer != nullptr) {

--- a/be/src/exprs/runtime_filter_bank.h
+++ b/be/src/exprs/runtime_filter_bank.h
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <mutex>
+#include <semaphore>
 #include <set>
 
 #include "column/column.h"
@@ -35,6 +36,7 @@
 #include "runtime/runtime_state.h"
 #include "types/logical_type.h"
 #include "util/blocking_queue.hpp"
+#include "util/failpoint/fail_point.h"
 
 namespace starrocks::pipeline {
 struct RuntimeMembershipFilterBuildParam;
@@ -229,6 +231,10 @@ public:
     void set_has_push_down_to_storage(bool v) { _has_push_down_to_storage = v; }
     bool has_push_down_to_storage() const { return _has_push_down_to_storage; }
 
+#ifdef FIU_ENABLE
+    failpoint::OneToAnyBarrier barrier;
+#endif
+
 private:
     friend class HashJoinNode;
     friend class hashJoiner;
@@ -252,6 +258,7 @@ private:
 
     std::atomic<const RuntimeFilter*> _runtime_filter = nullptr;
     std::shared_ptr<const RuntimeFilter> _shared_runtime_filter = nullptr;
+    RuntimeState* _runtime_state = nullptr;
     pipeline::Observable _observable;
     bool _has_push_down_to_storage = false;
 };

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -579,6 +579,9 @@ public:
 
     DebugActionMgr& debug_action_mgr() { return _debug_action_mgr; }
 
+    bool fragment_prepared() const { return _fragment_prepared; }
+    void set_fragment_prepared(bool prepared) { _fragment_prepared = prepared; }
+
 private:
     // Set per-query state.
     void _init(const TUniqueId& fragment_instance_id, const TQueryOptions& query_options,
@@ -720,6 +723,8 @@ private:
     DebugActionMgr _debug_action_mgr;
 
     bool _enable_event_scheduler = false;
+
+    bool _fragment_prepared = false;
 };
 
 #define RETURN_IF_LIMIT_EXCEEDED(state, msg)                                                \

--- a/test/sql/test_pipeline/R/test_event_schedule_with_grf
+++ b/test/sql/test_pipeline/R/test_event_schedule_with_grf
@@ -1,0 +1,74 @@
+-- name: test_event_scheduler_with_grf @sequential
+CREATE TABLE `t0` (
+  `c0` int DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` string DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `t1` (
+  `c0` int DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` string DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t0 SELECT generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  409600));
+-- result:
+-- !result
+insert into t1 SELECT generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  409600));
+-- result:
+-- !result
+select count(*) from t0;
+-- result:
+409600
+-- !result
+select count(*) from t1;
+-- result:
+409600
+-- !result
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":0, "debug_action":"WAIT", "value":500}]}';
+-- result:
+-- !result
+select count(*) from t0 t join [shuffle] t1 s on t.c0 = s.c0 where s.c1 < 100;
+-- result:
+99
+-- !result
+set query_debug_options = '';
+-- result:
+-- !result
+admin enable failpoint 'global_runtime_filter_sync_A';
+-- result:
+-- !result
+admin enable failpoint 'global_runtime_filter_sync_B';
+-- result:
+-- !result
+select count(*) from t0 t join [shuffle] t1 s on t.c0 = s.c0 where s.c1 < 100;
+-- result:
+99
+-- !result
+admin disable failpoint 'global_runtime_filter_sync_A';
+-- result:
+-- !result
+admin disable failpoint 'global_runtime_filter_sync_B';
+-- result:
+-- !result
+set runtime_join_filter_push_down_limit = 1;
+-- result:
+-- !result
+select count(*) from t0 t join [shuffle] t1 s on t.c0 = s.c0;
+-- result:
+409600
+-- !result

--- a/test/sql/test_pipeline/T/test_event_schedule_with_grf
+++ b/test/sql/test_pipeline/T/test_event_schedule_with_grf
@@ -1,0 +1,47 @@
+-- name: test_event_scheduler_with_grf @sequential
+
+CREATE TABLE `t0` (
+  `c0` int DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` string DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `t1` (
+  `c0` int DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` string DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into t0 SELECT generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  409600));
+insert into t1 SELECT generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  409600));
+
+select count(*) from t0;
+select count(*) from t1;
+
+-- case1: grf arrive first
+set query_debug_options = '{"execDebugOptions":[{"plan_node_id":0, "debug_action":"WAIT", "value":500}]}';
+select count(*) from t0 t join [shuffle] t1 s on t.c0 = s.c0 where s.c1 < 100;
+set query_debug_options = '';
+-- case3 race condition
+admin enable failpoint 'global_runtime_filter_sync_A';
+admin enable failpoint 'global_runtime_filter_sync_B';
+select count(*) from t0 t join [shuffle] t1 s on t.c0 = s.c0 where s.c1 < 100;
+admin disable failpoint 'global_runtime_filter_sync_A';
+admin disable failpoint 'global_runtime_filter_sync_B';
+-- case2: grf exceed
+set runtime_join_filter_push_down_limit = 1;
+select count(*) from t0 t join [shuffle] t1 s on t.c0 = s.c0;
+
+


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/10547

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Synchronizes global runtime filter notifications with fragment preparation using a barrier and new failpoints, and adds tests to cover the race condition under the event scheduler.
> 
> - **Execution/runtime coordination**:
>   - Set `RuntimeState::fragment_prepared` in `FragmentExecutor::prepare()` after registering context; gate RF observer notifications on this flag.
>   - Store `RuntimeState*` in `RuntimeFilterProbeDescriptor` during `prepare()`.
> - **Runtime filter synchronization**:
>   - Notify observers in `RuntimeFilterProbeDescriptor::set_runtime_filter()` only when `fragment_prepared()` is true.
>   - Introduce a failpoint-driven `OneToAnyBarrier` to coordinate GRF arrival/notification.
> - **Failpoints and hooks**:
>   - Define `global_runtime_filter_sync_A` in `pipeline_driver.cpp` and `global_runtime_filter_sync_B` in `runtime_filter_bank.cpp`.
>   - Trigger A at RF descriptor collection in `PipelineDriver::prepare()`; trigger B before notifying observers.
>   - Add `OneToAnyBarrier` implementation in `util/fail_point.h`.
> - **Tests**:
>   - Add `test_event_schedule_with_grf` SQL tests to validate GRF behavior (normal, race, and pushdown-limit cases) with failpoints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b8e330872bf528c15e5b952fbbef733bc1c0da3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->