### PR TITLE
[BugFix] masking OBS ak/sk in ui

### DIFF
--- a/be/src/fs/credential/cloud_configuration_factory.h
+++ b/be/src/fs/credential/cloud_configuration_factory.h
@@ -62,6 +62,13 @@ static const std::string AZURE_BLOB_OAUTH2_CLIENT_ID = "azure.blob.oauth2_client
 static const std::string AZURE_BLOB_OAUTH2_CLIENT_SECRET = "azure.blob.oauth2_client_secret";
 static const std::string AZURE_BLOB_OAUTH2_TENANT_ID = "azure.blob.oauth2_tenant_id";
 
+// Credentials for Huawei OBS
+static const std::string HUAWEI_OBS_ACCESS_KEY = "fs.obs.access_key";
+static const std::string HUAWEI_OBS_SECRET_KEY = "fs.obs.secret_key";
+static const std::string HUAWEI_OBS_ACCESS_KEY_DOT = "fs.obs.access.key";
+static const std::string HUAWEI_OBS_SECRET_KEY_DOT = "fs.obs.secret.key";
+static const std::string HUAWEI_OBS_ENDPOINT = "fs.obs.endpoint";
+
 class CloudConfigurationFactory {
 public:
     static const AWSCloudConfiguration create_aws(const TCloudConfiguration& t_cloud_configuration);

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PrintableMap.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PrintableMap.java
@@ -64,6 +64,10 @@ public class PrintableMap<K, V> {
         SENSITIVE_KEY.add("authentication_ldap_simple_ssl_conn_trust_store_pwd");
         SENSITIVE_KEY.add("client_secret");
         SENSITIVE_KEY.add("ldap_bind_root_pwd");
+        SENSITIVE_KEY.add("fs.obs.access_key");
+        SENSITIVE_KEY.add("fs.obs.secret_key");
+        SENSITIVE_KEY.add("fs.obs.access.key");
+        SENSITIVE_KEY.add("fs.obs.secret.key");
     }
 
     public PrintableMap(Map<K, V> map, String keyValueSaperator,

--- a/fe/fe-core/src/main/java/com/starrocks/credential/CredentialUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/CredentialUtil.java
@@ -55,6 +55,12 @@ public class CredentialUtil {
         doMask(properties, CloudConfigurationConstants.ALIYUN_OSS_ACCESS_KEY);
         doMask(properties, CloudConfigurationConstants.ALIYUN_OSS_SECRET_KEY);
 
+        // Mask for huawei obs credential
+        doMask(properties, CloudConfigurationConstants.HUAWEI_OBS_ACCESS_KEY);
+        doMask(properties, CloudConfigurationConstants.HUAWEI_OBS_SECRET_KEY);
+        doMask(properties, CloudConfigurationConstants.HUAWEI_OBS_ACCESS_KEY_DOT);
+        doMask(properties, CloudConfigurationConstants.HUAWEI_OBS_SECRET_KEY_DOT);
+
         // Mask for iceberg rest catalog credential
         doMask(properties, IcebergCatalogProperties.ICEBERG_CUSTOM_PROPERTIES_PREFIX +
                 OAuth2SecurityConfig.OAUTH2_CREDENTIAL);

--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
@@ -326,6 +326,8 @@ public class HdfsFsManager {
     // arguments for obs
     public static final String FS_OBS_ACCESS_KEY = "fs.obs.access.key";
     public static final String FS_OBS_SECRET_KEY = "fs.obs.secret.key";
+    public static final String FS_OBS_ACCESS_KEY_UNDERSCORE = "fs.obs.access_key";
+    public static final String FS_OBS_SECRET_KEY_UNDERSCORE = "fs.obs.secret_key";
     protected static final String FS_OBS_ENDPOINT = "fs.obs.endpoint";
     // This property is used like 'fs.hdfs.impl.disable.cache'
     protected static final String FS_OBS_IMPL_DISABLE_CACHE = "fs.obs.impl.disable.cache";

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CredentialUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CredentialUtilTest.java
@@ -98,16 +98,16 @@ public class CredentialUtilTest {
         properties.put(CloudConfigurationConstants.HUAWEI_OBS_ACCESS_KEY, "AKIAIOSFODNN7EXAMPLE");
         properties.put(CloudConfigurationConstants.HUAWEI_OBS_SECRET_KEY, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
         CredentialUtil.maskCredential(properties);
-        Assert.assertEquals("AK******LE", properties.get(CloudConfigurationConstants.HUAWEI_OBS_ACCESS_KEY));
-        Assert.assertEquals("wJ******EY", properties.get(CloudConfigurationConstants.HUAWEI_OBS_SECRET_KEY));
+        Assertions.assertEquals("AK******LE", properties.get(CloudConfigurationConstants.HUAWEI_OBS_ACCESS_KEY));
+        Assertions.assertEquals("wJ******EY", properties.get(CloudConfigurationConstants.HUAWEI_OBS_SECRET_KEY));
         
         // Test dot format
         properties.clear();
         properties.put(CloudConfigurationConstants.HUAWEI_OBS_ACCESS_KEY_DOT, "AKIAIOSFODNN7EXAMPLE");
         properties.put(CloudConfigurationConstants.HUAWEI_OBS_SECRET_KEY_DOT, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
         CredentialUtil.maskCredential(properties);
-        Assert.assertEquals("AK******LE", properties.get(CloudConfigurationConstants.HUAWEI_OBS_ACCESS_KEY_DOT));
-        Assert.assertEquals("wJ******EY", properties.get(CloudConfigurationConstants.HUAWEI_OBS_SECRET_KEY_DOT));
+        Assertions.assertEquals("AK******LE", properties.get(CloudConfigurationConstants.HUAWEI_OBS_ACCESS_KEY_DOT));
+        Assertions.assertEquals("wJ******EY", properties.get(CloudConfigurationConstants.HUAWEI_OBS_SECRET_KEY_DOT));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CredentialUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CredentialUtilTest.java
@@ -91,6 +91,26 @@ public class CredentialUtilTest {
     }
 
     @Test
+    public void testMaskHuaweiOBSCredential() {
+        Map<String, String> properties = new HashMap<>();
+        
+        // Test underscore format
+        properties.put(CloudConfigurationConstants.HUAWEI_OBS_ACCESS_KEY, "AKIAIOSFODNN7EXAMPLE");
+        properties.put(CloudConfigurationConstants.HUAWEI_OBS_SECRET_KEY, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
+        CredentialUtil.maskCredential(properties);
+        Assert.assertEquals("AK******LE", properties.get(CloudConfigurationConstants.HUAWEI_OBS_ACCESS_KEY));
+        Assert.assertEquals("wJ******EY", properties.get(CloudConfigurationConstants.HUAWEI_OBS_SECRET_KEY));
+        
+        // Test dot format
+        properties.clear();
+        properties.put(CloudConfigurationConstants.HUAWEI_OBS_ACCESS_KEY_DOT, "AKIAIOSFODNN7EXAMPLE");
+        properties.put(CloudConfigurationConstants.HUAWEI_OBS_SECRET_KEY_DOT, "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
+        CredentialUtil.maskCredential(properties);
+        Assert.assertEquals("AK******LE", properties.get(CloudConfigurationConstants.HUAWEI_OBS_ACCESS_KEY_DOT));
+        Assert.assertEquals("wJ******EY", properties.get(CloudConfigurationConstants.HUAWEI_OBS_SECRET_KEY_DOT));
+    }
+
+    @Test
     public void testAzurePathParseWithABFS() {
         String uri = "abfs://bottle@smith.dfs.core.windows.net/path/1/2";
         AzureStoragePath path = CredentialUtil.parseAzureStoragePath(uri);

--- a/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/credential/CloudConfigurationConstants.java
+++ b/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/share/credential/CloudConfigurationConstants.java
@@ -147,4 +147,11 @@ public class CloudConfigurationConstants {
     public static final String TENCENT_COS_ACCESS_KEY = "tencent.cos.access_key";
     public static final String TENCENT_COS_SECRET_KEY = "tencent.cos.secret_key";
     public static final String TENCENT_COS_ENDPOINT = "tencent.cos.endpoint";
+
+    // Credential for Huawei Cloud OBS
+    public static final String HUAWEI_OBS_ACCESS_KEY = "fs.obs.access_key";
+    public static final String HUAWEI_OBS_SECRET_KEY = "fs.obs.secret_key";
+    public static final String HUAWEI_OBS_ACCESS_KEY_DOT = "fs.obs.access.key";
+    public static final String HUAWEI_OBS_SECRET_KEY_DOT = "fs.obs.secret.key";
+    public static final String HUAWEI_OBS_ENDPOINT = "fs.obs.endpoint";
 }


### PR DESCRIPTION
## Why I'm doing:
When an external catalog created with OBS ak/sk credentials, those credentials were showing in SHOW CREATE CATALOG x output.
## What I'm doing:
Adding masking for OBS credentials
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Masks Huawei OBS access/secret keys (dot and underscore forms) across FE/BE; updates constants/HDFS manager; adds tests.
> 
> - **Security/Masking**:
>   - Mask Huawei OBS credentials: `fs.obs.access_key`, `fs.obs.secret_key`, `fs.obs.access.key`, `fs.obs.secret.key` in `CredentialUtil.maskCredential`.
>   - Add OBS keys to `PrintableMap.SENSITIVE_KEY` to hide in outputs.
> - **Constants/Config**:
>   - Define Huawei OBS constants in `CloudConfigurationConstants` (FE and BE) and include `fs.obs.endpoint`.
> - **HDFS Manager**:
>   - Add underscore-form OBS keys (`FS_OBS_ACCESS_KEY_UNDERSCORE`, `FS_OBS_SECRET_KEY_UNDERSCORE`) in `HdfsFsManager`.
> - **Tests**:
>   - Add unit test to verify masking for both underscore and dot OBS key formats.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad2062cf1fdd505366f900b2f3b76afe52d9fe71. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->