### PR TITLE
[UT] Fix FE ut not work on windows platform

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -933,6 +933,12 @@ under the License.
             <artifactId>google-api-client</artifactId>
             <version>2.8.1</version>
         </dependency>
+        <dependency>
+            <groupId>com.starrocks</groupId>
+            <artifactId>hadoop-ext</artifactId>
+            <version>1.0.0</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -933,12 +933,6 @@ under the License.
             <artifactId>google-api-client</artifactId>
             <version>2.8.1</version>
         </dependency>
-        <dependency>
-            <groupId>com.starrocks</groupId>
-            <artifactId>hadoop-ext</artifactId>
-            <version>1.0.0</version>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/fe/fe-core/src/main/java/com/starrocks/metric/SystemMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/SystemMetrics.java
@@ -42,6 +42,8 @@ import org.apache.logging.log4j.Logger;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 
@@ -72,7 +74,15 @@ public class SystemMetrics {
         if (FeConstants.runningUnitTest) {
             procFile = getClass().getClassLoader().getResource("data/net_snmp_normal").getFile();
         }
-        if (Files.notExists(Paths.get(procFile))) {
+
+        Path path;
+        try {
+            path = Paths.get(procFile);
+        } catch (InvalidPathException e) {
+            return;
+        }
+
+        if (Files.notExists(path)) {
             LOG.warn("{} doesn't exist", procFile);
             return;
         }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Gracefully handle invalid or non-existent `/proc/net/snmp` by catching `InvalidPathException` and using a `Path`-based existence check in `SystemMetrics`.
> 
> - **Metrics** (`fe/fe-core/src/main/java/com/starrocks/metric/SystemMetrics.java`):
>   - Catch `InvalidPathException` when creating `Path` from `procFile` and return early.
>   - Switch to `Path`-based existence check (`Files.notExists(path)`) before reading `/proc/net/snmp`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a4ad948c6d2b30e986fa674732c96160e443fde. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->