### PR TITLE
[BugFix] fix NPE in case of LDAP user

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -291,11 +291,12 @@ public class TaskRun implements Comparable<TaskRun> {
         context.setQueryId(UUID.fromString(status.getQueryId()));
         context.setIsLastStmt(true);
         context.resetSessionVariable();
-        switchUser(context);
 
         // NOTE: Ensure the thread local connect context is always the same with the newest ConnectContext.
         // NOTE: Ensure this thread local is removed after this method to avoid memory leak in JVM.
         context.setThreadLocalInfo();
+        // NOTE: The switchUser might depend on the thread-local context if it's LDAP user
+        switchUser(context);
         return context;
     }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

```
2025-11-21 11:49:15.954+08:00 WARN (starrocks-taskrun-pool-9|6750) [TaskRunExecutor.lambda$executeTaskRun$0():67] failed to execute TaskRun. 
java.lang.NullPointerException: null 	
at com.starrocks.epack.authorization.AuthorizationMgrEpack.getRoleIdsByUserUnlocked(AuthorizationMgrEpack.java:75) ~[starrocks-fe.jar:?] 	
at com.starrocks.privilege.AuthorizationMgr.getRoleIdsByUser(AuthorizationMgr.java:1422) ~[starrocks-fe.jar:?] 	
at com.starrocks.scheduler.TaskRun.switchUser(TaskRun.java:278) ~[starrocks-fe.jar:?] 	
at com.starrocks.scheduler.TaskRun.buildTaskRunConnectContext(TaskRun.java:248) ~[starrocks-fe.jar:?] 	
at com.starrocks.scheduler.TaskRun.executeTaskRun(TaskRun.java:296) ~[starrocks-fe.jar:?] 	
at com.starrocks.scheduler.TaskRunExecutor.lambda$executeTaskRun$0(TaskRunExecutor.java:60) ~[starrocks-fe.jar:?] 	
at java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700) ~[?:?] 	
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) ~[?:?] 	
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) ~[?:?] 	
at java.lang.Thread.run(Thread.java:829) ~[?:?]
```


The `switchUser` function depends on the `ConnectContext.get()`, which is used for LDAP user, but this condition is not guaranteed by `TaskRun.buildTaskRunConnectContext`.

It only occurs in enterprise-version but not OSS.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
