### PR TITLE
[Doc] docs(fe_config): update en, zh, ja documentation

### DIFF
--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -115,48 +115,48 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### big_query_log_delete_age
 
-- Default: `7d`
+- Default: 7d
 - Type: String
 - Unit: Duration (supports suffixes: d/h/m/s)
 - Is mutable: No
 - Description: Controls how long FE big query log files (fe.big_query.log.*) are retained before automatic deletion. The value is passed to Log4j's deletion policy as the IfLastModified age — any rotated big query log whose last-modified time is older than this value will be removed. Supported formats: "7d" (days), "10h" (hours), "60m" (minutes), "120s" (seconds). This works together with `big_query_log_roll_interval` and `big_query_log_roll_num` to determine which files are kept versus purged.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### big_query_log_dir
 
-- Default: `Config.STARROCKS_HOME_DIR + "/log"`
+- Default: Config.STARROCKS_HOME_DIR + "/log"
 - Type: String
 - Unit: -
 - Is mutable: No
 - Description: Directory where the FE writes big query dump logs (file name: fe.big_query.log). The Log4j configuration uses this path to create a RollingFile appender for `fe.big_query.log` and its rotated files. Rotation and retention are governed by `big_query_log_roll_interval` (time-based suffix), `log_roll_size_mb` (size trigger), `big_query_log_roll_num` (max files) and `big_query_log_delete_age` (age-based deletion). Big-query records are emitted for queries that exceed user-defined thresholds such as `big_query_log_cpu_second_threshold`, `big_query_log_scan_rows_threshold`, or `big_query_log_scan_bytes_threshold`. Use `big_query_log_modules` to control which modules log to this file.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### big_query_log_modules
 
-- Default: `{"query"}`
+- Default: {"query"}
 - Type: String[]
 - Unit: -
 - Is mutable: No
 - Description: List of module name suffixes that enable per-module BigQuery logging. For each entry X, Log4jConfig creates a logger named `big_query.&lt;X&gt;` at INFO level; those logger entries route output to the BigQueryFile appender (the file and roll behavior are controlled by `big_query_log_dir`, `big_query_log_roll_interval`, `big_query_log_roll_num`, and related `big_query_*` settings). Typical values are logical component names (for example the default `query` produces `big_query.query`). Configure this array in the server configuration before startup; changes are not applied at runtime.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### big_query_log_roll_interval
 
-- Default: `"DAY"`
+- Default: "DAY"
 - Type: String
 - Unit: -
 - Is mutable: No
 - Description: Specifies the time interval used to construct the date component of the rolling file name for the `big_query` log appender. Accepted (case-insensitive) values are `DAY` (default) and `HOUR`. `DAY` produces a daily pattern ("%d{yyyyMMdd}") and `HOUR` produces an hourly pattern ("%d{yyyyMMddHH}"). The value is combined with size-based rollover (`big_query_roll_maxsize`) and index-based rollover (`big_query_log_roll_num`) to form the RollingFile filePattern. An invalid value causes log configuration generation to fail (IOException) and may prevent log initialization or reconfiguration. Use alongside `big_query_log_dir`, `big_query_roll_maxsize`, `big_query_log_roll_num`, and `big_query_log_delete_age`.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### big_query_log_roll_num
 
-- Default: `10`
+- Default: 10
 - Type: Int
 - Unit: -
 - Is mutable: No
 - Description: Maximum number of rotated FE big query log files to retain per `big_query_log_roll_interval`. This value is bound to the RollingFile appender's DefaultRolloverStrategy `max` attribute for `fe.big_query.log`; when logs roll (by time or by `log_roll_size_mb`), StarRocks keeps up to `big_query_log_roll_num` indexed files (filePattern uses a time suffix plus index). Files older than this count may be removed by rollover, and `big_query_log_delete_age` can additionally delete files by last-modified age. Change to this value requires restarting the FE to take effect.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### dump_log_delete_age
 
@@ -216,21 +216,21 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### enable_profile_log
 
-- Default: `true`
+- Default: true
 - Type: Boolean
 - Unit: -
 - Is mutable: No
 - Description: When enabled, the FE writes per-query profile logs (the serialized `queryDetail` JSON produced by `ProfileManager`) to the profile log sink. This logging is performed only if `enable_collect_query_detail_info` is also enabled; when `enable_profile_log_compress` is enabled the JSON may be gzipped before logging. Profile files are managed by `profile_log_dir`, `profile_log_roll_num`, `profile_log_roll_interval` and rotated/deleted according to `profile_log_delete_age` (supports formats like `7d`, `10h`, `60m`, `120s`). Disabling this flag stops writing profile logs (reducing disk I/O, compression CPU and storage usage). Change requires process restart because the option is not mutable at runtime.
-- Introduced in: `v3.2.5`
+- Introduced in: v3.2.5
 
 ##### enable_profile_log_compress
 
-- Default: `false`
+- Default: false
 - Type: Boolean
 - Unit: -
 - Is mutable: No
 - Description: When enabled, the JSON query profile produced by ProfileManager is GZIP-compressed via `CompressionUtils.gzipCompressString` before being written to PROFILE_LOG. This compression only takes effect when both `enable_collect_query_detail_info` and `enable_profile_log` are true. Compression reduces log volume and I/O at the cost of CPU; consumers of PROFILE_LOG must decompress the GZIP payload to read query details. If compression fails, the code logs a warning and the compressed profile is not written.
-- Introduced in: `v3.2.7`
+- Introduced in: v3.2.7
 
 ##### enable_qe_slow_log
 
@@ -252,43 +252,43 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### internal_log_delete_age
 
-- Default: `7d`
+- Default: 7d
 - Type: String
 - Unit: Time duration string (supports suffixes: d, h, m, s)
 - Is mutable: No
 - Description: Specifies the retention period for FE internal log files (written to `internal_log_dir`). The value is a duration string (examples: `7d` = 7 days, `10h` = 10 hours, `60m` = 60 minutes, `120s` = 120 seconds) and is substituted into the log4j configuration as the <IfLastModified age="..."/> predicate used by the RollingFile Delete policy. Files whose last-modified time is older than this duration will be removed during log rollover. Shorten this to free disk space sooner; lengthen to retain internal MV/statistics logs longer. Because the setting is not mutable, changes require restarting the FE process to take effect.
-- Introduced in: `v3.2.4`
+- Introduced in: v3.2.4
 
 ##### internal_log_dir
 
-- Default: `Config.STARROCKS_HOME_DIR + "/log"`
+- Default: Config.STARROCKS_HOME_DIR + "/log"
 - Type: String
 - Unit: Directory path
 - Is mutable: No
 - Description: Directory path used by the FE logging subsystem for internal logs (files named like fe.internal.log). `internal_log_dir` is substituted into the Log4j configuration and determines where the InternalFile appender writes internal/MV/statistics logs and where per-module loggers under `internal.<module>` place their files. Ensure the directory exists and is writable and has sufficient disk space. Log rotation and retention for files in this directory are controlled by `log_roll_size_mb`, `internal_log_roll_num`, `internal_log_delete_age`, and `internal_log_roll_interval`. If `sys_log_to_console` is enabled, internal logs may be written to console instead of this directory.
-- Introduced in: `v3.2.4`
+- Introduced in: v3.2.4
 
 ##### internal_log_modules
 
-- Default: `{"base", "statistic"}`
+- Default: {"base", "statistic"}
 - Type: String[]
 - Unit: -
 - Is mutable: No
 - Description: A list of module identifiers that will receive dedicated internal logging. For each entry X, Log4j creates a logger named `internal.&lt;X&gt;` with level INFO and additivity="false". Those loggers are routed to the internal appender (written to `fe.internal.log`) or to console when `sys_log_to_console` is enabled. Use short names or package fragments as needed — the exact logger name becomes `internal.` + the configured string. Internal log file rotation and retention follow `internal_log_dir`, `internal_log_roll_num`, `internal_log_delete_age`, `internal_log_roll_interval`, and `log_roll_size_mb`. Adding a module causes its runtime messages to be separated into the internal logger stream for easier debugging and audit.
-- Introduced in: `v3.2.4`
+- Introduced in: v3.2.4
 
 ##### internal_log_roll_interval
 
-- Default: `DAY`
+- Default: DAY
 - Type: String
 - Unit: -
 - Is mutable: No
 - Description: Controls the time-based roll interval for the FE internal log appender. Accepted (case-insensitive) values are `HOUR` and `DAY`. `HOUR` produces an hourly file pattern ("%d{yyyyMMddHH}") and `DAY` produces a daily file pattern ("%d{yyyyMMdd}"), which are used by the RollingFile TimeBasedTriggeringPolicy to name rotated `fe.internal.log` files. An invalid value causes initialization to fail (an IOException is thrown when building the active Log4j configuration). Roll behavior also depends on related settings such as `internal_log_dir`, `internal_roll_maxsize`, `internal_log_roll_num`, and `internal_log_delete_age`.
-- Introduced in: `v3.2.4`
+- Introduced in: v3.2.4
 
 ##### internal_log_roll_num
 
-- Default: `90`
+- Default: 90
 - Type: Int
 - Unit: Files
 - Is mutable: No
@@ -297,21 +297,21 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### log_plan_cancelled_by_crash_be
 
-- Default: `true`
+- Default: true
 - Type: boolean
 - Unit: -
 - Is mutable: Yes
 - Description: When enabled, StarRocks logs the query execution plan (at TExplainLevel.COSTS) as a WARN entry when a query is cancelled due to backend crash or an `RpcException`. The log entry includes QueryId, SQL and the COSTS plan; in the ExecuteExceptionHandler path the exception stacktrace is also logged. The logging is skipped when `enable_collect_query_detail_info` is enabled (the plan is then stored in the query detail) — in code paths the check is performed by verifying the query detail is null. Note: in ExecuteExceptionHandler the plan is logged only on the first retry (`retryTime == 0`). Enabling this may increase log volume because full COSTS plans can be large.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### log_register_and_unregister_query_id
 
-- Default: `false`
+- Default: false
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
 - Description: When enabled, FE logs query registration and deregistration messages (e.g., "register query id = {}" and "deregister query id = {}") from QeProcessorImpl. The log is emitted only when the query has a non-null ConnectContext and either the command is not `COM_STMT_EXECUTE` or the session variable `isAuditExecuteStmt()` is true. Because these messages are written for every query lifecycle event, enabling this option can produce high log volume and become a throughput bottleneck in high-concurrency environments. Enable for debugging or auditing; disable to reduce logging overhead and improve performance.
-- Introduced in: `v3.3.0, v3.4.0, v3.5.0`
+- Introduced in: v3.3.0, v3.4.0, v3.5.0
 
 ##### log_roll_size_mb
 
@@ -324,16 +324,16 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### profile_log_delete_age
 
-- Default: `1d`
+- Default: 1d
 - Type: String
 - Unit: Duration string (supports `d`, `h`, `m`, `s`)
 - Is mutable: No
 - Description: Controls how long FE profile log files are retained before they are eligible for deletion. The value is injected into Log4j's &lt;IfLastModified age="..."/&gt; policy (via `Log4jConfig`) and is applied together with rotation settings such as `profile_log_roll_interval` and `profile_log_roll_num`. Supported formats: e.g. `7d` (7 days), `10h` (10 hours), `60m` (60 minutes), `120s` (120 seconds). The configuration is read at startup when the logging XML is generated; changes will not be applied dynamically and require restarting the FE to take effect.
-- Introduced in: `v3.2.5`
+- Introduced in: v3.2.5
 
 ##### profile_log_dir
 
-- Default: `Config.STARROCKS_HOME_DIR + "/log"`
+- Default: Config.STARROCKS_HOME_DIR + "/log"
 - Type: String
 - Unit: -
 - Is mutable: No
@@ -342,7 +342,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### profile_log_roll_interval
 
-- Default: `DAY`
+- Default: DAY
 - Type: String
 - Unit: -
 - Is mutable: No
@@ -356,11 +356,11 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Unit: Number of files
 - Is mutable: No
 - Description: Specifies the maximum number of rotated profile log files retained by Log4j's DefaultRolloverStrategy for the profile logger. This value is injected into the logging XML as ${profile_log_roll_num} (e.g. &lt;DefaultRolloverStrategy max="${profile_log_roll_num}" fileIndex="min"&gt;). Rotations are triggered by `profile_log_roll_size_mb` or `profile_log_roll_interval`; when rotation occurs Log4j keeps at most this many indexed files and older index files become eligible for removal. Actual retention on disk is also affected by `profile_log_delete_age` and the `profile_log_dir` location. Lower values reduce disk usage but limit retained history; higher values preserve more historical profile logs.
-- Introduced in: `v3.2.5`
+- Introduced in: v3.2.5
 
 ##### profile_log_roll_size_mb
 
-- Default: `1024`
+- Default: 1024
 - Type: Int
 - Unit: MB
 - Is mutable: No
@@ -387,12 +387,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### slow_lock_print_stack
 
-- Default: `true`
+- Default: true
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
 - Description: When enabled, LockManager includes the owning thread's full stack trace in the JSON payload of slow-lock warnings emitted by `logSlowLockTrace` (the "stack" array is populated via LogUtil.getStackTraceToJsonArray with start=0 and max=Short.MAX_VALUE). This flag controls only the extra stack information for lock owners shown when a lock acquisition exceeds the threshold configured by `slow_lock_threshold_ms`. Enabling helps debugging by giving precise thread stacks that hold the lock; disabling reduces log volume and CPU/memory overhead caused by capturing and serializing stack traces in high-concurrency environments.
-- Introduced in: `v3.3.16, v3.4.5, v3.5.1`
+- Introduced in: v3.3.16, v3.4.5, v3.5.1
 
 ##### slow_lock_threshold_ms
 
@@ -700,7 +700,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### slow_lock_stack_trace_reserve_levels
 
-- Default: `15`
+- Default: 15
 - Type: Int
 - Unit: Stack frames
 - Is mutable: Yes
@@ -1698,12 +1698,12 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 
 ##### task_check_interval_second
 
-- Default: `60`
+- Default: 60
 - Type: Int
 - Unit: Seconds
 - Is mutable: Yes
 - Description: Interval in seconds between executions of task background jobs. GlobalStateMgr uses this value to schedule the TaskCleaner FrontendDaemon which invokes `doTaskBackgroundJob()`; the value is multiplied by 1000 to set the daemon interval in milliseconds. Decreasing the value makes background maintenance (task cleanup, checks) run more frequently and react faster but increases CPU/IO overhead; increasing it reduces overhead but delays cleanup and detection of stale tasks. Tune this value to balance maintenance responsiveness and resource usage.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ### Loading and unloading
 
@@ -1902,21 +1902,21 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 
 ##### loads_history_retained_days
 
-- Default: `30`
+- Default: 30
 - Type: Int
 - Unit: Days
 - Is mutable: Yes
 - Description: Number of days to retain load history in the internal `_statistics_.loads_history` table. This value is used when creating the table to set the table property `'partition_live_number'` and is passed to `TableKeeper` (clamped to a minimum of 1) to determine how many daily partitions to keep. Increasing or decreasing this value adjusts how long completed load jobs are retained in daily partitions; it affects new table creation and the keeper's pruning behavior but does not automatically recreate past partitions. The `LoadsHistorySyncer` relies on this retention when managing the loads history lifecycle; its sync cadence is controlled by `loads_history_sync_interval_second`.
-- Introduced in: `v3.3.6, v3.4.0, v3.5.0`
+- Introduced in: v3.3.6, v3.4.0, v3.5.0
 
 ##### loads_history_sync_interval_second
 
-- Default: `60`
+- Default: 60
 - Type: Int
 - Unit: Seconds
 - Is mutable: Yes
 - Description: Interval (in seconds) used by LoadsHistorySyncer to schedule periodic syncs of finished load jobs from `information_schema.loads` into the internal `_statistics_.loads_history` table. The value is multiplied by 1000L in the constructor to set the FrontendDaemon interval. The syncer also re-reads this configuration at each run and calls setInterval when changed, so updates take effect at runtime without restart. The syncer skips the first run (to allow table creation) and only imports loads that finished more than one minute ago; frequent (small) values increase DML and executor load, while larger values delay availability of historical load records. See `loads_history_retained_days` for retention/partitioning behavior of the target table.
-- Introduced in: `v3.3.6, v3.4.0, v3.5.0`
+- Introduced in: v3.3.6, v3.4.0, v3.5.0
 
 ##### max_broker_load_job_concurrency
 
@@ -2119,21 +2119,21 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 
 ##### stream_load_task_keep_max_num
 
-- Default: `1000`
+- Default: 1000
 - Type: Int
 - Unit: Count
 - Is mutable: Yes
 - Description: Maximum number of StreamLoadTasks that StreamLoadMgr keeps in memory (global across all databases). When the number of tracked tasks (idToStreamLoadTask) exceeds this threshold, StreamLoadMgr first calls cleanSyncStreamLoadTasks() to remove completed synchronous stream-load tasks; if the size still remains greater than half of this threshold, it invokes cleanOldStreamLoadTasks(true) to force removal of older or finished tasks. Increase to retain more task history in memory; decrease to reduce memory usage and make cleanup more aggressive. This value controls in-memory retention only and does not affect persisted/replayed tasks.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### stream_load_task_keep_max_second
 
-- Default: `3 * 24 * 3600`
+- Default: 3 * 24 * 3600
 - Type: Int
 - Unit: Seconds
 - Is mutable: Yes
 - Description: Retention window (in seconds) for finished or cancelled StreamLoad tasks. After a task reaches a final state and its end timestamp is older than this threshold (the code compares milliseconds: currentMs - endTimeMs > stream_load_task_keep_max_second * 1000), it becomes eligible for removal by `StreamLoadMgr.cleanOldStreamLoadTasks` and is discarded when loading persisted state. Applies to both `StreamLoadTask` and `StreamLoadMultiStmtTask`. If total task count exceeds `stream_load_task_keep_max_num`, cleanup may be triggered earlier (synchronous tasks are prioritized by `cleanSyncStreamLoadTasks`). Set this to balance history/debugability against memory usage.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### transaction_clean_interval_second
 
@@ -2281,12 +2281,12 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 
 ##### max_dynamic_partition_num
 
-- Default: `500`
+- Default: 500
 - Type: Int
 - Unit: Count
 - Is mutable: Yes
 - Description: Limits the maximum number of partitions that can be created at once when analyzing or creating a dynamic-partitioned table. During dynamic partition property validation, StarRocks computes expected partitions (end offset + history partition number) and throws a DDL error if that total exceeds `max_dynamic_partition_num`. Raise this value only when you expect legitimately large partition ranges; increasing it allows more partitions to be created but can increase metadata size, scheduling work, and operational complexity.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### max_partition_number_per_table
 

--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -117,36 +117,36 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 - Default: 7d
 - Type: String
-- Unit: Duration (supports suffixes: d/h/m/s)
+- Unit: -
 - Is mutable: No
-- Description: Controls how long FE big query log files (fe.big_query.log.*) are retained before automatic deletion. The value is passed to Log4j's deletion policy as the IfLastModified age — any rotated big query log whose last-modified time is older than this value will be removed. Supported formats: "7d" (days), "10h" (hours), "60m" (minutes), "120s" (seconds). This works together with `big_query_log_roll_interval` and `big_query_log_roll_num` to determine which files are kept versus purged.
+- Description: Controls how long FE big query log files (`fe.big_query.log.*`) are retained before automatic deletion. The value is passed to Log4j's deletion policy as the IfLastModified age — any rotated big query log whose last-modified time is older than this value will be removed. Supports suffixes include `d` (day), `h` (hour), `m` (minute), and `s` (second). Example: `7d` (7 days), `10h` (10 hours), `60m` (60 minutes), and `120s` (120 seconds). This item works together with `big_query_log_roll_interval` and `big_query_log_roll_num` to determine which files are kept or purged.
 - Introduced in: v3.2.0
 
 ##### big_query_log_dir
 
-- Default: Config.STARROCKS_HOME_DIR + "/log"
+- Default: `Config.STARROCKS_HOME_DIR + "/log"`
 - Type: String
 - Unit: -
 - Is mutable: No
-- Description: Directory where the FE writes big query dump logs (file name: fe.big_query.log). The Log4j configuration uses this path to create a RollingFile appender for `fe.big_query.log` and its rotated files. Rotation and retention are governed by `big_query_log_roll_interval` (time-based suffix), `log_roll_size_mb` (size trigger), `big_query_log_roll_num` (max files) and `big_query_log_delete_age` (age-based deletion). Big-query records are emitted for queries that exceed user-defined thresholds such as `big_query_log_cpu_second_threshold`, `big_query_log_scan_rows_threshold`, or `big_query_log_scan_bytes_threshold`. Use `big_query_log_modules` to control which modules log to this file.
+- Description: Directory where the FE writes big query dump logs (`fe.big_query.log.*`). The Log4j configuration uses this path to create a RollingFile appender for `fe.big_query.log` and its rotated files. Rotation and retention are governed by `big_query_log_roll_interval` (time-based suffix), `log_roll_size_mb` (size trigger), `big_query_log_roll_num` (max files), and `big_query_log_delete_age` (age-based deletion). Big query records are logged for queries that exceed user-defined thresholds such as `big_query_log_cpu_second_threshold`, `big_query_log_scan_rows_threshold`, or `big_query_log_scan_bytes_threshold`. Use `big_query_log_modules` to control which modules log to this file.
 - Introduced in: v3.2.0
 
 ##### big_query_log_modules
 
-- Default: {"query"}
+- Default: `{"query"}`
 - Type: String[]
 - Unit: -
 - Is mutable: No
-- Description: List of module name suffixes that enable per-module BigQuery logging. For each entry X, Log4jConfig creates a logger named `big_query.&lt;X&gt;` at INFO level; those logger entries route output to the BigQueryFile appender (the file and roll behavior are controlled by `big_query_log_dir`, `big_query_log_roll_interval`, `big_query_log_roll_num`, and related `big_query_*` settings). Typical values are logical component names (for example the default `query` produces `big_query.query`). Configure this array in the server configuration before startup; changes are not applied at runtime.
+- Description: List of module name suffixes that enable per-module big query logging. Typical values are logical component names. For example, the default `query` produces `big_query.query`.
 - Introduced in: v3.2.0
 
 ##### big_query_log_roll_interval
 
-- Default: "DAY"
+- Default: `"DAY"`
 - Type: String
 - Unit: -
 - Is mutable: No
-- Description: Specifies the time interval used to construct the date component of the rolling file name for the `big_query` log appender. Accepted (case-insensitive) values are `DAY` (default) and `HOUR`. `DAY` produces a daily pattern ("%d{yyyyMMdd}") and `HOUR` produces an hourly pattern ("%d{yyyyMMddHH}"). The value is combined with size-based rollover (`big_query_roll_maxsize`) and index-based rollover (`big_query_log_roll_num`) to form the RollingFile filePattern. An invalid value causes log configuration generation to fail (IOException) and may prevent log initialization or reconfiguration. Use alongside `big_query_log_dir`, `big_query_roll_maxsize`, `big_query_log_roll_num`, and `big_query_log_delete_age`.
+- Description: Specifies the time interval used to construct the date component of the rolling file name for the `big_query` log appender. Valid values (case-insensitive) are `DAY` (default) and `HOUR`. `DAY` produces a daily pattern (`"%d{yyyyMMdd}"`) and `HOUR` produces an hourly pattern (`"%d{yyyyMMddHH}"`). The value is combined with size-based rollover (`big_query_roll_maxsize`) and index-based rollover (`big_query_log_roll_num`) to form the RollingFile filePattern. An invalid value causes log configuration generation to fail (IOException) and may prevent log initialization or reconfiguration. Use alongside `big_query_log_dir`, `big_query_roll_maxsize`, `big_query_log_roll_num`, and `big_query_log_delete_age`.
 - Introduced in: v3.2.0
 
 ##### big_query_log_roll_num
@@ -155,7 +155,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: -
 - Is mutable: No
-- Description: Maximum number of rotated FE big query log files to retain per `big_query_log_roll_interval`. This value is bound to the RollingFile appender's DefaultRolloverStrategy `max` attribute for `fe.big_query.log`; when logs roll (by time or by `log_roll_size_mb`), StarRocks keeps up to `big_query_log_roll_num` indexed files (filePattern uses a time suffix plus index). Files older than this count may be removed by rollover, and `big_query_log_delete_age` can additionally delete files by last-modified age. Change to this value requires restarting the FE to take effect.
+- Description: Maximum number of rotated FE big query log files to retain per `big_query_log_roll_interval`. This value is bound to the RollingFile appender's DefaultRolloverStrategy `max` attribute for `fe.big_query.log`; when logs roll (by time or by `log_roll_size_mb`), StarRocks keeps up to `big_query_log_roll_num` indexed files (filePattern uses a time suffix plus index). Files older than this count may be removed by rollover, and `big_query_log_delete_age` can additionally delete files by last-modified age.
 - Introduced in: v3.2.0
 
 ##### dump_log_delete_age
@@ -220,7 +220,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: No
-- Description: When enabled, the FE writes per-query profile logs (the serialized `queryDetail` JSON produced by `ProfileManager`) to the profile log sink. This logging is performed only if `enable_collect_query_detail_info` is also enabled; when `enable_profile_log_compress` is enabled the JSON may be gzipped before logging. Profile files are managed by `profile_log_dir`, `profile_log_roll_num`, `profile_log_roll_interval` and rotated/deleted according to `profile_log_delete_age` (supports formats like `7d`, `10h`, `60m`, `120s`). Disabling this flag stops writing profile logs (reducing disk I/O, compression CPU and storage usage). Change requires process restart because the option is not mutable at runtime.
+- Description: Whether to enable profile logging. When this feature is enabled, the FE writes per-query profile logs (the serialized `queryDetail` JSON produced by `ProfileManager`) to the profile log sink. This logging is performed only if `enable_collect_query_detail_info` is also enabled; when `enable_profile_log_compress` is enabled, the JSON may be gzipped before logging. Profile log files are managed by `profile_log_dir`, `profile_log_roll_num`, `profile_log_roll_interval` and rotated/deleted according to `profile_log_delete_age` (supports formats like `7d`, `10h`, `60m`, `120s`). Disabling this feature stops writing profile logs (reducing disk I/O, compression CPU and storage usage).
 - Introduced in: v3.2.5
 
 ##### enable_profile_log_compress
@@ -229,7 +229,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: No
-- Description: When enabled, the JSON query profile produced by ProfileManager is GZIP-compressed via `CompressionUtils.gzipCompressString` before being written to PROFILE_LOG. This compression only takes effect when both `enable_collect_query_detail_info` and `enable_profile_log` are true. Compression reduces log volume and I/O at the cost of CPU; consumers of PROFILE_LOG must decompress the GZIP payload to read query details. If compression fails, the code logs a warning and the compressed profile is not written.
+- Description: Whether to enable compression for profile logging. When this feature is enabled, the JSON query profile produced by ProfileManager is GZIP-compressed via `CompressionUtils.gzipCompressString` before being written to profile logs. This compression only takes effect when both `enable_collect_query_detail_info` and `enable_profile_log` are set to `true`. Compression reduces log volume and I/O at the cost of CPU; consumers of profile logs must decompress the GZIP payload to read query details. If compression fails, a warning is logged and the compressed profile is not written.
 - Introduced in: v3.2.7
 
 ##### enable_qe_slow_log
@@ -254,23 +254,23 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 - Default: 7d
 - Type: String
-- Unit: Time duration string (supports suffixes: d, h, m, s)
+- Unit: -
 - Is mutable: No
-- Description: Specifies the retention period for FE internal log files (written to `internal_log_dir`). The value is a duration string (examples: `7d` = 7 days, `10h` = 10 hours, `60m` = 60 minutes, `120s` = 120 seconds) and is substituted into the log4j configuration as the <IfLastModified age="..."/> predicate used by the RollingFile Delete policy. Files whose last-modified time is older than this duration will be removed during log rollover. Shorten this to free disk space sooner; lengthen to retain internal MV/statistics logs longer. Because the setting is not mutable, changes require restarting the FE process to take effect.
+- Description: Specifies the retention period for FE internal log files (written to `internal_log_dir`). The value is a duration string. Supported suffixes: `d` (day), `h` (hour), `m` (minute), `s` (second). Examples: `7d` (7 days), `10h` (10 hours), `60m` (60 minutes), `120s` (120 seconds). This item is substituted into the log4j configuration as the `<IfLastModified age="..."/>` predicate used by the RollingFile Delete policy. Files whose last-modified time is earlier than this duration will be removed during log rollover. Increase this value to free disk space sooner, or decrease it to retain internal materialized view or statistics logs longer.
 - Introduced in: v3.2.4
 
 ##### internal_log_dir
 
-- Default: Config.STARROCKS_HOME_DIR + "/log"
+- Default: `Config.STARROCKS_HOME_DIR + "/log"`
 - Type: String
-- Unit: Directory path
+- Unit: -
 - Is mutable: No
-- Description: Directory path used by the FE logging subsystem for internal logs (files named like fe.internal.log). `internal_log_dir` is substituted into the Log4j configuration and determines where the InternalFile appender writes internal/MV/statistics logs and where per-module loggers under `internal.<module>` place their files. Ensure the directory exists and is writable and has sufficient disk space. Log rotation and retention for files in this directory are controlled by `log_roll_size_mb`, `internal_log_roll_num`, `internal_log_delete_age`, and `internal_log_roll_interval`. If `sys_log_to_console` is enabled, internal logs may be written to console instead of this directory.
+- Description: Directory used by the FE logging subsystem for storing internal logs (`fe.internal.log`). This configuration is substituted into the Log4j configuration and determines where the InternalFile appender writes internal/materialized view/statistics logs and where per-module loggers under `internal.<module>` place their files. Ensure the directory exists, is writable, and has sufficient disk space. Log rotation and retention for files in this directory are controlled by `log_roll_size_mb`, `internal_log_roll_num`, `internal_log_delete_age`, and `internal_log_roll_interval`. If `sys_log_to_console` is enabled, internal logs may be written to console instead of this directory.
 - Introduced in: v3.2.4
 
 ##### internal_log_modules
 
-- Default: {"base", "statistic"}
+- Default: `{"base", "statistic"}`
 - Type: String[]
 - Unit: -
 - Is mutable: No
@@ -283,16 +283,16 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: No
-- Description: Controls the time-based roll interval for the FE internal log appender. Accepted (case-insensitive) values are `HOUR` and `DAY`. `HOUR` produces an hourly file pattern ("%d{yyyyMMddHH}") and `DAY` produces a daily file pattern ("%d{yyyyMMdd}"), which are used by the RollingFile TimeBasedTriggeringPolicy to name rotated `fe.internal.log` files. An invalid value causes initialization to fail (an IOException is thrown when building the active Log4j configuration). Roll behavior also depends on related settings such as `internal_log_dir`, `internal_roll_maxsize`, `internal_log_roll_num`, and `internal_log_delete_age`.
+- Description: Controls the time-based roll interval for the FE internal log appender. Accepted values (case-insensitive) are `HOUR` and `DAY`. `HOUR` produces an hourly file pattern (`"%d{yyyyMMddHH}"`) and `DAY` produces a daily file pattern (`"%d{yyyyMMdd}"`), which are used by the RollingFile TimeBasedTriggeringPolicy to name rotated `fe.internal.log` files. An invalid value causes initialization to fail (an IOException is thrown when building the active Log4j configuration). Roll behavior also depends on related settings such as `internal_log_dir`, `internal_roll_maxsize`, `internal_log_roll_num`, and `internal_log_delete_age`.
 - Introduced in: v3.2.4
 
 ##### internal_log_roll_num
 
 - Default: 90
 - Type: Int
-- Unit: Files
+- Unit: -
 - Is mutable: No
-- Description: Maximum number of rolled internal FE log files to retain for the internal appender (fe.internal.log). This value is used as the Log4j DefaultRolloverStrategy `max` attribute; when rollovers occur StarRocks keeps up to `internal_log_roll_num` archived files and removes older ones (also governed by `internal_log_delete_age`). A lower value reduces disk usage but shortens log history; a higher value preserves more historical internal logs. Works together with `internal_log_dir`, `internal_log_roll_interval`, and `internal_roll_maxsize`. Changes require a restart to take effect.
+- Description: Maximum number of rolled internal FE log files to retain for the internal appender (`fe.internal.log`). This value is used as the Log4j DefaultRolloverStrategy `max` attribute; when rollovers occur, StarRocks keeps up to `internal_log_roll_num` archived files and removes older ones (also governed by `internal_log_delete_age`). A lower value reduces disk usage but shortens log history; a higher value preserves more historical internal logs. This item works together with `internal_log_dir`, `internal_log_roll_interval`, and `internal_roll_maxsize`.
 - Introduced in: v3.2.4
 
 ##### log_plan_cancelled_by_crash_be
@@ -301,7 +301,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: boolean
 - Unit: -
 - Is mutable: Yes
-- Description: When enabled, StarRocks logs the query execution plan (at TExplainLevel.COSTS) as a WARN entry when a query is cancelled due to backend crash or an `RpcException`. The log entry includes QueryId, SQL and the COSTS plan; in the ExecuteExceptionHandler path the exception stacktrace is also logged. The logging is skipped when `enable_collect_query_detail_info` is enabled (the plan is then stored in the query detail) — in code paths the check is performed by verifying the query detail is null. Note: in ExecuteExceptionHandler the plan is logged only on the first retry (`retryTime == 0`). Enabling this may increase log volume because full COSTS plans can be large.
+- Description: Whether to enable the query execution plan logging when a query is cancelled due to BE crash or an RPC exception. When this feature is enabled, StarRocks logs the query execution plan (at `TExplainLevel.COSTS`) as a WARN entry when a query is cancelled due to BE crash or an `RpcException`. The log entry includes QueryId, SQL and the COSTS plan; in the ExecuteExceptionHandler path, the exception stacktrace is also logged. The logging is skipped when `enable_collect_query_detail_info` is enabled (the plan is then stored in the query detail) — in code paths, the check is performed by verifying the query detail is null. Note that, in ExecuteExceptionHandler, the plan is logged only on the first retry (`retryTime == 0`). Enabling this may increase log volume because full COSTS plans can be large.
 - Introduced in: v3.2.0
 
 ##### log_register_and_unregister_query_id
@@ -310,7 +310,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: When enabled, FE logs query registration and deregistration messages (e.g., "register query id = {}" and "deregister query id = {}") from QeProcessorImpl. The log is emitted only when the query has a non-null ConnectContext and either the command is not `COM_STMT_EXECUTE` or the session variable `isAuditExecuteStmt()` is true. Because these messages are written for every query lifecycle event, enabling this option can produce high log volume and become a throughput bottleneck in high-concurrency environments. Enable for debugging or auditing; disable to reduce logging overhead and improve performance.
+- Description: Whether to allow FE to log query registration and deregistration messages (e.g., `"register query id = {}"` and `"deregister query id = {}"`) from QeProcessorImpl. The log is emitted only when the query has a non-null ConnectContext and either the command is not `COM_STMT_EXECUTE` or the session variable `isAuditExecuteStmt()` is true. Because these messages are written for every query lifecycle event, enabling this feature can produce high log volume and become a throughput bottleneck in high-concurrency environments. Enable it for debugging or auditing; and disable it to reduce logging overhead and improve performance.
 - Introduced in: v3.3.0, v3.4.0, v3.5.0
 
 ##### log_roll_size_mb
@@ -326,18 +326,18 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 - Default: 1d
 - Type: String
-- Unit: Duration string (supports `d`, `h`, `m`, `s`)
+- Unit: -
 - Is mutable: No
-- Description: Controls how long FE profile log files are retained before they are eligible for deletion. The value is injected into Log4j's &lt;IfLastModified age="..."/&gt; policy (via `Log4jConfig`) and is applied together with rotation settings such as `profile_log_roll_interval` and `profile_log_roll_num`. Supported formats: e.g. `7d` (7 days), `10h` (10 hours), `60m` (60 minutes), `120s` (120 seconds). The configuration is read at startup when the logging XML is generated; changes will not be applied dynamically and require restarting the FE to take effect.
+- Description: Controls how long FE profile log files are retained before they are eligible for deletion. The value is injected into Log4j's `&lt;IfLastModified age="..."/&gt;` policy (via `Log4jConfig`) and is applied together with rotation settings such as `profile_log_roll_interval` and `profile_log_roll_num`. Supported suffixes: `d` (day), `h` (hour), `m` (minute), `s` (second). For example: `7d` (7 days), `10h` (10 hours), `60m` (60 minutes), `120s` (120 seconds).
 - Introduced in: v3.2.5
 
 ##### profile_log_dir
 
-- Default: Config.STARROCKS_HOME_DIR + "/log"
+- Default: `Config.STARROCKS_HOME_DIR + "/log"`
 - Type: String
 - Unit: -
 - Is mutable: No
-- Description: Directory path where FE profile logs are written. `Log4jConfig` uses this value to place profile-related appenders (creates files like fe.profile.log and fe.features.log under this directory). Rotation and retention for these files are governed by `profile_log_roll_size_mb`, `profile_log_roll_num` and `profile_log_delete_age`; the timestamp suffix format is controlled by `profile_log_roll_interval` (supports DAY or HOUR). Because the default is inside `STARROCKS_HOME_DIR`, ensure the FE process has write and rotation/delete permissions on this directory.
+- Description: Directory where FE profile logs are written. Log4jConfig uses this value to place profile-related appenders (creates files like `fe.profile.log` and `fe.features.log` under this directory). Rotation and retention for these files are governed by `profile_log_roll_size_mb`, `profile_log_roll_num` and `profile_log_delete_age`; the timestamp suffix format is controlled by `profile_log_roll_interval` (supports DAY or HOUR). Because the default directory is under `STARROCKS_HOME_DIR`, ensure the FE process has write and rotation/delete permissions on this directory.
 - Introduced in: v3.2.5
 
 ##### profile_log_roll_interval
@@ -346,16 +346,16 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: String
 - Unit: -
 - Is mutable: No
-- Description: Controls the time granularity used to generate the date part of profile log filenames. Valid (case-insensitive) values are `HOUR` and `DAY`. `HOUR` produces a pattern of "%d{yyyyMMddHH}" (hourly time bucket) and `DAY` produces "%d{yyyyMMdd}" (daily time bucket). This value is used when computing `profile_file_pattern` in the Log4j configuration and only affects the time-based component of rollover file names; size-based rollover is still controlled by `profile_log_roll_size_mb` and retention by `profile_log_roll_num` / `profile_log_delete_age`. Invalid values cause an IOException during logging initialization (error message: "profile_log_roll_interval config error: <value>"). Choose `HOUR` for high-volume profiling to limit per-file size per hour, or `DAY` for daily aggregation.
+- Description: Controls the time granularity used to generate the date part of profile log filenames. Valid values (case-insensitive) are `HOUR` and `DAY`. `HOUR` produces a pattern of `"%d{yyyyMMddHH}"` (hourly time bucket) and `DAY` produces `"%d{yyyyMMdd}"` (daily time bucket). This value is used when computing `profile_file_pattern` in the Log4j configuration and only affects the time-based component of rollover file names; size-based rollover is still controlled by `profile_log_roll_size_mb` and retention by `profile_log_roll_num` / `profile_log_delete_age`. Invalid values cause an IOException during logging initialization (error message: `"profile_log_roll_interval config error: <value>"`). Choose `HOUR` for high-volume profiling to limit per-file size per hour, or `DAY` for daily aggregation.
 - Introduced in: v3.2.5
 
 ##### profile_log_roll_num
 
 - Default: 5
 - Type: Int
-- Unit: Number of files
+- Unit: -
 - Is mutable: No
-- Description: Specifies the maximum number of rotated profile log files retained by Log4j's DefaultRolloverStrategy for the profile logger. This value is injected into the logging XML as ${profile_log_roll_num} (e.g. &lt;DefaultRolloverStrategy max="${profile_log_roll_num}" fileIndex="min"&gt;). Rotations are triggered by `profile_log_roll_size_mb` or `profile_log_roll_interval`; when rotation occurs Log4j keeps at most this many indexed files and older index files become eligible for removal. Actual retention on disk is also affected by `profile_log_delete_age` and the `profile_log_dir` location. Lower values reduce disk usage but limit retained history; higher values preserve more historical profile logs.
+- Description: Specifies the maximum number of rotated profile log files retained by Log4j's DefaultRolloverStrategy for the profile logger. This value is injected into the logging XML as `${profile_log_roll_num}` (e.g. `&lt;DefaultRolloverStrategy max="${profile_log_roll_num}" fileIndex="min"&gt;`). Rotations are triggered by `profile_log_roll_size_mb` or `profile_log_roll_interval`; when rotation occurs, Log4j keeps at most these indexed files and older index files become eligible for removal. Actual retention on disk is also affected by `profile_log_delete_age` and the `profile_log_dir` location. Lower values reduce disk usage but limit retained history; higher values preserve more historical profile logs.
 - Introduced in: v3.2.5
 
 ##### profile_log_roll_size_mb
@@ -364,7 +364,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: MB
 - Is mutable: No
-- Description: Sets the size threshold (in megabytes) that triggers a size-based rollover of the FE profile log file. This value is used by the Log4j RollingFile SizeBasedTriggeringPolicy for the `ProfileFile` appender; when a profile log exceeds `profile_log_roll_size_mb` it will be rotated. Rotation can also occur by time when `profile_log_roll_interval` is reached — either condition will trigger rollover. Combined with `profile_log_roll_num` and `profile_log_delete_age`, this controls how many historical profile files are retained and when old files are deleted. Compression of rotated files is controlled by `enable_profile_log_compress`. Changing this value requires a process restart to take effect.
+- Description: Sets the size threshold (in megabytes) that triggers a size-based rollover of the FE profile log file. This value is used by the Log4j RollingFile SizeBasedTriggeringPolicy for the `ProfileFile` appender; when a profile log exceeds `profile_log_roll_size_mb` it will be rotated. Rotation can also occur by time when `profile_log_roll_interval` is reached — either condition will trigger rollover. Combined with `profile_log_roll_num` and `profile_log_delete_age`, this item controls how many historical profile files are retained and when old files are deleted. Compression of rotated files is controlled by `enable_profile_log_compress`.
 - Introduced in: v3.2.5
 
 ##### qe_slow_log_ms
@@ -391,7 +391,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: When enabled, LockManager includes the owning thread's full stack trace in the JSON payload of slow-lock warnings emitted by `logSlowLockTrace` (the "stack" array is populated via LogUtil.getStackTraceToJsonArray with start=0 and max=Short.MAX_VALUE). This flag controls only the extra stack information for lock owners shown when a lock acquisition exceeds the threshold configured by `slow_lock_threshold_ms`. Enabling helps debugging by giving precise thread stacks that hold the lock; disabling reduces log volume and CPU/memory overhead caused by capturing and serializing stack traces in high-concurrency environments.
+- Description: Whether to allow LockManager to include the owning thread's full stack trace in the JSON payload of slow-lock warnings emitted by `logSlowLockTrace` (the "stack" array is populated via `LogUtil.getStackTraceToJsonArray` with `start=0` and `max=Short.MAX_VALUE`). This configuration controls only the extra stack information for lock owners shown when a lock acquisition exceeds the threshold configured by `slow_lock_threshold_ms`. Enabling this feature helps debugging by giving precise thread stacks that hold the lock; disabling it reduces log volume and CPU/memory overhead caused by capturing and serializing stack traces in high-concurrency environments.
 - Introduced in: v3.3.16, v3.4.5, v3.5.1
 
 ##### slow_lock_threshold_ms
@@ -702,7 +702,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 - Default: 15
 - Type: Int
-- Unit: Stack frames
+- Unit: -
 - Is mutable: Yes
 - Description: Controls how many stack-trace frames are captured and emitted when StarRocks dumps lock debug information for slow or held locks. This value is passed to `LogUtil.getStackTraceToJsonArray` by `QueryableReentrantReadWriteLock` when producing JSON for the exclusive lock owner, current thread, and oldest/shared readers. Increasing this value provides more context for diagnosing slow-lock or deadlock issues at the cost of larger JSON payloads and slightly higher CPU/memory for stack capture; decreasing it reduces overhead. Note: reader entries can be filtered by `slow_lock_threshold_ms` when only logging slow locks.
 - Introduced in: v3.4.0, v3.5.0
@@ -1069,7 +1069,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: Seconds
 - Is mutable: Yes
-- Description: Controls the time-to-live (TTL) for task run history. When a TaskRunStatus is created its expire_time is computed as create_time + `task_runs_ttl_second` * 1000, and in-memory task run entries are removed once expired. This value also bounds the maximum effective task run timeout (TaskRun.getExecuteTimeoutS will not exceed `task_runs_ttl_second` and `task_ttl_second`). When archive to a repository table is enabled, the table keeper derives partition retention from `task_runs_ttl_second` (hours/days). Lowering this value shortens history retention and reduces memory/disk usage; raising it keeps histories longer but increases resource usage. Adjust together with `task_runs_max_history_number` and `enable_task_history_archive` for predictable retention and storage behavior.
+- Description: Controls the time-to-live (TTL) for task run history. Lowering this value shortens history retention and reduces memory/disk usage; raising it keeps histories longer but increases resource usage. Adjust together with `task_runs_max_history_number` and `enable_task_history_archive` for predictable retention and storage behavior.
 - Introduced in: v3.2.0
 
 ##### task_ttl_second
@@ -1078,7 +1078,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Type: Int
 - Unit: Seconds
 - Is mutable: Yes
-- Description: Time-to-live (TTL) for tasks, expressed in seconds. For manual tasks (when no schedule is set) TaskBuilder uses this value to compute the task's expireTime (expireTime = now + task_ttl_second * 1000L). TaskRun also uses this value as an upper bound when computing a run's execute timeout — the effective execute timeout is min(`task_runs_timeout_second`, `task_runs_ttl_second`, `task_ttl_second`). Adjusting this value changes how long manually created tasks remain valid and can indirectly limit the maximum allowed execution time of task runs.
+- Description: Time-to-live (TTL) for tasks. For manual tasks (when no schedule is set), TaskBuilder uses this value to compute the task's `expireTime` (`expireTime = now + task_ttl_second * 1000L`). TaskRun also uses this value as an upper bound when computing a run's execute timeout — the effective execute timeout is `min(task_runs_timeout_second, task_runs_ttl_second, task_ttl_second)`. Adjusting this value changes how long manually created tasks remain valid and can indirectly limit the maximum allowed execution time of task runs.
 - Introduced in: v3.2.0
 
 ##### txn_latency_metric_report_groups
@@ -1702,7 +1702,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Type: Int
 - Unit: Seconds
 - Is mutable: Yes
-- Description: Interval in seconds between executions of task background jobs. GlobalStateMgr uses this value to schedule the TaskCleaner FrontendDaemon which invokes `doTaskBackgroundJob()`; the value is multiplied by 1000 to set the daemon interval in milliseconds. Decreasing the value makes background maintenance (task cleanup, checks) run more frequently and react faster but increases CPU/IO overhead; increasing it reduces overhead but delays cleanup and detection of stale tasks. Tune this value to balance maintenance responsiveness and resource usage.
+- Description: Interval between executions of task background jobs. GlobalStateMgr uses this value to schedule the TaskCleaner FrontendDaemon which invokes `doTaskBackgroundJob()`; the value is multiplied by 1000 to set the daemon interval in milliseconds. Decreasing the value makes background maintenance (task cleanup, checks) run more frequently and react faster but increases CPU/IO overhead; increasing it reduces overhead but delays cleanup and detection of stale tasks. Tune this value to balance maintenance responsiveness and resource usage.
 - Introduced in: v3.2.0
 
 ### Loading and unloading
@@ -1906,7 +1906,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Type: Int
 - Unit: Days
 - Is mutable: Yes
-- Description: Number of days to retain load history in the internal `_statistics_.loads_history` table. This value is used when creating the table to set the table property `'partition_live_number'` and is passed to `TableKeeper` (clamped to a minimum of 1) to determine how many daily partitions to keep. Increasing or decreasing this value adjusts how long completed load jobs are retained in daily partitions; it affects new table creation and the keeper's pruning behavior but does not automatically recreate past partitions. The `LoadsHistorySyncer` relies on this retention when managing the loads history lifecycle; its sync cadence is controlled by `loads_history_sync_interval_second`.
+- Description: Number of days to retain load history in the internal `_statistics_.loads_history` table. This value is used for table creation to set the table property `partition_live_number` and is passed to `TableKeeper` (clamped to a minimum of 1) to determine how many daily partitions to keep. Increasing or decreasing this value adjusts how long completed load jobs are retained in daily partitions; it affects new table creation and the keeper's pruning behavior but does not automatically recreate past partitions. The `LoadsHistorySyncer` relies on this retention when managing the loads history lifecycle; its sync cadence is controlled by `loads_history_sync_interval_second`.
 - Introduced in: v3.3.6, v3.4.0, v3.5.0
 
 ##### loads_history_sync_interval_second
@@ -1915,7 +1915,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Type: Int
 - Unit: Seconds
 - Is mutable: Yes
-- Description: Interval (in seconds) used by LoadsHistorySyncer to schedule periodic syncs of finished load jobs from `information_schema.loads` into the internal `_statistics_.loads_history` table. The value is multiplied by 1000L in the constructor to set the FrontendDaemon interval. The syncer also re-reads this configuration at each run and calls setInterval when changed, so updates take effect at runtime without restart. The syncer skips the first run (to allow table creation) and only imports loads that finished more than one minute ago; frequent (small) values increase DML and executor load, while larger values delay availability of historical load records. See `loads_history_retained_days` for retention/partitioning behavior of the target table.
+- Description: Interval (in seconds) used by LoadsHistorySyncer to schedule periodic syncs of finished load jobs from `information_schema.loads` into the internal `_statistics_.loads_history` table. The value is multiplied by 1000 in the constructor to set the FrontendDaemon interval. The syncer skips the first run (to allow table creation) and only imports loads that finished more than one minute ago; small values increase DML and executor load, while larger values delay availability of historical load records. See `loads_history_retained_days` for retention/partitioning behavior of the target table.
 - Introduced in: v3.3.6, v3.4.0, v3.5.0
 
 ##### max_broker_load_job_concurrency
@@ -2121,9 +2121,9 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 
 - Default: 1000
 - Type: Int
-- Unit: Count
+- Unit: -
 - Is mutable: Yes
-- Description: Maximum number of StreamLoadTasks that StreamLoadMgr keeps in memory (global across all databases). When the number of tracked tasks (idToStreamLoadTask) exceeds this threshold, StreamLoadMgr first calls cleanSyncStreamLoadTasks() to remove completed synchronous stream-load tasks; if the size still remains greater than half of this threshold, it invokes cleanOldStreamLoadTasks(true) to force removal of older or finished tasks. Increase to retain more task history in memory; decrease to reduce memory usage and make cleanup more aggressive. This value controls in-memory retention only and does not affect persisted/replayed tasks.
+- Description: Maximum number of Stream Load tasks that StreamLoadMgr keeps in memory (global across all databases). When the number of tracked tasks (`idToStreamLoadTask`) exceeds this threshold, StreamLoadMgr first calls `cleanSyncStreamLoadTasks()` to remove completed synchronous stream-load tasks; if the size still remains greater than half of this threshold, it invokes `cleanOldStreamLoadTasks(true)` to force removal of older or finished tasks. Increase this value to retain more task history in memory; decrease it to reduce memory usage and make cleanup more aggressive. This value controls in-memory retention only and does not affect persisted/replayed tasks.
 - Introduced in: v3.2.0
 
 ##### stream_load_task_keep_max_second
@@ -2132,7 +2132,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Type: Int
 - Unit: Seconds
 - Is mutable: Yes
-- Description: Retention window (in seconds) for finished or cancelled StreamLoad tasks. After a task reaches a final state and its end timestamp is older than this threshold (the code compares milliseconds: currentMs - endTimeMs > stream_load_task_keep_max_second * 1000), it becomes eligible for removal by `StreamLoadMgr.cleanOldStreamLoadTasks` and is discarded when loading persisted state. Applies to both `StreamLoadTask` and `StreamLoadMultiStmtTask`. If total task count exceeds `stream_load_task_keep_max_num`, cleanup may be triggered earlier (synchronous tasks are prioritized by `cleanSyncStreamLoadTasks`). Set this to balance history/debugability against memory usage.
+- Description: Retention window for finished or cancelled Stream Load tasks. After a task reaches a final state and its end timestamp is ealier than this threshold (`currentMs - endTimeMs > stream_load_task_keep_max_second * 1000`), it becomes eligible for removal by `StreamLoadMgr.cleanOldStreamLoadTasks` and is discarded when loading persisted state. Applies to both `StreamLoadTask` and `StreamLoadMultiStmtTask`. If total task count exceeds `stream_load_task_keep_max_num`, cleanup may be triggered earlier (synchronous tasks are prioritized by `cleanSyncStreamLoadTasks`). Set this to balance history/debugability against memory usage.
 - Introduced in: v3.2.0
 
 ##### transaction_clean_interval_second
@@ -2283,9 +2283,9 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 
 - Default: 500
 - Type: Int
-- Unit: Count
+- Unit: -
 - Is mutable: Yes
-- Description: Limits the maximum number of partitions that can be created at once when analyzing or creating a dynamic-partitioned table. During dynamic partition property validation, StarRocks computes expected partitions (end offset + history partition number) and throws a DDL error if that total exceeds `max_dynamic_partition_num`. Raise this value only when you expect legitimately large partition ranges; increasing it allows more partitions to be created but can increase metadata size, scheduling work, and operational complexity.
+- Description: Limits the maximum number of partitions that can be created at once when analyzing or creating a dynamic-partitioned table. During dynamic partition property validation, the systemtask_runs_max_history_number computes expected partitions (end offset + history partition number) and throws a DDL error if that total exceeds `max_dynamic_partition_num`. Raise this value only when you expect legitimately large partition ranges; increasing it allows more partitions to be created but can increase metadata size, scheduling work, and operational complexity.
 - Introduced in: v3.2.0
 
 ##### max_partition_number_per_table
@@ -3586,7 +3586,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: Maximum number of task run records to retain in memory and to use as a default LIMIT when querying archived task-run history. When `enable_task_history_archive` is false, this value bounds in-memory history: Force GC trims older entries so only the newest `task_runs_max_history_number` remain. When archive history is queried (and no explicit LIMIT is provided), `TaskRunHistoryTable.lookup` applies "ORDER BY create_time DESC LIMIT <value>" if this value &gt; 0. Note: setting this to 0 disables the query-side LIMIT (no cap) but will cause in-memory history to be truncated to zero (unless archiving is enabled).
+- Description: Maximum number of task run records to retain in memory and to use as a default LIMIT when querying archived task-run history. When `enable_task_history_archive` is false, this value bounds in-memory history: Force GC trims older entries so only the newest `task_runs_max_history_number` remain. When archive history is queried (and no explicit LIMIT is provided), `TaskRunHistoryTable.lookup` uses `"ORDER BY create_time DESC LIMIT <value>"` if this value is greater than 0. Note: setting this to 0 disables the query-side LIMIT (no cap) but will cause in-memory history to be truncated to zero (unless archiving is enabled).
 - Introduced in: v3.2.0
 
 ##### tmp_dir

--- a/docs/ja/administration/management/FE_configuration.md
+++ b/docs/ja/administration/management/FE_configuration.md
@@ -97,21 +97,21 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### big_query_log_dir
 
-- デフォルト: `Config.STARROCKS_HOME_DIR + "/log"`
+- デフォルト: Config.STARROCKS_HOME_DIR + "/log"
 - タイプ: String
 - 単位: -
 - 変更可能: No
 - 説明: FE が big query ダンプログを書き込むディレクトリ（ファイル名: fe.big_query.log）。Log4j の設定はこのパスを使用して `fe.big_query.log` とローテートされたファイル用の RollingFile appender を作成します。ローテーションと保持は `big_query_log_roll_interval`（時間ベースのサフィックス）、`log_roll_size_mb`（サイズトリガー）、`big_query_log_roll_num`（最大ファイル数）、および `big_query_log_delete_age`（年齢ベースの削除）によって制御されます。big-query レコードは `big_query_log_cpu_second_threshold`、`big_query_log_scan_rows_threshold`、`big_query_log_scan_bytes_threshold` のようなユーザー定義の閾値を超えたクエリについて出力されます。どのモジュールがこのファイルにログを出力するかは `big_query_log_modules` で制御してください。
-- 導入バージョン: `v3.2.0`
+- 導入バージョン: v3.2.0
 
 ##### big_query_log_roll_num
 
-- デフォルト: `10`
+- デフォルト: 10
 - タイプ: Int
 - 単位: -
 - 変更可能: No
 - 説明: `big_query_log_roll_interval` ごとに保持する FE big query ログのローテート済みファイルの最大数です。この値は RollingFile appender の DefaultRolloverStrategy の `max` 属性（`fe.big_query.log` 用）にバインドされます。ログが時間または `log_roll_size_mb` によってロールすると、StarRocks は最大で `big_query_log_roll_num` 個のインデックス付きファイルを保持します（filePattern は時間サフィックスとインデックスを使用します）。この数より古いファイルはロールオーバーにより削除される可能性があり、`big_query_log_delete_age` によって最終更新日時に基づく削除が追加で行われることがあります。この値を変更するには、FE の再起動が必要です。
-- 導入バージョン: `v3.2.0`
+- 導入バージョン: v3.2.0
 
 ##### dump_log_delete_age
 
@@ -171,12 +171,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### enable_profile_log_compress
 
-- デフォルト: `false`
+- デフォルト: false
 - タイプ: Boolean
 - 単位: -
 - 変更可能: No
 - 説明: 有効にすると、ProfileManager が生成する JSON クエリプロファイルを PROFILE_LOG に書き込む前に `CompressionUtils.gzipCompressString` を使って GZIP 圧縮します。この圧縮は `enable_collect_query_detail_info` と `enable_profile_log` の両方が true の場合にのみ有効です。圧縮によりログ量と I/O は削減されますが CPU 負荷が増加します。PROFILE_LOG の消費者はクエリ詳細を読むために GZIP ペイロードを解凍する必要があります。圧縮が失敗した場合、コードは警告をログに出力し、圧縮されたプロファイルは書き込まれません。
-- 導入バージョン: `v3.2.7`
+- 導入バージョン: v3.2.7
 
 ##### log_roll_size_mb
 
@@ -189,7 +189,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### profile_log_roll_size_mb
 
-- デフォルト: `1024`
+- デフォルト: 1024
 - タイプ: Int
 - 単位: MB
 - 変更可能: No

--- a/docs/ja/administration/management/FE_configuration.md
+++ b/docs/ja/administration/management/FE_configuration.md
@@ -95,6 +95,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明: `audit_log_roll_interval` パラメータで指定された保持期間内に保持できる監査ログファイルの最大数。
 - 導入バージョン: -
 
+##### big_query_log_dir
+
+- デフォルト: `Config.STARROCKS_HOME_DIR + "/log"`
+- タイプ: String
+- 単位: -
+- 変更可能: No
+- 説明: FE が big query ダンプログを書き込むディレクトリ（ファイル名: fe.big_query.log）。Log4j の設定はこのパスを使用して `fe.big_query.log` とローテートされたファイル用の RollingFile appender を作成します。ローテーションと保持は `big_query_log_roll_interval`（時間ベースのサフィックス）、`log_roll_size_mb`（サイズトリガー）、`big_query_log_roll_num`（最大ファイル数）、および `big_query_log_delete_age`（年齢ベースの削除）によって制御されます。big-query レコードは `big_query_log_cpu_second_threshold`、`big_query_log_scan_rows_threshold`、`big_query_log_scan_bytes_threshold` のようなユーザー定義の閾値を超えたクエリについて出力されます。どのモジュールがこのファイルにログを出力するかは `big_query_log_modules` で制御してください。
+- 導入バージョン: `v3.2.0`
+
+##### big_query_log_roll_num
+
+- デフォルト: `10`
+- タイプ: Int
+- 単位: -
+- 変更可能: No
+- 説明: `big_query_log_roll_interval` ごとに保持する FE big query ログのローテート済みファイルの最大数です。この値は RollingFile appender の DefaultRolloverStrategy の `max` 属性（`fe.big_query.log` 用）にバインドされます。ログが時間または `log_roll_size_mb` によってロールすると、StarRocks は最大で `big_query_log_roll_num` 個のインデックス付きファイルを保持します（filePattern は時間サフィックスとインデックスを使用します）。この数より古いファイルはロールオーバーにより削除される可能性があり、`big_query_log_delete_age` によって最終更新日時に基づく削除が追加で行われることがあります。この値を変更するには、FE の再起動が必要です。
+- 導入バージョン: `v3.2.0`
+
 ##### dump_log_delete_age
 
 - デフォルト: 7d
@@ -151,6 +169,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明: true の場合、Frontend の監査サブシステムは ConnectProcessor によって処理される FE の監査ログ (fe.audit.log) にステートメントの SQL テキストを記録します。格納されるステートメントは他の制御を尊重します：暗号化されたステートメントは (AuditEncryptionChecker により) マスキングされ、認証情報は enable_sql_desensitize_in_log が設定されていると赤字化または脱感作される可能性があり、ダイジェストの記録は enable_sql_digest で制御されます。false の場合、ConnectProcessor は監査イベント内のステートメントテキストを "?" に置き換えます — 他の監査フィールド（user、host、duration、status、qe_slow_log_ms によるスロークエリ検出、メトリクス）は引き続き記録されます。SQL 監査を有効にするとフォレンジックやトラブルシューティングの可視性は向上しますが、機密性の高い SQL 内容が露出したりログの量および I/O が増加したりする可能性があります。無効にすると監査ログでの完全なステートメントの可視性を失う代わりにプライバシーが向上します。このオプションはランタイムで変更できません。
 - 導入バージョン: -
 
+##### enable_profile_log_compress
+
+- デフォルト: `false`
+- タイプ: Boolean
+- 単位: -
+- 変更可能: No
+- 説明: 有効にすると、ProfileManager が生成する JSON クエリプロファイルを PROFILE_LOG に書き込む前に `CompressionUtils.gzipCompressString` を使って GZIP 圧縮します。この圧縮は `enable_collect_query_detail_info` と `enable_profile_log` の両方が true の場合にのみ有効です。圧縮によりログ量と I/O は削減されますが CPU 負荷が増加します。PROFILE_LOG の消費者はクエリ詳細を読むために GZIP ペイロードを解凍する必要があります。圧縮が失敗した場合、コードは警告をログに出力し、圧縮されたプロファイルは書き込まれません。
+- 導入バージョン: `v3.2.7`
+
 ##### log_roll_size_mb
 
 - デフォルト: 1024
@@ -160,6 +187,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明: システムログファイルまたは監査ログファイルの最大サイズ。
 - 導入バージョン: -
 
+##### profile_log_roll_size_mb
+
+- デフォルト: `1024`
+- タイプ: Int
+- 単位: MB
+- 変更可能: No
+- 説明: FE のプロファイルログファイルをサイズベースでローテーションするトリガーとなる閾値（メガバイト単位）を設定します。この値は `ProfileFile` appender の Log4j RollingFile SizeBasedTriggeringPolicy によって使用され、プロファイルログが `profile_log_roll_size_mb` を超えるとローテーションされます。ローテーションは `profile_log_roll_interval` に達したときの時間ベースでも発生するため、いずれかの条件でロールオーバーが行われます。`profile_log_roll_num` および `profile_log_delete_age` と組み合わせて、過去のプロファイルファイルの保持数や古いファイルの削除タイミングを制御します。ローテートされたファイルの圧縮は `enable_profile_log_compress` によって制御されます。この値を変更した場合、適用するにはプロセスの再起動が必要です。
+- 導入バージョン: v3.2.5
+
 ##### qe_slow_log_ms
 
 - デフォルト: 5000
@@ -168,6 +204,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 変更可能: はい
 - 説明: クエリがスロークエリであるかどうかを判断するために使用されるしきい値。クエリの応答時間がこのしきい値を超える場合、**fe.audit.log** にスロークエリとして記録されます。
 - 導入バージョン: -
+
+##### slow_lock_threshold_ms
+
+- デフォルト: 3000L
+- タイプ: long
+- 単位: Milliseconds
+- 変更可能: はい
+- 説明: ロック操作または保持中のロックを「遅い(slow)」と分類するための閾値（ms単位）。ロックの経過待機時間または保持時間がこの値を超えると、StarRocks は（コンテキストに応じて）診断ログを出力したり、スタックトレースや待ち手/所有者情報を含めたり、—LockManagerではこの遅延後にデッドロック検出を開始します。LockUtils（slow-lock ロギング）、QueryableReentrantReadWriteLock（遅いリーダーのフィルタリング）、LockManager（デッドロック検出の遅延および遅いロックのトレース）、LockChecker（定期的な遅いロック検出）、およびその他の呼び出し元（例: DiskAndTabletLoadReBalancer のログ出力）で使用されます。値を下げると感度およびログ/診断のオーバーヘッドが増加します。値を 0 または負に設定すると、初期の待機ベースのデッドロック検出遅延の動作が無効になります。slow_lock_log_every_ms、slow_lock_print_stack、slow_lock_stack_trace_reserve_levels と合わせて調整してください。
+- 導入バージョン: 3.2.0
 
 ##### sys_log_delete_age
 
@@ -186,6 +231,33 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 変更可能: いいえ
 - 説明: システムログファイルを保存するディレクトリ。
 - 導入バージョン: -
+
+##### sys_log_enable_compress
+
+- デフォルト: false
+- タイプ: boolean
+- 単位: -
+- 変更可能: いいえ
+- 説明: この項目が `true` に設定されていると、システムはローテートされたシステムログファイル名に ".gz" の後置を付け、Log4j によって gzip 圧縮されたローテート済み FE システムログ（例: fe.log.*）が出力されるようになります。この値は Log4j 設定生成時（Log4jConfig.initLogging / generateActiveLog4jXmlConfig）に読み取られ、RollingFile の filePattern で使用される `sys_file_postfix` プロパティを制御します。この機能を有効にすると保持ログのディスク使用量は減少しますが、ロールオーバー時の CPU と I/O が増加し、ログファイル名が変更されるためログを読むツールやスクリプトが .gz ファイルを扱える必要があります。なお、監査ログは圧縮に別の設定（`audit_log_enable_compress`）を使用します。
+- 導入バージョン: v3.2.12
+
+##### sys_log_json_max_string_length
+
+- デフォルト: 1048576
+- タイプ: Int
+- 単位: Bytes
+- 変更可能: No
+- 説明: JSON形式のシステムログに使用される JsonTemplateLayout の "maxStringLength" 値を設定します。`sys_log_format` が `"json"` に設定されている場合、文字列値のフィールド（例えば "message" や文字列化された例外スタックトレース）は、その長さがこの上限を超えると切り詰められます。この値は `Log4jConfig.generateActiveLog4jXmlConfig()` 内で生成される Log4j XML に注入され、default、warning、audit、dump および bigquery のレイアウトに適用されます。profile レイアウトは別の設定（`sys_log_json_profile_max_string_length`）を使用します。この値を下げるとログサイズは小さくなりますが、有用な情報が切り落とされる可能性があります。
+- 導入バージョン: 3.2.11
+
+##### sys_log_json_profile_max_string_length
+
+- デフォルト: 104857600 (100 MB)
+- タイプ: Int
+- 単位: Bytes
+- 変更可能: いいえ
+- 説明: `sys_log_format` が "json" のとき、profile（および関連機能）のログ appender に対して JsonTemplateLayout の maxStringLength を設定します。JSON 形式の profile ログ内の文字列フィールドの値はこのバイト長で切り詰められ、非文字列フィールドには影響しません。この設定は Log4jConfig の `JsonTemplateLayout maxStringLength` に適用され、`plaintext` ログが使用されている場合は無視されます。必要な全メッセージが収まるように十分大きな値にしてください。ただし、大きな値はログサイズと I/O を増加させる点に注意してください。
+- 導入バージョン: v3.2.11
 
 ##### sys_log_level
 
@@ -224,6 +296,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 変更可能: いいえ
 - 説明: StarRocks がシステムログを生成するモジュール。このパラメータが `org.apache.starrocks.catalog` に設定されている場合、StarRocks は catalog モジュールのシステムログのみを生成します。モジュール名はカンマ (,) とスペースで区切ります。
 - 導入バージョン: -
+
+##### sys_log_warn_modules
+
+- デフォルト: {}
+- タイプ: String[]
+- 単位: -
+- 変更可能: いいえ
+- 説明: システム起動時に WARN レベルのロガーとして設定し、警告アペンダ（SysWF）— `fe.warn.log` ファイル— にルーティングするロガー名またはパッケージプレフィックスのリストです。エントリは生成された Log4j 設定に挿入され（org.apache.kafka、org.apache.hudi、org.apache.hadoop.io.compress といった組み込みの warn モジュールとともに）、`<Logger name="... " level="WARN"><AppenderRef ref="SysWF"/></Logger>` のような logger 要素を生成します。冗長な INFO/DEBUG 出力を通常のログに抑制し、警告を別途捕捉するために完全修飾のパッケージやクラスのプレフィックス（例: "com.example.lib"）を使用することが推奨されます。
+- 導入バージョン: v3.2.13
 
 ### サーバー
 
@@ -765,6 +846,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
   - `NO_SYNC`: トランザクションがコミットされるときにログエントリの生成とフラッシュは同時に行われません。
   - `WRITE_NO_SYNC`: トランザクションがコミットされると、ログエントリが同時に生成されますが、ディスクにフラッシュされません。
 - 導入バージョン: -
+
+##### task_ttl_second
+
+- デフォルト: 24 * 3600
+- タイプ: Int
+- 単位: Seconds
+- 変更可能: Yes
+- 説明: タスクの存続時間（TTL）を秒単位で指定します。スケジュールが設定されていない手動タスクの場合、TaskBuilder はこの値を用いてタスクの expireTime を算出します（expireTime = now + task_ttl_second * 1000L）。TaskRun もランの実行タイムアウトを計算する際の上限としてこの値を参照します — 実効的な実行タイムアウトは min(`task_runs_timeout_second`, `task_runs_ttl_second`, `task_ttl_second`) です。この値を調整すると、手動で作成されたタスクが有効でいられる期間が変わり、間接的にタスクランの最大実行時間の上限を制限することになります。
+- 導入バージョン: v3.2.0
 
 ##### txn_latency_metric_report_groups
 
@@ -2604,6 +2694,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 単位: 秒
 - 変更可能: いいえ
 - 説明: 共有データクラスタ内の FE が StarMgr と の定期的なメタデータ同期を実行する間隔。
+- 導入バージョン: -
+
+##### starmgr_grpc_server_max_worker_threads
+
+- デフォルト: 1024
+- タイプ: Int
+- 単位: -
+- 変更可能: Yes
+- 説明: FE の starmgr モジュール内で grpc サーバが使用するワーカースレッドの最大数。
+- 導入バージョン: v4.0.0, v3.5.8
+
+##### starmgr_grpc_timeout_seconds
+
+- デフォルト: 5
+- タイプ: Int
+- 単位: Seconds
+- 変更可能: Yes
+- 説明:
 - 導入バージョン: -
 
 ### その他

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -145,21 +145,21 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### internal_log_modules
 
-- 默认值: `{"base", "statistic"}`
+- 默认值: {"base", "statistic"}
 - 类型: String[]
 - 単位: -
 - 是否可变: No
 - 描述: 一个将接收专用内部日志记录的模块标识符列表。对于每个条目 X，Log4j 会创建一个名为 `internal.&lt;X&gt;` 的 logger，级别为 INFO 且 additivity="false"。这些 logger 会被路由到 internal appender（写入 `fe.internal.log`），当启用 `sys_log_to_console` 时则输出到控制台。根据需要使用简短名称或包片段 —— 精确的 logger 名称将成为 `internal.` + 配置的字符串。内部日志文件的滚动和保留遵循 `internal_log_dir`、`internal_log_roll_num`、`internal_log_delete_age`、`internal_log_roll_interval` 和 `log_roll_size_mb` 的设置。添加模块会将其运行时消息分离到内部 logger 流中，便于调试和审计。
-- 引入版本: `v3.2.4`
+- 引入版本: v3.2.4
 
 ##### internal_log_roll_interval
 
-- 默认值: `DAY`
+- 默认值: DAY
 - 类型: String
 - 単位: -
 - 是否可变: No
 - 描述: 控制 FE 内部日志 appender 的基于时间的滚动间隔。接受（不区分大小写）的值为 `HOUR` 和 `DAY`。`HOUR` 生成每小时的文件模式 ("%d{yyyyMMddHH}")，`DAY` 生成每日的文件模式 ("%d{yyyyMMdd}")，这些模式由 RollingFile TimeBasedTriggeringPolicy 用于命名旋转后的 `fe.internal.log` 文件。无效的值会导致初始化失败（在构建活动 Log4j 配置时会抛出 IOException）。滚动行为还取决于相关设置，例如 `internal_log_dir`、`internal_roll_maxsize`、`internal_log_roll_num` 和 `internal_log_delete_age`。
-- 引入版本: `v3.2.4`
+- 引入版本: v3.2.4
 
 ##### log_roll_size_mb
 
@@ -172,7 +172,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### profile_log_dir
 
-- 默认值: `Config.STARROCKS_HOME_DIR + "/log"`
+- 默认值: Config.STARROCKS_HOME_DIR + "/log"
 - 类型: String
 - 单位: -
 - 是否可变: No
@@ -186,7 +186,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 单位: Number of files
 - 是否可变: No
 - 描述: 指定 Log4j 的 DefaultRolloverStrategy 为 profile logger 保留的最大轮换 profile 日志文件数。该值会作为 ${profile_log_roll_num} 注入到日志 XML 中（例如 &lt;DefaultRolloverStrategy max="${profile_log_roll_num}" fileIndex="min"&gt;）。轮换由 `profile_log_roll_size_mb` 或 `profile_log_roll_interval` 触发；发生轮换时，Log4j 最多保留这么多带索引的文件，较旧的索引文件将成为可删除对象。磁盘上的实际保留还受 `profile_log_delete_age` 和 `profile_log_dir` 位置的影响。较低的值可降低磁盘使用，但限制可保留的历史；较高的值则保留更多历史 profile 日志。
-- 引入版本: `v3.2.5`
+- 引入版本: v3.2.5
 
 ##### qe_slow_log_ms
 
@@ -1651,12 +1651,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### loads_history_sync_interval_second
 
-- 默认值: `60`
+- 默认值: 60
 - 类型: Int
 - 单位: Seconds
 - 是否可变: Yes
 - 描述: 由 LoadsHistorySyncer 用于调度周期性同步的时间间隔（秒），用于将已完成的 load 作业从 `information_schema.loads` 同步到内部表 `_statistics_.loads_history`。构造函数中将该值乘以 1000L 以设置 FrontendDaemon 的间隔。syncer 在每次运行时也会重新读取该配置，并在变化时调用 setInterval，因此更新可以在运行时生效而无需重启。syncer 会跳过首次运行（以允许表创建），且仅导入结束时间超过一分钟的 load；较小的频繁值会增加 DML 和 executor 负载，而较大的值会延迟历史 load 记录的可用性。关于目标表的保留/分区行为，请参见 `loads_history_retained_days`。
-- 引入版本: `v3.3.6, v3.4.0, v3.5.0`
+- 引入版本: v3.3.6, v3.4.0, v3.5.0
 
 ##### max_broker_load_job_concurrency
 
@@ -1859,12 +1859,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### stream_load_task_keep_max_second
 
-- 默认值: `3 * 24 * 3600`
+- 默认值: 3 * 24 * 3600
 - 类型: Int
 - 单位: Seconds
 - 是否可变: Yes
 - 描述: 已完成或已取消的 StreamLoad 任务的保留窗口（秒）。当任务达到最终状态且其结束时间戳早于此阈值时（代码以毫秒比较：currentMs - endTimeMs > stream_load_task_keep_max_second * 1000），该任务将有资格被 `StreamLoadMgr.cleanOldStreamLoadTasks` 移除，并在加载持久化状态时被丢弃。适用于 `StreamLoadTask` 和 `StreamLoadMultiStmtTask`。如果总任务数超过 `stream_load_task_keep_max_num`，可能会提前触发清理（同步任务由 `cleanSyncStreamLoadTasks` 优先处理）。请根据历史记录/可调试性与内存使用之间的权衡设置此值。
-- 引入版本: `v3.2.0`
+- 引入版本: v3.2.0
 
 ##### transaction_clean_interval_second
 

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -185,7 +185,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 类型: Int
 - 单位: Number of files
 - 是否可变: No
-- 描述: 指定 Log4j 的 DefaultRolloverStrategy 为 profile logger 保留的最大轮换 profile 日志文件数。该值会作为 ${profile_log_roll_num} 注入到日志 XML 中（例如 `&lt;DefaultRolloverStrategy max="${profile_log_roll_num}" fileIndex="min"&gt;`）。轮换由 `profile_log_roll_size_mb` 或 `profile_log_roll_interval` 触发；发生轮换时，Log4j 最多保留这么多带索引的文件，较旧的索引文件将成为可删除对象。磁盘上的实际保留还受 `profile_log_delete_age` 和 `profile_log_dir` 位置的影响。较低的值可降低磁盘使用，但限制可保留的历史；较高的值则保留更多历史 profile 日志。
+- 描述: 指定 Log4j 的 DefaultRolloverStrategy 为 profile logger 保留的最大轮换 profile 日志文件数。该值会作为 `${profile_log_roll_num}` 注入到日志 XML 中（例如 `&lt;DefaultRolloverStrategy max="${profile_log_roll_num}" fileIndex="min"&gt;`）。轮换由 `profile_log_roll_size_mb` 或 `profile_log_roll_interval` 触发；发生轮换时，Log4j 最多保留这么多带索引的文件，较旧的索引文件将成为可删除对象。磁盘上的实际保留还受 `profile_log_delete_age` 和 `profile_log_dir` 位置的影响。较低的值可降低磁盘使用，但限制可保留的历史；较高的值则保留更多历史 profile 日志。
 - 引入版本: v3.2.5
 
 ##### qe_slow_log_ms

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -145,7 +145,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### internal_log_modules
 
-- 默认值: {"base", "statistic"}
+- 默认值: `{"base", "statistic"}`
 - 类型: String[]
 - 単位: -
 - 是否可变: No
@@ -158,7 +158,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 类型: String
 - 単位: -
 - 是否可变: No
-- 描述: 控制 FE 内部日志 appender 的基于时间的滚动间隔。接受（不区分大小写）的值为 `HOUR` 和 `DAY`。`HOUR` 生成每小时的文件模式 ("%d{yyyyMMddHH}")，`DAY` 生成每日的文件模式 ("%d{yyyyMMdd}")，这些模式由 RollingFile TimeBasedTriggeringPolicy 用于命名旋转后的 `fe.internal.log` 文件。无效的值会导致初始化失败（在构建活动 Log4j 配置时会抛出 IOException）。滚动行为还取决于相关设置，例如 `internal_log_dir`、`internal_roll_maxsize`、`internal_log_roll_num` 和 `internal_log_delete_age`。
+- 描述: 控制 FE 内部日志 appender 的基于时间的滚动间隔。接受（不区分大小写）的值为 `HOUR` 和 `DAY`。`HOUR` 生成每小时的文件模式 (`"%d{yyyyMMddHH}"`)，`DAY` 生成每日的文件模式 (`"%d{yyyyMMdd}"`)，这些模式由 RollingFile TimeBasedTriggeringPolicy 用于命名旋转后的 `fe.internal.log` 文件。无效的值会导致初始化失败（在构建活动 Log4j 配置时会抛出 IOException）。滚动行为还取决于相关设置，例如 `internal_log_dir`、`internal_roll_maxsize`、`internal_log_roll_num` 和 `internal_log_delete_age`。
 - 引入版本: v3.2.4
 
 ##### log_roll_size_mb
@@ -172,11 +172,11 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### profile_log_dir
 
-- 默认值: Config.STARROCKS_HOME_DIR + "/log"
+- 默认值: `Config.STARROCKS_HOME_DIR + "/log"`
 - 类型: String
 - 单位: -
 - 是否可变: No
-- 描述: FE profile 日志写入的目录路径。`Log4jConfig` 使用此值来放置与 profile 相关的 appender（在该目录下创建类似 fe.profile.log 和 fe.features.log 的文件）。这些文件的轮换和保留由 `profile_log_roll_size_mb`、`profile_log_roll_num` 和 `profile_log_delete_age` 控制；时间戳后缀格式由 `profile_log_roll_interval` 控制（支持 DAY 或 HOUR）。由于默认值位于 `STARROCKS_HOME_DIR` 内，请确保 FE 进程对该目录具有写入及轮换/删除权限。
+- 描述: FE profile 日志写入的目录路径。`Log4jConfig` 使用此值来放置与 profile 相关的 appender（在该目录下创建类似 `fe.profile.log` 和 `fe.features.log` 的文件）。这些文件的轮换和保留由 `profile_log_roll_size_mb`、`profile_log_roll_num` 和 `profile_log_delete_age` 控制；时间戳后缀格式由 `profile_log_roll_interval` 控制（支持 DAY 或 HOUR）。由于默认值位于 `STARROCKS_HOME_DIR` 内，请确保 FE 进程对该目录具有写入及轮换/删除权限。
 - 引入版本: v3.2.5
 
 ##### profile_log_roll_num
@@ -185,7 +185,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 类型: Int
 - 单位: Number of files
 - 是否可变: No
-- 描述: 指定 Log4j 的 DefaultRolloverStrategy 为 profile logger 保留的最大轮换 profile 日志文件数。该值会作为 ${profile_log_roll_num} 注入到日志 XML 中（例如 &lt;DefaultRolloverStrategy max="${profile_log_roll_num}" fileIndex="min"&gt;）。轮换由 `profile_log_roll_size_mb` 或 `profile_log_roll_interval` 触发；发生轮换时，Log4j 最多保留这么多带索引的文件，较旧的索引文件将成为可删除对象。磁盘上的实际保留还受 `profile_log_delete_age` 和 `profile_log_dir` 位置的影响。较低的值可降低磁盘使用，但限制可保留的历史；较高的值则保留更多历史 profile 日志。
+- 描述: 指定 Log4j 的 DefaultRolloverStrategy 为 profile logger 保留的最大轮换 profile 日志文件数。该值会作为 ${profile_log_roll_num} 注入到日志 XML 中（例如 `&lt;DefaultRolloverStrategy max="${profile_log_roll_num}" fileIndex="min"&gt;`）。轮换由 `profile_log_roll_size_mb` 或 `profile_log_roll_interval` 触发；发生轮换时，Log4j 最多保留这么多带索引的文件，较旧的索引文件将成为可删除对象。磁盘上的实际保留还受 `profile_log_delete_age` 和 `profile_log_dir` 位置的影响。较低的值可降低磁盘使用，但限制可保留的历史；较高的值则保留更多历史 profile 日志。
 - 引入版本: v3.2.5
 
 ##### qe_slow_log_ms
@@ -203,7 +203,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 类型: Long
 - 単位: 毫秒
 - 是否可变: 是
-- 描述: 在对同一个 SlowLockLogStats 实例再次输出“慢锁”警告之前，至少要等待的最小间隔（毫秒）。当锁等待时间超过 slow_lock_threshold_ms 后，LockUtils 会检查此值并在最近一次记录的慢锁事件发生到现在未达到 slow_lock_log_every_ms 毫秒时抑制额外警告。在长时间争用期间使用较大的值以减少日志量，或使用较小的值以获取更频繁的诊断信息。更改在运行时对后续检查生效。
+- 描述: 在对同一个 SlowLockLogStats 实例再次输出“慢锁”警告之前，至少要等待的最小间隔（毫秒）。当锁等待时间超过 `slow_lock_threshold_ms` 后，LockUtils 会检查此值并在最近一次记录的慢锁事件发生到现在未达到 `slow_lock_log_every_ms` 毫秒时抑制额外警告。在长时间争用期间使用较大的值以减少日志量，或使用较小的值以获取更频繁的诊断信息。更改在运行时对后续检查生效。
 - 引入版本: v3.2.0
 
 ##### slow_lock_threshold_ms
@@ -212,7 +212,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 类型: long
 - 単位: 毫秒
 - 是否可变: 是
-- 描述: 用于将一个锁操作或持有的锁归类为“慢”的阈值（毫秒）。当锁的等待时间或持有时间超过此值时，StarRocks 将（视上下文）输出诊断日志、包含堆栈跟踪或 waiter/owner 信息，并且在 LockManager 中在该延迟后启动死锁检测。此配置由 LockUtils（慢锁日志）、QueryableReentrantReadWriteLock（筛选慢读取者）、LockManager（死锁检测延迟和慢锁跟踪）、LockChecker（周期性慢锁检测）以及其他调用方（例如 DiskAndTabletLoadReBalancer 日志）使用。降低该值会提高敏感度并增加日志/诊断开销；将其设置为 0 或负值会禁用基于初始等待的死锁检测延迟行为。请与 slow_lock_log_every_ms、slow_lock_print_stack 和 slow_lock_stack_trace_reserve_levels 一起调整。
+- 描述: 用于将一个锁操作或持有的锁归类为“慢”的阈值（毫秒）。当锁的等待时间或持有时间超过此值时，StarRocks 将（视上下文）输出诊断日志、包含堆栈跟踪或 waiter/owner 信息，并且在 LockManager 中在该延迟后启动死锁检测。此配置由 LockUtils（慢锁日志）、QueryableReentrantReadWriteLock（筛选慢读取者）、LockManager（死锁检测延迟和慢锁跟踪）、LockChecker（周期性慢锁检测）以及其他调用方（例如 DiskAndTabletLoadReBalancer 日志）使用。降低该值会提高敏感度并增加日志/诊断开销；将其设置为 0 或负值会禁用基于初始等待的死锁检测延迟行为。请与 `slow_lock_log_every_ms`、`slow_lock_print_stack` 和 `slow_lock_stack_trace_reserve_levels` 一起调整。
 - 引入版本: 3.2.0
 
 ##### sys_log_delete_age
@@ -239,7 +239,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 类型: boolean
 - 単位: -
 - 是否可变: No
-- 描述: 当此项设置为 `true` 时，系统会在轮转的系统日志文件名后追加 ".gz" 后缀，从而使 Log4j 在轮转时生成 gzip 压缩的 FE 系统日志（例如，fe.log.*）。此值在生成 Log4j 配置时读取（Log4jConfig.initLogging / generateActiveLog4jXmlConfig），并控制用于 RollingFile filePattern 的 `sys_file_postfix` 属性。启用此功能可减少保留日志的磁盘占用，但会在轮转期间增加 CPU 和 I/O 开销，并改变日志文件名，因此读取日志的工具或脚本必须能够处理 .gz 文件。注意，审计日志使用单独的压缩配置，即 `audit_log_enable_compress`。
+- 描述: 当此项设置为 `true` 时，系统会在轮转的系统日志文件名后追加 ".gz" 后缀，从而使 Log4j 在轮转时生成 gzip 压缩的 FE 系统日志（例如，`fe.log.*`）。此值在生成 Log4j 配置时读取（Log4jConfig.initLogging / generateActiveLog4jXmlConfig），并控制用于 RollingFile filePattern 的 `sys_file_postfix` 属性。启用此功能可减少保留日志的磁盘占用，但会在轮转期间增加 CPU 和 I/O 开销，并改变日志文件名，因此读取日志的工具或脚本必须能够处理 .gz 文件。注意，审计日志使用单独的压缩配置，即 `audit_log_enable_compress`。
 - 引入版本: v3.2.12
 
 ##### sys_log_json_max_string_length
@@ -300,7 +300,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### sys_log_warn_modules
 
-- 默认值: {}
+- 默认值: `{}`
 - 类型: String[]
 - 単位: -
 - 是否可变: No

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -143,6 +143,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述：每个 `dump_log_roll_interval` 时间内，允许保留的 Dump 日志文件的最大数目。
 - 引入版本：-
 
+##### internal_log_modules
+
+- 默认值: `{"base", "statistic"}`
+- 类型: String[]
+- 単位: -
+- 是否可变: No
+- 描述: 一个将接收专用内部日志记录的模块标识符列表。对于每个条目 X，Log4j 会创建一个名为 `internal.&lt;X&gt;` 的 logger，级别为 INFO 且 additivity="false"。这些 logger 会被路由到 internal appender（写入 `fe.internal.log`），当启用 `sys_log_to_console` 时则输出到控制台。根据需要使用简短名称或包片段 —— 精确的 logger 名称将成为 `internal.` + 配置的字符串。内部日志文件的滚动和保留遵循 `internal_log_dir`、`internal_log_roll_num`、`internal_log_delete_age`、`internal_log_roll_interval` 和 `log_roll_size_mb` 的设置。添加模块会将其运行时消息分离到内部 logger 流中，便于调试和审计。
+- 引入版本: `v3.2.4`
+
+##### internal_log_roll_interval
+
+- 默认值: `DAY`
+- 类型: String
+- 単位: -
+- 是否可变: No
+- 描述: 控制 FE 内部日志 appender 的基于时间的滚动间隔。接受（不区分大小写）的值为 `HOUR` 和 `DAY`。`HOUR` 生成每小时的文件模式 ("%d{yyyyMMddHH}")，`DAY` 生成每日的文件模式 ("%d{yyyyMMdd}")，这些模式由 RollingFile TimeBasedTriggeringPolicy 用于命名旋转后的 `fe.internal.log` 文件。无效的值会导致初始化失败（在构建活动 Log4j 配置时会抛出 IOException）。滚动行为还取决于相关设置，例如 `internal_log_dir`、`internal_roll_maxsize`、`internal_log_roll_num` 和 `internal_log_delete_age`。
+- 引入版本: `v3.2.4`
+
 ##### log_roll_size_mb
 
 - 默认值：1024
@@ -152,6 +170,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述：单个系统日志或审计日志文件的大小上限。
 - 引入版本：-
 
+##### profile_log_dir
+
+- 默认值: `Config.STARROCKS_HOME_DIR + "/log"`
+- 类型: String
+- 单位: -
+- 是否可变: No
+- 描述: FE profile 日志写入的目录路径。`Log4jConfig` 使用此值来放置与 profile 相关的 appender（在该目录下创建类似 fe.profile.log 和 fe.features.log 的文件）。这些文件的轮换和保留由 `profile_log_roll_size_mb`、`profile_log_roll_num` 和 `profile_log_delete_age` 控制；时间戳后缀格式由 `profile_log_roll_interval` 控制（支持 DAY 或 HOUR）。由于默认值位于 `STARROCKS_HOME_DIR` 内，请确保 FE 进程对该目录具有写入及轮换/删除权限。
+- 引入版本: v3.2.5
+
+##### profile_log_roll_num
+
+- 默认值: 5
+- 类型: Int
+- 单位: Number of files
+- 是否可变: No
+- 描述: 指定 Log4j 的 DefaultRolloverStrategy 为 profile logger 保留的最大轮换 profile 日志文件数。该值会作为 ${profile_log_roll_num} 注入到日志 XML 中（例如 &lt;DefaultRolloverStrategy max="${profile_log_roll_num}" fileIndex="min"&gt;）。轮换由 `profile_log_roll_size_mb` 或 `profile_log_roll_interval` 触发；发生轮换时，Log4j 最多保留这么多带索引的文件，较旧的索引文件将成为可删除对象。磁盘上的实际保留还受 `profile_log_delete_age` 和 `profile_log_dir` 位置的影响。较低的值可降低磁盘使用，但限制可保留的历史；较高的值则保留更多历史 profile 日志。
+- 引入版本: `v3.2.5`
+
 ##### qe_slow_log_ms
 
 - 默认值：5000
@@ -160,6 +196,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 是否动态：是
 - 描述：Slow query 的认定时长。如果查询的响应时间超过此阈值，则会在审计日志 `fe.audit.log` 中记录为 slow query。
 - 引入版本：-
+
+##### slow_lock_log_every_ms
+
+- 默认值: 3000L
+- 类型: Long
+- 単位: 毫秒
+- 是否可变: 是
+- 描述: 在对同一个 SlowLockLogStats 实例再次输出“慢锁”警告之前，至少要等待的最小间隔（毫秒）。当锁等待时间超过 slow_lock_threshold_ms 后，LockUtils 会检查此值并在最近一次记录的慢锁事件发生到现在未达到 slow_lock_log_every_ms 毫秒时抑制额外警告。在长时间争用期间使用较大的值以减少日志量，或使用较小的值以获取更频繁的诊断信息。更改在运行时对后续检查生效。
+- 引入版本: v3.2.0
+
+##### slow_lock_threshold_ms
+
+- 默认值: 3000L
+- 类型: long
+- 単位: 毫秒
+- 是否可变: 是
+- 描述: 用于将一个锁操作或持有的锁归类为“慢”的阈值（毫秒）。当锁的等待时间或持有时间超过此值时，StarRocks 将（视上下文）输出诊断日志、包含堆栈跟踪或 waiter/owner 信息，并且在 LockManager 中在该延迟后启动死锁检测。此配置由 LockUtils（慢锁日志）、QueryableReentrantReadWriteLock（筛选慢读取者）、LockManager（死锁检测延迟和慢锁跟踪）、LockChecker（周期性慢锁检测）以及其他调用方（例如 DiskAndTabletLoadReBalancer 日志）使用。降低该值会提高敏感度并增加日志/诊断开销；将其设置为 0 或负值会禁用基于初始等待的死锁检测延迟行为。请与 slow_lock_log_every_ms、slow_lock_print_stack 和 slow_lock_stack_trace_reserve_levels 一起调整。
+- 引入版本: 3.2.0
 
 ##### sys_log_delete_age
 
@@ -178,6 +232,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 是否动态：否
 - 描述：系统日志文件的保存目录。
 - 引入版本：-
+
+##### sys_log_enable_compress
+
+- 默认值: false
+- 类型: boolean
+- 単位: -
+- 是否可变: No
+- 描述: 当此项设置为 `true` 时，系统会在轮转的系统日志文件名后追加 ".gz" 后缀，从而使 Log4j 在轮转时生成 gzip 压缩的 FE 系统日志（例如，fe.log.*）。此值在生成 Log4j 配置时读取（Log4jConfig.initLogging / generateActiveLog4jXmlConfig），并控制用于 RollingFile filePattern 的 `sys_file_postfix` 属性。启用此功能可减少保留日志的磁盘占用，但会在轮转期间增加 CPU 和 I/O 开销，并改变日志文件名，因此读取日志的工具或脚本必须能够处理 .gz 文件。注意，审计日志使用单独的压缩配置，即 `audit_log_enable_compress`。
+- 引入版本: v3.2.12
 
 ##### sys_log_json_max_string_length
 
@@ -234,6 +297,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 是否动态：否
 - 描述：打印系统日志的模块。如果设置参数取值为 `org.apache.starrocks.catalog`，则表示只打印 Catalog 模块下的日志。
 - 引入版本：-
+
+##### sys_log_warn_modules
+
+- 默认值: {}
+- 类型: String[]
+- 単位: -
+- 是否可变: No
+- 描述: 一个记录器名称或包前缀列表，系统在启动时会将其配置为 WARN 级别的记录器并路由到警告 appender（SysWF）— 即 `fe.warn.log` 文件。条目会被插入到生成的 Log4j 配置中（与内置的 warn 模块一起，例如 org.apache.kafka、org.apache.hudi 和 org.apache.hadoop.io.compress），并生成类似 `<Logger name="... " level="WARN"><AppenderRef ref="SysWF"/></Logger>` 的 logger 元素。建议使用完全限定的包和类前缀（例如 "com.example.lib"）来抑制在常规日志中产生噪声的 INFO/DEBUG 输出，并允许将警告单独捕获。
+- 引入版本: v3.2.13
 
 ### 服务器
 
@@ -1577,6 +1649,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述：控制 BE 副本最大容忍的导入落后时长，超过这个时长就进行克隆。
 - 引入版本：-
 
+##### loads_history_sync_interval_second
+
+- 默认值: `60`
+- 类型: Int
+- 单位: Seconds
+- 是否可变: Yes
+- 描述: 由 LoadsHistorySyncer 用于调度周期性同步的时间间隔（秒），用于将已完成的 load 作业从 `information_schema.loads` 同步到内部表 `_statistics_.loads_history`。构造函数中将该值乘以 1000L 以设置 FrontendDaemon 的间隔。syncer 在每次运行时也会重新读取该配置，并在变化时调用 setInterval，因此更新可以在运行时生效而无需重启。syncer 会跳过首次运行（以允许表创建），且仅导入结束时间超过一分钟的 load；较小的频繁值会增加 DML 和 executor 负载，而较大的值会延迟历史 load 记录的可用性。关于目标表的保留/分区行为，请参见 `loads_history_retained_days`。
+- 引入版本: `v3.3.6, v3.4.0, v3.5.0`
+
 ##### max_broker_load_job_concurrency
 
 - 默认值：5
@@ -1775,6 +1856,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 是否动态：是
 - 描述：Stream Load 的默认超时时间。
 - 引入版本：-
+
+##### stream_load_task_keep_max_second
+
+- 默认值: `3 * 24 * 3600`
+- 类型: Int
+- 单位: Seconds
+- 是否可变: Yes
+- 描述: 已完成或已取消的 StreamLoad 任务的保留窗口（秒）。当任务达到最终状态且其结束时间戳早于此阈值时（代码以毫秒比较：currentMs - endTimeMs > stream_load_task_keep_max_second * 1000），该任务将有资格被 `StreamLoadMgr.cleanOldStreamLoadTasks` 移除，并在加载持久化状态时被丢弃。适用于 `StreamLoadTask` 和 `StreamLoadMultiStmtTask`。如果总任务数超过 `stream_load_task_keep_max_num`，可能会提前触发清理（同步任务由 `cleanSyncStreamLoadTasks` 优先处理）。请根据历史记录/可调试性与内存使用之间的权衡设置此值。
+- 引入版本: `v3.2.0`
 
 ##### transaction_clean_interval_second
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:  
```
EXECUTION SUMMARY
Document Type: fe_config
Duration: 1763.35 seconds
ITEM EXTRACTION:
  ├─ Items from meta files: 726
  ├─ Items from code parsing: 0
  └─ Total unique items: 0
DOCUMENT GENERATION:
  ├─ EN: 30 documents
  ├─ JA: 6 documents
  ├─ ZH: 5 documents
  └─ Total: 41 documents
AGENT INVOCATIONS:
  ├─ ConfigDocAgent: 33 calls
  ├─ TranslationAgent_ja: 6 calls
  ├─ TranslationAgent_zh: 5 calls
  └─ Total: 44 calls
TOOL INVOCATIONS:
  ├─ read_file: 53 calls
  ├─ search_code: 5 calls
  └─ Total: 58 calls
GENERATED ITEMS:
  ├─ Total: 30 items
  ├─ slow_lock_stack_trace_reserve_levels
  ├─ slow_lock_print_stack
  ├─ internal_log_dir
  ├─ internal_log_roll_num
  ├─ internal_log_modules
  ├─ internal_log_roll_interval
  ├─ internal_log_delete_age
  ├─ big_query_log_dir
  ├─ big_query_log_roll_num
  ├─ big_query_log_modules
  ├─ big_query_log_roll_interval
  ├─ big_query_log_delete_age
  ├─ enable_profile_log
  ├─ profile_log_dir
  ├─ profile_log_roll_num
  ├─ profile_log_roll_interval
  ├─ profile_log_delete_age
  ├─ profile_log_roll_size_mb
  ├─ enable_profile_log_compress
  ├─ log_plan_cancelled_by_crash_be
  ├─ log_register_and_unregister_query_id
  ├─ max_dynamic_partition_num
  ├─ stream_load_task_keep_max_num
  ├─ stream_load_task_keep_max_second
  ├─ loads_history_sync_interval_second
  ├─ loads_history_retained_days
  ├─ task_check_interval_second
  ├─ task_ttl_second
  ├─ task_runs_ttl_second
  └─ task_runs_max_history_number
TRANSLATED ITEMS:
  ├─ Total: 50 items
  ├─ enable_profile_log_compress
  ├─ enable_internal_sql
  ├─ internal_log_roll_num
  ├─ big_query_log_roll_num
  ├─ enable_collect_tablet_num_in_show_proc_backend_disk_path
  ├─ enable_profile_log
  ├─ audit_log_enable_compress
  ├─ starmgr_grpc_server_max_worker_threads
  ├─ profile_log_roll_interval
  ├─ log_register_and_unregister_query_id
  ├─ enable_materialized_view_concurrent_prepare
  ├─ task_runs_ttl_second
  ├─ log_plan_cancelled_by_crash_be
  ├─ internal_log_json_format
  ├─ max_dynamic_partition_num
  ├─ max_task_consecutive_fail_count
  ├─ internal_log_delete_age
  ├─ task_runs_timeout_second
  ├─ internal_log_dir
  ├─ audit_log_json_format
  ├─ profile_log_delete_age
  ├─ task_ttl_second
  ├─ task_check_interval_second
  ├─ stream_load_task_keep_max_num
  ├─ enable_audit_sql
  ├─ profile_log_dir
  ├─ profile_log_roll_num
  ├─ task_runs_max_history_number
  ├─ big_query_log_delete_age
  ├─ internal_log_roll_interval
  ├─ big_query_log_roll_interval
  ├─ enable_sql_desensitize_in_log
  ├─ starmgr_grpc_timeout_seconds
  ├─ profile_log_roll_size_mb
  ├─ enable_qe_slow_log
  ├─ slow_lock_stack_trace_reserve_levels
  ├─ big_query_log_modules
  ├─ sys_log_enable_compress
  ├─ sys_log_warn_modules
  ├─ sys_log_json_profile_max_string_length
  ├─ internal_log_modules
  ├─ big_query_log_dir
  ├─ stream_load_task_keep_max_second
  ├─ sys_log_to_console
  ├─ slow_lock_log_every_ms
  ├─ loads_history_sync_interval_second
  ├─ loads_history_retained_days
  ├─ slow_lock_print_stack
  ├─ sys_log_format
  └─ slow_lock_threshold_ms
ERRORS:
  ├─ Generation failed for internal_log_json_format: 'NoneType' object is not iterable
  ├─ Generation failed for max_task_consecutive_fail_count: 'NoneType' object is not iterable
  ├─ Generation failed for task_runs_timeout_second: 'NoneType' object is not iterable    
```

This Pr is generated by [DocsAgent](https://github.com/StarRocks/DocsAgent)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3