### PR TITLE
[Enhancement] Fix MaterializedIndex rowCount inconsistency after publish

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndex.java
@@ -243,6 +243,20 @@ public class MaterializedIndex extends MetaObject implements Writable, GsonPostP
         this.rowCount = rowCount;
     }
 
+    /**
+     * Update rowCount by calculating from all tablets' rowCount for the given version.
+     * This method ensures consistency between replica rowCount and MaterializedIndex rowCount.
+     *
+     * @param version the version to use when getting rowCount from tablets
+     */
+    public void updateRowCount(long version) {
+        long indexRowCount = 0L;
+        for (Tablet tablet : getTablets()) {
+            indexRowCount += tablet.getRowCount(version);
+        }
+        this.rowCount = indexRowCount;
+    }
+
     public long getDataSize() {
         return getDataSize(false);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1295,6 +1295,9 @@ public class DatabaseTransactionMgr {
                                     transactionState.addUnknownReplica(replicaId);
                                 }
                             }
+                            // Update MaterializedIndex rowCount after updating all replicas' rowCount
+                            // to keep consistency between replica rowCount and MaterializedIndex rowCount
+                            index.updateRowCount(partitionCommitInfo.getVersion());
                         }
                     }
                     for (Long partitionId : droppedPartitionIds) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

When publishing a transaction, the `replica rowCount` was updated, but the `MaterializedIndex rowCount` was not immediately synchronized. This led to a temporary inconsistency between the `replica rowCount` and the `MaterializedIndex rowCount` until the periodic task of `TabletStatMgr` resolved it.

- Invoked the `updateRowCount()` method in `DatabaseTransactionMgr` right after updating the `replica rowCount` during the publish phase.
- Ensured that the `MaterializedIndex rowCount` is immediately aligned with the `replica rowCount` following the transaction publish process.


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
