### PR TITLE
[BugFix] Fix querying information_schema.tables/views in different dbs when enable_evaluate_schema_scan_rule is true

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablesSystemTable.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.service.InformationSchemaDataSource;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -177,10 +178,9 @@ public class TablesSystemTable extends SystemTable {
             return result.getTables_infos().stream()
                     .map(t -> infoToScalar(this, t))
                     .collect(Collectors.toList());
-        } catch (Exception e) {
-            LOG.warn("Failed to query tables ", e);
-            // Return empty result if query failed
-            return Lists.newArrayList();
+        } catch (TException e) {
+            LOG.debug("Failed to get table info for table: {}, error: ", params.getTable_name(), e);
+            throw new SemanticException("Failed to get table info for table: " + params.getTable_name(), e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablesSystemTable.java
@@ -17,7 +17,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.authentication.UserIdentityUtils;
 import com.starrocks.catalog.Column;
-import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemId;
 import com.starrocks.catalog.system.SystemTable;
@@ -155,10 +154,6 @@ public class TablesSystemTable extends SystemTable {
         TGetTablesInfoRequest params = new TGetTablesInfoRequest();
         TAuthInfo authInfo = new TAuthInfo();
         authInfo.setCurrent_user_ident(userIdentity);
-        authInfo.setCatalog_name(this.getCatalogName());
-        if (InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME.equalsIgnoreCase(this.getCatalogName())) {
-            authInfo.setPattern(context.getDatabase());
-        }
         for (ScalarOperator conjunct : conjuncts) {
             BinaryPredicateOperator binary = (BinaryPredicateOperator) conjunct;
             ColumnRefOperator columnRef = binary.getChild(0).cast();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablesSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/TablesSystemTable.java
@@ -155,6 +155,7 @@ public class TablesSystemTable extends SystemTable {
         TGetTablesInfoRequest params = new TGetTablesInfoRequest();
         TAuthInfo authInfo = new TAuthInfo();
         authInfo.setCurrent_user_ident(userIdentity);
+        authInfo.setCatalog_name(this.getCatalogName());
         for (ScalarOperator conjunct : conjuncts) {
             BinaryPredicateOperator binary = (BinaryPredicateOperator) conjunct;
             ColumnRefOperator columnRef = binary.getChild(0).cast();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ViewsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/ViewsSystemTable.java
@@ -123,7 +123,6 @@ public class ViewsSystemTable extends SystemTable {
         TUserIdentity userIdentity = UserIdentityUtils.toThrift(context.getCurrentUserIdentity());
         TGetTablesParams params = new TGetTablesParams();
         params.setCurrent_user_ident(userIdentity);
-        params.setDb(context.getDatabase());
         params.setType(VIEW);
         for (ScalarOperator conjunct : conjuncts) {
             BinaryPredicateOperator binary = (BinaryPredicateOperator) conjunct;

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/MultiUserLock.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/lock/MultiUserLock.java
@@ -184,7 +184,8 @@ public class MultiUserLock extends Lock {
         }
 
         if (!hasOwner) {
-            throw new IllegalMonitorStateException("Attempt to unlock lock, not locked by current locker");
+            throw new IllegalMonitorStateException(String.format("Attempt to unlock lock, not locked by current locker, " +
+                    "firstOwner:%s, otherOwners:%s", firstOwner, otherOwners));
         }
 
         if (reentrantLock) {

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -532,37 +532,30 @@ public class InformationSchemaDataSource {
             }
 
             List<BasicTable> tables = new ArrayList<>();
-            Locker locker = new Locker();
-            try {
-                locker.lockDatabase(db.getId(), LockType.READ);
-                List<String> tableNames = metadataMgr.listTableNames(context, catalogName, dbName);
-                for (String tableName : tableNames) {
-                    if (request.isSetTable_name()) {
-                        if (!tableName.equals(request.getTable_name())) {
-                            continue;
-                        }
-                    }
-
-                    BasicTable table = null;
-                    try {
-                        table = metadataMgr.getBasicTable(context, catalogName, dbName, tableName);
-                    } catch (Exception e) {
-                        LOG.warn(e.getMessage(), e);
-                    }
-                    if (table == null) {
+            List<String> tableNames = metadataMgr.listTableNames(context, catalogName, dbName);
+            for (String tableName : tableNames) {
+                if (request.isSetTable_name()) {
+                    if (!tableName.equals(request.getTable_name())) {
                         continue;
                     }
-
-                    try {
-                        Authorizer.checkAnyActionOnTableLikeObject(context, dbName, table);
-                    } catch (AccessDeniedException e) {
-                        continue;
-                    }
-
-                    tables.add(table);
                 }
-            } finally {
-                locker.unLockDatabase(db.getId(), LockType.READ);
+
+                BasicTable table = null;
+                try {
+                    table = metadataMgr.getBasicTable(context, catalogName, dbName, tableName);
+                } catch (Exception e) {
+                    LOG.warn(e.getMessage(), e);
+                }
+                if (table == null) {
+                    continue;
+                }
+
+                try {
+                    Authorizer.checkAnyActionOnTableLikeObject(context, dbName, table);
+                } catch (AccessDeniedException e) {
+                    continue;
+                }
+                tables.add(table);
             }
 
             for (BasicTable table : tables) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -44,6 +44,7 @@ import com.starrocks.catalog.PaimonTable;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
@@ -942,6 +943,10 @@ public class AnalyzerUtils {
             }
 
             Table table = node.getTable();
+            // system table is immutable
+            if (table instanceof SystemTable) {
+                return null;
+            }
             int relatedMVCount = node.getTable().getRelatedMaterializedViews().size();
             boolean useNonLockOptimization = Config.skip_whole_phase_lock_mv_limit < 0 ||
                     relatedMVCount <= Config.skip_whole_phase_lock_mv_limit;

--- a/test/sql/test_information_schema/R/test_materialized_views
+++ b/test/sql/test_information_schema/R/test_materialized_views
@@ -1,0 +1,104 @@
+-- name: test_materialized_views
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE TABLE ss( event_day DATE, pv BIGINT) DUPLICATE KEY(event_day) DISTRIBUTED BY HASH(event_day) BUCKETS 8 PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+insert into ss values('2020-01-14', 1), ('2020-01-14', 3), ('2020-01-15', 2);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv1 DISTRIBUTED BY hash(event_day) 
+REFRESH DEFERRED MANUAL
+AS SELECT event_day, sum(pv) as sum_pv FROM ss GROUP BY event_day;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW mv1 with sync mode ;
+set enable_evaluate_schema_scan_rule=true;
+-- result:
+-- !result
+[UC] select if count(*) from information_schema.materialized_views;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
+-- result:
+E: (1064, 'StarRocks planner use long time 18280 ms in logical phase, This probably because 1. FE Full GC, current query allocated=131.0 MiB, optimizerContextInUse=4.9 MiB2. Hive external table fetch metadata took a long time, 3. The SQL is very complex. You could 1. adjust FE JVM config, 2. try query again, 3. enlarge new_planner_optimize_timeout session variable')
+-- !result
+[UC] select if count(*) from information_schema.materialized_views;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
+-- result:
+E: (1064, 'StarRocks planner use long time 16832 ms in logical phase, This probably because 1. FE Full GC, current query allocated=130.6 MiB, optimizerContextInUse=4.9 MiB2. Hive external table fetch metadata took a long time, 3. The SQL is very complex. You could 1. adjust FE JVM config, 2. try query again, 3. enlarge new_planner_optimize_timeout session variable')
+-- !result
+set enable_evaluate_schema_scan_rule=false;
+-- result:
+-- !result
+[UC] select if count(*) from information_schema.materialized_views;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
+-- result:
+OK
+-- !result
+[UC] select if count(*) from information_schema.materialized_views;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
+-- result:
+OK
+-- !result
+create database if not exists test_information_schema_materialized_views;
+-- result:
+-- !result
+use test_information_schema_materialized_views;
+-- result:
+-- !result
+[UC] select if count(*) from information_schema.materialized_views;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
+-- result:
+OK
+-- !result
+[UC] select if count(*) from information_schema.materialized_views;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
+-- result:
+OK
+-- !result
+set enable_evaluate_schema_scan_rule=false;
+-- result:
+-- !result
+[UC] select if count(*) from information_schema.materialized_views;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
+-- result:
+OK
+-- !result
+[UC] select if count(*) from information_schema.materialized_views;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
+-- result:
+OK
+-- !result
+drop database if exists test_information_schema_materialized_views;
+-- result:
+-- !result
+drop database db_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_information_schema/R/test_materialized_views
+++ b/test/sql/test_information_schema/R/test_materialized_views
@@ -20,36 +20,20 @@ AS SELECT event_day, sum(pv) as sum_pv FROM ss GROUP BY event_day;
 set enable_evaluate_schema_scan_rule=true;
 -- result:
 -- !result
-[UC] select if count(*) from information_schema.materialized_views;
+[UC] select count(*) from information_schema.materialized_views;
 -- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
--- !result
-select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
--- result:
-E: (1064, 'StarRocks planner use long time 18280 ms in logical phase, This probably because 1. FE Full GC, current query allocated=131.0 MiB, optimizerContextInUse=4.9 MiB2. Hive external table fetch metadata took a long time, 3. The SQL is very complex. You could 1. adjust FE JVM config, 2. try query again, 3. enlarge new_planner_optimize_timeout session variable')
--- !result
-[UC] select if count(*) from information_schema.materialized_views;
--- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
--- !result
-select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
--- result:
-E: (1064, 'StarRocks planner use long time 16832 ms in logical phase, This probably because 1. FE Full GC, current query allocated=130.6 MiB, optimizerContextInUse=4.9 MiB2. Hive external table fetch metadata took a long time, 3. The SQL is very complex. You could 1. adjust FE JVM config, 2. try query again, 3. enlarge new_planner_optimize_timeout session variable')
--- !result
-set enable_evaluate_schema_scan_rule=false;
--- result:
--- !result
-[UC] select if count(*) from information_schema.materialized_views;
--- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+1
 -- !result
 select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
 -- result:
 OK
 -- !result
-[UC] select if count(*) from information_schema.materialized_views;
+set enable_evaluate_schema_scan_rule=false;
 -- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+[UC] select count(*) from information_schema.materialized_views;
+-- result:
+1
 -- !result
 select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
 -- result:
@@ -61,17 +45,9 @@ create database if not exists test_information_schema_materialized_views;
 use test_information_schema_materialized_views;
 -- result:
 -- !result
-[UC] select if count(*) from information_schema.materialized_views;
+[UC] select count(*) from information_schema.materialized_views;
 -- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
--- !result
-select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
--- result:
-OK
--- !result
-[UC] select if count(*) from information_schema.materialized_views;
--- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+1
 -- !result
 select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
 -- result:
@@ -80,17 +56,9 @@ OK
 set enable_evaluate_schema_scan_rule=false;
 -- result:
 -- !result
-[UC] select if count(*) from information_schema.materialized_views;
+[UC] select count(*) from information_schema.materialized_views;
 -- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
--- !result
-select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
--- result:
-OK
--- !result
-[UC] select if count(*) from information_schema.materialized_views;
--- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+1
 -- !result
 select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
 -- result:

--- a/test/sql/test_information_schema/R/test_tables
+++ b/test/sql/test_information_schema/R/test_tables
@@ -17,26 +17,26 @@ BASE TABLE	None	None
 -- !result
 [UC]select * from information_schema.tables a full join information_schema.tables_config b on a.TABLE_SCHEMA=b.TABLE_SCHEMA where b.TABLE_NAME='unique_table_with_null';
 -- result:
-def	db_d98bf82a6f4e4d5891e95a3d4a407e06	unique_view_with_null	VIEW	None	None	None	None	None	None	None	None	None	None	2025-11-14 15:28:09	None	1970-01-01 08:00:00	utf8_general_ci	None	None		db_d98bf82a6f4e4d5891e95a3d4a407e06	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	11517
-def	db_d98bf82a6f4e4d5891e95a3d4a407e06	unique_table_with_null	BASE TABLE	StarRocks	None	None	0	0	0	None	None	None	None	2025-11-14 15:28:09	2025-11-14 15:28:09	1970-01-01 08:00:00	utf8_general_ci	None	None	OLAP	db_d98bf82a6f4e4d5891e95a3d4a407e06	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	11517
+def	db_1b289bc796044317a138ee5a6c79b56a	unique_view_with_null	VIEW	None	None	None	None	None	None	None	None	None	None	2025-11-17 10:39:50	None	1970-01-01 08:00:00	utf8_general_ci	None	None		db_1b289bc796044317a138ee5a6c79b56a	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	11003
+def	db_1b289bc796044317a138ee5a6c79b56a	unique_table_with_null	BASE TABLE	StarRocks	None	None	0	0	0	None	None	None	None	2025-11-17 10:39:50	2025-11-17 10:39:50	1970-01-01 08:00:00	utf8_general_ci	None	None	OLAP	db_1b289bc796044317a138ee5a6c79b56a	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	11003
 -- !result
 [UC]select a.TABLE_NAME, b.* from information_schema.tables a full join information_schema.tables_config b on a.TABLE_SCHEMA=b.TABLE_SCHEMA where b.TABLE_NAME='unique_table_with_null';
 -- result:
-unique_view_with_null	db_d98bf82a6f4e4d5891e95a3d4a407e06	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	11517
-unique_table_with_null	db_d98bf82a6f4e4d5891e95a3d4a407e06	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	11517
+unique_view_with_null	db_1b289bc796044317a138ee5a6c79b56a	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	11003
+unique_table_with_null	db_1b289bc796044317a138ee5a6c79b56a	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	11003
 -- !result
 set enable_evaluate_schema_scan_rule=true;
 -- result:
 -- !result
-select a.TABLE_NAME, b.TABLE_MODEL, b.PRIMARY_KEY, b.PARTITION_KEY, b.DISTRIBUTE_KEY from information_schema.tables a full join information_schema.tables_config b on a.TABLE_SCHEMA=b.TABLE_SCHEMA where b.TABLE_NAME='unique_table_with_null' and a.TABLE_SCHEMA='db_${uuid0}';
+select a.TABLE_NAME, b.TABLE_MODEL, b.PRIMARY_KEY, b.PARTITION_KEY, b.DISTRIBUTE_KEY from information_schema.tables a full join information_schema.tables_config b on a.TABLE_SCHEMA=b.TABLE_SCHEMA where b.TABLE_NAME='unique_table_with_null' and a.TABLE_SCHEMA='db_${uuid0}' ORDER BY a.TABLE_NAME;
 -- result:
-unique_view_with_null	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`
 unique_table_with_null	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`
+unique_view_with_null	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`
 -- !result
 set enable_evaluate_schema_scan_rule=false;
 -- result:
 -- !result
-select a.TABLE_NAME, b.TABLE_MODEL, b.PRIMARY_KEY, b.PARTITION_KEY, b.DISTRIBUTE_KEY from information_schema.tables a full join information_schema.tables_config b on a.TABLE_SCHEMA=b.TABLE_SCHEMA where b.TABLE_NAME='unique_table_with_null' and a.TABLE_SCHEMA='db_${uuid0}';
+select a.TABLE_NAME, b.TABLE_MODEL, b.PRIMARY_KEY, b.PARTITION_KEY, b.DISTRIBUTE_KEY from information_schema.tables a full join information_schema.tables_config b on a.TABLE_SCHEMA=b.TABLE_SCHEMA where b.TABLE_NAME='unique_table_with_null' and a.TABLE_SCHEMA='db_${uuid0}' ORDER BY a.TABLE_NAME;
 -- result:
 unique_table_with_null	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`
 unique_view_with_null	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`

--- a/test/sql/test_information_schema/R/test_tables
+++ b/test/sql/test_information_schema/R/test_tables
@@ -11,41 +11,35 @@ CREATE TABLE `unique_table_with_null` ( `k1` date, `k2` datetime, `k3` char(20),
 CREATE VIEW `unique_view_with_null` AS SELECT * FROM `unique_table_with_null`;
 -- result:
 -- !result
-select TABLE_TYPE, `VERSION`, ROW_FORMAT  from information_schema.tables where TABLE_SCHEMA='db_${uuid0}' limit 1;
+select TABLE_TYPE, `VERSION`, ROW_FORMAT  from information_schema.tables where TABLE_SCHEMA='db_${uuid0}' order by TABLE_NAME limit 1;
 -- result:
 BASE TABLE	None	None
 -- !result
 [UC]select * from information_schema.tables a full join information_schema.tables_config b on a.TABLE_SCHEMA=b.TABLE_SCHEMA where b.TABLE_NAME='unique_table_with_null';
 -- result:
-def	db_9949a2cf56024ba1b1aa6efff42afb13	unique_table_with_null	BASE TABLE	StarRocks	None	None	0	0	0	None	None	None	None	2025-11-14 15:17:57	2025-11-14 15:17:57	1970-01-01 08:00:00	utf8_general_ci	None	None	OLAP	db_9949a2cf56024ba1b1aa6efff42afb13	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	45536
-def	db_9949a2cf56024ba1b1aa6efff42afb13	unique_view_with_null	VIEW	None	None	None	None	None	None	None	None	None	None	2025-11-14 15:17:57	None	1970-01-01 08:00:00	utf8_general_ci	None	None		db_9949a2cf56024ba1b1aa6efff42afb13	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	45536
-def	test	test_mv1	VIEW	StarRocks	None	None	5	2837	14187	None	None	None	None	2025-11-13 21:19:42	2025-11-13 21:21:37	1970-01-01 08:00:00	utf8_general_ci	None	None		test	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	44058
-def	test	unique_view_with_null	VIEW	None	None	None	None	None	None	None	None	None	None	2025-11-14 14:49:05	None	1970-01-01 08:00:00	utf8_general_ci	None	None		test	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	44058
-def	test	unique_table_with_null	BASE TABLE	StarRocks	None	None	0	0	0	None	None	None	None	2025-11-14 14:49:02	2025-11-14 14:49:02	1970-01-01 08:00:00	utf8_general_ci	None	None	OLAP	test	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	44058
+def	db_d98bf82a6f4e4d5891e95a3d4a407e06	unique_view_with_null	VIEW	None	None	None	None	None	None	None	None	None	None	2025-11-14 15:28:09	None	1970-01-01 08:00:00	utf8_general_ci	None	None		db_d98bf82a6f4e4d5891e95a3d4a407e06	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	11517
+def	db_d98bf82a6f4e4d5891e95a3d4a407e06	unique_table_with_null	BASE TABLE	StarRocks	None	None	0	0	0	None	None	None	None	2025-11-14 15:28:09	2025-11-14 15:28:09	1970-01-01 08:00:00	utf8_general_ci	None	None	OLAP	db_d98bf82a6f4e4d5891e95a3d4a407e06	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	11517
 -- !result
 [UC]select a.TABLE_NAME, b.* from information_schema.tables a full join information_schema.tables_config b on a.TABLE_SCHEMA=b.TABLE_SCHEMA where b.TABLE_NAME='unique_table_with_null';
 -- result:
-test_mv1	test	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	44058
-unique_view_with_null	test	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	44058
-unique_table_with_null	test	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	44058
-unique_table_with_null	db_9949a2cf56024ba1b1aa6efff42afb13	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	45536
-unique_view_with_null	db_9949a2cf56024ba1b1aa6efff42afb13	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	45536
+unique_view_with_null	db_d98bf82a6f4e4d5891e95a3d4a407e06	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	11517
+unique_table_with_null	db_d98bf82a6f4e4d5891e95a3d4a407e06	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	11517
 -- !result
 set enable_evaluate_schema_scan_rule=true;
 -- result:
 -- !result
 select a.TABLE_NAME, b.TABLE_MODEL, b.PRIMARY_KEY, b.PARTITION_KEY, b.DISTRIBUTE_KEY from information_schema.tables a full join information_schema.tables_config b on a.TABLE_SCHEMA=b.TABLE_SCHEMA where b.TABLE_NAME='unique_table_with_null' and a.TABLE_SCHEMA='db_${uuid0}';
 -- result:
-unique_table_with_null	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`
 unique_view_with_null	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`
+unique_table_with_null	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`
 -- !result
 set enable_evaluate_schema_scan_rule=false;
 -- result:
 -- !result
 select a.TABLE_NAME, b.TABLE_MODEL, b.PRIMARY_KEY, b.PARTITION_KEY, b.DISTRIBUTE_KEY from information_schema.tables a full join information_schema.tables_config b on a.TABLE_SCHEMA=b.TABLE_SCHEMA where b.TABLE_NAME='unique_table_with_null' and a.TABLE_SCHEMA='db_${uuid0}';
 -- result:
-unique_view_with_null	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`
 unique_table_with_null	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`
+unique_view_with_null	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`
 -- !result
 set enable_evaluate_schema_scan_rule=true;
 -- result:
@@ -58,13 +52,13 @@ select if (count(*) > 0, "OK", "FAILED") from information_schema.views;
 -- result:
 OK
 -- !result
-[UC] select if count(*) from information_schema.tables;
+[UC] select count(*) from information_schema.tables;
 -- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+76
 -- !result
-[UC] select if count(*) from information_schema.views;
+[UC] select count(*) from information_schema.views;
 -- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+1
 -- !result
 set enable_evaluate_schema_scan_rule=false;
 -- result:
@@ -77,13 +71,13 @@ select if (count(*) > 0, "OK", "FAILED") from information_schema.views;
 -- result:
 OK
 -- !result
-[UC] select if count(*) from information_schema.tables;
+[UC] select count(*) from information_schema.tables;
 -- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+76
 -- !result
-[UC] select if count(*) from information_schema.views;
+[UC] select count(*) from information_schema.views;
 -- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+1
 -- !result
 create database if not exists test_information_schema_tables;
 -- result:
@@ -102,13 +96,13 @@ select if (count(*) > 0, "OK", "FAILED") from information_schema.views;
 -- result:
 OK
 -- !result
-[UC] select if count(*) from information_schema.tables;
+[UC] select count(*) from information_schema.tables;
 -- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+76
 -- !result
-[UC] select if count(*) from information_schema.views;
+[UC] select count(*) from information_schema.views;
 -- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+1
 -- !result
 set enable_evaluate_schema_scan_rule=false;
 -- result:
@@ -121,13 +115,13 @@ select if (count(*) > 0, "OK", "FAILED") from information_schema.views;
 -- result:
 OK
 -- !result
-[UC] select if count(*) from information_schema.tables;
+[UC] select count(*) from information_schema.tables;
 -- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+76
 -- !result
-[UC] select if count(*) from information_schema.views;
+[UC] select count(*) from information_schema.views;
 -- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+1
 -- !result
 drop database if exists test_information_schema;
 -- result:

--- a/test/sql/test_information_schema/R/test_tables
+++ b/test/sql/test_information_schema/R/test_tables
@@ -8,31 +8,130 @@ use db_${uuid0};
 CREATE TABLE `unique_table_with_null` ( `k1` date, `k2` datetime, `k3` char(20), `k4` varchar(20), `k5` boolean, `v1` tinyint, `v2` smallint, `v3` int, `v4` bigint, `v5` largeint, `v6` float, `v7` double, `v8` decimal(27,9) ) UNIQUE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) COMMENT "OLAP" DISTRIBUTED BY HASH(`k1`, `k2`, `k3`, `k4`, `k5`) BUCKETS 3;
 -- result:
 -- !result
+CREATE VIEW `unique_view_with_null` AS SELECT * FROM `unique_table_with_null`;
+-- result:
+-- !result
 select TABLE_TYPE, `VERSION`, ROW_FORMAT  from information_schema.tables where TABLE_SCHEMA='db_${uuid0}' limit 1;
 -- result:
 BASE TABLE	None	None
 -- !result
 [UC]select * from information_schema.tables a full join information_schema.tables_config b on a.TABLE_SCHEMA=b.TABLE_SCHEMA where b.TABLE_NAME='unique_table_with_null';
 -- result:
-def	db_9597b2c82a3945b4bb46e90786cce39f	unique_table_with_null	BASE TABLE	StarRocks	None	None	0	0	0	None	None	None	None	2025-07-28 15:59:03	2025-07-28 15:59:03	1970-01-01 08:00:00	utf8_general_ci	None	None	OLAP	db_9597b2c82a3945b4bb46e90786cce39f	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	47167
-None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	test_info_tables_fcb94f92_6b78_11f0_bd7f_00163e0e489a	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	43024
+def	db_9949a2cf56024ba1b1aa6efff42afb13	unique_table_with_null	BASE TABLE	StarRocks	None	None	0	0	0	None	None	None	None	2025-11-14 15:17:57	2025-11-14 15:17:57	1970-01-01 08:00:00	utf8_general_ci	None	None	OLAP	db_9949a2cf56024ba1b1aa6efff42afb13	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	45536
+def	db_9949a2cf56024ba1b1aa6efff42afb13	unique_view_with_null	VIEW	None	None	None	None	None	None	None	None	None	None	2025-11-14 15:17:57	None	1970-01-01 08:00:00	utf8_general_ci	None	None		db_9949a2cf56024ba1b1aa6efff42afb13	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	45536
+def	test	test_mv1	VIEW	StarRocks	None	None	5	2837	14187	None	None	None	None	2025-11-13 21:19:42	2025-11-13 21:21:37	1970-01-01 08:00:00	utf8_general_ci	None	None		test	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	44058
+def	test	unique_view_with_null	VIEW	None	None	None	None	None	None	None	None	None	None	2025-11-14 14:49:05	None	1970-01-01 08:00:00	utf8_general_ci	None	None		test	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	44058
+def	test	unique_table_with_null	BASE TABLE	StarRocks	None	None	0	0	0	None	None	None	None	2025-11-14 14:49:02	2025-11-14 14:49:02	1970-01-01 08:00:00	utf8_general_ci	None	None	OLAP	test	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	44058
 -- !result
 [UC]select a.TABLE_NAME, b.* from information_schema.tables a full join information_schema.tables_config b on a.TABLE_SCHEMA=b.TABLE_SCHEMA where b.TABLE_NAME='unique_table_with_null';
 -- result:
-unique_table_with_null	db_9597b2c82a3945b4bb46e90786cce39f	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	47167
-None	test_info_tables_fcb94f92_6b78_11f0_bd7f_00163e0e489a	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	43024
+test_mv1	test	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	44058
+unique_view_with_null	test	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	44058
+unique_table_with_null	test	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	44058
+unique_table_with_null	db_9949a2cf56024ba1b1aa6efff42afb13	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	45536
+unique_view_with_null	db_9949a2cf56024ba1b1aa6efff42afb13	unique_table_with_null	OLAP	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`	HASH	3	`k1`, `k2`, `k3`, `k4`, `k5`	{"compression":"LZ4","fast_schema_evolution":"true","replicated_storage":"true","replication_num":"1"}	45536
 -- !result
-set enable_constant_execute_in_fe=true;
+set enable_evaluate_schema_scan_rule=true;
 -- result:
 -- !result
 select a.TABLE_NAME, b.TABLE_MODEL, b.PRIMARY_KEY, b.PARTITION_KEY, b.DISTRIBUTE_KEY from information_schema.tables a full join information_schema.tables_config b on a.TABLE_SCHEMA=b.TABLE_SCHEMA where b.TABLE_NAME='unique_table_with_null' and a.TABLE_SCHEMA='db_${uuid0}';
 -- result:
 unique_table_with_null	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`
+unique_view_with_null	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`
 -- !result
-set enable_constant_execute_in_fe=false;
+set enable_evaluate_schema_scan_rule=false;
 -- result:
 -- !result
 select a.TABLE_NAME, b.TABLE_MODEL, b.PRIMARY_KEY, b.PARTITION_KEY, b.DISTRIBUTE_KEY from information_schema.tables a full join information_schema.tables_config b on a.TABLE_SCHEMA=b.TABLE_SCHEMA where b.TABLE_NAME='unique_table_with_null' and a.TABLE_SCHEMA='db_${uuid0}';
 -- result:
+unique_view_with_null	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`
 unique_table_with_null	UNIQUE_KEYS	`k1`, `k2`, `k3`, `k4`, `k5`		`k1`, `k2`, `k3`, `k4`, `k5`
+-- !result
+set enable_evaluate_schema_scan_rule=true;
+-- result:
+-- !result
+select if (count(*) > 0, "OK", "FAILED") from information_schema.tables;
+-- result:
+OK
+-- !result
+select if (count(*) > 0, "OK", "FAILED") from information_schema.views;
+-- result:
+OK
+-- !result
+[UC] select if count(*) from information_schema.tables;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+[UC] select if count(*) from information_schema.views;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+set enable_evaluate_schema_scan_rule=false;
+-- result:
+-- !result
+select if (count(*) > 0, "OK", "FAILED") from information_schema.tables;
+-- result:
+OK
+-- !result
+select if (count(*) > 0, "OK", "FAILED") from information_schema.views;
+-- result:
+OK
+-- !result
+[UC] select if count(*) from information_schema.tables;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+[UC] select if count(*) from information_schema.views;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+create database if not exists test_information_schema_tables;
+-- result:
+-- !result
+use test_information_schema_tables;
+-- result:
+-- !result
+set enable_evaluate_schema_scan_rule=true;
+-- result:
+-- !result
+select if (count(*) > 0, "OK", "FAILED") from information_schema.tables;
+-- result:
+OK
+-- !result
+select if (count(*) > 0, "OK", "FAILED") from information_schema.views;
+-- result:
+OK
+-- !result
+[UC] select if count(*) from information_schema.tables;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+[UC] select if count(*) from information_schema.views;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+set enable_evaluate_schema_scan_rule=false;
+-- result:
+-- !result
+select if (count(*) > 0, "OK", "FAILED") from information_schema.tables;
+-- result:
+OK
+-- !result
+select if (count(*) > 0, "OK", "FAILED") from information_schema.views;
+-- result:
+OK
+-- !result
+[UC] select if count(*) from information_schema.tables;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+[UC] select if count(*) from information_schema.views;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+drop database if exists test_information_schema;
+-- result:
+-- !result
+drop database if exists db_${uuid0};
+-- result:
 -- !result

--- a/test/sql/test_information_schema/R/test_task_run_status
+++ b/test/sql/test_information_schema/R/test_task_run_status
@@ -40,7 +40,7 @@ SELECT count(1) FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 
 -- !result
 [UC]task_name=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='mv1';
 -- result:
-mv-28357
+mv-45440
 -- !result
 SELECT count(1) FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}';
 -- result:
@@ -55,7 +55,7 @@ admin set frontend config('enable_task_run_fe_evaluation'='false');
 -- !result
 [UC]query_id=SELECT `QUERY_ID` FROM information_schema.task_runs WHERE task_name = '${task_name}' limit 1;
 -- result:
-a780f383-44da-11ef-a7c8-e2d8918adc6e
+019a813a-3992-7157-ba4f-5ab020a653e7
 -- !result
 SELECT count(1) FROM information_schema.task_runs WHERE QUERY_ID = '${query_id}';
 -- result:
@@ -72,6 +72,104 @@ SUCCESS
 SELECT count(1) FROM information_schema.task_runs WHERE `STATE` = '${state}' and task_name = '${task_name}' and QUERY_ID = '${query_id}';
 -- result:
 1
+-- !result
+set enable_evaluate_schema_scan_rule=true;
+-- result:
+-- !result
+[UC] select if count(*) from information_schema.task_runs;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+[UC] select if count(*) from information_schema.task_runs;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
+-- result:
+OK
+-- !result
+[UC] select if count(*) from information_schema.task_runs;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
+-- result:
+OK
+-- !result
+set enable_evaluate_schema_scan_rule=false;
+-- result:
+-- !result
+[UC] select if count(*) from information_schema.task_runs;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+[UC] select if count(*) from information_schema.task_runs;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
+-- result:
+OK
+-- !result
+[UC] select if count(*) from information_schema.task_runs;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
+-- result:
+OK
+-- !result
+create database if not exists test_information_schema_task_runs;
+-- result:
+-- !result
+use test_information_schema_task_runs;
+-- result:
+-- !result
+[UC] select if count(*) from information_schema.task_runs;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+[UC] select if count(*) from information_schema.task_runs;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
+-- result:
+OK
+-- !result
+[UC] select if count(*) from information_schema.task_runs;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
+-- result:
+OK
+-- !result
+set enable_evaluate_schema_scan_rule=false;
+-- result:
+-- !result
+[UC] select if count(*) from information_schema.task_runs;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+[UC] select if count(*) from information_schema.task_runs;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
+-- result:
+OK
+-- !result
+[UC] select if count(*) from information_schema.task_runs;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+-- !result
+select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
+-- result:
+OK
+-- !result
+drop database if exists test_information_schema_task_runs;
+-- result:
 -- !result
 drop database db_${uuid0};
 -- result:

--- a/test/sql/test_information_schema/R/test_task_run_status
+++ b/test/sql/test_information_schema/R/test_task_run_status
@@ -40,7 +40,7 @@ SELECT count(1) FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 
 -- !result
 [UC]task_name=SELECT TASK_NAME FROM information_schema.materialized_views WHERE TABLE_SCHEMA = 'db_${uuid0}' AND TABLE_NAME='mv1';
 -- result:
-mv-45440
+mv-11425
 -- !result
 SELECT count(1) FROM information_schema.task_runs WHERE TASK_NAME = '${task_name}';
 -- result:
@@ -55,7 +55,7 @@ admin set frontend config('enable_task_run_fe_evaluation'='false');
 -- !result
 [UC]query_id=SELECT `QUERY_ID` FROM information_schema.task_runs WHERE task_name = '${task_name}' limit 1;
 -- result:
-019a813a-3992-7157-ba4f-5ab020a653e7
+019a8143-9531-7cd3-9983-023d5aeae57e
 -- !result
 SELECT count(1) FROM information_schema.task_runs WHERE QUERY_ID = '${query_id}';
 -- result:
@@ -76,21 +76,9 @@ SELECT count(1) FROM information_schema.task_runs WHERE `STATE` = '${state}' and
 set enable_evaluate_schema_scan_rule=true;
 -- result:
 -- !result
-[UC] select if count(*) from information_schema.task_runs;
+[UC] select count(*) from information_schema.task_runs;
 -- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
--- !result
-[UC] select if count(*) from information_schema.task_runs;
--- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
--- !result
-select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
--- result:
-OK
--- !result
-[UC] select if count(*) from information_schema.task_runs;
--- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+7
 -- !result
 select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
 -- result:
@@ -99,21 +87,9 @@ OK
 set enable_evaluate_schema_scan_rule=false;
 -- result:
 -- !result
-[UC] select if count(*) from information_schema.task_runs;
+[UC] select count(*) from information_schema.task_runs;
 -- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
--- !result
-[UC] select if count(*) from information_schema.task_runs;
--- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
--- !result
-select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
--- result:
-OK
--- !result
-[UC] select if count(*) from information_schema.task_runs;
--- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+7
 -- !result
 select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
 -- result:
@@ -125,21 +101,12 @@ create database if not exists test_information_schema_task_runs;
 use test_information_schema_task_runs;
 -- result:
 -- !result
-[UC] select if count(*) from information_schema.task_runs;
+set enable_evaluate_schema_scan_rule=true;
 -- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
 -- !result
-[UC] select if count(*) from information_schema.task_runs;
+[UC] select count(*) from information_schema.task_runs;
 -- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
--- !result
-select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
--- result:
-OK
--- !result
-[UC] select if count(*) from information_schema.task_runs;
--- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+7
 -- !result
 select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
 -- result:
@@ -148,21 +115,9 @@ OK
 set enable_evaluate_schema_scan_rule=false;
 -- result:
 -- !result
-[UC] select if count(*) from information_schema.task_runs;
+[UC] select count(*) from information_schema.task_runs;
 -- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
--- !result
-[UC] select if count(*) from information_schema.task_runs;
--- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
--- !result
-select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
--- result:
-OK
--- !result
-[UC] select if count(*) from information_schema.task_runs;
--- result:
-E: (1064, "Getting syntax error at line 1, column 11. Detail message: Unexpected input 'count', the most similar input is {'('}.")
+7
 -- !result
 select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
 -- result:

--- a/test/sql/test_information_schema/T/test_materialized_views
+++ b/test/sql/test_information_schema/T/test_materialized_views
@@ -12,31 +12,20 @@ AS SELECT event_day, sum(pv) as sum_pv FROM ss GROUP BY event_day;
 [UC]REFRESH MATERIALIZED VIEW mv1 with sync mode ;
 
 set enable_evaluate_schema_scan_rule=true;
-[UC] select if count(*) from information_schema.materialized_views;
+[UC] select count(*) from information_schema.materialized_views;
 select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
-[UC] select if count(*) from information_schema.materialized_views;
-select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
-
 set enable_evaluate_schema_scan_rule=false;
-[UC] select if count(*) from information_schema.materialized_views;
-select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
-[UC] select if count(*) from information_schema.materialized_views;
+[UC] select count(*) from information_schema.materialized_views;
 select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
 
 create database if not exists test_information_schema_materialized_views;
 use test_information_schema_materialized_views;
 
-[UC] select if count(*) from information_schema.materialized_views;
+[UC] select count(*) from information_schema.materialized_views;
 select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
-[UC] select if count(*) from information_schema.materialized_views;
-select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
-
 set enable_evaluate_schema_scan_rule=false;
-[UC] select if count(*) from information_schema.materialized_views;
+[UC] select count(*) from information_schema.materialized_views;
 select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
-[UC] select if count(*) from information_schema.materialized_views;
-select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
-
 
 drop database if exists test_information_schema_materialized_views;
 drop database db_${uuid0};

--- a/test/sql/test_information_schema/T/test_materialized_views
+++ b/test/sql/test_information_schema/T/test_materialized_views
@@ -1,0 +1,42 @@
+-- name: test_materialized_views
+
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE TABLE ss( event_day DATE, pv BIGINT) DUPLICATE KEY(event_day) DISTRIBUTED BY HASH(event_day) BUCKETS 8 PROPERTIES("replication_num" = "1");
+insert into ss values('2020-01-14', 1), ('2020-01-14', 3), ('2020-01-15', 2);
+
+CREATE MATERIALIZED VIEW mv1 DISTRIBUTED BY hash(event_day) 
+REFRESH DEFERRED MANUAL
+AS SELECT event_day, sum(pv) as sum_pv FROM ss GROUP BY event_day;
+[UC]REFRESH MATERIALIZED VIEW mv1 with sync mode ;
+
+set enable_evaluate_schema_scan_rule=true;
+[UC] select if count(*) from information_schema.materialized_views;
+select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
+[UC] select if count(*) from information_schema.materialized_views;
+select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
+
+set enable_evaluate_schema_scan_rule=false;
+[UC] select if count(*) from information_schema.materialized_views;
+select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
+[UC] select if count(*) from information_schema.materialized_views;
+select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
+
+create database if not exists test_information_schema_materialized_views;
+use test_information_schema_materialized_views;
+
+[UC] select if count(*) from information_schema.materialized_views;
+select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
+[UC] select if count(*) from information_schema.materialized_views;
+select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
+
+set enable_evaluate_schema_scan_rule=false;
+[UC] select if count(*) from information_schema.materialized_views;
+select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
+[UC] select if count(*) from information_schema.materialized_views;
+select if (count(*) > 0, "OK", "FAILED") from information_schema.materialized_views;
+
+
+drop database if exists test_information_schema_materialized_views;
+drop database db_${uuid0};

--- a/test/sql/test_information_schema/T/test_tables
+++ b/test/sql/test_information_schema/T/test_tables
@@ -3,11 +3,42 @@ create database db_${uuid0};
 use db_${uuid0};
 
 CREATE TABLE `unique_table_with_null` ( `k1` date, `k2` datetime, `k3` char(20), `k4` varchar(20), `k5` boolean, `v1` tinyint, `v2` smallint, `v3` int, `v4` bigint, `v5` largeint, `v6` float, `v7` double, `v8` decimal(27,9) ) UNIQUE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) COMMENT "OLAP" DISTRIBUTED BY HASH(`k1`, `k2`, `k3`, `k4`, `k5`) BUCKETS 3;
+CREATE VIEW `unique_view_with_null` AS SELECT * FROM `unique_table_with_null`;
+
 select TABLE_TYPE, `VERSION`, ROW_FORMAT  from information_schema.tables where TABLE_SCHEMA='db_${uuid0}' limit 1;
 [UC]select * from information_schema.tables a full join information_schema.tables_config b on a.TABLE_SCHEMA=b.TABLE_SCHEMA where b.TABLE_NAME='unique_table_with_null';
 [UC]select a.TABLE_NAME, b.* from information_schema.tables a full join information_schema.tables_config b on a.TABLE_SCHEMA=b.TABLE_SCHEMA where b.TABLE_NAME='unique_table_with_null';
-set enable_constant_execute_in_fe=true;
+set enable_evaluate_schema_scan_rule=true;
 select a.TABLE_NAME, b.TABLE_MODEL, b.PRIMARY_KEY, b.PARTITION_KEY, b.DISTRIBUTE_KEY from information_schema.tables a full join information_schema.tables_config b on a.TABLE_SCHEMA=b.TABLE_SCHEMA where b.TABLE_NAME='unique_table_with_null' and a.TABLE_SCHEMA='db_${uuid0}';
 
-set enable_constant_execute_in_fe=false;
+set enable_evaluate_schema_scan_rule=false;
 select a.TABLE_NAME, b.TABLE_MODEL, b.PRIMARY_KEY, b.PARTITION_KEY, b.DISTRIBUTE_KEY from information_schema.tables a full join information_schema.tables_config b on a.TABLE_SCHEMA=b.TABLE_SCHEMA where b.TABLE_NAME='unique_table_with_null' and a.TABLE_SCHEMA='db_${uuid0}';
+
+set enable_evaluate_schema_scan_rule=true;
+select if (count(*) > 0, "OK", "FAILED") from information_schema.tables;
+select if (count(*) > 0, "OK", "FAILED") from information_schema.views;
+[UC] select if count(*) from information_schema.tables;
+[UC] select if count(*) from information_schema.views;
+set enable_evaluate_schema_scan_rule=false;
+select if (count(*) > 0, "OK", "FAILED") from information_schema.tables;
+select if (count(*) > 0, "OK", "FAILED") from information_schema.views;
+[UC] select if count(*) from information_schema.tables;
+[UC] select if count(*) from information_schema.views;
+
+-- test query information_schema.tables and information_schema.views in a new database
+create database if not exists test_information_schema_tables;
+use test_information_schema_tables;
+set enable_evaluate_schema_scan_rule=true;
+select if (count(*) > 0, "OK", "FAILED") from information_schema.tables;
+select if (count(*) > 0, "OK", "FAILED") from information_schema.views;
+[UC] select if count(*) from information_schema.tables;
+[UC] select if count(*) from information_schema.views;
+
+set enable_evaluate_schema_scan_rule=false;
+select if (count(*) > 0, "OK", "FAILED") from information_schema.tables;
+select if (count(*) > 0, "OK", "FAILED") from information_schema.views;
+[UC] select if count(*) from information_schema.tables;
+[UC] select if count(*) from information_schema.views;
+
+drop database if exists test_information_schema;
+drop database if exists db_${uuid0};

--- a/test/sql/test_information_schema/T/test_tables
+++ b/test/sql/test_information_schema/T/test_tables
@@ -5,7 +5,8 @@ use db_${uuid0};
 CREATE TABLE `unique_table_with_null` ( `k1` date, `k2` datetime, `k3` char(20), `k4` varchar(20), `k5` boolean, `v1` tinyint, `v2` smallint, `v3` int, `v4` bigint, `v5` largeint, `v6` float, `v7` double, `v8` decimal(27,9) ) UNIQUE KEY(`k1`, `k2`, `k3`, `k4`, `k5`) COMMENT "OLAP" DISTRIBUTED BY HASH(`k1`, `k2`, `k3`, `k4`, `k5`) BUCKETS 3;
 CREATE VIEW `unique_view_with_null` AS SELECT * FROM `unique_table_with_null`;
 
-select TABLE_TYPE, `VERSION`, ROW_FORMAT  from information_schema.tables where TABLE_SCHEMA='db_${uuid0}' limit 1;
+select TABLE_TYPE, `VERSION`, ROW_FORMAT  from information_schema.tables where TABLE_SCHEMA='db_${uuid0}' order by TABLE_NAME limit 1;
+
 [UC]select * from information_schema.tables a full join information_schema.tables_config b on a.TABLE_SCHEMA=b.TABLE_SCHEMA where b.TABLE_NAME='unique_table_with_null';
 [UC]select a.TABLE_NAME, b.* from information_schema.tables a full join information_schema.tables_config b on a.TABLE_SCHEMA=b.TABLE_SCHEMA where b.TABLE_NAME='unique_table_with_null';
 set enable_evaluate_schema_scan_rule=true;
@@ -17,13 +18,13 @@ select a.TABLE_NAME, b.TABLE_MODEL, b.PRIMARY_KEY, b.PARTITION_KEY, b.DISTRIBUTE
 set enable_evaluate_schema_scan_rule=true;
 select if (count(*) > 0, "OK", "FAILED") from information_schema.tables;
 select if (count(*) > 0, "OK", "FAILED") from information_schema.views;
-[UC] select if count(*) from information_schema.tables;
-[UC] select if count(*) from information_schema.views;
+[UC] select count(*) from information_schema.tables;
+[UC] select count(*) from information_schema.views;
 set enable_evaluate_schema_scan_rule=false;
 select if (count(*) > 0, "OK", "FAILED") from information_schema.tables;
 select if (count(*) > 0, "OK", "FAILED") from information_schema.views;
-[UC] select if count(*) from information_schema.tables;
-[UC] select if count(*) from information_schema.views;
+[UC] select count(*) from information_schema.tables;
+[UC] select count(*) from information_schema.views;
 
 -- test query information_schema.tables and information_schema.views in a new database
 create database if not exists test_information_schema_tables;
@@ -31,14 +32,14 @@ use test_information_schema_tables;
 set enable_evaluate_schema_scan_rule=true;
 select if (count(*) > 0, "OK", "FAILED") from information_schema.tables;
 select if (count(*) > 0, "OK", "FAILED") from information_schema.views;
-[UC] select if count(*) from information_schema.tables;
-[UC] select if count(*) from information_schema.views;
+[UC] select count(*) from information_schema.tables;
+[UC] select count(*) from information_schema.views;
 
 set enable_evaluate_schema_scan_rule=false;
 select if (count(*) > 0, "OK", "FAILED") from information_schema.tables;
 select if (count(*) > 0, "OK", "FAILED") from information_schema.views;
-[UC] select if count(*) from information_schema.tables;
-[UC] select if count(*) from information_schema.views;
+[UC] select count(*) from information_schema.tables;
+[UC] select count(*) from information_schema.views;
 
 drop database if exists test_information_schema;
 drop database if exists db_${uuid0};

--- a/test/sql/test_information_schema/T/test_tables
+++ b/test/sql/test_information_schema/T/test_tables
@@ -10,10 +10,10 @@ select TABLE_TYPE, `VERSION`, ROW_FORMAT  from information_schema.tables where T
 [UC]select * from information_schema.tables a full join information_schema.tables_config b on a.TABLE_SCHEMA=b.TABLE_SCHEMA where b.TABLE_NAME='unique_table_with_null';
 [UC]select a.TABLE_NAME, b.* from information_schema.tables a full join information_schema.tables_config b on a.TABLE_SCHEMA=b.TABLE_SCHEMA where b.TABLE_NAME='unique_table_with_null';
 set enable_evaluate_schema_scan_rule=true;
-select a.TABLE_NAME, b.TABLE_MODEL, b.PRIMARY_KEY, b.PARTITION_KEY, b.DISTRIBUTE_KEY from information_schema.tables a full join information_schema.tables_config b on a.TABLE_SCHEMA=b.TABLE_SCHEMA where b.TABLE_NAME='unique_table_with_null' and a.TABLE_SCHEMA='db_${uuid0}';
+select a.TABLE_NAME, b.TABLE_MODEL, b.PRIMARY_KEY, b.PARTITION_KEY, b.DISTRIBUTE_KEY from information_schema.tables a full join information_schema.tables_config b on a.TABLE_SCHEMA=b.TABLE_SCHEMA where b.TABLE_NAME='unique_table_with_null' and a.TABLE_SCHEMA='db_${uuid0}' ORDER BY a.TABLE_NAME;
 
 set enable_evaluate_schema_scan_rule=false;
-select a.TABLE_NAME, b.TABLE_MODEL, b.PRIMARY_KEY, b.PARTITION_KEY, b.DISTRIBUTE_KEY from information_schema.tables a full join information_schema.tables_config b on a.TABLE_SCHEMA=b.TABLE_SCHEMA where b.TABLE_NAME='unique_table_with_null' and a.TABLE_SCHEMA='db_${uuid0}';
+select a.TABLE_NAME, b.TABLE_MODEL, b.PRIMARY_KEY, b.PARTITION_KEY, b.DISTRIBUTE_KEY from information_schema.tables a full join information_schema.tables_config b on a.TABLE_SCHEMA=b.TABLE_SCHEMA where b.TABLE_NAME='unique_table_with_null' and a.TABLE_SCHEMA='db_${uuid0}' ORDER BY a.TABLE_NAME;
 
 set enable_evaluate_schema_scan_rule=true;
 select if (count(*) > 0, "OK", "FAILED") from information_schema.tables;

--- a/test/sql/test_information_schema/T/test_task_run_status
+++ b/test/sql/test_information_schema/T/test_task_run_status
@@ -29,4 +29,34 @@ SELECT count(1) FROM information_schema.task_runs WHERE query_id= '${query_id}';
 [UC]state=SELECT `STATE` FROM information_schema.task_runs WHERE QUERY_ID = '${query_id}';
 SELECT count(1) FROM information_schema.task_runs WHERE `STATE` = '${state}' and task_name = '${task_name}' and QUERY_ID = '${query_id}';
 
+set enable_evaluate_schema_scan_rule=true;
+[UC] select if count(*) from information_schema.task_runs;
+[UC] select if count(*) from information_schema.task_runs;
+select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
+[UC] select if count(*) from information_schema.task_runs;
+select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
+
+set enable_evaluate_schema_scan_rule=false;
+[UC] select if count(*) from information_schema.task_runs;
+[UC] select if count(*) from information_schema.task_runs;
+select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
+[UC] select if count(*) from information_schema.task_runs;
+select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
+
+create database if not exists test_information_schema_task_runs;
+use test_information_schema_task_runs;
+[UC] select if count(*) from information_schema.task_runs;
+[UC] select if count(*) from information_schema.task_runs;
+select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
+[UC] select if count(*) from information_schema.task_runs;
+select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
+
+set enable_evaluate_schema_scan_rule=false;
+[UC] select if count(*) from information_schema.task_runs;
+[UC] select if count(*) from information_schema.task_runs;
+select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
+[UC] select if count(*) from information_schema.task_runs;
+select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
+
+drop database if exists test_information_schema_task_runs;
 drop database db_${uuid0};

--- a/test/sql/test_information_schema/T/test_task_run_status
+++ b/test/sql/test_information_schema/T/test_task_run_status
@@ -30,32 +30,20 @@ SELECT count(1) FROM information_schema.task_runs WHERE query_id= '${query_id}';
 SELECT count(1) FROM information_schema.task_runs WHERE `STATE` = '${state}' and task_name = '${task_name}' and QUERY_ID = '${query_id}';
 
 set enable_evaluate_schema_scan_rule=true;
-[UC] select if count(*) from information_schema.task_runs;
-[UC] select if count(*) from information_schema.task_runs;
+[UC] select count(*) from information_schema.task_runs;
 select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
-[UC] select if count(*) from information_schema.task_runs;
-select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
-
 set enable_evaluate_schema_scan_rule=false;
-[UC] select if count(*) from information_schema.task_runs;
-[UC] select if count(*) from information_schema.task_runs;
-select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
-[UC] select if count(*) from information_schema.task_runs;
+[UC] select count(*) from information_schema.task_runs;
 select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
 
 create database if not exists test_information_schema_task_runs;
 use test_information_schema_task_runs;
-[UC] select if count(*) from information_schema.task_runs;
-[UC] select if count(*) from information_schema.task_runs;
-select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
-[UC] select if count(*) from information_schema.task_runs;
-select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
 
-set enable_evaluate_schema_scan_rule=false;
-[UC] select if count(*) from information_schema.task_runs;
-[UC] select if count(*) from information_schema.task_runs;
+set enable_evaluate_schema_scan_rule=true;
+[UC] select count(*) from information_schema.task_runs;
 select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
-[UC] select if count(*) from information_schema.task_runs;
+set enable_evaluate_schema_scan_rule=false;
+[UC] select count(*) from information_schema.task_runs;
 select if (count(*) > 0, "OK", "FAILED") from information_schema.task_runs;
 
 drop database if exists test_information_schema_task_runs;


### PR DESCRIPTION
## Why I'm doing:

Fix bugs introduced by: https://github.com/StarRocks/starrocks/pull/61107


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes FE-side evaluation of information_schema.tables/views across databases, refactors view lookup, improves error handling, and adds coverage tests.
> 
> - **Information Schema**:
>   - `TablesSystemTable`: honor `TABLE_SCHEMA` via auth pattern; remove current-DB restriction; on `TException`, throw `SemanticException`.
>   - `ViewsSystemTable`: support cross-DB view listing with auth/filters; introduce `GetViewResult`, `queryImpl`, and `collectViewsInDb`; update `infoToScalar`; throw `SemanticException` on failures.
>   - `InformationSchemaDataSource.generateTablesInfoResponse`: adjust flow to list table names, auth per table, and lock per table (drop db-level lock); keep metrics population.
> - **Analyzer/Planner**:
>   - `AnalyzerUtils`: treat `SystemTable` as immutable in copy-safety checks.
> - **Concurrency**:
>   - `MultiUserLock`: enhance unlock error message with owner details.
> - **Tests**:
>   - Add/update SQL tests for `information_schema.tables`, `views`, `materialized_views`, and `task_runs` with `enable_evaluate_schema_scan_rule` on/off and across different DBs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c86de051627faed8a8e454b7ee7c23651cec800a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->