### PR TITLE
[BugFix] Fix mv rewrite prepare lock table too many time

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -337,12 +337,18 @@ public class MvRewritePreprocessor {
         }
     }
 
-    private static MaterializedView copyOnlyMaterializedView(MaterializedView mv) {
+    private static MaterializedView copyOnlyMaterializedView(MaterializedView mv, long timeoutMs) {
         // Query will not lock dbs in the optimizer stage, so use a shallow copy of mv to avoid
         // metadata race for different operations.
         // Ensure to re-optimize if the mv's version has changed after the optimization.
+        long timeoutMsPerTry = timeoutMs <= 0 ? 1000 : timeoutMs;
         Locker locker = new Locker();
-        locker.lockTableWithIntensiveDbLock(mv.getDbId(), mv.getId(), LockType.READ);
+        // Add a timeout to avoid waiting too long for the lock in some cases to avoid affecting query latency.
+        if (!locker.tryLockTableWithIntensiveDbLock(mv.getDbId(), mv.getId(), LockType.READ,
+                timeoutMsPerTry, TimeUnit.MILLISECONDS)) {
+            logMVPrepare("Failed to lock mv {} for copying, use mv directly", mv.getName());
+            return mv;
+        }
         try {
             MaterializedView copiedMV = new MaterializedView();
             mv.copyOnlyForQuery(copiedMV);
@@ -533,7 +539,7 @@ public class MvRewritePreprocessor {
         int queryScanOpNum = MvUtils.getOlapScanNode(queryOptExpression).size();
         Set<String> queryTableNames = queryTables.stream().map(t -> t.getName()).collect(Collectors.toSet());
         List<MVCorrelation> mvCorrelations = Lists.newArrayList();
-        long timeoutMs = getPrepareTimeoutMsPerMV(Math.min(validMVs.size(), maxRelatedMVsLimit));
+        long timeoutMs = getPrepareTimeoutMsPerMV(connectContext, Math.min(validMVs.size(), maxRelatedMVsLimit));
         for (MaterializedViewWrapper wrapper : validMVs) {
             MaterializedView mv = wrapper.getMV();
             List<BaseTableInfo> baseTableInfos = mv.getBaseTableInfos();
@@ -582,7 +588,7 @@ public class MvRewritePreprocessor {
                                                               OptExpression queryOptExpression) {
         // choose all valid mvs and filter mvs that cannot be rewritten for the query
         int maxRelatedMVsLimit = connectContext.getSessionVariable().getCboMaterializedViewRewriteRelatedMVsLimit();
-        long timeoutMs = getPrepareTimeoutMsPerMV(Math.min(relatedMVs.size(), maxRelatedMVsLimit));
+        long timeoutMs = getPrepareTimeoutMsPerMV(connectContext, Math.min(relatedMVs.size(), maxRelatedMVsLimit));
         // to make unit test more stable, force build mv plan in unit test
         Set<MaterializedViewWrapper> validMVs = relatedMVs.stream()
                 .filter(wrapper -> isMVValidToRewriteQuery(connectContext, wrapper.getMV(),
@@ -599,7 +605,7 @@ public class MvRewritePreprocessor {
     public List<MaterializedViewWrapper> getMvWithPlanContext(List<MaterializedViewWrapper> validMVs) {
         // filter mvs which are active and have valid plans
         final List<MaterializedViewWrapper> mvWithPlanContexts = Lists.newArrayList();
-        final long timeoutMs = getPrepareTimeoutMsPerMV(validMVs.size());
+        final long timeoutMs = getPrepareTimeoutMsPerMV(connectContext, validMVs.size());
         for (MaterializedViewWrapper wrapper : validMVs) {
             MaterializedView mv = wrapper.getMV();
             try {
@@ -761,7 +767,7 @@ public class MvRewritePreprocessor {
     }
 
     private void prepareMV(Tracers tracers, Set<Table> queryTables, MaterializedViewWrapper mvWithPlanContext,
-                           MvUpdateInfo mvUpdateInfo) {
+                           MvUpdateInfo mvUpdateInfo, long timeoutMs) {
         MaterializedView mv = mvWithPlanContext.getMV();
         MvPlanContext mvPlanContext = mvWithPlanContext.getMvPlanContext();
         PCellSortedSet partitionNamesToRefresh = mvUpdateInfo.getMVToRefreshPCells();
@@ -776,7 +782,7 @@ public class MvRewritePreprocessor {
         }
 
         MaterializationContext materializationContext = buildMaterializationContext(context, mv, mvPlanContext,
-                mvUpdateInfo, queryTables, mvWithPlanContext.getLevel());
+                mvUpdateInfo, queryTables, mvWithPlanContext.getLevel(), timeoutMs);
         if (materializationContext == null) {
             logMVPrepare(connectContext, "Prepare MV {} failed to build materialization context", mv.getName());
             return;
@@ -794,7 +800,10 @@ public class MvRewritePreprocessor {
      * @param mvCount: the number of MVs to process
      * @return: timeout in milliseconds for each MV preparation
      */
-    private long getPrepareTimeoutMsPerMV(int mvCount) {
+    private static long getPrepareTimeoutMsPerMV(ConnectContext connectContext, int mvCount) {
+        if (connectContext == null) {
+            return 1000;
+        }
         long defaultTimeout = connectContext.getSessionVariable().getOptimizerExecuteTimeout() / 2;
         if (mvCount == 0) {
             return defaultTimeout;
@@ -818,7 +827,7 @@ public class MvRewritePreprocessor {
         if (mvInfos.isEmpty()) {
             return;
         }
-        long individualTimeoutMs = getPrepareTimeoutMsPerMV(mvInfos.size());
+        long individualTimeoutMs = getPrepareTimeoutMsPerMV(connectContext, mvInfos.size());
         logMVPrepare(connectContext, "Processing {} MVs with individual timeout of {} ms each", mvInfos.size(),
                 individualTimeoutMs);
         
@@ -831,7 +840,7 @@ public class MvRewritePreprocessor {
         for (Pair<MaterializedViewWrapper, MvUpdateInfo> mvInfo : mvInfos) {
             CompletableFuture<Void> future = CompletableFuture.supplyAsync(
                     () -> {
-                        prepareMV(tracers, queryTables, mvInfo.first, mvInfo.second);
+                        prepareMV(tracers, queryTables, mvInfo.first, mvInfo.second, individualTimeoutMs);
                         return null;
                     }, exec);
             
@@ -953,6 +962,17 @@ public class MvRewritePreprocessor {
                                                                      MvUpdateInfo mvUpdateInfo,
                                                                      Set<Table> queryTables,
                                                                      int level) {
+        long timeoutMs = getPrepareTimeoutMsPerMV(context.getConnectContext(), 1);
+        return buildMaterializationContext(context, mv, mvPlanContext, mvUpdateInfo, queryTables, level, timeoutMs);
+    }
+
+    private static MaterializationContext buildMaterializationContext(OptimizerContext context,
+                                                                      MaterializedView mv,
+                                                                      MvPlanContext mvPlanContext,
+                                                                      MvUpdateInfo mvUpdateInfo,
+                                                                      Set<Table> queryTables,
+                                                                      int level,
+                                                                      long timeoutMs) {
         if (mvPlanContext == null) {
             logMVPrepare(context.getConnectContext(), "MV {} plan context is null", mv.getName());
             return null;
@@ -976,7 +996,7 @@ public class MvRewritePreprocessor {
 
         // If query tables are set which means use related mv for non lock optimization,
         // copy mv's metadata into a ready-only object.
-        MaterializedView copiedMV = (context.getQueryTables() != null) ? copyOnlyMaterializedView(mv) : mv;
+        MaterializedView copiedMV = (context.getQueryTables() != null) ? copyOnlyMaterializedView(mv, timeoutMs) : mv;
         return buildMaterializationContext(context, copiedMV, mvPlanContext, mvUpdateInfo,
                 baseTables, intersectingTables, mvPlan, level);
     }


### PR DESCRIPTION
## Why I'm doing:

<img width="1010" height="738" alt="image" src="https://github.com/user-attachments/assets/6935a876-fa04-4d0f-b875-a7d8f112ddfe" />



```
2025-11-20 14:30:18.474+08:00 WARN (starrocks-taskrun-pool-631|10698) [LockManager.logSlowLockTrace():425] LockManager detects slow lock : {"owners":[{"id":5411,"name":"starrocks-mysql-nio-pool-66","type":"RE
AD","heldFor":64038889,"waitTime":0,"stack":["java.base@11.0.23/jdk.internal.misc.Unsafe.park(Native Method)","java.base@11.0.23/java.util.concurrent.locks.LockSupport.park(LockSupport.java:194)","java.base@1
1.0.23/java.util.concurrent.CompletableFuture$Signaller.block(CompletableFuture.java:1796)","java.base@11.0.23/java.util.concurrent.ForkJoinPool.managedBlock(ForkJoinPool.java:3128)","java.base@11.0.23/java.u
til.concurrent.CompletableFuture.waitingGet(CompletableFuture.java:1830)","java.base@11.0.23/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2004)","app//com.starrocks.sql.optimizer.MvRewrit
ePreprocessor.prepareRelatedMVs(MvRewritePreprocessor.java:730)","app//com.starrocks.sql.optimizer.MvRewritePreprocessor.prepare(MvRewritePreprocessor.java:170)","app//com.starrocks.sql.optimizer.Optimizer.pr
epareMvRewrite(Optimizer.java:364)","app//com.starrocks.sql.optimizer.Optimizer.optimize(Optimizer.java:203)","app//com.starrocks.sql.StatementPlanner.createQueryPlanWithReTry(StatementPlanner.java:375)","app
//com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:147)","app//com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:104)","app//com.starrocks.load.DeleteMgr.partitionPruneForDelete(Delet
eMgr.java:323)","app//com.starrocks.load.DeleteMgr.createJob(DeleteMgr.java:236)","app//com.starrocks.load.DeleteMgr.process(DeleteMgr.java:190)","app//com.starrocks.qe.StmtExecutor.handleDMLStmt(StmtExecutor
.java:2350)","app//com.starrocks.qe.StmtExecutor.handleDMLStmtWithProfile(StmtExecutor.java:2299)","app//com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:770)","app//com.starrocks.qe.ConnectProcessor.h
andleQuery(ConnectProcessor.java:419)","app//com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:644)","app//com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:990)","app//com.st
arrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:71)","app//com.starrocks.mysql.nio.ReadListener$$Lambda$481/0x00000008408eec40.run(Unknown Source)","java.base@11.0.23/java.util.concurren
t.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)","java.base@11.0.23/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)","java.base@11.0.23/java.lang.Thread.run(Thread
.java:829)"]}],"waiter":[{"id":36,"name":"tablet scheduler","type":"WRITE","waitTime":64038888},{"id":350,"name":"mv-prepare-2","type":"INTENTION_SHARED","waitTime":64038887},{"id":318,"name":"mv-prepare-0","
type":"INTENTION_SHARED","waitTime":64038887},{"id":5318,"name":"starrocks-mysql-nio-pool-65","type":"READ","waitTime":64037348},{"id":17,"name":"schema change","type":"INTENTION_EXCLUSIVE","waitTime":6403728
6},{"id":5525,"name":"starrocks-mysql-nio-pool-67","type":"READ","waitTime":64033322},{"id":59,"name":"MemoryUsageTracker","type":"READ","waitTime":64032408},{"id":37,"name":"tablet checker","type":"READ","wa
itTime":64023828},{"id":21,"name":"consistency checker","type":"READ","waitTime":64019390},{"id":121,"name":"ReportHandler","type":"READ","waitTime":64014289},{"id":27,"name":"AutoStatistic","type":"INTENTION
_SHARED","waitTime":63906842,"queryId":"96779524-c545-11f0-b2b3-00163e25b7ce"},{"id":30,"name":"tablet stat mgr","type":"INTENTION_SHARED","waitTime":63852028},{"id":47,"name":"DynamicPartitionScheduler","typ
e":"READ","waitTime":63549854},{"id":274,"name":"analyze-task-concurrency-pool-2","type":"INTENTION_SHARED","waitTime":63039300,"queryId":"9b8ffc9a-c547-11f0-b2b3-00163e25b7ce"},{"id":273,"name":"analyze-task
-concurrency-pool-1","type":"INTENTION_SHARED","waitTime":62213952,"queryId":"8781f23c-c549-11f0-b2b3-00163e25b7ce"},{"id":272,"name":"analyze-task-concurrency-pool-0","type":"INTENTION_SHARED","waitTime":618
20777,"queryId":"71dbd7ec-c54a-11f0-b2b3-00163e25b7ce"},{"id":7662,"name":"starrocks-mysql-nio-pool-75","type":"READ","waitTime":3012472},{"id":10481,"name":"starrocks-mysql-nio-pool-77","type":"READ","waitTi
me":42353},{"id":10698,"name":"starrocks-taskrun-pool-631","type":"INTENTION_SHARED","waitTime":3001}]}
```

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/10624


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
