### PR TITLE
[BugFix] Fix `partition_retention_condition` bugs  in referring mv's columns

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
@@ -62,8 +62,8 @@ public final class IcebergUtil {
                 case INT:
                 case DATE:
                     texpr.setType(TExprNodeType.INT_LITERAL);
-                    texpr.setMin_int_value((Long) minValue);
-                    texpr.setMax_int_value((Long) maxValue);
+                    texpr.setMin_int_value((Integer) minValue);
+                    texpr.setMax_int_value((Integer) maxValue);
                     break;
                 case BIGINT:
                 case TIME:

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
@@ -62,8 +62,8 @@ public final class IcebergUtil {
                 case INT:
                 case DATE:
                     texpr.setType(TExprNodeType.INT_LITERAL);
-                    texpr.setMin_int_value((Integer) minValue);
-                    texpr.setMax_int_value((Integer) maxValue);
+                    texpr.setMin_int_value((Long) minValue);
+                    texpr.setMax_int_value((Long) maxValue);
                     break;
                 case BIGINT:
                 case TIME:

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -2169,10 +2169,10 @@ public class MaterializedViewAnalyzer {
         mv.getBaseSchema().forEach(col ->
                 fields.add(new Field(col.getName(), col.getType(), null, null)));
         Scope scope = new Scope(RelationId.anonymous(), new RelationFields(fields));
+        ExpressionAnalyzer.analyzeExpression(retentionCondtiionExpr, new AnalyzeState(), scope, connectContext);
         Map<Expr, Expr> partitionByExprMap = getMVPartitionByExprToAdjustMap(null, mv);
         retentionCondtiionExpr = MaterializedViewAnalyzer.adjustWhereExprIfNeeded(partitionByExprMap, retentionCondtiionExpr,
                 scope, connectContext);
-        ExpressionAnalyzer.analyzeExpression(retentionCondtiionExpr, new AnalyzeState(), scope, connectContext);
         return Optional.of(retentionCondtiionExpr);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -2165,14 +2165,14 @@ public class MaterializedViewAnalyzer {
         if (retentionCondtiionExpr == null) {
             return Optional.empty();
         }
-        Scope scope = new Scope(RelationId.anonymous(), new RelationFields(
-                refBaseTable.getBaseSchema().stream()
-                        .map(col -> new Field(col.getName(), col.getType(), null, null))
-                        .collect(Collectors.toList())));
-        ExpressionAnalyzer.analyzeExpression(retentionCondtiionExpr, new AnalyzeState(), scope, connectContext);
+        List<Field> fields = new ArrayList<>();
+        mv.getBaseSchema().forEach(col ->
+                fields.add(new Field(col.getName(), col.getType(), null, null)));
+        Scope scope = new Scope(RelationId.anonymous(), new RelationFields(fields));
         Map<Expr, Expr> partitionByExprMap = getMVPartitionByExprToAdjustMap(null, mv);
         retentionCondtiionExpr = MaterializedViewAnalyzer.adjustWhereExprIfNeeded(partitionByExprMap, retentionCondtiionExpr,
                 scope, connectContext);
+        ExpressionAnalyzer.analyzeExpression(retentionCondtiionExpr, new AnalyzeState(), scope, connectContext);
         return Optional.of(retentionCondtiionExpr);
     }
 
@@ -2185,7 +2185,7 @@ public class MaterializedViewAnalyzer {
         }
         Expr retentionCondtiionExpr = exprOpt.get();
         ColumnRefFactory columnRefFactory = new ColumnRefFactory();
-        List<ColumnRefOperator> columnRefOperators = refBaseTable.getBaseSchema()
+        List<ColumnRefOperator> columnRefOperators = mv.getBaseSchema()
                 .stream()
                 .map(col -> columnRefFactory.create(col.getName(), col.getType(), col.isAllowNull()))
                 .collect(Collectors.toList());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
@@ -23,7 +23,6 @@ import com.starrocks.common.Config;
 import com.starrocks.connector.iceberg.MockIcebergMetadata;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.MaterializedViewAnalyzer;
-import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
 import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;


### PR DESCRIPTION
## Why I'm doing:
MV refresh failure when using generated column in partition_retention_condition, 
got error when using 'partition_retention_condition = ds >= current_date() - interval 1 month'
```
last_refresh_error_message: Materialized view: participant_mqsr_nps_ca_aggr_join_mv11/4936621 is not active due to reload failed: Getting analyzing error. Detail message: Column 'ds' cannot be resolved..
```
## What I'm doing:
as title
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fix retention condition analysis to resolve MV columns (not base table) and add a test covering Iceberg transform with retention condition.
> 
> - **Analyzer (MaterializedViewAnalyzer)**:
>   - Use `mv.getBaseSchema()` instead of `refBaseTable.getBaseSchema()` when analyzing `partition_retention_condition` in `analyzeMVRetentionCondition` and `analyzeMVRetentionConditionOperator`.
>   - Build analysis `Scope` from MV fields to correctly resolve MV column refs.
> - **Tests**:
>   - Add `testRefBaseTablePartitionWithTransform3` in `MvRefreshAndRewriteIcebergTest` to validate `partition_retention_condition` like `ds >= current_date() - interval 1 month` with Iceberg transform.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea5e04e7763087e4aab154d3a2e7222846e9bdb3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->