### PR TITLE
[BugFix] fix delvec crc32 upgrade compatibility

### DIFF
--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -34,6 +34,8 @@ message DelvecPagePB {
     optional uint64 offset = 2;
     optional uint64 size = 3;
     optional uint32 crc32c = 4;
+    // For upgrade compatibility.
+    optional int64 crc32c_gen_version = 5;
 }
 
 message PersistentIndexSstablePB {


### PR DESCRIPTION
## Why I'm doing:
In upgrade and downgrade scenarios, since some versions do not support generating the CRC for delete vectors, the delete vector’s CRC32 may have been generated by an older version, which can lead to misjudgments.

## What I'm doing:
This pull request updates how the `crc32c_gen_version` field is handled in the `DelvecPagePB` protobuf and related logic in the lake meta file code. The main goal is to improve compatibility and correctness when working with delete vector metadata, especially during upgrades and cache key generation.

**Protobuf and Metadata Handling Updates:**

* Added an optional `crc32c_gen_version` field to the `DelvecPagePB` protobuf for upgrade compatibility.
* When finalizing delete vector metadata in `_finalize_delvec`, the code now sets the `crc32c_gen_version` field to the current version for each delvec entry, ensuring version tracking. [[1]](diffhunk://#diff-8da1a78cf605cdb609488453fb2de6df00421063acf7c75a05bc227a91e4271cR497) [[2]](diffhunk://#diff-8da1a78cf605cdb609488453fb2de6df00421063acf7c75a05bc227a91e4271cR507)

**Cache Key and Integrity Check Improvements:**

* Modified `delvec_cache_key` to exclude the `crc32c_gen_version` from the cache key, preventing unnecessary cache key changes due to version updates.
* Updated the CRC32C integrity check logic to only verify CRC32C if `crc32c_gen_version` matches the delvec's version, improving compatibility during upgrades.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
