### PR TITLE
[Enhancement] Cloud Native Table should not set replicated storage.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -503,26 +503,27 @@ public class OlapTableFactory implements AbstractTableFactory {
                 throw new DdlException(e.getMessage());
             }
 
-            // replicated storage
-            table.setEnableReplicatedStorage(
-                    PropertyAnalyzer.analyzeBooleanProp(
-                            properties, PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE,
-                            Config.enable_replicated_storage_as_default_engine));
+            if (table.isOlapTableOrMaterializedView()) {
+                // replicated storage
+                table.setEnableReplicatedStorage(
+                        PropertyAnalyzer.analyzeBooleanProp(
+                                properties, PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE,
+                                Config.enable_replicated_storage_as_default_engine));
 
+                boolean hasGin = table.getIndexes().stream()
+                        .anyMatch(index -> index.getIndexType() == IndexType.GIN);
+                if (hasGin && table.enableReplicatedStorage()) {
+                    // GIN indexes are incompatible with replicated_storage right now and we will disable replicated_storage
+                    // if table contains GIN Index.
+                    table.setEnableReplicatedStorage(false);
+                }
 
-            boolean hasGin = table.getIndexes().stream()
-                            .anyMatch(index -> index.getIndexType() == IndexType.GIN);
-            if (hasGin && table.enableReplicatedStorage()) {
-                // GIN indexes are incompatible with replicated_storage right now and we will disable replicated_storage
-                // if table contains GIN Index.
-                table.setEnableReplicatedStorage(false);
-            }
-
-            if (table.enableReplicatedStorage().equals(false)) {
-                for (Column col : baseSchema) {
-                    if (col.isAutoIncrement()) {
-                        throw new DdlException("Table with AUTO_INCREMENT column must use Replicated Storage " +
-                                " and not compatible with GIN Index");
+                if (table.enableReplicatedStorage().equals(false)) {
+                    for (Column col : baseSchema) {
+                        if (col.isAutoIncrement()) {
+                            throw new DdlException("Table with AUTO_INCREMENT column must use Replicated Storage " +
+                                    " and not compatible with GIN Index");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Why I'm doing:

Currently, cloud native table/view set replicated storage by default event if it is useless. And cloud native table/view cannot use auto increment unless specify replicated_storage=false manually.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
