### PR TITLE
[BugFix] Fix tenann SVE build not compatible with old arm platform

### DIFF
--- a/thirdparty/vars-aarch64.sh
+++ b/thirdparty/vars-aarch64.sh
@@ -46,10 +46,15 @@ JINDOSDK_SOURCE="jindosdk-4.6.8-linux-el7-aarch64"
 JINDOSDK_MD5SUM="27a4e2cd9a403c6e21079a866287d88b"
 
 # tenann
-TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.0-RELEASE/tenann-v0.5.0-RELEASE-arm64.tar.gz"
-TENANN_NAME="tenann-v0.5.0-RELEASE-arm64.tar.gz"
+TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.0-RELEASE/tenann-v0.5.0-RELEASE-arm64-nosve.tar.gz"
+TENANN_NAME="tenann-v0.5.0-RELEASE-arm64-nosve.tar.gz"
 TENANN_SOURCE="tenann-v0.5.0-RELEASE"
-TENANN_MD5SUM="b8683b3df546944b60bc8fe3db8db3af"
+TENANN_MD5SUM="18c61b80e3e4039bd3c6ca95231cb645"
+# uncomment this for SVE version for better performance on ARM servers with SVE support
+#TENANN_DOWNLOAD="https://github.com/StarRocks/tenann/releases/download/v0.5.0-RELEASE/tenann-v0.5.0-RELEASE-arm64.tar.gz"
+#TENANN_NAME="tenann-v0.5.0-RELEASE-arm64.tar.gz"
+#TENANN_SOURCE="tenann-v0.5.0-RELEASE"
+#TENANN_MD5SUM="b8683b3df546944b60bc8fe3db8db3af"
 
 # starcache
 STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v3.5-rc4/starcache-centos7_arm64.tar.gz"


### PR DESCRIPTION
## Why I'm doing:

The tenann used currently add requires SVE support on arm64 platform, but some custom still use old arm processor like NeoVerseN1 which does not support SVE

## What I'm doing:

This PR uses tenann nosve build variant for better compatibility.

Fixes  https://starrocks.atlassian.net/browse/SR-36851

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
