### PR TITLE
[UT] Update gradle build script to support proto files auto detect

### DIFF
--- a/fe/fe-core/build.gradle.kts
+++ b/fe/fe-core/build.gradle.kts
@@ -302,24 +302,22 @@ tasks.register<Task>("generateProtoSources") {
     val protoDir = file("../../gensrc/proto")
     val outputDir = layout.buildDirectory.get().dir("generated-sources/proto").asFile
 
-    // List of proto files to process
-    val protoFiles = listOf(
-        "lake_types.proto",
-        "internal_service.proto",
-        "types.proto",
-        "tablet_schema.proto",
-        "lake_service.proto",
-        "encryption.proto"
-    )
+    // Automatically detect all .proto files in the directory
+    val protoFiles = fileTree(protoDir) {
+        include("*.proto")
+    }.files.map { it.name }.sorted()
 
-    // Declare inputs (proto files)
-    inputs.files(protoFiles.map { file("$protoDir/$it") })
+    // Declare inputs (all proto files in the directory)
+    inputs.dir(protoDir).withPropertyName("protoSourceDir")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
 
     // Declare output directory
     outputs.dir(outputDir)
 
     doFirst {
         mkdir(outputDir)
+
+        logger.lifecycle("Detected ${protoFiles.size} proto files to process")
 
         // Process each proto file individually
         protoFiles.forEach { protoFile ->


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This pull request updates the Gradle build script to improve how proto files are detected and processed for source generation. Instead of relying on a hardcoded list, the build now automatically finds all `.proto` files in the specified directory, making the process more robust and easier to maintain.

**Improvements to proto file detection and build inputs:**

* Automatically detects all `.proto` files in the `protoDir` directory using `fileTree`, replacing the previous hardcoded list of proto files.
* Updates the Gradle input declaration to use the entire proto source directory with path sensitivity, ensuring changes to any proto file are tracked and trigger regeneration.
* Adds a log statement to indicate the number of proto files detected, improving build transparency.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches `generateProtoSources` to discover all `.proto` files via `fileTree` and tracks the proto directory as an input with relative path sensitivity, adding a log of detected files.
> 
> - **Build (Gradle)**:
>   - `generateProtoSources`:
>     - Replace hardcoded proto list with auto-discovery using `fileTree` in `../../gensrc/proto`.
>     - Update inputs to track the entire proto source directory with `PathSensitivity.RELATIVE`.
>     - Add lifecycle log reporting the number of detected proto files.
>     - Keep per-file processing via `javaexec` and existing output directory.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbd85117a7219ee6f992e16d2c19c62845a964b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->