### PR TITLE
[BugFix] Resource group concurrency limit

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
@@ -157,7 +157,8 @@ public class QueryQueueManager {
         long queryQueuePendingTimeoutSecond =
                 slotManager.getQueryQueuePendingTimeoutSecond(context.getCurrentWarehouseId());
         long expiredPendingTimeMs = nowMs + queryQueuePendingTimeoutSecond * 1000L;
-        long expiredAllocatedTimeMs = nowMs + queryQueuePendingTimeoutSecond * 1000L;
+        long execTimeoutS = context.getExecTimeout() - context.getPendingTimeSecond();
+        long expiredAllocatedTimeMs = expiredPendingTimeMs + execTimeoutS * 1000L;
 
         int numFragments = coord.getFragments().size();
         int pipelineDop = coord.getJobSpec().getQueryOptions().getPipeline_dop();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/BaseSlotTracker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/BaseSlotTracker.java
@@ -294,7 +294,7 @@ public abstract class BaseSlotTracker {
         final long nowMs = System.currentTimeMillis();
         List<LogicalSlot> expiredSlots = new ArrayList<>();
         for (LogicalSlot slot : slotsOrderByExpiredTime) {
-            if (!slot.isAllocatedExpired(nowMs)) {
+            if (!slot.isExpired(nowMs)) {
                 break;
             }
             expiredSlots.add(slot);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/LogicalSlot.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/LogicalSlot.java
@@ -177,8 +177,19 @@ public class LogicalSlot {
         return System.currentTimeMillis() >= expiredPendingTimeMs;
     }
 
+    public boolean isRequiringExpired(long nowMs) {
+        return nowMs >= expiredPendingTimeMs;
+    }
+
     public boolean isAllocatedExpired(long nowMs) {
         return nowMs >= expiredAllocatedTimeMs;
+    }
+
+    public boolean isExpired(long nowMs) {
+        if (state == State.CREATED || state == State.REQUIRING) {
+            return isRequiringExpired(nowMs);
+        }
+        return isAllocatedExpired(nowMs);
     }
 
     public long getFeStartTimeMs() {


### PR DESCRIPTION
## Why I'm doing:
Because of love
## What I'm doing:

Fixes #65618 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Compute allocated expiry as pending expiry plus remaining exec timeout and use state-aware slot expiration checks.
> 
> - **Query queueing/scheduling**:
>   - Compute `expiredAllocatedTimeMs` as `expiredPendingTimeMs + execTimeoutS` (remaining exec timeout after pending), instead of equal to pending timeout.
>   - Add `LogicalSlot.isRequiringExpired` and `LogicalSlot.isExpired` to determine expiration based on slot state.
>   - Update `BaseSlotTracker.peakExpiredSlots()` to use `slot.isExpired(nowMs)` for unified pending/allocated expiry handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b087b2904ea2854f70f5ee9c8df6b6119e9947e2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->