### PR TITLE
[BugFix] Fix statistics collection strategy after overwrite

### DIFF
--- a/test/sql/test_analyze_statistics/R/test_overwrite_statistics.sql
+++ b/test/sql/test_analyze_statistics/R/test_overwrite_statistics.sql
@@ -73,3 +73,23 @@ select count(*) from _statistics_.column_statistics where table_name = 'test_ove
 select * from information_schema.analyze_status where `Database`='test_overwrite_statistics' and `Table`='sales_data' and Status='FAILED';
 -- result:
 -- !result
+delete from _statistics_.column_statistics where table_name='test_overwrite_statistics.test_overwrite_with_full';
+-- result:
+-- !result
+create table test_overwrite_statistics.test_overwrite_with_full (k1 int) properties("replication_num"="1");
+-- result:
+-- !result
+insert overwrite test_overwrite_statistics.test_overwrite_with_full select generate_series from table(generate_series(1, 5000));
+-- result:
+-- !result
+function: assert_explain_costs_contains("select * from test_overwrite_statistics.test_overwrite_with_full;","cardinality: 5000", "ESTIMATE")
+-- result:
+None
+-- !result
+insert overwrite test_overwrite_statistics.test_overwrite_with_full select generate_series from table(generate_series(1, 5000));
+-- result:
+-- !result
+function: assert_explain_costs_contains("select * from test_overwrite_statistics.test_overwrite_with_full;","cardinality: 5000", "ESTIMATE")
+-- result:
+None
+-- !result

--- a/test/sql/test_analyze_statistics/T/test_overwrite_statistics.sql
+++ b/test/sql/test_analyze_statistics/T/test_overwrite_statistics.sql
@@ -12,7 +12,6 @@ select count(*) from _statistics_.column_statistics where table_name = 'test_ove
 insert overwrite test_overwrite_stats_table select 123;
 select count(*) from _statistics_.column_statistics where table_name = 'test_overwrite_statistics.test_overwrite_stats_table';
 
-
 CREATE TABLE sales_data (
     id BIGINT,
     sale_date DATE
@@ -47,3 +46,9 @@ select count(*) from _statistics_.column_statistics where table_name = 'test_ove
 
 select * from information_schema.analyze_status where `Database`='test_overwrite_statistics' and `Table`='sales_data' and Status='FAILED';
 
+delete from _statistics_.column_statistics where table_name='test_overwrite_statistics.test_overwrite_with_full';
+create table test_overwrite_statistics.test_overwrite_with_full (k1 int) properties("replication_num"="1");
+insert overwrite test_overwrite_statistics.test_overwrite_with_full select generate_series from table(generate_series(1, 5000));
+function: assert_explain_costs_contains("select * from test_overwrite_statistics.test_overwrite_with_full;","cardinality: 5000", "ESTIMATE")
+insert overwrite test_overwrite_statistics.test_overwrite_with_full select generate_series from table(generate_series(1, 5000));
+function: assert_explain_costs_contains("select * from test_overwrite_statistics.test_overwrite_with_full;","cardinality: 5000", "ESTIMATE")


### PR DESCRIPTION
## Why I'm doing:

### Current Statistics Collection Strategy

After an INSERT OVERWRITE operation, we collect statistics based on the following rules:

1. **Strategy 1 (Copy existing stats)**: If the difference between `targetRows` and `sourceRows` is within `statistic_sample_collect_ratio_threshold_of_first_load` (default 10%), we skip statistics collection and simply copy the stats from the source partition to the new partition.

2. **Strategy 2 (Collect new stats)**: If the row count change exceeds 10% AND `targetRows` > `statistic_sample_collect_rows` (default 200K rows), we use sample-based collection; otherwise, we use full collection.

### Root Cause

The problem is that `sourceRows` and `targetRows` in `InsertOverwriteJobRunner` are obtained via `Partition.getRowCount()`, which relies on asynchronous tablet statistics reporting.

**For `targetRows`**: Always returns **0** because:
- The partition is newly created
- Both FE and BE collect tablet information asynchronously
- No statistics have been reported yet at commit time

**For `sourceRows`**: May return **0** or inaccurate values because:
- TabletStatMgr collects statistics every 5 minutes by default
- BE also collects statistics asynchronously
- Accurate `sourceRows` is only available 10+ minutes after data loading

### Problems with Strategy 1

The current calculation formula is:
```
Math.abs(targetRows - sourceRows) / (sourceRows + 1)
```

This leads to the following issues:

1. **Both `targetRows` and `sourceRows` are 0**: Statistics collection is skipped entirely, even though data may have changed significantly.

2. **`sourceRows` ≠ 0, but `targetRows` = 0**: Every INSERT OVERWRITE triggers Strategy 2 (statistics collection), making Strategy 1 (copy stats) completely ineffective.

### Solution

**For `sourceRows`**: Keep using `Partition.getRowCount()` despite its asynchronous nature, considering:
- Performance concerns
- Inaccuracies from operations like DELETE
- The existing calculation formula remains unchanged

**For `targetRows`**: Use `loadedRows` from `TxnCommitAttachment` instead, which:
- Is accurate and available at transaction commit time
- Comes directly from BE's real-time write statistics
- Avoids dependency on asynchronous tablet reporting

### Result After Fix

1. **When `sourceRows` = 0** (no prior statistics reported): Statistics collection will be triggered, ensuring data is properly analyzed.

2. **When `sourceRows` ≠ 0**: Both strategies work as intended:
   - Strategy 1 (copy stats) applies when row count change is < 10%
   - Strategy 2 (collect stats) applies when row count change is ≥ 10%


TODO:
Sample collection requires partition row count as a metric, but row count will not exist after overwrite. This [PR](https://github.com/StarRocks/starrocks/pull/57277 ) has already reported the related tablet metrics after import. However, it only adapted insert into and did not handle overwrite. I will adapt this in the next PR.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Compute `targetRows` using `InsertTxnCommitAttachment.getLoadedRows()` during commit, with a warning and fallback to partition `getRowCount()` if unavailable.
> 
> - **Backend (Insert Overwrite)**
>   - Update `doCommit` in `InsertOverwriteJobRunner` to set `targetRows` from `TransactionState`'s `TxnCommitAttachment` (`InsertTxnCommitAttachment.getLoadedRows()`).
>     - If missing/invalid or zero, log a warning and fallback to summing `Partition#getRowCount` over temp partitions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48192b54795ec609a4fb5f11fdee24bedcbeffcd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->