### PR TITLE
[BugFix] Fix Arrow Flight Context Reset

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectContext.java
@@ -97,6 +97,10 @@ public class ArrowFlightSqlConnectContext extends ConnectContext {
                 );
             }
             this.query = query;
+            removeAllResults();
+            coordinatorFuture.complete(null);
+            coordinatorFuture = new CompletableFuture<>();
+
             this.setQueryId(UUIDUtil.genUUID());
             this.setExecutionId(UUIDUtil.toTUniqueId(this.getQueryId()));
         } finally {
@@ -109,11 +113,7 @@ public class ArrowFlightSqlConnectContext extends ConnectContext {
         try {
             this.query = ""; 
             this.statement = null; 
-
-            coordinatorFuture.complete(null);
-            coordinatorFuture = new CompletableFuture<>();
-            returnResultFromFE = true; 
-            removeAllResults();
+            this.returnResultFromFE = true; 
         } finally {
             queryLock.unlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
@@ -169,9 +169,6 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
     @Override
     public void closePreparedStatement(FlightSql.ActionClosePreparedStatementRequest request, CallContext context,
                                        StreamListener<Result> listener) {
-        String token = context.peerIdentity();
-        ArrowFlightSqlConnectContext ctx = sessionManager.validateAndGetConnectContext(token);
-        ctx.reset(); 
         executor.submit(listener::onCompleted);
     }
 
@@ -519,9 +516,10 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
             Location endpoint = Location.forGrpcInsecure(worker.getHost(), worker.getArrowFlightPort());
             return buildFlightInfo(ticketStatement, descriptor, schema, endpoint);
         } catch (Exception e) {
-            ctx.reset();
             LOG.warn("[ARROW] failed to getFlightInfoFromQuery [queryID={}]", DebugUtil.printId(ctx.getExecutionId()), e);
             throw CallStatus.INTERNAL.withDescription(e.getMessage()).toRuntimeException();
+        } finally {
+            ctx.reset();
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:
closePreparedStatement is not guaranteed to be called when a query finishes. Sequential queries will fail if the context is not reset and it is only reset in closePreparedStatement during normal execution. This includes queries where checking the result is not natural, such as setting a session variable. 
## What I'm doing:
* Move the reset to the end of query execution in `getFlightInfoFromQuery`
* Reset the cache on new query, not on read
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3