### PR TITLE
[BugFix] fix iceberg scan bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnectorScanRangeSource.java
@@ -290,10 +290,12 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
     protected THdfsScanRange buildScanRange(FileScanTask task, ContentFile<?> file, Long partitionId) throws AnalysisException {
         DescriptorTable.ReferencedPartitionInfo referencedPartitionInfo = referencedPartitions.get(partitionId);
         THdfsScanRange hdfsScanRange = new THdfsScanRange();
-        if (file.path().toString().startsWith(table.getTableLocation())) {
-            hdfsScanRange.setRelative_path(file.path().toString().substring(table.getTableLocation().length()));
+        String filePath = file.path().toString();
+        String tableLocation = table.getTableLocation();
+        if (isFileUnderTableLocation(filePath, tableLocation)) {
+            hdfsScanRange.setRelative_path(buildRelativePath(filePath, tableLocation));
         } else {
-            hdfsScanRange.setFull_path(file.path().toString());
+            hdfsScanRange.setFull_path(filePath);
         }
 
         hdfsScanRange.setOffset(file.content() == FileContent.DATA ? task.start() : 0);
@@ -518,5 +520,39 @@ public class IcebergConnectorScanRangeSource extends ConnectorScanRangeSource {
 
     public Set<DeleteFile> getEqualAppliedDeleteFiles() {
         return appliedEqualDeleteFiles;
+    }
+
+    private static boolean isFileUnderTableLocation(String filePath, String tableLocation) {
+        if (filePath == null || tableLocation == null || tableLocation.isEmpty()) {
+            LOG.warn("File path or table location is null or empty");
+            return false;
+        }
+        String normalizedTableLocation = normalizeTableLocation(tableLocation);
+        if (normalizedTableLocation.isEmpty()) {
+            LOG.warn("Normalized table location is empty");
+            return false;
+        }
+        String prefixWithSeparator = normalizedTableLocation + "/";
+        return filePath.startsWith(prefixWithSeparator);
+    }
+
+    private static String buildRelativePath(String filePath, String tableLocation) {
+        String normalizedTableLocation = normalizeTableLocation(tableLocation);
+        if (filePath.length() <= normalizedTableLocation.length()) {
+            LOG.warn("File path {} is shorter than table location {}", filePath, tableLocation);
+            return "";
+        }
+        return filePath.substring(normalizedTableLocation.length());
+    }
+
+    private static String normalizeTableLocation(String tableLocation) {
+        if (tableLocation == null || tableLocation.isEmpty()) {
+            LOG.warn("Table location is null or empty");
+            return "";
+        }
+        if (tableLocation.length() > 1 && tableLocation.charAt(tableLocation.length() - 1) == '/') {
+            return tableLocation.substring(0, tableLocation.length() - 1);
+        }
+        return tableLocation;
     }
 }

--- a/test/sql/test_iceberg/R/test_iceberg_scan_bug
+++ b/test/sql/test_iceberg/R/test_iceberg_scan_bug
@@ -1,0 +1,15 @@
+-- name: test_iceberg_scan_bug
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_oss_db.t_scan_bug$files;
+-- result:
+0	oss://starrocks-ci-test/dla_test_data/iceberg/t_scan_bug_new/data/00000-0-614af1fa-d44f-4be0-ae46-14d0c5418439-0-00001.parquet	PARQUET	0	1	407	{1:39}	{1:1}	{1:0}	{}	{1:"1"}	{1:"1"}	[4]	0	None	None
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_oss_db.t_scan_bug;
+-- result:
+1
+-- !result
+drop catalog iceberg_sql_test_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_scan_bug
+++ b/test/sql/test_iceberg/T/test_iceberg_scan_bug
@@ -1,0 +1,12 @@
+-- name: test_iceberg_scan_bug
+
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+
+select * from iceberg_sql_test_${uuid0}.iceberg_oss_db.t_scan_bug$files;
+select * from iceberg_sql_test_${uuid0}.iceberg_oss_db.t_scan_bug;
+
+drop catalog iceberg_sql_test_${uuid0};
+
+
+
+


### PR DESCRIPTION
## Why I'm doing:
For table t1, we assume its default location is `s3://warehouse/t1`. However, users may rename the table or modify its location, for example to `s3://warehouse/t1_new`, and place files under that path. Later, the user may change the table name or location back to t1.

In this scenario, according to the current logic in the code, the file path
`s3://warehouse/t1_new/t.parquet`
would be incorrectly interpreted as
`s3://warehouse/t1/_new/t.parquet`


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes Iceberg scan range path handling by only using relative paths when files are strictly under the table location (with normalization), and adds a regression SQL test.
> 
> - **Iceberg scan range handling**:
>   - In `IcebergConnectorScanRangeSource.buildScanRange`, compute `relative_path` only when `isFileUnderTableLocation(filePath, tableLocation)`; otherwise use `full_path`.
>   - Add helpers: `isFileUnderTableLocation`, `buildRelativePath`, `normalizeTableLocation` to normalize table location and ensure prefix checks use a path separator.
> - **Tests**:
>   - Add regression test `test/sql/test_iceberg/T/test_iceberg_scan_bug` with expected results in `test/sql/test_iceberg/R/test_iceberg_scan_bug`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1223e2486ae3d8da804112539057b18f993b0ed7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->