### PR TITLE
[Refactor] Replace clone method calls with ExprSubstitutionVisitor.rewrite for improved expression handling

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/AggregateInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AggregateInfo.java
@@ -36,10 +36,8 @@ package com.starrocks.planner;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.sql.ast.expression.Expr;
-import com.starrocks.sql.ast.expression.ExprSubstitutionMap;
 import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
 
@@ -66,15 +64,6 @@ public final class AggregateInfo extends AggregateInfoBase {
     private AggregateInfo secondPhaseDistinctAggInfo_;
 
     private final AggPhase aggPhase_;
-
-    // Map from all grouping and aggregate exprs to a SlotRef referencing the corresp. slot
-    // in the intermediate tuple. Identical to outputTupleSmap_ if no aggregateExpr has an
-    // output type that is different from its intermediate type.
-    protected ExprSubstitutionMap intermediateTupleSmap_ = new ExprSubstitutionMap();
-
-    // Map from all grouping and aggregate exprs to a SlotRef referencing the corresp. slot
-    // in the output tuple.
-    protected ExprSubstitutionMap outputTupleSmap_ = new ExprSubstitutionMap();
 
     // if set, a subset of groupingExprs_; set and used during planning
     private List<Expr> partitionExprs_;
@@ -106,13 +95,6 @@ public final class AggregateInfo extends AggregateInfoBase {
             secondPhaseDistinctAggInfo_ = other.secondPhaseDistinctAggInfo_.clone();
         }
         aggPhase_ = other.aggPhase_;
-        outputTupleSmap_ = other.outputTupleSmap_.clone();
-        if (other.requiresIntermediateTuple()) {
-            intermediateTupleSmap_ = other.intermediateTupleSmap_.clone();
-        } else {
-            Preconditions.checkState(other.intermediateTupleDesc_ == other.outputTupleDesc_);
-            intermediateTupleSmap_ = outputTupleSmap_;
-        }
         partitionExprs_ =
                 (other.partitionExprs_ != null) ? ExprUtils.cloneList(other.partitionExprs_) : null;
     }
@@ -148,8 +130,6 @@ public final class AggregateInfo extends AggregateInfoBase {
         StringBuilder out = new StringBuilder(super.debugString());
         out.append(MoreObjects.toStringHelper(this)
                 .add("phase", aggPhase_)
-                .add("intermediate_smap", intermediateTupleSmap_.debugString())
-                .add("output_smap", outputTupleSmap_.debugString())
                 .toString());
         if (mergeAggInfo_ != this && mergeAggInfo_ != null) {
             out.append("\nmergeAggInfo:\n" + mergeAggInfo_.debugString());

--- a/fe/fe-core/src/main/java/com/starrocks/planner/LoadScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/LoadScanNode.java
@@ -46,6 +46,7 @@ import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprSubstitutionMap;
+import com.starrocks.sql.ast.expression.ExprSubstitutionVisitor;
 import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.system.ComputeNode;
@@ -80,12 +81,11 @@ public abstract class LoadScanNode extends ScanNode {
                 throw new StarRocksException("unknown column in where statement. "
                         + "the column '" + slot.getColumnName() + "' in where clause must be in the target table.");
             }
-            smap.getLhs().add(slot);
             SlotRef slotRef = new SlotRef(slotDesc);
             slotRef.setColumnName(slot.getColumnName());
-            smap.getRhs().add(slotRef);
+            smap.put(slot, slotRef);
         }
-        whereExpr = whereExpr.clone(smap);
+        whereExpr = ExprSubstitutionVisitor.rewrite(whereExpr, smap);
         whereExpr = ExprUtils.analyzeAndCastFold(whereExpr);
 
         if (!whereExpr.getType().isBoolean()) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -87,6 +87,7 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.IndexDef.IndexType;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprSubstitutionMap;
+import com.starrocks.sql.ast.expression.ExprSubstitutionVisitor;
 import com.starrocks.sql.ast.expression.ExprToSql;
 import com.starrocks.sql.ast.expression.ExprToThriftVisitor;
 import com.starrocks.sql.ast.expression.ExprUtils;
@@ -453,12 +454,11 @@ public class OlapTableSink extends DataSink {
                 for (SlotRef slot : slots) {
                     SlotDescriptor slotDesc = descMap.get(slot.getColumnName());
                     Preconditions.checkNotNull(slotDesc);
-                    smap.getLhs().add(slot);
                     SlotRef slotRef = new SlotRef(slotDesc);
                     slotRef.setColumnName(slot.getColumnName());
-                    smap.getRhs().add(slotRef);
+                    smap.put(slot, slotRef);
                 }
-                whereClause = whereClause.clone(smap);
+                whereClause = ExprSubstitutionVisitor.rewrite(whereClause, smap);
 
                 // sourceScope must be set null tableName for its Field in RelationFields
                 // because we hope slotRef can not be resolved in sourceScope but can be
@@ -1002,4 +1002,3 @@ public class OlapTableSink extends DataSink {
         this.automaticBucketSize = automaticBucketSize;
     }
 }
-

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -92,6 +92,7 @@ import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.ViewRelation;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprSubstitutionMap;
+import com.starrocks.sql.ast.expression.ExprSubstitutionVisitor;
 import com.starrocks.sql.ast.expression.ExprToSql;
 import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
@@ -2018,7 +2019,7 @@ public class MaterializedViewAnalyzer {
         if (CollectionUtils.sizeIsEmpty(partitionByExprMap)) {
             return expr;
         }
-        ExprSubstitutionMap exprSubstitutionMap = new ExprSubstitutionMap(false);
+        ExprSubstitutionMap exprSubstitutionMap = new ExprSubstitutionMap();
         partitionByExprMap.entrySet().forEach(e -> {
             Expr lExpr = e.getKey();
             Expr rExpr = e.getValue();
@@ -2026,7 +2027,7 @@ public class MaterializedViewAnalyzer {
             ExpressionAnalyzer.analyzeExpression(rExpr, new AnalyzeState(), scope, context);
             exprSubstitutionMap.put(lExpr, rExpr);
         });
-        return expr.substitute(exprSubstitutionMap);
+        return ExprSubstitutionVisitor.rewrite(expr, exprSubstitutionMap);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
@@ -41,6 +41,7 @@ import com.starrocks.sql.ast.expression.CaseExpr;
 import com.starrocks.sql.ast.expression.CaseWhenClause;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprSubstitutionMap;
+import com.starrocks.sql.ast.expression.ExprSubstitutionVisitor;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
 import com.starrocks.sql.ast.expression.IsNullPredicate;
 import com.starrocks.sql.ast.expression.JoinOperator;
@@ -295,7 +296,7 @@ public class IVMAnalyzer {
         }
         // new aggregate functions
         List<IVMAggFunctionInfo> newAggFuncInfos = Lists.newArrayList();
-        ExprSubstitutionMap substitutionMap = new ExprSubstitutionMap(false);
+        ExprSubstitutionMap substitutionMap = new ExprSubstitutionMap();
         for (FunctionCallExpr aggFuncExpr : aggregateExprs) {
             String aggFuncName = aggFuncExpr.getFnName().getFunction();
             // build intermediate aggregate function
@@ -355,7 +356,7 @@ public class IVMAnalyzer {
     }
 
     private Expr substituteWithMap(Expr expr, ExprSubstitutionMap substitutionMap) {
-        return expr.substitute(substitutionMap);
+        return ExprSubstitutionVisitor.rewrite(expr, substitutionMap);
     }
 
     public static MaterializedView.RefreshMode getRefreshMode(CreateMaterializedViewStatement statement) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowColumnStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowColumnStmt.java
@@ -23,6 +23,7 @@ import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.ast.expression.CompoundPredicate;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprSubstitutionMap;
+import com.starrocks.sql.ast.expression.ExprSubstitutionVisitor;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.ast.expression.TableName;
@@ -96,50 +97,50 @@ public class ShowColumnStmt extends EnhancedShowStmt {
 
         // Columns
         SelectList selectList = new SelectList();
-        ExprSubstitutionMap aliasMap = new ExprSubstitutionMap(false);
+        ExprSubstitutionMap aliasMap = new ExprSubstitutionMap();
         // Field
         SelectListItem item = new SelectListItem(new SlotRef(TABLE_NAME, "COLUMN_NAME"), "Field");
         selectList.addItem(item);
         // TODO: Fix analyze error: Rhs expr must be analyzed.
-        aliasMap.put(new SlotRef(null, "Field"), item.getExpr().clone(null));
+        aliasMap.put(new SlotRef(null, "Field"), item.getExpr().clone());
         // Type
         item = new SelectListItem(new SlotRef(TABLE_NAME, "DATA_TYPE"), "Type");
         selectList.addItem(item);
-        aliasMap.put(new SlotRef(null, "Type"), item.getExpr().clone(null));
+        aliasMap.put(new SlotRef(null, "Type"), item.getExpr().clone());
         // Collation
         if (isVerbose) {
             item = new SelectListItem(new SlotRef(TABLE_NAME, "COLLATION_NAME"), "Collation");
             selectList.addItem(item);
-            aliasMap.put(new SlotRef(null, "Collation"), item.getExpr().clone(null));
+            aliasMap.put(new SlotRef(null, "Collation"), item.getExpr().clone());
         }
         // Null
         item = new SelectListItem(new SlotRef(TABLE_NAME, "IS_NULLABLE"), "Null");
         selectList.addItem(item);
-        aliasMap.put(new SlotRef(null, "Null"), item.getExpr().clone(null));
+        aliasMap.put(new SlotRef(null, "Null"), item.getExpr().clone());
         // Key
         item = new SelectListItem(new SlotRef(TABLE_NAME, "COLUMN_KEY"), "Key");
         selectList.addItem(item);
-        aliasMap.put(new SlotRef(null, "Key"), item.getExpr().clone(null));
+        aliasMap.put(new SlotRef(null, "Key"), item.getExpr().clone());
         // Default
         item = new SelectListItem(new SlotRef(TABLE_NAME, "COLUMN_DEFAULT"), "Default");
         selectList.addItem(item);
-        aliasMap.put(new SlotRef(null, "Default"), item.getExpr().clone(null));
+        aliasMap.put(new SlotRef(null, "Default"), item.getExpr().clone());
         // Extra
         item = new SelectListItem(new SlotRef(TABLE_NAME, "EXTRA"), "Extra");
         selectList.addItem(item);
-        aliasMap.put(new SlotRef(null, "Extra"), item.getExpr().clone(null));
+        aliasMap.put(new SlotRef(null, "Extra"), item.getExpr().clone());
         if (isVerbose) {
             // Privileges
             item = new SelectListItem(new SlotRef(TABLE_NAME, "PRIVILEGES"), "Privileges");
             selectList.addItem(item);
-            aliasMap.put(new SlotRef(null, "Privileges"), item.getExpr().clone(null));
+            aliasMap.put(new SlotRef(null, "Privileges"), item.getExpr().clone());
             // Comment
             item = new SelectListItem(new SlotRef(TABLE_NAME, "COLUMN_COMMENT"), "Comment");
             selectList.addItem(item);
-            aliasMap.put(new SlotRef(null, "Comment"), item.getExpr().clone(null));
+            aliasMap.put(new SlotRef(null, "Comment"), item.getExpr().clone());
         }
 
-        where = where.substitute(aliasMap);
+        where = ExprSubstitutionVisitor.rewrite(where, aliasMap);
         where = new CompoundPredicate(CompoundPredicate.Operator.AND, where,
                 new CompoundPredicate(CompoundPredicate.Operator.AND,
                         new BinaryPredicate(BinaryType.EQ, new SlotRef(TABLE_NAME, "TABLE_NAME"),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowDbStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowDbStmt.java
@@ -18,6 +18,7 @@ package com.starrocks.sql.ast;
 import com.starrocks.catalog.system.information.InfoSchemaDb;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprSubstitutionMap;
+import com.starrocks.sql.ast.expression.ExprSubstitutionVisitor;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.ast.expression.TableName;
 import com.starrocks.sql.parser.NodePosition;
@@ -71,11 +72,11 @@ public class ShowDbStmt extends EnhancedShowStmt {
         }
         // Columns
         SelectList selectList = new SelectList();
-        ExprSubstitutionMap aliasMap = new ExprSubstitutionMap(false);
+        ExprSubstitutionMap aliasMap = new ExprSubstitutionMap();
         SelectListItem item = new SelectListItem(new SlotRef(TABLE_NAME, "SCHEMA_NAME"), DB_COL);
         selectList.addItem(item);
-        aliasMap.put(new SlotRef(null, DB_COL), item.getExpr().clone(null));
-        where = where.substitute(aliasMap);
+        aliasMap.put(new SlotRef(null, DB_COL), item.getExpr().clone());
+        where = ExprSubstitutionVisitor.rewrite(where, aliasMap);
         return new QueryStatement(new SelectRelation(selectList, new TableRelation(TABLE_NAME),
                 where, null, null), this.origStmt);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowTableStatusStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowTableStatusStmt.java
@@ -18,6 +18,7 @@ import com.starrocks.catalog.system.information.InfoSchemaDb;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprSubstitutionMap;
+import com.starrocks.sql.ast.expression.ExprSubstitutionVisitor;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.ast.expression.TableName;
 import com.starrocks.sql.parser.NodePosition;
@@ -63,80 +64,80 @@ public class ShowTableStatusStmt extends EnhancedShowStmt {
 
         // Columns
         SelectList selectList = new SelectList();
-        ExprSubstitutionMap aliasMap = new ExprSubstitutionMap(false);
+        ExprSubstitutionMap aliasMap = new ExprSubstitutionMap();
         // Name
         SelectListItem item = new SelectListItem(new SlotRef(TABLE_NAME, "TABLE_NAME"), "Name");
         selectList.addItem(item);
-        aliasMap.put(new SlotRef(null, "Name"), item.getExpr().clone(null));
+        aliasMap.put(new SlotRef(null, "Name"), item.getExpr().clone());
         // Engine
         item = new SelectListItem(new SlotRef(TABLE_NAME, "ENGINE"), "Engine");
         selectList.addItem(item);
-        aliasMap.put(new SlotRef(null, "Engine"), item.getExpr().clone(null));
+        aliasMap.put(new SlotRef(null, "Engine"), item.getExpr().clone());
         // Version
         item = new SelectListItem(new SlotRef(TABLE_NAME, "VERSION"), "Version");
         selectList.addItem(item);
-        aliasMap.put(new SlotRef(null, "Version"), item.getExpr().clone(null));
+        aliasMap.put(new SlotRef(null, "Version"), item.getExpr().clone());
         // Version
         item = new SelectListItem(new SlotRef(TABLE_NAME, "ROW_FORMAT"), "Row_format");
         selectList.addItem(item);
-        aliasMap.put(new SlotRef(null, "Row_format"), item.getExpr().clone(null));
+        aliasMap.put(new SlotRef(null, "Row_format"), item.getExpr().clone());
         // Rows
         item = new SelectListItem(new SlotRef(TABLE_NAME, "TABLE_ROWS"), "Rows");
         selectList.addItem(item);
-        aliasMap.put(new SlotRef(null, "Rows"), item.getExpr().clone(null));
+        aliasMap.put(new SlotRef(null, "Rows"), item.getExpr().clone());
         // Avg_row_length
         item = new SelectListItem(new SlotRef(TABLE_NAME, "AVG_ROW_LENGTH"), "Avg_row_length");
         selectList.addItem(item);
-        aliasMap.put(new SlotRef(null, "Avg_row_length"), item.getExpr().clone(null));
+        aliasMap.put(new SlotRef(null, "Avg_row_length"), item.getExpr().clone());
         // Data_length
         item = new SelectListItem(new SlotRef(TABLE_NAME, "DATA_LENGTH"), "Data_length");
         selectList.addItem(item);
-        aliasMap.put(new SlotRef(null, "Data_length"), item.getExpr().clone(null));
+        aliasMap.put(new SlotRef(null, "Data_length"), item.getExpr().clone());
         // Max_data_length
         item = new SelectListItem(new SlotRef(TABLE_NAME, "MAX_DATA_LENGTH"), "Max_data_length");
         selectList.addItem(item);
-        aliasMap.put(new SlotRef(null, "Max_data_length"), item.getExpr().clone(null));
+        aliasMap.put(new SlotRef(null, "Max_data_length"), item.getExpr().clone());
         // Index_length
         item = new SelectListItem(new SlotRef(TABLE_NAME, "INDEX_LENGTH"), "Index_length");
         selectList.addItem(item);
-        aliasMap.put(new SlotRef(null, "Index_length"), item.getExpr().clone(null));
+        aliasMap.put(new SlotRef(null, "Index_length"), item.getExpr().clone());
         // Data_free
         item = new SelectListItem(new SlotRef(TABLE_NAME, "DATA_FREE"), "Data_free");
         selectList.addItem(item);
-        aliasMap.put(new SlotRef(null, "Data_free"), item.getExpr().clone(null));
+        aliasMap.put(new SlotRef(null, "Data_free"), item.getExpr().clone());
         // Data_free
         item = new SelectListItem(new SlotRef(TABLE_NAME, "AUTO_INCREMENT"), "Auto_increment");
         selectList.addItem(item);
-        aliasMap.put(new SlotRef(null, "Auto_increment"), item.getExpr().clone(null));
+        aliasMap.put(new SlotRef(null, "Auto_increment"), item.getExpr().clone());
         // Create_time
         item = new SelectListItem(new SlotRef(TABLE_NAME, "CREATE_TIME"), "Create_time");
         selectList.addItem(item);
-        aliasMap.put(new SlotRef(null, "Create_time"), item.getExpr().clone(null));
+        aliasMap.put(new SlotRef(null, "Create_time"), item.getExpr().clone());
         // Update_time
         item = new SelectListItem(new SlotRef(TABLE_NAME, "UPDATE_TIME"), "Update_time");
         selectList.addItem(item);
         // Check_time
         item = new SelectListItem(new SlotRef(TABLE_NAME, "CHECK_TIME"), "Check_time");
         selectList.addItem(item);
-        aliasMap.put(new SlotRef(null, "Check_time"), item.getExpr().clone(null));
+        aliasMap.put(new SlotRef(null, "Check_time"), item.getExpr().clone());
         // Collation
         item = new SelectListItem(new SlotRef(TABLE_NAME, "TABLE_COLLATION"), "Collation");
         selectList.addItem(item);
-        aliasMap.put(new SlotRef(null, "Collation"), item.getExpr().clone(null));
+        aliasMap.put(new SlotRef(null, "Collation"), item.getExpr().clone());
         // Checksum
         item = new SelectListItem(new SlotRef(TABLE_NAME, "CHECKSUM"), "Checksum");
         selectList.addItem(item);
-        aliasMap.put(new SlotRef(null, "Checksum"), item.getExpr().clone(null));
+        aliasMap.put(new SlotRef(null, "Checksum"), item.getExpr().clone());
         // Create_options
         item = new SelectListItem(new SlotRef(TABLE_NAME, "CREATE_OPTIONS"), "Create_options");
         selectList.addItem(item);
-        aliasMap.put(new SlotRef(null, "Create_options"), item.getExpr().clone(null));
+        aliasMap.put(new SlotRef(null, "Create_options"), item.getExpr().clone());
         // Comment
         item = new SelectListItem(new SlotRef(TABLE_NAME, "TABLE_COMMENT"), "Comment");
         selectList.addItem(item);
-        aliasMap.put(new SlotRef(null, "Comment"), item.getExpr().clone(null));
+        aliasMap.put(new SlotRef(null, "Comment"), item.getExpr().clone());
 
-        where = where.substitute(aliasMap);
+        where = ExprSubstitutionVisitor.rewrite(where, aliasMap);
 
         return new QueryStatement(new SelectRelation(selectList, new TableRelation(TABLE_NAME),
                 where, null, null), this.origStmt);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowTableStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowTableStmt.java
@@ -21,6 +21,7 @@ import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.ast.expression.CompoundPredicate;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprSubstitutionMap;
+import com.starrocks.sql.ast.expression.ExprSubstitutionVisitor;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.ast.expression.TableName;
@@ -84,18 +85,18 @@ public class ShowTableStmt extends EnhancedShowStmt {
         }
         // Columns
         SelectList selectList = new SelectList();
-        ExprSubstitutionMap aliasMap = new ExprSubstitutionMap(false);
+        ExprSubstitutionMap aliasMap = new ExprSubstitutionMap();
         SelectListItem item = new SelectListItem(new SlotRef(TABLE_NAME, "TABLE_NAME"),
                 NAME_COL_PREFIX + db);
         selectList.addItem(item);
         aliasMap.put(new SlotRef(null, NAME_COL_PREFIX + db),
-                item.getExpr().clone(null));
+                item.getExpr().clone());
         if (isVerbose) {
             item = new SelectListItem(new SlotRef(TABLE_NAME, "TABLE_TYPE"), TYPE_COL);
             selectList.addItem(item);
-            aliasMap.put(new SlotRef(null, TYPE_COL), item.getExpr().clone(null));
+            aliasMap.put(new SlotRef(null, TYPE_COL), item.getExpr().clone());
         }
-        where = where.substitute(aliasMap);
+        where = ExprSubstitutionVisitor.rewrite(where, aliasMap);
         // where databases_name = currentdb
         Expr whereDbEQ = new BinaryPredicate(
                 BinaryType.EQ,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/Expr.java
@@ -345,47 +345,6 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
     }
 
     /**
-     * Create a deep copy of 'this'. If sMap is non-null,
-     * use it to substitute 'this' or its subnodes.
-     * <p/>
-     * Expr subclasses that add non-value-type members must override this.
-     */
-    public Expr clone(ExprSubstitutionMap sMap) {
-        if (sMap != null) {
-            for (int i = 0; i < sMap.getLhs().size(); ++i) {
-                if (this.equals(sMap.getLhs().get(i))) {
-                    return sMap.getRhs().get(i).clone(null);
-                }
-            }
-        }
-        Expr result = (Expr) this.clone();
-        result.children = Lists.newArrayList();
-        for (Expr child : children) {
-            result.children.add(((Expr) child).clone(sMap));
-        }
-        return result;
-    }
-
-    /**
-     * Return 'this' with all sub-exprs substituted according to
-     * sMap. Ids of 'this' and its children are retained.
-     */
-    @Deprecated
-    public Expr substitute(ExprSubstitutionMap sMap) {
-        Preconditions.checkNotNull(sMap);
-        for (int i = 0; i < sMap.getLhs().size(); ++i) {
-            if (this.equals(sMap.getLhs().get(i))) {
-                Expr result = sMap.getRhs().get(i).clone(null);
-                return result;
-            }
-        }
-        for (int i = 0; i < children.size(); ++i) {
-            children.set(i, children.get(i).substitute(sMap));
-        }
-        return this;
-    }
-
-    /**
      * Returns true if expr is fully bound by tids, otherwise false.
      */
     public boolean isBoundByTupleIds(List<TupleId> tids) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ExprSubstitutionMap.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ExprSubstitutionMap.java
@@ -12,79 +12,40 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/analysis/ExprSubstitutionMap.java
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
 package com.starrocks.sql.ast.expression;
 
-import com.google.common.base.Joiner;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
 /**
- * Map of expression substitutions: lhs[i] gets substituted with rhs[i].
- * To support expression substitution across query blocks, rhs exprs must already be
- * analyzed when added to this map. Otherwise, analysis of a SlotRef may fail after
- * substitution, e.g., because the table it refers to is in a different query block
- * that is not visible.
- * See Expr.substitute() and related functions for details on the actual substitution.
+ * Simple container for expression substitutions, consumed exclusively by
+ * {@link ExprSubstitutionVisitor}. Each entry maps an original expression to
+ * the expression that should replace it during AST rewrites. Callers must ensure
+ * the replacement expr has already been analyzed and is visible in the target
+ * scope; otherwise the visitor may generate invalid SlotRefs when cloning.
  */
 public final class ExprSubstitutionMap {
-    private static final Logger LOG = LoggerFactory.getLogger(ExprSubstitutionMap.class);
-
-    private boolean checkAnalyzed = true;
-    private List<Expr> lhs; // left-hand side
-    private List<Expr> rhs; // right-hand side
+    private final List<Expr> lhs;
+    private final List<Expr> rhs;
 
     public ExprSubstitutionMap() {
-        this(Lists.<Expr>newArrayList(), Lists.<Expr>newArrayList());
-    }
-
-    // Only used to convert show statement to select statement
-    public ExprSubstitutionMap(boolean checkAnalyzed) {
-        this(Lists.<Expr>newArrayList(), Lists.<Expr>newArrayList());
-        this.checkAnalyzed = checkAnalyzed;
-    }
-
-    public ExprSubstitutionMap(List<Expr> lhs, List<Expr> rhs) {
-        this.lhs = lhs;
-        this.rhs = rhs;
+        this.lhs = Lists.newArrayList();
+        this.rhs = Lists.newArrayList();
     }
 
     /**
-     * Add an expr mapping. The rhsExpr must be analyzed to support correct substitution
-     * across query blocks. It is not required that the lhsExpr is analyzed.
+     * Adds a mapping from {@code lhsExpr} to {@code rhsExpr}. The visitor will look up entries
+     * using {@link Expr#equals(Object)}, so callers should pass the references they expect to replace.
+     * The {@code rhsExpr} must already be analyzed and valid in the target scope.
      */
     public void put(Expr lhsExpr, Expr rhsExpr) {
-        Preconditions.checkState(!checkAnalyzed || rhsExpr.isAnalyzed(),
-                "Rhs expr must be analyzed.");
         lhs.add(lhsExpr);
         rhs.add(rhsExpr);
     }
 
     /**
-     * Returns the expr mapped to lhsExpr or null if no mapping to lhsExpr exists.
+     * Returns the replacement expression registered for {@code lhsExpr}, or {@code null} if none exists.
      */
     public Expr get(Expr lhsExpr) {
         for (int i = 0; i < lhs.size(); ++i) {
@@ -93,79 +54,5 @@ public final class ExprSubstitutionMap {
             }
         }
         return null;
-    }
-
-    /**
-     * Returns the union of two substitution maps. Always returns a non-null map.
-     */
-    public static ExprSubstitutionMap combine(ExprSubstitutionMap f,
-                                              ExprSubstitutionMap g) {
-        if (f == null && g == null) {
-            return new ExprSubstitutionMap();
-        }
-        if (f == null) {
-            return g;
-        }
-        if (g == null) {
-            return f;
-        }
-        ExprSubstitutionMap result = new ExprSubstitutionMap();
-        result.lhs = Lists.newArrayList(f.lhs);
-        result.lhs.addAll(g.lhs);
-        result.rhs = Lists.newArrayList(f.rhs);
-        result.rhs.addAll(g.rhs);
-        result.verify();
-        return result;
-    }
-
-    public List<Expr> getLhs() {
-        return lhs;
-    }
-
-    public List<Expr> getRhs() {
-        return rhs;
-    }
-
-    public int size() {
-        return lhs.size();
-    }
-
-    public String debugString() {
-        Preconditions.checkState(lhs.size() == rhs.size());
-        List<String> output = Lists.newArrayList();
-        for (int i = 0; i < lhs.size(); ++i) {
-            output.add(ExprToSql.toSql(lhs.get(i)) + ":" + ExprToSql.toSql(rhs.get(i)));
-            output.add("(" + lhs.get(i).debugString() + ":" + rhs.get(i).debugString() + ")");
-        }
-        return "smap(" + Joiner.on(" ").join(output) + ")";
-    }
-
-    /**
-     * Verifies the internal state of this smap: Checks that the lhs_ has no duplicates,
-     * and that all rhs exprs are analyzed.
-     */
-    private void verify() {
-        for (int i = 0; i < lhs.size(); ++i) {
-            for (int j = i + 1; j < lhs.size(); ++j) {
-                if (lhs.get(i).equals(lhs.get(j))) {
-                    if (LOG.isTraceEnabled()) {
-                        LOG.trace("verify: smap=" + this.debugString());
-                    }
-                    // TODO(zc): partition by k1, order by k1, there is failed.
-                    // Preconditions.checkState(false);
-                }
-            }
-            Preconditions.checkState(!checkAnalyzed || rhs.get(i).isAnalyzed());
-        }
-    }
-
-    public void clear() {
-        lhs.clear();
-        rhs.clear();
-    }
-
-    @Override
-    public ExprSubstitutionMap clone() {
-        return new ExprSubstitutionMap(ExprUtils.cloneList(lhs), ExprUtils.cloneList(rhs));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ExprSubstitutionVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ExprSubstitutionVisitor.java
@@ -1,0 +1,55 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast.expression;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.sql.ast.AstVisitorExtendInterface;
+
+/**
+ * Visitor-based implementation of expression substitution. It provides a single
+ * entry point to rewrite an expression tree based on {@link ExprSubstitutionMap}.
+ */
+public final class ExprSubstitutionVisitor implements AstVisitorExtendInterface<Expr, ExprSubstitutionMap> {
+    private static final ExprSubstitutionVisitor INSTANCE = new ExprSubstitutionVisitor();
+
+    private ExprSubstitutionVisitor() {
+    }
+
+    /**
+     * Returns a new expression where every occurrence of {@code lhs[i]} is substituted
+     * with {@code rhs[i]} from {@code substitutionMap}. The original expression remains unchanged.
+     */
+    public static Expr rewrite(Expr expr, ExprSubstitutionMap substitutionMap) {
+        Preconditions.checkNotNull(expr, "expr cannot be null");
+        Preconditions.checkNotNull(substitutionMap, "substitutionMap cannot be null");
+        return expr.accept(INSTANCE, substitutionMap);
+    }
+
+    @Override
+    public Expr visitExpression(Expr node, ExprSubstitutionMap context) {
+        Expr replacement = context.get(node);
+        if (replacement != null) {
+            return replacement.clone();
+        }
+
+        Expr cloned = node.clone();
+        int childCount = node.getChildren().size();
+        for (int i = 0; i < childCount; ++i) {
+            Expr rewrittenChild = node.getChild(i).accept(this, context);
+            cloned.setChild(i, rewrittenChild);
+        }
+        return cloned;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ExprUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/expression/ExprUtils.java
@@ -161,7 +161,8 @@ public class ExprUtils {
         Preconditions.checkNotNull(l);
         ArrayList<C> result = new ArrayList<C>();
         for (C element : l) {
-            result.add((C) element.clone(sMap));
+            C cloned = (C) (sMap == null ? element.clone() : ExprSubstitutionVisitor.rewrite(element, sMap));
+            result.add(cloned);
         }
         return result;
     }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This pull request refactors how expression substitution is performed throughout the codebase, replacing direct usage of the `clone` and `substitute` methods with the new `ExprSubstitutionVisitor.rewrite` method. This change makes expression rewriting more explicit and consistent, improving code clarity and maintainability. Additionally, some legacy code and unused members related to expression substitution maps are cleaned up.

### Expression substitution refactoring

* Replaced calls to `expr.clone(smap)` and `expr.substitute(smap)` with `ExprSubstitutionVisitor.rewrite(expr, smap)` in major components such as `RollupJobV2`, `Load`, `LoadScanNode`, `OlapTableSink`, `MaterializedViewAnalyzer`, `IVMAnalyzer`, and `ShowColumnStmt`, ensuring a unified approach to expression rewriting. [[1]](diffhunk://#diff-373bd2cfff2d32a6888f75de28c7ae7bab5bd54ddb6501db6a10bf59c623a1e3L455-R460) [[2]](diffhunk://#diff-ba32a08360646fed43acc52291c6999efaa2c9356943433ef2500b47dbe22937L802-R807) [[3]](diffhunk://#diff-ba32a08360646fed43acc52291c6999efaa2c9356943433ef2500b47dbe22937L848-R865) [[4]](diffhunk://#diff-ba32a08360646fed43acc52291c6999efaa2c9356943433ef2500b47dbe22937L892-R901) [[5]](diffhunk://#diff-b94c6c9aeb07060943e33bb3341976e5ffe3507ed394b3726e2cca247ea2743dL83-R88) [[6]](diffhunk://#diff-b0dd1943e6dee863d455359fe7ba963508c81f06b0bb2ccd70aef7de2ae6fd2eL456-R461) [[7]](diffhunk://#diff-2ef2ec3eb099ffc05bbc17579709e4f9645eefca73b3ce70ae56277894aba3c0L2021-R2030) [[8]](diffhunk://#diff-c6a588d216b2f912b00e91991e586ecd70772b9ef3c6a0854aa5ae4753692e32L358-R359) [[9]](diffhunk://#diff-7f94742833a8558fb5fb719b33940e1594ee06d7fff568ae1d70dcd4a34a027cL99-R143)
* Updated imports to include `ExprSubstitutionVisitor` in all affected files. [[1]](diffhunk://#diff-373bd2cfff2d32a6888f75de28c7ae7bab5bd54ddb6501db6a10bf59c623a1e3R84) [[2]](diffhunk://#diff-ba32a08360646fed43acc52291c6999efaa2c9356943433ef2500b47dbe22937R77) [[3]](diffhunk://#diff-b94c6c9aeb07060943e33bb3341976e5ffe3507ed394b3726e2cca247ea2743dR49) [[4]](diffhunk://#diff-b0dd1943e6dee863d455359fe7ba963508c81f06b0bb2ccd70aef7de2ae6fd2eR90) [[5]](diffhunk://#diff-2ef2ec3eb099ffc05bbc17579709e4f9645eefca73b3ce70ae56277894aba3c0R95) [[6]](diffhunk://#diff-c6a588d216b2f912b00e91991e586ecd70772b9ef3c6a0854aa5ae4753692e32R44) [[7]](diffhunk://#diff-7f94742833a8558fb5fb719b33940e1594ee06d7fff568ae1d70dcd4a34a027cR26) [[8]](diffhunk://#diff-8c77ac34cb460125b221e8425667f287e45585a6f8002e836cbda2056b15afdeR21)

### Expression substitution map usage

* Standardized the construction of `ExprSubstitutionMap` by removing the boolean parameter, simplifying its usage across the codebase. [[1]](diffhunk://#diff-2ef2ec3eb099ffc05bbc17579709e4f9645eefca73b3ce70ae56277894aba3c0L2021-R2030) [[2]](diffhunk://#diff-c6a588d216b2f912b00e91991e586ecd70772b9ef3c6a0854aa5ae4753692e32L298-R299) [[3]](diffhunk://#diff-7f94742833a8558fb5fb719b33940e1594ee06d7fff568ae1d70dcd4a34a027cL99-R143)

### Code cleanup

* Removed unused or legacy members and related debug output from `AggregateInfo`, specifically the `intermediateTupleSmap_` and `outputTupleSmap_` fields and their associated logic, reducing code complexity. [[1]](diffhunk://#diff-a470c3fb0e41d32a343070bce07b1fc5bcda923640496882d30fc26c2a9cf736L70-L78) [[2]](diffhunk://#diff-a470c3fb0e41d32a343070bce07b1fc5bcda923640496882d30fc26c2a9cf736L109-L115) [[3]](diffhunk://#diff-a470c3fb0e41d32a343070bce07b1fc5bcda923640496882d30fc26c2a9cf736L151-L152)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces clone/substitute-based expr rewriting with ExprSubstitutionVisitor.rewrite, simplifies ExprSubstitutionMap, removes deprecated substitution methods/fields, and updates all call sites.
> 
> - **Expression Rewriting**:
>   - Introduce `ExprSubstitutionVisitor` and migrate all rewrites from `expr.clone(smap)`/`expr.substitute(smap)` to `ExprSubstitutionVisitor.rewrite(...)` in `alter`, `load`, `planner`, `analyzer`, and `ast` (e.g., `RollupJobV2`, `Load`, `LoadScanNode`, `OlapTableSink`, `MaterializedViewAnalyzer`, `IVMAnalyzer`, `Show*` statements, `PartitionSelector`).
>   - Simplify `ExprSubstitutionMap` API and usage (remove boolean flag and auxiliary methods).
>   - Update `ExprUtils.cloneList` to use the new visitor path.
> - **API Cleanup**:
>   - Remove deprecated `Expr.clone(ExprSubstitutionMap)` and `Expr.substitute(...)` implementations.
>   - Add new `ExprSubstitutionVisitor` class.
> - **Planner Cleanup**:
>   - `AggregateInfo`: remove unused `intermediateTupleSmap_`/`outputTupleSmap_` and related debug/clone logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27667c20d4829c7746c82d443cc71be28f74a1fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->