### PR TITLE
[BugFix] Fix encode_fingerprint_sha256 crash in ASAN mode

### DIFF
--- a/be/src/exprs/agg/data_sketch/ds_theta.cpp
+++ b/be/src/exprs/agg/data_sketch/ds_theta.cpp
@@ -17,13 +17,14 @@
 #include <memory>
 #include <string>
 
+#include "common/status.h"
 #include "util/slice.h"
 
 namespace starrocks {
 
 DataSketchesTheta::DataSketchesTheta(const Slice& src, int64_t* memory_usage) : _memory_usage(memory_usage) {
     if (!deserialize(src)) {
-        LOG(WARNING) << "Failed to init DataSketchesFrequent from slice, will be reset to 0.";
+        DLOG(INFO) << "Failed to init DataSketchesTheta from slice, will be reset to 0.";
     }
 }
 
@@ -83,7 +84,7 @@ bool DataSketchesTheta::deserialize(const Slice& slice) {
         auto sk = wrapped_compact_theta_sketch::wrap(slice.get_data(), slice.get_size());
         get_sketch_union()->update(sk);
     } catch (std::logic_error& e) {
-        LOG(WARNING) << "DataSketchesTheta deserialize error: " << e.what();
+        DLOG(INFO) << "DataSketchesTheta deserialize error with exception:" << e.what();
         return false;
     }
     return true;

--- a/be/src/exprs/agg/data_sketch/ds_theta.cpp
+++ b/be/src/exprs/agg/data_sketch/ds_theta.cpp
@@ -14,10 +14,11 @@
 
 #include "exprs/agg/data_sketch/ds_theta.h"
 
+#include <glog/logging.h>
+
 #include <memory>
 #include <string>
 
-#include "common/status.h"
 #include "util/slice.h"
 
 namespace starrocks {

--- a/be/src/types/hll_sketch.cpp
+++ b/be/src/types/hll_sketch.cpp
@@ -24,7 +24,7 @@ namespace starrocks {
 
 DataSketchesHll::DataSketchesHll(const Slice& src, int64_t* memory_usage) : _memory_usage(memory_usage) {
     if (!deserialize(src)) {
-        LOG(WARNING) << "Failed to init DataSketchHll from slice, will be reset to 0.";
+        DLOG(INFO) << "Failed to init DataSketchesHll from slice, will be reset to 0.";
     }
 }
 
@@ -101,7 +101,7 @@ bool DataSketchesHll::deserialize(const Slice& slice) {
         _sketch_union->update(*sketch);
         this->mark_changed();
     } catch (std::logic_error& e) {
-        LOG(WARNING) << "DataSketchesHll deserialize error: " << e.what();
+        DLOG(INFO) << "DataSketchesHll deserialize error with exception:" << e.what();
         return false;
     }
 

--- a/be/src/types/hll_sketch.cpp
+++ b/be/src/types/hll_sketch.cpp
@@ -17,7 +17,8 @@
 
 #include "types/hll_sketch.h"
 
-#include "common/logging.h"
+#include <glog/logging.h>
+
 #include "runtime/mem_pool.h"
 
 namespace starrocks {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Avoids crashes in ENCODE_FINGERPRINT_SHA256 by null-guarding only-null columns and adds DCHECKs; downgrades some datasketch warnings to debug logs using glog.
> 
> - **Encryption/Hashing**:
>   - `encode_fingerprint_sha256`: Treats `only_null` columns as `nullptr` and adds null-aware handling in `EncodeColumnToDigest` (with `DCHECK`s) to prevent dereferencing and crashes.
> - **DataSketches**:
>   - Switch to `glog` and downgrade error logs to `DLOG(INFO)` in `exprs/agg/data_sketch/ds_theta.cpp` and `types/hll_sketch.cpp`; update log messages during initialization/deserialization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e0c32d031c6d65ae054108188c00e75f47d0330. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->