### PR TITLE
[BugFix] Fix ASAN crash because of crc_hash gloabl init

### DIFF
--- a/be/src/util/cpu_info.cpp
+++ b/be/src/util/cpu_info.cpp
@@ -201,8 +201,10 @@ void CpuInfo::init() {
         LOG(WARNING) << "Kernel does not support sched_getcpu(). Performance may be impacted.";
     }
 #else
+#ifndef __APPLE__
     LOG(WARNING) << "Built on a system without sched_getcpu() support. Performance may"
                  << " be impacted.";
+#endif
 #endif
 
     _init_numa();
@@ -218,7 +220,9 @@ void CpuInfo::_init_numa() {
     core_to_numa_node_.reset(new int[max_num_cores_]);
 
     if (!std::filesystem::is_directory("/sys/devices/system/node")) {
+#ifndef __APPLE__
         LOG(WARNING) << "/sys/devices/system/node is not present - no NUMA support";
+#endif
         // Assume a single NUMA node.
         max_num_numa_nodes_ = 1;
         std::fill_n(core_to_numa_node_.get(), max_num_cores_, 0);


### PR DESCRIPTION
## Why I'm doing:

```
kks@192 output % starrocks_be(42761,0x206e920c0) malloc: nano zone abandoned due to inability to reserve vm space.
AddressSanitizer:DEADLYSIGNAL
=================================================================
==42761==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000017 (pc 0x00011a8b0f84 bp 0x00016d057fd0 sp 0x00016d057e90 T0)
==42761==The signal is caused by a READ memory access.
==42761==Hint: address points to the zero page.
    #0 0x00011a8b0f84 in google::LogMessage::Init(char const*, int, google::LogSeverity, void (google::LogMessage::*)())+0x6d4 (starrocks_be:arm64+0x117b10f84)
    #1 0x00011a8b1a80 in google::LogMessage::LogMessage(char const*, int, google::LogSeverity)+0x34 (starrocks_be:arm64+0x117b11a80)
    #2 0x000118cfd04c in starrocks::CpuInfo::init() cpu_info.cpp:204
    #3 0x000118d9a0a4 in starrocks::select_hash_functions() hash_util.cpp:49
    #4 0x000198b7aef8  (<unknown module>)
```

for https://github.com/StarRocks/starrocks/pull/64985
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wrap Linux-only warning logs in `CpuInfo` with `#ifndef __APPLE__` to avoid emitting them on macOS.
> 
> - **Backend - `be/src/util/cpu_info.cpp`**:
>   - Guard warning for missing `sched_getcpu()` with `#ifndef __APPLE__`.
>   - Guard warning for missing `/sys/devices/system/node` (NUMA) with `#ifndef __APPLE__`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75f9fd144267352334091a850975d1450cc7e738. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->