### PR TITLE
[Enhancement] Enable rapid memory release on hash table OOM

### DIFF
--- a/be/src/exec/hash_join_components.cpp
+++ b/be/src/exec/hash_join_components.cpp
@@ -24,7 +24,6 @@
 #include "common/object_pool.h"
 #include "exec/hash_joiner.h"
 #include "exec/join/join_hash_map.h"
-#include "exprs/agg/distinct.h"
 #include "exprs/expr_context.h"
 #include "gutil/casts.h"
 #include "runtime/descriptors.h"

--- a/be/src/exec/join/join_hash_map.cpp
+++ b/be/src/exec/join/join_hash_map.cpp
@@ -14,21 +14,25 @@
 
 #include "join_hash_map.h"
 
-#include <column/chunk.h>
-#include <runtime/descriptors.h>
-
 #include <memory>
+#include <new>
 
+#include "column/chunk.h"
 #include "column/vectorized_fwd.h"
 #include "common/statusor.h"
 #include "exec/hash_join_node.h"
+#include "runtime/descriptors.h"
 #include "serde/column_array_serde.h"
 #include "simd/simd.h"
 #include "types/logical_type_infra.h"
+#include "util/failpoint/fail_point.h"
 #include "util/runtime_profile.h"
 #include "util/stack_util.h"
 
 namespace starrocks {
+
+DEFINE_FAIL_POINT(hash_join_append_bad_alloc);
+DEFINE_FAIL_POINT(hash_join_build_bad_alloc);
 
 // ------------------------------------------------------------------------------------
 // JoinHashMapSelector
@@ -642,6 +646,12 @@ int64_t JoinHashTable::mem_usage() const {
 }
 
 Status JoinHashTable::build(RuntimeState* state) {
+    CancelableDefer defer = CancelableDefer([&]() {
+        _table_items->key_columns.clear();
+        _table_items->build_chunk->columns().clear();
+        _hash_map = {};
+    });
+
     RETURN_IF_ERROR(_table_items->build_chunk->upgrade_if_overflow());
     _table_items->has_large_column = _table_items->build_chunk->has_large_column();
 
@@ -682,7 +692,9 @@ Status JoinHashTable::build(RuntimeState* state) {
         hash_map->build_prepare(state);
         hash_map->probe_prepare(state);
         hash_map->build(state);
+        FAIL_POINT_TRIGGER_EXECUTE(hash_join_build_bad_alloc, { throw std::bad_alloc(); });
     });
+    defer.cancel();
 
     return Status::OK();
 }
@@ -715,6 +727,11 @@ Status JoinHashTable::probe_remain(RuntimeState* state, ChunkPtr* chunk, bool* e
 void JoinHashTable::append_chunk(const ChunkPtr& chunk, const Columns& key_columns) {
     auto& columns = _table_items->build_chunk->columns();
 
+    CancelableDefer defer = CancelableDefer([&]() {
+        columns.clear();
+        _table_items->key_columns.clear();
+    });
+
     for (size_t i = 0; i < _table_items->build_column_count; i++) {
         SlotDescriptor* slot = _table_items->build_slots[i].slot;
         ColumnPtr& column = chunk->get_column_by_slot_id(slot->id());
@@ -724,6 +741,9 @@ void JoinHashTable::append_chunk(const ChunkPtr& chunk, const Columns& key_colum
             columns[i] = NullableColumn::create(columns[i], NullColumn::create(columns[i]->size(), 0));
         }
         columns[i]->append(*column);
+        FAIL_POINT_TRIGGER_EXECUTE(hash_join_append_bad_alloc, {
+            if (i > 1) throw std::bad_alloc();
+        });
     }
 
     for (size_t i = 0; i < _table_items->key_columns.size(); i++) {
@@ -741,13 +761,20 @@ void JoinHashTable::append_chunk(const ChunkPtr& chunk, const Columns& key_colum
     }
 
     _table_items->row_count += chunk->num_rows();
+
+    defer.cancel();
 }
 
 void JoinHashTable::merge_ht(const JoinHashTable& ht) {
-    _table_items->row_count += ht._table_items->row_count;
-
     auto& columns = _table_items->build_chunk->columns();
     auto& other_columns = ht._table_items->build_chunk->columns();
+
+    CancelableDefer defer = CancelableDefer([&]() {
+        columns.clear();
+        other_columns.clear();
+    });
+
+    _table_items->row_count += ht._table_items->row_count;
 
     for (size_t i = 0; i < _table_items->build_column_count; i++) {
         if (!columns[i]->is_nullable() && !columns[i]->is_view() && other_columns[i]->is_nullable()) {
@@ -771,6 +798,7 @@ void JoinHashTable::merge_ht(const JoinHashTable& ht) {
             key_columns[i]->append(*other_key_columns[i]);
         }
     }
+    defer.cancel();
 }
 
 ChunkPtr JoinHashTable::convert_to_spill_schema(const ChunkPtr& chunk) const {

--- a/be/src/exec/join/join_hash_map.cpp
+++ b/be/src/exec/join/join_hash_map.cpp
@@ -742,7 +742,7 @@ void JoinHashTable::append_chunk(const ChunkPtr& chunk, const Columns& key_colum
         }
         columns[i]->append(*column);
         FAIL_POINT_TRIGGER_EXECUTE(hash_join_append_bad_alloc, {
-            if (i > 1) throw std::bad_alloc();
+            if (i > 0) throw std::bad_alloc();
         });
     }
 

--- a/test/sql/test_join/R/test_join_with_exception
+++ b/test/sql/test_join/R/test_join_with_exception
@@ -1,0 +1,60 @@
+-- name: test_join_with_exception @sequential
+CREATE TABLE `t0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 48
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `t1` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 48
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  40960));
+-- result:
+-- !result
+insert into t0 values (null,null,null,null);
+-- result:
+-- !result
+insert into t1 SELECT * FROM t0;
+-- result:
+-- !result
+select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [colocate] t1 r on l.c0 = r.c0 and l.c1 = r.c1;
+-- result:
+40960	20480.5	40960	40960	40960
+-- !result
+admin enable failpoint 'hash_join_append_bad_alloc';
+-- result:
+-- !result
+[UC]select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [colocate] t1 r on l.c0 = r.c0 and l.c1 = r.c1;
+-- result:
+-- !result
+admin disable failpoint 'hash_join_append_bad_alloc';
+-- result:
+-- !result
+admin enable failpoint 'hash_join_build_bad_alloc';
+-- result:
+-- !result
+[UC]select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [colocate] t1 r on l.c0 = r.c0 and l.c1 = r.c1;
+-- result:
+-- !result
+admin disable failpoint 'hash_join_build_bad_alloc';
+-- result:
+-- !result

--- a/test/sql/test_join/R/test_join_with_exception
+++ b/test/sql/test_join/R/test_join_with_exception
@@ -45,6 +45,7 @@ admin enable failpoint 'hash_join_append_bad_alloc';
 -- !result
 [UC]select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [colocate] t1 r on l.c0 = r.c0 and l.c1 = r.c1;
 -- result:
+E: (1064, 'Mem usage has exceed the limit of BE: BE:10004')
 -- !result
 admin disable failpoint 'hash_join_append_bad_alloc';
 -- result:
@@ -54,6 +55,7 @@ admin enable failpoint 'hash_join_build_bad_alloc';
 -- !result
 [UC]select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [colocate] t1 r on l.c0 = r.c0 and l.c1 = r.c1;
 -- result:
+E: (1064, 'Mem usage has exceed the limit of BE: BE:10004')
 -- !result
 admin disable failpoint 'hash_join_build_bad_alloc';
 -- result:

--- a/test/sql/test_join/T/test_join_with_exception
+++ b/test/sql/test_join/T/test_join_with_exception
@@ -1,0 +1,41 @@
+-- name: test_join_with_exception @sequential
+
+CREATE TABLE `t0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 48
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `t1` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 48
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  40960));
+insert into t0 values (null,null,null,null);
+insert into t1 SELECT * FROM t0;
+
+select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [colocate] t1 r on l.c0 = r.c0 and l.c1 = r.c1;
+
+admin enable failpoint 'hash_join_append_bad_alloc';
+[UC]select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [colocate] t1 r on l.c0 = r.c0 and l.c1 = r.c1;
+admin disable failpoint 'hash_join_append_bad_alloc';
+
+admin enable failpoint 'hash_join_build_bad_alloc';
+[UC]select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join [colocate] t1 r on l.c0 = r.c0 and l.c1 = r.c1;
+admin disable failpoint 'hash_join_build_bad_alloc';


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/10528

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds failpoints to simulate OOM in hash join and defers cleanup to promptly release memory, with new SQL tests validating behavior.
> 
> - **Backend (hash join)**:
>   - **Memory failure handling**:
>     - Add `CancelableDefer` in `JoinHashTable::build`, `append_chunk`, and `merge_ht` to clear `key_columns`, build `columns`, and reset `_hash_map` on failure.
>     - Introduce failpoints `hash_join_append_bad_alloc` and `hash_join_build_bad_alloc`; trigger in append/build paths to simulate `std::bad_alloc`.
>   - **Misc**: include adjustments and failpoint header integration.
> - **Tests**:
>   - Add `test/sql/test_join/T|R/test_join_with_exception` to enable/disable failpoints and assert OOM handling during colocated joins.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a80f705dcbe08141ae5e8f0a882527c5baadc6d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->