### PR TITLE
[BugFix] avoid calling function has_output as it's not thread_safe

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_parallel_merge_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_parallel_merge_source_operator.cpp
@@ -71,7 +71,7 @@ StatusOr<ChunkPtr> ExchangeParallelMergeSourceOperator::pull_chunk(RuntimeState*
 
 std::string ExchangeParallelMergeSourceOperator::get_name() const {
     std::string finished = is_finished() ? "X" : "O";
-    return fmt::format("{}_{}_{}({}) {{ has_output:{}}}", _name, _plan_node_id, (void*)this, finished, has_output());
+    return fmt::format("{}_{}_{}({})", _name, _plan_node_id, static_cast<const void*>(this), finished);
 }
 
 Status ExchangeParallelMergeSourceOperatorFactory::prepare(RuntimeState* state) {

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -555,10 +555,9 @@ std::string ConnectorScanOperator::get_name() const {
     bool has_active = has_shared_chunk_source();
     std::string morsel_queue_name = _morsel_queue->name();
     bool morsel_queue_empty = _morsel_queue->empty();
-    return fmt::format(
-            "{}_{}_{}({}) {{ full:{} iostasks:{} has_active:{} num_chunks:{} morsel:{} empty:{} has_output:{}}}", _name,
-            _plan_node_id, (void*)this, finished, full, io_tasks, has_active, num_buffered_chunks(), morsel_queue_name,
-            morsel_queue_empty, has_output());
+    return fmt::format("{}_{}_{}({}) {{ full:{} iostasks:{} has_active:{} num_chunks:{} morsel:{} empty:{}}}", _name,
+                       _plan_node_id, (void*)this, finished, full, io_tasks, has_active, num_buffered_chunks(),
+                       morsel_queue_name, morsel_queue_empty);
 }
 
 bool ConnectorScanOperator::need_notify_all() {

--- a/be/src/exec/pipeline/scan/olap_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/olap_scan_operator.cpp
@@ -139,10 +139,9 @@ std::string OlapScanOperator::get_name() const {
     bool has_active = _ctx->has_active_input();
     std::string morsel_queue_name = _morsel_queue->name();
     bool morsel_queue_empty = _morsel_queue->empty();
-    return fmt::format(
-            "{}_{}_{}({}) {{ full:{} iostasks:{} has_active:{} num_chunks:{} morsel:{} empty:{} has_output:{}}}", _name,
-            _plan_node_id, (void*)this, finished, full, io_tasks, has_active, num_buffered_chunks(), morsel_queue_name,
-            morsel_queue_empty, has_output());
+    return fmt::format("{}_{}_{}({}) {{ full:{} iostasks:{} has_active:{} num_chunks:{} morsel:{} empty:{}}}", _name,
+                       _plan_node_id, (void*)this, finished, full, io_tasks, has_active, num_buffered_chunks(),
+                       morsel_queue_name, morsel_queue_empty);
 }
 
 } // namespace starrocks::pipeline


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

The `Operator::has_output` function is not truly thread-safe, as it may alter the mutable state `_unplugging`. However, in `PipelineObserver`, this function could be invoked concurrently, potentially causing a crash.

So I removed the call to `has_output` to fix it.

Fixes #65513


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove has_output() from operator get_name() debug strings and switch to a safer pointer cast in the exchange operator.
> 
> - **Debug/name formatting updates**:
>   - `be/src/exec/pipeline/scan/connector_scan_operator.cpp`: `get_name()` no longer calls `has_output()`; drops the `has_output` field from the formatted string.
>   - `be/src/exec/pipeline/scan/olap/olap_scan_operator.cpp`: `get_name()` stops invoking `has_output()`; removes the `has_output` field from the output.
>   - `be/src/exec/pipeline/exchange/exchange_parallel_merge_source_operator.cpp`: `get_name()` no longer uses `has_output()` and switches pointer cast to `static_cast<const void*>` in the formatted output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7799ddc43cac3d1261ed302bf29adffccc3ca4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->