### PR TITLE
[BugFix] Override isVariable() in DictMappingOperator to fix infinite loop

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/DictMappingOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/DictMappingOperator.java
@@ -84,6 +84,11 @@ public class DictMappingOperator extends ScalarOperator {
     }
 
     @Override
+    public boolean isVariable() {
+        return true;
+    }
+
+    @Override
     public String toString() {
         String stringOperator = stringProvideOperator == null ? "" : ", " + stringProvideOperator;
         return "DictMapping(" + dictColumn + ", " + originScalaOperator + stringOperator + ")";


### PR DESCRIPTION
## Why I'm doing:

Fix infinite loop in NormalizePredicateRule when both sides of a binary predicate are DictMappingOperators.

After PR [#62139](https://github.com/StarRocks/starrocks/pull/62139) was merged, queries with low cardinality optimization enabled may hang indefinitely when the predicate contains DictMappingOperators on both sides (e.g., `DictMapping(col1) != DictMapping(col2)`).

**Root cause:**
1. Before PR #62139, `DictMappingOperator` did not override `isConstant()`, so it inherited the default implementation which returned `true` (because `getChildren()` returns empty list)
2. PR #62139 fixed `isConstant()` to explicitly return `false`, but did not override `isVariable()`, which still returns `false` by default
3. This caused `DictMappingOperator` to be neither constant nor variable (`isConstant() = false`, `isVariable() = false`)
4. In `NormalizePredicateRule.visitBinaryPredicate()`, the logic is:
   - If left side is variable, return (no swap)
   - If right side is constant, return (no swap)
   - Otherwise, swap the two sides
5. When both sides are `DictMappingOperator`:
   - First rewrite: left is not variable, right is not constant → swap → returns new predicate (changed)
   - Second rewrite: left is still not variable, right is still not constant → swap again → returns new predicate (changed)
   - Since each rewrite returns a changed predicate, `ScalarOperatorRewriter` keeps applying the rule
   - This creates an infinite loop: the rule continuously swaps the two sides back and forth

**Impact:**
- Queries with predicates like `WHERE DictMapping(col1) != DictMapping(col2)` hang indefinitely

## What I'm doing:

Override `isVariable()` in `DictMappingOperator` to return `true`, which correctly represents its semantic meaning:

1. **Semantically correct**: `DictMappingOperator` contains a `ColumnRefOperator` (dictColumn) and accesses column values at runtime, so it should be treated as a variable, not a constant
2. **Fixes the infinite loop**: When `isVariable()` returns `true`, `NormalizePredicateRule.visitBinaryPredicate()` will return early (line 69-70) without swapping, preventing the infinite loop

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
