### PR TITLE
[Doc] docs(be_config): update en, zh, ja documentation

### DIFF
--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -109,6 +109,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - Description: When a single allocation request exceeds the configured large-allocation threshold (g_large_memory_alloc_failure_threshold `>` 0 and requested size `>` threshold), this flag controls how the process responds. If true, StarRocks calls std::abort() immediately (hard crash) when such a large allocation is detected. If false, the allocation is blocked and the allocator returns failure (nullptr or ENOMEM) so callers can handle the error. This check only takes effect for allocations that are not wrapped with the TRY_CATCH_BAD_ALLOC path (the mem hook uses a different flow when bad-alloc is being caught). Enable for fail-fast debugging of unexpected huge allocations; keep disabled in production unless you want an immediate process abort on over-large allocation attempts.
 - Introduced in: v3.4.3, 3.5.0, 4.0.0
 
+##### arrow_flight_port
+
+- Default: `-1`
+- Type: Int
+- Unit: Port
+- Is mutable: No
+- Description: TCP port for the BE Arrow Flight SQL server. Set to `-1` to disable the Arrow Flight service. On non-macOS builds the BE invokes ArrowFlightSqlServer::start(`arrow_flight_port`) during startup; if the port is unavailable the server startup fails and the BE process exits. The configured port is reported to the FE in the heartbeat payload (`arrow_flight_port`). Configure this value in `be.conf` before starting the BE.
+- Introduced in: `v3.4.0, v3.5.0`
+
 ##### be_exit_after_disk_write_hang_second
 
 - Default: 60
@@ -342,6 +351,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - Is mutable: No
 - Description: Connection timeout (in seconds) used when creating Thrift clients. ClientCacheHelper::_create_client multiplies this value by 1000 and passes it to ThriftClientImpl::set_conn_timeout(), so it controls the TCP/connect handshake timeout for new Thrift connections opened by the BE client cache. This setting affects only connection establishment; send/receive timeouts are configured separately. Very small values can cause spurious connection failures on high-latency networks, while large values delay detection of unreachable peers.
 - Introduced in: v3.2.0
+
+##### thrift_port
+
+- Default: `0`
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: Port number used to export the internal Thrift-based BackendService (ImpalaInternalService). When the process runs as CN (control node) and `thrift_port` is non-zero, it overrides `be_port` and the Thrift server binds to this value; otherwise `be_port` is used. This option is deprecated — setting a non-zero `thrift_port` logs a warning advising to use `be_port` instead. Ensure the chosen port is available and permitted by host network/firewall settings.
+- Introduced in: `v3.2.0`
 
 ##### thrift_rpc_connection_max_valid_time_ms
 
@@ -1096,6 +1114,15 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Is mutable: No
 - Description: Timeout (in seconds) used by backend broker operations for write/IO RPCs. The value is multiplied by 1000 to produce millisecond timeouts and is passed as the default timeout_ms to BrokerFileSystem and BrokerServiceConnection instances (e.g., file export and snapshot upload/download). Increase this when brokers or network are slow or when transferring large files to avoid premature timeouts; decreasing it may cause broker RPCs to fail earlier. This value is defined in common/config and is applied at process start (not dynamically reloadable).
 - Introduced in: v3.2.0
+
+##### enable_load_channel_rpc_async
+
+- Default: `true`
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: When enabled, handling of load-channel open RPCs (e.g., PTabletWriterOpen) is offloaded from the BRPC worker to a dedicated thread pool: the request handler creates a ChannelOpenTask and submits it to the internal `_async_rpc_pool` instead of running `LoadChannelMgr::_open` inline. This reduces work and blocking inside BRPC threads and lets you tune concurrency via `load_channel_rpc_thread_pool_num` and `load_channel_rpc_thread_pool_queue_size`. If the thread-pool submission fails (pool is full or shut down), the request is canceled and an error status is returned. The pool is shut down on `LoadChannelMgr::close()`, so consider capacity and lifecycle when enabling to avoid request rejections or delayed processing.
+- Introduced in: `v3.5.0`
 
 ##### pull_load_task_dir
 

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -111,12 +111,12 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 ##### arrow_flight_port
 
-- Default: `-1`
+- Default: -1
 - Type: Int
-- Unit: Port
+- Unit: -
 - Is mutable: No
-- Description: TCP port for the BE Arrow Flight SQL server. Set to `-1` to disable the Arrow Flight service. On non-macOS builds the BE invokes ArrowFlightSqlServer::start(`arrow_flight_port`) during startup; if the port is unavailable the server startup fails and the BE process exits. The configured port is reported to the FE in the heartbeat payload (`arrow_flight_port`). Configure this value in `be.conf` before starting the BE.
-- Introduced in: `v3.4.0, v3.5.0`
+- Description: TCP port for the BE Arrow Flight SQL server. `-1` indicaes to disable the Arrow Flight service. On non-macOS builds, BE invokes Arrow Flight SQL Server with this port during startup; if the port is unavailable, the server startup fails and the BE process exits. The configured port is reported to the FE in the heartbeat payload.
+- Introduced in: v3.4.0, v3.5.0
 
 ##### be_exit_after_disk_write_hang_second
 
@@ -354,12 +354,12 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 ##### thrift_port
 
-- Default: `0`
+- Default: 0
 - Type: Int
 - Unit: -
 - Is mutable: No
-- Description: Port number used to export the internal Thrift-based BackendService (ImpalaInternalService). When the process runs as CN (control node) and `thrift_port` is non-zero, it overrides `be_port` and the Thrift server binds to this value; otherwise `be_port` is used. This option is deprecated — setting a non-zero `thrift_port` logs a warning advising to use `be_port` instead. Ensure the chosen port is available and permitted by host network/firewall settings.
-- Introduced in: `v3.2.0`
+- Description: Port used to export the internal Thrift-based BackendService. When the process runs as a Compute Node and this item is set to a non-zero value, it overrides `be_port` and the Thrift server binds to this value; otherwise `be_port` is used. This configuration is deprecated — setting a non-zero `thrift_port` logs a warning advising to use `be_port` instead.
+- Introduced in: v3.2.0
 
 ##### thrift_rpc_connection_max_valid_time_ms
 
@@ -1117,12 +1117,12 @@ When this value is set to less than `0`, the system uses the product of its abso
 
 ##### enable_load_channel_rpc_async
 
-- Default: `true`
+- Default: true
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: When enabled, handling of load-channel open RPCs (e.g., PTabletWriterOpen) is offloaded from the BRPC worker to a dedicated thread pool: the request handler creates a ChannelOpenTask and submits it to the internal `_async_rpc_pool` instead of running `LoadChannelMgr::_open` inline. This reduces work and blocking inside BRPC threads and lets you tune concurrency via `load_channel_rpc_thread_pool_num` and `load_channel_rpc_thread_pool_queue_size`. If the thread-pool submission fails (pool is full or shut down), the request is canceled and an error status is returned. The pool is shut down on `LoadChannelMgr::close()`, so consider capacity and lifecycle when enabling to avoid request rejections or delayed processing.
-- Introduced in: `v3.5.0`
+- Description: When enabled, handling of load-channel open RPCs (for example, `PTabletWriterOpen`) is offloaded from the BRPC worker to a dedicated thread pool: the request handler creates a `ChannelOpenTask` and submits it to the internal `_async_rpc_pool` instead of running `LoadChannelMgr::_open` inline. This reduces work and blocking inside BRPC threads and allows tuning concurrency via `load_channel_rpc_thread_pool_num` and `load_channel_rpc_thread_pool_queue_size`. If the thread pool submission fails (when pool is full or shut down), the request is canceled and an error status is returned. The pool is shut down on `LoadChannelMgr::close()`, so consider capacity and lifecycle when you want to enable this feature so as to avoid request rejections or delayed processing.
+- Introduced in: v3.5.0
 
 ##### pull_load_task_dir
 

--- a/docs/ja/administration/management/BE_configuration.md
+++ b/docs/ja/administration/management/BE_configuration.md
@@ -110,12 +110,12 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 ##### arrow_flight_port
 
-- デフォルト: `-1`
+- デフォルト: -1
 - タイプ: Int
 - 単位: Port
 - 変更可能: いいえ
-- 説明: BE の Arrow Flight SQL サーバー用の TCP ポート。Arrow Flight サービスを無効化するには `-1` に設定します。macOS 以外のビルドでは、BE は起動時に ArrowFlightSqlServer::start(`arrow_flight_port`) を呼び出します。ポートが利用できない場合、サーバーの起動は失敗し BE プロセスは終了します。設定されたポートはハートビートペイロード（`arrow_flight_port`）で FE に報告されます。BE を起動する前に `be.conf` でこの値を設定してください。
-- 導入バージョン: `v3.4.0, v3.5.0`
+- 説明: BE の Arrow Flight SQL サーバー用の TCP ポート。Arrow Flight サービスを無効化するには `-1` に設定します。macOS 以外のビルドでは、BE は起動時に Arrow Flight SQL Server を呼び出します。ポートが利用できない場合、サーバーの起動は失敗し BE プロセスは終了します。設定されたポートは HeartBeat Payload で FE に報告されます。BE を起動する前に `be.conf` でこの値を設定してください。
+- 導入バージョン: v3.4.0, v3.5.0
 
 ##### be_exit_after_disk_write_hang_second
 
@@ -347,7 +347,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 ##### ssl_certificate_path
 
-- デフォルト: 
+- デフォルト: 空の文字列
 - タイプ: String
 - 単位: -
 - 変更可能: No

--- a/docs/ja/administration/management/BE_configuration.md
+++ b/docs/ja/administration/management/BE_configuration.md
@@ -108,6 +108,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 説明: 単一の割り当て要求が設定された large-allocation 閾値を超えた場合（g_large_memory_alloc_failure_threshold > 0 かつ 要求サイズ > 閾値）、プロセスがどのように応答するかを制御します。true の場合、こうした大きな割り当てが検出されると直ちに std::abort() を呼び出して（ハードクラッシュ）終了します。false の場合は割り当てがブロックされ、アロケータは失敗（nullptr または ENOMEM）を返すため、呼び出し元がエラーを処理できます。このチェックは TRY_CATCH_BAD_ALLOC パスでラップされていない割り当てに対してのみ有効です（mem hook は bad-alloc を捕捉している場合に別のフローを使用します）。予期しない巨大な割り当ての fail-fast デバッグ目的で有効にしてください。運用環境では、過大な割り当て試行で即時プロセス中断を望む場合を除き無効のままにしてください。
 - 導入バージョン: 3.4.3, 3.5.0, 4.0.0
 
+##### arrow_flight_port
+
+- デフォルト: `-1`
+- タイプ: Int
+- 単位: Port
+- 変更可能: いいえ
+- 説明: BE の Arrow Flight SQL サーバー用の TCP ポート。Arrow Flight サービスを無効化するには `-1` に設定します。macOS 以外のビルドでは、BE は起動時に ArrowFlightSqlServer::start(`arrow_flight_port`) を呼び出します。ポートが利用できない場合、サーバーの起動は失敗し BE プロセスは終了します。設定されたポートはハートビートペイロード（`arrow_flight_port`）で FE に報告されます。BE を起動する前に `be.conf` でこの値を設定してください。
+- 導入バージョン: `v3.4.0, v3.5.0`
+
 ##### be_exit_after_disk_write_hang_second
 
 - デフォルト: 60
@@ -189,6 +198,33 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 説明: BE 間の RPC で行バッチを圧縮するかどうかを制御するブール値です。`true` は行バッチを圧縮することを示し、`false` は圧縮しないことを示します。
 - 導入バージョン: -
 
+##### delete_worker_count_normal_priority
+
+- デフォルト: 2
+- タイプ: Int
+- 単位: Threads
+- 変更可能: No
+- 説明: BE エージェント上で delete (REALTIME_PUSH with DELETE) タスクを処理するために割り当てられる通常優先度のワーカースレッド数。起動時にこの値は delete_worker_count_high_priority に加算されて DeleteTaskWorkerPool のサイズ決定に使われます（agent_server.cpp を参照）。プールは最初の delete_worker_count_high_priority スレッドを HIGH 優先度として割り当て、残りを NORMAL とします。通常優先度スレッドは標準の delete タスクを処理し、全体の削除スループットに寄与します。並行削除容量を上げるには増やしてください（CPU/IO 使用量が増加します）。リソース競合を減らすには減らしてください。
+- 導入バージョン: v3.2.0
+
+##### enable_https
+
+- デフォルト: false
+- タイプ: Boolean
+- 単位: -
+- 変更可能: No
+- 説明: この項目が `true` に設定されると、BE の bRPC サーバは TLS を使用するように構成されます: `ServerOptions.ssl_options` は BE 起動時に `ssl_certificate_path` と `ssl_private_key_path` で指定された証明書と秘密鍵で設定されます。これにより受信 bRPC 接続に対して HTTPS/TLS が有効になり、クライアントは TLS を用いて接続する必要があります。証明書および鍵ファイルが存在し、BE プロセスからアクセス可能であり、bRPC/SSL の要件に合致していることを確認してください。
+- 導入バージョン: v4.0.0
+
+##### enable_jemalloc_memory_tracker
+
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: No
+- 説明: この項目が `true` に設定されていると、BE はバックグラウンドスレッド（jemalloc_tracker_daemon）を起動し、jemalloc の統計を1秒ごとにポーリングして、jemalloc の "stats.metadata" 値で GlobalEnv の jemalloc メタデータ MemTracker を更新します。これにより jemalloc のメタデータ消費が StarRocks プロセスのメモリ集計に含まれ、jemalloc 内部により使用されるメモリの過小報告を防ぎます。トラッカーは macOS 以外のビルド（#ifndef __APPLE__）でのみコンパイル/起動され、"jemalloc_tracker_daemon" という名前のデーモンスレッドとして動作します。この設定は起動時の振る舞いや MemTracker の状態を維持するスレッドに影響するため、変更には再起動が必要です。jemalloc を使用していない場合、または jemalloc のトラッキングを別途意図的に管理している場合のみ無効にし、それ以外は正確なメモリ集計と割り当て保護を維持するために有効のままにしてください。
+- 導入バージョン: v3.2.12
+
 ##### heartbeat_service_port
 
 - デフォルト: 9050
@@ -242,6 +278,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 可変: はい
 - 説明: thrift クライアントがリトライする時間間隔。
 - 導入バージョン: -
+
+##### thrift_connect_timeout_seconds
+
+- デフォルト: 3
+- タイプ: Int
+- 単位: Seconds
+- 変更可能: No
+- 説明: Thrift クライアントを作成する際に使用される接続タイムアウト（秒）。ClientCacheHelper::_create_client はこの値に 1000 を掛けて ThriftClientImpl::set_conn_timeout() に渡すため、BE クライアントキャッシュによってオープンされる新しい Thrift 接続の TCP/接続ハンドシェイクのタイムアウトを制御します。この設定は接続確立にのみ影響し、送受信タイムアウトは別途設定されます。非常に小さい値は高レイテンシのネットワークで誤検知による接続失敗を引き起こす可能性があり、大きすぎる値は到達不能なピアの検出を遅らせます。
+- 導入バージョン: v3.2.0
 
 ##### thrift_rpc_connection_max_valid_time_ms
 
@@ -299,6 +344,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 導入バージョン: 3.2.3
 
 ### ユーザー、ロール、および権限
+
+##### ssl_certificate_path
+
+- デフォルト: 
+- タイプ: String
+- 単位: -
+- 変更可能: No
+- 説明: `enable_https` が true のときに BE の brpc サーバが使用する TLS/SSL 証明書ファイル（PEM）への絶対パス。BE 起動時にこの値は `brpc::ServerOptions::ssl_options().default_cert.certificate` にコピーされます。対応する秘密鍵は必ず `ssl_private_key_path` に設定してください。必要に応じてサーバ証明書および中間証明書を PEM 形式（証明書チェーン）で提供してください。ファイルは StarRocks BE プロセスから読み取り可能でなければならず、起動時にのみ適用されます。`enable_https` が有効でこの値が未設定または無効な場合、brpc の TLS 設定が失敗しサーバが正しく起動できない可能性があります。
+- 導入バージョン: v4.0.0
 
 ### クエリエンジン
 
@@ -940,6 +994,24 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 導入バージョン: -
 
 ### ロードとアンロード
+
+##### broker_write_timeout_seconds
+
+- デフォルト: 30
+- タイプ: int
+- 単位: Seconds
+- 変更可能: No
+- 説明: バックエンドの broker 操作で書き込み/IO RPC に使用されるタイムアウト（秒）。この値は 1000 を掛けられてミリ秒タイムアウトとなり、BrokerFileSystem および BrokerServiceConnection インスタンス（例：ファイルエクスポートやスナップショットのアップロード/ダウンロード）にデフォルトの timeout_ms として渡されます。broker やネットワークが遅い場合、または大きなファイルを転送する場合は早期タイムアウトを避けるために増やしてください；減らすと broker RPC が早期に失敗する可能性があります。この値は common/config に定義され、プロセス起動時に適用されます（動的リロード不可）。
+- 導入バージョン: v3.2.0
+
+##### enable_load_channel_rpc_async
+
+- デフォルト: `true`
+- タイプ: Boolean
+- 単位: -
+- 変更可能: はい
+- 説明: 有効にすると、load-channel の open RPC（例: PTabletWriterOpen）の処理が BRPC ワーカーから専用のスレッドプールへオフロードされます。リクエストハンドラは ChannelOpenTask を生成して内部 `_async_rpc_pool` に投入し、`LoadChannelMgr::_open` をインラインで実行しません。これにより BRPC スレッド内の作業量とブロッキングが減少し、`load_channel_rpc_thread_pool_num` と `load_channel_rpc_thread_pool_queue_size` で同時実行性を調整できるようになります。スレッドプールへの投入が失敗する（プールが満杯またはシャットダウン済み）と、リクエストはキャンセルされエラー状態が返されます。プールは `LoadChannelMgr::close()` でシャットダウンされるため、有効化する際は容量とライフサイクルを考慮し、リクエストの拒否や処理遅延を避けるようにしてください。
+- 導入バージョン: `v3.5.0`
 
 ### 統計レポート
 
@@ -1814,6 +1886,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 ### 共有データ
 
+##### download_buffer_size
+
+- デフォルト: 4194304
+- タイプ: Int
+- 単位: Bytes
+- 変更可能: Yes
+- 説明: スナップショットファイルをダウンロードする際に使用されるメモリ内コピー用バッファのサイズ（バイト）。SnapshotLoader::download はこの値を fs::copy に対してリモートの sequential file からローカルの writable file へ読み込む際の 1 回あたりのチャンクサイズとして渡します。帯域幅の大きいリンクでは、より大きな値にすることで syscall/IO オーバーヘッドが減りスループットが向上する可能性があります。小さい値はアクティブな転送ごとのピークメモリ使用量を削減します。注意: このパラメータはストリームごとのバッファサイズを制御するものであり、ダウンロードスレッド数を制御するものではありません — 総メモリ消費量 = download_buffer_size * number_of_concurrent_downloads です。
+- 導入バージョン: v3.2.13
+
 ##### graceful_exit_wait_for_frontend_heartbeat
 
 - デフォルト: false
@@ -2215,6 +2296,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 可変: いいえ
 - 説明: to_base64() 関数の入力値の最大長。
 - 導入バージョン: -
+
+##### memory_high_level
+
+- デフォルト: 75
+- タイプ: Long
+- 単位: Percent
+- 変更可能: Yes
+- 説明: プロセスのメモリ上限に対する割合で表されるハイウォーターメモリ閾値。総メモリ使用量がこの割合を超えると、BE はメモリ圧力を緩和するために徐々にメモリを解放し始めます（現在はデータキャッシュと更新キャッシュの追い出しで実施）。モニタはこの値を用いて memory_high = mem_limit * memory_high_level / 100 を計算し、消費量が `>` memory_high の場合は GC アドバイザに導かれた制御されたエビクションを行います；消費量が別の設定である memory_urgent_level を超えると、より攻撃的な即時削減が行われます。この値は閾値超過時に一部のメモリ集約的な操作（例えば primary-key preload）を無効化するかどうかの判断にも使われます。memory_urgent_level と合わせた検証を満たす必要があります（memory_urgent_level `>` memory_high_level、memory_high_level `>=` 1、memory_urgent_level `<=` 100）。
+- 導入バージョン: v3.2.0
 
 ##### report_exec_rpc_request_retry_num
 

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -98,12 +98,12 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 ##### arrow_flight_port
 
-- 默认值: `-1`
+- 默认值: -1
 - 类型: Int
 - 单位: Port
 - 是否可变: 否
-- 描述: TCP 端口，用于 BE 的 Arrow Flight SQL 服务器。将其设置为 `-1` 以禁用 Arrow Flight 服务。在非 macOS 构建中，BE 在启动期间会调用 ArrowFlightSqlServer::start(`arrow_flight_port`)；如果端口不可用，服务器启动会失败并且 BE 进程退出。配置的端口会在心跳负载（`arrow_flight_port`）中上报给 FE。在启动 BE 之前在 `be.conf` 中配置此值。
-- 引入版本: `v3.4.0, v3.5.0`
+- 描述: TCP 端口，用于 BE 的 Arrow Flight SQL 服务器。将其设置为 `-1` 以禁用 Arrow Flight 服务。在非 macOS 构建中，BE 在启动期间会调用通过该端口启动 Arrow Flight SQL Server；如果端口不可用，服务器启动会失败并且 BE 进程退出。配置的端口会在心跳负载中上报给 FE。
+- 引入版本: v3.4.0, v3.5.0
 
 ##### be_exit_after_disk_write_hang_second
 
@@ -201,7 +201,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 类型: Boolean
 - 单位: -
 - 是否可变: No
-- 描述: 当此项设置为 `true` 时，BE 的 bRPC 服务配置为使用 TLS：在 BE 启动时，`ServerOptions.ssl_options` 会用 `ssl_certificate_path` 和 `ssl_private_key_path` 指定的证书和私钥填充。这样会为传入的 bRPC 连接启用 HTTPS/TLS；客户端必须使用 TLS 连接。确保证书和密钥文件存在、对 BE 进程可访问，并符合 bRPC/SSL 的要求。
+- 描述: 当此项设置为 `true` 时，BE 的 bRPC 服务配置为使用 TLS，并使用 `ssl_certificate_path` 和 `ssl_private_key_path` 指定的证书和私钥。这样会为传入的 bRPC 连接启用 HTTPS/TLS。客户端必须使用 TLS 连接。请确保证书和密钥文件存在、且 BE 进程可访问，并符合 bRPC/SSL 的要求。
 - 引入版本: v4.0.0
 
 ##### enable_jemalloc_memory_tracker
@@ -219,7 +219,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 类型: Int
 - 単位: -
 - 是否可变: 是
-- 描述: 为 UpdateManager 中的 "get_pindex" 线程池设置工作线程数，该线程池用于加载/获取持久化索引数据（在为主键表应用 rowset 时使用）。在运行时，配置更新会调整池的最大线程数：如果 `>0` 则应用该值；如果为 0 则运行时回调使用 CPU 核心数 (CpuInfo::num_cores())。在初始化时，池的最大线程数计算为 max(get_pindex_worker_count, max_apply_thread_cnt * 2)，其中 max_apply_thread_cnt 是 apply-thread 池的最大值。增大此值可提高 pindex 加载的并行度；降低则减少并发和内存/CPU 使用。
+- 描述: 为 UpdateManager 中的 "get_pindex" 线程池设置工作线程数，该线程池用于加载/获取持久化索引数据（在为主键表应用 rowset 时使用）。如果设置为大于 0 则系统应用该值；如果设置为 0 则运行时回调使用 CPU 核心数。在初始化时，改线程池的最大线程数计算为 `max(get_pindex_worker_count, max_apply_thread_cnt * 2)`，其中 `max_apply_thread_cnt` 是 apply-thread 池的最大值。增大此值可提高 pindex 加载的并行度；降低则减少并发和内存/CPU 使用。
 - 引入版本: v3.2.0
 
 ##### heartbeat_service_port
@@ -327,7 +327,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 类型: Int
 - 単位: Threads
 - 是否可变: 是
-- 描述: 为 BE 的 UpdateManager 中的 "update_apply" 线程池设置最小线程数——该线程池用于为主键表应用 rowset。值为 0 表示禁用固定最小值（不强制下限）；当 transaction_apply_worker_count 也为 0 时，池的最大线程数默认为 CPU 核心数，因此有效的工作线程容量等于 CPU 核心数。可以增大此值以保证应用事务的基线并发；设置过高可能增加 CPU 争用。更改通过 update_config HTTP 处理器在运行时生效（它会在 apply 线程池上调用 update_min_threads）。
+- 描述: 为 BE 的 UpdateManager 中的 "update_apply" 线程池设置最小线程数。该线程池用于为主键表应用 rowset。值为 0 表示禁用固定最小值（不强制下限）；当 `transaction_apply_worker_count` 也为 0 时，该线程池的最大线程数默认为 CPU 核心数，因此有效的工作线程容量等于 CPU 核心数。可以增大此值以保证应用事务的基线并发；设置过高可能增加 CPU 争用。
 - 引入版本: v3.2.11
 
 ### 元数据与集群管理
@@ -337,8 +337,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值: -1
 - 类型: Int
 - 单位: -
-- 是否可变: No
-- 描述: 该 StarRocks 后端的全局集群标识符。启动时 StorageEngine 会将 config::cluster_id 读入其生效的 cluster id，并验证所有 data root 路径都包含相同的 cluster id（参见 StorageEngine::_check_all_root_path_cluster_id）。值为 -1 表示“未设置”——引擎可以从现有数据目录或来自 master 心跳推导出生效的 id。如果配置了非负 id，则配置的 id 与存储在数据目录中的 id 之间的任何不匹配都会导致启动验证失败（Status::Corruption）。当某些 root 缺少 id 并且引擎被允许写入 id（options.need_write_cluster_id）时，它会将生效的 id 持久化到那些 root 中。
+- 是否可变: 否
+- 描述: BE 节点在集群的全局集群标识符。具有相同集群 ID 的 FE 或 BE 属于同一个 StarRocks 集群。取值范围：正整数。默认值 -1 表示在 Leader FE 首次启动时随机生成一个。
 - 引入版本: v3.2.0
 
 ### 用户，角色及权限
@@ -977,11 +977,11 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 ##### enable_load_channel_rpc_async
 
-- 默认值: `true`
+- 默认值: true
 - 类型: Boolean
 - 单位: -
 - 是否可变: 是
-- 描述: 启用后，load-channel 打开类型的 RPC（例如 PTabletWriterOpen）的处理会从 BRPC worker 卸载到一个专用的线程池：请求处理器会创建一个 ChannelOpenTask 并将其提交到内部 `_async_rpc_pool`，而不是内联执行 `LoadChannelMgr::_open`。这样可以减少 BRPC 线程内的工作量和阻塞，并允许通过 `load_channel_rpc_thread_pool_num` 和 `load_channel_rpc_thread_pool_queue_size` 调整并发。如果线程池提交失败（池已满或已关闭），该请求会被取消并返回错误状态。该线程池会在 `LoadChannelMgr::close()` 时关闭，因此在启用该功能时需要考虑容量和生命周期，以避免请求被拒绝或处理延迟。
+- 描述: 启用后，load-channel Open 类型的 RPC（例如 PTabletWriterOpen）的处理会从 BRPC worker 转移到一个专用的线程池：请求处理器会创建一个 ChannelOpenTask 并将其提交到内部 `_async_rpc_pool`，而不是内联执行 `LoadChannelMgr::_open`。这样可以减少 BRPC 线程内的工作量和阻塞，并允许通过 `load_channel_rpc_thread_pool_num` 和 `load_channel_rpc_thread_pool_queue_size` 调整并发。如果线程池提交失败（池已满或已关闭），该请求会被取消并返回错误状态。该线程池会在 `LoadChannelMgr::close()` 时关闭，因此在启用该功能时需要考虑容量和生命周期，以避免请求被拒绝或处理延迟。
 - 引入版本: `v3.5.0`
 
 ##### pull_load_task_dir
@@ -990,7 +990,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 类型: string
 - 単位: -
 - 是否可变: No
-- 描述: BE 存储 “pull load” 任务的数据和工作文件（下载的源文件、任务状态、临时输出等）的文件系统路径。该目录必须对 BE 进程可写，并且具有足够的磁盘空间以容纳即将到来的加载。默认值相对于 STARROCKS_HOME；测试会创建并期望该目录存在（参见测试配置）。
+- 描述: BE 存储 “pull load” 任务的数据和工作文件（下载的源文件、任务状态、临时输出等）的文件系统路径。该目录必须对 BE 进程可写，并且具有足够的磁盘空间以容纳下载的内容。
 - 引入版本: v3.2.0
 
 ### 统计信息
@@ -1165,7 +1165,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 类型: Int
 - 单位: Bytes
 - 是否可变: No
-- 描述: 构建列数据与索引页时使用的目标未压缩页面大小（以字节为单位）。该值会被拷贝到 ColumnWriterOptions.data_page_size 和 IndexedColumnWriterOptions.index_page_size，并被页面构建器（例如 BinaryPlainPageBuilder::is_page_full 和缓冲区预留逻辑）用来决定何时完成一个页面以及预留多少内存。值为 0 会在构建器中禁用页面大小限制。更改此值会影响页面数量、元数据开销、内存预留以及 I/O/压缩的权衡（页面越小 → 页面数和元数据越多；页面越大 → 页面更少，压缩可能更好，但内存峰值可能更大）。
+- 描述: 构建列数据与索引页时使用的目标未压缩 Page 大小（以字节为单位）。该值会被 Page Builder 用来决定何时完成一个 Page 以及预留多少内存。值为 0 会在构建器中禁用 Page 大小限制。更改此值会影响 Page 数量、元数据开销、内存预留以及 I/O/压缩的权衡（Page 越小 → Page 数和元数据越多；Page 越大 → Page 更少，压缩比更大，但内存峰值可能更大）。
 - 引入版本: v3.2.4
 
 ##### default_num_rows_per_column_file_block
@@ -1308,9 +1308,9 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值: false
 - 类型: Boolean
 - 单位: -
-- 是否可变: No
-- 描述: 启用后，StarRocks 将为新写入的存储对象（segment 文件、delete/update 文件、rowset segments、lake SSTs、persistent index 文件等）创建磁盘加密产物。写入路径（RowsetWriter/SegmentWriter、lake UpdateManager/LakePersistentIndex 及相关代码路径）会从 KeyCache 请求加密信息，将 encryption_info 附加到可写文件，并将 encryption_meta 持久化到 rowset / segment / sstable 元数据中（如 segment_encryption_metas、delete/update encryption metadata）。Frontend 与 Backend/CN 的加密标志必须匹配——不匹配会导致 BE 在心跳时中止（LOG(FATAL)）。此标志不可在运行时修改；请在部署前启用，并确保密钥管理（KEK）与 KeyCache 已在集群中正确配置并同步。
-- 引入版本: v3.3.1, 3.4.0, 3.5.0, 4.0.0
+- 是否可变: 否
+- 描述: 启用后，StarRocks 将为新写入的存储对象（segment 文件、delete/update 文件、rowset segments、lake SSTs、persistent index 文件等）进行磁盘加密。写入路径（RowsetWriter/SegmentWriter、lake UpdateManager/LakePersistentIndex 及相关代码路径）会从 KeyCache 请求加密信息，将 encryption_info 附加到可写文件，并将 encryption_meta 持久化到 rowset / segment / sstable 元数据中（如 segment_encryption_metas、delete/update encryption metadata）。FE 与 FE/CN 的加密标志必须匹配。如果不匹配会导致 BE 在心跳时中止（LOG(FATAL)）。此参数不可在运行时修改，必须在第一次部署集群前启用，并确保密钥管理（KEK）与 KeyCache 已在集群中正确配置并同步。
+- 引入版本: v3.3.1
 
 ##### file_descriptor_cache_clean_interval
 
@@ -2318,7 +2318,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值: 1048576 (1 MB)
 - 类型: long
 - 単位: Bytes
-- 是否可变: No
-- 描述: 从 INFO 日志文件读取并在 BE 调试 webserver 的日志页面上显示的最大字节数。该处理器使用此值计算一个 seek 偏移量（显示最后 N 字节），以避免读取或提供非常大的日志文件。如果日志文件小于该值则显示整个文件。注意：在当前实现中，用于读取并服务 INFO 日志的代码被注释掉了，处理器会报告无法打开 INFO 日志文件，因此除非启用日志服务代码，否则此参数可能无效。
+- 是否可变: 否
+- 描述: 从 INFO 日志文件读取并在 BE 调试 Web Server 的日志页面上显示的最大字节数。该处理器使用此值计算一个 seek 偏移量（显示最后 N 字节），以避免读取或提供非常大的日志文件。如果日志文件小于该值则显示整个文件。注意：在当前实现中，用于读取并服务 INFO 日志的代码被注释掉了，处理器会报告无法打开 INFO 日志文件，因此除非启用日志服务代码，否则此参数可能无效。
 - 引入版本: v3.2.0
 

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -96,6 +96,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 ### 服务器
 
+##### arrow_flight_port
+
+- 默认值: `-1`
+- 类型: Int
+- 单位: Port
+- 是否可变: 否
+- 描述: TCP 端口，用于 BE 的 Arrow Flight SQL 服务器。将其设置为 `-1` 以禁用 Arrow Flight 服务。在非 macOS 构建中，BE 在启动期间会调用 ArrowFlightSqlServer::start(`arrow_flight_port`)；如果端口不可用，服务器启动会失败并且 BE 进程退出。配置的端口会在心跳负载（`arrow_flight_port`）中上报给 FE。在启动 BE 之前在 `be.conf` 中配置此值。
+- 引入版本: `v3.4.0, v3.5.0`
+
 ##### be_exit_after_disk_write_hang_second
 
 - 默认值：60
@@ -186,6 +195,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：BE 之间 RPC 通信是否压缩 RowBatch，用于查询层之间的数据传输。`true` 表示压缩，`false` 表示不压缩。
 - 引入版本：-
 
+##### enable_https
+
+- 默认值: false
+- 类型: Boolean
+- 单位: -
+- 是否可变: No
+- 描述: 当此项设置为 `true` 时，BE 的 bRPC 服务配置为使用 TLS：在 BE 启动时，`ServerOptions.ssl_options` 会用 `ssl_certificate_path` 和 `ssl_private_key_path` 指定的证书和私钥填充。这样会为传入的 bRPC 连接启用 HTTPS/TLS；客户端必须使用 TLS 连接。确保证书和密钥文件存在、对 BE 进程可访问，并符合 bRPC/SSL 的要求。
+- 引入版本: v4.0.0
+
 ##### enable_jemalloc_memory_tracker
 
 - 默认值: true
@@ -194,6 +212,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 是否可变: 否
 - 描述: 该项设置为 `true` 时，BE 会启动一个后台线程（`jemalloc_tracker_daemon`），该线程以每秒一次的频率轮询 Jemalloc 统计信息，并将 Jemalloc 的 "stats.metadata" 值更新到 GlobalEnv 的 Jemalloc 元数据 MemTracker 中。这可确保 Jemalloc 元数据的消耗被计入 StarRocks 进程的内存统计，防止低报 Jemalloc 内部使用的内存。该 Tracker 仅在非 macOS 构建上编译/启动（#ifndef __APPLE__），并以名为 "jemalloc_tracker_daemon" 的守护线程运行。仅在未使用 Jemalloc 或者 Jemalloc 跟踪被有意以不同方式管理时才禁用，否则请保持启用以维护准确的内存计量和分配保护。
 - 引入版本: v3.2.12
+
+##### get_pindex_worker_count
+
+- 默认值: 0
+- 类型: Int
+- 単位: -
+- 是否可变: 是
+- 描述: 为 UpdateManager 中的 "get_pindex" 线程池设置工作线程数，该线程池用于加载/获取持久化索引数据（在为主键表应用 rowset 时使用）。在运行时，配置更新会调整池的最大线程数：如果 `>0` 则应用该值；如果为 0 则运行时回调使用 CPU 核心数 (CpuInfo::num_cores())。在初始化时，池的最大线程数计算为 max(get_pindex_worker_count, max_apply_thread_cnt * 2)，其中 max_apply_thread_cnt 是 apply-thread 池的最大值。增大此值可提高 pindex 加载的并行度；降低则减少并发和内存/CPU 使用。
+- 引入版本: v3.2.0
 
 ##### heartbeat_service_port
 
@@ -294,7 +321,25 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：Thrift RPC 超时的时长。
 - 引入版本：-
 
+##### transaction_apply_thread_pool_num_min
+
+- 默认值: 0
+- 类型: Int
+- 単位: Threads
+- 是否可变: 是
+- 描述: 为 BE 的 UpdateManager 中的 "update_apply" 线程池设置最小线程数——该线程池用于为主键表应用 rowset。值为 0 表示禁用固定最小值（不强制下限）；当 transaction_apply_worker_count 也为 0 时，池的最大线程数默认为 CPU 核心数，因此有效的工作线程容量等于 CPU 核心数。可以增大此值以保证应用事务的基线并发；设置过高可能增加 CPU 争用。更改通过 update_config HTTP 处理器在运行时生效（它会在 apply 线程池上调用 update_min_threads）。
+- 引入版本: v3.2.11
+
 ### 元数据与集群管理
+
+##### cluster_id
+
+- 默认值: -1
+- 类型: Int
+- 单位: -
+- 是否可变: No
+- 描述: 该 StarRocks 后端的全局集群标识符。启动时 StorageEngine 会将 config::cluster_id 读入其生效的 cluster id，并验证所有 data root 路径都包含相同的 cluster id（参见 StorageEngine::_check_all_root_path_cluster_id）。值为 -1 表示“未设置”——引擎可以从现有数据目录或来自 master 心跳推导出生效的 id。如果配置了非负 id，则配置的 id 与存储在数据目录中的 id 之间的任何不匹配都会导致启动验证失败（Status::Corruption）。当某些 root 缺少 id 并且引擎被允许写入 id（options.need_write_cluster_id）时，它会将生效的 id 持久化到那些 root 中。
+- 引入版本: v3.2.0
 
 ### 用户，角色及权限
 
@@ -930,6 +975,24 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 ### 导入导出
 
+##### enable_load_channel_rpc_async
+
+- 默认值: `true`
+- 类型: Boolean
+- 单位: -
+- 是否可变: 是
+- 描述: 启用后，load-channel 打开类型的 RPC（例如 PTabletWriterOpen）的处理会从 BRPC worker 卸载到一个专用的线程池：请求处理器会创建一个 ChannelOpenTask 并将其提交到内部 `_async_rpc_pool`，而不是内联执行 `LoadChannelMgr::_open`。这样可以减少 BRPC 线程内的工作量和阻塞，并允许通过 `load_channel_rpc_thread_pool_num` 和 `load_channel_rpc_thread_pool_queue_size` 调整并发。如果线程池提交失败（池已满或已关闭），该请求会被取消并返回错误状态。该线程池会在 `LoadChannelMgr::close()` 时关闭，因此在启用该功能时需要考虑容量和生命周期，以避免请求被拒绝或处理延迟。
+- 引入版本: `v3.5.0`
+
+##### pull_load_task_dir
+
+- 默认值: `${STARROCKS_HOME}/var/pull_load`
+- 类型: string
+- 単位: -
+- 是否可变: No
+- 描述: BE 存储 “pull load” 任务的数据和工作文件（下载的源文件、任务状态、临时输出等）的文件系统路径。该目录必须对 BE 进程可写，并且具有足够的磁盘空间以容纳即将到来的加载。默认值相对于 STARROCKS_HOME；测试会创建并期望该目录存在（参见测试配置）。
+- 引入版本: v3.2.0
+
 ### 统计信息
 
 ##### profile_report_interval
@@ -1096,6 +1159,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：每个磁盘 Cumulative Compaction 线程的数目。
 - 引入版本：-
 
+##### data_page_size
+
+- 默认值: 65536
+- 类型: Int
+- 单位: Bytes
+- 是否可变: No
+- 描述: 构建列数据与索引页时使用的目标未压缩页面大小（以字节为单位）。该值会被拷贝到 ColumnWriterOptions.data_page_size 和 IndexedColumnWriterOptions.index_page_size，并被页面构建器（例如 BinaryPlainPageBuilder::is_page_full 和缓冲区预留逻辑）用来决定何时完成一个页面以及预留多少内存。值为 0 会在构建器中禁用页面大小限制。更改此值会影响页面数量、元数据开销、内存预留以及 I/O/压缩的权衡（页面越小 → 页面数和元数据越多；页面越大 → 页面更少，压缩可能更好，但内存峰值可能更大）。
+- 引入版本: v3.2.4
+
 ##### default_num_rows_per_column_file_block
 
 - 默认值：1024
@@ -1230,6 +1302,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 是否动态：是
 - 描述：当enable_strict_delvec_crc_check设置为true后，我们会对delete vector的crc32进行严格检查，如果不一致，将返回失败。
 - 引入版本：-
+
+##### enable_transparent_data_encryption
+
+- 默认值: false
+- 类型: Boolean
+- 单位: -
+- 是否可变: No
+- 描述: 启用后，StarRocks 将为新写入的存储对象（segment 文件、delete/update 文件、rowset segments、lake SSTs、persistent index 文件等）创建磁盘加密产物。写入路径（RowsetWriter/SegmentWriter、lake UpdateManager/LakePersistentIndex 及相关代码路径）会从 KeyCache 请求加密信息，将 encryption_info 附加到可写文件，并将 encryption_meta 持久化到 rowset / segment / sstable 元数据中（如 segment_encryption_metas、delete/update encryption metadata）。Frontend 与 Backend/CN 的加密标志必须匹配——不匹配会导致 BE 在心跳时中止（LOG(FATAL)）。此标志不可在运行时修改；请在部署前启用，并确保密钥管理（KEK）与 KeyCache 已在集群中正确配置并同步。
+- 引入版本: v3.3.1, 3.4.0, 3.5.0, 4.0.0
 
 ##### file_descriptor_cache_clean_interval
 
@@ -2231,4 +2312,13 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 是否动态：否
 - 描述：UDF 存放的路径。
 - 引入版本：-
+
+##### web_log_bytes
+
+- 默认值: 1048576 (1 MB)
+- 类型: long
+- 単位: Bytes
+- 是否可变: No
+- 描述: 从 INFO 日志文件读取并在 BE 调试 webserver 的日志页面上显示的最大字节数。该处理器使用此值计算一个 seek 偏移量（显示最后 N 字节），以避免读取或提供非常大的日志文件。如果日志文件小于该值则显示整个文件。注意：在当前实现中，用于读取并服务 INFO 日志的代码被注释掉了，处理器会报告无法打开 INFO 日志文件，因此除非启用日志服务代码，否则此参数可能无效。
+- 引入版本: v3.2.0
 


### PR DESCRIPTION

## Why I'm doing:

## What I'm doing:  

    EXECUTION SUMMARY
    Document Type: be_config
    Duration: 616.38 seconds
    
    ITEM EXTRACTION:
      ├─ Items from meta files: 654
      ├─ Items from code parsing: 0
      └─ Total unique items: 0
    
    DOCUMENT GENERATION:
      ├─ EN: 3 documents
      ├─ JA: 5 documents
      ├─ ZH: 5 documents
      └─ Total: 13 documents
    
    AGENT INVOCATIONS:
      ├─ TranslationAgent_ja: 5 calls
      ├─ TranslationAgent_zh: 5 calls
      ├─ ConfigDocAgent: 3 calls
      └─ Total: 13 calls
    
    TOOL INVOCATIONS:
      ├─ read_file: 5 calls
      └─ Total: 5 calls
    
    GENERATED ITEMS:
      ├─ Total: 3 items
      ├─ thrift_port
      ├─ arrow_flight_port
      └─ enable_load_channel_rpc_async
    
    TRANSLATED ITEMS:
      ├─ Total: 50 items
      ├─ enable_transparent_data_encryption
      ├─ parquet_reader_bloom_filter_enable
      ├─ lz4_expected_compression_ratio
      ├─ abort_on_large_memory_allocation
      ├─ pull_load_task_dir
      ├─ thrift_connect_timeout_seconds
      ├─ brpc_max_connections_per_server
      ├─ udf_thread_pool_size
      ├─ memory_high_level
      ├─ local_library_dir
      ├─ parallel_clone_task_per_path
      ├─ chaos_test_enable_random_compaction_strategy
      ├─ transaction_publish_version_thread_pool_num_min
      ├─ enable_load_channel_rpc_async
      ├─ transaction_apply_thread_pool_num_min
      ├─ data_page_size
      ├─ report_resource_usage_interval_ms
      ├─ be_service_threads
      ├─ upload_buffer_size
      ├─ delete_worker_count_normal_priority
      ├─ update_compaction_chunk_size_for_row_store
      ├─ transaction_apply_worker_idle_time_ms
      ├─ broker_write_timeout_seconds
      ├─ ssl_certificate_path
      ├─ memory_ratio_for_sorting_schema_change
      ├─ arrow_flight_port
      ├─ lz4_expected_compression_speed_mbps
      ├─ web_log_bytes
      ├─ partial_update_memory_limit_per_worker
      ├─ create_tablet_worker_count
      ├─ delete_worker_count_high_priority
      ├─ get_pindex_worker_count
      ├─ download_buffer_size
      ├─ enable_zero_copy_from_page_cache
      ├─ sleep_one_second
      ├─ rpc_compress_ratio_threshold
      ├─ clear_udf_cache_when_start
      ├─ lz4_acceleration
      ├─ enable_lazy_delta_column_compaction
      ├─ thrift_port
      ├─ cluster_id
      ├─ size_tiered_max_compaction_level
      ├─ enable_jemalloc_memory_tracker
      ├─ memory_urgent_level
      ├─ ssl_private_key_path
      ├─ transaction_apply_worker_count
      ├─ enable_https
      ├─ max_hdfs_scanner_num
      ├─ profile_report_interval
      └─ update_schema_worker_count
    

This Pr is generated by [DocsAgent](https://github.com/StarRocks/DocsAgent)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3