### PR TITLE
[BugFix] Add variant type in LakeMetaHelper

### DIFF
--- a/be/src/formats/parquet/meta_helper.cpp
+++ b/be/src/formats/parquet/meta_helper.cpp
@@ -162,6 +162,10 @@ bool LakeMetaHelper::_is_valid_type(const ParquetField* parquet_field, const TIc
             }
         }
     } else if (parquet_field->type == ColumnType::STRUCT) {
+        if (type_descriptor->type == LogicalType::TYPE_VARIANT) {
+            return true;
+        }
+
         std::unordered_map<int32_t, const TIcebergSchemaField*> field_id_2_lake_schema{};
         std::unordered_map<int32_t, const TypeDescriptor*> field_id_2_type{};
         for (const auto& field : field_schema->children) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fix Variant type convertion when reading data lake parquet files

When I tested reading an Iceberg table that contains a variant column and loaded some production records, I found that the variant column was returned as NULL.

The root cause is that StarRocks checks whether the Parquet field is compatible with both the Iceberg type and the StarRocks type via `LakeMetaHelper::_is_valid_type`. 

The previous unit tests only covered Parquet files written directly by Spark, so their schemas differ from the actual production data.(via `ParquetMetaHelper::_is_valid_type`)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Treat VARIANT as valid for STRUCT fields in Lake parquet schema validation to enable reading variant-mapped columns.
> 
> - **Parquet Lake schema validation**:
>   - In `LakeMetaHelper::_is_valid_type`, when encountering `STRUCT` with `TYPE_VARIANT`, immediately accept the type, allowing `VARIANT` to map to Parquet `STRUCT`.
>   - No other logic changes; existing child-field validation remains intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e37073ef091defff89dd8feed6a690ec958cef6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->