### PR TITLE
[BugFix] Fix statistics collection for INSERT OVERWRITE with dynamic overwrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -541,7 +541,19 @@ public class InsertOverwriteJobRunner {
                             throw new DmlException("transaction state is null dbId:%s, txnId:%s", dbId, insertStmt.getTxnId());
                         }
                         tmpPartitionNames = txnState.getCreatedPartitionNames(tableId);
-                        job.setTmpPartitionIds(tmpPartitionNames.stream()
+                        
+                        List<Long> dynamicSourcePartitionIds = new ArrayList<>();
+                        for (String tempPartitionName : tmpPartitionNames) {
+                            String oldPartitionName = tempPartitionName.substring(
+                                    tempPartitionName.indexOf(AnalyzerUtils.PARTITION_NAME_PREFIX_SPLIT) + 1);
+                            Partition oldPartition = targetTable.getPartition(oldPartitionName, false);
+                            if (oldPartition != null) {
+                                dynamicSourcePartitionIds.add(oldPartition.getId());
+                            }
+                        }
+                        
+                        // Collect target partition IDs for stats (the new temp partitions)
+                        List<Long> dynamicTargetPartitionIds = tmpPartitionNames.stream()
                                 .map(name -> {
                                     Partition partition = targetTable.getPartition(name, true);
                                     if (partition == null) {
@@ -549,8 +561,20 @@ public class InsertOverwriteJobRunner {
                                     }
                                     return partition.getId();
                                 })
-                                .collect(Collectors.toList()));
-                        tmpPartitionIds = job.getTmpPartitionIds();
+                                .collect(Collectors.toList());
+                        
+                        job.setTmpPartitionIds(dynamicTargetPartitionIds);
+                        tmpPartitionIds = dynamicTargetPartitionIds;
+                        
+                        stats.setSourcePartitionIds(dynamicSourcePartitionIds);
+                        stats.setTargetPartitionIds(dynamicTargetPartitionIds);
+                        
+                        // Recalculate sumSourceRows for dynamic overwrite
+                        sumSourceRows = dynamicSourcePartitionIds.stream()
+                                .mapToLong(pid -> targetTable.mayGetPartition(pid).stream()
+                                        .mapToLong(Partition::getRowCount).sum())
+                                .sum();
+                        stats.setSourceRows(sumSourceRows);
                     }
                     LOG.info("dynamic overwrite job {} replace tmpPartitionNames:{}", job.getJobId(), tmpPartitionNames);
                     ensureTempPartitionsVisible(targetTable, tmpPartitionIds);

--- a/test/sql/test_analyze_statistics/R/test_overwrite_statistics.sql
+++ b/test/sql/test_analyze_statistics/R/test_overwrite_statistics.sql
@@ -193,3 +193,41 @@ function: assert_explain_costs_contains("select * from test_overwrite_statistics
 -- result:
 None
 -- !result
+delete from _statistics_.column_statistics where table_name='test_overwrite_statistics.expr_range_partitioned_table';
+-- result:
+-- !result
+drop table if exists expr_range_partitioned_table;
+-- result:
+-- !result
+create table expr_range_partitioned_table (
+    dt datetime,
+    k1 int,
+    k2 varchar(20)
+)
+partition by date_trunc('day', dt)
+properties("replication_num"="1");
+-- result:
+-- !result
+insert into expr_range_partitioned_table select '2024-01-01 08:00:00', generate_series, "data1" from table(generate_series(1, 1000));
+-- result:
+-- !result
+set dynamic_overwrite=true;
+-- result:
+-- !result
+insert overwrite expr_range_partitioned_table select '2024-01-01 08:00:00', generate_series, "data1" from table(generate_series(1, 2000));
+-- result:
+-- !result
+function: assert_explain_costs_contains("select * from test_overwrite_statistics.expr_range_partitioned_table;", "cardinality: 2000", "2000.0")
+-- result:
+None
+-- !result
+insert overwrite expr_range_partitioned_table select '2024-01-01 08:00:00', generate_series, "data1" from table(generate_series(1, 300000));
+-- result:
+-- !result
+set dynamic_overwrite=false;
+-- result:
+-- !result
+function: assert_explain_costs_contains("select * from test_overwrite_statistics.expr_range_partitioned_table;", "300000.0")
+-- result:
+None
+-- !result

--- a/test/sql/test_analyze_statistics/T/test_overwrite_statistics.sql
+++ b/test/sql/test_analyze_statistics/T/test_overwrite_statistics.sql
@@ -102,3 +102,21 @@ insert into test_overwrite_stats_table select generate_series from table(generat
 insert overwrite test_overwrite_stats_table select generate_series from table(generate_series(10000, 20000));
 function: assert_explain_costs_contains("select * from test_overwrite_statistics.test_overwrite_stats_table;", "20000.0")
 
+delete from _statistics_.column_statistics where table_name='test_overwrite_statistics.expr_range_partitioned_table';
+drop table if exists expr_range_partitioned_table;
+create table expr_range_partitioned_table (
+    dt datetime,
+    k1 int,
+    k2 varchar(20)
+)
+partition by date_trunc('day', dt)
+properties("replication_num"="1");
+insert into expr_range_partitioned_table select '2024-01-01 08:00:00', generate_series, "data1" from table(generate_series(1, 1000));
+set dynamic_overwrite=true;
+insert overwrite expr_range_partitioned_table select '2024-01-01 08:00:00', generate_series, "data1" from table(generate_series(1, 2000));
+function: assert_explain_costs_contains("select * from test_overwrite_statistics.expr_range_partitioned_table;", "cardinality: 2000", "2000.0")
+insert overwrite expr_range_partitioned_table select '2024-01-01 08:00:00', generate_series, "data1" from table(generate_series(1, 300000));
+set dynamic_overwrite=false;
+function: assert_explain_costs_contains("select * from test_overwrite_statistics.expr_range_partitioned_table;", "300000.0")
+
+


### PR DESCRIPTION
## Why I'm doing:

When using `INSERT OVERWRITE` with dynamic overwrite semantic (where partitions are auto-created based on data), statistics are not collected after the overwrite because the `InsertOverwriteJobStats` object has empty `sourcePartitionIds` and `targetPartitionIds`, resulting in `sourceRows = 0`.

In `InsertOverwriteJobRunner.doCommit()` for dynamic overwrite scenarios:
- The `InsertOverwriteJob` is initialized with empty source/target partition IDs because partitions are identified dynamically during execution
- The actual partition mapping is only available after `executeInsert()` completes via `TransactionState.getCreatedPartitionNames()`
- Without this fix, `stats` would have empty partition IDs and 0 source rows

This prevents the subsequent statistics collection triggered by `StatisticsCollectionTrigger.executeOverWrite()` from running, as it has no partition information to work with.

## What I'm doing:
Populate `sourcePartitionIds`, `targetPartitionIds`, and `sourceRows` in `InsertOverwriteJobStats` for dynamic overwrite.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
