### PR TITLE
[Enhancement] Add metrics base_cumulative_compaction_duration_us

### DIFF
--- a/be/src/storage/compaction_task.cpp
+++ b/be/src/storage/compaction_task.cpp
@@ -44,8 +44,10 @@ void CompactionTask::run() {
     _task_info.start_time = UnixMillis();
     scoped_refptr<Trace> trace(new Trace);
     SCOPED_CLEANUP({
-        uint64_t time_s = _watch.elapsed_time() / 1000000000;
-        if (time_s > config::compaction_trace_threshold) {
+        const uint64_t elapsed_us = _watch.elapsed_time() / 1000;
+        StarRocksMetrics::instance()->base_cumulative_compaction_duration_us.increment(elapsed_us);
+        const uint64_t elapsed_sec = elapsed_us / 1'000'000;
+        if (elapsed_sec > config::compaction_trace_threshold) {
             LOG(INFO) << "Trace:" << std::endl << trace->DumpToString(Trace::INCLUDE_ALL);
         }
     });

--- a/be/src/util/starrocks_metrics.cpp
+++ b/be/src/util/starrocks_metrics.cpp
@@ -182,6 +182,7 @@ StarRocksMetrics::StarRocksMetrics() : _metrics(_s_registry_name) {
                              &update_compaction_outputs_bytes_total);
     _metrics.register_metric("update_compaction_duration_us", MetricLabels().add("type", "update"),
                              &update_compaction_duration_us);
+    REGISTER_STARROCKS_METRIC(base_cumulative_compaction_duration_us);
 
     _metrics.register_metric("meta_request_total", MetricLabels().add("type", "write"), &meta_write_request_total);
     _metrics.register_metric("meta_request_total", MetricLabels().add("type", "read"), &meta_read_request_total);

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -166,6 +166,7 @@ public:
     METRIC_DEFINE_INT_COUNTER(update_compaction_outputs_total, MetricUnit::ROWSETS);
     METRIC_DEFINE_INT_COUNTER(update_compaction_outputs_bytes_total, MetricUnit::BYTES);
     METRIC_DEFINE_INT_COUNTER(update_compaction_duration_us, MetricUnit::MICROSECONDS);
+    METRIC_DEFINE_INT_COUNTER(base_cumulative_compaction_duration_us, MetricUnit::MICROSECONDS);
 
     METRIC_DEFINE_INT_COUNTER(publish_task_request_total, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(publish_task_failed_total, MetricUnit::REQUESTS);

--- a/test/sql/test_information_schema/R/test_execution_time_metrics
+++ b/test/sql/test_information_schema/R/test_execution_time_metrics
@@ -1,5 +1,5 @@
 -- name: test_execution_time_metrics
-select distinct name, labels from information_schema.be_metrics where name in ('pipe_connector_scan_execution_time', 'pipe_scan_execution_time', 'pipe_driver_execution_time') order  by name, labels;
+select distinct name, labels from information_schema.be_metrics where name in ('pipe_connector_scan_execution_time', 'pipe_scan_execution_time', 'pipe_driver_execution_time') order by name, labels;
 -- result:
 pipe_connector_scan_execution_time	workload_type=load
 pipe_connector_scan_execution_time	workload_type=query
@@ -10,4 +10,9 @@ pipe_driver_execution_time	workload_type=unknown
 pipe_scan_execution_time	workload_type=load
 pipe_scan_execution_time	workload_type=query
 pipe_scan_execution_time	workload_type=unknown
+-- !result
+select distinct name, labels from information_schema.be_metrics where name in ('base_cumulative_compaction_duration_us', 'update_compaction_duration_us') order by name, labels;
+-- result:
+base_cumulative_compaction_duration_us	
+update_compaction_duration_us	type=update
 -- !result

--- a/test/sql/test_information_schema/T/test_execution_time_metrics
+++ b/test/sql/test_information_schema/T/test_execution_time_metrics
@@ -1,3 +1,5 @@
 -- name: test_execution_time_metrics
 
-select distinct name, labels from information_schema.be_metrics where name in ('pipe_connector_scan_execution_time', 'pipe_scan_execution_time', 'pipe_driver_execution_time') order  by name, labels;
+select distinct name, labels from information_schema.be_metrics where name in ('pipe_connector_scan_execution_time', 'pipe_scan_execution_time', 'pipe_driver_execution_time') order by name, labels;
+
+select distinct name, labels from information_schema.be_metrics where name in ('base_cumulative_compaction_duration_us', 'update_compaction_duration_us') order by name, labels;


### PR DESCRIPTION
## Why I'm doing:

Query
- `pipe_connector_scan_execution_time`, `pipe_scan_execution_time`, `pipe_driver_execution_time` with label `workload_type=query`

Load
- Query part for load: `pipe_connector_scan_execution_time`, `pipe_scan_execution_time`, `pipe_driver_execution_time` with label `workload_type=load`
- 


```sql
select distinct name, labels from information_schema.be_metrics 
where name in ('base_cumulative_compaction_duration_us', 'update_compaction_duration_us') 
order by name, labels
+----------------------------------------+-----------------------+
| name                                   | labels                |
+----------------------------------------+-----------------------+
| base_cumulative_compaction_duration_us | type=update           |
| update_compaction_duration_us          |                       |
+----------------------------------------+-----------------------+
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
