### PR TITLE
[BugFix] Resolve crash issue when `flat_path` is empty in `_extract_with_hyper`

### DIFF
--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -548,7 +548,9 @@ static StatusOr<ColumnPtr> _extract_with_hyper(NativeJsonState* state, const std
                 state->is_partial_match = true;
                 state->flat_column_type = TYPE_JSON;
             }
-            state->flat_path = flat_path.substr(1);
+            // Remove leading dot if flat_path is not empty
+            // flat_path starts with "." when paths are added, but can be empty if no paths were added
+            state->flat_path = flat_path.empty() ? "" : flat_path.substr(1);
             state->init_flat = true;
         });
     }

--- a/be/test/exprs/flat_json_functions_test.cpp
+++ b/be/test/exprs/flat_json_functions_test.cpp
@@ -435,6 +435,7 @@ class FlatGetJsonXXXTestFixture2 : public ::testing::TestWithParam<GetJsonXXXPar
 public:
     StatusOr<Columns> setup() {
         config::enable_json_flat_complex_type = true;
+        config::enable_lazy_dynamic_flat_json = true; // Enable hyper extraction path to test _extract_with_hyper
         _ctx = std::unique_ptr<FunctionContext>(FunctionContext::create_test_context());
         auto ints = JsonColumn::create();
         ColumnBuilder<TYPE_VARCHAR> builder(1);
@@ -594,7 +595,10 @@ INSTANTIATE_TEST_SUITE_P(GetJsonXXXTest, FlatGetJsonXXXTestFixture2,
         std::make_tuple(R"( {"k1": false} )", "$.k1", std::vector<std::string> { "k1"}, std::vector<LogicalType> {TYPE_JSON}, 0, 0, "false", 0.0),
         std::make_tuple(R"( {"k1": true} )", "$.k1", std::vector<std::string> { "k1"}, std::vector<LogicalType> {TYPE_VARCHAR}, 1, -1, "true", -1),
         std::make_tuple(R"( {"k1": false} )", "$.k1", std::vector<std::string> { "k1"}, std::vector<LogicalType> {TYPE_VARCHAR}, 0, -1, "false", -1),
-        std::make_tuple(R"( {"k1": "value" } )", "$.k1", std::vector<std::string> { "k1"}, std::vector<LogicalType> {TYPE_VARCHAR}, -1, -1, R"( value )", -1)
+        std::make_tuple(R"( {"k1": "value" } )", "$.k1", std::vector<std::string> { "k1"}, std::vector<LogicalType> {TYPE_VARCHAR}, -1, -1, R"( value )", -1),
+        // Test case to cover the bug fix: empty flat_path should not cause crash when calling substr(1)
+        // When path is "$", flat_path will be empty, and calling substr(1) on empty string would throw std::out_of_range
+        std::make_tuple(R"( {"k1": 1} )", "$", std::vector<std::string> { "k1"}, std::vector<LogicalType> {TYPE_BIGINT}, -1, -1, "NULL", -1)
     ));
 // clang-format on
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:


When the JSON path is "$" or all path segments are skipped, `flat_path` remains empty. Attempting to call `substr(1)` on an empty string triggers a `std::out_of_range` exception, leading to a process crash.

- Implement a check to ensure `flat_path` is not empty before invoking `substr(1)`.
- Add a unit test to validate scenarios where `flat_path` is empty.

Fixes #https://github.com/StarRocks/starrocks/issues/65248

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents out_of_range crash by conditionally stripping the leading dot from `flat_path` only when non-empty, and adds test coverage (enabling hyper extraction) for the `$` path case.
> 
> - **JSON extraction (backend)**:
>   - Update `_extract_with_hyper` in `be/src/exprs/json_functions.cpp` to set `state->flat_path` with a non-empty check (`flat_path.empty() ? "" : flat_path.substr(1)`), avoiding `std::out_of_range` when the JSON path is `$`.
> - **Tests**:
>   - Enable `config::enable_lazy_dynamic_flat_json` in `FlatGetJsonXXXTestFixture2` to exercise the hyper extraction path.
>   - Add test case where path is `$` to verify no crash and `NULL` result in `be/test/exprs/flat_json_functions_test.cpp`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a815c47559e5de7211f90d2b12358db5f006fcbf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->