### PR TITLE
[BugFix] fix data race of partition id allocation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DescriptorTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DescriptorTable.java
@@ -39,6 +39,7 @@ import com.google.common.collect.Maps;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.IdGenerator;
+import com.starrocks.planner.PartitionIdGenerator;
 import com.starrocks.thrift.TDescriptorTable;
 
 import java.util.ArrayList;
@@ -63,6 +64,7 @@ public class DescriptorTable {
     private final IdGenerator<TupleId> tupleIdGenerator_ = TupleId.createGenerator();
     private final IdGenerator<SlotId> slotIdGenerator_ = SlotId.createGenerator();
     private final HashMap<SlotId, SlotDescriptor> slotDescs = Maps.newHashMap();
+    private final Map<Table, PartitionIdGenerator> tableToPartitionIdGen = Maps.newHashMap();
 
     public DescriptorTable() {
     }
@@ -176,6 +178,10 @@ public class DescriptorTable {
                     tbl.toThrift(referencedPartitionsPerTable.getOrDefault(tbl, Lists.newArrayList())));
         }
         return result;
+    }
+
+    public PartitionIdGenerator getTablePartitionIdGenerator(Table table) {
+        return tableToPartitionIdGen.computeIfAbsent(table, k -> new PartitionIdGenerator());
     }
 
     public static class ReferencedPartitionInfo {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaConnectorScanRangeSource.java
@@ -24,6 +24,7 @@ import com.starrocks.connector.PartitionUtil;
 import com.starrocks.connector.RemoteFileInfoSource;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.RemoteFileInputFormat;
+import com.starrocks.planner.PartitionIdGenerator;
 import com.starrocks.thrift.TDeletionVectorDescriptor;
 import com.starrocks.thrift.THdfsScanRange;
 import com.starrocks.thrift.TNetworkAddress;
@@ -42,23 +43,25 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
 
 import static com.starrocks.common.profile.Tracers.Module.EXTERNAL;
 
 public class DeltaConnectorScanRangeSource extends ConnectorScanRangeSource {
     private static final Logger LOG = LogManager.getLogger(DeltaConnectorScanRangeSource.class);
-    private DeltaLakeTable table;
-    private RemoteFileInfoSource remoteFileInfoSource;
-    private RemoteFileInputFormat remoteFileInputFormat;
-    private final AtomicLong partitionIdGen = new AtomicLong(0L);
+    private final DeltaLakeTable table;
+    private final RemoteFileInfoSource remoteFileInfoSource;
+    private final RemoteFileInputFormat remoteFileInputFormat;
+    private final PartitionIdGenerator partitionIdGenerator;
+
     private Map<PartitionKey, Long> partitionKeys = new HashMap<>();
     private Map<Long, DescriptorTable.ReferencedPartitionInfo> referencedPartitions = new HashMap<>();
 
-    public DeltaConnectorScanRangeSource(DeltaLakeTable table, RemoteFileInfoSource remoteFileInfoSource) {
+    public DeltaConnectorScanRangeSource(DeltaLakeTable table, RemoteFileInfoSource remoteFileInfoSource,
+                                         PartitionIdGenerator partitionIdGenerator) {
         this.table = table;
         this.remoteFileInfoSource = remoteFileInfoSource;
         this.remoteFileInputFormat = DeltaUtils.getRemoteFileFormat(table.getDeltaMetadata().getFormat().getProvider());
+        this.partitionIdGenerator = partitionIdGenerator;
     }
 
     private long addPartition(FileScanTask fileScanTask) throws AnalysisException {
@@ -72,7 +75,7 @@ public class DeltaConnectorScanRangeSource extends ConnectorScanRangeSource {
             return partitionKeys.get(partitionKey);
         }
 
-        long partitionId = partitionIdGen.getAndIncrement();
+        long partitionId = partitionIdGenerator.getOrGenerate(partitionKey);
         FileStatus fileStatus = fileScanTask.getFileStatus();
         Path filePath = new Path(URLDecoder.decode(fileStatus.getPath(), StandardCharsets.UTF_8));
         DescriptorTable.ReferencedPartitionInfo referencedPartitionInfo =

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
@@ -216,8 +216,7 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
                             }
                         } else if (del.content() == FileContent.EQUALITY_DELETES) {
                             // to judge if a equality delete is fully applied is not easy. Only the rewrite-all can make sure
-                            // that
-                            // we can eliminate the equality delete files.
+                            // that we can eliminate the equality delete files.
                         }
                     }
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
@@ -109,7 +109,9 @@ public class DeltaLakeScanNode extends ScanNode {
         reachLimit = true;
     }
 
-    public void setupScanRangeSource(ScalarOperator predicate, List<String> fieldNames, boolean enableIncrementalScanRanges)
+    public void setupScanRangeSource(ScalarOperator predicate, List<String> fieldNames,
+                                     PartitionIdGenerator partitionIdGenerator,
+                                     boolean enableIncrementalScanRanges)
             throws StarRocksException {
         SnapshotImpl snapshot = (SnapshotImpl) deltaLakeTable.getDeltaSnapshot();
         DeltaUtils.checkProtocolAndMetadata(snapshot.getProtocol(), snapshot.getMetadata());
@@ -126,7 +128,7 @@ public class DeltaLakeScanNode extends ScanNode {
             remoteFileInfoSource = new RemoteFileInfoDefaultSource(
                     GlobalStateMgr.getCurrentState().getMetadataMgr().getRemoteFiles(deltaLakeTable, params));
         }
-        scanRangeSource = new DeltaConnectorScanRangeSource(deltaLakeTable, remoteFileInfoSource);
+        scanRangeSource = new DeltaConnectorScanRangeSource(deltaLakeTable, remoteFileInfoSource, partitionIdGenerator);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -77,16 +77,19 @@ public class IcebergScanNode extends ScanNode {
     private volatile boolean reachLimit = false;
     private int selectedPartitionCount = -1;
     private Optional<List<BucketProperty>> bucketProperties = Optional.empty();
+    private PartitionIdGenerator partitionIdGenerator = null;
     private IcebergMetricsReporter icebergScanMetricsReporter;
 
     public IcebergScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName,
-                           IcebergTableMORParams tableFullMORParams, IcebergMORParams morParams) {
+                           IcebergTableMORParams tableFullMORParams, IcebergMORParams morParams,
+                           PartitionIdGenerator partitionIdGenerator) {
         super(id, desc, planNodeName);
         this.icebergTable = (IcebergTable) desc.getTable();
         this.tableFullMORParams = tableFullMORParams;
         this.morParams = morParams;
         this.icebergScanMetricsReporter = new IcebergMetricsReporter();
         this.icebergTable.setIcebergMetricsReporter(icebergScanMetricsReporter);
+        this.partitionIdGenerator = partitionIdGenerator;
         setupCloudCredential();
     }
 
@@ -147,7 +150,7 @@ public class IcebergScanNode extends ScanNode {
         }
 
         scanRangeSource = new IcebergConnectorScanRangeSource(icebergTable,
-                remoteFileInfoSource, morParams, desc, bucketProperties, true);
+                remoteFileInfoSource, morParams, desc, bucketProperties, partitionIdGenerator, true);
     }
 
     public void setupScanRangeLocations(boolean enableIncrementalScanRanges) throws StarRocksException {
@@ -187,7 +190,7 @@ public class IcebergScanNode extends ScanNode {
         }
 
         scanRangeSource = new IcebergConnectorScanRangeSource(icebergTable,
-                remoteFileInfoSource, morParams, desc, bucketProperties);
+                remoteFileInfoSource, morParams, desc, bucketProperties, partitionIdGenerator);
     }
 
     private void setupCloudCredential() {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PartitionIdGenerator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PartitionIdGenerator.java
@@ -1,0 +1,39 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License
+package com.starrocks.planner;
+
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.PartitionKey;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * PartitionIdGenerator is used to ensure each PartitionKey get a unique and consistent partitionId in the lifetime of a query.
+ */
+public class PartitionIdGenerator {
+    private final Map<PartitionKey, Long> tablePartitionKeyToId = Maps.newHashMap();
+    private final AtomicLong partitionIdGen = new AtomicLong(0L);
+
+    public PartitionIdGenerator() {
+    }
+
+    public static PartitionIdGenerator of() {
+        return new PartitionIdGenerator();
+    }
+
+    public long getOrGenerate(PartitionKey partitionKey) {
+        return tablePartitionKeyToId.computeIfAbsent(partitionKey, k -> partitionIdGen.getAndIncrement());
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -5101,6 +5101,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return enableIcebergIdentityColumnOptimize;
     }
 
+    public void setEnableIcebergIdentityColumnOptimize(boolean enableIcebergIdentityColumnOptimize) {
+        this.enableIcebergIdentityColumnOptimize = enableIcebergIdentityColumnOptimize;
+    }
+
     public boolean getEnablePlanSerializeConcurrently() {
         return enablePlanSerializeConcurrently;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -104,6 +104,7 @@ import com.starrocks.planner.OdpsScanNode;
 import com.starrocks.planner.OlapScanNode;
 import com.starrocks.planner.OlapTableSink;
 import com.starrocks.planner.PaimonScanNode;
+import com.starrocks.planner.PartitionIdGenerator;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.PlanNode;
 import com.starrocks.planner.ProjectNode;
@@ -1342,6 +1343,8 @@ public class PlanFragmentBuilder {
 
             prepareContextSlots(node, context, tupleDescriptor);
 
+            PartitionIdGenerator partitionIdGenerator = context.getDescTbl().getTablePartitionIdGenerator(referenceTable);
+
             DeltaLakeScanNode deltaLakeScanNode =
                     new DeltaLakeScanNode(context.getNextNodeId(), tupleDescriptor, "DeltaLakeScanNode");
             deltaLakeScanNode.computeStatistics(optExpression.getStatistics());
@@ -1360,7 +1363,7 @@ public class PlanFragmentBuilder {
                 List<String> fieldNames = node.getColRefToColumnMetaMap().keySet().stream()
                         .map(ColumnRefOperator::getName)
                         .collect(Collectors.toList());
-                deltaLakeScanNode.setupScanRangeSource(node.getPredicate(), fieldNames,
+                deltaLakeScanNode.setupScanRangeSource(node.getPredicate(), fieldNames, partitionIdGenerator,
                         context.getConnectContext().getSessionVariable().isEnableConnectorIncrementalScanRanges());
 
                 HDFSScanNodePredicates scanNodePredicates = deltaLakeScanNode.getScanNodePredicates();
@@ -1545,20 +1548,22 @@ public class PlanFragmentBuilder {
             // set slot
             prepareContextSlots(node, context, tupleDescriptor);
 
+            PartitionIdGenerator partitionIdGenerator = context.getDescTbl().getTablePartitionIdGenerator(referenceTable);
+
             boolean isEqDeleteScan = node.getOpType() != OperatorType.PHYSICAL_ICEBERG_SCAN;
             IcebergScanNode icebergScanNode;
             String planNodeName = isEqDeleteScan ? "IcebergEqualityDeleteScanNode" : "IcebergScanNode";
             if (!isEqDeleteScan) {
                 PhysicalIcebergScanOperator op = node.cast();
                 icebergScanNode = new IcebergScanNode(context.getNextNodeId(), tupleDescriptor, planNodeName,
-                        op.getTableFullMORParams(), op.getMORParams());
+                        op.getTableFullMORParams(), op.getMORParams(), partitionIdGenerator);
                 icebergScanNode.updateAppliedDictStringColumns(
                         ((PhysicalIcebergScanOperator) node).getGlobalDicts().stream()
                                 .map(entry -> entry.first).collect(Collectors.toSet()));
             } else {
                 PhysicalIcebergEqualityDeleteScanOperator op = node.cast();
                 icebergScanNode = new IcebergScanNode(context.getNextNodeId(), tupleDescriptor, planNodeName,
-                        op.getTableFullMORParams(), op.getMORParams());
+                        op.getTableFullMORParams(), op.getMORParams(), partitionIdGenerator);
             }
 
             icebergScanNode.setScanOptimizeOption(node.getScanOptimizeOption());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSourceTest.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.connector.BucketProperty;
 import com.starrocks.connector.RemoteFileInfoDefaultSource;
+import com.starrocks.planner.PartitionIdGenerator;
 import org.apache.iceberg.FileScanTask;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,16 +47,16 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
     public void setUp() {
         // Setup tuple descriptor
         tupleDescriptor = new TupleDescriptor(new TupleId(1));
-        
+
         // Setup slot descriptors
         SlotDescriptor idSlot = new SlotDescriptor(new SlotId(1), tupleDescriptor);
         idSlot.setType(INT);
         idSlot.setColumn(new Column("id", INT));
-        
+
         SlotDescriptor dataSlot = new SlotDescriptor(new SlotId(2), tupleDescriptor);
         dataSlot.setType(VARCHAR);
         dataSlot.setColumn(new Column("data", VARCHAR));
-        
+
         tupleDescriptor.addSlot(idSlot);
         tupleDescriptor.addSlot(dataSlot);
     }
@@ -73,7 +74,8 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
         List<BucketProperty> bucketProperties = icebergTable.getBucketProperties();
 
         IcebergConnectorScanRangeSource scanRangeSource = new IcebergConnectorScanRangeSource(icebergTable,
-                RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, tupleDescriptor, Optional.of(bucketProperties));
+                RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, tupleDescriptor, Optional.of(bucketProperties),
+                PartitionIdGenerator.of());
 
         List<FileScanTask> fileScanTasks = Lists.newArrayList(mockedNativeTable2Bucket.newScan().planFiles());
         Assertions.assertEquals(2, fileScanTasks.size());
@@ -103,7 +105,8 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
         List<BucketProperty> oneBucketProperties = List.of(bucketProperties.get(0));
 
         IcebergConnectorScanRangeSource scanRangeSource = new IcebergConnectorScanRangeSource(icebergTable,
-                RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, tupleDescriptor, Optional.of(oneBucketProperties));
+                RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, tupleDescriptor, Optional.of(oneBucketProperties),
+                PartitionIdGenerator.of());
 
         List<FileScanTask> fileScanTasks = Lists.newArrayList(mockedNativeTable2Bucket.newScan().planFiles());
         Assertions.assertEquals(2, fileScanTasks.size());
@@ -117,6 +120,38 @@ public class IcebergConnectorScanRangeSourceTest extends TableTestBase {
                 // 2 data-j2
                 Assertions.assertEquals(2, mappingId);
             }
+        }
+    }
+
+    @Test
+    public void testSamePartitionIdForSamePartitionKeysAcrossDifferentSources() throws Exception {
+        List<Column> schema = new ArrayList<>();
+        schema.add(new Column("id", INT));
+        schema.add(new Column("k1", INT));
+        schema.add(new Column("k2", VARCHAR));
+        mockedNativeTable2Bucket.newFastAppend().appendFile(FILE_J_1).appendFile(FILE_J_2).commit();
+        IcebergTable icebergTable = new IcebergTable(1, "iceberg_table", "iceberg_catalog",
+                "resource", "db", "table", "", schema,
+                mockedNativeTable2Bucket, Maps.newHashMap());
+        Assertions.assertTrue(icebergTable.hasBucketProperties());
+        List<BucketProperty> bucketProperties = icebergTable.getBucketProperties();
+        List<BucketProperty> oneBucketProperties = List.of(bucketProperties.get(0));
+        // Use the same partition key values for both
+        PartitionIdGenerator partitionIdGenerator = PartitionIdGenerator.of();
+        IcebergConnectorScanRangeSource scanRangeSource1 = new IcebergConnectorScanRangeSource(
+                icebergTable, RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, tupleDescriptor,
+                Optional.of(oneBucketProperties), partitionIdGenerator);
+        IcebergConnectorScanRangeSource scanRangeSource2 = new IcebergConnectorScanRangeSource(
+                icebergTable, RemoteFileInfoDefaultSource.EMPTY, IcebergMORParams.EMPTY, tupleDescriptor,
+                Optional.of(oneBucketProperties), partitionIdGenerator);
+        List<FileScanTask> fileScanTasks = Lists.newArrayList(mockedNativeTable2Bucket.newScan().planFiles());
+        Assertions.assertFalse(fileScanTasks.isEmpty());
+        for (FileScanTask fileScanTask : fileScanTasks) {
+            // Simulate partition id generation for the same partition key values
+            long partitionId1 = scanRangeSource1.addPartition(fileScanTask);
+            long partitionId2 = scanRangeSource2.addPartition(fileScanTask);
+            Assertions.assertEquals(partitionId1, partitionId2, "Partition IDs should " +
+                    "be the same for the same partition keys and values");
         }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

If a query references the same table for multiple times, we will allocate multiple scan node nodes but use the same descriptor table. 

However, if each scan node uses `AtomicIdGenerator` for incremental allocation, then this partition ID will be duplicated.

Suppose there are two scan nodes A and B, both referencing table T 
- A partition 1 -> [K1]
- B partition 1-> [K2]

If allocated in this way, there will be a conflict.

So the solution is to use a partition ID generator for the partition allocation under the same table 
- A partition 1-> [K1]
- B partition 2->[K2]

## What I'm doing:

This bug has been resolved in this pr: https://github.com/StarRocks/starrocks/pull/63290/

but that pr is just enhancement and not backported to 4.0 and 3.5 

Fixes https://github.com/StarRocks/starrocks/issues/65598

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
