### PR TITLE
[Enhancement] Add http service to get service id in shared-data mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
@@ -60,6 +60,7 @@ import com.starrocks.http.meta.MetaService.InfoAction;
 import com.starrocks.http.meta.MetaService.JournalIdAction;
 import com.starrocks.http.meta.MetaService.PutAction;
 import com.starrocks.http.meta.MetaService.RoleAction;
+import com.starrocks.http.meta.MetaService.ServiceIdAction;
 import com.starrocks.http.meta.MetaService.VersionAction;
 import com.starrocks.http.rest.BootstrapFinishAction;
 import com.starrocks.http.rest.CancelStreamLoadAction;
@@ -257,6 +258,7 @@ public class HttpServer {
         CheckAction.registerAction(controller);
         DumpAction.registerAction(controller);
         DumpStarMgrAction.registerAction(controller);
+        ServiceIdAction.registerAction(controller);
         RoleAction.registerAction(controller);
 
         // external usage

--- a/fe/fe-core/src/main/java/com/starrocks/http/meta/MetaService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/meta/MetaService.java
@@ -483,4 +483,40 @@ public class MetaService {
             return;
         }
     }
+
+    public static class ServiceIdAction extends MetaBaseAction {
+
+        public ServiceIdAction(ActionController controller) {
+            super(controller);
+        }
+
+        public static void registerAction(ActionController controller)
+                throws IllegalArgException {
+            controller.registerHandler(HttpMethod.GET, "/service_id", new ServiceIdAction(controller));
+        }
+
+        @Override
+        public boolean needAdmin() {
+            return true;
+        }
+
+        @Override
+        protected boolean needCheckClientIsFe() {
+            return false;
+        }
+
+        @Override
+        public void executeGet(BaseRequest request, BaseResponse response) {
+            if (RunMode.getCurrentRunMode() != RunMode.SHARED_DATA) {
+                String str = "Current run mode " + RunMode.name() + " does not support service id.";
+                response.appendContent(str);
+                writeResponse(request, response, HttpResponseStatus.NOT_FOUND);
+            } else {
+                response.setContentType("application/json");
+                String serviceId = GlobalStateMgr.getCurrentState().getStarOSAgent().getRawServiceId();
+                response.appendContent("{\"service_id\": \"" + serviceId + "\"}");
+                writeResponse(request, response);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Add http service to get service id in shared-data mode

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds GET `/service_id` to return StarOS service id as JSON in shared-data mode (404 otherwise) and registers the handler in `HttpServer`.
> 
> - **HTTP Meta Service**:
>   - **New endpoint**: `GET /service_id` (`MetaService.ServiceIdAction`)
>     - Admin-only; client need not be FE.
>     - Returns JSON `{"service_id": "..."}` in `SHARED_DATA` mode; responds 404 otherwise.
> - **Server wiring**:
>   - Registers `ServiceIdAction` in `HttpServer` and adds necessary imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e821ec786ad0c8c4a497d9057b740174b590b021. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->