### PR TITLE
[BugFix] Fix merge union to values cause wrong nullable property

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
@@ -722,4 +722,28 @@ public class SetTest extends PlanTestBase {
                 + "         row([1,2,3], [4,5,6]) | row([1,2,3], [4,5,6]).col1[true]\n"
                 + "         row([5,6,7], [6,7]) | row([5,6,7], [6,7]).col1[true]");
     }
+
+    @Test
+    public void testUnionMulNull() throws Exception {
+        String sql = "WITH\n" +
+                "`CTE_0` AS (\n" +
+                "    SELECT \"table\" AS `TABLE_NAME`\n" +
+                "),\n" +
+                "`CTE_1` AS (\n" +
+                "    SELECT `TABLE_NAME` AS `TABLE_NAME`\n" +
+                "    FROM `CTE_0`\n" +
+                "    LIMIT 2147483646\n" +
+                ")\n" +
+                "SELECT `TABLE_NAME` FROM `CTE_1`\n" +
+                "    UNION ALL (SELECT NULL)\n" +
+                "    UNION ALL (SELECT NULL)\n" +
+                "    UNION ALL (SELECT NULL)";
+        final String plan = getCostExplain(sql);
+        assertContains(plan, "  0:UNION\n" +
+                "  |  output exprs:\n" +
+                "  |      [14, VARCHAR, true]\n" +
+                "  |  child exprs:\n" +
+                "  |      [4: TABLE_NAME, VARCHAR, false]\n" +
+                "  |      [17: TABLE_NAME, VARCHAR, true]");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

```
UNKNOWN RELEASE (build UNKNOWN distro ubuntu arch x86_64)
query_id:019a7b07-5846-729d-b7ab-b0b9378a288e, fragment_instance:019a7b07-5846-729d-b7ab-b0b9378a2891
*** Aborted at 1763000670 (unix time) try "date -d @1763000670" if you are using GNU date ***
PC: @          0x76c7bc8 void std::vector<unsigned char, starrocks::raw::RawAllocator<unsigned char, 16ul, starrocks::ColumnAllocator<unsigned char> > >:
:_M_range_insert<unsigned char const*>(__gnu_cxx::__normal_iterator<unsigned char*, std::vector<unsigned char, starrocks::raw::Rc^A
*** SIGSEGV (@0x0) received by PID 4027542 (TID 0x7f4e77dfc640) LWP(4029847) from PID 0; stack trace: ***
    @     0x7f4fe118bee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @          0xdbc3688 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7f4fe1134520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @          0x76c7bc8 void std::vector<unsigned char, starrocks::raw::RawAllocator<unsigned char, 16ul, starrocks::ColumnAllocator<unsigned char> > >:
:_M_range_insert<unsigned char const*>(__gnu_cxx::__normal_iterator<unsigned char*, std::vector<unsigned char, starrocks::raw::Rc^A
    @          0x76dd2c1 starrocks::BinaryColumnBase<unsigned int>::append(starrocks::Column const&, unsigned long, unsigned long)
    @          0x94929f5 starrocks::pipeline::UnionConstSourceOperator::pull_chunk(starrocks::RuntimeState*)
    @          0x941c19b starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0x9405ae1 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0xcb27498 starrocks::ThreadPool::dispatch_thread()
    @          0xcb1e445 starrocks::Thread::supervise_thread(void*)
    @     0x7f4fe1186ac3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
    @     0x7f4fe12188c0 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x1268bf)
```

## What I'm doing:

reproduce case see test case.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
