### PR TITLE
[BugFix] Fix MaterializedView colocate metadata not persisted to EditLog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -49,7 +49,6 @@ import com.starrocks.connector.PartitionUtil;
 import com.starrocks.metric.MaterializedViewMetricsRegistry;
 import com.starrocks.mv.analyzer.MVPartitionExpr;
 import com.starrocks.persist.AlterMaterializedViewBaseTableInfosLog;
-import com.starrocks.persist.ColocatePersistInfo;
 import com.starrocks.persist.ExpressionSerializedObject;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.persist.gson.GsonPreProcessable;
@@ -1278,16 +1277,8 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      */
     @Override
     public void onCreate(Database database) throws DdlException {
+        super.onCreate(database);
         onReload(false, isActive(), true);
-        
-        ColocateTableIndex colocateTableIndex = GlobalStateMgr.getCurrentState().getColocateTableIndex();
-        if (colocateTableIndex.isColocateTable(getId())) {
-            ColocateTableIndex.GroupId groupId = colocateTableIndex.getGroup(getId());
-            List<List<Long>> backendsPerBucketSeq = colocateTableIndex.getBackendsPerBucketSeq(groupId);
-            ColocatePersistInfo colocatePersistInfo = ColocatePersistInfo.createForAddTable(groupId, getId(),
-                    backendsPerBucketSeq);
-            GlobalStateMgr.getCurrentState().getEditLog().logColocateAddTable(colocatePersistInfo);
-        }
     }
 
     /**


### PR DESCRIPTION
## Why I'm doing:

When creating a materialized view with `colocate_with` property, the MV is correctly added to the colocate group on the Leader FE (in-memory state), but the colocate metadata is not written to the EditLog. This causes Follower FEs to miss the colocate group information when replaying the EditLog, resulting in:

1. The MV is not in the colocate group on Follower FEs
2. Queries involving MV joins on Follower FEs use `BUCKET_SHUFFLE` instead of `COLOCATE` join, leading to performance degradation

This issue was introduced by PR #64914 (backported on Nov 4, 2025), which added `MaterializedView.onCreate()` to validate MV definitions during creation, but failed to write colocate metadata to the EditLog.

## What I'm doing:

Add colocate metadata persistence logic in `MaterializedView.onCreate()`:


This ensures:
- Leader FE: MV is in the colocate group (in-memory state + EditLog)
- Follower FEs: MV can correctly replay the colocate group information from EditLog and use colocate join


Fixes 
https://github.com/StarRocks/StarRocksTest/issues/10563

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
