### PR TITLE
[Enhancement] report error message if partition id duplicated

### DIFF
--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -152,6 +152,13 @@ Status HdfsPartitionDescriptor::create_part_key_exprs(RuntimeState* state, Objec
     return Status::OK();
 }
 
+std::string HdfsPartitionDescriptor::debug_string() const {
+    std::stringstream out;
+    out << "HdfsPartition(id=" << _id << " location=" << _location << " file_format=" << _file_format
+        << " partition_key_value_evals=" << Expr::debug_string(_partition_key_value_evals);
+    return out.str();
+}
+
 HdfsTableDescriptor::HdfsTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool)
         : HiveTableDescriptor(tdesc, pool) {
     _hdfs_base_path = tdesc.hdfsTable.hdfs_base_dir;
@@ -460,8 +467,12 @@ Status HiveTableDescriptor::add_partition_value(RuntimeState* runtime_state, Obj
     RETURN_IF_ERROR(partition->create_part_key_exprs(runtime_state, pool));
     {
         std::unique_lock lock(_map_mutex);
-        if (_partition_id_to_desc_map.find(id) != _partition_id_to_desc_map.end()) {
-            return Status::InternalError(fmt::format("Partition id {} already exists", id));
+        const auto it = _partition_id_to_desc_map.find(id);
+        if (it != _partition_id_to_desc_map.end()) {
+            auto* old_partition = it->second;
+            return Status::InternalError(
+                    fmt::format("Partition id {} already exists. new partition = {}, old_partition = {}", id,
+                                partition->debug_string(), old_partition->debug_string()));
         }
         _partition_id_to_desc_map[id] = partition;
     }

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -460,6 +460,9 @@ Status HiveTableDescriptor::add_partition_value(RuntimeState* runtime_state, Obj
     RETURN_IF_ERROR(partition->create_part_key_exprs(runtime_state, pool));
     {
         std::unique_lock lock(_map_mutex);
+        if (_partition_id_to_desc_map.find(id) != _partition_id_to_desc_map.end()) {
+            return Status::InternalError(fmt::format("Partition id {} already exists", id));
+        }
         _partition_id_to_desc_map[id] = partition;
     }
     return Status::OK();

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -175,6 +175,7 @@ public:
     // partition key values wold be [1, 2]
     std::vector<ExprContext*>& partition_key_value_evals() { return _partition_key_value_evals; }
     Status create_part_key_exprs(RuntimeState* state, ObjectPool* pool);
+    std::string debug_string() const;
 
 private:
     int64_t _id = 0;

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -174,6 +174,7 @@ public:
     // partition slots would be [x, y]
     // partition key values wold be [1, 2]
     std::vector<ExprContext*>& partition_key_value_evals() { return _partition_key_value_evals; }
+    const std::vector<TExpr>& thrift_partition_key_exprs() const { return _thrift_partition_key_exprs; }
     Status create_part_key_exprs(RuntimeState* state, ObjectPool* pool);
     std::string debug_string() const;
 
@@ -182,7 +183,8 @@ private:
     THdfsFileFormat::type _file_format;
     std::string _location;
 
-    const std::vector<TExpr>& _thrift_partition_key_exprs;
+    // holding thrift exprs for partition keys for duplication check during runtime
+    const std::vector<TExpr> _thrift_partition_key_exprs;
     std::vector<ExprContext*> _partition_key_value_evals;
 };
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Detects duplicate partition IDs during partition addition and returns a detailed error instead of overwriting, adding debug output and storing/accessing thrift key exprs.
> 
> - **Runtime (Descriptors)**:
>   - `HiveTableDescriptor::add_partition_value`: Prevent overwrite on duplicate `partition_id`; if existing entry differs in `partition_key_exprs`, return detailed `InternalError` with new/old `debug_string()`.
>   - `HdfsPartitionDescriptor`:
>     - Store thrift `partition_key_exprs` by value for runtime duplication checks and expose `thrift_partition_key_exprs()`.
>     - Add `debug_string()` for detailed partition state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ebd42fd1e5822edd896cdc7e4bdd73088807c46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->