### PR TITLE
[Enhancement] Add table property cloud_native_fast_schema_evolution_v2

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -467,7 +467,8 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
             } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX)
                     || properties.containsKey(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE)
                     || properties.containsKey(PropertyAnalyzer.PROPERTIES_FILE_BUNDLING)
-                    || properties.containsKey(PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY)) {
+                    || properties.containsKey(PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY)
+                    || properties.containsKey(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2)) {
                 if (table.isCloudNativeTable()) {
                     Locker locker = new Locker();
                     locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.WRITE);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
@@ -24,7 +24,6 @@ import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.SchemaInfo;
-import com.starrocks.catalog.TableProperty;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.TimeUtils;
@@ -135,9 +134,7 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
     private void updateCatalogUnprotected(Database db, LakeTable table) {
         if (disableFastSchemaEvolutionV2) {
             // only update the property, no need to update schema which is actually not changed
-            TableProperty tableProperty = table.getTableProperty();
-            tableProperty.getProperties().put(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2, "false");
-            tableProperty.buildCloudNativeFastSchemaEvolutionV2();
+            table.setFastSchemaEvolutionV2(false);
             LOG.info("Schema change job finish to disable {}, job_id: {}, table: {}",
                     PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2, getJobId(), table.getName());
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
@@ -24,7 +24,9 @@ import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.SchemaInfo;
+import com.starrocks.catalog.TableProperty;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.lake.LakeTable;
 import com.starrocks.persist.gson.GsonPostProcessable;
@@ -33,6 +35,8 @@ import com.starrocks.task.TabletMetadataUpdateAgentTask;
 import com.starrocks.task.TabletMetadataUpdateAgentTaskFactory;
 import com.starrocks.warehouse.Warehouse;
 import org.apache.commons.collections4.ListUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -56,9 +60,21 @@ import static java.util.Objects.requireNonNull;
  * 8. Finish the transaction
  */
 public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase implements GsonPostProcessable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LakeTableAsyncFastSchemaChangeJob.class);
+
     // shadow index id -> index schema
     @SerializedName(value = "schemaInfos")
     private List<IndexSchemaInfo> schemaInfos;
+
+    /**
+     * Whether this job is used to disable fast schema evolution v2. When this flag is true,
+     * this job will not perform a regular schema change, but will instead update tablet metadata
+     * to the latest schema version, and set the table property to false.
+     */
+    @SerializedName(value = "disableFseV2")
+    private boolean disableFastSchemaEvolutionV2 = false;
+
     private Set<String> partitionsWithSchemaFile = new HashSet<>();
 
     // for deserialization
@@ -76,6 +92,7 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
         for (IndexSchemaInfo indexSchemaInfo : other.schemaInfos) {
             setIndexTabletSchema(indexSchemaInfo.indexId, indexSchemaInfo.indexName, indexSchemaInfo.schemaInfo);
         }
+        this.disableFastSchemaEvolutionV2 = other.disableFastSchemaEvolutionV2;
         partitionsWithSchemaFile.addAll(other.partitionsWithSchemaFile);
     }
 
@@ -116,6 +133,16 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
     }
 
     private void updateCatalogUnprotected(Database db, LakeTable table) {
+        if (disableFastSchemaEvolutionV2) {
+            // only update the property, no need to update schema which is actually not changed
+            TableProperty tableProperty = table.getTableProperty();
+            tableProperty.getProperties().put(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2, "false");
+            tableProperty.buildCloudNativeFastSchemaEvolutionV2();
+            LOG.info("Schema change job finish to disable {}, job_id: {}, table: {}",
+                    PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2, getJobId(), table.getName());
+            return;
+        }
+
         Set<String> droppedOrModifiedColumns = Sets.newHashSet();
         boolean hasMv = !table.getRelatedMaterializedViews().isEmpty();
         for (IndexSchemaInfo indexSchemaInfo : schemaInfos) {
@@ -155,10 +182,12 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
         // This PR(#55282) only writes the schemaInfo once in the entire schema change job process, 
         // but it has compatibility issues with previous versions, so it was reverted.
         // However, since some versions include this PR, the schemaInfo may be null when upgrading from these versions.
-        List<IndexSchemaInfo> jobSchemaInfos = ((LakeTableAsyncFastSchemaChangeJob) job).schemaInfos;
+        LakeTableAsyncFastSchemaChangeJob schemaChangeJob = (LakeTableAsyncFastSchemaChangeJob) job;
+        List<IndexSchemaInfo> jobSchemaInfos = schemaChangeJob.schemaInfos;
         if (jobSchemaInfos != null && !jobSchemaInfos.isEmpty()) {
             this.schemaInfos = new ArrayList<>(jobSchemaInfos);
         }
+        this.disableFastSchemaEvolutionV2 = schemaChangeJob.disableFastSchemaEvolutionV2;
     }
 
     @Override
@@ -190,6 +219,15 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
         return schemaInfos.stream().map(i -> i.schemaInfo).collect(Collectors.toList());
     }
 
+    public void setDisableFastSchemaEvolutionV2() {
+        this.disableFastSchemaEvolutionV2 = true;
+    }
+
+    boolean isDisableFastSchemaEvolutionV2() {
+        return disableFastSchemaEvolutionV2;
+    }
+
+    @SuppressWarnings("rawtypes")
     @Override
     protected void getInfo(List<List<Comparable>> infos) {
         String progress = FeConstants.NULL_STRING;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -3240,7 +3240,9 @@ public class SchemaChangeHandler extends AlterHandler {
             SchemaInfo schemaInfo = SchemaInfo.fromMaterializedIndex(table, indexMeta);
             job.setIndexTabletSchema(indexId, indexName, schemaInfo);
         }
-        final ComputeResource computeResource = ConnectContext.get().getCurrentComputeResource();
+        ConnectContext connectContext = ConnectContext.get();
+        ComputeResource computeResource  = connectContext != null ?
+                connectContext.getCurrentComputeResource() : WarehouseManager.DEFAULT_RESOURCE;
         if (!GlobalStateMgr.getCurrentState().getWarehouseMgr().isResourceAvailable(computeResource)) {
             throw new DdlException("no available compute nodes:" + computeResource);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -86,6 +86,7 @@ import com.starrocks.common.util.WriteQuorum;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.persist.ModifyColumnCommentLog;
 import com.starrocks.persist.TableAddOrDropColumnsInfo;
@@ -2182,6 +2183,8 @@ public class SchemaChangeHandler extends AlterHandler {
                 compactionStrategy = properties.getOrDefault(PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY,
                         TableProperty.DEFAULT_COMPACTION_STRATEGY);
                 metaType = TTabletMetaType.COMPACTION_STRATEGY;
+            } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2)) {
+                return processAlterCloudNativeFastSchemaEvolutionV2Property(db, olapTable, properties).orElse(null);
             } else {
                 throw new DdlException("does not support alter " + properties.entrySet().iterator().next().getKey() +
                         " in shared_data mode");
@@ -3170,5 +3173,78 @@ public class SchemaChangeHandler extends AlterHandler {
                 .withComputeResource(schemaChangeData.getComputeResource())
                 .withDisableReplicatedStorageForGIN(schemaChangeData.isDisableReplicatedStorageForGIN())
                 .build();
+    }
+
+    /**
+     * Processes the alteration of the 'cloud_native_fast_schema_evolution_v2' property for a table.
+     *
+     * <p>This method handles the logic for enabling or disabling the fast schema evolution v2 feature.
+     * If the feature is being enabled, it modifies the table property directly. If it's being disabled,
+     * it creates a new {@link LakeTableAsyncFastSchemaChangeJob} to synchronize the tablet metadata
+     * with the latest schema.
+     *
+     * @param db The database containing the table.
+     * @param olapTable The table to be altered.
+     * @param properties The properties map from the ALTER TABLE statement.
+     * @return An {@link Optional} containing the {@link AlterJobV2} if a job is created for disabling the feature,
+     *         otherwise an empty Optional.
+     * @throws DdlException if the property modification is invalid.
+     */
+    private Optional<AlterJobV2> processAlterCloudNativeFastSchemaEvolutionV2Property(
+            Database db, OlapTable olapTable, Map<String, String> properties) throws DdlException {
+        boolean enableFastSchemaEvolutionV2 = PropertyAnalyzer.analyzeCloudNativeFastSchemaEvolutionV2(
+                olapTable.getType(), properties, false);
+        AlterJobV2 alterJob = null;
+        if (enableFastSchemaEvolutionV2 == ((LakeTable) olapTable).isFastSchemaEvolutionV2()) {
+            LOG.info("Property [{}] for table [{}] is already {}, and nothing needs to do",
+                    PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2,
+                    olapTable.getName(), enableFastSchemaEvolutionV2);
+        } else if (enableFastSchemaEvolutionV2) {
+            // from false to true, just modify the property in traditional way
+            GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
+            LOG.info("Property [{}] for table [{}] is set to {}",
+                    PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2,
+                    olapTable.getName(), enableFastSchemaEvolutionV2);
+        } else {
+            // from true to false, need to update tablet metas to the latest schema. Here we reuse
+            // LakeTableAsyncFastSchemaChangeJob to do it
+            alterJob = createJobToDisableCloudNativeFastSchemaEvolutionV2(db, olapTable);
+            LOG.info("Create a schema change job to disable {}, job_id: {},  table: {}",
+                    PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2, alterJob.getJobId(), olapTable.getName());
+        }
+        return Optional.ofNullable(alterJob);
+    }
+
+    /**
+     * Creates an {@link LakeTableAsyncFastSchemaChangeJob} to disable the 'cloud_native_fast_schema_evolution_v2' 
+     * feature for a table.
+     *
+     * <p>When disabling this feature, it's necessary to ensure all tablet metadata is updated to the latest
+     * schema version. This method creates a special {@link LakeTableAsyncFastSchemaChangeJob} that, instead of
+     * performing a schema change, iterates through all tablets and updates their metadata.
+     *
+     * @param db The database containing the table.
+     * @param table The table for which to disable the feature.
+     * @return The created {@link AlterJobV2} to be executed.
+     * @throws DdlException if there are no available compute nodes.
+     */
+    private LakeTableAsyncFastSchemaChangeJob createJobToDisableCloudNativeFastSchemaEvolutionV2(
+            Database db, OlapTable table) throws DdlException {
+        long jobId = GlobalStateMgr.getCurrentState().getNextId();
+        LakeTableAsyncFastSchemaChangeJob job = new LakeTableAsyncFastSchemaChangeJob(
+                jobId, db.getId(), table.getId(), table.getName(), Config.alter_table_timeout_second * 1000L);
+        job.setDisableFastSchemaEvolutionV2();
+        for (MaterializedIndexMeta indexMeta : table.getIndexIdToMeta().values()) {
+            long indexId = indexMeta.getIndexId();
+            String indexName = table.getIndexNameById(indexId);
+            SchemaInfo schemaInfo = SchemaInfo.fromMaterializedIndex(table, indexMeta);
+            job.setIndexTabletSchema(indexId, indexName, schemaInfo);
+        }
+        final ComputeResource computeResource = ConnectContext.get().getCurrentComputeResource();
+        if (!GlobalStateMgr.getCurrentState().getWarehouseMgr().isResourceAvailable(computeResource)) {
+            throw new DdlException("no available compute nodes:" + computeResource);
+        }
+        job.setComputeResource(computeResource);
+        return job;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaInfo.java
@@ -289,4 +289,22 @@ public class SchemaInfo {
             return new SchemaInfo(this);
         }
     }
+
+    public static SchemaInfo fromMaterializedIndex(OlapTable table, MaterializedIndexMeta indexMeta) {
+        return SchemaInfo.newBuilder()
+                .setId(indexMeta.getSchemaId())
+                .setKeysType(indexMeta.getKeysType())
+                .setShortKeyColumnCount(indexMeta.getShortKeyColumnCount())
+                .setStorageType(table.getStorageType())
+                .setVersion(indexMeta.getSchemaVersion())
+                .addColumns(indexMeta.getSchema())
+                .setSortKeyIndexes(indexMeta.getSortKeyIdxes())
+                .setSortKeyUniqueIds(indexMeta.getSortKeyUniqueIds())
+                .setIndexes(OlapTable.getIndexesBySchema(table.getCopiedIndexes(), indexMeta.getSchema()))
+                .setBloomFilterColumnNames(table.getBfColumnIds())
+                .setBloomFilterFpp(table.getBfFpp())
+                .setCompressionType(table.getCompressionType())
+                .setCompressionLevel(table.getCompressionLevel())
+                .build();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -333,6 +333,14 @@ public class TableProperty implements Writable, GsonPostProcessable {
     @SerializedName(value = "enableStatisticCollectOnFirstLoad")
     private boolean enableStatisticCollectOnFirstLoad = true;
 
+    /**
+     * Whether to enable the v2 implementation of fast schema evolution for cloud-native tables.
+     * This version is more lightweight, modifying only FE metadata instead of both FE and tablet metadata.
+     * It is disabled by default for existing tables to ensure backward compatibility after an upgrade.
+     * New tables will have this property explicitly set to true upon creation.
+     */
+    private boolean cloudNativeFastSchemaEvolutionV2 = false;
+
     public TableProperty() {
         this(Maps.newLinkedHashMap());
     }
@@ -422,6 +430,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
                 buildLocation();
                 buildStorageCoolDownTTL();
                 buildEnableStatisticCollectOnFirstLoad();
+                buildCloudNativeFastSchemaEvolutionV2();
                 break;
             case OperationType.OP_MODIFY_TABLE_CONSTRAINT_PROPERTY:
                 buildConstraint();
@@ -1246,6 +1255,18 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return this;
     }
 
+    public TableProperty buildCloudNativeFastSchemaEvolutionV2() {
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2)) {
+            cloudNativeFastSchemaEvolutionV2 = Boolean.parseBoolean(
+                    properties.get(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2));
+        }
+        return this;
+    }
+
+    public boolean isCloudNativeFastSchemaEvolutionV2() {
+        return cloudNativeFastSchemaEvolutionV2;
+    }
+
     @Override
     public void gsonPostProcess() throws IOException {
         try {
@@ -1273,6 +1294,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
         buildBinlogAvailableVersion();
         buildDataCachePartitionDuration();
         buildUseFastSchemaEvolution();
+        buildCloudNativeFastSchemaEvolutionV2();
         buildStorageType();
         buildMvProperties();
         buildLocation();

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -259,6 +259,12 @@ public class PropertyAnalyzer {
     // fast schema evolution
     public static final String PROPERTIES_USE_FAST_SCHEMA_EVOLUTION = "fast_schema_evolution";
     public static final String PROPERTIES_USE_LIGHT_SCHEMA_CHANGE = "light_schema_change";
+ 
+    /**
+     * Configuration for the v2 implementation of fast schema evolution for cloud-native table.
+     * This version is more lightweight, modifying only FE metadata instead of both FE and tablet metadata.
+     */
+    public static final String PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2 = "cloud_native_fast_schema_evolution_v2";
 
     public static final String PROPERTIES_DEFAULT_PREFIX = "default.";
 
@@ -1949,6 +1955,25 @@ public class PropertyAnalyzer {
         }
     }
 
+    public static boolean analyzeCloudNativeFastSchemaEvolutionV2(Table.TableType tableType,
+            Map<String, String> properties, boolean removeFromProperties) throws SemanticException {
+        if (tableType != Table.TableType.CLOUD_NATIVE) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                    String.format("Property %s only supports cloud-native tables, but table type is %s",
+                            PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2, tableType.name()));
+        }
+        boolean cloudNativeFastSchemaEvolutionV2 = true;
+        String value = properties.get(PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2);
+        if (value != null) {
+            cloudNativeFastSchemaEvolutionV2 = parseBooleanStrictly(PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2,
+                    value);
+        }
+        if (removeFromProperties) {
+            properties.remove(PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2);
+        }
+        return cloudNativeFastSchemaEvolutionV2;
+    }
+
     @NotNull
     private static String getExcludeString(List<TableName> tables) {
         StringBuilder tableSb = new StringBuilder();
@@ -2025,13 +2050,15 @@ public class PropertyAnalyzer {
         return sb.toString();
     }
 
-    public static boolean parseBoolean(String value) {
-        if (value.equalsIgnoreCase("true")) {
-            return true;
+    public static boolean parseBooleanStrictly(String property, String value) throws SemanticException {
+        boolean ret = false;
+        if ("true".equalsIgnoreCase(value)) {
+            ret = true;
+        } else if ("false".equalsIgnoreCase(value)) {
+            ret = false;
+        } else {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_INVALID_VALUE, property, value, "'true' or 'false'");
         }
-        if (value.equalsIgnoreCase("false")) {
-            return false;
-        }
-        throw new IllegalArgumentException("Illegal boolean value: " + value);
+        return ret;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTable.java
@@ -164,6 +164,8 @@ public class LakeTable extends OlapTable {
                 && !Strings.isNullOrEmpty(getPersistentIndexTypeString())) {
             properties.put(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE, getPersistentIndexTypeString());
         }
+        properties.put(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2,
+                String.valueOf(isFastSchemaEvolutionV2()));
 
         return properties;
     }
@@ -262,5 +264,23 @@ public class LakeTable extends OlapTable {
                         .map(id -> id == physicalPartitionId)
                         .orElse(false));
             });
+    }
+
+    public void setFastSchemaEvolutionV2(boolean enabled) {
+        if (tableProperty == null) {
+            tableProperty = new TableProperty(new HashMap<>());
+        }
+        tableProperty.modifyTableProperties(
+                PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2,
+                Boolean.valueOf(enabled).toString());
+        tableProperty.buildCloudNativeFastSchemaEvolutionV2();
+    }
+
+    public boolean isFastSchemaEvolutionV2() {
+        if (tableProperty == null) {
+            // if the table is upgraded from previous version, the v2 implementation is not enabled by default
+            return false;
+        }
+        return tableProperty.isCloudNativeFastSchemaEvolutionV2(); 
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -122,6 +122,7 @@ import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.journal.SerializeException;
 import com.starrocks.lake.DataCacheInfo;
 import com.starrocks.lake.LakeMaterializedView;
+import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.StorageInfo;
 import com.starrocks.load.pipe.PipeManager;
@@ -3817,12 +3818,10 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                 GlobalStateMgr.getCurrentState().getEditLog().logAlterTableProperties(info);
             }
             if (propertiesToPersist.containsKey(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2)) {
-                String value = propertiesToPersist.get(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2);
-                tableProperty.getProperties().put(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2, value);
-                tableProperty.buildCloudNativeFastSchemaEvolutionV2();
-                ModifyTablePropertyOperationLog info =
-                        new ModifyTablePropertyOperationLog(db.getId(), table.getId(),
-                                ImmutableMap.of(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2, value));
+                boolean value = (boolean) results.get(key);
+                ((LakeTable) table).setFastSchemaEvolutionV2(value);
+                ModifyTablePropertyOperationLog info = new ModifyTablePropertyOperationLog(db.getId(), table.getId(),
+                        ImmutableMap.of(key, propertiesToPersist.get(key)));
                 GlobalStateMgr.getCurrentState().getEditLog().logAlterTableProperties(info);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3816,6 +3816,15 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
                         ImmutableMap.of(key, propertiesToPersist.get(key)));
                 GlobalStateMgr.getCurrentState().getEditLog().logAlterTableProperties(info);
             }
+            if (propertiesToPersist.containsKey(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2)) {
+                String value = propertiesToPersist.get(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2);
+                tableProperty.getProperties().put(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2, value);
+                tableProperty.buildCloudNativeFastSchemaEvolutionV2();
+                ModifyTablePropertyOperationLog info =
+                        new ModifyTablePropertyOperationLog(db.getId(), table.getId(),
+                                ImmutableMap.of(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2, value));
+                GlobalStateMgr.getCurrentState().getEditLog().logAlterTableProperties(info);
+            }
         }
     }
 
@@ -3900,6 +3909,10 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
             boolean enable = PropertyAnalyzer.analyzeEnableStatisticCollectOnFirstLoad(properties);
             results.put(PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD, enable);
             properties.remove(PropertyAnalyzer.PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD);
+        }
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2)) {
+            boolean value = PropertyAnalyzer.analyzeCloudNativeFastSchemaEvolutionV2(table.getType(), properties, true);
+            results.put(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2, value);
         }
         if (!properties.isEmpty()) {
             throw new DdlException("Modify failed because unknown properties: " + properties);

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -256,7 +256,6 @@ public class OlapTableFactory implements AbstractTableFactory {
                 metastore.setLakeStorageInfo(db, table, storageVolumeId, properties);
 
                 processFlatJsonConfig(properties, table, tableName);
-
             } else {
                 table = new OlapTable(tableId, tableName, baseSchema, keysType, partitionInfo, distributionInfo, indexes);
             }
@@ -285,6 +284,13 @@ public class OlapTableFactory implements AbstractTableFactory {
                 throw new DdlException(e.getMessage());
             }
             table.setUseFastSchemaEvolution(useFastSchemaEvolution);
+
+            if (table.isCloudNativeTable()) {
+                boolean fastSchemaEvolutionV2 = properties == null ? true :
+                        PropertyAnalyzer.analyzeCloudNativeFastSchemaEvolutionV2(table.getType(), properties, true);
+                ((LakeTable) table).setFastSchemaEvolutionV2(fastSchemaEvolutionV2);
+            }
+
             for (Column column : baseSchema) {
                 column.setUniqueId(table.incAndGetMaxColUniqueId());
                 // check reserved column for PK table

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -460,6 +460,8 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
                 ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "The compaction strategy can be only " +
                         "update for a primary key table. ");
             }
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2)) {
+            PropertyAnalyzer.analyzeCloudNativeFastSchemaEvolutionV2(table.getType(), properties, false);
         } else {
             ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "Unknown properties: " + properties);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/CloudNativeFastSchemaEvolutionV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/CloudNativeFastSchemaEvolutionV2Test.java
@@ -1,0 +1,324 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.google.common.collect.Maps;
+import com.google.gson.stream.JsonReader;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndexMeta;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.SchemaInfo;
+import com.starrocks.catalog.Table.TableType;
+import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.lake.LakeTable;
+import com.starrocks.persist.ImageWriter;
+import com.starrocks.persist.ModifyTablePropertyOperationLog;
+import com.starrocks.persist.OperationType;
+import com.starrocks.persist.metablock.SRMetaBlockReader;
+import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.QueryState;
+import com.starrocks.qe.ShowExecutor;
+import com.starrocks.qe.ShowResultSet;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
+import com.starrocks.server.RunMode;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.sql.ast.ShowCreateTableStmt;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.StarRocksTestBase;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nullable;
+
+public class CloudNativeFastSchemaEvolutionV2Test extends StarRocksTestBase {
+    private static final String DB_NAME = "test_cloud_native_fse_v2";
+    private static final AtomicInteger TABLE_SUFFIX = new AtomicInteger(0);
+
+    private static ConnectContext connectContext;
+    private static SchemaChangeHandler schemaChangeHandler;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withDatabase(DB_NAME).useDatabase(DB_NAME);
+        schemaChangeHandler = GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler();
+        schemaChangeHandler.setStop();
+        schemaChangeHandler.interrupt();
+        long startTime = System.currentTimeMillis();
+        while (schemaChangeHandler.isRunning()) {
+            Thread.sleep(100);
+            Assertions.assertTrue(System.currentTimeMillis() - startTime < 60000,
+                    "Schema change handler is not stopped in 60 seconds");
+        }
+        UtFrameUtils.setUpForPersistTest();
+    }
+
+    @Test
+    public void testCreateTableProperty() throws Exception {
+        LakeTable defaultTable = createLakeTable(uniqueName("create_default"), null);
+        assertTableProperty(defaultTable, "true");
+
+        LakeTable explicitTrue = createLakeTable(uniqueName("create_true"), "true");
+        assertTableProperty(explicitTrue, "true");
+
+        LakeTable explicitFalse = createLakeTable(uniqueName("create_false"), "false");
+        assertTableProperty(explicitFalse, "false");
+
+        Assertions.assertThrows(SemanticException.class,
+                () -> createLakeTable(uniqueName("create_invalid"), "maybe"));
+
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2, "true");
+        Assertions.assertThrows(SemanticException.class,
+                () -> PropertyAnalyzer.analyzeCloudNativeFastSchemaEvolutionV2(TableType.OLAP, properties, false));
+    }
+
+    @Test
+    public void testAlterTableProperty() throws Exception {
+        LakeTable table = createLakeTable(uniqueName("alter_all"), null);
+        Map<Long, SchemaInfo> originalSchema = snapshotTableSchema(table);
+        assertTableProperty(table, "true");
+
+        // true -> true no-op
+        alterTableProperty(table.getName(), "true");
+        Assertions.assertTrue(getAlterJobs(table.getId()).isEmpty());
+        assertTableProperty(table, "true");
+
+        // true -> false requires async job
+        alterTableProperty(table.getName(), "false");
+        LakeTableAsyncFastSchemaChangeJob job = waitForAsyncSchemaChangeJob(table);
+        Assertions.assertTrue(job.isDisableFastSchemaEvolutionV2());
+        assertJobSchemaMatchesSnapshot(job, originalSchema);
+        assertTableSchemaMatchesSnapshot(table, originalSchema);
+        assertTableProperty(table, "false");
+
+        // false -> false no-op
+        alterTableProperty(table.getName(), "false");
+        Assertions.assertTrue(getAlterJobs(table.getId()).isEmpty());
+        assertTableProperty(table, "false");
+
+        // false -> true metadata-only
+        alterTableProperty(table.getName(), "true");
+        Assertions.assertTrue(getAlterJobs(table.getId()).isEmpty());
+        assertTableProperty(table, "true");
+
+        // invalid alter value
+        alterTableProperty(table.getName(), "maybe");
+        Assertions.assertEquals(QueryState.ErrType.ANALYSIS_ERR, connectContext.getState().getErrType());
+        Assertions.assertTrue(connectContext.getState().getErrorMessage()
+                .contains("Invalid " + PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2));
+    }
+
+    @Test
+    public void testReplayProperty() throws Exception {
+        LakeTable table = createLakeTable(uniqueName("restore_property"), "false");
+        Map<Long, SchemaInfo> schemaSnapshot = snapshotTableSchema(table);
+        assertTableProperty(table, "false");
+        UtFrameUtils.PseudoJournalReplayer.resetFollowerJournalQueue();
+        UtFrameUtils.PseudoImage initialImage = new UtFrameUtils.PseudoImage();
+        ImageWriter imageWriter = initialImage.getImageWriter();
+        GlobalStateMgr.getCurrentState().getLocalMetastore().save(imageWriter);
+        GlobalStateMgr.getCurrentState().getAlterJobMgr().save(imageWriter);
+
+        // false -> true
+        alterTableProperty(table.getName(), "true");
+        assertTableProperty(table, "true");
+
+        // true -> false
+        alterTableProperty(table.getName(), "false");
+        LakeTableAsyncFastSchemaChangeJob job = waitForAsyncSchemaChangeJob(table);
+        assertJobSchemaMatchesSnapshot(job, schemaSnapshot);
+        Assertions.assertTrue(job.isDisableFastSchemaEvolutionV2());
+        assertTableProperty(table, "false");
+
+        LocalMetastore restoredMetastore =
+                new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
+        AlterJobMgr restoredAlterJobMgr =
+                new AlterJobMgr(new SchemaChangeHandler(), new MaterializedViewHandler(), new SystemHandler());
+        JsonReader jsonReader = initialImage.getJsonReader();
+        SRMetaBlockReader blockReader = new SRMetaBlockReaderV2(jsonReader);
+        restoredMetastore.load(blockReader);
+        blockReader.close();
+        blockReader = new SRMetaBlockReaderV2(jsonReader);
+        restoredAlterJobMgr.load(blockReader);
+        blockReader.close();
+        Database restoredDb = restoredMetastore.getDb(DB_NAME);
+        Assertions.assertNotNull(restoredDb, "Restored database not found");
+        LakeTable restoredTable = (LakeTable) restoredMetastore.getTable(DB_NAME, table.getName());
+        Assertions.assertNotNull(restoredTable, "Restored table not found");
+        assertTableProperty(restoredTable, "false");
+
+        // replay false -> true
+        ModifyTablePropertyOperationLog info = (ModifyTablePropertyOperationLog)
+                UtFrameUtils.PseudoJournalReplayer.replayNextJournal(OperationType.OP_ALTER_TABLE_PROPERTIES);
+        restoredMetastore.replayModifyTableProperty(OperationType.OP_ALTER_TABLE_PROPERTIES, info);
+        Assertions.assertTrue(restoredTable.isFastSchemaEvolutionV2());
+
+        // replay true -> false
+        SchemaChangeHandler restoredHandler = restoredAlterJobMgr.getSchemaChangeHandler();
+        LocalMetastore originalMetastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        try {
+            // restoredHandler can restore state to restoredMetastore
+            GlobalStateMgr.getCurrentState().setLocalMetastore(restoredMetastore);
+            // there is expected 4 edit log in the lifecycle of LakeTableAsyncFastSchemaChangeJob
+            for (int i = 0; i < 4; i++) {
+                AlterJobV2 alterJob = (AlterJobV2)
+                        UtFrameUtils.PseudoJournalReplayer.replayNextJournal(OperationType.OP_ALTER_JOB_V2);
+                Assertions.assertInstanceOf(LakeTableAsyncFastSchemaChangeJob.class, alterJob);
+                Assertions.assertEquals(job.getJobId(), alterJob.getJobId());
+                restoredHandler.replayAlterJobV2(alterJob);
+            }
+        } finally {
+            GlobalStateMgr.getCurrentState().setLocalMetastore(originalMetastore);
+        }
+        AlterJobV2 restoredJob = restoredHandler.getAlterJobsV2().get(job.getJobId());
+        Assertions.assertInstanceOf(LakeTableAsyncFastSchemaChangeJob.class, restoredJob);
+        LakeTableAsyncFastSchemaChangeJob fseJob = (LakeTableAsyncFastSchemaChangeJob) restoredJob;
+        Assertions.assertEquals(AlterJobV2.JobState.FINISHED, fseJob.getJobState());
+        Assertions.assertTrue(fseJob.isDisableFastSchemaEvolutionV2());
+        Assertions.assertFalse(restoredTable.isFastSchemaEvolutionV2());
+    }
+
+    private static void assertTableProperty(LakeTable table, String expectedValue) throws Exception {
+        Assertions.assertEquals(Boolean.parseBoolean(expectedValue), table.isFastSchemaEvolutionV2());
+        Assertions.assertEquals(expectedValue, table.getTableProperty().getProperties()
+                .get(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2));
+        String showStmt = showCreateTable(table.getName());
+        String expectedFragment = String.format("\"%s\" = \"%s\"",
+                PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2, expectedValue);
+        Assertions.assertTrue(showStmt.contains(expectedFragment),
+                () -> String.format("SHOW CREATE TABLE result [%s] missing fragment [%s]", showStmt, expectedFragment));
+    }
+
+    private static LakeTable createLakeTable(String tableName, @Nullable String propertyValue) throws Exception {
+        StringBuilder builder = new StringBuilder();
+        builder.append("CREATE TABLE ").append(DB_NAME).append(".").append(tableName)
+                .append(" (c0 INT) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 ")
+                .append("PROPERTIES ('replication_num' = '1'");
+        if (propertyValue != null) {
+            builder.append(", '").append(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2)
+                    .append("' = '").append(propertyValue).append("'");
+        }
+        builder.append(")");
+        CreateTableStmt stmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(builder.toString(), connectContext);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(stmt);
+        return getLakeTable(tableName);
+    }
+
+    private static Database getDatabase() {
+        return GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+    }
+
+    private static String uniqueName(String prefix) {
+        return prefix + "_" + TABLE_SUFFIX.incrementAndGet();
+    }
+
+    private static String showCreateTable(String tableName) throws Exception {
+        ShowCreateTableStmt stmt = (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(
+                "SHOW CREATE TABLE " + DB_NAME + "." + tableName, connectContext);
+        ShowResultSet resultSet = ShowExecutor.execute(stmt, connectContext);
+        return resultSet.getResultRows().get(0).get(1).toString();
+    }
+
+    private static void alterTableProperty(String tableName, String value) throws Exception {
+        String sql = String.format("ALTER TABLE %s.%s SET ('%s' = '%s')",
+                DB_NAME, tableName, PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2, value);
+        connectContext.executeSql(sql);
+    }
+
+    private static List<AlterJobV2> getAlterJobs(long tableId) {
+        return schemaChangeHandler.getUnfinishedAlterJobV2ByTableId(tableId);
+    }
+
+    private static LakeTable getLakeTable(String tableName) {
+        Database db = getDatabase();
+        return (LakeTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), tableName);
+    }
+
+    private static LakeTableAsyncFastSchemaChangeJob waitForAsyncSchemaChangeJob(LakeTable table) throws Exception {
+        List<AlterJobV2> jobs = getAlterJobs(table.getId());
+        Assertions.assertEquals(1, jobs.size(), "Expected exactly one schema change job");
+        AlterJobV2 job = jobs.get(0);
+        Assertions.assertInstanceOf(LakeTableAsyncFastSchemaChangeJob.class, job);
+        long startTime = System.currentTimeMillis();
+        long timeoutMs = 10 * 60 * 1000;
+        while (job.getJobState() != AlterJobV2.JobState.FINISHED
+                || table.getState() != OlapTable.OlapTableState.NORMAL) {
+            if (System.currentTimeMillis() - startTime > timeoutMs) {
+                throw new RuntimeException(String.format(
+                        "Alter job timeout. Job state: %s, table state: %s", job.getJobState(), table.getState()));
+            }
+            job.run();
+            Thread.sleep(100);
+        }
+        return (LakeTableAsyncFastSchemaChangeJob) job;
+    }
+
+    private static Map<Long, SchemaInfo> snapshotTableSchema(LakeTable table) {
+        Map<Long, SchemaInfo> snapshot = Maps.newHashMap();
+        table.getIndexIdToMeta().forEach((indexId, meta) -> snapshot.put(indexId, toSchemaInfo(meta)));
+        return snapshot;
+    }
+
+    private static void assertTableSchemaMatchesSnapshot(LakeTable table, Map<Long, SchemaInfo> snapshot) {
+        snapshot.forEach((indexId, signature) -> {
+            MaterializedIndexMeta meta = table.getIndexIdToMeta().get(indexId);
+            Assertions.assertNotNull(meta, () -> "Table missing indexId " + indexId);
+            assertSchemaInfoEquals(signature, toSchemaInfo(meta));
+        });
+    }
+
+    private static void assertJobSchemaMatchesSnapshot(LakeTableAsyncFastSchemaChangeJob job,
+                                                       Map<Long, SchemaInfo> snapshot) {
+        List<SchemaInfo> jobSchemas = job.getSchemaInfoList();
+        Assertions.assertEquals(snapshot.size(), jobSchemas.size());
+        jobSchemas.forEach(schemaInfo -> {
+            SchemaInfo expected = snapshot.get(schemaInfo.getId());
+            assertSchemaInfoEquals(expected, schemaInfo);
+        });
+    }
+
+    private static SchemaInfo toSchemaInfo(MaterializedIndexMeta meta) {
+        return SchemaInfo.newBuilder()
+                .setId(meta.getSchemaId())
+                .setVersion(meta.getSchemaVersion())
+                .setKeysType(meta.getKeysType())
+                .setShortKeyColumnCount(meta.getShortKeyColumnCount())
+                .setStorageType(meta.getStorageType())
+                .addColumns(meta.getSchema())
+                .build();
+    }
+
+    private static void assertSchemaInfoEquals(SchemaInfo expected, SchemaInfo actual) {
+        Assertions.assertNotNull(actual);
+        Assertions.assertEquals(expected.getId(), actual.getId());
+        Assertions.assertEquals(expected.getVersion(), actual.getVersion());
+        Assertions.assertEquals(expected.getKeysType(), actual.getKeysType());
+        Assertions.assertEquals(expected.getShortKeyColumnCount(), actual.getShortKeyColumnCount());
+        Assertions.assertEquals(expected.getStorageType(), actual.getStorageType());
+        Assertions.assertEquals(expected.getColumns(), actual.getColumns());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/CreateLakeTableTest.java
@@ -519,6 +519,7 @@ public class CreateLakeTableTest {
                 "PARTITION p3 VALUES [(\"2024-02-01\"), (\"2024-02-02\")))\n" +
                 "DISTRIBUTED BY HASH(`k2`) BUCKETS 3 \n" +
                 "PROPERTIES (\n" +
+                "\"cloud_native_fast_schema_evolution_v2\" = \"true\",\n" +
                 "\"compression\" = \"LZ4\",\n" +
                 "\"datacache.enable\" = \"true\",\n" +
                 "\"enable_async_write_back\" = \"false\",\n" +


### PR DESCRIPTION
## Why I'm doing:
Add a table property to control whether to enable fast schema evolution for cloud-native tables which only modifies FE metadata

## What I'm doing:
* Add table property `cloud_native_fast_schema_evolution_v2` for cloud-native tables.
    * by default true for new created tables
    * false for existing tables
* support to alter the property
    * false -> true, just modify the FE table property
    * true -> false: trigger a  traditional fast schema evolution to apply the latest schema to  table meta, so that the table can be downgraded to old versions

Fixes #65706

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `cloud_native_fast_schema_evolution_v2` for cloud-native tables with ALTER support, metadata-only enable, and async job-based disable flow.
> 
> - **Cloud-native table property (`cloud_native_fast_schema_evolution_v2`)**:
>   - Default: `true` on new tables; `false` on existing tables.
>   - `ALTER TABLE ... SET ('cloud_native_fast_schema_evolution_v2'='true|false')`:
>     - `true` → updates FE metadata only.
>     - `false` → schedules `LakeTableAsyncFastSchemaChangeJob` to sync tablet metadata, then disables the property.
> - **Execution/handling**:
>   - `AlterJobExecutor` routes property changes to lake alter-meta path.
>   - `SchemaChangeHandler` validates, persists, and creates the disable job; includes job creation helper and catalog update.
>   - `LakeTableAsyncFastSchemaChangeJob` gains a mode to only disable v2 (no schema change) and logs/completes accordingly.
> - **Catalog/metadata**:
>   - `LakeTable` exposes `is/setFastSchemaEvolutionV2`; property included in `SHOW CREATE TABLE`.
>   - `TableProperty` stores/builds the new flag; deserialization support.
>   - `LocalMetastore` validates, persists, and replays the property.
>   - `PropertyAnalyzer` adds constant, parser, strict boolean parsing, and validation (cloud-native only).
>   - `SchemaInfo.fromMaterializedIndex(...)` helper for job schema snapshot.
>   - `OlapTableFactory` sets default for new cloud-native tables.
>   - `AlterTableClauseAnalyzer` validates ALTER usage.
> - **Tests**:
>   - New `CloudNativeFastSchemaEvolutionV2Test` for create/alter/replay flows and job behavior.
>   - Update `CreateLakeTableTest` expectations to include the new property in `SHOW CREATE TABLE`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43843fc8e9c72197b4636e5e510dfc3917314f30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->