### PR TITLE
[BugFix] SqlCredentialRedactor change the regex to re2 for safety

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/SqlCredentialRedactor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/SqlCredentialRedactor.java
@@ -15,6 +15,8 @@
 package com.starrocks.common.util;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.re2j.Matcher;
+import com.google.re2j.Pattern;
 import com.starrocks.connector.share.credential.CloudConfigurationConstants;
 import com.starrocks.fs.hdfs.HdfsFsManager;
 import com.starrocks.sql.ast.CreateRoutineLoadStmt;
@@ -22,8 +24,6 @@ import com.starrocks.sql.ast.LoadStmt;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Utility class to redact sensitive credentials from SQL strings.

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/SqlCredentialRedactorBench.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/SqlCredentialRedactorBench.java
@@ -42,7 +42,8 @@ public class SqlCredentialRedactorBench {
     private String sqlWithManyKeys;
     private String sqlWithFewKeys;
     private String sqlWithoutCredentials;
-    private String sqlLong;
+    private String sqlLong1;
+    private String sqlLong2;
     private Pattern oldPattern;
 
     public static void main(String[] args) throws Exception {
@@ -115,8 +116,10 @@ public class SqlCredentialRedactorBench {
         sqlWithoutCredentials = "SELECT * FROM table WHERE id = 1";
 
         // long string
-        String longString = "abcdefdhi".repeat(104857);
-        sqlLong = "INSERT INTO t1 VALUES(\"" + longString + "\",)";
+        String longString1 = "abcdefdhi".repeat(104857);
+        sqlLong1 = "INSERT INTO t1 VALUES(\"" + longString1 + "\",)";
+        String longString2 = "a".repeat(104857);
+        sqlLong2 = "ALTER TABLE t1 SET PROPERTIES('key1' = '" + longString2 + "')";
     }
 
     @Benchmark
@@ -125,13 +128,23 @@ public class SqlCredentialRedactorBench {
     }
 
     @Benchmark
-    public void benchmarkLongString() {
-        SqlCredentialRedactor.redact(sqlLong);
+    public void benchmarkLongString1() {
+        SqlCredentialRedactor.redact(sqlLong1);
     }
 
     @Benchmark
-    public void benchmarkOldVersionLongString() {
-        redactOldVersion(sqlLong);
+    public void benchmarkLongString2() {
+        SqlCredentialRedactor.redact(sqlLong2);
+    }
+
+    @Benchmark
+    public void benchmarkOldVersionLongString1() {
+        redactOldVersion(sqlLong1);
+    }
+
+    @Benchmark
+    public void benchmarkOldVersionLongString2() {
+        redactOldVersion(sqlLong2);
     }
 
     @Benchmark

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/SqlCredentialRedactorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/SqlCredentialRedactorTest.java
@@ -200,9 +200,29 @@ public class SqlCredentialRedactorTest {
     @Test
     @Timeout(10)
     public void testLongString() {
-        String longString = "1234567890".repeat(104857);
-        String longSql = "INSERT INTO t1 VALUES(\"" + longString + "\", 1)";
-        String redacted = SqlCredentialRedactor.redact(longSql);
-        Assertions.assertEquals(longSql, redacted);
+        {
+            // long key
+            String longString = "1234567890".repeat(104857);
+            String longSql = "INSERT INTO t1 VALUES(\"" + longString + "\", 1)";
+            String redacted = SqlCredentialRedactor.redact(longSql);
+            Assertions.assertEquals(longSql, redacted);
+        }
+        {
+            // long key & value
+            String longString = "a".repeat(104857);
+            String longSql = "ALTER TABLE t1 SET PROPERTIES(\"" + longString + "\"= \"" + longString + "\")";
+            String redacted = SqlCredentialRedactor.redact(longSql);
+            Assertions.assertEquals(longSql, redacted);
+            longSql = "ALTER TABLE t1 SET PROPERTIES('" + longString + "'= '" + longString + "')";
+            redacted = SqlCredentialRedactor.redact(longSql);
+            Assertions.assertEquals(longSql, redacted);
+        }
+        {
+            // long value
+            String longString = '"' + "a".repeat(104857) + '"';
+            String longSql = "ALTER  TABLE t1 SET PROPERTIES('key'= " + longString + ")";
+            String redacted = SqlCredentialRedactor.redact(longSql);
+            Assertions.assertEquals(longSql, redacted);
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:


Follow up #https://github.com/StarRocks/starrocks/pull/65148. The `java.util.regex` library has long been prone to stack overflow issues when handling excessively repeated strings, such as `("key"="<long_string>")`. To enhance stability and safety, we are switching to `re2j`, even though it may be slightly slower.

Performance comparison:
```
-- re2
Benchmark                                                  Mode  Cnt       Score      Error  Units
SqlCredentialRedactorBench.benchmarkFewKeys                avgt    3      25.170 ±   71.346  us/op
SqlCredentialRedactorBench.benchmarkLongString1            avgt    3   25895.829 ± 5493.042  us/op
SqlCredentialRedactorBench.benchmarkLongString2            avgt    3   19996.912 ±  394.541  us/op
SqlCredentialRedactorBench.benchmarkManyKeys               avgt    3     529.941 ±  153.027  us/op
SqlCredentialRedactorBench.benchmarkNoCredentials          avgt    3       0.920 ±    0.141  us/op
SqlCredentialRedactorBench.benchmarkOldVersionLongString1  avgt    3  102552.243 ± 4243.165  us/op
SqlCredentialRedactorBench.benchmarkOldVersionLongString2  avgt    3   12560.209 ±  526.957  us/op
SqlCredentialRedactorBench.benchmarkOldVersionManyKeys     avgt    3     405.748 ±   79.831  us/op

-- java.util.regex
Benchmark                                                  Mode  Cnt      Score       Error  Units
SqlCredentialRedactorBench.benchmarkFewKeys                avgt    3      2.836 ±     5.582  us/op
SqlCredentialRedactorBench.benchmarkLongString1            avgt    3   3919.876 ±  5473.754  us/op
SqlCredentialRedactorBench.benchmarkLongString2            avgt    3   stackoverflow
SqlCredentialRedactorBench.benchmarkManyKeys               avgt    3     55.455 ±   332.406  us/op
SqlCredentialRedactorBench.benchmarkNoCredentials          avgt    3      0.060 ±     0.065  us/op
SqlCredentialRedactorBench.benchmarkOldVersionLongString1  avgt    3  97631.309 ±  3246.419  us/op
SqlCredentialRedactorBench.benchmarkOldVersionLongString2  avgt    3  13978.375 ± 33801.811  us/op
SqlCredentialRedactorBench.benchmarkOldVersionManyKeys     avgt    3    427.757 ±   290.602  us/op
```

Fixes #https://github.com/StarRocks/StarRocksTest/issues/10542

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces java.util.regex with re2j and a bounded key-value pattern in SqlCredentialRedactor to avoid catastrophic backtracking; updates benchmarks and tests to cover long-string cases.
> 
> - **Util (`SqlCredentialRedactor`)**:
>   - Replace `java.util.regex` with `re2j` (`Pattern`, `Matcher`).
>   - Introduce bounded key-length regex (`MAX_KEY_LENGTH`) and simplified key-value pattern; keep case-insensitive key set lookup; redact to `***`.
> - **Tests**:
>   - Expand long-input scenarios (very long keys/values; quoted/unquoted variants) with timeouts to validate performance and correctness.
> - **Benchmarks**:
>   - Add separate long-string cases and corresponding old-version comparisons; minor renames and setup adjustments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3534f84cec61c276ca7c6c6a0468f4864786095a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->