### PR TITLE
[BugFix] Query Id Collision on Arrow Flight

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -1051,6 +1051,7 @@ under the License.
                     <reuseForks>false</reuseForks>
 
                     <argLine>
+                        --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED
                         -javaagent:${settings.localRepository}/com/github/hazendaz/jmockit/jmockit/1.49.4/jmockit-1.49.4.jar
                         ${async.profiler.arg}
                         -Xmx4096m

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
@@ -25,6 +25,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.util.ArrowUtil;
 import com.starrocks.common.util.DebugUtil;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.scheduler.Coordinator;
@@ -186,7 +187,11 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
         if (!StringUtils.isEmpty(database)) {
             ctx.setDatabase(database);
         }
-        return getFlightInfoFromQuery(ctx, descriptor);
+        synchronized(ctx) {  // Synchronize on the shared context
+            ctx.setQueryId(UUIDUtil.genUUID());
+            ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
+            return getFlightInfoFromQuery(ctx, descriptor);
+        }
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
@@ -93,7 +93,6 @@ import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;


### PR DESCRIPTION
## Why I'm doing:
**Issue**: Duplicate query IDs when using multiple threads with Arrow Flight SQL
When multiple threads share a single Arrow Flight SQL connection and execute queries concurrently, they encounter "queryId already exists" errors and receive incorrect/incomplete results.
Root Cause:
The `ArrowFlightSqlConnectContext` stores the current query string in a single shared field (query). When multiple concurrent requests call `createPreparedStatement`, they overwrite each other's queries in the shared context:

Thread 1 calls `createPreparedStatement` → sets `ctx.query = query1, ctx.queryId = UUID1`
Thread 2 calls `createPreparedStatement` → overwrites `ctx.query = query2, ctx.queryId = UUID2`
Thread 1 calls `getFlightInfoPreparedStatement` → executes with `query2` instead of `query1`, `UUID2` instead of `UUID1`
Thread 2 calls `getFlightInfoPreparedStatement` → executes with `query2`, `UUID2` (but queryId already exists)
Both threads generate the same execution ID, causing "queryId already exists" errors

Additionally, `ctx.reset()` calls `removeAllResults()` which clears the result cache while other queries may still be storing results, leading to incomplete data.
## What I'm doing:
Solution: Store queries by handle instead of in shared context state

Embed queries directly in prepared statement handles (`token:query format`)
Extract queries from handles when executing, rather than reading from shared context
Add synchronization to `getFlightInfoPreparedStatement` and `getFlightInfoStatement` to ensure only one query executes per connection at a time, preventing cache corruption

Changes:

Modified `createPreparedStatement` to embed the query string in the returned handle
Modified `getFlightInfoPreparedStatement` to extract the query from the handle
Added `synchronized(ctx)` blocks around query execution to prevent concurrent cache modifications
Added test to verify multiple prepared statements maintain query isolation

Result: Each prepared statement maintains its own query independently, eliminating race conditions and ensuring correct execution with complete results. For each connection, each query will execute sequentially instead of attempting parallel execution and failing. 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Embed queries in prepared statement handles and execute under synchronized context; add tests verifying isolation and update surefire args for Arrow.
> 
> - **Arrow Flight SQL service (`ArrowFlightSqlServiceImpl`)**:
>   - Embed query into prepared statement handle via `context.peerIdentity() + ":" + request.getQuery()` in `createPreparedStatement`.
>   - In `getFlightInfoPreparedStatement`, parse query from handle, call `ctx.reset(query)`, set thread-local info, optionally set `database` from headers, and execute within `synchronized (ctx)`.
> - **Tests (`ArrowFlightSqlServiceImplTest`)**:
>   - Add `testCreateTwoPreparedStatementThenExecute` to verify query isolation and proper context resets.
>   - Minor test enhancements (additional Mockito matchers/usages).
> - **Build (`fe/fe-core/pom.xml`)**:
>   - Add `--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED` to surefire `argLine`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fed0293037c21ca6530ddf9e80e17700cc92fbbf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->