### PR TITLE
[BugFix] Fix query hang caused by merge exchange

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -205,6 +205,7 @@ set(EXEC_FILES
     pipeline/operator.cpp
     pipeline/source_operator.cpp
     pipeline/limit_operator.cpp
+    pipeline/offset_operator.cpp
     pipeline/pipeline_builder.cpp
     pipeline/project_operator.cpp
     pipeline/dict_decode_operator.cpp

--- a/be/src/exec/pipeline/offset_operator.cpp
+++ b/be/src/exec/pipeline/offset_operator.cpp
@@ -1,0 +1,55 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/pipeline/offset_operator.h"
+
+#include "column/chunk.h"
+#include "runtime/runtime_state.h"
+
+namespace starrocks::pipeline {
+
+StatusOr<ChunkPtr> OffsetOperator::pull_chunk(RuntimeState*) {
+    return std::move(_cur_chunk);
+}
+
+// Core logic similar to LimitOperator::push_chunk
+Status OffsetOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
+    _cur_chunk = chunk;
+
+    if (_offset <= 0) {
+        return Status::OK();
+    }
+
+    int64_t old_offset;
+    int64_t rows_to_skip;
+    do {
+        old_offset = _offset.load(std::memory_order_relaxed);
+        rows_to_skip = std::min(old_offset, (int64_t)chunk->num_rows());
+    } while (rows_to_skip && !_offset.compare_exchange_strong(old_offset, old_offset - rows_to_skip));
+
+    if (rows_to_skip == chunk->num_rows()) {
+        _cur_chunk.reset();
+        return Status::OK();
+    }
+
+    if (rows_to_skip > 0) {
+        auto new_chunk = _cur_chunk->clone_empty();
+        new_chunk->append(*_cur_chunk, rows_to_skip, chunk->num_rows() - rows_to_skip);
+        _cur_chunk = std::move(new_chunk);
+    }
+
+    return Status::OK();
+}
+
+} // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/offset_operator.h
+++ b/be/src/exec/pipeline/offset_operator.h
@@ -1,0 +1,65 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "exec/pipeline/operator.h"
+
+namespace starrocks::pipeline {
+
+class OffsetOperator final : public Operator {
+public:
+    OffsetOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
+                   std::atomic<int64_t>& offset)
+            : Operator(factory, id, "offset", plan_node_id, false, driver_sequence), _offset(offset) {}
+
+    ~OffsetOperator() override = default;
+
+    bool has_output() const override { return _cur_chunk != nullptr; }
+
+    bool need_input() const override { return !_is_finished && _cur_chunk == nullptr; }
+
+    bool is_finished() const override { return _is_finished && _cur_chunk == nullptr; }
+
+    Status set_finishing(RuntimeState*) override {
+        _is_finished = true;
+        return Status::OK();
+    }
+
+    StatusOr<ChunkPtr> pull_chunk(RuntimeState*) override;
+
+    Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
+
+private:
+    bool _is_finished = false;
+    std::atomic<int64_t>& _offset;
+    ChunkPtr _cur_chunk = nullptr;
+};
+
+class OffsetOperatorFactory final : public OperatorFactory {
+public:
+    OffsetOperatorFactory(int32_t id, int32_t plan_node_id, int64_t offset)
+            : OperatorFactory(id, "offset", plan_node_id), _offset(offset) {}
+
+    ~OffsetOperatorFactory() override = default;
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
+        return std::make_shared<OffsetOperator>(this, _id, _plan_node_id, driver_sequence, _offset);
+    }
+
+private:
+    std::atomic<int64_t> _offset;
+};
+
+} // namespace starrocks::pipeline

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ExchangeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ExchangeNode.java
@@ -210,6 +210,7 @@ public class ExchangeNode extends PlanNode {
         }
         if (partitionType != null) {
             msg.exchange_node.setPartition_type(partitionType);
+            msg.exchange_node.setOffset(offset);
         }
         SessionVariable sv = ConnectContext.get().getSessionVariable();
         msg.exchange_node.setEnable_parallel_merge(isUseParallelMerge());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -130,7 +130,6 @@ import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.ExprUtils;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
-import com.starrocks.sql.ast.expression.IntLiteral;
 import com.starrocks.sql.ast.expression.JoinOperator;
 import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.ast.expression.SlotRef;
@@ -3602,9 +3601,7 @@ public class PlanFragmentBuilder {
                 }
                 ExchangeNode exchangeNode = (ExchangeNode) child.getPlanRoot();
                 if (!exchangeNode.isMerge()) {
-                    SortInfo sortInfo = new SortInfo(Lists.newArrayList(), Operator.DEFAULT_LIMIT,
-                            Lists.newArrayList(new IntLiteral(1)), Lists.newArrayList(true), Lists.newArrayList(false));
-                    exchangeNode.setMergeInfo(sortInfo, limit.getOffset());
+                    exchangeNode.setOffset(limit.getOffset());
                 } else if (exchangeNode.getOffset() <= 0) {
                     exchangeNode.setOffset(limit.getOffset());
                 } else if (exchangeNode.getOffset() > 0) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
@@ -877,7 +877,7 @@ public class LimitTest extends PlanTestBase {
                 "LIMIT \n" +
                 "  61202;";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "7:MERGING-EXCHANGE\n" +
+        assertContains(plan, "7:EXCHANGE\n" +
                 "     offset: 6\n" +
                 "     limit: 15");
         assertContains(plan, "4:TOP-N\n" +
@@ -910,7 +910,7 @@ public class LimitTest extends PlanTestBase {
                 "  |  order by: <slot 9> 9: expr ASC, <slot 4> 4: S_NATIONKEY ASC\n" +
                 "  |  offset: 0\n" +
                 "  |  limit: 21");
-        assertContains(plan, "5:MERGING-EXCHANGE\n" +
+        assertContains(plan, "5:EXCHANGE\n" +
                 "     offset: 6\n" +
                 "     limit: 15");
     }
@@ -947,7 +947,7 @@ public class LimitTest extends PlanTestBase {
     public void testConstantOrderByLimit() throws Exception {
         String sql = "select * from t0 order by 'abc' limit 100, 100 ";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "  1:MERGING-EXCHANGE\n" +
+        assertContains(plan, "  1:EXCHANGE\n" +
                 "     offset: 100\n" +
                 "     limit: 100");
     }
@@ -956,7 +956,7 @@ public class LimitTest extends PlanTestBase {
     public void testOrderByConstant() throws Exception {
         String sql = "select * from t0 limit 100, 100";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "  1:MERGING-EXCHANGE\n" +
+        assertContains(plan, "  1:EXCHANGE\n" +
                 "     offset: 100\n" +
                 "     limit: 100");
     }
@@ -965,7 +965,7 @@ public class LimitTest extends PlanTestBase {
     public void testMergeLimit() throws Exception {
         String sql = "select * from (select * from t0 limit 100, 100) x limit 1, 2";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "  1:MERGING-EXCHANGE\n" +
+        assertContains(plan, "  1:EXCHANGE\n" +
                 "     offset: 101\n" +
                 "     limit: 2");
 
@@ -975,13 +975,13 @@ public class LimitTest extends PlanTestBase {
 
         sql = "select * from (select * from t0 limit 1, 5) x limit 1, 100";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "  1:MERGING-EXCHANGE\n" +
+        assertContains(plan, "  1:EXCHANGE\n" +
                 "     offset: 2\n" +
                 "     limit: 4");
 
         sql = "select * from (select * from t0 limit 1, 5) x limit 3";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "  1:MERGING-EXCHANGE\n" +
+        assertContains(plan, "  1:EXCHANGE\n" +
                 "     offset: 1\n" +
                 "     limit: 3");
 
@@ -1005,7 +1005,7 @@ public class LimitTest extends PlanTestBase {
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(-1);
         String sql = "select count(*) from (select * from TABLE(generate_series(1, 100000)) limit 50000, 10) x;";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "4:MERGING-EXCHANGE\n" +
+        assertContains(plan, "4:EXCHANGE\n" +
                 "     offset: 50000\n" +
                 "     limit: 10");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
@@ -995,7 +995,7 @@ public class LimitTest extends PlanTestBase {
     public void testLimitAgg() throws Exception {
         String sql = "select count(*) from (select * from t0 limit 50, 20) xx;";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "  2:MERGING-EXCHANGE\n" +
+        assertContains(plan, "  2:EXCHANGE\n" +
                 "     offset: 50\n" +
                 "     limit: 20");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetTest.java
@@ -567,7 +567,7 @@ public class SetTest extends PlanTestBase {
         // order by null literal with limit offset
         sql = "select v1+v2 as x from t0 union all select v4 as x from t1 order by null limit 10, 20";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "  6:MERGING-EXCHANGE\n" +
+        assertContains(plan, "  6:EXCHANGE\n" +
                 "     offset: 10\n" +
                 "     limit: 20");
 


### PR DESCRIPTION
## Why I'm doing:

In previous implementations, we used merge exchanges to achieve offsets. However, merge exchanges require all child exchanges to have data before outputting. This can potentially cause data flow to enter a deadlock state.

a reproduce case:
```
explain analyze with cte0 as (
  SELECT
    *
  FROM
    etl_scan_test
  where
    col1 > 0
  limit
    1
), cte1 as (
  SELECT
    *
  FROM
    etl_scan_test
  where
    col1 > 0
), cte2 as (
  select
    *
  from
    (
      SELECT
        *
      FROM
        cte1
    ) t
)
select
  *
from
  cte2
limit
  2100000000, 1;
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements a new pipeline `OffsetOperator` and applies OFFSET on non-merging `EXCHANGE`, adjusts planner to set exchange offsets directly, and updates tests accordingly.
> 
> - **Backend (BE)**:
>   - **New Operator**: Add `pipeline/offset_operator.{h,cpp}` and wire into build (`CMakeLists.txt`).
>   - **Exchange Pipeline**: In `exchange_node.cpp`, drop merge-only DCHECK and, for non-merging exchanges with `offset>0`, insert `OffsetOperatorFactory` into the pipeline; keep existing limit handling.
> - **Frontend (FE)**:
>   - **Planner**: In `PlanFragmentBuilder`, when `PhysicalLimit` has offset and child is `EXCHANGE`, set `exchangeNode.setOffset(...)` without forcing merge exchange; simplify earlier merge-info hack. 
>   - **Thrift Msg**: Ensure `ExchangeNode` always sets `offset` (also when `partition_type` present).
> - **Tests**:
>   - Update expected plans from `MERGING-EXCHANGE` to `EXCHANGE` with `offset` across limit/union/set tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eafcd902606bdbb596a54ea5fd3540d2c3d29729. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->