### PR TITLE
[Enhancement] [Refactor] Optimize inspect_related_mvs meta function

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvId.java
@@ -28,7 +28,8 @@ public class MvId {
     @SerializedName(value = "id")
     private final long id;
 
-    private final Supplier<String> lazyName;
+    // ignore in gson serialization
+    private final transient Supplier<String> lazyName;
 
     public MvId(long dbId, long id) {
         this.dbId = dbId;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvId.java
@@ -14,7 +14,11 @@
 
 package com.starrocks.catalog;
 
+import com.google.common.base.Strings;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.server.GlobalStateMgr;
 
 import java.util.Objects;
 
@@ -24,9 +28,12 @@ public class MvId {
     @SerializedName(value = "id")
     private final long id;
 
+    private final Supplier<String> lazyName;
+
     public MvId(long dbId, long id) {
         this.dbId = dbId;
         this.id = id;
+        this.lazyName = Suppliers.memoize(() -> getNameByMVId());
     }
 
     public long getDbId() {
@@ -54,11 +61,32 @@ public class MvId {
         return Objects.hash(dbId, id);
     }
 
+    public String getName() {
+        return lazyName.get();
+    }
+
+    /**
+     * Get the mv's name
+     */
+    private String getNameByMVId() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbId);
+        if (db == null) {
+            return "";
+        }
+        Table table = db.getTable(id);
+        if (table == null) {
+            return "";
+        }
+        return String.format("%s.%s", db.getFullName(), table.getName());
+    }
+
     @Override
     public String toString() {
-        return "MvId{" +
-                "dbId=" + dbId +
-                ", id=" + id +
-                '}';
+        String name =  getName();
+        if (Strings.isNullOrEmpty(name)) {
+            return String.format("%s.%s", dbId, id);
+        } else {
+            return name;
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryMaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryMaterializationContext.java
@@ -200,10 +200,10 @@ public class QueryMaterializationContext {
 
     /**
      * Add related mvs about this query.
-     * @param mvs: related mvs
+     * @param mv: related mvs
      */
-    public void addRelatedMVs(Set<MaterializedView> mvs) {
-        relatedMVs.addAll(mvs);
+    public void addRelatedMV(MaterializedView mv) {
+        relatedMVs.add(mv);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewWrapper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewWrapper.java
@@ -19,7 +19,7 @@ import com.starrocks.catalog.MvPlanContext;
 
 import java.util.Objects;
 
-public class MaterializedViewWrapper {
+public class MaterializedViewWrapper implements Comparable<MaterializedViewWrapper> {
     private final MaterializedView mv;
     private final int level;
     private final MvPlanContext mvPlanContext;
@@ -53,14 +53,11 @@ public class MaterializedViewWrapper {
     }
 
     public static MaterializedViewWrapper create(MaterializedView mv, int level, MvPlanContext mvPlanContext) {
-        return new MaterializedViewWrapper(mv, level, mvPlanContext);
-    }
+        return new MaterializedViewWrapper(mv, level, mvPlanContext); }
 
     @Override
     public int hashCode() {
-        int result = mv.hashCode();
-        result = 31 * result + level;
-        return result;
+        return Objects.hash(mv);
     }
 
     @Override
@@ -73,13 +70,16 @@ public class MaterializedViewWrapper {
         }
 
         MaterializedViewWrapper mvWrapper = (MaterializedViewWrapper) o;
-        if (level != mvWrapper.level) {
-            return false;
+        return Objects.equals(mv, mvWrapper.mv);
+    }
+
+    @Override
+    public int compareTo(MaterializedViewWrapper o) {
+        int ans = Integer.compare(level, o.level);
+        if (ans != 0) {
+            return ans;
         }
-        if (!mv.equals(mvWrapper.mv)) {
-            return false;
-        }
-        return Objects.equals(mvPlanContext, mvWrapper.mvPlanContext);
+        return Integer.compare(mv.hashCode(), o.mv.hashCode());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewWrapper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewWrapper.java
@@ -75,11 +75,12 @@ public class MaterializedViewWrapper implements Comparable<MaterializedViewWrapp
 
     @Override
     public int compareTo(MaterializedViewWrapper o) {
-        int ans = Integer.compare(level, o.level);
-        if (ans != 0) {
-            return ans;
+        // First compare by level
+        int levelCompare = Integer.compare(level, o.level);
+        if (levelCompare != 0) {
+            return levelCompare;
         }
-        return Integer.compare(mv.hashCode(), o.mv.hashCode());
+        return Long.compare(mv.getId(), o.mv.getId());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -129,6 +129,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.SortedSet;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -139,13 +140,19 @@ import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
 public class MvUtils {
     private static final Logger LOG = LogManager.getLogger(MvUtils.class);
 
-    public static Set<MaterializedViewWrapper> getRelatedMvs(ConnectContext connectContext,
-                                                             int maxLevel,
-                                                             Set<Table> tablesToCheck) {
+    /**
+     * @param connectContext connect context
+     * @param maxLevel max level to collect
+     * @param tablesToCheck input tables to check
+     * @return a sorted related mvs by level result.
+     */
+    public static SortedSet<MaterializedViewWrapper> getRelatedMvs(ConnectContext connectContext,
+                                                                   int maxLevel,
+                                                                   Set<Table> tablesToCheck) {
         if (tablesToCheck.isEmpty()) {
-            return Sets.newHashSet();
+            return Sets.newTreeSet();
         }
-        Set<MaterializedViewWrapper> mvs = Sets.newHashSet();
+        SortedSet<MaterializedViewWrapper> mvs = Sets.newTreeSet();
         getRelatedMvs(connectContext, maxLevel, 0, tablesToCheck, mvs);
         return mvs;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/MetaFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/MetaFunctionsTest.java
@@ -289,4 +289,155 @@ public class MetaFunctionsTest extends MVTestBase {
         assertThrows(SemanticException.class,
                 () -> MetaFunctions.inspectTablePartitionInfo(ConstantOperator.createVarchar("test.non_existent_table")));
     }
+
+    @Test
+    public void testInspectRelatedMvWithNoRelatedMVs() throws Exception {
+        starRocksAssert.withTable("create table base_table_no_mv(k1 int, v1 int) properties('replication_num'='1')");
+        ConstantOperator result = MetaFunctions.inspectRelatedMv(ConstantOperator.createVarchar("test.base_table_no_mv"));
+        Assertions.assertNotNull(result);
+        Assertions.assertEquals("[]", result.getVarchar());
+        starRocksAssert.dropTable("base_table_no_mv");
+    }
+
+    @Test
+    public void testInspectRelatedMvWithSingleMV() throws Exception {
+        starRocksAssert.withTable("create table base_table_single_mv(k1 int, v1 int) properties('replication_num'='1')");
+        starRocksAssert.withRefreshedMaterializedView("create materialized view mv_single distributed by random " +
+                "as select k1, sum(v1) from test.base_table_single_mv group by k1");
+        
+        ConstantOperator result = MetaFunctions.inspectRelatedMv(ConstantOperator.createVarchar("test.base_table_single_mv"));
+        Assertions.assertNotNull(result);
+        String json = result.getVarchar();
+        Assertions.assertTrue(json.contains("\"name\":\"mv_single\""));
+        Assertions.assertTrue(json.contains("\"level\":0"));
+        Assertions.assertTrue(json.contains("\"related_mvs\":[]"));
+        
+        starRocksAssert.dropMaterializedView("mv_single");
+        starRocksAssert.dropTable("base_table_single_mv");
+    }
+
+    @Test
+    public void testInspectRelatedMvWithNestedMVs() throws Exception {
+        // Create base table
+        starRocksAssert.withTable("create table base_table_nested(k1 int, v1 int) properties('replication_num'='1')");
+        
+        // Create first level MV
+        starRocksAssert.withRefreshedMaterializedView("create materialized view mv_level_0 distributed by random " +
+                "as select k1, sum(v1) as sum_v1 from test.base_table_nested group by k1");
+        
+        // Create second level MV (nested)
+        starRocksAssert.withRefreshedMaterializedView("create materialized view mv_level_1 distributed by random " +
+                "as select k1, sum(sum_v1) as total from test.mv_level_0 group by k1");
+        
+        ConstantOperator result = MetaFunctions.inspectRelatedMv(ConstantOperator.createVarchar("test.base_table_nested"));
+        Assertions.assertNotNull(result);
+        String json = result.getVarchar();
+        
+        // Check level 0 MV
+        Assertions.assertTrue(json.contains("\"name\":\"mv_level_0\""));
+        Assertions.assertTrue(json.contains("\"level\":0"));
+        
+        // Check nested level 1 MV
+        Assertions.assertTrue(json.contains("\"name\":\"mv_level_1\""));
+        Assertions.assertTrue(json.contains("\"level\":1"));
+        
+        // Clean up in reverse order
+        starRocksAssert.dropMaterializedView("mv_level_1");
+        starRocksAssert.dropMaterializedView("mv_level_0");
+        starRocksAssert.dropTable("base_table_nested");
+    }
+
+    @Test
+    public void testInspectRelatedMvWithMultipleMVsAtSameLevel() throws Exception {
+        starRocksAssert.withTable("create table base_table_multi_mv(k1 int, v1 int, v2 int) properties('replication_num'='1')");
+        
+        // Create multiple MVs at level 0
+        starRocksAssert.withRefreshedMaterializedView("create materialized view mv_multi_1 distributed by random " +
+                "as select k1, sum(v1) from test.base_table_multi_mv group by k1");
+        starRocksAssert.withRefreshedMaterializedView("create materialized view mv_multi_2 distributed by random " +
+                "as select k1, sum(v2) from test.base_table_multi_mv group by k1");
+        
+        ConstantOperator result = MetaFunctions.inspectRelatedMv(ConstantOperator.createVarchar("test.base_table_multi_mv"));
+        Assertions.assertNotNull(result);
+        String json = result.getVarchar();
+        
+        // Both MVs should be at level 0
+        Assertions.assertTrue(json.contains("\"name\":\"mv_multi_1\"") || json.contains("\"name\":\"mv_multi_2\""));
+        Assertions.assertTrue(json.contains("\"level\":0"));
+        
+        starRocksAssert.dropMaterializedView("mv_multi_1");
+        starRocksAssert.dropMaterializedView("mv_multi_2");
+        starRocksAssert.dropTable("base_table_multi_mv");
+    }
+
+    @Test
+    public void testInspectRelatedMvWithDeepNesting() throws Exception {
+        // Create base table
+        starRocksAssert.withTable("create table base_table_deep(k1 int, v1 int) properties('replication_num'='1')");
+        
+        // Create level 0 MV
+        starRocksAssert.withRefreshedMaterializedView("create materialized view mv_deep_0 distributed by random " +
+                "as select k1, sum(v1) as sum_v1 from test.base_table_deep group by k1");
+        
+        // Create level 1 MV
+        starRocksAssert.withRefreshedMaterializedView("create materialized view mv_deep_1 distributed by random " +
+                "as select k1, sum(sum_v1) as sum_v2 from test.mv_deep_0 group by k1");
+        
+        // Create level 2 MV
+        starRocksAssert.withRefreshedMaterializedView("create materialized view mv_deep_2 distributed by random " +
+                "as select k1, sum(sum_v2) as sum_v3 from test.mv_deep_1 group by k1");
+        
+        ConstantOperator result = MetaFunctions.inspectRelatedMv(ConstantOperator.createVarchar("test.base_table_deep"));
+        Assertions.assertNotNull(result);
+        String json = result.getVarchar();
+        
+        // Verify all levels exist
+        Assertions.assertTrue(json.contains("\"name\":\"mv_deep_0\""));
+        Assertions.assertTrue(json.contains("\"level\":0"));
+        Assertions.assertTrue(json.contains("\"name\":\"mv_deep_1\""));
+        Assertions.assertTrue(json.contains("\"level\":1"));
+        Assertions.assertTrue(json.contains("\"name\":\"mv_deep_2\""));
+        Assertions.assertTrue(json.contains("\"level\":2"));
+        
+        // Clean up in reverse order
+        starRocksAssert.dropMaterializedView("mv_deep_2");
+        starRocksAssert.dropMaterializedView("mv_deep_1");
+        starRocksAssert.dropMaterializedView("mv_deep_0");
+        starRocksAssert.dropTable("base_table_deep");
+    }
+
+    @Test
+    public void testInspectRelatedMvThrowsExceptionForNonExistentTable() {
+        assertThrows(SemanticException.class,
+                () -> MetaFunctions.inspectRelatedMv(ConstantOperator.createVarchar("test.non_existent_table")));
+    }
+
+    @Test
+    public void testInspectRelatedMvReturnsValidJsonStructure() throws Exception {
+        starRocksAssert.withTable("create table base_table_json(k1 int, v1 int) properties('replication_num'='1')");
+        starRocksAssert.withRefreshedMaterializedView("create materialized view mv_json distributed by random " +
+                "as select k1, sum(v1) from test.base_table_json group by k1");
+        
+        ConstantOperator result = MetaFunctions.inspectRelatedMv(ConstantOperator.createVarchar("test.base_table_json"));
+        Assertions.assertNotNull(result);
+        String json = result.getVarchar();
+        
+        // Verify JSON structure contains required fields
+        Assertions.assertTrue(json.contains("\"id\":"));
+        Assertions.assertTrue(json.contains("\"name\":"));
+        Assertions.assertTrue(json.contains("\"level\":"));
+        Assertions.assertTrue(json.contains("\"related_mvs\":"));
+        
+        starRocksAssert.dropMaterializedView("mv_json");
+        starRocksAssert.dropTable("base_table_json");
+    }
+
+    @Test
+    public void testInspectRelatedMvWithExternalTable() throws Exception {
+        ConstantOperator result = MetaFunctions.inspectRelatedMv(
+                ConstantOperator.createVarchar("test.mysql_external_table"));
+        Assertions.assertNotNull(result);
+        // External tables typically have no related MVs
+        Assertions.assertEquals("[]", result.getVarchar());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePreprocessorTest.java
@@ -18,10 +18,13 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Pair;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
@@ -325,7 +328,7 @@ public class MvRewritePreprocessorTest extends MVTestBase {
                 OptExpression logicalTree = result.second;
 
                 Set<Table> queryTables = MvUtils.getAllTables(logicalTree).stream().collect(Collectors.toSet());
-                Set<MaterializedViewWrapper> relatedMVs = preprocessor.getRelatedMVs(queryTables, false);
+                List<MaterializedViewWrapper> relatedMVs = preprocessor.getRelatedMVs(queryTables, false);
                 Assertions.assertEquals(4, relatedMVs.size());
                 // mv2 contains extra mvs.
                 Assertions.assertTrue(containsMV(relatedMVs, "mv_1", "mv_2", "mv_3", "mv_4"));
@@ -355,7 +358,7 @@ public class MvRewritePreprocessorTest extends MVTestBase {
                 OptExpression logicalTree = result.second;
 
                 Set<Table> queryTables = MvUtils.getAllTables(logicalTree).stream().collect(Collectors.toSet());
-                Set<MaterializedViewWrapper> relatedMVs = preprocessor.getRelatedMVs(queryTables, false);
+                List<MaterializedViewWrapper> relatedMVs = preprocessor.getRelatedMVs(queryTables, false);
                 Assertions.assertEquals(4, relatedMVs.size());
                 // mv2 contains extra mvs.
                 Assertions.assertTrue(containsMV(relatedMVs, "mv_1", "mv_2", "mv_3", "mv_4"));
@@ -403,7 +406,7 @@ public class MvRewritePreprocessorTest extends MVTestBase {
                 OptExpression logicalTree = result.second;
 
                 Set<Table> queryTables = MvUtils.getAllTables(logicalTree).stream().collect(Collectors.toSet());
-                Set<MaterializedViewWrapper> relatedMVs = preprocessor.getRelatedMVs(queryTables, false);
+                List<MaterializedViewWrapper> relatedMVs = preprocessor.getRelatedMVs(queryTables, false);
                 Assertions.assertEquals(4, relatedMVs.size());
                 // mv2 contains extra mvs.
                 Assertions.assertTrue(containsMV(relatedMVs, "mv_1", "mv_2", "mv_3", "mv_4"));
@@ -437,7 +440,7 @@ public class MvRewritePreprocessorTest extends MVTestBase {
                 OptExpression logicalTree = result.second;
 
                 Set<Table> queryTables = MvUtils.getAllTables(logicalTree).stream().collect(Collectors.toSet());
-                Set<MaterializedViewWrapper> relatedMVs = preprocessor.getRelatedMVs(queryTables, false);
+                List<MaterializedViewWrapper> relatedMVs = preprocessor.getRelatedMVs(queryTables, false);
                 Assertions.assertEquals(4, relatedMVs.size());
                 // mv2 contains extra mvs.
                 Assertions.assertTrue(containsMV(relatedMVs, "mv_1", "mv_2", "mv_3", "mv_4"));
@@ -552,7 +555,7 @@ public class MvRewritePreprocessorTest extends MVTestBase {
                 OptExpression logicalTree = result.second;
 
                 Set<Table> queryTables = MvUtils.getAllTables(logicalTree).stream().collect(Collectors.toSet());
-                Set<MaterializedViewWrapper> relatedMVs = preprocessor.getRelatedMVs(queryTables, false);
+                List<MaterializedViewWrapper> relatedMVs = preprocessor.getRelatedMVs(queryTables, false);
                 Assertions.assertEquals(5, relatedMVs.size());
                 // mv2 contains extra mvs.
                 Assertions.assertTrue(containsMV(relatedMVs, "mv_1", "mv_2", "mv_3", "mv_4", "mv_5"));
@@ -604,7 +607,7 @@ public class MvRewritePreprocessorTest extends MVTestBase {
                 OptExpression logicalTree = result.second;
 
                 Set<Table> queryTables = MvUtils.getAllTables(logicalTree).stream().collect(Collectors.toSet());
-                Set<MaterializedViewWrapper> relatedMVs = preprocessor.getRelatedMVs(queryTables, false);
+                List<MaterializedViewWrapper> relatedMVs = preprocessor.getRelatedMVs(queryTables, false);
                 Assertions.assertEquals(relatedMVs.size(), mvNum);
                 List<MaterializedViewWrapper> validMVs = preprocessor.chooseBestRelatedMVs(queryTables, relatedMVs, logicalTree);
                 Assertions.assertEquals(validMVs.size(), oldVal);
@@ -688,7 +691,7 @@ public class MvRewritePreprocessorTest extends MVTestBase {
             OptExpression logicalTree = result.second;
 
             Set<Table> queryTables = MvUtils.getAllTables(logicalTree).stream().collect(Collectors.toSet());
-            Set<MaterializedViewWrapper> relatedMVs = preprocessor.getRelatedMVs(queryTables, false);
+            List<MaterializedViewWrapper> relatedMVs = preprocessor.getRelatedMVs(queryTables, false);
             Assertions.assertEquals(1, relatedMVs.size());
             Assertions.assertTrue(containsMV(relatedMVs, "invalid_plan_mv"));
 
@@ -840,18 +843,18 @@ public class MvRewritePreprocessorTest extends MVTestBase {
                 String query = "select k1, v1, v2 from t1";
                 Pair<MvRewritePreprocessor, OptExpression> result = buildMvProcessor(query);
                 Assertions.assertNotNull(result);
-                
+
                 MvRewritePreprocessor preprocessor = result.first;
                 OptExpression logicalTree = result.second;
-                
+
                 // This should not throw an exception even with timeouts
                 preprocessor.prepare(logicalTree);
-                
+
                 // Verify that the process completed without throwing exceptions
                 // The exact number of candidate MVs may vary due to timeouts, but the process should complete
                 // The preprocessor should complete successfully even with timeouts
                 Assertions.assertNotNull(preprocessor);
-                
+
             } finally {
                 // Restore original timeout
                 connectContext.getSessionVariable().setOptimizerExecuteTimeout(originalTimeout);
@@ -880,17 +883,17 @@ public class MvRewritePreprocessorTest extends MVTestBase {
                 String query = "select k1, v1 from t1";
                 Pair<MvRewritePreprocessor, OptExpression> result = buildMvProcessor(query);
                 Assertions.assertNotNull(result);
-                
+
                 MvRewritePreprocessor preprocessor = result.first;
                 OptExpression logicalTree = result.second;
-                
+
                 // The process should complete successfully with 2 MVs
                 // Each MV should get 5000ms timeout (10000/2), but minimum 1000ms
                 preprocessor.prepare(logicalTree);
-                
+
                 // Verify the process completed
                 Assertions.assertNotNull(preprocessor);
-                
+
             } finally {
                 // Restore original timeout
                 connectContext.getSessionVariable().setOptimizerExecuteTimeout(originalTimeout);
@@ -922,15 +925,15 @@ public class MvRewritePreprocessorTest extends MVTestBase {
                 String query = "select k1, v1 from t1";
                 Pair<MvRewritePreprocessor, OptExpression> result = buildMvProcessor(query);
                 Assertions.assertNotNull(result);
-                
+
                 MvRewritePreprocessor preprocessor = result.first;
                 OptExpression logicalTree = result.second;
-                
+
                 // Process should complete - each MV gets 1000ms (minimum enforced)
                 preprocessor.prepare(logicalTree);
-                
+
                 Assertions.assertNotNull(preprocessor);
-                
+
             } finally {
                 connectContext.getSessionVariable().setOptimizerExecuteTimeout(originalTimeout);
             }
@@ -946,13 +949,13 @@ public class MvRewritePreprocessorTest extends MVTestBase {
         String query = "select k1, v1 from t1";
         Pair<MvRewritePreprocessor, OptExpression> result = buildMvProcessor(query);
         Assertions.assertNotNull(result);
-        
+
         MvRewritePreprocessor preprocessor = result.first;
         OptExpression logicalTree = result.second;
-        
+
         // Should handle empty MV list without issues
         preprocessor.prepare(logicalTree);
-        
+
         Assertions.assertNotNull(preprocessor);
     }
 
@@ -978,15 +981,15 @@ public class MvRewritePreprocessorTest extends MVTestBase {
                 String query = "select k1, v1 from t1";
                 Pair<MvRewritePreprocessor, OptExpression> result = buildMvProcessor(query);
                 Assertions.assertNotNull(result);
-                
+
                 MvRewritePreprocessor preprocessor = result.first;
                 OptExpression logicalTree = result.second;
-                
+
                 // Should complete even if some MVs have issues
                 preprocessor.prepare(logicalTree);
-                
+
                 Assertions.assertNotNull(preprocessor);
-                
+
             } finally {
                 connectContext.getSessionVariable().setOptimizerExecuteTimeout(originalTimeout);
             }
@@ -1011,19 +1014,19 @@ public class MvRewritePreprocessorTest extends MVTestBase {
                 // Enable concurrent processing
                 connectContext.getSessionVariable().setEnableMaterializedViewConcurrentPrepare(true);
                 connectContext.getSessionVariable().setOptimizerExecuteTimeout(10000);
-                
+
                 String query = "select k1, v1 from t1";
                 Pair<MvRewritePreprocessor, OptExpression> result = buildMvProcessor(query);
                 Assertions.assertNotNull(result);
-                
+
                 MvRewritePreprocessor preprocessor = result.first;
                 OptExpression logicalTree = result.second;
-                
+
                 // Should handle concurrent processing with timeouts
                 preprocessor.prepare(logicalTree);
-                
+
                 Assertions.assertNotNull(preprocessor);
-                
+
             } finally {
                 connectContext.getSessionVariable().setOptimizerExecuteTimeout((originalTimeout));
                 connectContext.getSessionVariable().setEnableMaterializedViewConcurrentPrepare(false);
@@ -1045,17 +1048,17 @@ public class MvRewritePreprocessorTest extends MVTestBase {
             long originalTimeout = connectContext.getSessionVariable().getOptimizerExecuteTimeout();
             try {
                 connectContext.getSessionVariable().setOptimizerExecuteTimeout(10000);
-                
+
                 String query = "select k1, v1 from t1";
                 Pair<MvRewritePreprocessor, OptExpression> result = buildMvProcessor(query);
                 Assertions.assertNotNull(result);
-                
+
                 MvRewritePreprocessor preprocessor = result.first;
                 OptExpression logicalTree = result.second;
-                
+
                 // Interrupt the current thread
                 Thread.currentThread().interrupt();
-                
+
                 // Should handle interruption and throw appropriate exception
                 try {
                     preprocessor.prepare(logicalTree);
@@ -1064,12 +1067,12 @@ public class MvRewritePreprocessorTest extends MVTestBase {
                     Thread.interrupted();
                 } catch (RuntimeException e) {
                     // Expected if interruption causes failure
-                    Assertions.assertTrue(e.getMessage().contains("interrupted") || 
-                                         e.getCause() instanceof InterruptedException);
+                    Assertions.assertTrue(e.getMessage().contains("interrupted") ||
+                            e.getCause() instanceof InterruptedException);
                     // Clear the interrupt flag
                     Thread.interrupted();
                 }
-                
+
             } finally {
                 // Restore original timeout
                 connectContext.getSessionVariable().setOptimizerExecuteTimeout(originalTimeout);
@@ -1077,5 +1080,491 @@ public class MvRewritePreprocessorTest extends MVTestBase {
                 Thread.interrupted();
             }
         });
+    }
+
+    @Test
+    public void testMvIdConstructorAndGetters() {
+        starRocksAssert.withMaterializedView("create materialized view mvid_test_mv1 " +
+                        "distributed by random as select k1, v1 from t1",
+                (obj) -> {
+                    MaterializedView mv = getMv(DB_NAME, "mvid_test_mv1");
+                    Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+
+                    MvId mvId = new MvId(db.getId(), mv.getId());
+
+                    Assertions.assertEquals(db.getId(), mvId.getDbId());
+                    Assertions.assertEquals(mv.getId(), mvId.getId());
+                });
+    }
+
+    @Test
+    public void testMvIdEquals() {
+        starRocksAssert.withMaterializedView("create materialized view mvid_test_mv2 " +
+                        "distributed by random as select k1, v1 from t1",
+                (obj) -> {
+                    MaterializedView mv = getMv(DB_NAME, "mvid_test_mv2");
+                    Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+
+                    MvId mvId1 = new MvId(db.getId(), mv.getId());
+                    MvId mvId2 = new MvId(db.getId(), mv.getId());
+                    MvId mvId3 = new MvId(db.getId() + 1, mv.getId());
+                    MvId mvId4 = new MvId(db.getId(), mv.getId() + 1);
+
+                    // Same dbId and id should be equal
+                    Assertions.assertEquals(mvId1, mvId2);
+
+                    // Self equality
+                    Assertions.assertEquals(mvId1, mvId1);
+
+                    // Different dbId should not be equal
+                    Assertions.assertNotEquals(mvId1, mvId3);
+
+                    // Different id should not be equal
+                    Assertions.assertNotEquals(mvId1, mvId4);
+
+                    // Null check
+                    Assertions.assertNotEquals(mvId1, null);
+
+                    // Different class check
+                    Assertions.assertNotEquals(mvId1, "string");
+                });
+    }
+
+    @Test
+    public void testMvIdHashCode() {
+        starRocksAssert.withMaterializedView("create materialized view mvid_test_mv3 " +
+                "distributed by random as select k1, v1 from t1",
+                (obj) -> {
+                    MaterializedView mv = getMv(DB_NAME, "mvid_test_mv3");
+                    Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+
+                    MvId mvId1 = new MvId(db.getId(), mv.getId());
+                    MvId mvId2 = new MvId(db.getId(), mv.getId());
+
+                    // Same dbId and id should have same hashCode
+                    Assertions.assertEquals(mvId1.hashCode(), mvId2.hashCode());
+                });
+    }
+
+    @Test
+    public void testMvIdHashCodeWithDifferentIds() {
+        starRocksAssert.withMaterializedView("create materialized view mvid_test_mv4 " +
+                        "distributed by random as select k1, v1 from t1",
+                (obj) -> {
+                    MaterializedView mv = getMv(DB_NAME, "mvid_test_mv4");
+                    Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+
+                    MvId mvId1 = new MvId(db.getId(), mv.getId());
+                    MvId mvId2 = new MvId(db.getId() + 1, mv.getId());
+                    MvId mvId3 = new MvId(db.getId(), mv.getId() + 1);
+
+                    // Different ids typically have different hashCodes (not guaranteed but expected)
+                    Assertions.assertNotNull(mvId1.hashCode());
+                    Assertions.assertNotNull(mvId2.hashCode());
+                    Assertions.assertNotNull(mvId3.hashCode());
+                });
+    }
+
+    @Test
+    public void testMvIdGetNameWithValidMv() {
+        starRocksAssert.withMaterializedView("create materialized view mvid_test_mv5 " +
+                        "distributed by random as select k1, v1 from t1",
+                (obj) -> {
+                    MaterializedView mv = getMv(DB_NAME, "mvid_test_mv5");
+                    Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+
+                    MvId mvId = new MvId(db.getId(), mv.getId());
+                    String name = mvId.getName();
+
+                    Assertions.assertNotNull(name);
+                    Assertions.assertTrue(name.contains(DB_NAME));
+                    Assertions.assertTrue(name.contains("mvid_test_mv5"));
+                    Assertions.assertTrue(name.contains("."));
+                });
+    }
+
+    @Test
+    public void testMvIdGetNameWithInvalidDbId() {
+        // Create MvId with non-existent database ID
+        long invalidDbId = 999999999L;
+        long validMvId = 1L;
+
+        MvId mvId = new MvId(invalidDbId, validMvId);
+        String name = mvId.getName();
+
+        // Should return empty string when DB doesn't exist
+        Assertions.assertEquals("", name);
+    }
+
+    @Test
+    public void testMvIdGetNameWithInvalidMvId() {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        long invalidMvId = 999999999L;
+
+        MvId mvId = new MvId(db.getId(), invalidMvId);
+        String name = mvId.getName();
+
+        // Should return empty string when table doesn't exist
+        Assertions.assertEquals("", name);
+    }
+
+    @Test
+    public void testMvIdToStringWithValidMv() {
+        starRocksAssert.withMaterializedView("create materialized view mvid_test_mv6 " +
+                        "distributed by random as select k1, v1 from t1",
+                (obj) -> {
+                    MaterializedView mv = getMv(DB_NAME, "mvid_test_mv6");
+                    Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+
+                    MvId mvId = new MvId(db.getId(), mv.getId());
+                    String toString = mvId.toString();
+
+                    Assertions.assertNotNull(toString);
+                    // Should return the full name (db.table) when MV exists
+                    Assertions.assertTrue(toString.contains(DB_NAME));
+                    Assertions.assertTrue(toString.contains("mvid_test_mv6"));
+                });
+    }
+
+    @Test
+    public void testMvIdToStringWithInvalidMv() {
+        // Create MvId with non-existent database ID
+        long invalidDbId = 999999999L;
+        long invalidMvId = 888888888L;
+
+        MvId mvId = new MvId(invalidDbId, invalidMvId);
+        String toString = mvId.toString();
+
+        Assertions.assertNotNull(toString);
+        // Should return "dbId.mvId" format when name is empty
+        Assertions.assertTrue(toString.contains(String.valueOf(invalidDbId)));
+        Assertions.assertTrue(toString.contains(String.valueOf(invalidMvId)));
+        Assertions.assertTrue(toString.contains("."));
+    }
+
+    @Test
+    public void testMvIdLazyNameCaching() {
+        starRocksAssert.withMaterializedView("create materialized view mvid_test_mv7 " +
+                        "distributed by random as select k1, v1 from t1",
+                (obj) -> {
+                    MaterializedView mv = getMv(DB_NAME, "mvid_test_mv7");
+                    Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+
+                    MvId mvId = new MvId(db.getId(), mv.getId());
+
+                    // First call - should compute and cache
+                    String name1 = mvId.getName();
+                    // Second call - should return cached value
+                    String name2 = mvId.getName();
+
+                    // Both calls should return the same value
+                    Assertions.assertEquals(name1, name2);
+                    Assertions.assertNotNull(name1);
+                    Assertions.assertTrue(name1.contains("mvid_test_mv7"));
+                });
+    }
+
+    @Test
+    public void testMvIdWithDifferentDatabases() {
+        try {
+            // Create another database
+            starRocksAssert.withDatabase("test_db2");
+            starRocksAssert.useDatabase("test_db2");
+            starRocksAssert.withTable("CREATE TABLE test_db2.t1\n" +
+                    "(\n" +
+                    "    k1 int,\n" +
+                    "    v1 int\n" +
+                    ")\n" +
+                    "DISTRIBUTED BY HASH(k1) BUCKETS 3\n" +
+                    "PROPERTIES('replication_num' = '1');");
+
+            starRocksAssert.withMaterializedView("create materialized view mvid_test_mv8 " +
+                            "distributed by random as select k1, v1 from test_db2.t1",
+                    (obj) -> {
+                        MaterializedView mv = getMv("test_db2", "mvid_test_mv8");
+                        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test_db2");
+
+                        MvId mvId = new MvId(db.getId(), mv.getId());
+                        String name = mvId.getName();
+
+                        Assertions.assertNotNull(name);
+                        Assertions.assertTrue(name.contains("test_db2"));
+                        Assertions.assertTrue(name.contains("mvid_test_mv8"));
+                    });
+
+            starRocksAssert.dropDatabase("test_db2");
+            starRocksAssert.useDatabase(DB_NAME);
+        } catch (Exception e) {
+            Assertions.fail("Test failed with exception: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testMvIdEqualityContract() {
+        starRocksAssert.withMaterializedView("create materialized view mvid_test_mv9 " +
+                        "distributed by random as select k1, v1 from t1",
+                (obj) -> {
+                    MaterializedView mv = getMv(DB_NAME, "mvid_test_mv9");
+                    Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+
+                    MvId mvId1 = new MvId(db.getId(), mv.getId());
+                    MvId mvId2 = new MvId(db.getId(), mv.getId());
+                    MvId mvId3 = new MvId(db.getId(), mv.getId());
+
+                    // Reflexive: x.equals(x) should be true
+                    Assertions.assertEquals(mvId1, mvId1);
+
+                    // Symmetric: x.equals(y) == y.equals(x)
+                    Assertions.assertEquals(mvId1, mvId2);
+                    Assertions.assertEquals(mvId2, mvId1);
+
+                    // Transitive: if x.equals(y) and y.equals(z), then x.equals(z)
+                    Assertions.assertEquals(mvId1, mvId2);
+                    Assertions.assertEquals(mvId2, mvId3);
+                    Assertions.assertEquals(mvId1, mvId3);
+
+                    // Consistent hashCode
+                    Assertions.assertEquals(mvId1.hashCode(), mvId2.hashCode());
+                    Assertions.assertEquals(mvId2.hashCode(), mvId3.hashCode());
+                });
+    }
+
+    @Test
+    public void testMaterializedViewWrapperConstructorWithTwoParams() {
+        starRocksAssert.withMaterializedView("create materialized view wrapper_test_mv1 " +
+                        "distributed by random as select k1, v1 from t1",
+                (obj) -> {
+                    MaterializedView mv = getMv(DB_NAME, "wrapper_test_mv1");
+                    MaterializedViewWrapper wrapper = new MaterializedViewWrapper(mv, 0);
+
+                    Assertions.assertEquals(mv, wrapper.getMV());
+                    Assertions.assertEquals(0, wrapper.getLevel());
+                    Assertions.assertNull(wrapper.getMvPlanContext());
+                });
+    }
+
+    @Test
+    public void testMaterializedViewWrapperConstructorWithThreeParams() {
+        starRocksAssert.withMaterializedView("create materialized view wrapper_test_mv2 " +
+                        "distributed by random as select k1, v1 from t1",
+                (obj) -> {
+                    MaterializedView mv = getMv(DB_NAME, "wrapper_test_mv2");
+                    MvPlanContext mvPlanContext = getOptimizedPlan(mv, false);
+                    MaterializedViewWrapper wrapper = new MaterializedViewWrapper(mv, 1, mvPlanContext);
+
+                    Assertions.assertEquals(mv, wrapper.getMV());
+                    Assertions.assertEquals(1, wrapper.getLevel());
+                    Assertions.assertNotNull(wrapper.getMvPlanContext());
+                    Assertions.assertEquals(mvPlanContext, wrapper.getMvPlanContext());
+                });
+    }
+
+    @Test
+    public void testMaterializedViewWrapperCreateWithTwoParams() {
+        starRocksAssert.withMaterializedView("create materialized view wrapper_test_mv3 " +
+                        "distributed by random as select k1, v1 from t1",
+                (obj) -> {
+                    MaterializedView mv = getMv(DB_NAME, "wrapper_test_mv3");
+                    MaterializedViewWrapper wrapper = MaterializedViewWrapper.create(mv, 2);
+
+                    Assertions.assertEquals(mv, wrapper.getMV());
+                    Assertions.assertEquals(2, wrapper.getLevel());
+                    Assertions.assertNull(wrapper.getMvPlanContext());
+                });
+    }
+
+    @Test
+    public void testMaterializedViewWrapperCreateWithThreeParams() {
+        starRocksAssert.withMaterializedView("create materialized view wrapper_test_mv4 " +
+                        "distributed by random as select k1, v1 from t1",
+                (obj) -> {
+                    MaterializedView mv = getMv(DB_NAME, "wrapper_test_mv4");
+                    MvPlanContext mvPlanContext = getOptimizedPlan(mv, false);
+                    MaterializedViewWrapper wrapper = MaterializedViewWrapper.create(mv, 3, mvPlanContext);
+
+                    Assertions.assertEquals(mv, wrapper.getMV());
+                    Assertions.assertEquals(3, wrapper.getLevel());
+                    Assertions.assertNotNull(wrapper.getMvPlanContext());
+                    Assertions.assertEquals(mvPlanContext, wrapper.getMvPlanContext());
+                });
+    }
+
+    @Test
+    public void testMaterializedViewWrapperEquals() {
+        starRocksAssert.withMaterializedView("create materialized view wrapper_test_mv5 " +
+                        "distributed by random as select k1, v1 from t1",
+                (obj) -> {
+                    MaterializedView mv = getMv(DB_NAME, "wrapper_test_mv5");
+                    MaterializedViewWrapper wrapper1 = MaterializedViewWrapper.create(mv, 0);
+                    MaterializedViewWrapper wrapper2 = MaterializedViewWrapper.create(mv, 1);
+                    MaterializedViewWrapper wrapper3 = MaterializedViewWrapper.create(mv, 0);
+
+                    // Same MV should be equal regardless of level
+                    Assertions.assertEquals(wrapper1, wrapper2);
+                    Assertions.assertEquals(wrapper1, wrapper3);
+                    Assertions.assertEquals(wrapper2, wrapper3);
+
+                    // Self equality
+                    Assertions.assertEquals(wrapper1, wrapper1);
+
+                    // Null check
+                    Assertions.assertNotEquals(wrapper1, null);
+
+                    // Different class check
+                    Assertions.assertNotEquals(wrapper1, "string");
+                });
+    }
+
+    @Test
+    public void testMaterializedViewWrapperEqualsWithDifferentMVs() {
+        List<String> mvs = ImmutableList.of(
+                "create materialized view wrapper_test_mv6 distributed by random as select k1, v1 from t1",
+                "create materialized view wrapper_test_mv7 distributed by random as select k1, v2 from t1"
+        );
+
+        starRocksAssert.withMaterializedViews(mvs,
+                (obj) -> {
+                    MaterializedView mv1 = getMv(DB_NAME, "wrapper_test_mv6");
+                    MaterializedView mv2 = getMv(DB_NAME, "wrapper_test_mv7");
+
+                    MaterializedViewWrapper wrapper1 = MaterializedViewWrapper.create(mv1, 0);
+                    MaterializedViewWrapper wrapper2 = MaterializedViewWrapper.create(mv2, 0);
+
+                    // Different MVs should not be equal
+                    Assertions.assertNotEquals(wrapper1, wrapper2);
+                });
+    }
+
+    @Test
+    public void testMaterializedViewWrapperHashCode() {
+        starRocksAssert.withMaterializedView("create materialized view wrapper_test_mv8 " +
+                        "distributed by random as select k1, v1 from t1",
+                (obj) -> {
+                    MaterializedView mv = getMv(DB_NAME, "wrapper_test_mv8");
+                    MaterializedViewWrapper wrapper1 = MaterializedViewWrapper.create(mv, 0);
+                    MaterializedViewWrapper wrapper2 = MaterializedViewWrapper.create(mv, 1);
+
+                    // Same MV should have same hashCode regardless of level
+                    Assertions.assertEquals(wrapper1.hashCode(), wrapper2.hashCode());
+                });
+    }
+
+    @Test
+    public void testMaterializedViewWrapperHashCodeWithDifferentMVs() {
+        List<String> mvs = ImmutableList.of(
+                "create materialized view wrapper_test_mv9 distributed by random as select k1, v1 from t1",
+                "create materialized view wrapper_test_mv10 distributed by random as select k1, v2 from t1"
+        );
+
+        starRocksAssert.withMaterializedViews(mvs,
+                (obj) -> {
+                    MaterializedView mv1 = getMv(DB_NAME, "wrapper_test_mv9");
+                    MaterializedView mv2 = getMv(DB_NAME, "wrapper_test_mv10");
+
+                    MaterializedViewWrapper wrapper1 = MaterializedViewWrapper.create(mv1, 0);
+                    MaterializedViewWrapper wrapper2 = MaterializedViewWrapper.create(mv2, 0);
+
+                    // Different MVs typically have different hashCodes (not guaranteed but expected)
+                    // This is just a sanity check
+                    Assertions.assertNotNull(wrapper1.hashCode());
+                    Assertions.assertNotNull(wrapper2.hashCode());
+                });
+    }
+
+    @Test
+    public void testMaterializedViewWrapperCompareTo() {
+        starRocksAssert.withMaterializedView("create materialized view wrapper_test_mv11 " +
+                        "distributed by random as select k1, v1 from t1",
+                (obj) -> {
+                    MaterializedView mv = getMv(DB_NAME, "wrapper_test_mv11");
+                    MaterializedViewWrapper wrapper0 = MaterializedViewWrapper.create(mv, 0);
+                    MaterializedViewWrapper wrapper1 = MaterializedViewWrapper.create(mv, 1);
+                    MaterializedViewWrapper wrapper2 = MaterializedViewWrapper.create(mv, 2);
+
+                    // Lower level should come before higher level
+                    Assertions.assertTrue(wrapper0.compareTo(wrapper1) < 0);
+                    Assertions.assertTrue(wrapper1.compareTo(wrapper2) < 0);
+                    Assertions.assertTrue(wrapper0.compareTo(wrapper2) < 0);
+
+                    // Higher level should come after lower level
+                    Assertions.assertTrue(wrapper1.compareTo(wrapper0) > 0);
+                    Assertions.assertTrue(wrapper2.compareTo(wrapper1) > 0);
+                    Assertions.assertTrue(wrapper2.compareTo(wrapper0) > 0);
+
+                    // Same level should be equal
+                    MaterializedViewWrapper wrapper1Copy = MaterializedViewWrapper.create(mv, 1);
+                    Assertions.assertEquals(0, wrapper1.compareTo(wrapper1Copy));
+                });
+    }
+
+    @Test
+    public void testMaterializedViewWrapperCompareToWithDifferentMVs() {
+        List<String> mvs = ImmutableList.of(
+                "create materialized view wrapper_test_mv12 distributed by random as select k1, v1 from t1",
+                "create materialized view wrapper_test_mv13 distributed by random as select k1, v2 from t1"
+        );
+
+        starRocksAssert.withMaterializedViews(mvs,
+                (obj) -> {
+                    MaterializedView mv1 = getMv(DB_NAME, "wrapper_test_mv12");
+                    MaterializedView mv2 = getMv(DB_NAME, "wrapper_test_mv13");
+
+                    MaterializedViewWrapper wrapper1Level0 = MaterializedViewWrapper.create(mv1, 0);
+                    MaterializedViewWrapper wrapper2Level1 = MaterializedViewWrapper.create(mv2, 1);
+
+                    // Comparison is based on level, not on MV
+                    Assertions.assertTrue(wrapper1Level0.compareTo(wrapper2Level1) < 0);
+                    Assertions.assertTrue(wrapper2Level1.compareTo(wrapper1Level0) > 0);
+                });
+    }
+
+    @Test
+    public void testMaterializedViewWrapperToString() {
+        starRocksAssert.withMaterializedView("create materialized view wrapper_test_mv14 " +
+                        "distributed by random as select k1, v1 from t1",
+                (obj) -> {
+                    MaterializedView mv = getMv(DB_NAME, "wrapper_test_mv14");
+                    MaterializedViewWrapper wrapper = MaterializedViewWrapper.create(mv, 2);
+
+                    String toString = wrapper.toString();
+                    Assertions.assertNotNull(toString);
+                    Assertions.assertTrue(toString.contains("MVWrapper{"));
+                    Assertions.assertTrue(toString.contains("mv="));
+                    Assertions.assertTrue(toString.contains("level=2"));
+                });
+    }
+
+    @Test
+    public void testMaterializedViewWrapperLevelValues() {
+        starRocksAssert.withMaterializedView("create materialized view wrapper_test_mv15 " +
+                        "distributed by random as select k1, v1 from t1",
+                (obj) -> {
+                    MaterializedView mv = getMv(DB_NAME, "wrapper_test_mv15");
+
+                    // Test various level values
+                    MaterializedViewWrapper wrapper0 = MaterializedViewWrapper.create(mv, 0);
+                    MaterializedViewWrapper wrapper1 = MaterializedViewWrapper.create(mv, 1);
+                    MaterializedViewWrapper wrapper5 = MaterializedViewWrapper.create(mv, 5);
+                    MaterializedViewWrapper wrapper10 = MaterializedViewWrapper.create(mv, 10);
+
+                    Assertions.assertEquals(0, wrapper0.getLevel());
+                    Assertions.assertEquals(1, wrapper1.getLevel());
+                    Assertions.assertEquals(5, wrapper5.getLevel());
+                    Assertions.assertEquals(10, wrapper10.getLevel());
+                });
+    }
+
+    @Test
+    public void testMaterializedViewWrapperWithNullMvPlanContext() {
+        starRocksAssert.withMaterializedView("create materialized view wrapper_test_mv16 " +
+                        "distributed by random as select k1, v1 from t1",
+                (obj) -> {
+                    MaterializedView mv = getMv(DB_NAME, "wrapper_test_mv16");
+                    MaterializedViewWrapper wrapper = MaterializedViewWrapper.create(mv, 0, null);
+
+                    Assertions.assertEquals(mv, wrapper.getMV());
+                    Assertions.assertEquals(0, wrapper.getLevel());
+                    Assertions.assertNull(wrapper.getMvPlanContext());
+                });
     }
 }

--- a/test/sql/test_materialized_view/R/test_nested_mv_rewrite
+++ b/test/sql/test_materialized_view/R/test_nested_mv_rewrite
@@ -4,8 +4,7 @@ ffund_union string,
  famt bigint, 
   fuser_id string,
   fdate bigint
-)
-PARTITION BY range(fdate) (
+)PARTITION BY range(fdate) (
     PARTITION p1 VALUES LESS THAN ("20230703"),
     PARTITION p2 VALUES LESS THAN ("20230706"),
     PARTITION p3 VALUES LESS THAN ("20230716")
@@ -14,19 +13,22 @@ PARTITION BY range(fdate) (
   PROPERTIES (
     "replication_num" = "1"
 );
-
+-- result:
+-- !result
 insert into  dal_aaaa (ffund_union,famt,fuser_id,fdate)
 values ('xfdfdf',100,'xxxxx',20230702);
+-- result:
+-- !result
 insert into  dal_aaaa (ffund_union,famt,fuser_id,fdate)
 values ('xfdafdf',100,'xxxdxx',20230715);
-
+-- result:
+-- !result
 create table dal_bbb(
     ffund_union string, 
     famt bigint, 
     fuser_id string,
     fdate bigint
-)
-PARTITION BY range(fdate) (
+)PARTITION BY range(fdate) (
     PARTITION p1 VALUES LESS THAN ("20230703"),
     PARTITION p2 VALUES LESS THAN ("20230706"),
     PARTITION p3 VALUES LESS THAN ("20230716")
@@ -35,7 +37,8 @@ PARTITION BY range(fdate) (
  PROPERTIES (
     "replication_num" = "1"
 );
-
+-- result:
+-- !result
 create table dim_ccc(
      fdate bigint,
      `lvl1` string,
@@ -44,7 +47,8 @@ create table dim_ccc(
 PROPERTIES (
     "replication_num" = "1"
 );
-
+-- result:
+-- !result
 create MATERIALIZED VIEW join_mv1
 DISTRIBUTED BY HASH(a_ds, dim_1_ffund_union_5061_lvl1)
 REFRESH MANUAL
@@ -78,7 +82,8 @@ SELECT `fdate` AS a_ds, a.`ffund_union_5061_lvl1` AS `dim_1_ffund_union_5061_lvl
                 ON t1.`ffund_union` = t3.`ffund_union`
         ) a
         GROUP BY a_ds, `dim_1_ffund_union_5061_lvl1`;
-
+-- result:
+-- !result
 create MATERIALIZED VIEW join_mv2
 DISTRIBUTED BY HASH(a_ds, dim_1_ffund_union_5061_lvl1)
 REFRESH MANUAL
@@ -111,7 +116,8 @@ SELECT `fdate` AS a_ds, a.`ffund_union_5061_lvl1` AS `dim_1_ffund_union_5061_lvl
                     ON t12.`ffund_union` = t14.`ffund_union`
             ) a
             GROUP BY a_ds, `dim_1_ffund_union_5061_lvl1`;
-
+-- result:
+-- !result
 create MATERIALIZED VIEW join_mv3
 DISTRIBUTED BY HASH(a_ds, dim_1_ffund_union_5061_lvl1)
 REFRESH MANUAL
@@ -132,12 +138,11 @@ AS
         FULL JOIN join_mv2 t_join1
         ON coalesce(CAST(t_join0.a_ds AS string), '无值') = coalesce(CAST(t_join1.a_ds AS string), '无值')
             AND coalesce(CAST(t_join0.`dim_1_ffund_union_5061_lvl1` AS string), '无值') = coalesce(CAST(t_join1.`dim_1_ffund_union_5061_lvl1` AS string), '无值');
- 
-
+-- result:
+-- !result
 refresh materialized view join_mv1 with sync mode;
 refresh materialized view join_mv2 with sync mode;
 refresh materialized view join_mv3 with sync mode;
-
 explain logical
   SELECT CASE 
             WHEN t_join0.a_ds IS NOT NULL THEN t_join0.a_ds
@@ -213,5 +218,27 @@ explain logical
         ) t_join1
         ON coalesce(CAST(t_join0.a_ds AS string), '无值') = coalesce(CAST(t_join1.a_ds AS string), '无值')
             AND coalesce(CAST(t_join0.`dim_1_ffund_union_5061_lvl1` AS string), '无值') = coalesce(CAST(t_join1.`dim_1_ffund_union_5061_lvl1` AS string), '无值');
+select inspect_related_mv('dal_aaaa');
 -- result:
-[REGEX]join_mv3
+[{"id":.*,"name":"join_mv1","level":0,"related_mvs":[{"id":.*,"name":"join_mv3","level":1,"related_mvs":[]}]}]
+-- !result
+select inspect_related_mv('dal_bbb');
+-- result:
+[{"id":.*,"name":"join_mv2","level":0,"related_mvs":[{"id":.*,"name":"join_mv3","level":1,"related_mvs":[]}]}]
+-- !result
+select inspect_related_mv('dim_ccc');
+-- result:
+[{"id":.*,"name":"join_mv2","level":0,"related_mvs":[{"id":.*,"name":"join_mv3","level":1,"related_mvs":[]}]},{"id":.*,"name":"join_mv1","level":0,"related_mvs":[]}]
+-- !result
+select inspect_related_mv('join_mv1');
+-- result:
+[{"id":.*,"name":"join_mv3","level":0,"related_mvs":[]}]
+-- !result
+select inspect_related_mv('join_mv2');
+-- result:
+[{"id":.*,"name":"join_mv3","level":0,"related_mvs":[]}]
+-- !result
+select inspect_related_mv('join_mv3');
+-- result:
+[]
+-- !result

--- a/test/sql/test_materialized_view/R/test_nested_mv_rewrite
+++ b/test/sql/test_materialized_view/R/test_nested_mv_rewrite
@@ -218,27 +218,27 @@ explain logical
         ) t_join1
         ON coalesce(CAST(t_join0.a_ds AS string), '无值') = coalesce(CAST(t_join1.a_ds AS string), '无值')
             AND coalesce(CAST(t_join0.`dim_1_ffund_union_5061_lvl1` AS string), '无值') = coalesce(CAST(t_join1.`dim_1_ffund_union_5061_lvl1` AS string), '无值');
-select inspect_related_mv('dal_aaaa');
+[UC]select regexp_replace(inspect_related_mv('dal_aaaa'), '"id":[0-9]+', '"id":0');
 -- result:
-[{"id":.*,"name":"join_mv1","level":0,"related_mvs":[{"id":.*,"name":"join_mv3","level":1,"related_mvs":[]}]}]
+[{"id":0,"name":"join_mv1","level":0,"related_mvs":[{"id":0,"name":"join_mv3","level":1,"related_mvs":[]}]}]
 -- !result
-select inspect_related_mv('dal_bbb');
+[UC]select regexp_replace(inspect_related_mv('dal_bbb'), '"id":[0-9]+', '"id":0');
 -- result:
-[{"id":.*,"name":"join_mv2","level":0,"related_mvs":[{"id":.*,"name":"join_mv3","level":1,"related_mvs":[]}]}]
+[{"id":0,"name":"join_mv2","level":0,"related_mvs":[{"id":0,"name":"join_mv3","level":1,"related_mvs":[]}]}]
 -- !result
-select inspect_related_mv('dim_ccc');
+[UC]select regexp_replace(inspect_related_mv('dim_ccc'), '"id":[0-9]+', '"id":0');
 -- result:
-[{"id":.*,"name":"join_mv2","level":0,"related_mvs":[{"id":.*,"name":"join_mv3","level":1,"related_mvs":[]}]},{"id":.*,"name":"join_mv1","level":0,"related_mvs":[]}]
+[{"id":0,"name":"join_mv2","level":0,"related_mvs":[{"id":0,"name":"join_mv3","level":1,"related_mvs":[]}]},{"id":0,"name":"join_mv1","level":0,"related_mvs":[]}]
 -- !result
-select inspect_related_mv('join_mv1');
+[UC]select regexp_replace(inspect_related_mv('join_mv1'), '"id":[0-9]+', '"id":0');
 -- result:
-[{"id":.*,"name":"join_mv3","level":0,"related_mvs":[]}]
+[{"id":0,"name":"join_mv3","level":0,"related_mvs":[]}]
 -- !result
-select inspect_related_mv('join_mv2');
+[UC]select regexp_replace(inspect_related_mv('join_mv2'), '"id":[0-9]+', '"id":0');
 -- result:
-[{"id":.*,"name":"join_mv3","level":0,"related_mvs":[]}]
+[{"id":0,"name":"join_mv3","level":0,"related_mvs":[]}]
 -- !result
-select inspect_related_mv('join_mv3');
+[UC]select inspect_related_mv('join_mv3');
 -- result:
 []
 -- !result

--- a/test/sql/test_materialized_view/T/test_nested_mv_rewrite
+++ b/test/sql/test_materialized_view/T/test_nested_mv_rewrite
@@ -214,9 +214,9 @@ explain logical
         ON coalesce(CAST(t_join0.a_ds AS string), '无值') = coalesce(CAST(t_join1.a_ds AS string), '无值')
             AND coalesce(CAST(t_join0.`dim_1_ffund_union_5061_lvl1` AS string), '无值') = coalesce(CAST(t_join1.`dim_1_ffund_union_5061_lvl1` AS string), '无值');
 
-select inspect_related_mv('dal_aaaa');
-select inspect_related_mv('dal_bbb');
-select inspect_related_mv('dim_ccc');
-select inspect_related_mv('join_mv1');
-select inspect_related_mv('join_mv2');
-select inspect_related_mv('join_mv3');
+[UC]select regexp_replace(inspect_related_mv('dal_aaaa'), '"id":[0-9]+', '"id":0');
+[UC]select regexp_replace(inspect_related_mv('dal_bbb'), '"id":[0-9]+', '"id":0');
+[UC]select regexp_replace(inspect_related_mv('dim_ccc'), '"id":[0-9]+', '"id":0');
+[UC]select regexp_replace(inspect_related_mv('join_mv1'), '"id":[0-9]+', '"id":0');
+[UC]select regexp_replace(inspect_related_mv('join_mv2'), '"id":[0-9]+', '"id":0');
+[UC]select inspect_related_mv('join_mv3');

--- a/test/sql/test_materialized_view/T/test_nested_mv_rewrite
+++ b/test/sql/test_materialized_view/T/test_nested_mv_rewrite
@@ -213,3 +213,10 @@ explain logical
         ) t_join1
         ON coalesce(CAST(t_join0.a_ds AS string), '无值') = coalesce(CAST(t_join1.a_ds AS string), '无值')
             AND coalesce(CAST(t_join0.`dim_1_ffund_union_5061_lvl1` AS string), '无值') = coalesce(CAST(t_join1.`dim_1_ffund_union_5061_lvl1` AS string), '无值');
+
+select inspect_related_mv('dal_aaaa');
+select inspect_related_mv('dal_bbb');
+select inspect_related_mv('dim_ccc');
+select inspect_related_mv('join_mv1');
+select inspect_related_mv('join_mv2');
+select inspect_related_mv('join_mv3');


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
- Optimize inspect_related_mvs meta function to display related mvs relatively.

This pull request refactors the handling of related materialized views (MVs) in the optimizer and catalog code. The main change is a shift from using unordered sets to sorted lists and sets, ensuring deterministic ordering by MV level and simplifying deduplication and filtering logic. Additionally, the `MvId` class now supports lazy name resolution, and recursive MV relationships are now exposed in meta functions. These changes improve MV selection, usability, and maintainability.

### Materialized View (MV) Selection and Ordering

* Changed related MV collections in `MvRewritePreprocessor` and `MaterializedViewWrapper` from `Set` to `List` or `SortedSet`, and implemented deterministic ordering by MV level using `Comparable` in `MaterializedViewWrapper`. This ensures predictable MV selection and deduplication. [[1]](diffhunk://#diff-565dceabf92a7345c0008486fed83f5c2e42e70236ca44e2598a4bf2e2aaaf5eL138-R153) [[2]](diffhunk://#diff-565dceabf92a7345c0008486fed83f5c2e42e70236ca44e2598a4bf2e2aaaf5eL380-R386) [[3]](diffhunk://#diff-565dceabf92a7345c0008486fed83f5c2e42e70236ca44e2598a4bf2e2aaaf5eL616-R635) [[4]](diffhunk://#diff-68b00d2dc3e9b0c59a2206434b53c8192218a2d14111b8f01dd07ea08ce5ecbaL22-R22) [[5]](diffhunk://#diff-68b00d2dc3e9b0c59a2206434b53c8192218a2d14111b8f01dd07ea08ce5ecbaL76-R82) [[6]](diffhunk://#diff-2bb26249a2c1cd7977c10054f3fdfe6041cbe990f4ab008c1cbeb11e8a1f74afL142-R155)
* Updated MV filtering and selection methods to work with lists, including filtering by user config and limiting candidates, improving the pipeline for MV rewrite. (Fcf83791L24R28, [[1]](diffhunk://#diff-565dceabf92a7345c0008486fed83f5c2e42e70236ca44e2598a4bf2e2aaaf5eR355-R375) [[2]](diffhunk://#diff-565dceabf92a7345c0008486fed83f5c2e42e70236ca44e2598a4bf2e2aaaf5eL575-R581)

### Catalog and MV Metadata Improvements

* Added lazy name resolution to `MvId`, allowing the name to be fetched only when needed and improving `toString()` output for better debugging and logging. [[1]](diffhunk://#diff-7932c93b3b4de7f303489480777fb0894f9d3268068e1fdf03f54f49a1e307f2R17-R21) [[2]](diffhunk://#diff-7932c93b3b4de7f303489480777fb0894f9d3268068e1fdf03f54f49a1e307f2R31-R36) [[3]](diffhunk://#diff-7932c93b3b4de7f303489480777fb0894f9d3268068e1fdf03f54f49a1e307f2R64-R90)
* Refactored MV addition in `QueryMaterializationContext` to add single MVs instead of sets, simplifying the API.

### MV Hierarchy and Meta Functions

* Enhanced the `inspect_related_mv` meta function to recursively traverse and return all nested related MVs in a JSON array, exposing the MV hierarchy for inspection and debugging.

### Internal Consistency and Code Quality

* Updated hash and equality logic in `MaterializedViewWrapper` to only consider the MV, and implemented `Comparable` for sorting by level and hash, ensuring consistent behavior in collections. [[1]](diffhunk://#diff-68b00d2dc3e9b0c59a2206434b53c8192218a2d14111b8f01dd07ea08ce5ecbaL56-R60) [[2]](diffhunk://#diff-68b00d2dc3e9b0c59a2206434b53c8192218a2d14111b8f01dd07ea08ce5ecbaL76-R82)
* Changed MV utility methods in `MvUtils` to return `SortedSet` for deterministic ordering and easier deduplication. [[1]](diffhunk://#diff-2bb26249a2c1cd7977c10054f3fdfe6041cbe990f4ab008c1cbeb11e8a1f74afR132) [[2]](diffhunk://#diff-2bb26249a2c1cd7977c10054f3fdfe6041cbe990f4ab008c1cbeb11e8a1f74afL142-R155)

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes inspect_related_mv return a nested MV hierarchy and refactors MV selection to deterministic, level-based ordering; adds lazy MV name resolution in MvId.
> 
> - **Meta functions**:
>   - `inspect_related_mv` now recursively returns nested related MVs with `level` and `related_mvs` fields.
> - **Optimizer**:
>   - Switch MV collections from `Set` to `List`/`SortedSet` for deterministic, level-based ordering in `MvRewritePreprocessor` and `MvUtils`.
>   - Update filtering/selection pipeline to operate on lists; candidate addition via `addRelatedMV`.
>   - `MaterializedViewWrapper` now `Comparable`; equality/hash by `mv`, ordering by `level` then `mv.id`.
> - **Catalog**:
>   - `MvId` adds lazy name resolution and improved `toString()` (prints `db.table` or `dbId.id`).
> - **Tests/SQL**:
>   - Add/adjust unit and SQL tests for nested MV inspection, ordering, timeouts, and new APIs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a983503bc0259a2f77d50e1912c71a95b8385b00. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->