### PR TITLE
[BugFix] fix iceberg min/max value type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
@@ -113,6 +113,7 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
     private final Set<DeleteFile> appliedPosDeleteFiles;
     private final Set<DeleteFile> appliedEqualDeleteFiles;
     private final boolean recordScanFiles;
+    private final boolean useMinMaxOpt;
     private final PartitionIdGenerator partitionIdGenerator;
 
     public IcebergConnectorScanRangeSource(IcebergTable table,
@@ -121,7 +122,8 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
                                            TupleDescriptor desc,
                                            Optional<List<BucketProperty>> bucketProperties,
                                            PartitionIdGenerator partitionIdGenerator,
-                                           boolean recordScanFiles) {
+                                           boolean recordScanFiles,
+                                           boolean useMinMaxOpt) {
         this.table = table;
         this.remoteFileInfoSource = remoteFileInfoSource;
         this.morParams = morParams;
@@ -133,15 +135,7 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
         this.appliedPosDeleteFiles = new HashSet<>();
         this.appliedEqualDeleteFiles = new HashSet<>();
         this.partitionIdGenerator = partitionIdGenerator;
-    }
-
-    public IcebergConnectorScanRangeSource(IcebergTable table,
-                                           RemoteFileInfoSource remoteFileInfoSource,
-                                           IcebergMORParams morParams,
-                                           TupleDescriptor desc,
-                                           Optional<List<BucketProperty>> bucketProperties,
-                                           PartitionIdGenerator partitionIdGenerator) {
-        this(table, remoteFileInfoSource, morParams, desc, bucketProperties, partitionIdGenerator, false);
+        this.useMinMaxOpt = useMinMaxOpt;
     }
 
     public void clearScannedFiles() {
@@ -203,7 +197,7 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
                                 res.add(fileScanTask);
                             }
                         } else if (del.content() == FileContent.EQUALITY_DELETES) {
-                            // to judge if a equality delete is fully applied is not easy. Only the rewrite-all can make sure that 
+                            // to judge if a equality delete is fully applied is not easy. Only the rewrite-all can make sure that
                             // we can eliminate the equality delete files.
                         }
                     }
@@ -355,7 +349,7 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
         hdfsScanRange.setRecord_count(file.recordCount());
         hdfsScanRange.setIs_first_split(isFirstSplit);
 
-        if (file.nullValueCounts() != null && file.valueCounts() != null) {
+        if (useMinMaxOpt && file.nullValueCounts() != null && file.valueCounts() != null) {
             // fill min/max value
             Map<Integer, TExprMinMaxValue> tExprMinMaxValueMap = IcebergUtil.toThriftMinMaxValueBySlots(
                     table.getNativeTable().schema(), file.lowerBounds(), file.upperBounds(),
@@ -489,7 +483,7 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
                 partitionValues.add(partitionValue);
             } else {
                 partitionValues.add(null);
-            } 
+            }
             cols.add(table.getColumn(field.name()));
         });
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
@@ -68,8 +68,16 @@ public final class IcebergUtil {
                 case BIGINT:
                 case TIME:
                     texpr.setType(TExprNodeType.INT_LITERAL);
-                    texpr.setMin_int_value((Long) minValue);
-                    texpr.setMax_int_value((Long) maxValue);
+                    if (minValue instanceof Integer) {
+                        texpr.setMin_int_value(((Integer) minValue).longValue());
+                    } else {
+                        texpr.setMin_int_value((Long) minValue);
+                    }
+                    if (maxValue instanceof Integer) {
+                        texpr.setMax_int_value(((Integer) maxValue).longValue());
+                    } else {
+                        texpr.setMax_int_value((Long) maxValue);
+                    }
                     break;
                 case FLOAT:
                     texpr.setType(TExprNodeType.FLOAT_LITERAL);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -148,7 +148,8 @@ public class IcebergScanNode extends ScanNode {
         }
 
         scanRangeSource = new IcebergConnectorScanRangeSource(icebergTable,
-                remoteFileInfoSource, morParams, desc, bucketProperties, partitionIdGenerator, true);
+                remoteFileInfoSource, morParams, desc, bucketProperties, partitionIdGenerator, true,
+                scanOptimizeOption.getCanUseMinMaxOpt());
     }
 
     public void setupScanRangeLocations(boolean enableIncrementalScanRanges) throws StarRocksException {
@@ -188,7 +189,8 @@ public class IcebergScanNode extends ScanNode {
         }
 
         scanRangeSource = new IcebergConnectorScanRangeSource(icebergTable,
-                remoteFileInfoSource, morParams, desc, bucketProperties, partitionIdGenerator);
+                remoteFileInfoSource, morParams, desc, bucketProperties, partitionIdGenerator, false,
+                scanOptimizeOption.getCanUseMinMaxOpt());
     }
 
     private void setupCloudCredential() {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
@@ -75,7 +75,7 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
 
         IcebergConnectorScanRangeSource scanRangeSource = new IcebergConnectorScanRangeSource(icebergTable,
                 RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, tupleDescriptor, Optional.of(bucketProperties),
-                PartitionIdGenerator.of());
+                PartitionIdGenerator.of(), false, false);
 
         List<FileScanTask> fileScanTasks = Lists.newArrayList(mockedNativeTable2Bucket.newScan().planFiles());
         Assertions.assertEquals(2, fileScanTasks.size());
@@ -106,7 +106,7 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
 
         IcebergConnectorScanRangeSource scanRangeSource = new IcebergConnectorScanRangeSource(icebergTable,
                 RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, tupleDescriptor, Optional.of(oneBucketProperties),
-                PartitionIdGenerator.of());
+                PartitionIdGenerator.of(), false, false);
 
         List<FileScanTask> fileScanTasks = Lists.newArrayList(mockedNativeTable2Bucket.newScan().planFiles());
         Assertions.assertEquals(2, fileScanTasks.size());
@@ -140,10 +140,10 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
         PartitionIdGenerator partitionIdGenerator = PartitionIdGenerator.of();
         IcebergConnectorScanRangeSource scanRangeSource1 = new IcebergConnectorScanRangeSource(
                 icebergTable, RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, tupleDescriptor,
-                Optional.of(oneBucketProperties), partitionIdGenerator);
+                Optional.of(oneBucketProperties), partitionIdGenerator, false, false);
         IcebergConnectorScanRangeSource scanRangeSource2 = new IcebergConnectorScanRangeSource(
                 icebergTable, RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, tupleDescriptor,
-                Optional.of(oneBucketProperties), partitionIdGenerator);
+                Optional.of(oneBucketProperties), partitionIdGenerator, false, false);
         List<FileScanTask> fileScanTasks = Lists.newArrayList(mockedNativeTable2Bucket.newScan().planFiles());
         Assertions.assertFalse(fileScanTasks.isEmpty());
         for (FileScanTask fileScanTask : fileScanTasks) {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
@@ -40,6 +40,7 @@ import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.IcebergRewriteStmt;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.optimizer.ScanOptimizeOption;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TBucketFunction;
 import com.starrocks.thrift.TIcebergTable;
@@ -159,6 +160,7 @@ public class IcebergScanNodeTest {
                 new PlanNodeId(0), desc, catalog,
                 tableMORParams, IcebergMORParams.DATA_FILE_WITHOUT_EQ_DELETE, null);
         scanNode.setTvrVersionRange(TvrTableSnapshot.of(Optional.of(12345L)));
+        scanNode.setScanOptimizeOption(new ScanOptimizeOption());
 
         IcebergRemoteFileInfo remoteFileInfo = new IcebergRemoteFileInfo(fileScanTask);
         List<RemoteFileInfo> remoteFileInfos = List.of(remoteFileInfo);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
@@ -103,7 +103,8 @@ public class IcebergScanNodeTest {
                     Deencapsulation.getField(original, "desc"),
                     Deencapsulation.getField(original, "bucketProperties"),
                     Deencapsulation.getField(original, "partitionIdGenerator"),
-                    Deencapsulation.getField(original, "recordScanFiles")
+                    Deencapsulation.getField(original, "recordScanFiles"),
+                    Deencapsulation.getField(original, "useMinMaxOpt")
             );
         }
 
@@ -208,7 +209,8 @@ public class IcebergScanNodeTest {
 
         IcebergConnectorScanRangeSource scanSource = new IcebergConnectorScanRangeSource(
                 null, mockSource, null, null, Optional.empty(),
-                PartitionIdGenerator.of(), true  // recordScanFiles = true
+                PartitionIdGenerator.of(), true,  // recordScanFiles = true
+                false
         ) {
             private int callCount = 0;
 
@@ -525,12 +527,12 @@ public class IcebergScanNodeTest {
         DeleteFile eq1 = Mockito.mock(DeleteFile.class);
         DataFile data1 = Mockito.mock(DataFile.class);
         DataFile data2 = Mockito.mock(DataFile.class);
-    
+
         Mockito.when(scanNode.getPlanNodeName()).thenReturn("IcebergScanNode");
         Mockito.when(scanNode.getPosAppliedDeleteFiles()).thenReturn(Set.of(pos1, pos2));
         Mockito.when(scanNode.getEqualAppliedDeleteFiles()).thenReturn(Set.of(eq1));
         Mockito.when(scanNode.getScannedDataFiles()).thenReturn(Set.of(data1, data2));
-    
+
         // 3. Mock PlanFragment
         PlanFragment fragment = Mockito.mock(PlanFragment.class);
         Mockito.when(fragment.collectScanNodes())
@@ -618,8 +620,8 @@ public class IcebergScanNodeTest {
                 morParams,
                 tupleDesc,
                 Optional.empty(),
-                PartitionIdGenerator.of()
-                );
+                PartitionIdGenerator.of(), false, false
+        );
 
         List<FileScanTask> result = source.getSourceFileScanOutputs(
                 10, // maxSize
@@ -725,7 +727,7 @@ public class IcebergScanNodeTest {
         Mockito.when(context.getSessionVariable()).thenReturn(sessVar);
         Mockito.when(sessVar.clone()).thenReturn(sessVar);
         Mockito.doNothing().when(sessVar).setQueryTimeoutS(Mockito.anyInt());
-    
+
         // --- Mock DataFile ---
         DataFile dataFile = Mockito.mock(DataFile.class);
         Mockito.when(dataFile.fileSizeInBytes()).thenReturn(500L);
@@ -756,8 +758,8 @@ public class IcebergScanNodeTest {
                 morParams,
                 tupleDesc,
                 Optional.empty(),
-                PartitionIdGenerator.of()
-                );
+                PartitionIdGenerator.of(), false, false
+        );
         Mockito.when(scanNode.getSourceRange()).thenReturn(fakeSourceRange);
         StmtExecutor executor = Mockito.mock(StmtExecutor.class);
         new MockUp<StmtExecutor>() {


### PR DESCRIPTION
## Why I'm doing:

When I tested tpch sf100 iceberg, and ps_partkey is bigint type, but the min/max value is integer type.

and we don't need to send min/max values map down to be if we don't use min/max optimization

## What I'm doing:

Fixes https://github.com/StarRocks/starrocks/pull/65551

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes min/max value typing for BIGINT/TIME and only attaches min/max stats to scan ranges when min/max optimization is enabled.
> 
> - **Iceberg scan range source**:
>   - Add `useMinMaxOpt` flag and constructor param; only set `min_max_values` in `THdfsScanRange` when enabled.
>   - Plumb option from `IcebergScanNode` via `scanOptimizeOption.getCanUseMinMaxOpt()`; also set `enableColumnStats` in remote file params.
> - **Min/max typing fix**:
>   - In `IcebergUtil`, handle `BIGINT`/`TIME` bounds that may be `Integer` or `Long` when converting to thrift.
> - **Tests**:
>   - Update constructors/usages to include `useMinMaxOpt`; set `ScanOptimizeOption` in tests where needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b3f3131e58b4775794cfa82fce9b8b13bea1cdd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->