### PR TITLE
[BugFix] fix meta scan rewrite bugs on temporay partition and random buckets

### DIFF
--- a/be/src/exec/olap_meta_scanner.cpp
+++ b/be/src/exec/olap_meta_scanner.cpp
@@ -50,7 +50,8 @@ Status OlapMetaScanner::_init_meta_reader_params() {
                                                 ? _parent->_meta_scan_node.low_cardinality_threshold
                                                 : DICT_DECODE_MAX_SIZE;
     if (_parent->_meta_scan_node.__isset.columns && !_parent->_meta_scan_node.columns.empty() &&
-        (_parent->_meta_scan_node.columns[0].col_unique_id > 0 || _version > _tablet->tablet_schema()->schema_version())) {
+        (_parent->_meta_scan_node.columns[0].col_unique_id > 0 ||
+         _version > _tablet->tablet_schema()->schema_version())) {
         _reader_params.tablet_schema = TabletSchema::copy(*_tablet->tablet_schema(), _parent->_meta_scan_node.columns);
     } else {
         _reader_params.tablet_schema = _tablet->tablet_schema();

--- a/be/src/exec/olap_meta_scanner.cpp
+++ b/be/src/exec/olap_meta_scanner.cpp
@@ -49,12 +49,20 @@ Status OlapMetaScanner::_init_meta_reader_params() {
     _reader_params.low_card_threshold = _parent->_meta_scan_node.__isset.low_cardinality_threshold
                                                 ? _parent->_meta_scan_node.low_cardinality_threshold
                                                 : DICT_DECODE_MAX_SIZE;
-    if (_parent->_meta_scan_node.__isset.columns && !_parent->_meta_scan_node.columns.empty() &&
-        (_parent->_meta_scan_node.columns[0].col_unique_id > 0 ||
-         _version > _tablet->tablet_schema()->schema_version())) {
-        _reader_params.tablet_schema = TabletSchema::copy(*_tablet->tablet_schema(), _parent->_meta_scan_node.columns);
-    } else {
+
+    if (_parent->_meta_scan_node.__isset.schema_id && _parent->_meta_scan_node.schema_id > 0 &&
+        _parent->_meta_scan_node.schema_id == _tablet->tablet_schema()->id()) {
         _reader_params.tablet_schema = _tablet->tablet_schema();
+    }
+
+    if (_reader_params.tablet_schema == nullptr) {
+        if (_parent->_meta_scan_node.__isset.columns && !_parent->_meta_scan_node.columns.empty() &&
+            (_parent->_meta_scan_node.columns[0].col_unique_id >= 0)) {
+            _reader_params.tablet_schema =
+                    TabletSchema::copy(*_tablet->tablet_schema(), _parent->_meta_scan_node.columns);
+        } else {
+            _reader_params.tablet_schema = _tablet->tablet_schema();
+        }
     }
 
     if (_parent->_meta_scan_node.__isset.column_access_paths && !_parent->_column_access_paths.empty()) {

--- a/be/src/exec/olap_meta_scanner.cpp
+++ b/be/src/exec/olap_meta_scanner.cpp
@@ -50,11 +50,12 @@ Status OlapMetaScanner::_init_meta_reader_params() {
                                                 ? _parent->_meta_scan_node.low_cardinality_threshold
                                                 : DICT_DECODE_MAX_SIZE;
     if (_parent->_meta_scan_node.__isset.columns && !_parent->_meta_scan_node.columns.empty() &&
-        _parent->_meta_scan_node.columns[0].col_unique_id > 0) {
+        (_parent->_meta_scan_node.columns[0].col_unique_id > 0 || _version > _tablet->tablet_schema()->schema_version())) {
         _reader_params.tablet_schema = TabletSchema::copy(*_tablet->tablet_schema(), _parent->_meta_scan_node.columns);
     } else {
         _reader_params.tablet_schema = _tablet->tablet_schema();
     }
+
     if (_parent->_meta_scan_node.__isset.column_access_paths && !_parent->_column_access_paths.empty()) {
         _reader_params.column_access_paths = &_parent->_column_access_paths;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/MetaScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/MetaScanNode.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
@@ -59,14 +60,17 @@ public class MetaScanNode extends ScanNode {
     private final List<Column> tableSchema;
     private final List<String> selectPartitionNames;
     private final List<TScanRangeLocations> result = Lists.newArrayList();
+    private long selectedIndexId = -1;
 
     public MetaScanNode(PlanNodeId id, TupleDescriptor desc, OlapTable olapTable,
-                        Map<Integer, String> columnIdToNames, List<String> selectPartitionNames, ComputeResource computeResource) {
+                        Map<Integer, String> columnIdToNames, List<String> selectPartitionNames,
+                        long selectedIndexId, ComputeResource computeResource) {
         super(id, desc, "MetaScan");
         this.olapTable = olapTable;
         this.tableSchema = olapTable.getBaseSchema();
         this.columnIdToNames = columnIdToNames;
         this.selectPartitionNames = selectPartitionNames;
+        this.selectedIndexId = selectedIndexId;
         this.computeResource = computeResource;
     }
 
@@ -181,6 +185,13 @@ public class MetaScanNode extends ScanNode {
             columnsDesc.add(tColumn);
         }
         msg.meta_scan_node.setColumns(columnsDesc);
+        if (selectedIndexId != -1) {
+            MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(selectedIndexId);
+            if (indexMeta != null) {
+                long schemaId = indexMeta.getSchemaId();
+                msg.meta_scan_node.setSchema_id(schemaId);
+            }
+        }
 
         if (CollectionUtils.isNotEmpty(columnAccessPaths)) {
             msg.meta_scan_node.setColumn_access_paths(columnAccessPathToThrift());

--- a/fe/fe-core/src/main/java/com/starrocks/planner/MetaScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/MetaScanNode.java
@@ -75,8 +75,13 @@ public class MetaScanNode extends ScanNode {
         if (selectPartitionNames.isEmpty()) {
             partitions = olapTable.getPhysicalPartitions();
         } else {
-            partitions = selectPartitionNames.stream().map(olapTable::getPartition)
-                    .map(Partition::getDefaultPhysicalPartition).collect(Collectors.toList());
+            partitions = selectPartitionNames.stream().map(name -> {
+                Partition partition = olapTable.getPartition(name, false);
+                if (partition != null) {
+                    return partition;
+                }
+                return olapTable.getPartition(name, true);
+            }).map(Partition::getSubPartitions).flatMap(Collection::stream).collect(Collectors.toList());
         }
         for (PhysicalPartition partition : partitions) {
             MaterializedIndex index = partition.getBaseIndex();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalMetaScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalMetaScanOperator.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Objects;
 
 public class LogicalMetaScanOperator extends LogicalScanOperator {
+    private long selectedIndexId = -1;
     private Map<Integer, String> aggColumnIdToNames = ImmutableMap.of();
     private List<String> selectPartitionNames = Collections.emptyList();
 
@@ -38,6 +39,10 @@ public class LogicalMetaScanOperator extends LogicalScanOperator {
 
     public List<String> getSelectPartitionNames() {
         return selectPartitionNames;
+    }
+
+    public long getSelectedIndexId() {
+        return selectedIndexId;
     }
 
     @Override
@@ -58,7 +63,8 @@ public class LogicalMetaScanOperator extends LogicalScanOperator {
         }
         LogicalMetaScanOperator that = (LogicalMetaScanOperator) o;
         return Objects.equals(aggColumnIdToNames, that.aggColumnIdToNames) &&
-                Objects.equals(selectPartitionNames, that.selectPartitionNames);
+                Objects.equals(selectPartitionNames, that.selectPartitionNames) &&
+                selectedIndexId == that.selectedIndexId;
     }
 
     @Override
@@ -94,6 +100,11 @@ public class LogicalMetaScanOperator extends LogicalScanOperator {
 
         public LogicalMetaScanOperator.Builder setSelectPartitionNames(List<String> selectPartitionNames) {
             builder.selectPartitionNames = selectPartitionNames;
+            return this;
+        }
+
+        public LogicalMetaScanOperator.Builder setSelectedIndexId(long selectedIndexId) {
+            builder.selectedIndexId = selectedIndexId;
             return this;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalMetaScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalMetaScanOperator.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 public class PhysicalMetaScanOperator extends PhysicalScanOperator {
     private Map<Integer, String> aggColumnIdToNames;
     private List<String> selectPartitionNames;
+    private long selectedIndexId = -1;
 
     public PhysicalMetaScanOperator() {
         super(OperatorType.PHYSICAL_META_SCAN);
@@ -40,6 +41,7 @@ public class PhysicalMetaScanOperator extends PhysicalScanOperator {
         super(OperatorType.PHYSICAL_META_SCAN, scanOperator);
         this.aggColumnIdToNames = scanOperator.getAggColumnIdToNames();
         this.selectPartitionNames = scanOperator.getSelectPartitionNames();
+        this.selectedIndexId = scanOperator.getSelectedIndexId();
     }
 
     public Map<Integer, String> getAggColumnIdToNames() {
@@ -48,6 +50,10 @@ public class PhysicalMetaScanOperator extends PhysicalScanOperator {
 
     public List<String> getSelectPartitionNames() {
         return selectPartitionNames;
+    }
+
+    public long getSelectedIndexId() {
+        return selectedIndexId;
     }
 
     @Override
@@ -72,12 +78,13 @@ public class PhysicalMetaScanOperator extends PhysicalScanOperator {
 
         PhysicalMetaScanOperator that = (PhysicalMetaScanOperator) o;
         return Objects.equals(aggColumnIdToNames, that.aggColumnIdToNames) &&
-                Objects.equals(selectPartitionNames, that.selectPartitionNames);
+                Objects.equals(selectPartitionNames, that.selectPartitionNames) &&
+                selectedIndexId == that.selectedIndexId;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), aggColumnIdToNames, selectPartitionNames);
+        return Objects.hash(super.hashCode(), aggColumnIdToNames, selectPartitionNames, selectedIndexId);
     }
 
     public static Builder builder() {
@@ -97,6 +104,7 @@ public class PhysicalMetaScanOperator extends PhysicalScanOperator {
             super.withOperator(operator);
             builder.aggColumnIdToNames = ImmutableMap.copyOf(operator.aggColumnIdToNames);
             builder.selectPartitionNames = ImmutableList.copyOf(operator.selectPartitionNames);
+            builder.selectedIndexId = operator.selectedIndexId;
             return this;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToMetaScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToMetaScanRule.java
@@ -167,6 +167,7 @@ public class RewriteSimpleAggToMetaScanRule extends TransformationRule {
         LogicalMetaScanOperator newMetaScan = LogicalMetaScanOperator.builder()
                 .setTable(scanOperator.getTable())
                 .setSelectPartitionNames(selectedPartitionNames)
+                .setSelectedIndexId(scanOperator.getSelectedIndexId())
                 .setColRefToColumnMetaMap(newScanColumnRefs)
                 .setAggColumnIdToNames(aggColumnIdToNames).build();
         LogicalAggregationOperator newAggOperator = new LogicalAggregationOperator(aggregationOperator.getType(),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -644,6 +644,7 @@ public class RelationTransformer implements AstVisitorExtendInterface<LogicalPla
                         .setColRefToColumnMetaMap(colRefToColumnMetaMapBuilder.build())
                         .setSelectPartitionNames(node.getPartitionNames() == null ? Collections.emptyList() :
                                 node.getPartitionNames().getPartitionNames())
+                        .setSelectedIndexId(((OlapTable) node.getTable()).getBaseIndexId())
                         .build();
             } else if (!isMVPlanner) {
                 scanOperator = LogicalOlapScanOperator.builder()

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1097,9 +1097,10 @@ public class PlanFragmentBuilder {
             tupleDescriptor.setTable(scan.getTable());
             ComputeResource computeResource = ConnectContext.get() != null ?
                     ConnectContext.get().getCurrentComputeResource() : WarehouseManager.DEFAULT_RESOURCE;
+
             MetaScanNode scanNode = new MetaScanNode(context.getNextNodeId(),
                     tupleDescriptor, (OlapTable) scan.getTable(), scan.getAggColumnIdToNames(),
-                    scan.getSelectPartitionNames(),
+                    scan.getSelectPartitionNames(), scan.getSelectedIndexId(),
                     context.getConnectContext().getCurrentComputeResource());
 
             scanNode.setColumnAccessPaths(scan.getColumnAccessPaths());

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -1285,6 +1285,7 @@ struct TMetaScanNode {
     2: optional list<Descriptors.TColumn> columns
     3: optional i32 low_cardinality_threshold
     4: optional list<TColumnAccessPath> column_access_paths
+    5: optional i64 schema_id
 }
 
 struct TDecodeNode {

--- a/test/sql/test_agg/R/test_meta_scan_agg
+++ b/test/sql/test_agg/R/test_meta_scan_agg
@@ -51,3 +51,52 @@ select min(c0),max(c0),min(c1),max(c1),min(c2),max(c2) from t0[_META_];
 -- result:
 2024-01-01	2024-01-05	1	5	1	5
 -- !result
+create table t1 (
+    c0 DATE,
+    c1 INT
+) DUPLICATE key (c0) 
+PARTITION BY RANGE(c0) (
+    PARTITION p202401 VALUES [("2024-01-01"), ("2024-02-01")),
+    PARTITION p202402 VALUES [("2024-02-01"), ("2024-03-01"))
+)
+DISTRIBUTED BY HASH(c1) BUCKETS 3 
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t1 values ('2024-01-15', 10), ('2024-01-20', 20), ('2024-02-10', 30), ('2024-02-15', 40);
+-- result:
+-- !result
+alter table t1 add temporary partition tp202403 VALUES [("2024-03-01"), ("2024-04-01"));
+-- result:
+-- !result
+insert into t1 TEMPORARY PARTITION(tp202403) values ('2024-03-10', 50), ('2024-03-15', 60), ('2024-03-20', 70);
+-- result:
+-- !result
+select count(*) from t1 partition(p202401);
+-- result:
+2
+-- !result
+select count(*) from t1 TEMPORARY PARTITION(tp202403);
+-- result:
+3
+-- !result
+select count(c0) from t1 TEMPORARY PARTITION(tp202403);
+-- result:
+3
+-- !result
+select count(c1) from t1 TEMPORARY PARTITION(tp202403);
+-- result:
+3
+-- !result
+select min(c0), max(c0) from t1 TEMPORARY PARTITION(tp202403);
+-- result:
+2024-03-10	2024-03-20
+-- !result
+select min(c1), max(c1) from t1 TEMPORARY PARTITION(tp202403);
+-- result:
+50	70
+-- !result
+select min(c0), max(c0), min(c1), max(c1) from t1 TEMPORARY PARTITION(tp202403);
+-- result:
+2024-03-10	2024-03-20	50	70
+-- !result

--- a/test/sql/test_agg/T/test_meta_scan_agg
+++ b/test/sql/test_agg/T/test_meta_scan_agg
@@ -20,3 +20,29 @@ select count(c0) from t0[_META_];
 select count(c1) from t0[_META_];
 select count(c2) from t0[_META_];
 select min(c0),max(c0),min(c1),max(c1),min(c2),max(c2) from t0[_META_];
+
+create table t1 (
+    c0 DATE,
+    c1 INT
+) DUPLICATE key (c0) 
+PARTITION BY RANGE(c0) (
+    PARTITION p202401 VALUES [("2024-01-01"), ("2024-02-01")),
+    PARTITION p202402 VALUES [("2024-02-01"), ("2024-03-01"))
+)
+DISTRIBUTED BY HASH(c1) BUCKETS 3 
+PROPERTIES('replication_num' = '1');
+
+insert into t1 values ('2024-01-15', 10), ('2024-01-20', 20), ('2024-02-10', 30), ('2024-02-15', 40);
+
+alter table t1 add temporary partition tp202403 VALUES [("2024-03-01"), ("2024-04-01"));
+
+insert into t1 TEMPORARY PARTITION(tp202403) values ('2024-03-10', 50), ('2024-03-15', 60), ('2024-03-20', 70);
+
+select count(*) from t1 partition(p202401);
+select count(*) from t1 TEMPORARY PARTITION(tp202403);
+select count(c0) from t1 TEMPORARY PARTITION(tp202403);
+select count(c1) from t1 TEMPORARY PARTITION(tp202403);
+select min(c0), max(c0) from t1 TEMPORARY PARTITION(tp202403);
+select min(c1), max(c1) from t1 TEMPORARY PARTITION(tp202403);
+select min(c0), max(c0), min(c1), max(c1) from t1 TEMPORARY PARTITION(tp202403);
+


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/10609

1. handle temporary partitions in RewriteSimpleAggToMetaScanRule
2. pass schema_id in meta_scan_node to ensure that the olap meta scanner can use the correct tablet schema.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> MetaScan now enumerates sub/temporary partitions and BE copies tablet schema when scan version exceeds schema version; adds SQL tests for meta scan on temporary partitions.
> 
> - **Frontend (planner)**:
>   - `MetaScanNode.computeRangeLocations`: when specific partitions are selected, resolve by name to normal or temporary `Partition`, then enumerate `Partition.getSubPartitions()` to build scan ranges.
> - **Backend (scanner)**:
>   - `olap_meta_scanner.cpp`: copy `tablet_schema` if specified columns use positive `col_unique_id` or if scan `_version` > tablet schema version; otherwise reuse existing schema.
> - **Tests**:
>   - Extend `test_meta_scan_agg` to create a temporary partition and validate meta-scan counts/min/max over it.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e9c6d7fb2a497074db3eaee548775297b3ad0560. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->