### PR TITLE
[BugFix]Fix filesystem cache failure.

### DIFF
--- a/be/src/service/staros_worker.cpp
+++ b/be/src/service/staros_worker.cpp
@@ -285,7 +285,7 @@ absl::StatusOr<std::shared_ptr<fslib::FileSystem>> StarOSWorker::build_filesyste
 
 absl::StatusOr<std::pair<std::shared_ptr<std::string>, std::shared_ptr<fslib::FileSystem>>>
 StarOSWorker::build_filesystem_from_shard_info(const ShardInfo& info, const Configuration& conf,
-                                               std::shared_ptr<std::string> existing_fs_cache_key) {
+                                               const std::shared_ptr<std::string>& existing_fs_cache_key) {
     auto localconf = build_conf_from_shard_info(info);
     if (!localconf.ok()) {
         return localconf.status();
@@ -295,7 +295,7 @@ StarOSWorker::build_filesystem_from_shard_info(const ShardInfo& info, const Conf
         return scheme.status();
     }
 
-    return new_shared_filesystem(info.id, *scheme, *localconf, std::move(existing_fs_cache_key));
+    return new_shared_filesystem(info.id, *scheme, *localconf, existing_fs_cache_key);
 }
 
 bool StarOSWorker::need_enable_cache(const ShardInfo& info) {
@@ -338,7 +338,7 @@ absl::StatusOr<fslib::Configuration> StarOSWorker::build_conf_from_shard_info(co
 
 absl::StatusOr<std::pair<std::shared_ptr<std::string>, std::shared_ptr<fslib::FileSystem>>>
 StarOSWorker::new_shared_filesystem(ShardId shard_id, std::string_view scheme, const Configuration& conf,
-                                    std::shared_ptr<std::string> existing_fs_cache_key) {
+                                    const std::shared_ptr<std::string>& existing_fs_cache_key) {
     std::string cache_key = get_cache_key(scheme, conf);
 
     // Lookup LRU cache

--- a/be/src/service/staros_worker.cpp
+++ b/be/src/service/staros_worker.cpp
@@ -221,14 +221,14 @@ absl::StatusOr<std::shared_ptr<fslib::FileSystem>> StarOSWorker::get_shard_files
             return build_filesystem_on_demand(id, conf);
         }
 
-        auto fs = lookup_fs_cache(it->second.fs_cache_key);
-        if (fs != nullptr) {
-            return fs;
-        }
-
         // Cache miss: reset the fs_cache_key to ensure a new shared_ptr will be created
         {
             std::lock_guard<std::mutex> reset_lock(_fs_cache_key_reset_mtx);
+            auto fs = lookup_fs_cache(it->second.fs_cache_key);
+            if (fs != nullptr) {
+                return fs;
+            }
+
             it->second.fs_cache_key.reset();
         }
         shard_info = it->second.shard_info;

--- a/be/src/service/staros_worker.cpp
+++ b/be/src/service/staros_worker.cpp
@@ -230,7 +230,7 @@ absl::StatusOr<std::shared_ptr<fslib::FileSystem>> StarOSWorker::get_shard_files
 
     // Build the filesystem under no lock, so the op won't hold the lock for a long time.
     // It is possible that multiple filesystems are built for the same shard from multiple threads under no lock here.
-    auto fs_or = build_filesystem_from_shard_info(id, shard_info, conf);
+    auto fs_or = build_filesystem_from_shard_info(shard_info, conf);
     if (!fs_or.ok()) {
         return fs_or.status();
     }
@@ -272,7 +272,7 @@ absl::StatusOr<std::shared_ptr<fslib::FileSystem>> StarOSWorker::build_filesyste
     if (!info_or.ok()) {
         return info_or.status();
     }
-    auto fs_or = build_filesystem_from_shard_info(id, info_or.value(), conf);
+    auto fs_or = build_filesystem_from_shard_info(info_or.value(), conf);
     if (!fs_or.ok()) {
         return fs_or.status();
     }
@@ -282,7 +282,7 @@ absl::StatusOr<std::shared_ptr<fslib::FileSystem>> StarOSWorker::build_filesyste
 }
 
 absl::StatusOr<std::pair<std::shared_ptr<std::string>, std::shared_ptr<fslib::FileSystem>>>
-StarOSWorker::build_filesystem_from_shard_info(ShardId shard_id, const ShardInfo& info, const Configuration& conf) {
+StarOSWorker::build_filesystem_from_shard_info(const ShardInfo& info, const Configuration& conf) {
     auto localconf = build_conf_from_shard_info(info);
     if (!localconf.ok()) {
         return localconf.status();
@@ -292,7 +292,7 @@ StarOSWorker::build_filesystem_from_shard_info(ShardId shard_id, const ShardInfo
         return scheme.status();
     }
 
-    return new_shared_filesystem(shard_id, *scheme, *localconf);
+    return new_shared_filesystem(info.id, *scheme, *localconf);
 }
 
 bool StarOSWorker::need_enable_cache(const ShardInfo& info) {

--- a/be/src/service/staros_worker.cpp
+++ b/be/src/service/staros_worker.cpp
@@ -295,7 +295,7 @@ StarOSWorker::build_filesystem_from_shard_info(const ShardInfo& info, const Conf
         return scheme.status();
     }
 
-    return new_shared_filesystem(info.id, *scheme, *localconf, existing_fs_cache_key);
+    return new_shared_filesystem(info.id, *scheme, *localconf, std::move(existing_fs_cache_key));
 }
 
 bool StarOSWorker::need_enable_cache(const ShardInfo& info) {
@@ -384,7 +384,7 @@ std::string StarOSWorker::get_cache_key(std::string_view scheme, const Configura
 
 std::shared_ptr<std::string> StarOSWorker::insert_fs_cache(const std::string& key,
                                                            const std::shared_ptr<FileSystem>& fs,
-                                                           std::shared_ptr<std::string> existing_fs_cache_key) {
+                                                           const std::shared_ptr<std::string>& existing_fs_cache_key) {
     std::shared_ptr<std::string> fs_cache_key;
 
     // Reuse existing fs_cache_key if it matches the current key

--- a/be/src/service/staros_worker.cpp
+++ b/be/src/service/staros_worker.cpp
@@ -295,7 +295,7 @@ StarOSWorker::build_filesystem_from_shard_info(const ShardInfo& info, const Conf
         return scheme.status();
     }
 
-    return new_shared_filesystem(info.id, *scheme, *localconf, existing_fs_cache_key);
+    return new_shared_filesystem(*scheme, *localconf, existing_fs_cache_key);
 }
 
 bool StarOSWorker::need_enable_cache(const ShardInfo& info) {
@@ -337,7 +337,7 @@ absl::StatusOr<fslib::Configuration> StarOSWorker::build_conf_from_shard_info(co
 }
 
 absl::StatusOr<std::pair<std::shared_ptr<std::string>, std::shared_ptr<fslib::FileSystem>>>
-StarOSWorker::new_shared_filesystem(ShardId shard_id, std::string_view scheme, const Configuration& conf,
+StarOSWorker::new_shared_filesystem(std::string_view scheme, const Configuration& conf,
                                     const std::shared_ptr<std::string>& existing_fs_cache_key) {
     std::string cache_key = get_cache_key(scheme, conf);
 

--- a/be/src/service/staros_worker.h
+++ b/be/src/service/staros_worker.h
@@ -123,7 +123,7 @@ private:
 
     absl::StatusOr<std::shared_ptr<FileSystem>> build_filesystem_on_demand(ShardId id, const Configuration& conf);
     absl::StatusOr<std::pair<std::shared_ptr<std::string>, std::shared_ptr<FileSystem>>>
-    build_filesystem_from_shard_info(ShardId shard_id, const ShardInfo& info, const Configuration& conf);
+    build_filesystem_from_shard_info(const ShardInfo& info, const Configuration& conf);
     absl::StatusOr<std::pair<std::shared_ptr<std::string>, std::shared_ptr<FileSystem>>> new_shared_filesystem(
             ShardId shard_id, std::string_view scheme, const Configuration& conf);
     absl::Status invalidate_fs(const ShardInfo& shard);

--- a/be/src/service/staros_worker.h
+++ b/be/src/service/staros_worker.h
@@ -123,12 +123,13 @@ private:
 
     absl::StatusOr<std::shared_ptr<FileSystem>> build_filesystem_on_demand(ShardId id, const Configuration& conf);
     absl::StatusOr<std::pair<std::shared_ptr<std::string>, std::shared_ptr<FileSystem>>>
-    build_filesystem_from_shard_info(const ShardInfo& info, const Configuration& conf);
+    build_filesystem_from_shard_info(ShardId shard_id, const ShardInfo& info, const Configuration& conf);
     absl::StatusOr<std::pair<std::shared_ptr<std::string>, std::shared_ptr<FileSystem>>> new_shared_filesystem(
-            std::string_view scheme, const Configuration& conf);
+            ShardId shard_id, std::string_view scheme, const Configuration& conf);
     absl::Status invalidate_fs(const ShardInfo& shard);
 
-    std::shared_ptr<std::string> insert_fs_cache(const std::string& key, const std::shared_ptr<FileSystem>& fs);
+    std::shared_ptr<std::string> insert_fs_cache(ShardId shard_id, const std::string& key,
+                                                 const std::shared_ptr<FileSystem>& fs);
     void erase_fs_cache(const std::string& key);
     std::shared_ptr<FileSystem> lookup_fs_cache(const std::string& key);
     std::shared_ptr<FileSystem> lookup_fs_cache(const std::shared_ptr<std::string>& key);

--- a/be/src/service/staros_worker.h
+++ b/be/src/service/staros_worker.h
@@ -124,10 +124,10 @@ private:
     absl::StatusOr<std::shared_ptr<FileSystem>> build_filesystem_on_demand(ShardId id, const Configuration& conf);
     absl::StatusOr<std::pair<std::shared_ptr<std::string>, std::shared_ptr<FileSystem>>>
     build_filesystem_from_shard_info(const ShardInfo& info, const Configuration& conf,
-                                     std::shared_ptr<std::string> existing_fs_cache_key = nullptr);
+                                     const std::shared_ptr<std::string>& existing_fs_cache_key = nullptr);
     absl::StatusOr<std::pair<std::shared_ptr<std::string>, std::shared_ptr<FileSystem>>> new_shared_filesystem(
             ShardId shard_id, std::string_view scheme, const Configuration& conf,
-            std::shared_ptr<std::string> existing_fs_cache_key = nullptr);
+            const std::shared_ptr<std::string>& existing_fs_cache_key = nullptr);
     absl::Status invalidate_fs(const ShardInfo& shard);
 
     std::shared_ptr<std::string> insert_fs_cache(const std::string& key, const std::shared_ptr<FileSystem>& fs,

--- a/be/src/service/staros_worker.h
+++ b/be/src/service/staros_worker.h
@@ -123,13 +123,15 @@ private:
 
     absl::StatusOr<std::shared_ptr<FileSystem>> build_filesystem_on_demand(ShardId id, const Configuration& conf);
     absl::StatusOr<std::pair<std::shared_ptr<std::string>, std::shared_ptr<FileSystem>>>
-    build_filesystem_from_shard_info(const ShardInfo& info, const Configuration& conf);
+    build_filesystem_from_shard_info(const ShardInfo& info, const Configuration& conf,
+                                     std::shared_ptr<std::string> existing_fs_cache_key = nullptr);
     absl::StatusOr<std::pair<std::shared_ptr<std::string>, std::shared_ptr<FileSystem>>> new_shared_filesystem(
-            ShardId shard_id, std::string_view scheme, const Configuration& conf);
+            ShardId shard_id, std::string_view scheme, const Configuration& conf,
+            std::shared_ptr<std::string> existing_fs_cache_key = nullptr);
     absl::Status invalidate_fs(const ShardInfo& shard);
 
-    std::shared_ptr<std::string> insert_fs_cache(ShardId shard_id, const std::string& key,
-                                                 const std::shared_ptr<FileSystem>& fs);
+    std::shared_ptr<std::string> insert_fs_cache(const std::string& key, const std::shared_ptr<FileSystem>& fs,
+                                                 std::shared_ptr<std::string> existing_fs_cache_key = nullptr);
     void erase_fs_cache(const std::string& key);
     std::shared_ptr<FileSystem> lookup_fs_cache(const std::string& key);
     std::shared_ptr<FileSystem> lookup_fs_cache(const std::shared_ptr<std::string>& key);

--- a/be/src/service/staros_worker.h
+++ b/be/src/service/staros_worker.h
@@ -131,7 +131,7 @@ private:
     absl::Status invalidate_fs(const ShardInfo& shard);
 
     std::shared_ptr<std::string> insert_fs_cache(const std::string& key, const std::shared_ptr<FileSystem>& fs,
-                                                 std::shared_ptr<std::string> existing_fs_cache_key = nullptr);
+                                                 const std::shared_ptr<std::string>& existing_fs_cache_key = nullptr);
     void erase_fs_cache(const std::string& key);
     std::shared_ptr<FileSystem> lookup_fs_cache(const std::string& key);
     std::shared_ptr<FileSystem> lookup_fs_cache(const std::shared_ptr<std::string>& key);

--- a/be/src/service/staros_worker.h
+++ b/be/src/service/staros_worker.h
@@ -123,15 +123,12 @@ private:
 
     absl::StatusOr<std::shared_ptr<FileSystem>> build_filesystem_on_demand(ShardId id, const Configuration& conf);
     absl::StatusOr<std::pair<std::shared_ptr<std::string>, std::shared_ptr<FileSystem>>>
-    build_filesystem_from_shard_info(const ShardInfo& info, const Configuration& conf,
-                                     const std::shared_ptr<std::string>& existing_fs_cache_key = nullptr);
+    build_filesystem_from_shard_info(const ShardInfo& info, const Configuration& conf);
     absl::StatusOr<std::pair<std::shared_ptr<std::string>, std::shared_ptr<FileSystem>>> new_shared_filesystem(
-            std::string_view scheme, const Configuration& conf,
-            const std::shared_ptr<std::string>& existing_fs_cache_key = nullptr);
+            std::string_view scheme, const Configuration& conf);
     absl::Status invalidate_fs(const ShardInfo& shard);
 
-    std::shared_ptr<std::string> insert_fs_cache(const std::string& key, const std::shared_ptr<FileSystem>& fs,
-                                                 const std::shared_ptr<std::string>& existing_fs_cache_key = nullptr);
+    std::shared_ptr<std::string> insert_fs_cache(const std::string& key, const std::shared_ptr<FileSystem>& fs);
     void erase_fs_cache(const std::string& key);
     std::shared_ptr<FileSystem> lookup_fs_cache(const std::string& key);
     std::shared_ptr<FileSystem> lookup_fs_cache(const std::shared_ptr<std::string>& key);
@@ -141,6 +138,7 @@ private:
 private:
     mutable std::shared_mutex _mtx;
     std::shared_mutex _cache_mtx;
+    std::mutex _fs_cache_key_reset_mtx; // Protects fs_cache_key reset operations
     std::unordered_map<ShardId, ShardInfoDetails> _shards;
     std::unique_ptr<Cache> _fs_cache;
     add_shard_listener _add_shard_listener;

--- a/be/src/service/staros_worker.h
+++ b/be/src/service/staros_worker.h
@@ -126,7 +126,7 @@ private:
     build_filesystem_from_shard_info(const ShardInfo& info, const Configuration& conf,
                                      const std::shared_ptr<std::string>& existing_fs_cache_key = nullptr);
     absl::StatusOr<std::pair<std::shared_ptr<std::string>, std::shared_ptr<FileSystem>>> new_shared_filesystem(
-            ShardId shard_id, std::string_view scheme, const Configuration& conf,
+            std::string_view scheme, const Configuration& conf,
             const std::shared_ptr<std::string>& existing_fs_cache_key = nullptr);
     absl::Status invalidate_fs(const ShardInfo& shard);
 


### PR DESCRIPTION
## Why I'm doing:

1. select takes 0.06s
```
919 rows in set (0.06 sec)

mysql> 
mysql> 
mysql> select * from ads_member_integral_dashboard_1day_new;
```
2. set starlet_filesystem_instance_cache_capacity to 0
```
mysql> update information_schema.be_configs set value = 0 where name = "starlet_filesystem_instance_cache_capacity";
Query OK, 0 rows affected (0.17 sec)
```
3.  select takes  24.33s
```
919 rows in set (24.33 sec)

mysql> select * from ads_member_integral_dashboard_1day_new;
```

4.  set starlet_filesystem_instance_cache_capacity to 10000
```
mysql> update information_schema.be_configs set value = 10000 where name = "starlet_filesystem_instance_cache_capacity";
Query OK, 0 rows affected (0.02 sec)

```
5. select still takes
```
919 rows in set (21.30 sec)

mysql> select * from ads_member_integral_dashboard_1day_new;
```

6. create new table from ads_member_integral_dashboard_1day_new
```
create table a01 as select * from ads_member_integral_dashboard_1day_new;
Query OK, 919 rows affected (23.72 sec)
{'label':'insert_66677f66-c61f-11f0-86f9-525400979433', 'status':'VISIBLE', 'txnId':'34767'}
```

7. select a01 takes 
```
919 rows in set (0.06 sec)

mysql> select * from a01;
```
## What I'm doing:
https://github.com/StarRocks/starrocks/pull/60053  has been fixed the bug resolving the cache failure issue. However, the problem still persists where the same string cache_key holds two `std::shared_ptr<std::string>` objects.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
