### PR TITLE
[BugFix] Fix JsonPathRewriteRule using wrong table after transparent MV rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
@@ -189,6 +189,10 @@ public class OptExpressionDuplicator {
             Operator.Builder opBuilder = OperatorBuilderFactory.build(optExpression.getOp());
             LogicalScanOperator scanOperator = (LogicalScanOperator) optExpression.getOp();
             opBuilder.withOperator(scanOperator);
+            // Use scan operator's table instead of columnRefFactory's table
+            // This fixes the issue where transparent MV rewrite rewrites MV scan to base table scan,
+            // but columnRefFactory still maps column refs to MV table
+            Table scanTable = scanOperator.getTable();
             Map<ColumnRefOperator, Column> columnRefOperatorColumnMap = scanOperator.getColRefToColumnMetaMap();
             ImmutableMap.Builder<ColumnRefOperator, Column> columnRefColumnMapBuilder = new ImmutableMap.Builder<>();
             Map<Integer, Integer> relationIdMapping = Maps.newHashMap();
@@ -197,8 +201,9 @@ public class OptExpressionDuplicator {
                 ColumnRefOperator newColumnRef = columnRefFactory.create(key, key.getType(), key.isNullable());
                 columnRefColumnMapBuilder.put(newColumnRef, entry.getValue());
                 columnMapping.put(entry.getKey(), newColumnRef);
-                columnRefFactory.updateColumnRefToColumns(newColumnRef, columnRefFactory.getColumn(key),
-                        columnRefFactory.getColumnRefToTable().get(key));
+                // Use scan operator's table instead of columnRefFactory's table
+                Column column = entry.getValue();
+                columnRefFactory.updateColumnRefToColumns(newColumnRef, column, scanTable);
                 Integer newRelationId = relationIdMapping.computeIfAbsent(columnRefFactory.getRelationId(key.getId()),
                         k -> columnRefFactory.getNextRelationId());
                 columnRefFactory.updateColumnToRelationIds(newColumnRef.getId(), newRelationId);
@@ -211,8 +216,9 @@ public class OptExpressionDuplicator {
                 ColumnRefOperator key = entry.getValue();
                 ColumnRefOperator mapped = columnMapping.computeIfAbsent(key,
                         k -> columnRefFactory.create(k, k.getType(), k.isNullable()));
-                columnRefFactory.updateColumnRefToColumns(mapped, columnRefFactory.getColumn(key),
-                        columnRefFactory.getColumnRefToTable().get(key));
+                // Use scan operator's table and column instead of columnRefFactory's
+                Column column = entry.getKey();
+                columnRefFactory.updateColumnRefToColumns(mapped, column, scanTable);
                 Integer newRelationId = relationIdMapping.computeIfAbsent(columnRefFactory.getRelationId(key.getId()),
                         k -> columnRefFactory.getNextRelationId());
                 columnRefFactory.updateColumnToRelationIds(mapped.getId(), newRelationId);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonPathRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonPathRewriteTest.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.plan;
 
 import com.starrocks.common.FeConstants;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -324,5 +325,56 @@ public class JsonPathRewriteTest extends PlanTestBase {
                 )
 
         );
+    }
+
+    /*
+     * @see https://github.com/StarRocks/starrocks/issues/64124
+     * Test case for issue: transparent_mv_rewrite_mode conflicts with cbo_json_v2_rewrite
+     * This reproduces the bug where JsonPathRewriteRule creates extended columns based on
+     * the wrong table (MV table) when the scan operator has been rewritten to base table scan
+     */
+    @Test
+    public void testJsonPathRewriteWithTransparentMVRewrite() throws Exception {
+
+        connectContext.getSessionVariable().setEnableJSONV2Rewrite(true);
+        connectContext.getSessionVariable().setEnableLowCardinalityOptimize(false);
+
+        starRocksAssert.withTable("CREATE TABLE test_json_mv_base (\n" +
+                "  id INT,\n" +
+                "  user_object JSON,\n" +
+                "  ts DATETIME\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(id)\n" +
+                "DISTRIBUTED BY HASH(id) BUCKETS 1\n" +
+                "PROPERTIES (\"replication_num\" = \"1\");");
+
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW test_json_mv\n" +
+                "DISTRIBUTED BY HASH(id) BUCKETS 1\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "  'transparent_mv_rewrite_mode' = 'true',\n" +
+                "  'replication_num' = '1'\n" +
+                ")\n" +
+                "AS SELECT\n" +
+                "  id,\n" +
+                "  get_json_string(user_object, '$.custom.tier') AS user_object_custom_tier,\n" +
+                "  get_json_string(user_object, '$.custom.service') AS user_object_custom_service,\n" +
+                "  ts\n" +
+                "FROM test_json_mv_base;");
+
+        // Refresh MV to make it available for transparent rewrite
+        starRocksAssert.refreshMV("REFRESH MATERIALIZED VIEW test_json_mv WITH SYNC MODE");
+
+        // Query MV - this should trigger transparent rewrite, then JSON path rewrite
+        // Without the fix, this will fail with NPE in DecodeCollector
+        String sql = "SELECT * FROM test_json_mv LIMIT 10";
+        String plan = getFragmentPlan(sql);
+
+        // Verify the plan is generated successfully
+        // The plan should use base table scan, not MV scan
+        assertContains(plan, "test_json_mv_base");
+
+        starRocksAssert.dropMaterializedView("test_json_mv");
+        starRocksAssert.dropTable("test_json_mv_base");
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

When `transparent_mv_rewrite_mode` is enabled, the `MaterializedViewTransparentRewriteRule` rewrites materialized view scans into base table scans. However, the `JsonPathRewriteRule` continued to reference the materialized view table from `columnRefFactory` when generating extended columns for JSON paths. This mismatch resulted in extended columns being created for the incorrect table, ultimately causing a `NullPointerException` in `DecodeCollector` when attempting to access non-existent columns.

Fixes: #64124


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
