### PR TITLE
[BugFix] always analyze replicated storage

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -513,12 +513,12 @@ public class OlapTableFactory implements AbstractTableFactory {
                 throw new DdlException(e.getMessage());
             }
 
+            boolean enableReplicatedStorage = PropertyAnalyzer.analyzeBooleanProp(
+                    properties, PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE,
+                    Config.enable_replicated_storage_as_default_engine);
             if (table.isOlapTableOrMaterializedView()) {
                 // replicated storage
-                table.setEnableReplicatedStorage(
-                        PropertyAnalyzer.analyzeBooleanProp(
-                                properties, PropertyAnalyzer.PROPERTIES_REPLICATED_STORAGE,
-                                Config.enable_replicated_storage_as_default_engine));
+                table.setEnableReplicatedStorage(enableReplicatedStorage);
 
                 boolean hasGin = table.getIndexes().stream()
                         .anyMatch(index -> index.getIndexType() == IndexType.GIN);


### PR DESCRIPTION
## Why I'm doing:

After https://github.com/StarRocks/starrocks/pull/65304 merged, if creating table with table properties `replicated_storage` in cloud native mode, no matter it is true or not, it will throw exception like 'Unknown properties: replicated_storage' because the `PropertyAnalyzer` will analyze properties and remove it from properties map which will be check empty when finishing processing creating table.

## What I'm doing:

Always analyze `replicated_storage` property but never set in cloud native table.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
