### PR TITLE
[BugFix] Fix daily bug on spm & feature extractor

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/OperatorType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/OperatorType.java
@@ -167,6 +167,7 @@ public enum OperatorType {
     private static final Set<OperatorType> PHYSICAL_SCANS =
             Arrays.stream(OperatorType.values())
                     .filter(x -> x.name().startsWith("PHYSICAL") && x.name().endsWith("SCAN"))
+                    .filter(x -> !x.equals(PHYSICAL_STREAM_SCAN))
                     .collect(Collectors.toUnmodifiableSet());
 
     public boolean isPhysicalScan() {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -128,6 +128,7 @@ public class StatisticUtils {
         // set the max task num of connector io tasks per scan operator to collectStatsIoTasksPerConnectorOperator,
         // default value is 4, avoid generate too many chunk source for collect stats in BE
         context.getSessionVariable().setConnectorIoTasksPerScanOperator(Config.collect_stats_io_tasks_per_connector_operator);
+        context.getSessionVariable().setEnableSPMRewrite(false);
 
         WarehouseManager manager = GlobalStateMgr.getCurrentState().getWarehouseMgr();
         Warehouse warehouse = manager.getBackgroundWarehouse();

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatsConstants.java
@@ -18,6 +18,7 @@ package com.starrocks.statistic;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 
+import java.util.List;
 import java.util.Map;
 
 public class StatsConstants {
@@ -121,6 +122,17 @@ public class StatsConstants {
     public static final String FULL_SCHEDULE_TIMES = "full_schedule_times";
     public static final String SAMPLE_ONCE_TIMES = "sample_once_times";
     public static final String SAMPLE_SCHEDULE_TIMES = "sample_schedule_times";
+
+    public static final List<String> STATISTICS_TABLES = List.of(
+            QUERY_HISTORY_TABLE_NAME,
+            SPM_BASELINE_TABLE_NAME,
+            FULL_STATISTICS_TABLE_NAME,
+            SAMPLE_STATISTICS_TABLE_NAME,
+            EXTERNAL_FULL_STATISTICS_TABLE_NAME,
+            MULTI_COLUMN_STATISTICS_TABLE_NAME,
+            HISTOGRAM_STATISTICS_TABLE_NAME,
+            EXTERNAL_HISTOGRAM_STATISTICS_TABLE_NAME
+    );
 
     public enum AnalyzeType {
         SAMPLE,

--- a/fe/fe-core/src/main/java/com/starrocks/summary/QueryHistoryMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/summary/QueryHistoryMgr.java
@@ -125,9 +125,11 @@ public class QueryHistoryMgr {
             loadQueryHistory(Lists.newArrayList(histories));
             histories.clear();
         }
-        if (ctx.isStatisticsConnection() || ctx.isStatisticsJob() || plan.getScanNodes().size() < 2
-                || StringUtils.containsIgnoreCase(ctx.getExecutor().getOriginStmtInString(),
-                StatsConstants.INFORMATION_SCHEMA)) {
+        if (ctx.isStatisticsConnection() || ctx.isStatisticsJob() || plan.getScanNodes().size() < 2) {
+            return;
+        }
+        String sql = ctx.getExecutor().getOriginStmtInString();
+        if (StatsConstants.STATISTICS_TABLES.stream().anyMatch(c -> StringUtils.containsIgnoreCase(sql, c))) {
             return;
         }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
Bug 1:
```
        at com.starrocks.sql.spm.SPMPlanner.plan(SPMPlanner.java:89) ~[fe-core-main.jar:?]
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:126) ~[fe-core-main.jar:?]
        at com.starrocks.qe.SimpleExecutor.executeDQL(SimpleExecutor.java:117) ~[fe-core-main.jar:?]
        at com.starrocks.qe.SimpleExecutor.executeDQL(SimpleExecutor.java:104) ~[fe-core-main.jar:?]
        at com.starrocks.sql.spm.SQLPlanGlobalStorage.getBaselines(SQLPlanGlobalStorage.java:151) ~[fe-core-main.jar:?]
        at com.starrocks.sql.spm.SQLPlanGlobalStorage.init(SQLPlanGlobalStorage.java:112) ~[fe-core-main.jar:?]
        at com.starrocks.sql.spm.SQLPlanGlobalStorage.findBaselinePlan(SQLPlanGlobalStorage.java:204) ~[fe-core-main.jar:?]
        at com.starrocks.sql.spm.SPMPlanner.plan(SPMPlanner.java:89) ~[fe-core-main.jar:?]
        at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:126) ~[fe-core-main.jar:?]
        at com.starrocks.qe.SimpleExecutor.executeDQL(SimpleExecutor.java:117) ~[fe-core-main.jar:?]
        at com.starrocks.qe.SimpleExecutor.executeDQL(SimpleExecutor.java:104) ~[fe-core-main.jar:?]
        at com.starrocks.sql.spm.SQLPlanGlobalStorage.getBaselines(SQLPlanGlobalStorage.java:151) ~[fe-core-main.jar:?]
        at com.starrocks.sql.spm.SQLPlanGlobalStorage.init(SQLPlanGlobalStorage.java:112) ~[fe-core-main.jar:?]
        at com.starrocks.sql.spm.SQLPlanGlobalStorage.findBaselinePlan(SQLPlanGlobalStorage.java:204) ~[fe-core-main.jar:?]
```

query -> generate SPM plan -> get SPM baseline -> query -> get SPM baseline ->.....

into dead-loops, disable SPM_REWRITE when execute internal sql

Bug 2:
```
java.lang.ClassCastException: class com.starrocks.sql.optimizer.operator.stream.PhysicalStreamScanOperator cannot be cast to class co
m.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator (com.starrocks.sql.optimizer.operator.stream.PhysicalStreamScanOpera
tor and com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator are in unnamed module of loader 'app')
        at com.starrocks.sql.optimizer.cost.feature.OperatorFeatures$ScanOperatorFeatures.<init>(OperatorFeatures.java:120) ~[fe-core
-main.jar:?]
        at com.starrocks.sql.optimizer.cost.feature.FeatureExtractor$Extractor.createOperatorFeatures(FeatureExtractor.java:96) ~[fe-
core-main.jar:?]
        at com.starrocks.sql.optimizer.cost.feature.FeatureExtractor$Extractor.visit(FeatureExtractor.java:78) ~[fe-core-main.jar:?]
        at com.starrocks.sql.optimizer.cost.feature.FeatureExtractor$Extractor.visit(FeatureExtractor.java:72) ~[fe-core-main.jar:?]
        at com.starrocks.sql.optimizer.OptExpressionVisitor.visitPhysicalStreamScan(OptExpressionVisitor.java:286) ~[fe-core-main.jar
:?]
        at com.starrocks.sql.optimizer.operator.stream.PhysicalStreamScanOperator.accept(PhysicalStreamScanOperator.java:79) ~[fe-core-main.jar:?]
        at com.starrocks.sql.optimizer.cost.feature.FeatureExtractor$Extractor.visitChildren(FeatureExtractor.java:87) ~[fe-core-main.jar:?]
        at com.starrocks.sql.optimizer.cost.feature.FeatureExtractor$Extractor.visit(FeatureExtractor.java:80) ~[fe-core-main.jar:?]
        at com.starrocks.sql.optimizer.cost.feature.FeatureExtractor$Extractor.visit(FeatureExtractor.java:72) ~[fe-core-main.jar:?]
        at com.starrocks.sql.optimizer.OptExpressionVisitor.visitPhysicalStreamAgg(OptExpressionVisitor.java:294) ~[fe-core-main.jar:?]
        at com.starrocks.sql.optimizer.operator.stream.PhysicalStreamAggOperator.accept(PhysicalStreamAggOperator.java:86) ~[fe-core-main.jar:?]
        at com.starrocks.sql.optimizer.cost.feature.FeatureExtractor.extractFeatures(FeatureExtractor.java:41) ~[fe-core-main.jar:?]
```
the feature_extractor doesn't filter `PhysicalStreamScanOperator`


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
