### PR TITLE
[Enhancement] Adapt to corner cases for sample type cardinality evaluation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalcUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalcUtils.java
@@ -281,8 +281,8 @@ public class StatisticsCalcUtils {
             }
 
             // attempt use updateRows from basicStatsMeta to adjust estimated row counts
-            if (StatsConstants.AnalyzeType.SAMPLE == analyzeType
-                    && basicStatsMeta.getUpdateTime().isAfter(lastWorkTimestamp)) {
+            if (StatsConstants.AnalyzeType.SAMPLE == analyzeType &&
+                    (basicStatsMeta.getUpdateTime().isAfter(lastWorkTimestamp) || rowCount == 0)) {
                 long statsRowCount = Math.max(basicStatsMeta.getTotalRows() / table.getPartitions().size(), 1)
                         * selectedPartitions.size();
                 if (statsRowCount > rowCount) {


### PR DESCRIPTION
## Why I'm doing:
I found a corner case that cardinality will be 1 with sample type.
```
ADMIN SET FRONTEND CONFIG ("statistic_collect_interval_sec" = "6");
ADMIN SET FRONTEND CONFIG ("tablet_stat_update_interval_second" = "3");
ADMIN SET FRONTEND CONFIG ("enable_statistic_collect_on_first_load" = "true");
ADMIN SET FRONTEND CONFIG ("loads_history_sync_interval_second" = "1000000");
ADMIN SET FRONTEND CONFIG ("enable_auto_collect_statistics" = "false");
ADMIN SET FRONTEND CONFIG ("enable_statistic_collect" = "false");
ADMIN SET FRONTEND CONFIG ("enable_sync_tablet_stats" = "false");
ADMIN SET FRONTEND CONFIG ("enable_sync_tablet_stats" = "true");
ADMIN SET FRONTEND CONFIG ("enable_statistic_collect_on_first_load" = "false");
drop stats unpartitioned_table;
drop table unpartitioned_table;
create table unpartitioned_table (k1 int) properties("replication_num"="1");
insert into unpartitioned_table select generate_series from table(generate_series(1, 250000));
250000","ESTIMATE", "250000.0")
insert into unpartitioned_table select generate_series from table(generate_series(250000, 500000));
insert overwrite unpartitioned_table select generate_series from table(generate_series(500000, 1000000));

explain costs select * from test_statistics_behavior.unpartitioned_table;

mysql> explain costs select * from test_statistics_behavior.unpartitioned_table;
+--------------------------------------------------------------+
| Explain String                                               |
+--------------------------------------------------------------+
| PLAN COST                                                    |
|   CPU: 4.0                                                   |
|   Memory: 0.0                                                |
|                                                              |
| PLAN FRAGMENT 0(F00)                                         |
|   Output Exprs:1: k1                                         |
|   Input Partition: RANDOM                                    |
|   RESULT SINK                                                |
|                                                              |
|   0:OlapScanNode                                             |
|      table: unpartitioned_table, rollup: unpartitioned_table |
|      preAggregation: on                                      |
|      partitionsRatio=1/1, tabletsRatio=1/1                   |
|      tabletList=815170                                       |
|      actualRows=0, avgRowSize=4.0                            |
|      cardinality: 1                                          |
|      column statistics:                                      |
|      * k1-->[1.0, 250000.0, 0.0, 4.0, 48543.0] ESTIMATE      |
+--------------------------------------------------------------+
18 rows in set (0.00 sec)

```
tablet report time and basic meta update time are very close. the condition won't be met.
https://github.com/StarRocks/starrocks/blob/main/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalcUtils.java#L285.
I have confirmed this issue by printing conditional logs 

## What I'm doing:
When row count is 0, perform fallback evaluation.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
