### PR TITLE
[BugFix] Fix NPE in replay upsert transaction state when database not found

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1920,18 +1920,20 @@ public class DatabaseTransactionMgr {
             // set transaction status will call txn state change listener
             transactionState.replaySetTransactionStatus();
             Database db = globalStateMgr.getLocalMetastore().getDb(transactionState.getDbId());
-            if (transactionState.getTransactionStatus() == TransactionStatus.COMMITTED) {
-                if (!isCheckpoint) {
-                    LOG.info("replay a committed transaction {}", transactionState.getBrief());
+            if (db != null) {
+                if (transactionState.getTransactionStatus() == TransactionStatus.COMMITTED) {
+                    if (!isCheckpoint) {
+                        LOG.info("replay a committed transaction {}", transactionState.getBrief());
+                    }
+                    LOG.debug("replay a committed transaction {}", transactionState);
+                    updateCatalogAfterCommitted(transactionState, db);
+                } else if (transactionState.getTransactionStatus() == TransactionStatus.VISIBLE) {
+                    if (!isCheckpoint) {
+                        LOG.info("replay a visible transaction {}", transactionState.getBrief());
+                    }
+                    LOG.debug("replay a visible transaction {}", transactionState);
+                    updateCatalogAfterVisible(transactionState, db);
                 }
-                LOG.debug("replay a committed transaction {}", transactionState);
-                updateCatalogAfterCommitted(transactionState, db);
-            } else if (transactionState.getTransactionStatus() == TransactionStatus.VISIBLE) {
-                if (!isCheckpoint) {
-                    LOG.info("replay a visible transaction {}", transactionState.getBrief());
-                }
-                LOG.debug("replay a visible transaction {}", transactionState);
-                updateCatalogAfterVisible(transactionState, db);
             }
             unprotectUpsertTransactionState(transactionState);
             if (transactionState.isExpired(System.currentTimeMillis())) {


### PR DESCRIPTION
## Why I'm doing:
```
2025-11-16 23:23:39.623+08:00 INFO (replayer|117) [DatabaseTransactionMgr.replayUpsertTransactionState():1836] replay a committed transaction TransactionState. txn_id: 11720, db id: 76505, table id list: 76513, error replicas num: 0, unknown replicas num: 0, write cost: 1091ms
2025-11-16 23:23:39.632+08:00 WARN (replayer|117) [GlobalStateMgr.replayJournalInner():2109] catch exception when replaying journal, id: 78362, data: {"dd":76505,"tl":[76513],"tx":11720,"lb":"COMPACTION_76505-76513-76512-1763306618528","ci":{"76513":{"td":76513,"pc":{"76512":{"partitionId":76512,"version":42,"versionTime":0,"dataVersion":42,"versionEpoch":0,"invalidColumns":[],"validColumns":[],"DictCollectedVersion":[]}}}},"tc":{"st":"FE","ip":"172.26.80.80"},"ts":"COMMITTED","st":"LAKE_COMPACTION","pt":1763306618528,"pet":1763306619619,"ct":1763306619619,"ft":-1,"rs":"","nf":false,"er":[],"ur":[],"ctl":false,"cb":-1,"to":86400000,"wid":0},
com.starrocks.journal.JournalInconsistentException: failed to load journal type 12110
        at com.starrocks.epack.persist.EditLogEPack.loadJournal(EditLogEPack.java:123) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.replayJournalInner(GlobalStateMgr.java:2098) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr$5.runOneCycle(GlobalStateMgr.java:1953) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.Daemon.run(Daemon.java:109) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr$5.run(GlobalStateMgr.java:2018) ~[starrocks-fe.jar:?]
Caused by: com.starrocks.journal.JournalInconsistentException: failed to load journal type 12110
        at com.starrocks.persist.EditLog.loadJournal(EditLog.java:1311) ~[starrocks-fe.jar:?]
        at com.starrocks.epack.persist.EditLogEPack.loadJournal(EditLogEPack.java:119) ~[starrocks-fe.jar:?]
        ... 4 more
Caused by: java.lang.NullPointerException
        at com.starrocks.transaction.DatabaseTransactionMgr.updateCatalogAfterCommitted(DatabaseTransactionMgr.java:1718) ~[starrocks-fe.jar:?]
        at com.starrocks.transaction.DatabaseTransactionMgr.replayUpsertTransactionState(DatabaseTransactionMgr.java:1839) ~[starrocks-fe.jar:?]
        at com.starrocks.transaction.GlobalTransactionMgr.replayUpsertTransactionState(GlobalTransactionMgr.java:723) ~[starrocks-fe.jar:?]
        at com.starrocks.persist.EditLog.loadJournal(EditLog.java:602) ~[starrocks-fe.jar:?]
        at com.starrocks.epack.persist.EditLogEPack.loadJournal(EditLogEPack.java:119) ~[starrocks-fe.jar:?]
        ... 4 more

```

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/10608

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
