### PR TITLE
[BugFix] Do not collect statistics for temporary partitions after overwrite partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
@@ -282,6 +282,12 @@ public class StatisticsCollectionTrigger {
                 if (partitionCommitInfo.getVersion() == Partition.PARTITION_INIT_VERSION + 1) {
                     PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
                     Long partitionId = table.getPartition(physicalPartition.getParentId()).getId();
+                    if (table.isNativeTableOrMaterializedView()) {
+                        OlapTable olapTable = (OlapTable) table;
+                        if (olapTable.isTempPartition(partitionId)) {
+                            continue;
+                        }
+                    }
                     partitionIds.add(partitionId);
                     tabletRows.forEach((tabletId, rowCount) -> partitionTabletRowCounts.put(partitionId, tabletId, rowCount));
                 }

--- a/test/sql/test_analyze_statistics/R/test_overwrite_statistics.sql
+++ b/test/sql/test_analyze_statistics/R/test_overwrite_statistics.sql
@@ -63,10 +63,13 @@ select count(*) from _statistics_.column_statistics where table_name = 'test_ove
 -- result:
 8
 -- !result
-INSERT OVERWRITE sales_data partition("p202401") VALUES (101, '2024-01-10');
+INSERT OVERWRITE test_overwrite_statistics.sales_data partition("p202401") VALUES (101, '2024-01-10');
 -- result:
 -- !result
 select count(*) from _statistics_.column_statistics where table_name = 'test_overwrite_statistics.sales_data';
 -- result:
 10
+-- !result
+select * from information_schema.analyze_status where `Database`='test_overwrite_statistics' and `Table`='sales_data' and Status='FAILED';
+-- result:
 -- !result

--- a/test/sql/test_analyze_statistics/T/test_overwrite_statistics.sql
+++ b/test/sql/test_analyze_statistics/T/test_overwrite_statistics.sql
@@ -42,6 +42,8 @@ INSERT INTO sales_data VALUES
 (8, '2024-04-18');
 select count(*) from _statistics_.column_statistics where table_name = 'test_overwrite_statistics.sales_data';
 
-INSERT OVERWRITE sales_data partition("p202401") VALUES (101, '2024-01-10');
+INSERT OVERWRITE test_overwrite_statistics.sales_data partition("p202401") VALUES (101, '2024-01-10');
 select count(*) from _statistics_.column_statistics where table_name = 'test_overwrite_statistics.sales_data';
+
+select * from information_schema.analyze_status where `Database`='test_overwrite_statistics' and `Table`='sales_data' and Status='FAILED';
 


### PR DESCRIPTION
## Why I'm doing:
overwrite partition first creates a temp partition and then write data. and this import will trigger statistics collection. However, statistics collection for this temporary partition is unnecessary, and we cannot query data through the temporary partition either. There will be many errors in `show analyze status`.
error msg:
Detail message: Unknown partition 'p202401_760270' in table 'sales_data'. |
```
 760287 | default_catalog | test_overwrite_statistics | sales_data | ALL     | FULL | ONCE     | FAILED | 2025-11-11 15:44:59 | 2025-11-11 15:44:59 | {}         | query statistic job failed due to too many failed tasks: 2/2, the last failure is java.lang.RuntimeException: execute statistics query failed, sql: SELECT cast(9 as INT), cast(760271 as BIGINT), 'sale_date', cast(COUNT(1) as BIGINT), cast(COUNT(`sale_date`) * 4 as BIGINT), hex(hll_serialize(IFNULL(hll_raw(`sale_date`), hll_empty()))), cast(COUNT(*) - COUNT(`sale_date`) as BIGINT), IFNULL(MAX(`sale_date`), ''), IFNULL(MIN(`sale_date`), ''), cast(-1.0 as BIGINT) FROM `test_overwrite_statistics`.`sales_data` partition `p202401_760270`, error: Getting analyzing error. Detail message: Unknown partition 'p202401_760270' in table 'sales_data'. |
```

## What I'm doing:
skipping temp partitions when collection statistics

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
