### PR TITLE
[Enhancement] Restrict SplitTopNAggregateRule's check condition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitTopNAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitTopNAggregateRule.java
@@ -51,7 +51,7 @@ import java.util.Map;
 /*
  * e.g.
  *    select a, b, count(c) as cc, sum(d)
- *    from t
+ *    from t group by a, b
  *    order by cc limit 10
  *
  * -> select t.a, t.b, cc, sum(d)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitTopNAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitTopNAggregateRule.java
@@ -38,7 +38,6 @@ import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rule.RuleType;
@@ -127,21 +126,9 @@ public class SplitTopNAggregateRule extends TransformationRule {
         return true;
     }
 
-    /**
-     * Check predicate and column type constraints for split topN aggregate optimization.
-     * Only check columns that will be read twice (duplicated columns).
-     * <p>
-     * Rules:
-     * 1. No predicate: allow if duplicated columns have no long string/complex types
-     * 2. Single predicate:
-     * - Fixed-length types: allow (low cost for predicate evaluation)
-     * - String types:
-     * - Long strings (averageRowSize > 5 or no statistics): disallow (high cost for reading and evaluation)
-     * - Short strings (averageRowSize <= 5) + col != '': allow (low cost, likely to reduce agg input)
-     * 3. Multiple predicates: disallow (complex case)
-     */
     private boolean checkPredicateAndColumnConstraints(LogicalOlapScanOperator scan, Statistics scanStatistics,
                                                        ColumnRefSet duplicatedColumns) {
+        // if read too much repeated columns, scan's extra costs may bigger then agg's
         if (duplicatedColumns.size() > 3) {
             return false;
         }
@@ -152,53 +139,11 @@ public class SplitTopNAggregateRule extends TransformationRule {
 
         ScalarOperator predicate = scan.getPredicate();
         List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);
+        List<ScalarOperator> disconjuncts = Utils.extractDisjunctive(predicate);
 
-        // Case 1: No predicate
-        if (conjuncts.isEmpty()) {
-            return true;
-        }
-
-        if (conjuncts.size() > 1 || predicate)
-
-        // Case 3: Single predicate
-        ScalarOperator singlePredicate = conjuncts.get(0);
-
-        // Extract column references from the predicate that are in duplicated columns
-        List<ColumnRefOperator> predicateColumns = singlePredicate.getColumnRefs().stream()
-                .filter(colRef -> duplicatedColumns.contains(colRef))
-                .collect(java.util.stream.Collectors.toList());
-
-        if (predicateColumns.isEmpty()) {
-            // No duplicated column in predicate, check all duplicated columns
-            return !hasLongStringOrComplexType(scan, duplicatedColumns, scanStatistics);
-        }
-
-        // Check each duplicated column used in the predicate
-        // If any column doesn't meet the requirements, disallow the optimization
-        for (ColumnRefOperator colRef : predicateColumns) {
-            Type colType = colRef.getType();
-
-            // Complex type: disallow
-            if (isComplexType(colType)) {
-                return false;
-            }
-
-            // Check if it's a fixed-length type (non-string, non-complex)
-            if (!colType.isStringType()) {
-                // Fixed-length type: allow (low cost)
-                continue;
-            }
-
-            // String type: need to check average row size and predicate form
-            // Long string: disallow if averageRowSize > 5 or no statistics
-            if (isLongString(colRef, scanStatistics)) {
-                return false;
-            }
-
-            // Short string: only allow if predicate is col != ''
-            if (!isNotEqualEmptyStringPredicate(singlePredicate, colRef)) {
-                return false;
-            }
+        // if evaluate too much predicates, scan's extra costs may bigger then agg's
+        if (conjuncts.size() > 2 || disconjuncts.size() > 2) {
+            return false;
         }
 
         return true;
@@ -234,7 +179,7 @@ public class SplitTopNAggregateRule extends TransformationRule {
      * Check if a string column is a long string based on statistics.
      * Returns true if:
      * - No statistics available, OR
-     * - averageRowSize > 5
+     * - averageRowSize >= 5
      */
     private boolean isLongString(ColumnRefOperator colRef, Statistics scanStatistics) {
         if (scanStatistics == null) {
@@ -249,8 +194,7 @@ public class SplitTopNAggregateRule extends TransformationRule {
         }
 
         double averageRowSize = columnStatistic.getAverageRowSize();
-        // Long string if averageRowSize > 5
-        return averageRowSize > 5;
+        return averageRowSize >= 5;
     }
 
     /**
@@ -258,51 +202,6 @@ public class SplitTopNAggregateRule extends TransformationRule {
      */
     private boolean isComplexType(Type type) {
         return type.isComplexType() || type.isJsonType() || type.isVariantType();
-    }
-
-    /**
-     * Check if the predicate is of form: col != '' (not equal to empty string).
-     */
-    private boolean isNotEqualEmptyStringPredicate(ScalarOperator predicate, ColumnRefOperator colRef) {
-        if (!(predicate instanceof BinaryPredicateOperator)) {
-            return false;
-        }
-
-        BinaryPredicateOperator binPred = (BinaryPredicateOperator) predicate;
-        if (binPred.getBinaryType() != BinaryType.NE) {
-            return false;
-        }
-
-        // Check if one side is the column and the other is empty string constant
-        ScalarOperator left = binPred.getChild(0);
-        ScalarOperator right = binPred.getChild(1);
-
-        return (isColumnRef(left, colRef) && isEmptyStringConstant(right)) ||
-                (isColumnRef(right, colRef) && isEmptyStringConstant(left));
-    }
-
-    /**
-     * Check if the operator is a ColumnRefOperator matching the given column.
-     */
-    private boolean isColumnRef(ScalarOperator op, ColumnRefOperator colRef) {
-        return op instanceof ColumnRefOperator && op.equals(colRef);
-    }
-
-    /**
-     * Check if the operator is a ConstantOperator representing empty string.
-     */
-    private boolean isEmptyStringConstant(ScalarOperator op) {
-        if (!(op instanceof ConstantOperator)) {
-            return false;
-        }
-
-        ConstantOperator constOp = (ConstantOperator) op;
-        if (constOp.isNull() || !constOp.getType().isStringType()) {
-            return false;
-        }
-
-        String value = constOp.getVarchar();
-        return value != null && value.isEmpty();
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -3198,17 +3198,97 @@ public class AggregateTest extends PlanTestBase {
     public void testSplitTopNAgg() throws Exception {
         FeConstants.runningUnitTest = true;
         try {
-            String plan = getFragmentPlan("SELECT L_ORDERKEY, L_PARTKEY, COUNT(*) AS c, SUM(L_EXTENDEDPRICE), AVG(L_QUANTITY) "
-                    + "FROM lineitem_partition "
-                    + "WHERE L_LINENUMBER <> 123 "
-                    + "GROUP BY L_ORDERKEY, L_PARTKEY "
-                    + "ORDER BY c DESC LIMIT 10;");
+            // Test basic case - should apply the rule
+            String plan = getFragmentPlan(
+                    "SELECT L_ORDERKEY, L_PARTKEY, COUNT(*) AS c, SUM(L_EXTENDEDPRICE), AVG(L_QUANTITY) "
+                            + "FROM lineitem_partition "
+                            + "WHERE L_LINENUMBER <> 123 "
+                            + "GROUP BY L_ORDERKEY, L_PARTKEY "
+                            + "ORDER BY c DESC LIMIT 10;");
 
             assertContains(plan, "HASH JOIN\n"
                     + "  |  join op: INNER JOIN (BROADCAST)\n"
                     + "  |  colocate: false, reason: \n"
                     + "  |  equal join conjunct: 1: L_ORDERKEY = 21: L_ORDERKEY\n"
                     + "  |  equal join conjunct: 2: L_PARTKEY = 22: L_PARTKEY");
+
+            // Test case 1: duplicatedColumns.size() > 3 - should not apply the rule
+            // This query has 4 columns in first scan: L_ORDERKEY, L_PARTKEY, L_SUPPKEY, L_LINENUMBER
+            plan = getFragmentPlan(
+                    "SELECT L_ORDERKEY, L_PARTKEY, L_SUPPKEY, COUNT(*) AS c, SUM(L_EXTENDEDPRICE), AVG(L_QUANTITY) "
+                            + "FROM lineitem_partition "
+                            + "WHERE L_LINENUMBER <> 123 "
+                            + "GROUP BY L_ORDERKEY, L_PARTKEY, L_SUPPKEY "
+                            + "ORDER BY c DESC LIMIT 10;");
+            // Should not contain HASH JOIN, meaning the rule was not applied
+            assertNotContains(plan, "equal join conjunct: 1: L_ORDERKEY = 21: L_ORDERKEY");
+
+            // Test case 2: conjuncts.size() > 2 - should not apply the rule
+            plan = getFragmentPlan("SELECT L_ORDERKEY, L_PARTKEY, COUNT(*) AS c, SUM(L_EXTENDEDPRICE), AVG(L_QUANTITY) "
+                    + "FROM lineitem_partition "
+                    + "WHERE L_LINENUMBER <> 123 AND L_QUANTITY > 0 AND L_DISCOUNT < 1 "
+                    + "GROUP BY L_ORDERKEY, L_PARTKEY "
+                    + "ORDER BY c DESC LIMIT 10;");
+            // Should not contain HASH JOIN, meaning the rule was not applied
+            assertNotContains(plan, "equal join conjunct: 1: L_ORDERKEY = 21: L_ORDERKEY");
+
+            // Test case 3: disconjuncts.size() > 2 - should not apply the rule
+            plan = getFragmentPlan("SELECT L_ORDERKEY, L_PARTKEY, COUNT(*) AS c, SUM(L_EXTENDEDPRICE), AVG(L_QUANTITY) "
+                    + "FROM lineitem_partition "
+                    + "WHERE L_LINENUMBER = 1 OR L_LINENUMBER = 2 OR L_DISCOUNT = 3 "
+                    + "GROUP BY L_ORDERKEY, L_PARTKEY "
+                    + "ORDER BY c DESC LIMIT 10;");
+            // Should not contain HASH JOIN, meaning the rule was not applied
+            assertNotContains(plan, "equal join conjunct: 1: L_ORDERKEY = 21: L_ORDERKEY");
+
+            // Test case 4: conjuncts.size() = 2 - should apply the rule
+            plan = getFragmentPlan("SELECT L_PARTKEY, COUNT(*) AS c, SUM(L_EXTENDEDPRICE), AVG(L_QUANTITY) "
+                    + "FROM lineitem_partition "
+                    + "WHERE L_LINENUMBER <> 123 AND L_QUANTITY > 0 "
+                    + "GROUP BY L_PARTKEY "
+                    + "ORDER BY c DESC LIMIT 10;");
+            // Should contain HASH JOIN, meaning the rule was applied
+            assertContains(plan, "HASH JOIN\n"
+                    + "  |  join op: INNER JOIN (BROADCAST)");
+
+            // Test case 5: disconjuncts.size() = 2 - should apply the rule
+            plan = getFragmentPlan("SELECT L_ORDERKEY, L_PARTKEY, COUNT(*) AS c, SUM(L_EXTENDEDPRICE), AVG(L_QUANTITY) "
+                    + "FROM lineitem_partition "
+                    + "WHERE L_LINENUMBER = 1 OR L_LINENUMBER = 2 "
+                    + "GROUP BY L_ORDERKEY, L_PARTKEY "
+                    + "ORDER BY c DESC LIMIT 10;");
+            // Should contain HASH JOIN, meaning the rule was applied
+            assertContains(plan, "HASH JOIN\n"
+                    + "  |  join op: INNER JOIN (BROADCAST)");
+
+            // Test case 6: duplicatedColumns.size() = 3 - should apply the rule (boundary case)
+            plan = getFragmentPlan("SELECT L_ORDERKEY, L_PARTKEY, COUNT(*) AS c, SUM(L_EXTENDEDPRICE), AVG(L_QUANTITY) "
+                    + "FROM lineitem_partition "
+                    + "WHERE L_LINENUMBER <> 123 "
+                    + "GROUP BY L_ORDERKEY, L_PARTKEY "
+                    + "ORDER BY c DESC LIMIT 10;");
+            // Should contain HASH JOIN, meaning the rule was applied
+            assertContains(plan, "HASH JOIN\n"
+                    + "  |  join op: INNER JOIN (BROADCAST)");
+
+            // Test case 7: long string column (averageRowSize > 5) - should not apply the rule
+
+            plan = getFragmentPlan("SELECT L_ORDERKEY, L_PARTKEY, COUNT(*) AS c, SUM(L_EXTENDEDPRICE), AVG(L_QUANTITY) "
+                    + "FROM lineitem_partition "
+                    + "WHERE L_COMMENT <> '' "
+                    + "GROUP BY L_ORDERKEY, L_PARTKEY "
+                    + "ORDER BY c DESC LIMIT 10;");
+            // Should not contain HASH JOIN, meaning the rule was not applied due to long string
+            assertNotContains(plan, "equal join conjunct: 1: L_ORDERKEY = 21: L_ORDERKEY");
+
+            plan = getFragmentPlan("SELECT L_ORDERKEY, L_PARTKEY, COUNT(*) AS c, SUM(L_EXTENDEDPRICE), AVG(L_QUANTITY) "
+                    + "FROM lineitem_partition "
+                    + "WHERE L_RETURNFLAG <> '' "
+                    + "GROUP BY L_ORDERKEY, L_PARTKEY "
+                    + "ORDER BY c DESC LIMIT 10;");
+            // Should contain HASH JOIN, meaning the rule was applied for short string
+            assertContains(plan, "HASH JOIN\n"
+                    + "  |  join op: INNER JOIN (BROADCAST)");
         } finally {
             FeConstants.runningUnitTest = false;
         }


### PR DESCRIPTION
## Why I'm doing:
SplitTopNAggregateRule will rewrite a sql like :
`select a, b, count(c) as cc, sum(d)    from t  where e != 1 group by a, b order by cc limit 10
`into:
```
select t.a, t.b, cc, sum(d)
   from t join (select a, b, count(c) as cc from t where e != 1 group by a, b order by cc limit 10) t1 on t.a = t1.a and t.b = t1.b and e != 1 group by t.a, t.b, cc  order by cc limit 10

```
but if scan is the bottleneck, this optimization will cause performance downgrade

## What I'm doing:
find the repeated scan columns in plan, for case like upper, column a,b,e are read twice.
only do this optimization if repeated columns <=3, doesn't have complex type  column or big string column
scan's predicates should less then 3


Fixes [#issue](https://github.com/StarRocks/StarRocksTest/issues/10580)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
