### PR TITLE
[Enhancement] Add interface truncated_bytes to JsonDocumentStreamParser

### DIFF
--- a/be/src/exec/json_parser.cpp
+++ b/be/src/exec/json_parser.cpp
@@ -173,7 +173,7 @@ std::string JsonDocumentStreamParser::left_bytes_string(size_t sz) noexcept {
     return std::string(_data + off, len);
 }
 
-size_t JsonDocumentStreamParser::truncated_bytes() noexcept {
+size_t JsonDocumentStreamParser::truncated_bytes() const noexcept {
     return _doc_stream.truncated_bytes();
 }
 

--- a/be/src/exec/json_parser.cpp
+++ b/be/src/exec/json_parser.cpp
@@ -170,7 +170,11 @@ std::string JsonDocumentStreamParser::left_bytes_string(size_t sz) noexcept {
     }
 
     auto len = std::min(_len - off, sz);
-    return std::string(reinterpret_cast<char*>(_data) + off, len);
+    return std::string(_data + off, len);
+}
+
+size_t JsonDocumentStreamParser::truncated_bytes() noexcept {
+    return _doc_stream.truncated_bytes();
 }
 
 Status JsonArrayParser::parse(char* data, size_t len, size_t allocated) noexcept {

--- a/be/src/exec/json_parser.h
+++ b/be/src/exec/json_parser.h
@@ -50,7 +50,7 @@ public:
     Status get_current(simdjson::ondemand::object* row) noexcept override;
     Status advance() noexcept override;
     std::string left_bytes_string(size_t sz) noexcept override;
-    size_t truncated_bytes() noexcept;
+    size_t truncated_bytes() const noexcept;
 
 private:
     Status _get_current_impl(simdjson::ondemand::object* row);

--- a/be/src/exec/json_parser.h
+++ b/be/src/exec/json_parser.h
@@ -23,7 +23,7 @@ namespace starrocks {
 
 class JsonParser {
 public:
-    JsonParser(simdjson::ondemand::parser* parser) : _parser(parser){};
+    explicit JsonParser(simdjson::ondemand::parser* parser) : _parser(parser){};
     virtual ~JsonParser() = default;
     // parse initiates the parser. The inner iterator would point to the first object to be returned.
     virtual Status parse(char* data, size_t len, size_t allocated) noexcept = 0;
@@ -45,11 +45,12 @@ protected:
 // input: {"key":1} {"key":2}
 class JsonDocumentStreamParser : public JsonParser {
 public:
-    JsonDocumentStreamParser(simdjson::ondemand::parser* parser);
+    explicit JsonDocumentStreamParser(simdjson::ondemand::parser* parser);
     Status parse(char* data, size_t len, size_t allocated) noexcept override;
     Status get_current(simdjson::ondemand::object* row) noexcept override;
     Status advance() noexcept override;
     std::string left_bytes_string(size_t sz) noexcept override;
+    size_t truncated_bytes() noexcept;
 
 private:
     Status _get_current_impl(simdjson::ondemand::object* row);
@@ -99,7 +100,7 @@ private:
 // input: [{"key": 1}, {"key": 2}].
 class JsonArrayParser : public JsonParser {
 public:
-    JsonArrayParser(simdjson::ondemand::parser* parser) : JsonParser(parser){};
+    explicit JsonArrayParser(simdjson::ondemand::parser* parser) : JsonParser(parser){};
     Status parse(char* data, size_t len, size_t allocated) noexcept override;
     Status get_current(simdjson::ondemand::object* row) noexcept override;
     Status advance() noexcept override;
@@ -128,7 +129,7 @@ private:
 // eg:
 // input: {"data": {"key":1}} {"data": {"key":2}}
 // json root: $.data
-class JsonDocumentStreamParserWithRoot : public JsonDocumentStreamParser {
+class JsonDocumentStreamParserWithRoot final : public JsonDocumentStreamParser {
 public:
     JsonDocumentStreamParserWithRoot(simdjson::ondemand::parser* parser, std::vector<SimpleJsonPath>& root_paths)
             : JsonDocumentStreamParser(parser), _root_paths(root_paths) {}
@@ -153,7 +154,7 @@ private:
 // eg:
 // input: [{"data": {"key":1}}, {"data": {"key":2}}]
 // json root: $.data
-class JsonArrayParserWithRoot : public JsonArrayParser {
+class JsonArrayParserWithRoot final : public JsonArrayParser {
 public:
     JsonArrayParserWithRoot(simdjson::ondemand::parser* parser, std::vector<SimpleJsonPath> root_paths)
             : JsonArrayParser(parser), _root_paths(std::move(root_paths)) {}
@@ -178,7 +179,7 @@ private:
 // eg:
 // input: {"data": [{"key":1}, {"key":2}]} {"data": [{"key":3}, {"key":4}]}
 // json root: $.data
-class ExpandedJsonDocumentStreamParserWithRoot : public JsonDocumentStreamParser {
+class ExpandedJsonDocumentStreamParserWithRoot final : public JsonDocumentStreamParser {
 public:
     ExpandedJsonDocumentStreamParserWithRoot(simdjson::ondemand::parser* parser, std::vector<SimpleJsonPath> root_paths)
             : JsonDocumentStreamParser(parser), _root_paths(std::move(root_paths)) {}
@@ -213,7 +214,7 @@ private:
 // eg:
 // input: [{"data": [{"key":1}, {"key":2}]}, {"data": [{"key":3}, {"key":4}]}]
 // json root: $.data
-class ExpandedJsonArrayParserWithRoot : public JsonArrayParser {
+class ExpandedJsonArrayParserWithRoot final : public JsonArrayParser {
 public:
     ExpandedJsonArrayParserWithRoot(simdjson::ondemand::parser* parser, std::vector<SimpleJsonPath> root_paths)
             : JsonArrayParser(parser), _root_paths(std::move(root_paths)) {}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Add the interface `truncated_bytes` to `JsonDocumentStreamParser` to fetch the remaining unprocessed bytes.

This interface will be later used for external catalog JSON processing.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
