### PR TITLE
[BugFix] Fix use-after-free when storage engine is stopped in local pk index manager.

### DIFF
--- a/be/src/storage/lake/local_pk_index_manager.cpp
+++ b/be/src/storage/lake/local_pk_index_manager.cpp
@@ -27,12 +27,6 @@
 
 namespace starrocks::lake {
 
-LocalPkIndexManager::~LocalPkIndexManager() {
-    if (_worker_thread_pool != nullptr) {
-        _worker_thread_pool->shutdown();
-    }
-}
-
 Status LocalPkIndexManager::clear_persistent_index(int64_t tablet_id) {
     // remove meta in RocksDB
     auto data_dir = StorageEngine::instance()->get_persistent_index_store(tablet_id);

--- a/be/src/storage/lake/local_pk_index_manager.h
+++ b/be/src/storage/lake/local_pk_index_manager.h
@@ -34,7 +34,7 @@ class LocalPkIndexManager : public PersistentIndexCompactionManager {
 public:
     LocalPkIndexManager() = default;
 
-    ~LocalPkIndexManager();
+    ~LocalPkIndexManager() override = default;
 
     static void gc(UpdateManager* update_manager, DataDir* data_dir, std::set<std::string>& tablet_ids);
 

--- a/be/src/storage/persistent_index_compaction_manager.cpp
+++ b/be/src/storage/persistent_index_compaction_manager.cpp
@@ -23,9 +23,17 @@
 namespace starrocks {
 
 PersistentIndexCompactionManager::~PersistentIndexCompactionManager() {
+    stop();
+}
+
+void PersistentIndexCompactionManager::stop() {
+    if (_stopped) {
+        return;
+    }
     if (_worker_thread_pool != nullptr) {
         _worker_thread_pool->shutdown();
     }
+    _stopped = true;
 }
 
 Status PersistentIndexCompactionManager::init() {

--- a/be/src/storage/persistent_index_compaction_manager.h
+++ b/be/src/storage/persistent_index_compaction_manager.h
@@ -51,6 +51,8 @@ public:
     // Is tablet's disk out of concurrency limit
     bool disk_limit(DataDir* data_dir);
 
+    virtual void stop();
+
 protected:
     std::mutex _mutex;
     // Sorted by prority
@@ -59,6 +61,7 @@ protected:
     std::unique_ptr<ThreadPool> _worker_thread_pool;
     std::unordered_map<DataDir*, uint64_t> _data_dir_to_task_num_map;
     size_t _last_schedule_time = 0;
+    bool _stopped = false;
 };
 
 } // namespace starrocks

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -677,6 +677,13 @@ void StorageEngine::stop() {
     if (_compaction_manager) {
         _compaction_manager->stop();
     }
+
+#ifdef USE_STAROS
+    if (_local_pk_index_manager) {
+        _local_pk_index_manager->stop();
+    }
+#endif
+
 }
 
 void StorageEngine::clear_transaction_task(const TTransactionId transaction_id) {

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -683,7 +683,6 @@ void StorageEngine::stop() {
         _local_pk_index_manager->stop();
     }
 #endif
-
 }
 
 void StorageEngine::clear_transaction_task(const TTransactionId transaction_id) {

--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -135,6 +135,9 @@ void UpdateManager::stop() {
     if (_pindex_load_executor) {
         _pindex_load_executor->shutdown();
     }
+    if (_persistent_index_compaction_mgr) {
+        _persistent_index_compaction_mgr->stop();
+    }
 }
 
 int64_t UpdateManager::get_index_cache_expire_ms(const Tablet& tablet) const {

--- a/be/test/storage/lake/local_pk_index_manager_test.cpp
+++ b/be/test/storage/lake/local_pk_index_manager_test.cpp
@@ -277,6 +277,14 @@ TEST_F(LocalPkIndexManagerTest, test_gc_while_index_dir_changed) {
     ASSERT_OK(publish_single_version(_tablet_metadata->id(), 2, txn_id).status());
 }
 
+TEST_F(LocalPkIndexManagerTest, test_stop_is_idempotent) {
+    LocalPkIndexManager mgr;
+    ASSERT_OK(mgr.init());
+    mgr.stop();
+    // stop() should be safe to call multiple times for derived class as well.
+    mgr.stop();
+}
+
 TEST_F(LocalPkIndexManagerTest, test_evict) {
     SyncPoint::GetInstance()->EnableProcessing();
     SyncPoint::GetInstance()->SetCallBack("LocalPkIndexManager::evict:1", [](void* arg) { *(bool*)arg = true; });

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -3257,6 +3257,14 @@ TEST_P(PersistentIndexTest, pindex_compaction_schedule_with_migration) {
     ASSERT_FALSE(mgr.is_running(tablet->tablet_id()));
 }
 
+TEST_P(PersistentIndexTest, pindex_compaction_stop_is_idempotent) {
+    PersistentIndexCompactionManager mgr;
+    ASSERT_OK(mgr.init());
+    mgr.stop();
+    // stop() should be safe to call multiple times.
+    mgr.stop();
+}
+
 TEST_P(PersistentIndexTest, test_multi_l2_not_tmp_l1_update) {
     int64_t old_config = config::max_allow_pindex_l2_num;
     config::max_allow_pindex_l2_num = 100;


### PR DESCRIPTION
## Why I'm doing:
For the graceful shutdown of the BE, if there are some submitted local pk index compaction tasks,
the BE exiting process will not consider the submitted tasks as finished. After ExecEnv is destoryed,
the submitted tasks still can be scheduled and access some resources that have been destroyed.

In shared nothing mode, there is a similar issue when the storage engine is stopped.

## What I'm doing:
Add the stop() method to the PersistentIndexCompactionManager class, and call it when:
1. destroy the PersistentIndexCompactionManager instance
2. stop the update manager in shared nothing mode
3. stop the storage engine in shared data mode

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add an idempotent stop() to `PersistentIndexCompactionManager` and call it during BE shutdown (StorageEngine/UpdateManager/LocalPkIndexManager); add tests.
> 
> - **Core (Persistent Index Compaction)**:
>   - Add virtual `stop()` in `PersistentIndexCompactionManager` with `_stopped` guard; destructor now calls `stop()`.
>   - Track stop state via new `_stopped` member.
> - **Integration (Shutdown wiring)**:
>   - `StorageEngine::stop()` invokes `_local_pk_index_manager->stop()` (STAROS) and `_compaction_manager->stop()`.
>   - `UpdateManager::stop()` invokes `_persistent_index_compaction_mgr->stop()`.
>   - `LocalPkIndexManager`: remove custom destructor; default dtor; relies on base `stop()`.
> - **Tests**:
>   - Add idempotency tests for `stop()` in `LocalPkIndexManagerTest` and `PersistentIndexTest`.
> - **Other**:
>   - `LocalPkIndexManager::clear_persistent_index` safely handles null data dir (returns `NotFound`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4b7985cb3d910d749be09f541347bd6b5a945d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->