### PR TITLE
[BugFix] Fix compression settings not being applied during table creation and schema changes in shared-data

### DIFF
--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -459,10 +459,8 @@ Status SchemaChangeHandler::do_process_update_tablet_meta(const TTabletMetaInfo&
         metadata_update_info->set_persistent_index_type(index_type);
     }
     if (tablet_meta_info.__isset.tablet_schema) {
-        // FIXME: pass compression type
-        auto compression_type = TCompressionType::LZ4_FRAME;
         auto new_schema = metadata_update_info->mutable_tablet_schema();
-        RETURN_IF_ERROR(convert_t_schema_to_pb_schema(tablet_meta_info.tablet_schema, compression_type, new_schema));
+        RETURN_IF_ERROR(convert_t_schema_to_pb_schema(tablet_meta_info.tablet_schema, new_schema));
         if (tablet_meta_info.create_schema_file) {
             RETURN_IF_ERROR(_tablet_manager->create_schema_file(tablet_id, *new_schema));
         }

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -237,6 +237,8 @@ Status TabletManager::create_tablet(const TCreateTabletReq& req) {
     auto compress_type = req.__isset.compression_type ? req.compression_type : TCompressionType::LZ4_FRAME;
     RETURN_IF_ERROR(
             convert_t_schema_to_pb_schema(req.tablet_schema, compress_type, tablet_metadata_pb->mutable_schema()));
+    auto compession_level = req.__isset.compression_level ? req.compression_level : -1;
+    tablet_metadata_pb->mutable_schema()->set_compression_level(compession_level);
     if (req.create_schema_file) {
         RETURN_IF_ERROR(create_schema_file(req.tablet_id, tablet_metadata_pb->schema()));
     }

--- a/be/src/storage/metadata_util.cpp
+++ b/be/src/storage/metadata_util.cpp
@@ -410,4 +410,12 @@ Status convert_t_schema_to_pb_schema(const TTabletSchema& t_schema, TCompression
     }
     return convert_t_schema_to_pb_schema(t_schema, next_unique_id, col_idx_to_unique_id, out_schema, compression_type);
 }
+
+Status convert_t_schema_to_pb_schema(const TTabletSchema& t_schema, TabletSchemaPB* out_schema) {
+    auto compression_type = t_schema.__isset.compression_type ? t_schema.compression_type : TCompressionType::LZ4_FRAME;
+    auto compression_level = t_schema.__isset.compression_level ? t_schema.compression_level : -1;
+    out_schema->set_compression_level(compression_level);
+    return convert_t_schema_to_pb_schema(t_schema, compression_type, out_schema);
+}
+
 } // namespace starrocks

--- a/be/src/storage/metadata_util.h
+++ b/be/src/storage/metadata_util.h
@@ -40,6 +40,8 @@ enum class FieldTypeVersion {
     kV2,
 };
 
+Status convert_t_schema_to_pb_schema(const TTabletSchema& t_schema, TabletSchemaPB* out_schema);
+
 // If the columns in |t_schema| do not have a unique id, then the columns in |out_schema| will use the
 // column's position in the schema (starting from 0) as their unique id.
 Status convert_t_schema_to_pb_schema(const TTabletSchema& t_schema, TCompressionType::type compression_type,

--- a/be/test/storage/metadata_util_test.cpp
+++ b/be/test/storage/metadata_util_test.cpp
@@ -144,4 +144,83 @@ TEST(MetadataUtilTest, testConvertThriftSchemaToPbSchema) {
     ASSERT_EQ(schemaPb.table_indices(1).index_name(), "vector_index");
 }
 
+TEST(MetadataUtilTest, test_convert_schema_compression_settings) {
+    auto setup_basic_schema = [](TTabletSchema& schema) {
+        schema.__set_schema_hash(12345);
+        schema.__set_keys_type(TKeysType::DUP_KEYS);
+        schema.__set_short_key_column_count(1);
+        schema.columns.emplace_back();
+        TTypeNode type;
+        type.__set_type(TTypeNodeType::SCALAR);
+        type.__set_scalar_type(TScalarType());
+        type.scalar_type.__set_type(TPrimitiveType::INT);
+        schema.columns.back().__set_column_name("c0");
+        schema.columns.back().__set_is_key(true);
+        schema.columns.back().__set_index_len(sizeof(int32_t));
+        schema.columns.back().__set_aggregation_type(TAggregationType::NONE);
+        schema.columns.back().__set_is_allow_null(true);
+        schema.columns.back().__set_type_desc(TTypeDesc());
+        schema.columns.back().type_desc.__set_types({type});
+    };
+
+    // Test 1: Both ZSTD and level 9 set
+    {
+        TTabletSchema schema;
+        setup_basic_schema(schema);
+        schema.__set_compression_type(TCompressionType::ZSTD);
+        schema.__set_compression_level(9);
+        schema.__isset.compression_type = true;
+        schema.__isset.compression_level = true;
+
+        TabletSchemaPB schema_pb;
+        ASSERT_TRUE(convert_t_schema_to_pb_schema(schema, &schema_pb).ok());
+        ASSERT_EQ(schema_pb.compression_type(), ZSTD);
+        ASSERT_EQ(schema_pb.compression_level(), 9);
+        ASSERT_EQ(schema_pb.column().size(), 1);
+        ASSERT_EQ(schema_pb.column(0).name(), "c0");
+        ASSERT_EQ(schema_pb.column(0).type(), "INT");
+    }
+
+    // Test 2: Only ZSTD set
+    {
+        TTabletSchema schema;
+        setup_basic_schema(schema);
+        schema.__set_compression_type(TCompressionType::ZSTD);
+        schema.__isset.compression_type = true;
+        schema.__isset.compression_level = false;
+
+        TabletSchemaPB schema_pb;
+        ASSERT_TRUE(convert_t_schema_to_pb_schema(schema, &schema_pb).ok());
+        ASSERT_EQ(schema_pb.compression_type(), ZSTD);
+        ASSERT_EQ(schema_pb.compression_level(), -1);
+    }
+
+    // Test 3: Only level 9 set
+    {
+        TTabletSchema schema;
+        setup_basic_schema(schema);
+        schema.__set_compression_level(9);
+        schema.__isset.compression_type = false;
+        schema.__isset.compression_level = true;
+
+        TabletSchemaPB schema_pb;
+        ASSERT_TRUE(convert_t_schema_to_pb_schema(schema, &schema_pb).ok());
+        ASSERT_EQ(schema_pb.compression_type(), LZ4_FRAME);
+        ASSERT_EQ(schema_pb.compression_level(), 9);
+    }
+
+    // Test 4: Neither compression_type nor compression_level set
+    {
+        TTabletSchema schema;
+        setup_basic_schema(schema);
+        schema.__isset.compression_type = false;
+        schema.__isset.compression_level = false;
+
+        TabletSchemaPB schema_pb;
+        ASSERT_TRUE(convert_t_schema_to_pb_schema(schema, &schema_pb).ok());
+        ASSERT_EQ(schema_pb.compression_type(), LZ4_FRAME);
+        ASSERT_EQ(schema_pb.compression_level(), -1);
+    }
+}
+
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -3145,6 +3145,8 @@ public class SchemaChangeHandler extends AlterHandler {
                     .setSortKeyIndexes(schemaChangeData.getSortKeyIdxes())
                     .setSortKeyUniqueIds(schemaChangeData.getSortKeyUniqueIds())
                     .setIndexes(schemaChangeData.getIndexes())
+                    .setCompressionType(schemaChangeData.getTable().getCompressionType())
+                    .setCompressionLevel(schemaChangeData.getTable().getCompressionLevel())
                     .build();
             job.setIndexTabletSchema(indexId, indexName, schemaInfo);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaInfo.java
@@ -121,6 +121,14 @@ public class SchemaInfo {
         return bloomFilterFpp;
     }
 
+    public TCompressionType getCompressionType() {
+        return compressionType;
+    }
+
+    public int getCompressionLevel() {
+        return compressionLevel;
+    }
+
     public TTabletSchema toTabletSchema() {
         TTabletSchema tSchema = new TTabletSchema();
         tSchema.setShort_key_column_count(shortKeyColumnCount);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaInfo.java
@@ -17,6 +17,7 @@ package com.starrocks.catalog;
 import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.thrift.TColumn;
+import com.starrocks.thrift.TCompressionType;
 import com.starrocks.thrift.TOlapTableIndex;
 import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TTabletSchema;
@@ -54,6 +55,10 @@ public class SchemaInfo {
     private final Set<ColumnId> bloomFilterColumnNames;
     @SerializedName("bfColumnFpp")
     private final double bloomFilterFpp; // false positive probability
+    @SerializedName("compressionType")
+    private final TCompressionType compressionType;
+    @SerializedName("compressionLevel")
+    private final int compressionLevel;
 
     private SchemaInfo(Builder builder) {
         this.id = builder.id;
@@ -68,6 +73,8 @@ public class SchemaInfo {
         this.bloomFilterColumnNames = builder.bloomFilterColumnNames;
         this.bloomFilterFpp = builder.bloomFilterFpp;
         this.schemaHash = builder.schemaHash;
+        this.compressionType = builder.compressionType;
+        this.compressionLevel = builder.compressionLevel;
     }
 
     public long getId() {
@@ -148,6 +155,10 @@ public class SchemaInfo {
         if (bloomFilterColumnNames != null) {
             tSchema.setBloom_filter_fpp(bloomFilterFpp);
         }
+        if (compressionType != null) {
+            tSchema.setCompression_type(compressionType);
+            tSchema.setCompression_level(compressionLevel);
+        }
         return tSchema;
     }
 
@@ -168,6 +179,8 @@ public class SchemaInfo {
         private List<Index> indexes;
         private Set<ColumnId> bloomFilterColumnNames;
         private double bloomFilterFpp; // false positive probability
+        private TCompressionType compressionType;
+        private int compressionLevel = -1;
 
         private Builder() {
         }
@@ -246,6 +259,16 @@ public class SchemaInfo {
 
         public Builder setSchemaHash(int schemaHash) {
             this.schemaHash = schemaHash;
+            return this;
+        }
+
+        public Builder setCompressionLevel(int compressionLevel) {
+            this.compressionLevel = compressionLevel;
+            return this;
+        }
+
+        public Builder setCompressionType(TCompressionType compressionType) {
+            this.compressionType = compressionType;
             return this;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
@@ -21,22 +21,33 @@ import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.rpc.ThriftConnectionPool;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.CreateDbStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.thrift.TAgentTaskRequest;
+import com.starrocks.thrift.TCompressionType;
+import com.starrocks.thrift.TTabletMetaInfo;
+import com.starrocks.thrift.TTabletSchema;
+import com.starrocks.thrift.TTaskType;
+import com.starrocks.thrift.TUpdateTabletMetaInfoReq;
 import com.starrocks.type.DateType;
 import com.starrocks.type.FloatType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
+import com.starrocks.utframe.MockGenericPool;
+import com.starrocks.utframe.MockedBackend;
+import com.starrocks.utframe.MockedBackend.MockBeThriftClient;
 import com.starrocks.utframe.StarRocksTestBase;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
@@ -45,7 +56,9 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class LakeTableAsyncFastSchemaChangeJobTest extends StarRocksTestBase {
     private static ConnectContext connectContext;
@@ -556,6 +569,79 @@ public class LakeTableAsyncFastSchemaChangeJobTest extends StarRocksTestBase {
         {
             String alterSql = "ALTER TABLE t_modify_index_type MODIFY COLUMN c2 BIGINT";
             executeAlterAndWaitFinish(table, alterSql, true);
+        }
+    }
+
+    @Test
+    public void testCompressionSettings() throws Exception {
+        // Create a table with zstd compression and level 9
+        LakeTable table = createTable(connectContext,
+                "CREATE TABLE t_compression_test(c0 INT) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) " +
+                "BUCKETS 1 PROPERTIES('fast_schema_evolution'='true', 'compression'='zstd(9)')");
+        
+        Assertions.assertEquals(TCompressionType.ZSTD, table.getCompressionType());
+        Assertions.assertEquals(9, table.getCompressionLevel());
+        
+        List<MockBeThriftClient> thriftClients = ((MockGenericPool<?>) ThriftConnectionPool.backendPool).getAllBackends()
+                .stream().map(MockedBackend::getMockBeThriftClient).toList();
+        Assertions.assertFalse(thriftClients.isEmpty());
+        thriftClients.forEach(client -> client.setCaptureAgentTask(true));
+        try {
+            String alterSql = "ALTER TABLE t_compression_test ADD COLUMN c1 BIGINT";
+            AlterJobV2 alterJob = executeAlterAndWaitFinish(table, alterSql, true);
+            Assertions.assertInstanceOf(LakeTableAsyncFastSchemaChangeJob.class, alterJob);
+            LakeTableAsyncFastSchemaChangeJob job = (LakeTableAsyncFastSchemaChangeJob) alterJob;
+            List<SchemaInfo> schemaInfos = job.getSchemaInfoList();
+            Assertions.assertEquals(1, schemaInfos.size());
+            Assertions.assertEquals(TCompressionType.ZSTD, schemaInfos.get(0).getCompressionType());
+            Assertions.assertEquals(9, schemaInfos.get(0).getCompressionLevel());
+
+            // Get all tablet IDs from the table
+            Set<Long> tableTabletIds = new HashSet<>();
+            for (Partition partition : table.getPartitions()) {
+                for (com.starrocks.catalog.PhysicalPartition physicalPartition : partition.getSubPartitions()) {
+                    com.starrocks.catalog.MaterializedIndex index = physicalPartition.getIndex(table.getBaseIndexId());
+                    if (index != null) {
+                        for (com.starrocks.catalog.Tablet tablet : index.getTablets()) {
+                            tableTabletIds.add(tablet.getId());
+                        }
+                    }
+                }
+            }
+            Assertions.assertEquals(1, tableTabletIds.size());
+
+            // 1. get all TAgentTask by using MockBeThriftClient::getCapturedAgentTasks
+            List<TAgentTaskRequest> allTasks = thriftClients.stream()
+                    .flatMap(client -> client.getCapturedAgentTasks().stream())
+                    .toList();
+
+            // 2. get all tasks related to fast schema evolution for table t_compression_test
+            // Fast schema evolution uses UPDATE_TABLET_META_INFO task type
+            List<TAgentTaskRequest> fastSchemaEvolutionTasks = allTasks.stream()
+                    .filter(task -> task.getTask_type() == TTaskType.UPDATE_TABLET_META_INFO)
+                    .filter(task -> task.isSetUpdate_tablet_meta_info_req())
+                    .toList();
+
+            // 3. get TTabletSchema from agent task, filter by tablet IDs belonging to the table
+            List<TTabletSchema> tabletSchemas = fastSchemaEvolutionTasks.stream()
+                    .map(TAgentTaskRequest::getUpdate_tablet_meta_info_req)
+                    .map(TUpdateTabletMetaInfoReq::getTabletMetaInfos)
+                    .flatMap(List::stream)
+                    .filter(metaInfo -> tableTabletIds.contains(metaInfo.getTablet_id()))
+                    .filter(TTabletMetaInfo::isSetTablet_schema)
+                    .map(TTabletMetaInfo::getTablet_schema)
+                    .toList();
+
+            Assertions.assertEquals(1, tabletSchemas.size(), 
+                    "There should be exactly one TTabletSchema for fast schema evolution");
+
+            // 4. verify the compression type and level in TTabletSchema is correct
+            TTabletSchema tabletSchema = tabletSchemas.get(0);
+            Assertions.assertEquals(TCompressionType.ZSTD, tabletSchema.getCompression_type());
+            Assertions.assertEquals(9, tabletSchema.getCompression_level());
+        } finally {
+            thriftClients.forEach(client -> client.setCaptureAgentTask(false));
+            thriftClients.forEach(MockBeThriftClient::clearCapturedAgentTasks);
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockGenericPool.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockGenericPool.java
@@ -23,6 +23,8 @@ import com.starrocks.thrift.HeartbeatService;
 import com.starrocks.thrift.TNetworkAddress;
 import org.apache.commons.pool2.impl.GenericKeyedObjectPoolConfig;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public class MockGenericPool<VALUE extends org.apache.thrift.TServiceClient> extends ThriftConnectionPool<VALUE> {
@@ -65,6 +67,10 @@ public class MockGenericPool<VALUE extends org.apache.thrift.TServiceClient> ext
 
     @Override
     public void invalidateObject(TNetworkAddress address, VALUE object) {
+    }
+
+    public List<MockedBackend> getAllBackends() {
+        return new ArrayList<>(backendMap.values());
     }
 
     public static class HeatBeatPool extends MockGenericPool<HeartbeatService.Client> {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -55,6 +55,8 @@ struct TTabletSchema {
     10: optional list<i32> sort_key_idxes
     11: optional list<i32> sort_key_unique_ids
     12: optional i32 schema_version;
+    13: optional Types.TCompressionType compression_type = Types.TCompressionType.LZ4_FRAME
+    14: optional i32 compression_level = -1;
 }
 
 // this enum stands for different storage format in src_backends


### PR DESCRIPTION
## Why I'm doing:
Compression settings defined in FE were not reliably propagated to BE or persisted in tablet schemas. This caused new tablets and schema changes to fallback to defaults (e.g., LZ4) and ignore configured compression levels, leading to inconsistent storage layout and unpredictable performance/size characteristics.

## What I'm doing:
* Propagate compressionType and compressionLevel from FE to BE through TTabletSchema.
* Persist compression type/level in tablet schemas on both create and schema change.
* Use provided compression values in BE (no hardcoded LZ4); set compression_level on TabletSchemaPB.
* Extend Thrift with optional fields to carry compression settings end-to-end.
* Add tests verifying propagation/persistence and enhance mocks to capture agent tasks.


Fixes #issue

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 4.0
  - [X] 3.5
  - [X] 3.4
  - [X] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure compression type/level flow from FE to BE and are persisted in tablet schemas for table creation and fast schema evolution, with tests and Thrift/mocks updated.
> 
> - **Backend (BE)**:
>   - `convert_t_schema_to_pb_schema` overload reads `compression_type`/`compression_level` from `TTabletSchema` and sets `TabletSchemaPB.compression_level`.
>   - `lake/schema_change.cpp`: use new converter without hardcoded compression; create schema file when needed.
>   - `lake/tablet_manager.cpp`: set schema `compression_level` during tablet creation.
> - **Frontend (FE)**:
>   - `SchemaInfo`: add `compressionType`/`compressionLevel`; propagate into `TTabletSchema`.
>   - `SchemaChangeHandler`: include compression settings when building `SchemaInfo` for fast schema evolution.
> - **Thrift**:
>   - `TTabletSchema`: add optional `compression_type` and `compression_level`.
>   - `TCreateTabletReq`: add optional `compression_level`.
> - **Tests & Mocks**:
>   - BE UT validates compression propagation to `TabletSchemaPB`.
>   - FE UT verifies compression passed via fast schema evolution and captured in `TAgentTaskRequest`.
>   - Mocks enhanced to list backends and capture agent tasks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 842598db8efa1fefc4085b135c2ff0272fc1af17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->