### PR TITLE
[BugFix] avoid inline non-deterministic CTE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1333,7 +1333,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     // If true, force CTE reuse when CTE contains LIMIT without ORDER BY to avoid unstable results.
     // When false, allow inline even if CTE has LIMIT without ORDER BY (may cause inconsistent results).
-    @VarAttr(name = CBO_CTE_FORCE_REUSE_LIMIT_WITHOUT_ORDER_BY)
+    @VarAttr(name = CBO_CTE_FORCE_REUSE_LIMIT_WITHOUT_ORDER_BY, flag = VariableMgr.INVISIBLE)
     private boolean cboCTEForceReuseLimitWithoutOrderBy = true;
 
     @VarAttr(name = PREFER_CTE_REWRITE, flag = VariableMgr.INVISIBLE)

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -3154,7 +3154,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         this.cboCTEForceReuseNodeCount = cboCTEForceReuseNodeCount;
     }
 
-    public boolean isCboCTEForceReuseLimitWithoutOrderBy() { return cboCTEForceReuseLimitWithoutOrderBy; }
+    public boolean isCboCTEForceReuseLimitWithoutOrderBy() {
+        return cboCTEForceReuseLimitWithoutOrderBy;
+    }
 
     public void setCboCTEForceReuseLimitWithoutOrderBy(boolean cboCTEForceReuseLimitWithoutOrderBy) {
         this.cboCTEForceReuseLimitWithoutOrderBy = cboCTEForceReuseLimitWithoutOrderBy;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -416,6 +416,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CBO_CTE_REUSE_RATE_V2 = "cbo_cte_reuse_rate_v2";
     public static final String PREFER_CTE_REWRITE = "prefer_cte_rewrite";
     public static final String CBO_CTE_FORCE_REUSE_NODE_COUNT = "cbo_cte_force_reuse_node_count";
+    public static final String CBO_CTE_FORCE_REUSE_LIMIT_WITHOUT_ORDER_BY =
+            "cbo_cte_force_reuse_limit_without_order_by";
     public static final String ENABLE_SQL_DIGEST = "enable_sql_digest";
     public static final String CBO_MAX_REORDER_NODE = "cbo_max_reorder_node";
     public static final String CBO_PRUNE_SHUFFLE_COLUMN_RATE = "cbo_prune_shuffle_column_rate";
@@ -1328,6 +1330,11 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // When the value is 0, disable the force reuse optimization.
     @VarAttr(name = CBO_CTE_FORCE_REUSE_NODE_COUNT)
     private int cboCTEForceReuseNodeCount = 2000;
+
+    // If true, force CTE reuse when CTE contains LIMIT without ORDER BY to avoid unstable results.
+    // When false, allow inline even if CTE has LIMIT without ORDER BY (may cause inconsistent results).
+    @VarAttr(name = CBO_CTE_FORCE_REUSE_LIMIT_WITHOUT_ORDER_BY)
+    private boolean cboCTEForceReuseLimitWithoutOrderBy = true;
 
     @VarAttr(name = PREFER_CTE_REWRITE, flag = VariableMgr.INVISIBLE)
     private boolean preferCTERewrite = false;
@@ -3145,6 +3152,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setCboCTEForceReuseNodeCount(int cboCTEForceReuseNodeCount) {
         this.cboCTEForceReuseNodeCount = cboCTEForceReuseNodeCount;
+    }
+
+    public boolean isCboCTEForceReuseLimitWithoutOrderBy() { return cboCTEForceReuseLimitWithoutOrderBy; }
+
+    public void setCboCTEForceReuseLimitWithoutOrderBy(boolean cboCTEForceReuseLimitWithoutOrderBy) {
+        this.cboCTEForceReuseLimitWithoutOrderBy = cboCTEForceReuseLimitWithoutOrderBy;
     }
 
     public double getCboPruneShuffleColumnRate() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ForceCTEReuseRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ForceCTEReuseRule.java
@@ -17,18 +17,22 @@ package com.starrocks.sql.optimizer.rule.transformation;
 
 import com.starrocks.sql.optimizer.CTEContext;
 import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEProduceOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalLimitOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.rule.NonDeterministicVisitor;
 import com.starrocks.sql.optimizer.rule.RuleType;
-
 import java.util.Collections;
 import java.util.List;
 
 /**
- * If the opt expression contains non-deterministic function, force cte reuse to avoid producing wrong result.
+ * Force cte reuse to avoid producing wrong result in the following cases:
+ * 1. The opt expression contains non-deterministic function
+ * 2. The opt expression contains LIMIT without ORDER BY (unstable result order)
  */
 public class ForceCTEReuseRule extends TransformationRule {
     public ForceCTEReuseRule() {
@@ -38,7 +42,19 @@ public class ForceCTEReuseRule extends TransformationRule {
 
     @Override
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
+        boolean shouldForceReuse = false;
+
+        // Always force reuse for non-deterministic functions
         if (hasNonDeterministicFunction(input)) {
+            shouldForceReuse = true;
+        }
+
+        // Force reuse for LIMIT without ORDER BY if enabled by session variable
+        if (hasLimitWithoutOrderBy(input) && context.getSessionVariable().isCboCTEForceReuseLimitWithoutOrderBy()) {
+            shouldForceReuse = true;
+        }
+
+        if (shouldForceReuse) {
             LogicalCTEProduceOperator produce = (LogicalCTEProduceOperator) input.getOp();
             CTEContext cteContext = context.getCteContext();
             int cteId = produce.getCteId();
@@ -50,5 +66,47 @@ public class ForceCTEReuseRule extends TransformationRule {
 
     private boolean hasNonDeterministicFunction(OptExpression root) {
         return root.getOp().accept(new NonDeterministicVisitor(), root, null);
+    }
+
+    /**
+     * Check if the opt expression contains LIMIT without ORDER BY.
+     * If a CTE has LIMIT without ORDER BY, inline it may cause different results
+     * in different consume points due to unstable row order.
+     */
+    private boolean hasLimitWithoutOrderBy(OptExpression root) {
+        LimitWithoutOrderByVisitor visitor = new LimitWithoutOrderByVisitor();
+        return root.getOp().accept(visitor, root, null);
+    }
+
+    /**
+     * Visitor to check if there's a LogicalLimitOperator (LIMIT without ORDER BY)
+     * in the expression tree. LogicalTopNOperator (ORDER BY with optional LIMIT)
+     * is considered stable and doesn't need to force CTE reuse.
+     */
+    private static class LimitWithoutOrderByVisitor extends OptExpressionVisitor<Boolean, Void> {
+        @Override
+        public Boolean visit(OptExpression optExpression, Void context) {
+            // Visit children to check for LIMIT without ORDER BY
+            for (OptExpression child : optExpression.getInputs()) {
+                if (child.getOp().accept(this, child, null)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public Boolean visitLogicalLimit(OptExpression optExpression, Void context) {
+            // Found LogicalLimitOperator, which means LIMIT without ORDER BY
+            // This is unstable and should force CTE reuse
+            return true;
+        }
+
+        @Override
+        public Boolean visitLogicalTopN(OptExpression optExpression, Void context) {
+            // LogicalTopNOperator has ORDER BY, so it's stable
+            // Continue checking children but don't mark as unstable
+            return visit(optExpression, context);
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ForceCTEReuseRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ForceCTEReuseRule.java
@@ -48,7 +48,7 @@ public class ForceCTEReuseRule extends TransformationRule {
         }
 
         // Force reuse for LIMIT without ORDER BY if enabled by session variable
-        if (hasLimitWithoutOrderBy(input) && context.getSessionVariable().isCboCTEForceReuseLimitWithoutOrderBy()) {
+        if (context.getSessionVariable().isCboCTEForceReuseLimitWithoutOrderBy() && hasLimitWithoutOrderBy(input)) {
             shouldForceReuse = true;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ForceCTEReuseRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ForceCTEReuseRule.java
@@ -78,8 +78,8 @@ public class ForceCTEReuseRule extends TransformationRule {
 
     /**
      * Visitor to check if there's a LogicalLimitOperator (LIMIT without ORDER BY)
-     * in the expression tree. LogicalTopNOperator (ORDER BY with optional LIMIT)
-     * is considered stable and doesn't need to force CTE reuse.
+     * in the expression tree. Since Limit will merge with TopN, checking for
+     * LogicalLimitOperator is sufficient.
      */
     private static class LimitWithoutOrderByVisitor extends OptExpressionVisitor<Boolean, Void> {
         @Override
@@ -98,13 +98,6 @@ public class ForceCTEReuseRule extends TransformationRule {
             // Found LogicalLimitOperator, which means LIMIT without ORDER BY
             // This is unstable and should force CTE reuse
             return true;
-        }
-
-        @Override
-        public Boolean visitLogicalTopN(OptExpression optExpression, Void context) {
-            // LogicalTopNOperator has ORDER BY, so it's stable
-            // Continue checking children but don't mark as unstable
-            return visit(optExpression, context);
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ForceCTEReuseRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ForceCTEReuseRule.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rule.transformation;
 
 import com.starrocks.sql.optimizer.CTEContext;
@@ -21,11 +20,10 @@ import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEProduceOperator;
-import com.starrocks.sql.optimizer.operator.logical.LogicalLimitOperator;
-import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.rule.NonDeterministicVisitor;
 import com.starrocks.sql.optimizer.rule.RuleType;
+
 import java.util.Collections;
 import java.util.List;
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
@@ -1117,9 +1117,7 @@ public class CTEPlanTest extends PlanTestBase {
                 + "cte2 as(select * from cte0)\n"
                 + "select * from cte1 union all select * from cte2;";
         String plan = getFragmentPlan(sql);
-        // With ORDER BY, ForceCTEReuseRule should not trigger
-        // The CTE reuse decision will be based on ratio and consume count
-        // This test verifies that ORDER BY prevents the force reuse rule from triggering
+        assertNotContains("MultiCast");
     }
 
     @ParameterizedTest
@@ -1165,9 +1163,7 @@ public class CTEPlanTest extends PlanTestBase {
                 + "cte0 as(select * from t0 limit 10)\n"
                 + "select * from cte0;";
         String plan = getFragmentPlan(sql);
-        // With ratio=0, it would normally force CTE reuse anyway
-        // But this test verifies the rule still applies
-        // Note: Single consume with ratio=0 will still use CTE reuse
+        assertContains("MultiCast");
     }
 
     @ParameterizedTest

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/CTEPlanTest.java
@@ -59,6 +59,7 @@ public class CTEPlanTest extends PlanTestBase {
     public void defaultCTEReuse() {
         connectContext.getSessionVariable().setCboCTERuseRatio(1.5);
         connectContext.getSessionVariable().setCboCTEForceReuseNodeCount(0);
+        connectContext.getSessionVariable().setCboCTEForceReuseLimitWithoutOrderBy(true);
     }
 
     @ParameterizedTest
@@ -1085,5 +1086,110 @@ public class CTEPlanTest extends PlanTestBase {
                 "\n" +
                 "  1:Project\n" +
                 "  |  <slot 2> : rand()");
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    public void testCTEWithLimitWithoutOrderBy(int forceReuseNodeCount) throws Exception {
+        connectContext.getSessionVariable().setCboCTEForceReuseNodeCount(forceReuseNodeCount);
+        // CTE with LIMIT but no ORDER BY should force CTE reuse
+        String sql = "with\n"
+                + "cte0 as(select * from t0 limit 10),\n"
+                + "cte1 as(select * from cte0),\n"
+                + "cte2 as(select * from cte0),\n"
+                + "cte3 as(select * from cte1 union all select * from cte2)\n"
+                + "select * from cte3;";
+        String plan = getFragmentPlan(sql);
+        // Should force CTE reuse because cte0 has LIMIT without ORDER BY
+        assertContains(plan, "MultiCastDataSinks");
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    public void testCTEWithOrderByAndLimit(int forceReuseNodeCount) throws Exception {
+        connectContext.getSessionVariable().setCboCTEForceReuseNodeCount(forceReuseNodeCount);
+        connectContext.getSessionVariable().setCboCTERuseRatio(1.5);
+        // CTE with ORDER BY and LIMIT should not force CTE reuse via ForceCTEReuseRule
+        // (ORDER BY makes it stable, so the rule won't trigger)
+        String sql = "with\n"
+                + "cte0 as(select * from t0 order by v1 limit 10),\n"
+                + "cte1 as(select * from cte0),\n"
+                + "cte2 as(select * from cte0)\n"
+                + "select * from cte1 union all select * from cte2;";
+        String plan = getFragmentPlan(sql);
+        // With ORDER BY, ForceCTEReuseRule should not trigger
+        // The CTE reuse decision will be based on ratio and consume count
+        // This test verifies that ORDER BY prevents the force reuse rule from triggering
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    public void testCTEWithLimitWithoutOrderByMultipleConsume(int forceReuseNodeCount) throws Exception {
+        connectContext.getSessionVariable().setCboCTEForceReuseNodeCount(forceReuseNodeCount);
+        // CTE with LIMIT without ORDER BY, consumed multiple times, should force reuse
+        String sql = "with\n"
+                + "cte0 as(select * from t0 limit 5),\n"
+                + "cte1 as(select * from cte0),\n"
+                + "cte2 as(select * from cte0),\n"
+                + "cte3 as(select * from cte0)\n"
+                + "select * from cte1 union all select * from cte2 union all select * from cte3;";
+        String plan = getFragmentPlan(sql);
+        // Should force CTE reuse because cte0 has LIMIT without ORDER BY
+        assertContains(plan, "MultiCastDataSinks");
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    public void testCTEWithNonDeterministicAndLimitWithoutOrderBy(int forceReuseNodeCount) throws Exception {
+        connectContext.getSessionVariable().setCboCTEForceReuseNodeCount(forceReuseNodeCount);
+        // CTE with both non-deterministic function and LIMIT without ORDER BY
+        String sql = "with\n"
+                + "cte0 as(select rand() as r, v1 from t0 limit 10),\n"
+                + "cte1 as(select * from cte0),\n"
+                + "cte2 as(select * from cte0)\n"
+                + "select * from cte1 union all select * from cte2;";
+        String plan = getFragmentPlan(sql);
+        // Should force CTE reuse because of both non-deterministic function and LIMIT without ORDER BY
+        assertContains(plan, "MultiCastDataSinks");
+        assertContains(plan, "rand()");
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    public void testCTEWithLimitWithoutOrderBySingleConsume(int forceReuseNodeCount) throws Exception {
+        connectContext.getSessionVariable().setCboCTEForceReuseNodeCount(forceReuseNodeCount);
+        connectContext.getSessionVariable().setCboCTERuseRatio(0);
+        // CTE with LIMIT without ORDER BY, but only consumed once
+        // Even with single consume, should force reuse due to LIMIT without ORDER BY
+        String sql = "with\n"
+                + "cte0 as(select * from t0 limit 10)\n"
+                + "select * from cte0;";
+        String plan = getFragmentPlan(sql);
+        // With ratio=0, it would normally force CTE reuse anyway
+        // But this test verifies the rule still applies
+        // Note: Single consume with ratio=0 will still use CTE reuse
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1})
+    public void testCTEWithLimitWithoutOrderBySessionVariable(int forceReuseNodeCount) throws Exception {
+        connectContext.getSessionVariable().setCboCTEForceReuseNodeCount(forceReuseNodeCount);
+        // Test with session variable enabled (default)
+        connectContext.getSessionVariable().setCboCTEForceReuseLimitWithoutOrderBy(true);
+        String sql = "with\n"
+                + "cte0 as(select * from t0 limit 10),\n"
+                + "cte1 as(select * from cte0),\n"
+                + "cte2 as(select * from cte0)\n"
+                + "select * from cte1 union all select * from cte2;";
+        String plan = getFragmentPlan(sql);
+        // Should force CTE reuse when variable is enabled
+        assertContains(plan, "MultiCastDataSinks");
+
+        // Test with session variable disabled
+        connectContext.getSessionVariable().setCboCTEForceReuseLimitWithoutOrderBy(false);
+        plan = getFragmentPlan(sql);
+        // Should not force CTE reuse when variable is disabled
+        // (CTE reuse decision will be based on other factors like ratio and consume count)
+        // Note: The actual behavior depends on CTE reuse ratio and consume count
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsSQLTest.java
@@ -162,7 +162,7 @@ public class StatisticsSQLTest extends PlanTestBase {
 
         String plan = getFragmentPlan(simpleSql);
 
-        Assertions.assertEquals(2, StringUtils.countMatches(plan, "OlapScanNode"));
+        Assertions.assertEquals(1, StringUtils.countMatches(plan, "OlapScanNode"));
         assertCContains(plan, "left(");
     }
 

--- a/test/sql/test_limit/R/test_limit
+++ b/test/sql/test_limit/R/test_limit
@@ -130,6 +130,9 @@ set enable_multi_cast_limit_push_down = false;
 set cbo_enable_low_cardinality_optimize=false;
 -- result:
 -- !result
+set cbo_cte_force_reuse_limit_without_order_by = false;
+-- result:
+-- !result
 with C as (select region, sum(income) as total from t0 group by 1), 
      L as (select total from C limit 3), 
      R as (select total from C limit 4)
@@ -156,5 +159,8 @@ function: assert_explain_verbose_contains('with C as (select region, sum(income)
 None
 -- !result
 set cbo_enable_low_cardinality_optimize=true;
+-- result:
+-- !result
+set cbo_cte_force_reuse_limit_without_order_by = true;
 -- result:
 -- !result

--- a/test/sql/test_limit/T/test_limit
+++ b/test/sql/test_limit/T/test_limit
@@ -73,6 +73,7 @@ select count(*) from (select * from TABLE(generate_series(1, 100000)) limit 1, 1
 
 set enable_multi_cast_limit_push_down = false;
 set cbo_enable_low_cardinality_optimize=false;
+set cbo_cte_force_reuse_limit_without_order_by = false;
 
 with C as (select region, sum(income) as total from t0 group by 1), 
      L as (select total from C limit 3), 
@@ -92,3 +93,4 @@ select count(*) from ( select * from L union all select * from R ) as U;
 function: assert_explain_verbose_contains('with C as (select region, sum(income) as total from t0 group by 1), L as (select total from C limit 3),  R as (select total from C limit 4) select count(*) from ( select * from L union all select * from R ) as U;', '6:EXCHANGE\n     distribution type: SHUFFLE\n     partition exprs: [1: region, VARCHAR(128), false]\n     limit: 3\n     cardinality: 3', '10:EXCHANGE\n     distribution type: SHUFFLE\n     partition exprs: [1: region, VARCHAR(128), false]\n     limit: 4\n     cardinality: 4')
 
 set cbo_enable_low_cardinality_optimize=true;
+set cbo_cte_force_reuse_limit_without_order_by = true;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

```
DROP TABLE IF EXISTS t;
CREATE TABLE t(id INT);

INSERT INTO t (id)
SELECT seq
FROM (
    SELECT 1 AS seq UNION ALL
    SELECT 2 UNION ALL
    SELECT 3 UNION ALL
    SELECT 4 UNION ALL
    SELECT 5 UNION ALL
    SELECT 6 UNION ALL
    SELECT 7 UNION ALL
    SELECT 8 UNION ALL
    SELECT 9 UNION ALL
    SELECT 10
) AS x;

WITH c AS (
    SELECT id
    FROM t
    LIMIT 5
)
SELECT 'A' AS src, id FROM c
UNION ALL
SELECT 'B' AS src, id FROM c;
```

Inlining a non-deterministic CTE (such as one with a LIMIT) may lead to unexpected query results; therefore, we recommend avoiding its inlining.

**Behavior change:**
- Before: CTE with `LIMIT X` can be inlined
- After: CTE with `LIMIT X` will not be inlined

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
