### PR TITLE
[Feature] Add tablet range proto and find split points rpc interface

### DIFF
--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -359,6 +359,26 @@ message VacuumFullResponse {
     optional int64 vacuumed_file_size = 3;
 }
 
+message FindSplitPointRequest {
+    message TabletSplitInfo {
+        optional int64 tablet_id = 1;
+        // How many new tablets should this tablet be split into
+        optional int32 split_count = 2;
+    }
+
+    repeated TabletSplitInfo tablet_split_infos = 1;
+}
+
+message FindSplitPointResponse {
+    message TabletSplitResult {
+        optional int64 tablet_id = 1;
+        repeated TabletRangePB split_ranges = 2;
+    }
+
+    optional StatusPB status = 1;
+    repeated TabletSplitResult tablet_split_results = 2;
+}
+
 service LakeService {
     rpc publish_version(PublishVersionRequest) returns (PublishVersionResponse);
     rpc aggregate_publish_version(AggregatePublishVersionRequest) returns (PublishVersionResponse);
@@ -379,5 +399,6 @@ service LakeService {
     rpc vacuum(VacuumRequest) returns (VacuumResponse);
     rpc vacuum_full(VacuumFullRequest) returns (VacuumFullResponse);
     rpc aggregate_compact(AggregateCompactRequest) returns (CompactResponse);
+    rpc find_split_point(FindSplitPointRequest) returns (FindSplitPointResponse);
 }
 

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -231,3 +231,20 @@ message TransactionStatePB {
     optional TransactionStatusPB status = 2;
     optional string reason = 3;
 }
+
+message VariantPB {
+    optional PTypeDesc type = 1;
+    optional int64 int_value = 2;
+    optional string string_value = 3;
+}
+
+message TuplePB {
+    repeated VariantPB values = 1;
+}
+
+message TabletRangePB {
+    optional TuplePB lower_bound = 1;
+    optional TuplePB upper_bound = 2;
+    optional bool lower_bound_included = 3;
+    optional bool upper_bound_included = 4;
+}


### PR DESCRIPTION
## Why I'm doing:
Add tablet range proto and find split points rpc interface.

## What I'm doing:
- Add VariantPB to save different type of values.
- Add VariantTuplePB to save a list of different type of values, for example, sort key.
- Add TabletRangePB to save the range of a tablet.
- Add FindSplitPointRequest and FindSplitPointResponse and find_split_point rpc interface.

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `TabletRangePB` (with `VariantPB`/`TuplePB`) and introduces `find_split_point` RPC with request/response messages in `LakeService`.
> 
> - **Proto definitions**:
>   - **Types (`gensrc/proto/types.proto`)**:
>     - Add `VariantPB` for typed variant values.
>     - Add `TuplePB` to hold heterogeneous value lists.
>     - Add `TabletRangePB` to represent tablet key ranges.
>   - **Lake service (`gensrc/proto/lake_service.proto`)**:
>     - Add `FindSplitPointRequest`/`FindSplitPointResponse` with per-tablet split messages and `TabletRangePB` results.
>     - Add RPC `find_split_point(FindSplitPointRequest) returns (FindSplitPointResponse)` to `LakeService`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f828d29c1cd032c327f5d84a78691ed264380a0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->