### PR TITLE
[BugFix] Fix MV async refresh skipping sub-partition updates in multi-level partitioned base tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/OlapPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/OlapPartitionTraits.java
@@ -30,6 +30,7 @@ import org.apache.commons.lang.NotImplementedException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -133,10 +134,23 @@ public class OlapPartitionTraits extends DefaultTraits {
      */
     public static boolean isBaseTableChanged(Partition partition,
                                              MaterializedView.BasePartitionInfo mvRefreshedPartitionInfo) {
-        return mvRefreshedPartitionInfo.getId() != partition.getId()
-                || partition.getDefaultPhysicalPartition().getVisibleVersion() != mvRefreshedPartitionInfo.getVersion()
-                || partition.getDefaultPhysicalPartition().getVisibleVersionTime()
-                > mvRefreshedPartitionInfo.getLastRefreshTime();
+        if (mvRefreshedPartitionInfo.getId() != partition.getId()) {
+            return true;
+        }
+        long lastRefreshTime = mvRefreshedPartitionInfo.getLastRefreshTime();
+        Collection<PhysicalPartition> subPartitions = partition.getSubPartitions();
+        if (subPartitions != null && !subPartitions.isEmpty()) {
+            for (PhysicalPartition subPartition : subPartitions) {
+                if (subPartition.getVisibleVersionTime() > lastRefreshTime) {
+                    return true;
+                }
+            }
+            return false;
+        } else {
+            PhysicalPartition defaultPartition = partition.getDefaultPhysicalPartition();
+            return defaultPartition.getVisibleVersion() != mvRefreshedPartitionInfo.getVersion()
+                    || defaultPartition.getVisibleVersionTime() > lastRefreshTime;
+        }
     }
 
     public List<Column> getPartitionColumns() {


### PR DESCRIPTION

## Why I'm doing:

## What I'm doing:
This PR fixes the bug where asynchronous materialized view (MV) refreshes skip updates in multi-level partitioned base tables. The issue occurs because the refresh logic only checks the parent partition's metadata (ID, VisibleVersion, VisibleVersionTime), failing to detect changes in sub-partitions.

Fixes #issue
https://github.com/StarRocks/starrocks/issues/65144

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [x] 3.4
  - [ ] 3.3

