### PR TITLE
[Enhancement] iceberg sink follows the table property "write.data.path"

### DIFF
--- a/be/src/runtime/iceberg_table_sink.cpp
+++ b/be/src/runtime/iceberg_table_sink.cpp
@@ -65,8 +65,8 @@ Status IcebergTableSink::decompose_to_pipeline(pipeline::OpFactories prev_operat
     auto& t_iceberg_sink = thrift_sink.iceberg_table_sink;
 
     auto sink_ctx = std::make_shared<connector::IcebergChunkSinkContext>();
-    sink_ctx->path = t_iceberg_sink.__isset.data_location && !t_iceberg_sink.data_location.empty() 
-                             ? t_iceberg_sink.data_location 
+    sink_ctx->path = t_iceberg_sink.__isset.data_location && !t_iceberg_sink.data_location.empty()
+                             ? t_iceberg_sink.data_location
                              : t_iceberg_sink.location + connector::IcebergUtils::DATA_DIRECTORY;
     sink_ctx->cloud_conf = t_iceberg_sink.cloud_configuration;
     sink_ctx->column_names = iceberg_table_desc->full_column_names();

--- a/be/src/runtime/iceberg_table_sink.cpp
+++ b/be/src/runtime/iceberg_table_sink.cpp
@@ -65,8 +65,9 @@ Status IcebergTableSink::decompose_to_pipeline(pipeline::OpFactories prev_operat
     auto& t_iceberg_sink = thrift_sink.iceberg_table_sink;
 
     auto sink_ctx = std::make_shared<connector::IcebergChunkSinkContext>();
-    sink_ctx->path = t_iceberg_sink.__isset.data_location && !t_iceberg_sink.data_location.empty() ? t_iceberg_sink.data_location : 
-        t_iceberg_sink.location + connector::IcebergUtils::DATA_DIRECTORY;
+    sink_ctx->path = t_iceberg_sink.__isset.data_location && !t_iceberg_sink.data_location.empty() 
+                             ? t_iceberg_sink.data_location 
+                             : t_iceberg_sink.location + connector::IcebergUtils::DATA_DIRECTORY;
     sink_ctx->cloud_conf = t_iceberg_sink.cloud_configuration;
     sink_ctx->column_names = iceberg_table_desc->full_column_names();
     sink_ctx->partition_column_names = iceberg_table_desc->partition_column_names();

--- a/be/src/runtime/iceberg_table_sink.cpp
+++ b/be/src/runtime/iceberg_table_sink.cpp
@@ -65,7 +65,8 @@ Status IcebergTableSink::decompose_to_pipeline(pipeline::OpFactories prev_operat
     auto& t_iceberg_sink = thrift_sink.iceberg_table_sink;
 
     auto sink_ctx = std::make_shared<connector::IcebergChunkSinkContext>();
-    sink_ctx->path = t_iceberg_sink.location + connector::IcebergUtils::DATA_DIRECTORY;
+    sink_ctx->path = t_iceberg_sink.__isset.data_location && !t_iceberg_sink.data_location.empty() ? t_iceberg_sink.data_location : 
+        t_iceberg_sink.location + connector::IcebergUtils::DATA_DIRECTORY;
     sink_ctx->cloud_conf = t_iceberg_sink.cloud_configuration;
     sink_ctx->column_names = iceberg_table_desc->full_column_names();
     sink_ctx->partition_column_names = iceberg_table_desc->partition_column_names();

--- a/be/test/connector_sink/iceberg_table_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_table_sink_test.cpp
@@ -95,4 +95,99 @@ TEST_F(IcebergTableSinkTest, decompose_to_pipeline) {
     EXPECT_EQ(sink_ctx->sort_ordering->sort_descs.descs.size(), 1);
 }
 
+// Test case for verifying the path construction logic in IcebergTableSink
+TEST_F(IcebergTableSinkTest, path_construction_logic) {
+    TDescriptorTableBuilder table_desc_builder;
+    TSlotDescriptorBuilder slot_desc_builder;
+    auto slot1 = slot_desc_builder.type(LogicalType::TYPE_INT).column_name("c1").column_pos(0).nullable(true).build();
+    TTupleDescriptorBuilder tuple_desc_builder;
+    tuple_desc_builder.add_slot(slot1);
+    tuple_desc_builder.build(&table_desc_builder);
+    DescriptorTbl* tbl = nullptr;
+    EXPECT_OK(DescriptorTbl::create(_runtime_state, &_pool, table_desc_builder.desc_tbl(), &tbl,
+                                    config::vector_chunk_size));
+    _runtime_state->set_desc_tbl(tbl);
+
+    TIcebergTable t_iceberg_table;
+    TColumn t_column;
+    t_column.__set_column_name("c1");
+    t_iceberg_table.__set_columns({t_column});
+    TTableDescriptor tdesc;
+    tdesc.__set_icebergTable(t_iceberg_table);
+
+    IcebergTableDescriptor* ice_table_desc = _pool.add(new IcebergTableDescriptor(tdesc, &_pool));
+    tbl->get_tuple_descriptor(0)->set_table_desc(ice_table_desc);
+    tbl->_tbl_desc_map[0] = ice_table_desc;
+
+    auto context = std::make_shared<pipeline::PipelineBuilderContext>(_fragment_context.get(), 1, 1, false);
+
+    // Test case 1: data_location is set and not empty, should use data_location
+    {
+        TDataSink data_sink;
+        TIcebergTableSink iceberg_table_sink;
+        iceberg_table_sink.__set_location("s3://bucket/table-location");
+        iceberg_table_sink.__set_data_location("s3://bucket/data-location");
+        data_sink.__set_iceberg_table_sink(iceberg_table_sink);
+
+        std::vector<starrocks::TExpr> exprs = {};
+        IcebergTableSink sink(&_pool, exprs);
+        pipeline::OpFactories prev_operators{std::make_shared<pipeline::EmptySetOperatorFactory>(1, 1)};
+
+        EXPECT_OK(sink.decompose_to_pipeline(prev_operators, data_sink, context.get()));
+
+        pipeline::Pipeline* pl = const_cast<pipeline::Pipeline*>(context->last_pipeline());
+        pipeline::OperatorFactory* op_factory = pl->sink_operator_factory();
+        auto connector_sink_factory = dynamic_cast<pipeline::ConnectorSinkOperatorFactory*>(op_factory);
+        auto sink_ctx = dynamic_cast<connector::IcebergChunkSinkContext*>(connector_sink_factory->_sink_context.get());
+        
+        // Should use data_location when it's set and not empty
+        EXPECT_EQ(sink_ctx->path, "s3://bucket/data-location");
+    }
+
+    // Test case 2: data_location is not set, should use location + "/data"
+    {
+        TDataSink data_sink;
+        TIcebergTableSink iceberg_table_sink;
+        iceberg_table_sink.__set_location("s3://bucket/table-location");
+        // data_location is not set
+        data_sink.__set_iceberg_table_sink(iceberg_table_sink);
+
+        std::vector<starrocks::TExpr> exprs = {};
+        IcebergTableSink sink(&_pool, exprs);
+        pipeline::OpFactories prev_operators{std::make_shared<pipeline::EmptySetOperatorFactory>(2, 2)};
+
+        EXPECT_OK(sink.decompose_to_pipeline(prev_operators, data_sink, context.get()));
+
+        pipeline::Pipeline* pl = const_cast<pipeline::Pipeline*>(context->last_pipeline());
+        pipeline::OperatorFactory* op_factory = pl->sink_operator_factory();
+        auto connector_sink_factory = dynamic_cast<pipeline::ConnectorSinkOperatorFactory*>(op_factory);
+        auto sink_ctx = dynamic_cast<connector::IcebergChunkSinkContext*>(connector_sink_factory->_sink_context.get());
+        
+        // Should use location + "/data" when data_location is not set
+        EXPECT_EQ(sink_ctx->path, "s3://bucket/table-location/data");
+    }
+
+    // Test case 3: data_location is set but empty, should use location + "/data"
+    {
+        TDataSink data_sink;
+        TIcebergTableSink iceberg_table_sink;
+        iceberg_table_sink.__set_location("s3://bucket/table-location");
+        iceberg_table_sink.__set_data_location(""); // Empty data_location
+        data_sink.__set_iceberg_table_sink(iceberg_table_sink);
+
+        std::vector<starrocks::TExpr> exprs = {};
+        IcebergTableSink sink(&_pool, exprs);
+        pipeline::OpFactories prev_operators{std::make_shared<pipeline::EmptySetOperatorFactory>(3, 3)};
+
+        EXPECT_OK(sink.decompose_to_pipeline(prev_operators, data_sink, context.get()));
+
+        pipeline::Pipeline* pl = const_cast<pipeline::Pipeline*>(context->last_pipeline());
+        pipeline::OperatorFactory* op_factory = pl->sink_operator_factory();
+        auto connector_sink_factory = dynamic_cast<pipeline::ConnectorSinkOperatorFactory*>(op_factory);
+        auto sink_ctx = dynamic_cast<connector::IcebergChunkSinkContext*>(connector_sink_factory->_sink_context.get());
+        
+        // Should use location + "/data" when data_location is empty
+        EXPECT_EQ(sink_ctx->path, "s3://bucket/table-location/data");
+    }
+}
 } // namespace starrocks

--- a/be/test/connector_sink/iceberg_table_sink_test.cpp
+++ b/be/test/connector_sink/iceberg_table_sink_test.cpp
@@ -139,7 +139,7 @@ TEST_F(IcebergTableSinkTest, path_construction_logic) {
         pipeline::OperatorFactory* op_factory = pl->sink_operator_factory();
         auto connector_sink_factory = dynamic_cast<pipeline::ConnectorSinkOperatorFactory*>(op_factory);
         auto sink_ctx = dynamic_cast<connector::IcebergChunkSinkContext*>(connector_sink_factory->_sink_context.get());
-        
+
         // Should use data_location when it's set and not empty
         EXPECT_EQ(sink_ctx->path, "s3://bucket/data-location");
     }
@@ -162,7 +162,7 @@ TEST_F(IcebergTableSinkTest, path_construction_logic) {
         pipeline::OperatorFactory* op_factory = pl->sink_operator_factory();
         auto connector_sink_factory = dynamic_cast<pipeline::ConnectorSinkOperatorFactory*>(op_factory);
         auto sink_ctx = dynamic_cast<connector::IcebergChunkSinkContext*>(connector_sink_factory->_sink_context.get());
-        
+
         // Should use location + "/data" when data_location is not set
         EXPECT_EQ(sink_ctx->path, "s3://bucket/table-location/data");
     }
@@ -185,7 +185,7 @@ TEST_F(IcebergTableSinkTest, path_construction_logic) {
         pipeline::OperatorFactory* op_factory = pl->sink_operator_factory();
         auto connector_sink_factory = dynamic_cast<pipeline::ConnectorSinkOperatorFactory*>(op_factory);
         auto sink_ctx = dynamic_cast<connector::IcebergChunkSinkContext*>(connector_sink_factory->_sink_context.get());
-        
+
         // Should use location + "/data" when data_location is empty
         EXPECT_EQ(sink_ctx->path, "s3://bucket/table-location/data");
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1337,7 +1337,7 @@ public class IcebergMetadata implements ConnectorMetadata {
             }
             if (partitionSpec.isPartitioned()) {
                 String relativePartitionLocation = getIcebergRelativePartitionPath(
-                        nativeTbl.location(), dataFile.partition_path);
+                        IcebergUtil.tableDataLocation(nativeTbl), dataFile.partition_path);
                 IcebergPartitionData partitionData = IcebergPartitionData.partitionDataFromPath(
                         relativePartitionLocation, nullFingerprint, partitionSpec);
                 builder.withPartition(partitionData);
@@ -1393,10 +1393,10 @@ public class IcebergMetadata implements ConnectorMetadata {
         return new Append(transaction);
     }
 
-    public static String getIcebergRelativePartitionPath(String tableLocation, String partitionLocation) {
-        tableLocation = tableLocation.endsWith("/") ? tableLocation.substring(0, tableLocation.length() - 1) : tableLocation;
-        String tableLocationWithData = tableLocation + "/data/";
-        String path = PartitionUtil.getSuffixName(tableLocationWithData, partitionLocation);
+    public static String getIcebergRelativePartitionPath(String tableDataLocation, String partitionLocation) {
+        tableDataLocation = tableDataLocation.endsWith("/") ? tableDataLocation.substring(0, tableDataLocation.length() - 1) :
+                tableDataLocation;
+        String path = PartitionUtil.getSuffixName(tableDataLocation, partitionLocation);
         if (path.startsWith("/")) {
             path = path.substring(1);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergUtil.java
@@ -20,9 +20,12 @@ import com.starrocks.planner.SlotDescriptor;
 import com.starrocks.thrift.TExprMinMaxValue;
 import com.starrocks.thrift.TExprNodeType;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.LocationUtil;
 
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -180,5 +183,12 @@ public final class IcebergUtil {
             minMaxValue.toThrift(result, slot);
         }
         return result;
+    }
+
+    public static String tableDataLocation(Table table) {
+        Preconditions.checkArgument(table != null, "table is null");
+        String tableLocation = table.location();
+        return table.properties().getOrDefault(TableProperties.WRITE_DATA_LOCATION,
+                String.format("%s/data", LocationUtil.stripTrailingSlash(tableLocation)));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergUtilTest.java
@@ -20,6 +20,7 @@ import com.starrocks.planner.SlotId;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.StringType;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
@@ -94,5 +95,21 @@ public class IcebergUtilTest {
             assertEquals(1, result.get(3).nullValueCount);
             assertEquals(10, result.get(3).valueCount);
         }
+    }
+
+    @Test
+    public void testTableDataLocationDefaultAndCustom() {
+        org.apache.iceberg.Table table = org.mockito.Mockito.mock(org.apache.iceberg.Table.class);
+
+        org.mockito.Mockito.when(table.location()).thenReturn("s3://bucket/path/");
+        Map<String, String> properties = new HashMap<>();
+        org.mockito.Mockito.when(table.properties()).thenReturn(properties);
+
+        String defaultLocation = IcebergUtil.tableDataLocation(table);
+        assertEquals("s3://bucket/path/data", defaultLocation);
+
+        properties.put(TableProperties.WRITE_DATA_LOCATION, "s3://bucket/custom_data");
+        String customLocation = IcebergUtil.tableDataLocation(table);
+        assertEquals("s3://bucket/custom_data", customLocation);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
@@ -43,7 +43,9 @@ import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.ScanOptimizeOption;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TBucketFunction;
+import com.starrocks.thrift.TDataSink;
 import com.starrocks.thrift.TIcebergTable;
+import com.starrocks.thrift.TIcebergTableSink;
 import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.thrift.TSinkCommitInfo;
 import com.starrocks.thrift.TTableDescriptor;
@@ -68,6 +70,7 @@ import org.apache.iceberg.ReplacePartitions;
 import org.apache.iceberg.RewriteFiles;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.Transaction;
@@ -138,19 +141,35 @@ public class IcebergScanNodeTest {
         delFiles.add(mockEqDelFile);
         new Expectations() {{
             GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalog);
-            result = connector; minTimes = 0;
+            result = connector;
+            minTimes = 0;
             connector.getMetadata().getCloudConfiguration();
-            result = cc; minTimes = 0;
-            table.getCatalogName(); result = catalog; minTimes = 0;
-            table.getCatalogDBName(); result = "db1"; minTimes = 0;
-            table.getCatalogTableName(); result = "tbl1"; minTimes = 0;
+            result = cc;
+            minTimes = 0;
+            table.getCatalogName();
+            result = catalog;
+            minTimes = 0;
+            table.getCatalogDBName();
+            result = "db1";
+            minTimes = 0;
+            table.getCatalogTableName();
+            result = "tbl1";
+            minTimes = 0;
             // mockPosDelFile.content(); result = FileContent.POSITION_DELETES; minTimes = 0;
             // mockEqDelFile.content(); result = FileContent.EQUALITY_DELETES; minTimes = 0;
             // fileScanTask.deletes(); result = delFiles; minTimes = 0;
-            fileScanTask.file(); result = mockDataFile; minTimes = 0;
-            mockDataFile.fileSizeInBytes(); result = 10000000L; minTimes = 0;
-            mockDataFile.specId(); result = 1; minTimes = 0;
-            mockDataFile.partition(); result = null; minTimes = 0;
+            fileScanTask.file();
+            result = mockDataFile;
+            minTimes = 0;
+            mockDataFile.fileSizeInBytes();
+            result = 10000000L;
+            minTimes = 0;
+            mockDataFile.specId();
+            result = 1;
+            minTimes = 0;
+            mockDataFile.partition();
+            result = null;
+            minTimes = 0;
         }};
 
         TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
@@ -202,11 +221,21 @@ public class IcebergScanNodeTest {
         IcebergRemoteFileInfo mockIcebergRemoteFileInfo = new IcebergRemoteFileInfo(mockScanTask);
 
         new Expectations() {{
-            mockSource.getOutput(); result = mockIcebergRemoteFileInfo; minTimes = 0;
-            mockScanTask.file(); result = mockDataFile; minTimes = 0;
-            mockScanTask.deletes(); result = deleteFiles; minTimes = 0;
-            mockPosDelFile.content(); result = FileContent.POSITION_DELETES; minTimes = 0;
-            mockEqDelFile.content(); result = FileContent.EQUALITY_DELETES; minTimes = 0;
+            mockSource.getOutput();
+            result = mockIcebergRemoteFileInfo;
+            minTimes = 0;
+            mockScanTask.file();
+            result = mockDataFile;
+            minTimes = 0;
+            mockScanTask.deletes();
+            result = deleteFiles;
+            minTimes = 0;
+            mockPosDelFile.content();
+            result = FileContent.POSITION_DELETES;
+            minTimes = 0;
+            mockEqDelFile.content();
+            result = FileContent.EQUALITY_DELETES;
+            minTimes = 0;
         }};
 
         IcebergConnectorScanRangeSource scanSource = new IcebergConnectorScanRangeSource(
@@ -218,7 +247,7 @@ public class IcebergScanNodeTest {
 
             @Override
             public boolean sourceHasMoreOutput() {
-                return callCount++ == 0;  
+                return callCount++ == 0;
             }
 
             @Override
@@ -250,19 +279,19 @@ public class IcebergScanNodeTest {
             result = Collections.emptyList();
             minTimes = 0;
 
-            mockTask.spec(); 
+            mockTask.spec();
             result = mockSpec;
             minTimes = 0;
-            mockSpec.partitionType(); 
+            mockSpec.partitionType();
             result = Types.StructType.of();
             minTimes = 0;
-            mockTask.file(); 
+            mockTask.file();
             result = mockDataFile;
             minTimes = 0;
-            mockDataFile.partition(); 
+            mockDataFile.partition();
             result = null;
             minTimes = 0;
-            mockDataFile.fileSizeInBytes(); 
+            mockDataFile.fileSizeInBytes();
             result = 1024L;
             minTimes = 0;
         }};
@@ -467,7 +496,7 @@ public class IcebergScanNodeTest {
 
     @Test
     void testDynamicOverwrite() {
-        
+
         InMemoryCatalog catalog = new InMemoryCatalog();
         catalog.initialize("test", new HashMap<>());
 
@@ -520,10 +549,10 @@ public class IcebergScanNodeTest {
         // 1. Mock InsertStmt
         IcebergRewriteStmt rewriteStmt = Mockito.mock(IcebergRewriteStmt.class);
         Mockito.when(rewriteStmt.rewriteAll()).thenReturn(true);
-    
+
         // 2. Mock IcebergScanNode
         IcebergScanNode scanNode = Mockito.mock(IcebergScanNode.class);
-    
+
         DeleteFile pos1 = Mockito.mock(DeleteFile.class);
         DeleteFile pos2 = Mockito.mock(DeleteFile.class);
         DeleteFile eq1 = Mockito.mock(DeleteFile.class);
@@ -539,27 +568,27 @@ public class IcebergScanNodeTest {
         PlanFragment fragment = Mockito.mock(PlanFragment.class);
         Mockito.when(fragment.collectScanNodes())
                 .thenReturn(Map.of(new PlanNodeId(0), scanNode));
-    
+
         // 4. Mock ExecPlan
         ExecPlan execPlan = Mockito.mock(ExecPlan.class);
         Mockito.when(execPlan.getFragments()).thenReturn(new ArrayList<>(List.of(fragment)));
-    
+
         // 5. Prepare commitInfos
         List<TSinkCommitInfo> commitInfos = new ArrayList<>();
         TSinkCommitInfo info1 = new TSinkCommitInfo();
         TSinkCommitInfo info2 = new TSinkCommitInfo();
         commitInfos.add(info1);
         commitInfos.add(info2);
-    
+
         // 6. Executor and extra
         StatementBase fakeStmt = Mockito.mock(StatementBase.class);
         ConnectContext ctx = new ConnectContext();
         StmtExecutor executor = new StmtExecutor(ctx, fakeStmt);
         IcebergMetadata.IcebergSinkExtra extra = new IcebergMetadata.IcebergSinkExtra();
-    
+
         // 7. Call target method
         executor.fillRewriteFiles(rewriteStmt, execPlan, commitInfos, extra);
-    
+
         // 8. Assert
         Assertions.assertTrue(info1.isIs_rewrite());
         Assertions.assertTrue(info2.isIs_rewrite());
@@ -746,10 +775,19 @@ public class IcebergScanNodeTest {
         Mockito.when(remoteFileInfo.cast()).thenReturn(icebergRemoteFileInfo);
         RemoteFileInfoSource remoteFileInfoSource = new RemoteFileInfoSource() {
             int count = 0;
-            @Override public RemoteFileInfo getOutput() { count++; return remoteFileInfo; }
-            @Override public boolean hasMoreOutput() { return count == 0; }
+
+            @Override
+            public RemoteFileInfo getOutput() {
+                count++;
+                return remoteFileInfo;
+            }
+
+            @Override
+            public boolean hasMoreOutput() {
+                return count == 0;
+            }
         };
-    
+
         IcebergTable icebergTable = Mockito.mock(IcebergTable.class);
         IcebergMORParams morParams = Mockito.mock(IcebergMORParams.class);
         TupleDescriptor tupleDesc = Mockito.mock(TupleDescriptor.class);
@@ -766,13 +804,17 @@ public class IcebergScanNodeTest {
         StmtExecutor executor = Mockito.mock(StmtExecutor.class);
         new MockUp<StmtExecutor>() {
             private static StmtExecutor HOLDER;
-            { HOLDER = executor; }
+
+            {
+                HOLDER = executor;
+            }
+
             @Mock
             public static StmtExecutor newInternalExecutor(ConnectContext c, StatementBase s) {
                 return HOLDER;
             }
         };
-    
+
         new MockUp<com.starrocks.sql.parser.SqlParser>() {
             @Mock
             public List<com.starrocks.sql.ast.StatementBase> parse(String sql, SessionVariable sessionVariable) {
@@ -813,7 +855,7 @@ public class IcebergScanNodeTest {
         Deencapsulation.setField(job, "scanNodes", Arrays.asList(scanNode));
         Deencapsulation.setField(job, "rewriteStmt", rewriteStmt);
         Deencapsulation.setField(job, "rewriteData", rewriteData);
-        
+
         ConcurrentLinkedQueue<IcebergRewriteDataJob.FinishArgs> finishArg = new ConcurrentLinkedQueue<>();
         finishArg.add(job.new FinishArgs(
                 "c", "db", "t",
@@ -828,9 +870,9 @@ public class IcebergScanNodeTest {
         Mockito.verify(rewriteData, Mockito.times(2)).hasMoreTaskGroup();
         Mockito.verify(rewriteData, Mockito.times(1)).nextTaskGroup();
         Mockito.verify(scanNode, Mockito.times(1)).rebuildScanRange(oneGroup);
-    
+
         Mockito.verify(executor, Mockito.times(1))
-               .handleDMLStmt(eq(execPlan), isA(IcebergRewriteStmt.class));
+                .handleDMLStmt(eq(execPlan), isA(IcebergRewriteStmt.class));
     }
 
     @Test
@@ -845,18 +887,18 @@ public class IcebergScanNodeTest {
         List<RemoteFileInfo> oneGroup = new ArrayList<>();
         RemoteFileInfo rfi = Mockito.mock(RemoteFileInfo.class);
         oneGroup.add(rfi);
-    
+
         Mockito.when(rewriteData.hasMoreTaskGroup()).thenReturn(true).thenReturn(false);
         Mockito.when(rewriteData.nextTaskGroup()).thenReturn(oneGroup);
         Mockito.when(scanNode.getPlanNodeName()).thenReturn("IcebergScanNode");
-    
+
         Mockito.when(context.getQueryId()).thenReturn(java.util.UUID.randomUUID());
         Mockito.when(context.getSkipFinishSink()).thenReturn(true);
         Mockito.when(context.getSessionVariable()).thenReturn(sessVar);
         Mockito.when(sessVar.clone()).thenReturn(sessVar);
         Mockito.doNothing().when(sessVar).setQueryTimeoutS(Mockito.anyInt());
 
-    
+
         PlanFragment fragment = Mockito.mock(PlanFragment.class);
         ArrayList<PlanFragment> fragments = new ArrayList<>();
         fragments.add(fragment);
@@ -865,12 +907,14 @@ public class IcebergScanNodeTest {
         scanMap.put(new PlanNodeId(1), scanNode);
         Mockito.when(execPlan.getFragments()).thenReturn(fragments);
         Mockito.when(fragment.collectScanNodes()).thenReturn(scanMap);
-    
+
         com.starrocks.sql.ast.InsertStmt parsedInsert = Mockito.mock(com.starrocks.sql.ast.InsertStmt.class);
-    
+
         new mockit.MockUp<StatementPlanner>() {
             @mockit.Mock
-            public ExecPlan plan(StatementBase stmt, ConnectContext session) { return execPlan; }
+            public ExecPlan plan(StatementBase stmt, ConnectContext session) {
+                return execPlan;
+            }
         };
         new mockit.MockUp<IcebergRewriteStmt>() {
             @mockit.Mock
@@ -880,17 +924,23 @@ public class IcebergScanNodeTest {
             @mockit.Mock
             public void rebuildScanRange(List<RemoteFileInfo> splits) { /* no-op */ }
         };
-    
+
         StmtExecutor executor = Mockito.mock(StmtExecutor.class);
         Mockito.doThrow(new RuntimeException("boom"))
-               .when(executor)
-               .handleDMLStmt(Mockito.eq(execPlan), Mockito.isA(IcebergRewriteStmt.class));
-    
+                .when(executor)
+                .handleDMLStmt(Mockito.eq(execPlan), Mockito.isA(IcebergRewriteStmt.class));
+
         new mockit.MockUp<StmtExecutor>() {
             private static StmtExecutor HOLDER;
-            { HOLDER = executor; }     
+
+            {
+                HOLDER = executor;
+            }
+
             @mockit.Mock
-            public static StmtExecutor newInternalExecutor(ConnectContext c, StatementBase s) { return HOLDER; }
+            public static StmtExecutor newInternalExecutor(ConnectContext c, StatementBase s) {
+                return HOLDER;
+            }
         };
 
         IcebergRewriteDataJob job = new IcebergRewriteDataJob(
@@ -941,5 +991,40 @@ public class IcebergScanNodeTest {
         Assertions.assertEquals(360, result);
         // wrong method
         Assertions.assertEquals(876, Stream.of(2, 3, 4, 5).reduce(1, (a, b) -> (a + 1) * (b + 1)));
+    }
+
+    @Test
+    public void testIcebergTableSinkToThrift(
+            @Mocked GlobalStateMgr globalStateMgr,
+            @Mocked CatalogConnector connector,
+            @Mocked ConnectorMetadata connectorMetadata,
+            @Mocked IcebergTable icebergTable,
+            @Mocked Table icebergNativeTable) throws Exception {
+        new Expectations() {{
+            GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(icebergTable.getCatalogName());
+            result = connector;
+            minTimes = 0;
+            connector.getMetadata();
+            result = connectorMetadata;
+            minTimes = 0;
+            connectorMetadata.getCloudConfiguration();
+            result = new CloudConfiguration();
+            minTimes = 0;
+            icebergTable.getNativeTable();
+            result = icebergNativeTable;
+            minTimes = 0;
+            icebergNativeTable.location();
+            result = "s3://bucket/path/";
+            minTimes = 0;
+        }};
+
+        TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
+        desc.setTable(icebergTable);
+        SessionVariable sessionVariable = new SessionVariable();
+        IcebergTableSink sink = new IcebergTableSink(icebergTable, desc, false, sessionVariable, "main");
+        TDataSink tDataSink = Deencapsulation.invoke(sink, "toThrift");
+        TIcebergTableSink tIceberg = tDataSink.getIceberg_table_sink();
+        Assertions.assertEquals("main", sink.getTargetBranch());
+        Assertions.assertTrue(tIceberg.isSetCloud_configuration());
     }
 }

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -244,6 +244,7 @@ struct TSchemaTableSink {
 }
 
 struct TIcebergTableSink {
+    // table location
     1: optional string location
     2: optional string file_format
     3: optional i64 target_table_id
@@ -252,6 +253,7 @@ struct TIcebergTableSink {
     6: optional CloudConfiguration.TCloudConfiguration cloud_configuration
     7: optional i64 target_max_file_size
     8: optional i32 tuple_id
+    9: optional string data_location
 }
 
 struct THiveTableSink {


### PR DESCRIPTION
## Why I'm doing:
iceberg has table property "write.data.path" to specify the data fle location, but starrocks do not respect to this proptery

## What I'm doing:
This pull request refactors and improves the way Iceberg table data locations are handled throughout the codebase. The main change is to distinguish between the table's root location and its data directory, allowing for custom data locations specified via Iceberg table properties. This ensures compatibility with advanced Iceberg features and improves flexibility for data file management. The changes also include updates to the Thrift interface, utility methods, and comprehensive unit tests.

**Iceberg data location handling improvements:**

* Added a new `data_location` field to the `TIcebergTableSink` Thrift struct, enabling explicit transmission of the data directory path separate from the table root location.
* Updated `IcebergTableSink` to store both `tableLocation` and `dataLocation`, with `dataLocation` determined by the new `IcebergUtil.tableDataLocation()` method, which checks for a custom property and defaults to `<table_location>/data`.
* Modified the BE sink pipeline to prioritize the new `data_location` field if set, falling back to the legacy behavior otherwise.

**Utility and metadata updates:**

* Introduced `IcebergUtil.tableDataLocation(Table)` to centralize logic for determining the data directory, considering both default and custom property-based locations.
* Updated usage of partition path calculation to use the new data location logic, ensuring correct relative partition paths even with custom data directories. [[1]]


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use Iceberg table data location (write.data.path) for sink output and partition path resolution, adding a new Thrift field and related FE/BE logic with tests.
> 
> - **Iceberg data location handling**:
>   - BE `IcebergTableSink`: `sink_ctx->path` now prioritizes `TIcebergTableSink.data_location`, else falls back to ``location + "/data"``.
>   - FE `IcebergUtil.tableDataLocation(Table)`: derives data dir from `TableProperties.WRITE_DATA_LOCATION` or defaults to ``<table_location>/data``.
>   - FE `IcebergTableSink`: carries both `tableLocation` and `dataLocation`; sets `TIcebergTableSink.location` and `TIcebergTableSink.data_location`.
>   - FE `IcebergMetadata.getIcebergRelativePartitionPath(...)`: now uses `IcebergUtil.tableDataLocation(nativeTbl)` for correct relative partition paths.
> - **Thrift**:
>   - Add `TIcebergTableSink.data_location` field.
> - **Tests**:
>   - Add BE test for path selection with/without `data_location`.
>   - Add FE tests for `tableDataLocation()` default/custom and `IcebergTableSink` thrift emission.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 83856915422d8ee20aadb7383ae9e91a6a9754b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->