### PR TITLE
[BugFix] Fix ingestion failed during alter

### DIFF
--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -402,10 +402,9 @@ void DataDir::load() {
                 rowset_meta->set_tablet_schema(tablet_schema_ptr);
                 rowset_meta->set_skip_tablet_schema(true);
             }
-            Status commit_txn_status = _txn_manager->commit_txn(
-                    _kv_store, rowset_meta->partition_id(), rowset_meta->txn_id(), rowset_meta->tablet_id(),
-                    rowset_meta->tablet_schema_hash(), rowset_meta->tablet_uid(), rowset_meta->load_id(), rowset, true,
-                    tablet->tablet_state() != TABLET_RUNNING, tablet);
+            Status commit_txn_status = _txn_manager->commit_txn(tablet, rowset_meta->partition_id(),
+                                                                rowset_meta->txn_id(), rowset_meta->load_id(), rowset,
+                                                                true, tablet->tablet_state() != TABLET_RUNNING);
             if (!commit_txn_status.ok() && !commit_txn_status.is_already_exist()) {
                 LOG(WARNING) << "Fail to add committed rowset=" << rowset_meta->rowset_id()
                              << " tablet=" << rowset_meta->tablet_id() << " txn_id: " << rowset_meta->txn_id();

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -405,7 +405,7 @@ void DataDir::load() {
             Status commit_txn_status = _txn_manager->commit_txn(
                     _kv_store, rowset_meta->partition_id(), rowset_meta->txn_id(), rowset_meta->tablet_id(),
                     rowset_meta->tablet_schema_hash(), rowset_meta->tablet_uid(), rowset_meta->load_id(), rowset, true,
-                    tablet->tablet_state() != TABLET_RUNNING);
+                    tablet->tablet_state() != TABLET_RUNNING, tablet);
             if (!commit_txn_status.ok() && !commit_txn_status.is_already_exist()) {
                 LOG(WARNING) << "Fail to add committed rowset=" << rowset_meta->rowset_id()
                              << " tablet=" << rowset_meta->tablet_id() << " txn_id: " << rowset_meta->txn_id();

--- a/be/src/storage/txn_manager.cpp
+++ b/be/src/storage/txn_manager.cpp
@@ -218,7 +218,6 @@ Status TxnManager::prepare_txn(TPartitionId partition_id, TTransactionId transac
 Status TxnManager::commit_txn(const TabletSharedPtr& tablet, TPartitionId partition_id, TTransactionId transaction_id,
                               const PUniqueId& load_id, const RowsetSharedPtr& rowset_ptr, bool is_recovery,
                               bool is_shadow) {
-    DCHECK(tablet != nullptr);
     if (tablet == nullptr) {
         return Status::InternalError("tablet not exist during commit txn");
     }

--- a/be/src/storage/txn_manager.cpp
+++ b/be/src/storage/txn_manager.cpp
@@ -215,11 +215,10 @@ Status TxnManager::prepare_txn(TPartitionId partition_id, TTransactionId transac
     return Status::OK();
 }
 
-Status TxnManager::commit_txn(KVStore* meta, TPartitionId partition_id, TTransactionId transaction_id,
-                              TTabletId tablet_id, SchemaHash schema_hash, const TabletUid& tablet_uid,
+Status TxnManager::commit_txn(const TabletSharedPtr& tablet, TPartitionId partition_id, TTransactionId transaction_id,
                               const PUniqueId& load_id, const RowsetSharedPtr& rowset_ptr, bool is_recovery,
-                              bool is_shadow, const TabletSharedPtr& tablet) {
-    DCEHCK(tablet != nullptr);
+                              bool is_shadow) {
+    DCHECK(tablet != nullptr);
     if (tablet == nullptr) {
         return Status::InternalError("tablet not exist during commit txn");
     }

--- a/be/src/storage/txn_manager.cpp
+++ b/be/src/storage/txn_manager.cpp
@@ -150,8 +150,7 @@ Status TxnManager::commit_txn(TPartitionId partition_id, const TabletSharedPtr& 
                               bool is_shadow) {
     auto scoped =
             trace::Scope(Tracer::Instance().start_trace_txn_tablet("txn_commit", transaction_id, tablet->tablet_id()));
-    return commit_txn(tablet->data_dir()->get_meta(), partition_id, transaction_id, tablet->tablet_id(),
-                      tablet->schema_hash(), tablet->tablet_uid(), load_id, rowset_ptr, is_recovery, is_shadow, tablet);
+    return commit_txn(tablet, partition_id, transaction_id, load_id, rowset_ptr, is_recovery, is_shadow);
 }
 
 // delete the txn from manager if it is not committed(not have a valid rowset)
@@ -220,6 +219,15 @@ Status TxnManager::commit_txn(KVStore* meta, TPartitionId partition_id, TTransac
                               TTabletId tablet_id, SchemaHash schema_hash, const TabletUid& tablet_uid,
                               const PUniqueId& load_id, const RowsetSharedPtr& rowset_ptr, bool is_recovery,
                               bool is_shadow, const TabletSharedPtr& tablet) {
+    DCEHCK(tablet != nullptr);
+    if (tablet == nullptr) {
+        return Status::InternalError("tablet not exist during commit txn");
+    }
+    auto meta = tablet->data_dir()->get_meta();
+    auto tablet_id = tablet->tablet_id();
+    auto schema_hash = tablet->schema_hash();
+    auto tablet_uid = tablet->tablet_uid();
+
     if (partition_id < 1 || transaction_id < 1 || tablet_id < 1) {
         LOG(FATAL) << "Invalid commit req "
                    << " partition_id=" << partition_id << " txn_id: " << transaction_id << " tablet_id=" << tablet_id;
@@ -270,10 +278,6 @@ Status TxnManager::commit_txn(KVStore* meta, TPartitionId partition_id, TTransac
     // if not in recovery mode, then should persist the meta to meta env
     // save meta need access disk, it maybe very slow, so that it is not in global txn lock
     // it is under a single txn lock
-    if (tablet == nullptr) {
-        return Status::InternalError("tablet not exist during commit txn");
-    }
-
     if (!is_recovery) {
         Status st;
         RowsetMetaPB rowset_meta_pb;

--- a/be/src/storage/txn_manager.h
+++ b/be/src/storage/txn_manager.h
@@ -128,7 +128,8 @@ public:
 
     Status commit_txn(KVStore* meta, TPartitionId partition_id, TTransactionId transaction_id, TTabletId tablet_id,
                       SchemaHash schema_hash, const TabletUid& tablet_uid, const PUniqueId& load_id,
-                      const RowsetSharedPtr& rowset_ptr, bool is_recovery, bool is_shadow);
+                      const RowsetSharedPtr& rowset_ptr, bool is_recovery, bool is_shadow,
+                      const TabletSharedPtr& tablet);
 
     // delete the txn from manager if it is not committed(not have a valid rowset)
     Status rollback_txn(TPartitionId partition_id, TTransactionId transaction_id, TTabletId tablet_id,

--- a/be/src/storage/txn_manager.h
+++ b/be/src/storage/txn_manager.h
@@ -126,10 +126,8 @@ public:
     Status prepare_txn(TPartitionId partition_id, TTransactionId transaction_id, TTabletId tablet_id,
                        SchemaHash schema_hash, const TabletUid& tablet_uid, const PUniqueId& load_id);
 
-    Status commit_txn(KVStore* meta, TPartitionId partition_id, TTransactionId transaction_id, TTabletId tablet_id,
-                      SchemaHash schema_hash, const TabletUid& tablet_uid, const PUniqueId& load_id,
-                      const RowsetSharedPtr& rowset_ptr, bool is_recovery, bool is_shadow,
-                      const TabletSharedPtr& tablet);
+    Status commit_txn(const TabletSharedPtr& tablet, TPartitionId partition_id, TTransactionId transaction_id,
+                      const PUniqueId& load_id, const RowsetSharedPtr& rowset_ptr, bool is_recovery, bool is_shadow);
 
     // delete the txn from manager if it is not committed(not have a valid rowset)
     Status rollback_txn(TPartitionId partition_id, TTransactionId transaction_id, TTabletId tablet_id,

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -463,6 +463,7 @@ SET(DW_TEST_FILES
     ./storage/conjunctive_predicates_test.cpp
     ./storage/convert_helper_test.cpp
     ./storage/cumulative_compaction_test.cpp
+    ./storage/data_dir_test.cpp
     ./storage/decimal12_test.cpp
     ./storage/default_compaction_policy_test.cpp
     ./storage/delete_handler_test.cpp

--- a/be/test/storage/data_dir_test.cpp
+++ b/be/test/storage/data_dir_test.cpp
@@ -1,0 +1,125 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/data_dir.h"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <memory>
+
+#include "gen_cpp/Types_types.h"
+#include "gen_cpp/olap_file.pb.h"
+#include "storage/olap_common.h"
+#include "storage/rowset/rowset_factory.h"
+#include "storage/rowset/rowset_meta.h"
+#include "storage/rowset/rowset_meta_manager.h"
+#include "storage/tablet.h"
+#include "storage/tablet_manager.h"
+#include "storage/tablet_meta.h"
+#include "storage/tablet_meta_manager.h"
+#include "storage/txn_manager.h"
+
+namespace starrocks {
+
+namespace sfs = std::filesystem;
+
+class DataDirTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Create TabletManager and TxnManager
+        _tablet_manager = std::make_unique<TabletManager>(1);
+        _txn_manager = std::make_unique<TxnManager>(1, 1, 1);
+        sfs::path tmp = sfs::temp_directory_path();
+        sfs::path dir = tmp / "data_dir_test";
+        sfs::remove_all(dir);
+        CHECK(sfs::create_directory(dir));
+        _data_dir =
+                std::make_unique<DataDir>(dir.string(), TStorageMedium::HDD, _tablet_manager.get(), _txn_manager.get());
+        ASSERT_TRUE(_data_dir->init().ok());
+    }
+
+    void TearDown() override { _data_dir.reset(); }
+
+    std::unique_ptr<DataDir> _data_dir;
+    std::unique_ptr<TabletManager> _tablet_manager;
+    std::unique_ptr<TxnManager> _txn_manager;
+};
+
+// NOLINTNEXTLINE
+TEST_F(DataDirTest, test_load_committed_rowset_meta) {
+    // Create tablet using TabletManager
+    TCreateTabletReq create_tablet_req;
+    create_tablet_req.tablet_id = 2001;
+    create_tablet_req.__set_version(1);
+    create_tablet_req.__set_version_hash(0);
+    create_tablet_req.tablet_schema.__set_id(1);
+    create_tablet_req.tablet_schema.__set_schema_hash(3001);
+    create_tablet_req.tablet_schema.__set_keys_type(TKeysType::DUP_KEYS);
+    create_tablet_req.tablet_schema.__set_short_key_column_count(1);
+    create_tablet_req.tablet_schema.__set_storage_type(TStorageType::COLUMN);
+    TColumn k0;
+    k0.column_name = "c0";
+    k0.__set_is_key(true);
+    TColumnType ctype;
+    ctype.__set_type(TPrimitiveType::INT);
+    ctype.__set_len(4);
+    k0.__set_column_type(ctype);
+    create_tablet_req.tablet_schema.columns.push_back(k0);
+
+    std::vector<DataDir*> data_dirs;
+    data_dirs.push_back(_data_dir.get());
+    Status create_st = _tablet_manager->create_tablet(create_tablet_req, data_dirs);
+    ASSERT_TRUE(create_st.ok()) << create_st.to_string();
+
+    // Get the created tablet
+    TabletSharedPtr tablet = _tablet_manager->get_tablet(2001);
+    ASSERT_TRUE(tablet != nullptr);
+
+    // Create a rowset meta with COMMITTED state
+    RowsetMetaPB rowset_meta_pb;
+    rowset_meta_pb.set_rowset_id("001");
+    rowset_meta_pb.set_rowset_seg_id(0);
+    rowset_meta_pb.set_partition_id(1001);
+    rowset_meta_pb.set_txn_id(5001);
+    rowset_meta_pb.set_tablet_id(2001);
+    rowset_meta_pb.set_tablet_schema_hash(3001);
+    // Use the actual tablet uid from the created tablet
+    rowset_meta_pb.mutable_tablet_uid()->set_lo(tablet->tablet_uid().lo);
+    rowset_meta_pb.mutable_tablet_uid()->set_hi(tablet->tablet_uid().hi);
+    rowset_meta_pb.set_rowset_state(RowsetStatePB::COMMITTED);
+    rowset_meta_pb.set_start_version(1);
+    rowset_meta_pb.set_end_version(1);
+    rowset_meta_pb.set_num_rows(100);
+    rowset_meta_pb.set_num_segments(1);
+    rowset_meta_pb.set_data_disk_size(1024);
+    rowset_meta_pb.set_empty(false);
+    rowset_meta_pb.set_creation_time(time(nullptr));
+    rowset_meta_pb.mutable_load_id()->set_hi(1);
+    rowset_meta_pb.mutable_load_id()->set_lo(2);
+    rowset_meta_pb.set_deprecated_rowset_id(0);
+
+    // Copy tablet schema to rowset meta from the created tablet
+    TabletSchemaPB schema_pb;
+    tablet->tablet_schema()->to_schema_pb(&schema_pb);
+    rowset_meta_pb.mutable_tablet_schema()->CopyFrom(schema_pb);
+
+    // Save rowset meta to KVStore
+    TabletUid tablet_uid = tablet->tablet_uid();
+    ASSERT_TRUE(RowsetMetaManager::save(_data_dir->get_meta(), tablet_uid, rowset_meta_pb).ok());
+    _tablet_manager->drop_tablet(2001, kKeepMetaAndFiles);
+    _data_dir->load();
+}
+
+} // namespace starrocks

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -3951,7 +3951,7 @@ TEST_F(TabletUpdatesTest, test_skip_schema) {
     ASSERT_TRUE(StorageEngine::instance()
                         ->txn_manager()
                         ->commit_txn(_tablet->data_dir()->get_meta(), 100, 100, _tablet->tablet_id(),
-                                     _tablet->schema_hash(), _tablet->tablet_uid(), load_id, rs1, false, false)
+                                     _tablet->schema_hash(), _tablet->tablet_uid(), load_id, rs1, false, false, _tablet)
                         .ok());
     ASSERT_EQ(true, rs1->rowset_meta()->skip_tablet_schema());
     ASSERT_EQ(1, _tablet->committed_rowset_size());
@@ -3990,7 +3990,7 @@ TEST_F(TabletUpdatesTest, test_skip_schema) {
     ASSERT_TRUE(StorageEngine::instance()
                         ->txn_manager()
                         ->commit_txn(_tablet->data_dir()->get_meta(), 101, 101, _tablet->tablet_id(),
-                                     _tablet->schema_hash(), _tablet->tablet_uid(), load_id, rs2, false, false)
+                                     _tablet->schema_hash(), _tablet->tablet_uid(), load_id, rs2, false, false, _tablet)
                         .ok());
     ASSERT_EQ(true, rs2->rowset_meta()->skip_tablet_schema());
     ASSERT_EQ(1, _tablet->committed_rowset_size());
@@ -4039,7 +4039,7 @@ TEST_F(TabletUpdatesTest, test_skip_schema) {
     ASSERT_TRUE(StorageEngine::instance()
                         ->txn_manager()
                         ->commit_txn(_tablet->data_dir()->get_meta(), 102, 102, _tablet->tablet_id(),
-                                     _tablet->schema_hash(), _tablet->tablet_uid(), load_id, rs3, false, false)
+                                     _tablet->schema_hash(), _tablet->tablet_uid(), load_id, rs3, false, false, _tablet)
                         .ok());
     ASSERT_EQ(false, rs3->rowset_meta()->skip_tablet_schema());
     ASSERT_EQ(0, _tablet->committed_rowset_size());
@@ -4064,7 +4064,7 @@ TEST_F(TabletUpdatesTest, test_skip_schema) {
     ASSERT_TRUE(StorageEngine::instance()
                         ->txn_manager()
                         ->commit_txn(_tablet->data_dir()->get_meta(), 103, 103, _tablet->tablet_id(),
-                                     _tablet->schema_hash(), _tablet->tablet_uid(), load_id, rs4, false, false)
+                                     _tablet->schema_hash(), _tablet->tablet_uid(), load_id, rs4, false, false, _tablet)
                         .ok());
     ASSERT_EQ(true, rs4->rowset_meta()->skip_tablet_schema());
     ASSERT_EQ(1, _tablet->committed_rowset_size());

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -3948,11 +3948,8 @@ TEST_F(TabletUpdatesTest, test_skip_schema) {
     PUniqueId load_id;
     load_id.set_hi(1000);
     load_id.set_lo(1000);
-    ASSERT_TRUE(StorageEngine::instance()
-                        ->txn_manager()
-                        ->commit_txn(_tablet->data_dir()->get_meta(), 100, 100, _tablet->tablet_id(),
-                                     _tablet->schema_hash(), _tablet->tablet_uid(), load_id, rs1, false, false, _tablet)
-                        .ok());
+    ASSERT_TRUE(
+            StorageEngine::instance()->txn_manager()->commit_txn(_tablet, 100, 100, load_id, rs1, false, false).ok());
     ASSERT_EQ(true, rs1->rowset_meta()->skip_tablet_schema());
     ASSERT_EQ(1, _tablet->committed_rowset_size());
     ASSERT_TRUE(rs1->tablet_schema() != nullptr);
@@ -3987,11 +3984,8 @@ TEST_F(TabletUpdatesTest, test_skip_schema) {
     ASSERT_EQ(false, rs2->rowset_meta()->skip_tablet_schema());
     load_id.set_hi(1001);
     load_id.set_lo(1001);
-    ASSERT_TRUE(StorageEngine::instance()
-                        ->txn_manager()
-                        ->commit_txn(_tablet->data_dir()->get_meta(), 101, 101, _tablet->tablet_id(),
-                                     _tablet->schema_hash(), _tablet->tablet_uid(), load_id, rs2, false, false, _tablet)
-                        .ok());
+    ASSERT_TRUE(
+            StorageEngine::instance()->txn_manager()->commit_txn(_tablet, 101, 101, load_id, rs2, false, false).ok());
     ASSERT_EQ(true, rs2->rowset_meta()->skip_tablet_schema());
     ASSERT_EQ(1, _tablet->committed_rowset_size());
     ASSERT_TRUE(rs2->tablet_schema() != nullptr);
@@ -4036,11 +4030,8 @@ TEST_F(TabletUpdatesTest, test_skip_schema) {
     _tablet->set_update_schema_running(true);
     load_id.set_hi(1002);
     load_id.set_lo(1002);
-    ASSERT_TRUE(StorageEngine::instance()
-                        ->txn_manager()
-                        ->commit_txn(_tablet->data_dir()->get_meta(), 102, 102, _tablet->tablet_id(),
-                                     _tablet->schema_hash(), _tablet->tablet_uid(), load_id, rs3, false, false, _tablet)
-                        .ok());
+    ASSERT_TRUE(
+            StorageEngine::instance()->txn_manager()->commit_txn(_tablet, 102, 102, load_id, rs3, false, false).ok());
     ASSERT_EQ(false, rs3->rowset_meta()->skip_tablet_schema());
     ASSERT_EQ(0, _tablet->committed_rowset_size());
     ASSERT_TRUE(rs3->tablet_schema() != nullptr);
@@ -4061,11 +4052,8 @@ TEST_F(TabletUpdatesTest, test_skip_schema) {
     ASSERT_EQ(false, rs4->rowset_meta()->skip_tablet_schema());
     load_id.set_hi(1003);
     load_id.set_lo(1003);
-    ASSERT_TRUE(StorageEngine::instance()
-                        ->txn_manager()
-                        ->commit_txn(_tablet->data_dir()->get_meta(), 103, 103, _tablet->tablet_id(),
-                                     _tablet->schema_hash(), _tablet->tablet_uid(), load_id, rs4, false, false, _tablet)
-                        .ok());
+    ASSERT_TRUE(
+            StorageEngine::instance()->txn_manager()->commit_txn(_tablet, 103, 103, load_id, rs4, false, false).ok());
     ASSERT_EQ(true, rs4->rowset_meta()->skip_tablet_schema());
     ASSERT_EQ(1, _tablet->committed_rowset_size());
     ASSERT_TRUE(rs4->tablet_schema() != nullptr);


### PR DESCRIPTION
## Why I'm doing:
Import tasks may fail during ALTER execution, as the tablet being written to could be dropped by the ALTER task:
1. At t1, the import starts and writes data to tablet1.
2. At t2, the ALTER completes and issues a drop command for tablet1.
3. At t3, the write finishes, but when committing the transaction (TxnManager::commit_txn), `TabletManager::get_tablet` fails to find the corresponding tablet, resulting in a write failure.

## What I'm doing:
Tablet is captured before import task start, so we should use tablet ref but not get tablet according tablet id.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors TxnManager::commit_txn to accept a TabletSharedPtr and derive meta/ids internally, updates call sites, and adds a unit test for loading committed rowset meta.
> 
> - **Storage**:
>   - **TxnManager**: Change `commit_txn` signature to take `TabletSharedPtr`; derive `meta`, `tablet_id`, `schema_hash`, `tablet_uid` from `tablet` and add null checks.
>   - **DataDir**: In `load()`, use new `commit_txn(tablet, ...)` when loading COMMITTED rowsets.
> - **Tests**:
>   - Update `tablet_updates_test.cpp` to use new `commit_txn` API.
>   - Add `storage/data_dir_test.cpp` to verify loading of committed rowset meta; register in `be/test/CMakeLists.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca6b257d0bbaaa4bf3c12676f10d745f7995ce8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->