### PR TITLE
[UT] fix thrift client test by using dynamic port

### DIFF
--- a/be/test/util/thrift_client_test.cpp
+++ b/be/test/util/thrift_client_test.cpp
@@ -21,6 +21,7 @@
 #include <thrift/server/TThreadPoolServer.h>
 #include <thrift/transport/TServerSocket.h>
 #include <thrift/transport/TSocket.h>
+#include <unistd.h>
 
 #include <memory>
 
@@ -46,12 +47,14 @@ public:
         _thr->join();
     }
 
-    static inline const int MOCK_PORT = 18040;
+    int get_port() const { return _port; }
 
 private:
     std::unique_ptr<std::thread> _thr;
     std::shared_ptr<FrontendServiceProcessor> _processer;
     std::unique_ptr<apache::thrift::server::TSimpleServer> _server;
+    std::shared_ptr<apache::thrift::transport::TServerSocket> _server_transport;
+    int _port = 0;
 };
 
 void MockedFrontendService::init() {
@@ -62,14 +65,24 @@ void MockedFrontendService::init() {
     auto service = std::make_shared<MockedThriftService>();
     _processer = std::make_unique<FrontendServiceProcessor>(service);
 
-    auto serverTransport = std::make_shared<TServerSocket>(MOCK_PORT);
+    // Use port 0 to let the OS assign an available port
+    _server_transport = std::make_shared<TServerSocket>(0);
     auto transportFactory = std::make_shared<TBufferedTransportFactory>();
     auto protocolFactory = std::make_shared<TBinaryProtocolFactory>();
-    _server = std::make_unique<TSimpleServer>(_processer, serverTransport, transportFactory, protocolFactory);
+    _server = std::make_unique<TSimpleServer>(_processer, _server_transport, transportFactory, protocolFactory);
     _thr = std::make_unique<std::thread>([this]() { _server->serve(); });
     // thrift server don't provide a start function
-    // wait server ready
-    sleep(3);
+    // wait server ready and get the actual port that was assigned
+    // The port is assigned when the server starts listening
+    for (int i = 0; i < 30; ++i) {
+        _port = _server_transport->getPort();
+        if (_port > 0) {
+            break;
+        }
+        usleep(100000); // sleep 100ms
+    }
+    // Additional wait to ensure server is fully ready
+    sleep(1);
 }
 
 TEST(ThriftRpcClientCacheTest, test_all) {
@@ -79,7 +92,7 @@ TEST(ThriftRpcClientCacheTest, test_all) {
     TGetProfileRequest req;
 
     auto client_cache = std::make_unique<FrontendServiceClientCache>(config::max_client_cache_size_per_host);
-    TNetworkAddress address = make_network_address("127.0.0.1", MockedFrontendService::MOCK_PORT);
+    TNetworkAddress address = make_network_address("127.0.0.1", service.get_port());
     Status status;
     FrontendServiceConnection client(client_cache.get(), address, 1000, &status);
     ASSERT_OK(status);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch thrift client test to an OS-assigned port with a readiness loop and connect via the retrieved port.
> 
> - **Tests**:
>   - **Thrift client test uses dynamic server port** in `be/test/util/thrift_client_test.cpp`:
>     - Replace fixed `MOCK_PORT` with `TServerSocket(0)`, keep `_server_transport`, retrieve assigned port via `_server_transport->getPort()`, expose via `get_port()`.
>     - Add readiness loop and short sleep to ensure server is listening before clients connect.
>     - Update client to connect using `service.get_port()` instead of a hardcoded port.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 540bbe45bb37d0a9c3c47817497d5a43db8a1202. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->