### PR TITLE
[Enhancement] Add partition filter when loading statistics to avoid stale data after INSERT OVERWRITE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2386,6 +2386,11 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "Whether to allow auto collection of the NDV of array columns")
     public static boolean enable_auto_collect_array_ndv = false;
 
+    @ConfField(mutable = true, comment = "Maximum number of partitions to include in partition_id filter " +
+            "when loading statistics. If a table has more partitions than this threshold, " +
+            "the partition_id filter will be skipped to avoid performance overhead. Default 1000.")
+    public static int statistic_load_max_partition_filter_num = 1000;
+
     @ConfField(mutable = true, comment = "Synchronously load statistics for testing purpose")
     public static boolean enable_sync_statistics_load = false;
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
@@ -168,6 +168,11 @@ public class StatisticSQLBuilder {
     }
 
     public static String buildQueryFullStatisticsSQL(Long tableId, List<String> columnNames, List<Type> columnTypes) {
+        return buildQueryFullStatisticsSQL(tableId, columnNames, columnTypes, null);
+    }
+
+    public static String buildQueryFullStatisticsSQL(Long tableId, List<String> columnNames, List<Type> columnTypes,
+                                                     List<Long> partitionIds) {
         Map<String, List<String>> nameGroups = groupByTypes(columnNames, columnTypes, false);
 
         List<String> querySQL = new ArrayList<>();
@@ -175,8 +180,19 @@ public class StatisticSQLBuilder {
             VelocityContext context = new VelocityContext();
             context.put("updateTime", "now()");
             context.put("type", type);
-            context.put("predicate", "table_id = " + tableId + " and column_name in (" +
-                    names.stream().map(c -> "\"" + c + "\"").collect(Collectors.joining(", ")) + ")");
+            
+            // Build predicate with partition_id filter to exclude temp partitions
+            StringBuilder predicateBuilder = new StringBuilder();
+            predicateBuilder.append("table_id = ").append(tableId);
+            predicateBuilder.append(" and column_name in (")
+                    .append(names.stream().map(c -> "\"" + c + "\"").collect(Collectors.joining(", ")))
+                    .append(")");
+            if (partitionIds != null && !partitionIds.isEmpty()) {
+                predicateBuilder.append(" and partition_id in (")
+                        .append(partitionIds.stream().map(String::valueOf).collect(Collectors.joining(", ")))
+                        .append(")");
+            }
+            context.put("predicate", predicateBuilder.toString());
 
             if (type.startsWith("array") || type.startsWith("map")) {
                 querySQL.add(build(context, QUERY_COLLECTION_FULL_STATISTIC_TEMPLATE));

--- a/test/sql/test_analyze_statistics/R/test_overwrite_statistics.sql
+++ b/test/sql/test_analyze_statistics/R/test_overwrite_statistics.sql
@@ -171,3 +171,25 @@ select count(*) from _statistics_.column_statistics where table_name = 'test_ove
 -- result:
 2
 -- !result
+drop stats test_overwrite_statistics.test_overwrite_stats_table;
+-- result:
+-- !result
+drop table test_overwrite_statistics.test_overwrite_stats_table;
+-- result:
+-- !result
+delete from _statistics_.column_statistics where table_name='test_overwrite_statistics.test_overwrite_stats_table';
+-- result:
+-- !result
+create table test_overwrite_stats_table (k1 int) properties("replication_num"="1");
+-- result:
+-- !result
+insert into test_overwrite_stats_table select generate_series from table(generate_series(1, 1000));
+-- result:
+-- !result
+insert overwrite test_overwrite_stats_table select generate_series from table(generate_series(10000, 20000));
+-- result:
+-- !result
+function: assert_explain_costs_contains("select * from test_overwrite_statistics.test_overwrite_stats_table;", "20000.0")
+-- result:
+None
+-- !result

--- a/test/sql/test_analyze_statistics/T/test_overwrite_statistics.sql
+++ b/test/sql/test_analyze_statistics/T/test_overwrite_statistics.sql
@@ -93,3 +93,12 @@ select count(*) from _statistics_.column_statistics where table_name = 'test_ove
 alter table test_overwrite_statistics.sales_data set("enable_statistic_collect_on_first_load"="true");
 INSERT OVERWRITE test_overwrite_statistics.sales_data partition("p202401") VALUES (102, '2024-01-10');
 select count(*) from _statistics_.column_statistics where table_name = 'test_overwrite_statistics.sales_data';
+
+drop stats test_overwrite_statistics.test_overwrite_stats_table;
+drop table test_overwrite_statistics.test_overwrite_stats_table;
+delete from _statistics_.column_statistics where table_name='test_overwrite_statistics.test_overwrite_stats_table';
+create table test_overwrite_stats_table (k1 int) properties("replication_num"="1");
+insert into test_overwrite_stats_table select generate_series from table(generate_series(1, 1000));
+insert overwrite test_overwrite_stats_table select generate_series from table(generate_series(10000, 20000));
+function: assert_explain_costs_contains("select * from test_overwrite_statistics.test_overwrite_stats_table;", "20000.0")
+


### PR DESCRIPTION
## Why I'm doing:

When `INSERT OVERWRITE` triggers statistics collection, the statistics cache is refreshed immediately after collection completes. The cache is keyed at the table level, and the cache loading SQL aggregates all partition-level statistics into table-level statistics using queries like:
```
SELECT cast(10 as INT), now(), db_id, table_id, column_name, 
       sum(row_count), cast(sum(data_size) as bigint), hll_union_agg(ndv), sum(null_count),  
       cast(max(cast(max as bigint)) as string), cast(min(cast(min as bigint)) as string), 
       cast(avg(collection_size) as bigint) 
FROM column_statistics 
WHERE table_id = 806917 and column_name in ("k1") 
GROUP BY db_id, table_id, column_name
```

However, after `INSERT OVERWRITE`, old partition statistics remain in the `column_statistics` table (temp partition‘s stats are not immediately cleaned up). This causes inaccurate aggregated statistics, especially when the table has fewer partitions. The impact is more significant for statistics like `min`/`max`, depending on the data distribution before and after the overwrite.

**Example scenario:**
- Table has 1 partition with data range [1, 1000]
- After `INSERT OVERWRITE` with data range [10000, 20000]
- Both partitions' statistics exist in `column_statistics`
- Aggregated `min` = 1 (incorrect, should be 10000)
- Aggregated `max` = 20000 (correct by chance)

This leads to poor cardinality estimation and suboptimal query plans.

## What I'm doing:

1. **Add partition_id filter to statistics loading SQL**
   - Modified `StatisticSQLBuilder.buildQueryFullStatisticsSQL()` to accept a `partitionIds` parameter
   - When loading statistics, only query statistics from current valid partitions (excluding temp partitions)
   - Generated SQL now includes: `WHERE table_id = xxx AND column_name IN (...) AND partition_id IN (...)`

2. **Add partition count threshold to balance accuracy and performance**
   - Added new FE config: `statistic_load_max_partition_filter_num` (default: 1000)
   - If a table has ≤ 1000 partitions, apply the `partition_id` filter for accuracy
   - If a table has > 1000 partitions, skip the filter to avoid:
     - Statistics loading is frequent (triggered by DML operations, query optimization, etc.)
     - Excessively long IN (...) clauses cause performance overhead (SQL parsing, planning, execution)
     - Accuracy impact is minimal when a table has many partitions (a few temp partitions among thousands have negligible effect on aggregated statistics)


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
