### PR TITLE
[Refactor] Remove RCTEXT from RemoteFileInputFormat in FE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FileTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FileTable.java
@@ -180,7 +180,7 @@ public class FileTable extends Table {
                 0, "", "");
         tTableDescriptor.setFileTable(tFileTable);
 
-        HiveStorageFormat storageFormat = HiveStorageFormat.get(fileProperties.get(JSON_KEY_FORMAT));
+        HiveStorageFormat storageFormat = getFileFormat();
         tFileTable.setSerde_lib(storageFormat.getSerde());
         tFileTable.setInput_format(storageFormat.getInputFormat());
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -100,7 +100,6 @@ import static com.starrocks.catalog.HudiTable.HUDI_TABLE_TYPE;
 import static com.starrocks.connector.ColumnTypeConverter.fromHudiType;
 import static com.starrocks.connector.ColumnTypeConverter.fromHudiTypeToHiveTypeString;
 import static com.starrocks.connector.hive.HiveMetadata.STARROCKS_QUERY_ID;
-import static com.starrocks.connector.hive.RemoteFileInputFormat.fromHdfsInputFormatClass;
 import static com.starrocks.server.CatalogMgr.ResourceMappingCatalog.toResourceName;
 import static java.util.Objects.requireNonNull;
 import static org.apache.hadoop.hive.common.StatsSetupConst.NUM_FILES;
@@ -161,6 +160,11 @@ public class HiveMetastoreApiConverter {
     public static HiveTable toHiveTable(Table table, String catalogName) {
         validateHiveTableType(table.getTableType());
 
+        Map<String, String> properties = toHiveProperties(table);
+        HiveStorageFormat storageFormat = HiveStorageFormat.get(
+                properties.getOrDefault(HIVE_TABLE_INPUT_FORMAT, HiveStorageFormat.UNSUPPORTED.getInputFormat()),
+                properties.getOrDefault(HIVE_TABLE_SERDE_LIB, HiveStorageFormat.UNSUPPORTED.getSerde()));
+
         HiveTable.Builder tableBuilder = HiveTable.builder()
                 .setId(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt())
                 .setTableName(table.getTableName())
@@ -177,11 +181,9 @@ public class HiveMetastoreApiConverter {
                 .setFullSchema(toFullSchemasForHiveTable(table))
                 .setComment(toComment(table.getParameters()))
                 .setTableLocation(toTableLocation(table.getSd(), table.getParameters()))
-                .setProperties(toHiveProperties(table,
-                        HiveStorageFormat.get(fromHdfsInputFormatClass(table.getSd().getInputFormat()).name())))
+                .setProperties(properties)
                 .setSerdeProperties(toSerDeProperties(table))
-                .setStorageFormat(
-                        HiveStorageFormat.get(fromHdfsInputFormatClass(table.getSd().getInputFormat()).name()))
+                .setStorageFormat(storageFormat)
                 .setCreateTime(table.getCreateTime())
                 .setHiveTableType(HiveTable.HiveTableType.fromString(table.getTableType()));
 
@@ -393,33 +395,25 @@ public class HiveMetastoreApiConverter {
         return result;
     }
 
-    public static Map<String, String> toHiveProperties(Table metastoreTable, HiveStorageFormat storageFormat) {
+    public static Map<String, String> toHiveProperties(Table metastoreTable) {
         Map<String, String> hiveProperties = Maps.newHashMap();
+        StorageDescriptor sd = metastoreTable.getSd();
 
-        String serdeLib = storageFormat.getSerde();
-        if (!Strings.isNullOrEmpty(serdeLib)) {
-            // metaStore has more accurate information about serde
-            if (metastoreTable.getSd() != null && metastoreTable.getSd().getSerdeInfo() != null &&
-                    metastoreTable.getSd().getSerdeInfo().getSerializationLib() != null) {
-                serdeLib = metastoreTable.getSd().getSerdeInfo().getSerializationLib();
-            }
-            hiveProperties.put(HIVE_TABLE_SERDE_LIB, serdeLib);
+        if (sd.getSerdeInfo() != null && sd.getSerdeInfo().getSerializationLib() != null) {
+            hiveProperties.put(HIVE_TABLE_SERDE_LIB, sd.getSerdeInfo().getSerializationLib());
         }
 
-        String inputFormat = storageFormat.getInputFormat();
-        if (!Strings.isNullOrEmpty(inputFormat)) {
-            hiveProperties.put(HIVE_TABLE_INPUT_FORMAT, inputFormat);
+        if (sd.getInputFormat() != null) {
+            hiveProperties.put(HIVE_TABLE_INPUT_FORMAT, sd.getInputFormat());
         }
 
-        String dataColumnNames = metastoreTable.getSd().getCols().stream()
-                .map(FieldSchema::getName).collect(Collectors.joining(","));
+        String dataColumnNames = sd.getCols().stream().map(FieldSchema::getName).collect(Collectors.joining(","));
 
         if (!Strings.isNullOrEmpty(dataColumnNames)) {
             hiveProperties.put(HIVE_TABLE_COLUMN_NAMES, dataColumnNames);
         }
 
-        String dataColumnTypes = metastoreTable.getSd().getCols().stream()
-                .map(FieldSchema::getType).collect(Collectors.joining("#"));
+        String dataColumnTypes = sd.getCols().stream().map(FieldSchema::getType).collect(Collectors.joining("#"));
 
         if (!Strings.isNullOrEmpty(dataColumnTypes)) {
             hiveProperties.put(HIVE_TABLE_COLUMN_TYPES, dataColumnTypes);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -580,11 +580,6 @@ public class HiveMetastoreApiConverter {
     }
 
     public static TextFileFormatDesc toTextFileFormatDesc(Map<String, String> parameters) {
-        final String DEFAULT_FIELD_DELIM = "\001";
-        final String DEFAULT_COLLECTION_DELIM = "\002";
-        final String DEFAULT_MAPKEY_DELIM = "\003";
-        final String DEFAULT_LINE_DELIM = "\n";
-
         // Get properties 'field.delim', 'line.delim', 'collection.delim' and 'mapkey.delim' from StorageDescriptor
         // Detail refer to:
         // https://github.com/apache/hive/blob/90428cc5f594bd0abb457e4e5c391007b2ad1cb8/serde/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/serde/serdeConstants.java#L34-L40

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreOperations.java
@@ -46,6 +46,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.starrocks.connector.hive.HiveStorageFormat.PARQUET;
 import static com.starrocks.connector.hive.HiveWriteUtils.checkLocationProperties;
 import static com.starrocks.connector.hive.HiveWriteUtils.createDirectory;
 import static com.starrocks.connector.hive.HiveWriteUtils.isDirectory;
@@ -199,7 +200,7 @@ public class HiveMetastoreOperations {
                 .setFullSchema(stmt.getColumns())
                 .setTableLocation(tablePath == null ? null : tablePath.toString())
                 .setProperties(stmt.getProperties())
-                .setStorageFormat(HiveStorageFormat.get(properties.getOrDefault(FILE_FORMAT, "parquet")))
+                .setStorageFormat(HiveStorageFormat.get(properties.getOrDefault(FILE_FORMAT, PARQUET.name())))
                 .setCreateTime(System.currentTimeMillis())
                 .setHiveTableType(tableType);
         Table table = builder.build();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveStorageFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveStorageFormat.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.connector.hive;
 
+import com.google.common.collect.ImmutableMap;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.thrift.THdfsFileFormat;
 
@@ -79,13 +80,29 @@ public enum HiveStorageFormat {
     private final String inputFormat;
     private final String outputFormat;
 
-    public static HiveStorageFormat get(String format) {
-        for (HiveStorageFormat storageFormat : HiveStorageFormat.values()) {
-            if (storageFormat.name().equalsIgnoreCase(format)) {
-                return storageFormat;
-            }
+    private static final ImmutableMap<String, HiveStorageFormat> FORMAT_MAP;
+    private static final ImmutableMap<String, HiveStorageFormat> FORMAT_SERDE_MAP;
+
+    static {
+        ImmutableMap.Builder<String, HiveStorageFormat> formatMapBuilder = ImmutableMap.builder();
+        for (HiveStorageFormat format : values()) {
+            formatMapBuilder.put(format.name().toLowerCase(), format);
         }
-        return UNSUPPORTED;
+        FORMAT_MAP = formatMapBuilder.build();
+
+        ImmutableMap.Builder<String, HiveStorageFormat> formatSerdeMapBuilder = ImmutableMap.builder();
+        for (HiveStorageFormat format : values()) {
+            formatSerdeMapBuilder.put(format.inputFormat + ":" + format.serde, format);
+        }
+        FORMAT_SERDE_MAP = formatMapBuilder.build();
+    }
+
+    public static HiveStorageFormat get(String name) {
+        return FORMAT_MAP.getOrDefault(name.toLowerCase(), UNSUPPORTED);
+    }
+
+    public static HiveStorageFormat get(String inputFormat, String serde) {
+        return FORMAT_SERDE_MAP.getOrDefault(inputFormat + ":" + serde, UNSUPPORTED);
     }
 
     public static void check(Map<String, String> properties) {
@@ -94,7 +111,7 @@ public enum HiveStorageFormat {
                     "Please use 'file_format' instead of 'format' in the table properties");
         }
 
-        String fileFormat = properties.getOrDefault(FILE_FORMAT, "parquet");
+        String fileFormat = properties.getOrDefault(FILE_FORMAT, PARQUET.name());
         HiveStorageFormat storageFormat = get(fileFormat);
         if (storageFormat == UNSUPPORTED) {
             throw new StarRocksConnectorException("Unsupported hive storage format %s", fileFormat);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveStorageFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveStorageFormat.java
@@ -94,7 +94,7 @@ public enum HiveStorageFormat {
         for (HiveStorageFormat format : values()) {
             formatSerdeMapBuilder.put(format.inputFormat + ":" + format.serde, format);
         }
-        FORMAT_SERDE_MAP = formatMapBuilder.build();
+        FORMAT_SERDE_MAP = formatSerdeMapBuilder.build();
     }
 
     public static HiveStorageFormat get(String name) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/RemoteFileInputFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/RemoteFileInputFormat.java
@@ -30,8 +30,7 @@ public enum RemoteFileInputFormat {
     ORC,
     TEXTFILE,
     AVRO,
-    RCBINARY,
-    RCTEXT,
+    RCFILE,
     SEQUENCE,
     UNKNOWN;
     private static final ImmutableMap<String, RemoteFileInputFormat> CLASS_NAME_TO_INPUT_FORMAT =
@@ -40,7 +39,7 @@ public enum RemoteFileInputFormat {
                     .put(ORC_INPUT_FORMAT_CLASS, ORC)
                     .put(TEXT_INPUT_FORMAT_CLASS, TEXTFILE)
                     .put(AVRO_INPUT_FORMAT_CLASS, AVRO)
-                    .put(RCFILE_INPUT_FORMAT_CLASS, RCBINARY)
+                    .put(RCFILE_INPUT_FORMAT_CLASS, RCFILE)
                     .put(SEQUENCE_INPUT_FORMAT_CLASS, SEQUENCE)
                     .build();
     private static final ImmutableMap<String, Boolean> INPUT_FORMAT_SPLITTABLE =
@@ -82,7 +81,7 @@ public enum RemoteFileInputFormat {
             case ORC -> THdfsFileFormat.ORC;
             case TEXTFILE -> THdfsFileFormat.TEXT;
             case AVRO -> THdfsFileFormat.AVRO;
-            case RCBINARY, RCTEXT -> THdfsFileFormat.RC_FILE;
+            case RCFILE -> THdfsFileFormat.RC_FILE;
             case SEQUENCE -> THdfsFileFormat.SEQUENCE_FILE;
             default -> THdfsFileFormat.UNKNOWN;
         };

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
@@ -329,9 +329,10 @@ public class HiveMetastoreTest {
             StorageDescriptor sd = new StorageDescriptor();
             sd.setCols(unPartKeys);
             sd.setLocation(hdfsPath);
-            sd.setInputFormat("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat");
+            sd.setInputFormat(HiveClassNames.ORC_INPUT_FORMAT_CLASS);
             SerDeInfo serDeInfo = new SerDeInfo();
             serDeInfo.setParameters(ImmutableMap.of());
+            serDeInfo.setSerializationLib(HiveClassNames.ORC_SERDE_CLASS);
             sd.setSerdeInfo(serDeInfo);
             Table msTable1 = new Table();
             msTable1.setDbName(dbName);

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -68,7 +68,7 @@ struct TTupleDescriptor {
 
 enum THdfsFileFormat {
   TEXT = 0,
-  LZO_TEXT = 1,
+  LZO_TEXT = 1, // Deprecated
   RC_FILE = 2,
   // THdfsFileFormat is only used to represent FileFormat, not SerializeFormat,
   // so there is no need to split it into RC_BINARY and RC_TEXT.


### PR DESCRIPTION
## Why I'm doing:

* RemoteFileInputFormat is used to represent the file input format.
* HiveStorageFormat is used to represent the combination of file input format and row serde format.

## What I'm doing:

* Remove RCTEXT from RemoteFileInputFormat in FE
* Mark LZO_TEXT as Deprecated

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates RCFILE handling (remove RCTEXT/RCBINARY in RemoteFileInputFormat), resolves Hive storage format via inputFormat+serde, updates defaults/properties, and marks LZO_TEXT deprecated.
> 
> - **Hive connector**:
>   - **RemoteFileInputFormat**: Remove `RCTEXT`/`RCBINARY` variants; use unified `RCFILE` with updated class mappings and thrift conversion.
>   - **HiveStorageFormat**:
>     - Add fast lookups (`FORMAT_MAP`, `FORMAT_SERDE_MAP`) and support `get(inputFormat, serde)`.
>     - Default `file_format` to `PARQUET.name()`; tighten validation.
>   - **HiveMetastoreApiConverter**:
>     - Derive properties from `StorageDescriptor` (`serde_lib`, `input_format`, column names/types).
>     - Determine storage format using `HiveStorageFormat.get(inputFormat, serde)`.
>     - Simplify `toHiveProperties` signature and call sites; minor cleanup in text format desc.
>   - **HiveMetastoreOperations**: Use `PARQUET` constant for default `file_format`.
>   - **FileTable**: Use `getFileFormat()` when building thrift and keep RCFILE formats via `HiveStorageFormat`.
> - **Tests**:
>   - Update mocks to use ORC class constants and set `serializationLib`.
> - **Thrift**:
>   - Mark `THdfsFileFormat.LZO_TEXT` as deprecated in comments; keep `RC_FILE` as the single RC format.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99e27ab9a8fcffc8e1bf227e41720623a39d20db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->