### PR TITLE
[BugFix] Fix NullPointerException when viewDefineSql is null

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -2574,12 +2574,14 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                 }
             }
             if (this.defineQueryParseNode == null) {
-                try {
-                    connectContext.setDatabase(db.getOriginName());
-                    this.defineQueryParseNode = MvUtils.getQueryAst(viewDefineSql, connectContext);
-                } catch (Exception e) {
-                    // ignore
-                    LOG.warn("parse view define sql failed:", e);
+                if (!Strings.isNullOrEmpty(viewDefineSql)) {
+                    try {
+                        connectContext.setDatabase(db.getOriginName());
+                        this.defineQueryParseNode = MvUtils.getQueryAst(viewDefineSql, connectContext);
+                    } catch (Exception e) {
+                        // ignore
+                        LOG.warn("parse view define sql failed:", e);
+                    }
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -12,11 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rule.transformation.materialization;
-
-import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVPrepare;
-import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
@@ -119,6 +115,10 @@ import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
 import com.starrocks.sql.optimizer.transformer.TransformerContext;
 import com.starrocks.sql.parser.ParsingException;
 import com.starrocks.sql.util.Box;
+import org.apache.commons.collections4.SetUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -132,9 +132,9 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import org.apache.commons.collections4.SetUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+
+import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVPrepare;
+import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
 
 public class MvUtils {
     private static final Logger LOG = LogManager.getLogger(MvUtils.class);
@@ -574,7 +574,8 @@ public class MvUtils {
     public static Set<ScalarOperator> getAllValidPredicatesFromScans(OptExpression root) {
         List<LogicalScanOperator> scanOperators = getScanOperator(root);
         Set<ScalarOperator> predicates = Sets.newHashSet();
-        scanOperators.stream().forEach(scanOperator -> predicates.addAll(Utils.extractConjuncts(scanOperator.getPredicate())));
+        scanOperators.stream()
+                .forEach(scanOperator -> predicates.addAll(Utils.extractConjuncts(scanOperator.getPredicate())));
         return predicates.stream().filter(MvUtils::isValidPredicate).collect(Collectors.toSet());
     }
 
@@ -691,7 +692,8 @@ public class MvUtils {
                         IsNullPredicateOperator isNullPredicateOperator = conjunct.cast();
                         if (isNullPredicateOperator.isNotNull() && context != null
                                 && context.containsAll(isNullPredicateOperator.getUsedColumns())) {
-                            // if column ref is join key and column ref is not null can be ignored for inner and semi join
+                            // if column ref is join key and column ref is not null can be ignored for inner and semi
+                            // join
                             continue;
                         }
                     }
@@ -918,7 +920,7 @@ public class MvUtils {
     }
 
     public static Set<ColumnRefOperator> collectScanColumn(OptExpression optExpression,
-                                                            Predicate<LogicalScanOperator> predicate) {
+                                                           Predicate<LogicalScanOperator> predicate) {
 
         Set<ColumnRefOperator> columnRefOperators = Sets.newHashSet();
         OptExpressionVisitor visitor = new OptExpressionVisitor<Void, Void>() {
@@ -957,22 +959,26 @@ public class MvUtils {
                 continue;
             } else if (lowerExpr.isMinValue()) {
                 ConstantOperator upperBound =
-                        (ConstantOperator) SqlToScalarOperatorTranslator.translate(range.upperEndpoint().getKeys().get(0));
+                        (ConstantOperator) SqlToScalarOperatorTranslator.translate(
+                                range.upperEndpoint().getKeys().get(0));
                 BinaryPredicateOperator upperPredicate = new BinaryPredicateOperator(
                         BinaryType.LT, partitionScalar, upperBound);
                 rangeParts.add(upperPredicate);
             } else if (range.upperEndpoint().isMaxValue()) {
                 ConstantOperator lowerBound =
-                        (ConstantOperator) SqlToScalarOperatorTranslator.translate(range.lowerEndpoint().getKeys().get(0));
+                        (ConstantOperator) SqlToScalarOperatorTranslator.translate(
+                                range.lowerEndpoint().getKeys().get(0));
                 BinaryPredicateOperator lowerPredicate = new BinaryPredicateOperator(
                         BinaryType.GE, partitionScalar, lowerBound);
                 rangeParts.add(lowerPredicate);
             } else {
                 // close, open range
                 ConstantOperator lowerBound =
-                        (ConstantOperator) SqlToScalarOperatorTranslator.translate(range.lowerEndpoint().getKeys().get(0));
+                        (ConstantOperator) SqlToScalarOperatorTranslator.translate(
+                                range.lowerEndpoint().getKeys().get(0));
                 ConstantOperator upperBound =
-                        (ConstantOperator) SqlToScalarOperatorTranslator.translate(range.upperEndpoint().getKeys().get(0));
+                        (ConstantOperator) SqlToScalarOperatorTranslator.translate(
+                                range.upperEndpoint().getKeys().get(0));
                 BinaryPredicateOperator lowerPredicate = new BinaryPredicateOperator(
                         BinaryType.GE, partitionScalar, lowerBound);
                 BinaryPredicateOperator upperPredicate = new BinaryPredicateOperator(
@@ -1158,7 +1164,6 @@ public class MvUtils {
         return partitionKey;
     }
 
-
     public static String toString(Object o) {
         if (o == null) {
             return "";
@@ -1182,7 +1187,8 @@ public class MvUtils {
      * Returns the maximum refresh timestamp from a single partition info map.
      * If no valid refresh time is found, returns the current system time.
      */
-    public static long getMaxTablePartitionInfoRefreshTime(Map<String, MaterializedView.BasePartitionInfo> partitionInfos) {
+    public static long getMaxTablePartitionInfoRefreshTime(
+            Map<String, MaterializedView.BasePartitionInfo> partitionInfos) {
         return partitionInfos.values().stream()
                 .map(MaterializedView.BasePartitionInfo::getLastRefreshTime)
                 .filter(Objects::nonNull)
@@ -1283,7 +1289,8 @@ public class MvUtils {
                 Operator.Builder builder = OperatorBuilderFactory.build(inlineViewOp);
                 builder.withOperator(inlineViewOp);
                 if (viewScanOperator.getPredicate() != null) {
-                    // If viewScanOperator contains predicate, we need to rewrite them, otherwise predicate will be lost.
+                    // If viewScanOperator contains predicate, we need to rewrite them, otherwise predicate will be
+                    // lost.
                     ScalarOperator rewrittenPredicate = rewriter.rewrite(viewScanOperator.getPredicate());
                     builder.setPredicate(rewrittenPredicate);
                 }
@@ -1357,7 +1364,8 @@ public class MvUtils {
             return mvPlanContexts.get(0);
         }
         // step2: get from optimize
-        return new MaterializedViewOptimizer().optimize(mv, connectContext, isInlineView, isCheckNonDeterministicFunction);
+        return new MaterializedViewOptimizer().optimize(mv, connectContext, isInlineView,
+                isCheckNonDeterministicFunction);
     }
 
     /**
@@ -1429,7 +1437,8 @@ public class MvUtils {
                                                         ColumnRefFactory queryColumnRefFactory,
                                                         ReplaceColumnRefRewriter queryColumnRefRewriter,
                                                         Rule rule) {
-        // Cache partition predicate predicates because it's expensive time costing if there are too many materialized views or
+        // Cache partition predicate predicates because it's expensive time costing if there are too many
+        // materialized views or
         // query expressions are too complex.
         final ScalarOperator queryPartitionPredicate = MvPartitionCompensator.compensateQueryPartitionPredicate(
                 mvContext, rule, queryColumnRefFactory, queryExpression);
@@ -1469,7 +1478,8 @@ public class MvUtils {
 
     public static Optional<Table> getTableWithIdentifier(BaseTableInfo baseTableInfo) {
         try {
-            return GlobalStateMgr.getCurrentState().getMetadataMgr().getTableWithIdentifier(new ConnectContext(), baseTableInfo);
+            return GlobalStateMgr.getCurrentState().getMetadataMgr()
+                    .getTableWithIdentifier(new ConnectContext(), baseTableInfo);
         } catch (Exception e) {
             // For hive catalog, when meets NoSuchObjectException, we should return empty
             //  msg: NoSuchObjectException: hive_db_8b48cd2f_4bfe_11f0_bc1a_00163e09349d.t1 table not found
@@ -1555,7 +1565,8 @@ public class MvUtils {
      */
     public static <K, V> Map<K, V> shrinkToSize(Map<K, V> map, int maxLength) {
         if (map != null && map.size() > maxLength) {
-            return map.entrySet().stream().limit(maxLength).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            return map.entrySet().stream().limit(maxLength)
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
         }
         return map;
     }
@@ -1572,13 +1583,15 @@ public class MvUtils {
             return null;
         }
         return partitionExprMaps.entrySet().stream()
-                .filter(entry -> SRStringUtils.areTableNamesEqual(table, entry.getValue().getTblNameWithoutAnalyzed().getTbl()))
+                .filter(entry -> SRStringUtils.areTableNamesEqual(table,
+                        entry.getValue().getTblNameWithoutAnalyzed().getTbl()))
                 .map(entry -> new MVPartitionExpr(entry.getKey(), entry.getValue()))
                 .collect(Collectors.toList());
     }
 
     /**
      * Get the column by slot ref from table's columns.
+     *
      * @return the column if found, otherwise empty
      */
     public static Optional<Column> getColumnBySlotRef(List<Column> columns, SlotRef slotRef) {
@@ -1601,8 +1614,9 @@ public class MvUtils {
 
     /**
      * Convert partition range cells to predicates
+     *
      * @param partitionColRefs partition column refs
-     * @param pRangeCells  partition range cells to be converted
+     * @param pRangeCells      partition range cells to be converted
      * @return the converted predicates
      * @throws AnalysisException
      */
@@ -1661,7 +1675,8 @@ public class MvUtils {
                         // add is null to represent min value
                         subPredicates.add(new IsNullPredicateOperator(partitionColRef));
                     } else {
-                        ConstantOperator upperBound = (ConstantOperator) SqlToScalarOperatorTranslator.translate(literalExpr);
+                        ConstantOperator upperBound =
+                                (ConstantOperator) SqlToScalarOperatorTranslator.translate(literalExpr);
                         subPredicates.add(new BinaryPredicateOperator(BinaryType.EQ, partitionColRef, upperBound));
                     }
                 }
@@ -1672,7 +1687,7 @@ public class MvUtils {
     }
 
     private static ScalarOperator convertRangeKeysToPredicate(
-            List<? extends  ScalarOperator> partitionColRefs,
+            List<? extends ScalarOperator> partitionColRefs,
             List<Range<PartitionKey>> partitionRanges,
             boolean canConvertToInPredicate) throws AnalysisException {
         // can convert to in predicate when all ranges are singletons or canConvertToInPredicate is true
@@ -1722,9 +1737,10 @@ public class MvUtils {
 
     /**
      * Optimize the inlined view plan.
-     * @param logicalTree logical opt expression tree which has not been optimized
-     * @param connectContext connect context
-     * @param requiredColumns required columns
+     *
+     * @param logicalTree      logical opt expression tree which has not been optimized
+     * @param connectContext   connect context
+     * @param requiredColumns  required columns
      * @param columnRefFactory query column ref factory
      * @return optimized view plan which has been rule based optimized
      */
@@ -1744,7 +1760,8 @@ public class MvUtils {
 
     /**
      * Trim the input string if its length is larger than maxLength.
-     * @param input the input string
+     *
+     * @param input     the input string
      * @param maxLength the max length
      */
     public static String shrinkToSize(String input, int maxLength) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -15,8 +15,12 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization;
 
+import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVPrepare;
+import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
+
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
@@ -115,10 +119,6 @@ import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
 import com.starrocks.sql.optimizer.transformer.TransformerContext;
 import com.starrocks.sql.parser.ParsingException;
 import com.starrocks.sql.util.Box;
-import org.apache.commons.collections4.SetUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -132,9 +132,9 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-
-import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVPrepare;
-import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
+import org.apache.commons.collections4.SetUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class MvUtils {
     private static final Logger LOG = LogManager.getLogger(MvUtils.class);
@@ -1398,6 +1398,9 @@ public class MvUtils {
     }
 
     public static ParseNode getQueryAst(String query, ConnectContext connectContext) {
+        if (Strings.isNullOrEmpty(query)) {
+            return null;
+        }
         try {
             List<StatementBase> statementBases =
                     com.starrocks.sql.parser.SqlParser.parse(query, connectContext.getSessionVariable());


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

```
 java.lang.NullPointerException: Cannot invoke "String.length()" because "s" is null
  	at org.antlr.v4.runtime.CharStreams.fromString(CharStreams.java:222) ~[antlr4-runtime-4.9.3.jar:4.9.3]
  	at org.antlr.v4.runtime.CharStreams.fromString(CharStreams.java:212) ~[antlr4-runtime-4.9.3.jar:4.9.3]
  	at com.starrocks.sql.parser.SqlParser.invokeParser(SqlParser.java:253) ~[classes/:?]
  	at com.starrocks.sql.parser.SqlParser.parseWithStarRocksDialect(SqlParser.java:154) ~[classes/:?]
  	at com.starrocks.sql.parser.SqlParser.parse(SqlParser.java:70) ~[classes/:?]
  	at com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.getQueryAst(MvUtils.java:1403) ~[classes/:?]
  	at com.starrocks.catalog.MaterializedView.getDefineQueryParseNode(MaterializedView.java:2579) ~[classes/:?]
  	at com.starrocks.sql.optimizer.CachingMvPlanContextBuilder.getAstKeysOfMV(CachingMvPlanContextBuilder.java:333) ~[classes/:?]

```



Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Guard SQL parsing with null/empty checks in MV parsing utilities to prevent NullPointerException.
> 
> - **Bug Fix**:
>   - `MaterializedView#getDefineQueryParseNode`: Parse `originalViewDefineSql`/`viewDefineSql` only when non-empty; keep existing fallback and exception handling.
>   - `MvUtils#getQueryAst`: Return `null` immediately for null/empty `query`; otherwise parse and analyze safely.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae2a55dafa19cbdd69536faef3e7d0a4ebd947fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->