### PR TITLE
[BugFix] drop old partition stats after statistics collection triggered by insert overwrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
@@ -228,6 +228,10 @@ public class StatisticsCollectionTrigger {
 
                 statisticExecutor.collectStatistics(statsConnectCtx, job, analyzeStatus, false,
                         true /* resetWarehouse */);
+                if (dmlType == DmlType.INSERT_OVERWRITE && overwriteJobStats != null) {
+                    AnalyzeMgr analyzeMgr = GlobalStateMgr.getCurrentState().getAnalyzeMgr();
+                    overwriteJobStats.getSourcePartitionIds().forEach(analyzeMgr::recordDropPartition);
+                }
             };
 
             CancelableAnalyzeTask cancelableTask = new CancelableAnalyzeTask(originalTask, analyzeStatus);


### PR DESCRIPTION
## Why I'm doing:
starrocks will auto clear stale partition's stats in the background. For a dropped partition, if it is recorded in `AnalyzerMgr#dropPartitionIds`, we will perform batch cleanup every minute; otherwise, once every `clear_stale_stats_interval_sec`, with a default value 12 hours.

## What I'm doing:
record staled partitions used for cleaning once per minute 
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
