### PR TITLE
[Refactor] Move construct_json_type to JsonUtils so that it can be used by HdfsJsonScanner later.

### DIFF
--- a/be/src/exec/file_scanner/json_scanner.h
+++ b/be/src/exec/file_scanner/json_scanner.h
@@ -17,15 +17,11 @@
 #include <string_view>
 
 #include "column/nullable_column.h"
-#include "common/compiler_util.h"
 #include "exec/file_scanner/file_scanner.h"
 #include "exprs/json_functions.h"
 #include "fs/fs.h"
 #include "runtime/stream_load/load_stream_mgr.h"
 #include "simdjson.h"
-#include "util/compression/stream_compression.h"
-#include "util/raw_container.h"
-#include "util/slice.h"
 
 namespace starrocks {
 
@@ -118,7 +114,6 @@ private:
     Status _read_and_parse_json();
     Status _read_file_stream();
     Status _read_file_broker();
-    Status _parse_payload();
 
     Status _construct_row(simdjson::ondemand::object* row, Chunk* chunk);
 
@@ -132,7 +127,6 @@ private:
 
     void _append_error_msg(const std::string&, const std::string& error_msg);
 
-private:
     RuntimeState* _state = nullptr;
     ScannerCounter* _counter = nullptr;
     JsonScanner* _scanner = nullptr;

--- a/be/src/formats/CMakeLists.txt
+++ b/be/src/formats/CMakeLists.txt
@@ -33,6 +33,7 @@ ADD_BE_LIB(Formats
         csv/default_value_converter.cpp
         csv/string_converter.cpp
         csv/varbinary_converter.cpp
+        json/json_utils.cpp
         json/nullable_column.cpp
         json/numeric_column.cpp
         json/binary_column.cpp

--- a/be/src/formats/json/json_utils.cpp
+++ b/be/src/formats/json/json_utils.cpp
@@ -1,0 +1,40 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/json/json_utils.h"
+
+namespace starrocks {
+TypeDescriptor JsonUtils::construct_json_type(const TypeDescriptor& src_type) {
+    switch (src_type.type) {
+    case TYPE_ARRAY:
+    case TYPE_STRUCT:
+    case TYPE_MAP:
+    case TYPE_FLOAT:
+    case TYPE_DOUBLE:
+    case TYPE_BIGINT:
+    case TYPE_INT:
+    case TYPE_SMALLINT:
+    case TYPE_TINYINT:
+    case TYPE_BOOLEAN:
+    case TYPE_CHAR:
+    case TYPE_VARCHAR:
+    case TYPE_JSON: {
+        return src_type;
+    }
+    default:
+        // Treat other types as VARCHAR.
+        return TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
+    }
+}
+} // namespace starrocks

--- a/be/src/formats/json/json_utils.cpp
+++ b/be/src/formats/json/json_utils.cpp
@@ -17,9 +17,28 @@
 namespace starrocks {
 TypeDescriptor JsonUtils::construct_json_type(const TypeDescriptor& src_type) {
     switch (src_type.type) {
-    case TYPE_ARRAY:
-    case TYPE_STRUCT:
-    case TYPE_MAP:
+    case TYPE_ARRAY: {
+        TypeDescriptor json_type(TYPE_ARRAY);
+        const auto& child_type = src_type.children[0];
+        json_type.children.emplace_back(construct_json_type(child_type));
+        return json_type;
+    }
+    case TYPE_STRUCT: {
+        TypeDescriptor json_type(TYPE_STRUCT);
+        json_type.field_names = src_type.field_names;
+        for (auto& child_type : src_type.children) {
+            json_type.children.emplace_back(construct_json_type(child_type));
+        }
+        return json_type;
+    }
+    case TYPE_MAP: {
+        TypeDescriptor json_type(TYPE_MAP);
+        const auto& key_type = src_type.children[0];
+        const auto& value_type = src_type.children[1];
+        json_type.children.emplace_back(construct_json_type(key_type));
+        json_type.children.emplace_back(construct_json_type(value_type));
+        return json_type;
+    }
     case TYPE_FLOAT:
     case TYPE_DOUBLE:
     case TYPE_BIGINT:

--- a/be/src/formats/json/json_utils.h
+++ b/be/src/formats/json/json_utils.h
@@ -1,0 +1,22 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include "runtime/types.h"
+namespace starrocks {
+class JsonUtils {
+public:
+    static TypeDescriptor construct_json_type(const TypeDescriptor& src_type);
+};
+} // namespace starrocks

--- a/be/test/exec/file_scanner/json_scanner_test.cpp
+++ b/be/test/exec/file_scanner/json_scanner_test.cpp
@@ -573,11 +573,8 @@ TEST_F(JsonScannerTest, test_invalid_nested_level2) {
 
     auto scanner = create_json_scanner(types, ranges, {"value"});
 
-    Status st;
-    st = scanner->open();
-    ASSERT_TRUE(st.ok());
-
-    ChunkPtr chunk = scanner->get_next().value();
+    ASSERT_OK(scanner->open());
+    ASSIGN_OR_ASSERT_FAIL(auto chunk, scanner->get_next());
     EXPECT_EQ(1, chunk->num_columns());
     EXPECT_EQ(1, chunk->num_rows());
 


### PR DESCRIPTION
## Why I'm doing:

We will add HdfsJsonScanner later, so we need to abstract the common logic.

## What I'm doing:

Move construct_json_type to JsonUtils so that it can be used by HdfsJsonScanner later.
## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves `construct_json_type` into new `JsonUtils` and updates `JsonScanner` to use it; adds utility files and updates build and tests.
> 
> - **Refactor**:
>   - Extract `construct_json_type` into `formats/json/JsonUtils` (`json_utils.h/.cpp`).
>   - Update `JsonScanner` to call `JsonUtils::construct_json_type` and remove the local implementation.
> - **Build**:
>   - Add `json/json_utils.cpp` to `be/src/formats/CMakeLists.txt`.
> - **Cleanup**:
>   - Remove unused includes and a dead declaration (`_parse_payload`) in `json_scanner.h`.
>   - Minor test assertions streamlined in `json_scanner_test.cpp`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff5579e801504b774c10bc81275eebbdc21c9214. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->