### PR TITLE
[Enhancement] Fast schema evolution jobs keep history schemas until no ingestions use them

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/IndexSchemaInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/IndexSchemaInfo.java
@@ -1,0 +1,47 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.SchemaInfo;
+
+import static java.util.Objects.requireNonNull;
+
+public class IndexSchemaInfo {
+    @SerializedName("indexId")
+    private final long indexId;
+    @SerializedName("indexName")
+    private final String indexName;
+    @SerializedName("schemaInfo")
+    private final SchemaInfo schemaInfo;
+
+    IndexSchemaInfo(long indexId, String indexName, SchemaInfo schemaInfo) {
+        this.indexId = indexId;
+        this.indexName = indexName;
+        this.schemaInfo = requireNonNull(schemaInfo, "schema is null");
+    }
+
+    public long getIndexId() {
+        return indexId;
+    }
+
+    public String getIndexName() {
+        return indexName;
+    }
+
+    public SchemaInfo getSchemaInfo() {
+        return schemaInfo;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
@@ -96,7 +96,7 @@ public class LakeTableAlterMetaJob extends LakeTableAlterMetaJobBase {
     }
 
     @Override
-    protected void updateCatalog(Database db, LakeTable table) {
+    protected void updateCatalog(Database db, LakeTable table, boolean isReplay) {
         if (metaType == TTabletMetaType.ENABLE_PERSISTENT_INDEX) {
             // re-use ENABLE_PERSISTENT_INDEX for both enable index and index's type.
             table.getTableProperty().modifyTableProperties(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX,

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -128,7 +128,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
     protected abstract TabletMetadataUpdateAgentTask createTask(PhysicalPartition partition,
                                                                 MaterializedIndex index, long nodeId, Set<Long> tablets);
 
-    protected abstract void updateCatalog(Database db, LakeTable table);
+    protected abstract void updateCatalog(Database db, LakeTable table, boolean isReplay);
 
     protected abstract void restoreState(LakeTableAlterMetaJobBase job);
 
@@ -211,7 +211,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.WRITE);
         try {
-            updateCatalog(db, table);
+            updateCatalog(db, table, false);
             this.jobState = JobState.FINISHED;
             this.finishedTimeMs = System.currentTimeMillis();
             GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this);
@@ -526,7 +526,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
                 updateNextVersion(table);
             } else if (jobState == JobState.FINISHED) {
                 updateVisibleVersion(table);
-                updateCatalog(db, table);
+                updateCatalog(db, table, true);
                 table.setState(OlapTable.OlapTableState.NORMAL);
             } else if (jobState == JobState.CANCELLED) {
                 table.setState(OlapTable.OlapTableState.NORMAL);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
@@ -42,6 +42,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -74,6 +75,9 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
     @SerializedName(value = "disableFseV2")
     private boolean disableFastSchemaEvolutionV2 = false;
 
+    @SerializedName(value = "historySchema")
+    private OlapTableHistorySchema historySchema;
+
     private Set<String> partitionsWithSchemaFile = new HashSet<>();
 
     // for deserialization
@@ -89,9 +93,10 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
     LakeTableAsyncFastSchemaChangeJob(LakeTableAsyncFastSchemaChangeJob other) {
         this(other.getJobId(), other.getDbId(), other.getTableId(), other.getTableName(), other.getTimeoutMs());
         for (IndexSchemaInfo indexSchemaInfo : other.schemaInfos) {
-            setIndexTabletSchema(indexSchemaInfo.indexId, indexSchemaInfo.indexName, indexSchemaInfo.schemaInfo);
+            setIndexTabletSchema(indexSchemaInfo.getIndexId(), indexSchemaInfo.getIndexName(), indexSchemaInfo.getSchemaInfo());
         }
         this.disableFastSchemaEvolutionV2 = other.disableFastSchemaEvolutionV2;
+        this.historySchema = other.historySchema;
         partitionsWithSchemaFile.addAll(other.partitionsWithSchemaFile);
     }
 
@@ -106,12 +111,12 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
         TabletMetadataUpdateAgentTask task = null;
         boolean needUpdateSchema = false;
         for (IndexSchemaInfo info : schemaInfos) {
-            if (info.indexId == index.getId()) {
+            if (info.getIndexId() == index.getId()) {
                 needUpdateSchema = true;
                 // `Set.add()` returns true means this set did not already contain the specified element
                 boolean createSchemaFile = partitionsWithSchemaFile.add(tag);
                 task = TabletMetadataUpdateAgentTaskFactory.createTabletSchemaUpdateTask(nodeId,
-                        new ArrayList<>(tablets), info.schemaInfo.toTabletSchema(), createSchemaFile);
+                        new ArrayList<>(tablets), info.getSchemaInfo().toTabletSchema(), createSchemaFile);
                 break;
             }
         }
@@ -127,11 +132,11 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
     }
 
     @Override
-    protected void updateCatalog(Database db, LakeTable table) {
-        updateCatalogUnprotected(db, table);
+    protected void updateCatalog(Database db, LakeTable table, boolean isReplay) {
+        updateCatalogUnprotected(db, table, isReplay);
     }
 
-    private void updateCatalogUnprotected(Database db, LakeTable table) {
+    private void updateCatalogUnprotected(Database db, LakeTable table, boolean isReplay) {
         if (disableFastSchemaEvolutionV2) {
             // only update the property, no need to update schema which is actually not changed
             table.setFastSchemaEvolutionV2(false);
@@ -142,11 +147,14 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
 
         Set<String> droppedOrModifiedColumns = Sets.newHashSet();
         boolean hasMv = !table.getRelatedMaterializedViews().isEmpty();
+        OlapTableHistorySchema.Builder historySchemaBuilder = OlapTableHistorySchema.newBuilder();
         for (IndexSchemaInfo indexSchemaInfo : schemaInfos) {
-            SchemaInfo schemaInfo = indexSchemaInfo.schemaInfo;
-            long indexId = indexSchemaInfo.indexId;
+            SchemaInfo schemaInfo = indexSchemaInfo.getSchemaInfo();
+            long indexId = indexSchemaInfo.getIndexId();
             MaterializedIndexMeta indexMeta = requireNonNull(table.getIndexMetaByIndexId(indexId)).shallowCopy();
             List<Column> oldColumns = indexMeta.getSchema();
+            SchemaInfo oldSchemaInfo = SchemaInfo.fromMaterializedIndex(table, indexId, indexMeta);
+            historySchemaBuilder.addIndexSchema(new IndexSchemaInfo(indexId, table.getIndexNameById(indexId), oldSchemaInfo));
 
             Preconditions.checkState(Objects.equals(indexMeta.getKeysType(), schemaInfo.getKeysType()));
             Preconditions.checkState(Objects.equals(ListUtils.emptyIfNull(indexMeta.getSortKeyUniqueIds()),
@@ -169,6 +177,12 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
             table.renameColumnNamePrefix(indexId);
         }
         table.rebuildFullSchema();
+        if (!isReplay) {
+            long txnId = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getTransactionIDGenerator()
+                    .getNextTransactionId();
+            historySchemaBuilder.setHistoryTxnIdThreshold(txnId);
+            this.historySchema = historySchemaBuilder.build();
+        }
 
         // If modified columns are already done, inactive related mv
         AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(table, droppedOrModifiedColumns);
@@ -185,6 +199,7 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
             this.schemaInfos = new ArrayList<>(jobSchemaInfos);
         }
         this.disableFastSchemaEvolutionV2 = schemaChangeJob.disableFastSchemaEvolutionV2;
+        this.historySchema = ((LakeTableAsyncFastSchemaChangeJob) job).historySchema;
     }
 
     @Override
@@ -197,23 +212,33 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
         return false;
     }
 
-    private static class IndexSchemaInfo {
-        @SerializedName("indexId")
-        private final long indexId;
-        @SerializedName("indexName")
-        private final String indexName;
-        @SerializedName("schemaInfo")
-        private final SchemaInfo schemaInfo;
-
-        IndexSchemaInfo(long indexId, String indexName, SchemaInfo schemaInfo) {
-            this.indexId = indexId;
-            this.indexName = indexName;
-            this.schemaInfo = requireNonNull(schemaInfo, "schema is null");
+    @Override
+    public boolean isExpire() {
+        boolean expiredByTime = super.isExpire();
+        boolean expiredByHistorySchema = true;
+        if (historySchema != null && !historySchema.isExpired()) {
+            try {
+                expiredByHistorySchema = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                    .isPreviousTransactionsFinished(historySchema.getHistoryTxnIdThreshold(), dbId, Lists.newArrayList(tableId));
+            } catch (Exception e) {
+                // As isPreviousTransactionsFinished said, exception happens only when db does not exist,
+                // so could clean the history schema safely
+            }
+            if (expiredByHistorySchema) {
+                historySchema.setExpire();
+                LOG.info("Expire the history schema, jobId: {}, tableName: {}, expireTxnIdThreshold: {}",
+                        jobId, tableName, historySchema.getHistoryTxnIdThreshold());
+            }
         }
+        return expiredByTime && expiredByHistorySchema;
     }
 
     List<SchemaInfo> getSchemaInfoList() {
-        return schemaInfos.stream().map(i -> i.schemaInfo).collect(Collectors.toList());
+        return schemaInfos.stream().map(IndexSchemaInfo::getSchemaInfo).collect(Collectors.toList());
+    }
+
+    public Optional<OlapTableHistorySchema> getHistorySchema() {
+        return Optional.ofNullable(historySchema);
     }
 
     public void setDisableFastSchemaEvolutionV2() {
@@ -238,10 +263,10 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
             info.add(tableName);
             info.add(TimeUtils.longToTimeString(createTimeMs));
             info.add(TimeUtils.longToTimeString(finishedTimeMs));
-            info.add(schemaInfo.indexName);
-            info.add(schemaInfo.indexId);
-            info.add(schemaInfo.indexId);
-            info.add(String.format("%d:0", schemaInfo.schemaInfo.getVersion())); // schema version and schema hash
+            info.add(schemaInfo.getIndexName());
+            info.add(schemaInfo.getIndexId());
+            info.add(schemaInfo.getIndexId());
+            info.add(String.format("%d:0", schemaInfo.getSchemaInfo().getVersion())); // schema version and schema hash
             info.add(getWatershedTxnId());
             info.add(jobState.name());
             info.add(errMsg);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableHistorySchema.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableHistorySchema.java
@@ -1,0 +1,99 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.SchemaInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class OlapTableHistorySchema {
+
+    // This schema can be used by those transaction ids lower than it
+    @SerializedName(value = "historyTxnIdThreshold")
+    private long historyTxnIdThreshold = -1;
+    // index id -> schema info. not thread safety, can be set to null concurrently
+    @SerializedName(value = "schemaInfos")
+    private volatile List<IndexSchemaInfo> indexSchemaInfos;
+
+    public OlapTableHistorySchema() {
+    }
+
+    private OlapTableHistorySchema(Builder builder) {
+        this.historyTxnIdThreshold = builder.historyTxnIdThreshold;
+        this.indexSchemaInfos = builder.indexSchemaInfos;
+    }
+
+    public long getHistoryTxnIdThreshold() {
+        return historyTxnIdThreshold;
+    }
+
+    public Optional<SchemaInfo> getSchemaByIndexId(long indexId) {
+        return getSchemaInfosSafety().flatMap(
+                    infos -> infos.stream()
+                        .filter(schema -> schema.getIndexId() == indexId)
+                        .findFirst().map(IndexSchemaInfo::getSchemaInfo)
+                );
+    }
+
+    public Optional<SchemaInfo> getSchemaBySchemaId(long schemaId) {
+        return getSchemaInfosSafety().flatMap(
+                infos -> infos.stream()
+                        .filter(schema -> schema.getSchemaInfo().getId() == schemaId)
+                        .findFirst().map(IndexSchemaInfo::getSchemaInfo)
+        );
+    }
+
+    public void setExpire() {
+        this.indexSchemaInfos = null;
+    }
+
+    public boolean isExpired() {
+        return indexSchemaInfos == null;
+    }
+
+    private Optional<List<IndexSchemaInfo>> getSchemaInfosSafety() {
+        List<IndexSchemaInfo> schemaInfos = indexSchemaInfos;
+        return Optional.ofNullable(schemaInfos);
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private long historyTxnIdThreshold = -1;
+        private List<IndexSchemaInfo> indexSchemaInfos = new ArrayList<>();
+
+        public Builder() {
+        }
+
+        public Builder setHistoryTxnIdThreshold(long historyTxnIdThreshold) {
+            this.historyTxnIdThreshold = historyTxnIdThreshold;
+            return this;
+        }
+
+        public Builder addIndexSchema(IndexSchemaInfo schemaInfo) {
+            indexSchemaInfos.add(schemaInfo);
+            return this;
+        }
+
+        public OlapTableHistorySchema build() {
+            return new OlapTableHistorySchema(this);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/SchemaInfo.java
@@ -170,6 +170,30 @@ public class SchemaInfo {
         return tSchema;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SchemaInfo that = (SchemaInfo) o;
+        return id == that.id && shortKeyColumnCount == that.shortKeyColumnCount && version == that.version &&
+                schemaHash == that.schemaHash && Double.compare(bloomFilterFpp, that.bloomFilterFpp) == 0 &&
+                compressionLevel == that.compressionLevel && keysType == that.keysType &&
+                storageType == that.storageType &&
+                Objects.equals(columns, that.columns) &&
+                Objects.equals(sortKeyIndexes, that.sortKeyIndexes) &&
+                Objects.equals(sortKeyUniqueIds, that.sortKeyUniqueIds) &&
+                Objects.equals(indexes, that.indexes) &&
+                Objects.equals(bloomFilterColumnNames, that.bloomFilterColumnNames) &&
+                compressionType == that.compressionType;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, shortKeyColumnCount, keysType, storageType, version, schemaHash, columns, sortKeyIndexes,
+                sortKeyUniqueIds, indexes, bloomFilterColumnNames, bloomFilterFpp, compressionType, compressionLevel);
+    }
+
     public static Builder newBuilder() {
         return new Builder();
     }
@@ -228,9 +252,11 @@ public class SchemaInfo {
         }
 
         public Builder addColumns(List<Column> columns) {
-            for (Column col : columns) {
-                addColumn(col);
+            Objects.requireNonNull(columns, "column list is null");
+            if (this.columns == null) {
+                this.columns = new ArrayList<>();
             }
+            this.columns.addAll(columns);
             return this;
         }
 
@@ -290,17 +316,20 @@ public class SchemaInfo {
         }
     }
 
-    public static SchemaInfo fromMaterializedIndex(OlapTable table, MaterializedIndexMeta indexMeta) {
+    public static SchemaInfo fromMaterializedIndex(OlapTable table, long indexId, MaterializedIndexMeta indexMeta) {
+        List<Index> indexes = table.getBaseIndexId() == indexId ? table.getCopiedIndexes() :
+                OlapTable.getIndexesBySchema(table.getCopiedIndexes(), indexMeta.getSchema());
         return SchemaInfo.newBuilder()
                 .setId(indexMeta.getSchemaId())
+                .setVersion(indexMeta.getSchemaVersion())
+                .setSchemaHash(indexMeta.getSchemaHash())
                 .setKeysType(indexMeta.getKeysType())
                 .setShortKeyColumnCount(indexMeta.getShortKeyColumnCount())
                 .setStorageType(table.getStorageType())
-                .setVersion(indexMeta.getSchemaVersion())
                 .addColumns(indexMeta.getSchema())
                 .setSortKeyIndexes(indexMeta.getSortKeyIdxes())
                 .setSortKeyUniqueIds(indexMeta.getSortKeyUniqueIds())
-                .setIndexes(OlapTable.getIndexesBySchema(table.getCopiedIndexes(), indexMeta.getSchema()))
+                .setIndexes(indexes)
                 .setBloomFilterColumnNames(table.getBfColumnIds())
                 .setBloomFilterFpp(table.getBfFpp())
                 .setCompressionType(table.getCompressionType())

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
@@ -68,16 +68,7 @@ public class LakeTableSchemaChangeJobTest {
     public static void setUp() throws Exception {
         UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
         connectContext = UtFrameUtils.createDefaultCtx();
-        // Schema change job is executed manually, so stop the schema change daemon to avoid interfering with the test.
-        SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler();
-        schemaChangeHandler.setStop();
-        schemaChangeHandler.interrupt();
-        long startTime = System.currentTimeMillis();
-        while (schemaChangeHandler.isRunning()) {
-            Thread.sleep(100);
-            Assertions.assertTrue(System.currentTimeMillis() - startTime < 60000,
-                    "Schema change handler is not stopped in 60 seconds");
-        }
+        UtFrameUtils.stopBackgroundSchemaChangeHandler(60000);
     }
 
     private static LakeTable createTable(ConnectContext connectContext, String sql) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
@@ -428,25 +428,25 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         List<Index> newIndexes = tbl.getCopiedIndexes();
 
         Assertions.assertDoesNotThrow(
-                    () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
-                                .modifyTableAddOrDrop(db, tbl, indexSchemaMap, newIndexes, 100, 100,
-                                            indexToNewSchemaId, false));
+                    () -> GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler()
+                                .modifyTableAddOrDrop(db, tbl, indexSchemaMap, newIndexes, 100,
+                                            indexToNewSchemaId, false, -1));
         jobSize++;
         Assertions.assertEquals(jobSize, alterJobs.size());
 
         Assertions.assertDoesNotThrow(
-                    () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
-                                .modifyTableAddOrDrop(db, tbl, indexSchemaMap, newIndexes, 101, 101,
-                                            indexToNewSchemaId, true));
+                    () -> GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler()
+                                .modifyTableAddOrDrop(db, tbl, indexSchemaMap, newIndexes, 101,
+                                            indexToNewSchemaId, true, 101));
         jobSize++;
         Assertions.assertEquals(jobSize, alterJobs.size());
 
         OlapTableState beforeState = tbl.getState();
         tbl.setState(OlapTableState.ROLLUP);
         Assertions.assertThrows(DdlException.class,
-                    () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
-                                .modifyTableAddOrDrop(db, tbl, indexSchemaMap, newIndexes, 102, 102, indexToNewSchemaId,
-                                            false));
+                    () -> GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler()
+                                .modifyTableAddOrDrop(db, tbl, indexSchemaMap, newIndexes, 102, indexToNewSchemaId,
+                                            false, -1));
         tbl.setState(beforeState);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeJobV2Test.java
@@ -35,8 +35,10 @@
 package com.starrocks.alter;
 
 import com.google.common.collect.Lists;
+import com.google.gson.stream.JsonReader;
 import com.starrocks.alter.AlterJobV2.JobState;
 import com.starrocks.backup.CatalogMocker;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DynamicPartitionProperty;
 import com.starrocks.catalog.GlobalStateMgrTestUtil;
@@ -45,15 +47,25 @@ import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.MaterializedIndex.IndexState;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.OlapTable.OlapTableState;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Partition.PartitionState;
 import com.starrocks.catalog.Replica;
+import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
+import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.ThreadUtil;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.persist.ImageWriter;
+import com.starrocks.persist.OperationType;
+import com.starrocks.persist.TableAddOrDropColumnsInfo;
+import com.starrocks.persist.metablock.SRMetaBlockReader;
+import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
 import com.starrocks.server.RunMode;
@@ -63,6 +75,7 @@ import com.starrocks.sql.ast.AlterClause;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.ModifyTablePropertiesClause;
 import com.starrocks.sql.ast.ReorderColumnsClause;
+import com.starrocks.transaction.TransactionState;
 import com.starrocks.utframe.MockedWarehouseManager;
 import com.starrocks.utframe.UtFrameUtils;
 import com.starrocks.warehouse.cngroup.ComputeResource;
@@ -73,23 +86,33 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SchemaChangeJobV2Test extends DDLTestBase {
-    private static final String TEST_FILE_NAME = SchemaChangeJobV2Test.class.getCanonicalName();
-    private AlterTableStmt alterTableStmt;
 
     private static final Logger LOG = LogManager.getLogger(SchemaChangeJobV2Test.class);
+    private AlterTableStmt alterTableStmt;
+
+    @BeforeAll
+    public static void setupAll() throws Exception {
+        DDLTestBase.beforeAll();
+        UtFrameUtils.stopBackgroundSchemaChangeHandler(60000);
+        UtFrameUtils.setUpForPersistTest();
+    }
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -450,5 +473,185 @@ public class SchemaChangeJobV2Test extends DDLTestBase {
         schemaChangeJob.setWaitingCreatingReplica(true);
         schemaChangeJob.cancel("");
         schemaChangeJob.setWaitingCreatingReplica(false);
+    }
+
+    @Test
+    public void testFastSchemaEvolutionHistorySchema() throws Exception {
+        Database db = starRocksAssert.getDb(ctx.getDatabase());
+        starRocksAssert.withTable("CREATE TABLE t_history_schema(c0 INT) DUPLICATE KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES ('replication_num' = '1')");
+        OlapTable table = (OlapTable) starRocksAssert.getTable(db.getFullName(), "t_history_schema");
+
+        TransactionState.TxnCoordinator coordinator = new TransactionState.TxnCoordinator(
+                TransactionState.TxnSourceType.BE, "127.0.0.1");
+
+        long baseIndexId = table.getBaseIndexId();
+        MaterializedIndexMeta preAlterIndexMeta1 = table.getIndexMetaByIndexId(baseIndexId).shallowCopy();
+        long runningTxn1 = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().beginTransaction(
+                db.getId(), List.of(table.getId()), UUID.randomUUID().toString(), coordinator,
+                TransactionState.LoadJobSourceType.BACKEND_STREAMING, 60000L);
+        SchemaChangeJobV2 job1 = (SchemaChangeJobV2) executeAlterAndWaitFinish(
+                table, "ALTER TABLE t_history_schema ADD COLUMN c1 BIGINT");
+        Assertions.assertTrue(isSchemaMatch(db, table, Lists.newArrayList("c0", "c1")));
+        OlapTableHistorySchema historySchema1 = job1.getHistorySchema().orElse(null);
+        Assertions.assertNotNull(historySchema1);
+        Assertions.assertTrue(historySchema1.getHistoryTxnIdThreshold() > runningTxn1);
+        assertHistorySchemaMatches(table, baseIndexId, preAlterIndexMeta1, historySchema1);
+
+        MaterializedIndexMeta preAlterIndexMeta2 = table.getIndexMetaByIndexId(baseIndexId).shallowCopy();
+        long runningTxn2 = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().beginTransaction(
+                db.getId(), List.of(table.getId()), UUID.randomUUID().toString(), coordinator,
+                TransactionState.LoadJobSourceType.BACKEND_STREAMING, 60000L);
+        SchemaChangeJobV2 job2 = (SchemaChangeJobV2) executeAlterAndWaitFinish(
+                table, "ALTER TABLE t_history_schema ADD COLUMN c2 BIGINT");
+        Assertions.assertTrue(isSchemaMatch(db, table, Lists.newArrayList("c0", "c1", "c2")));
+        OlapTableHistorySchema historySchema2 = job2.getHistorySchema().orElse(null);
+        Assertions.assertNotNull(historySchema2);
+        Assertions.assertTrue(historySchema2.getHistoryTxnIdThreshold() > runningTxn2);
+        assertHistorySchemaMatches(table, baseIndexId, preAlterIndexMeta2, historySchema2);
+
+        SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
+        job1.setFinishedTimeMs(System.currentTimeMillis() / 1000 - Config.alter_table_timeout_second - 100);
+        schemaChangeHandler.runAfterCatalogReady();
+        Assertions.assertSame(job1, schemaChangeHandler.getAlterJobsV2().get(job1.getJobId()));
+        Assertions.assertFalse(job1.getHistorySchema().orElse(null).isExpired());
+        GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(db.getId(), runningTxn1, "fail1");
+        schemaChangeHandler.runAfterCatalogReady();
+        Assertions.assertNull(schemaChangeHandler.getAlterJobsV2().get(job1.getJobId()));
+
+        GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(db.getId(), runningTxn2, "fail2");
+        schemaChangeHandler.runAfterCatalogReady();
+        Assertions.assertSame(job2, schemaChangeHandler.getAlterJobsV2().get(job2.getJobId()));
+        Assertions.assertTrue(job2.getHistorySchema().orElse(null).isExpired());
+        Assertions.assertNull(job2.getHistorySchema().orElse(null).getSchemaByIndexId(baseIndexId).orElse(null));
+        Assertions.assertNull(job2.getHistorySchema().orElse(null)
+                .getSchemaBySchemaId(preAlterIndexMeta2.getSchemaId()).orElse(null));
+        job2.setFinishedTimeMs(System.currentTimeMillis() / 1000 - Config.alter_table_timeout_second - 100);
+        schemaChangeHandler.runAfterCatalogReady();
+        Assertions.assertNull(schemaChangeHandler.getAlterJobsV2().get(job2.getJobId()));
+    }
+
+    @Test
+    public void testReplayHistorySchema() throws Exception {
+        Database db = starRocksAssert.getDb(ctx.getDatabase());
+        starRocksAssert.withTable("CREATE TABLE t_history_schema_replay(c0 INT) DUPLICATE KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES ('replication_num' = '1')");
+        OlapTable table = (OlapTable) starRocksAssert.getTable(db.getFullName(), "t_history_schema_replay");
+
+        UtFrameUtils.PseudoJournalReplayer.resetFollowerJournalQueue();
+        UtFrameUtils.PseudoImage initialImage = new UtFrameUtils.PseudoImage();
+        ImageWriter imageWriter = initialImage.getImageWriter();
+        GlobalStateMgr.getCurrentState().getLocalMetastore().save(imageWriter);
+        GlobalStateMgr.getCurrentState().getAlterJobMgr().save(imageWriter);
+
+        long baseIndexId = table.getBaseIndexId();
+        MaterializedIndexMeta preAlterIndexMeta = table.getIndexMetaByIndexId(baseIndexId).shallowCopy();
+        SchemaChangeJobV2 job = (SchemaChangeJobV2) executeAlterAndWaitFinish(
+                table, "ALTER TABLE t_history_schema_replay ADD COLUMN c1 BIGINT");
+        Assertions.assertTrue(isSchemaMatch(db, table, Lists.newArrayList("c0", "c1")));
+        OlapTableHistorySchema historySchema = job.getHistorySchema().orElse(null);
+        Assertions.assertNotNull(historySchema);
+        assertHistorySchemaMatches(table, baseIndexId, preAlterIndexMeta, historySchema);
+
+        LocalMetastore restoredMetastore =
+                new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
+        AlterJobMgr restoredAlterJobMgr =
+                new AlterJobMgr(new SchemaChangeHandler(), new MaterializedViewHandler(), new SystemHandler());
+        JsonReader jsonReader = initialImage.getJsonReader();
+        SRMetaBlockReader blockReader = new SRMetaBlockReaderV2(jsonReader);
+        restoredMetastore.load(blockReader);
+        blockReader.close();
+        blockReader = new SRMetaBlockReaderV2(jsonReader);
+        restoredAlterJobMgr.load(blockReader);
+        blockReader.close();
+        Database restoredDb = restoredMetastore.getDb(db.getFullName());
+        Assertions.assertNotNull(restoredDb, "Restored database not found");
+        OlapTable restoredTable = (OlapTable) restoredMetastore.getTable(restoredDb.getFullName(), table.getName());
+        Assertions.assertNotNull(restoredTable, "Restored table not found");
+        Assertions.assertEquals(SchemaInfo.fromMaterializedIndex(table, baseIndexId, preAlterIndexMeta),
+                SchemaInfo.fromMaterializedIndex(restoredTable, baseIndexId, restoredTable.getIndexMetaByIndexId(baseIndexId)));
+        Assertions.assertFalse(getLatestAlterJob(restoredTable, restoredAlterJobMgr.getSchemaChangeHandler()).isPresent());
+        isSchemaMatch(restoredDb, restoredTable, Lists.newArrayList("c0"));
+
+        SchemaChangeHandler restoredHandler = restoredAlterJobMgr.getSchemaChangeHandler();
+        LocalMetastore originalMetastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        try {
+            // restoredHandler can restore state to restoredMetastore
+            GlobalStateMgr.getCurrentState().setLocalMetastore(restoredMetastore);
+            TableAddOrDropColumnsInfo alterInfo = (TableAddOrDropColumnsInfo)
+                    UtFrameUtils.PseudoJournalReplayer.replayNextJournal(OperationType.OP_MODIFY_TABLE_ADD_OR_DROP_COLUMNS);
+            restoredHandler.replayModifyTableAddOrDrop(alterInfo);
+        } finally {
+            GlobalStateMgr.getCurrentState().setLocalMetastore(originalMetastore);
+        }
+        Assertions.assertTrue(isSchemaMatch(restoredDb, restoredTable, Lists.newArrayList("c0", "c1")));
+        Assertions.assertEquals(SchemaInfo.fromMaterializedIndex(table, baseIndexId, table.getIndexMetaByIndexId(baseIndexId)),
+                SchemaInfo.fromMaterializedIndex(restoredTable, baseIndexId, restoredTable.getIndexMetaByIndexId(baseIndexId)));
+        AlterJobV2 restoredJob = restoredHandler.getAlterJobsV2().get(job.getJobId());
+        Assertions.assertInstanceOf(SchemaChangeJobV2.class, restoredJob);
+        SchemaChangeJobV2 fseJob = (SchemaChangeJobV2) restoredJob;
+        OlapTableHistorySchema restoredHistorySchema = fseJob.getHistorySchema().orElse(null);
+        Assertions.assertNotNull(restoredHistorySchema);
+        Assertions.assertEquals(historySchema.getHistoryTxnIdThreshold(), restoredHistorySchema.getHistoryTxnIdThreshold());
+        assertHistorySchemaMatches(table, baseIndexId, preAlterIndexMeta, restoredHistorySchema);
+    }
+
+    private void assertHistorySchemaMatches(OlapTable table, long indexId, MaterializedIndexMeta originMeta,
+                                            OlapTableHistorySchema historySchema) {
+        SchemaInfo originSchemaInfo = SchemaInfo.fromMaterializedIndex(table, indexId, originMeta);
+        Assertions.assertNotNull(historySchema);
+        SchemaInfo schemaInfo = historySchema.getSchemaByIndexId(indexId).orElse(null);
+        Assertions.assertNotNull(schemaInfo);
+        Assertions.assertEquals(originSchemaInfo, schemaInfo);
+        Assertions.assertEquals(originSchemaInfo.hashCode(), schemaInfo.hashCode());
+        Assertions.assertSame(schemaInfo, historySchema.getSchemaBySchemaId(originMeta.getSchemaId()).orElse(null));
+    }
+
+    private AlterJobV2 executeAlterAndWaitFinish(OlapTable table, String sql) throws Exception {
+        starRocksAssert.alterTable(sql);
+        AlterJobV2 alterJob = getLatestAlterJob(table, GlobalStateMgr.getCurrentState().getSchemaChangeHandler()).orElse(null);
+        Assertions.assertNotNull(alterJob);
+        long startTime = System.currentTimeMillis();
+        long timeoutMs = 10 * 60 * 1000; // 10 minutes timeout
+        while (alterJob.getJobState() != AlterJobV2.JobState.FINISHED
+                || table.getState() != OlapTable.OlapTableState.NORMAL) {
+            long currentTime = System.currentTimeMillis();
+            if (currentTime - startTime > timeoutMs) {
+                throw new RuntimeException(
+                        String.format("Alter job timeout after 10 minutes. Job state: %s, table state: %s",
+                                alterJob.getJobState(), table.getState()));
+            }
+            alterJob.run();
+            Thread.sleep(100);
+        }
+        return alterJob;
+    }
+
+    private Optional<AlterJobV2> getLatestAlterJob(Table table, SchemaChangeHandler schemaChangeHandler) {
+        return schemaChangeHandler.getAlterJobsV2().values()
+                .stream().filter(job -> job.getTableId() == table.getId())
+                .max(Comparator.comparingLong(AlterJobV2::getJobId));
+    }
+
+    private boolean isSchemaMatch(Database db, OlapTable table, List<String> columNames) {
+        Locker locker = new Locker();
+        locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
+        try {
+            long baseIndexId = table.getBaseIndexId();
+            MaterializedIndexMeta indexMeta = table.getIndexMetaByIndexId(baseIndexId);
+            List<Column> schema = indexMeta.getSchema();
+            if (schema.size() != columNames.size()) {
+                return false;
+
+            }
+            for (int i = 0; i < schema.size(); i++) {
+                if (!schema.get(i).getName().equals(columNames.get(i))) {
+                    return false;
+                }
+            }
+            return true;
+        } finally {
+            locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -42,6 +42,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.gson.stream.JsonReader;
 import com.staros.starlet.StarletAgentFactory;
+import com.starrocks.alter.SchemaChangeHandler;
 import com.starrocks.authentication.AuthenticationMgr;
 import com.starrocks.authorization.PrivilegeBuiltinConstants;
 import com.starrocks.catalog.Database;
@@ -64,6 +65,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.NotImplementedException;
 import com.starrocks.common.Pair;
+import com.starrocks.common.TimeoutException;
 import com.starrocks.common.io.DataOutputBuffer;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.profile.Timer;
@@ -1491,5 +1493,22 @@ public class UtFrameUtils {
         Assertions.assertNotNull(optExpression);
         List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(optExpression);
         return scanOperators;
+    }
+
+    public static void stopBackgroundSchemaChangeHandler(long timeoutMs) throws Exception {
+        SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler();
+        schemaChangeHandler.setStop();
+        schemaChangeHandler.interrupt();
+        long endTime = System.currentTimeMillis() + timeoutMs;
+        while (schemaChangeHandler.isRunning()) {
+            if (System.currentTimeMillis() > endTime) {
+                throw new TimeoutException(String.format("failed to stop SchemaChangeHandler after %s ms", timeoutMs));
+            }
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                throw new Exception("stopping SchemaChangeHandler is interrupted");
+            }
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:
* Traditional FSE creates a schema file which is never deleted, so running ingestions started before the FSE can still get history schemas from schema file
* But in the new implementation, FSE only modifies FE metadata without creating a schema file, so running ingestions need a new way to find the history schemas

## What I'm doing:
This PR implements history schema tracking for fast schema evolution jobs to ensure old schemas are preserved until all dependent transactions complete, so ingestions can send RPC from CN to FE leader to get the history schema by schema id. The implementation includes:
1. **History Schema Tracking**: Fast schema change jobs now capture and store previous schemas in `OlapTableHistorySchema` objects
2. **Transaction-based Expiration**: History schemas are only expired after verifying all previous transactions have finished using `isPreviousTransactionsFinished`
3. **Persistence & Replay**: History schema state is serialized in image/journal and properly restored during replay

**Note running queries started before FSE use a different way to track history schemas**
* Each query has a `DefaultCoordinator` on FE to manage the its lifecycle. The coordinator keeps the plan, and the plan keeps a copy of `OlapTable` stored in `OlapScanNode.olapTable`, so queries can retrieve the schema from the copied `OlapTable`. Because queries can be executed on FE leader, follower and observer, so RPCs from CNs can be balanced across all FEs 
* Although there is a `DefaultCoordinator` for each ingestion, the coordinator only manages the write phase, but not publish phase, so  the coordinator is not reliable.

**TODO the below functions will be implemented in following PRs**
* new FSE in shared-data reuses the same logic as shared-nothing to do alter, so it will use `SchemaChangeJobV2`. That's why need also to track history schemas in `SchemaChangeJobV2`
* ingestions send thrift RPC from CN to FE leader to get history schema by schema id

Fixes #65706

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add history schema tracking with txn-based expiration and replay/persistence for fast schema evolution and classic schema change jobs, plus related API updates and tests.
> 
> - **Core**:
>   - Introduce `OlapTableHistorySchema` to store prior `SchemaInfo`s per index with `historyTxnIdThreshold`, retrieval by index/schema id, and expiry controls.
>   - Extract `IndexSchemaInfo` to `com.starrocks.alter` for sharing across components.
>   - Enhance `SchemaInfo`: add `equals/hashCode`, bulk `addColumns`, and `fromMaterializedIndex` helper.
> - **Fast Schema Evolution (Lake)**:
>   - Update `LakeTableAsyncFastSchemaChangeJob` to capture pre-alter schemas, build and persist `historySchema` (set on commit), and expire it only after preceding txns finish; add `isReplay` path.
>   - Adjust `LakeTableAlterMetaJobBase`/`LakeTableAlterMetaJob`: `updateCatalog(Database, LakeTable, boolean isReplay)`.
> - **Classic Schema Change**:
>   - In `SchemaChangeHandler.modifyTableAddOrDrop(...)`, record old schemas into `historySchema`, set txn threshold (supports replay via `replayedTxnId`), and attach to `SchemaChangeJobV2`.
>   - Extend `SchemaChangeJobV2` to carry `historySchema` and apply the same expiration policy.
> - **Persistence & Replay**:
>   - Serialize/restore `historySchema` in job logs/images; replay paths call updated `updateCatalog(..., isReplay)` and restore `historySchema`.
> - **Tests/Utils**:
>   - Add comprehensive UTs for history schema capture, expiration, and replay in both lake and classic paths.
>   - Add `UtFrameUtils.stopBackgroundSchemaChangeHandler(...)` helper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2eb2fa422fb73f26d011d771f41369d9ecde1a23. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->