### PR TITLE
[Enhancement] distinct aggregation over framed window

### DIFF
--- a/be/src/exec/analytor.cpp
+++ b/be/src/exec/analytor.cpp
@@ -1053,12 +1053,14 @@ void Analytor::_init_window_result_columns() {
                 ColumnHelper::create_column(_agg_fn_types[i].result_type, _agg_fn_types[i].has_nullable_child);
         // Binary column cound't call resize method like Numeric Column,
         // so we only reserve it.
-        if (_agg_fn_types[i].result_type.type == LogicalType::TYPE_CHAR ||
-            _agg_fn_types[i].result_type.type == LogicalType::TYPE_VARCHAR ||
-            _agg_fn_types[i].result_type.type == LogicalType::TYPE_JSON ||
-            _agg_fn_types[i].result_type.type == LogicalType::TYPE_ARRAY ||
-            _agg_fn_types[i].result_type.type == LogicalType::TYPE_MAP ||
-            _agg_fn_types[i].result_type.type == LogicalType::TYPE_STRUCT) {
+        if (_agg_functions[i]->get_name().ends_with("fused_multi_distinct")) {
+            _result_window_columns[i]->resize(chunk_size);
+        } else if (_agg_fn_types[i].result_type.type == LogicalType::TYPE_CHAR ||
+                   _agg_fn_types[i].result_type.type == LogicalType::TYPE_VARCHAR ||
+                   _agg_fn_types[i].result_type.type == LogicalType::TYPE_JSON ||
+                   _agg_fn_types[i].result_type.type == LogicalType::TYPE_ARRAY ||
+                   _agg_fn_types[i].result_type.type == LogicalType::TYPE_MAP ||
+                   _agg_fn_types[i].result_type.type == LogicalType::TYPE_STRUCT) {
             _result_window_columns[i]->reserve(chunk_size);
         } else {
             _result_window_columns[i]->resize(chunk_size);

--- a/be/src/exprs/agg/distinct.h
+++ b/be/src/exprs/agg/distinct.h
@@ -27,6 +27,7 @@
 #include "exec/aggregator_fwd.h"
 #include "exprs/agg/aggregate.h"
 #include "exprs/agg/aggregate_state_allocator.h"
+#include "exprs/agg/avg.h"
 #include "exprs/agg/sum.h"
 #include "exprs/function_context.h"
 #include "gen_cpp/Data_types.h"
@@ -104,6 +105,12 @@ struct AdaptiveSliceHashSet {
     using KeyType = typename SliceHashSet::key_type;
 
     AdaptiveSliceHashSet() { set = std::make_shared<SliceHashSetWithAggStateAllocator>(); }
+
+    void clear() {
+        set = std::make_shared<SliceHashSetWithAggStateAllocator>();
+        two_level_set.reset();
+        distinct_size = 0;
+    }
 
     void try_convert_to_two_level(MemPool* mem_pool) {
         if (distinct_size % 65536 == 0 && mem_pool->total_allocated_bytes() >= agg::two_level_memory_threshold) {
@@ -241,6 +248,7 @@ struct DistinctAggregateState<LT, SumLT, StringLTGuard<LT>> {
     DistinctAggregateState() = default;
     using KeyType = typename SliceHashSet::key_type;
 
+    void reset() { set.clear(); }
     void update(MemPool* mem_pool, Slice raw_key) { set.emplace(mem_pool, raw_key); }
 
     void update_with_hash(MemPool* mem_pool, Slice raw_key, size_t hash) {
@@ -273,18 +281,37 @@ struct DistinctAggregateState<LT, SumLT, StringLTGuard<LT>> {
 };
 
 // use a different way to do serialization to gain performance.
-template <LogicalType LT, LogicalType SumLT, typename = guard::Guard>
-struct DistinctAggregateStateV2 {};
+template <LogicalType LT, LogicalType SumLT, bool compute_sum = false, typename = guard::Guard>
+struct DistinctAggregateStateV2Base {};
 
-template <LogicalType LT, LogicalType SumLT>
-struct DistinctAggregateStateV2<LT, SumLT, FixedLengthLTGuard<LT>> {
+template <LogicalType LT, LogicalType SumLT, bool compute_sum>
+struct DistinctAggregateStateV2Base<LT, SumLT, compute_sum, FixedLengthLTGuard<LT>> {
     using T = RunTimeCppType<LT>;
     using SumType = RunTimeCppType<SumLT>;
     using MyHashSet = HashSetWithAggStateAllocator<T>;
 
-    void update(T key) { set.insert(key); }
+    void reset() {
+        set.clear();
+        sum = SumType{};
+    }
 
-    void update_with_hash([[maybe_unused]] MemPool* mempool, T key, size_t hash) { set.emplace_with_hash(hash, key); }
+    void update(T key) {
+        [[maybe_unused]] const auto result = set.insert(key);
+        if constexpr (compute_sum) {
+            if (result.second) {
+                sum += key;
+            }
+        }
+    }
+
+    void update_with_hash([[maybe_unused]] MemPool* mempool, T key, size_t hash) {
+        [[maybe_unused]] const auto result = set.emplace_with_hash(hash, key);
+        if constexpr (compute_sum) {
+            if (result.second) {
+                sum += key;
+            }
+        }
+    }
 
     void prefetch(T key) { set.prefetch(key); }
 
@@ -334,7 +361,7 @@ struct DistinctAggregateStateV2<LT, SumLT, FixedLengthLTGuard<LT>> {
     }
 
     // NOLINTBEGIN
-    ~DistinctAggregateStateV2() {
+    ~DistinctAggregateStateV2Base() {
 #ifdef PHMAP_USE_CUSTOM_INFO_HANDLE
         const auto& info = set.infoz();
         VLOG_FILE << "HashSet Info: # of insert = " << info.insert_number
@@ -344,12 +371,18 @@ struct DistinctAggregateStateV2<LT, SumLT, FixedLengthLTGuard<LT>> {
     // NOLINTEND
 
     MyHashSet set;
+    SumType sum{};
 };
 
 template <LogicalType LT, LogicalType SumLT>
-struct DistinctAggregateStateV2<LT, SumLT, StringLTGuard<LT>> : public DistinctAggregateState<LT, SumLT> {};
+struct DistinctAggregateStateV2Base<LT, SumLT, false, StringLTGuard<LT>> : public DistinctAggregateState<LT, SumLT> {};
 
-// Dear god this template class as template parameter kills me!
+template <LogicalType LT, LogicalType SumLT, typename = guard::Guard>
+struct DistinctAggregateStateV2 : public DistinctAggregateStateV2Base<LT, SumLT, false> {};
+
+template <LogicalType LT, LogicalType SumLT, bool compute_sum, typename = guard::Guard>
+struct FusedMultiDistinctAggregateState : public DistinctAggregateStateV2Base<LT, SumLT, compute_sum> {};
+
 template <LogicalType LT, LogicalType SumLT,
           template <LogicalType X, LogicalType Y, typename = guard::Guard> class TDistinctAggState,
           AggDistinctType DistinctType, typename T = RunTimeCppType<LT>>
@@ -691,5 +724,159 @@ public:
 
     std::string get_name() const override { return "dict_merge"; }
 };
+
+static constexpr int COMPUTE_SUM_BIT = 0x1;
+static constexpr int COMPUTE_AVG_BIT = 0x2;
+
+static constexpr int compute_bits(const bool compute_sum, const bool compute_avg) {
+    return (COMPUTE_SUM_BIT * compute_sum) | (COMPUTE_AVG_BIT * compute_avg);
+}
+
+static constexpr bool enable_bit_sum(const int bits) {
+    return (bits & COMPUTE_SUM_BIT) != 0;
+}
+
+static constexpr bool enable_bit_avg(const int bits) {
+    return (bits & COMPUTE_AVG_BIT) != 0;
+}
+
+template <LogicalType LT, LogicalType SumLT, int compute_bits,
+          template <LogicalType X, LogicalType Y, bool, typename = guard::Guard> class TDistinctAggState,
+          typename T = RunTimeCppType<LT>>
+struct TFusedMultiDistinctFunction final
+        : public AggregateFunctionBatchHelper<
+                  TDistinctAggState<LT, SumLT, lt_is_numeric<LT> && compute_bits != 0>,
+                  TFusedMultiDistinctFunction<LT, SumLT, compute_bits, TDistinctAggState, T>> {
+    using State = TDistinctAggState<LT, SumLT, lt_is_numeric<LT> && compute_bits != 0>;
+    using InputColumn = RunTimeColumnType<LT>;
+    using SumColumn = RunTimeColumnType<SumLT>;
+    static constexpr auto AvgLT = AvgResultLT<LT>;
+    using AvgColumn = RunTimeColumnType<AvgLT>;
+    using AvgCppType = RunTimeCppType<AvgLT>;
+
+    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
+        this->data(state).reset();
+    }
+
+    void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
+                    size_t end) const override {
+        auto& state_impl = this->data(const_cast<AggDataPtr>(state));
+        auto* struct_column = down_cast<StructColumn*>(dst);
+        // compute count
+        {
+            auto* count_column = struct_column->field_column("count").get();
+            auto* count_data_column = down_cast<Int64Column*>(ColumnHelper::get_data_column(count_column));
+            const auto count = state_impl.distinct_count();
+            for (auto i = start; i < end; ++i) {
+                count_data_column->get_data()[i] = count;
+            }
+        }
+
+        // compute sum
+        if constexpr (lt_is_numeric<LT> && enable_bit_sum(compute_bits)) {
+            auto* sum_column = struct_column->field_column("sum").get();
+            auto* sum_data_column = down_cast<SumColumn*>(ColumnHelper::get_data_column(sum_column));
+            const auto sum = state_impl.sum;
+            for (auto i = start; i < end; ++i) {
+                sum_data_column->get_data()[i] = sum;
+            }
+        }
+
+        // compute avg
+        if constexpr (lt_is_numeric<LT> && enable_bit_avg(compute_bits)) {
+            auto* avg_column = struct_column->field_column("avg").get();
+            auto* avg_data_column = down_cast<AvgColumn*>(ColumnHelper::get_data_column(avg_column));
+            const auto sum = state_impl.sum;
+            const auto count = state_impl.distinct_count();
+
+            if (count == 0) {
+                DCHECK(avg_column->is_nullable());
+                auto& null_data = down_cast<NullableColumn*>(avg_column)->null_column()->get_data();
+                for (auto i = start; i < end; ++i) {
+                    null_data[i] = DATUM_NULL;
+                }
+                return;
+            }
+
+            AvgCppType avg;
+            if constexpr (lt_is_arithmetic<LT>) {
+                avg = static_cast<AvgCppType>(static_cast<double>(sum) / static_cast<double>(count));
+            } else if constexpr (lt_is_decimal<LT>) {
+                static_assert(lt_is_decimal128<AvgLT> || lt_is_decimal256<AvgLT>,
+                              "Result type of avg on decimal32/64/128/256 is decimal 128 or 256");
+                avg = decimal_div_integer<AvgCppType>(AvgCppType(sum), AvgCppType(count), ctx->get_arg_type(0)->scale);
+            } else {
+                DCHECK(false) << "Invalid LogicalTypes for avg function";
+            }
+            for (auto i = start; i < end; ++i) {
+                avg_data_column->get_data()[i] = avg;
+            }
+        }
+    }
+
+    void update(FunctionContext* ctx, const Column** columns, AggDataPtr state, size_t row_num) const override {
+        const auto* column = down_cast<const InputColumn*>(columns[0]);
+        if constexpr (IsSlice<T>) {
+            this->data(state).update(ctx->mem_pool(), column->get_slice(row_num));
+        } else {
+            const auto immutable_data = column->immutable_data();
+            this->data(state).update(immutable_data[row_num]);
+        }
+    }
+
+    void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
+                                              int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
+                                              int64_t frame_end) const override {
+        const auto* column = down_cast<const InputColumn*>(columns[0]);
+        if constexpr (IsSlice<T>) {
+            for (auto i = frame_start; i < frame_end; ++i) {
+                this->data(state).update(ctx->mem_pool(), column->get_slice(i));
+            }
+        } else {
+            const auto* data = column->immutable_data().data();
+            for (size_t i = frame_start; i < frame_end; ++i) {
+                this->data(state).update(data[i]);
+            }
+        }
+    }
+
+    std::string get_name() const override { return "fused_multi_distinct"; }
+
+    void merge(FunctionContext* ctx, const Column* column, AggDataPtr state, size_t row_num) const override {
+        DCHECK(false) << "Shouldn't call this method for window function!";
+    }
+
+    void serialize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+        DCHECK(false) << "Shouldn't call this method for window function!";
+    }
+
+    void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr state, Column* to) const override {
+        DCHECK(false) << "Shouldn't call this method for window function!";
+    }
+
+    void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
+                                     ColumnPtr* dst) const override {
+        DCHECK(false) << "Shouldn't call this method for window function!";
+    }
+};
+
+template <LogicalType LT, typename = guard::Guard>
+inline constexpr LogicalType DistinctSumLT = SumResultLT<LT>;
+
+template <LogicalType LT>
+inline constexpr LogicalType DistinctSumLT<LT, Decimal256LTGuard<LT>> = TYPE_DECIMAL256;
+
+template <LogicalType LT>
+inline constexpr LogicalType DistinctSumLT<LT, Decimal128LTGuard<LT>> = TYPE_DECIMAL128;
+
+template <LogicalType LT>
+inline constexpr LogicalType DistinctSumLT<LT, Decimal64LTGuard<LT>> = TYPE_DECIMAL128;
+
+template <LogicalType LT>
+inline constexpr LogicalType DistinctSumLT<LT, Decimal32LTGuard<LT>> = TYPE_DECIMAL128;
+
+template <LogicalType LT, int compute_bits, typename T = RunTimeCppType<LT>>
+using FusedMultiDistinctFunction =
+        TFusedMultiDistinctFunction<LT, DistinctSumLT<LT>, compute_bits, FusedMultiDistinctAggregateState, T>;
 
 } // namespace starrocks

--- a/be/src/exprs/agg/factory/aggregate_factory.hpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.hpp
@@ -179,6 +179,8 @@ public:
     static auto MakeSumDistinctAggregateFunctionV2();
     template <LogicalType LT>
     static auto MakeDecimalSumDistinctAggregateFunction();
+    template <LogicalType LT, int compute_bits>
+    static auto MakeFusedMultiDistinctAggregateFunction();
 
     static AggregateFunctionPtr MakeDictMergeAggregateFunction();
     static AggregateFunctionPtr MakeRetentionAggregateFunction();
@@ -404,6 +406,11 @@ auto AggregateFactory::MakeSumDistinctAggregateFunctionV2() {
 template <LogicalType LT>
 auto AggregateFactory::MakeDecimalSumDistinctAggregateFunction() {
     return std::make_shared<DecimalDistinctAggregateFunction<LT, AggDistinctType::SUM>>();
+}
+
+template <LogicalType LT, int compute_bits>
+auto AggregateFactory::MakeFusedMultiDistinctAggregateFunction() {
+    return std::make_shared<FusedMultiDistinctFunction<LT, compute_bits>>();
 }
 
 template <LogicalType LT>

--- a/be/src/exprs/agg/factory/aggregate_resolver.hpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver.hpp
@@ -150,6 +150,17 @@ public:
     }
 
     template <LogicalType ArgType, LogicalType RetType, class StateType,
+              typename SpecificAggFunctionPtr = AggregateFunctionPtr, bool IgnoreNull = true,
+              IsAggNullPred<StateType> AggNullPred = AggNonNullPred<StateType>>
+    void add_window_mapping(const std::string& name, SpecificAggFunctionPtr fun,
+                            AggNullPred null_pred = AggNullPred()) {
+        _infos_mapping.emplace(std::make_tuple(name, ArgType, RetType, true, false), fun);
+        auto nullable_agg = AggregateFactory::MakeNullableAggregateFunctionUnary<StateType, true, IgnoreNull>(
+                fun, std::move(null_pred));
+        _infos_mapping.emplace(std::make_tuple(name, ArgType, RetType, true, true), nullable_agg);
+    }
+
+    template <LogicalType ArgType, LogicalType RetType, class StateType,
               typename SpecificAggFunctionPtr = AggregateFunctionPtr,
               IsAggNullPred<StateType> AggNullPred = AggNonNullPred<StateType>>
     void add_aggregate_mapping_variadic(const std::string& name, bool is_window, SpecificAggFunctionPtr fun,

--- a/be/src/exprs/agg/factory/aggregate_resolver_distinct.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_distinct.cpp
@@ -19,7 +19,6 @@
 #include "types/logical_type.h"
 
 namespace starrocks {
-
 struct DistinctDispatcher {
     template <LogicalType lt>
     void operator()(AggregateFuncResolver* resolver) {
@@ -35,6 +34,27 @@ struct DistinctDispatcher {
                     "multi_distinct_sum", false, AggregateFactory::MakeSumDistinctAggregateFunction<lt>());
             resolver->add_aggregate_mapping<lt, SumResultLT<lt>, DistinctState2>(
                     "multi_distinct_sum2", false, AggregateFactory::MakeSumDistinctAggregateFunctionV2<lt>());
+
+            static constexpr auto count = compute_bits(false, false);
+            resolver->add_window_mapping<lt, TYPE_STRUCT, typename FusedMultiDistinctFunction<lt, count>::State>(
+                    "fused_multi_distinct_count",
+                    AggregateFactory::MakeFusedMultiDistinctAggregateFunction<lt, count>());
+
+            static constexpr auto count_avg = compute_bits(false, true);
+            resolver->add_window_mapping<lt, TYPE_STRUCT, typename FusedMultiDistinctFunction<lt, count_avg>::State>(
+                    "fused_multi_distinct_count_avg",
+                    AggregateFactory::MakeFusedMultiDistinctAggregateFunction<lt, count_avg>());
+
+            static constexpr auto count_sum = compute_bits(true, false);
+            resolver->add_window_mapping<lt, TYPE_STRUCT, typename FusedMultiDistinctFunction<lt, count_sum>::State>(
+                    "fused_multi_distinct_count_sum",
+                    AggregateFactory::MakeFusedMultiDistinctAggregateFunction<lt, count_sum>());
+
+            static constexpr auto count_sum_avg = compute_bits(true, true);
+            resolver->add_window_mapping<lt, TYPE_STRUCT,
+                                         typename FusedMultiDistinctFunction<lt, count_sum_avg>::State>(
+                    "fused_multi_distinct_count_sum_avg",
+                    AggregateFactory::MakeFusedMultiDistinctAggregateFunction<lt, count_sum_avg>());
         }
     }
 };

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -337,6 +337,10 @@ public class FunctionSet {
     public static final String NDV = "ndv";
     public static final String MULTI_DISTINCT_COUNT = "multi_distinct_count";
     public static final String MULTI_DISTINCT_SUM = "multi_distinct_sum";
+    public static final String FUSED_MULTI_DISTINCT_COUNT = "fused_multi_distinct_count";
+    public static final String FUSED_MULTI_DISTINCT_COUNT_SUM = "fused_multi_distinct_count_sum";
+    public static final String FUSED_MULTI_DISTINCT_COUNT_AVG = "fused_multi_distinct_count_avg";
+    public static final String FUSED_MULTI_DISTINCT_COUNT_SUM_AVG = "fused_multi_distinct_count_sum_avg";
     public static final String DICT_MERGE = "dict_merge";
     public static final String WINDOW_FUNNEL = "window_funnel";
     public static final String DISTINCT_PC = "distinct_pc";
@@ -1371,6 +1375,22 @@ public class FunctionSet {
 
         }
 
+        for (Type type : MULTI_DISTINCT_COUNT_TYPES) {
+            Type returnType = createFusedMultiDistinctReturnType(type);
+            for (String name : new String[] {
+                    FunctionSet.FUSED_MULTI_DISTINCT_COUNT,
+                    FunctionSet.FUSED_MULTI_DISTINCT_COUNT_SUM,
+                    FunctionSet.FUSED_MULTI_DISTINCT_COUNT_AVG,
+                    FunctionSet.FUSED_MULTI_DISTINCT_COUNT_SUM_AVG
+            }) {
+                addBuiltin(AggregateFunction.createBuiltin(name,
+                        Lists.newArrayList(type),
+                        returnType,
+                        VarbinaryType.VARBINARY,
+                        false, true, true));
+            }
+        }
+
         addBuiltin(AggregateFunction.createBuiltin(DS_HLL_COMBINE,
                 Lists.newArrayList(VarbinaryType.VARBINARY), VarbinaryType.VARBINARY, VarbinaryType.VARBINARY,
                 true, false, true));
@@ -1607,6 +1627,35 @@ public class FunctionSet {
         }
         addBuiltin(AggregateFunction.createBuiltin(name,
                 Lists.newArrayList(DecimalType.DECIMALV2), DecimalType.DECIMALV2, DecimalType.DECIMALV2, false, true, false));
+    }
+
+    private static Type createFusedMultiDistinctReturnType(Type type) {
+        StructField countField = new StructField(FunctionSet.COUNT, IntegerType.BIGINT);
+        Type sumType = type.clone();
+        Type avgType = type.clone();
+        if (type.isBoolean()) {
+            sumType = IntegerType.BIGINT;
+            avgType = FloatType.DOUBLE;
+        } else if (type.isLargeint()) {
+            sumType = IntegerType.LARGEINT;
+            avgType = FloatType.DOUBLE;
+        } else if (type.isIntegerType()) {
+            sumType = IntegerType.BIGINT;
+            avgType = FloatType.DOUBLE;
+        } else if (type.isDecimal256()) {
+            sumType = DecimalType.DECIMAL256;
+            avgType = DecimalType.DECIMAL256;
+        } else if (type.isDecimalV3()) {
+            sumType = DecimalType.DECIMAL128;
+            avgType = DecimalType.DECIMAL128;
+        } else if (type.isFloatingPointType()) {
+            sumType = FloatType.DOUBLE;
+            avgType = FloatType.DOUBLE;
+        }
+
+        StructField sumField = new StructField(FunctionSet.SUM, sumType);
+        StructField avgField = new StructField(FunctionSet.AVG, avgType);
+        return new StructType(List.of(countField, sumField, avgField), true);
     }
 
     private void registerBuiltinMultiDistinctSumAggFunction() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -693,6 +693,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String SPLIT_TOPN_AGG_LIMIT = "enable_split_topn_agg_limit";
 
+    public static final String ENABLE_DISTINCT_AGG_OVER_WINDOW =
+            "enable_distinct_agg_over_window";
+
+    public static final String OPTIMIZE_DISTINCT_AGG_OVER_FRAMED_WINDOW =
+            "optimize_distinct_agg_over_framed_window";
+
     // Flag to control whether to proxy follower's query statement to leader/follower.
     public enum FollowerQueryForwardMode {
         DEFAULT,    // proxy queries by the follower's replay progress (default)
@@ -1369,6 +1375,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = SPLIT_TOPN_AGG_LIMIT)
     private long splitTopNAggLimit = 10000;
+
+    @VarAttr(name = ENABLE_DISTINCT_AGG_OVER_WINDOW)
+    private boolean enableDistinctAggOverWindow = true;
+    // 0: auto, 1: opimize, -1: do not optimize
+    @VarAttr(name = OPTIMIZE_DISTINCT_AGG_OVER_FRAMED_WINDOW, flag = VariableMgr.INVISIBLE)
+    private int optimizeDistinctAggOverFramedWindow = 0;
 
     /*
      * the parallel exec instance num for one Fragment in one BE
@@ -2080,6 +2092,22 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public long getSplitTopNAggLimit() {
         return splitTopNAggLimit;
+    }
+
+    public void setEnableDistinctAggOverWindow(boolean value) {
+        this.enableDistinctAggOverWindow = value;
+    }
+
+    public boolean isEnableDistinctAggOverWindow() {
+        return enableDistinctAggOverWindow;
+    }
+
+    public void setOptimizeDistinctAggOverFramedWindow(int value) {
+        this.optimizeDistinctAggOverFramedWindow = value;
+    }
+
+    public int getOptimizeDistinctAggOverFramedWindow() {
+        return optimizeDistinctAggOverFramedWindow;
     }
 
     public boolean isEnableDesensitizeExplain() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperatorUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperatorUtil.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.optimizer.operator.scalar;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionName;
 import com.starrocks.catalog.FunctionSet;
@@ -26,9 +27,15 @@ import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.InvalidType;
 import com.starrocks.type.ScalarType;
+import com.starrocks.type.StructField;
+import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
 import com.starrocks.type.TypeFactory;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.starrocks.catalog.Function.CompareMode.IS_IDENTICAL;
@@ -48,6 +55,46 @@ public class ScalarOperatorUtil {
         return (CallOperator) scalarOpRewriter.rewrite(
                 new CallOperator(FunctionSet.MULTI_DISTINCT_COUNT, fn.getReturnType(), oldFunctionCall.getChildren(),
                         fn),
+                DEFAULT_TYPE_CAST_RULE);
+    }
+
+    public static CallOperator buildFusedMultiDistinct(List<CallOperator> calls, ColumnRefOperator arg) {
+        Map<String, List<CallOperator>> groups = calls.stream().collect(Collectors.groupingBy(CallOperator::getFnName));
+        List<CallOperator> sumGroup = groups.getOrDefault(FunctionSet.SUM, List.of());
+        List<CallOperator> avgGroup = groups.getOrDefault(FunctionSet.AVG, List.of());
+        String fusedFunName;
+        if (sumGroup.isEmpty() && avgGroup.isEmpty()) {
+            fusedFunName = FunctionSet.FUSED_MULTI_DISTINCT_COUNT;
+        } else if (avgGroup.isEmpty()) {
+            fusedFunName = FunctionSet.FUSED_MULTI_DISTINCT_COUNT_SUM;
+        } else if (sumGroup.isEmpty()) {
+            fusedFunName = FunctionSet.FUSED_MULTI_DISTINCT_COUNT_AVG;
+        } else {
+            fusedFunName = FunctionSet.FUSED_MULTI_DISTINCT_COUNT_SUM_AVG;
+        }
+
+        Function searchDesc = new Function(new FunctionName(fusedFunName),
+                List.of(arg.getType()), InvalidType.INVALID, false);
+        Function fn = GlobalStateMgr.getCurrentState().getFunction(searchDesc, IS_NONSTRICT_SUPERTYPE_OF);
+        fn = Objects.requireNonNull(fn);
+        AggregateFunction newFn = (AggregateFunction) fn.copy();
+        newFn.setArgsType(new Type[] {arg.getType()});
+        StructType type = (StructType) newFn.getReturnType();
+        List<StructField> fields = Lists.newArrayList();
+        Type countType = type.getField(FunctionSet.COUNT).getType().clone();
+        fields.add(new StructField(FunctionSet.COUNT, countType));
+        if (!sumGroup.isEmpty()) {
+            Type sumType = sumGroup.get(0).getType().clone();
+            fields.add(new StructField(FunctionSet.SUM, sumType));
+        }
+        if (!avgGroup.isEmpty()) {
+            Type avgType = avgGroup.get(0).getType().clone();
+            fields.add(new StructField(FunctionSet.AVG, avgType));
+        }
+        newFn.setRetType(new StructType(fields, true));
+        ScalarOperatorRewriter scalarOpRewriter = new ScalarOperatorRewriter();
+        return (CallOperator) scalarOpRewriter.rewrite(
+                new CallOperator(fusedFunName, newFn.getReturnType(), Lists.newArrayList(arg), newFn),
                 DEFAULT_TYPE_CAST_RULE);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/DistinctAggregationOverWindowRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/DistinctAggregationOverWindowRule.java
@@ -14,14 +14,19 @@
 
 package com.starrocks.sql.optimizer.rule.transformation;
 
+import com.google.api.client.util.Lists;
 import com.google.common.base.Functions;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.sql.ast.JoinOperator;
+import com.starrocks.sql.ast.expression.AnalyticWindow;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.base.Ordering;
 import com.starrocks.sql.optimizer.operator.AggType;
 import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
@@ -34,10 +39,17 @@ import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorUtil;
+import com.starrocks.sql.optimizer.operator.scalar.SubfieldOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rule.tree.TreeRewriteRule;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.optimizer.statistics.Statistics;
+import com.starrocks.sql.optimizer.statistics.StatisticsCalculator;
 import com.starrocks.sql.optimizer.task.TaskContext;
+import org.apache.commons.math3.util.Pair;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -46,20 +58,117 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 /*
-Rewrite count(distinct) over window without sliding frames into null-safe-equal join + aggregation
-for an example:
+This rule is used to support count/sum/avg(distinct) over range-frame window.
+range-frame windows can be categorized into two types:
+1. type-1. overall window:  for examples:
+```sql
+    -- Q1
+    select a, b, count(distinct a) over() from t;
+    -- Q2
+    select a, b, count(distinct a) over(partition by b) from t;
+```
+2. type-2. framed window: for examples:
+```sql
+    -- Q3
+    select a, b, count(distinct a) over(order by b) from t;
+    -- Q4
+    select a, b, c, count(distinct a) over(partition by b order by c) from t;
+```
 
-select v1,v2,v3,count(distinct v3) over(partition by v1,v2) from t;
-can be rewritten into
-
+both types of distinct aggregations over range-frame windows are supported now.
+For Q1, the query is rewritten into agg + cross-join, as following:
+```sql
 with cte as(
-  select v1, v2, count(distinct v3) cd
-  from t0
-  group by v1,v2
+select count(distinct a) cda from t
 )
-select t0.v1, t0.v2, t0.v3, cte.cd
-from t0 inner join cte on t0.v1 <=> cte.v1 and t0.v2 <=> cte.v2;
+select t.a, t.b, cte.cda from t CROSS JOIN cte;
+```
+For Q2, the query is rewritten into agg + null-safe-equal-join, as following:
 
+```sql
+with cte as(
+  select b, count(distinct a) cda
+  from t
+  group by b
+)
+select t.a, t.b, cte.cda
+from t inner join cte on t.b <=> t.b;
+```
+
+for Q3 and Q4, we introduce fused_multi_distinct aggregation function for process count/sum/avg(distinct), when
+the distinct aggregations are applied to same window and same column, then its agg state are fused into one state.
+
+fused_multi_distinct prototype as follows
+```
+fused_multi_distinct_count[_sum][_avg]: Type -> StructType("count": BIGINT[, "sum": sumType][, "avg": avgType);
+```
+for an example:
+```sql
+select a, b, c,
+    count(distinct c) over(partition by a order by b),
+    sum(distinct c) over(partition by a order by b),
+    avg(distinct c) over(partition by a order by b),
+from t;
+```
+above query is rewritten into the plan just as follow query shows
+```
+with cte as(
+select a,b,c,
+fused_multi_distinct_count_sum_avg(c) over(partition by a order by b) fmdc
+from t
+)
+select a,b,c, fmdc.count, fmdc.sum, fmdc.avg
+from cte;
+```
+So for Q3, it is transformed into
+
+```sql
+with cte as (
+select a, b, fused_multi_distinct_count(distinct a) over(order by b) fmdc from t
+)
+select a, b, fmdc.count from cte
+```
+
+For Q4, it is transformed into
+```
+with cte as (
+select a, b, c, fused_multi_distinct_count(distinct a) over(partition by b order by c) fmdc from t;
+)
+select a, b, c, fmdc.count from cte;
+```
+
+For framed windows(Q3,Q4), we try to optimize the queries to reduce input rows of window operators when
+1. when multi column cardinality of partition-by columns, order-by columns and distinct columns are low;
+2. when session variable optimize_distinct_agg_over_framed_window = 1.
+
+when optimization is enabled, Q3 and Q4 would be transformed into
+
+```sql
+-- optimized Q3
+with cte0 as (
+select distinct a,b from t
+),
+cte1 as (
+select b, fused_multi_distinct_count(distinct a) over(order by b) fmdc from cte0
+),
+cte2 as (
+select distinct b, fmdc.count
+)
+
+select t.a, t.b, cte2.fmdc.count from t inner join cte2 on t.b <=> cte2.b
+
+-- optimized Q4
+with cte0 as (
+select distinct a, b, c from t
+),
+cte1 as (
+select b, c, fused_multi_distinct_count(distinct a) over(partition by b order by c) fmdc from cte0
+),
+cte2 as (
+select distinct b, c, fmdc.count
+)
+select t.a, t.b, t.c, cte2.fmdc.count from t inner join cte2 on t.b <=> cte2.b and t.c <=> cte2.c
+```
 */
 
 public class DistinctAggregationOverWindowRule implements TreeRewriteRule {
@@ -79,6 +188,29 @@ public class DistinctAggregationOverWindowRule implements TreeRewriteRule {
         @Override
         public Optional<OptExpression> visitLogicalWindow(OptExpression optExpression, TaskContext context) {
             LogicalWindowOperator windowOp = optExpression.getOp().cast();
+            if (isOverallWindow(windowOp)) {
+                return handleDistinctAggOverOverallWindow(optExpression, context);
+            } else if (isFramedWindow(windowOp)) {
+                return handleDistinctAggOverFramedWindow(optExpression, context);
+            } else {
+                return Optional.empty();
+            }
+        }
+
+        int classifyWindowCall(Map.Entry<ColumnRefOperator, CallOperator> call) {
+            Set<String> funcNames = ImmutableSet.of(FunctionSet.SUM, FunctionSet.COUNT, FunctionSet.AVG);
+            if (FunctionSet.onlyAnalyticUsedFunctions.contains(call.getValue().getFnName())) {
+                return 0;
+            } else if (call.getValue().isDistinct() && funcNames.contains(call.getValue().getFnName())) {
+                return 1;
+            } else {
+                return 2;
+            }
+        }
+
+        public Optional<OptExpression> handleDistinctAggOverOverallWindow(OptExpression optExpression,
+                                                                          TaskContext context) {
+            LogicalWindowOperator windowOp = optExpression.getOp().cast();
 
             boolean isWindowWithSlidingFrame = windowOp.getAnalyticWindow() != null &&
                     !(windowOp.getAnalyticWindow().getRightBoundary().getBoundaryType().isAbsolutePos() &&
@@ -87,19 +219,10 @@ public class DistinctAggregationOverWindowRule implements TreeRewriteRule {
             if (isWindowWithSlidingFrame || !windowOp.getOrderByElements().isEmpty()) {
                 return Optional.empty();
             }
-            Set<String> funcNames = ImmutableSet.of(FunctionSet.SUM, FunctionSet.COUNT, FunctionSet.AVG);
-            java.util.function.Function<Map.Entry<ColumnRefOperator, CallOperator>, Integer> classify = e -> {
-                if (FunctionSet.onlyAnalyticUsedFunctions.contains(e.getValue().getFnName())) {
-                    return 0;
-                } else if (e.getValue().isDistinct() && funcNames.contains(e.getValue().getFnName())) {
-                    return 1;
-                } else {
-                    return 2;
-                }
-            };
+
             Map<Integer, Map<ColumnRefOperator, CallOperator>> windowCallGroups =
-                    windowOp.getWindowCall().entrySet().stream().collect(
-                            Collectors.groupingBy(classify, Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+                    windowOp.getWindowCall().entrySet().stream().collect(Collectors.groupingBy(this::classifyWindowCall,
+                            Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
             Map<ColumnRefOperator, CallOperator> analyticCalls = windowCallGroups.getOrDefault(0, Maps.newHashMap());
             Map<ColumnRefOperator, CallOperator> distinctAggCalls = windowCallGroups.getOrDefault(1, Maps.newHashMap());
             Map<ColumnRefOperator, CallOperator> aggCalls = windowCallGroups.getOrDefault(2, Maps.newHashMap());
@@ -179,6 +302,303 @@ public class DistinctAggregationOverWindowRule implements TreeRewriteRule {
                     LogicalWindowOperator.builder().withOperator(windowOp).setWindowCall(analyticCalls).build();
             OptExpression windowOptExpr = OptExpression.create(newWindowOp, cteAnchorOptExpr);
             return Optional.of(windowOptExpr);
+        }
+
+        // non-sliding window is a window contains no order-by clause and both sides of the frame is
+        // unbounded.
+        public boolean isOverallWindow(LogicalWindowOperator windowOp) {
+            AnalyticWindow windowDef = windowOp.getAnalyticWindow();
+            return windowOp.getOrderByElements().isEmpty() && (windowDef == null ||
+                    (windowDef.getLeftBoundary().getBoundaryType().isAbsolutePos() &&
+                            windowDef.getRightBoundary().getBoundaryType().isAbsolutePos()));
+        }
+
+        //  sliding-range-frame window is a window contains order-by clause and at least one of sides of frame
+        //  is bounded and
+        public boolean isFramedWindow(LogicalWindowOperator windowOp) {
+            AnalyticWindow windowDef = windowOp.getAnalyticWindow();
+            return !windowOp.getOrderByElements().isEmpty() && windowDef != null &&
+                    windowDef.getType().equals(AnalyticWindow.Type.RANGE) &&
+                    !(windowDef.getLeftBoundary().getBoundaryType().isAbsolutePos() &&
+                            windowDef.getRightBoundary().getBoundaryType().isAbsolutePos());
+        }
+
+        private static class DistinctAggRewriteResult {
+            public final ColumnRefOperator distinctColRef;
+            public final Map<ColumnRefOperator, CallOperator> windowCalls;
+            public final Map<ColumnRefOperator, ScalarOperator> outputExprs;
+
+            public DistinctAggRewriteResult(ColumnRefOperator inputColumnRef,
+                                            Map<ColumnRefOperator, CallOperator> windowCalls,
+                                            Map<ColumnRefOperator, ScalarOperator> outputExprs) {
+                this.distinctColRef = inputColumnRef;
+                this.windowCalls = windowCalls;
+                this.outputExprs = outputExprs;
+            }
+        }
+
+        private List<DistinctAggRewriteResult> rewriteDistinctAgg(Map<ColumnRefOperator, CallOperator> distinctAgg,
+                                                                  ColumnRefFactory columnRefFactory) {
+            Map<List<ScalarOperator>, List<Pair<ColumnRefOperator, CallOperator>>> sameArgsDistinctAggGroups =
+                    distinctAgg.entrySet().stream().map(e -> Pair.create(e.getKey(), e.getValue()))
+                            .collect(Collectors.groupingBy(p -> p.getSecond().getArguments()));
+
+            List<DistinctAggRewriteResult> results = Lists.newArrayList();
+            for (Map.Entry<List<ScalarOperator>, List<Pair<ColumnRefOperator, CallOperator>>> e :
+                    sameArgsDistinctAggGroups.entrySet()) {
+                Preconditions.checkArgument(e.getKey().size() == 1 && e.getKey().get(0) instanceof ColumnRefOperator);
+                ColumnRefOperator arg = (ColumnRefOperator) e.getKey().get(0);
+                List<CallOperator> calls = e.getValue().stream().map(Pair::getSecond).collect(Collectors.toList());
+                CallOperator fusedMultiDistinct = ScalarOperatorUtil.buildFusedMultiDistinct(calls, arg);
+                ColumnRefOperator fusedMultiDistinctColRef =
+                        columnRefFactory.create(fusedMultiDistinct, fusedMultiDistinct.getType(),
+                                fusedMultiDistinct.isNullable());
+
+                Map<ColumnRefOperator, ScalarOperator> outputExprs = e.getValue().stream().collect(
+                        Collectors.toMap(Pair::getFirst,
+                                p -> new SubfieldOperator(fusedMultiDistinctColRef, p.getSecond().getType(),
+                                        List.of(p.getValue().getFnName()))));
+                Map<ColumnRefOperator, CallOperator> windowCalls = Maps.newHashMap();
+                windowCalls.put(fusedMultiDistinctColRef, fusedMultiDistinct);
+                results.add(new DistinctAggRewriteResult(arg, windowCalls, outputExprs));
+            }
+            return results;
+        }
+
+        public OptExpression convertSingleDistinctAgg(OptExpression joinLhsOpt, List<ColumnRefOperator> groupBy,
+                                                      LogicalWindowOperator windowOp, int cteId,
+                                                      List<ColumnRefOperator> cteProduceOutputColumnRef,
+                                                      DistinctAggRewriteResult result, TaskContext context) {
+
+            java.util.function.Function<ColumnRefOperator, ColumnRefOperator> forkColumnRef =
+                    colRef -> context.getOptimizerContext().getColumnRefFactory()
+                            .create(colRef.getName(), colRef.getType(), colRef.isNullable());
+
+            Map<ColumnRefOperator, ColumnRefOperator> cteConsumeOutputColumnRefMap =
+                    cteProduceOutputColumnRef.stream().collect(Collectors.toMap(forkColumnRef, Functions.identity()));
+
+            Map<ColumnRefOperator, ScalarOperator> replaceMap = cteConsumeOutputColumnRefMap.entrySet().stream()
+                    .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+
+            ReplaceColumnRefRewriter replaceRewriter = new ReplaceColumnRefRewriter(replaceMap, false);
+
+            List<ColumnRefOperator> groupByColumnRefs =
+                    groupBy.stream().map(replaceRewriter::rewrite).map(expr -> (ColumnRefOperator) expr)
+                            .collect(Collectors.toList());
+
+            groupByColumnRefs.add((ColumnRefOperator) replaceRewriter.rewrite(result.distinctColRef));
+
+            LogicalCTEConsumeOperator cteConsumeOp = new LogicalCTEConsumeOperator(cteId, cteConsumeOutputColumnRefMap);
+            LogicalAggregationOperator distinctOp1 =
+                    new LogicalAggregationOperator(AggType.GLOBAL, groupByColumnRefs, Maps.newHashMap());
+            Map<ColumnRefOperator, ScalarOperator> distinctOp1ColRefMap =
+                    groupByColumnRefs.stream().collect(Collectors.toMap(Function.identity(), Function.identity()));
+            distinctOp1.setProjection(new Projection(distinctOp1ColRefMap));
+
+            List<ScalarOperator> newPartitionExprs =
+                    windowOp.getPartitionExpressions().stream().map(replaceRewriter::rewrite)
+                            .collect(Collectors.toList());
+
+            List<Ordering> newOrderByElements = windowOp.getOrderByElements().stream()
+                    .map(ord -> new Ordering((ColumnRefOperator) replaceRewriter.rewrite(ord.getColumnRef()),
+                            ord.isAscending(), ord.isNullsFirst())).collect(Collectors.toList());
+
+            List<Ordering> newEnforceSortColumns = windowOp.getEnforceSortColumns().stream()
+                    .map(ord -> new Ordering((ColumnRefOperator) replaceRewriter.rewrite(ord.getColumnRef()),
+                            ord.isAscending(), ord.isNullsFirst())).collect(Collectors.toList());
+
+            Map<ColumnRefOperator, CallOperator> newWindowCalls = result.windowCalls.entrySet().stream().collect(
+                    Collectors.toMap(Map.Entry::getKey, e -> (CallOperator) replaceRewriter.rewrite(e.getValue())));
+
+            Map<ColumnRefOperator, ScalarOperator> windowOpColumnRefMap = Maps.newHashMap();
+            newPartitionExprs.forEach(e -> windowOpColumnRefMap.put((ColumnRefOperator) e, e));
+            newOrderByElements.forEach(e -> windowOpColumnRefMap.put(e.getColumnRef(), e.getColumnRef()));
+            windowOpColumnRefMap.putAll(result.outputExprs);
+
+            LogicalWindowOperator newWindowOp =
+                    LogicalWindowOperator.builder().setAnalyticWindow(windowOp.getAnalyticWindow().clone())
+                            .setPartitionExpressions(newPartitionExprs).setOrderByElements(newOrderByElements)
+                            .setEnforceSortColumns(newEnforceSortColumns).setWindowCall(newWindowCalls)
+                            .setProjection(new Projection(windowOpColumnRefMap)).build();
+
+            List<ColumnRefOperator> distinctGroupBy =
+                    windowOpColumnRefMap.keySet().stream().sorted(Comparator.comparingInt(ColumnRefOperator::getId))
+                            .collect(Collectors.toList());
+
+            LogicalAggregationOperator distinctOp2 =
+                    new LogicalAggregationOperator(AggType.GLOBAL, distinctGroupBy, Maps.newHashMap());
+            Map<ColumnRefOperator, ScalarOperator> distinctOp2ColumnRefMap =
+                    distinctGroupBy.stream().collect(Collectors.toMap(Function.identity(), Function.identity()));
+            distinctOp2.setProjection(new Projection(distinctOp2ColumnRefMap));
+
+            List<ColumnRefOperator> joinColumnRefs = Lists.newArrayList();
+            newPartitionExprs.forEach(e -> joinColumnRefs.add((ColumnRefOperator) e));
+            newOrderByElements.forEach(e -> joinColumnRefs.add(e.getColumnRef()));
+
+            List<ScalarOperator> eqConjuncts = joinColumnRefs.stream()
+                    .map(expr -> BinaryPredicateOperator.null_safe_eq(expr, cteConsumeOutputColumnRefMap.get(expr)))
+                    .collect(Collectors.toList());
+
+            LogicalJoinOperator joinOp =
+                    new LogicalJoinOperator(JoinOperator.INNER_JOIN, Utils.compoundAnd(eqConjuncts));
+            Map<ColumnRefOperator, ScalarOperator> joinOpColumnRefMap =
+                    Stream.concat(cteProduceOutputColumnRef.stream(), result.outputExprs.keySet().stream())
+                            .collect(Collectors.toMap(Function.identity(), Function.identity()));
+            joinOp.setProjection(new Projection(joinOpColumnRefMap));
+
+            OptExpression joinRhsOpt = OptExpression.create(cteConsumeOp);
+            joinRhsOpt = OptExpression.create(distinctOp1, joinRhsOpt);
+            joinRhsOpt = OptExpression.create(newWindowOp, joinRhsOpt);
+            joinRhsOpt = OptExpression.create(distinctOp2, joinRhsOpt);
+            return OptExpression.create(joinOp, joinLhsOpt, joinRhsOpt);
+        }
+
+        private boolean shouldOptimizeFramedWindow(Statistics inputStatistics, List<ColumnRefOperator> groupBy,
+                                                   ColumnRefOperator distinctColumnRef, int optimizeOption) {
+
+            if (optimizeOption >= 1) {
+                return true;
+            } else if (optimizeOption <= -1) {
+                return false;
+            } else {
+                List<ColumnRefOperator> distinctColumns = Lists.newArrayList(groupBy);
+                distinctColumns.add(distinctColumnRef);
+                Map<ColumnRefOperator, ColumnStatistic> distinctColumnStatistics = Maps.newHashMap();
+                double rowCount = StatisticsCalculator.computeGroupByStatistics(distinctColumns, inputStatistics,
+                        distinctColumnStatistics);
+
+                double inputRowCount = inputStatistics.getOutputRowCount();
+                inputRowCount = inputRowCount == 0.0 ? 1.0 : inputRowCount;
+                return 0 <= rowCount && rowCount <= inputRowCount && (rowCount / inputRowCount <= 0.1);
+            }
+        }
+
+        public Optional<OptExpression> handleDistinctAggOverFramedWindow(OptExpression optExpression,
+                                                                         TaskContext context) {
+            LogicalWindowOperator windowOp = optExpression.getOp().cast();
+
+            if (!isFramedWindow(windowOp)) {
+                return Optional.empty();
+            }
+
+            Map<Integer, Map<ColumnRefOperator, CallOperator>> windowCallGroups =
+                    windowOp.getWindowCall().entrySet().stream().collect(Collectors.groupingBy(this::classifyWindowCall,
+                            Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+
+            Map<ColumnRefOperator, CallOperator> analyticCalls = windowCallGroups.getOrDefault(0, Maps.newHashMap());
+            Map<ColumnRefOperator, CallOperator> distinctAggCalls = windowCallGroups.getOrDefault(1, Maps.newHashMap());
+            Map<ColumnRefOperator, CallOperator> aggCalls = windowCallGroups.getOrDefault(2, Maps.newHashMap());
+
+            if (distinctAggCalls.isEmpty()) {
+                return Optional.empty();
+            }
+
+            List<ColumnRefOperator> groupBy = Lists.newArrayList();
+            Optional.ofNullable(windowOp.getPartitionExpressions())
+                    .ifPresent(exprs -> exprs.stream().map(e -> (ColumnRefOperator) e).forEach(groupBy::add));
+
+            Optional.ofNullable(windowOp.getOrderByElements())
+                    .ifPresent(orderings -> orderings.stream().map(Ordering::getColumnRef).forEach(groupBy::add));
+
+            OptExpression child = optExpression.inputAt(0);
+            int cteId = context.getOptimizerContext().getCteContext().getNextCteId();
+
+            // when distinct arguments are expr(not ColumnRefOperator), we must push them down to input OptExpression,
+            // since distinct arguments may be group-by columns in optimized plan.
+            Map<ScalarOperator, ColumnRefOperator> pushDownDistinctArgs = Maps.newHashMap();
+            for (CallOperator call : distinctAggCalls.values()) {
+                Preconditions.checkArgument(call.getChildren().size() == 1);
+                ScalarOperator arg = call.getChild(0);
+                if (arg.isColumnRef()) {
+                    continue;
+                }
+                Optional<ColumnRefOperator> optColRef = Optional.ofNullable(pushDownDistinctArgs.get(arg));
+                ColumnRefOperator colRef = optColRef.orElseGet(() -> context.getOptimizerContext().getColumnRefFactory()
+                        .create(arg, arg.getType(), arg.isNullable()));
+                call.setChild(0, colRef);
+                if (optColRef.isEmpty()) {
+                    pushDownDistinctArgs.put(arg, colRef);
+                }
+            }
+
+            if (!pushDownDistinctArgs.isEmpty()) {
+                Map<ColumnRefOperator, ScalarOperator> childColRefMap =
+                        Optional.ofNullable(child.getOp().getProjection())
+                                .map(Projection::getColumnRefMap)
+                                .orElseGet(() -> child.getRowOutputInfo().getColumnRefMap().entrySet()
+                                        .stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getKey)));
+
+                pushDownDistinctArgs.forEach((k, v) -> childColRefMap.put(v, k));
+                child.getOp().setProjection(new Projection(childColRefMap));
+            }
+
+            List<DistinctAggRewriteResult> results =
+                    rewriteDistinctAgg(distinctAggCalls, context.getOptimizerContext().getColumnRefFactory());
+
+            List<ColumnRefOperator> inputColumnRefs = child.getRowOutputInfo().getOutputColRefs();
+            Map<ColumnRefOperator, ColumnRefOperator> cteOutputColumnRefMap =
+                    inputColumnRefs.stream().collect(Collectors.toMap(Function.identity(), Function.identity()));
+
+            LogicalCTEAnchorOperator cteAnchorOp = new LogicalCTEAnchorOperator(cteId);
+            LogicalCTEProduceOperator cteProduceOp = new LogicalCTEProduceOperator(cteId);
+            LogicalCTEConsumeOperator joinLhsCteConsumeOp = new LogicalCTEConsumeOperator(cteId, cteOutputColumnRefMap);
+
+            OptExpression newOpt = OptExpression.create(joinLhsCteConsumeOp);
+            Map<ColumnRefOperator, ScalarOperator> fusedResultSubfieldMap = Maps.newHashMap();
+            int optOption = context.getOptimizerContext().getSessionVariable().getOptimizeDistinctAggOverFramedWindow();
+            Utils.calculateStatistics(child, context.getOptimizerContext());
+            List<DistinctAggRewriteResult> needOptimizeResults = Lists.newArrayList();
+            for (DistinctAggRewriteResult result : results) {
+                if (!shouldOptimizeFramedWindow(child.getStatistics(), groupBy, result.distinctColRef, optOption)) {
+                    analyticCalls.putAll(result.windowCalls);
+                    fusedResultSubfieldMap.putAll(result.outputExprs);
+                } else {
+                    needOptimizeResults.add(result);
+                }
+            }
+            analyticCalls.putAll(aggCalls);
+            Optional<LogicalWindowOperator> optNewWindowOp = Optional.empty();
+
+            if (!analyticCalls.isEmpty()) {
+                Map<ColumnRefOperator, ScalarOperator> outputColRefMap = Optional.ofNullable(windowOp.getProjection())
+                        .map(Projection::getColumnRefMap)
+                        .orElseGet(() -> optExpression.getRowOutputInfo().getColumnRefMap().entrySet()
+                                .stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getKey)));
+
+                ReplaceColumnRefRewriter colRefRewriter = new ReplaceColumnRefRewriter(fusedResultSubfieldMap);
+                Map<ColumnRefOperator, ScalarOperator> newColRefMap = outputColRefMap.entrySet()
+                        .stream()
+                        .collect(Collectors.toMap(Map.Entry::getKey,
+                                e -> Optional.ofNullable(fusedResultSubfieldMap.get(e.getKey()))
+                                        .orElseGet(() -> colRefRewriter.rewrite(e.getValue()))));
+
+                LogicalWindowOperator newWindowOp = LogicalWindowOperator.builder().withOperator(windowOp)
+                        .setProjection(new Projection(newColRefMap)).setWindowCall(analyticCalls).build();
+                optNewWindowOp = Optional.of(newWindowOp);
+            }
+
+            if (needOptimizeResults.isEmpty()) {
+                Preconditions.checkArgument(optNewWindowOp.isPresent());
+                return Optional.of(OptExpression.create(optNewWindowOp.get(), child));
+            }
+
+            for (DistinctAggRewriteResult result : needOptimizeResults) {
+                newOpt = convertSingleDistinctAgg(newOpt, groupBy, windowOp, cteId, inputColumnRefs, result, context);
+            }
+
+            if (optNewWindowOp.isEmpty() && windowOp.getProjection() != null) {
+                newOpt.getOp().setProjection(windowOp.getProjection());
+            }
+
+            OptExpression cteProduceOptExpr = OptExpression.create(cteProduceOp, child);
+            OptExpression cteAnchorOptExpr = OptExpression.create(cteAnchorOp, cteProduceOptExpr, newOpt);
+
+            if (optNewWindowOp.isEmpty()) {
+                return Optional.of(cteAnchorOptExpr);
+            }
+            newOpt = optNewWindowOp.map(newWindowOp -> OptExpression.create(newWindowOp, cteAnchorOptExpr))
+                    .orElse(cteAnchorOptExpr);
+            return Optional.of(newOpt);
         }
 
         private Optional<OptExpression> process(OptExpression opt, TaskContext context) {

--- a/test/sql/test_distinct_aggregation_over_framed_window/R/test_distinct_aggregation_over_framed_window
+++ b/test/sql/test_distinct_aggregation_over_framed_window/R/test_distinct_aggregation_over_framed_window
@@ -1,0 +1,859 @@
+-- name: test_distinct_aggregation_over_framed_window
+CREATE TABLE `t0` (
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `v3` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP
+PROPERTIES("replication_num"="1");
+-- result:
+-- !result
+insert into t0 select i/19 as v1, i/11 as v2, i/5 as v3 from table(generate_series(1,100)) t(i);
+-- result:
+-- !result
+select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0))+murmur_hash3_32(ifnull(sum,0))+murmur_hash3_32(ifnull(avg,0))+murmur_hash3_32(ifnull(count,0))+murmur_hash3_32(ifnull(rank,0))+murmur_hash3_32(ifnull(d_rank,0))+murmur_hash3_32(ifnull(rn,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_avg,
+sum(cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as sum,
+avg(cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as avg,
+count(cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as count,
+rank()over(partition by v1 order by v2) as rank,
+dense_rank()over(partition by v1 order by v2) as d_rank,
+row_number()over(partition by v1 order by v2) as rn
+from t0) as t;
+-- result:
+158406994077
+-- !result
+with cte as(
+select distinct v1,v2,v3,
+ count(distinct v3)over(partition by v1 order by v2) as dist_count,
+ sum(distinct v3)over(partition by v1 order by v2) as dist_sum,
+ avg(distinct v3)over(partition by v1 order by v2) as dist_avg
+from t0
+),
+cte1 as(
+select v1,v2,v3,
+ count(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_count,
+ sum(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_sum,
+ avg(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_avg
+from t0 
+)
+select 
+   assert_true(count(1)=count(if(cte.dist_count = cte1.dist_count, 1, NULL))), 
+   assert_true(count(1)=count(if(cte.dist_sum = cte1.dist_sum, 1, NULL))), 
+   assert_true(count(1)=count(if(cte.dist_avg = cte1.dist_avg, 1, NULL)))
+from cte join cte1 on cte.v1 = cte1.v1 and cte.v2 = cte1.v2 and cte.v3 = cte1.v3;
+-- result:
+1	1	1
+-- !result
+/*q0*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(7,2)))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as decimal(7,2)))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as decimal(7,2)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+70808484609
+-- !result
+/*q1*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(7,2)))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as decimal(7,2)))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+125432124625
+-- !result
+/*q2*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(7,2)))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as decimal(7,2)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+26307328584
+-- !result
+/*q3*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as decimal(7,2)))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as decimal(7,2)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-1558760228
+-- !result
+/*q4*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(7,2)))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+-- result:
+80930968600
+-- !result
+/*q5*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as decimal(7,2)))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+53064879788
+-- !result
+/*q6*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as decimal(7,2)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-46059916253
+-- !result
+/*q7*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+70808484609
+-- !result
+/*q8*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+125432124625
+-- !result
+/*q9*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+26307328584
+-- !result
+/*q10*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-1558760228
+-- !result
+/*q11*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+-- result:
+80930968600
+-- !result
+/*q12*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+53064879788
+-- !result
+/*q13*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-46059916253
+-- !result
+/*q14*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(38,19)))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as decimal(38,19)))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as decimal(38,19)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+141542173594
+-- !result
+/*q15*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(38,19)))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as decimal(38,19)))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+65364570663
+-- !result
+/*q16*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(38,19)))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as decimal(38,19)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+157108571531
+-- !result
+/*q17*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as decimal(38,19)))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as decimal(38,19)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+69174928757
+-- !result
+/*q18*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(38,19)))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+-- result:
+80930968600
+-- !result
+/*q19*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as decimal(38,19)))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+-7002674174
+-- !result
+/*q20*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as decimal(38,19)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+84741326694
+-- !result
+/*q21*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(38,20)))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as decimal(38,20)))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as decimal(38,20)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+141542173594
+-- !result
+/*q22*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(38,20)))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as decimal(38,20)))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+65364570663
+-- !result
+/*q23*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(38,20)))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as decimal(38,20)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+157108571531
+-- !result
+/*q24*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as decimal(38,20)))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as decimal(38,20)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+69174928757
+-- !result
+/*q25*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(38,20)))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+-- result:
+80930968600
+-- !result
+/*q26*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as decimal(38,20)))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+-7002674174
+-- !result
+/*q27*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as decimal(38,20)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+84741326694
+-- !result
+/*q28*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(38,18)))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as decimal(38,18)))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as decimal(38,18)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+141542173594
+-- !result
+/*q29*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(38,18)))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as decimal(38,18)))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+65364570663
+-- !result
+/*q30*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(38,18)))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as decimal(38,18)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+157108571531
+-- !result
+/*q31*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as decimal(38,18)))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as decimal(38,18)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+69174928757
+-- !result
+/*q32*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(38,18)))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+-- result:
+80930968600
+-- !result
+/*q33*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as decimal(38,18)))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+-7002674174
+-- !result
+/*q34*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as decimal(38,18)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+84741326694
+-- !result
+/*q35*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(39,18)))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as decimal(39,18)))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as decimal(39,18)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+11145379306
+-- !result
+/*q36*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(39,18)))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as decimal(39,18)))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+74681965146
+-- !result
+/*q37*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(39,18)))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as decimal(39,18)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+17394382760
+-- !result
+/*q38*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as decimal(39,18)))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as decimal(39,18)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-61221865531
+-- !result
+/*q39*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(39,18)))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+-- result:
+80930968600
+-- !result
+/*q40*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as decimal(39,18)))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+2314720309
+-- !result
+/*q41*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as decimal(39,18)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-54972862077
+-- !result
+/*q42*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as boolean))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as boolean))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as boolean))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-454307243545
+-- !result
+/*q43*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as boolean))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as boolean))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+-297607543439
+-- !result
+/*q44*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as boolean))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as boolean))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-269440297745
+-- !result
+/*q45*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as boolean))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as boolean))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-333002922143
+-- !result
+/*q46*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as boolean))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+-- result:
+-112740597639
+-- !result
+/*q47*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as boolean))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+-176303222037
+-- !result
+/*q48*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as boolean))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-148135976343
+-- !result
+/*q49*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as tinyint))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as tinyint))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as tinyint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+11145379306
+-- !result
+/*q50*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as tinyint))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as tinyint))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+74681965146
+-- !result
+/*q51*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as tinyint))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as tinyint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+17394382760
+-- !result
+/*q52*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as tinyint))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as tinyint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-61221865531
+-- !result
+/*q53*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as tinyint))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+-- result:
+80930968600
+-- !result
+/*q54*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as tinyint))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+2314720309
+-- !result
+/*q55*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as tinyint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-54972862077
+-- !result
+/*q56*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as int))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as int))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as int))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+11145379306
+-- !result
+/*q57*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as int))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as int))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+74681965146
+-- !result
+/*q58*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as int))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as int))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+17394382760
+-- !result
+/*q59*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as int))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as int))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-61221865531
+-- !result
+/*q60*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as int))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+-- result:
+80930968600
+-- !result
+/*q61*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as int))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+2314720309
+-- !result
+/*q62*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as int))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-54972862077
+-- !result
+/*q63*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as smallint))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as smallint))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as smallint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+11145379306
+-- !result
+/*q64*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as smallint))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as smallint))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+74681965146
+-- !result
+/*q65*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as smallint))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as smallint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+17394382760
+-- !result
+/*q66*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as smallint))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as smallint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-61221865531
+-- !result
+/*q67*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as smallint))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+-- result:
+80930968600
+-- !result
+/*q68*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as smallint))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+2314720309
+-- !result
+/*q69*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as smallint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-54972862077
+-- !result
+/*q70*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as bigint))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as bigint))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as bigint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+11145379306
+-- !result
+/*q71*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as bigint))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as bigint))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+74681965146
+-- !result
+/*q72*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as bigint))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as bigint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+17394382760
+-- !result
+/*q73*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as bigint))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as bigint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-61221865531
+-- !result
+/*q74*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as bigint))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+-- result:
+80930968600
+-- !result
+/*q75*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as bigint))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+2314720309
+-- !result
+/*q76*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as bigint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-54972862077
+-- !result
+/*q77*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as largeint))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as largeint))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as largeint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+11145379306
+-- !result
+/*q78*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as largeint))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as largeint))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+74681965146
+-- !result
+/*q79*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as largeint))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as largeint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+17394382760
+-- !result
+/*q80*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as largeint))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as largeint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-61221865531
+-- !result
+/*q81*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as largeint))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+-- result:
+80930968600
+-- !result
+/*q82*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as largeint))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+2314720309
+-- !result
+/*q83*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as largeint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-54972862077
+-- !result
+/*q84*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as float))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as float))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as float))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+11145379306
+-- !result
+/*q85*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as float))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as float))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+74681965146
+-- !result
+/*q86*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as float))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as float))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+17394382760
+-- !result
+/*q87*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as float))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as float))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-61221865531
+-- !result
+/*q88*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as float))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+-- result:
+80930968600
+-- !result
+/*q89*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as float))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+2314720309
+-- !result
+/*q90*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as float))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-54972862077
+-- !result
+/*q91*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as double))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as double))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as double))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+11145379306
+-- !result
+/*q92*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as double))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as double))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+74681965146
+-- !result
+/*q93*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as double))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as double))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+17394382760
+-- !result
+/*q94*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as double))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as double))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-61221865531
+-- !result
+/*q95*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as double))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+-- result:
+80930968600
+-- !result
+/*q96*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as double))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+2314720309
+-- !result
+/*q97*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as double))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-54972862077
+-- !result
+/*q98*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as string))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as string))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as string))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+11145379306
+-- !result
+/*q99*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as string))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as string))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+74681965146
+-- !result
+/*q100*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as string))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as string))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+17394382760
+-- !result
+/*q101*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as string))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as string))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-61221865531
+-- !result
+/*q102*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as string))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+-- result:
+80930968600
+-- !result
+/*q103*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as string))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+2314720309
+-- !result
+/*q104*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as string))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-54972862077
+-- !result
+/*q105*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as varchar))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as varchar))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as varchar))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+11145379306
+-- !result
+/*q106*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as varchar))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as varchar))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+74681965146
+-- !result
+/*q107*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as varchar))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as varchar))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+17394382760
+-- !result
+/*q108*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as varchar))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as varchar))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-61221865531
+-- !result
+/*q109*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as varchar))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+-- result:
+80930968600
+-- !result
+/*q110*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as varchar))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+2314720309
+-- !result
+/*q111*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as varchar))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-54972862077
+-- !result
+/*q112*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as char))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as char))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as char))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+11145379306
+-- !result
+/*q113*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as char))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as char))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+74681965146
+-- !result
+/*q114*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as char))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as char))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+17394382760
+-- !result
+/*q115*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as char))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as char))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-61221865531
+-- !result
+/*q116*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as char))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+-- result:
+80930968600
+-- !result
+/*q117*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as char))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+-- result:
+2314720309
+-- !result
+/*q118*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as char))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+-- result:
+-54972862077
+-- !result
+/*q119*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(days_add('2025-01-01',v3) as date))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+-- result:
+80930968600
+-- !result
+/*q120*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct days_add('2025-01-01 00:00:00',v3))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+-- result:
+80930968600
+-- !result

--- a/test/sql/test_distinct_aggregation_over_framed_window/T/test_distinct_aggregation_over_framed_window
+++ b/test/sql/test_distinct_aggregation_over_framed_window/T/test_distinct_aggregation_over_framed_window
@@ -1,0 +1,486 @@
+-- name: test_distinct_aggregation_over_framed_window
+CREATE TABLE `t0` (
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `v3` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP
+PROPERTIES("replication_num"="1");
+insert into t0 select i/19 as v1, i/11 as v2, i/5 as v3 from table(generate_series(1,100)) t(i);
+select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0))+murmur_hash3_32(ifnull(sum,0))+murmur_hash3_32(ifnull(avg,0))+murmur_hash3_32(ifnull(count,0))+murmur_hash3_32(ifnull(rank,0))+murmur_hash3_32(ifnull(d_rank,0))+murmur_hash3_32(ifnull(rn,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_avg,
+sum(cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as sum,
+avg(cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as avg,
+count(cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as count,
+rank()over(partition by v1 order by v2) as rank,
+dense_rank()over(partition by v1 order by v2) as d_rank,
+row_number()over(partition by v1 order by v2) as rn
+from t0) as t;
+with cte as(
+select distinct v1,v2,v3,
+ count(distinct v3)over(partition by v1 order by v2) as dist_count,
+ sum(distinct v3)over(partition by v1 order by v2) as dist_sum,
+ avg(distinct v3)over(partition by v1 order by v2) as dist_avg
+from t0
+),
+cte1 as(
+select v1,v2,v3,
+ count(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_count,
+ sum(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_sum,
+ avg(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_avg
+from t0 
+)
+select 
+   assert_true(count(1)=count(if(cte.dist_count = cte1.dist_count, 1, NULL))), 
+   assert_true(count(1)=count(if(cte.dist_sum = cte1.dist_sum, 1, NULL))), 
+   assert_true(count(1)=count(if(cte.dist_avg = cte1.dist_avg, 1, NULL)))
+from cte join cte1 on cte.v1 = cte1.v1 and cte.v2 = cte1.v2 and cte.v3 = cte1.v3;
+/*q0*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(7,2)))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as decimal(7,2)))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as decimal(7,2)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q1*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(7,2)))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as decimal(7,2)))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q2*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(7,2)))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as decimal(7,2)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q3*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as decimal(7,2)))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as decimal(7,2)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q4*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(7,2)))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+/*q5*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as decimal(7,2)))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q6*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as decimal(7,2)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q7*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q8*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q9*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q10*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q11*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+/*q12*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q13*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as decimal(19,2)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q14*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(38,19)))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as decimal(38,19)))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as decimal(38,19)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q15*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(38,19)))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as decimal(38,19)))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q16*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(38,19)))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as decimal(38,19)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q17*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as decimal(38,19)))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as decimal(38,19)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q18*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(38,19)))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+/*q19*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as decimal(38,19)))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q20*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as decimal(38,19)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q21*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(38,20)))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as decimal(38,20)))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as decimal(38,20)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q22*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(38,20)))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as decimal(38,20)))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q23*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(38,20)))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as decimal(38,20)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q24*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as decimal(38,20)))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as decimal(38,20)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q25*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(38,20)))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+/*q26*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as decimal(38,20)))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q27*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as decimal(38,20)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q28*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(38,18)))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as decimal(38,18)))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as decimal(38,18)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q29*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(38,18)))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as decimal(38,18)))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q30*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(38,18)))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as decimal(38,18)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q31*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as decimal(38,18)))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as decimal(38,18)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q32*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(38,18)))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+/*q33*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as decimal(38,18)))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q34*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as decimal(38,18)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q35*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(39,18)))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as decimal(39,18)))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as decimal(39,18)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q36*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(39,18)))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as decimal(39,18)))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q37*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(39,18)))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as decimal(39,18)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q38*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as decimal(39,18)))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as decimal(39,18)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q39*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as decimal(39,18)))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+/*q40*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as decimal(39,18)))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q41*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as decimal(39,18)))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q42*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as boolean))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as boolean))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as boolean))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q43*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as boolean))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as boolean))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q44*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as boolean))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as boolean))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q45*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as boolean))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as boolean))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q46*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as boolean))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+/*q47*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as boolean))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q48*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as boolean))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q49*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as tinyint))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as tinyint))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as tinyint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q50*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as tinyint))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as tinyint))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q51*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as tinyint))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as tinyint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q52*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as tinyint))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as tinyint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q53*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as tinyint))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+/*q54*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as tinyint))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q55*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as tinyint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q56*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as int))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as int))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as int))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q57*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as int))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as int))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q58*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as int))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as int))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q59*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as int))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as int))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q60*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as int))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+/*q61*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as int))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q62*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as int))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q63*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as smallint))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as smallint))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as smallint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q64*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as smallint))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as smallint))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q65*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as smallint))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as smallint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q66*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as smallint))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as smallint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q67*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as smallint))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+/*q68*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as smallint))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q69*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as smallint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q70*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as bigint))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as bigint))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as bigint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q71*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as bigint))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as bigint))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q72*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as bigint))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as bigint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q73*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as bigint))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as bigint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q74*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as bigint))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+/*q75*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as bigint))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q76*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as bigint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q77*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as largeint))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as largeint))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as largeint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q78*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as largeint))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as largeint))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q79*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as largeint))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as largeint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q80*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as largeint))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as largeint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q81*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as largeint))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+/*q82*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as largeint))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q83*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as largeint))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q84*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as float))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as float))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as float))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q85*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as float))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as float))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q86*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as float))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as float))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q87*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as float))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as float))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q88*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as float))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+/*q89*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as float))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q90*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as float))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q91*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as double))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as double))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as double))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q92*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as double))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as double))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q93*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as double))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as double))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q94*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as double))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as double))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q95*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as double))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+/*q96*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as double))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q97*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as double))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q98*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as string))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as string))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as string))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q99*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as string))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as string))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q100*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as string))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as string))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q101*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as string))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as string))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q102*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as string))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+/*q103*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as string))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q104*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as string))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q105*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as varchar))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as varchar))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as varchar))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q106*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as varchar))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as varchar))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q107*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as varchar))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as varchar))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q108*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as varchar))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as varchar))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q109*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as varchar))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+/*q110*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as varchar))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q111*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as varchar))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q112*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as char))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as char))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as char))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q113*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as char))over(partition by v1 order by v2) as dist_count,
+sum(distinct cast(v3 as char))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q114*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as char))over(partition by v1 order by v2) as dist_count,
+avg(distinct cast(v3 as char))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q115*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as char))over(partition by v1 order by v2) as dist_sum,
+avg(distinct cast(v3 as char))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q116*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(v3 as char))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+/*q117*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_sum,0)))) as fingerprint from (select v1,v2,v3,
+sum(distinct cast(v3 as char))over(partition by v1 order by v2) as dist_sum
+from t0) as t;
+/*q118*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_avg,0)))) as fingerprint from (select v1,v2,v3,
+avg(distinct cast(v3 as char))over(partition by v1 order by v2) as dist_avg
+from t0) as t;
+/*q119*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct cast(days_add('2025-01-01',v3) as date))over(partition by v1 order by v2) as dist_count
+from t0) as t;
+/*q120*/select  (sum(murmur_hash3_32(ifnull(v1,0))+murmur_hash3_32(ifnull(v2,0))+murmur_hash3_32(ifnull(v3,0))+murmur_hash3_32(ifnull(dist_count,0)))) as fingerprint from (select v1,v2,v3,
+count(distinct days_add('2025-01-01 00:00:00',v3))over(partition by v1 order by v2) as dist_count
+from t0) as t;


### PR DESCRIPTION
## Why I'm doing:

This PR is used to support count/sum/avg(distinct) over range-frame window.

range-frame windows can be categorized into two types:
1. type-1. overall window:  for examples:
```sql
    -- Q1
    select a, b, count(distinct a) over() from t;
    -- Q2
    select a, b, count(distinct a) over(partition by b) from t;
```
2. type-2. framed window: for examples:
```sql
    -- Q3
    select a, b, count(distinct a) over(order by b) from t;
    -- Q4
    select a, b, c, count(distinct a) over(partition by b order by c) from t;
```

both types of distinct aggregations over range-frame windows are supported now.
two session variables are used to control behavior:
1. enable_distinct_agg_over_window(in default true): turn on this enhancements. 
2. optimize_distinct_agg_over_framed_window(in default 0): -1 disabled, 0: adapts on multi-column cardinality, 1: open forcely; this variables are used to optimize type-2(framed window). 

For Q1, the query is rewritten into agg + cross-join, as following:
```sql
with cte as(
select count(distinct a) cda from t
)
select t.a, t.b, cte.cda from t CROSS JOIN cte;
```
For Q2, the query is rewritten into agg + null-safe-equal-join, as following:

```sql
with cte as(
  select b, count(distinct a) cda
  from t
  group by b
)
select t.a, t.b, cte.cda
from t inner join cte on t.b <=> t.b;
```

for Q3 and Q4, we introduce fused_multi_distinct aggregation function for process count/sum/avg(distinct), when
the distinct aggregations are applied to same window and same column, then its agg state are fused into one state.

fused_multi_distinct prototype as follows
```
fused_multi_distinct_count[_sum][_avg]: Type -> StructType("count": BIGINT[, "sum": sumType][, "avg": avgType);
```
for an example:
```sql
select a, b, c,
    count(distinct c) over(partition by a order by b),
    sum(distinct c) over(partition by a order by b),
    avg(distinct c) over(partition by a order by b),
from t;
```
above query is rewritten into the plan just as follow query shows
```
with cte as(
select a,b,c,
fused_multi_distinct_count_sum_avg(c) over(partition by a order by b) fmdc
from t
)
select a,b,c, fmdc.count, fmdc.sum, fmdc.avg
from cte;
```
So for Q3, it is transformed into

```sql
with cte as (
select a, b, fused_multi_distinct_count(distinct a) over(order by b) fmdc from t
)
select a, b, fmdc.count from cte
```

For Q4, it is transformed into
```
with cte as (
select a, b, c, fused_multi_distinct_count(distinct a) over(partition by b order by c) fmdc from t;
)
select a, b, c, fmdc.count from cte;
```

For framed windows(Q3,Q4), we try to optimize the queries to reduce input rows of window operators when
1. when multi column cardinality of partition-by columns, order-by columns and distinct columns are low;
4. when session variable optimize_distinct_agg_over_framed_window = 1.

when optimization is enabled, Q3 and Q4 would be transformed into

```sql
-- optimized Q3
with cte0 as (
select distinct a,b from t
),
cte1 as (
select b, fused_multi_distinct_count(distinct a) over(order by b) fmdc from cte0
),
cte2 as (
select distinct b, fmdc.count
)

select t.a, t.b, cte2.fmdc.count from t inner join cte2 on t.b <=> cte2.b

-- optimized Q4
with cte0 as (
select distinct a, b, c from t
),
cte1 as (
select b, c, fused_multi_distinct_count(distinct a) over(partition by b order by c) fmdc from cte0
),
cte2 as (
select distinct b, c, fmdc.count
)
select t.a, t.b, t.c, cte2.fmdc.count from t inner join cte2 on t.b <=> cte2.b and t.c <=> cte2.c
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds COUNT/SUM/AVG DISTINCT over RANGE windows via new `fused_multi_distinct_*` window aggs and planner rewrites, with session-controlled optimization.
> 
> - **Window DISTINCT over RANGE frames**:
>   - Enable `COUNT/SUM/AVG(DISTINCT ...)` for RANGE windows, including overall and framed cases.
>   - Planner rewrites:
>     - Overall windows -> aggregate + cross/null-safe join.
>     - Framed windows -> new `fused_multi_distinct_*` window agg with optional pre-dedup/CTE+join optimization.
>   - Controlled by session vars: `enable_distinct_agg_over_window`, `optimize_distinct_agg_over_framed_window`.
> - **Backend (BE)**:
>   - Implement `TFusedMultiDistinctFunction` and supporting aggregate states; compute `count`/`sum`/`avg` in-place.
>   - Register factory/resolver for `fused_multi_distinct_count[_sum][_avg]` window functions.
>   - `Analytor`: ensure result column sizing for `fused_multi_distinct` outputs.
> - **Frontend (FE)**:
>   - New function names in `FunctionSet` and builtin registrations with struct return type (`count`, `sum`, `avg`).
>   - Analyzer: allow DISTINCT in RANGE windows for `sum/avg/count`.
>   - Optimizer:
>     - New/expanded `DistinctAggregationOverWindowRule` handling overall/framed windows and fusion; placement adjusted in pipeline.
>     - `ScalarOperatorUtil`: build fused multi-distinct call and projected subfields.
>   - Session variables added/getters.
> - **Tests**:
>   - Planner and SQL tests covering framed windows, fused types, and mixed functions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 073ab6b51e2d248ea1fb8d785037bb05980257ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->