### PR TITLE
[BugFix] Fix HTTP context leak on TCP reuse

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/BaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/BaseAction.java
@@ -120,6 +120,10 @@ public abstract class BaseAction implements IAction {
 
     public abstract void execute(BaseRequest request, BaseResponse response) throws DdlException, AccessDeniedException;
 
+    public boolean isSqlAction() {
+        return false;
+    }
+
     protected void writeResponse(BaseRequest request, BaseResponse response, HttpResponseStatus status) {
         // if (HttpHeaders.is100ContinueExpected(request.getRequest())) {
         // ctx.write(new DefaultFullHttpResponse(HttpVersion.HTTP_1_1,

--- a/fe/fe-core/src/main/java/com/starrocks/http/BaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/BaseAction.java
@@ -51,7 +51,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
-import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelProgressiveFuture;
 import io.netty.channel.ChannelProgressiveFutureListener;
 import io.netty.channel.DefaultFileRegion;
@@ -272,9 +271,6 @@ public abstract class BaseAction implements IAction {
         for (Cookie cookie : response.getCookies()) {
             responseObj.headers().add(HttpHeaderNames.SET_COOKIE.toString(), ServerCookieEncoder.LAX.encode(cookie));
         }
-    }
-
-    protected void handleChannelInactive(ChannelHandlerContext ctx) {
     }
 
     public static class ActionAuthorizationInfo {

--- a/fe/fe-core/src/main/java/com/starrocks/http/BaseRequest.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/BaseRequest.java
@@ -59,10 +59,9 @@ public class BaseRequest {
     private boolean isAuthorized = false;
     private QueryStringDecoder decoder;
 
-    public BaseRequest(ChannelHandlerContext ctx, HttpRequest request, HttpConnectContext connectContext) {
+    public BaseRequest(ChannelHandlerContext ctx, HttpRequest request) {
         this.context = ctx;
         this.request = request;
-        this.connectContext = connectContext;
     }
 
     public ChannelHandlerContext getContext() {
@@ -187,5 +186,9 @@ public class BaseRequest {
 
     public HttpConnectContext getConnectContext() {
         return connectContext;
+    }
+
+    public void setConnectContext(HttpConnectContext connectContext) {
+        this.connectContext = connectContext;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpConnectContext.java
@@ -55,7 +55,7 @@ public class HttpConnectContext extends ConnectContext {
 
     // for http sql, we need register connectContext to connectScheduler
     // when connection is established
-    private boolean initialized;
+    private boolean registered;
 
     // used for test. only output result raws
     private boolean onlyOutputResultRaw;
@@ -73,7 +73,7 @@ public class HttpConnectContext extends ConnectContext {
     public HttpConnectContext() {
         super();
         sendDate = false;
-        initialized = false;
+        registered = false;
         onlyOutputResultRaw = false;
     }
 
@@ -93,12 +93,12 @@ public class HttpConnectContext extends ConnectContext {
         this.forwardToLeader = forwardToLeader;
     }
 
-    public boolean isInitialized() {
-        return initialized;
+    public boolean isRegistered() {
+        return registered;
     }
 
-    public void setInitialized(boolean initialized) {
-        this.initialized = initialized;
+    public void setRegistered(boolean registered) {
+        this.registered = registered;
     }
 
     public boolean getSendDate() {

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpConnectContext.java
@@ -53,8 +53,8 @@ public class HttpConnectContext extends ConnectContext {
     // we parse the sql at the beginning for validating, so keep it in context for handle_query
     private StatementBase statement;
 
-    // for http sql, we need register connectContext to connectScheduler
-    // when connection is established
+    // After the TCP connection is established, the first time `ExecuteSqlAction` runs it registers the `ConnectContext` to the
+    // `ConnectScheduler`.
     private boolean registered;
 
     // used for test. only output result raws

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServerHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServerHandler.java
@@ -168,7 +168,7 @@ public class HttpServerHandler extends ChannelInboundHandlerAdapter {
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         HttpServerHandlerMetrics.getInstance().httpConnectionsNum.increase(-1L);
         HttpConnectContext context = ctx.channel().attr(HTTP_CONNECT_CONTEXT_ATTRIBUTE_KEY).get();
-        if (context != null && context.isInitialized()) {
+        if (context != null && context.isRegistered()) {
             // Context is registered in ExecuteSqlAction#executeWithoutPassword
             ExecuteEnv.getInstance().getScheduler().unregisterConnection(context);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServerHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServerHandler.java
@@ -59,8 +59,9 @@ import java.util.concurrent.Executor;
 
 public class HttpServerHandler extends ChannelInboundHandlerAdapter {
     private static final Logger LOG = LogManager.getLogger(HttpServerHandler.class);
-    // keep connectContext when channel is open
-    public static final AttributeKey<HttpConnectContext> HTTP_CONNECT_CONTEXT_ATTRIBUTE_KEY =
+    // All Execute SQL Actions within this channel share the same ConnectContext, while other Actions create a new ConnectContext
+    // each time. The lifecycle of the shared ConnectContext for Execute SQL Actions is the same as that of the channel.
+    public static final AttributeKey<HttpConnectContext> HTTP_SQL_CONNECT_CONTEXT_ATTRIBUTE_KEY =
             AttributeKey.valueOf("httpContextKey");
     protected HttpRequest request = null;
     private final ActionController controller;
@@ -97,10 +98,14 @@ public class HttpServerHandler extends ChannelInboundHandlerAdapter {
                 return;
             }
 
-            // get HttpConnectContext from channel, HttpConnectContext's lifetime is same as channel
-            HttpConnectContext connectContext = ctx.channel().attr(HTTP_CONNECT_CONTEXT_ATTRIBUTE_KEY).get();
-            BaseRequest req = new BaseRequest(ctx, request, connectContext);
+            BaseRequest req = new BaseRequest(ctx, request);
             action = getAction(req);
+            if (action.isSqlAction()) {
+                req.setConnectContext(ctx.channel().attr(HTTP_SQL_CONNECT_CONTEXT_ATTRIBUTE_KEY).get());
+            } else {
+                req.setConnectContext(new HttpConnectContext());
+            }
+
             if (action != null) {
                 if (LOG.isDebugEnabled()) {
                     LOG.debug("action: {} ", action.getClass().getName());
@@ -160,14 +165,14 @@ public class HttpServerHandler extends ChannelInboundHandlerAdapter {
     public void channelActive(ChannelHandlerContext ctx) throws Exception {
         HttpServerHandlerMetrics.getInstance().httpConnectionsNum.increase(1L);
         // create HttpConnectContext when channel is established, and store it in channel attr
-        ctx.channel().attr(HTTP_CONNECT_CONTEXT_ATTRIBUTE_KEY).setIfAbsent(new HttpConnectContext());
+        ctx.channel().attr(HTTP_SQL_CONNECT_CONTEXT_ATTRIBUTE_KEY).setIfAbsent(new HttpConnectContext());
         super.channelActive(ctx);
     }
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         HttpServerHandlerMetrics.getInstance().httpConnectionsNum.increase(-1L);
-        HttpConnectContext context = ctx.channel().attr(HTTP_CONNECT_CONTEXT_ATTRIBUTE_KEY).get();
+        HttpConnectContext context = ctx.channel().attr(HTTP_SQL_CONNECT_CONTEXT_ATTRIBUTE_KEY).get();
         if (context != null && context.isRegistered()) {
             // Context is registered in ExecuteSqlAction#executeWithoutPassword
             ExecuteEnv.getInstance().getScheduler().unregisterConnection(context);

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServerHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServerHandler.java
@@ -37,6 +37,7 @@ package com.starrocks.http;
 import com.starrocks.common.Config;
 import com.starrocks.http.action.IndexAction;
 import com.starrocks.http.action.NotFoundAction;
+import com.starrocks.service.ExecuteEnv;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
@@ -166,8 +167,10 @@ public class HttpServerHandler extends ChannelInboundHandlerAdapter {
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         HttpServerHandlerMetrics.getInstance().httpConnectionsNum.increase(-1L);
-        if (action != null) {
-            action.handleChannelInactive(ctx);
+        HttpConnectContext context = ctx.channel().attr(HTTP_CONNECT_CONTEXT_ATTRIBUTE_KEY).get();
+        if (context != null && context.isInitialized()) {
+            // Context is registered in ExecuteSqlAction#executeWithoutPassword
+            ExecuteEnv.getInstance().getScheduler().unregisterConnection(context);
         }
         super.channelInactive(ctx);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/ExecuteSqlAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/ExecuteSqlAction.java
@@ -99,6 +99,11 @@ public class ExecuteSqlAction extends RestBaseAction {
     }
 
     @Override
+    public boolean isSqlAction() {
+        return true;
+    }
+
+    @Override
     protected void executeWithoutPassword(BaseRequest request, BaseResponse response) throws DdlException {
         StatementBase parsedStmt;
 

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
@@ -377,7 +377,7 @@ public class RestBaseAction extends BaseAction {
     }
 
     protected void sendSuccessResponse(BaseResponse response, String content, BaseRequest request) {
-        sendResult(request, response,  RestBaseResultV2.ok(content));
+        sendResult(request, response, RestBaseResultV2.ok(content));
     }
 
     protected void sendErrorResponse(BaseResponse response, String message, HttpResponseStatus status, BaseRequest request) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
@@ -57,7 +57,9 @@ import com.starrocks.http.HttpUtils;
 import com.starrocks.http.WebUtils;
 import com.starrocks.http.rest.v2.RestBaseResultV2;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.ConnectScheduler;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.service.ExecuteEnv;
 import com.starrocks.system.Frontend;
 import com.starrocks.thrift.TNetworkAddress;
 import io.netty.handler.codec.http.HttpHeaderNames;
@@ -75,6 +77,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import static io.netty.handler.codec.http.HttpResponseStatus.SERVICE_UNAVAILABLE;
 
 public class RestBaseAction extends BaseAction {
 
@@ -150,11 +154,24 @@ public class RestBaseAction extends BaseAction {
         ActionAuthorizationInfo authInfo = getAuthorizationInfo(request);
         // check password
         UserIdentity currentUser = checkPassword(authInfo);
-        // ctx lifetime is the same as the channel
+
         HttpConnectContext ctx = request.getConnectContext();
+
+        // Change user for ConnectContext if necessary
+        String prevUserName = ctx.getQualifiedUser();
+        ctx.setQualifiedUser(authInfo.fullUserName);
+        if (ctx.isRegistered() && prevUserName != null && !prevUserName.equals(authInfo.fullUserName)) {
+            ConnectScheduler connectScheduler = ExecuteEnv.getInstance().getScheduler();
+            Pair<Boolean, String> userChangeRes = connectScheduler.onUserChanged(ctx, prevUserName, ctx.getQualifiedUser());
+            if (!userChangeRes.first) {
+                ctx.setQualifiedUser(prevUserName);
+                throw new StarRocksHttpException(SERVICE_UNAVAILABLE, userChangeRes.second);
+            }
+        }
+
+        // ctx lifetime is the same as the channel
         ctx.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
         ctx.setNettyChannel(request.getContext());
-        ctx.setQualifiedUser(authInfo.fullUserName);
         ctx.setQueryId(UUIDUtil.genUUID());
         ctx.setRemoteIP(authInfo.remoteIp);
         ctx.setCurrentUserIdentity(currentUser);

--- a/fe/fe-core/src/test/java/com/starrocks/http/HttpServerTestUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/HttpServerTestUtils.java
@@ -24,7 +24,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 
-import static com.starrocks.http.HttpServerHandler.HTTP_CONNECT_CONTEXT_ATTRIBUTE_KEY;
+import static com.starrocks.http.HttpServerHandler.HTTP_SQL_CONNECT_CONTEXT_ATTRIBUTE_KEY;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.CALLS_REAL_METHODS;
 import static org.mockito.Mockito.mock;
@@ -79,7 +79,7 @@ public class HttpServerTestUtils {
             Attribute attribute = mock(Attribute.class);
             when(attribute.get()).thenReturn(null);
             this.channel = mock(Channel.class);
-            when(channel.attr(same(HTTP_CONNECT_CONTEXT_ATTRIBUTE_KEY))).thenReturn(attribute);
+            when(channel.attr(same(HTTP_SQL_CONNECT_CONTEXT_ATTRIBUTE_KEY))).thenReturn(attribute);
             this.channelFuture = mock(ChannelFuture.class);
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/http/MetricsActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/MetricsActionTest.java
@@ -42,7 +42,7 @@ public class MetricsActionTest {
         }
         DefaultHttpRequest rawRequest =
                 new DefaultHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, uri, headers);
-        return new BaseRequest(null, rawRequest, null);
+        return new BaseRequest(null, rawRequest);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectionTest.java
@@ -167,12 +167,12 @@ public class ConnectionTest {
         ExecuteEnv.setup();
 
         Deencapsulation.invoke(executeSqlAction,
-                "registerContext",
+                "registerContextOnce",
                 "select 1",
                 createHttpConnectContextForUser("test"));
         try {
             Deencapsulation.invoke(executeSqlAction,
-                    "registerContext",
+                    "registerContextOnce",
                     "select 1",
                     createHttpConnectContextForUser("test"));
         } catch (StarRocksHttpException e) {


### PR DESCRIPTION
## Why I'm doing:

When multiple HTTP requests reuse the same TCP connection, if a non-ExecuteSQL request arrives after an ExecuteSQL request, the `HttpConnectContext` cannot be released anymore.

Current lifecycle of `HttpConnectContext`:
1. Create `HttpConnectContext` when the TCP connection is established (`channelActive()`).
2. Determine the `Action` to execute based on the HTTP request.
3. Execute the corresponding `Action`. For `ExecuteSQL`, this is `ExecuteSqlAction`, which registers the `HttpConnectContext`.
4. Repeat steps 2–3 until the TCP connection closes, at which point `channelnActive()`-> `action.handleChannelInactive()` is invoked. **For `ExecuteSqlAction`, this will unregister the `HttpConnectContext`.**

**Problem:**
When multiple HTTP requests share the same TCP connection, **a subsequent non-ExecuteSQL request overrides the `Action`**. As a result, when the TCP connection closes, the invoked `action.handleChannelInactive()` is not `ExecuteSqlAction.handleChannelInactive()`, and the `HttpConnectContext` is not unregistered.

**Change:**
1. unregister context should be called directly by `channelnactive()`, 
    rather than through the chain `channelnactive()` → `action.handleChannelInactive()`.
2. All Execute SQL Actions within the same TCP channel share the same `ConnectContext`, 
    while other Actions create a new `ConnectContext`  each time. The lifecycle of the shared ConnectContext for Execute SQL Actions is the same as that of the channel.
3. Maintain user changes
    If the user of an Execute SQL request differs from the previous one, invoke `connectScheduler.onUserChanged()` to update the user-related information within `connectScheduler`.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Share a per-channel `HttpConnectContext` for SQL actions, unregister it on channel close, handle user changes via scheduler, and refactor request/context wiring with tests updated.
> 
> - **HTTP Server/Lifecycle**:
>   - Share per-channel SQL context: use channel attribute `HTTP_SQL_CONNECT_CONTEXT_ATTRIBUTE_KEY`; non-SQL actions instantiate a fresh `HttpConnectContext` per request.
>   - Unregister SQL connection directly in `channelInactive()` via `ExecuteEnv.getInstance().getScheduler().unregisterConnection(...)`.
> - **SQL Execution**:
>   - Add `BaseAction.isSqlAction()` (overridden by `ExecuteSqlAction`).
>   - Register context once per channel with `registerContextOnce(...)` and mark `HttpConnectContext` as `registered` (renamed from `initialized`).
> - **Auth/User switching**:
>   - In `RestBaseAction.execute()`, if the channel-bound context is registered and the user changes, call `ConnectScheduler.onUserChanged(...)` or return `503` on failure.
> - **API/Refactor**:
>   - `BaseRequest` constructor drops `HttpConnectContext`; add `setConnectContext(...)`.
>   - Remove action-level channel inactive hook.
> - **Tests**:
>   - Update tests to new constructor, attribute key, and `registerContextOnce` method; add/extend user-change and connection limit cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3497ba2918ee752dea1e22e5192ff227555330b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->