### PR TITLE
[BugFix] fix be crash when cache select reorder schema

### DIFF
--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1577,6 +1577,9 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
                 continue;
             }
             ColumnPtr& col = chunk->get_column_by_index(column_index++);
+            if (!_scan_range.empty()) {
+                RETURN_IF_ERROR(_column_iterators[cid]->seek_to_ordinal(_scan_range.begin()));
+            }
             ASSIGN_OR_RETURN(auto vec, _column_iterators[cid]->get_io_range_vec(_scan_range, col.get()));
             for (auto e : vec) {
                 // if buf_size is 1MB, offset is 123, and size is 2MB
@@ -2776,6 +2779,10 @@ ChunkIteratorPtr new_segment_iterator(const std::shared_ptr<Segment>& segment, c
     if (options.pred_tree.empty() || options.pred_tree.num_columns() >= schema.num_fields()) {
         return std::make_shared<SegmentIterator>(segment, schema, options);
     } else {
+        // CACHE SELECT disable late materialization
+        if (options.lake_io_opts.cache_file_only) {
+            return new_projection_iterator(schema, std::make_shared<SegmentIterator>(segment, schema, options));
+        }
         Schema ordered_schema = reorder_schema(schema, options.pred_tree);
         auto seg_iter = std::make_shared<SegmentIterator>(segment, ordered_schema, options);
         return new_projection_iterator(schema, seg_iter);


### PR DESCRIPTION
## Why I'm doing:

crash
```
starrocks_be: be/src/gutil/casts.h:79: To down_cast(From*) [with To = starrocks::ArrayColumn*; From = starrocks::Column]: Assertion `f == NULL || dynamic_cast<To>(f) != NULL' failed.
*** SIGABRT (@0x1f) received by PID 31 (TID 0x7ff39be3c640) LWP(835) from PID 31; stack trace: ***
    @     0x7ff4d9a99ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @         0x1f0f76a9 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7ff4d9a42520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @     0x7ff4d9a969fc pthread_kill
    @     0x7ff4d9a42476 raise
    @     0x7ff4d9a287f3 abort
    @     0x7ff4d9a2871b (/usr/lib/x86_64-linux-gnu/libc.so.6+0x2871a)
    @     0x7ff4d9a39e96 __assert_fail
    @         0x153d04f1 starrocks::ArrayColumn* down_cast<starrocks::ArrayColumn*, starrocks::Column>(starrocks::Column*)
    @         0x18bcd5ef starrocks::unpack_array_column(starrocks::Column*)
    @         0x18bd0c14 starrocks::ArrayColumnIterator::get_io_range_vec(starrocks::SparseRange<unsigned int> const&, starrocks::Column*)
    @         0x165f2e34 starrocks::SegmentIterator::_do_get_next(starrocks::Chunk*, std::vector<unsigned int, std::allocator<unsigned int> >*)
    @         0x165f21c7 starrocks::SegmentIterator::do_get_next(starrocks::Chunk*)
    @         0x15db5bd7 starrocks::ChunkIterator::get_next(starrocks::Chunk*)
    @         0x168cccfe starrocks::ProjectionIterator::do_get_next(starrocks::Chunk*)
    @         0x15db5bd7 starrocks::ChunkIterator::get_next(starrocks::Chunk*)
    @         0x17435012 starrocks::TimedChunkIterator::do_get_next(starrocks::Chunk*)
    @         0x15db5bd7 starrocks::ChunkIterator::get_next(starrocks::Chunk*)
    @         0x16a3d3ec starrocks::lake::TabletReader::do_get_next(starrocks::Chunk*)
    @         0x15db5bd7 starrocks::ChunkIterator::get_next(starrocks::Chunk*)
    @         0x1a541617 starrocks::connector::LakeDataSource::get_next(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*)
    @         0x1a583e92 starrocks::pipeline::ConnectorChunkSource::_read_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*)
    @         0x19ad0a45 starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking(starrocks::RuntimeState*, unsigned long, starrocks::workgroup::WorkGroup const*)
    @         0x14de6298 auto starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}::operator()<starrocks::workgroup::YieldContext>(starrocks::workgroup::YieldContext&) const
    @         0x14de95ed void std::__invoke_impl<void, starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}&, starrocks::workgroup::YieldContext&>(std::__invoke_other, starrocks::pipeline::ScanOperator::_trigger_next_scan(starro
    @         0x14de9434 std::enable_if<is_invocable_r_v<void, starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}&, starrocks::workgroup::YieldContext&>, void>::type std::__invoke_r<void, starrocks::pipeline::ScanOperator::_tr
    @         0x14de91be std::_Function_handler<void (starrocks::workgroup::YieldContext&), starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}>::_M_invoke(std::_Any_data const&, starrocks::workgroup::YieldContext&)
    @         0x194faffd std::function<void (starrocks::workgroup::YieldContext&)>::operator()(starrocks::workgroup::YieldContext&) const
    @         0x194faea3 starrocks::workgroup::ScanTask::run()
    @         0x194f79b5 starrocks::workgroup::ScanExecutor::worker_thread()
    @         0x194f7619 starrocks::workgroup::ScanExecutor::initialize(int)::{lambda()#1}::operator()() const
    @         0x194f87d4 void std::__invoke_impl<void, starrocks::workgroup::ScanExecutor::initialize(int)::{lambda()#1}&>(std::__invoke_other, starrocks::workgroup::ScanExecutor::initialize(int)::{lambda()#1}&)
```

or

```
Check failed: range.empty() || (range.begin() == _array_size_iterator->get_current_ordinal()) F20251121 17:35:39.091351 140570853254720 array_column_iterator.cpp:365] Check failed: range.empty() || (range.begin() == _array_size_iterator->get_current_ordinal()) 
F00000000 00:00:00.000000 140570853254720 logging.cc:1962] RAW: Check data_->num_chars_to_log_ > 0 && data_->message_text_[data_->num_chars_to_log_ - 1] == '\n' failed: 
    @     0x7fda78899ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @         0x1f0f8e29 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7fda78842520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @     0x7fda788969fc pthread_kill
    @     0x7fda78842476 raise
    @     0x7fda788287f3 abort
    @         0x1acc26a3 starrocks::failure_function()
    @         0x1f0ec5be google::LogMessage::Fail()
    @         0x1f0ed839 google::LogMessageFatal::~LogMessageFatal()
    @         0x18bd2177 starrocks::ArrayColumnIterator::get_io_range_vec(starrocks::SparseRange<unsigned int> const&, starrocks::Column*)
    @         0x165f37f8 starrocks::SegmentIterator::_do_get_next(starrocks::Chunk*, std::vector<unsigned int, std::allocator<unsigned int> >*)
    @         0x165f27c9 starrocks::SegmentIterator::do_get_next(starrocks::Chunk*)
    @         0x15db5bd7 starrocks::ChunkIterator::get_next(starrocks::Chunk*)
    @         0x168cde52 starrocks::ProjectionIterator::do_get_next(starrocks::Chunk*)
    @         0x15db5bd7 starrocks::ChunkIterator::get_next(starrocks::Chunk*)
    @         0x174362e6 starrocks::TimedChunkIterator::do_get_next(starrocks::Chunk*)
    @         0x15db5bd7 starrocks::ChunkIterator::get_next(starrocks::Chunk*)
    @         0x16a3e7a0 starrocks::lake::TabletReader::do_get_next(starrocks::Chunk*)
    @         0x15db5bd7 starrocks::ChunkIterator::get_next(starrocks::Chunk*)
    @         0x1a5428eb starrocks::connector::LakeDataSource::get_next(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*)
    @         0x1a5855f8 starrocks::pipeline::ConnectorChunkSource::_read_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*)
```

## What I'm doing:

When performing a cache select, it is not necessary to reorder the schema.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> For CACHE SELECT, seek column iterators to the scan-range start before touching cache and bypass schema reordering/late materialization.
> 
> - **Storage/SegmentIterator**:
>   - CACHE SELECT path: seek each active column iterator to `_scan_range.begin()` before computing IO ranges and touching cache.
>   - Iterator creation: when `lake_io_opts.cache_file_only` is set, skip schema reordering/late materialization by constructing `SegmentIterator` with the original `schema` and wrapping in `new_projection_iterator`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c796d0c7e19ca73a9c30affd575f5fc2aaf938d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->