### PR TITLE
[BugFix] Make sure page will not be inserted into the storage page cache when PageReadOptions.use_page_cache is false.

### DIFF
--- a/be/src/storage/rowset/page_io.cpp
+++ b/be/src/storage/rowset/page_io.cpp
@@ -286,8 +286,8 @@ static Status decompress_if_needed(const PageReadOptions& opts, const PageFooter
 
 Status insert_page_cache(bool cache_enabled, const PageReadOptions& opts, StoragePageCache* cache, const std::string& cache_key,
                          std::unique_ptr<std::vector<uint8_t>> page, PageHandle* handle) {
-    // If cache is not enabled, just return
-    if (!cache_enabled && opts.use_page_cache) {
+    // If cache is not enabled or use_page_cache is false, just return
+    if (!cache_enabled || !opts.use_page_cache) {
         *handle = PageHandle(page.get());
         page.release();
         return Status::OK();

--- a/be/src/storage/rowset/page_io.cpp
+++ b/be/src/storage/rowset/page_io.cpp
@@ -284,10 +284,10 @@ static Status decompress_if_needed(const PageReadOptions& opts, const PageFooter
     return Status::OK();
 }
 
-Status insert_page_cache(bool cache_enabled, StoragePageCache* cache, const std::string& cache_key,
+Status insert_page_cache(bool cache_enabled, const PageReadOptions& opts, StoragePageCache* cache, const std::string& cache_key,
                          std::unique_ptr<std::vector<uint8_t>> page, PageHandle* handle) {
     // If cache is not enabled, just return
-    if (!cache_enabled) {
+    if (!cache_enabled && opts.use_page_cache) {
         *handle = PageHandle(page.get());
         page.release();
         return Status::OK();
@@ -317,7 +317,7 @@ static Status read_and_decompress_page_internal(const PageReadOptions& opts, Pag
 #ifdef __APPLE__
     bool page_cache_available = false;
 #else
-    bool page_cache_available = (cache != nullptr) && cache->available() && opts.use_page_cache;
+    bool page_cache_available = (cache != nullptr) && cache->available();
 #endif
     PageCacheHandle cache_handle;
     std::string cache_key = encode_cache_key(opts.read_file->filename(), opts.page_pointer.offset);

--- a/be/src/storage/rowset/page_io.cpp
+++ b/be/src/storage/rowset/page_io.cpp
@@ -317,7 +317,7 @@ static Status read_and_decompress_page_internal(const PageReadOptions& opts, Pag
 #ifdef __APPLE__
     bool page_cache_available = false;
 #else
-    bool page_cache_available = (cache != nullptr) && cache->available();
+    bool page_cache_available = (cache != nullptr) && cache->available() && opts.use_page_cache;
 #endif
     PageCacheHandle cache_handle;
     std::string cache_key = encode_cache_key(opts.read_file->filename(), opts.page_pointer.offset);

--- a/be/src/storage/rowset/page_io.cpp
+++ b/be/src/storage/rowset/page_io.cpp
@@ -338,7 +338,7 @@ static Status read_and_decompress_page_internal(const PageReadOptions& opts, Pag
     RETURN_IF_ERROR(StoragePageDecoder::decode_page(footer, footer_size + 4, opts.encoding_type, &page, &page_slice));
 
     *body = Slice(page_slice.data, page_slice.size - 4 - footer_size);
-    RETURN_IF_ERROR(insert_page_cache(page_cache_available, cache, cache_key, std::move(page), handle));
+    RETURN_IF_ERROR(insert_page_cache(page_cache_available, opts, cache, cache_key, std::move(page), handle));
 
     return Status::OK();
 }

--- a/be/src/storage/rowset/page_io.cpp
+++ b/be/src/storage/rowset/page_io.cpp
@@ -284,8 +284,8 @@ static Status decompress_if_needed(const PageReadOptions& opts, const PageFooter
     return Status::OK();
 }
 
-Status insert_page_cache(bool cache_enabled, const PageReadOptions& opts, StoragePageCache* cache, const std::string& cache_key,
-                         std::unique_ptr<std::vector<uint8_t>> page, PageHandle* handle) {
+Status insert_page_cache(bool cache_enabled, const PageReadOptions& opts, StoragePageCache* cache,
+                         const std::string& cache_key, std::unique_ptr<std::vector<uint8_t>> page, PageHandle* handle) {
     // If cache is not enabled or use_page_cache is false, just return
     if (!cache_enabled || !opts.use_page_cache) {
         *handle = PageHandle(page.get());

--- a/be/test/storage/rowset/page_io_test.cpp
+++ b/be/test/storage/rowset/page_io_test.cpp
@@ -244,6 +244,50 @@ TEST_F(PageIOTest, test_use_cache_hit) {
     }
 }
 
+// When use_page_cache = false, PageIO should not insert the page into StoragePageCache.
+// Otherwise a later read with use_page_cache = true may hit a stale page from cache.
+TEST_F(PageIOTest, test_no_cache_not_insert_into_cache) {
+    std::vector<int32_t> values{1, 2, 3};
+    OwnedSlice page = _build_data_page(values);
+    size_t uncompressed_size = page.slice().size;
+
+    // write an uncompressed page
+    WritableFileOptions write_opts;
+    write_opts.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE;
+    ASSIGN_OR_ASSERT_FAIL(auto write_file,
+                          _fs->new_writable_file(write_opts, "/test_no_cache_not_insert_into_cache"));
+
+    PageFooterPB footer = _build_page_footer(uncompressed_size);
+    PagePointer result;
+    std::vector<Slice> page_body{page.slice()};
+    ASSERT_OK(PageIO::write_page(write_file.get(), page_body, footer, &result));
+    ASSERT_OK(write_file->close());
+    uint64_t file_size = write_file->size();
+
+    // first read with use_page_cache = false, this must NOT insert into cache
+    ASSIGN_OR_ASSERT_FAIL(auto read_file,
+                          _fs->new_random_access_file("/test_no_cache_not_insert_into_cache"));
+    PageReadOptions read_opts_no_cache = _build_read_options(read_file.get(), 0, file_size, false);
+    {
+        PageHandle handle;
+        Slice body;
+        PageFooterPB read_footer;
+        ASSERT_OK(PageIO::read_and_decompress_page(read_opts_no_cache, &handle, &body, &read_footer));
+    }
+
+    // second read with use_page_cache = true.
+    // If the first read had incorrectly inserted the page into cache, this read would hit cache
+    // and increase cached_pages_num to 1. With the correct behavior, cached_pages_num should remain 0.
+    PageReadOptions read_opts_use_cache = _build_read_options(read_file.get(), 0, file_size, true);
+    {
+        PageHandle handle;
+        Slice body;
+        PageFooterPB read_footer;
+        ASSERT_OK(PageIO::read_and_decompress_page(read_opts_use_cache, &handle, &body, &read_footer));
+        ASSERT_EQ(_stats.cached_pages_num, 0);
+    }
+}
+
 TEST_F(PageIOTest, test_corrupted_cache) {
     // open file
     WritableFileOptions write_opts;

--- a/be/test/storage/rowset/page_io_test.cpp
+++ b/be/test/storage/rowset/page_io_test.cpp
@@ -254,8 +254,7 @@ TEST_F(PageIOTest, test_no_cache_not_insert_into_cache) {
     // write an uncompressed page
     WritableFileOptions write_opts;
     write_opts.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE;
-    ASSIGN_OR_ASSERT_FAIL(auto write_file,
-                          _fs->new_writable_file(write_opts, "/test_no_cache_not_insert_into_cache"));
+    ASSIGN_OR_ASSERT_FAIL(auto write_file, _fs->new_writable_file(write_opts, "/test_no_cache_not_insert_into_cache"));
 
     PageFooterPB footer = _build_page_footer(uncompressed_size);
     PagePointer result;
@@ -265,8 +264,7 @@ TEST_F(PageIOTest, test_no_cache_not_insert_into_cache) {
     uint64_t file_size = write_file->size();
 
     // first read with use_page_cache = false, this must NOT insert into cache
-    ASSIGN_OR_ASSERT_FAIL(auto read_file,
-                          _fs->new_random_access_file("/test_no_cache_not_insert_into_cache"));
+    ASSIGN_OR_ASSERT_FAIL(auto read_file, _fs->new_random_access_file("/test_no_cache_not_insert_into_cache"));
     PageReadOptions read_opts_no_cache = _build_read_options(read_file.get(), 0, file_size, false);
     {
         PageHandle handle;


### PR DESCRIPTION
## Why I'm doing:
This PR fixes a bug in the storage page cache interaction that could lead to stale data being read. The refactoring for the page_io.cpp by pr #65131 make a behavior change that the page will be inserted into the storage page cache even when PageReadOptions.use_page_cache is false. During the segment rewrite for auto_increment column, apply process will read the page from the old segment and write a new segment with the same file name. But the read process of the old segment inserted the page into the storage page cache, so the new segment will read the stale page from the storage page cache.

## What I'm doing:
Make sure the page will not be inserted into the storage page cache when PageReadOptions.use_page_cache is false.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Respect PageReadOptions.use_page_cache by skipping StoragePageCache insertion and add a unit test to prevent stale cache reads.
> 
> - **Storage (PageIO)**:
>   - Update `insert_page_cache` to take `PageReadOptions` and skip cache insertion when `opts.use_page_cache` is false.
>   - Adjust call site in `read_and_decompress_page_internal` to pass `opts`.
> - **Tests**:
>   - Add `test_no_cache_not_insert_into_cache` in `be/test/storage/rowset/page_io_test.cpp` to verify no cache insertion when `use_page_cache=false`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e40919ee679a3206c975caff8970c20c3fa91dd8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->