### PR TITLE
[BugFix] fix bucket aware incremental scan range

### DIFF
--- a/test/sql/test_iceberg/R/test_bucket_aware_incremental_scan_range
+++ b/test/sql/test_iceberg/R/test_bucket_aware_incremental_scan_range
@@ -1,0 +1,45 @@
+-- name: test_bucket_aware_incremental_scan_range
+create external catalog iceberg_${uuid0} PROPERTIES ("type"="iceberg",
+    "iceberg.catalog.type"="hive", 
+    "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}"
+);
+-- result:
+-- !result
+select distinct entity_type_id from iceberg_${uuid0}.iceberg_oss_db.entity order by entity_type_id;
+-- result:
+a
+b
+c
+d
+e
+f
+g
+type_a
+type_b
+type_c
+-- !result
+SELECT
+  owner_id,
+  COUNT(*) AS count
+FROM iceberg_${uuid0}.iceberg_oss_db.entity
+GROUP BY owner_id
+ORDER BY count DESC, owner_id ASC
+LIMIT 10;
+-- result:
+owner_0	1000
+owner_1	1000
+owner_10	1000
+owner_100	1000
+owner_101	1000
+owner_102	1000
+owner_103	1000
+owner_104	1000
+owner_105	1000
+owner_106	1000
+-- !result
+drop catalog iceberg_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_bucket_aware_incremental_scan_range
+++ b/test/sql/test_iceberg/T/test_bucket_aware_incremental_scan_range
@@ -1,0 +1,21 @@
+-- name: test_bucket_aware_incremental_scan_range
+
+create external catalog iceberg_${uuid0} PROPERTIES ("type"="iceberg",
+    "iceberg.catalog.type"="hive", 
+    "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}",
+    "aws.s3.access_key" = "${oss_ak}",
+    "aws.s3.secret_key" = "${oss_sk}",
+    "aws.s3.endpoint" = "${oss_endpoint}"
+);
+
+select distinct entity_type_id from iceberg_${uuid0}.iceberg_oss_db.entity order by entity_type_id;
+
+SELECT
+  owner_id,
+  COUNT(*) AS count
+FROM iceberg_${uuid0}.iceberg_oss_db.entity
+GROUP BY owner_id
+ORDER BY count DESC, owner_id ASC
+LIMIT 10;
+
+drop catalog iceberg_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
For bucketed Iceberg tables, queries using bucket-aware execution may get stuck because incremental scan ranges cannot be deployed correctly in this scenario.
## What I'm doing:

Fixes [https://github.com/StarRocks/starrocks/issues/64786](https://github.com/StarRocks/starrocks/issues/64786)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
