### PR TITLE
[BugFix] Fix statistics collection after overwrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.statistic;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
@@ -666,7 +665,6 @@ public class StatisticExecutor {
                                                     long targetPartition) {
         List<String> sqlList =
                 FullStatisticsCollectJob.buildOverwritePartitionSQL(tableId, sourcePartition, targetPartition);
-        Preconditions.checkState(sqlList.size() == 2);
 
         // copy
         executeDML(context, sqlList.get(0));

--- a/test/sql/test_analyze_statistics/R/test_overwrite_statistics.sql
+++ b/test/sql/test_analyze_statistics/R/test_overwrite_statistics.sql
@@ -1,0 +1,72 @@
+-- name: test_overwrite_statistics @sequential
+drop database if exists test_overwrite_statistics;
+-- result:
+-- !result
+create database test_overwrite_statistics;
+-- result:
+-- !result
+use test_overwrite_statistics;
+-- result:
+-- !result
+create table test_overwrite_stats_table (k1 int) properties("replication_num"="1");
+-- result:
+-- !result
+delete from _statistics_.column_statistics where table_name='test_overwrite_statistics.test_overwrite_stats_table';
+-- result:
+-- !result
+insert into test_overwrite_stats_table select 123;
+-- result:
+-- !result
+select count(*) from _statistics_.column_statistics where table_name = 'test_overwrite_statistics.test_overwrite_stats_table';
+-- result:
+1
+-- !result
+insert overwrite test_overwrite_stats_table select 123;
+-- result:
+-- !result
+select count(*) from _statistics_.column_statistics where table_name = 'test_overwrite_statistics.test_overwrite_stats_table';
+-- result:
+2
+-- !result
+CREATE TABLE sales_data (
+    id BIGINT,
+    sale_date DATE
+)
+DUPLICATE KEY(id)
+PARTITION BY RANGE(sale_date) (
+    PARTITION p202401 VALUES [('2024-01-01'), ('2024-02-01')),
+    PARTITION p202402 VALUES [('2024-02-01'), ('2024-03-01')),
+    PARTITION p202403 VALUES [('2024-03-01'), ('2024-04-01')),
+    PARTITION p202404 VALUES [('2024-04-01'), ('2024-05-01'))
+)
+DISTRIBUTED BY HASH(id) BUCKETS 4
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+delete from _statistics_.column_statistics where table_name='test_overwrite_statistics.sales_data';
+-- result:
+-- !result
+INSERT INTO sales_data VALUES
+(1, '2024-01-15'),
+(2, '2024-01-20'),
+(3, '2024-02-10'),
+(4, '2024-02-15'),
+(5, '2024-03-05'),
+(6, '2024-03-12'),
+(7, '2024-04-08'),
+(8, '2024-04-18');
+-- result:
+-- !result
+select count(*) from _statistics_.column_statistics where table_name = 'test_overwrite_statistics.sales_data';
+-- result:
+8
+-- !result
+INSERT OVERWRITE sales_data partition("p202401") VALUES (101, '2024-01-10');
+-- result:
+-- !result
+select count(*) from _statistics_.column_statistics where table_name = 'test_overwrite_statistics.sales_data';
+-- result:
+10
+-- !result

--- a/test/sql/test_analyze_statistics/T/test_overwrite_statistics.sql
+++ b/test/sql/test_analyze_statistics/T/test_overwrite_statistics.sql
@@ -1,0 +1,47 @@
+-- name: test_overwrite_statistics @sequential
+
+drop database if exists test_overwrite_statistics;
+create database test_overwrite_statistics;
+use test_overwrite_statistics;
+create table test_overwrite_stats_table (k1 int) properties("replication_num"="1");
+
+delete from _statistics_.column_statistics where table_name='test_overwrite_statistics.test_overwrite_stats_table';
+
+insert into test_overwrite_stats_table select 123;
+select count(*) from _statistics_.column_statistics where table_name = 'test_overwrite_statistics.test_overwrite_stats_table';
+insert overwrite test_overwrite_stats_table select 123;
+select count(*) from _statistics_.column_statistics where table_name = 'test_overwrite_statistics.test_overwrite_stats_table';
+
+
+CREATE TABLE sales_data (
+    id BIGINT,
+    sale_date DATE
+)
+DUPLICATE KEY(id)
+PARTITION BY RANGE(sale_date) (
+    PARTITION p202401 VALUES [('2024-01-01'), ('2024-02-01')),
+    PARTITION p202402 VALUES [('2024-02-01'), ('2024-03-01')),
+    PARTITION p202403 VALUES [('2024-03-01'), ('2024-04-01')),
+    PARTITION p202404 VALUES [('2024-04-01'), ('2024-05-01'))
+)
+DISTRIBUTED BY HASH(id) BUCKETS 4
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+delete from _statistics_.column_statistics where table_name='test_overwrite_statistics.sales_data';
+
+INSERT INTO sales_data VALUES
+(1, '2024-01-15'),
+(2, '2024-01-20'),
+(3, '2024-02-10'),
+(4, '2024-02-15'),
+(5, '2024-03-05'),
+(6, '2024-03-12'),
+(7, '2024-04-08'),
+(8, '2024-04-18');
+select count(*) from _statistics_.column_statistics where table_name = 'test_overwrite_statistics.sales_data';
+
+INSERT OVERWRITE sales_data partition("p202401") VALUES (101, '2024-01-10');
+select count(*) from _statistics_.column_statistics where table_name = 'test_overwrite_statistics.sales_data';
+


### PR DESCRIPTION
## Why I'm doing:
https://github.com/StarRocks/starrocks/pull/60897 this patch uses background drop partition stats to replace delete SQL. 
Therefore, when the cardinality deviation is small after overwrite, only one SQL is used to supplement the statistics

## What I'm doing:
remove check state. 
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
