### PR TITLE
[Doc] docs(fe_config): update en, zh, ja documentation

### DIFF
--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -273,6 +273,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述：是否在 FE 节点上同时启用 HTTPS 服务器和 HTTP 服务器。
 - 引入版本：v4.0
 
+##### ssl_cipher_whitelist
+
+- 默认值: Empty string
+- 类型: String
+- 单位: -
+- 是否可变: No
+- 描述: 以逗号分隔的列表，支持正则，用于按 IANA 名称对白名单化 SSL cipher suites。如果同时设置了白名单和黑名单，以黑名单为准。
+- 引入版本: v4.0
+
+##### ssl_cipher_blacklist
+
+- 默认值: Empty string
+- 类型: String
+- 单位: -
+- 是否可变: No
+- 描述: 以逗号分隔的列表，支持正则，用于按 IANA 名称对 SSL cipher suites 进行黑名单化。如果同时设置了白名单和黑名单，以黑名单为准。
+- 引入版本: v4.0
+
 ##### http_worker_threads_num
 
 - 默认值：0
@@ -602,6 +620,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述：BE 被下线后，是否删除该 BE。true 代表 BE 被下线后会立即删除该 BE。False 代表下线完成后不删除 BE。
 - 引入版本：-
 
+##### txn_latency_metric_report_groups
+
+- 默认值：空字符串
+- 类型：String
+- 单位：-
+- 是否可变: 是
+- 描述：需要汇报的事务延迟监控指标组，多个指标组通过逗号分隔。导入类型基于监控组分类，被启用的组其名称会作为 'type' 标签添加到监控指标中。常见的组包括 `stream_load`、`routine_load`、`broker_load`、`insert`，以及 `compaction` (仅适用于存算分离集群)。示例：`"stream_load,routine_load"`。
+- 引入版本: v4.0
+
 ##### ignore_materialized_view_error
 
 - 默认值：false
@@ -730,15 +757,6 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
   - 您只能在创建集群时启用此功能。**集群启动后，此配置项的值无法通过任何方式修改**。任何修改尝试均会导致错误。当 FE 检测到此配置项的值与集群首次启动时不一致时，FE 将无法启动。  
   - 目前，此功能不支持 JDBC Catalog 和表名。若需对 JDBC 或 ODBC 数据源进行大小写不敏感处理，请勿启用此功能。
 - 引入版本：v4.0
-
-##### txn_latency_metric_report_groups
-
-- 默认值：空字符串
-- 类型：String
-- 单位：-
-- 是否可变: 是
-- 描述：需要汇报的事务延迟监控指标组，多个指标组通过逗号分隔。导入类型基于监控组分类，被启用的组其名称会作为 'type' 标签添加到监控指标中。常见的组包括 `stream_load`、`routine_load`、`broker_load`、`insert`，以及 `compaction` (仅适用于存算分离集群)。示例：`"stream_load,routine_load"`。
-- 引入版本: v4.0
 
 ### 用户，角色及权限
 
@@ -966,41 +984,36 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 类型：Boolean
 - 单位：-
 - 是否动态：是
-- 描述：控制数据导入操作触发的自动统计信息采集和维护。包括：
-  - 分区首次导入数据时的统计信息采集（分区版本号为 2）。
-  - 多分区表的空分区导入数据时的统计信息采集。
-  - INSERT OVERWRITE 操作的统计信息复制和更新。
+- 描述：控制数据导入操作触发的自动统计信息采集和维护。包括：(1) 分区首次导入数据时的统计信息采集（分区版本号为 2）。(2) 多分区表的空分区导入数据时的统计信息采集。(3) INSERT OVERWRITE 操作的统计信息复制和更新。
 
   **统计信息采集类型的决策策略：**
   
   - 对于 INSERT OVERWRITE：`deltaRatio = |targetRows - sourceRows| / (sourceRows + 1)`
-    - 如果 `deltaRatio < statistic_sample_collect_ratio_threshold_of_first_load`（默认：0.1），则不采集统计信息，仅复制现有统计信息。
-    - 否则，如果 `targetRows > statistic_sample_collect_rows`（默认：200000），则使用抽样统计信息。
-    - 否则，使用全量统计信息。
+    - 如果 `deltaRatio < statistic_sample_collect_ratio_threshold_of_first_load`（默认 0.1）：不采集，复制现有统计信息
+    - 否则如果 `targetRows > statistic_sample_collect_rows`（默认 200000）：使用抽样统计信息
+    - 否则：使用全量统计信息
   
-  - 对于首次导入：`deltaRatio = loadRows / (totalRows + 1)`
-    - 如果 `deltaRatio < statistic_sample_collect_ratio_threshold_of_first_load`（默认：0.1），则不采集统计信息。
-    - 否则，如果 `loadRows > statistic_sample_collect_rows`（默认：200000），则使用抽样统计信息。
-    - 否则，使用全量统计信息。
+  - 对于首次加载：`deltaRatio = loadRows / (totalRows + 1)`
+    - 如果 `deltaRatio < statistic_sample_collect_ratio_threshold_of_first_load`（默认 0.1）：不采集
+    - 否则如果 `loadRows > statistic_sample_collect_rows`（默认 200000）：使用抽样统计信息
+    - 否则：使用全量统计信息
   
   **同步行为：**
   
-  - DML 语句（INSERT INTO/INSERT OVERWRITE）：同步模式，带表锁。等待统计信息采集完成（最多等待 `semi_sync_collect_statistic_await_seconds` 秒）。
-  - Stream Load 和 Broker Load：异步模式，不加锁。统计信息采集在后台运行，不阻塞导入。
+  - DML 语句（INSERT/INSERT OVERWRITE）：同步模式，带表锁。等待统计信息采集完成（最多等待 `semi_sync_collect_statistic_await_seconds` 秒）。
+  - Stream load 和 Broker load：异步模式，不加锁。统计信息采集在后台运行，不阻塞导入。
   
-  :::note
-  禁用此配置将阻止所有由导入触发的统计信息操作，包括 INSERT OVERWRITE 的统计信息维护，这可能导致表缺少统计信息。如果系统频繁创建新表并且导入数据，启用此功能会存在一定内存和 CPU 开销。
-  :::
+  **注意：** 禁用此配置将阻止所有由导入触发的统计信息操作，包括 INSERT OVERWRITE 的统计信息维护，这可能导致表缺少统计信息。如果系统频繁创建新表并且导入数据，启用此功能会存在一定内存和 CPU 开销。
 
 - 引入版本：v3.1
 
 ##### semi_sync_collect_statistic_await_seconds
 
 - 默认值：30
-- 类型：Int
+- 类型：Long
 - 单位：Seconds
 - 是否动态：是
-- 描述：DML 操作（INSERT 和 INSERT OVERWRITE 语句）期间半同步统计信息采集的最大等待时间。Stream Load 和 Broker Load 使用异步模式，不受此设置影响。如果统计信息采集超过此超时时间，导入将继续进行而不等待采集完成。此设置与 `enable_statistic_collect_on_first_load` 配合使用。
+- 描述：DML 操作（INSERT 和 INSERT OVERWRITE 语句）期间半同步统计信息采集的最大等待时间。Stream load 和 Broker load 使用异步模式，不受此设置影响。如果统计信息采集超过此超时时间，导入将继续进行而不等待采集完成。此设置与 `enable_statistic_collect_on_first_load` 配合使用。
 - 引入版本：v3.1
 
 ##### statistic_auto_analyze_start_time
@@ -1037,6 +1050,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 单位：Seconds
 - 是否动态：是
 - 描述：自动定期采集任务中，检测数据更新的间隔时间。
+- 引入版本：-
+
+##### enable_predicate_columns_collection
+
+- 默认值：true
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：是否启用 Predicate Column 采集。如果禁用，在查询优化期间将不会记录 Predicate Column。
 - 引入版本：-
 
 ##### statistic_cache_columns
@@ -1137,15 +1159,6 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 是否动态：是
 - 描述：是否允许自动采集 ARRAY 类型列的 NDV 信息。
 - 引入版本：v4.0
-
-##### enable_predicate_columns_collection
-
-- 默认值：true
-- 类型：Boolean
-- 单位：-
-- 是否动态：是
-- 描述：是否启用 Predicate Column 采集。如果禁用，在查询优化期间将不会记录 Predicate Column。
-- 引入版本：-
 
 ##### histogram_buckets_size
 
@@ -1813,15 +1826,6 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 是否动态：是
 - 描述：删除表/数据库之后，元数据在回收站中保留的时长，超过这个时长，数据就不可以通过[RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md) 语句恢复。
 - 引入版本：-
-
-##### partition_recycle_retention_period_secs
-
-- 默认值：1800
-- 类型：Long
-- 单位：Seconds
-- 是否动态：是
-- 描述：因 INSERT OVERWRITE 或物化视图刷新操作而被删除的分区的元数据保留时间。请注意，此类元数据无法通过执行 [RECOVER](../../sql-reference/sql-statements/backup_restore/RECOVER.md) 命令恢复。
-- 引入版本：v3.5.9
 
 ##### check_consistency_default_timeout_second
 
@@ -2624,8 +2628,6 @@ Compaction Score 代表了一个表分区是否值得进行 Compaction 的评分
 - 是否动态：是
 - 描述：在物化视图创建和 CTAS 操作中，是否优先对固定长度的 VARCHAR 列使用 STRING 类型。
 - 引入版本：v4.0.0
-
-<EditionSpecificFEItem />
 
 ##### backup_job_default_timeout_ms
 


### PR DESCRIPTION

## Why I'm doing:

## What I'm doing:        

This PR updates the fe_config documentation for the following languages:
- en, zh, ja

### Changed Files
- `docs/en/administration/management/FE_configuration.md`
- `docs/zh/administration/management/FE_configuration.md`
- `docs/ja/administration/management/FE_configuration.md`

### Generated by DocsAgent

This documentation was automatically generated by DocsAgent.

Please review the changes and merge if they look correct.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3