### PR TITLE
[Enhancement] Support enable_statistic_collect_on_first_load at table granularity

### DIFF
--- a/docs/zh/using_starrocks/Cost_based_optimizer.md
+++ b/docs/zh/using_starrocks/Cost_based_optimizer.md
@@ -467,7 +467,7 @@ CREATE ANALYZE FULL ALL db_name PROPERTIES (
 
 | **PROPERTIES**                        | **类型** | **默认值** | **说明**                                                                                                                           |
 |-------------------------------------------|--------|---------|---------------------------------------------------------------------------------------------------------------------------- |
-| enable_statistic_collect_on_first_load    | BOOLEAN  | TRUE     | 执行 INSERT INTO/OVERWRITE 后是否触发统计信息采集任务。                                                                       |
+| enable_statistic_collect_on_first_load    | BOOLEAN  | TRUE     | 执行 INSERT INTO/OVERWRITE 后是否触发统计信息采集任务。该属性既是 FE 全局配置项，也可在表级别通过 CREATE TABLE 或 ALTER TABLE 设置。只有当全局配置和表级配置均为 `TRUE` 时，才会触发统计信息采集。                                                                       |
 | semi_sync_collect_statistic_await_seconds | LONG    | 30     | 返回结果前等待统计信息采集的最长时间。                                                                  |
 | statistic_sample_collect_ratio_threshold_of_first_load | DOUBLE    | 0.1  | OVERWRITE 不触发统计信息搜集任务的数据变动比例。                                                               |
 | statistic_sample_collect_rows             | LONG | 200000    | DML 导入总数据量超过该值时，使用抽样采集统计信息。                                                                               |

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -586,6 +586,8 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
                         GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
                     } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_LABELS_LOCATION)) {
                         GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
+                    } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD)) {
+                        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
                     } else {
                         schemaChangeHandler.process(Lists.newArrayList(clause), db, olapTable);
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2313,6 +2313,22 @@ public class OlapTable extends Table {
         tableProperty.buildReplicatedStorage();
     }
 
+    public boolean enableStatisticCollectOnFirstLoad() {
+        if (tableProperty != null) {
+            return tableProperty.enableStatisticCollectOnFirstLoad();
+        }
+        return true;
+    }
+
+    public void setEnableStatisticCollectOnFirstLoad(boolean enable) {
+        if (tableProperty == null) {
+            tableProperty = new TableProperty(new HashMap<>());
+        }
+        tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD,
+                Boolean.valueOf(enable).toString());
+        tableProperty.buildEnableStatisticCollectOnFirstLoad();
+    }
+
     public boolean allowBucketSizeSetting() {
         return (defaultDistributionInfo instanceof RandomDistributionInfo) && Config.enable_automatic_bucket;
     }
@@ -3163,6 +3179,11 @@ public class OlapTable extends Table {
         Boolean enableLoadProfile = enableLoadProfile();
         if (enableLoadProfile) {
             properties.put(PropertyAnalyzer.PROPERTIES_ENABLE_LOAD_PROFILE, "true");
+        }
+
+        Boolean enableStatisticCollectOnFirstLoad = enableStatisticCollectOnFirstLoad();
+        if (!enableStatisticCollectOnFirstLoad) {
+            properties.put(PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD, "false");
         }
 
         // base compaction forbidden time ranges

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -331,6 +331,9 @@ public class TableProperty implements Writable, GsonPostProcessable {
 
     private TCompactionStrategy compactionStrategy = TCompactionStrategy.DEFAULT;
 
+    @SerializedName(value = "enableStatisticCollectOnFirstLoad")
+    private boolean enableStatisticCollectOnFirstLoad = true;
+
     public TableProperty() {
         this(Maps.newLinkedHashMap());
     }
@@ -419,6 +422,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
                 buildDataCachePartitionDuration();
                 buildLocation();
                 buildStorageCoolDownTTL();
+                buildEnableStatisticCollectOnFirstLoad();
                 break;
             case OperationType.OP_MODIFY_TABLE_CONSTRAINT_PROPERTY:
                 buildConstraint();
@@ -1113,6 +1117,14 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return location;
     }
 
+    public boolean enableStatisticCollectOnFirstLoad() {
+        return enableStatisticCollectOnFirstLoad;
+    }
+
+    public void setEnableStatisticCollectOnFirstLoad(boolean enableStatisticCollectOnFirstLoad) {
+        this.enableStatisticCollectOnFirstLoad = enableStatisticCollectOnFirstLoad;
+    }
+
     public TWriteQuorumType writeQuorum() {
         return writeQuorum;
     }
@@ -1229,6 +1241,12 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return useFastSchemaEvolution;
     }
 
+    public TableProperty buildEnableStatisticCollectOnFirstLoad() {
+        enableStatisticCollectOnFirstLoad = Boolean.parseBoolean(
+                properties.getOrDefault(PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD, "true"));
+        return this;
+    }
+
     @Override
     public void gsonPostProcess() throws IOException {
         try {
@@ -1263,5 +1281,6 @@ public class TableProperty implements Writable, GsonPostProcessable {
         buildFileBundling();
         buildMutableBucketNum();
         buildCompactionStrategy();
+        buildEnableStatisticCollectOnFirstLoad();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -267,6 +267,8 @@ public class PropertyAnalyzer {
 
     public static final String PROPERTIES_DYNAMIC_TABLET_SPLIT_SIZE = "dynamic_tablet_split_size";
 
+    public static final String PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD = "enable_statistic_collect_on_first_load";
+
     /**
      * Matches location labels like : ["*", "a:*", "bcd_123:*", "123bcd_:val_123", "  a :  b  "],
      * leading and trailing space of key and value will be ignored.
@@ -584,6 +586,14 @@ public class PropertyAnalyzer {
             enableLoadProfile = Boolean.parseBoolean(properties.get(PROPERTIES_ENABLE_LOAD_PROFILE));
         }
         return enableLoadProfile;
+    }
+
+    public static boolean analyzeEnableStatisticCollectOnFirstLoad(Map<String, String> properties) {
+        boolean enable = true;
+        if (properties != null && properties.containsKey(PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD)) {
+            enable = Boolean.parseBoolean(properties.get(PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD));
+        }
+        return enable;
     }
 
     public static String analyzeBaseCompactionForbiddenTimeRanges(Map<String, String> properties) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3792,6 +3792,13 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                         ImmutableMap.of(key, propertiesToPersist.get(key)));
                 GlobalStateMgr.getCurrentState().getEditLog().logAlterTableProperties(info);
             }
+            if (propertiesToPersist.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD)) {
+                boolean enable = (boolean) results.get(key);
+                table.setEnableStatisticCollectOnFirstLoad(enable);
+                ModifyTablePropertyOperationLog info = new ModifyTablePropertyOperationLog(db.getId(), table.getId(),
+                        ImmutableMap.of(key, propertiesToPersist.get(key)));
+                GlobalStateMgr.getCurrentState().getEditLog().logAlterTableProperties(info);
+            }
         }
     }
 
@@ -3871,6 +3878,11 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             }
             String locations = PropertyAnalyzer.analyzeLocation(properties, true);
             results.put(PropertyAnalyzer.PROPERTIES_LABELS_LOCATION, locations);
+        }
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD)) {
+            boolean enable = PropertyAnalyzer.analyzeEnableStatisticCollectOnFirstLoad(properties);
+            results.put(PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD, enable);
+            properties.remove(PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD);
         }
         if (!properties.isEmpty()) {
             throw new DdlException("Modify failed because unknown properties: " + properties);

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -467,6 +467,13 @@ public class OlapTableFactory implements AbstractTableFactory {
                 table.setEnableLoadProfile(true);
             }
 
+            if (PropertyAnalyzer.analyzeBooleanProp(properties,
+                    PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD, true)) {
+                table.setEnableStatisticCollectOnFirstLoad(true);
+            } else {
+                table.setEnableStatisticCollectOnFirstLoad(false);
+            }
+
             try {
                 table.setBaseCompactionForbiddenTimeRanges(PropertyAnalyzer.analyzeBaseCompactionForbiddenTimeRanges(properties));
                 if (!table.getBaseCompactionForbiddenTimeRanges().isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -359,6 +359,8 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
             PropertyAnalyzer.analyzeMutableBucketNum(properties);
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_LOAD_PROFILE)) {
             PropertyAnalyzer.analyzeEnableLoadProfile(properties);
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD)) {
+            PropertyAnalyzer.analyzeEnableStatisticCollectOnFirstLoad(properties);
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_BASE_COMPACTION_FORBIDDEN_TIME_RANGES)) {
             if (table instanceof OlapTable) {
                 OlapTable olapTable = (OlapTable) table;

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
@@ -123,7 +123,12 @@ public class StatisticsCollectionTrigger {
     }
 
     private void process() {
-        // check if this feature is disabled
+        if (table instanceof OlapTable) {
+            if (!((OlapTable) table).enableStatisticCollectOnFirstLoad()) {
+                return;
+            }
+        }
+
         if (!Config.enable_statistic_collect_on_first_load) {
             return;
         }

--- a/test/sql/test_analyze_statistics/R/test_overwrite_statistics.sql
+++ b/test/sql/test_analyze_statistics/R/test_overwrite_statistics.sql
@@ -113,3 +113,61 @@ function: assert_explain_costs_contains("select * from test_overwrite_statistics
 -- result:
 None
 -- !result
+drop table sales_data;
+-- result:
+-- !result
+delete from _statistics_.column_statistics where table_name='test_overwrite_statistics.sales_data';
+-- result:
+-- !result
+CREATE TABLE sales_data (
+    id BIGINT,
+    sale_date DATE
+)
+DUPLICATE KEY(id)
+PARTITION BY RANGE(sale_date) (
+    PARTITION p202401 VALUES [('2024-01-01'), ('2024-02-01')),
+    PARTITION p202402 VALUES [('2024-02-01'), ('2024-03-01')),
+    PARTITION p202403 VALUES [('2024-03-01'), ('2024-04-01')),
+    PARTITION p202404 VALUES [('2024-04-01'), ('2024-05-01'))
+)
+DISTRIBUTED BY HASH(id) BUCKETS 4
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+alter table test_overwrite_statistics.sales_data set("enable_statistic_collect_on_first_load"="false");
+-- result:
+-- !result
+INSERT INTO sales_data VALUES
+(1, '2024-01-15'),
+(2, '2024-01-20'),
+(3, '2024-02-10'),
+(4, '2024-02-15'),
+(5, '2024-03-05'),
+(6, '2024-03-12'),
+(7, '2024-04-08'),
+(8, '2024-04-18');
+-- result:
+-- !result
+select count(*) from _statistics_.column_statistics where table_name = 'test_overwrite_statistics.sales_data';
+-- result:
+0
+-- !result
+INSERT OVERWRITE test_overwrite_statistics.sales_data partition("p202401") VALUES (101, '2024-01-10');
+-- result:
+-- !result
+select count(*) from _statistics_.column_statistics where table_name = 'test_overwrite_statistics.sales_data';
+-- result:
+0
+-- !result
+alter table test_overwrite_statistics.sales_data set("enable_statistic_collect_on_first_load"="true");
+-- result:
+-- !result
+INSERT OVERWRITE test_overwrite_statistics.sales_data partition("p202401") VALUES (102, '2024-01-10');
+-- result:
+-- !result
+select count(*) from _statistics_.column_statistics where table_name = 'test_overwrite_statistics.sales_data';
+-- result:
+2
+-- !result

--- a/test/sql/test_analyze_statistics/T/test_overwrite_statistics.sql
+++ b/test/sql/test_analyze_statistics/T/test_overwrite_statistics.sql
@@ -59,3 +59,37 @@ insert overwrite test_overwrite_statistics.test_overwrite_with_sample select gen
 function: assert_explain_costs_contains("select * from test_overwrite_statistics.test_overwrite_with_sample;", "ESTIMATE")
 insert overwrite test_overwrite_statistics.test_overwrite_with_sample select generate_series from table(generate_series(1, 300000));
 function: assert_explain_costs_contains("select * from test_overwrite_statistics.test_overwrite_with_sample;", "ESTIMATE")
+
+drop table sales_data;
+delete from _statistics_.column_statistics where table_name='test_overwrite_statistics.sales_data';
+CREATE TABLE sales_data (
+    id BIGINT,
+    sale_date DATE
+)
+DUPLICATE KEY(id)
+PARTITION BY RANGE(sale_date) (
+    PARTITION p202401 VALUES [('2024-01-01'), ('2024-02-01')),
+    PARTITION p202402 VALUES [('2024-02-01'), ('2024-03-01')),
+    PARTITION p202403 VALUES [('2024-03-01'), ('2024-04-01')),
+    PARTITION p202404 VALUES [('2024-04-01'), ('2024-05-01'))
+)
+DISTRIBUTED BY HASH(id) BUCKETS 4
+PROPERTIES (
+    "replication_num" = "1"
+);
+alter table test_overwrite_statistics.sales_data set("enable_statistic_collect_on_first_load"="false");
+INSERT INTO sales_data VALUES
+(1, '2024-01-15'),
+(2, '2024-01-20'),
+(3, '2024-02-10'),
+(4, '2024-02-15'),
+(5, '2024-03-05'),
+(6, '2024-03-12'),
+(7, '2024-04-08'),
+(8, '2024-04-18');
+select count(*) from _statistics_.column_statistics where table_name = 'test_overwrite_statistics.sales_data';
+INSERT OVERWRITE test_overwrite_statistics.sales_data partition("p202401") VALUES (101, '2024-01-10');
+select count(*) from _statistics_.column_statistics where table_name = 'test_overwrite_statistics.sales_data';
+alter table test_overwrite_statistics.sales_data set("enable_statistic_collect_on_first_load"="true");
+INSERT OVERWRITE test_overwrite_statistics.sales_data partition("p202401") VALUES (102, '2024-01-10');
+select count(*) from _statistics_.column_statistics where table_name = 'test_overwrite_statistics.sales_data';


### PR DESCRIPTION
## **Why I'm doing:**

Users need table-level granularity to selectively disable statistics collection for specific tables while keeping the global feature enabled for others. This PR addresses this need by introducing a table-level property. 

## **What I'm doing:**

Add support for `enable_statistic_collect_on_first_load` property at table granularity to provide fine-grained control over statistics collection behavior. It is mainly used to determine whether to update statistics after insert into/overwrite operations.

### **Key Changes:**

1. **New Table Property**: `enable_statistic_collect_on_first_load` (default: `true`)
   - Can be set during `CREATE TABLE` via `PROPERTIES` clause
   - Can be modified via `ALTER TABLE ... SET ("enable_statistic_collect_on_first_load" = "true|false")`
   - Displayed in `SHOW CREATE TABLE` output when set to `false`

2. **Statistics Collection Logic**: The system now checks both global config and table-level property
   - Statistics collection occurs **only when both** global config (`Config.enable_statistic_collect_on_first_load`) **and** table property are enabled
   - This allows users to selectively disable statistics collection for specific tables while keeping the global feature enabled

### **Statistics Collection Behavior Matrix:**

| Global Config (`Config`) | Table Property     | Statistics Collection |
|--------------------------|--------------------|----------------------|
| Enabled (default)        | Enabled (default)  | ✅ **Collect**       |
| Enabled                  | Disabled           | ❌ Not Collect       |
| Disabled                 | Enabled            | ❌ Not Collect       |
| Disabled                 | Disabled           | ❌ Not Collect       |

**Summary**: Statistics are collected **only when both** global config and table property are enabled (logical AND).

### **Use Cases:**

- **High-frequency load tables**: Skip statistics for tables with frequent `INSERT INTO`/`INSERT OVERWRITE` operations to improve load performance
- **Intermediate/Staging tables**: Disable statistics for temporary or staging tables where accurate statistics are not critical
- **Performance optimization**: Reduce system overhead for tables where statistics don't significantly benefit query optimization


### **SQL Examples:**

```sql
-- Create a large table with statistics collection disabled
CREATE TABLE large_fact_table (
    id BIGINT,
    event_time DATETIME,
    user_id BIGINT,
    -- ... more columns ...
) 
PROPERTIES (
    "enable_statistic_collect_on_first_load" = "false"
);

-- Disable statistics collection for a high-frequency load table
ALTER TABLE realtime_logs SET ("enable_statistic_collect_on_first_load" = "false");

-- Re-enable statistics collection when needed
ALTER TABLE realtime_logs SET ("enable_statistic_collect_on_first_load" = "true");

-- Check current setting in SHOW CREATE TABLE
SHOW CREATE TABLE realtime_logs;
-- Output includes: "enable_statistic_collect_on_first_load" = "false" (only shown when set to false)
```


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce table property `enable_statistic_collect_on_first_load` (default true) to gate post-DML stats collection per table, enforced in creation, ALTER, and trigger logic, with docs and tests.
> 
> - **Statistics collection behavior**:
>   - Add table-level property `enable_statistic_collect_on_first_load` (default `true`); stats collect runs only if both global config and this table property are `true`.
>   - `StatisticsCollectionTrigger`: checks table flag before triggering.
> - **DDL/metadata support**:
>   - `CREATE TABLE`/`ALTER TABLE ... SET` support via `OlapTableFactory`, `AlterTableClauseAnalyzer`, `AlterJobExecutor`, `LocalMetastore` (validation/persist/edit log).
>   - `TableProperty`/`OlapTable`: new field, getters/setters, (de)serialization, include in `SHOW CREATE TABLE` when `false`.
>   - `PropertyAnalyzer`: add constant and analyzers.
> - **Docs**:
>   - Update CBO docs to describe table-level property and AND semantics with global config.
> - **Tests**:
>   - Extend SQL tests to verify disabling/enabling property suppresses/enables stats after INSERT/OVERWRITE.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eeb01e14bba7a36f5f4d529413a085dbad3724d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->