### PR TITLE
[Enhancement] Add flip_to_write to ByteBuffer

### DIFF
--- a/be/src/exec/file_scanner/json_scanner.cpp
+++ b/be/src/exec/file_scanner/json_scanner.cpp
@@ -707,7 +707,7 @@ Status JsonReader::_read_file_stream() {
                                            _file_stream_buffer->remaining() + simdjson::SIMDJSON_PADDING,
                                            _file_stream_buffer->meta()->type()));
         buf->put_bytes(_file_stream_buffer->ptr, _file_stream_buffer->remaining());
-        buf->flip();
+        buf->flip_to_read();
         // copying meta fail should not affect the scan
         Status copy_st = buf->meta()->copy_from(_file_stream_buffer->meta());
         if (!copy_st.ok()) {

--- a/be/src/http/action/transaction_stream_load.cpp
+++ b/be/src/http/action/transaction_stream_load.cpp
@@ -223,7 +223,7 @@ void TransactionStreamLoadAction::handle(HttpRequest* req) {
     // For CSV, it supports parsing in stream.
     // For JSON, now the buffer contains a complete json.
     if (ctx->buffer != nullptr && ctx->buffer->pos > 0) {
-        ctx->buffer->flip();
+        ctx->buffer->flip_to_read();
         WARN_IF_ERROR(ctx->body_sink->append(std::move(ctx->buffer)),
                       "append MessageBodySink failed when handle TransactionStreamLoad");
         ctx->buffer = nullptr;
@@ -613,7 +613,7 @@ void TransactionStreamLoadAction::on_chunk_data(HttpRequest* req) {
             } else {
                 // For non-json format, we could push buffer to the body_sink in streaming mode.
                 // buffer capacity is not enough, so we push the buffer to the pipe and allocate new one.
-                ctx->buffer->flip();
+                ctx->buffer->flip_to_read();
                 auto st = ctx->body_sink->append(std::move(ctx->buffer));
                 if (!st.ok()) {
                     LOG(WARNING) << "append body content failed. errmsg=" << st << " context=" << ctx->brief();

--- a/be/src/runtime/batch_write/batch_write_mgr.cpp
+++ b/be/src/runtime/batch_write/batch_write_mgr.cpp
@@ -236,7 +236,7 @@ void BatchWriteMgr::receive_stream_load_rpc(ExecEnv* exec_env, brpc::Controller*
                                                             io_buf.size(), copy_size)));
     }
     ctx->buffer->pos += io_buf.size();
-    ctx->buffer->flip();
+    ctx->buffer->flip_to_read();
     ctx->receive_bytes = io_buf.size();
     ctx->mc_read_data_cost_nanos = MonotonicNanos() - ctx->start_nanos;
     ctx->status = append_data(ctx);

--- a/be/src/runtime/routine_load/kafka_consumer_pipe.h
+++ b/be/src/runtime/routine_load/kafka_consumer_pipe.h
@@ -82,7 +82,7 @@ public:
                                            size + simdjson::SIMDJSON_PADDING,
                                            need_meta ? ByteBufferMetaType::KAFKA : ByteBufferMetaType::NONE));
         buf->put_bytes(data, size);
-        buf->flip();
+        buf->flip_to_read();
         if (need_meta) {
             KafkaByteBufferMeta* meta = static_cast<KafkaByteBufferMeta*>(buf->meta());
             meta->set_partition(partition);

--- a/be/src/runtime/stream_load/stream_load_pipe.cpp
+++ b/be/src/runtime/stream_load/stream_load_pipe.cpp
@@ -77,7 +77,7 @@ Status StreamLoadPipe::append(const char* data, size_t size) {
             pos = _write_buf->remaining();
             _write_buf->put_bytes(data, pos);
 
-            _write_buf->flip();
+            _write_buf->flip_to_read();
             RETURN_IF_ERROR(_append(_write_buf));
             _write_buf.reset();
         }
@@ -216,7 +216,7 @@ Status StreamLoadPipe::no_block_read(uint8_t* data, size_t* data_size, bool* eof
 
 Status StreamLoadPipe::finish() {
     if (_write_buf != nullptr) {
-        _write_buf->flip();
+        _write_buf->flip_to_read();
         RETURN_IF_ERROR(_append(_write_buf));
         _write_buf.reset();
     }
@@ -323,7 +323,7 @@ StatusOr<ByteBufferPtr> CompressedStreamLoadPipeReader::read() {
             _decompressed_buffer->put_bytes(piece->ptr, piece->pos);
         }
     }
-    _decompressed_buffer->flip();
+    _decompressed_buffer->flip_to_read();
     return _decompressed_buffer;
 }
 

--- a/be/src/runtime/stream_load/transaction_mgr.cpp
+++ b/be/src/runtime/stream_load/transaction_mgr.cpp
@@ -347,7 +347,7 @@ Status TransactionMgr::_commit_transaction(StreamLoadContext* ctx, bool prepare)
     if (ctx->body_sink != nullptr) {
         // 1. finish stream pipe & wait it done
         if (ctx->buffer != nullptr && ctx->buffer->pos > 0) {
-            ctx->buffer->flip();
+            ctx->buffer->flip_to_read();
             RETURN_IF_ERROR(ctx->body_sink->append(std::move(ctx->buffer)));
             ctx->buffer = nullptr;
         }

--- a/be/src/runtime/stream_load/transaction_mgr.h
+++ b/be/src/runtime/stream_load/transaction_mgr.h
@@ -209,7 +209,7 @@ public:
                         StreamLoadContext* ctx = it2->second;
                         // 1. finish stream pipe & wait it done
                         if (ctx->buffer != nullptr && ctx->buffer->pos > 0) {
-                            ctx->buffer->flip();
+                            ctx->buffer->flip_to_read();
                             RETURN_IF_ERROR(ctx->body_sink->append(std::move(ctx->buffer)));
                             ctx->buffer = nullptr;
                         }

--- a/be/src/util/byte_buffer.h
+++ b/be/src/util/byte_buffer.h
@@ -174,15 +174,30 @@ struct ByteBuffer {
         DCHECK(pos <= limit);
     }
 
-    void flip() {
+    void flip_to_read() {
         limit = pos;
         pos = 0;
+    }
+
+    void flip_to_write() {
+        if (pos > 0) {
+            if (has_remaining()) {
+                size_t size = remaining();
+                std::memmove(ptr, ptr + pos, size);
+                pos = size;
+            } else {
+                pos = 0;
+            }
+        } else {
+            pos = limit;
+        }
+        limit = capacity;
     }
 
     size_t remaining() const { return limit - pos; }
     bool has_remaining() const { return limit > pos; }
 
-    ByteBufferMeta* meta() { return _meta; }
+    ByteBufferMeta* meta() const { return _meta; }
 
     char* const ptr;
     size_t pos{0};

--- a/be/test/runtime/batch_write/batch_write_mgr_test.cpp
+++ b/be/test/runtime/batch_write/batch_write_mgr_test.cpp
@@ -68,7 +68,7 @@ public:
         ctx->enable_batch_write = true;
         auto buf = ByteBuffer::allocate_with_tracker(64).value();
         buf->put_bytes(data.c_str(), data.size());
-        buf->flip();
+        buf->flip_to_read();
         ctx->buffer = buf;
         _to_release_contexts.emplace(ctx);
         return ctx;

--- a/be/test/runtime/batch_write/isomorphic_batch_write_test.cpp
+++ b/be/test/runtime/batch_write/isomorphic_batch_write_test.cpp
@@ -89,7 +89,7 @@ public:
         ctx->load_parameters = batch_write_id.load_params;
         auto buf = ByteBuffer::allocate_with_tracker(64).value();
         buf->put_bytes(data.c_str(), data.size());
-        buf->flip();
+        buf->flip_to_read();
         ctx->buffer = buf;
         _to_release_contexts.emplace(ctx);
         return ctx;

--- a/be/test/runtime/stream_load_pipe_test.cpp
+++ b/be/test/runtime/stream_load_pipe_test.cpp
@@ -154,7 +154,7 @@ PARALLEL_TEST(StreamLoadPipeTest, append_buffer) {
             char c = '0' + (k++ % 10);
             buf->put_bytes(&c, sizeof(c));
         }
-        buf->flip();
+        buf->flip_to_read();
         pipe.append(std::move(buf));
         pipe.finish();
     };
@@ -193,7 +193,7 @@ PARALLEL_TEST(StreamLoadPipeTest, append_and_read_buffer) {
             char c = '0' + (k++ % 10);
             buf->put_bytes(&c, sizeof(c));
         }
-        buf->flip();
+        buf->flip_to_read();
         pipe.append(std::move(buf));
         pipe.finish();
     };
@@ -273,7 +273,7 @@ PARALLEL_TEST(StreamLoadPipeTest, compressed_reader) {
         auto buf = readFileAsBytes("./be/test/runtime/test_data/compressed_file/foo.json.lz4");
         auto byte_buffer = ByteBuffer::allocate_with_tracker(buf.size(), ByteBufferMetaType::KAFKA).value();
         byte_buffer->put_bytes(buf.data(), buf.size());
-        byte_buffer->flip();
+        byte_buffer->flip_to_read();
         KafkaByteBufferMeta* meta = dynamic_cast<KafkaByteBufferMeta*>(byte_buffer->meta());
         EXPECT_TRUE(meta != nullptr);
         meta->set_partition(1);
@@ -304,7 +304,7 @@ PARALLEL_TEST(StreamLoadPipeTest, append_after_finish) {
         char c = '0' + j;
         buf1->put_bytes(&c, sizeof(c));
     }
-    buf1->flip();
+    buf1->flip_to_read();
     ASSERT_OK(pipe.append(std::move(buf1)));
 
     auto appender = [&pipe] {
@@ -320,7 +320,7 @@ PARALLEL_TEST(StreamLoadPipeTest, append_after_finish) {
         char c = '0' + j;
         buf2->put_bytes(&c, sizeof(c));
     }
-    buf2->flip();
+    buf2->flip_to_read();
     EXPECT_TRUE(pipe.append(std::move(buf2)).is_capacity_limit_exceeded());
     t1.join();
 }
@@ -335,7 +335,7 @@ PARALLEL_TEST(StreamLoadPipeTest, non_blocking_read) {
         char c = '0' + j;
         buf->put_bytes(&c, sizeof(c));
     }
-    buf->flip();
+    buf->flip_to_read();
     ASSERT_OK(pipe.append(std::move(buf)));
 
     auto ret = pipe.read();

--- a/be/test/runtime/time_bounded_stream_load_pipe_test.cpp
+++ b/be/test/runtime/time_bounded_stream_load_pipe_test.cpp
@@ -44,7 +44,7 @@ PARALLEL_TEST(TimeBoundedStreamLoadPipeTest, read_buffer_finish) {
         char c = '0' + j;
         buf1->put_bytes(&c, sizeof(c));
     }
-    buf1->flip();
+    buf1->flip_to_read();
     ASSERT_OK(pipe.append(std::move(buf1)));
 
     auto ret = pipe.read();
@@ -78,7 +78,7 @@ PARALLEL_TEST(TimeBoundedStreamLoadPipeTest, read_data_finish) {
         char c = '0' + j;
         buf1->put_bytes(&c, sizeof(c));
     }
-    buf1->flip();
+    buf1->flip_to_read();
     ASSERT_OK(pipe.append(std::move(buf1)));
 
     char read_buf[128];

--- a/be/test/util/byte_buffer_test.cpp
+++ b/be/test/util/byte_buffer_test.cpp
@@ -28,6 +28,10 @@ class ByteBufferTest : public testing::Test {
 public:
     ByteBufferTest() = default;
     ~ByteBufferTest() override = default;
+
+protected:
+    char _write_data[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    char _read_data[10];
 };
 
 TEST_F(ByteBufferTest, normal) {
@@ -44,7 +48,7 @@ TEST_F(ByteBufferTest, normal) {
     ASSERT_EQ(4, buf->capacity);
 
     ASSERT_EQ(1, buf->remaining());
-    buf->flip();
+    buf->flip_to_read();
     ASSERT_EQ(0, buf->pos);
     ASSERT_EQ(3, buf->limit);
     ASSERT_EQ(4, buf->capacity);
@@ -106,6 +110,80 @@ TEST_F(ByteBufferTest, test_allocate_with_meta) {
     ASSERT_TRUE(meta2 != meta3);
     ASSERT_EQ(2, meta3->partition());
     ASSERT_EQ(4, meta3->offset());
+}
+
+TEST_F(ByteBufferTest, test_flip_to_write_partial_read) {
+    auto buf = ByteBuffer::allocate_with_tracker(16).value();
+
+    // write [1, 2, 3, 4, 5]
+    buf->put_bytes(_write_data, 5);
+
+    // read [1, 2, 3]
+    buf->flip_to_read();
+    buf->get_bytes(_read_data, 3);
+
+    // write [1, 2, 3, 4]
+    buf->flip_to_write();
+    buf->put_bytes(_write_data, 4);
+
+    // read all bytes
+    buf->flip_to_read();
+    ASSERT_EQ(6, buf->remaining());
+    buf->get_bytes(_read_data, 6);
+    char check_data[] = {4, 5, 1, 2, 3, 4};
+    ASSERT_EQ(0, memcmp(check_data, _read_data, 6));
+    ASSERT_EQ(16, buf->capacity);
+    ASSERT_EQ(6, buf->pos);
+    ASSERT_EQ(6, buf->limit);
+}
+
+TEST_F(ByteBufferTest, test_flip_to_write_read_all) {
+    auto buf = ByteBuffer::allocate_with_tracker(16).value();
+
+    // write [1, 2, 3, 4, 5]
+    buf->put_bytes(_write_data, 5);
+
+    // read [1, 2, 3, 4, 5]
+    buf->flip_to_read();
+    buf->get_bytes(_read_data, 5);
+
+    // write [1, 2, 3, 4]
+    buf->flip_to_write();
+    buf->put_bytes(_write_data, 4);
+
+    // read all bytes
+    buf->flip_to_read();
+    ASSERT_EQ(4, buf->remaining());
+    buf->get_bytes(_read_data, 4);
+    char check_data[] = {1, 2, 3, 4};
+    ASSERT_EQ(0, memcmp(check_data, _read_data, 4));
+    ASSERT_EQ(16, buf->capacity);
+    ASSERT_EQ(4, buf->pos);
+    ASSERT_EQ(4, buf->limit);
+}
+
+TEST_F(ByteBufferTest, test_flip_to_write_read_nothing) {
+    auto buf = ByteBuffer::allocate_with_tracker(16).value();
+
+    // write [1, 2, 3, 4, 5]
+    buf->put_bytes(_write_data, 5);
+
+    // read [1, 2, 3, 4, 5]
+    buf->flip_to_read();
+
+    // write [1, 2, 3, 4]
+    buf->flip_to_write();
+    buf->put_bytes(_write_data, 4);
+
+    // read all bytes
+    buf->flip_to_read();
+    ASSERT_EQ(9, buf->remaining());
+    buf->get_bytes(_read_data, 9);
+    char check_data[] = {1, 2, 3, 4, 5, 1, 2, 3, 4};
+    ASSERT_EQ(0, memcmp(check_data, _read_data, 9));
+    ASSERT_EQ(16, buf->capacity);
+    ASSERT_EQ(9, buf->pos);
+    ASSERT_EQ(9, buf->limit);
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

To later support streaming JSON processing and reduce memory usage, we will add a new interface flip_to_write to ByteBuffer for incremental writing.

Rename flip to flip_to_read

## What I'm doing:

Add flip_to_write to ByteBuffer

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce ByteBuffer::flip_to_write and replace all usages of flip() with flip_to_read(), updating related code and tests.
> 
> - **Util**:
>   - `ByteBuffer`: add `flip_to_write()`; rename `flip()` to `flip_to_read()`; make `meta()` const; support reallocation preserving meta.
> - **Stream Load / IO**:
>   - Replace `flip()` with `flip_to_read()` across `stream_load_pipe`, HTTP actions (`stream_load.cpp`, `transaction_stream_load.cpp`), transaction manager, batch write manager, Kafka consumer pipe, and JSON scanner.
> - **Tests**:
>   - Update tests to use `flip_to_read()`.
>   - Add unit tests validating `flip_to_write()` behavior and buffer semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94f366b0cfdb5b324d491235258afb61e3495f9c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->