### PR TITLE
[Enhancement] disable table stats when single table for all connectors

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
@@ -146,14 +146,7 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
     public Statistics getTableStatistics(OptimizerContext session, Table table, Map<ColumnRefOperator, Column> columns,
                                          List<PartitionKey> partitionKeys, ScalarOperator predicate, long limit,
                                          TvrVersionRange versionRange) {
-        boolean useDefaultStats = false;
         if (!properties.enableGetTableStatsFromExternalMetadata()) {
-            useDefaultStats = true;
-        }
-        if (session.getSessionVariable().disableTableStatsFromMetadataForSingleTable() && session.getSourceTablesCount() == 1) {
-            useDefaultStats = true;
-        }
-        if (useDefaultStats) {
             return StatisticsUtils.buildDefaultStatistics(columns.keySet());
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1081,7 +1081,7 @@ public class IcebergMetadata implements ConnectorMetadata {
                             IcebergMetricsReporter metricsReporter =
                                     ((StarRocksIcebergTableScan) tableScan).getMetricsReporter();
                             if (metricsReporter.getScanReport() != null) {
-                                String name = "ICEBERG.ScanMetrics." + 
+                                String name = "ICEBERG.ScanMetrics." +
                                         ((StarRocksIcebergTableScan) tableScan).getIcebergTableName().toString();
                                 String value = metricsReporter.getScanReport().toString();
                                 Tracers.record(Tracers.Module.EXTERNAL, name, value);
@@ -1175,14 +1175,7 @@ public class IcebergMetadata implements ConnectorMetadata {
                                          ScalarOperator predicate,
                                          long limit,
                                          TvrVersionRange version) {
-        boolean useDefaultStats = false;
         if (!properties.enableGetTableStatsFromExternalMetadata()) {
-            useDefaultStats = true;
-        }
-        if (session.getSessionVariable().disableTableStatsFromMetadataForSingleTable() && session.getSourceTablesCount() == 1) {
-            useDefaultStats = true;
-        }
-        if (useDefaultStats) {
             return StatisticsUtils.buildDefaultStatistics(columns.keySet());
         }
         IcebergTable icebergTable = (IcebergTable) table;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -2922,6 +2922,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return disableTableStatsFromMetadataForSingleTable;
     }
 
+    public void setDisableTableStatsFromMetadataForSingleTable(boolean value) {
+        this.disableTableStatsFromMetadataForSingleTable = value;
+    }
+
     public boolean enableIcebergColumnStatistics() {
         return enableIcebergColumnStatistics;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -66,6 +66,7 @@ import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.metadata.MetadataTable;
 import com.starrocks.connector.metadata.MetadataTableType;
 import com.starrocks.connector.statistics.ConnectorTableColumnStats;
+import com.starrocks.connector.statistics.StatisticsUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.analyzer.FeNameFormat;
 import com.starrocks.sql.ast.AlterTableStmt;
@@ -745,6 +746,9 @@ public class MetadataMgr {
             // Avoid `analyze table` to collect table statistics from metadata.
             if (StatisticUtils.statisticTableBlackListCheck(table.getId())) {
                 return internalStatistics;
+            } else if (session.getSessionVariable().disableTableStatsFromMetadataForSingleTable() &&
+                    session.getSourceTablesCount() == 1) {
+                return StatisticsUtils.buildDefaultStatistics(columns.keySet());
             } else {
                 Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
                 Statistics connectorBasicStats = connectorMetadata.map(metadata -> metadata.getTableStatistics(

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -750,6 +750,8 @@ public class MetadataMgr {
                     session.getSourceTablesCount() == 1) {
                 return StatisticsUtils.buildDefaultStatistics(columns.keySet());
             } else {
+                LOG.warn("Get table statistics from connector metadata. query: {}, table: {}, predicate: {}",
+                        session.getQueryId(), table.getName(), predicate);
                 Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
                 Statistics connectorBasicStats = connectorMetadata.map(metadata -> metadata.getTableStatistics(
                         session, table, columns, partitionKeys, predicate, limit, versionRange)).orElse(null);

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -750,8 +750,6 @@ public class MetadataMgr {
                     session.getSourceTablesCount() == 1) {
                 return StatisticsUtils.buildDefaultStatistics(columns.keySet());
             } else {
-                LOG.warn("Get table statistics from connector metadata. query: {}, table: {}, predicate: {}",
-                        session.getQueryId(), table.getName(), predicate);
                 Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
                 Statistics connectorBasicStats = connectorMetadata.map(metadata -> metadata.getTableStatistics(
                         session, table, columns, partitionKeys, predicate, limit, versionRange)).orElse(null);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/plan/SchedulerHiveTPCHTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/plan/SchedulerHiveTPCHTest.java
@@ -32,6 +32,7 @@ public class SchedulerHiveTPCHTest extends SchedulerConnectorTestBase {
     @BeforeEach
     public void before() throws DdlException {
         connectContext.changeCatalogDb("hive0.tpch");
+        connectContext.getSessionVariable().setDisableTableStatsFromMetadataForSingleTable(false);
     }
 
     @MethodSource("getTPCHTestFileNames")

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/ivm/IVMBasedMvRefreshProcessorIcebergTest.java
@@ -228,7 +228,6 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
         connectContext.getSessionVariable().setEnableMaterializedViewTextMatchRewrite(false);
     }
 
-
     @Test
     public void testPartitionedIVMWithAggregate1() throws Exception {
         doTestWith3Runs("SELECT date, sum(id), approx_count_distinct(data) " +
@@ -239,10 +238,10 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
                                     "     TABLE: partitioned_db.t1\n" +
                                     "     TABLE VERSION: Delta@[MIN,1]");
                     PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.NORMAL),
-                            "HASH JOIN\n" +
-                                    "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
+                            "  7:HASH JOIN\n" +
+                                    "  |  join op: RIGHT OUTER JOIN (BUCKET_SHUFFLE)\n" +
                                     "  |  colocate: false, reason: \n" +
-                                    "  |  equal join conjunct: 17: from_binary = 9: __ROW_ID__");
+                                    "  |  equal join conjunct: 9: __ROW_ID__ = 17: from_binary");
                 },
                 plan -> {
                     PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.NORMAL),
@@ -253,10 +252,10 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
                             "  6:OlapScanNode\n" +
                                     "     TABLE: test_mv1");
                     PlanTestBase.assertContains(plan.getExplainString(TExplainLevel.NORMAL),
-                            "HASH JOIN\n" +
-                                    "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
+                            "  7:HASH JOIN\n" +
+                                    "  |  join op: RIGHT OUTER JOIN (BUCKET_SHUFFLE)\n" +
                                     "  |  colocate: false, reason: \n" +
-                                    "  |  equal join conjunct: 17: from_binary = 9: __ROW_ID__");
+                                    "  |  equal join conjunct: 9: __ROW_ID__ = 17: from_binary");
                 }
         );
     }
@@ -358,7 +357,7 @@ public class IVMBasedMvRefreshProcessorIcebergTest extends MVIVMIcebergTestBase 
                 }
         );
     }
-    
+
     @Test
     public void testUnionAllAndAggregate() throws Exception {
         connectContext.getSessionVariable().setEnableMaterializedViewTextMatchRewrite(true);


### PR DESCRIPTION
## Why I'm doing:

This is the further version of https://github.com/StarRocks/starrocks/pull/64443/files

I think the rule "don't collect table stats when single table" also applies for other connectors beside iceberg & deltalake, like hive,hudi,odps etc.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves the single-table “disable table stats from external metadata” logic from Iceberg/Delta to MetadataMgr to apply to all connectors, adds a session variable setter, and updates related tests.
> 
> - **Statistics/Planner**:
>   - Centralizes single-table fallback to default stats in `MetadataMgr#getTableStatistics` when `session.disableTableStatsFromMetadataForSingleTable` is true and only 1 source table.
>   - Removes redundant checks from `IcebergMetadata#getTableStatistics` and `DeltaLakeMetadata#getTableStatistics`; they now only respect connector property `enableGetTableStatsFromExternalMetadata`.
> - **Session Variables**:
>   - Adds `SessionVariable#setDisableTableStatsFromMetadataForSingleTable(boolean)`.
> - **Tests**:
>   - Sets session variable in `SchedulerHiveTPCHTest` setup.
>   - Adjusts expected plan strings in `IVMBasedMvRefreshProcessorIcebergTest`.
> - **Minor**:
>   - Trivial formatting fix in Iceberg scan metrics logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67689e1cee0d6a25ab6ef6576ec8d92220c32fe9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->