### PR TITLE
[Enhancement] Split pipeline CPU execution_time metrics by query vs. load

### DIFF
--- a/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.cpp
+++ b/be/src/exec/pipeline/exchange/mem_limited_chunk_queue.cpp
@@ -20,6 +20,7 @@
 #include "common/logging.h"
 #include "exec/pipeline/exchange/multi_cast_local_exchange.h"
 #include "exec/pipeline/exchange/multi_cast_local_exchange_sink_operator.h"
+#include "exec/pipeline/fragment_context.h"
 #include "exec/spill/block_manager.h"
 #include "exec/spill/data_stream.h"
 #include "exec/spill/dir_manager.h"
@@ -28,6 +29,7 @@
 #include "exec/spill/options.h"
 #include "fmt/format.h"
 #include "fs/fs.h"
+#include "gen_cpp/InternalService_types.h"
 #include "serde/column_array_serde.h"
 #include "serde/protobuf_serde.h"
 #include "testutil/sync_point.h"
@@ -479,6 +481,7 @@ Status MemLimitedChunkQueue::_submit_flush_task() {
     };
 
     auto io_task = workgroup::ScanTask(_state->fragment_ctx()->workgroup(), std::move(flush_task));
+    io_task.set_query_type(_state->query_options().query_type);
     RETURN_IF_ERROR(spill::IOTaskExecutor::submit(std::move(io_task)));
     return Status::OK();
 }
@@ -551,6 +554,7 @@ Status MemLimitedChunkQueue::_submit_load_task(Block* block) {
         }
     };
     auto io_task = workgroup::ScanTask(_state->fragment_ctx()->workgroup(), std::move(load_task));
+    io_task.set_query_type(_state->query_options().query_type);
     RETURN_IF_ERROR(spill::IOTaskExecutor::submit(std::move(io_task)));
     return Status::OK();
 }

--- a/be/src/exec/pipeline/fragment_context.cpp
+++ b/be/src/exec/pipeline/fragment_context.cpp
@@ -370,6 +370,13 @@ void FragmentContext::clear_pipeline_timer() {
     }
 }
 
+TQueryType::type FragmentContext::query_type() const {
+    if (_runtime_state == nullptr) {
+        return TQueryType::EXTERNAL;
+    }
+    return _runtime_state->query_options().query_type;
+}
+
 Status FragmentContext::reset_epoch() {
     _num_finished_epoch_pipelines = 0;
     const std::function<Status(Pipeline*)> caller = [this](Pipeline* pipeline) {

--- a/be/src/exec/pipeline/fragment_context.h
+++ b/be/src/exec/pipeline/fragment_context.h
@@ -145,6 +145,7 @@ public:
     void set_workgroup(workgroup::WorkGroupPtr wg) { _workgroup = std::move(wg); }
     const workgroup::WorkGroupPtr& workgroup() const { return _workgroup; }
     bool enable_resource_group() const { return _workgroup != nullptr; }
+    TQueryType::type query_type() const;
 
     // STREAM MV
     Status reset_epoch();

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -329,6 +329,7 @@ Status SpillableHashJoinProbeOperator::_load_all_partition_build_side(RuntimeSta
         auto yield_func = [&](workgroup::ScanTask&& task) { spill::IOTaskExecutor::force_submit(std::move(task)); };
         auto io_task =
                 workgroup::ScanTask(_join_builder->spiller()->options().wg, std::move(task), std::move(yield_func));
+        io_task.set_query_type(state->query_options().query_type);
         RETURN_IF_ERROR(spill::IOTaskExecutor::submit(std::move(io_task)));
     }
     return Status::OK();

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -113,6 +113,7 @@ void GlobalDriverExecutor::_worker_thread() {
         }
         auto* query_ctx = driver->query_ctx();
         auto* fragment_ctx = driver->fragment_ctx();
+        const TQueryType::type query_type = fragment_ctx->query_type();
 
         driver->increment_schedule_times();
         _metrics->driver_schedule_count.increment(1);
@@ -167,7 +168,7 @@ void GlobalDriverExecutor::_worker_thread() {
             Status status = maybe_state.status();
             this->_driver_queue->update_statistics(driver);
             int64_t end_time = driver->get_active_time();
-            _metrics->driver_execution_time.increment(end_time - start_time);
+            _metrics->driver_execution_time.increment(query_type, end_time - start_time);
             _metrics->exec_running_tasks.increment(-1);
             _metrics->exec_finished_tasks.increment(1);
 

--- a/be/src/exec/pipeline/pipeline_driver_executor.h
+++ b/be/src/exec/pipeline/pipeline_driver_executor.h
@@ -122,8 +122,6 @@ private:
     std::atomic_int64_t _driver_execution_ns = 0;
 
     // metrics
-    std::unique_ptr<UIntGauge> _driver_queue_len;
-    std::unique_ptr<UIntGauge> _driver_poller_block_queue_len;
     DriverExecutorMetrics* _metrics;
 };
 

--- a/be/src/exec/pipeline/pipeline_metrics.h
+++ b/be/src/exec/pipeline/pipeline_metrics.h
@@ -16,6 +16,7 @@
 
 #include <mutex>
 
+#include "gen_cpp/InternalService_types.h"
 #include "util/metrics.h"
 
 namespace starrocks {
@@ -23,8 +24,21 @@ class MetricRegistry;
 class ThreadPool;
 namespace pipeline {
 
+class QueryTypeTimeMetric {
+public:
+    void register_metrics(MetricRegistry* registry, const std::string& metric_name);
+    void increment(TQueryType::type query_type, int64_t delta);
+
+private:
+    IntCounter* counter(TQueryType::type query_type);
+
+    METRIC_DEFINE_INT_COUNTER(_query_counter, MetricUnit::NANOSECONDS);
+    METRIC_DEFINE_INT_COUNTER(_load_counter, MetricUnit::NANOSECONDS);
+    METRIC_DEFINE_INT_COUNTER(_unknown_counter, MetricUnit::NANOSECONDS);
+};
+
 struct ScanExecutorMetrics {
-    METRIC_DEFINE_INT_COUNTER(execution_time, MetricUnit::NANOSECONDS);
+    QueryTypeTimeMetric execution_time;
     METRIC_DEFINE_INT_COUNTER(finished_tasks, MetricUnit::NOUNIT);
     METRIC_DEFINE_INT_CORE_LOCAL_GAUGE(running_tasks, MetricUnit::NOUNIT);
     METRIC_DEFINE_INT_CORE_LOCAL_GAUGE(pending_tasks, MetricUnit::NOUNIT);
@@ -79,7 +93,7 @@ struct PollerMetrics {
 
 struct DriverExecutorMetrics {
     METRIC_DEFINE_INT_COUNTER(driver_schedule_count, MetricUnit::NOUNIT);
-    METRIC_DEFINE_INT_COUNTER(driver_execution_time, MetricUnit::NANOSECONDS);
+    QueryTypeTimeMetric driver_execution_time;
     METRIC_DEFINE_INT_CORE_LOCAL_GAUGE(exec_running_tasks, MetricUnit::NOUNIT);
     METRIC_DEFINE_INT_CORE_LOCAL_GAUGE(exec_finished_tasks, MetricUnit::NOUNIT);
     void register_all_metrics(MetricRegistry* registry);

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -504,6 +504,8 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
         }
     };
 
+    task.set_query_type(state->query_options().query_type);
+
     bool submit_success;
     {
         SCOPED_TIMER(_submit_io_task_timer);

--- a/be/src/exec/workgroup/scan_executor.cpp
+++ b/be/src/exec/workgroup/scan_executor.cpp
@@ -81,7 +81,7 @@ void ScanExecutor::worker_thread() {
         _task_queue->update_statistics(task, time_spent_ns);
         _metrics->running_tasks.increment(-1);
         _metrics->finished_tasks.increment(1);
-        _metrics->execution_time.increment(time_spent_ns);
+        _metrics->execution_time.increment(task.query_type(), time_spent_ns);
 
         // task
         if (!task.is_finished()) {

--- a/be/src/exec/workgroup/scan_task_queue.h
+++ b/be/src/exec/workgroup/scan_task_queue.h
@@ -25,6 +25,7 @@
 
 #include "common/statusor.h"
 #include "exec/workgroup/work_group_fwd.h"
+#include "gen_cpp/InternalService_types.h"
 #include "util/blocking_priority_queue.hpp"
 #include "util/defer_op.h"
 #include "util/race_detect.h"
@@ -107,6 +108,9 @@ public:
 
     const YieldContext& get_work_context() const { return work_context; }
 
+    void set_query_type(TQueryType::type type) { _query_type = type; }
+    TQueryType::type query_type() const { return _query_type; }
+
 public:
     WorkGroupPtr workgroup;
     YieldContext work_context;
@@ -115,6 +119,9 @@ public:
     int priority = 0;
     std::shared_ptr<ScanTaskGroup> task_group = nullptr;
     RuntimeProfile::HighWaterMarkCounter* peak_scan_task_queue_size_counter = nullptr;
+
+private:
+    TQueryType::type _query_type = TQueryType::EXTERNAL;
 };
 
 /// There are two types of ScanTaskQueue:

--- a/be/src/util/starrocks_metrics.cpp
+++ b/be/src/util/starrocks_metrics.cpp
@@ -55,12 +55,6 @@ StarRocksMetrics::StarRocksMetrics() : _metrics(_s_registry_name) {
     REGISTER_STARROCKS_METRIC(query_scan_bytes);
     REGISTER_STARROCKS_METRIC(query_scan_rows);
 
-    REGISTER_STARROCKS_METRIC(pipe_scan_executor_queuing);
-    REGISTER_STARROCKS_METRIC(pipe_driver_schedule_count);
-    REGISTER_STARROCKS_METRIC(pipe_driver_execution_time);
-    REGISTER_STARROCKS_METRIC(pipe_driver_queue_len);
-    REGISTER_STARROCKS_METRIC(pipe_poller_block_queue_len);
-
     REGISTER_STARROCKS_METRIC(load_channel_add_chunks_total);
     REGISTER_STARROCKS_METRIC(load_channel_add_chunks_eos_total);
     REGISTER_STARROCKS_METRIC(load_channel_add_chunks_duration_us);

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -91,12 +91,7 @@ public:
     // query execution
     pipeline::PipelineExecutorMetrics pipeline_executor_metrics;
     METRIC_DEFINE_INT_GAUGE(pipe_prepare_pool_queue_len, MetricUnit::NOUNIT);
-    METRIC_DEFINE_INT_GAUGE(pipe_scan_executor_queuing, MetricUnit::NOUNIT);
     METRIC_DEFINE_INT_GAUGE(pipe_driver_overloaded, MetricUnit::NOUNIT);
-    METRIC_DEFINE_INT_GAUGE(pipe_driver_schedule_count, MetricUnit::NOUNIT);
-    METRIC_DEFINE_INT_GAUGE(pipe_driver_execution_time, MetricUnit::NANOSECONDS);
-    METRIC_DEFINE_INT_GAUGE(pipe_driver_queue_len, MetricUnit::NOUNIT);
-    METRIC_DEFINE_INT_GAUGE(pipe_poller_block_queue_len, MetricUnit::NOUNIT);
     METRIC_DEFINE_INT_GAUGE(query_scan_bytes_per_second, MetricUnit::BYTES);
     METRIC_DEFINE_INT_GAUGE(runtime_filter_event_queue_len, MetricUnit::NOUNIT);
     METRIC_DEFINE_INT_COUNTER(query_scan_bytes, MetricUnit::BYTES);

--- a/test/sql/test_information_schema/R/test_execution_time_metrics
+++ b/test/sql/test_information_schema/R/test_execution_time_metrics
@@ -1,0 +1,13 @@
+-- name: test_execution_time_metrics
+select distinct name, labels from information_schema.be_metrics where name in ('pipe_connector_scan_execution_time', 'pipe_scan_execution_time', 'pipe_driver_execution_time') order  by name, labels;
+-- result:
+pipe_connector_scan_execution_time	workload_type=load
+pipe_connector_scan_execution_time	workload_type=query
+pipe_connector_scan_execution_time	workload_type=unknown
+pipe_driver_execution_time	workload_type=load
+pipe_driver_execution_time	workload_type=query
+pipe_driver_execution_time	workload_type=unknown
+pipe_scan_execution_time	workload_type=load
+pipe_scan_execution_time	workload_type=query
+pipe_scan_execution_time	workload_type=unknown
+-- !result

--- a/test/sql/test_information_schema/T/test_execution_time_metrics
+++ b/test/sql/test_information_schema/T/test_execution_time_metrics
@@ -1,0 +1,3 @@
+-- name: test_execution_time_metrics
+
+select distinct name, labels from information_schema.be_metrics where name in ('pipe_connector_scan_execution_time', 'pipe_scan_execution_time', 'pipe_driver_execution_time') order  by name, labels;


### PR DESCRIPTION
## Why I'm doing:
To better diagnose which type of workload is driving high CPU usage, add a `workload_type` label (with possible values `load`, `query`, and `unknown`) to the metrics `pipe_connector_scan_execution_time`, `pipe_driver_execution_time`, and `pipe_scan_execution_time`.


## What I'm doing:


In terms of implementation, each fragment instance already stores `query_type` in `query_options`. Therefore, when updating these metrics, we only need to set the corresponding label based on `fragment_context->runtime_state->query_options->query_type`.

```sql
select distinct name, labels from information_schema.be_metrics 
where name in ('pipe_connector_scan_execution_time', 'pipe_scan_execution_time', 'pipe_driver_execution_time') 
order by name, labels
+------------------------------------+-----------------------+
| name                               | labels                |
+------------------------------------+-----------------------+
| pipe_connector_scan_execution_time | workload_type=load    |
| pipe_connector_scan_execution_time | workload_type=query   |
| pipe_connector_scan_execution_time | workload_type=unknown |
| pipe_driver_execution_time         | workload_type=load    |
| pipe_driver_execution_time         | workload_type=query   |
| pipe_driver_execution_time         | workload_type=unknown |
| pipe_scan_execution_time           | workload_type=load    |
| pipe_scan_execution_time           | workload_type=query   |
| pipe_scan_execution_time           | workload_type=unknown |
+------------------------------------+-----------------------+
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds workload_type (query/load/unknown) labels to pipeline execution time metrics and plumbs query_type through executors/tasks to record labeled timings.
> 
> - **Metrics**:
>   - Introduce `QueryTypeTimeMetric` to register per-`workload_type` counters and use it for `pipe_scan_execution_time`, `pipe_connector_scan_execution_time`, and `pipe_driver_execution_time`.
>   - Update metric registration to expose labeled counters and increment by query type.
> - **Execution plumbing**:
>   - Add `TQueryType` propagation: `ScanTask` gains `set_query_type/query_type`; set from `RuntimeState` in scan IO, spill, exchange, and hash join tasks.
>   - `FragmentContext::query_type()` added; `DriverExecutor` fetches it and increments `driver_execution_time` by type; scan executor increments `execution_time` by type.
> - **Cleanup**:
>   - Remove obsolete direct gauges/counters for old unlabeled executor metrics in `StarRocksMetrics` and related headers.
> - **Tests**:
>   - Add `information_schema` test verifying labeled metrics for the three execution time metrics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c19652eb8e71b82976ddddc10e319f7833615801. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->