### PR TITLE
[BugFix] turn to db intent lock in TabletChecker.doCheck()

### DIFF
--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -2094,6 +2094,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: Soft limit of the remaining storage space in a BE directory. If the remaining storage space in the BE storage directory is less than this value and the storage usage (in percentage) exceeds `storage_usage_soft_limit_percent`, tablets cannot be cloned into this directory.
 - Introduced in: -
 
+##### tablet_checker_lock_time_per_cycle_ms
+
+- Default: 1000
+- Type: Int
+- Unit: Milliseconds
+- Is mutable: Yes
+- Description: The maximum lock hold time per cycle for tablet checker before releasing and reacquiring the table lock. Values less than 100 will be treated as 100.
+- Introduced in: v3.5.9, v4.0.2
+
 ##### tablet_create_timeout_second
 
 - Default: 10

--- a/docs/ja/administration/management/FE_configuration.md
+++ b/docs/ja/administration/management/FE_configuration.md
@@ -1986,6 +1986,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明: BE ディレクトリ内の残りストレージスペースのソフトリミット。BE ストレージディレクトリの残りストレージスペースがこの値より少なく、ストレージ使用率（パーセンテージ）が `storage_usage_soft_limit_percent` を超える場合、tablets はこのディレクトリにクローンできません。
 - 導入バージョン: -
 
+##### tablet_checker_lock_time_per_cycle_ms
+
+- デフォルト: 1000
+- タイプ: Int
+- 単位: ミリ秒
+- 変更可能: はい
+- 説明: Tablet Checker がテーブルロックを解放して再取得する前の、サイクルごとの最大ロック保持時間（ミリ秒）。100 未満の値は 100 として扱われます。
+- 導入バージョン: v3.5.9, v4.0.2
+
 ##### tablet_create_timeout_second
 
 - デフォルト: 10

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -1988,6 +1988,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述：单个 BE 存储目录剩余空间软限制。如果 BE 存储目录下剩余空间小于该值且空间使用率超过 `storage_usage_soft_limit_percent`，则不能继续向该路径克隆 Tablet。
 - 引入版本：-
 
+##### tablet_checker_lock_time_per_cycle_ms
+
+- 默认值：1000
+- 类型：Int
+- 单位：Milliseconds
+- 是否动态：是
+- 描述：Tablet Checker 在释放并重新获取表锁之前，每个周期持有锁的最大时间（毫秒）。小于 100 的值将被视为 100。
+- 引入版本：v3.5.9, v4.0.2
+
 ##### tablet_create_timeout_second
 
 - 默认值：10

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
@@ -63,6 +63,7 @@ import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
 import com.starrocks.sql.ast.AdminCancelRepairTableStmt;
 import com.starrocks.sql.ast.AdminRepairTableStmt;
 import com.starrocks.sql.ast.PartitionRef;
@@ -89,8 +90,9 @@ import java.util.stream.Collectors;
  */
 public class TabletChecker extends FrontendDaemon {
     private static final Logger LOG = LogManager.getLogger(TabletChecker.class);
-    // 1 min
+
     private static final long LOG_PRINT_INTERVAL = 60000L;
+    private static final long MIN_LOCK_HOLD_TIME_MS = 100L;
 
     private final TabletScheduler tabletScheduler;
     private final TabletSchedulerStat stat;
@@ -140,6 +142,12 @@ public class TabletChecker extends FrontendDaemon {
             this.tblId = tblId;
             this.partIds = partIds;
         }
+    }
+
+    private static class LockStatistic {
+        public long lockHoldTotalTime = 0L;
+        public long lockAcquireCount = 0L;
+        public long proactiveReleaseCount = 0L;
     }
 
     public TabletChecker(TabletScheduler tabletScheduler, TabletSchedulerStat stat) {
@@ -265,131 +273,158 @@ public class TabletChecker extends FrontendDaemon {
     }
 
     private void doCheck(boolean isUrgent) {
-        long start = System.nanoTime();
+        long start = System.currentTimeMillis();
         TabletCheckerStat totStat = new TabletCheckerStat();
+        LockStatistic lockStat = new LockStatistic();
+        GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIdsIncludeRecycleBin()
+                .forEach(x -> checkOneDatabase(x, isUrgent, totStat, lockStat));
 
-        long lockTotalTime = 0;
-        long waitTotalTime = 0;
-        long lockStart;
-        List<Long> dbIds = GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIdsIncludeRecycleBin();
-        DATABASE:
-        for (Long dbId : dbIds) {
-            Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIncludeRecycleBin(dbId);
-            if (db == null) {
-                continue;
-            }
-
-            if (db.isSystemDatabase()) {
-                continue;
-            }
-
-            // set the config to a local variable to avoid config params changed.
-            int partitionBatchNum = Config.tablet_checker_partition_batch_num;
-            int partitionChecked = 0;
-            Locker locker = new Locker();
-            locker.lockDatabase(db.getId(), LockType.READ);
-            lockStart = System.nanoTime();
-            try {
-                List<Long> aliveBeIdsInCluster =
-                        GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds(true);
-                TABLE:
-                for (Table table : GlobalStateMgr.getCurrentState().getLocalMetastore().getTablesIncludeRecycleBin(db)) {
-                    if (!table.needSchedule(false)) {
-                        continue;
-                    }
-                    if (table.isCloudNativeTableOrMaterializedView()) {
-                        // replicas are managed by StarOS and cloud storage.
-                        continue;
-                    }
-
-                    if ((isUrgent && !isUrgentTable(dbId, table.getId()))) {
-                        continue;
-                    }
-
-                    OlapTable olapTbl = (OlapTable) table;
-                    for (PhysicalPartition physicalPartition : GlobalStateMgr.getCurrentState().getLocalMetastore()
-                            .getAllPhysicalPartitionsIncludeRecycleBin(olapTbl)) {
-                        partitionChecked++;
-
-                        boolean isPartitionUrgent = isPartitionUrgent(dbId, table.getId(), physicalPartition.getId());
-                        totStat.isUrgentPartitionHealthy = true;
-                        if ((isUrgent && !isPartitionUrgent) || (!isUrgent && isPartitionUrgent)) {
-                            continue;
-                        }
-
-                        if (partitionChecked % partitionBatchNum == 0) {
-                            LOG.debug("partition checked reached batch value, release lock");
-                            lockTotalTime += System.nanoTime() - lockStart;
-                            // release lock, so that lock can be acquired by other threads.
-                            locker.unLockDatabase(db.getId(), LockType.READ);
-                            locker.lockDatabase(db.getId(), LockType.READ);
-                            LOG.debug("checker get lock again");
-                            lockStart = System.nanoTime();
-                            if (GlobalStateMgr.getCurrentState().getLocalMetastore().getDbIncludeRecycleBin(dbId) == null) {
-                                continue DATABASE;
-                            }
-                            if (GlobalStateMgr.getCurrentState().getLocalMetastore()
-                                    .getTableIncludeRecycleBin(db, olapTbl.getId()) == null) {
-                                continue TABLE;
-                            }
-                            if (GlobalStateMgr.getCurrentState().getLocalMetastore()
-                                    .getPhysicalPartitionIncludeRecycleBin(olapTbl, physicalPartition.getId()) == null) {
-                                continue;
-                            }
-                        }
-
-                        Partition logicalPartition = olapTbl.getPartition(physicalPartition.getParentId());
-                        if (logicalPartition == null) {
-                            continue;
-                        }
-
-                        if (logicalPartition.getState() != PartitionState.NORMAL) {
-                            // when alter job is in FINISHING state, partition state will be set to NORMAL,
-                            // and we can schedule the tablets in it.
-                            continue;
-                        }
-
-                        short replicaNum = GlobalStateMgr.getCurrentState()
-                                .getLocalMetastore()
-                                .getReplicationNumIncludeRecycleBin(
-                                        olapTbl.getPartitionInfo(), physicalPartition.getParentId());
-                        if (replicaNum == (short) -1) {
-                            continue;
-                        }
-
-                        TabletCheckerStat partitionTabletCheckerStat = doCheckOnePartition(db, olapTbl, physicalPartition,
-                                replicaNum, aliveBeIdsInCluster, isPartitionUrgent);
-                        totStat.accumulateStat(partitionTabletCheckerStat);
-
-                        if (totStat.isUrgentPartitionHealthy && isPartitionUrgent) {
-                            // if all replicas in this partition are healthy, remove this partition from
-                            // priorities.
-                            LOG.debug("partition is healthy, remove from urgent table: {}-{}-{}",
-                                    db.getId(), olapTbl.getId(), physicalPartition.getId());
-                            removeFromUrgentTable(new RepairTabletInfo(db.getId(),
-                                    olapTbl.getId(), Lists.newArrayList(physicalPartition.getId())));
-                        }
-                    } // partitions
-                } // tables
-            } finally {
-                lockTotalTime += System.nanoTime() - lockStart;
-                locker.unLockDatabase(db.getId(), LockType.READ);
-            }
-        } // end for dbs
-
-        long cost = (System.nanoTime() - start) / 1000000;
-        lockTotalTime = lockTotalTime / 1000000;
-
+        // Update statistics
+        long cost = System.currentTimeMillis() - start;
         stat.counterTabletCheckCostMs.addAndGet(cost);
         stat.counterTabletChecked.addAndGet(totStat.totalTabletNum);
         stat.counterUnhealthyTabletNum.addAndGet(totStat.unhealthyTabletNum);
         stat.counterTabletAddToBeScheduled.addAndGet(totStat.addToSchedulerTabletNum);
 
-        LOG.info("finished to check tablets. isUrgent: {}, " +
+        LOG.info("Finished one cycle check of tablets. isUrgent: {}, " +
                         "unhealthy/total/added/in_sched/not_ready: {}/{}/{}/{}/{}, " +
-                        "cost: {} ms, in lock time: {} ms, wait time: {}ms",
+                        "cost: {} ms, in lock time: {} ms, wait time: {}ms, " +
+                "lock acquire count: {}, lock proactive release count: {}",
                 isUrgent, totStat.unhealthyTabletNum, totStat.totalTabletNum, totStat.addToSchedulerTabletNum,
-                totStat.tabletInScheduler, totStat.tabletNotReady, cost, lockTotalTime - waitTotalTime, waitTotalTime);
+                totStat.tabletInScheduler, totStat.tabletNotReady, cost, lockStat.lockHoldTotalTime,
+                totStat.waitTotalTime, lockStat.lockAcquireCount, lockStat.proactiveReleaseCount);
+    }
+
+    private void checkOneDatabase(long dbId, boolean isUrgent, TabletCheckerStat totStat, LockStatistic lockStat) {
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        Database db = metastore.getDbIncludeRecycleBin(dbId);
+        if (db == null) {
+            return;
+        }
+        if (db.isSystemDatabase()) {
+            return;
+        }
+        for (Table table : metastore.getTablesIncludeRecycleBin(db)) {
+            // Acquire the READ lock and do some sanity check first.
+            checkOneTable(db, table, isUrgent, totStat, lockStat);
+        }
+    }
+
+    /**
+     * Check one table for unhealthy tablets.
+     * This method implements a lock release/reacquire mechanism to prevent
+     * holding the table lock for extended periods when processing large tables.
+     *
+     */
+    private void checkOneTable(Database db, Table table, boolean isUrgent, TabletCheckerStat totStat,
+                               LockStatistic lockStat) {
+        long maxLockHoldTimeMs = Config.tablet_checker_lock_time_per_cycle_ms;
+        if (maxLockHoldTimeMs < MIN_LOCK_HOLD_TIME_MS) {
+            // Value less than 100ms is not reasonable.
+            maxLockHoldTimeMs = MIN_LOCK_HOLD_TIME_MS;
+        }
+        LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        List<Long> aliveBeIdsInCluster;
+
+        Locker locker = new Locker();
+        locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
+        boolean locked = true;
+        long lockStartTime = 0L;
+        try {
+            lockStat.lockAcquireCount++;
+            lockStartTime = System.currentTimeMillis();
+            aliveBeIdsInCluster = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds(true);
+
+            if (metastore.getTableIncludeRecycleBin(db, table.getId()) == null) {
+                // Get the table by tableId again, ensure it still exists under the lock.
+                return;
+            }
+            if (!table.needSchedule(false)) {
+                return;
+            }
+            if (table.isCloudNativeTableOrMaterializedView()) {
+                // replicas are managed by StarOS and cloud storage.
+                return;
+            }
+            if ((isUrgent && !isUrgentTable(db.getId(), table.getId()))) {
+                return;
+            }
+            if (!(table instanceof OlapTable)) {
+                return;
+            }
+            OlapTable olapTbl = (OlapTable) table;
+            List<Long> physicalPartitionIds =
+                    olapTbl.getPhysicalPartitions().stream().map(PhysicalPartition::getId).collect(Collectors.toList());
+            for (long physicalPartitionId : physicalPartitionIds) {
+                // Retrieve the physical partition by physicalPartitionId to ensure it still exists, because the
+                // table lock can be released and acquired again in the middle.
+                PhysicalPartition physicalPartition =
+                        metastore.getPhysicalPartitionIncludeRecycleBin(olapTbl, physicalPartitionId);
+                if (physicalPartition == null) {
+                    continue;
+                }
+                boolean isPartitionUrgent = isPartitionUrgent(db.getId(), table.getId(), physicalPartition.getId());
+                totStat.isUrgentPartitionHealthy = true;
+                if ((isUrgent && !isPartitionUrgent) || (!isUrgent && isPartitionUrgent)) {
+                    continue;
+                }
+                Partition logicalPartition = olapTbl.getPartition(physicalPartition.getParentId());
+                if (logicalPartition == null) {
+                    continue;
+                }
+                if (logicalPartition.getState() != PartitionState.NORMAL) {
+                    // when alter job is in FINISHING state, partition state will be set to NORMAL,
+                    // and we can schedule the tablets in it.
+                    continue;
+                }
+
+                short replicaNum = metastore.getReplicationNumIncludeRecycleBin(olapTbl.getPartitionInfo(),
+                        physicalPartition.getParentId());
+                if (replicaNum == (short) -1) {
+                    continue;
+                }
+
+                TabletCheckerStat partitionTabletCheckerStat =
+                        doCheckOnePartition(db, olapTbl, physicalPartition, replicaNum, aliveBeIdsInCluster,
+                                isPartitionUrgent);
+                totStat.accumulateStat(partitionTabletCheckerStat);
+
+                if (totStat.isUrgentPartitionHealthy && isPartitionUrgent) {
+                    // if all replicas in this partition are healthy, remove this partition from
+                    // priorities.
+                    LOG.debug("partition is healthy, remove from urgent table: {}-{}-{}",
+                            db.getId(), olapTbl.getId(), physicalPartition.getId());
+                    removeFromUrgentTable(new RepairTabletInfo(db.getId(),
+                            olapTbl.getId(), Lists.newArrayList(physicalPartition.getId())));
+                }
+                long lockElapsedTime = System.currentTimeMillis() - lockStartTime;
+                if (lockElapsedTime >= maxLockHoldTimeMs) {
+                    locker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
+                    locked = false;
+                    lockStat.proactiveReleaseCount++;
+
+                    LOG.debug("lock time for one cycle reached the limit {}, release lock.", maxLockHoldTimeMs);
+                    lockStat.lockHoldTotalTime += lockElapsedTime;
+
+                    locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
+                    locked = true;
+                    lockStat.lockAcquireCount++;
+                    lockStartTime = System.currentTimeMillis();
+                    if (metastore.getTableIncludeRecycleBin(db, table.getId()) == null) {
+                        // Get the table by tableId again, ensure it still exists under the lock.
+                        return;
+                    }
+                    // Refresh alive BE list after reacquire the lock
+                    aliveBeIdsInCluster =
+                            GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendIds(true);
+                }
+            }
+        } finally {
+            if (locked) {
+                locker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
+                lockStat.lockHoldTotalTime += System.currentTimeMillis() - lockStartTime;
+            }
+        }
     }
 
     private static class TabletCheckerStat {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1846,9 +1846,19 @@ public class Config extends ConfigBase {
     /**
      * After checked tablet_checker_partition_batch_num partitions, db lock will be released,
      * so that other threads can get the lock.
+     * TODO: deprecate this configuration after ColocateTableBalancer.java module is optimized by lock holding time.
      */
     @ConfField(mutable = true)
     public static int tablet_checker_partition_batch_num = 500;
+
+    /**
+     * Default 1000ms provides a good balance between lock fairness and overhead.
+     * Allows processing hundreds of partitions while preventing lock monopolization.
+     */
+    @ConfField(mutable = true, comment = "The maximum lock hold time per cycle for tablet checker before releasing " +
+            "and reacquiring the table lock in milliseconds, default is 1000 (ms). " +
+            "Values less than 100 will be treated as 100")
+    public static int tablet_checker_lock_time_per_cycle_ms = 1000;
 
     @Deprecated
     @ConfField(mutable = true)


### PR DESCRIPTION
1. Locking Strategy Change: Replaced the previous approach of releasing and reacquiring database locks after a fixed number of partitions with a time-based approach that releases locks after a configurable time interval.
2. New Configuration Parameter: Added tablet_checker_lock_time_per_cycle_ms to control the maximum time a lock can be held in each cycle.
3. Refactored Structure: Restructured the code to use a more granular approach with checkOneDatabase and checkOneTable methods.

```
    "java.base@11.0.24/java.util.stream.StreamOpFlag.fromCharacteristics(StreamOpFlag.java:733)",
    "java.base@11.0.24/java.util.stream.StreamSupport.stream(StreamSupport.java:70)",
    "java.base@11.0.24/java.util.Collection.stream(Collection.java:711)",
    "app//com.starrocks.system.Backend.isDiskDecommissioned(Backend.java:541)",
    "app//com.starrocks.clone.TabletChecker.collectLocalTabletHealthStats(TabletChecker.java:910)",
    "app//com.starrocks.clone.TabletChecker.getTabletHealthStatusWithPriorityUnlocked(TabletChecker.java:1045)",
    "app//com.starrocks.clone.TabletChecker.getTabletHealthStatusWithPriority(TabletChecker.java:825)",
    "app//com.starrocks.clone.TabletChecker.doCheckOnePartition(TabletChecker.java:433)",
    "app//com.starrocks.clone.TabletChecker.doCheck(TabletChecker.java:359)",
    "app//com.starrocks.clone.TabletChecker.checkNonUrgentTablets(TabletChecker.java:241)",
    "app//com.starrocks.clone.TabletChecker.checkAllTablets(TabletChecker.java:233)",
    "app//com.starrocks.clone.TabletChecker.runAfterCatalogReady(TabletChecker.java:219)",
    "app//com.starrocks.common.util.FrontendDaemon.runOneCycle(FrontendDaemon.java:72)",
    "app//com.starrocks.common.util.Daemon.run(Daemon.java:109)"
```

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reworks TabletChecker to release/reacquire table locks based on a configurable time limit and documents a new FE config `tablet_checker_lock_time_per_cycle_ms`.
> 
> - **FE core (tablet checking)**
>   - Refactors `TabletChecker#doCheck` into `checkOneDatabase`/`checkOneTable` with per-table processing.
>   - Implements time-based lock release/reacquire using `Config.tablet_checker_lock_time_per_cycle_ms` (min 100 ms), replacing partition-count-based lock cycling.
>   - Adds lock metrics (`LockStatistic`: hold time, acquire count, proactive releases) and updates cycle logging; switches timing to `currentTimeMillis`.
>   - Introduces `MIN_LOCK_HOLD_TIME_MS`, imports `LocalMetastore`, and adjusts stats accumulation.
> - **Config**
>   - Adds mutable `tablet_checker_lock_time_per_cycle_ms` (default 1000 ms) to control TabletChecker lock hold per cycle; updates comment on `tablet_checker_partition_batch_num` (future deprecation note).
> - **Docs**
>   - Documents `tablet_checker_lock_time_per_cycle_ms` in EN/JA/ZH `FE_configuration.md` (default, unit, mutability, min treated as 100; introduced in v3.5.10, v4.0.2).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c8aadb4a16eabf9324b014d4a36f82934fb07b91. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->