### PR TITLE
[BugFix] Fix MV async refresh skipping sub-partition updates in multi-level partitioned base tables

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/PCTTableSnapshotInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/PCTTableSnapshotInfoTest.java
@@ -1,0 +1,99 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.mv;
+
+import com.starrocks.catalog.BaseTableInfo;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.scheduler.mv.pct.PCTTableSnapshotInfo;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PCTTableSnapshotInfoTest {
+
+    @Test
+    void testUpdatePartitionInfos() {
+        // Mock olap table
+        BaseTableInfo baseTableInfo = mock(BaseTableInfo.class);
+        OlapTable baseTable = mock(OlapTable.class);
+        when(baseTable.isNativeTableOrMaterializedView()).thenReturn(true);
+        // Mock partition without sub-partitions
+        Partition partition = mock(Partition.class);
+        PhysicalPartition mockDefault = mock(PhysicalPartition.class);
+        when(partition.getDefaultPhysicalPartition()).thenReturn(mockDefault);
+        when(partition.getSubPartitions()).thenReturn(null);
+        when(partition.getName()).thenReturn("p1");
+        when(partition.getId()).thenReturn(1L);
+        when(mockDefault.getVisibleVersion()).thenReturn(10L);
+        when(mockDefault.getVisibleVersionTime()).thenReturn(1000L);
+
+        when(baseTable.getPartition("p1")).thenReturn(partition);
+
+        PCTTableSnapshotInfo pctTableSnapshotInfo = new PCTTableSnapshotInfo(baseTableInfo, baseTable);
+        pctTableSnapshotInfo.updatePartitionInfos(List.of("p1"));
+        Map<String, MaterializedView.BasePartitionInfo> refreshedPartitionInfos =
+                pctTableSnapshotInfo.getRefreshedPartitionInfos();
+        MaterializedView.BasePartitionInfo mvPartitionInfo = refreshedPartitionInfos.get("p1");
+
+        Assertions.assertEquals(1L, mvPartitionInfo.getId());
+        Assertions.assertEquals(10L, mvPartitionInfo.getVersion());
+        Assertions.assertEquals(1000L, mvPartitionInfo.getLastRefreshTime());
+    }
+
+    @Test
+    void testUpdatePartitionInfosWithSubPartitions() {
+        // Mock olap table
+        BaseTableInfo baseTableInfo = mock(BaseTableInfo.class);
+        OlapTable baseTable = mock(OlapTable.class);
+        when(baseTable.isNativeTableOrMaterializedView()).thenReturn(true);
+        // Mock partition with sub-partitions
+        Partition partition = mock(Partition.class);
+        PhysicalPartition mockDefault = mock(PhysicalPartition.class);
+        PhysicalPartition sub1 = mock(PhysicalPartition.class);
+        PhysicalPartition sub2 = mock(PhysicalPartition.class);
+        List<PhysicalPartition> subs = Arrays.asList(sub1, sub2);
+
+        when(partition.getDefaultPhysicalPartition()).thenReturn(mockDefault);
+        when(partition.getSubPartitions()).thenReturn(subs);
+        when(partition.getName()).thenReturn("p1");
+        when(partition.getId()).thenReturn(1L);
+
+        when(sub1.getVisibleVersionTime()).thenReturn(2000L);
+        when(sub1.getVisibleVersion()).thenReturn(20L);
+        when(sub2.getVisibleVersionTime()).thenReturn(3000L);
+        when(sub2.getVisibleVersion()).thenReturn(30L);
+
+        when(baseTable.getPartition("p1")).thenReturn(partition);
+
+        PCTTableSnapshotInfo pctTableSnapshotInfo = new PCTTableSnapshotInfo(baseTableInfo, baseTable);
+        pctTableSnapshotInfo.updatePartitionInfos(List.of("p1"));
+        Map<String, MaterializedView.BasePartitionInfo> refreshedPartitionInfos =
+                pctTableSnapshotInfo.getRefreshedPartitionInfos();
+        MaterializedView.BasePartitionInfo mvPartitionInfo = refreshedPartitionInfos.get("p1");
+
+        Assertions.assertEquals(1L, mvPartitionInfo.getId());
+        Assertions.assertEquals(30L, mvPartitionInfo.getVersion());
+        Assertions.assertEquals(3000L, mvPartitionInfo.getLastRefreshTime());
+    }
+}


### PR DESCRIPTION

## Why I'm doing:

## What I'm doing:
This PR fixes the bug where asynchronous materialized view (MV) refreshes skip updates in multi-level partitioned base tables. The issue occurs because the refresh logic only checks the parent partition's metadata (ID, VisibleVersion, VisibleVersionTime), failing to detect changes in sub-partitions.
Fixes #issue
https://github.com/StarRocks/starrocks/issues/65144
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
