### PR TITLE
[Enhancement] Add ConvertTimeZonePredicateRule to support partition prune

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
@@ -22,6 +22,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.scalar.ArithmeticCommutativeRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ConsolidateLikesRule;
+import com.starrocks.sql.optimizer.rewrite.scalar.ConvertTimeZonePredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ExtractCommonPredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.FoldConstantsRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ImplicitCastRule;
@@ -55,6 +56,8 @@ public class ScalarOperatorRewriter {
             new SimplifiedDateColumnPredicateRule(),
             new ExtractCommonPredicateRule(),
             new ArithmeticCommutativeRule(),
+            new ConvertTimeZonePredicateRule(),
+
             ConsolidateLikesRule.INSTANCE
     );
 
@@ -85,6 +88,7 @@ public class ScalarOperatorRewriter {
             new SimplifiedDateColumnPredicateRule(),
             new ExtractCommonPredicateRule(),
             new ArithmeticCommutativeRule(),
+            new ConvertTimeZonePredicateRule(),
             ConsolidateLikesRule.INSTANCE
     );
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ConvertTimeZonePredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ConvertTimeZonePredicateRule.java
@@ -1,0 +1,63 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rewrite.scalar;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriteContext;
+
+import java.util.List;
+
+/**
+ * e.g.
+ * select * from t where convert_tz(__time, '+08:00', '+09:00') > '2025-11-21 10:00:00'
+ * ->
+ * select * from t where __time > convert_tz('2025-11-21 10:00:00', '+09:00', '+08:00')
+ */
+public class ConvertTimeZonePredicateRule extends TopDownScalarOperatorRewriteRule {
+
+    @Override
+    public ScalarOperator visitBinaryPredicate(BinaryPredicateOperator predicate,
+                                               ScalarOperatorRewriteContext context) {
+        if (!predicate.getChild(1).isConstant()
+                || !OperatorType.CALL.equals(predicate.getChild(0).getOpType())) {
+            return predicate;
+        }
+
+        CallOperator call = (CallOperator) predicate.getChild(0);
+        if (!call.getFnName().equals(FunctionSet.CONVERT_TZ) || call.getChildren().size() != 3) {
+            return predicate;
+        }
+        if (!call.getChild(1).isConstant() || !call.getChild(2).isConstant()) {
+            return predicate;
+        }
+
+        ScalarOperator column = call.getChild(0);
+        ConstantOperator fromTimeZone = (ConstantOperator) call.getChild(1);
+        ConstantOperator toTimeZone = (ConstantOperator) call.getChild(2);
+        ScalarOperator constant = predicate.getChild(1);
+
+        List<ScalarOperator> newArgs = Lists.newArrayList(constant, toTimeZone, fromTimeZone);
+        CallOperator newCall =
+                new CallOperator(FunctionSet.CONVERT_TZ, call.getType(), newArgs, call.getFunction());
+
+        return new BinaryPredicateOperator(predicate.getBinaryType(), column, newCall);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConvertTimeZonePredicateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConvertTimeZonePredicateTest.java
@@ -1,0 +1,38 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.sql.plan;
+
+import org.junit.jupiter.api.Test;
+
+public class ConvertTimeZonePredicateTest extends PlanTestBase {
+
+    @Test
+    public void testConvert_tz() throws Exception {
+        String sql = "SELECT count(1)\n" +
+                "FROM test_time\n" +
+                "WHERE (convert_tz(__time, '+08:00', '+09:00') >= '2025-11-16 10:00:00')";
+        String planFragment = getFragmentPlan(sql);
+        assertContains(planFragment, "PREDICATES: 1: __time >= '2025-11-16 09:00:00'");
+
+        sql = "SELECT count(1)\n" +
+                "FROM test_time\n" +
+                "WHERE (convert_tz(__time, '+08:00', 'Asia/Yakutsk') >= '2025-11-16 10:00:00')";
+        planFragment = getFragmentPlan(sql);
+        assertContains(planFragment, "PREDICATES: 1: __time >= '2025-11-16 09:00:00'");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
@@ -1000,6 +1000,18 @@ public class PlanTestBase extends PlanTestNoneDBBase {
                 "\"replication_num\" = \"1\"\n" +
                 ");");
 
+        starRocksAssert.withTable("CREATE TABLE `test_time` (\n" +
+                "  `__time` datetime NOT NULL DEFAULT \"1970-01-01 00:00:00\" COMMENT \"\",\n" +
+                "  `eventType` varchar(65533) NULL DEFAULT \"\" COMMENT \"\",\n" +
+                "  `count` bigint(20) NULL DEFAULT \"1\" COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`__time`)\n" +
+                "DISTRIBUTED BY RANDOM\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\"\n" +
+                ");");
+
         connectContext.getGlobalStateMgr().setStatisticStorage(new MockTpchStatisticStorage(connectContext, 1));
         GlobalStateMgr.getCurrentState().getAnalyzeMgr().getBasicStatsMetaMap().clear();
         ColocateTableBalancer.getInstance().setStop();


### PR DESCRIPTION
## Why I'm doing:
The convert_tz function causes a full table scan.

## What I'm doing:

select * from t where convert_tz(__time, '+08:00', '+09:00') > '2025-11-21 10:00:00'
->
select * from t where __time > convert_tz('2025-11-21 10:00:00', '+09:00', '+08:00')

**before plan:**
```
0:OlapScanNode
     TABLE: test_time
     PREAGGREGATION: ON
     PREDICATES: convert_tz(1: __time, '+08:00', '+09:00') >= '2025-11-16 10:00:00'
     partitions=0/1
     rollup: test_time
     tabletRatio=0/0
     tabletList=
     cardinality=1
     avgRowSize=2.0
```

**after plan:**
```
0:OlapScanNode
     TABLE: test_time
     PREAGGREGATION: ON
     PREDICATES: 1: __time >= '2025-11-16 09:00:00'
     partitions=0/1
     rollup: test_time
     tabletRatio=0/0
     tabletList=
     cardinality=1
     avgRowSize=2.0
```
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3