### PR TITLE
[BugFix] Fix read listener not support ssl

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlChannel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlChannel.java
@@ -37,6 +37,7 @@ package com.starrocks.mysql;
 import com.starrocks.common.util.NetUtils;
 import com.starrocks.mysql.nio.MySQLReadListener;
 import com.starrocks.mysql.ssl.SSLChannel;
+import com.starrocks.mysql.ssl.SSLDecoder;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ConnectProcessor;
 import org.apache.logging.log4j.LogManager;
@@ -141,6 +142,13 @@ public class MysqlChannel {
 
     public void setSSLChannel(SSLChannel sslChannel) {
         this.sslChannel = sslChannel;
+    }
+
+    public SSLDecoder getSSLDecoder() {
+        if (this.sslChannel == null) {
+            return null;
+        }
+        return this.sslChannel.createDecoder();
     }
 
     protected int readAll(ByteBuffer dstBuf) throws IOException {

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/ssl/SSLChannel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/ssl/SSLChannel.java
@@ -24,4 +24,6 @@ public interface SSLChannel {
     int readAll(ByteBuffer buffer) throws IOException;
 
     void write(ByteBuffer buffer) throws IOException;
+
+    SSLDecoder createDecoder();
 }

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/ssl/SSLChannelImp.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/ssl/SSLChannelImp.java
@@ -433,4 +433,8 @@ public class SSLChannelImp implements SSLChannel {
         replaceBuffer.put(buffer);
         return replaceBuffer;
     }
+
+    public SSLDecoder createDecoder() {
+        return new SSLDecoder(sslEngine, peerNetData, peerAppData);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/ssl/SSLDecoder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/ssl/SSLDecoder.java
@@ -1,0 +1,103 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.mysql.ssl;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLEngineResult;
+
+public class SSLDecoder {
+    private static final Logger LOG = LogManager.getLogger(SSLDecoder.class);
+
+    private final SSLEngine sslEngine;
+
+    // Encrypted data buffer (network)
+    private ByteBuffer netBuffer;
+    // Decrypted plaintext buffer
+    private ByteBuffer appBuffer;
+
+    public SSLDecoder(SSLEngine sslEngine, ByteBuffer netBuffer, ByteBuffer appBuffer) {
+        this.sslEngine = sslEngine;
+        this.netBuffer = netBuffer;
+        this.appBuffer = appBuffer;
+        this.netBuffer.compact();
+    }
+
+    public void feed(ByteBuffer encryptedInput) throws IOException {
+        // Check if netBuffer has enough remaining capacity
+        if (encryptedInput.remaining() > netBuffer.remaining()) {
+            // Expand netBuffer if needed
+            ByteBuffer newBuf = ByteBuffer.allocate(
+                    Math.max(netBuffer.capacity() * 2, netBuffer.position() + encryptedInput.remaining()));
+            netBuffer.flip();
+            newBuf.put(netBuffer);
+            netBuffer = newBuf;
+        }
+        netBuffer.put(encryptedInput);
+    }
+
+    public ByteBuffer decode() throws IOException {
+        if (!appBuffer.hasRemaining()) {
+            appBuffer.clear();
+        }
+        netBuffer.flip();
+
+        while (netBuffer.hasRemaining()) {
+            SSLEngineResult result = sslEngine.unwrap(netBuffer, appBuffer);
+            switch (result.getStatus()) {
+                case OK:
+                    // No progress (no bytes consumed or produced), break the loop to avoid busy-wait
+                    if (result.bytesConsumed() == 0 && result.bytesProduced() == 0) {
+                        netBuffer.compact();
+                        appBuffer.flip();
+                        return appBuffer;
+                    }
+                    break;
+                case BUFFER_OVERFLOW:
+                    // appBuffer is too small, expand it and retry
+                    expandAppBuffer();
+                    continue;
+                case BUFFER_UNDERFLOW:
+                    // Not enough encrypted data, preserve remaining data in netBuffer
+                    // and exit. More data will be fed in the next read event.
+                    netBuffer.compact();
+                    appBuffer.flip();
+                    return appBuffer;
+                case CLOSED:
+                    throw new IOException("SSL engine closed");
+                default:
+                    throw new IllegalStateException("Unexpected SSL status: " + result.getStatus());
+            }
+        }
+
+        // All encrypted data consumed, flip appBuffer for reading
+        netBuffer.compact();
+        appBuffer.flip();
+        return appBuffer;
+    }
+
+    private void expandAppBuffer() {
+        int newCapacity = appBuffer.capacity() * 2;
+        ByteBuffer newBuf = ByteBuffer.allocateDirect(newCapacity);
+        appBuffer.flip();
+        newBuf.put(appBuffer);
+        appBuffer = newBuf;
+    }
+
+}


### PR DESCRIPTION
## Why I'm doing:

#64355 does not support SSL. In this patch we add the ssl implements.

## What I'm doing:

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a streaming SSL decoder and wire it into the MySQL read listener so SSL-encrypted traffic is decoded before MySQL packet parsing.
> 
> - **MySQL I/O (SSL support)**:
>   - Add `SSLDecoder` for streaming TLS unwrap (`feed`/`decode`).
>   - Extend `SSLChannel` with `createDecoder()` and implement in `SSLChannelImp`.
>   - Expose `MysqlChannel.getSSLDecoder()` to provide per-connection decoder.
>   - Update `MySQLReadListener` to use `SSLDecoder` (if present) before `MysqlPackageDecoder`; minor variable rename.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 936f6691d41c8808009e48c25d285337bbaa3a1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->