### PR TITLE
[BugFix] Add slow lock detection for critical locks

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/common/util/concurrent/QueryableReentrantReadWriteLockSlowLockTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/concurrent/QueryableReentrantReadWriteLockSlowLockTest.java
@@ -1,0 +1,255 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util.concurrent;
+
+import mockit.Expectations;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Unit tests for slow lock detection in QueryableReentrantReadWriteLock.
+ * Tests verify that slow lock detection properly triggers and captures
+ * lock info when lock acquisition exceeds the configured threshold.
+ */
+public class QueryableReentrantReadWriteLockSlowLockTest {
+    private static final long SLOW_LOCK_THRESHOLD_MS = 500;
+    private static final long LOCK_HOLD_TIME_MS = 1500;
+
+    private QueryableReentrantReadWriteLock lock;
+
+    @BeforeEach
+    public void setUp() {
+        lock = new QueryableReentrantReadWriteLock(true);
+    }
+
+    /**
+     * Scenario: A separate thread holds the exclusive lock for a long time, then releases it.
+     * The main thread attempts to acquire a shared lock and should capture lock info about slow lock detection.
+     */
+    @Test
+    public void testSharedLockDetectingSlowLock() throws Exception {
+        new Expectations(lock) {
+            {
+                lock.getLockInfoToJson(null);
+                minTimes = 1;
+            }
+        };
+
+        // Start a background thread that holds the exclusive lock
+        AtomicBoolean lockAcquired = new AtomicBoolean(false);
+        Thread writerThread = new Thread(() -> {
+            lock.exclusiveLock();
+            lockAcquired.set(true);
+            try {
+                // Hold the lock for longer than the threshold
+                Thread.sleep(LOCK_HOLD_TIME_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                lock.exclusiveUnlock();
+            }
+        }, "WriterThread");
+
+        writerThread.start();
+
+        // Wait for the writer thread to acquire the lock
+        while (!lockAcquired.get()) {
+            Thread.sleep(1);
+        }
+        assertTrue(lockAcquired.get(), "Writer thread should have acquired the lock");
+
+        // Main thread attempts to acquire shared lock with slow lock detection
+        // This will timeout and trigger slow lock detection
+        long startTime = System.currentTimeMillis();
+        lock.sharedLockDetectingSlowLock(SLOW_LOCK_THRESHOLD_MS, TimeUnit.MILLISECONDS);
+        long elapsedTime = System.currentTimeMillis() - startTime;
+
+        // Verify that we waited for the lock to be released
+        // elapseTime in [LOCK_HOLD_TIME_MS - 100, LOCK_HOLD_TIME_MS + 100]
+        assertTrue(elapsedTime >= LOCK_HOLD_TIME_MS - 100,
+                "Should have waited for the writer thread to release the lock. Elapsed: " + elapsedTime);
+        assertTrue(elapsedTime <= LOCK_HOLD_TIME_MS + 100,
+                "Should have waited for the writer thread to release the lock. Elapsed: " + elapsedTime);
+
+        // Ensure the reader now holds the lock and can clean up
+        lock.sharedUnlock();
+
+        // Wait for writer thread to finish
+        writerThread.join();
+    }
+
+    /**
+     * Scenario: A separate thread holds the exclusive lock for a long time, then releases it.
+     * Another thread attempts to acquire an exclusive lock and should capture lock info about slow lock detection.
+     */
+    @Test
+    public void testExclusiveLockDetectingSlowLock() throws Exception {
+        new Expectations(lock) {
+            {
+                lock.getLockInfoToJson(null);
+                minTimes = 1;
+            }
+        };
+
+        // Start a background thread that holds the exclusive lock
+        AtomicBoolean lockAcquired = new AtomicBoolean(false);
+        Thread writerThread1 = new Thread(() -> {
+            lock.exclusiveLock();
+            lockAcquired.set(true);
+            try {
+                // Hold the lock for longer than the threshold
+                Thread.sleep(LOCK_HOLD_TIME_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                lock.exclusiveUnlock();
+            }
+        }, "WriterThread1");
+
+        writerThread1.start();
+
+        // Wait for the writer thread to acquire the lock
+        while (!lockAcquired.get()) {
+            Thread.sleep(1);
+        }
+        assertTrue(lockAcquired.get(), "Writer thread should have acquired the lock");
+
+        // Main thread attempts to acquire exclusive lock with slow lock detection
+        // This will timeout and trigger slow lock detection
+        long startTime = System.currentTimeMillis();
+        lock.exclusiveLockDetectingSlowLock(SLOW_LOCK_THRESHOLD_MS, TimeUnit.MILLISECONDS);
+        long elapsedTime = System.currentTimeMillis() - startTime;
+
+        // Verify that we waited for the lock to be released
+        // elapseTime in [LOCK_HOLD_TIME_MS - 100, LOCK_HOLD_TIME_MS + 100]
+        assertTrue(elapsedTime >= LOCK_HOLD_TIME_MS - 100,
+                "Should have waited for the writer thread to release the lock. Elapsed: " + elapsedTime);
+        assertTrue(elapsedTime <= LOCK_HOLD_TIME_MS + 100,
+                "Should have waited for the writer thread to release the lock. Elapsed: " + elapsedTime);
+
+        // Ensure the current thread now holds the lock and can clean up
+        lock.exclusiveUnlock();
+
+        // Wait for writer thread to finish
+        writerThread1.join();
+    }
+
+    /**
+     * Test that sharedLockDetectingSlowLock() does NOT capture lock info when lock is acquired within threshold.
+     * Scenario: No contention on the lock, acquisition should be fast.
+     */
+    @Test
+    public void testSharedLockNoSlowLockWhenFast() {
+        new Expectations(lock) {
+            {
+                lock.getLockInfoToJson(null);
+                maxTimes = 0;
+                minTimes = 0;
+            }
+        };
+
+        // Directly acquire shared lock with no contention
+        lock.sharedLockDetectingSlowLock(SLOW_LOCK_THRESHOLD_MS, TimeUnit.MILLISECONDS);
+
+        // Verify the lock is held
+        assertTrue(lock.isReadLockHeldByCurrentThread(), "Current thread should hold the read lock");
+
+        // Clean up
+        lock.sharedUnlock();
+    }
+
+    /**
+     * Test that exclusiveLockDetectingSlowLock() does NOT capture lock info when lock is acquired within threshold.
+     * Scenario: No contention on the lock, acquisition should be fast.
+     */
+    @Test
+    public void testExclusiveLockNoSlowLockWhenFast() {
+        new Expectations(lock) {
+            {
+                lock.getLockInfoToJson(null);
+                maxTimes = 0;
+                minTimes = 0;
+            }
+        };
+
+        // Directly acquire exclusive lock with no contention
+        lock.exclusiveLockDetectingSlowLock(SLOW_LOCK_THRESHOLD_MS, TimeUnit.MILLISECONDS);
+
+        // Verify the lock is held
+        assertTrue(lock.isWriteLockHeldByCurrentThread(), "Current thread should hold the write lock");
+
+        // Clean up
+        lock.exclusiveUnlock();
+    }
+
+    /**
+     * Test concurrent scenario: Multiple threads contending for shared lock while exclusive lock is held.
+     * Verifies that all waiting threads properly detect and capture the slow lock.
+     */
+    @Test
+    public void testMultipleReadersDetectSlowLock() throws Exception {
+        new Expectations(lock) {
+            {
+                lock.getLockInfoToJson(null);
+                minTimes = 2;
+            }
+        };
+
+        // Start a writer thread holding the lock
+        AtomicBoolean writerLockAcquired = new AtomicBoolean(false);
+        Thread writerThread = new Thread(() -> {
+            lock.exclusiveLock();
+            writerLockAcquired.set(true);
+            try {
+                Thread.sleep(LOCK_HOLD_TIME_MS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } finally {
+                lock.exclusiveUnlock();
+            }
+        }, "Writer");
+
+        writerThread.start();
+        while (!writerLockAcquired.get()) {
+            Thread.sleep(1);
+        }
+        assertTrue(writerLockAcquired.get(), "Writer should have acquired the lock");
+
+        // Start multiple reader threads that will wait for the shared lock
+        Thread reader1 = new Thread(() -> {
+            lock.sharedLockDetectingSlowLock(SLOW_LOCK_THRESHOLD_MS, TimeUnit.MILLISECONDS);
+            lock.sharedUnlock();
+        }, "Reader1");
+
+        Thread reader2 = new Thread(() -> {
+            lock.sharedLockDetectingSlowLock(SLOW_LOCK_THRESHOLD_MS, TimeUnit.MILLISECONDS);
+            lock.sharedUnlock();
+        }, "Reader2");
+
+        reader1.start();
+        reader2.start();
+
+        // Wait for all threads to complete
+        writerThread.join();
+        reader1.join();
+        reader2.join();
+    }
+}
+


### PR DESCRIPTION
Problem:
Lock contention in production systems is difficult to diagnose because we lack visibility into which threads are holding locks and how long lock acquisitions take. When the FE becomes unresponsive, it's nearly impossible to identify the root cause without extensive debugging.

Solution:
Replace ReentrantReadWriteLock with QueryableReentrantReadWriteLock in TabletInvertedIndex and RoutineLoadJob modules. This custom lock wrapper provides automatic slow lock detection and rich diagnostic information.

Implementation Details:
1. Added sharedLockDetectingSlowLock() and exclusiveLockDetectingSlowLock() methods to QueryableReentrantReadWriteLock that:
   - Attempt lock acquisition with configurable timeout
   - Capture lock state (holders, waiters, stack traces) on timeout
   - Log warning with wait time and diagnostic info if threshold exceeded

2. Updated TabletInvertedIndex to use QueryableReentrantReadWriteLock:
   - readLock()/writeLock() now use slow lock detection
   - readUnlock()/writeUnlock() properly track lock release timing
   - Uses Config.slow_lock_threshold_ms for threshold configuration

3. Updated RoutineLoadJob to use QueryableReentrantReadWriteLock:
   - All lock/unlock methods consistently use wrapper methods
   - Maintains fair lock semantics (fair=true)
   - Proper tracking of shared and exclusive lock acquisitions

Benefits:
- Zero overhead for uncontended locks (fast path with tryLock)
- Automatic detection and logging of lock contention issues
- Rich diagnostic information in JSON format for monitoring
- Configurable threshold via Config.slow_lock_threshold_ms
- Helps identify deadlocks and performance bottlenecks in production

Technical Notes:
- Lock state is captured BEFORE final blocking acquisition to avoid holding the lock while generating diagnostics
- Race condition between timeout and state capture is acceptable since approximate information is sufficient for debugging

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce slow lock detection in `QueryableReentrantReadWriteLock` and adopt it in `TabletInvertedIndex` and `RoutineLoadJob`, with unit tests covering slow/fast paths and contention.
> 
> - **Concurrency**:
>   - Add slow lock detection to `QueryableReentrantReadWriteLock` via `sharedLockDetectingSlowLock()` and `exclusiveLockDetectingSlowLock()` using timed `tryLock`, JSON lock-state capture, and warn logging; includes default ctor and interruption handling.
> - **Integration**:
>   - Replace `ReentrantReadWriteLock` with `QueryableReentrantReadWriteLock` in `TabletInvertedIndex` and `RoutineLoadJob`.
>   - Route `readLock`/`writeLock` calls through slow-detect variants; use `Config.slow_lock_threshold_ms` and `TimeUnit.MILLISECONDS`.
> - **Tests**:
>   - Add `QueryableReentrantReadWriteLockSlowLockTest` covering shared/exclusive slow detection, fast paths (no detection), and multiple-reader contention.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15bc2c1a3044a1ffb1dd2d48dfedf9fe295c6cf7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->