### PR TITLE
[BugFix] add a configuration to skip delete vector CRC misjudgments in special upgrade/downgrade scenarios

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1211,6 +1211,7 @@ CONF_mInt64(lake_pk_compaction_min_input_segments, "5");
 CONF_mInt32(lake_pk_preload_memory_limit_percent, "30");
 CONF_mInt32(lake_pk_index_sst_min_compaction_versions, "2");
 CONF_mInt32(lake_pk_index_sst_max_compaction_versions, "100");
+CONF_mBool(enable_strict_delvec_crc_check, "true");
 // When the ratio of cumulative level to base level is greater than this config, use base merge.
 CONF_mDouble(lake_pk_index_cumulative_base_compaction_ratio, "0.1");
 CONF_Int32(lake_pk_index_block_cache_limit_percent, "10");

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -1521,6 +1521,15 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Description: When enable_pk_parallel_execution is set to true, the Primary Key table parallel execution strategy will be enabled if the data generated during import or compaction exceeds this threshold.
 - Introduced in: -
 
+##### enable_strict_delvec_crc_check
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: When enable_strict_delvec_crc_check is set to true, we will perform a strict CRC32 check on the delete vector, and if a mismatch is detected, a failure will be returned.
+- Introduced in: -
+
 ##### size_tiered_min_level_size
 
 - Default: 131072

--- a/docs/ja/administration/management/BE_configuration.md
+++ b/docs/ja/administration/management/BE_configuration.md
@@ -1509,6 +1509,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 説明: enable_pk_parallel_execution が true に設定されている場合、インポートまたはコンパクションで生成されるデータがこの閾値を超えると、Primary Key テーブルの並列実行戦略が有効になります。
 - 導入バージョン: -
 
+##### enable_strict_delvec_crc_check
+
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 可変: はい
+- 説明: enable_strict_delvec_crc_check を true に設定すると、delete vector の CRC32 を厳密にチェックし、一致しない場合はエラーを返します。
+- 導入バージョン: -
+
 ##### size_tiered_min_level_size
 
 - デフォルト: 131072

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -1498,6 +1498,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：当enable_pk_parallel_execution设置为true后，导入或者compaction生成的数据大于该阈值时，Primary Key 表并行执行策略将被启用。
 - 引入版本：-
 
+##### enable_strict_delvec_crc_check
+
+- 默认值：true
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：当enable_strict_delvec_crc_check设置为true后，我们会对delete vector的crc32进行严格检查，如果不一致，将返回失败。
+- 引入版本：-
+
 ##### size_tiered_min_level_size
 
 - 默认值：131072


### PR DESCRIPTION
## Why I'm doing:
In some ABA upgrade/downgrade scenarios, misjudgments may occur.
For example, version A includes the code for generating and verifying the CRC32 of delete vectors, while version B does not yet support it.
Consider a situation where a delete vector and its corresponding CRC32 are correctly generated in version A.
After downgrading to version B, the delete vector is updated, but since version B does not support CRC32-related logic, the CRC32 is not updated. Later, when upgrading back to version A, the CRC32 verification fails.

## What I'm doing:
Considering that such upgrade/downgrade scenarios are relatively rare, we will first introduce a temporary configuration enable_strict_delvec_crc_check to bypass the issue. When enable_strict_delvec_crc_check is set to false, errors will not be enforced.
This pull request introduces a new configuration option to control strict CRC32 validation for delete vectors and improves error handling in scenarios where CRC mismatches may occur due to version upgrades or downgrades. The changes mainly enhance the robustness and flexibility of delete vector integrity checks.

Configuration:

* Added a new boolean config `enable_strict_delvec_crc_check` to allow enabling or disabling strict CRC32 checking for delete vectors.

Delete vector CRC validation logic:

* Updated the CRC32 validation in `meta_file.cpp` to conditionally return a corruption status based on the new config, allowing for more flexible handling in mixed-version upgrade/downgrade scenarios.
* Added detailed comments explaining potential CRC mismatch issues during ABA upgrade/downgrade cycles, improving code maintainability and developer understanding.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `enable_strict_delvec_crc_check` config and updates delete vector CRC32 validation to optionally bypass mismatches; documents the new setting (EN/JA/ZH).
> 
> - **Storage/Lake**:
>   - Update `get_del_vec` in `be/src/storage/lake/meta_file.cpp` to conditionally return corruption on CRC32 mismatches based on `config::enable_strict_delvec_crc_check`.
>   - Add explanatory comments for upgrade/downgrade ABA scenarios causing CRC mismatches.
> - **Configuration**:
>   - Add new boolean `enable_strict_delvec_crc_check` (default `true`) in `be/src/common/config.h`.
> - **Docs**:
>   - Document `enable_strict_delvec_crc_check` in `docs/en/administration/management/BE_configuration.md`, `docs/ja/...`, and `docs/zh/...`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcc70c604af14d1b51b55fb71ddbbbe6730dab84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->