### PR TITLE
[BugFix] change the dop of PredicateColumnStorage to 1

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SimpleExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SimpleExecutor.java
@@ -57,6 +57,8 @@ public class SimpleExecutor {
 
     private final TResultSinkType queryResultProtocol;
 
+    private int dop = 0;
+
     public SimpleExecutor(String name, TResultSinkType queryResultProtocol) {
         this.name = name;
         this.queryResultProtocol = queryResultProtocol;
@@ -73,6 +75,15 @@ public class SimpleExecutor {
         return sql;
     }
 
+    /**
+     * Set the execution DOP of this executor
+     *
+     * @param dop
+     */
+    public void setDop(int dop) {
+        this.dop = dop;
+    }
+
     public void executeDML(String sql) {
         ConnectContext prev = ConnectContext.get();
         try {
@@ -83,6 +94,7 @@ public class SimpleExecutor {
             StmtExecutor executor = StmtExecutor.newInternalExecutor(context, parsedStmt);
             context.setExecutor(executor);
             context.setQueryId(UUIDUtil.genUUID());
+            context.getSessionVariable().setPipelineDop(dop);
             AuditLog.getInternalAudit()
                     .info("{} execute SQL | Query_id {} | DML {}", name, DebugUtil.printId(context.getQueryId()), sql);
             executor.execute();
@@ -118,6 +130,7 @@ public class SimpleExecutor {
             StmtExecutor executor = StmtExecutor.newInternalExecutor(context, parsedStmt);
             context.setExecutor(executor);
             context.setQueryId(UUIDUtil.genUUID());
+            context.getSessionVariable().setPipelineDop(dop);
             AuditLog.getInternalAudit()
                     .info("{} execute SQL | Query_id {} | DQL {}", name, DebugUtil.printId(context.getQueryId()), sql);
             Pair<List<TResultBatch>, Status> sqlResult = executor.executeStmtWithExecPlan(context, execPlan);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/columns/PredicateColumnsStorage.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/columns/PredicateColumnsStorage.java
@@ -35,6 +35,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
 import com.starrocks.statistic.StatsConstants;
 import com.starrocks.thrift.TResultBatch;
+import com.starrocks.thrift.TResultSinkType;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.apache.commons.collections4.ListUtils;
@@ -135,7 +136,9 @@ public class PredicateColumnsStorage {
     }
 
     public PredicateColumnsStorage() {
-        this.executor = SimpleExecutor.getRepoExecutor();
+        this.executor = new SimpleExecutor("predicate_column", TResultSinkType.HTTP_PROTOCAL);
+        // Set the DOP to 1 to reduce impact on normal queries
+        this.executor.setDop(1);
     }
 
     public PredicateColumnsStorage(SimpleExecutor executor) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:


Set the DOP of PredicateColumnStorage to 1 to minimize the impact on regular queries.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
