### PR TITLE
[BugFix] Fix missing semaphore header in fail_point.h

### DIFF
--- a/be/src/util/failpoint/fail_point.h
+++ b/be/src/util/failpoint/fail_point.h
@@ -3,6 +3,7 @@
 #include <condition_variable>
 #include <memory>
 #include <mutex>
+#include <semaphore>
 #include <shared_mutex>
 #include <unordered_map>
 


### PR DESCRIPTION
## Why I'm doing:


```
  In file included from /Users/kks/git/starrocks/be/src/exec/schema_scanner/schema_variables_scanner.cpp:20:
  /Users/kks/git/starrocks/build-mac/../be/src/util/failpoint/fail_point.h:119:10: error: no template named 'counting_semaphore' in
  namespace 'std'
    119 |     std::counting_semaphore<1> sem_B_{0};
        |     ~~~~~^
  1 error generated.
  [290/1008] Building CXX object CMakeFiles/starrocks_core.dir/Users/kks/git/starrocks/be/src/exec/sorted_streaming_aggregator.cpp.o
  ninja: build stopped: subcommand failed.
```
Fix #65200
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
