### PR TITLE
[BugFix] Query Id Collision on Arrow Flight

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectContext.java
@@ -88,7 +88,7 @@ public class ArrowFlightSqlConnectContext extends ConnectContext {
         this.returnResultFromFE = true;
     }
 
-    public void reset(String query) {
+    public void initWithStatement(String query) {
         queryLock.lock(); 
         try {
             if (!this.query.isEmpty()) {
@@ -110,7 +110,7 @@ public class ArrowFlightSqlConnectContext extends ConnectContext {
         }
     }
 
-    public void clearQuery() {
+    public void reset() {
         queryLock.lock(); 
         try {
             this.query = ""; 
@@ -181,7 +181,7 @@ public class ArrowFlightSqlConnectContext extends ConnectContext {
     public void cancelQuery() {
         if (executor != null) {
             executor.cancel("Arrow Flight SQL client disconnected");
-            clearQuery();
+            reset();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectContext.java
@@ -45,6 +45,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.ReentrantLock;
 
 // one connection will create one ArrowFlightSqlConnectContext
 public class ArrowFlightSqlConnectContext extends ConnectContext {
@@ -55,6 +56,8 @@ public class ArrowFlightSqlConnectContext extends ConnectContext {
     private StatementBase statement;
 
     private String query;
+
+    private final ReentrantLock queryLock = new ReentrantLock();
 
     private CompletableFuture<Coordinator> coordinatorFuture;
 
@@ -86,14 +89,34 @@ public class ArrowFlightSqlConnectContext extends ConnectContext {
     }
 
     public void reset(String query) {
-        removeAllResults();
-        statement = null;
-        coordinatorFuture.complete(null);
-        coordinatorFuture = new CompletableFuture<>();
-        returnResultFromFE = true;
-        this.query = query;
-        this.setQueryId(UUIDUtil.genUUID());
-        this.setExecutionId(UUIDUtil.toTUniqueId(this.getQueryId()));
+        queryLock.lock(); 
+        try {
+            if (!this.query.isEmpty()) {
+                throw new IllegalStateException(
+                        "Query already in progress on this connection"
+                );
+            }
+
+            removeAllResults();
+            statement = null;
+            coordinatorFuture.complete(null);
+            coordinatorFuture = new CompletableFuture<>();
+            returnResultFromFE = true;
+            this.query = query;
+            this.setQueryId(UUIDUtil.genUUID());
+            this.setExecutionId(UUIDUtil.toTUniqueId(this.getQueryId()));
+        } finally {
+            queryLock.unlock();
+        }
+    }
+
+    public void clearQuery() {
+        queryLock.lock(); 
+        try {
+            this.query = ""; 
+        } finally {
+            queryLock.unlock();
+        }
     }
 
     public StatementBase getStatement() {
@@ -153,6 +176,7 @@ public class ArrowFlightSqlConnectContext extends ConnectContext {
     public void cancelQuery() {
         if (executor != null) {
             executor.cancel("Arrow Flight SQL client disconnected");
+            clearQuery();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectContext.java
@@ -146,7 +146,12 @@ public class ArrowFlightSqlConnectContext extends ConnectContext {
     }
 
     public String getQuery() {
-        return query;
+        queryLock.lock(); 
+        try {
+            return query;
+        } finally {
+            queryLock.unlock();
+        }
     }
 
     public boolean returnFromFE() {

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectContext.java
@@ -96,12 +96,6 @@ public class ArrowFlightSqlConnectContext extends ConnectContext {
                         "Query already in progress on this connection"
                 );
             }
-
-            removeAllResults();
-            statement = null;
-            coordinatorFuture.complete(null);
-            coordinatorFuture = new CompletableFuture<>();
-            returnResultFromFE = true;
             this.query = query;
             this.setQueryId(UUIDUtil.genUUID());
             this.setExecutionId(UUIDUtil.toTUniqueId(this.getQueryId()));
@@ -114,6 +108,12 @@ public class ArrowFlightSqlConnectContext extends ConnectContext {
         queryLock.lock(); 
         try {
             this.query = ""; 
+            this.statement = null; 
+
+            coordinatorFuture.complete(null);
+            coordinatorFuture = new CompletableFuture<>();
+            returnResultFromFE = true; 
+            removeAllResults();
         } finally {
             queryLock.unlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
@@ -138,7 +138,7 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
                 String token = context.peerIdentity();
                 ArrowFlightSqlConnectContext ctx = sessionManager.validateAndGetConnectContext(token);
 
-                ctx.reset(request.getQuery());
+                ctx.initWithStatement(request.getQuery());
                 // To prevent the client from mistakenly interpreting an empty Schema as an update statement (instead of a query statement),
                 // we need to ensure that the Schema returned by createPreparedStatement includes the query metadata.
                 // This means we need to correctly set the DatasetSchema and ParameterSchema in ActionCreatePreparedStatementResult.
@@ -202,7 +202,7 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
                                              FlightDescriptor descriptor) {
         String token = context.peerIdentity();
         ArrowFlightSqlConnectContext ctx = sessionManager.validateAndGetConnectContext(token);
-        ctx.reset(command.getQuery());
+        ctx.initWithStatement(command.getQuery());
         ctx.setThreadLocalInfo();
         return getFlightInfoFromQuery(ctx, descriptor);
     }
@@ -442,7 +442,7 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
             listener.completed();
         } finally {
             ctx.removeResult(queryId);
-            ctx.clearQuery();
+            ctx.reset();
         }
     }
 
@@ -520,7 +520,7 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
             Location endpoint = Location.forGrpcInsecure(worker.getHost(), worker.getArrowFlightPort());
             return buildFlightInfo(ticketStatement, descriptor, schema, endpoint);
         } catch (Exception e) {
-            ctx.clearQuery();
+            ctx.reset();
             LOG.warn("[ARROW] failed to getFlightInfoFromQuery [queryID={}]", DebugUtil.printId(ctx.getExecutionId()), e);
             throw CallStatus.INTERNAL.withDescription(e.getMessage()).toRuntimeException();
         }

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectContextTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectContextTest.java
@@ -81,7 +81,7 @@ public class ArrowFlightSqlConnectContextTest {
 
     @Test
     public void testReset() {
-        context.reset("SELECT 1");
+        context.initWithStatement("SELECT 1");
         assertEquals("SELECT 1", context.getQuery());
         assertNotNull(context.getQueryId());
     }
@@ -89,12 +89,12 @@ public class ArrowFlightSqlConnectContextTest {
     @Test
     public void testResetThrowsWhenQueryAlreadySet() {
         // First reset should succeed
-        context.reset("SELECT 1");
+        context.initWithStatement("SELECT 1");
         assertEquals("SELECT 1", context.getQuery());
         
         // Second reset should throw IllegalStateException
         IllegalStateException exception = assertThrows(IllegalStateException.class, () -> {
-            context.reset("SELECT 2");
+            context.initWithStatement("SELECT 2");
         });
         
         assertTrue(exception.getMessage().contains("Query already in progress"));
@@ -102,24 +102,24 @@ public class ArrowFlightSqlConnectContextTest {
 
     @Test
     public void testResetAfterClearQuery() {
-        context.reset("SELECT 1");
-        context.clearQuery();
+        context.initWithStatement("SELECT 1");
+        context.reset();
         
         // Should not throw since query was cleared
-        context.reset("SELECT 2");
+        context.initWithStatement("SELECT 2");
         assertEquals("SELECT 2", context.getQuery());
     }
 
     @Test
     public void testClearQuery() {
-        context.reset("SELECT 1");
+        context.initWithStatement("SELECT 1");
         assertEquals("SELECT 1", context.getQuery());
         
-        context.clearQuery();
+        context.reset();
         assertEquals("", context.getQuery());
         
         // After clearing, reset should work again
-        context.reset("SELECT 2");
+        context.initWithStatement("SELECT 2");
         assertEquals("SELECT 2", context.getQuery());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectContextTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectContextTest.java
@@ -87,6 +87,43 @@ public class ArrowFlightSqlConnectContextTest {
     }
 
     @Test
+    public void testResetThrowsWhenQueryAlreadySet() {
+        // First reset should succeed
+        context.reset("SELECT 1");
+        assertEquals("SELECT 1", context.getQuery());
+        
+        // Second reset should throw IllegalStateException
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> {
+            context.reset("SELECT 2");
+        });
+        
+        assertTrue(exception.getMessage().contains("Query already in progress"));
+    }
+
+    @Test
+    public void testResetAfterClearQuery() {
+        context.reset("SELECT 1");
+        context.clearQuery();
+        
+        // Should not throw since query was cleared
+        context.reset("SELECT 2");
+        assertEquals("SELECT 2", context.getQuery());
+    }
+
+    @Test
+    public void testClearQuery() {
+        context.reset("SELECT 1");
+        assertEquals("SELECT 1", context.getQuery());
+        
+        context.clearQuery();
+        assertEquals("", context.getQuery());
+        
+        // After clearing, reset should work again
+        context.reset("SELECT 2");
+        assertEquals("SELECT 2", context.getQuery());
+    }
+
+    @Test
     public void testSetReturnResultFromFE() {
         context.setReturnResultFromFE(false);
         assertFalse(context.returnFromFE());

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImplTest.java
@@ -377,6 +377,59 @@ public class ArrowFlightSqlServiceImplTest {
     }
 
     @Test
+    public void testCreatePreparedStatementTwiceThrowsException() throws Exception {
+        // Setup
+        FlightSql.ActionCreatePreparedStatementRequest request1 = mock(FlightSql.ActionCreatePreparedStatementRequest.class);
+        when(request1.getQuery()).thenReturn("SELECT 1");
+        
+        FlightSql.ActionCreatePreparedStatementRequest request2 = mock(FlightSql.ActionCreatePreparedStatementRequest.class);
+        when(request2.getQuery()).thenReturn("SELECT 2");
+
+        FlightProducer.CallContext callContext = mock(FlightProducer.CallContext.class);
+        when(callContext.peerIdentity()).thenReturn("token123");
+
+        // Create a real context to test the actual locking behavior
+        ArrowFlightSqlConnectContext realContext = new ArrowFlightSqlConnectContext("token123");
+        when(sessionManager.validateAndGetConnectContext("token123")).thenReturn(realContext);
+
+        FlightProducer.StreamListener<Result> listener1 = mock(FlightProducer.StreamListener.class);
+        FlightProducer.StreamListener<Result> listener2 = mock(FlightProducer.StreamListener.class);
+
+        try (
+                MockedStatic<ArrowUtil> mockArrowUtil = mockStatic(ArrowUtil.class);
+                MockedStatic<ArrowFlightSqlServiceImpl> mockStatic =
+                        mockStatic(ArrowFlightSqlServiceImpl.class, CALLS_REAL_METHODS)
+        ) {
+            VectorSchemaRoot mockRoot = mock(VectorSchemaRoot.class);
+            Schema mockSchema = mock(Schema.class);
+            when(mockRoot.getSchema()).thenReturn(mockSchema);
+            mockArrowUtil.when(() -> ArrowUtil.createSingleSchemaRoot(anyString(), anyString())).thenReturn(mockRoot);
+            mockStatic.when(() -> ArrowFlightSqlServiceImpl.serializeMetadata(mockSchema))
+                    .thenReturn(ByteBuffer.wrap("mock".getBytes(StandardCharsets.UTF_8)));
+
+            // First call - this should succeed and set the query
+            service.createPreparedStatement(request1, callContext, listener1);
+            
+            // Wait for first call to complete
+            Thread.sleep(200);
+
+            // Second call - this should fail because query is already set
+            service.createPreparedStatement(request2, callContext, listener2);
+            
+            // Wait for second call to complete
+            Thread.sleep(200);
+
+            // Verify that listener2 received an error about query already in progress
+            verify(listener2, timeout(1000)).onError(any(FlightRuntimeException.class));
+            verify(listener2, timeout(1000)).onCompleted();
+            
+            // Verify listener1 succeeded
+            verify(listener1, timeout(1000)).onNext(any(Result.class));
+            verify(listener1, timeout(1000)).onCompleted();
+        }
+    }
+
+    @Test
     public void testSetSessionOptions() throws Exception {
         // Arrange
         ArrowFlightSqlServiceImpl service = new ArrowFlightSqlServiceImpl(mock(ArrowFlightSqlSessionManager.class), null);


### PR DESCRIPTION
## Why I'm doing:
**Issue**: Duplicate query IDs when using multiple threads with Arrow Flight SQL
When multiple threads share a single Arrow Flight SQL connection and execute queries concurrently, they encounter "queryId already exists" errors and receive incorrect/incomplete results.
**Root Cause**:
The `ArrowFlightSqlConnectContext` stores the current query string in a single shared field (query). When multiple concurrent requests call `createPreparedStatement`, they overwrite each other's queries in the shared context:

Thread 1 calls `createPreparedStatement` → sets `ctx.query = query1, ctx.queryId = UUID1`
Thread 2 calls `createPreparedStatement` → overwrites `ctx.query = query2, ctx.queryId = UUID2`
Thread 1 calls `getFlightInfoPreparedStatement` → executes with `query2` instead of `query1`, `UUID2` instead of `UUID1`
Thread 2 calls `getFlightInfoPreparedStatement` → executes with `query2`, `UUID2` (but queryId already exists)
Both threads generate the same execution ID, causing "queryId already exists" errors.

Additionally, `ctx.reset()` calls `removeAllResults()` which clears the result cache while other queries may still be storing results, leading to incomplete data.
## What I'm doing:
**Solution**: Throw an error when query is already set. 

Changes:

Add a lock `queryLock` to `query` in `ArrowFlightSqlConnectContext`. 
`ArrowFlightSqlConnectContext.reset` checks for existence of a currently running query before resetting. If it exists, throws an error. 

Result: On concurrent queries being submitted, only the first will execute. The rest will fail with a descriptive error about a query already being in progress on the connection. 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Serializes query lifecycle with a lock, introducing initWithStatement/reset, updating service calls, and clearing state on cancel/error; adds tests for new behavior.
> 
> - **ArrowFlightSqlConnectContext**:
>   - Add `ReentrantLock` to guard `query` access; make `getQuery()` thread-safe.
>   - Replace `reset(String)` with `initWithStatement(String)` and parameterless `reset()`; generate IDs in `initWithStatement` and throw `IllegalStateException` if a query is already in progress.
>   - On `cancelQuery()` and error paths, call `reset()`; keep result cache management.
> - **ArrowFlightSqlServiceImpl**:
>   - Use `ctx.initWithStatement(...)` instead of `ctx.reset(query)` in `createPreparedStatement` and `getFlightInfoStatement`.
>   - Call `ctx.reset()` on `closePreparedStatement` and on exceptions in `getFlightInfoFromQuery`.
> - **Tests**:
>   - Update and add unit tests to cover `initWithStatement`, `reset`, single in-flight query enforcement, and state clearing behaviors.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96692adbc1c811835dcb5207072b55479ba758c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->