### PR TITLE
[BugFix] suppress global dict error

### DIFF
--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -225,6 +225,8 @@ public:
 
     bool is_global_dict_error() const { return code() == TStatusCode::GLOBAL_DICT_ERROR; }
 
+    bool is_suppressed() const { return is_global_dict_error(); }
+
     // Convert into TStatus. Call this if 'status_container' contains an optional
     // TStatus field named 'status'. This also sets __isset.status.
     template <typename T>

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -333,7 +333,8 @@ StatusOr<DriverState> PipelineDriver::process(RuntimeState* runtime_state, int w
                 return_status = maybe_chunk.status();
                 if (!return_status.ok() && !return_status.is_end_of_file()) {
                     curr_op->common_metrics()->add_info_string("ErrorMsg", std::string(return_status.message()));
-                    LOG(WARNING) << "pull_chunk returns not ok status " << return_status.to_string();
+                    LOG_IF(WARNING, !return_status.is_suppressed())
+                            << "pull_chunk returns not ok status " << return_status.to_string();
                     return return_status;
                 }
 

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -187,9 +187,10 @@ void GlobalDriverExecutor::_worker_thread() {
                 auto o_id = get_backend_id();
                 int64_t be_id = o_id.has_value() ? o_id.value() : -1;
                 status = status.clone_and_append(fmt::format("BE:{}", be_id));
-                LOG(WARNING) << "[Driver] Process error, query_id=" << print_id(driver->query_ctx()->query_id())
-                             << ", instance_id=" << print_id(driver->fragment_ctx()->fragment_instance_id())
-                             << ", status=" << status;
+                LOG_IF(WARNING, !status.is_suppressed())
+                        << "[Driver] Process error, query_id=" << print_id(driver->query_ctx()->query_id())
+                        << ", instance_id=" << print_id(driver->fragment_ctx()->fragment_instance_id())
+                        << ", status=" << status;
                 driver->runtime_profile()->add_info_string("ErrorMsg", std::string(status.message()));
                 query_ctx->cancel(status, false);
                 runtime_state->set_is_cancelled(true);

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -477,8 +477,8 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
             // kick start this chunk source
             auto start_status = chunk_source->start(state);
             if (!start_status.ok()) {
-                LOG(ERROR) << "start chunk_source failed, fragment_instance_id="
-                           << print_id(state->fragment_instance_id()) << ", error=" << start_status.to_string();
+                LOG(WARNING) << "start chunk_source failed, fragment_instance_id="
+                             << print_id(state->fragment_instance_id()) << ", error=" << start_status.to_string();
                 _set_scan_status(start_status);
             }
             Status status;
@@ -488,8 +488,9 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
             }
 
             if (!status.ok() && !status.is_end_of_file()) {
-                LOG(ERROR) << "scan fragment " << print_id(state->fragment_instance_id()) << " driver "
-                           << get_driver_sequence() << " Scan tasks error: " << status.to_string();
+                LOG_IF(WARNING, !status.is_suppressed())
+                        << "scan fragment " << print_id(state->fragment_instance_id()) << " driver "
+                        << get_driver_sequence() << " Scan tasks error: " << status.to_string();
                 _set_scan_status(status);
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Status.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Status.java
@@ -118,6 +118,10 @@ public class Status {
         return this.errorCode == TStatusCode.GLOBAL_DICT_ERROR;
     }
 
+    public boolean isSuppressedError() {
+        return isGlobalDictError();
+    }
+
     public boolean isGlobalDictNotMatch() {
         return this.errorCode == TStatusCode.GLOBAL_DICT_NOT_MATCH;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -884,10 +884,13 @@ public class DefaultCoordinator extends Coordinator {
             }
 
             queryStatus.setStatus(status);
-            LOG.warn(
-                    "one instance report fail throw updateStatus(), need cancel. job id: {}, query id: {}, instance id: {}",
-                    jobSpec.getLoadJobId(), DebugUtil.printId(jobSpec.getQueryId()),
-                    instanceId != null ? DebugUtil.printId(instanceId) : "NaN");
+            if (!status.isSuppressedError()) {
+                LOG.warn(
+                        "one instance report fail throw updateStatus(), need cancel. job id: {}, " +
+                                "query id: {}, instance id: {}",
+                        jobSpec.getLoadJobId(), DebugUtil.printId(jobSpec.getQueryId()),
+                        instanceId != null ? DebugUtil.printId(instanceId) : "NaN");
+            }
             cancelInternal(PPlanFragmentCancelReason.INTERNAL_ERROR);
         } finally {
             lock.unlock();
@@ -912,7 +915,9 @@ public class DefaultCoordinator extends Coordinator {
                 throw new RpcException("unknown", status.getErrorMsg());
             } else {
                 String errMsg = status.getErrorMsg();
-                LOG.warn("query {} failed: {}", connectContext.queryId, errMsg);
+                if (!status.isSuppressedError()) {
+                    LOG.warn("query {} failed: {}", connectContext.queryId, errMsg);
+                }
 
                 // hide host info
                 int hostIndex = errMsg.indexOf("host");
@@ -949,8 +954,10 @@ public class DefaultCoordinator extends Coordinator {
         resultBatch = receiver.getNext(status);
         if (!status.ok()) {
             connectContext.setErrorCodeOnce(status.getErrorCodeString());
-            LOG.warn("get next fail, need cancel. status {}, query id: {}", status,
-                    DebugUtil.printId(jobSpec.getQueryId()));
+            if (!status.isSuppressedError()) {
+                LOG.warn("get next fail, need cancel. status {}, query id: {}", status,
+                        DebugUtil.printId(jobSpec.getQueryId()));
+            }
         }
         updateStatus(status, null /* no instance id */);
 
@@ -1169,10 +1176,12 @@ public class DefaultCoordinator extends Coordinator {
             if (ctx != null) {
                 ctx.setErrorCodeOnce(status.getErrorCodeString());
             }
-            LOG.warn("exec state report failed status={}, query_id={}, instance_id={}, backend_id={}",
-                    status, DebugUtil.printId(jobSpec.getQueryId()),
-                    DebugUtil.printId(params.getFragment_instance_id()),
-                    params.getBackend_id());
+            if (!status.isSuppressedError()) {
+                LOG.warn("exec state report failed status={}, query_id={}, instance_id={}, backend_id={}",
+                        status, DebugUtil.printId(jobSpec.getQueryId()),
+                        DebugUtil.printId(params.getFragment_instance_id()),
+                        params.getBackend_id());
+            }
             updateStatus(status, params.getFragment_instance_id());
         }
     }


### PR DESCRIPTION
These error logs may cause confusion for users

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce suppressed error handling for global dict errors and gate/downgrade related logs in BE pipeline and FE coordinator to reduce noise.
> 
> - **Core Status APIs**:
>   - Add `be/src/common/status.h`: `Status::is_suppressed()` (maps to `GLOBAL_DICT_ERROR`).
>   - Add `fe/.../Status.java`: `isSuppressedError()` (maps to `GLOBAL_DICT_ERROR`).
> - **BE Pipeline**:
>   - `pipeline_driver.cpp`, `pipeline_driver_executor.cpp`: wrap warnings with `LOG_IF(...,!status.is_suppressed())` for pull/process errors.
>   - `scan_operator.cpp`: gate scan task warnings with suppression and downgrade `start chunk_source failed` from error to warning.
> - **FE Coordinator**:
>   - `DefaultCoordinator.java`: gate multiple `LOG.warn` paths (status updates, query failures, getNext, exec state report) with `!status.isSuppressedError()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a05768f98d4e1fbfc4f346726a537ca86636c28c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->