### PR TITLE
[BugFix] Fix record info for prepare and execute stmt

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpConnectContext.java
@@ -170,4 +170,9 @@ public class HttpConnectContext extends ConnectContext {
             });
         }
     }
+
+    @Override
+    public String getCommandStr() {
+        return "HTTP.Query";
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
@@ -167,6 +167,12 @@ public class AuditEvent {
     @AuditField(value = "QuerySource")
     public String querySource = "";
 
+    @AuditField(value = "Command")
+    public String command = "";
+
+    @AuditField(value = "PreparedStmtId", ignore_zero = true)
+    public String preparedStmtId = null;
+
     public long readLocalCnt = 0;
     public long readRemoteCnt = 0;
     @AuditField(value = "CacheHitRatio", ignore_empty = true)
@@ -468,6 +474,16 @@ public class AuditEvent {
 
         public AuditEventBuilder setQuerySource(String querySource) {
             auditEvent.querySource = querySource;
+            return this;
+        }
+
+        public AuditEventBuilder setCommand(String command) {
+            auditEvent.command = command;
+            return this;
+        }
+
+        public AuditEventBuilder setPreparedStmtId(String preparedStmtId) {
+            auditEvent.preparedStmtId = preparedStmtId;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -695,6 +695,14 @@ public class ConnectContext {
         return command;
     }
 
+    public String getCommandStr() {
+        if (command == null) {
+            return "MySQL.UNKNOWN";
+        } else {
+            return "MySQL." + command;
+        }
+    }
+
     public void setCommand(MysqlCommand command) {
         this.command = command;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetail.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryDetail.java
@@ -100,6 +100,9 @@ public class QueryDetail implements Serializable {
     private String digest;
     private String catalog;
 
+    private String command = "";
+    private String preparedStmtId;
+
     private long queryFeMemory = 0;
 
     public QueryDetail() {
@@ -107,7 +110,8 @@ public class QueryDetail implements Serializable {
 
     public QueryDetail(String queryId, boolean isQuery, int connId, String remoteIP,
                        long startTime, long endTime, long latency, QueryMemState state,
-                       String database, String sql, String user, String resourceGroupName, String catalog) {
+                       String database, String sql, String user, String resourceGroupName, String catalog,
+                       String command, String preparedStmtId) {
         this.queryId = queryId;
         this.isQuery = isQuery;
         this.connId = connId;
@@ -129,14 +133,17 @@ public class QueryDetail implements Serializable {
         this.sql = sql;
         this.user = user;
         this.catalog = catalog;
+        this.command = command;
+        this.preparedStmtId = preparedStmtId;
     }
 
     public QueryDetail(String queryId, boolean isQuery, int connId, String remoteIP,
                        long startTime, long endTime, long latency, QueryMemState state,
                        String database, String sql, String user, String resourceGroupName,
-                       String warehouse, String catalog) {
+                       String warehouse, String catalog,
+                       String command, String preparedStmtId) {
         this(queryId, isQuery, connId, remoteIP, startTime, endTime, latency,
-                state, database, sql, user, resourceGroupName, catalog);
+                state, database, sql, user, resourceGroupName, catalog, command, preparedStmtId);
         this.warehouse = warehouse;
     }
 
@@ -170,6 +177,8 @@ public class QueryDetail implements Serializable {
         queryDetail.catalog = this.catalog;
         queryDetail.queryFeMemory = this.queryFeMemory;
         queryDetail.querySource = this.querySource;
+        queryDetail.command = this.command;
+        queryDetail.preparedStmtId = this.preparedStmtId;
         return queryDetail;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -2681,7 +2681,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private boolean enableNestedLoopJoin = true;
 
     @VariableMgr.VarAttr(name = AUDIT_EXECUTE_STMT)
-    private boolean auditExecuteStmt = false;
+    private boolean auditExecuteStmt = true;
 
     @VariableMgr.VarAttr(name = ENABLE_SHORT_CIRCUIT)
     private boolean enableShortCircuit = false;

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectContext.java
@@ -228,4 +228,9 @@ public class ArrowFlightSqlConnectContext extends ConnectContext {
         Coordinator coordinator = coordinatorFuture.getNow(null);
         return !(coordinator instanceof DefaultCoordinator);
     }
+
+    @Override
+    public String getCommandStr() {
+        return "ARROW_FLIGHT_SQL.Query";
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2SQLVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2SQLVisitor.java
@@ -42,6 +42,7 @@ import com.starrocks.sql.ast.expression.LargeInPredicate;
 import com.starrocks.sql.ast.expression.LimitElement;
 import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.ast.expression.MapExpr;
+import com.starrocks.sql.ast.expression.Parameter;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.ast.expression.TableName;
 import com.starrocks.type.Type;
@@ -668,5 +669,13 @@ public class AST2SQLVisitor extends AST2StringVisitor {
         output.append(options.indent()).append("END");
         
         return output.toString();
+    }
+
+    @Override
+    public String visitParameterExpr(Parameter node, Void context) {
+        if (node.getExpr() == null) {
+            return super.visitParameterExpr(node, context);
+        }
+        return visit(node.getExpr(), context);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/formatter/AST2StringVisitor.java
@@ -116,6 +116,7 @@ import com.starrocks.sql.ast.expression.LimitElement;
 import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.ast.expression.MapExpr;
 import com.starrocks.sql.ast.expression.MatchExpr;
+import com.starrocks.sql.ast.expression.Parameter;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.ast.expression.SubfieldExpr;
@@ -1532,9 +1533,17 @@ public class AST2StringVisitor implements AstVisitorExtendInterface<String, Void
     protected String printWithParentheses(ParseNode node) {
         if (node instanceof SlotRef || node instanceof LiteralExpr) {
             return visit(node);
-        } else {
-            return "(" + visit(node) + ")";
         }
+
+        if (node instanceof Parameter) {
+            Parameter parameter = (Parameter) node;
+            Expr expr = parameter.getExpr();
+            if ((expr instanceof SlotRef || expr instanceof LiteralExpr)) {
+                return visit(node);
+            }
+        }
+
+        return "(" + visit(node) + ")";
     }
 
     // --------------------------------------------Storage volume Statement ----------------------------------------

--- a/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/QueryDetailV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/QueryDetailV2Test.java
@@ -60,7 +60,7 @@ public class QueryDetailV2Test extends StarRocksHttpTestCase {
         QueryDetail startQueryDetail = new QueryDetail("219a2d5443c542d4-8fc938db37c892e3", false, 1, "127.0.0.1",
                 System.currentTimeMillis(), -1, -1, QueryDetail.QueryMemState.RUNNING,
                 "testDb", "select * from table1 limit 1",
-                "root", "", "default_catalog");
+                "root", "", "default_catalog", "MySQL.Query", null);
         startQueryDetail.setScanRows(100);
         startQueryDetail.setScanBytes(10001);
         startQueryDetail.setReturnRows(1);
@@ -97,7 +97,7 @@ public class QueryDetailV2Test extends StarRocksHttpTestCase {
         QueryDetail startQueryDetail = new QueryDetail("219a2d5443c542d4-8fc938db37c892e3", false, 1, "127.0.0.1",
                 System.currentTimeMillis(), -1, -1, QueryDetail.QueryMemState.RUNNING,
                 "testDb", "select * from table1 limit 1",
-                "root", "", "default_catalog");
+                "root", "", "default_catalog", "MySQL.Query", null);
         startQueryDetail.setScanRows(100);
         startQueryDetail.setScanBytes(10001);
         startQueryDetail.setReturnRows(1);
@@ -113,7 +113,7 @@ public class QueryDetailV2Test extends StarRocksHttpTestCase {
                 QueryDetail startQueryDetail = new QueryDetail("219a2d5443c542d4-8fc938db37c892e5", false, 1, "127.0.0.1",
                         System.currentTimeMillis(), -1, -1, QueryDetail.QueryMemState.RUNNING,
                         "testDb", "select * from table2 limit 1",
-                        "root", "", "default_catalog");
+                        "root", "", "default_catalog", "MySQL.Query", null);
                 startQueryDetail.setScanRows(150);
                 startQueryDetail.setScanBytes(10005);
                 startQueryDetail.setReturnRows(1);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailQueueTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailQueueTest.java
@@ -50,7 +50,7 @@ public class QueryDetailQueueTest extends PlanTestBase {
         QueryDetail startQueryDetail = new QueryDetail("219a2d5443c542d4-8fc938db37c892e3", false, 1, "127.0.0.1",
                 System.currentTimeMillis(), -1, -1, QueryDetail.QueryMemState.RUNNING,
                 "testDb", "select * from table1 limit 1",
-                "root", "", "default_catalog");
+                "root", "", "default_catalog", "MySQL.Query", null);
         startQueryDetail.setScanRows(100);
         startQueryDetail.setScanBytes(10001);
         startQueryDetail.setReturnRows(1);
@@ -88,6 +88,7 @@ public class QueryDetailQueueTest extends PlanTestBase {
                 "\"cacheMissRatio\":0.0," +
                 "\"warehouse\":\"default_warehouse\"," +
                 "\"catalog\":\"default_catalog\"," +
+                "\"command\":\"MySQL.Query\"," +
                 "\"queryFeMemory\":0}]";
         Assertions.assertEquals(queryDetailString, jsonString);
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/QueryDetailTest.java
@@ -45,7 +45,7 @@ public class QueryDetailTest {
         QueryDetail queryDetail = new QueryDetail("219a2d5443c542d4-8fc938db37c892e3", true, 1, "127.0.0.1",
                 System.currentTimeMillis(), -1, -1, QueryDetail.QueryMemState.RUNNING,
                 "testDb", "select * from table1 limit 1",
-                "root", "", "default_catalog");
+                "root", "", "default_catalog", "MySQL.Query", null);
         queryDetail.setProfile("bbbbb");
         queryDetail.setErrorMessage("cancelled");
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/QueryDetailTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/QueryDetailTest.java
@@ -33,7 +33,7 @@ public class QueryDetailTest extends PlanTestBase {
         QueryDetail startQueryDetail = new QueryDetail("219a2d5443c542d4-8fc938db37c892e3", false, 1, "127.0.0.1",
                 System.currentTimeMillis(), -1, -1, QueryDetail.QueryMemState.RUNNING,
                 "testDb", "select * from table1 limit 1",
-                "root", "", "default_catalog");
+                "root", "", "default_catalog", "MySQL.Query", null);
         connectContext.setQueryDetail(startQueryDetail);
     }
 

--- a/test/lib/mysql_prepared_stmt_lib.py
+++ b/test/lib/mysql_prepared_stmt_lib.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+# -- coding: utf-8 --
+###########################################################################
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###########################################################################
+
+import mysql.connector
+
+from lib import close_conn
+
+
+class MysqlPreparedStmtLib(object):
+    def __init__(self):
+        self.connector = None
+        self.prepared_stmt_cursor = None
+
+    def connect(self, query_dict):
+        if "database" not in query_dict:
+            self.connector = mysql.connector.connect(
+                host=query_dict["host"],
+                port=int(query_dict["port"]),
+                user=query_dict["user"],
+                password=query_dict["password"],
+            )
+        else:
+            self.connector = mysql.connector.connect(
+                host=query_dict["host"],
+                port=int(query_dict["port"]),
+                user=query_dict["user"],
+                password=query_dict["password"],
+                database=query_dict["database"],
+            )
+        self.prepared_stmt_cursor = self.connector.cursor(prepared=True)
+
+    def close(self):
+        if self.prepared_stmt_cursor:
+            self.prepared_stmt_cursor.close()
+            self.prepared_stmt_cursor = None
+        if self.connector:
+            close_conn(self.connector, "MySQL for Prepared Statement")
+            self.connector = None
+
+    def execute_prepared(self, sql, params):
+        self.prepared_stmt_cursor.execute(sql, params)
+        return self._res_to_str(self.prepared_stmt_cursor.fetchall())
+
+    def execute(self, sql):
+        cursor = self.connector.cursor()
+        try:
+            cursor.execute(sql)
+            return self._res_to_str(cursor.fetchall())
+        finally:
+            cursor.close()
+
+    @staticmethod
+    def _res_to_str(res):
+        if not res:
+            return ""
+
+        res_log = []
+        if isinstance(res[0], tuple) or isinstance(res[0], list):
+            res_log.extend(["\t".join([str(col) for col in row]) for row in res])
+        else:
+            res_log.extend(["\t".join(str(row)) for row in res])
+        return "\n".join(res_log)

--- a/test/lib/mysql_prepared_stmt_lib.py
+++ b/test/lib/mysql_prepared_stmt_lib.py
@@ -60,6 +60,8 @@ class MysqlPreparedStmtLib(object):
         cursor = self.connector.cursor()
         try:
             cursor.execute(sql)
+            if not cursor.with_rows:
+                return None
             return self._res_to_str(cursor.fetchall())
         finally:
             cursor.close()

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -9,7 +9,7 @@ flaky==3.7.0
 fuzzywuzzy
 python-Levenshtein
 PyGithub
-mysql-connector==9.0.0
+mysql-connector-python==9.0.0
 trino
 pure-sasl
 thrift

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -9,7 +9,7 @@ flaky==3.7.0
 fuzzywuzzy
 python-Levenshtein
 PyGithub
-mysql-connector
+mysql-connector==9.0.0
 trino
 pure-sasl
 thrift

--- a/test/sql/test_preparestatement/R/test_prepare_stmt_query_history
+++ b/test/sql/test_preparestatement/R/test_prepare_stmt_query_history
@@ -1,0 +1,148 @@
+-- name: test_prepare_stmt_query_history @sequential
+admin set frontend config ("enable_collect_query_detail_info" = "true");
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+-- result:
+-- !result
+insert into __row_util_base select * from __row_util_base;
+-- result:
+-- !result
+insert into __row_util_base select * from __row_util_base;
+-- result:
+-- !result
+insert into __row_util_base select * from __row_util_base;
+-- result:
+-- !result
+insert into __row_util_base select * from __row_util_base;
+-- result:
+-- !result
+CREATE TABLE __row_util (
+  idx bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into __row_util select row_number() over() as idx from __row_util_base;
+-- result:
+-- !result
+CREATE TABLE t1 (
+    k1 bigint NULL,
+    c_1 int,
+    c_2 int,
+    c_3 int,
+    c_4 int
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1 
+select
+    idx, idx + 1, idx + 2, idx + 3, idx + 4
+from __row_util;
+-- result:
+-- !result
+function: execute_with_prepared_connection("use db_${uuid0}")
+-- result:
+
+-- !result
+function: execute_with_prepared_connection("set audit_execute_stmt = true")
+-- result:
+
+-- !result
+function: execute_with_prepared_connection("set enable_async_profile = false")
+-- result:
+
+-- !result
+function: execute_prepared_sql("SELECT k1, c_1, c_2, c_3, c_4 FROM t1 WHERE (c_1 = ? AND c_2 = ?) OR (c_3 = ? AND c_4 = ?)", [100, 101, 102, 103])
+-- result:
+99	100	101	102	103
+-- !result
+[UC]function: query_id=execute_with_prepared_connection("SELECT last_query_id()")
+-- result:
+-- !result
+[UC]function: execute_detail=wait_for_query_detail("${query_id}")
+-- result:
+-- !result
+WITH w1 as (SELECT parse_json('${execute_detail}') detail)
+SELECT 
+    detail->'command' AS command,
+    regexp_extract(detail->'profile' , 'Query ID: (.*?)\n', 1) = '${query_id}' AS is_correct_query_id_from_profile
+FROM w1;
+-- result:
+"MySQL.COM_STMT_EXECUTE"	1
+-- !result
+WITH w1 as (SELECT parse_json('${execute_detail}') detail)
+SELECT 
+    detail->'sql' as query
+FROM w1;
+-- result:
+[REGEX]"SELECT `\w+`\.`t1`\.`k1`, `\w+`\.`t1`\.`c_1`, `\w+`\.`t1`\.`c_2`, `\w+`\.`t1`\.`c_3`, `\w+`\.`t1`\.`c_4`\\nFROM `\w+`\.`t1`\\nWHERE \(\(`\w+`\.`t1`\.`c_1` = 100\) AND \(`\w+`\.`t1`\.`c_2` = 101\)\) OR \(\(`\w+`\.`t1`\.`c_3` = 102\) AND \(`\w+`\.`t1`\.`c_4` = 103\)\)"
+-- !result
+[UC]prepared_stmt_id=WITH w1 as (SELECT parse_json('${execute_detail}') detail) SELECT detail->'preparedStmtId' preparedStmtId FROM w1;
+-- result:
+-- !result
+[UC]function: prepare_detail=wait_for_prepared_stmt_detail(${prepared_stmt_id})
+-- result:
+-- !result
+WITH w1 as (
+    SELECT parse_json('${prepare_detail}') detail
+)
+SELECT 
+    detail->'command' AS command,
+    detail->'queryId' != '${query_id}' AS is_correct_query_id,
+    detail->'profile' as profile
+FROM w1;
+-- result:
+"MySQL.COM_STMT_PREPARE"	1	None
+-- !result
+WITH w1 as (
+    SELECT parse_json('${prepare_detail}') detail
+)
+SELECT 
+    detail->'sql' as query
+FROM w1;
+-- result:
+"SELECT k1, c_1, c_2, c_3, c_4 FROM t1 WHERE (c_1 = ? AND c_2 = ?) OR (c_3 = ? AND c_4 = ?)"
+-- !result
+function: execute_with_prepared_connection("set audit_execute_stmt = false")
+-- result:
+
+-- !result
+function: execute_prepared_sql("SELECT k1, c_1, c_2, c_3, c_4 FROM t1 WHERE (c_1 = ? AND c_2 = ?) OR (c_3 = ? AND c_4 = ?)", [100, 101, 102, 103])
+-- result:
+99	100	101	102	103
+-- !result
+[UC]function: assert_prepared_stmt_details()
+-- result:
+-- !result
+admin set frontend config ("enable_collect_query_detail_info" = "false");
+-- result:
+-- !result
+drop database db_${uuid0} FORCE;
+-- result:
+-- !result

--- a/test/sql/test_preparestatement/T/test_prepare_stmt_query_history
+++ b/test/sql/test_preparestatement/T/test_prepare_stmt_query_history
@@ -1,0 +1,102 @@
+-- name: test_prepare_stmt_query_history @sequential
+
+admin set frontend config ("enable_collect_query_detail_info" = "true");
+
+create database db_${uuid0};
+use db_${uuid0};
+
+-- # Prepare Data.
+
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+insert into __row_util_base select * from __row_util_base;
+insert into __row_util_base select * from __row_util_base;
+insert into __row_util_base select * from __row_util_base;
+insert into __row_util_base select * from __row_util_base;
+
+CREATE TABLE __row_util (
+  idx bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util select row_number() over() as idx from __row_util_base;
+
+
+CREATE TABLE t1 (
+    k1 bigint NULL,
+    c_1 int,
+    c_2 int,
+    c_3 int,
+    c_4 int
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into t1 
+select
+    idx, idx + 1, idx + 2, idx + 3, idx + 4
+from __row_util;
+
+function: execute_with_prepared_connection("use db_${uuid0}")
+function: execute_with_prepared_connection("set enable_profile = true")
+function: execute_with_prepared_connection("set enable_async_profile = false")
+
+
+-- # Enable audit_execute_stmt
+
+function: execute_prepared_sql("SELECT k1, c_1, c_2, c_3, c_4 FROM t1 WHERE (c_1 = ? AND c_2 = ?) OR (c_3 = ? AND c_4 = ?)", [100, 101, 102, 103])
+
+-- ## Get execute stmt query detail.
+[UC]function: query_id=execute_with_prepared_connection("SELECT last_query_id()")
+[UC]function: execute_detail=wait_for_query_detail("${query_id}")
+
+WITH w1 as (SELECT parse_json('${execute_detail}') detail)
+SELECT 
+    detail->'command' AS command,
+    regexp_extract(detail->'profile' , 'Query ID: (.*?)\n', 1) = '${query_id}' AS is_correct_query_id_from_profile
+FROM w1;
+
+WITH w1 as (SELECT parse_json('${execute_detail}') detail)
+SELECT detail->'sql' as query FROM w1;
+
+-- ## Get prepare stmt query detail.
+[UC]prepared_stmt_id=WITH w1 as (SELECT parse_json('${execute_detail}') detail) SELECT detail->'preparedStmtId' preparedStmtId FROM w1;
+[UC]function: prepare_detail=wait_for_prepared_stmt_detail(${prepared_stmt_id})
+
+WITH w1 as (
+    SELECT parse_json('${prepare_detail}') detail
+)
+SELECT 
+    detail->'command' AS command,
+    detail->'queryId' != '${query_id}' AS is_correct_query_id,
+    detail->'profile' as profile
+FROM w1;
+
+WITH w1 as (SELECT parse_json('${prepare_detail}') detail)
+SELECT detail->'sql' as queryFROM w1;
+
+
+-- # Disable audit_execute_stmt
+
+function: execute_with_prepared_connection("set audit_execute_stmt = false")
+
+function: execute_prepared_sql("SELECT k1, c_1, c_2, c_3, c_4 FROM t1 WHERE (c_1 = ? AND c_2 = ?) OR (c_3 = ? AND c_4 = ?)", [100, 101, 102, 103])
+[UC]function: assert_prepared_stmt_details()
+
+-- # Clean up.
+admin set frontend config ("enable_collect_query_detail_info" = "false");
+drop database db_${uuid0} FORCE;
+


### PR DESCRIPTION
## Why I'm doing:

The MySQL protocol supports `COM_STMT_PREPARE` and `COM_STMT_EXECUTE` so that a query can be executed in two phases:
1. Execute `COM_STMT_PREPARE`: send the SQL to the FE and return a `StmtId` to the client.
2. Execute `COM_STMT_EXECUTE`: send the previously returned `StmtId` to the FE and return the result to the client.


Issues and changes
1. The profile of `ExecuteStmt` is written into the `query detail` of `PrepareStmt`.
    - Problem: When `audit_execute_stmt` is disabled, executing `ExecuteStmt` does not generate audit logs or query detail. However, the profile produced by `ExecuteStmt` is written into the `query detail` of `PrepareStmt`. This happens because both run in the same `ConnectContext`, and when generating the profile, if `ConnectContext::queryDetail != null`, the profile is appended to `ConnectContext::queryDetail`.
    - Fix: When `audit_execute_stmt` is disabled, `ExecuteStmt` clears `ConnectContext::queryDetail`.
2. By default, there is no audit log or query detail entry for the execution result of `COM_STMT_EXECUTE`.
    - Problem: When the JDBC URL is configured with `useCursorFetch=true`, a single SQL statement is implicitly split into `COM_STMT_PREPARE` and `COM_STMT_EXECUTE`. If `audit_execute_stmt` is not enabled, only one audit log and query detail entry is generated for the very fast `COM_STMT_PREPARE`, which is confusing to users.
    - Fix: Enable the session variable `audit_execute_stmt` by default.
3. De-parameterize SQL in audit logs and query detail.
    - Replace all `?` placeholders with their concrete values.
4. `last_query_id` supports both `COM_STMT_PREPARE` and `COM_STMT_EXECUTE`.
5. Add two fields, `Command` and `PreparedStmtId`, to audit logs and query detail to track prepare/execute behavior.
    - `Command`: `MySQL.COM_STMT_PREPARE`, `MySQL.COM_STMT_EXECUTE`, `MySQL.Query`, `HTTP.Query`, `ARROW_FLIGHT_SQL.Query`.
    - `PreparedStmtId` is not shown in the audit log when the command is neither prepare nor execute.

## What I'm doing:


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Records command and prepared statement IDs in audit/query detail, enables auditing of COM_STMT_EXECUTE by default, de-parameterizes SQL for EXECUTE, fixes last_query_id handling, and adds prepared-statement tests/utilities.
> 
> - **Auditing & Query Detail**:
>   - Add `command` and `preparedStmtId` to `AuditEvent` and `QueryDetail`; include via builder/setters and QueryDetail constructors/copy.
>   - Populate audit fields in `ConnectProcessor` (`setCommand`, `setPreparedStmtId`), and include in `StmtExecutor.addRunningQueryDetail`.
>   - New `ConnectContext#getCommandStr()` with overrides for HTTP and Arrow Flight SQL; used to tag source as `MySQL/HTTP/ARROW_FLIGHT_SQL`.
>   - Update `last_query_id` logic to cover `COM_STMT_PREPARE` and `COM_STMT_EXECUTE`.
> - **Prepared Statements**:
>   - For `COM_STMT_EXECUTE`, assign parameter values and render original SQL (de-parameterized) for audit/log via `AstToSQLBuilder`.
>   - Clear `queryDetail` when `audit_execute_stmt` is disabled to avoid leaking previous profile.
>   - Track prepared-stmt ID via `StmtExecutor#getPreparedStmtId()`.
>   - Set `executionId` when executing prepared statements.
> - **Defaults/Session**:
>   - Enable `audit_execute_stmt` by default in `SessionVariable`.
> - **SQL Formatting**:
>   - `AST2SQLVisitor/AST2StringVisitor`: print `Parameter` expressions with actual values and tweak parentheses rules.
> - **Tests & Tooling**:
>   - Add E2E tests for prepared statement query history; adjust existing tests for new fields.
>   - Extend Python test libs to support MySQL prepared statements; bump `mysql-connector-python` to `9.0.0` and add helper methods.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 67e3c941ac0070572adbdfe7514e5890d36015f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->