### PR TITLE
[UT] Add reusable NoOpEditLog for authentication tests

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/authentication/SecurityIntegrationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authentication/SecurityIntegrationTest.java
@@ -20,7 +20,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.mysql.MysqlCodec;
 import com.starrocks.mysql.privilege.AuthPlugin;
-import com.starrocks.persist.EditLog;
+import com.starrocks.persist.NoOpEditLog;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ShowExecutor;
 import com.starrocks.qe.ShowResultSet;
@@ -61,11 +61,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyShort;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.spy;
-
 public class SecurityIntegrationTest {
     private final MockTokenUtils mockTokenUtils = new MockTokenUtils();
     private ConnectContext ctx;
@@ -78,10 +73,7 @@ public class SecurityIntegrationTest {
 
     @BeforeEach
     public void setUp() throws Exception {
-        // Mock EditLog
-        EditLog editLog = spy(new EditLog(null));
-        doNothing().when(editLog).logEdit(anyShort(), any());
-        GlobalStateMgr.getCurrentState().setEditLog(editLog);
+        GlobalStateMgr.getCurrentState().setEditLog(new NoOpEditLog());
 
         // Initialize authentication manager
         authenticationMgr = new AuthenticationMgr();
@@ -264,9 +256,7 @@ public class SecurityIntegrationTest {
 
     @Test
     public void testLDAPSecurityIntegrationPassword() throws DdlException, AuthenticationException, IOException {
-        EditLog editLog = spy(new EditLog(null));
-        doNothing().when(editLog).logEdit(anyShort(), any());
-        GlobalStateMgr.getCurrentState().setEditLog(editLog);
+        GlobalStateMgr.getCurrentState().setEditLog(new NoOpEditLog());
         AuthenticationMgr authenticationMgr = new AuthenticationMgr();
         GlobalStateMgr.getCurrentState().setAuthenticationMgr(authenticationMgr);
 
@@ -297,9 +287,7 @@ public class SecurityIntegrationTest {
 
     @Test
     public void testShowCreateGroupProviderPassword() throws DdlException {
-        EditLog editLog = spy(new EditLog(null));
-        doNothing().when(editLog).logEdit(anyShort(), any());
-        GlobalStateMgr.getCurrentState().setEditLog(editLog);
+        GlobalStateMgr.getCurrentState().setEditLog(new NoOpEditLog());
         AuthenticationMgr authenticationMgr = new AuthenticationMgr();
         GlobalStateMgr.getCurrentState().setAuthenticationMgr(authenticationMgr);
 
@@ -778,4 +766,5 @@ public class SecurityIntegrationTest {
         authenticationMgr.dropSecurityIntegration("valid_jwt", true);
         authenticationMgr.dropSecurityIntegration("full_jwt", true);
     }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/persist/NoOpEditLog.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/NoOpEditLog.java
@@ -1,0 +1,43 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.persist;
+
+import com.starrocks.common.io.Writable;
+
+/**
+ * Lightweight {@link EditLog} stub for unit tests that only need to bypass persistence.
+ */
+public class NoOpEditLog extends EditLog {
+    public NoOpEditLog() {
+        super(null);
+    }
+
+    @Override
+    public void logEdit(short op, Writable writable) {
+        // intentionally left blank
+    }
+
+    @Override
+    public void logJsonObject(short op, Object obj) {
+        // intentionally left blank
+    }
+
+    @Override
+    public void logJsonObject(short op, Object obj, WALApplier applier) {
+        if (applier != null) {
+            applier.apply(obj);
+        }
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a NoOpEditLog test stub and updates SecurityIntegrationTest to use it instead of Mockito-spied EditLog.
> 
> - **Tests**:
>   - **New utility**: Add `com.starrocks.persist.NoOpEditLog` to bypass persistence in unit tests.
>   - **Authentication tests**: Replace Mockito-spied `EditLog` with `NoOpEditLog` in `authentication/SecurityIntegrationTest` setup and specific test cases; remove Mockito-based stubbing accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84cec963ac9b00c36da934b279a54c730a658f36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->