### PR TITLE
[BugFix] Fix MySql 8.0 Schema Introspection

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -185,6 +185,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String TRANSACTION_READ_ONLY = "transaction_read_only";
     public static final String DEFAULT_STORAGE_ENGINE = "default_storage_engine";
     public static final String DEFAULT_TMP_STORAGE_ENGINE = "default_tmp_storage_engine";
+    public static final String DEFAULT_AUTHENTICATION_PLUGIN = "default_authentication_plugin"; 
+    public static final String AUTHENTICATION_POLICY = "authentication_policy"; 
     public static final String CHARACTER_SET_CLIENT = "character_set_client";
     public static final String CHARACTER_SET_CONNNECTION = "character_set_connection";
     public static final String CHARACTER_SET_RESULTS = "character_set_results";
@@ -1215,6 +1217,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private String defaultStorageEngine = "InnoDB";
     @VariableMgr.VarAttr(name = DEFAULT_TMP_STORAGE_ENGINE)
     private String defaultTmpStorageEngine = "InnoDB";
+    @VariableMgr.VarAttr(name = DEFAULT_AUTHENTICATION_PLUGIN)
+    private String defaultAuthenticationPlugin = "mysql_native_password"; 
+    @VariableMgr.VarAttr(name = AUTHENTICATION_POLICY)
+    private String authenticationPolicy = "*,,"; 
 
     // this is used to make c3p0 library happy
     @VariableMgr.VarAttr(name = CHARACTER_SET_CLIENT)


### PR DESCRIPTION
## Why I'm doing:
When connecting to StarRocks using DataGrip (or other IDEs) using the MySQL 8.0 driver, there is an error with expected system variables. 
```
Getting analyzing error. Detail message: Unknown system variable 'default_authentication_plugin', the most similar variables are {'default_storage_engine', 'default_table_compression', 'default_rowset_type'}.
Getting analyzing error. Detail message: Unknown system variable 'authentication_policy', the most similar variables are {'default_authentication_plugin', 'computation_fragment_scheduling_policy', 'enable_count_star_optimization'}.
```
## What I'm doing:
Adds two variables `authentication_policy` and `default_authentication_plugin` in order to be compatible with MySQL 8.0's driver. 
Fixes #65315. 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `default_authentication_plugin` and `authentication_policy` session variables (with defaults) to align with MySQL 8.0 expectations.
> 
> - **FE/qe**:
>   - Add MySQL 8.0 compatibility variables in `SessionVariable`:
>     - Constants: `DEFAULT_AUTHENTICATION_PLUGIN`, `AUTHENTICATION_POLICY`.
>     - New `@VarAttr` fields with defaults: `defaultAuthenticationPlugin = "mysql_native_password"`, `authenticationPolicy = "*,,"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22478c7a00960e09a1b2edbaadecb0ce9cb1a255. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->