### PR TITLE
[BugFix] Fix inactive mv with nested mvs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -646,7 +646,7 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
             GlobalStateMgr.getCurrentState().getLocalMetastore().renameColumn(db, table, clause);
 
             // If modified columns are already done, inactive related mv
-            AlterMVJobExecutor.inactiveRelatedMaterializedViews(db, (OlapTable) table, modifiedColumns);
+            AlterMVJobExecutor.inactiveRelatedMaterializedViews((OlapTable) table, modifiedColumns);
 
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.WRITE);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -432,9 +432,9 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
                 }
 
                 // inactive the related MVs
-                AlterMVJobExecutor.inactiveRelatedMaterializedView(origTable,
+                AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(origTable,
                         MaterializedViewExceptions.inactiveReasonForBaseTableSwapped(origTblName), false);
-                AlterMVJobExecutor.inactiveRelatedMaterializedView(olapNewTbl,
+                AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(olapNewTbl,
                         MaterializedViewExceptions.inactiveReasonForBaseTableSwapped(newTblName), false);
 
                 SwapTableOperationLog log = new SwapTableOperationLog(db.getId(), origTable.getId(), olapNewTbl.getId());
@@ -646,7 +646,7 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
             GlobalStateMgr.getCurrentState().getLocalMetastore().renameColumn(db, table, clause);
 
             // If modified columns are already done, inactive related mv
-            AlterMVJobExecutor.inactiveRelatedMaterializedViews((OlapTable) table, modifiedColumns);
+            AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive((OlapTable) table, modifiedColumns);
 
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.WRITE);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -232,7 +232,7 @@ public class AlterJobMgr {
             try {
                 mvQueryStatement = recreateMVQuery(materializedView, context, createMvSql);
             } catch (Exception e) {
-                LOG.warn("alter mv {} to active failed:", e);
+                LOG.warn("alter mv {} to active failed", materializedView.getName(), e);
                 throw new SemanticException("Can not active materialized view [%s]" +
                         " because analyze materialized view define sql: \n\n%s" +
                         "\n\nCause an error: %s", materializedView.getName(), createMvSql, e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -210,6 +210,13 @@ public class AlterJobMgr {
         }
     }
 
+    /**
+     * NOTE: Inactive the specific mv and not inactive its relative mvs recursively.
+     * @param materializedView target mv to inactive
+     * @param status status to be set
+     * @param reason reason why to set inactive
+     * @param isReplay whehter this is called in replay
+     */
     public void alterMaterializedViewStatus(MaterializedView materializedView, String status, String reason, boolean isReplay) {
         LOG.info("process change materialized view {} status to {}, isReplay: {}",
                 materializedView.getName(), status, isReplay);
@@ -225,6 +232,7 @@ public class AlterJobMgr {
             try {
                 mvQueryStatement = recreateMVQuery(materializedView, context, createMvSql);
             } catch (Exception e) {
+                LOG.warn("alter mv {} to active failed:", e);
                 throw new SemanticException("Can not active materialized view [%s]" +
                         " because analyze materialized view define sql: \n\n%s" +
                         "\n\nCause an error: %s", materializedView.getName(), createMvSql, e.getMessage());
@@ -621,7 +629,7 @@ public class AlterJobMgr {
             }
             view.setNewFullSchema(newFullSchema);
             view.setComment(comment);
-            AlterMVJobExecutor.inactiveRelatedMaterializedView(view,
+            AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(view,
                     MaterializedViewExceptions.inactiveReasonForBaseViewChanged(viewName), isReplay);
             db.dropTable(viewName);
             db.registerTableUnlocked(view);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -642,7 +642,7 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
         if (mv == null || !GlobalStateMgr.getCurrentState().isLeader()) {
             return;
         }
-        if (visited.contains(mv.getId())) {
+        if (visited.contains(mv.getMvId())) {
             return;
         }
         // inactive this mv first
@@ -651,7 +651,7 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
         visited.add(mv.getMvId());
 
         // reset inactive reason
-        reason = MaterializedViewExceptions.inactiveReasonForBaseTableActive(mv.getName());
+        reason = MaterializedViewExceptions.inactiveReasonForBaseTableInActive(mv.getName());
         // recursive inactive
         for (MvId mvId : mv.getRelatedMaterializedViews()) {
             if (visited.contains(mvId)) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -687,7 +687,7 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
             GlobalStateMgr.getCurrentState().getAlterJobMgr().
                     alterMaterializedViewStatus(mv, status, reason, false);
             AlterMaterializedViewStatusLog log = new AlterMaterializedViewStatusLog(mv.getDbId(),
-                    mv.getId(), status, MANUAL_INACTIVE_MV_REASON);
+                    mv.getId(), status, reason);
             GlobalStateMgr.getCurrentState().getEditLog().logAlterMvStatus(log);
         } else {
             mv.setInactiveAndReason(reason);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
@@ -147,7 +147,7 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
         table.rebuildFullSchema();
 
         // If modified columns are already done, inactive related mv
-        AlterMVJobExecutor.inactiveRelatedMaterializedViews(table, droppedOrModifiedColumns);
+        AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(table, droppedOrModifiedColumns);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
@@ -147,7 +147,7 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
         table.rebuildFullSchema();
 
         // If modified columns are already done, inactive related mv
-        AlterMVJobExecutor.inactiveRelatedMaterializedViews(db, table, droppedOrModifiedColumns);
+        AlterMVJobExecutor.inactiveRelatedMaterializedViews(table, droppedOrModifiedColumns);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -3046,7 +3046,7 @@ public class SchemaChangeHandler extends AlterHandler {
             olapTable.rebuildFullSchema();
 
             // If modified columns are already done, inactive related mv
-            AlterMVJobExecutor.inactiveRelatedMaterializedViews(db, olapTable, modifiedColumns);
+            AlterMVJobExecutor.inactiveRelatedMaterializedViews(olapTable, modifiedColumns);
 
             if (!isReplay) {
                 TableAddOrDropColumnsInfo info = new TableAddOrDropColumnsInfo(db.getId(), olapTable.getId(),

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -172,7 +172,7 @@ public class SchemaChangeHandler extends AlterHandler {
         }
 
         // If optimized olap table contains related mvs, set those mv state to inactive.
-        AlterMVJobExecutor.inactiveRelatedMaterializedView(olapTable,
+        AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(olapTable,
                 MaterializedViewExceptions.inactiveReasonForBaseTableOptimized(olapTable.getName()), false);
 
         long timeoutSecond = PropertyAnalyzer.analyzeTimeout(propertyMap, Config.alter_table_timeout_second);
@@ -2048,14 +2048,14 @@ public class SchemaChangeHandler extends AlterHandler {
                             sortKeyUniqueIds);
 
                     // If optimized olap table contains related mvs, set those mv state to inactive.
-                    AlterMVJobExecutor.inactiveRelatedMaterializedView(olapTable,
+                    AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(olapTable,
                             MaterializedViewExceptions.inactiveReasonForBaseTableReorderColumns(olapTable.getName()), false);
                     return createJobForProcessModifySortKeyColumn(db.getId(), olapTable, indexSchemaMap, sortKeyIdxes,
                             sortKeyUniqueIds);
                 } else {
                     processReorderColumn((ReorderColumnsClause) alterClause, olapTable, indexSchemaMap);
                     // If optimized olap table contains related mvs, set those mv state to inactive.
-                    AlterMVJobExecutor.inactiveRelatedMaterializedView(olapTable,
+                    AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(olapTable,
                             MaterializedViewExceptions.inactiveReasonForBaseTableReorderColumns(olapTable.getName()), false);
                 }
             } else if (alterClause instanceof ModifyTablePropertiesClause) {
@@ -3046,7 +3046,7 @@ public class SchemaChangeHandler extends AlterHandler {
             olapTable.rebuildFullSchema();
 
             // If modified columns are already done, inactive related mv
-            AlterMVJobExecutor.inactiveRelatedMaterializedViews(olapTable, modifiedColumns);
+            AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(olapTable, modifiedColumns);
 
             if (!isReplay) {
                 TableAddOrDropColumnsInfo info = new TableAddOrDropColumnsInfo(db.getId(), olapTable.getId(),

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -804,7 +804,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
             onFinished(tbl);
 
             // If schema changes include fields which defined in related mv, set those mv state to inactive.
-            AlterMVJobExecutor.inactiveRelatedMaterializedViews(tbl, modifiedColumns);
+            AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(tbl, modifiedColumns);
 
             pruneMeta();
             tbl.onReload();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -804,7 +804,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
             onFinished(tbl);
 
             // If schema changes include fields which defined in related mv, set those mv state to inactive.
-            AlterMVJobExecutor.inactiveRelatedMaterializedViews(db, tbl, modifiedColumns);
+            AlterMVJobExecutor.inactiveRelatedMaterializedViews(tbl, modifiedColumns);
 
             pruneMeta();
             tbl.onReload();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1477,7 +1477,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                     LOG.warn("tableName :{} is invalid. set materialized view:{} to invalid",
                             baseTableInfo.getTableName(), id);
                     res = InactiveReason.ofInactive(
-                            MaterializedViewExceptions.inactiveReasonForBaseTableActive(baseTableInfo.getTableName()));
+                            MaterializedViewExceptions.inactiveReasonForBaseTableInActive(baseTableInfo.getTableName()));
                 }
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -721,7 +721,7 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
      */
     public void onDrop(Database db, boolean force, boolean replay) {
         // inactive relative materialized views if the base table/view/external table is dropped.
-        AlterMVJobExecutor.inactiveRelatedMaterializedView(this,
+        AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(this,
                 MaterializedViewExceptions.inactiveReasonForBaseTableNotExists(getName()), replay);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/MaterializedViewExceptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/MaterializedViewExceptions.java
@@ -71,7 +71,7 @@ public class MaterializedViewExceptions {
         return INACTIVE_REASON_FOR_METADATA_TABLE_RESTORE_CORRUPTED + tableName;
     }
 
-    public static String inactiveReasonForBaseTableActive(String tableName) {
+    public static String inactiveReasonForBaseTableInActive(String tableName) {
         return "base-mv inactive: " + tableName;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3484,7 +3484,7 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
 
         db.dropTable(oldTableName);
         db.registerTableUnlocked(olapTable);
-        AlterMVJobExecutor.inactiveRelatedMaterializedView(olapTable,
+        AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(olapTable,
                 MaterializedViewExceptions.inactiveReasonForBaseTableRenamed(oldTableName), false);
 
         TableInfo tableInfo = TableInfo.createForTableRename(db.getId(), olapTable.getId(), newTableName);

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -2577,6 +2577,20 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         return database.getTable(tblName);
     }
 
+    /**
+     * @param mvId mv's mvid
+     * @return a checked mv by input mvid.
+     */
+    public MaterializedView getMaterializedView(MvId mvId) {
+        long dbId = mvId.getDbId();
+        long tableId = mvId.getId();
+        Table table = getTable(dbId, tableId);
+        if (table == null || !(table instanceof MaterializedView)) {
+            return null;
+        }
+        return (MaterializedView) table;
+    }
+
     public Table getTable(Long dbId, Long tableId) {
         Database database = getDb(dbId);
         if (database == null) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
@@ -309,7 +309,7 @@ public class AlterMaterializedViewTest extends MVTestBase  {
         // inactive mv when base table's schema changed
         Database db = starRocksAssert.getDb(connectContext.getDatabase());
         Table parTbl1 = starRocksAssert.getTable(connectContext.getDatabase(), "par_tbl1");
-        AlterMVJobExecutor.inactiveRelatedMaterializedViews(db, (OlapTable) parTbl1, Set.of("item_id"));
+        AlterMVJobExecutor.inactiveRelatedMaterializedViews((OlapTable) parTbl1, Set.of("item_id"));
         baseTableVisibleVersionMap = mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
         Assertions.assertTrue(baseTableVisibleVersionMap.isEmpty());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
@@ -309,7 +309,7 @@ public class AlterMaterializedViewTest extends MVTestBase  {
         // inactive mv when base table's schema changed
         Database db = starRocksAssert.getDb(connectContext.getDatabase());
         Table parTbl1 = starRocksAssert.getTable(connectContext.getDatabase(), "par_tbl1");
-        AlterMVJobExecutor.inactiveRelatedMaterializedViews((OlapTable) parTbl1, Set.of("item_id"));
+        AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive((OlapTable) parTbl1, Set.of("item_id"));
         baseTableVisibleVersionMap = mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
         Assertions.assertTrue(baseTableVisibleVersionMap.isEmpty());
     }


### PR DESCRIPTION
## Why I'm doing:

When executing `inactive mv`, should inactive related mvs recursively. because the depend mv is inactive, the related mvs will always fail in refreshing and may cause some unexpected errors(data inconsistent or metadata corrupt).

## What I'm doing:
- inactive related mvs recursively;

This will cause behavior changes.

Before:
- `inactive mv` only inactive the specific input mv;

After:
- `inactive mv` will inactive all the related mvs recursively.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors MV inactivation to recursively disable dependent MVs (with proper logging/version-map handling) and updates all callers, reasons, and utilities accordingly.
> 
> - **Materialized View inactivation (core)**:
>   - Add `doInactiveMaterializedViewRecursive` and `doInactiveMaterializedViewOnly` with conditional version-map clearing and edit-log writes.
>   - Manual `INACTIVE` now recursively inactivates dependent MVs without clearing version maps by default.
>   - Standardize reason to `inactiveReasonForBaseTableInActive` and adjust usage in `MaterializedView`.
> - **API/Utilities**:
>   - Replace `inactiveRelatedMaterializedView(s)` with `inactiveRelatedMaterializedViewsRecursive` across codebase.
>   - Add `LocalMetastore.getMaterializedView(MvId)` helper.
>   - Improve logging when activating MV fails.
> - **Callers updated**:
>   - Apply recursive MV inactivation on table/view swap/rename/drop, schema change (add/drop/modify/reorder/optimize), column rename, and partition jobs (`AlterJobExecutor`, `SchemaChangeHandler`, `LakeTableAsyncFastSchemaChangeJob`, `SchemaChangeJobV2`, `AlterJobMgr`, `Table`, `LocalMetastore`).
> - **Tests**:
>   - Update tests to use new recursive API and validate version-map behavior after schema changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79f5695bd67d1243f0a3901d4c21263bf03f9743. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->