### PR TITLE
[BugFix] Fix ABI compile error in clang

### DIFF
--- a/be/src/util/raw_container.h
+++ b/be/src/util/raw_container.h
@@ -129,9 +129,16 @@ public:
 
 // see details about ABI compatibility issue https://github.com/StarRocks/starrocks/issues/233
 #if _GLIBCXX_USE_CXX11_ABI
+// GNU libstdc++ with new CXX11 ABI
+using RawString = std::basic_string<char, std::char_traits<char>, RawAllocator<char, 0>>;
+using RawStringPad16 = std::basic_string<char, std::char_traits<char>, RawAllocator<char, 16>>;
+#elif defined(_LIBCPP_VERSION)
+// LLVM libc++ (used on macOS and some Linux systems)
+// libc++ never used COW semantics, so RawString optimization is safe
 using RawString = std::basic_string<char, std::char_traits<char>, RawAllocator<char, 0>>;
 using RawStringPad16 = std::basic_string<char, std::char_traits<char>, RawAllocator<char, 16>>;
 #else
+// Old GNU libstdc++ ABI (COW semantics) - not compatible with RawString optimization
 #error "Cannot use RawString optimization with old CXX11 ABI"
 #endif
 // From cpp reference: "A trivial destructor is a destructor that performs no action. Objects with


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Gate `RawString`/`RawStringPad16` typedefs on detected standard library/ABI and add a libc++ path to fix clang/libc++ compilation.
> 
> - **ABI handling in `be/src/util/raw_container.h`**:
>   - Conditionally define `RawString` and `RawStringPad16` using `RawAllocator` based on stdlib/ABI:
>     - GNU libstdc++ with new C++11 ABI (`_GLIBCXX_USE_CXX11_ABI`).
>     - LLVM libc++ (`_LIBCPP_VERSION`).
>   - Emit compile error for old GNU libstdc++ (COW) ABI to prevent unsafe optimization.
>   - Add clarifying comments for each branch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e79fa93e1e9d79035948a0b6e9b03f3390b4d5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->