### PR TITLE
[Enhancement] close prune complex type default

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -2613,7 +2613,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = CBO_REORDER_THRESHOLD_USE_EXHAUSTIVE)
     private int cboReorderThresholdUseExhaustive = 6;
 
-    @VarAttr(name = "enable_prune_complex_types_v2", show = ENABLE_PRUNE_COMPLEX_TYPES)
+    @VarAttr(name = "enable_prune_complex_types_v2", alias = ENABLE_PRUNE_COMPLEX_TYPES, show = ENABLE_PRUNE_COMPLEX_TYPES)
     private boolean enablePruneComplexTypes = false;
 
     @VarAttr(name = ENABLE_SUBFIELD_NO_COPY)

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -2613,8 +2613,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = CBO_REORDER_THRESHOLD_USE_EXHAUSTIVE)
     private int cboReorderThresholdUseExhaustive = 6;
 
-    @VarAttr(name = ENABLE_PRUNE_COMPLEX_TYPES)
-    private boolean enablePruneComplexTypes = true;
+    @VarAttr(name = "enable_prune_complex_types_v2", show = ENABLE_PRUNE_COMPLEX_TYPES)
+    private boolean enablePruneComplexTypes = false;
 
     @VarAttr(name = ENABLE_SUBFIELD_NO_COPY)
     private boolean enableSubfieldNoCopy = true;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveSubfieldPrunePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveSubfieldPrunePlanTest.java
@@ -27,6 +27,7 @@ public class HiveSubfieldPrunePlanTest extends PlanTestBase {
 
     @Test
     public void testAggCTE() throws Exception {
+        connectContext.getSessionVariable().setEnablePruneComplexTypes(true);
         String sql = "with stream as (select array_agg(col_struct.c0) as t1 from hive0.subfield_db.subfield group by " +
                 "col_int) select t1 from stream";
         String plan = getVerboseExplain(sql);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Default-disables `enable_prune_complex_types` (introducing `enable_prune_complex_types_v2` with alias) and updates a Hive subfield pruning test to explicitly enable it.
> 
> - **Session variables**:
>   - `enable_prune_complex_types`: underlying var renamed to `enable_prune_complex_types_v2` with alias/show to `enable_prune_complex_types`; default changed to `false`.
> - **Tests**:
>   - `HiveSubfieldPrunePlanTest`: explicitly enables `enable_prune_complex_types` before asserting pruning behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53d17afd9551acde3acff725498320fdd50d40ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->