### PR TITLE
[Feature] Introduce tablet range to thrift rpc for range data distribution

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -336,7 +336,7 @@ Status OlapTableSink::_init_node_channels(RuntimeState* state, IndexIdToTabletBE
         auto* index = _schema->indexes()[i];
         auto& tablet_to_be = index_id_to_tablet_be_map[index->index_id];
         for (auto& [id, part] : partitions) {
-            for (auto tablet_id : part->indexes[i].tablets) {
+            for (auto tablet_id : part->indexes[i].tablet_ids) {
                 auto& tablet_info = tablets.emplace_back();
                 tablet_info.set_tablet_id(tablet_id);
                 tablet_info.set_partition_id(part->id);
@@ -538,7 +538,7 @@ Status OlapTableSink::_incremental_open_node_channel(const std::vector<TOlapTabl
             auto& tablets = index_tablets_map[index.index_id];
             auto& tablet_to_be = index_tablet_bes_map[index.index_id];
             // setup new partitions's tablets
-            for (auto tablet_id : index.tablets) {
+            for (auto tablet_id : index.tablet_ids) {
                 auto& tablet_info = tablets.emplace_back();
                 tablet_info.set_tablet_id(tablet_id);
                 // TODO: support logical materialized views;

--- a/be/src/exec/tablet_sink_colocate_sender.cpp
+++ b/be/src/exec/tablet_sink_colocate_sender.cpp
@@ -61,8 +61,8 @@ Status TabletSinkColocateSender::send_chunk(const OlapTableSchemaParam* schema,
                 uint16_t selection = validate_select_idx[j];
                 const auto* partition = partitions[selection];
                 index_id_partition_id[index->index_id].emplace(partition->id);
-                const auto& tablets = partition->indexes[i].tablets;
-                _index_tablet_ids[i][selection] = tablets[record_hashes[selection] % tablets.size()];
+                const auto& tablet_ids = partition->indexes[i].tablet_ids;
+                _index_tablet_ids[i][selection] = tablet_ids[record_hashes[selection] % tablet_ids.size()];
             }
         }
         return _send_chunks(schema, chunk, _index_tablet_ids, validate_select_idx);
@@ -75,8 +75,8 @@ Status TabletSinkColocateSender::send_chunk(const OlapTableSchemaParam* schema,
             for (size_t j = 0; j < num_rows; ++j) {
                 const auto* partition = partitions[j];
                 index_id_partition_id[index->index_id].emplace(partition->id);
-                const auto& tablets = partition->indexes[i].tablets;
-                _index_tablet_ids[i][j] = tablets[record_hashes[j] % tablets.size()];
+                const auto& tablet_ids = partition->indexes[i].tablet_ids;
+                _index_tablet_ids[i][j] = tablet_ids[record_hashes[j] % tablet_ids.size()];
             }
         }
         return _send_chunks(schema, chunk, _index_tablet_ids, validate_select_idx);

--- a/be/src/exec/tablet_sink_sender.cpp
+++ b/be/src/exec/tablet_sink_sender.cpp
@@ -60,8 +60,8 @@ Status TabletSinkSender::send_chunk(const OlapTableSchemaParam* schema,
                 uint16_t selection = validate_select_idx[j];
                 const auto* partition = partitions[selection];
                 index_id_partition_id[index->index_id].emplace(partition->id);
-                const auto& tablets = partition->indexes[i].tablets;
-                _tablet_ids[selection] = tablets[record_hashes[selection] % tablets.size()];
+                const auto& tablet_ids = partition->indexes[i].tablet_ids;
+                _tablet_ids[selection] = tablet_ids[record_hashes[selection] % tablet_ids.size()];
             }
             RETURN_IF_ERROR(_send_chunk_by_node(chunk, _channels[i], validate_select_idx));
         }
@@ -72,8 +72,8 @@ Status TabletSinkSender::send_chunk(const OlapTableSchemaParam* schema,
             for (size_t j = 0; j < num_rows; ++j) {
                 const auto* partition = partitions[j];
                 index_id_partition_id[index->index_id].emplace(partition->id);
-                const auto& tablets = partition->indexes[i].tablets;
-                _tablet_ids[j] = tablets[record_hashes[j] % tablets.size()];
+                const auto& tablet_ids = partition->indexes[i].tablet_ids;
+                _tablet_ids[j] = tablet_ids[record_hashes[j] % tablet_ids.size()];
             }
             RETURN_IF_ERROR(_send_chunk_by_node(chunk, _channels[i], validate_select_idx));
         }

--- a/be/src/storage/table_reader.cpp
+++ b/be/src/storage/table_reader.cpp
@@ -134,8 +134,8 @@ Status TableReader::multi_get(Chunk& keys, const std::vector<std::string>& value
     for (size_t i = 0; i < selected_size; ++i) {
         size_t key_index = validate_select_idx[i];
         const auto* partition = partitions[key_index];
-        const auto& tablets = partition->indexes[0].tablets;
-        int64_t tablet_id = tablets[record_hashes[key_index] % tablets.size()];
+        const auto& tablet_ids = partition->indexes[0].tablet_ids;
+        int64_t tablet_id = tablet_ids[record_hashes[key_index] % tablet_ids.size()];
         auto iter = multi_gets_by_tablet.find(tablet_id);
         TabletMultiGet* multi_get = nullptr;
         if (iter == multi_gets_by_tablet.end()) {

--- a/be/test/exec/tablet_info_test.cpp
+++ b/be/test/exec/tablet_info_test.cpp
@@ -112,7 +112,7 @@ TEST_F(OlapTablePartitionParamTest, unknown_distributed_col) {
     t_partition_param.partitions[0].id = 10;
     t_partition_param.partitions[0].indexes.resize(2);
     t_partition_param.partitions[0].indexes[0].index_id = 4;
-    t_partition_param.partitions[0].indexes[0].tablets = {21};
+    t_partition_param.partitions[0].indexes[0].tablet_ids = {21};
     t_partition_param.partitions[0].indexes[1].index_id = 5;
 
     OlapTablePartitionParam part(schema, t_partition_param);
@@ -138,7 +138,7 @@ TEST_F(OlapTablePartitionParamTest, bad_index) {
         t_partition_param.partitions[0].id = 10;
         t_partition_param.partitions[0].indexes.resize(1);
         t_partition_param.partitions[0].indexes[0].index_id = 4;
-        t_partition_param.partitions[0].indexes[0].tablets = {21};
+        t_partition_param.partitions[0].indexes[0].tablet_ids = {21};
 
         OlapTablePartitionParam part(schema, t_partition_param);
         st = part.init(nullptr);
@@ -156,7 +156,7 @@ TEST_F(OlapTablePartitionParamTest, bad_index) {
         t_partition_param.partitions[0].id = 10;
         t_partition_param.partitions[0].indexes.resize(2);
         t_partition_param.partitions[0].indexes[0].index_id = 4;
-        t_partition_param.partitions[0].indexes[0].tablets = {21};
+        t_partition_param.partitions[0].indexes[0].tablet_ids = {21};
         t_partition_param.partitions[0].indexes[1].index_id = 6;
 
         OlapTablePartitionParam part(schema, t_partition_param);

--- a/be/test/exec/tablet_sink_index_channel_test.cpp
+++ b/be/test/exec/tablet_sink_index_channel_test.cpp
@@ -90,7 +90,7 @@ protected:
         partition.partitions[0].id = 0;
         partition.partitions[0].indexes.resize(1);
         partition.partitions[0].indexes[0].index_id = 0;
-        partition.partitions[0].indexes[0].tablets.push_back(0);
+        partition.partitions[0].indexes[0].tablet_ids.push_back(0);
 
         TOlapTableLocationParam& location = table_sink.location;
         location.db_id = _db_id;

--- a/be/test/storage/table_reader_remote_test.cpp
+++ b/be/test/storage/table_reader_remote_test.cpp
@@ -143,7 +143,7 @@ public:
         params.partition_param.partitions[0].id = 1;
         params.partition_param.partitions[0].indexes.resize(1);
         params.partition_param.partitions[0].indexes[0].index_id = 1111;
-        params.partition_param.partitions[0].indexes[0].tablets = _tablet_ids;
+        params.partition_param.partitions[0].indexes[0].tablet_ids = _tablet_ids;
         params.partition_param.distributed_columns = {"pk1"};
         params.partition_versions[1] = version;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -2265,7 +2265,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             if (tPartition != null) {
                 partitions.add(tPartition);
                 for (TOlapTableIndexTablets index : tPartition.getIndexes()) {
-                    for (long tabletId : index.getTablets()) {
+                    for (long tabletId : index.getTablet_ids()) {
                         TTabletLocation tablet = txnState.getTabletIdToTTabletLocation().get(tabletId);
                         if (tablet != null) {
                             tablets.add(tablet);

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoOlapTableSink.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoOlapTableSink.java
@@ -208,7 +208,7 @@ public class PseudoOlapTableSink {
         partitions = tOlapTableSink.partition.partitions.stream().map(p -> {
             Partition partition = new Partition();
             partition.id = p.id;
-            partition.indexToTabletIds = p.indexes.stream().collect(Collectors.toMap(e -> e.index_id, e -> e.tablets));
+            partition.indexToTabletIds = p.indexes.stream().collect(Collectors.toMap(e -> e.index_id, e -> e.tablet_ids));
             return partition;
         }).collect(Collectors.toList());
         tabletIdToNodeIds = tOlapTableSink.location.tablets.stream().collect(Collectors.toMap(e -> e.tablet_id, e -> e.node_ids));

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -245,9 +245,15 @@ struct TColumn {
     21: optional Types.TTypeDesc type_desc         
 }
 
+struct TOlapTableTablet {
+    1: optional i64 id // tablet id
+    2: optional Types.TTabletRange range
+}
+
 struct TOlapTableIndexTablets {
     1: required i64 index_id
-    2: required list<i64> tablets
+    2: required list<i64> tablet_ids
+    3: optional list<TOlapTableTablet> tablets
 }
 
 // its a closed-open range

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -628,3 +628,20 @@ struct TParquetOptions {
     // for files table function
     4: optional string version
 }
+
+struct TVariant {
+    1: optional TTypeDesc type
+    2: optional i64 int_value
+    3: optional string string_value
+}
+
+struct TTuple {
+    1: optional list<TVariant> values
+}
+
+struct TTabletRange {
+    1: optional TTuple lower_bound
+    2: optional TTuple upper_bound
+    3: optional bool lower_bound_included
+    4: optional bool upper_bound_included
+}


### PR DESCRIPTION
## Why I'm doing:
Introduce tablet range to thrift rpc for range data distribution.

## What I'm doing:
- Add tablet range information to TOlapTableIndexTablets
- Correct the filed name of tablet ids in TOlapTableIndexTablets

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces tablet range support in thrift and renames index tablet field to tablet_ids, updating BE/FE code and tests accordingly.
> 
> - **Thrift/RPC schema**:
>   - Add `TVariant`, `TTuple`, `TTabletRange` and new `TOlapTableTablet`.
>   - Change `TOlapTableIndexTablets`: rename `tablets` to `tablet_ids`; add optional `tablets` carrying per-tablet ranges.
> - **Backend**:
>   - Replace `partition.indexes[i].tablets` with `tablet_ids` in `exec/tablet_sink*.cpp` and `storage/table_reader.cpp`.
>   - Update unit tests to use `tablet_ids`.
> - **Frontend**:
>   - Adjust `FrontendServiceImpl` and pseudo cluster `PseudoOlapTableSink` to read `tablet_ids`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e7d5384b707ddfd36f70bb607ffb0bff193b18a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->