### PR TITLE
[Enhancement] support overwrite s3 unpartitioned hive table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -173,11 +173,6 @@ public class InsertAnalyzer {
         }
 
         if (table.isIcebergTable() || table.isHiveTable()) {
-            // if (table.isHiveTable() && table.isUnPartitioned() &&
-            //         HiveWriteUtils.isS3Url(table.getTableLocation()) && insertStmt.isOverwrite()) {
-            //     throw new SemanticException("Unsupported insert overwrite hive unpartitioned table with s3 location");
-            // }
-
             if (table.isHiveTable() && ((HiveTable) table).getHiveTableType() != HiveTable.HiveTableType.MANAGED_TABLE &&
                     !session.getSessionVariable().enableWriteHiveExternalTable()) {
                 throw new SemanticException("Only support to write hive managed table, tableType: " +

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -39,7 +39,6 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
-import com.starrocks.connector.hive.HiveWriteUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
@@ -174,10 +173,10 @@ public class InsertAnalyzer {
         }
 
         if (table.isIcebergTable() || table.isHiveTable()) {
-            if (table.isHiveTable() && table.isUnPartitioned() &&
-                    HiveWriteUtils.isS3Url(table.getTableLocation()) && insertStmt.isOverwrite()) {
-                throw new SemanticException("Unsupported insert overwrite hive unpartitioned table with s3 location");
-            }
+            // if (table.isHiveTable() && table.isUnPartitioned() &&
+            //         HiveWriteUtils.isS3Url(table.getTableLocation()) && insertStmt.isOverwrite()) {
+            //     throw new SemanticException("Unsupported insert overwrite hive unpartitioned table with s3 location");
+            // }
 
             if (table.isHiveTable() && ((HiveTable) table).getHiveTableType() != HiveTable.HiveTableType.MANAGED_TABLE &&
                     !session.getSessionVariable().enableWriteHiveExternalTable()) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
@@ -289,20 +289,23 @@ public class AnalyzeInsertTest {
             {
                 hiveTable.supportInsert();
                 result = true;
+                minTimes = 0;
 
                 hiveTable.isHiveTable();
                 result = true;
+                minTimes = 0;
 
                 hiveTable.isUnPartitioned();
                 result = false;
+                minTimes = 0;
 
                 hiveTable.getHiveTableType();
                 result = HiveTable.HiveTableType.EXTERNAL_TABLE;
+                minTimes = 0;
             }
         };
 
-        analyzeFail("insert into hive_catalog.db.tbl select 1, 2, 3",
-                "Only support to write hive managed table");
+        analyzeFail("insert into hive_catalog.db.tbl select 1, 2, 3");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
@@ -305,7 +305,8 @@ public class AnalyzeInsertTest {
             }
         };
 
-        analyzeFail("insert into hive_catalog.db.tbl select 1, 2, 3");
+        analyzeFail("insert into hive_catalog.db.tbl select 1, 2, 3", 
+                "Only support to write hive managed table");
     }
 
     @Test

--- a/test/sql/test_hive/R/test_hive_overwrite
+++ b/test/sql/test_hive/R/test_hive_overwrite
@@ -1,0 +1,66 @@
+-- name: test_hive_overwrite
+create external catalog hive_sink_test_${uuid0} PROPERTIES ("type"="hive", "hive.metastore.uris"="${hive_metastore_uris}","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+-- !result
+create database hive_sink_test_${uuid0}.hive_db_${uuid0} PROPERTIES("location" = "oss://starrocks-ci-test/dla_test_data/hive_db_${uuid0}.db");
+-- result:
+-- !result
+create table hive_sink_test_${uuid0}.hive_db_${uuid0}.t1(c1 int);
+-- result:
+-- !result
+insert into hive_sink_test_${uuid0}.hive_db_${uuid0}.t1 values(1);
+-- result:
+-- !result
+select * from hive_sink_test_${uuid0}.hive_db_${uuid0}.t1;
+-- result:
+1
+-- !result
+insert overwrite hive_sink_test_${uuid0}.hive_db_${uuid0}.t1 values(2), (3);
+-- result:
+-- !result
+select * from hive_sink_test_${uuid0}.hive_db_${uuid0}.t1;
+-- result:
+2
+3
+-- !result
+create table hive_sink_test_${uuid0}.hive_db_${uuid0}.t2 (c1 int, c2 int) partition by c2;
+-- result:
+-- !result
+insert into hive_sink_test_${uuid0}.hive_db_${uuid0}.t2 values(1, 2);
+-- result:
+-- !result
+insert into hive_sink_test_${uuid0}.hive_db_${uuid0}.t2 values(2, 2);
+-- result:
+-- !result
+insert into hive_sink_test_${uuid0}.hive_db_${uuid0}.t2 values(3, 2);
+-- result:
+-- !result
+select * from hive_sink_test_${uuid0}.hive_db_${uuid0}.t2;
+-- result:
+2	2
+3	2
+1	2
+-- !result
+insert overwrite hive_sink_test_${uuid0}.hive_db_${uuid0}.t2 values(1, 1);
+-- result:
+-- !result
+insert overwrite hive_sink_test_${uuid0}.hive_db_${uuid0}.t2 values(4, 2);
+-- result:
+-- !result
+select * from hive_sink_test_${uuid0}.hive_db_${uuid0}.t2;
+-- result:
+4	2
+1	1
+-- !result
+drop table hive_sink_test_${uuid0}.hive_db_${uuid0}.t1 force;
+-- result:
+-- !result
+drop table hive_sink_test_${uuid0}.hive_db_${uuid0}.t2 force;
+-- result:
+-- !result
+drop database hive_sink_test_${uuid0}.hive_db_${uuid0};
+-- result:
+-- !result
+drop catalog hive_sink_test_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_hive/T/test_hive_overwrite
+++ b/test/sql/test_hive/T/test_hive_overwrite
@@ -1,0 +1,25 @@
+-- name: test_hive_overwrite
+
+create external catalog hive_sink_test_${uuid0} PROPERTIES ("type"="hive", "hive.metastore.uris"="${hive_metastore_uris}","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+create database hive_sink_test_${uuid0}.hive_db_${uuid0} PROPERTIES("location" = "oss://starrocks-ci-test/dla_test_data/hive_db_${uuid0}.db");
+
+create table hive_sink_test_${uuid0}.hive_db_${uuid0}.t1(c1 int);
+insert into hive_sink_test_${uuid0}.hive_db_${uuid0}.t1 values(1);
+select * from hive_sink_test_${uuid0}.hive_db_${uuid0}.t1;
+insert overwrite hive_sink_test_${uuid0}.hive_db_${uuid0}.t1 values(2), (3);
+select * from hive_sink_test_${uuid0}.hive_db_${uuid0}.t1;
+
+create table hive_sink_test_${uuid0}.hive_db_${uuid0}.t2 (c1 int, c2 int) partition by c2;
+insert into hive_sink_test_${uuid0}.hive_db_${uuid0}.t2 values(1, 2);
+insert into hive_sink_test_${uuid0}.hive_db_${uuid0}.t2 values(2, 2);
+insert into hive_sink_test_${uuid0}.hive_db_${uuid0}.t2 values(3, 2);
+select * from hive_sink_test_${uuid0}.hive_db_${uuid0}.t2;
+insert overwrite hive_sink_test_${uuid0}.hive_db_${uuid0}.t2 values(1, 1);
+insert overwrite hive_sink_test_${uuid0}.hive_db_${uuid0}.t2 values(4, 2);
+select * from hive_sink_test_${uuid0}.hive_db_${uuid0}.t2;
+
+
+drop table hive_sink_test_${uuid0}.hive_db_${uuid0}.t1 force;
+drop table hive_sink_test_${uuid0}.hive_db_${uuid0}.t2 force;
+drop database hive_sink_test_${uuid0}.hive_db_${uuid0};
+drop catalog hive_sink_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allows overwriting Hive tables on S3 by removing non-current-query files instead of renaming, removes analyzer restriction, and adds end-to-end tests.
> 
> - **Hive sink (`HiveCommitter`)**:
>   - Overwrite on S3: delete non-current-query files in `targetPath` (`removeNotCurrentQueryFiles`) instead of staging/renaming; non-S3 keeps rename flow.
>   - Refresh files cache and update stats preserved.
> - **Analyzer (`InsertAnalyzer`)**:
>   - Removes check blocking `INSERT OVERWRITE` for S3 unpartitioned Hive tables.
>   - External-table write guard for non-managed Hive tables remains.
> - **Tests**:
>   - Add SQL E2E test `test/sql/test_hive/{T,R}/test_hive_overwrite` covering overwrite of unpartitioned and partitioned Hive tables on OSS/S3.
>   - Minor unit test expectation tweaks in `AnalyzeInsertTest`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c84eaf6b2f06cef13e3bccd4869b5309a869f14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->