### PR TITLE
[Enhancement] percentile_approx support array type parameter

### DIFF
--- a/be/src/exprs/agg/combinator/state_combinator.h
+++ b/be/src/exprs/agg/combinator/state_combinator.h
@@ -94,6 +94,11 @@ protected:
     // convert the column to the nullable column if the arg is nullable and the column is not nullable
     StatusOr<ColumnPtr> _convert_to_nullable_column(const ColumnPtr& column, bool arg_nullable,
                                                     bool is_unpack_column) const {
+        // For constant columns, we don't need to unpack or wrap them in NullableColumn, e.g.: [0.2,0.5,0.75]
+        if (column->is_constant()) {
+            return column;
+        }
+
         auto unpack_column =
                 is_unpack_column ? ColumnHelper::unpack_and_duplicate_const_column(column->size(), column) : column;
         if (!arg_nullable && unpack_column->is_nullable()) {

--- a/be/src/exprs/agg/combinator/state_combinator.h
+++ b/be/src/exprs/agg/combinator/state_combinator.h
@@ -94,8 +94,9 @@ protected:
     // convert the column to the nullable column if the arg is nullable and the column is not nullable
     StatusOr<ColumnPtr> _convert_to_nullable_column(const ColumnPtr& column, bool arg_nullable,
                                                     bool is_unpack_column) const {
-        // For constant columns, we don't need to unpack or wrap them in NullableColumn, e.g.: [0.2,0.5,0.75]
-        if (column->is_constant()) {
+        // For constant columns, if we don't need to unpack, return directly to keep efficiency
+        // e.g.: StateFunction with constant parameters like [0.2,0.5,0.75]
+        if (!is_unpack_column && column->is_constant()) {
             return column;
         }
 

--- a/be/src/exprs/agg/factory/aggregate_factory.cpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.cpp
@@ -76,8 +76,16 @@ AggregateFunctionPtr AggregateFactory::MakePercentileApproxAggregateFunction() {
     return std::make_shared<PercentileApproxAggregateFunction>();
 }
 
+AggregateFunctionPtr AggregateFactory::MakePercentileApproxArrayAggregateFunction() {
+    return std::make_shared<PercentileApproxArrayAggregateFunction>();
+}
+
 AggregateFunctionPtr AggregateFactory::MakePercentileApproxWeightedAggregateFunction() {
     return std::make_shared<PercentileApproxWeightedAggregateFunction>();
+}
+
+AggregateFunctionPtr AggregateFactory::MakePercentileApproxWeightedArrayAggregateFunction() {
+    return std::make_shared<PercentileApproxWeightedArrayAggregateFunction>();
 }
 
 AggregateFunctionPtr AggregateFactory::MakePercentileUnionAggregateFunction() {

--- a/be/src/exprs/agg/factory/aggregate_factory.hpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.hpp
@@ -202,7 +202,11 @@ public:
 
     static AggregateFunctionPtr MakePercentileApproxAggregateFunction();
 
+    static AggregateFunctionPtr MakePercentileApproxArrayAggregateFunction();
+
     static AggregateFunctionPtr MakePercentileApproxWeightedAggregateFunction();
+
+    static AggregateFunctionPtr MakePercentileApproxWeightedArrayAggregateFunction();
 
     static AggregateFunctionPtr MakePercentileUnionAggregateFunction();
 

--- a/be/src/exprs/agg/factory/aggregate_resolver_others.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_others.cpp
@@ -53,10 +53,24 @@ void AggregateFuncResolver::register_others() {
     add_aggregate_mapping_variadic<TYPE_DOUBLE, TYPE_DOUBLE, PercentileApproxState>(
             "percentile_approx", false, AggregateFactory::MakePercentileApproxAggregateFunction());
 
+    // percentile_approx(expr, ARRAY<DOUBLE>) -> ARRAY<DOUBLE>
+    add_aggregate_mapping_variadic<TYPE_BIGINT, TYPE_ARRAY, PercentileApproxState>(
+            "percentile_approx", false, AggregateFactory::MakePercentileApproxArrayAggregateFunction());
+    add_aggregate_mapping_variadic<TYPE_DOUBLE, TYPE_ARRAY, PercentileApproxState>(
+            "percentile_approx", false, AggregateFactory::MakePercentileApproxArrayAggregateFunction());
+
     add_aggregate_mapping_variadic<TYPE_BIGINT, TYPE_DOUBLE, PercentileApproxState>(
             "percentile_approx_weighted", false, AggregateFactory::MakePercentileApproxWeightedAggregateFunction());
     add_aggregate_mapping_variadic<TYPE_DOUBLE, TYPE_DOUBLE, PercentileApproxState>(
             "percentile_approx_weighted", false, AggregateFactory::MakePercentileApproxWeightedAggregateFunction());
+
+    // percentile_approx_weighted(expr, weight, ARRAY<DOUBLE>) -> ARRAY<DOUBLE>
+    add_aggregate_mapping_variadic<TYPE_BIGINT, TYPE_ARRAY, PercentileApproxState>(
+            "percentile_approx_weighted", false,
+            AggregateFactory::MakePercentileApproxWeightedArrayAggregateFunction());
+    add_aggregate_mapping_variadic<TYPE_DOUBLE, TYPE_ARRAY, PercentileApproxState>(
+            "percentile_approx_weighted", false,
+            AggregateFactory::MakePercentileApproxWeightedArrayAggregateFunction());
 
     add_aggregate_mapping<TYPE_PERCENTILE, TYPE_PERCENTILE, PercentileValue>(
             "percentile_union", false, AggregateFactory::MakePercentileUnionAggregateFunction());

--- a/be/src/exprs/agg/percentile_approx.h
+++ b/be/src/exprs/agg/percentile_approx.h
@@ -42,8 +42,9 @@ public:
     int64_t mem_usage() const { return percentile->mem_usage(); }
 
     std::unique_ptr<PercentileValue> percentile;
-    double targetQuantile = std::numeric_limits<double>::infinity();
     bool compression_initialized = false; // Flag to track if compression has been initialized from FunctionContext
+    std::vector<double>
+            targetQuantiles; // Stores target quantile(s), single value for scalar mode, multiple for array mode
 };
 
 class PercentileApproxAggregateFunctionBase
@@ -69,33 +70,36 @@ public:
         memcpy(&quantile, src.data, sizeof(double));
 
         PercentileApproxState src_percentile(compression);
-        src_percentile.targetQuantile = quantile;
         src_percentile.percentile->deserialize((char*)src.data + sizeof(double));
 
         int64_t prev_memory = data(state).percentile->mem_usage();
         data(state).percentile->merge(src_percentile.percentile.get());
-        data(state).targetQuantile = quantile;
+        if (data(state).targetQuantiles.empty()) {
+            data(state).targetQuantiles.push_back(quantile);
+        }
         ctx->add_mem_usage(data(state).percentile->mem_usage() - prev_memory);
     }
 
     void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         size_t size = data(state).percentile->serialize_size();
         uint8_t result[size + sizeof(double)];
-        memcpy(result, &(data(state).targetQuantile), sizeof(double));
+        double quantile = data(state).targetQuantiles.empty() ? 0.0 : data(state).targetQuantiles[0];
+        memcpy(result, &quantile, sizeof(double));
         data(state).percentile->serialize(result + sizeof(double));
         auto* column = down_cast<BinaryColumn*>(to);
-        column->append(Slice(result, size));
+        column->append(Slice(result, size + sizeof(double)));
     }
 
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
         auto* data_column = down_cast<DoubleColumn*>(to);
-        double result = data(state).percentile->quantile(data(state).targetQuantile);
+        double quantile = data(state).targetQuantiles.empty() ? 0.0 : data(state).targetQuantiles[0];
+        double result = data(state).percentile->quantile(quantile);
         data_column->append_numbers(&result, sizeof(result));
     }
 };
 
 // PercentileApproxAggregateFunction: percentile_approx(expr, DOUBLE p[, DOUBLE compression])
-class PercentileApproxAggregateFunction final : public PercentileApproxAggregateFunctionBase {
+class PercentileApproxAggregateFunction : public PercentileApproxAggregateFunctionBase {
 public:
     double get_compression_factor(FunctionContext* ctx) const override {
         double compression = DEFAULT_COMPRESSION_FACTOR;
@@ -123,8 +127,8 @@ public:
         DCHECK(columns[1]->is_constant());
         DCHECK(!columns[1]->is_null(0));
         // first update
-        if (UNLIKELY(data(state).targetQuantile == std::numeric_limits<double>::infinity())) {
-            data(state).targetQuantile = columns[1]->get(0).get_double();
+        if (UNLIKELY(data(state).targetQuantiles.empty())) {
+            data(state).targetQuantiles.push_back(columns[1]->get(0).get_double());
         }
         double column_value = data_column->immutable_data()[row_num];
         int64_t prev_memory = data(state).percentile->mem_usage();
@@ -150,7 +154,7 @@ public:
         size_t old_size = bytes.size();
         for (size_t i = 0; i < chunk_size; ++i) {
             PercentileValue percentile;
-            percentile.add(data_column->immutable_data()[i]);
+            percentile.add(implicit_cast<float>(data_column->immutable_data()[i]));
 
             size_t new_size = old_size + sizeof(double) + percentile.serialize_size();
             bytes.resize(new_size);
@@ -165,7 +169,7 @@ public:
 };
 
 // PercentileApproxWeightedAggregateFunction: percentile_approx_weighted(expr, weight, DOUBLE p[, DOUBLE compression])
-class PercentileApproxWeightedAggregateFunction final : public PercentileApproxAggregateFunctionBase {
+class PercentileApproxWeightedAggregateFunction : public PercentileApproxAggregateFunctionBase {
 public:
     // SplitAggregateRule pass the const args to merge phase aggregator for performance.
     // Compression parameter is always the last constant parameter (if provided)
@@ -204,8 +208,8 @@ public:
         // argument 2
         DCHECK(columns[2]->is_constant());
         DCHECK(!columns[2]->is_null(0));
-        if (UNLIKELY(data(state).targetQuantile == std::numeric_limits<double>::infinity())) {
-            data(state).targetQuantile = columns[2]->get(0).get_double();
+        if (UNLIKELY(data(state).targetQuantiles.empty())) {
+            data(state).targetQuantiles.push_back(columns[2]->get(0).get_double());
         }
 
         double column_value = data_column->immutable_data()[row_num];
@@ -239,7 +243,7 @@ public:
                 for (size_t i = 0; i < chunk_size; ++i) {
                     PercentileValue percentile;
                     double value = data_column->immutable_data()[i];
-                    percentile.add(value, weight);
+                    percentile.add(implicit_cast<float>(value), weight);
                     size_t new_size = old_size + sizeof(double) + percentile.serialize_size();
                     bytes.resize(new_size);
                     memcpy(bytes.data() + old_size, &quantile, sizeof(double));
@@ -267,7 +271,7 @@ public:
                 PercentileValue percentile;
                 double value = data_column->immutable_data()[i];
                 if (LIKELY(weight != 0)) {
-                    percentile.add(value, weight);
+                    percentile.add(implicit_cast<float>(value), weight);
                 }
                 size_t new_size = old_size + sizeof(double) + percentile.serialize_size();
                 bytes.resize(new_size);
@@ -280,4 +284,364 @@ public:
     }
     std::string get_name() const override { return "percentile_approx_weighted"; }
 };
+
+// PercentileApproxArrayAggregateFunction: percentile_approx(expr, ARRAY<DOUBLE> p[, DOUBLE compression])
+// Returns ARRAY<DOUBLE>, using new serialization format
+class PercentileApproxArrayAggregateFunction final : public PercentileApproxAggregateFunction {
+public:
+    void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
+        // argument 1: array column wrapped in ConstColumn, no need to check is_null
+        DCHECK(columns[1]->is_constant());
+        // Lazy initialization of compression factor on first update
+        if (UNLIKELY(!data(state).compression_initialized)) {
+            double compression = get_compression_factor(ctx);
+            data(state).reinit_with_compression(compression);
+
+            const auto* array_column = down_cast<const ArrayColumn*>(ColumnHelper::get_data_column(columns[1]));
+            const auto* elements = down_cast<const DoubleColumn*>(
+                    ColumnHelper::get_data_column(array_column->elements_column().get()));
+            auto offsets = array_column->offsets().immutable_data();
+            size_t start = offsets[0];
+            size_t end = offsets[1];
+            DCHECK(end > start) << "Array length cannot be 0";
+            auto elements_data = elements->immutable_data();
+            auto sub = elements_data.subspan(start, end - start);
+            data(state).targetQuantiles.assign(sub.begin(), sub.end());
+        }
+
+        // argument 0
+        const auto* data_column = down_cast<const DoubleColumn*>(columns[0]);
+
+        double column_value = data_column->immutable_data()[row_num];
+        int64_t prev_memory = data(state).percentile->mem_usage();
+        data(state).percentile->add(implicit_cast<float>(column_value));
+        ctx->add_mem_usage(data(state).percentile->mem_usage() - prev_memory);
+    }
+
+    // Override merge method, deserialize using new format: [count(4 bytes), q1...qn(8*n bytes), TDigest_data]
+    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
+        double compression = get_compression_factor(ctx);
+        // Lazy initialization of compression factor on first merge
+        if (UNLIKELY(!data(state).compression_initialized)) {
+            data(state).reinit_with_compression(compression);
+        }
+
+        const auto* binary_column = down_cast<const BinaryColumn*>(column);
+        Slice src = binary_column->get_slice(row_num);
+
+        // Read quantile count
+        uint32_t count;
+        memcpy(&count, src.data, sizeof(uint32_t));
+
+        // Initialize targetQuantiles if empty (first merge without prior update)
+        if (UNLIKELY(data(state).targetQuantiles.empty())) {
+            data(state).targetQuantiles.resize(count);
+            memcpy(data(state).targetQuantiles.data(), (char*)src.data + sizeof(uint32_t), count * sizeof(double));
+        }
+
+        // Deserialize TDigest (skip quantiles array, only need TDigest for merging)
+        PercentileApproxState src_percentile(compression);
+        src_percentile.percentile->deserialize((char*)src.data + sizeof(uint32_t) + count * sizeof(double));
+
+        // Merge into current state
+        int64_t prev_memory = data(state).percentile->mem_usage();
+        data(state).percentile->merge(src_percentile.percentile.get());
+        ctx->add_mem_usage(data(state).percentile->mem_usage() - prev_memory);
+    }
+
+    // Override serialize_to_column method, serialize using new format: [count(4 bytes), q1...qn(8*n bytes), TDigest_data]
+    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
+        size_t tdigest_size = data(state).percentile->serialize_size();
+        uint32_t count = static_cast<uint32_t>(data(state).targetQuantiles.size());
+        size_t total_size = sizeof(uint32_t) + count * sizeof(double) + tdigest_size;
+
+        uint8_t result[total_size];
+
+        // Write quantile count
+        memcpy(result, &count, sizeof(uint32_t));
+
+        // Write all quantiles
+        memcpy(result + sizeof(uint32_t), data(state).targetQuantiles.data(), count * sizeof(double));
+
+        // Write TDigest data
+        data(state).percentile->serialize(result + sizeof(uint32_t) + count * sizeof(double));
+
+        auto* column = down_cast<BinaryColumn*>(to);
+        column->append(Slice(result, total_size));
+    }
+
+    // Override finalize_to_column method, returns ARRAY<DOUBLE>
+    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
+        auto* array_column = down_cast<ArrayColumn*>(to);
+        // Calculate all quantiles and build DatumArray
+        DatumArray result_array;
+        result_array.reserve(data(state).targetQuantiles.size());
+        for (double quantile : data(state).targetQuantiles) {
+            double result = data(state).percentile->quantile(quantile);
+            result_array.emplace_back(result);
+        }
+
+        array_column->append_datum(Datum(result_array));
+    }
+
+    void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
+                                     ColumnPtr* dst) const override {
+        // argument 0
+        const auto* data_column = down_cast<const DoubleColumn*>(src[0].get());
+        // argument 1: ARRAY<DOUBLE>
+        DCHECK(src[1]->is_constant());
+        const auto* array_column = down_cast<const ArrayColumn*>(ColumnHelper::get_data_column(src[1].get()));
+        const auto* elements =
+                down_cast<const DoubleColumn*>(ColumnHelper::get_data_column(array_column->elements_column().get()));
+
+        auto offsets = array_column->offsets().immutable_data();
+        size_t start = offsets[0];
+        size_t end = offsets[1];
+        uint32_t count = static_cast<uint32_t>(end - start);
+
+        // Extract quantiles
+        std::vector<double> quantiles(count);
+        auto elements_data = elements->immutable_data();
+        for (size_t i = 0; i < count; ++i) {
+            quantiles[i] = elements_data[start + i];
+        }
+
+        // result
+        BinaryColumn* result = down_cast<BinaryColumn*>((*dst).get());
+        Bytes& bytes = result->get_bytes();
+        // Calculate estimated size per row: count(4) + quantiles(8*n) + TDigest data(~16 bytes)
+        // 20 = sizeof(uint32_t) + percentile.serialize_size()
+        size_t estimated_size_per_row = count * sizeof(double) + 20;
+        bytes.reserve(chunk_size * estimated_size_per_row);
+        result->get_offset().resize(chunk_size + 1);
+
+        // serialize percentile one by one
+        size_t old_size = bytes.size();
+        for (size_t i = 0; i < chunk_size; ++i) {
+            PercentileValue percentile;
+            percentile.add(implicit_cast<float>(data_column->immutable_data()[i]));
+
+            size_t new_size = old_size + sizeof(uint32_t) + count * sizeof(double) + percentile.serialize_size();
+            bytes.resize(new_size);
+
+            // Write count
+            memcpy(bytes.data() + old_size, &count, sizeof(uint32_t));
+            // Write quantiles
+            memcpy(bytes.data() + old_size + sizeof(uint32_t), quantiles.data(), count * sizeof(double));
+            // Write TDigest
+            percentile.serialize(bytes.data() + old_size + sizeof(uint32_t) + count * sizeof(double));
+
+            result->get_offset()[i + 1] = new_size;
+            old_size = new_size;
+        }
+    }
+};
+
+// PercentileApproxWeightedArrayAggregateFunction: percentile_approx_weighted(expr, weight, ARRAY<DOUBLE> p[, DOUBLE compression])
+// Returns ARRAY<DOUBLE>, using new serialization format
+class PercentileApproxWeightedArrayAggregateFunction final : public PercentileApproxWeightedAggregateFunction {
+public:
+    void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
+        // argument 2: array column wrapped in ConstColumn, no need to check is_null
+        DCHECK(columns[2]->is_constant());
+        // Lazy initialization of compression factor on first update
+        if (UNLIKELY(!data(state).compression_initialized)) {
+            double compression = get_compression_factor(ctx);
+            data(state).reinit_with_compression(compression);
+
+            const auto* array_column = down_cast<const ArrayColumn*>(ColumnHelper::get_data_column(columns[2]));
+            const auto* elements = down_cast<const DoubleColumn*>(
+                    ColumnHelper::get_data_column(array_column->elements_column().get()));
+            auto offsets = array_column->offsets().immutable_data();
+            size_t start = offsets[0];
+            size_t end = offsets[1];
+            DCHECK(end > start) << "Array length cannot be 0";
+            auto elements_data = elements->immutable_data();
+            auto sub = elements_data.subspan(start, end - start);
+            data(state).targetQuantiles.assign(sub.begin(), sub.end());
+        }
+
+        // argument 0
+        const auto* data_column = down_cast<const DoubleColumn*>(columns[0]);
+        // argument 1: weight can be const or int64 column
+        size_t real_row_num = columns[1]->is_constant() ? 0 : row_num;
+        int64_t weight = columns[1]->get(real_row_num).get_int64();
+
+        double column_value = data_column->immutable_data()[row_num];
+        int64_t prev_memory = data(state).percentile->mem_usage();
+        // add value with weight
+        if (LIKELY(weight != 0)) {
+            data(state).percentile->add(implicit_cast<float>(column_value), weight);
+        }
+        ctx->add_mem_usage(data(state).percentile->mem_usage() - prev_memory);
+    }
+
+    // Override merge method, deserialize using new format: [count(4 bytes), q1...qn(8*n bytes), TDigest_data]
+    void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
+        double compression = get_compression_factor(ctx);
+        // Lazy initialization of compression factor on first merge
+        if (UNLIKELY(!data(state).compression_initialized)) {
+            data(state).reinit_with_compression(compression);
+        }
+
+        const auto* binary_column = down_cast<const BinaryColumn*>(column);
+        Slice src = binary_column->get_slice(row_num);
+
+        // Read quantile count
+        uint32_t count;
+        memcpy(&count, src.data, sizeof(uint32_t));
+
+        // Initialize targetQuantiles if empty (first merge without prior update)
+        if (UNLIKELY(data(state).targetQuantiles.empty())) {
+            data(state).targetQuantiles.resize(count);
+            memcpy(data(state).targetQuantiles.data(), (char*)src.data + sizeof(uint32_t), count * sizeof(double));
+        }
+
+        // Deserialize TDigest (skip quantiles array, only need TDigest for merging)
+        PercentileApproxState src_percentile(compression);
+        src_percentile.percentile->deserialize((char*)src.data + sizeof(uint32_t) + count * sizeof(double));
+
+        // Merge into current state
+        int64_t prev_memory = data(state).percentile->mem_usage();
+        data(state).percentile->merge(src_percentile.percentile.get());
+        ctx->add_mem_usage(data(state).percentile->mem_usage() - prev_memory);
+    }
+
+    // Override serialize_to_column method, serialize using new format: [count(4 bytes), q1...qn(8*n bytes), TDigest_data]
+    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
+        size_t tdigest_size = data(state).percentile->serialize_size();
+        uint32_t count = static_cast<uint32_t>(data(state).targetQuantiles.size());
+        size_t total_size = sizeof(uint32_t) + count * sizeof(double) + tdigest_size;
+
+        uint8_t result[total_size];
+
+        // Write quantile count
+        memcpy(result, &count, sizeof(uint32_t));
+
+        // Write all quantiles
+        memcpy(result + sizeof(uint32_t), data(state).targetQuantiles.data(), count * sizeof(double));
+
+        // Write TDigest data
+        data(state).percentile->serialize(result + sizeof(uint32_t) + count * sizeof(double));
+
+        auto* column = down_cast<BinaryColumn*>(to);
+        column->append(Slice(result, total_size));
+    }
+
+    // Override finalize_to_column method, returns ARRAY<DOUBLE>
+    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
+        auto* array_column = down_cast<ArrayColumn*>(to);
+        // Calculate all quantiles and build DatumArray
+        DatumArray result_array;
+        result_array.reserve(data(state).targetQuantiles.size());
+        for (double quantile : data(state).targetQuantiles) {
+            double result = data(state).percentile->quantile(quantile);
+            result_array.emplace_back(result);
+        }
+
+        array_column->append_datum(Datum(result_array));
+    }
+
+    void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
+                                     ColumnPtr* dst) const override {
+        // argument 0
+        const auto* data_column = down_cast<const DoubleColumn*>(src[0].get());
+        // argument 2: ARRAY<DOUBLE>
+        DCHECK(src[2]->is_constant());
+        const auto* array_column = down_cast<const ArrayColumn*>(ColumnHelper::get_data_column(src[2].get()));
+        const auto* elements =
+                down_cast<const DoubleColumn*>(ColumnHelper::get_data_column(array_column->elements_column().get()));
+
+        auto offsets = array_column->offsets().immutable_data();
+        size_t start = offsets[0];
+        size_t end = offsets[1];
+        uint32_t count = static_cast<uint32_t>(end - start);
+
+        // Extract quantiles
+        std::vector<double> quantiles(count);
+        auto elements_data = elements->immutable_data();
+        for (size_t i = 0; i < count; ++i) {
+            quantiles[i] = elements_data[start + i];
+        }
+
+        // result
+        BinaryColumn* result = down_cast<BinaryColumn*>((*dst).get());
+        Bytes& bytes = result->get_bytes();
+        // Calculate estimated size per row: count(4) + quantiles(8*n) + TDigest data(~16 bytes)
+        // 20 = sizeof(uint32_t) + percentile.serialize_size()
+        size_t estimated_size_per_row = count * sizeof(double) + 20;
+        bytes.reserve(chunk_size * estimated_size_per_row);
+        result->get_offset().resize(chunk_size + 1);
+
+        // argument 1, weight column can be int64 or const column
+        // serialize percentile one by one
+        size_t old_size = bytes.size();
+        if (src[1]->is_constant()) {
+            int64_t weight = src[1]->get(0).get_int64();
+            if (LIKELY(weight != 0)) {
+                for (size_t i = 0; i < chunk_size; ++i) {
+                    PercentileValue percentile;
+                    double value = data_column->immutable_data()[i];
+                    percentile.add(implicit_cast<float>(value), weight);
+
+                    size_t new_size =
+                            old_size + sizeof(uint32_t) + count * sizeof(double) + percentile.serialize_size();
+                    bytes.resize(new_size);
+
+                    // Write count
+                    memcpy(bytes.data() + old_size, &count, sizeof(uint32_t));
+                    // Write quantiles
+                    memcpy(bytes.data() + old_size + sizeof(uint32_t), quantiles.data(), count * sizeof(double));
+                    // Write TDigest
+                    percentile.serialize(bytes.data() + old_size + sizeof(uint32_t) + count * sizeof(double));
+
+                    old_size = new_size;
+                    result->get_offset()[i + 1] = new_size;
+                }
+            } else {
+                // TODO: optimize for empty weight but should not happen frequently
+                PercentileValue empty_percentile;
+                size_t delta_size = sizeof(uint32_t) + count * sizeof(double) + empty_percentile.serialize_size();
+                for (size_t i = 0; i < chunk_size; ++i) {
+                    size_t new_size = old_size + delta_size;
+                    bytes.resize(new_size);
+
+                    // Write count
+                    memcpy(bytes.data() + old_size, &count, sizeof(uint32_t));
+                    // Write quantiles
+                    memcpy(bytes.data() + old_size + sizeof(uint32_t), quantiles.data(), count * sizeof(double));
+                    // Write TDigest
+                    empty_percentile.serialize(bytes.data() + old_size + sizeof(uint32_t) + count * sizeof(double));
+
+                    old_size = new_size;
+                    result->get_offset()[i + 1] = new_size;
+                }
+            }
+        } else {
+            const auto* weight_column = down_cast<const Int64Column*>(src[1].get());
+            for (size_t i = 0; i < chunk_size; ++i) {
+                int64_t weight = weight_column->immutable_data()[i];
+                PercentileValue percentile;
+                double value = data_column->immutable_data()[i];
+                if (LIKELY(weight != 0)) {
+                    percentile.add(implicit_cast<float>(value), weight);
+                }
+
+                size_t new_size = old_size + sizeof(uint32_t) + count * sizeof(double) + percentile.serialize_size();
+                bytes.resize(new_size);
+
+                // Write count
+                memcpy(bytes.data() + old_size, &count, sizeof(uint32_t));
+                // Write quantiles
+                memcpy(bytes.data() + old_size + sizeof(uint32_t), quantiles.data(), count * sizeof(double));
+                // Write TDigest
+                percentile.serialize(bytes.data() + old_size + sizeof(uint32_t) + count * sizeof(double));
+
+                old_size = new_size;
+                result->get_offset()[i + 1] = new_size;
+            }
+        }
+    }
+};
+
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -1798,6 +1798,14 @@ public class FunctionSet {
                 Lists.newArrayList(FloatType.DOUBLE, FloatType.DOUBLE, FloatType.DOUBLE), FloatType.DOUBLE,
                 VarbinaryType.VARBINARY,
                 false, false, false));
+        addBuiltin(AggregateFunction.createBuiltin(PERCENTILE_APPROX,
+                Lists.newArrayList(FloatType.DOUBLE, new ArrayType(FloatType.DOUBLE)),
+                new ArrayType(FloatType.DOUBLE), VarbinaryType.VARBINARY,
+                false, false, false));
+        addBuiltin(AggregateFunction.createBuiltin(PERCENTILE_APPROX,
+                Lists.newArrayList(FloatType.DOUBLE, new ArrayType(FloatType.DOUBLE), FloatType.DOUBLE),
+                new ArrayType(FloatType.DOUBLE), VarbinaryType.VARBINARY,
+                false, false, false));
         // percentile_approx_weighted
         addBuiltin(AggregateFunction.createBuiltin(PERCENTILE_APPROX_WEIGHTED,
                 Lists.newArrayList(FloatType.DOUBLE, IntegerType.BIGINT, FloatType.DOUBLE), FloatType.DOUBLE,
@@ -1807,6 +1815,14 @@ public class FunctionSet {
         addBuiltin(AggregateFunction.createBuiltin(PERCENTILE_APPROX_WEIGHTED,
                 Lists.newArrayList(FloatType.DOUBLE, IntegerType.BIGINT, FloatType.DOUBLE, FloatType.DOUBLE), FloatType.DOUBLE,
                 VarbinaryType.VARBINARY,
+                false, false, false));
+        addBuiltin(AggregateFunction.createBuiltin(PERCENTILE_APPROX_WEIGHTED,
+                Lists.newArrayList(FloatType.DOUBLE, IntegerType.BIGINT, new ArrayType(FloatType.DOUBLE)),
+                new ArrayType(FloatType.DOUBLE), VarbinaryType.VARBINARY,
+                false, false, false));
+        addBuiltin(AggregateFunction.createBuiltin(PERCENTILE_APPROX_WEIGHTED,
+                Lists.newArrayList(FloatType.DOUBLE, IntegerType.BIGINT, new ArrayType(FloatType.DOUBLE), FloatType.DOUBLE),
+                new ArrayType(FloatType.DOUBLE), VarbinaryType.VARBINARY,
                 false, false, false));
 
         addBuiltin(AggregateFunction.createBuiltin(PERCENTILE_UNION,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectHintTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectHintTest.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.plan;
 
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.UserVariable;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -114,10 +115,11 @@ public class SelectHintTest extends PlanTestBase {
         });
         assertContains(exception.getMessage(), "The offset parameter of LEAD/LAG must be a constant positive integer");
 
-        exception = Assertions.assertThrows(SemanticException.class, () -> {
+        exception = Assertions.assertThrows(StarRocksPlannerException.class, () -> {
             String invalidSql = "select /*+ set_user_variable(@a = 1, @b = 10) */ percentile_approx(@a, @b) from t0";
             getFragmentPlan(invalidSql);
         });
-        assertContains(exception.getMessage(), " percentile_approx second parameter'value must be between 0 and 1");
+        assertContains(exception.getMessage(), "percentile parameter must " +
+                "be between 0 and 1 in percentile_approx, but got: 10.0");
     }
 }

--- a/test/sql/test_agg_function/R/test_percentile_approx
+++ b/test/sql/test_agg_function/R/test_percentile_approx
@@ -43,3 +43,27 @@ with tt as (select @v1 as v1, @v2 as v2, c1, c2 from t1) select /*+ set_user_var
 -- result:
 25000
 -- !result
+select /*+ SET_VAR (new_planner_agg_stage = '2') */ percentile_approx(c2, array<double>[0.25, 0.5, 0.75]) from t1;
+-- result:
+[12499.75,25000,37500.25]
+-- !result
+select /*+ SET_VAR (new_planner_agg_stage = '2') */ percentile_approx(c2, array<double>[0.0, 0.5, 1.0]) from t1;
+-- result:
+[1,25000,49999]
+-- !result
+select /*+ SET_VAR (new_planner_agg_stage = '2') */ percentile_approx(c2, [0.1, 0.25, 0.5, 0.75, 0.9]) from t1;
+-- result:
+[4999.6005859375,12499.75,25000,37500.25,45000.3984375]
+-- !result
+select /*+ SET_VAR (new_planner_agg_stage = '2') */ percentile_approx(c2, [0.25, 0.5, 0.75], 2048) from t1;
+-- result:
+[12499.75,25000,37500.25]
+-- !result
+select percentile_approx(c2, array<double>[0.5, 0.9], 5000) from t1;
+-- result:
+[25000,45000.40234375]
+-- !result
+select percentile_approx(c2, [0.1, 0.5, 0.9], 10000) from t1;
+-- result:
+[4999.6005859375,25000,45000.3984375]
+-- !result

--- a/test/sql/test_agg_function/R/test_percentile_approx
+++ b/test/sql/test_agg_function/R/test_percentile_approx
@@ -67,3 +67,25 @@ select percentile_approx(c2, [0.1, 0.5, 0.9], 10000) from t1;
 -- result:
 [4999.6005859375,25000,45000.3984375]
 -- !result
+CREATE TABLE `test_sorted_streaming_agg_percentile`
+(
+    `id_int` int(11) NOT NULL COMMENT "",
+    `value` double NOT NULL COMMENT ""
+)
+ENGINE=OLAP 
+DUPLICATE KEY(`id_int`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`id_int`)
+BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+); 
+
+insert into test_sorted_streaming_agg_percentile values(2,1),(2,6),(4,3),(4,8);
+-- result:
+-- !result
+select /*+ SET_VAR (enable_sort_aggregate = 'true') */ percentile_approx(value, array<double>[0.5, 0.9], 5000) from test_sorted_streaming_agg_percentile group by id_int;
+-- result:
+[3.5,6]
+[5.5,8]
+-- !result

--- a/test/sql/test_agg_function/R/test_percentile_approx_weighted
+++ b/test/sql/test_agg_function/R/test_percentile_approx_weighted
@@ -515,3 +515,34 @@ select percentile_approx_weighted(k, v, array<double>[0.1, 0.5, 0.9], 2048) from
 -- result:
 [2.066666603088379,3.4000000953674316,4]
 -- !result
+CREATE TABLE `test_sorted_streaming_agg_percentile_weighted`
+(
+    `id_int` int(11) NOT NULL COMMENT "",
+    `value` double NOT NULL COMMENT ""
+)
+ENGINE=OLAP 
+DUPLICATE KEY(`id_int`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`id_int`)
+BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+); 
+insert into test_sorted_streaming_agg_percentile_weighted values(2,1),(2,6),(4,3),(4,8);
+-- result:
+-- !result
+select /*+ SET_VAR (enable_sort_aggregate = 'true') */ percentile_approx_weighted(value, 10, array<double>[0.5, 0.9], 5000) from test_sorted_streaming_agg_percentile_weighted group by id_int;
+-- result:
+[3.5,6]
+[5.5,8]
+-- !result
+select /*+ SET_VAR (enable_sort_aggregate = 'true') */ percentile_approx_weighted(value, 0, array<double>[0.5, 0.9], 5000) from test_sorted_streaming_agg_percentile_weighted group by id_int;
+-- result:
+[nan,nan]
+[nan,nan]
+-- !result
+select /*+ SET_VAR (enable_sort_aggregate = 'true') */ percentile_approx_weighted(value, value, array<double>[0.5, 0.9], 5000) from test_sorted_streaming_agg_percentile_weighted group by id_int;
+-- result:
+[5.285714149475098,6]
+[6.636363506317139,8]
+-- !result

--- a/test/sql/test_agg_function/R/test_percentile_approx_weighted
+++ b/test/sql/test_agg_function/R/test_percentile_approx_weighted
@@ -43,7 +43,7 @@ select cast(percentile_approx_weighted(c1, 1, 0.9) as int) from t1;
 -- !result
 select cast(percentile_approx_weighted(c1, NULL, 0.9) as int) from t1;
 -- result:
-E: (1064, "Getting analyzing error. Detail message: percentile_approx requires the second parameter's type is bigint type column.")
+E: (1064, 'Getting analyzing error from line 1, column 12 to line 1, column 52. Detail message: percentile_approx_weighted requires the second parameter (weight) to be numeric type, but got: NULL_TYPE.')
 -- !result
 select cast(percentile_approx_weighted(c1, c1, 0.9, 10000) as int) from t1;
 -- result:
@@ -59,7 +59,7 @@ select cast(percentile_approx_weighted(c2, 1, 0.9) as int) from t1;
 -- !result
 select cast(percentile_approx_weighted(c2, 0, 0.9, 0) as int) from t1;
 -- result:
-None
+E: (1064, 'Type check failed. compression parameter must be positive in percentile_approx_weighted, but got: 0.0')
 -- !result
 select cast(percentile_approx_weighted(c2, 0, 0.9, 1) as int) from t1;
 -- result:
@@ -67,7 +67,7 @@ None
 -- !result
 select cast(percentile_approx_weighted(c2, 1, 0.9, 0) as int) from t1;
 -- result:
-44999
+E: (1064, 'Type check failed. compression parameter must be positive in percentile_approx_weighted, but got: 0.0')
 -- !result
 select cast(percentile_approx_weighted(c2, 1, 0.9, 1) as int) from t1;
 -- result:
@@ -183,15 +183,15 @@ select cast(percentile_approx_weighted(c6, 10, 0.9, 5000) as int) from t1;
 -- !result
 select cast(percentile_approx_weighted(c7, c1, 0.5) as int) from t1;
 -- result:
-E: (1064, "Getting analyzing error. Detail message: percentile_approx requires the first parameter's type is numeric type.")
+E: (1064, 'Getting analyzing error from line 1, column 12 to line 1, column 50. Detail message: percentile_approx_weighted requires the first parameter (value) to be numeric type, but got: varchar(65533).')
 -- !result
 select cast(percentile_approx_weighted(c9, c1, 0.5) as int) from t1;
 -- result:
-E: (1064, "Getting analyzing error. Detail message: percentile_approx requires the first parameter's type is numeric type.")
+E: (1064, 'Getting analyzing error from line 1, column 12 to line 1, column 50. Detail message: percentile_approx_weighted requires the first parameter (value) to be numeric type, but got: date.')
 -- !result
 select cast(percentile_approx_weighted(c10, c1, 0.5) as int) from t1;
 -- result:
-E: (1064, "Getting analyzing error. Detail message: percentile_approx requires the first parameter's type is numeric type.")
+E: (1064, 'Getting analyzing error from line 1, column 12 to line 1, column 51. Detail message: percentile_approx_weighted requires the first parameter (value) to be numeric type, but got: datetime.')
 -- !result
 select cast(percentile_approx_weighted(c11[0], c1, 0.5) as int) from t1;
 -- result:
@@ -258,7 +258,7 @@ select cast(percentile_approx_weighted(c1, 1, 0.9) as int) from t1;
 -- !result
 select cast(percentile_approx_weighted(c1, NULL, 0.9) as int) from t1;
 -- result:
-E: (1064, "Getting analyzing error. Detail message: percentile_approx requires the second parameter's type is bigint type column.")
+E: (1064, 'Getting analyzing error from line 1, column 12 to line 1, column 52. Detail message: percentile_approx_weighted requires the second parameter (weight) to be numeric type, but got: NULL_TYPE.')
 -- !result
 select cast(percentile_approx_weighted(c1, c1, 0.9, 10000) as int) from t1;
 -- result:
@@ -366,15 +366,15 @@ select cast(percentile_approx_weighted(c6, 10, 0.9, 5000) as int) from t1;
 -- !result
 select cast(percentile_approx_weighted(c7, c1, 0.5) as int) from t1;
 -- result:
-E: (1064, "Getting analyzing error. Detail message: percentile_approx requires the first parameter's type is numeric type.")
+E: (1064, 'Getting analyzing error from line 1, column 12 to line 1, column 50. Detail message: percentile_approx_weighted requires the first parameter (value) to be numeric type, but got: varchar(65533).')
 -- !result
 select cast(percentile_approx_weighted(c9, c1, 0.5) as int) from t1;
 -- result:
-E: (1064, "Getting analyzing error. Detail message: percentile_approx requires the first parameter's type is numeric type.")
+E: (1064, 'Getting analyzing error from line 1, column 12 to line 1, column 50. Detail message: percentile_approx_weighted requires the first parameter (value) to be numeric type, but got: date.')
 -- !result
 select cast(percentile_approx_weighted(c10, c1, 0.5) as int) from t1;
 -- result:
-E: (1064, "Getting analyzing error. Detail message: percentile_approx requires the first parameter's type is numeric type.")
+E: (1064, 'Getting analyzing error from line 1, column 12 to line 1, column 51. Detail message: percentile_approx_weighted requires the first parameter (value) to be numeric type, but got: datetime.')
 -- !result
 select cast(percentile_approx_weighted(c11[0], c1, 0.5) as int) from t1;
 -- result:
@@ -446,4 +446,72 @@ insert into t2 values(2,1),(3,2),(4,3);
 select /*+ SET_VAR (new_planner_agg_stage = '2') */ percentile_approx_weighted(k, v, 0.5, 10000) from t2;
 -- result:
 3.4000000953674316
+-- !result
+select percentile_approx_weighted(1, 1, 1.5) from t2;
+-- result:
+E: (1064, 'Type check failed. percentile parameter must be between 0 and 1 in percentile_approx_weighted, but got: 1.5')
+-- !result
+select percentile_approx_weighted(1, 1, -0.1) from t2;
+-- result:
+E: (1064, 'Type check failed. percentile parameter must be between 0 and 1 in percentile_approx_weighted, but got: -0.1')
+-- !result
+select percentile_approx_weighted(1, 1, 0.0) from t2;
+-- result:
+1.0
+-- !result
+select percentile_approx_weighted(1, 1, 1.0) from t2;
+-- result:
+1.0
+-- !result
+select percentile_approx_weighted(1, 1, 0.5) from t2;
+-- result:
+1.0
+-- !result
+select percentile_approx_weighted(k, v, array<double>[0.5, 1.5]) from t2;
+-- result:
+E: (1064, 'Type check failed. percentile array element[1] must be between 0 and 1 in percentile_approx_weighted, but got: 1.5')
+-- !result
+select percentile_approx_weighted(k, v, [-0.1, 0.5]) from t2;
+-- result:
+E: (1064, 'Type check failed. percentile array element[0] must be between 0 and 1 in percentile_approx_weighted, but got: -0.1')
+-- !result
+select percentile_approx_weighted(k, v, []) from t2;
+-- result:
+E: (1064, 'Getting analyzing error from line 1, column 7 to line 1, column 42. Detail message: percentile_approx_weighted requires the third parameter (percentile) to be ARRAY<NUMERIC>, but got: ARRAY<NULL_TYPE>.')
+-- !result
+select /*+ SET_VAR (new_planner_agg_stage = '2') */ percentile_approx_weighted(k, v, array<float>[0.0, 0.5, 1.0]) from t2;
+-- result:
+[2,3.4000000953674316,4]
+-- !result
+select percentile_approx_weighted(k, v, [0.25, 0.5, 0.75, 0.9]) from t2;
+-- result:
+[2.6666667461395264,3.4000000953674316,4,4]
+-- !result
+select percentile_approx_weighted(k, v, 0.5, 0) from t2;
+-- result:
+E: (1064, 'Type check failed. compression parameter must be positive in percentile_approx_weighted, but got: 0.0')
+-- !result
+select percentile_approx_weighted(k, v, 0.5, -100) from t2;
+-- result:
+E: (1064, 'Type check failed. compression parameter must be positive in percentile_approx_weighted, but got: -100.0')
+-- !result
+select percentile_approx_weighted(k, v, 0.5, 1) from t2;
+-- result:
+3.4000000953674316
+-- !result
+select percentile_approx_weighted(k, v, 0.5, 100) from t2;
+-- result:
+3.4000000953674316
+-- !result
+select /*+ SET_VAR (new_planner_agg_stage = '2') */ percentile_approx_weighted(k, v, 0.5, 10000) from t2;
+-- result:
+3.4000000953674316
+-- !result
+select /*+ SET_VAR (new_planner_agg_stage = '2') */ percentile_approx_weighted(k, v, [0.25, 0.5, 0.75], 1000) from t2;
+-- result:
+[2.6666667461395264,3.4000000953674316,4]
+-- !result
+select percentile_approx_weighted(k, v, array<double>[0.1, 0.5, 0.9], 2048) from t2;
+-- result:
+[2.066666603088379,3.4000000953674316,4]
 -- !result

--- a/test/sql/test_agg_function/T/test_percentile_approx
+++ b/test/sql/test_agg_function/T/test_percentile_approx
@@ -18,3 +18,10 @@ select cast(percentile_approx(c2, 0.9, 10000) as int) from t1;
 
 with tt as (select @v1 as v1, c1, c2 from t1) select /*+ set_user_variable(@v1 = 0.5) */ cast(percentile_approx(c2, v1) as int) from tt;
 with tt as (select @v1 as v1, @v2 as v2, c1, c2 from t1) select /*+ set_user_variable(@v1= 0.5, @v2 = 4096) */ cast(percentile_approx(c2, v1, v2 + 1) as int) from tt;
+
+select /*+ SET_VAR (new_planner_agg_stage = '2') */ percentile_approx(c2, array<double>[0.25, 0.5, 0.75]) from t1;
+select /*+ SET_VAR (new_planner_agg_stage = '2') */ percentile_approx(c2, array<double>[0.0, 0.5, 1.0]) from t1;
+select /*+ SET_VAR (new_planner_agg_stage = '2') */ percentile_approx(c2, [0.1, 0.25, 0.5, 0.75, 0.9]) from t1;
+select /*+ SET_VAR (new_planner_agg_stage = '2') */ percentile_approx(c2, [0.25, 0.5, 0.75], 2048) from t1;
+select percentile_approx(c2, array<double>[0.5, 0.9], 5000) from t1;
+select percentile_approx(c2, [0.1, 0.5, 0.9], 10000) from t1;

--- a/test/sql/test_agg_function/T/test_percentile_approx
+++ b/test/sql/test_agg_function/T/test_percentile_approx
@@ -25,3 +25,21 @@ select /*+ SET_VAR (new_planner_agg_stage = '2') */ percentile_approx(c2, [0.1, 
 select /*+ SET_VAR (new_planner_agg_stage = '2') */ percentile_approx(c2, [0.25, 0.5, 0.75], 2048) from t1;
 select percentile_approx(c2, array<double>[0.5, 0.9], 5000) from t1;
 select percentile_approx(c2, [0.1, 0.5, 0.9], 10000) from t1;
+
+-- Test percentile_approx sorted streaming aggregate
+CREATE TABLE `test_sorted_streaming_agg_percentile`
+(
+    `id_int` int(11) NOT NULL COMMENT "",
+    `value` double NOT NULL COMMENT ""
+)
+ENGINE=OLAP 
+DUPLICATE KEY(`id_int`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`id_int`)
+BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+); 
+
+insert into test_sorted_streaming_agg_percentile values(2,1),(2,6),(4,3),(4,8);
+select /*+ SET_VAR (enable_sort_aggregate = 'true') */ percentile_approx(value, array<double>[0.5, 0.9], 5000) from test_sorted_streaming_agg_percentile group by id_int;

--- a/test/sql/test_agg_function/T/test_percentile_approx_weighted
+++ b/test/sql/test_agg_function/T/test_percentile_approx_weighted
@@ -193,3 +193,22 @@ select /*+ SET_VAR (new_planner_agg_stage = '2') */ percentile_approx_weighted(k
 -- Test array percentile with compression
 select /*+ SET_VAR (new_planner_agg_stage = '2') */ percentile_approx_weighted(k, v, [0.25, 0.5, 0.75], 1000) from t2;
 select percentile_approx_weighted(k, v, array<double>[0.1, 0.5, 0.9], 2048) from t2;
+
+-- Test percentile_approx_weighted sorted streaming aggregate
+CREATE TABLE `test_sorted_streaming_agg_percentile_weighted`
+(
+    `id_int` int(11) NOT NULL COMMENT "",
+    `value` double NOT NULL COMMENT ""
+)
+ENGINE=OLAP 
+DUPLICATE KEY(`id_int`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`id_int`)
+BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+); 
+insert into test_sorted_streaming_agg_percentile_weighted values(2,1),(2,6),(4,3),(4,8);
+select /*+ SET_VAR (enable_sort_aggregate = 'true') */ percentile_approx_weighted(value, 10, array<double>[0.5, 0.9], 5000) from test_sorted_streaming_agg_percentile_weighted group by id_int;
+select /*+ SET_VAR (enable_sort_aggregate = 'true') */ percentile_approx_weighted(value, 0, array<double>[0.5, 0.9], 5000) from test_sorted_streaming_agg_percentile_weighted group by id_int;
+select /*+ SET_VAR (enable_sort_aggregate = 'true') */ percentile_approx_weighted(value, value, array<double>[0.5, 0.9], 5000) from test_sorted_streaming_agg_percentile_weighted group by id_int;

--- a/test/sql/test_agg_function/T/test_percentile_approx_weighted
+++ b/test/sql/test_agg_function/T/test_percentile_approx_weighted
@@ -168,3 +168,28 @@ PROPERTIES (
 );
 insert into t2 values(2,1),(3,2),(4,3);
 select /*+ SET_VAR (new_planner_agg_stage = '2') */ percentile_approx_weighted(k, v, 0.5, 10000) from t2;
+
+-- Test percentile parameter validation (single value)
+select percentile_approx_weighted(1, 1, 1.5) from t2;
+select percentile_approx_weighted(1, 1, -0.1) from t2;
+select percentile_approx_weighted(1, 1, 0.0) from t2;
+select percentile_approx_weighted(1, 1, 1.0) from t2;
+select percentile_approx_weighted(1, 1, 0.5) from t2;
+
+-- Test percentile parameter validation (array)
+select percentile_approx_weighted(k, v, array<double>[0.5, 1.5]) from t2;
+select percentile_approx_weighted(k, v, [-0.1, 0.5]) from t2;
+select percentile_approx_weighted(k, v, []) from t2;
+select /*+ SET_VAR (new_planner_agg_stage = '2') */ percentile_approx_weighted(k, v, array<float>[0.0, 0.5, 1.0]) from t2;
+select percentile_approx_weighted(k, v, [0.25, 0.5, 0.75, 0.9]) from t2;
+
+-- Test compression parameter validation
+select percentile_approx_weighted(k, v, 0.5, 0) from t2;
+select percentile_approx_weighted(k, v, 0.5, -100) from t2;
+select percentile_approx_weighted(k, v, 0.5, 1) from t2;
+select percentile_approx_weighted(k, v, 0.5, 100) from t2;
+select /*+ SET_VAR (new_planner_agg_stage = '2') */ percentile_approx_weighted(k, v, 0.5, 10000) from t2;
+
+-- Test array percentile with compression
+select /*+ SET_VAR (new_planner_agg_stage = '2') */ percentile_approx_weighted(k, v, [0.25, 0.5, 0.75], 1000) from t2;
+select percentile_approx_weighted(k, v, array<double>[0.1, 0.5, 0.9], 2048) from t2;

--- a/test/sql/test_user_variables/R/test_user_variable
+++ b/test/sql/test_user_variables/R/test_user_variable
@@ -81,7 +81,7 @@ select      /*+ set_user_variable(@a = (select c0 * 0.1 from always1)) */ percen
 -- !result
 select      /*+ set_user_variable(@a = (select c0 * 0.1 from alwaysnull)) */ percentile_approx(c0, @a)  from t0;
 -- result:
-E: (1064, "Getting analyzing error. Detail message: percentile_approx requires the second parameter's type is numeric type.")
+E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 101. Detail message: percentile_approx requires the second parameter (percentile) to be numeric type or array type, but got: varchar.')
 -- !result
 select      percentile_approx(c0, cast(null as double))  from t0;
 -- result:


### PR DESCRIPTION
## Why I'm doing:
select percentile_approx_weighted(k, v, [0.25, 0.5, 0.75, 0.9]) from t2;
## What I'm doing:

Fixes #38571

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add ARRAY<DOUBLE> percentile support and array-returning variants for percentile_approx(_weighted) with stricter validation and extensive tests.
> 
> - **Aggregation (BE)**:
>   - Add `percentile_approx`/`percentile_approx_weighted` array variants accepting `ARRAY<DOUBLE>` and returning `ARRAY<DOUBLE>` with new serialization format `[count | quantiles[] | TDigest]`.
>   - Introduce `PercentileApproxArrayAggregateFunction` and `PercentileApproxWeightedArrayAggregateFunction`; refactor base to store multiple `targetQuantiles` and fix serialization/merge; cast inputs via `implicit_cast<float>`.
>   - Optimize state combinator to skip unpack for constant columns.
> - **Function Registry & Resolution (FE)**:
>   - Register new array signatures in `FunctionSet`; map in resolver/factory.
>   - Analyzer: add reusable numeric/percentile param validators; support ARRAY percentile arguments.
>   - TypeChecker: enforce percentile params are constant (value or array), values ∈ [0,1], and compression > 0; improve error messages.
> - **Tests**:
>   - Add/extend unit and SQL tests for array percentile variants, validation errors, agg-state tables, and sorted streaming paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a51757db840505ff14b0b0fc4a11adeb43a0548. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->