### PR TITLE
[BugFix] Fix MV async refresh skipping sub-partition updates in multi-level partitioned base tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Partition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Partition.java
@@ -46,6 +46,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -230,6 +231,13 @@ public class Partition extends MetaObject implements GsonPostProcessable {
             return physicalPartition;
         }
         return nameToTempSubPartition.get(name);
+    }
+
+    public PhysicalPartition getLatestPhysicalPartition() {
+        return getSubPartitions()
+                .stream()
+                .max(Comparator.comparing(PhysicalPartition::getVisibleVersionTime))
+                .orElseGet(this::getDefaultPhysicalPartition);
     }
 
     public PhysicalPartition getDefaultPhysicalPartition() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/OlapPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/OlapPartitionTraits.java
@@ -138,7 +138,7 @@ public class OlapPartitionTraits extends DefaultTraits {
         }
         long lastRefreshTime = mvRefreshedPartitionInfo.getLastRefreshTime();
         Collection<PhysicalPartition> subPartitions = partition.getSubPartitions();
-        if (subPartitions != null && !subPartitions.isEmpty()) {
+        if (!subPartitions.isEmpty()) {
             for (PhysicalPartition subPartition : subPartitions) {
                 if (subPartition.getVisibleVersionTime() > lastRefreshTime) {
                     return true;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/OlapPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/partitiontraits/OlapPartitionTraits.java
@@ -29,7 +29,6 @@ import org.apache.commons.lang.NotImplementedException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -136,20 +135,9 @@ public class OlapPartitionTraits extends DefaultTraits {
         if (mvRefreshedPartitionInfo.getId() != partition.getId()) {
             return true;
         }
-        long lastRefreshTime = mvRefreshedPartitionInfo.getLastRefreshTime();
-        Collection<PhysicalPartition> subPartitions = partition.getSubPartitions();
-        if (!subPartitions.isEmpty()) {
-            for (PhysicalPartition subPartition : subPartitions) {
-                if (subPartition.getVisibleVersionTime() > lastRefreshTime) {
-                    return true;
-                }
-            }
-            return false;
-        } else {
-            PhysicalPartition defaultPartition = partition.getDefaultPhysicalPartition();
-            return defaultPartition.getVisibleVersion() != mvRefreshedPartitionInfo.getVersion()
-                    || defaultPartition.getVisibleVersionTime() > lastRefreshTime;
-        }
+        PhysicalPartition defaultPartition = partition.getLatestPhysicalPartition();
+        return defaultPartition.getVisibleVersion() != mvRefreshedPartitionInfo.getVersion()
+                || defaultPartition.getVisibleVersionTime() > mvRefreshedPartitionInfo.getLastRefreshTime();
     }
 
     public List<Column> getPartitionColumns() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTTableSnapshotInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTTableSnapshotInfo.java
@@ -38,7 +38,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -160,13 +159,7 @@ public class PCTTableSnapshotInfo extends BaseTableSnapshotInfo {
     }
 
     private static MaterializedView.BasePartitionInfo toBasePartitionInfo(Partition partition) {
-        PhysicalPartition defaultPartition = partition.getDefaultPhysicalPartition();
-        if (!partition.getSubPartitions().isEmpty()) {
-            defaultPartition = partition.getSubPartitions()
-                    .stream()
-                    .max(Comparator.comparing(PhysicalPartition::getVisibleVersionTime))
-                    .orElse(defaultPartition);
-        }
+        PhysicalPartition defaultPartition = partition.getLatestPhysicalPartition();
         return new MaterializedView.BasePartitionInfo(
                 partition.getId(),
                 defaultPartition.getVisibleVersion(),

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTTableSnapshotInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/PCTTableSnapshotInfo.java
@@ -161,7 +161,7 @@ public class PCTTableSnapshotInfo extends BaseTableSnapshotInfo {
 
     private static MaterializedView.BasePartitionInfo toBasePartitionInfo(Partition partition) {
         PhysicalPartition defaultPartition = partition.getDefaultPhysicalPartition();
-        if (partition.getSubPartitions() != null && partition.getSubPartitions().size() > 1) {
+        if (!partition.getSubPartitions().isEmpty()) {
             defaultPartition = partition.getSubPartitions()
                     .stream()
                     .max(Comparator.comparing(PhysicalPartition::getVisibleVersionTime))

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/PCTTableSnapshotInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/PCTTableSnapshotInfoTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -42,7 +43,7 @@ class PCTTableSnapshotInfoTest {
         Partition partition = mock(Partition.class);
         PhysicalPartition mockDefault = mock(PhysicalPartition.class);
         when(partition.getDefaultPhysicalPartition()).thenReturn(mockDefault);
-        when(partition.getSubPartitions()).thenReturn(null);
+        when(partition.getSubPartitions()).thenReturn(Collections.emptyList());
         when(partition.getName()).thenReturn("p1");
         when(partition.getId()).thenReturn(1L);
         when(mockDefault.getVisibleVersion()).thenReturn(10L);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/PCTTableSnapshotInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/PCTTableSnapshotInfoTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 class PCTTableSnapshotInfoTest {
@@ -42,7 +43,7 @@ class PCTTableSnapshotInfoTest {
         // Mock partition without sub-partitions
         Partition partition = mock(Partition.class);
         PhysicalPartition mockDefault = mock(PhysicalPartition.class);
-        when(partition.getDefaultPhysicalPartition()).thenReturn(mockDefault);
+        when(partition.getLatestPhysicalPartition()).thenReturn(mockDefault);
         when(partition.getSubPartitions()).thenReturn(Collections.emptyList());
         when(partition.getName()).thenReturn("p1");
         when(partition.getId()).thenReturn(1L);
@@ -68,22 +69,22 @@ class PCTTableSnapshotInfoTest {
         BaseTableInfo baseTableInfo = mock(BaseTableInfo.class);
         OlapTable baseTable = mock(OlapTable.class);
         when(baseTable.isNativeTableOrMaterializedView()).thenReturn(true);
-        // Mock partition with sub-partitions
-        Partition partition = mock(Partition.class);
+
+        Partition partition = spy(new Partition(1L, "p1", null));
+        // Mock the default physical partition and two sub-partitions
         PhysicalPartition mockDefault = mock(PhysicalPartition.class);
         PhysicalPartition sub1 = mock(PhysicalPartition.class);
         PhysicalPartition sub2 = mock(PhysicalPartition.class);
-        List<PhysicalPartition> subs = Arrays.asList(sub1, sub2);
-
-        when(partition.getDefaultPhysicalPartition()).thenReturn(mockDefault);
-        when(partition.getSubPartitions()).thenReturn(subs);
-        when(partition.getName()).thenReturn("p1");
-        when(partition.getId()).thenReturn(1L);
-
         when(sub1.getVisibleVersionTime()).thenReturn(2000L);
         when(sub1.getVisibleVersion()).thenReturn(20L);
         when(sub2.getVisibleVersionTime()).thenReturn(3000L);
         when(sub2.getVisibleVersion()).thenReturn(30L);
+
+        List<PhysicalPartition> subs = Arrays.asList(sub1, sub2);
+        when(partition.getDefaultPhysicalPartition()).thenReturn(mockDefault);
+        when(partition.getSubPartitions()).thenReturn(subs);
+        when(partition.getName()).thenReturn("p1");
+        when(partition.getId()).thenReturn(1L);
 
         when(baseTable.getPartition("p1")).thenReturn(partition);
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/PCTTableSnapshotInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/PCTTableSnapshotInfoTest.java
@@ -1,0 +1,99 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler.mv;
+
+import com.starrocks.catalog.BaseTableInfo;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.scheduler.mv.pct.PCTTableSnapshotInfo;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PCTTableSnapshotInfoTest {
+
+    @Test
+    void testUpdatePartitionInfos() {
+        // Mock olap table
+        BaseTableInfo baseTableInfo = mock(BaseTableInfo.class);
+        OlapTable baseTable = mock(OlapTable.class);
+        when(baseTable.isNativeTableOrMaterializedView()).thenReturn(true);
+        // Mock partition without sub-partitions
+        Partition partition = mock(Partition.class);
+        PhysicalPartition mockDefault = mock(PhysicalPartition.class);
+        when(partition.getDefaultPhysicalPartition()).thenReturn(mockDefault);
+        when(partition.getSubPartitions()).thenReturn(null);
+        when(partition.getName()).thenReturn("p1");
+        when(partition.getId()).thenReturn(1L);
+        when(mockDefault.getVisibleVersion()).thenReturn(10L);
+        when(mockDefault.getVisibleVersionTime()).thenReturn(1000L);
+
+        when(baseTable.getPartition("p1")).thenReturn(partition);
+
+        PCTTableSnapshotInfo pctTableSnapshotInfo = new PCTTableSnapshotInfo(baseTableInfo, baseTable);
+        pctTableSnapshotInfo.updatePartitionInfos(List.of("p1"));
+        Map<String, MaterializedView.BasePartitionInfo> refreshedPartitionInfos =
+                pctTableSnapshotInfo.getRefreshedPartitionInfos();
+        MaterializedView.BasePartitionInfo mvPartitionInfo = refreshedPartitionInfos.get("p1");
+
+        Assertions.assertEquals(1L, mvPartitionInfo.getId());
+        Assertions.assertEquals(10L, mvPartitionInfo.getVersion());
+        Assertions.assertEquals(1000L, mvPartitionInfo.getLastRefreshTime());
+    }
+
+    @Test
+    void testUpdatePartitionInfosWithSubPartitions() {
+        // Mock olap table
+        BaseTableInfo baseTableInfo = mock(BaseTableInfo.class);
+        OlapTable baseTable = mock(OlapTable.class);
+        when(baseTable.isNativeTableOrMaterializedView()).thenReturn(true);
+        // Mock partition with sub-partitions
+        Partition partition = mock(Partition.class);
+        PhysicalPartition mockDefault = mock(PhysicalPartition.class);
+        PhysicalPartition sub1 = mock(PhysicalPartition.class);
+        PhysicalPartition sub2 = mock(PhysicalPartition.class);
+        List<PhysicalPartition> subs = Arrays.asList(sub1, sub2);
+
+        when(partition.getDefaultPhysicalPartition()).thenReturn(mockDefault);
+        when(partition.getSubPartitions()).thenReturn(subs);
+        when(partition.getName()).thenReturn("p1");
+        when(partition.getId()).thenReturn(1L);
+
+        when(sub1.getVisibleVersionTime()).thenReturn(2000L);
+        when(sub1.getVisibleVersion()).thenReturn(20L);
+        when(sub2.getVisibleVersionTime()).thenReturn(3000L);
+        when(sub2.getVisibleVersion()).thenReturn(30L);
+
+        when(baseTable.getPartition("p1")).thenReturn(partition);
+
+        PCTTableSnapshotInfo pctTableSnapshotInfo = new PCTTableSnapshotInfo(baseTableInfo, baseTable);
+        pctTableSnapshotInfo.updatePartitionInfos(List.of("p1"));
+        Map<String, MaterializedView.BasePartitionInfo> refreshedPartitionInfos =
+                pctTableSnapshotInfo.getRefreshedPartitionInfos();
+        MaterializedView.BasePartitionInfo mvPartitionInfo = refreshedPartitionInfos.get("p1");
+
+        Assertions.assertEquals(1L, mvPartitionInfo.getId());
+        Assertions.assertEquals(30L, mvPartitionInfo.getVersion());
+        Assertions.assertEquals(3000L, mvPartitionInfo.getLastRefreshTime());
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
This PR fixes the bug where asynchronous materialized view (MV) refreshes skip updates in multi-level partitioned base tables. The issue occurs because the refresh logic only checks the parent partition's metadata (ID, VisibleVersion, VisibleVersionTime), failing to detect changes in sub-partitions.
Fixes #issue
https://github.com/StarRocks/starrocks/issues/65144

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use the latest physical sub-partition’s version/time when detecting base table changes for MV refresh; add tests to validate behavior.
> 
> - **MV Refresh Logic**:
>   - Update `OlapPartitionTraits.isBaseTableChanged` to compare against `partition.getLatestPhysicalPartition()` (with early ID check).
>   - Update `PCTTableSnapshotInfo.toBasePartitionInfo` to use `partition.getLatestPhysicalPartition()`.
> - **Catalog**:
>   - Add `Partition.getLatestPhysicalPartition()` selecting the sub-partition with max `visibleVersionTime`, falling back to the default.
> - **Tests**:
>   - Add `PCTTableSnapshotInfoTest` covering partitions with and without sub-partitions, ensuring latest sub-partition version/time is used.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9eb3bfa43e446b7544be0de52af7a63b462fcb0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->