### PR TITLE
[Enhancement] fix sample statistics collection after overwrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
@@ -311,6 +311,12 @@ public class StatisticsCollectionTrigger {
     private void prepareAnalyzeForOverwrite() {
         partitionIds.addAll(overwriteJobStats.getTargetPartitionIds());
         analyzeType = decideAnalyzeTypeForOverwrite();
+        
+        // Set partition tablet row counts for sample-based statistics collection
+        if (analyzeType == StatsConstants.AnalyzeType.SAMPLE &&
+                !overwriteJobStats.getPartitionTabletRowCounts().isEmpty()) {
+            partitionTabletRowCounts.putAll(overwriteJobStats.getPartitionTabletRowCounts());
+        }
     }
 
     private StatsConstants.AnalyzeType decideAnalyzeTypeForOverwrite() {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/InsertOverwriteJobStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/InsertOverwriteJobStats.java
@@ -14,6 +14,10 @@
 
 package com.starrocks.transaction;
 
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -21,10 +25,12 @@ import java.util.List;
  */
 public class InsertOverwriteJobStats {
 
-    private List<Long> sourcePartitionIds;
-    private List<Long> targetPartitionIds;
+    private List<Long> sourcePartitionIds = new ArrayList<>();
+    private List<Long> targetPartitionIds = new ArrayList<>();
     private long sourceRows;
     private long targetRows;
+    // Map<PartitionId, Map<TabletId, RowCount>>
+    private Table<Long, Long, Long> partitionTabletRowCounts = HashBasedTable.create();
 
     public InsertOverwriteJobStats() {
     }
@@ -67,5 +73,13 @@ public class InsertOverwriteJobStats {
 
     public void setTargetRows(long targetRows) {
         this.targetRows = targetRows;
+    }
+
+    public Table<Long, Long, Long> getPartitionTabletRowCounts() {
+        return partitionTabletRowCounts;
+    }
+
+    public void setPartitionTabletRowCounts(Table<Long, Long, Long> partitionTabletRowCounts) {
+        this.partitionTabletRowCounts = partitionTabletRowCounts;
     }
 }

--- a/test/sql/test_analyze_statistics/R/test_overwrite_statistics.sql
+++ b/test/sql/test_analyze_statistics/R/test_overwrite_statistics.sql
@@ -93,3 +93,23 @@ function: assert_explain_costs_contains("select * from test_overwrite_statistics
 -- result:
 None
 -- !result
+delete from _statistics_.column_statistics where table_name='test_overwrite_statistics.test_overwrite_with_sample';
+-- result:
+-- !result
+create table test_overwrite_statistics.test_overwrite_with_sample (k1 int) properties("replication_num"="1");
+-- result:
+-- !result
+insert overwrite test_overwrite_statistics.test_overwrite_with_sample select generate_series from table(generate_series(1, 300000));
+-- result:
+-- !result
+function: assert_explain_costs_contains("select * from test_overwrite_statistics.test_overwrite_with_sample;", "ESTIMATE")
+-- result:
+None
+-- !result
+insert overwrite test_overwrite_statistics.test_overwrite_with_sample select generate_series from table(generate_series(1, 300000));
+-- result:
+-- !result
+function: assert_explain_costs_contains("select * from test_overwrite_statistics.test_overwrite_with_sample;", "ESTIMATE")
+-- result:
+None
+-- !result

--- a/test/sql/test_analyze_statistics/T/test_overwrite_statistics.sql
+++ b/test/sql/test_analyze_statistics/T/test_overwrite_statistics.sql
@@ -52,3 +52,10 @@ insert overwrite test_overwrite_statistics.test_overwrite_with_full select gener
 function: assert_explain_costs_contains("select * from test_overwrite_statistics.test_overwrite_with_full;","cardinality: 5000", "ESTIMATE")
 insert overwrite test_overwrite_statistics.test_overwrite_with_full select generate_series from table(generate_series(1, 5000));
 function: assert_explain_costs_contains("select * from test_overwrite_statistics.test_overwrite_with_full;","cardinality: 5000", "ESTIMATE")
+
+delete from _statistics_.column_statistics where table_name='test_overwrite_statistics.test_overwrite_with_sample';
+create table test_overwrite_statistics.test_overwrite_with_sample (k1 int) properties("replication_num"="1");
+insert overwrite test_overwrite_statistics.test_overwrite_with_sample select generate_series from table(generate_series(1, 300000));
+function: assert_explain_costs_contains("select * from test_overwrite_statistics.test_overwrite_with_sample;", "ESTIMATE")
+insert overwrite test_overwrite_statistics.test_overwrite_with_sample select generate_series from table(generate_series(1, 300000));
+function: assert_explain_costs_contains("select * from test_overwrite_statistics.test_overwrite_with_sample;", "ESTIMATE")


### PR DESCRIPTION
## Why I'm doing:

PR #57277 added support for collecting tablet-level row counts during partition first load for `INSERT INTO` operations, enabling accurate sample-based statistics collection. However, `INSERT OVERWRITE` operations were not included in that change.

Without tablet row counts for INSERT OVERWRITE and when overwrite triggers sample collection:
- Sample-based statistics collection cannot accurately classify partitions
- Falls back to using partition-level row counts, which are 0 for newly replaced partitions (partition row counts depend on asynchronous tablet reporting via TabletStatMgr)
- Results in skipped or suboptimal statistics collection strategies

## What I'm doing:

Extending PR #57277's tablet row count collection to support `INSERT OVERWRITE` operations:

**1. Extend `InsertOverwriteJobStats` to carry tablet row counts:**

**2. Collect tablet row counts in `InsertOverwriteJobRunner.doCommit()`:**

**3. Use tablet row counts in `StatisticsCollectionTrigger.prepareAnalyzeForOverwrite()`:**

This ensures INSERT OVERWRITE operations have the same tablet-level statistics collection capability as INSERT INTO operations.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Captures tablet-level row counts during INSERT OVERWRITE, propagates them to stats collection for SAMPLE mode, and adds tests covering overwrite sampling and full stats paths.
> 
> - **Statistics collection (INSERT OVERWRITE)**:
>   - `InsertOverwriteJobRunner`
>     - Collects tablet row counts from `TransactionState` -> `TableCommitInfo` -> `PartitionCommitInfo` and maps them to logical partitions (`partitionTabletRowCounts`).
>     - Derives `targetRows` from `InsertTxnCommitAttachment` when available; adds detailed fallback logging; skips during replay.
>   - `InsertOverwriteJobStats`
>     - Adds `partitionTabletRowCounts` (`Table<partitionId, tabletId, rowCount>`); initializes partition ID lists; getters/setters.
>   - `StatisticsCollectionTrigger`
>     - On overwrite, forwards `partitionTabletRowCounts` when analyze type is `SAMPLE`; existing load path unchanged.
> - **Tests**:
>   - Extend `test_overwrite_statistics.sql` to verify analyze behavior for overwrite (both full and sample), including large-row sample scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4303360f827a49e027f75d4282c4a855cbca8a3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->