### PR TITLE
[BugFix] [Refactor] Fix MV compensation bug which causes rewrite result error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvBaseTableUpdateInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvBaseTableUpdateInfo.java
@@ -15,37 +15,39 @@
 package com.starrocks.catalog;
 
 import com.starrocks.sql.common.PCellSortedSet;
-import com.starrocks.sql.common.PRangeCell;
 
 /**
  * Store the update information of base table for MV
  */
 public class MvBaseTableUpdateInfo {
     // The partition names of base table that have been updated
-    private final PCellSortedSet toRefreshPartitionNames = PCellSortedSet.of();
-    // The mapping of partition name to partition range
-    private final PCellSortedSet partitionToCells = PCellSortedSet.of();
-
+    private final PCellSortedSet toRefreshPCells = PCellSortedSet.of();
+    // The base table partition cells snapshot
+    private final PCellSortedSet refBaseTablePCells = PCellSortedSet.of();
     // If the base table is a mv, needs to record the mapping of mv partition name to partition range
-    private final PCellSortedSet mvPartitionNameToCellMap = PCellSortedSet.of();
+    private final PCellSortedSet nestedRefBaseMVPCells = PCellSortedSet.of();
 
     public MvBaseTableUpdateInfo() {
     }
 
-    public PCellSortedSet getMvPartitionNameToCellMap() {
-        return mvPartitionNameToCellMap;
+    public static MvBaseTableUpdateInfo of() {
+        return new MvBaseTableUpdateInfo();
+    }
+
+    public PCellSortedSet getNestedRefBaseMVPCells() {
+        return nestedRefBaseMVPCells;
     }
 
     public void addMVPartitionNameToCellMap(PCellSortedSet partitionNameToRangeMap) {
-        mvPartitionNameToCellMap.addAll(partitionNameToRangeMap);
+        nestedRefBaseMVPCells.addAll(partitionNameToRangeMap);
     }
 
-    public PCellSortedSet getToRefreshPartitionNames() {
-        return toRefreshPartitionNames;
+    public PCellSortedSet getToRefreshPCells() {
+        return toRefreshPCells;
     }
 
-    public PCellSortedSet getPartitionToCells() {
-        return partitionToCells;
+    public PCellSortedSet getRefBaseTablePCells() {
+        return refBaseTablePCells;
     }
 
     /**
@@ -53,31 +55,13 @@ public class MvBaseTableUpdateInfo {
      * @param toRefreshPartitionNames the partition names that need to be refreshed
      */
     public void addToRefreshPartitionNames(PCellSortedSet toRefreshPartitionNames) {
-        this.toRefreshPartitionNames.addAll(toRefreshPartitionNames);
-    }
-
-    /**
-     * Add partition name that needs to be refreshed and its associated range partition key
-     * @param partitionName mv partition name
-     * @param rangeCell the associated range partition
-     */
-    public void addRangePartitionKeys(String partitionName,
-                                      PRangeCell rangeCell) {
-        partitionToCells.add(partitionName, rangeCell);
-    }
-
-    /**
-     * Add partition name that needs to be refreshed and its associated list partition key
-     */
-    public void addPartitionCells(PCellSortedSet cells) {
-        partitionToCells.addAll(cells);
+        this.toRefreshPCells.addAll(toRefreshPartitionNames);
     }
 
     @Override
     public String toString() {
         return "{" +
-                ", toRefreshPartitionNames=" + toRefreshPartitionNames +
-                ", nameToPartKeys=" + partitionToCells +
+                ", toRefreshPartitionNames=" + toRefreshPCells +
                 '}';
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvBaseTableUpdateInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvBaseTableUpdateInfo.java
@@ -25,7 +25,7 @@ public class MvBaseTableUpdateInfo {
     // The base table partition cells snapshot
     private final PCellSortedSet refBaseTablePCells = PCellSortedSet.of();
     // If the base table is a mv, needs to record the mapping of mv partition name to partition range
-    private final PCellSortedSet nestedRefBaseMVPCells = PCellSortedSet.of();
+    private final PCellSortedSet refBaseNestedMVPCells = PCellSortedSet.of();
 
     public MvBaseTableUpdateInfo() {
     }
@@ -34,12 +34,12 @@ public class MvBaseTableUpdateInfo {
         return new MvBaseTableUpdateInfo();
     }
 
-    public PCellSortedSet getNestedRefBaseMVPCells() {
-        return nestedRefBaseMVPCells;
+    public PCellSortedSet getRefBaseNestedMVPCells() {
+        return refBaseNestedMVPCells;
     }
 
     public void addMVPartitionNameToCellMap(PCellSortedSet partitionNameToRangeMap) {
-        nestedRefBaseMVPCells.addAll(partitionNameToRangeMap);
+        refBaseNestedMVPCells.addAll(partitionNameToRangeMap);
     }
 
     public PCellSortedSet getToRefreshPCells() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
@@ -183,7 +183,7 @@ public class MvRefreshArbiter {
                 }
                 // NOTE: if base table is mv, check to refresh partition names as the base table's update info.
                 updatedPCellSet.addAll(mvUpdateInfo.getMvToRefreshPCells());
-                baseTableUpdateInfo.addMVPartitionNameToCellMap(mvUpdateInfo.getNestedRefBaseMVPCells());
+                baseTableUpdateInfo.addMVPartitionNameToCellMap(mvUpdateInfo.getRefBaseNestedMVPCells());
             }
             // update base table's partition info
             baseTableUpdateInfo.addToRefreshPartitionNames(updatedPCellSet);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
@@ -141,7 +141,7 @@ public class MvRefreshArbiter {
                     return Optional.empty();
                 }
                 // NOTE: if base table is mv, check to refresh partition names as the base table's update info.
-                return Optional.of(!mvUpdateInfo.getMvToRefreshPartitionNames().isEmpty());
+                return Optional.of(!mvUpdateInfo.getMvToRefreshPCells().isEmpty());
             }
             return Optional.of(false);
         } else {
@@ -182,8 +182,8 @@ public class MvRefreshArbiter {
                     return null;
                 }
                 // NOTE: if base table is mv, check to refresh partition names as the base table's update info.
-                updatedPCellSet.addAll(mvUpdateInfo.getMvToRefreshPartitionNames());
-                baseTableUpdateInfo.addMVPartitionNameToCellMap(mvUpdateInfo.getMvPartitionNameToCellMap());
+                updatedPCellSet.addAll(mvUpdateInfo.getMvToRefreshPCells());
+                baseTableUpdateInfo.addMVPartitionNameToCellMap(mvUpdateInfo.getNestedRefBaseMVPCells());
             }
             // update base table's partition info
             baseTableUpdateInfo.addToRefreshPartitionNames(updatedPCellSet);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
@@ -141,7 +141,7 @@ public class MvRefreshArbiter {
                     return Optional.empty();
                 }
                 // NOTE: if base table is mv, check to refresh partition names as the base table's update info.
-                return Optional.of(!mvUpdateInfo.getMvToRefreshPCells().isEmpty());
+                return Optional.of(!mvUpdateInfo.getMVToRefreshPCells().isEmpty());
             }
             return Optional.of(false);
         } else {
@@ -182,7 +182,7 @@ public class MvRefreshArbiter {
                     return null;
                 }
                 // NOTE: if base table is mv, check to refresh partition names as the base table's update info.
-                updatedPCellSet.addAll(mvUpdateInfo.getMvToRefreshPCells());
+                updatedPCellSet.addAll(mvUpdateInfo.getMVToRefreshPCells());
                 baseTableUpdateInfo.addMVPartitionNameToCellMap(mvUpdateInfo.getRefBaseNestedMVPCells());
             }
             // update base table's partition info

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvUpdateInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvUpdateInfo.java
@@ -137,7 +137,7 @@ public class MvUpdateInfo {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("refreshType=").append(mvToRefreshType);
-        if (!PCellUtils.isNotEmpty(mvToRefreshPartitionNames)) {
+        if (!PCellUtils.isEmpty(mvToRefreshPartitionNames)) {
             sb.append(", mvToRefreshPartitionNames=").append(mvToRefreshPartitionNames);
         }
         if (!CollectionUtils.sizeIsEmpty(basePartToMvPartNames)) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvUpdateInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvUpdateInfo.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.common.Config;
 import com.starrocks.sql.common.PCellSetMapping;
 import com.starrocks.sql.common.PCellSortedSet;
+import com.starrocks.sql.common.PCellUtils;
 import com.starrocks.sql.common.PCellWithName;
 import org.apache.commons.collections4.CollectionUtils;
 
@@ -134,10 +135,9 @@ public class MvUpdateInfo {
 
     @Override
     public String toString() {
-        int maxLength = Config.max_mv_task_run_meta_message_values_length;
         StringBuilder sb = new StringBuilder();
         sb.append("refreshType=").append(mvToRefreshType);
-        if (!CollectionUtils.sizeIsEmpty(mvToRefreshPartitionNames)) {
+        if (!PCellUtils.isNotEmpty(mvToRefreshPartitionNames)) {
             sb.append(", mvToRefreshPartitionNames=").append(mvToRefreshPartitionNames);
         }
         if (!CollectionUtils.sizeIsEmpty(basePartToMvPartNames)) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvUpdateInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvUpdateInfo.java
@@ -43,7 +43,7 @@ public class MvUpdateInfo {
     private final TableProperty.QueryRewriteConsistencyMode queryRewriteConsistencyMode;
 
     // If the base table is a mv, needs to record the mapping of mv partition name to partition range
-    private final PCellSortedSet nestedRefBaseMVPCells = PCellSortedSet.of();
+    private final PCellSortedSet refBaseNestedMVPCells = PCellSortedSet.of();
 
     /**
      * Marks the type of mv refresh later.
@@ -130,11 +130,11 @@ public class MvUpdateInfo {
     }
 
     public void addMVPartitionNameToCellMap(PCellSortedSet m) {
-        nestedRefBaseMVPCells.addAll(m);
+        refBaseNestedMVPCells.addAll(m);
     }
 
-    public PCellSortedSet getNestedRefBaseMVPCells() {
-        return nestedRefBaseMVPCells;
+    public PCellSortedSet getRefBaseNestedMVPCells() {
+        return refBaseNestedMVPCells;
     }
 
     public MaterializedView getMv() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvUpdateInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvUpdateInfo.java
@@ -162,6 +162,7 @@ public class MvUpdateInfo {
                 sb.append("[").append(entry.getKey()).append(":");
                 sb.append(entry.getValue());
                 sb.append("]");
+                i++;
             }
         }
         return sb.toString();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvUpdateInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvUpdateInfo.java
@@ -85,7 +85,7 @@ public class MvUpdateInfo {
         return new MvUpdateInfo(mv, MvToRefreshType.PARTIAL, queryRewriteConsistencyMode);
     }
 
-    public MvToRefreshType getMvToRefreshType() {
+    public MvToRefreshType getMVToRefreshType() {
         return mvToRefreshType;
     }
 
@@ -93,15 +93,15 @@ public class MvUpdateInfo {
         return mvToRefreshType == MvToRefreshType.PARTIAL || mvToRefreshType == MvToRefreshType.NO_REFRESH;
     }
 
-    public void addMvToRefreshPartitionNames(PCellWithName partitionName) {
+    public void addMVToRefreshPartitionNames(PCellWithName partitionName) {
         mvToRefreshPCells.add(partitionName);
     }
 
-    public void addMvToRefreshPartitionNames(PCellSortedSet partitionNames) {
+    public void addMVToRefreshPartitionNames(PCellSortedSet partitionNames) {
         mvToRefreshPCells.addAll(partitionNames);
     }
 
-    public PCellSortedSet getMvToRefreshPCells() {
+    public PCellSortedSet getMVToRefreshPCells() {
         return mvToRefreshPCells;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
@@ -198,8 +198,8 @@ public abstract class MVTimelinessArbiter {
     protected void collectExtraBaseTableChangedPartitions(Map<Table, MvBaseTableUpdateInfo> baseTableUpdateInfoMap,
                                                           Map<Table, PCellSortedSet> basePartitionNameToRangeMap) {
         Map<Table, PCellSortedSet> extraChangedPartitions = baseTableUpdateInfoMap.entrySet().stream()
-                .filter(e -> !e.getValue().getNestedRefBaseMVPCells().isEmpty())
-                .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().getNestedRefBaseMVPCells()));
+                .filter(e -> !e.getValue().getRefBaseNestedMVPCells().isEmpty())
+                .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().getRefBaseNestedMVPCells()));
         for (Map.Entry<Table, PCellSortedSet> entry : extraChangedPartitions.entrySet()) {
             Table baseTable = entry.getKey();
             Preconditions.checkState(basePartitionNameToRangeMap.containsKey(baseTable));
@@ -227,8 +227,7 @@ public abstract class MVTimelinessArbiter {
     }
 
     /**
-     * Collect mv ref base table's partition cells into mv update info
-     *
+     * Collect mv ref base table's partition cells into mv update info.
      */
     public Map<Table, PCellSortedSet> syncBaseTablePartitions(MvUpdateInfo mvUpdateInfo) {
         PartitionInfo partitionInfo = mv.getPartitionInfo();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
@@ -184,7 +184,7 @@ public abstract class MVTimelinessArbiter {
                     true, isQueryRewrite);
             mvUpdateInfo.getBaseTableUpdateInfos().put(baseTable, mvBaseTableUpdateInfo);
             // If base table is a mv, its to-update partitions may not be created yet, skip it
-            baseChangedPartitionNames.put(baseTable, mvBaseTableUpdateInfo.getToRefreshPartitionNames());
+            baseChangedPartitionNames.put(baseTable, mvBaseTableUpdateInfo.getToRefreshPCells());
         }
         return baseChangedPartitionNames;
     }
@@ -198,8 +198,8 @@ public abstract class MVTimelinessArbiter {
     protected void collectExtraBaseTableChangedPartitions(Map<Table, MvBaseTableUpdateInfo> baseTableUpdateInfoMap,
                                                           Map<Table, PCellSortedSet> basePartitionNameToRangeMap) {
         Map<Table, PCellSortedSet> extraChangedPartitions = baseTableUpdateInfoMap.entrySet().stream()
-                .filter(e -> !e.getValue().getMvPartitionNameToCellMap().isEmpty())
-                .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().getMvPartitionNameToCellMap()));
+                .filter(e -> !e.getValue().getNestedRefBaseMVPCells().isEmpty())
+                .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().getNestedRefBaseMVPCells()));
         for (Map.Entry<Table, PCellSortedSet> entry : extraChangedPartitions.entrySet()) {
             Table baseTable = entry.getKey();
             Preconditions.checkState(basePartitionNameToRangeMap.containsKey(baseTable));
@@ -226,7 +226,11 @@ public abstract class MVTimelinessArbiter {
         });
     }
 
-    public Map<Table, PCellSortedSet> syncBaseTablePartitions(MaterializedView mv) {
+    /**
+     * Collect mv ref base table's partition cells into mv update info
+     *
+     */
+    public Map<Table, PCellSortedSet> syncBaseTablePartitions(MvUpdateInfo mvUpdateInfo) {
         PartitionInfo partitionInfo = mv.getPartitionInfo();
         if (partitionInfo.isUnPartitioned()) {
             return null;
@@ -235,6 +239,8 @@ public abstract class MVTimelinessArbiter {
         if (CollectionUtils.sizeIsEmpty(basePartitionNameToRangeMap)) {
             return null;
         }
+        // add into base table info
+        mvUpdateInfo.addRefBaseTablePCells(basePartitionNameToRangeMap);
         return basePartitionNameToRangeMap;
     }
 
@@ -263,7 +269,8 @@ public abstract class MVTimelinessArbiter {
      * Only need to check the mv partition existence.
      */
     public MvUpdateInfo getMVTimelinessUpdateInfoInLoose() {
-        Map<Table, PCellSortedSet> refBaseTablePartitionMap = syncBaseTablePartitions(mv);
+        MvUpdateInfo mvUpdateInfo = MvUpdateInfo.partialRefresh(mv, TableProperty.QueryRewriteConsistencyMode.LOOSE);
+        Map<Table, PCellSortedSet> refBaseTablePartitionMap = syncBaseTablePartitions(mvUpdateInfo);
         if (refBaseTablePartitionMap == null) {
             logMVPrepare(mv, "Sync base table partition infos failed");
             return MvUpdateInfo.fullRefresh(mv);
@@ -277,9 +284,8 @@ public abstract class MVTimelinessArbiter {
             }
         }
         PCellSortedSet adds = diff.getAdds();
-        MvUpdateInfo mvUpdateInfo = MvUpdateInfo.partialRefresh(mv, TableProperty.QueryRewriteConsistencyMode.LOOSE);
         if (adds != null && !adds.isEmpty()) {
-            mvUpdateInfo.getMvToRefreshPartitionNames().addAll(adds);
+            mvUpdateInfo.getMvToRefreshPCells().addAll(adds);
         }
         addEmptyPartitionsToRefresh(mvUpdateInfo);
         try (Timer ignored = Tracers.watchScope("CollectBaseTableUpdatePartitionNames")) {
@@ -303,7 +309,7 @@ public abstract class MVTimelinessArbiter {
         mvPartitionToCells.addAll(diff.getAdds());
         Map<String, Map<Table, PCellSortedSet>> mvToBaseNameRef = differ
                 .generateMvRefMap(mvPartitionToCells, refBaseTablePartitionMap);
-        mvUpdateInfo.getMvPartToBasePartNames().putAll(mvToBaseNameRef);
+        mvUpdateInfo.getMVPartNameToBasePCells().putAll(mvToBaseNameRef);
     }
     
     /**
@@ -327,7 +333,8 @@ public abstract class MVTimelinessArbiter {
         if (Strings.isNullOrEmpty(retentionCondition)) {
             return MvUpdateInfo.noRefresh(mv);
         }
-        Map<Table, PCellSortedSet> refBaseTablePartitionMap = syncBaseTablePartitions(mv);
+        MvUpdateInfo mvUpdateInfo = MvUpdateInfo.partialRefresh(mv, TableProperty.QueryRewriteConsistencyMode.FORCE_MV);
+        Map<Table, PCellSortedSet> refBaseTablePartitionMap = syncBaseTablePartitions(mvUpdateInfo);
         if (refBaseTablePartitionMap == null) {
             logMVPrepare(mv, "Sync base table partition infos failed");
             return MvUpdateInfo.fullRefresh(mv);
@@ -342,10 +349,9 @@ public abstract class MVTimelinessArbiter {
             }
         }
         PCellSortedSet adds = diff.getAdds();
-        MvUpdateInfo mvUpdateInfo = MvUpdateInfo.partialRefresh(mv, TableProperty.QueryRewriteConsistencyMode.FORCE_MV);
         addEmptyPartitionsToRefresh(mvUpdateInfo);
         if (adds != null && !adds.isEmpty()) {
-            mvUpdateInfo.getMvToRefreshPartitionNames().addAll(adds);
+            mvUpdateInfo.getMvToRefreshPCells().addAll(adds);
         }
         return mvUpdateInfo;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
@@ -221,7 +221,7 @@ public abstract class MVTimelinessArbiter {
                 // add empty partitions
                 Optional<PCellWithName> pCellWithName = PCellUtils.of(mv, mvPartitionName);
                 Preconditions.checkState(pCellWithName.isPresent());
-                mvUpdateInfo.addMvToRefreshPartitionNames(pCellWithName.get());
+                mvUpdateInfo.addMVToRefreshPartitionNames(pCellWithName.get());
             }
         });
     }
@@ -284,7 +284,7 @@ public abstract class MVTimelinessArbiter {
         }
         PCellSortedSet adds = diff.getAdds();
         if (adds != null && !adds.isEmpty()) {
-            mvUpdateInfo.getMvToRefreshPCells().addAll(adds);
+            mvUpdateInfo.getMVToRefreshPCells().addAll(adds);
         }
         addEmptyPartitionsToRefresh(mvUpdateInfo);
         try (Timer ignored = Tracers.watchScope("CollectBaseTableUpdatePartitionNames")) {
@@ -350,7 +350,7 @@ public abstract class MVTimelinessArbiter {
         PCellSortedSet adds = diff.getAdds();
         addEmptyPartitionsToRefresh(mvUpdateInfo);
         if (adds != null && !adds.isEmpty()) {
-            mvUpdateInfo.getMvToRefreshPCells().addAll(adds);
+            mvUpdateInfo.getMVToRefreshPCells().addAll(adds);
         }
         return mvUpdateInfo;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessListPartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessListPartitionArbiter.java
@@ -97,7 +97,7 @@ public final class MVTimelinessListPartitionArbiter extends MVTimelinessArbiter 
         }
 
         // update into mv's to refresh partitions
-        final PCellSortedSet mvToRefreshPartitionNames = mvTimelinessInfo.getMvToRefreshPCells();
+        final PCellSortedSet mvToRefreshPartitionNames = mvTimelinessInfo.getMVToRefreshPCells();
         mvToRefreshPartitionNames.addAll(diff.getDeletes());
         mvToRefreshPartitionNames.addAll(diff.getAdds());
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessListPartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessListPartitionArbiter.java
@@ -75,7 +75,7 @@ public final class MVTimelinessListPartitionArbiter extends MVTimelinessArbiter 
         // collect base table's partition infos
         Map<Table, PCellSortedSet> refBaseTablePartitionMap;
         try (Timer ignored = Tracers.watchScope("SyncBaseTablePartitions")) {
-            refBaseTablePartitionMap = syncBaseTablePartitions(mv);
+            refBaseTablePartitionMap = syncBaseTablePartitions(mvTimelinessInfo);
             if (refBaseTablePartitionMap == null) {
                 logMVPrepare(mv, "Sync base table partition infos failed");
                 return MvUpdateInfo.fullRefresh(mv);
@@ -97,7 +97,7 @@ public final class MVTimelinessListPartitionArbiter extends MVTimelinessArbiter 
         }
 
         // update into mv's to refresh partitions
-        final PCellSortedSet mvToRefreshPartitionNames = mvTimelinessInfo.getMvToRefreshPartitionNames();
+        final PCellSortedSet mvToRefreshPartitionNames = mvTimelinessInfo.getMvToRefreshPCells();
         mvToRefreshPartitionNames.addAll(diff.getDeletes());
         mvToRefreshPartitionNames.addAll(diff.getAdds());
 
@@ -117,8 +117,8 @@ public final class MVTimelinessListPartitionArbiter extends MVTimelinessArbiter 
         try (Timer ignored = Tracers.watchScope("GenerateMvRefMap")) {
             mvToBaseNameRef = differ.generateMvRefMap(mvPartitionNameToListMap, refBaseTablePartitionMap);
         }
-        mvTimelinessInfo.getBasePartToMvPartNames().putAll(baseToMvNameRef);
-        mvTimelinessInfo.getMvPartToBasePartNames().putAll(mvToBaseNameRef);
+        mvTimelinessInfo.getBasePartNameToMVPCells().putAll(baseToMvNameRef);
+        mvTimelinessInfo.getMVPartNameToBasePCells().putAll(mvToBaseNameRef);
 
         mvToRefreshPartitionNames.addAll(getMVToRefreshPartitionNames(baseChangedPartitionNames, baseToMvNameRef));
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessNonPartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessNonPartitionArbiter.java
@@ -70,8 +70,8 @@ public final class MVTimelinessNonPartitionArbiter extends MVTimelinessArbiter {
             MvBaseTableUpdateInfo mvBaseTableUpdateInfo = getMvBaseTableUpdateInfo(mv, table, true, isQueryRewrite);
             // TODO: fixme if mvBaseTableUpdateInfo is null, should return full refresh?
             if (mvBaseTableUpdateInfo != null &&
-                    mvBaseTableUpdateInfo.getToRefreshPartitionNames() != null &&
-                    !mvBaseTableUpdateInfo.getToRefreshPartitionNames().isEmpty()) {
+                    mvBaseTableUpdateInfo.getToRefreshPCells() != null &&
+                    !mvBaseTableUpdateInfo.getToRefreshPCells().isEmpty()) {
                 logMVPrepare(mv, "Non-partitioned base table has updated, need refresh totally.");
                 return MvUpdateInfo.fullRefresh(mv);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessRangePartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessRangePartitionArbiter.java
@@ -89,7 +89,7 @@ public final class MVTimelinessRangePartitionArbiter extends MVTimelinessArbiter
         Map<Table, PCellSortedSet> basePartitionNameToRangeMap;
 
         try (Timer ignored = Tracers.watchScope("SyncBaseTablePartitions")) {
-            basePartitionNameToRangeMap = syncBaseTablePartitions(mv);
+            basePartitionNameToRangeMap = syncBaseTablePartitions(mvTimelinessInfo);
             if (basePartitionNameToRangeMap == null) {
                 logMVPrepare(mv, "Sync base table partition infos failed");
                 return MvUpdateInfo.fullRefresh(mv);
@@ -134,8 +134,8 @@ public final class MVTimelinessRangePartitionArbiter extends MVTimelinessArbiter
         try (Timer ignored = Tracers.watchScope("GenerateMvRefMap")) {
             mvToBaseNameRef = differ.generateMvRefMap(mvPartitionToCells, basePartitionNameToRangeMap);
         }
-        mvTimelinessInfo.getBasePartToMvPartNames().putAll(baseToMvNameRef);
-        mvTimelinessInfo.getMvPartToBasePartNames().putAll(mvToBaseNameRef);
+        mvTimelinessInfo.getBasePartNameToMVPCells().putAll(baseToMvNameRef);
+        mvTimelinessInfo.getMVPartNameToBasePCells().putAll(mvToBaseNameRef);
 
         mvToRefreshPartitionNames.addAll(getMVToRefreshPartitionNames(baseChangedPartitionNames, baseToMvNameRef));
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessRangePartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessRangePartitionArbiter.java
@@ -150,7 +150,7 @@ public final class MVTimelinessRangePartitionArbiter extends MVTimelinessArbiter
             }
         }
         // update mv's to refresh partitions
-        mvTimelinessInfo.addMvToRefreshPartitionNames(mvToRefreshPartitionNames);
+        mvTimelinessInfo.addMVToRefreshPartitionNames(mvToRefreshPartitionNames);
         return mvTimelinessInfo;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPartitioner.java
@@ -521,7 +521,7 @@ public abstract class MVPCTRefreshPartitioner {
                         "%s failed, current mv partitions:%s", baseTable.getName(), mv.getName(), toRefreshPartitions));
             }
 
-            PCellSortedSet refBaseTablePartitionNames = mvBaseTableUpdateInfo.getToRefreshPartitionNames();
+            PCellSortedSet refBaseTablePartitionNames = mvBaseTableUpdateInfo.getToRefreshPCells();
             if (refBaseTablePartitionNames.isEmpty()) {
                 logger.info("The ref base table {} has no updated partitions, and no update related mv partitions: {}",
                         baseTable.getName(), toRefreshPartitions);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
@@ -58,6 +58,10 @@ public abstract class PartitionDiffer {
                                                              Map<Table, PCellSortedSet> refBaseTablePartitionMap);
     /**
      * Generate the reference map between the base table and the mv.
+     *
+     * NOTE: the result with base table's partition cell is not the normalized cell by mv's partition exprs, but the exact base
+     * tables' partition cell.
+     *
      * @param basePartitionMaps src partition sorted set of the base table
      * @param mvPartitionMap mv partition sorted set
      * @return base table -> <partition name, mv partition names> mapping
@@ -67,6 +71,10 @@ public abstract class PartitionDiffer {
 
     /**
      * Generate the mapping from materialized view partition to base table partition.
+     *
+     * NOTE: the result with base table's partition cell is not the normalized cell by mv's partition exprs, but the exact base
+     * tables' partition cell.
+     *
      * @param mvPCells : materialized view partition sorted set
      * @param baseTablePCells: base table partition sorted set map
      * @return mv partition name -> <base table, base partition names> mapping

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiffer.java
@@ -43,6 +43,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -648,6 +649,13 @@ public final class RangePartitionDiffer extends PartitionDiffer {
         return rangeMap.getPartitions()
                 .stream()
                 .map(pCell -> PCellWithNorm.of(pCell, toNormalizedCell(pCell, expr)))
+                // sort by normalized pcell
+                .sorted(new Comparator<PCellWithNorm>() {
+                    @Override
+                    public int compare(PCellWithNorm o1, PCellWithNorm o2) {
+                        return o1.normalized.compareTo(o2.normalized);
+                    }
+                })
                 .collect(Collectors.toList());
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -758,7 +758,7 @@ public class MvRewritePreprocessor {
                            MvUpdateInfo mvUpdateInfo) {
         MaterializedView mv = mvWithPlanContext.getMV();
         MvPlanContext mvPlanContext = mvWithPlanContext.getMvPlanContext();
-        PCellSortedSet partitionNamesToRefresh = mvUpdateInfo.getMvToRefreshPartitionNames();
+        PCellSortedSet partitionNamesToRefresh = mvUpdateInfo.getMvToRefreshPCells();
         if (!checkMvPartitionNamesToRefresh(connectContext, mv, partitionNamesToRefresh, mvPlanContext)) {
             return;
         }
@@ -990,7 +990,7 @@ public class MvRewritePreprocessor {
         LogicalOlapScanOperator scanMvOp;
         synchronized (materializationContext.getQueryRefFactory()) {
             scanMvOp = createScanMvOperator(mv, materializationContext.getQueryRefFactory(),
-                    mvUpdateInfo.getMvToRefreshPartitionNames(), false);
+                    mvUpdateInfo.getMvToRefreshPCells(), false);
         }
         materializationContext.setScanMvOperator(scanMvOp);
         // should keep the sequence of schema

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -758,7 +758,7 @@ public class MvRewritePreprocessor {
                            MvUpdateInfo mvUpdateInfo) {
         MaterializedView mv = mvWithPlanContext.getMV();
         MvPlanContext mvPlanContext = mvWithPlanContext.getMvPlanContext();
-        PCellSortedSet partitionNamesToRefresh = mvUpdateInfo.getMvToRefreshPCells();
+        PCellSortedSet partitionNamesToRefresh = mvUpdateInfo.getMVToRefreshPCells();
         if (!checkMvPartitionNamesToRefresh(connectContext, mv, partitionNamesToRefresh, mvPlanContext)) {
             return;
         }
@@ -990,7 +990,7 @@ public class MvRewritePreprocessor {
         LogicalOlapScanOperator scanMvOp;
         synchronized (materializationContext.getQueryRefFactory()) {
             scanMvOp = createScanMvOperator(mv, materializationContext.getQueryRefFactory(),
-                    mvUpdateInfo.getMvToRefreshPCells(), false);
+                    mvUpdateInfo.getMVToRefreshPCells(), false);
         }
         materializationContext.setScanMvOperator(scanMvOp);
         // should keep the sequence of schema

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
@@ -225,7 +225,7 @@ public class MaterializedViewTransparentRewriteRule extends TransformationRule {
                                                    LogicalOlapScanOperator olapScanOperator,
                                                    Set<Table> queryTables) {
         MvUpdateInfo mvUpdateInfo = MvUpdateInfo.fullRefresh(mv);
-        mvUpdateInfo.addMvToRefreshPartitionNames(mv.getPartitionCells(Optional.empty()));
+        mvUpdateInfo.addMVToRefreshPartitionNames(mv.getPartitionCells(Optional.empty()));
 
         MaterializationContext mvContext = MvRewritePreprocessor.buildMaterializationContext(context,
                 mv, mvPlanContext, mvUpdateInfo, queryTables, 0);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
@@ -148,7 +148,7 @@ public class MvPartitionCompensator {
                                                    MaterializationContext mvContext) {
         SessionVariable sessionVariable = mvContext.getOptimizerContext().getSessionVariable();
         MvUpdateInfo mvUpdateInfo = mvContext.getMvUpdateInfo();
-        PCellSortedSet mvPartitionNameToRefresh = mvUpdateInfo.getMvToRefreshPartitionNames();
+        PCellSortedSet mvPartitionNameToRefresh = mvUpdateInfo.getMvToRefreshPCells();
         // If mv contains no partitions to refresh, no need compensate
         if (PCellUtils.isEmpty(mvPartitionNameToRefresh)) {
             logMVRewrite(mvContext, "MV has no partitions to refresh, no need compensate");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
@@ -148,7 +148,7 @@ public class MvPartitionCompensator {
                                                    MaterializationContext mvContext) {
         SessionVariable sessionVariable = mvContext.getOptimizerContext().getSessionVariable();
         MvUpdateInfo mvUpdateInfo = mvContext.getMvUpdateInfo();
-        PCellSortedSet mvPartitionNameToRefresh = mvUpdateInfo.getMvToRefreshPCells();
+        PCellSortedSet mvPartitionNameToRefresh = mvUpdateInfo.getMVToRefreshPCells();
         // If mv contains no partitions to refresh, no need compensate
         if (PCellUtils.isEmpty(mvPartitionNameToRefresh)) {
             logMVRewrite(mvContext, "MV has no partitions to refresh, no need compensate");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
@@ -90,7 +90,7 @@ public class OptExpressionDuplicator {
         this.columnMapping = Maps.newHashMap();
         this.rewriter = new ReplaceColumnRefRewriter(columnMapping);
         this.mvRefBaseTableColumns = materializationContext.getMv().getRefBaseTablePartitionColumns();
-        this.partialPartitionRewrite = !materializationContext.getMvUpdateInfo().getMvToRefreshPartitionNames().isEmpty();
+        this.partialPartitionRewrite = !materializationContext.getMvUpdateInfo().getMvToRefreshPCells().isEmpty();
         this.optimizerContext = materializationContext.getOptimizerContext();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
@@ -90,7 +90,7 @@ public class OptExpressionDuplicator {
         this.columnMapping = Maps.newHashMap();
         this.rewriter = new ReplaceColumnRefRewriter(columnMapping);
         this.mvRefBaseTableColumns = materializationContext.getMv().getRefBaseTablePartitionColumns();
-        this.partialPartitionRewrite = !materializationContext.getMvUpdateInfo().getMvToRefreshPCells().isEmpty();
+        this.partialPartitionRewrite = !materializationContext.getMvUpdateInfo().getMVToRefreshPCells().isEmpty();
         this.optimizerContext = materializationContext.getOptimizerContext();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/MVCompensationBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/MVCompensationBuilder.java
@@ -69,7 +69,7 @@ public class MVCompensationBuilder {
         if (queryPlanOpt.isPresent()) {
             List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(queryPlanOpt.get());
             // If no partition to refresh, return directly.
-            PCellSortedSet mvToRefreshPartitionNames = mvUpdateInfo.getMvToRefreshPCells();
+            PCellSortedSet mvToRefreshPartitionNames = mvUpdateInfo.getMVToRefreshPCells();
             if (PCellUtils.isEmpty(mvToRefreshPartitionNames)) {
                 return MVCompensation.noCompensate(sessionVariable);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/MVCompensationBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/MVCompensationBuilder.java
@@ -69,7 +69,7 @@ public class MVCompensationBuilder {
         if (queryPlanOpt.isPresent()) {
             List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(queryPlanOpt.get());
             // If no partition to refresh, return directly.
-            PCellSortedSet mvToRefreshPartitionNames = mvUpdateInfo.getMvToRefreshPartitionNames();
+            PCellSortedSet mvToRefreshPartitionNames = mvUpdateInfo.getMvToRefreshPCells();
             if (PCellUtils.isEmpty(mvToRefreshPartitionNames)) {
                 return MVCompensation.noCompensate(sessionVariable);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
@@ -259,7 +259,7 @@ public class TextMatchBasedRewriteRule extends Rule {
                 final List<ColumnRefOperator>  mvScanOutputColumns = MvUtils.getMvScanOutputColumnRefs(mv, mvScanOperator);
 
                 // if mv is partitioned, and some partitions are outdated, then compensate it
-                final PCellSortedSet partitionNamesToRefresh = mvUpdateInfo.getMvToRefreshPCells();
+                final PCellSortedSet partitionNamesToRefresh = mvUpdateInfo.getMVToRefreshPCells();
                 OptExpression mvCompensatePlan = null;
                 if (PCellUtils.isEmpty(partitionNamesToRefresh)) {
                     mvCompensatePlan = OptExpression.create(mvScanOperator);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
@@ -259,7 +259,7 @@ public class TextMatchBasedRewriteRule extends Rule {
                 final List<ColumnRefOperator>  mvScanOutputColumns = MvUtils.getMvScanOutputColumnRefs(mv, mvScanOperator);
 
                 // if mv is partitioned, and some partitions are outdated, then compensate it
-                final PCellSortedSet partitionNamesToRefresh = mvUpdateInfo.getMvToRefreshPartitionNames();
+                final PCellSortedSet partitionNamesToRefresh = mvUpdateInfo.getMvToRefreshPCells();
                 OptExpression mvCompensatePlan = null;
                 if (PCellUtils.isEmpty(partitionNamesToRefresh)) {
                     mvCompensatePlan = OptExpression.create(mvScanOperator);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
@@ -307,7 +307,7 @@ public class RefreshMaterializedViewTest extends MVTestBase {
         Partition p2 = table.getPartition("p2");
         if (p2.getDefaultPhysicalPartition().getVisibleVersion() == 3) {
             MvUpdateInfo mvUpdateInfo = getMvUpdateInfo(mv1);
-            Assertions.assertTrue(mvUpdateInfo.getMvToRefreshType() == MvUpdateInfo.MvToRefreshType.FULL);
+            Assertions.assertTrue(mvUpdateInfo.getMVToRefreshType() == MvUpdateInfo.MvToRefreshType.FULL);
             Assertions.assertTrue(!mvUpdateInfo.isValidRewrite());
             partitionsToRefresh1 = getPartitionNamesToRefreshForMv(mv1);
             Assertions.assertTrue(partitionsToRefresh1.isEmpty());

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
@@ -297,7 +297,7 @@ public class PartitionBasedMvRefreshProcessorOlapPart2Test extends MVTestBase {
                         Thread.sleep(1000);
                     }
                     MvUpdateInfo mvUpdateInfo = getMvUpdateInfo(mv);
-                    Assertions.assertTrue(mvUpdateInfo.getMvToRefreshType() == MvUpdateInfo.MvToRefreshType.PARTIAL);
+                    Assertions.assertTrue(mvUpdateInfo.getMVToRefreshType() == MvUpdateInfo.MvToRefreshType.PARTIAL);
                     Assertions.assertTrue(mvUpdateInfo.isValidRewrite());
                     partitionsToRefresh1 = getPartitionNamesToRefreshForMv(mv);
                     Assertions.assertFalse(partitionsToRefresh1.isEmpty());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
@@ -317,7 +317,7 @@ public abstract class MVTestBase extends StarRocksTestBase {
     public static Set<String> getPartitionNamesToRefreshForMv(MaterializedView mv) {
         MvUpdateInfo mvUpdateInfo = MvRefreshArbiter.getMVTimelinessUpdateInfo(mv, true);
         Preconditions.checkState(mvUpdateInfo != null);
-        return mvUpdateInfo.getMvToRefreshPartitionNames().getPartitionNames();
+        return mvUpdateInfo.getMvToRefreshPCells().getPartitionNames();
     }
 
     public static void executeInsertSql(ConnectContext connectContext, String sql) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
@@ -317,7 +317,7 @@ public abstract class MVTestBase extends StarRocksTestBase {
     public static Set<String> getPartitionNamesToRefreshForMv(MaterializedView mv) {
         MvUpdateInfo mvUpdateInfo = MvRefreshArbiter.getMVTimelinessUpdateInfo(mv, true);
         Preconditions.checkState(mvUpdateInfo != null);
-        return mvUpdateInfo.getMvToRefreshPCells().getPartitionNames();
+        return mvUpdateInfo.getMVToRefreshPCells().getPartitionNames();
     }
 
     public static void executeInsertSql(ConnectContext connectContext, String sql) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
@@ -387,8 +387,8 @@ public class MvRewriteHiveTest extends MVTestBase {
                 "`l_orderkey`, `l_suppkey`, `l_shipdate`;");
         MaterializedView mv1 = getMv("test", "hive_unpartitioned_mv");
         MvUpdateInfo mvUpdateInfo = getMvUpdateInfo(mv1);
-        Set<String> toRefreshPartitions = mvUpdateInfo.getMvToRefreshPCells().getPartitionNames();
-        Assertions.assertTrue(mvUpdateInfo.getMvToRefreshType() == MvUpdateInfo.MvToRefreshType.FULL);
+        Set<String> toRefreshPartitions = mvUpdateInfo.getMVToRefreshPCells().getPartitionNames();
+        Assertions.assertTrue(mvUpdateInfo.getMVToRefreshType() == MvUpdateInfo.MvToRefreshType.FULL);
         Assertions.assertTrue(!mvUpdateInfo.isValidRewrite());
         Assertions.assertEquals(0, toRefreshPartitions.size());
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
@@ -387,7 +387,7 @@ public class MvRewriteHiveTest extends MVTestBase {
                 "`l_orderkey`, `l_suppkey`, `l_shipdate`;");
         MaterializedView mv1 = getMv("test", "hive_unpartitioned_mv");
         MvUpdateInfo mvUpdateInfo = getMvUpdateInfo(mv1);
-        Set<String> toRefreshPartitions = mvUpdateInfo.getMvToRefreshPartitionNames().getPartitionNames();
+        Set<String> toRefreshPartitions = mvUpdateInfo.getMvToRefreshPCells().getPartitionNames();
         Assertions.assertTrue(mvUpdateInfo.getMvToRefreshType() == MvUpdateInfo.MvToRefreshType.FULL);
         Assertions.assertTrue(!mvUpdateInfo.isValidRewrite());
         Assertions.assertEquals(0, toRefreshPartitions.size());

--- a/test/sql/test_materialized_view/R/test_mv_rewrite_with_iceberg_bugs1
+++ b/test/sql/test_materialized_view/R/test_mv_rewrite_with_iceberg_bugs1
@@ -1,0 +1,80 @@
+-- name: test_mv_rewrite_with_iceberg_bugs1
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_iceberg_db_${uuid0};
+-- result:
+-- !result
+use mv_iceberg_db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE t1 (
+    num int,
+    dt varchar(30)
+)PARTITION BY (dt);
+-- result:
+-- !result
+INSERT INTO t1 VALUES (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),
+    (1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),
+    (1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),
+    (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
+    (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11"),
+    (2,"2020-07-16"),(3,"2020-07-19"),(4,"2020-07-22"),(5,"2020-07-25");
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv1 PARTITION BY dt1 REFRESH MANUAL AS 
+SELECT date_trunc("month",str2date(dt,'%Y-%m-%d')) as dt1,sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 GROUP BY dt1;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+SELECT date_trunc("month",str2date(dt,'%Y-%m-%d')) as dt1,sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 GROUP BY dt1 order by 1;
+-- result:
+2020-06-01	24
+2020-07-01	48
+-- !result
+function: print_hit_materialized_view("SELECT date_trunc('month',str2date(dt,'%Y-%m-%d')) as dt1,sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 GROUP BY dt1 order by 1;", "mv1")
+-- result:
+True
+-- !result
+INSERT INTO mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 VALUES (3,"2020-06-15");
+-- result:
+-- !result
+function: print_hit_materialized_view("SELECT date_trunc('month',str2date(dt,'%Y-%m-%d')) as dt1,sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 GROUP BY dt1 order by 1;", "mv1")
+-- result:
+True
+-- !result
+SELECT date_trunc("month",str2date(dt,'%Y-%m-%d')) as dt1,sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 GROUP BY dt1 order by 1;
+-- result:
+2020-06-01	27
+2020-07-01	48
+-- !result
+drop database default_catalog.db_${uuid0} ;
+-- result:
+-- !result
+DROP TABLE mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 FORCE;
+-- result:
+-- !result
+drop database mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0};
+-- result:
+-- !result
+DROP CATALOG mv_iceberg_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/T/test_mv_rewrite_with_iceberg_bugs1
+++ b/test/sql/test_materialized_view/T/test_mv_rewrite_with_iceberg_bugs1
@@ -1,0 +1,47 @@
+-- name: test_mv_rewrite_with_iceberg_bugs1
+
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+
+-- create iceberg table
+set catalog mv_iceberg_${uuid0};
+create database mv_iceberg_db_${uuid0};
+use mv_iceberg_db_${uuid0};
+
+CREATE TABLE t1 (
+    num int,
+    dt varchar(30)
+)PARTITION BY (dt);
+INSERT INTO t1 VALUES (1,"2020-06-15"),(2,"2020-06-18"),(3,"2020-06-21"),(4,"2020-06-24"),
+    (1,"2020-07-02"),(2,"2020-07-05"),(3,"2020-07-08"),(4,"2020-07-11"),
+    (1,"2020-07-16"),(2,"2020-07-19"),(3,"2020-07-22"),(4,"2020-07-25"),
+    (2,"2020-06-15"),(3,"2020-06-18"),(4,"2020-06-21"),(5,"2020-06-24"),
+    (2,"2020-07-02"),(3,"2020-07-05"),(4,"2020-07-08"),(5,"2020-07-11"),
+    (2,"2020-07-16"),(3,"2020-07-19"),(4,"2020-07-22"),(5,"2020-07-25");
+
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE MATERIALIZED VIEW mv1 PARTITION BY dt1 REFRESH MANUAL AS 
+SELECT date_trunc("month",str2date(dt,'%Y-%m-%d')) as dt1,sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 GROUP BY dt1;
+
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+
+SELECT date_trunc("month",str2date(dt,'%Y-%m-%d')) as dt1,sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 GROUP BY dt1 order by 1;
+function: print_hit_materialized_view("SELECT date_trunc('month',str2date(dt,'%Y-%m-%d')) as dt1,sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 GROUP BY dt1 order by 1;", "mv1")
+
+INSERT INTO mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 VALUES (3,"2020-06-15");
+
+function: print_hit_materialized_view("SELECT date_trunc('month',str2date(dt,'%Y-%m-%d')) as dt1,sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 GROUP BY dt1 order by 1;", "mv1")
+SELECT date_trunc("month",str2date(dt,'%Y-%m-%d')) as dt1,sum(num) FROM mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 GROUP BY dt1 order by 1;
+
+drop database default_catalog.db_${uuid0} ;
+DROP TABLE mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0}.t1 FORCE;
+drop database mv_iceberg_${uuid0}.mv_iceberg_db_${uuid0};
+DROP CATALOG mv_iceberg_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
mv compensation error when ref base table-> mv contains a `transform` which has been applied normalized in Differ.


## What I'm doing:

1. introduce a `PCellWithNorm` to use original base table's pcell instead of normalized partition cell instead.
2. refactor associated codes as below

### Core Refactoring of MV Partition Update Information

* Renamed fields and methods in `MvUpdateInfo` and `MvBaseTableUpdateInfo` to use "PCells" instead of "partition names", e.g., `mvToRefreshPartitionNames` → `mvToRefreshPCells`, and updated all references and method names accordingly. [[1]](diffhunk://#diff-bfa11bf136a58187ad4896049e714d7fee4fb076379faba1531b4fbdb41e29caL34-R46) [[2]](diffhunk://#diff-381d5b7ad3f47a9f91d172259737d35db44ca04e8bc17971b4c35fc894a643c4L18-R64)
* Updated mapping structures for MV and base table partitions to use more explicit names and types, such as `mvPartNameToBasePCells` and `basePartNameToMVPCells`, replacing older ambiguous mappings.

### API and Logic Adjustments

* Refactored method signatures and logic in MV refresh and timeliness arbiter classes to use the new "PCells" fields and methods, ensuring consistent usage across MV update workflows. [[1]](diffhunk://#diff-85709ba65df54d9e664e8ae65347ef8df37397e0e513a17c558dcbb8486c60ccL144-R144) [[2]](diffhunk://#diff-85709ba65df54d9e664e8ae65347ef8df37397e0e513a17c558dcbb8486c60ccL185-R186) [[3]](diffhunk://#diff-0bd111112cc1eb37cd473f0d9088e8bcee87e15a4ff90ac2ff01fac6654c83caL187-R187) [[4]](diffhunk://#diff-0bd111112cc1eb37cd473f0d9088e8bcee87e15a4ff90ac2ff01fac6654c83caL201-R202) [[5]](diffhunk://#diff-0bd111112cc1eb37cd473f0d9088e8bcee87e15a4ff90ac2ff01fac6654c83caL224-R232) [[6]](diffhunk://#diff-0bd111112cc1eb37cd473f0d9088e8bcee87e15a4ff90ac2ff01fac6654c83caR241-R242) [[7]](diffhunk://#diff-0bd111112cc1eb37cd473f0d9088e8bcee87e15a4ff90ac2ff01fac6654c83caL266-R272) [[8]](diffhunk://#diff-0bd111112cc1eb37cd473f0d9088e8bcee87e15a4ff90ac2ff01fac6654c83caL280-R287) [[9]](diffhunk://#diff-0bd111112cc1eb37cd473f0d9088e8bcee87e15a4ff90ac2ff01fac6654c83caL306-R311) [[10]](diffhunk://#diff-0bd111112cc1eb37cd473f0d9088e8bcee87e15a4ff90ac2ff01fac6654c83caL330-R336) [[11]](diffhunk://#diff-0bd111112cc1eb37cd473f0d9088e8bcee87e15a4ff90ac2ff01fac6654c83caL345-R353) [[12]](diffhunk://#diff-06af043decc2af2286723b3cfe05f11fcf38ad694e6a5aca2031556d3a1a09bdL78-R78)

### Codebase Simplification and Readability

* Removed obsolete fields and methods from `MvBaseTableUpdateInfo` that previously handled partition name/range mappings, consolidating logic to focus on partition cells.
* Improved `toString()` methods and internal checks to use new structures, enhancing debug output and maintainability. [[1]](diffhunk://#diff-bfa11bf136a58187ad4896049e714d7fee4fb076379faba1531b4fbdb41e29caL137-R165) [[2]](diffhunk://#diff-bfa11bf136a58187ad4896049e714d7fee4fb076379faba1531b4fbdb41e29caL168-R191)

### Utility and Consistency Improvements

* Added utility imports and methods (such as `PCellUtils`) to support the new partition cell logic and checks. [[1]](diffhunk://#diff-bfa11bf136a58187ad4896049e714d7fee4fb076379faba1531b4fbdb41e29caR21) [[2]](diffhunk://#diff-bfa11bf136a58187ad4896049e714d7fee4fb076379faba1531b4fbdb41e29caL137-R165)

### Backward Compatibility and Migration

* Updated all usages and invocations of affected methods and fields throughout the MV management classes to ensure seamless migration to the new data structures and naming conventions. (All references above)

These changes collectively make the MV update tracking code more robust, easier to maintain, and less error-prone by using clear, consistent terminology and data structures.

Fixes https://github.com/StarRocks/StarRocksTest/issues/10570

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors MV update/refresh logic to PCell-based APIs, fixes range/list partition mapping and compensation, and updates callers with new tests (incl. Iceberg regression).
> 
> - **Core MV Update Info**:
>   - Replace `mvToRefreshPartitionNames` and related maps with PCell-based fields (`getMVToRefreshPCells`, `getMVPartNameToBasePCells`, `getBasePartNameToMVPCells`, `getRefBaseNestedMVPCells`).
>   - Add `addRefBaseTablePCells` and factory `MvBaseTableUpdateInfo.of()`; track ref base table snapshot cells.
> - **Arbiters/Timeliness**:
>   - Use new PCell getters; sync base table partitions into `MvUpdateInfo`; propagate nested MV PCells.
> - **Partition Differ (Range)**:
>   - Introduce `PCellWithNorm` to keep original base cell while normalizing; fix base↔MV intersection mappings to use original names; refactor normalization helpers.
> - **Optimizer/Rewrite**:
>   - Switch rewrite, preprocessor, transparent rewrite, duplication, and text-match paths to PCell-based APIs.
> - **Compensation**:
>   - Update MV compensation builders and external table compensation to derive refresh keys from PCells (range/list), respecting pruner/non-pruner paths.
> - **Scheduler/Refresh**:
>   - PCT refresh partitioner now reads ref base `getToRefreshPCells` and mapping updates.
> - **Tests**:
>   - Update unit tests to new APIs; add regression SQL test for Iceberg MV rewrite correctness.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 970614d70e9209cc9105d2eb1f33fe7cdf633e00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->