### PR TITLE
[BugFix] Fix exception when read DateTime('Asia/Shanghai') Type of Clickhouse

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolver.java
@@ -143,6 +143,10 @@ public class ClickhouseSchemaResolver extends JDBCSchemaResolver {
                     int scale = Integer.parseInt(precisionAndScale[1]);
                     return TypeFactory.createUnifiedDecimalType(precision, scale);
                 }
+            case Types.TIME_WITH_TIMEZONE:
+                // TIME_WITH_TIMEZONE
+            case Types.TIMESTAMP_WITH_TIMEZONE:
+                return TypeFactory.createVarcharType(65533);
             default:
                 primitiveType = PrimitiveType.UNKNOWN_TYPE;
                 break;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolver.java
@@ -143,7 +143,7 @@ public class ClickhouseSchemaResolver extends JDBCSchemaResolver {
                     int scale = Integer.parseInt(precisionAndScale[1]);
                     return TypeFactory.createUnifiedDecimalType(precision, scale);
                 }
-            case Types.TIME_WITH_TIMEZONE, Types.TIMESTAMP_WITH_TIMEZONE::
+            case Types.TIME_WITH_TIMEZONE, Types.TIMESTAMP_WITH_TIMEZONE:
                 return TypeFactory.createVarcharType(65533);
             default:
                 primitiveType = PrimitiveType.UNKNOWN_TYPE;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolver.java
@@ -143,9 +143,7 @@ public class ClickhouseSchemaResolver extends JDBCSchemaResolver {
                     int scale = Integer.parseInt(precisionAndScale[1]);
                     return TypeFactory.createUnifiedDecimalType(precision, scale);
                 }
-            case Types.TIME_WITH_TIMEZONE:
-                // TIME_WITH_TIMEZONE
-            case Types.TIMESTAMP_WITH_TIMEZONE:
+            case Types.TIME_WITH_TIMEZONE, Types.TIMESTAMP_WITH_TIMEZONE::
                 return TypeFactory.createVarcharType(65533);
             default:
                 primitiveType = PrimitiveType.UNKNOWN_TYPE;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/ClickhouseSchemaResolverTest.java
@@ -66,21 +66,21 @@ public class ClickhouseSchemaResolverTest {
                         Types.BIGINT, Types.NUMERIC, Types.NUMERIC, Types.NUMERIC, Types.NUMERIC, Types.NUMERIC,
                         Types.FLOAT,
                         Types.DOUBLE, Types.BOOLEAN, Types.DATE, Types.TIMESTAMP, Types.VARCHAR, Types.VARCHAR,
-                        Types.DECIMAL, Types.DECIMAL
+                        Types.DECIMAL, Types.DECIMAL, Types.TIMESTAMP_WITH_TIMEZONE
                 ));
         columnResult.addColumn("TYPE_NAME", Arrays.asList("Int8", "UInt8", "Int16", "UInt16", "Int32", "Int64",
                 "UInt32", "UInt64", "Int128", "UInt128", "Int256", "UInt256", "Float32", "Float64", "Bool", "Date",
                 "DateTime",
-                "String", "Nullable(String)", "Decimal(9,9)", "Nullable(Decimal(9,9))"));
+                "String", "Nullable(String)", "Decimal(9,9)", "Nullable(Decimal(9,9))", "DateTime64(3, 'Asia/Shanghai')"));
         columnResult.addColumn("COLUMN_SIZE",
-                Arrays.asList(3, 3, 5, 5, 10, 19, 10, 20, 39, 39, 77, 78, 12, 22, 1, 10, 29, 0, 0, 9, 9));
+                Arrays.asList(3, 3, 5, 5, 10, 19, 10, 20, 39, 39, 77, 78, 12, 22, 1, 10, 29, 0, 0, 9, 9, 29));
         columnResult.addColumn("DECIMAL_DIGITS",
-                Arrays.asList(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null, 0, 0, null, null, 9, 9));
+                Arrays.asList(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null, 0, 0, null, null, 9, 9, null));
         columnResult.addColumn("COLUMN_NAME", Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l",
-                "m", "n", "o", "p", "q", "r", "s", "t", "u"));
+                "m", "n", "o", "p", "q", "r", "s", "t", "u", "v"));
         columnResult.addColumn("IS_NULLABLE",
                 Arrays.asList("NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO",
-                        "NO", "NO", "NO", "YES", "NO", "YES"));
+                        "NO", "NO", "NO", "YES", "NO", "YES", "NO"));
         properties = new HashMap<>();
         properties.put(DRIVER_CLASS, "com.clickhouse.jdbc.ClickHouseDriver");
         properties.put(JDBCResource.URI, "jdbc:clickhouse://127.0.0.1:8123");


### PR DESCRIPTION
## Why I'm doing:
When excuting "select * from ck_catalog046.default.time_test;" to read the Clickhouse table with DateTime('Asia/Shanghai')/DateTime64(3,'UTC') type of column, starrocks will throw a ERROR.
The Error is as follows:
ERROR 1064 (HY000): Getting analyzing error. Detail message: Datatype of external table column [event_time] is not supported!.
## What I'm doing:
Add case condition to handle column in clickhouse with Types.TIME_WITH_TIMEZONE/Types.TIMESTAMP_WITH_TIMEZONE and return varchar(65533)
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Handle ClickHouse timezone-aware time/timestamp by mapping `TIME_WITH_TIMEZONE`/`TIMESTAMP_WITH_TIMEZONE` to `varchar(65533)` and update tests accordingly.
> 
> - **JDBC ClickHouse schema resolution**:
>   - Map `Types.TIME_WITH_TIMEZONE` and `Types.TIMESTAMP_WITH_TIMEZONE` to `varchar(65533)` in `convertColumnType`.
> - **Tests**:
>   - Extend `ClickhouseSchemaResolverTest` fixtures to include a timezone-aware timestamp column (e.g., `DateTime64(3, 'Asia/Shanghai')`).
>   - Update corresponding `DATA_TYPE`, `TYPE_NAME`, `COLUMN_SIZE`, `DECIMAL_DIGITS`, `COLUMN_NAME`, and `IS_NULLABLE` arrays to cover the new case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7343fe22d98e991f0de767d61727956939192466. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->