### PR TITLE
[Refactor]Transform AutoIncrement/BlackList/SPM/GroupProvider related edit logs to WAL format

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -249,7 +249,7 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
 
         if (statement.getAlterClause() == null) {
             AlterViewInfo alterViewInfo = new AlterViewInfo(db.getId(), table.getId(), statement.isSecurity());
-            GlobalStateMgr.getCurrentState().getAlterJobMgr().setViewSecurity(alterViewInfo, false);
+            GlobalStateMgr.getCurrentState().getAlterJobMgr().setViewSecurity(alterViewInfo);
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -632,11 +632,24 @@ public class AlterJobMgr {
         }
     }
 
-    public void setViewSecurity(AlterViewInfo alterViewInfo, boolean isReplay) {
+    public void setViewSecurity(AlterViewInfo alterViewInfo) {
+        GlobalStateMgr.getCurrentState().getEditLog().logJsonObject(
+                OperationType.OP_SET_VIEW_SECURITY_LOG, alterViewInfo, wal -> updateViewSecurity(alterViewInfo));
+    }
+
+    public void updateViewSecurity(AlterViewInfo alterViewInfo) {
         long dbId = alterViewInfo.getDbId();
         long tableId = alterViewInfo.getTableId();
         Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
+        if (db == null) {
+            LOG.warn("db {} is null when update view security", dbId);
+            return;
+        }
         View view = (View) GlobalStateMgr.getCurrentState().getLocalMetastore().getTable(db.getId(), tableId);
+        if (view == null) {
+            LOG.warn("view {} is null when update view security", tableId);
+            return;
+        }
 
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(view.getId()), LockType.WRITE);
@@ -644,10 +657,6 @@ public class AlterJobMgr {
             view.setSecurity(alterViewInfo.getSecurity());
         } finally {
             locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(view.getId()), LockType.WRITE);
-        }
-
-        if (!isReplay) {
-            GlobalStateMgr.getCurrentState().getEditLog().logJsonObject(OperationType.OP_SET_VIEW_SECURITY_LOG, alterViewInfo);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogIdGenerator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogIdGenerator.java
@@ -55,8 +55,9 @@ public class CatalogIdGenerator {
         if (nextId < batchEndId) {
             return nextId++;
         } else {
-            batchEndId = batchEndId + BATCH_ID_INTERVAL;
-            GlobalStateMgr.getCurrentState().getEditLog().logSaveNextId(batchEndId);
+            long newBachEndId = batchEndId + BATCH_ID_INTERVAL;
+            GlobalStateMgr.getCurrentState().getEditLog()
+                    .logSaveNextId(newBachEndId, wal -> batchEndId = newBachEndId);
             return nextId++;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -3075,7 +3075,11 @@ public class OlapTable extends Table {
     }
 
     public void removeTableBinds(boolean isReplay) {
-        GlobalStateMgr.getCurrentState().getLocalMetastore().removeAutoIncrementIdByTableId(getId(), isReplay);
+        if (isReplay) {
+            GlobalStateMgr.getCurrentState().getLocalMetastore().deleteAutoIncrementIdForTable(getId());
+        } else {
+            GlobalStateMgr.getCurrentState().getLocalMetastore().removeAutoIncrementIdByTableId(getId());
+        }
         GlobalStateMgr.getCurrentState().getColocateTableIndex().removeTable(getId(), this, isReplay);
         GlobalStateMgr.getCurrentState().getStorageVolumeMgr().unbindTableToStorageVolume(getId());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/encryption/KeyMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/encryption/KeyMgr.java
@@ -73,10 +73,9 @@ public class KeyMgr {
     }
 
     private void addKey(EncryptionKey key) {
-        idToKey.put(key.id, key);
         EncryptionKeyPB pb = new EncryptionKeyPB();
         key.toPB(pb, this);
-        GlobalStateMgr.getCurrentState().getEditLog().logAddKey(pb);
+        GlobalStateMgr.getCurrentState().getEditLog().logAddKey(pb, wal -> idToKey.put(key.id, key));
     }
 
     public void replayAddKey(EncryptionKeyPB keyPB) {

--- a/fe/fe-core/src/main/java/com/starrocks/meta/SqlBlackList.java
+++ b/fe/fe-core/src/main/java/com/starrocks/meta/SqlBlackList.java
@@ -177,5 +177,12 @@ public class SqlBlackList {
 
     // ids used in sql blacklist
     private final AtomicLong ids = new AtomicLong();
+
+    protected void cleanup() {
+        try (LockCloseable ignored = new LockCloseable(rwLock.writeLock())) {
+            sqlBlackListMap.clear();
+            ids.set(0);
+        }
+    }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/meta/SqlBlackList.java
+++ b/fe/fe-core/src/main/java/com/starrocks/meta/SqlBlackList.java
@@ -19,7 +19,9 @@ import com.staros.util.LockCloseable;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
+import com.starrocks.common.StarRocksException;
 import com.starrocks.metric.MetricRepo;
+import com.starrocks.persist.DeleteSqlBlackLists;
 import com.starrocks.persist.ImageWriter;
 import com.starrocks.persist.SqlBlackListPersistInfo;
 import com.starrocks.persist.metablock.SRMetaBlockEOFException;
@@ -27,6 +29,13 @@ import com.starrocks.persist.metablock.SRMetaBlockException;
 import com.starrocks.persist.metablock.SRMetaBlockID;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
 import com.starrocks.persist.metablock.SRMetaBlockWriter;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SimpleScheduler;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.Authorizer;
+import com.starrocks.sql.ast.AddBackendBlackListStmt;
+import com.starrocks.sql.ast.DelSqlBlackListStmt;
+import com.starrocks.system.SystemInfoService;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -78,7 +87,9 @@ public class SqlBlackList {
             BlackListSql blackListSql = sqlBlackListMap.get(pattern.toString());
             if (blackListSql == null) {
                 long id = ids.getAndIncrement();
-                sqlBlackListMap.put(pattern.toString(), new BlackListSql(pattern, id));
+                GlobalStateMgr.getCurrentState().getEditLog().logAddSQLBlackList(
+                        new SqlBlackListPersistInfo(id, pattern.pattern()),
+                        wal -> sqlBlackListMap.put(pattern.toString(), new BlackListSql(pattern, id)));
                 return id;
             } else {
                 return blackListSql.id;
@@ -93,6 +104,30 @@ public class SqlBlackList {
                 ids.set(Math.max(ids.get(), id + 1));
                 sqlBlackListMap.put(pattern.toString(), new BlackListSql(pattern, id));
             }
+        }
+    }
+
+    public void deleteBlackSql(DelSqlBlackListStmt delSqlBlackListStmt) {
+        List<Long> indexs = delSqlBlackListStmt.getIndexs();
+        if (indexs != null) {
+            GlobalStateMgr.getCurrentState().getEditLog()
+                    .logDeleteSQLBlackList(new DeleteSqlBlackLists(indexs), wal -> {
+                        for (long id : indexs) {
+                            GlobalStateMgr.getCurrentState().getSqlBlackList().delete(id);
+                        }
+                    });
+        }
+    }
+
+    public void addBlackSql(AddBackendBlackListStmt addBackendBlackListStmt, ConnectContext context)
+            throws StarRocksException {
+        Authorizer.check(addBackendBlackListStmt, context);
+        for (Long beId : addBackendBlackListStmt.getBackendIds()) {
+            SystemInfoService sis = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
+            if (sis.getBackend(beId) == null) {
+                throw new StarRocksException("Not found backend: " + beId);
+            }
+            SimpleScheduler.getHostBlacklist().addByManual(beId);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -370,7 +370,7 @@ public class EditLog {
                 }
                 case OperationType.OP_SET_VIEW_SECURITY_LOG: {
                     AlterViewInfo info = (AlterViewInfo) journal.data();
-                    globalStateMgr.getAlterJobMgr().setViewSecurity(info, true);
+                    globalStateMgr.getAlterJobMgr().updateViewSecurity(info);
                     break;
                 }
                 case OperationType.OP_RENAME_PARTITION_V2: {
@@ -1424,20 +1424,20 @@ public class EditLog {
         }
     }
 
-    public void logSaveNextId(long nextId) {
-        logJsonObject(OperationType.OP_SAVE_NEXTID_V2, new NextIdLog(nextId));
+    public void logSaveNextId(long nextId, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_SAVE_NEXTID_V2, new NextIdLog(nextId), walApplier);
     }
 
     public void logSaveTransactionId(long transactionId) {
         logJsonObject(OperationType.OP_SAVE_TRANSACTION_ID_V2, new TransactionIdInfo(transactionId));
     }
 
-    public void logSaveAutoIncrementId(AutoIncrementInfo info) {
-        logJsonObject(OperationType.OP_SAVE_AUTO_INCREMENT_ID, info);
+    public void logSaveAutoIncrementId(AutoIncrementInfo info, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_SAVE_AUTO_INCREMENT_ID, info, walApplier);
     }
 
-    public void logSaveDeleteAutoIncrementId(AutoIncrementInfo info) {
-        logJsonObject(OperationType.OP_DELETE_AUTO_INCREMENT_ID, info);
+    public void logSaveDeleteAutoIncrementId(AutoIncrementInfo info, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_DELETE_AUTO_INCREMENT_ID, info, walApplier);
     }
 
     public void logCreateDb(Database db, String storageVolumeId) {
@@ -1619,16 +1619,16 @@ public class EditLog {
         logJsonObject(OperationType.OP_BATCH_DELETE_REPLICA, info);
     }
 
-    public void logAddKey(EncryptionKeyPB key) {
-        logJsonObject(OperationType.OP_ADD_KEY, key);
+    public void logAddKey(EncryptionKeyPB key, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_ADD_KEY, key, walApplier);
     }
 
     public void logTimestamp(Timestamp stamp) {
         logJsonObject(OperationType.OP_TIMESTAMP_V2, stamp);
     }
 
-    public void logLeaderInfo(LeaderInfo info) {
-        logJsonObject(OperationType.OP_LEADER_INFO_CHANGE_V2, info);
+    public void logLeaderInfo(LeaderInfo info, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_LEADER_INFO_CHANGE_V2, info, walApplier);
     }
 
     public void logResetFrontends(Frontend frontend, WALApplier walApplier) {
@@ -2029,12 +2029,12 @@ public class EditLog {
         logJsonObject(OperationType.OP_ALTER_MATERIALIZED_VIEW_PROPERTIES, log);
     }
 
-    public void logAddSQLBlackList(SqlBlackListPersistInfo addBlackList) {
-        logJsonObject(OperationType.OP_ADD_SQL_QUERY_BLACK_LIST, addBlackList);
+    public void logAddSQLBlackList(SqlBlackListPersistInfo addBlackList, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_ADD_SQL_QUERY_BLACK_LIST, addBlackList, walApplier);
     }
 
-    public void logDeleteSQLBlackList(DeleteSqlBlackLists deleteBlacklists) {
-        logJsonObject(OperationType.OP_DELETE_SQL_QUERY_BLACK_LIST, deleteBlacklists);
+    public void logDeleteSQLBlackList(DeleteSqlBlackLists deleteBlacklists, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_DELETE_SQL_QUERY_BLACK_LIST, deleteBlacklists, walApplier);
     }
 
     public void logStarMgrOperation(StarMgrJournal journal) {
@@ -2218,19 +2218,19 @@ public class EditLog {
         logJsonObject(OperationType.OP_CLUSTER_SNAPSHOT_LOG, info);
     }
 
-    public void logCreateSPMBaseline(BaselinePlan.Info info) {
-        logJsonObject(OperationType.OP_CREATE_SPM_BASELINE_LOG, info);
+    public void logCreateSPMBaseline(BaselinePlan.Info info, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_CREATE_SPM_BASELINE_LOG, info, walApplier);
     }
 
-    public void logDropSPMBaseline(BaselinePlan.Info info) {
-        logJsonObject(OperationType.OP_DROP_SPM_BASELINE_LOG, info);
+    public void logDropSPMBaseline(BaselinePlan.Info info, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_DROP_SPM_BASELINE_LOG, info, walApplier);
     }
 
-    public void logUpdateSPMBaseline(BaselinePlan.Info info, boolean isEnable) {
+    public void logUpdateSPMBaseline(BaselinePlan.Info info, boolean isEnable, WALApplier walApplier) {
         if (isEnable) {
-            logJsonObject(OperationType.OP_ENABLE_SPM_BASELINE_LOG, info);
+            logJsonObject(OperationType.OP_ENABLE_SPM_BASELINE_LOG, info, walApplier);
         } else {
-            logJsonObject(OperationType.OP_DISABLE_SPM_BASELINE_LOG, info);
+            logJsonObject(OperationType.OP_DISABLE_SPM_BASELINE_LOG, info, walApplier);
         }
     }
 
@@ -2240,5 +2240,13 @@ public class EditLog {
 
     public void logRemoveDynamicTabletJob(long jobId) {
         logJsonObject(OperationType.OP_REMOVE_DYNAMIC_TABLET_JOB_LOG, new RemoveDynamicTabletJobLog(jobId));
+    }
+
+    public void logCreateGroupProvider(GroupProviderLog provider, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_CREATE_GROUP_PROVIDER, provider, walApplier);
+    }
+
+    public void logDropGroupProvider(GroupProviderLog groupProviderLog, WALApplier walApplier) {
+        logJsonObject(OperationType.OP_DROP_GROUP_PROVIDER, groupProviderLog, walApplier);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLogDeserializer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLogDeserializer.java
@@ -265,6 +265,8 @@ public class EditLogDeserializer {
             .put(OperationType.OP_DROP_GROUP_PROVIDER, GroupProviderLog.class)
             .put(OperationType.OP_CREATE_SPM_BASELINE_LOG, BaselinePlan.Info.class)
             .put(OperationType.OP_DROP_SPM_BASELINE_LOG, BaselinePlan.Info.class)
+            .put(OperationType.OP_ENABLE_SPM_BASELINE_LOG, BaselinePlan.Info.class)
+            .put(OperationType.OP_DISABLE_SPM_BASELINE_LOG, BaselinePlan.Info.class)
             .put(OperationType.OP_UPDATE_DYNAMIC_TABLET_JOB_LOG, DynamicTabletJob.class)
             .put(OperationType.OP_REMOVE_DYNAMIC_TABLET_JOB_LOG, RemoveDynamicTabletJobLog.class)
             .put(OperationType.OP_SAVE_NEXTID_V2, NextIdLog.class)

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -106,8 +106,6 @@ import com.starrocks.mysql.MysqlCommand;
 import com.starrocks.mysql.MysqlEofPacket;
 import com.starrocks.mysql.MysqlSerializer;
 import com.starrocks.persist.CreateInsertOverwriteJobLog;
-import com.starrocks.persist.DeleteSqlBlackLists;
-import com.starrocks.persist.SqlBlackListPersistInfo;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.planner.FileScanNode;
 import com.starrocks.planner.HiveTableSink;
@@ -1910,32 +1908,15 @@ public class StmtExecutor {
             throw new SemanticException("Sql pattern cannot be empty");
         }
 
-        long id = GlobalStateMgr.getCurrentState().getSqlBlackList().put(sqlPattern);
-        GlobalStateMgr.getCurrentState().getEditLog().logAddSQLBlackList(new SqlBlackListPersistInfo(id, sqlPattern.pattern()));
+        GlobalStateMgr.getCurrentState().getSqlBlackList().put(sqlPattern);
     }
 
     private void handleDelSqlBlackListStmt() {
-        DelSqlBlackListStmt delSqlBlackListStmt = (DelSqlBlackListStmt) parsedStmt;
-        List<Long> indexs = delSqlBlackListStmt.getIndexs();
-        if (indexs != null) {
-            for (long id : indexs) {
-                GlobalStateMgr.getCurrentState().getSqlBlackList().delete(id);
-            }
-            GlobalStateMgr.getCurrentState().getEditLog()
-                    .logDeleteSQLBlackList(new DeleteSqlBlackLists(indexs));
-        }
+        GlobalStateMgr.getCurrentState().getSqlBlackList().deleteBlackSql((DelSqlBlackListStmt) parsedStmt);
     }
 
     private void handleAddBackendBlackListStmt() throws StarRocksException {
-        AddBackendBlackListStmt addBackendBlackListStmt = (AddBackendBlackListStmt) parsedStmt;
-        Authorizer.check(addBackendBlackListStmt, context);
-        for (Long beId : addBackendBlackListStmt.getBackendIds()) {
-            SystemInfoService sis = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo();
-            if (sis.getBackend(beId) == null) {
-                throw new StarRocksException("Not found backend: " + beId);
-            }
-            SimpleScheduler.getHostBlacklist().addByManual(beId);
-        }
+        GlobalStateMgr.getCurrentState().getSqlBlackList().addBlackSql((AddBackendBlackListStmt) parsedStmt, context);
     }
 
     private void handleDelBackendBlackListStmt() throws StarRocksException {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -5170,6 +5170,10 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         }
     }
 
+    public void deleteAutoIncrementIdForTable(Long tableId) {
+        tableIdToIncrementId.remove(tableId);
+    }
+
     public void replayAutoIncrementId(AutoIncrementInfo info) throws IOException {
         for (Map.Entry<Long, Long> entry : info.tableIdToIncrementId().entrySet()) {
             Long tableId = entry.getKey();
@@ -5184,37 +5188,39 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
     }
 
     public Long allocateAutoIncrementId(Long tableId, Long rows) {
-        Long oldId = tableIdToIncrementId.putIfAbsent(tableId, 1L);
-        if (oldId == null) {
-            oldId = tableIdToIncrementId.get(tableId);
-        }
+        Long endId = tableIdToIncrementId.compute(tableId, (k, val) -> {
+            Long currentVal = val;
+            if (currentVal == null) {
+                currentVal = 1L;
+            }
 
-        Long newId = oldId + rows;
-        // AUTO_INCREMENT counter overflow
-        if (newId < oldId) {
-            throw new RuntimeException("AUTO_INCREMENT counter overflow");
-        }
-
-        while (!tableIdToIncrementId.replace(tableId, oldId, newId)) {
-            oldId = tableIdToIncrementId.get(tableId);
-            newId = oldId + rows;
-
-            // AUTO_INCREMENT counter overflow
-            if (newId < oldId) {
+            Long newVal = currentVal + rows;
+            if (newVal < currentVal) {
                 throw new RuntimeException("AUTO_INCREMENT counter overflow");
             }
-        }
 
-        return oldId;
+            // log the delta result.
+            ConcurrentHashMap<Long, Long> deltaMap = new ConcurrentHashMap<>();
+            deltaMap.put(tableId, newVal);
+            AutoIncrementInfo info = new AutoIncrementInfo(deltaMap);
+            GlobalStateMgr.getCurrentState().getEditLog().logSaveAutoIncrementId(info, wal -> {
+                // noting to do, tableIdToIncrementId will be updated after the compute end.
+            });
+            return newVal;
+        });
+
+        return endId - rows;
     }
 
-    public void removeAutoIncrementIdByTableId(Long tableId, boolean isReplay) {
-        Long id = tableIdToIncrementId.remove(tableId);
-        if (!isReplay && id != null) {
+    public void removeAutoIncrementIdByTableId(Long tableId) {
+        Long id = tableIdToIncrementId.get(tableId);
+
+        if (id != null) {
             ConcurrentHashMap<Long, Long> deltaMap = new ConcurrentHashMap<>();
             deltaMap.put(tableId, 0L);
             AutoIncrementInfo info = new AutoIncrementInfo(deltaMap);
-            GlobalStateMgr.getCurrentState().getEditLog().logSaveDeleteAutoIncrementId(info);
+            GlobalStateMgr.getCurrentState().getEditLog()
+                    .logSaveDeleteAutoIncrementId(info, wal -> tableIdToIncrementId.remove(tableId));
         }
     }
 
@@ -5369,12 +5375,11 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             throw new DdlException("Failed to drop auto increment cache in CN/BE");
         }
 
-        addOrReplaceAutoIncrementIdByTableId(tableId, newAutoIncrementValue);
-
         ConcurrentHashMap<Long, Long> idMap = new ConcurrentHashMap<>();
         idMap.put(tableId, newAutoIncrementValue);
         AutoIncrementInfo info = new AutoIncrementInfo(idMap);
-        stateMgr.getEditLog().logSaveAutoIncrementId(info);
+        stateMgr.getEditLog().logSaveAutoIncrementId(
+                info, wal -> addOrReplaceAutoIncrementIdByTableId(tableId, newAutoIncrementValue));
 
         LOG.info("Set auto_increment value for table {}.{} to {}", dbName, tableName, newAutoIncrementValue);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/NodeMgr.java
@@ -1227,11 +1227,12 @@ public class NodeMgr {
     }
 
     public void setLeaderInfo() {
-        this.leaderIp = FrontendOptions.getLocalHostAddress();
-        this.leaderRpcPort = Config.rpc_port;
-        this.leaderHttpPort = Config.http_port;
-        LeaderInfo info = new LeaderInfo(this.leaderIp, this.leaderHttpPort, this.leaderRpcPort);
-        GlobalStateMgr.getCurrentState().getEditLog().logLeaderInfo(info);
+        LeaderInfo info = new LeaderInfo(FrontendOptions.getLocalHostAddress(), Config.http_port, Config.rpc_port);
+        GlobalStateMgr.getCurrentState().getEditLog().logLeaderInfo(info, wal -> {
+            leaderIp = info.getIp();
+            leaderRpcPort = info.getRpcPort();
+            leaderHttpPort = info.getHttpPort();
+        });
 
         leaderChangeListeners.values().forEach(listener -> listener.accept(info));
     }
@@ -1262,5 +1263,9 @@ public class NodeMgr {
                 .stream()
                 .mapToLong(Frontend::getCpuCores)
                 .sum() + systemInfo.getTotalCpuCores();
+    }
+
+    protected LeaderInfo getLeaderInfo() {
+        return new LeaderInfo(leaderIp, leaderHttpPort, leaderRpcPort);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -131,7 +131,6 @@ import com.starrocks.load.streamload.StreamLoadKvParams;
 import com.starrocks.load.streamload.StreamLoadMgr;
 import com.starrocks.load.streamload.StreamLoadTask;
 import com.starrocks.metric.MetricRepo;
-import com.starrocks.persist.AutoIncrementInfo;
 import com.starrocks.planner.OlapTableSink;
 import com.starrocks.planner.SlotDescriptor;
 import com.starrocks.planner.SlotId;
@@ -392,7 +391,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
@@ -1751,11 +1749,6 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         Long nextId = null;
         try {
             nextId = GlobalStateMgr.getCurrentState().getLocalMetastore().allocateAutoIncrementId(request.table_id, rows);
-            // log the delta result.
-            ConcurrentHashMap<Long, Long> deltaMap = new ConcurrentHashMap<>();
-            deltaMap.put(request.table_id, nextId + rows);
-            AutoIncrementInfo info = new AutoIncrementInfo(deltaMap);
-            GlobalStateMgr.getCurrentState().getEditLog().logSaveAutoIncrementId(info);
         } catch (Exception e) {
             result.setAuto_increment_id(0);
             result.setAllocated_rows(0);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SQLPlanGlobalStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SQLPlanGlobalStorage.java
@@ -187,14 +187,14 @@ class SQLPlanGlobalStorage implements SQLPlanStorage {
             sb.append(";");
             executor.executeDML(sb.toString());
 
-            for (BaselinePlan plan : plans) {
-                allBaselineIds.add(new BaselineId(plan.getId(), plan.getBindSqlHash()));
-            }
-
             BaselinePlan.Info info = new BaselinePlan.Info();
             info.setReplayIds(plans.stream().map(BaselinePlan::getId).collect(Collectors.toList()));
             info.setReplayBindSQLHash(plans.stream().map(BaselinePlan::getBindSqlHash).collect(Collectors.toList()));
-            GlobalStateMgr.getCurrentState().getEditLog().logCreateSPMBaseline(info);
+            GlobalStateMgr.getCurrentState().getEditLog().logCreateSPMBaseline(info, wal -> {
+                for (BaselinePlan plan : plans) {
+                    allBaselineIds.add(new BaselineId(plan.getId(), plan.getBindSqlHash()));
+                }
+            });
         } catch (Exception e) {
             LOG.warn("sql plan baselines store baseline fail", e);
         }
@@ -211,10 +211,6 @@ class SQLPlanGlobalStorage implements SQLPlanStorage {
     public void dropBaselinePlan(List<Long> baseLineIds) {
         try {
             List<BaselineId> ids = allBaselineIds.stream().filter(b -> baseLineIds.contains(b.id)).toList();
-            for (BaselineId id : ids) {
-                allBaselineIds.remove(id);
-                cache.invalidate(id.id);
-            }
             if (!StatisticUtils.checkStatisticTables(List.of(StatsConstants.SPM_BASELINE_TABLE_NAME))) {
                 return;
             }
@@ -223,7 +219,12 @@ class SQLPlanGlobalStorage implements SQLPlanStorage {
             executor.executeDML(DELETE_SQL + "(" + s + ");");
             BaselinePlan.Info p = new BaselinePlan.Info();
             p.setReplayIds(ids.stream().map(BaselineId::id).collect(Collectors.toList()));
-            GlobalStateMgr.getCurrentState().getEditLog().logDropSPMBaseline(p);
+            GlobalStateMgr.getCurrentState().getEditLog().logDropSPMBaseline(p, wal -> {
+                for (BaselineId id : ids) {
+                    allBaselineIds.remove(id);
+                    cache.invalidate(id.id);
+                }
+            });
         } catch (Exception e) {
             LOG.warn("sql plan baselines drop baseline fail", e);
         }
@@ -309,9 +310,10 @@ class SQLPlanGlobalStorage implements SQLPlanStorage {
 
         BaselinePlan.Info p = new BaselinePlan.Info();
         p.setReplayIds(ids);
-        GlobalStateMgr.getCurrentState().getEditLog().logUpdateSPMBaseline(p, isEnable);
-        // invalidate cache
-        cache.invalidateAll(ids);
+        GlobalStateMgr.getCurrentState().getEditLog().logUpdateSPMBaseline(p, isEnable, wal -> {
+            // invalidate cache
+            cache.invalidateAll(ids);
+        });
     }
 
     @Override
@@ -377,4 +379,11 @@ class SQLPlanGlobalStorage implements SQLPlanStorage {
         }
     }
 
+    protected Set<Long> getAllBaselineIds() {
+        return allBaselineIds.stream().map(BaselineId::id).collect(Collectors.toSet());
+    }
+
+    protected LoadingCache<Long, BaselinePlan> getCache() {
+        return cache;
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobMgrEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobMgrEditLogTest.java
@@ -1,0 +1,156 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.View;
+import com.starrocks.persist.AlterViewInfo;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.transaction.MockedLocalMetaStore;
+import com.starrocks.transaction.MockedMetadataMgr;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class AlterJobMgrEditLogTest {
+    private AlterJobMgr alterJobMgr;
+    private MockedLocalMetaStore localMetastore;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        // Initialize test environment
+        UtFrameUtils.setUpForPersistTest();
+
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        localMetastore = new MockedLocalMetaStore(globalStateMgr, globalStateMgr.getRecycleBin(), null);
+        globalStateMgr.setLocalMetastore(localMetastore);
+
+        MockedMetadataMgr mockedMetadataMgr = new MockedMetadataMgr(localMetastore, globalStateMgr.getConnectorMgr());
+        globalStateMgr.setMetadataMgr(mockedMetadataMgr);
+
+        alterJobMgr = globalStateMgr.getAlterJobMgr();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    @Test
+    public void testSetViewSecurityNormalCase() throws Exception {
+        // 1. Prepare test data - create a database and view
+        localMetastore.createDb("test_db");
+        Database db = localMetastore.getDb("test_db");
+        Assertions.assertNotNull(db);
+
+        // Create a simple view
+        List<Column> columns = new ArrayList<>();
+        View view = new View(1L, "test_view", columns);
+        db.registerTableUnlocked(view);
+        
+        Table table = localMetastore.getTable("test_db", "test_view");
+        Assertions.assertNotNull(table);
+        Assertions.assertTrue(table.isView());
+        View testView = (View) table;
+        Assertions.assertFalse(testView.isSecurity());
+
+        // 2. Prepare AlterViewInfo
+        AlterViewInfo alterViewInfo = new AlterViewInfo(db.getId(), view.getId(), true);
+
+        // 3. Execute setViewSecurity operation (master side)
+        alterJobMgr.setViewSecurity(alterViewInfo);
+
+        // 4. Verify master state
+        View updatedView = (View) localMetastore.getTable("test_db", "test_view");
+        Assertions.assertNotNull(updatedView);
+        Assertions.assertTrue(updatedView.isSecurity());
+
+        // 5. Test follower replay functionality
+        // Use the same alterJobMgr for replay since we're testing the replay method
+        AlterJobMgr followerAlterJobMgr = alterJobMgr;
+        
+        // Create follower view with initial state
+        List<Column> followerColumns = new ArrayList<>();
+        View followerView = new View(view.getId(), "test_view", followerColumns);
+        followerView.setSecurity(false);
+        db.registerTableUnlocked(followerView);
+        
+        Assertions.assertFalse(followerView.isSecurity());
+
+        // Replay the operation
+        AlterViewInfo replayInfo = (AlterViewInfo) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_SET_VIEW_SECURITY_LOG);
+        followerAlterJobMgr.updateViewSecurity(replayInfo);
+
+        // 6. Verify follower state is consistent with master
+        View followerUpdatedView = (View) localMetastore.getTable("test_db", "test_view");
+        Assertions.assertNotNull(followerUpdatedView);
+        Assertions.assertTrue(followerUpdatedView.isSecurity());
+    }
+
+    @Test
+    public void testSetViewSecurityEditLogException() throws Exception {
+        // 1. Prepare test data - create a database and view
+        localMetastore.createDb("test_db");
+        Database db = localMetastore.getDb("test_db");
+        Assertions.assertNotNull(db);
+
+        // Create a simple view
+        List<Column> columns = new ArrayList<>();
+        View view = new View(1L, "test_view", columns);
+        db.registerTableUnlocked(view);
+        
+        Table table = localMetastore.getTable("test_db", "test_view");
+        Assertions.assertNotNull(table);
+        Assertions.assertTrue(table.isView());
+        View testView = (View) table;
+        Assertions.assertFalse(testView.isSecurity());
+
+        // 2. Prepare AlterViewInfo
+        AlterViewInfo alterViewInfo = new AlterViewInfo(db.getId(), view.getId(), true);
+
+        // 3. Mock EditLog.logJsonObject to throw exception
+        EditLog spyEditLog = spy(GlobalStateMgr.getCurrentState().getEditLog());
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logJsonObject(any(Short.class), any(), any());
+        
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 4. Execute setViewSecurity operation and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            alterJobMgr.setViewSecurity(alterViewInfo);
+        });
+        Assertions.assertEquals("EditLog write failed", exception.getMessage());
+
+        // 5. Verify view security remains unchanged after exception
+        Assertions.assertNotNull(exception);
+        Assertions.assertFalse(testView.isSecurity());
+    }
+}
+

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterDataCachePartitionDurationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterDataCachePartitionDurationTest.java
@@ -46,6 +46,8 @@ import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.StarOSAgent;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.ModifyTablePropertyOperationLog;
+import com.starrocks.persist.NextIdLog;
+import com.starrocks.persist.WALApplier;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
@@ -105,8 +107,8 @@ public class LakeTableAlterDataCachePartitionDurationTest {
             }
 
             @Mock
-            public void logSaveNextId(long nextId) {
-
+            public void logSaveNextId(long nextId, WALApplier applier) {
+                applier.apply(new NextIdLog(nextId));
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/authentication/AuthenticationMgrEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/AuthenticationMgrEditLogTest.java
@@ -1,0 +1,217 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.authentication;
+
+import com.starrocks.catalog.UserIdentity;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.GroupProviderLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.group.CreateGroupProviderStmt;
+import com.starrocks.sql.ast.group.DropGroupProviderStmt;
+import com.starrocks.sql.parser.NodePosition;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class AuthenticationMgrEditLogTest {
+    private AuthenticationMgr authenticationMgr;
+    private ConnectContext ctx;
+    private static final String TEST_PROVIDER_NAME = "test_provider_editlog";
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        // Initialize test environment
+        UtFrameUtils.setUpForPersistTest();
+
+        ctx = UtFrameUtils.initCtxForNewPrivilege(UserIdentity.ROOT);
+        authenticationMgr = GlobalStateMgr.getCurrentState().getAuthenticationMgr();
+
+        // Clean up any existing test providers
+        cleanupTestProviders();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        cleanupTestProviders();
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    private void cleanupTestProviders() {
+        try {
+            DropGroupProviderStmt dropStmt = new DropGroupProviderStmt(TEST_PROVIDER_NAME, true, NodePosition.ZERO);
+            authenticationMgr.dropGroupProviderStatement(dropStmt, ctx);
+        } catch (Exception e) {
+            // Ignore cleanup errors
+        }
+    }
+
+    private Map<String, String> createUnixGroupProviderProperties() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("type", "unix");
+        return properties;
+    }
+
+    @Test
+    public void testCreateGroupProviderStatementNormalCase() throws Exception {
+        // 1. Prepare test data
+        Map<String, String> properties = createUnixGroupProviderProperties();
+        CreateGroupProviderStmt stmt = new CreateGroupProviderStmt(TEST_PROVIDER_NAME, properties, false, NodePosition.ZERO);
+
+        // 2. Verify initial state
+        Assertions.assertNull(authenticationMgr.getGroupProvider(TEST_PROVIDER_NAME));
+
+        // 3. Execute createGroupProviderStatement operation (master side)
+        authenticationMgr.createGroupProviderStatement(stmt, ctx);
+
+        // 4. Verify master state
+        GroupProvider provider = authenticationMgr.getGroupProvider(TEST_PROVIDER_NAME);
+        Assertions.assertNotNull(provider);
+        Assertions.assertEquals(TEST_PROVIDER_NAME, provider.getName());
+        Assertions.assertEquals("unix", provider.getType());
+
+        // 5. Test follower replay functionality
+        AuthenticationMgr followerAuthMgr = new AuthenticationMgr();
+        
+        // Verify follower initial state
+        Assertions.assertNull(followerAuthMgr.getGroupProvider(TEST_PROVIDER_NAME));
+
+        // Replay the operation
+        GroupProviderLog replayLog = (GroupProviderLog) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_CREATE_GROUP_PROVIDER);
+        followerAuthMgr.replayCreateGroupProvider(replayLog.getName(), replayLog.getPropertyMap());
+
+        // 6. Verify follower state is consistent with master
+        GroupProvider followerProvider = followerAuthMgr.getGroupProvider(TEST_PROVIDER_NAME);
+        Assertions.assertNotNull(followerProvider);
+        Assertions.assertEquals(TEST_PROVIDER_NAME, followerProvider.getName());
+        Assertions.assertEquals("unix", followerProvider.getType());
+    }
+
+    @Test
+    public void testCreateGroupProviderStatementEditLogException() throws Exception {
+        // 1. Prepare test data
+        Map<String, String> properties = createUnixGroupProviderProperties();
+        CreateGroupProviderStmt stmt = new CreateGroupProviderStmt(TEST_PROVIDER_NAME, properties, false, NodePosition.ZERO);
+
+        // 2. Mock EditLog.logCreateGroupProvider to throw exception
+        EditLog spyEditLog = spy(GlobalStateMgr.getCurrentState().getEditLog());
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logCreateGroupProvider(any(GroupProviderLog.class), any());
+        
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // Verify initial state
+        Assertions.assertNull(authenticationMgr.getGroupProvider(TEST_PROVIDER_NAME));
+
+        // Save initial state snapshot
+        int initialProviderCount = authenticationMgr.getAllGroupProviders().size();
+
+        // 3. Execute createGroupProviderStatement operation and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            authenticationMgr.createGroupProviderStatement(stmt, ctx);
+        });
+        Assertions.assertEquals("EditLog write failed", exception.getMessage());
+
+        // 4. Verify leader memory state remains unchanged after exception
+        Assertions.assertNull(authenticationMgr.getGroupProvider(TEST_PROVIDER_NAME));
+        Assertions.assertEquals(initialProviderCount, authenticationMgr.getAllGroupProviders().size());
+    }
+
+    @Test
+    public void testDropGroupProviderStatementNormalCase() throws Exception {
+        // 1. Prepare test data - create a group provider first
+        Map<String, String> properties = createUnixGroupProviderProperties();
+        CreateGroupProviderStmt createStmt = new CreateGroupProviderStmt(
+                TEST_PROVIDER_NAME, properties, false, NodePosition.ZERO);
+        authenticationMgr.createGroupProviderStatement(createStmt, ctx);
+        
+        Assertions.assertNotNull(authenticationMgr.getGroupProvider(TEST_PROVIDER_NAME));
+
+        // 2. Prepare drop statement
+        DropGroupProviderStmt dropStmt = new DropGroupProviderStmt(TEST_PROVIDER_NAME, false, NodePosition.ZERO);
+
+        // 3. Execute dropGroupProviderStatement operation (master side)
+        authenticationMgr.dropGroupProviderStatement(dropStmt, ctx);
+
+        // 4. Verify master state
+        Assertions.assertNull(authenticationMgr.getGroupProvider(TEST_PROVIDER_NAME));
+
+        // 5. Test follower replay functionality
+        AuthenticationMgr followerAuthMgr = new AuthenticationMgr();
+        
+        // First create the provider in follower
+        followerAuthMgr.replayCreateGroupProvider(TEST_PROVIDER_NAME, properties);
+        Assertions.assertNotNull(followerAuthMgr.getGroupProvider(TEST_PROVIDER_NAME));
+
+        // Replay the drop operation
+        GroupProviderLog replayLog = (GroupProviderLog) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_DROP_GROUP_PROVIDER);
+        followerAuthMgr.replayDropGroupProvider(replayLog.getName());
+
+        // 6. Verify follower state is consistent with master
+        Assertions.assertNull(followerAuthMgr.getGroupProvider(TEST_PROVIDER_NAME));
+    }
+
+    @Test
+    public void testDropGroupProviderStatementEditLogException() throws Exception {
+        // 1. Prepare test data - create a group provider first
+        Map<String, String> properties = createUnixGroupProviderProperties();
+        CreateGroupProviderStmt createStmt = new CreateGroupProviderStmt(
+                TEST_PROVIDER_NAME, properties, false, NodePosition.ZERO);
+        authenticationMgr.createGroupProviderStatement(createStmt, ctx);
+        
+        Assertions.assertNotNull(authenticationMgr.getGroupProvider(TEST_PROVIDER_NAME));
+
+        // 2. Prepare drop statement
+        DropGroupProviderStmt dropStmt = new DropGroupProviderStmt(TEST_PROVIDER_NAME, false, NodePosition.ZERO);
+
+        // 3. Mock EditLog.logDropGroupProvider to throw exception
+        EditLog spyEditLog = spy(GlobalStateMgr.getCurrentState().getEditLog());
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logDropGroupProvider(any(GroupProviderLog.class), any());
+        
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // Save initial state snapshot
+        GroupProvider initialProvider = authenticationMgr.getGroupProvider(TEST_PROVIDER_NAME);
+        Assertions.assertNotNull(initialProvider);
+
+        // 4. Execute dropGroupProviderStatement operation and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            authenticationMgr.dropGroupProviderStatement(dropStmt, ctx);
+        });
+        Assertions.assertEquals("EditLog write failed", exception.getMessage());
+
+        // 5. Verify leader memory state remains unchanged after exception
+        GroupProvider unchangedProvider = authenticationMgr.getGroupProvider(TEST_PROVIDER_NAME);
+        Assertions.assertNotNull(unchangedProvider);
+        Assertions.assertEquals(TEST_PROVIDER_NAME, unchangedProvider.getName());
+    }
+}
+
+

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogIdGeneratorEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogIdGeneratorEditLogTest.java
@@ -1,0 +1,116 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.NextIdLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class CatalogIdGeneratorEditLogTest {
+    private CatalogIdGenerator idGenerator;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        // Initialize test environment
+        UtFrameUtils.setUpForPersistTest();
+
+        // Create CatalogIdGenerator instance with initial value
+        idGenerator = new CatalogIdGenerator(0L);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    @Test
+    public void testGetNextIdNormalCase() throws Exception {
+        // 1. Verify initial state
+        long initialBatchEndId = idGenerator.getBatchEndId();
+        Assertions.assertEquals(0L, initialBatchEndId);
+
+        // 2. Get IDs until we trigger a batch update (should happen after 1000 IDs)
+        // First, set the generator to near the batch end to trigger editlog write
+        idGenerator.setId(999L);
+        
+        // 3. Execute getNextId operation (master side) - this should trigger editlog write
+        // When nextId (999) >= batchEndId (999), it will trigger editlog write
+        // newBatchEndId = 999 + 1000 = 1999, then return nextId++ which is 999
+        long nextId = idGenerator.getNextId();
+
+        // 4. Verify master state
+        Assertions.assertEquals(999L, nextId);
+        Assertions.assertEquals(1999L, idGenerator.getBatchEndId());
+
+        // 5. Test follower replay functionality
+        CatalogIdGenerator followerIdGenerator = new CatalogIdGenerator(0L);
+        followerIdGenerator.setId(999L);
+        
+        // Verify follower initial state
+        Assertions.assertEquals(999L, followerIdGenerator.getBatchEndId());
+
+        // Replay the operation
+        NextIdLog replayLog = (NextIdLog) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_SAVE_NEXTID_V2);
+        GlobalStateMgr.getCurrentState().setNextId(replayLog.getId() + 1);
+        followerIdGenerator.setId(replayLog.getId());
+
+        // 6. Verify follower state is consistent with master
+        Assertions.assertTrue(followerIdGenerator.getBatchEndId() >= 1000L);
+    }
+
+    @Test
+    public void testGetNextIdEditLogException() throws Exception {
+        // 1. Set the generator to near the batch end to trigger editlog write
+        idGenerator.setId(999L);
+        
+        long initialBatchEndId = idGenerator.getBatchEndId();
+        Assertions.assertEquals(999L, initialBatchEndId);
+
+        // 2. Mock EditLog.logSaveNextId to throw exception
+        EditLog spyEditLog = spy(GlobalStateMgr.getCurrentState().getEditLog());
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logSaveNextId(anyLong(), any());
+        
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // Save initial state snapshot
+        long initialId = initialBatchEndId;
+
+        // 3. Execute getNextId operation and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            idGenerator.getNextId();
+        });
+        Assertions.assertEquals("EditLog write failed", exception.getMessage());
+
+        // 4. Verify leader memory state remains unchanged after exception
+        // The batchEndId should not have been updated
+        Assertions.assertEquals(initialId, idGenerator.getBatchEndId());
+    }
+}
+
+

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/FakeEditLog.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/FakeEditLog.java
@@ -41,6 +41,7 @@ import com.starrocks.persist.DropBackendInfo;
 import com.starrocks.persist.DropComputeNodeLog;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.ModifyTablePropertyOperationLog;
+import com.starrocks.persist.NextIdLog;
 import com.starrocks.persist.ReplicaPersistInfo;
 import com.starrocks.persist.RoutineLoadOperation;
 import com.starrocks.persist.UpdateBackendInfo;
@@ -82,7 +83,8 @@ public class FakeEditLog extends MockUp<EditLog> {
     }
 
     @Mock
-    public void logSaveNextId(long nextId) {
+    public void logSaveNextId(long nextId, WALApplier walApplier) {
+        walApplier.apply(new NextIdLog(nextId));
     }
 
     @Mock

--- a/fe/fe-core/src/test/java/com/starrocks/encryption/KeyMgrEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/encryption/KeyMgrEditLogTest.java
@@ -1,0 +1,135 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.encryption;
+
+import com.starrocks.common.Config;
+import com.starrocks.common.io.Text;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.proto.EncryptionKeyPB;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class KeyMgrEditLogTest {
+    private KeyMgr keyMgr;
+    private String oldConfig;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        // Initialize test environment
+        UtFrameUtils.setUpForPersistTest();
+
+        // Save old config
+        oldConfig = Config.default_master_key;
+        Config.default_master_key = "plain:aes_128:enwSdCUAiCLLx2Bs9E/neQ==";
+
+        keyMgr = new KeyMgr();
+        
+        // Initialize with a master key using createFromSpec to ensure proper initialization
+        EncryptionKey masterKey = EncryptionKey.createFromSpec(Config.default_master_key);
+        masterKey.setId(KeyMgr.DEFAULT_MASTER_KYE_ID);
+        EncryptionKeyPB masterKeyPB = new EncryptionKeyPB();
+        masterKey.toPB(masterKeyPB, keyMgr);
+        keyMgr.replayAddKey(masterKeyPB);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+        Config.default_master_key = oldConfig;
+    }
+
+    @Test
+    public void testAddKeyNormalCase() throws Exception {
+        // 1. Verify initial state
+        int initialKeyCount = keyMgr.numKeys();
+        Assertions.assertEquals(1, initialKeyCount); // Master key
+
+        // 2. Execute generateNewKEK which calls addKey internally
+        EncryptionKey kek = keyMgr.generateNewKEK();
+
+        // 3. Verify master state
+        Assertions.assertNotNull(kek);
+        Assertions.assertEquals(2, keyMgr.numKeys());
+        EncryptionKey addedKey = keyMgr.getKeyById(kek.id);
+        Assertions.assertNotNull(addedKey);
+        Assertions.assertEquals(kek.id, addedKey.id);
+
+        // 4. Test follower replay functionality
+        KeyMgr followerKeyMgr = new KeyMgr();
+        
+        // Initialize follower with master key using createFromSpec to ensure proper initialization
+        EncryptionKey followerMasterKey = EncryptionKey.createFromSpec(Config.default_master_key);
+        followerMasterKey.setId(KeyMgr.DEFAULT_MASTER_KYE_ID);
+        EncryptionKeyPB followerMasterKeyPB = new EncryptionKeyPB();
+        followerMasterKey.toPB(followerMasterKeyPB, followerKeyMgr);
+        followerKeyMgr.replayAddKey(followerMasterKeyPB);
+        
+        // Verify follower initial state
+        Assertions.assertEquals(1, followerKeyMgr.numKeys());
+
+        // Replay the operation
+        // OP_ADD_KEY is serialized as Text (JSON string), need to deserialize it
+        Text keyJson = (Text) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_ADD_KEY);
+        EncryptionKeyPB replayKeyPB = GsonUtils.GSON.fromJson(keyJson.toString(), EncryptionKeyPB.class);
+        followerKeyMgr.replayAddKey(replayKeyPB);
+
+        // 5. Verify follower state is consistent with master
+        EncryptionKey followerKey = followerKeyMgr.getKeyById(kek.id);
+        Assertions.assertNotNull(followerKey);
+        Assertions.assertEquals(kek.id, followerKey.id);
+        Assertions.assertEquals(2, followerKeyMgr.numKeys());
+    }
+
+    @Test
+    public void testAddKeyEditLogException() throws Exception {
+        // 1. Verify initial state
+        int initialKeyCount = keyMgr.numKeys();
+        Assertions.assertEquals(1, initialKeyCount); // Master key
+
+        // 2. Mock EditLog.logAddKey to throw exception
+        EditLog spyEditLog = spy(GlobalStateMgr.getCurrentState().getEditLog());
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logAddKey(any(EncryptionKeyPB.class), any());
+        
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // Save initial state snapshot
+        int initialCount = keyMgr.numKeys();
+
+        // 3. Execute generateNewKEK which calls addKey internally and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            keyMgr.generateNewKEK();
+        });
+        Assertions.assertEquals("EditLog write failed", exception.getMessage());
+
+        // 4. Verify leader memory state remains unchanged after exception
+        Assertions.assertEquals(initialCount, keyMgr.numKeys());
+        // Verify no new key was added
+        Assertions.assertEquals(1, keyMgr.numKeys());
+    }
+}
+

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
@@ -53,6 +53,8 @@ import com.starrocks.load.EtlStatus;
 import com.starrocks.load.FailMsg;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.persist.EditLog;
+import com.starrocks.persist.NextIdLog;
+import com.starrocks.persist.WALApplier;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AlterLoadStmt;
@@ -323,8 +325,8 @@ public class BrokerLoadJobTest {
         GlobalStateMgr.getCurrentState().setEditLog(new EditLog(new ArrayBlockingQueue<>(100)));
         new MockUp<EditLog>() {
             @Mock
-            public void logSaveNextId(long nextId) {
-
+            public void logSaveNextId(long nextId, WALApplier walApplier) {
+                walApplier.apply(new NextIdLog(nextId));
             }
         };
 
@@ -356,8 +358,8 @@ public class BrokerLoadJobTest {
         GlobalStateMgr.getCurrentState().setEditLog(new EditLog(new ArrayBlockingQueue<>(100)));
         new MockUp<EditLog>() {
             @Mock
-            public void logSaveNextId(long nextId) {
-
+            public void logSaveNextId(long nextId, WALApplier walApplier) {
+                walApplier.apply(new NextIdLog(nextId));
             }
 
             @Mock

--- a/fe/fe-core/src/test/java/com/starrocks/meta/SqlBlackListEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/meta/SqlBlackListEditLogTest.java
@@ -1,0 +1,203 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.meta;
+
+import com.starrocks.meta.BlackListSql;
+import com.starrocks.persist.DeleteSqlBlackLists;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.persist.SqlBlackListPersistInfo;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.DelSqlBlackListStmt;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class SqlBlackListEditLogTest {
+    private SqlBlackList sqlBlackList;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        // Initialize test environment
+        UtFrameUtils.setUpForPersistTest();
+
+        sqlBlackList = GlobalStateMgr.getCurrentState().getSqlBlackList();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    @Test
+    public void testAddBlackSqlNormalCase() throws Exception {
+        // 1. Prepare test data
+        String sqlPattern = "select.*from.*test";
+        Pattern pattern = Pattern.compile(sqlPattern);
+
+        // 2. Verify initial state
+        List<BlackListSql> initialBlackLists = sqlBlackList.getBlackLists();
+        int initialCount = initialBlackLists.size();
+
+        // 3. Execute put operation (which calls addBlackSql internally via editlog)
+        long id = sqlBlackList.put(pattern);
+
+        // 4. Verify master state
+        List<BlackListSql> blackLists = sqlBlackList.getBlackLists();
+        Assertions.assertEquals(initialCount + 1, blackLists.size());
+        Assertions.assertTrue(id >= 0);
+
+        // 5. Test follower replay functionality
+        SqlBlackList followerBlackList = new SqlBlackList();
+        
+        // Verify follower initial state
+        Assertions.assertEquals(0, followerBlackList.getBlackLists().size());
+
+        // Replay the operation
+        SqlBlackListPersistInfo replayInfo = (SqlBlackListPersistInfo) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_ADD_SQL_QUERY_BLACK_LIST);
+        followerBlackList.put(replayInfo.id, Pattern.compile(replayInfo.pattern));
+
+        // 6. Verify follower state is consistent with master
+        List<BlackListSql> followerBlackLists = followerBlackList.getBlackLists();
+        Assertions.assertEquals(1, followerBlackLists.size());
+        Assertions.assertEquals(id, followerBlackLists.get(0).id);
+        Assertions.assertEquals(sqlPattern, followerBlackLists.get(0).pattern.pattern());
+    }
+
+    @Test
+    public void testAddBlackSqlEditLogException() throws Exception {
+        // 1. Prepare test data
+        String sqlPattern = "select.*from.*exception";
+        Pattern pattern = Pattern.compile(sqlPattern);
+
+        // 2. Verify initial state
+        int initialCount = sqlBlackList.getBlackLists().size();
+
+        // 3. Mock EditLog.logAddSQLBlackList to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logAddSQLBlackList(any(SqlBlackListPersistInfo.class), any());
+        
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // Save initial state snapshot
+        int savedCount = initialCount;
+
+        // 4. Execute put operation and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            sqlBlackList.put(pattern);
+        });
+        Assertions.assertEquals("EditLog write failed", exception.getMessage());
+
+        // 5. Verify leader memory state remains unchanged after exception
+        int currentCount = sqlBlackList.getBlackLists().size();
+        Assertions.assertEquals(savedCount, currentCount);
+    }
+
+    @Test
+    public void testDeleteBlackSqlNormalCase() throws Exception {
+        // 1. Prepare test data - add a blacklist entry first
+        String sqlPattern = "select.*from.*delete";
+        Pattern pattern = Pattern.compile(sqlPattern);
+        long id = sqlBlackList.put(pattern);
+        
+        Assertions.assertNotNull(sqlBlackList.getBlackLists().stream()
+                .filter(b -> b.id == id).findFirst().orElse(null));
+
+        // 2. Prepare delete statement
+        List<Long> indexs = new ArrayList<>();
+        indexs.add(id);
+        DelSqlBlackListStmt delStmt = new DelSqlBlackListStmt(indexs);
+
+        // 3. Execute deleteBlackSql operation (master side)
+        sqlBlackList.deleteBlackSql(delStmt);
+
+        // 4. Verify master state
+        Assertions.assertNull(sqlBlackList.getBlackLists().stream()
+                .filter(b -> b.id == id).findFirst().orElse(null));
+
+        // 5. Test follower replay functionality
+        SqlBlackList followerBlackList = new SqlBlackList();
+        
+        // First add the blacklist entry in follower
+        followerBlackList.put(id, pattern);
+        Assertions.assertNotNull(followerBlackList.getBlackLists().stream()
+                .filter(b -> b.id == id).findFirst().orElse(null));
+
+        // Replay the delete operation
+        DeleteSqlBlackLists replayInfo = (DeleteSqlBlackLists) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_DELETE_SQL_QUERY_BLACK_LIST);
+        for (long deleteId : replayInfo.ids) {
+            followerBlackList.delete(deleteId);
+        }
+
+        // 6. Verify follower state is consistent with master
+        Assertions.assertNull(followerBlackList.getBlackLists().stream()
+                .filter(b -> b.id == id).findFirst().orElse(null));
+    }
+
+    @Test
+    public void testDeleteBlackSqlEditLogException() throws Exception {
+        // 1. Prepare test data - add a blacklist entry first
+        String sqlPattern = "select.*from.*delete_exception";
+        Pattern pattern = Pattern.compile(sqlPattern);
+        long id = sqlBlackList.put(pattern);
+        
+        BlackListSql initialEntry = sqlBlackList.getBlackLists().stream()
+                .filter(b -> b.id == id).findFirst().orElse(null);
+        Assertions.assertNotNull(initialEntry);
+
+        // 2. Prepare delete statement
+        List<Long> indexs = new ArrayList<>();
+        indexs.add(id);
+        DelSqlBlackListStmt delStmt = new DelSqlBlackListStmt(indexs);
+
+        // 3. Mock EditLog.logDeleteSQLBlackList to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logDeleteSQLBlackList(any(DeleteSqlBlackLists.class), any());
+        
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // Save initial state snapshot
+        BlackListSql savedEntry = initialEntry;
+
+        // 4. Execute deleteBlackSql operation and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            sqlBlackList.deleteBlackSql(delStmt);
+        });
+        Assertions.assertEquals("EditLog write failed", exception.getMessage());
+
+        // 5. Verify leader memory state remains unchanged after exception
+        BlackListSql currentEntry = sqlBlackList.getBlackLists().stream()
+                .filter(b -> b.id == id).findFirst().orElse(null);
+        Assertions.assertNotNull(currentEntry);
+        Assertions.assertEquals(savedEntry.id, currentEntry.id);
+    }
+}
+

--- a/fe/fe-core/src/test/java/com/starrocks/meta/SqlBlacklistTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/meta/SqlBlacklistTest.java
@@ -17,7 +17,6 @@ package com.starrocks.meta;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.persist.DeleteSqlBlackLists;
 import com.starrocks.persist.SqlBlackListPersistInfo;
-import com.starrocks.persist.WALApplier;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ShowExecutor;
 import com.starrocks.qe.ShowResultSet;
@@ -33,7 +32,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
 
 import java.util.List;
 import java.util.regex.Pattern;

--- a/fe/fe-core/src/test/java/com/starrocks/server/LocalMetastoreEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/LocalMetastoreEditLogTest.java
@@ -1,0 +1,259 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.server;
+
+import com.starrocks.persist.AutoIncrementInfo;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.transaction.MockedLocalMetaStore;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class LocalMetastoreEditLogTest {
+    private MockedLocalMetaStore localMetastore;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        // Initialize test environment
+        UtFrameUtils.setUpForPersistTest();
+
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        localMetastore = new MockedLocalMetaStore(globalStateMgr, globalStateMgr.getRecycleBin(), null);
+        globalStateMgr.setLocalMetastore(localMetastore);
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    @Test
+    public void testAllocateAutoIncrementIdNormalCase() throws Exception {
+        // 1. Prepare test data
+        Long tableId = 100L;
+        Long rows = 10L;
+
+        // 2. Verify initial state
+        Assertions.assertNull(localMetastore.getCurrentAutoIncrementIdByTableId(tableId));
+
+        // 3. Execute allocateAutoIncrementId operation (master side)
+        Long startId = localMetastore.allocateAutoIncrementId(tableId, rows);
+
+        // 4. Verify master state
+        Assertions.assertNotNull(startId);
+        Assertions.assertEquals(1L, startId);
+        Long currentId = localMetastore.getCurrentAutoIncrementIdByTableId(tableId);
+        Assertions.assertNotNull(currentId);
+        Assertions.assertEquals(11L, currentId); // 1 + 10
+
+        // 5. Test follower replay functionality
+        MockedLocalMetaStore followerMetastore = new MockedLocalMetaStore(
+                GlobalStateMgr.getCurrentState(), GlobalStateMgr.getCurrentState().getRecycleBin(), null);
+        
+        // Verify follower initial state
+        Assertions.assertNull(followerMetastore.getCurrentAutoIncrementIdByTableId(tableId));
+
+        // Replay the operation
+        AutoIncrementInfo replayInfo = (AutoIncrementInfo) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_SAVE_AUTO_INCREMENT_ID);
+        followerMetastore.replayAutoIncrementId(replayInfo);
+
+        // 6. Verify follower state is consistent with master
+        Long followerCurrentId = followerMetastore.getCurrentAutoIncrementIdByTableId(tableId);
+        Assertions.assertNotNull(followerCurrentId);
+        Assertions.assertEquals(currentId, followerCurrentId);
+    }
+
+    @Test
+    public void testAllocateAutoIncrementIdEditLogException() throws Exception {
+        // 1. Prepare test data
+        Long tableId = 200L;
+        Long rows = 5L;
+
+        // 2. Verify initial state
+        Assertions.assertNull(localMetastore.getCurrentAutoIncrementIdByTableId(tableId));
+
+        // 3. Mock EditLog.logSaveAutoIncrementId to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logSaveAutoIncrementId(any(AutoIncrementInfo.class), any());
+        
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 4. Execute allocateAutoIncrementId operation and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            localMetastore.allocateAutoIncrementId(tableId, rows);
+        });
+        Assertions.assertEquals("EditLog write failed", exception.getMessage());
+
+        // 5. Verify leader memory state remains unchanged after exception
+        // The compute function may have updated the value, but since editlog failed,
+        // the state should be rolled back or not committed
+        Long currentId = localMetastore.getCurrentAutoIncrementIdByTableId(tableId);
+        Assertions.assertNull(currentId);
+    }
+
+    @Test
+    public void testRemoveAutoIncrementIdByTableIdNormalCase() throws Exception {
+        // 1. Prepare test data - allocate an ID first
+        Long tableId = 300L;
+        localMetastore.allocateAutoIncrementId(tableId, 5L);
+        Assertions.assertNotNull(localMetastore.getCurrentAutoIncrementIdByTableId(tableId));
+
+        // 2. Execute removeAutoIncrementIdByTableId operation (master side)
+        localMetastore.removeAutoIncrementIdByTableId(tableId);
+
+        // 3. Verify master state
+        Assertions.assertNull(localMetastore.getCurrentAutoIncrementIdByTableId(tableId));
+
+        // 4. Test follower replay functionality
+        MockedLocalMetaStore followerMetastore = new MockedLocalMetaStore(
+                GlobalStateMgr.getCurrentState(), GlobalStateMgr.getCurrentState().getRecycleBin(), null);
+        
+        // First allocate in follower
+        followerMetastore.allocateAutoIncrementId(tableId, 5L);
+        Assertions.assertNotNull(followerMetastore.getCurrentAutoIncrementIdByTableId(tableId));
+
+        // Replay the remove operation
+        AutoIncrementInfo replayInfo = (AutoIncrementInfo) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_DELETE_AUTO_INCREMENT_ID);
+        followerMetastore.replayDeleteAutoIncrementId(replayInfo);
+
+        // 5. Verify follower state is consistent with master
+        Assertions.assertNull(followerMetastore.getCurrentAutoIncrementIdByTableId(tableId));
+    }
+
+    @Test
+    public void testRemoveAutoIncrementIdByTableIdEditLogException() throws Exception {
+        // 1. Prepare test data - allocate an ID first
+        Long tableId = 400L;
+        localMetastore.allocateAutoIncrementId(tableId, 5L);
+        Long initialId = localMetastore.getCurrentAutoIncrementIdByTableId(tableId);
+        Assertions.assertNotNull(initialId);
+
+        // 2. Mock EditLog.logSaveDeleteAutoIncrementId to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logSaveDeleteAutoIncrementId(any(AutoIncrementInfo.class), any());
+        
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 3. Execute removeAutoIncrementIdByTableId operation and expect exception
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            localMetastore.removeAutoIncrementIdByTableId(tableId);
+        });
+        Assertions.assertEquals("EditLog write failed", exception.getMessage());
+
+        // 4. Verify leader memory state remains unchanged after exception
+        Long currentId = localMetastore.getCurrentAutoIncrementIdByTableId(tableId);
+        Assertions.assertNotNull(currentId);
+        Assertions.assertEquals(initialId, currentId);
+    }
+
+    @Test
+    public void testAlterTableAutoIncrementNormalCase() throws Exception {
+        // 1. Prepare test data - create a database and table
+        localMetastore.createDb("test_db");
+        // Note: alterTableAutoIncrement requires a real table, so we'll test the editlog part
+        // by mocking the table lookup
+        Long tableId = 500L;
+        long newAutoIncrementValue = 1000L;
+
+        // Set up initial auto increment value
+        localMetastore.addOrReplaceAutoIncrementIdByTableId(tableId, 100L);
+        Assertions.assertEquals(100L, localMetastore.getCurrentAutoIncrementIdByTableId(tableId).longValue());
+
+        // 2. Since alterTableAutoIncrement requires a real OlapTable and calls sendDropAutoIncrementMapTask,
+        // we'll test the editlog part by directly calling the logic
+        // For a complete test, we would need to set up a real table, but for editlog testing,
+        // we can verify the editlog is called correctly
+        ConcurrentHashMap<Long, Long> idMap = new ConcurrentHashMap<>();
+        idMap.put(tableId, newAutoIncrementValue);
+        AutoIncrementInfo info = new AutoIncrementInfo(idMap);
+        GlobalStateMgr.getCurrentState().getEditLog().logSaveAutoIncrementId(
+                info, wal -> localMetastore.addOrReplaceAutoIncrementIdByTableId(tableId, newAutoIncrementValue));
+
+        // 3. Verify master state
+        Long currentId = localMetastore.getCurrentAutoIncrementIdByTableId(tableId);
+        Assertions.assertNotNull(currentId);
+        Assertions.assertEquals(newAutoIncrementValue, currentId.longValue());
+
+        // 4. Test follower replay functionality
+        MockedLocalMetaStore followerMetastore = new MockedLocalMetaStore(
+                GlobalStateMgr.getCurrentState(), GlobalStateMgr.getCurrentState().getRecycleBin(), null);
+        
+        // Set initial value in follower
+        followerMetastore.addOrReplaceAutoIncrementIdByTableId(tableId, 100L);
+
+        // Replay the operation
+        AutoIncrementInfo replayInfo = (AutoIncrementInfo) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_SAVE_AUTO_INCREMENT_ID);
+        followerMetastore.replayAutoIncrementId(replayInfo);
+
+        // 5. Verify follower state is consistent with master
+        Long followerCurrentId = followerMetastore.getCurrentAutoIncrementIdByTableId(tableId);
+        Assertions.assertNotNull(followerCurrentId);
+        Assertions.assertEquals(newAutoIncrementValue, followerCurrentId.longValue());
+    }
+
+    @Test
+    public void testAlterTableAutoIncrementEditLogException() throws Exception {
+        // 1. Prepare test data
+        Long tableId = 600L;
+        long newAutoIncrementValue = 2000L;
+
+        // Set up initial auto increment value
+        localMetastore.addOrReplaceAutoIncrementIdByTableId(tableId, 100L);
+        Long initialId = localMetastore.getCurrentAutoIncrementIdByTableId(tableId);
+        Assertions.assertNotNull(initialId);
+
+        // 2. Mock EditLog.logSaveAutoIncrementId to throw exception
+        EditLog spyEditLog = spy(new EditLog(null));
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logSaveAutoIncrementId(any(AutoIncrementInfo.class), any());
+        
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 3. Execute the editlog operation and expect exception
+        ConcurrentHashMap<Long, Long> idMap = new ConcurrentHashMap<>();
+        idMap.put(tableId, newAutoIncrementValue);
+        AutoIncrementInfo info = new AutoIncrementInfo(idMap);
+        
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            GlobalStateMgr.getCurrentState().getEditLog().logSaveAutoIncrementId(
+                    info, wal -> localMetastore.addOrReplaceAutoIncrementIdByTableId(tableId, newAutoIncrementValue));
+        });
+        Assertions.assertEquals("EditLog write failed", exception.getMessage());
+
+        // 4. Verify leader memory state remains unchanged after exception
+        Long currentId = localMetastore.getCurrentAutoIncrementIdByTableId(tableId);
+        Assertions.assertNotNull(currentId);
+        Assertions.assertEquals(initialId, currentId);
+    }
+}
+
+

--- a/fe/fe-core/src/test/java/com/starrocks/sql/spm/SQLPlanGlobalStorageEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/spm/SQLPlanGlobalStorageEditLogTest.java
@@ -1,0 +1,272 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.spm;
+
+import com.starrocks.common.FeConstants;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.qe.SimpleExecutor;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+
+public class SQLPlanGlobalStorageEditLogTest {
+    private SQLPlanGlobalStorage storage;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        // Initialize test environment
+        UtFrameUtils.setUpForPersistTest();
+
+        // Mock SimpleExecutor to avoid DML execution failures in test environment
+        new MockUp<SimpleExecutor>() {
+            @Mock
+            public void executeDML(String sql) {
+                // Do nothing in test - just skip DML execution
+            }
+        };
+
+        storage = new SQLPlanGlobalStorage();
+
+        FeConstants.runningUnitTest = true;
+    }
+
+    @AfterEach
+    public void tearDown() {
+        UtFrameUtils.tearDownForPersisTest();
+    }
+
+    @Test
+    public void testStoreBaselinePlanNormalCase() throws Exception {
+        // 1. Prepare test data
+        List<BaselinePlan> plans = new ArrayList<>();
+        BaselinePlan plan1 = new BaselinePlan("SELECT * FROM t1 WHERE id = ?", "SELECT * FROM t1 WHERE id = 1", 
+                12345L, "SELECT * FROM t1 WHERE id = 1", 100.0);
+        plan1.setId(GlobalStateMgr.getCurrentState().getNextId());
+        plans.add(plan1);
+
+        // 2. Execute storeBaselinePlan operation (master side)
+        storage.storeBaselinePlan(plans);
+
+        // 3. Verify master state - plan should be stored
+        Set<Long> foundIds = storage.getAllBaselineIds();
+        Assertions.assertTrue(foundIds.contains(plan1.getId()));
+
+        // 4. Test follower replay functionality
+        SQLPlanGlobalStorage followerStorage = new SQLPlanGlobalStorage();
+        
+        // Verify follower initial state
+        Set<Long> followerIds = followerStorage.getAllBaselineIds();
+        Assertions.assertFalse(followerIds.contains(plan1.getId()));
+
+        // Replay the operation
+        BaselinePlan.Info replayInfo = (BaselinePlan.Info) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_CREATE_SPM_BASELINE_LOG);
+        followerStorage.replayBaselinePlan(replayInfo, true);
+
+        // 5. Verify follower state is consistent with master
+        followerIds = followerStorage.getAllBaselineIds();
+        Assertions.assertTrue(followerIds.contains(plan1.getId()));
+    }
+
+    @Test
+    public void testStoreBaselinePlanEditLogException() throws Exception {
+        // 1. Prepare test data
+        List<BaselinePlan> plans = new ArrayList<>();
+        BaselinePlan plan1 = new BaselinePlan("SELECT * FROM t2 WHERE id = ?", "SELECT * FROM t2 WHERE id = 1", 
+                67890L, "SELECT * FROM t2 WHERE id = 1", 200.0);
+        plan1.setId(GlobalStateMgr.getCurrentState().getNextId());
+        plans.add(plan1);
+
+        // 2. Mock EditLog.logCreateSPMBaseline to throw exception
+        EditLog spyEditLog = spy(GlobalStateMgr.getCurrentState().getEditLog());
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logCreateSPMBaseline(any(BaselinePlan.Info.class), any());
+        
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 3. Execute storeBaselinePlan operation and expect exception
+        // Note: storeBaselinePlan catches exceptions, so we verify the editlog was called
+        // and that the exception is handled
+        storage.storeBaselinePlan(plans);
+
+        // verify master state unchanged
+        Set<Long> masterIds = storage.getAllBaselineIds();
+        Assertions.assertFalse(masterIds.contains(plan1.getId()));
+    }
+
+    @Test
+    public void testDropBaselinePlanNormalCase() throws Exception {
+        // 1. Prepare test data - store a plan first
+        List<BaselinePlan> plans = new ArrayList<>();
+        BaselinePlan plan1 = new BaselinePlan("SELECT * FROM t3 WHERE id = ?", "SELECT * FROM t3 WHERE id = 1", 
+                11111L, "SELECT * FROM t3 WHERE id = 1", 300.0);
+        plan1.setId(GlobalStateMgr.getCurrentState().getNextId());
+        plans.add(plan1);
+        storage.storeBaselinePlan(plans);
+        Set<Long> storedIds = storage.getAllBaselineIds();
+        Assertions.assertTrue(storedIds.contains(plan1.getId()));
+
+        // 2. Prepare drop operation
+        List<Long> baseLineIds = new ArrayList<>();
+        baseLineIds.add(plan1.getId());
+
+        // 3. Execute dropBaselinePlan operation (master side)
+        storage.dropBaselinePlan(baseLineIds);
+        Set<Long> masterIds = storage.getAllBaselineIds();
+        Assertions.assertFalse(masterIds.contains(plan1.getId()));
+
+        // 4. Test follower replay functionality
+        SQLPlanGlobalStorage followerStorage = new SQLPlanGlobalStorage();
+        
+        // First replay the create operation to set up the follower state
+        BaselinePlan.Info createReplayInfo = (BaselinePlan.Info) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_CREATE_SPM_BASELINE_LOG);
+        followerStorage.replayBaselinePlan(createReplayInfo, true);
+        Set<Long> followerIds = followerStorage.getAllBaselineIds();
+        Assertions.assertTrue(followerIds.contains(plan1.getId()));
+
+        // Then replay the drop operation
+        BaselinePlan.Info replayInfo = (BaselinePlan.Info) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_DROP_SPM_BASELINE_LOG);
+        followerStorage.replayBaselinePlan(replayInfo, false);
+        followerIds = followerStorage.getAllBaselineIds();
+
+        // 5. Verify follower state is consistent with master
+        Assertions.assertFalse(followerIds.contains(plan1.getId()));
+    }
+
+    @Test
+    public void testDropBaselinePlanEditLogException() throws Exception {
+        // 1. Prepare test data - store a plan first
+        List<BaselinePlan> plans = new ArrayList<>();
+        BaselinePlan plan1 = new BaselinePlan("SELECT * FROM t4 WHERE id = ?", "SELECT * FROM t4 WHERE id = 1", 
+                22222L, "SELECT * FROM t4 WHERE id = 1", 400.0);
+        plan1.setId(GlobalStateMgr.getCurrentState().getNextId());
+        plans.add(plan1);
+        storage.storeBaselinePlan(plans);
+
+        // check stored
+        Set<Long> storedIds = storage.getAllBaselineIds();
+        Assertions.assertTrue(storedIds.contains(plan1.getId()));
+        // 2. Prepare drop operation
+        List<Long> baseLineIds = new ArrayList<>();
+        baseLineIds.add(plan1.getId());
+
+        // 3. Mock EditLog.logDropSPMBaseline to throw exception
+        EditLog spyEditLog = spy(GlobalStateMgr.getCurrentState().getEditLog());
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logDropSPMBaseline(any(BaselinePlan.Info.class), any());
+        
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 4. Execute dropBaselinePlan operation
+        // Note: dropBaselinePlan catches exceptions, so we verify the editlog was called
+        storage.dropBaselinePlan(baseLineIds);
+        Set<Long> masterIds = storage.getAllBaselineIds();
+        Assertions.assertTrue(masterIds.contains(plan1.getId()));
+    }
+
+    @Test
+    public void testControlBaselinePlanNormalCase() throws Exception {
+        // 1. Prepare test data - store a plan first
+        List<BaselinePlan> plans = new ArrayList<>();
+        BaselinePlan plan1 = new BaselinePlan("SELECT * FROM t5 WHERE id = ?", "SELECT * FROM t5 WHERE id = 1", 
+                33333L, "SELECT * FROM t5 WHERE id = 1", 500.0);
+        plan1.setId(GlobalStateMgr.getCurrentState().getNextId());
+        plans.add(plan1);
+        storage.storeBaselinePlan(plans);
+
+        storage.getCache().put(plan1.getId(), new BaselinePlan(plan1.getId(), plan1.getBindSqlHash()));
+
+        // 2. Prepare control operation
+        List<Long> baseLineIds = new ArrayList<>();
+        baseLineIds.add(plan1.getId());
+        boolean isEnable = true;
+
+        // 3. Execute controlBaselinePlan operation (master side)
+        storage.controlBaselinePlan(isEnable, baseLineIds);
+        // verify cache is cleaned
+        Assertions.assertNull(storage.getCache().getIfPresent(plan1.getId()));
+
+        // 4. Test follower replay functionality
+        SQLPlanGlobalStorage followerStorage = new SQLPlanGlobalStorage();
+        followerStorage.getCache().put(plan1.getId(), new BaselinePlan(plan1.getId(), plan1.getBindSqlHash()));
+        
+        // First replay the create operation to set up the follower state
+        BaselinePlan.Info createReplayInfo = (BaselinePlan.Info) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_CREATE_SPM_BASELINE_LOG);
+        followerStorage.replayBaselinePlan(createReplayInfo, true);
+
+        // Then replay the control operation
+        BaselinePlan.Info replayInfo = (BaselinePlan.Info) UtFrameUtils.PseudoJournalReplayer
+                .replayNextJournal(OperationType.OP_ENABLE_SPM_BASELINE_LOG);
+        followerStorage.replayUpdateBaselinePlan(replayInfo, isEnable);
+
+        // 5. Verify follower state is updated
+        Assertions.assertNull(followerStorage.getCache().getIfPresent(plan1.getId()));
+    }
+
+    @Test
+    public void testControlBaselinePlanEditLogException() throws Exception {
+        // 1. Prepare test data - store a plan first
+        List<BaselinePlan> plans = new ArrayList<>();
+        BaselinePlan plan1 = new BaselinePlan("SELECT * FROM t6 WHERE id = ?", "SELECT * FROM t6 WHERE id = 1", 
+                44444L, "SELECT * FROM t6 WHERE id = 1", 600.0);
+        plan1.setId(GlobalStateMgr.getCurrentState().getNextId());
+        plans.add(plan1);
+        storage.storeBaselinePlan(plans);
+
+        storage.getCache().put(plan1.getId(), new BaselinePlan(plan1.getId(), plan1.getBindSqlHash()));
+
+        // 2. Prepare control operation
+        List<Long> baseLineIds = new ArrayList<>();
+        baseLineIds.add(plan1.getId());
+        boolean isEnable = false;
+
+        // 3. Mock EditLog.logUpdateSPMBaseline to throw exception
+        EditLog spyEditLog = spy(GlobalStateMgr.getCurrentState().getEditLog());
+        doThrow(new RuntimeException("EditLog write failed"))
+            .when(spyEditLog).logUpdateSPMBaseline(any(BaselinePlan.Info.class), anyBoolean(), any());
+        
+        // Temporarily set spy EditLog
+        GlobalStateMgr.getCurrentState().setEditLog(spyEditLog);
+
+        // 4. Execute controlBaselinePlan operation
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            storage.controlBaselinePlan(isEnable, baseLineIds);
+        });
+        Assertions.assertEquals("EditLog write failed", exception.getMessage());
+
+        // 5. Verify follower state unchanged
+        Assertions.assertNotNull(storage.getCache().getIfPresent(plan1.getId()));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Refer https://github.com/StarRocks/starrocks/issues/63357

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Converts various edit-log operations to WAL with applier callbacks (auto-increment, SQL blacklist, SPM, group provider, leader info, keys, view security), updates replay paths/APIs, and adds targeted unit tests.
> 
> - **Core WAL Refactor**:
>   - Update `EditLog` to WAL-style methods with applier callbacks for `nextId`, auto-increment save/delete, add key, leader info, SQL blacklist add/delete, SPM baseline create/drop/enable/disable, group provider create/drop.
>   - Adjust replay: e.g., `OP_SET_VIEW_SECURITY_LOG` now calls `updateViewSecurity`.
>   - Extend `EditLogDeserializer` for SPM enable/disable ops.
> - **Auto-Increment**:
>   - Rework `LocalMetastore.allocateAutoIncrementId` to atomic `compute` with WAL logging; add `deleteAutoIncrementIdForTable`; change delete/save paths to WAL.
>   - `OlapTable.removeTableBinds` and FE service paths updated to new metastore/editlog APIs.
> - **SQL Blacklist**:
>   - Move add/delete logic into `SqlBlackList` with WAL logging; expose `deleteBlackSql`/`addBlackSql`; add `cleanup` helper.
>   - `StmtExecutor` delegates to `SqlBlackList` APIs.
> - **Authentication (Group Provider)**:
>   - Switch create/drop to WAL with in-memory updates via appliers; keep replay methods.
> - **SPM (SQL Plan Baselines)**:
>   - Use WAL for create/drop/enable/disable and invalidate caches via appliers.
> - **Encryption**:
>   - `KeyMgr.addKey` logs via WAL and applies in-memory map on commit.
> - **Node/Leader**:
>   - `NodeMgr.setLeaderInfo` logs leader info via WAL; add `getLeaderInfo` accessor.
> - **Views**:
>   - `AlterJobMgr.setViewSecurity`/`updateViewSecurity` split; callers updated.
> - **Tests**:
>   - Add UTs covering WAL behavior and error handling for view security, group provider, ID generator, key manager, SQL blacklist, local metastore auto-increment, node leader info, and SPM storage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db3db3aefd81955dce6fd597d43015aed1d12c6f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->