### PR TITLE
[Doc] docs(fe_config): update en, zh, ja documentation

### DIFF
--- a/docs/ja/administration/management/FE_configuration.md
+++ b/docs/ja/administration/management/FE_configuration.md
@@ -113,6 +113,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明: システムログファイルの保持期間。デフォルト値 `7d` は、各システムログファイルが 7 日間保持されることを指定します。StarRocks は各システムログファイルをチェックし、7 日前に生成されたものを削除します。
 - 導入バージョン: -
 
+##### sys_log_json_max_string_length
+
+- デフォルト: 1048576
+- 型: Int
+- 単位: Characters
+- 変更可能: いいえ
+- 説明: sys_log_format が "json" のときに JsonTemplateLayout の "maxStringLength" を設定します。これにより JSON 形式のログイベントで出力される文字列フィールドの最大長が制限されます（default、warning、audit、dump、および big_query レイアウトに適用されます；profile ログは sys_log_json_profile_max_string_length を使用します）。この制限を超える値は Log4j の JsonTemplateLayout の挙動に従って切り詰められます。エントリごとの JSON サイズを上限し、極端に長いログ行を避けるために使用してください。デフォルトは 1,048,576 文字（≈1 MiB）です。Log4j の設定は起動時に生成されるため、変更を反映するには再起動が必要です。
+- 導入バージョン: 3.2.11
+
+##### sys_log_json_profile_max_string_length
+
+- デフォルト: 104857600 (100 MiB)
+- 型: Int
+- 単位: Characters
+- 変更可能: いいえ
+- 説明: sys_log_format が "json" に設定されている場合、この値は profile ロガーの JsonTemplateLayout 属性 maxStringLength に書き込まれます。JSON のプロファイルログで出力される文字列フィールド（例："message" や文字列化された "exception" スタックトレース）の最大長を制限し、無制限のログレコードを回避します。この設定は profile ロガーのレイアウトにのみ適用され、他のロガーは sys_log_json_max_string_length を使用します。非常に大きなプロファイルペイロードを保持したい場合は値を大きく、長いフィールドを切り詰めてログサイズ／性能影響を抑えたい場合は値を小さく設定してください。
+- 導入バージョン: 3.2.11
+
 ##### audit_log_dir
 
 - デフォルト: StarRocksFE.STARROCKS_HOME_DIR + "/log"
@@ -169,6 +187,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明: 監査ログファイルの保持期間。デフォルト値 `30d` は、各監査ログファイルが 30 日間保持されることを指定します。StarRocks は各監査ログファイルをチェックし、30 日前に生成されたものを削除します。
 - 導入バージョン: -
 
+##### slow_lock_stack_trace_reserve_levels
+
+- デフォルト: 15
+- 型: Int
+- 単位: スタックフレーム（レベル）
+- 変更可能か: Yes
+- 説明: QueryableReentrantReadWriteLock がスローロックや競合のデバッグのためにスタックトレースを取得する際に、何レベル（フレーム）を保持して出力するかを制御します。この値は LogUtil.getStackTraceToJsonArray に渡され、getLockInfoToJson、getCurrReadersInfoToJsonArray、getOldestSharedLockHolderInfo が生成する owner、current-thread、oldest-reader のスタックダンプに影響します。値を大きくすると生成される JSON により深いコールスタックが含まれ（診断に有用）、ただし CPU、メモリ、ペイロードサイズが増加します。値を小さくするとオーバーヘッドは減りますが関連するフレームが欠落する可能性があります。変更はランタイムでの以降のロックダンプに即時反映されます。スローロック問題を調査する際は slow_lock_threshold_ms と合わせて調整してください。
+- 導入: 3.4.0, 3.5.0, 4.0.0
+
+##### slow_lock_print_stack
+
+- デフォルト: true
+- 型: Boolean
+- 単位: N/A
+- 変更可能か: Yes
+- 説明: true の場合、LockManager はスローロック警告（logSlowLockTrace）で出力する JSON に各ロック所有者のスレッドスタックトレースを含めます。これにより、長時間保持されているロックやデッドロックの診断においてスローロックログが格段に有用になります。スタックトレースの取得は比較的コストが高く、非常に大規模なクラスターや多数のスレッドが関与する環境では CPU 停止や IO オーバーヘッドを引き起こすことがあるため、そのオーバーヘッドを避けたい場合は無効（false に設定）にしてください。このフラグはランタイムで参照されるため再起動なしで切り替え可能です。スタック深度をより細かく制御するには slow_lock_stack_trace_reserve_levels を参照してください。スローロック検出自体は slow_lock_threshold_ms によって駆動されます。
+- 導入: 3.3.16, 3.4.5, 3.5.1, 4.0.0
+
 ##### dump_log_dir
 
 - デフォルト: StarRocksFE.STARROCKS_HOME_DIR + "/log"
@@ -215,6 +251,42 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 変更可能: いいえ
 - 説明: ダンプログファイルの保持期間。デフォルト値 `7d` は、各ダンプログファイルが 7 日間保持されることを指定します。StarRocks は各ダンプログファイルをチェックし、7 日前に生成されたものを削除します。
 - 導入バージョン: -
+
+##### big_query_log_modules
+
+- デフォルト: {"query"}
+- 型: String[]
+- 単位: N/A
+- 変更可能か: いいえ
+- 説明: Log4j が専用の big_query ロガーを作成するモジュール識別子のリスト。各エントリ X に対して、Log4jConfig は INFO レベルで "big_query.X" という名前のロガーを登録し、その出力を BigQuery のローテーションファイルアペンダー (fe.big_query.log) にルーティングします。これを使うと、特定コンポーネント（例: "query"）に関連する BigQuery ログを big_query ログファイルにキャプチャして分離できます（BigQuery ログのロールおよび保持設定に従います）。この設定はログ初期化時に読み込まれるため、リストを変更するには FE プロセスを再起動する必要があります。
+- 導入バージョン: 3.2.0
+
+##### big_query_log_roll_interval
+
+- デフォルト: "DAY"
+- 型: String
+- 単位: N/A
+- 変更可能か: いいえ
+- 説明: BigQuery ロガー (fe.big_query.log) の時間ベースのファイルパターンを生成する際に使用される時間粒度を制御します。大文字小文字を区別しない受け入れ値: "HOUR" -> パターン "%d{yyyyMMddHH}"（毎時ロール）, "DAY" -> パターン "%d{yyyyMMdd}"（毎日ロール）。設定されたパターンは RollingFile アペンダーのサイズベースポリシーと組み合わされるため、ログファイルは設定された時間境界でロールするか、サイズ閾値を超えたときにロールします。その他の値が設定された場合、Log4jConfig はログ構成のビルド時に起動時に IOException を投げます。
+- 導入バージョン: 3.2.0
+
+##### log_plan_cancelled_by_crash_be
+
+- デフォルト: true
+- 型: Boolean
+- 単位: N/A
+- 変更可能: はい
+- 説明: true の場合、バックエンドのクラッシュ検出や RpcException によりクエリがキャンセルされ、かつ query-detail の収集が無効になっているときに、StarRocks はクエリ実行プラン（TExplainLevel.COSTS による explain）を FE のログに WARN レベルで出力します。このログ出力はバックエンド障害を検出するコード経路（StmtExecutor、TransactionStmtExecutor）および ExecuteExceptionHandler（最初のリトライ試行時のみ、retryTime == 0）で行われます。バックエンドが利用不能になるような障害のデバッグ支援を目的としています。Enable_collect_query_detail_info が有効な場合はこの設定より優先され、クエリ詳細が記録されるためここでの追加ログは不要です。注意: 有効にするとログ量が増加し、ログに SQL やプランの詳細が露出する可能性があります。
+- 導入: 3.2.0
+
+##### log_register_and_unregister_query_id
+
+- デフォルト: false
+- 型: Boolean
+- 単位: N/A
+- 変更可能: はい
+- 説明: 有効にすると、Frontend はクエリライフサイクル追跡中の register/unregister query ID イベントについてログを出力します。実際にログに記録されるのは ConnectContext が存在し、かつコマンドが COM_STMT_EXECUTE（prepared-statement execute）でないか、またはセッション変数 auditExecuteStmt が true の場合のみです（QeProcessorImpl.java の使用箇所を参照）。高並列環境ではこれらのログがスループットのボトルネック（I/O と同期）になることがあるため、このスイッチを無効にすると特定のライフサイクルログを停止してログオーバーヘッドと競合を減らせますが、クエリ監査/トレースの可視性は低下します。運用ニーズに応じてランタイムで切り替えてください（監査/トラブルシューティング時は有効に、ピーク性能/高スループット時は無効に）。
+- 導入: 3.3.0, 3.4.0, 3.5.0, 4.0.0
 
 ### サーバー
 
@@ -271,6 +343,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 変更可能: No
 - 説明: FEノードにおいて、HTTP サーバーと並行して HTTPS サーバーを有効化するかどうか。
 - 導入バージョン: v4.0
+
+##### ssl_cipher_whitelist
+
+- Default: Empty string
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: カンマ区切りのリスト。IANA 名による ssl cipher suites をホワイトリスト化するために regex をサポートします。whitelist と blacklist の両方が設定されている場合は blacklist が優先されます。
+- Introduced in: v4.0
+
+##### ssl_cipher_blacklist
+
+- Default: Empty string
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: カンマ区切りのリスト。IANA 名による ssl cipher suites をブラックリスト化するために regex をサポートします。whitelist と blacklist の両方が設定されている場合は blacklist が優先されます。
+- Introduced in: v4.0
 
 ##### http_worker_threads_num
 
@@ -968,6 +1058,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明: データが初めてテーブルにロードされるときに自動的に統計を収集するかどうか。テーブルに複数のパーティションがある場合、このテーブルの空のパーティションにデータがロードされると、自動統計収集がトリガーされます。新しいテーブルが頻繁に作成され、データが頻繁にロードされる場合、メモリと CPU のオーバーヘッドが増加します。
 - 導入バージョン: v3.1
 
+##### semi_sync_collect_statistic_await_seconds
+
+- Default: 30
+- Type: Long
+- Unit: Seconds
+- Is mutable: Yes
+- Description: DML 操作（INSERT および INSERT OVERWRITE 文）中の semi-synchronous 統計収集に対する最大待機時間。Stream load と broker load は非同期モードを使用するため、この設定の影響を受けません。統計収集がこのタイムアウトを超えた場合、収集の完了を待たずにロードは継続されます。この設定は `enable_statistic_collect_on_first_load` と併用されます。
+- Introduced in: v3.1
+
 ##### statistic_auto_analyze_start_time
 
 - デフォルト: 00:00:00
@@ -1003,6 +1102,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 変更可能: はい
 - 説明: 自動収集中にデータの更新をチェックする間隔。
 - 導入バージョン: -
+
+##### enable_predicate_columns_collection
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: predicate columns collection を有効にするかどうか。無効にすると、query optimization 時に predicate columns は記録されません。
+- Introduced in: -
 
 ##### statistic_cache_columns
 
@@ -3088,6 +3196,10 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 変更可能: いいえ
 - 説明: JWT 内のオーディエンス (`aud`) を識別するために使用される文字列のリスト。リスト内のいずれかの値が JWT のオーディエンスと一致する場合にのみ、JWT は有効と見なされます。
 - 導入バージョン: v3.5.0
+
+
+
+<EditionSpecificFEItem />
 
 
 

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -114,6 +114,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述：系统日志文件的保留时长。默认值 `7d` 表示系统日志文件可以保留 7 天，保留时长超过 7 天的系统日志文件会被删除。
 - 引入版本：-
 
+##### sys_log_to_console
+
+- 默认: ((System.getenv("SYS_LOG_TO_CONSOLE") != null) ? System.getenv("SYS_LOG_TO_CONSOLE").trim().equals("1") : false)
+- 类型: boolean
+- 单位: N/A
+- 是否可变: 否
+- 描述: 控制 StarRocks 是否将日志输出到控制台（stdout/stderr）而不是轮转日志文件。当为 true 时，Log4j 配置使用控制台 appender（ConsoleErr）和控制台 logger 模板；当为 false（默认）时，使用基于文件的 appender 和文件 logger 模板。默认值在进程启动时从环境变量 SYS_LOG_TO_CONSOLE 读取一次（设置为 "1" 以启用）。由于该项在运行时不可变，必须在启动 FE 进程之前设置或取消设置 SYS_LOG_TO_CONSOLE。对于容器化部署或收集 stdout/stderr 的场景使用控制台日志；需要文件轮转和磁盘保留时使用文件日志。
+- 引入版本: 3.2.0
+
+##### sys_log_format
+
+- 默认: "plaintext"
+- 类型: String
+- 单位: N/A
+- 是否可变: 否
+- 描述: 控制 FE 系统日志使用的 Log4j layout 格式。支持的值（不区分大小写）："json" 和 "plaintext"。如果设置为 "json"，Log4jConfig 会构建一个 JsonTemplateLayout（UTC 时间戳及结构化字段，如 level、thread、file、method、line、message、exception），并使用 Config.sys_log_json_max_string_length / sys_log_json_profile_max_string_length 作为字段最大长度。任何其他值（包括无效值）都会回退到 plaintext 的 PatternLayout，输出可读的行（包含时间戳、级别、线程、class.method:line）并在警告时包含堆栈跟踪。此设置决定应用于所有主要 appender（sys、warn、audit、dump、big_query、profile、internal、console）的 layout。因为该项不可变，修改需要重启 FE 进程才能生效。
+- 引入版本: 3.2.10
+
 ##### audit_log_dir
 
 - 默认值：StarRocksFE.STARROCKS_HOME_DIR + "/log"
@@ -170,6 +188,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述：审计日志文件的保留时长。默认值 `30d` 表示审计日志文件可以保留 30 天，保留时长超过 30 天的审计日志文件会被删除。
 - 引入版本：-
 
+##### slow_lock_threshold_ms
+
+- 默认: 3000L
+- 类型: long
+- 单位: Milliseconds
+- 是否可变: 是
+- 描述: 用于将锁操作归类为“慢”的阈值（毫秒）。当获取锁的时间或锁被持有的时间超过此值时，StarRocks 会将该锁纳入慢锁诊断和日志（由 LockUtils 和 QueryableReentrantReadWriteLock 使用）、包含在周期性报告中（LockChecker），并影响 LockManager 何时开始死锁检测和输出慢锁追踪。将此值降低会使系统更早检测并记录慢锁（增加日志与死锁检查活动）；提高此值会延迟检测并减少诊断噪音。值 <= 0 会禁用基于此阈值的延迟逻辑（即推迟死锁检查的初始延迟逻辑）。
+- 引入版本: 3.2.0
+
+##### slow_lock_log_every_ms
+
+- 默认: 3000L
+- 类型: Long
+- 单位: Milliseconds
+- 是否可变: 是
+- 描述: 控制对同一 SlowLockLogStats 实例连续输出“慢锁”警告日志之间的最小间隔（毫秒）。在 LockUtils.logSlowLockEventIfNeeded 中，代码仅在锁等待时间超过 slow_lock_threshold_ms 且当前时间大于 lastSlowLockLogTime + slow_lock_log_every_ms 时才发出警告。该参数有效地对同一锁拥有者/上下文的重复慢锁警告进行速率限制。在繁忙系统上可以调大以减少日志噪音，或调小以更频繁地观察重复的锁竞争。注意它与 slow_lock_threshold_ms（用于定义什么算“慢”）配合工作。
+- 引入版本: 3.2.0
+
 ##### dump_log_dir
 
 - 默认值：StarRocksFE.STARROCKS_HOME_DIR + "/log"
@@ -216,6 +252,42 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 是否动态：否
 - 描述：Dump 日志文件的保留时长。默认值 `7d` 表示 Dump 日志文件可以保留 7 天，保留时长超过 7 天的 Dump 日志文件会被删除。
 - 引入版本：-
+
+##### big_query_log_dir
+
+- 默认: Config.STARROCKS_HOME_DIR + "/log"
+- 类型: String
+- 单位: Path
+- 是否可变: 否
+- 描述: FE 将 FE 大查询转储日志 (fe.big_query.log) 写入的文件系统目录。Log4jConfig 使用此路径为大查询记录创建 RollingFile appender；该 appender 会写入 fe.big_query.log，并根据 big_query_log_roll_interval、big_query_log_roll_num 和 log_roll_size_mb 轮转文件，并根据 big_query_log_delete_age 删除旧文件。如果希望将大查询日志与常规日志分离，请将其设置为可写路径（最好位于具有足够空间和 I/O 的卷上）。由于此设置在运行时不可变，更改它需要更新配置并重启 FE 进程。
+- 引入于: 3.2.0
+
+##### big_query_log_roll_num
+
+- 默认: 10
+- 类型: Int
+- 单位: Files
+- 是否可变: 否
+- 描述: Log4j 的 DefaultRolloverStrategy 在每个轮转间隔内为 FE 大查询日志文件 (fe.big_query.log.*) 保留的最大已轮转文件数。该值设置为 Log4j 使用的 rollover 策略的 "max" 属性（参见 Log4jConfig），限定在基于时间或大小的轮转发生时会保留多少带索引/归档的文件。超过该计数的较旧文件将有资格被移除（删除还受 big_query_log_delete_age 和配置的轮转间隔/模式约束）。更改此值会影响磁盘使用量以及用于调试大查询的历史记录量；由于此设置在运行时不可变，更改需更新配置并重启 FE 以生效。
+- 引入于: 3.2.0
+
+##### profile_log_roll_size_mb
+
+- 默认: 1024
+- 类型: Int
+- 单位: MB
+- 是否可变: No
+- 描述: profile 日志 appender (fe.profile.log) 在 Log4j 触发基于大小的轮转之前的最大文件大小（以兆字节为单位）。用于 profile 日志的 RollingFile appender 同时使用 TimeBasedTriggeringPolicy 和 SizeBasedTriggeringPolicy，因此当满足配置的时间间隔到达或超过此大小阈值时都会触发轮转。增大此值会减少轮转频率并产生更大的单文件日志；减小它会增加轮转文件的数量。保留与清理由 profile_log_roll_num（轮转文件数量）和 profile_log_delete_age（基于年龄的删除）单独控制。
+- 引入于: 3.2.5
+
+##### enable_profile_log_compress
+
+- 默认: false
+- 类型: Boolean
+- 单位: N/A
+- 是否可变: No
+- 描述: 为 true 时，StarRocks 在将 JSON 序列化的查询 profile (queryDetail) 写入 PROFILE_LOG 之前使用 GZIP 进行压缩。此选项仅在 enable_collect_query_detail_info 和 enable_profile_log 同时启用时生效。压缩可减小日志大小，但会使记录的负载不可读；PROFILE_LOG 的消费者必须解码 GZIP 才能还原原始 JSON。如果压缩失败，代码会记录警告并且不会写入该 profile（不会自动回退为未压缩输出）。当下游日志处理器期望 gzip 负载且希望为大型 profile 条目节省存储和 I/O 时使用此设置。
+- 引入于: 3.2.7
 
 ### 服务器
 
@@ -272,6 +344,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 是否动态：No
 - 描述：是否在 FE 节点上同时启用 HTTPS 服务器和 HTTP 服务器。
 - 引入版本：v4.0
+
+##### ssl_cipher_whitelist
+
+- 默认: Empty string
+- 类型: String
+- 单位: -
+- 是否可变: No
+- 描述: 以逗号分隔的列表，支持正则，通过 IANA 名称将 SSL cipher suites 列入白名单。如果同时设置了白名单和黑名单，以黑名单优先。
+- 引入版本: v4.0
+
+##### ssl_cipher_blacklist
+
+- 默认: Empty string
+- 类型: String
+- 单位: -
+- 是否可变: No
+- 描述: 以逗号分隔的列表，支持正则，通过 IANA 名称将 SSL cipher suites 列入黑名单。如果同时设置了白名单和黑名单，以黑名单优先。
+- 引入版本: v4.0
 
 ##### http_worker_threads_num
 
@@ -731,15 +821,6 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
   - 目前，此功能不支持 JDBC Catalog 和表名。若需对 JDBC 或 ODBC 数据源进行大小写不敏感处理，请勿启用此功能。
 - 引入版本：v4.0
 
-##### txn_latency_metric_report_groups
-
-- 默认值：空字符串
-- 类型：String
-- 单位：-
-- 是否可变: 是
-- 描述：需要汇报的事务延迟监控指标组，多个指标组通过逗号分隔。导入类型基于监控组分类，被启用的组其名称会作为 'type' 标签添加到监控指标中。常见的组包括 `stream_load`、`routine_load`、`broker_load`、`insert`，以及 `compaction` (仅适用于存算分离集群)。示例：`"stream_load,routine_load"`。
-- 引入版本: v4.0
-
 ### 用户，角色及权限
 
 ##### privilege_max_total_roles_per_user
@@ -1034,6 +1115,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述：自动定期采集任务中，检测数据更新的间隔时间。
 - 引入版本：-
 
+##### enable_predicate_columns_collection
+
+- 默认值：true
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：是否启用 Predicate Column 采集。如果禁用，在查询优化期间将不会记录 Predicate Column。
+- 引入版本：-
+
 ##### statistic_cache_columns
 
 - 默认值：100000
@@ -1132,15 +1222,6 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 是否动态：是
 - 描述：是否允许自动采集 ARRAY 类型列的 NDV 信息。
 - 引入版本：v4.0
-
-##### enable_predicate_columns_collection
-
-- 默认值：true
-- 类型：Boolean
-- 单位：-
-- 是否动态：是
-- 描述：是否启用 Predicate Column 采集。如果禁用，在查询优化期间将不会记录 Predicate Column。
-- 引入版本：-
 
 ##### histogram_buckets_size
 
@@ -3134,6 +3215,11 @@ Compaction Score 代表了一个表分区是否值得进行 Compaction 的评分
 - 是否动态：是
 - 描述：是否允许系统跟踪历史节点。将此项设置为 `true`，就可以启用 Cache Sharing 功能，并允许系统在弹性扩展过程中选择正确的缓存节点。
 - 引入版本：v3.5.1
+
+
+
+
+<EditionSpecificFEItem />
 
 
 


### PR DESCRIPTION

## Why I'm doing:

## What I'm doing:        

This PR updates the fe_config documentation for the following languages:
- en, zh, ja

### Changed Files
- `docs/en/administration/management/FE_configuration.md`
- `docs/zh/administration/management/FE_configuration.md`
- `docs/ja/administration/management/FE_configuration.md`

### Generated by DocsAgent

This documentation was automatically generated by DocsAgent.

Please review the changes and merge if they look correct.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3