### PR TITLE
[UT] fix unstable optimizer timeout sql test

### DIFF
--- a/test/sql/test_phased_schedule/R/test_phased_schedule
+++ b/test/sql/test_phased_schedule/R/test_phased_schedule
@@ -2,6 +2,9 @@
 set enable_phased_scheduler = true;
 -- result:
 -- !result
+set cbo_max_reorder_node_use_dp=8;
+-- result:
+-- !result
 CREATE TABLE `t0` (
   `c0` int(11) NULL COMMENT "",
   `c1` varchar(20) NULL COMMENT "",
@@ -134,35 +137,35 @@ select count(*) from TMP;
 truncate table TMP;
 -- result:
 -- !result
-select * from small_table2 s1 union all select * from small_table2 s2 union all select * from small_table2 s3 union all select * from small_table2 s4 union all select * from small_table2 s4 union all select * from small_table2 s5;
+select * from small_table2 s1 union all select * from small_table2 s2 union all select * from small_table2 s3 union all select * from small_table2 s4 union all select * from small_table2 s4 union all select * from small_table2 s5 order by 1,2,3;
 -- result:
 1	1	1	1
-2	2	2	2
+1	1	1	1
+1	1	1	1
+1	1	1	1
+1	1	1	1
 1	1	1	1
 2	2	2	2
-1	1	1	1
 2	2	2	2
-1	1	1	1
 2	2	2	2
-1	1	1	1
 2	2	2	2
-1	1	1	1
+2	2	2	2
 2	2	2	2
 -- !result
-select c0,c1,c2 from small_table2 s1 group by 1,2,3 union all select c0,c1,c2 from small_table2 s2 group by 1,2,3  union all select c0,c1,c2 from small_table2 s3 group by 1,2,3  union all select c0,c1,c2 from small_table2 s4 group by 1,2,3 union all select c0,c1,c2 from small_table2 s4 group by 1,2,3 union all select c0,c1,c2 from small_table2 s5 group by 1,2,3;
+select c0,c1,c2 from small_table2 s1 group by 1,2,3 union all select c0,c1,c2 from small_table2 s2 group by 1,2,3  union all select c0,c1,c2 from small_table2 s3 group by 1,2,3  union all select c0,c1,c2 from small_table2 s4 group by 1,2,3 union all select c0,c1,c2 from small_table2 s4 group by 1,2,3 union all select c0,c1,c2 from small_table2 s5 group by 1,2,3 order by 1,2,3;
 -- result:
-2	2	2
+1	1	1
+1	1	1
+1	1	1
+1	1	1
+1	1	1
 1	1	1
 2	2	2
-1	1	1
 2	2	2
-1	1	1
 2	2	2
-1	1	1
 2	2	2
-1	1	1
 2	2	2
-1	1	1
+2	2	2
 -- !result
 select count(*) from small_table1 s1 join small_table2 s2 on s1.c0 = s2.c0;
 -- result:
@@ -219,6 +222,9 @@ set enable_async_profile=true;
 -- result:
 -- !result
 set profile_timeout=300;
+-- result:
+-- !result
+set cbo_max_reorder_node_use_dp=10;
 -- result:
 -- !result
 select count(*) from small_table1 s1 join small_table2 s2 on s1.c0 = s2.c0 join small_table3 s3 on s1.c0 = s3.c0 where s3.c3 = 0;

--- a/test/sql/test_phased_schedule/T/test_phased_schedule
+++ b/test/sql/test_phased_schedule/T/test_phased_schedule
@@ -1,6 +1,6 @@
 -- name: test_phased_schedule
 set enable_phased_scheduler = true;
-
+set cbo_max_reorder_node_use_dp=8;
 CREATE TABLE `t0` (
   `c0` int(11) NULL COMMENT "",
   `c1` varchar(20) NULL COMMENT "",
@@ -98,8 +98,8 @@ set phased_scheduler_max_concurrency = 1;
 insert into TMP select * from small_table2 s1 union all select * from small_table2 s2 union all select * from small_table2 s3 union all select * from small_table2 s4 union all select * from small_table2 s4 union all select * from small_table2 s5;
 select count(*) from TMP;
 truncate table TMP;
-select * from small_table2 s1 union all select * from small_table2 s2 union all select * from small_table2 s3 union all select * from small_table2 s4 union all select * from small_table2 s4 union all select * from small_table2 s5;
-select c0,c1,c2 from small_table2 s1 group by 1,2,3 union all select c0,c1,c2 from small_table2 s2 group by 1,2,3  union all select c0,c1,c2 from small_table2 s3 group by 1,2,3  union all select c0,c1,c2 from small_table2 s4 group by 1,2,3 union all select c0,c1,c2 from small_table2 s4 group by 1,2,3 union all select c0,c1,c2 from small_table2 s5 group by 1,2,3;
+select * from small_table2 s1 union all select * from small_table2 s2 union all select * from small_table2 s3 union all select * from small_table2 s4 union all select * from small_table2 s4 union all select * from small_table2 s5 order by 1,2,3;
+select c0,c1,c2 from small_table2 s1 group by 1,2,3 union all select c0,c1,c2 from small_table2 s2 group by 1,2,3  union all select c0,c1,c2 from small_table2 s3 group by 1,2,3  union all select c0,c1,c2 from small_table2 s4 group by 1,2,3 union all select c0,c1,c2 from small_table2 s4 group by 1,2,3 union all select c0,c1,c2 from small_table2 s5 group by 1,2,3 order by 1,2,3;
 -- join cases
 select count(*) from small_table1 s1 join small_table2 s2 on s1.c0 = s2.c0;
 -- short-circuit
@@ -124,4 +124,5 @@ with agged_table as ( select distinct c0, c1 from t0) select /*+SET_VAR(cbo_cte_
 set enable_profile=true;
 set enable_async_profile=true;
 set profile_timeout=300;
+set cbo_max_reorder_node_use_dp=10;
 select count(*) from small_table1 s1 join small_table2 s2 on s1.c0 = s2.c0 join small_table3 s3 on s1.c0 = s3.c0 where s3.c3 = 0;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
**Use greedy to observe if there will still be timeouts**
todo:
1. When the query has no aggregation, do not execute agg pushdown, so there is no need to execute join reorder an additional time in CBO
2. reduce memory usages of `Statistics` and `ColumnRefSet`
3. Exploring why dp uses so much memory



Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
