### PR TITLE
[Doc] docs(be_config): update en, zh, ja documentation

### DIFF
--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -109,6 +109,19 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - Description: The BE thrift server port, which is used to receive requests from FEs.
 - Introduced in: -
 
+## thrift_port
+
+// document start, just to marked the document is start and doesn't need to be included in the output.
+##### thrift_port
+
+- Default: 0
+- Type: Int
+- Unit: Port
+- Is mutable: No
+- Description: Port on which the BE Thrift service (the ImpalaInternalService / BackendService Thrift server) is published. When running in CN mode (as_cn=true) and this value is non‑zero, it overrides the value of be_port for the Thrift server bind port. Default 0 means "disabled" / ignored and be_port will be used. This option is deprecated — when used the BE startup logs a warning advising to switch to be_port. Misconfiguring this port (e.g., using an already‑occupied port) will prevent the Thrift server from starting.
+- Introduced in: 3.2.0
+// document end, just to marked the document is end and doesn't need to be included in the output.
+
 ##### brpc_port
 
 - Default: 8060
@@ -126,6 +139,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - Is mutable: No
 - Description: The number of bthreads of a bRPC. The value `-1` indicates the same number with the CPU threads.
 - Introduced in: -
+
+##### enable_https
+
+- Default: false
+- Type: Boolean
+- Unit: N/A
+- Is mutable: No
+- Description: When true, StarRocks configures BRPC to use TLS by populating ServerOptions::ssl_options with the certificate and private key from ssl_certificate_path and ssl_private_key_path. This enables HTTPS/TLS for BRPC services started by the BE process so clients must connect using TLS. You must provide valid paths to a PEM certificate and matching private key; the flag is read at startup and not applied dynamically, so changing it requires restarting the process. The option only affects BRPC server SSL setup (see server options -> mutable_ssl_options()).
+- Introduced in: 4.0.0
 
 ##### brpc_stub_expire_s
 
@@ -270,6 +292,21 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - Is mutable: No
 - Description: The maximum body size of a bRPC.
 - Introduced in: -
+
+### Metadata and cluster management
+
+## cluster_id
+
+// document start, just to marked the document is start and doesn't need to be included in the output.
+##### cluster_id
+
+- Default: -1
+- Type: Int
+- Unit: N/A
+- Is mutable: No
+- Description: Numeric identifier for the StarRocks cluster that this BE process belongs to. At startup StorageEngine reads config::cluster_id into its _effective_cluster_id and compares it with cluster ids persisted on each data-root. A value of -1 means "unset" (allowing the engine to accept a cluster id from existing data directories or from the frontend heartbeat). If a non -1 cluster_id is provided it is treated as the initial authoritative id; mismatches between this value and persisted root-path ids cause startup failure. If some root paths lack a stored id and the engine is allowed to write cluster ids (EngineOptions::need_write_cluster_id), the effective cluster id will be written to those paths. Set this to the correct cluster id to attach to an existing cluster, or leave -1 for automatic detection.
+- Introduced in: 3.2.0
+// document end, just to marked the document is end and doesn't need to be included in the output.
 
 ### Query engine
 

--- a/docs/ja/administration/management/BE_configuration.md
+++ b/docs/ja/administration/management/BE_configuration.md
@@ -108,6 +108,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 説明: BE の thrift サーバーポートで、FEs からのリクエストを受け取るために使用されます。
 - 導入バージョン: -
 
+
+
 ##### brpc_port
 
 - デフォルト: 8060
@@ -125,6 +127,17 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 可変: いいえ
 - 説明: bRPC の bthreads の数。値 `-1` は CPU スレッドと同じ数を示します。
 - 導入バージョン: -
+
+
+
+##### brpc_stub_expire_s
+
+- デフォルト: 3600
+- 型: Int
+- 単位: Seconds
+- 変更可能: Yes
+- 説明: BRPC stub cache の有効期限。デフォルト 60 minutes。
+- 導入: -
 
 ##### priority_networks
 
@@ -259,6 +272,10 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 可変: いいえ
 - 説明: bRPC の最大ボディサイズ。
 - 導入バージョン: -
+
+### メタデータとクラスタ管理
+
+
 
 ### クエリエンジン
 
@@ -543,6 +560,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 可変: いいえ
 - 説明: Pipeline 実行エンジンの PREPARE Fragment スレッドプールの最大キュー長。
 - 導入バージョン: -
+
+##### lake_tablet_ignore_invalid_delete_predicate
+
+- デフォルト: false
+- 型: Boolean
+- 単位: -
+- Is mutable: Yes
+- 説明: カラム名がリネームされた後、重複キー（duplicate key）テーブルに対する論理削除により tablet の rowset メタデータに導入される可能性のある無効な delete predicates を無視するかどうかを制御するブール値。
+- Introduced in: v4.0
 
 ##### max_hdfs_file_handle
 
@@ -1772,6 +1798,24 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 説明: 共有データクラスタでの主キーテーブルコンパクションタスクで許可される最大入力 rowset 数。このパラメータのデフォルト値は v3.2.4 および v3.1.10 以降 `5` から `1000` に、v3.3.1 および v3.2.9 以降 `500` に変更されました。主キーテーブルのためのサイズ階層型コンパクションポリシーが有効になった後 (`enable_pk_size_tiered_compaction_strategy` を `true` に設定することで)、StarRocks は各コンパクションの rowset 数を制限して書き込み増幅を減らす必要がなくなります。したがって、このパラメータのデフォルト値は増加しました。
 - 導入バージョン: v3.1.8, v3.2.3
 
+##### loop_count_wait_fragments_finish
+
+- デフォルト: 2
+- 型: Int
+- 単位: -
+- 変更可能: はい
+- 説明: BE/CN プロセスが終了する際に待機するループ回数です。各ループは固定間隔の10秒です。ループ待機を無効にするには `0` に設定します。v3.4 以降、この項目は変更可能になり、デフォルト値が `0` から `2` に変更されました。
+- 導入バージョン: v2.5
+
+##### graceful_exit_wait_for_frontend_heartbeat
+
+- デフォルト: false
+- 型: Boolean
+- 単位: -
+- 変更可能: はい
+- 説明: graceful exit（優雅な終了）を完了する前に、少なくとも1回の frontend からの HEARTBEAT 応答で SHUTDOWN ステータスを受け取るまで待機するかどうかを決定します。有効にすると、graceful shutdown プロセスは heartbeat RPC による SHUTDOWN 確認が返されるまで継続し、frontend が定期的な heartbeat 間隔の間に終了状態を検知するための十分な時間を確保します。
+- 導入バージョン: v3.4.5
+
 ### データレイク
 
 ##### disk_high_level
@@ -1945,6 +1989,17 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 説明: Data Cache のエビクションポリシー。有効な値: `lru` (最も最近使用されていない) および `slru` (セグメント化された LRU)。
 - 導入バージョン: v3.4.0
 
+##### rocksdb_write_buffer_memory_percent
+
+- Default: 5
+- Type: Int64
+- Unit: -
+- Is mutable: No
+- Description: rocksdb におけるメタ用 write buffer のメモリ割合です。デフォルトはシステムメモリの 5% です。ただし、これに加えて write buffer メモリの最終的な計算サイズは 64MB 未満にならず、1G (rocksdb_max_write_buffer_memory_bytes) を超えません。
+- Introduced in: v3.5.0
+
+
+
 ##### lake_service_max_concurrency
 
 - デフォルト: 0
@@ -1994,6 +2049,24 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 説明: ユーザー定義関数 (UDF) を保存するために使用されるディレクトリ。
 - 導入バージョン: -
 
+##### load_replica_status_check_interval_ms_on_success
+
+- デフォルト: 15000
+- 型: Int
+- 単位: Milliseconds
+- 変更可能: Yes
+- 説明: 最後のチェック RPC が成功した場合に、secondary replica が primary replica のステータスを確認する間隔。
+- 導入: 3.5.1
+
+##### load_replica_status_check_interval_ms_on_failure
+
+- デフォルト: 2000
+- 型: Int
+- 単位: Milliseconds
+- Is mutable: Yes
+- 説明: 直前のチェック RPC が失敗した場合に、セカンダリレプリカがプライマリレプリカの状態を再確認する間隔。
+- Introduced in: 3.5.1
+
 ##### enable_token_check
 
 - デフォルト: true
@@ -2011,6 +2084,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 可変: いいえ
 - 説明: ファイルマネージャーによってダウンロードされたファイルを保存するために使用されるディレクトリ。
 - 導入バージョン: -
+
+##### report_exec_rpc_request_retry_num
+
+- Default: 10
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: FE に対して exec rpc の完了を報告する RPC リクエストのリトライ回数です。デフォルト値は 10 で、fragment instance finish rpc の場合に限り失敗したときに RPC リクエストを最大 10 回リトライします。Report exec rpc request は load job にとって重要で、もしある fragment instance の finish レポートが失敗すると、ロードジョブはタイムアウトするまでハングします。
+- Introduced in: -
 
 ##### max_length_for_to_base64
 
@@ -2065,3 +2147,4 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 可変: はい
 - 説明: リソースグループ `default_mv_wg` のマテリアライズドビューリフレッシュタスクで中間結果のスピリングをトリガーする前のメモリ使用量のしきい値。デフォルト値はメモリの 80% を示します。
 - 導入バージョン: v3.1
+

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -105,6 +105,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：BE 上 Thrift Server 的端口，用于接收来自 FE 的请求。
 - 引入版本：-
 
+
+
 ##### brpc_port
 
 - 默认值：8060
@@ -122,6 +124,17 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 是否动态：否
 - 描述：bRPC 的 bthread 线程数量，`-1` 表示和 CPU 核数一样。
 - 引入版本：-
+
+
+
+##### brpc_stub_expire_s
+
+- Default: 3600
+- Type: Int
+- Unit: Seconds
+- Is mutable: Yes
+- Description: BRPC stub 缓存的过期时间，默认 60 分钟。
+- Introduced in: -
 
 ##### priority_networks
 
@@ -257,6 +270,10 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 是否动态：否
 - 描述：bRPC 最大的包容量。
 - 引入版本：-
+
+### 元数据与集群管理
+
+
 
 ### 查询引擎
 
@@ -543,6 +560,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：Pipeline 执行引擎在线程池中执行 PREPARE Fragment 的队列长度。
 - 引入版本：-
 
+
+
 ##### max_hdfs_file_handle
 
 - 默认值：1000
@@ -587,6 +606,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 是否动态：是
 - 描述：是否启用 Parquet 文件的 Bloom Filter 以提高性能。`true` 表示启用 Bloom Filter，`false` 表示禁用。还可以使用系统变量 `enable_parquet_reader_bloom_filter` 在 Session 级别上控制这一行为。Parquet 中的 Bloom Filter 是在**每个行组的列级维护的**。如果 Parquet 文件包含某些列的 Bloom Filter，查询就可以使用这些列上的谓词来有效地跳过行组。
 - 引入版本：v3.5
+
+
 
 ##### io_coalesce_adaptive_lazy_active
 
@@ -1570,6 +1591,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：在导入线程内存占用达到硬上限后，是否允许新的导入线程。`true` 表示允许新导入线程，`false` 表示拒绝新导入线程。
 - 引入版本：v3.3.2
 
+##### compaction_memory_limit_per_worker
+
+- Default: 2147483648
+- Type: Int
+- Unit: Bytes
+- Is mutable: No
+- Description: 每个 Compaction 线程允许使用的最大内存大小。
+- Introduced in: -
+
 ##### tablet_stat_cache_update_interval_second
 
 - 默认值：300
@@ -2009,6 +2039,24 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 是否动态：否
 - 描述：UDF 存放的路径。
 - 引入版本：-
+
+##### load_replica_status_check_interval_ms_on_success
+
+- Default: 15000
+- Type: Int
+- Unit: Milliseconds
+- Is mutable: Yes
+- Description: 当上一次检查 RPC 成功时，备副本向主副本检查其状态的间隔时间。
+- Introduced in: 3.5.1
+
+##### load_replica_status_check_interval_ms_on_failure
+
+- Default: 2000
+- Type: Int
+- Unit: Milliseconds
+- Is mutable: Yes
+- Description: 当最近一次检查 RPC 失败时，secondary replica 向 primary replica 再次检查其状态的间隔时间。
+- Introduced in: 3.5.1
 
 ##### enable_token_check
 


### PR DESCRIPTION

## Why I'm doing:

## What I'm doing:        

This PR updates the be_config documentation for the following languages:
- en, zh, ja

### Changed Files
- `docs/en/administration/management/BE_configuration.md`
- `docs/zh/administration/management/BE_configuration.md`
- `docs/ja/administration/management/BE_configuration.md`

### Generated by DocsAgent

This documentation was automatically generated by DocsAgent.

Please review the changes and merge if they look correct.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3