### PR TITLE
[Enhancement] Support Paimon Table in IVM Refresh

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/tvr/TvrTableSnapshot.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/tvr/TvrTableSnapshot.java
@@ -46,6 +46,10 @@ public final class TvrTableSnapshot extends TvrVersionRange {
         super(TvrVersion.MIN, to);
     }
 
+    public long getSnapshotId() {
+        return to.getVersion();
+    }
+
     @Override
     public boolean isEmpty() {
         return to.isMinOrMax();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -149,7 +149,7 @@ public interface ConnectorMetadata {
     }
 
     /**
-     * NOTE: ensure the last snapshot is in the last of the collection.
+     * NOTE: ensure the last snapshot is at the last of the collection.
      *
      * @param dbName  database name
      * @param table table name

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -139,10 +139,24 @@ public interface ConnectorMetadata {
         return TvrTableSnapshot.empty();
     }
 
+    /**
+     * @param dbName database name of the table
+     * @param table table name
+     * @return the current latest snapshot info of the input table.
+     */
     default TvrTableSnapshot getCurrentTvrSnapshot(String dbName, Table table) {
         return TvrTableSnapshot.empty();
     }
 
+    /**
+     * NOTE: ensure the last snapshot is in the last of the collection.
+     *
+     * @param dbName  database name
+     * @param table table name
+     * @param fromSnapshotExclusive from snapshot which is exclusive
+     * @param toSnapshotInclusive  to snapshot which is inclusive
+     * @return ordered delta traits which are from the start snapshot to the start snapshot.
+     */
     default List<TvrTableDeltaTrait> listTableDeltaTraits(String dbName, Table table,
                                                           TvrTableSnapshot fromSnapshotExclusive,
                                                           TvrTableSnapshot toSnapshotInclusive) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -568,7 +568,7 @@ public class IcebergMetadata implements ConnectorMetadata {
             return Collections.emptyList();
         }
         // fromSnapshotExclusive can be empty, but toSnapshotInclusive must have a valid snapshot ID
-        final long fromSnapshotIdExclusive = fromSnapshotExclusive.from.getVersion();
+        final long fromSnapshotIdExclusive = fromSnapshotExclusive.getSnapshotId();
         final long toSnapshotIdInclusive =
                 toSnapshotInclusive.end().orElseThrow(() -> new StarRocksConnectorException(
                         "toSnapshotInclusive must have a valid snapshot ID"));

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -301,7 +301,7 @@ public class PaimonMetadata implements ConnectorMetadata {
             return Collections.emptyList();
         }
         // fromSnapshotExclusive can be empty, but toSnapshotInclusive must have a valid snapshot ID
-        final long fromSnapshotIdExclusive = fromSnapshotExclusive.from.getVersion();
+        final long fromSnapshotIdExclusive = fromSnapshotExclusive.getSnapshotId();
         final long toSnapshotIdInclusive =
                 toSnapshotInclusive.end().orElseThrow(() -> new StarRocksConnectorException(
                         "toSnapshotInclusive must have a valid snapshot ID"));
@@ -345,7 +345,7 @@ public class PaimonMetadata implements ConnectorMetadata {
                     } else {
                         // ensure this snapshot id is equal to from
                         if (currentSnapshot.id() != fromSnapshotIdExclusive) {
-                            throw new SemanticException(String.format("Expect from snapshot id:{}, but got:{}",
+                            throw new SemanticException(String.format("Expect from snapshot id:%s, but got:%s",
                                     fromSnapshotIdExclusive, currentSnapshot.id()));
                         }
                     }
@@ -369,7 +369,6 @@ public class PaimonMetadata implements ConnectorMetadata {
             long endSnapshotId = tableDelta.end().get();
             dynamicOptions.put("incremental-between", startSnapshotId + "," + endSnapshotId);
             dynamicOptions.put("incremental-between-scan-mode", "auto");
-            dynamicOptions.put("ignore-delete", "true");
         }
         return nativeTable.copy(dynamicOptions);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -358,12 +358,18 @@ public class PaimonMetadata implements ConnectorMetadata {
         }
     }
 
+    /**
+     * If tvrVersionRange is present, build an incremental scan from start snapshot to end snapshot.
+     * @param nativeTable paimon native table
+     * @param tvrVersionRange input tvrVersionRange
+     * @return a native paimon table with
+     */
     private org.apache.paimon.table.Table getNativeTable(org.apache.paimon.table.Table nativeTable,
                                                          TvrVersionRange tvrVersionRange) {
-        // Build dynamic options for incremental-between
         Map<String, String> dynamicOptions = new HashMap<>();
         if (tvrVersionRange != null && tvrVersionRange.start().isPresent()
                 && tvrVersionRange.end().isPresent()) {
+            // Build dynamic options for incremental-between
             TvrTableDelta tableDelta = (TvrTableDelta) tvrVersionRange;
             long startSnapshotId = tableDelta.start().get();
             long endSnapshotId = tableDelta.end().get();
@@ -380,6 +386,7 @@ public class PaimonMetadata implements ConnectorMetadata {
 
         TvrVersionRange tvrVersionRange = params.getTableVersionRange();
         if (tvrVersionRange == null) {
+            // if input version range is null, use the lastest snapshot id as it
             long latestSnapshotId = -1L;
             try {
                 if (paimonTable.getNativeTable().latestSnapshot().isPresent()) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -24,6 +24,9 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
+import com.starrocks.common.tvr.TvrDeltaStats;
+import com.starrocks.common.tvr.TvrTableDelta;
+import com.starrocks.common.tvr.TvrTableDeltaTrait;
 import com.starrocks.common.tvr.TvrTableSnapshot;
 import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.ColumnTypeConverter;
@@ -41,6 +44,7 @@ import com.starrocks.connector.statistics.StatisticsUtils;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -51,6 +55,7 @@ import com.starrocks.type.Type;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.paimon.CoreOptions;
+import org.apache.paimon.Snapshot;
 import org.apache.paimon.catalog.CachingCatalog;
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Identifier;
@@ -76,6 +81,7 @@ import org.apache.paimon.types.DateType;
 import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.DateTimeUtils;
 import org.apache.paimon.utils.PartitionPathUtils;
+import org.apache.paimon.utils.SnapshotManager;
 import org.apache.paimon.utils.StringUtils;
 
 import java.time.LocalDateTime;
@@ -83,7 +89,9 @@ import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -279,33 +287,110 @@ public class PaimonMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public TvrTableSnapshot getCurrentTvrSnapshot(String dbName, Table table) {
+        PaimonTable paimonTable = (PaimonTable) table;
+        Optional<Long> snapshotId = paimonTable.getNativeTable().latestSnapshot().map(snapshot -> snapshot.id());
+        return TvrTableSnapshot.of(snapshotId);
+    }
+
+    @Override
+    public List<TvrTableDeltaTrait> listTableDeltaTraits(String dbName, Table table,
+                                                         TvrTableSnapshot fromSnapshotExclusive,
+                                                         TvrTableSnapshot toSnapshotInclusive) {
+        if (fromSnapshotExclusive.equals(toSnapshotInclusive)) {
+            return Collections.emptyList();
+        }
+        // fromSnapshotExclusive can be empty, but toSnapshotInclusive must have a valid snapshot ID
+        final long fromSnapshotIdExclusive = fromSnapshotExclusive.from.getVersion();
+        final long toSnapshotIdInclusive =
+                toSnapshotInclusive.end().orElseThrow(() -> new StarRocksConnectorException(
+                        "toSnapshotInclusive must have a valid snapshot ID"));
+        final PaimonTable paimonTable = (PaimonTable) table;
+        final org.apache.paimon.table.Table paimonNativeTable = paimonTable.getNativeTable();
+        if (paimonNativeTable instanceof org.apache.paimon.table.DataTable) {
+            org.apache.paimon.table.DataTable paimonDataTable = (org.apache.paimon.table.DataTable) paimonNativeTable;
+            SnapshotManager snapshotManager = new SnapshotManager(paimonNativeTable.fileIO(),
+                    paimonDataTable.location(), null, null, null);
+            // result is ensured to sort by snapshot id
+            Iterator<Snapshot> iterator = snapshotManager.snapshotsWithinRange(
+                    Optional.of(toSnapshotIdInclusive),
+                    Optional.of(fromSnapshotIdExclusive)
+            );
+            List<TvrTableDeltaTrait> result = new ArrayList<>();
+            Snapshot lastSnapshot = null;
+            while (iterator.hasNext()) {
+                Snapshot currentSnapshot = iterator.next();
+                if  (lastSnapshot != null) {
+                    long lastRecordCount = lastSnapshot.totalRecordCount();
+                    long currentRecordCount = currentSnapshot.totalRecordCount();
+                    long deltaRecordCount = currentRecordCount - lastRecordCount;
+                    TvrTableDelta delta = TvrTableDelta.of(lastSnapshot.id(), currentSnapshot.id());
+                    TvrDeltaStats stats = TvrDeltaStats.of(deltaRecordCount, 0L);
+                    if (currentSnapshot.commitKind() == Snapshot.CommitKind.APPEND) {
+                        result.add(TvrTableDeltaTrait.ofMonotonic(delta, stats));
+                    } else {
+                        result.add(TvrTableDeltaTrait.ofRetractable(delta, stats));
+                    }
+                }
+                lastSnapshot = currentSnapshot;
+            }
+            return result;
+        } else {
+            throw new SemanticException("Incremental read unsupported table type: " + paimonNativeTable.getClass());
+        }
+    }
+
+    private org.apache.paimon.table.Table getNativeTable(org.apache.paimon.table.Table nativeTable,
+                                                         TvrVersionRange tvrVersionRange) {
+        // Build dynamic options for incremental-between
+        Map<String, String> dynamicOptions = new HashMap<>();
+        if (tvrVersionRange != null && tvrVersionRange.start().isPresent()
+                && tvrVersionRange.end().isPresent()) {
+            TvrTableDelta tableDelta = (TvrTableDelta) tvrVersionRange;
+            long startSnapshotId = tableDelta.start().get();
+            long endSnapshotId = tableDelta.end().get();
+            dynamicOptions.put("incremental-between", startSnapshotId + "," + endSnapshotId);
+            dynamicOptions.put("incremental-between-scan-mode", "auto");
+            dynamicOptions.put("ignore-delete", "true");
+        }
+        return nativeTable.copy(dynamicOptions);
+    }
+
+    @Override
     public List<RemoteFileInfo> getRemoteFiles(Table table, GetRemoteFilesParams params) {
         RemoteFileInfo remoteFileInfo = new RemoteFileInfo();
         PaimonTable paimonTable = (PaimonTable) table;
-        long latestSnapshotId = -1L;
-        try {
-            if (paimonTable.getNativeTable().latestSnapshot().isPresent()) {
-                latestSnapshotId = paimonTable.getNativeTable().latestSnapshot().get().id();
+
+        TvrVersionRange tvrVersionRange = params.getTableVersionRange();
+        if (tvrVersionRange == null) {
+            long latestSnapshotId = -1L;
+            try {
+                if (paimonTable.getNativeTable().latestSnapshot().isPresent()) {
+                    latestSnapshotId = paimonTable.getNativeTable().latestSnapshot().get().id();
+                }
+            } catch (Exception e) {
+                // System table does not have snapshotId, ignore it.
+                LOG.warn("Cannot get snapshot because {}", e.getMessage());
             }
-        } catch (Exception e) {
-            // System table does not have snapshotId, ignore it.
-            LOG.warn("Cannot get snapshot because {}", e.getMessage());
+            tvrVersionRange = TvrTableSnapshot.of(latestSnapshotId);
         }
 
         GetRemoteFilesParams copyParams = params.copy();
-        copyParams.setTableVersionRange(TvrTableSnapshot.of(latestSnapshotId));
-
+        copyParams.setTableVersionRange(tvrVersionRange);
         PredicateSearchKey filter = PredicateSearchKey.of(paimonTable.getCatalogDBName(),
                 paimonTable.getCatalogTableName(), copyParams);
 
+        org.apache.paimon.table.Table paimonNativeTable = getNativeTable(paimonTable.getNativeTable(),
+                tvrVersionRange);
         if (!paimonSplits.containsKey(filter)) {
-            ReadBuilder readBuilder = paimonTable.getNativeTable().newReadBuilder();
+            ReadBuilder readBuilder = paimonNativeTable.newReadBuilder();
             int[] projected =
                     params.getFieldNames().stream().mapToInt(name -> (paimonTable.getFieldNames().indexOf(name))).toArray();
             List<Predicate> predicates = extractPredicates(paimonTable, params.getPredicate());
             boolean pruneManifestsByLimit = params.getLimit() != -1 && params.getLimit() < Integer.MAX_VALUE
                     && onlyHasPartitionPredicate(table, params.getPredicate());
             readBuilder = readBuilder.withFilter(predicates).withProjection(projected);
+
             if (pruneManifestsByLimit) {
                 readBuilder = readBuilder.withLimit((int) params.getLimit());
             }
@@ -399,7 +484,7 @@ public class PaimonMetadata implements ConnectorMetadata {
             if (!session.getSessionVariable().enablePaimonColumnStatistics()) {
                 return defaultStatistics(columns, table, predicate, limit);
             }
-            org.apache.paimon.table.Table nativeTable = ((PaimonTable) table).getNativeTable();
+            org.apache.paimon.table.Table nativeTable = getNativeTable(((PaimonTable) table).getNativeTable(), versionRange);
             Optional<org.apache.paimon.stats.Statistics> statistics = nativeTable.statistics();
             if (!statistics.isPresent() || statistics.get().colStats() == null
                     || !statistics.get().mergedRecordCount().isPresent()) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -68,7 +68,6 @@ public class IcebergScanNode extends ScanNode {
     private final HDFSScanNodePredicates scanNodePredicates = new HDFSScanNodePredicates();
     private ScalarOperator icebergJobPlanningPredicate = null;
     private CloudConfiguration cloudConfiguration = null;
-    protected TvrVersionRange tvrVersionRange;
     private IcebergConnectorScanRangeSource scanRangeSource = null;
     private final IcebergTableMORParams tableFullMORParams;
     private final IcebergMORParams morParams;
@@ -245,10 +244,6 @@ public class IcebergScanNode extends ScanNode {
     // for unit tests
     public IcebergTableMORParams getTableFullMORParams() {
         return tableFullMORParams;
-    }
-
-    public void setTvrVersionRange(TvrVersionRange tvrVersionRange) {
-        this.tvrVersionRange = tvrVersionRange;
     }
 
     public HDFSScanNodePredicates getScanNodePredicates() {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.PaimonTable;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
+import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.CatalogConnector;
 import com.starrocks.connector.ConnectorMetadatRequestContext;
 import com.starrocks.connector.GetRemoteFilesParams;
@@ -127,9 +128,12 @@ public class PaimonScanNode extends ScanNode {
     public void setupScanRangeLocations(TupleDescriptor tupleDescriptor, ScalarOperator predicate, long limit) {
         List<String> fieldNames =
                 tupleDescriptor.getSlots().stream().map(s -> s.getColumn().getName()).collect(Collectors.toList());
-        GetRemoteFilesParams params =
-                GetRemoteFilesParams.newBuilder().setPredicate(predicate).setFieldNames(fieldNames).setLimit(limit)
-                        .build();
+        GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder()
+                .setPredicate(predicate)
+                .setFieldNames(fieldNames)
+                .setTableVersionRange(tvrVersionRange)
+                .setLimit(limit)
+                .build();
         List<RemoteFileInfo> fileInfos;
         try (Timer ignored = Tracers.watchScope(EXTERNAL, paimonTable.getCatalogTableName() + ".getPaimonRemoteFileInfos")) {
             fileInfos = GlobalStateMgr.getCurrentState().getMetadataMgr().getRemoteFiles(paimonTable, params);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ScanNode.java
@@ -39,6 +39,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.ColumnAccessPath;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.common.tvr.TvrVersionRange;
 import com.starrocks.connector.BucketProperty;
 import com.starrocks.connector.RemoteFilesSampleStrategy;
 import com.starrocks.datacache.DataCacheOptions;
@@ -76,6 +77,8 @@ public abstract class ScanNode extends PlanNode {
     // NOTE: To avoid trigger a new compute resource creation, set the value when the scan node needs to use it.
     // The compute resource used by this scan node.
     protected ComputeResource computeResource = WarehouseManager.DEFAULT_RESOURCE;
+    // the scan node's version range to scan
+    protected TvrVersionRange tvrVersionRange;
 
     private Map<SlotId, Expr> heavyExprs = Maps.newHashMap();
 
@@ -157,6 +160,10 @@ public abstract class ScanNode extends PlanNode {
         } else {
             return expr;
         }
+    }
+
+    public void setTvrVersionRange(TvrVersionRange tvrVersionRange) {
+        this.tvrVersionRange = tvrVersionRange;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMBasedRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMBasedRefreshProcessor.java
@@ -194,7 +194,7 @@ public final class MVIVMBasedRefreshProcessor extends BaseMVRefreshProcessor {
                     baseTableInfo.getDbName(), baseTableInfo.getTableName());
         }
         if (!IVMAnalyzer.isTableTypeIVMSupported(snapshotTable.getType())) {
-            throw new SemanticException(String.format("Only support {} tables for MVIVMBasedRefreshProcessor, " +
+            throw new SemanticException(String.format("Only support %s tables for MVIVMBasedRefreshProcessor, " +
                     "but got: %s", Joiner.on(",").join(IVMAnalyzer.SUPPORTED_TABLE_TYPES),
                     snapshotTable.getType()));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMBasedRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/ivm/MVIVMBasedRefreshProcessor.java
@@ -14,11 +14,11 @@
 
 package com.starrocks.scheduler.mv.ivm;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
@@ -54,6 +54,7 @@ import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.PlannerMetaLocker;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.analyzer.mv.IVMAnalyzer;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.TableRelation;
@@ -192,13 +193,12 @@ public final class MVIVMBasedRefreshProcessor extends BaseMVRefreshProcessor {
             throw new SemanticException("Base table %s.%s does not exist",
                     baseTableInfo.getDbName(), baseTableInfo.getTableName());
         }
-        if (!snapshotTable.isIcebergTable()) {
-            throw new SemanticException("Only support Iceberg table for MVIVMBasedRefreshProcessor, " +
-                    "but got: " + snapshotTable.getType());
+        if (!IVMAnalyzer.isTableTypeIVMSupported(snapshotTable.getType())) {
+            throw new SemanticException(String.format("Only support {} tables for MVIVMBasedRefreshProcessor, " +
+                    "but got: %s", Joiner.on(",").join(IVMAnalyzer.SUPPORTED_TABLE_TYPES),
+                    snapshotTable.getType()));
         }
-        IcebergTable icebergTable = (IcebergTable) snapshotTable;
-
-        final TvrTableDelta maxTvrDelta = getMaxBaseTableChangedDelta(baseTableInfo, icebergTable, mvTvrVersionRangeMap);
+        final TvrTableDelta maxTvrDelta = getMaxBaseTableChangedDelta(baseTableInfo, snapshotTable, mvTvrVersionRangeMap);
         // if no change, return empty
         if (maxTvrDelta.isEmpty()) {
             return maxTvrDelta;
@@ -206,7 +206,7 @@ public final class MVIVMBasedRefreshProcessor extends BaseMVRefreshProcessor {
 
         // check the delta traits between the max delta
         List<TvrTableDeltaTrait> tableDeltaTraits = GlobalStateMgr.getCurrentState().getMetadataMgr()
-                .listTableDeltaTraits(baseTableInfo.getDbName(), icebergTable,
+                .listTableDeltaTraits(baseTableInfo.getDbName(), snapshotTable,
                         maxTvrDelta.fromSnapshot(), maxTvrDelta.toSnapshot());
         if (CollectionUtils.isEmpty(tableDeltaTraits)) {
             logger.warn("No tvr delta traits found for base table: {}, db: {}", baseTableInfo.getTableName(),
@@ -255,12 +255,12 @@ public final class MVIVMBasedRefreshProcessor extends BaseMVRefreshProcessor {
     }
 
     private TvrTableDelta getMaxBaseTableChangedDelta(BaseTableInfo baseTableInfo,
-                                                      IcebergTable icebergTable,
+                                                      Table table,
                                                       Map<BaseTableInfo, TvrVersionRange> mvTvrVersionRangeMap) {
         // For now, we always refresh the latest snapshot from the last refresh.
         // current tvr snapshot
         TvrVersionRange currentTvrSnapshot = GlobalStateMgr.getCurrentState().getMetadataMgr()
-                .getCurrentTvrSnapshot(baseTableInfo.getDbName(), icebergTable);
+                .getCurrentTvrSnapshot(baseTableInfo.getDbName(), table);
         if (currentTvrSnapshot == null || !(currentTvrSnapshot instanceof TvrTableSnapshot)) {
             logger.warn("Current tvr snapshot is null for base table: {}, db: {}",
                     baseTableInfo.getTableName(), baseTableInfo.getDbName());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
@@ -100,17 +100,11 @@ public class IVMAnalyzer {
         this.queryStatement = queryStatement;
     }
 
-    public static boolean isSupportedIVM(MaterializedView mv) {
-        if (mv == null) {
-            return false;
+    public static boolean isTableTypeIVMSupported(Table.TableType tableType) {
+        if (SUPPORTED_TABLE_TYPES.contains(tableType)) {
+            return true;
         }
-        // check table types
-        for (Table baseTable : mv.getBaseTables()) {
-            if (!SUPPORTED_TABLE_TYPES.contains(baseTable.getType())) {
-                return false;
-            }
-        }
-        return true;
+        return false;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/mv/IVMAnalyzer.java
@@ -76,7 +76,8 @@ public class IVMAnalyzer {
 
     // table tables that supports IVM
     public static final Set<Table.TableType> SUPPORTED_TABLE_TYPES = Set.of(
-            Table.TableType.ICEBERG
+            Table.TableType.ICEBERG,
+            Table.TableType.PAIMON
     );
 
     // join operators that supports IVM

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
@@ -202,10 +202,10 @@ public class CachingMvPlanContextBuilder {
         try {
             result = future.get(timeoutMs, TimeUnit.MILLISECONDS);
         } catch (TimeoutException e) {
-            LOG.warn("get mv plan cache timeout: {}", mv.getName());
+            LOG.warn("get mv plan cache timeout: {}, timeout(ms):{}", mv.getName(), timeoutMs);
             return null;
         } catch (Throwable e) {
-            LOG.warn("get mv plan cache failed: {}", mv.getName(), e);
+            LOG.warn("get mv plan cache failed: {}, timeout(ms):{}", mv.getName(), timeoutMs, e);
             return null;
         }
         if (LOG.isDebugEnabled()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -746,6 +746,9 @@ public class RelationTransformer implements AstVisitorExtendInterface<LogicalPla
             throw new StarRocksPlannerException("Not support table type: " + node.getTable().getType(),
                     ErrorType.UNSUPPORTED);
         }
+        if (tableVersionRange != null) {
+            scanOperator.setTvrVersionRange(tableVersionRange);
+        }
         OptExprBuilder scanBuilder = new OptExprBuilder(scanOperator, Collections.emptyList(),
                 new ExpressionMapping(node.getScope(), outputVariables));
         if (isAddExtraFilterOperator(session.getSessionVariable(), node)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1404,6 +1404,7 @@ public class PlanFragmentBuilder {
                     new PaimonScanNode(context.getNextNodeId(), tupleDescriptor, "PaimonScanNode");
             paimonScanNode.setScanOptimizeOption(node.getScanOptimizeOption());
             paimonScanNode.computeStatistics(optExpression.getStatistics());
+            paimonScanNode.setTvrVersionRange(node.getTvrVersionRange());
             currentExecGroup.add(paimonScanNode, true);
             try {
                 // set predicate


### PR DESCRIPTION
## Why I'm doing:
As https://github.com/StarRocks/starrocks/issues/61789 introduced IVM Framework and supports `iceberg` as the source table to generate incremental plans; we can also extend this abilitiy to `paimon` table.


## What I'm doing:
- Suport paimon table in IVM refresh and refactor associated codes for better extensibility.

Fixes https://github.com/StarRocks/starrocks/issues/61789

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds IVM support for Paimon by implementing TVR snapshot/delta APIs and wiring table-version ranges through optimizer and scan nodes to execute incremental reads.
> 
> - **IVM/TVR**:
>   - Add `TvrTableSnapshot#getSnapshotId()` and use it in Iceberg code.
>   - Generalize TVR table-scan rule to all scans and support PAIMON (was Iceberg-only).
>   - MV refresh processor now validates supported table types via `IVMAnalyzer` and works with generic `Table`.
> - **Paimon Connector**:
>   - Implement `getCurrentTvrSnapshot` and `listTableDeltaTraits` (via `SnapshotManager`).
>   - Support incremental reads by translating `TvrTableDelta` to Paimon dynamic options (`incremental-between`).
>   - Thread `TvrVersionRange` into `getRemoteFiles` and table statistics.
> - **Planner/Optimizer**:
>   - Add `tvrVersionRange` to `ScanNode`; remove duplicate field in `IcebergScanNode` and pass range in `PaimonScanNode`.
>   - Propagate table version ranges from `RelationTransformer` to logical scans; set on physical Paimon scans in `PlanFragmentBuilder`.
> - **Misc**:
>   - Extend `IVMAnalyzer` supported types to include `PAIMON`.
>   - Minor logging improvements in MV plan cache builder.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe6f84debcf5d246ac5ed768bd3a64ddca6bb05e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->