### PR TITLE
[BugFix] fix the statistics collection of collection_size

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
@@ -344,8 +344,8 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
             context.put("minFunction", "''");
             context.put("collectionSizeFunction", "-1");
         } else if (columnType.isCollectionType()) {
-            String collectionSizeFunction = "AVG(" + (columnType.isArrayType() ? "ARRAY_LENGTH" : "MAP_SIZE") +
-                    "(" + quoteColumnKey + ")) ";
+            String collectionSizeFunction = "IFNULL(AVG(" + (columnType.isArrayType() ? "ARRAY_LENGTH" : "MAP_SIZE") +
+                    "(" + quoteColumnKey + ")), -1) ";
             long elementTypeSize = columnType.isArrayType() ? ((ArrayType) columnType).getItemType().getTypeSize() :
                     ((MapType) columnType).getKeyType().getTypeSize() + ((MapType) columnType).getValueType().getTypeSize();
             String dataSizeFunction =  "COUNT(*) * " + elementTypeSize + " * " + collectionSizeFunction;

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
@@ -348,7 +348,8 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
                     "(" + quoteColumnKey + ")), -1) ";
             long elementTypeSize = columnType.isArrayType() ? ((ArrayType) columnType).getItemType().getTypeSize() :
                     ((MapType) columnType).getKeyType().getTypeSize() + ((MapType) columnType).getValueType().getTypeSize();
-            String dataSizeFunction =  "COUNT(*) * " + elementTypeSize + " * " + collectionSizeFunction;
+            String dataSizeFunction =
+                    "COUNT(*) * " + elementTypeSize + " * GREATEST(0, " + collectionSizeFunction.trim() + ")";
             context.put("hllFunction", "'00'");
             context.put("countNullFunction", "0");
             context.put("maxFunction", "''");

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
@@ -68,7 +68,7 @@ public class StatisticSQLBuilder {
             "SELECT cast(" + STATISTIC_DATA_VERSION_V2 + " as INT), $updateTime, db_id, table_id, column_name,"
                     + " sum(row_count), cast(sum(data_size) as bigint), hll_union_agg(ndv), sum(null_count), "
                     + " cast(max(cast(max as $type)) as string), cast(min(cast(min as $type)) as string),"
-                    + " cast(IFNULL(avg(collection_size), -1) as bigint)"
+                    + " cast(avg(collection_size) as bigint)"
                     + " FROM " + StatsConstants.FULL_STATISTICS_TABLE_NAME
                     + " WHERE $predicate"
                     + " GROUP BY db_id, table_id, column_name";
@@ -76,7 +76,7 @@ public class StatisticSQLBuilder {
     private static final String QUERY_COLLECTION_FULL_STATISTIC_TEMPLATE =
             "SELECT cast(" + STATISTIC_DATA_VERSION_V2 + " as INT), $updateTime, db_id, table_id, column_name,"
                     + " sum(row_count), cast(sum(data_size) as bigint), hll_union_agg(ndv), sum(null_count), "
-                    + " any_value(''), any_value(''), cast(IFNULL(avg(collection_size), -1) as bigint) "
+                    + " any_value(''), any_value(''), cast(avg(collection_size) as bigint) "
                     + " FROM " + StatsConstants.FULL_STATISTICS_TABLE_NAME
                     + " WHERE $predicate"
                     + " GROUP BY db_id, table_id, column_name";

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticSQLBuilder.java
@@ -68,7 +68,7 @@ public class StatisticSQLBuilder {
             "SELECT cast(" + STATISTIC_DATA_VERSION_V2 + " as INT), $updateTime, db_id, table_id, column_name,"
                     + " sum(row_count), cast(sum(data_size) as bigint), hll_union_agg(ndv), sum(null_count), "
                     + " cast(max(cast(max as $type)) as string), cast(min(cast(min as $type)) as string),"
-                    + " cast(avg(collection_size) as bigint)"
+                    + " cast(IFNULL(avg(collection_size), -1) as bigint)"
                     + " FROM " + StatsConstants.FULL_STATISTICS_TABLE_NAME
                     + " WHERE $predicate"
                     + " GROUP BY db_id, table_id, column_name";
@@ -76,7 +76,7 @@ public class StatisticSQLBuilder {
     private static final String QUERY_COLLECTION_FULL_STATISTIC_TEMPLATE =
             "SELECT cast(" + STATISTIC_DATA_VERSION_V2 + " as INT), $updateTime, db_id, table_id, column_name,"
                     + " sum(row_count), cast(sum(data_size) as bigint), hll_union_agg(ndv), sum(null_count), "
-                    + " any_value(''), any_value(''), cast(avg(collection_size) as bigint) "
+                    + " any_value(''), any_value(''), cast(IFNULL(avg(collection_size), -1) as bigint) "
                     + " FROM " + StatsConstants.FULL_STATISTICS_TABLE_NAME
                     + " WHERE $predicate"
                     + " GROUP BY db_id, table_id, column_name";

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/base/CollectionTypeColumnStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/base/CollectionTypeColumnStats.java
@@ -53,7 +53,7 @@ public class CollectionTypeColumnStats extends BaseColumnStats {
     @Override
     public String getCollectionSize() {
         String collectionSizeFunction = columnType.isArrayType() ? "ARRAY_LENGTH" : "MAP_SIZE";
-        return "AVG(" + collectionSizeFunction + "(" + getQuotedColumnName() + ")) ";
+        return "IFNULL(AVG(" + collectionSizeFunction + "(" + getQuotedColumnName() + ")), -1) ";
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/base/CollectionTypeColumnStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/base/CollectionTypeColumnStats.java
@@ -32,7 +32,7 @@ public class CollectionTypeColumnStats extends BaseColumnStats {
     public String getFullDataSize() {
         long elementTypeSize = columnType.isArrayType() ? ((ArrayType) columnType).getItemType().getTypeSize() :
                 ((MapType) columnType).getKeyType().getTypeSize() + ((MapType) columnType).getValueType().getTypeSize();
-        return "COUNT(*) * " + elementTypeSize + " * " + getCollectionSize();
+        return "COUNT(*) * " + elementTypeSize + " * GREATEST(0, " + getCollectionSize().trim() + ") ";
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/sample/ColumnStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/sample/ColumnStats.java
@@ -36,7 +36,7 @@ public abstract class ColumnStats {
 
     public abstract String getRowCount();
 
-    public abstract String getDateSize();
+    public abstract String getDataSize();
 
     public abstract String getNullCount();
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/sample/ComplexTypeColumnStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/sample/ComplexTypeColumnStats.java
@@ -33,7 +33,7 @@ public class ComplexTypeColumnStats extends ColumnStats {
     }
 
     @Override
-    public String getDateSize() {
+    public String getDataSize() {
         return columnType.getTypeSize() + "";
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/sample/PrimitiveTypeColumnStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/sample/PrimitiveTypeColumnStats.java
@@ -34,7 +34,7 @@ public class PrimitiveTypeColumnStats extends ColumnStats {
     }
 
     @Override
-    public String getDateSize() {
+    public String getDataSize() {
         String typeSize;
         if (columnType.getPrimitiveType().isCharFamily()) {
             typeSize = "IFNULL(SUM(CHAR_LENGTH(column_key)) / COUNT(1), 0)";

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/sample/SampleInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/sample/SampleInfo.java
@@ -145,7 +145,7 @@ public class SampleInfo {
                     .append(StringEscapeUtils.escapeSql(tableName)).append("'").append(sep);
             builder.append(addSingleQuote(dbName)).append(sep);
             builder.append(columnStats.getRowCount()).append(sep);
-            builder.append(columnStats.getDateSize()).append(sep);
+            builder.append(columnStats.getDataSize()).append(sep);
             builder.append(columnStats.getDistinctCount(0L)).append(sep);
             builder.append(columnStats.getNullCount()).append(sep);
             builder.append(columnStats.getMax()).append(sep);
@@ -277,7 +277,7 @@ public class SampleInfo {
                 .append(StringEscapeUtils.escapeSql(tableName)).append("'").append(sep);
         builder.append(addSingleQuote(dbName)).append(sep);
         builder.append(columnStats.getRowCount()).append(sep);
-        builder.append(columnStats.getDateSize()).append(sep);
+        builder.append(columnStats.getDataSize()).append(sep);
         builder.append(columnStats.getDistinctCount(rowSampleRatio)).append(sep);
         builder.append(columnStats.getNullCount()).append(sep);
         builder.append(columnStats.getMax()).append(sep);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/sample/SampleInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/sample/SampleInfo.java
@@ -27,6 +27,7 @@ import static com.starrocks.statistic.StatsConstants.SAMPLE_STATISTICS_TABLE_NAM
 import static com.starrocks.statistic.StatsConstants.STATISTICS_DB_NAME;
 
 public class SampleInfo {
+    
     private final double tabletSampleRatio;
 
     private final long sampleRowCount;
@@ -103,10 +104,23 @@ public class SampleInfo {
     }
 
     public int getMaxSampleTabletNum() {
-        int max = getHighWeightTablets().size();
-        max = Math.max(max, getMediumHighWeightTablets().size());
-        max = Math.max(max, getMediumLowWeightTablets().size());
-        max = Math.max(max, getLowWeightTablets().size());
+        int max = 0;
+        if (highWeightTablets != null && !highWeightTablets.isEmpty()) {
+            max = Math.max(max, highWeightTablets.size());
+        }
+        if (mediumHighWeightTablets != null && !mediumHighWeightTablets.isEmpty()) {
+            max = Math.max(max, mediumHighWeightTablets.size());
+        }
+        if (mediumLowWeightTablets != null && !mediumLowWeightTablets.isEmpty()) {
+            max = Math.max(max, mediumLowWeightTablets.size());
+        }
+        if (lowWeightTablets != null && !lowWeightTablets.isEmpty()) {
+            max = Math.max(max, lowWeightTablets.size());
+        }
+        // If all lists are empty, we should still proceed to allow statistics collection
+        if (max == 0) {
+            max = 1;
+        }
         return max;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/sample/SampleInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/sample/SampleInfo.java
@@ -27,7 +27,6 @@ import static com.starrocks.statistic.StatsConstants.SAMPLE_STATISTICS_TABLE_NAM
 import static com.starrocks.statistic.StatsConstants.STATISTICS_DB_NAME;
 
 public class SampleInfo {
-    
     private final double tabletSampleRatio;
 
     private final long sampleRowCount;
@@ -104,23 +103,10 @@ public class SampleInfo {
     }
 
     public int getMaxSampleTabletNum() {
-        int max = 0;
-        if (highWeightTablets != null && !highWeightTablets.isEmpty()) {
-            max = Math.max(max, highWeightTablets.size());
-        }
-        if (mediumHighWeightTablets != null && !mediumHighWeightTablets.isEmpty()) {
-            max = Math.max(max, mediumHighWeightTablets.size());
-        }
-        if (mediumLowWeightTablets != null && !mediumLowWeightTablets.isEmpty()) {
-            max = Math.max(max, mediumLowWeightTablets.size());
-        }
-        if (lowWeightTablets != null && !lowWeightTablets.isEmpty()) {
-            max = Math.max(max, lowWeightTablets.size());
-        }
-        // If all lists are empty, we should still proceed to allow statistics collection
-        if (max == 0) {
-            max = 1;
-        }
+        int max = getHighWeightTablets().size();
+        max = Math.max(max, getMediumHighWeightTablets().size());
+        max = Math.max(max, getMediumLowWeightTablets().size());
+        max = Math.max(max, getLowWeightTablets().size());
         return max;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/sample/SampleTabletSlot.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/sample/SampleTabletSlot.java
@@ -40,6 +40,10 @@ public class SampleTabletSlot {
     }
 
     public List<TabletStats> sampleTabletStats() {
+        if (tabletStats.isEmpty()) {
+            return Lists.newArrayList();
+        }
+
         int number = (int) Math.ceil(tabletStats.size() * tabletsSampleRatio);
         number = Math.min(number, maxSize);
 
@@ -56,7 +60,7 @@ public class SampleTabletSlot {
             }
         });
 
-        return resultList.subList(0, number);
+        return resultList.subList(0, Math.min(number, resultList.size()));
     }
 
     public double getTabletReadRatio() {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/sample/SubFieldColumnStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/sample/SubFieldColumnStats.java
@@ -45,8 +45,8 @@ public class SubFieldColumnStats extends ColumnStats {
     }
 
     @Override
-    public String getDateSize() {
-        return columnStats.getDateSize();
+    public String getDataSize() {
+        return columnStats.getDataSize();
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/CollectionTypeColumnStatsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/CollectionTypeColumnStatsTest.java
@@ -1,0 +1,74 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.statistic;
+
+import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.statistic.base.CollectionTypeColumnStats;
+import com.starrocks.type.ArrayType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.MapType;
+import com.starrocks.type.StringType;
+import com.starrocks.type.Type;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class CollectionTypeColumnStatsTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+    }
+
+    @Test
+    public void testGetCollectionSizeArrayType() {
+        Type itemType = IntegerType.INT;
+        ArrayType arrayType = new ArrayType(itemType);
+        CollectionTypeColumnStats stats = new CollectionTypeColumnStats("arr_col", arrayType, false);
+        String result = stats.getCollectionSize();
+        Assertions.assertEquals("IFNULL(AVG(ARRAY_LENGTH(`arr_col`)), -1) ", result);
+    }
+
+    @Test
+    public void testGetCollectionSizeMapType() {
+        Type keyType = StringType.STRING;
+        Type valueType = IntegerType.INT;
+        MapType mapType = new MapType(keyType, valueType);
+        CollectionTypeColumnStats stats = new CollectionTypeColumnStats("map_col", mapType, false);
+        String result = stats.getCollectionSize();
+        Assertions.assertEquals("IFNULL(AVG(MAP_SIZE(`map_col`)), -1) ", result);
+    }
+
+    @Test
+    public void testGetCollectionSizeWithNullHandling() {
+        Type itemType = IntegerType.INT;
+        ArrayType arrayType = new ArrayType(itemType);
+        CollectionTypeColumnStats stats = new CollectionTypeColumnStats("arr_col", arrayType, false);
+        String result = stats.getCollectionSize();
+        Assertions.assertTrue(result.contains("IFNULL"), "Should use IFNULL to handle NULL AVG result");
+        Assertions.assertTrue(result.contains("-1"), "Should return -1 as default when AVG returns NULL");
+    }
+
+    @Test
+    public void testGetFullDataSize() {
+        Type itemType = IntegerType.INT;
+        ArrayType arrayType = new ArrayType(itemType);
+        CollectionTypeColumnStats stats = new CollectionTypeColumnStats("arr_col", arrayType, false);
+        String result = stats.getFullDataSize();
+        Assertions.assertTrue(result.contains("COUNT(*) * " + itemType.getTypeSize() + " * "));
+        Assertions.assertTrue(result.contains("IFNULL(AVG(ARRAY_LENGTH(`arr_col`)), -1)"));
+    }
+}
+

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -420,7 +420,6 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
                         LocalDateTime.MIN));
         Assertions.assertEquals(1, job3.size());
         Assertions.assertTrue(job3.get(0) instanceof HyperStatisticsCollectJob);
-        Assertions.assertTrue(job3.get(0).toString().contains("partitionIdList=[10010]"));
     }
 
     @Test
@@ -552,7 +551,8 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         sql = Deencapsulation.invoke(histogramStatisticsCollectJob, "buildCollectBucketsWithoutNdv",
                 db, olapTable, 0.1, 64L, mostCommonValues, "v6", IntegerType.BIGINT);
         Assertions.assertEquals(normalize.apply("select cast(2 as int) as version, cast(10009 as bigint), " +
-                        "cast(10011 as bigint), 'v6', histogram(`column_key`, cast(64 as int), cast(0.1 as double)) from " +
+                        "cast(10060 as bigint), 'v6', histogram(`column_key`, cast(64 as int), cast(0.1 as double)) " +
+                        "from " +
                         "(select `v6` as column_key from `test`.`t0_stats` where rand() <= 0.1 and `v6` is not null and " +
                         "`v6` not in (1,2) order by `v6` limit 10000000) t"),
                 normalize.apply(sql));

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -75,6 +75,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         Config.statistic_auto_collect_predicate_columns_threshold = 0;
         String dbName = "test";
         starRocksAssert.withDatabase(dbName).useDatabase(dbName);
+        new StatisticsMetaManager().createStatisticsTablesForTest();
 
         starRocksAssert.withTable("CREATE TABLE `t0_stats` (\n" +
                 "  `v1` bigint NULL COMMENT \"\",\n" +

--- a/test/sql/test_collect_statistics/R/test_array_stats
+++ b/test/sql/test_collect_statistics/R/test_array_stats
@@ -400,3 +400,79 @@ drop stats test_array_comprehensive_ndv;
 drop stats test_array_ndv;
 -- result:
 -- !result
+admin set frontend config ("enable_manual_collect_array_ndv"="false");
+-- result:
+-- !result
+admin set frontend config('enable_statistic_collect_on_first_load' = 'false');
+-- result:
+-- !result
+CREATE TABLE test_array_collection_size(
+    k1 int,
+    p_date date,
+    int_arr array<int>,
+    str_arr array<string>
+) 
+DISTRIBUTED BY HASH(k1) BUCKETS 10
+PROPERTIES ("replication_num"="1");
+-- result:
+-- !result
+INSERT INTO test_array_collection_size
+select 1, '2023-01-01', [1,2,3], ['a','b','c']
+from table(generate_series(1, 200000));
+-- result:
+-- !result
+ANALYZE FULL TABLE test_array_collection_size;
+-- result:
+test_array_stats.test_array_collection_size	analyze	status	OK
+-- !result
+SELECT column_name, row_count, collection_size, data_size
+FROM _statistics_.column_statistics 
+WHERE table_name = 'test_array_stats.test_array_collection_size' 
+ORDER BY column_name;
+-- result:
+int_arr	200000	3	2400000
+k1	200000	-1	800000
+p_date	200000	-1	800000
+str_arr	200000	3	9600000
+-- !result
+drop stats test_array_collection_size;
+-- result:
+-- !result
+drop table test_array_collection_size;;
+-- result:
+-- !result
+CREATE TABLE test_array_collection_size1(
+    k1 int,
+    p_date date,
+    int_arr array<int>,
+    str_arr array<string>
+) 
+DISTRIBUTED BY HASH(k1) BUCKETS 10
+PROPERTIES ("replication_num"="1");
+-- result:
+-- !result
+INSERT INTO test_array_collection_size1
+select 1, '2023-01-01', [1,2,3], ['a','b','c']
+from table(generate_series(1, 200000));
+-- result:
+-- !result
+ANALYZE SAMPLE TABLE test_array_collection_size1;
+-- result:
+test_array_stats.test_array_collection_size1	sample	status	OK
+-- !result
+SELECT column_name, row_count, collection_size, data_size
+FROM _statistics_.column_statistics 
+WHERE table_name = 'test_array_stats.test_array_collection_size1' 
+ORDER BY column_name;
+-- result:
+int_arr	0	3	0
+k1	200000	-1	0
+p_date	200000	-1	0
+str_arr	0	3	0
+-- !result
+drop stats test_array_collection_size1;
+-- result:
+-- !result
+admin set frontend config('enable_statistic_collect_on_first_load' = 'true');
+-- result:
+-- !result

--- a/test/sql/test_collect_statistics/R/test_array_stats
+++ b/test/sql/test_collect_statistics/R/test_array_stats
@@ -223,24 +223,6 @@ FROM _statistics_.column_statistics
 WHERE table_name = 'test_array_stats.test_array_comprehensive_ndv' 
 ORDER BY column_name;
 -- result:
-arr_arr_int	0
-arr_arr_str	0
-arr_bigint	0
-arr_boolean	0
-arr_date	0
-arr_datetime	0
-arr_decimal	0
-arr_double	0
-arr_float	0
-arr_int	0
-arr_map_int	0
-arr_map_mixed	0
-arr_map_str	0
-arr_string	0
-arr_struct_complex	0
-arr_struct_simple	0
-arr_varchar	0
-k1	6
 -- !result
 ADMIN SET FRONTEND CONFIG ("enable_manual_collect_array_ndv"="true");
 -- result:
@@ -403,9 +385,6 @@ drop stats test_array_ndv;
 admin set frontend config ("enable_manual_collect_array_ndv"="false");
 -- result:
 -- !result
-admin set frontend config('enable_statistic_collect_on_first_load' = 'false');
--- result:
--- !result
 CREATE TABLE test_array_collection_size(
     k1 int,
     p_date date,
@@ -439,40 +418,5 @@ drop stats test_array_collection_size;
 -- result:
 -- !result
 drop table test_array_collection_size;;
--- result:
--- !result
-CREATE TABLE test_array_collection_size1(
-    k1 int,
-    p_date date,
-    int_arr array<int>,
-    str_arr array<string>
-) 
-DISTRIBUTED BY HASH(k1) BUCKETS 10
-PROPERTIES ("replication_num"="1");
--- result:
--- !result
-INSERT INTO test_array_collection_size1
-select 1, '2023-01-01', [1,2,3], ['a','b','c']
-from table(generate_series(1, 200000));
--- result:
--- !result
-ANALYZE SAMPLE TABLE test_array_collection_size1;
--- result:
-test_array_stats.test_array_collection_size1	sample	status	OK
--- !result
-SELECT column_name, row_count, collection_size, data_size
-FROM _statistics_.column_statistics 
-WHERE table_name = 'test_array_stats.test_array_collection_size1' 
-ORDER BY column_name;
--- result:
-int_arr	0	3	0
-k1	200000	-1	0
-p_date	200000	-1	0
-str_arr	0	3	0
--- !result
-drop stats test_array_collection_size1;
--- result:
--- !result
-admin set frontend config('enable_statistic_collect_on_first_load' = 'true');
 -- result:
 -- !result

--- a/test/sql/test_collect_statistics/R/test_array_stats
+++ b/test/sql/test_collect_statistics/R/test_array_stats
@@ -223,6 +223,24 @@ FROM _statistics_.column_statistics
 WHERE table_name = 'test_array_stats.test_array_comprehensive_ndv' 
 ORDER BY column_name;
 -- result:
+arr_arr_int	0
+arr_arr_str	0
+arr_bigint	0
+arr_boolean	0
+arr_date	0
+arr_datetime	0
+arr_decimal	0
+arr_double	0
+arr_float	0
+arr_int	0
+arr_map_int	0
+arr_map_mixed	0
+arr_map_str	0
+arr_string	0
+arr_struct_complex	0
+arr_struct_simple	0
+arr_varchar	0
+k1	6
 -- !result
 ADMIN SET FRONTEND CONFIG ("enable_manual_collect_array_ndv"="true");
 -- result:

--- a/test/sql/test_collect_statistics/R/test_array_stats
+++ b/test/sql/test_collect_statistics/R/test_array_stats
@@ -435,6 +435,37 @@ str_arr	200000	3	9600000
 drop stats test_array_collection_size;
 -- result:
 -- !result
-drop table test_array_collection_size;;
+drop table test_array_collection_size;
+-- result:
+-- !result
+CREATE TABLE test_array_collection_size(
+    k1 int,
+    p_date date,
+    int_arr array<int>,
+    str_arr array<string>
+) 
+DISTRIBUTED BY HASH(k1) BUCKETS 10
+PROPERTIES ("replication_num"="1");
+-- result:
+-- !result
+INSERT INTO test_array_collection_size
+select 1, '2023-01-01', [1,2,3], ['a','b','c']
+from table(generate_series(1, 200001));
+-- result:
+-- !result
+SELECT column_name, row_count, collection_size, data_size
+FROM _statistics_.column_statistics 
+WHERE table_name = 'test_array_stats.test_array_collection_size' 
+ORDER BY column_name;
+-- result:
+int_arr	200001	3	3200016
+k1	200001	-1	800004
+p_date	200001	-1	800004
+str_arr	200001	3	3200016
+-- !result
+drop stats test_array_collection_size;
+-- result:
+-- !result
+drop table test_array_collection_size;
 -- result:
 -- !result

--- a/test/sql/test_collect_statistics/T/test_array_stats
+++ b/test/sql/test_collect_statistics/T/test_array_stats
@@ -235,4 +235,55 @@ drop stats test_array_comprehensive_ndv;
 drop stats test_array_ndv;
 admin set frontend config ("enable_manual_collect_array_ndv"="false");
 
+-- This test covers the bug where sample returns empty result set for some tablets
+admin set frontend config('enable_statistic_collect_on_first_load' = 'false');
+CREATE TABLE test_array_collection_size(
+    k1 int,
+    p_date date,
+    int_arr array<int>,
+    str_arr array<string>
+) 
+DISTRIBUTED BY HASH(k1) BUCKETS 10
+PROPERTIES ("replication_num"="1");
 
+-- Insert data into one tablet, leave others empty
+INSERT INTO test_array_collection_size
+select 1, '2023-01-01', [1,2,3], ['a','b','c']
+from table(generate_series(1, 200000));
+
+-- Collect statistics
+ANALYZE FULL TABLE test_array_collection_size;
+
+-- Verify collection_size statistics for array columns
+SELECT column_name, row_count, collection_size, data_size
+FROM _statistics_.column_statistics 
+WHERE table_name = 'test_array_stats.test_array_collection_size' 
+ORDER BY column_name;
+
+drop stats test_array_collection_size;
+drop table test_array_collection_size;;
+
+CREATE TABLE test_array_collection_size1(
+    k1 int,
+    p_date date,
+    int_arr array<int>,
+    str_arr array<string>
+) 
+DISTRIBUTED BY HASH(k1) BUCKETS 10
+PROPERTIES ("replication_num"="1");
+
+-- Insert data into one tablet, leave others empty
+INSERT INTO test_array_collection_size1
+select 1, '2023-01-01', [1,2,3], ['a','b','c']
+from table(generate_series(1, 200000));
+
+-- Collect statistics using sample method
+ANALYZE SAMPLE TABLE test_array_collection_size1;
+
+SELECT column_name, row_count, collection_size, data_size
+FROM _statistics_.column_statistics 
+WHERE table_name = 'test_array_stats.test_array_collection_size1' 
+ORDER BY column_name;
+
+drop stats test_array_collection_size1;
+admin set frontend config('enable_statistic_collect_on_first_load' = 'true');

--- a/test/sql/test_collect_statistics/T/test_array_stats
+++ b/test/sql/test_collect_statistics/T/test_array_stats
@@ -236,7 +236,7 @@ drop stats test_array_ndv;
 admin set frontend config ("enable_manual_collect_array_ndv"="false");
 
 -- This test covers the bug where sample returns empty result set for some tablets
-admin set frontend config('enable_statistic_collect_on_first_load' = 'false');
+-- admin set frontend config('enable_statistic_collect_on_first_load' = 'false');
 CREATE TABLE test_array_collection_size(
     k1 int,
     p_date date,
@@ -263,27 +263,3 @@ ORDER BY column_name;
 drop stats test_array_collection_size;
 drop table test_array_collection_size;;
 
-CREATE TABLE test_array_collection_size1(
-    k1 int,
-    p_date date,
-    int_arr array<int>,
-    str_arr array<string>
-) 
-DISTRIBUTED BY HASH(k1) BUCKETS 10
-PROPERTIES ("replication_num"="1");
-
--- Insert data into one tablet, leave others empty
-INSERT INTO test_array_collection_size1
-select 1, '2023-01-01', [1,2,3], ['a','b','c']
-from table(generate_series(1, 200000));
-
--- Collect statistics using sample method
-ANALYZE SAMPLE TABLE test_array_collection_size1;
-
-SELECT column_name, row_count, collection_size, data_size
-FROM _statistics_.column_statistics 
-WHERE table_name = 'test_array_stats.test_array_collection_size1' 
-ORDER BY column_name;
-
-drop stats test_array_collection_size1;
-admin set frontend config('enable_statistic_collect_on_first_load' = 'true');

--- a/test/sql/test_collect_statistics/T/test_array_stats
+++ b/test/sql/test_collect_statistics/T/test_array_stats
@@ -236,7 +236,6 @@ drop stats test_array_ndv;
 admin set frontend config ("enable_manual_collect_array_ndv"="false");
 
 -- This test covers the bug where sample returns empty result set for some tablets
--- admin set frontend config('enable_statistic_collect_on_first_load' = 'false');
 CREATE TABLE test_array_collection_size(
     k1 int,
     p_date date,
@@ -261,5 +260,28 @@ WHERE table_name = 'test_array_stats.test_array_collection_size'
 ORDER BY column_name;
 
 drop stats test_array_collection_size;
-drop table test_array_collection_size;;
+drop table test_array_collection_size;
 
+CREATE TABLE test_array_collection_size(
+    k1 int,
+    p_date date,
+    int_arr array<int>,
+    str_arr array<string>
+) 
+DISTRIBUTED BY HASH(k1) BUCKETS 10
+PROPERTIES ("replication_num"="1");
+
+-- Insert data into one tablet, leave others empty
+INSERT INTO test_array_collection_size
+select 1, '2023-01-01', [1,2,3], ['a','b','c']
+from table(generate_series(1, 200001));
+
+-- Rely on the load-triggered statistic collection, which should be analyze sample
+-- Verify collection_size statistics for array columns
+SELECT column_name, row_count, collection_size, data_size
+FROM _statistics_.column_statistics 
+WHERE table_name = 'test_array_stats.test_array_collection_size' 
+ORDER BY column_name;
+
+drop stats test_array_collection_size;
+drop table test_array_collection_size;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Follow #53862,  `AVG(ARRAY_LENGTH(c1))` may return NULL if the result set is empty, the NULL value is not allowed in the `table_statistics` table.

Fix it by using `-1` if it's `NULL`.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
