### PR TITLE
[BugFix] Fix the issue where the tablet ID is missing when get initial tablet meta.

### DIFF
--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -503,7 +503,8 @@ StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(const string& pat
         metadata_or = load_tablet_metadata(new_path, cache_opts.fill_data_cache, expected_gtid, fs);
         // set tablet id for initial metadata
         if (metadata_or.ok()) {
-            metadata_or.value()->set_id(tablet_id);
+            auto metadata = const_cast<starrocks::TabletMetadataPB*>(metadata_or.value().get());
+            metadata->set_id(tablet_id);
         }
     }
 

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -501,6 +501,10 @@ StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(const string& pat
         // If the metadata is not found, we will try to read the initial metadata at least
         std::string new_path = join_path(prefix_name(path), tablet_initial_metadata_filename());
         metadata_or = load_tablet_metadata(new_path, cache_opts.fill_data_cache, expected_gtid, fs);
+        // set tablet id for initial metadata
+        if (metadata_or.ok()) {
+            metadata_or.value()->set_id(tablet_id);
+        }
     }
 
     if (!metadata_or.ok()) {

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -826,6 +826,27 @@ TEST_F(LakeTabletManagerTest, put_bundle_tablet_metadata) {
     ASSERT_TRUE(_tablet_manager->get_tablet_metadata(_tablet_manager->tablet_metadata_location(4, 1)).ok());
 }
 
+TEST_F(LakeTabletManagerTest, get_inital_tablet_metadata) {
+    auto tablet_id = next_id();
+
+    // Create initial tablet metadata without setting tablet id
+    starrocks::TabletMetadata initial_metadata;
+    initial_metadata.set_version(1);
+    initial_metadata.set_next_rowset_id(1);
+
+    // Save it to initial metadata location
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(std::make_shared<starrocks::TabletMetadata>(initial_metadata),
+                                                   _tablet_manager->tablet_initial_metadata_location(tablet_id)));
+
+    // Get tablet metadata by tablet_id and version
+    auto res = _tablet_manager->get_tablet_metadata(tablet_id, 1);
+    ASSERT_TRUE(res.ok());
+
+    // Verify that tablet_id is correctly set from the initial metadata
+    EXPECT_EQ(res.value()->id(), tablet_id);
+    EXPECT_EQ(res.value()->version(), 1);
+}
+
 TEST_F(LakeTabletManagerTest, cache_tablet_metadata) {
     auto metadata = std::make_shared<TabletMetadata>();
     auto tablet_id = next_id();


### PR DESCRIPTION
## Why I'm doing:
In certain code paths, we may fail to set the tablet ID when reading the initial tablet meta, which can result in loading an incorrect tablet meta.

## What I'm doing:
This pull request improves how initial tablet metadata is handled in the Lake Tablet Manager by ensuring the tablet ID is properly set when loading initial metadata. It also adds a unit test to verify this behavior.

Metadata handling improvements:

* Ensured that when loading initial tablet metadata, the `tablet_id` is explicitly set on the metadata object in `TabletManager::get_tablet_metadata` (`be/src/storage/lake/tablet_manager.cpp`).

Testing enhancements:

* Added a new test case `get_inital_tablet_metadata` to verify that the tablet ID is correctly set when retrieving initial metadata in `tablet_manager_test.cpp`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `tablet_id` is set when reading initial tablet metadata; add a unit test to verify.
> 
> - **Lake Storage**:
>   - In `TabletManager::get_tablet_metadata(path, ...)`, when falling back to initial metadata (`kInitialVersion`), set `metadata->id()` to the parsed `tablet_id` upon successful load.
> - **Tests**:
>   - Add `get_inital_tablet_metadata` to verify the tablet ID is correctly populated when retrieving initial metadata.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f50cf657e9ac75a14f7311053d5c574dbbf42f28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->