### PR TITLE
[Enhancement] reduce remote storage access when vaccum after file bundle enabled

### DIFF
--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -93,6 +93,9 @@ public:
     StatusOr<TabletMetadataPtr> get_tablet_metadata(int64_t tablet_id, int64_t version, bool fill_cache = true,
                                                     int64_t expected_gtid = 0,
                                                     const std::shared_ptr<FileSystem>& fs = nullptr);
+    StatusOr<TabletMetadataPtr> get_tablet_metadata(int64_t tablet_id, int64_t version, bool fill_meta_cache,
+                                                    bool fill_data_cache, int64_t expected_gtid = 0,
+                                                    const std::shared_ptr<FileSystem>& fs = nullptr);
     StatusOr<TabletMetadataPtr> get_tablet_metadata(int64_t tablet_id, int64_t version, const CacheOptions& cache_opts,
                                                     int64_t expected_gtid = 0,
                                                     const std::shared_ptr<FileSystem>& fs = nullptr);

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -267,7 +267,9 @@ static Status collect_alive_bundle_files(TabletManager* tablet_mgr, const std::v
     auto data_dir = join_path(root_dir, kSegmentDirectoryName);
     for (const auto& tablet_info : tablet_infos) {
         auto tablet_id = tablet_info.tablet_id();
-        auto res = tablet_mgr->get_tablet_metadata(tablet_id, version, false);
+        // fill data cache to avoid read bundle meta file from remote storage repeatedly.
+        auto res = tablet_mgr->get_tablet_metadata(tablet_id, version, false /* Not need to fill meta cache */,
+                                                   true /* fill data cache when enable file bundle */);
         TEST_SYNC_POINT_CALLBACK("collect_files_to_vacuum:get_tablet_metadata", &res);
         if (!res.ok()) {
             // must exist.
@@ -323,7 +325,10 @@ static Status collect_files_to_vacuum(TabletManager* tablet_mgr, std::string_vie
     // Starting at |*final_retain_version|, read the tablet metadata forward along
     // the |prev_garbage_version| pointer until the tablet metadata does not exist.
     while (version >= min_version) {
-        auto res = tablet_mgr->get_tablet_metadata(tablet_id, version, false);
+        // fill data cache to avoid read bundle meta file from remote storage repeatedly.
+        auto res = tablet_mgr->get_tablet_metadata(
+                tablet_id, version, false /* Not need to fill meta cache */,
+                vacuum_version_range != nullptr /* fill data cache when enable file bundle */);
         TEST_SYNC_POINT_CALLBACK("collect_files_to_vacuum:get_tablet_metadata", &res);
         if (res.status().is_not_found()) {
             break;


### PR DESCRIPTION
## Why I'm doing:
1. After file bundle is enabled, when publish version, we will put latest tablet meta in meta cache on every BE. But when auto vacuum run, each partition's vacuum job will only be handled by one BE, so some tablets which aren't belong to this BE will be cache miss when access by vacuum job. And also when call `get_tablet_metadata` in vacuum job, we won't do any cache refill, so there will be lots of data cache and meta cache miss events when handle vacuum job.
2. Whether a tablet uses the file-bundle format is a state stored in the metadata cache. In the current implementation, after the cache is evicted, the logic to refill this state during subsequent reads is missing.

## What I'm doing:
1. refill datacache when call `get_tablet_metadata` in vacuum job, so that tablets belong to one partition can reuse this datacache to reduce remote storage access.
3. Refill file bundle state after access.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
