### PR TITLE
[Enhancement] support output timezone in be log

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -222,6 +222,8 @@ CONF_Strings(sys_log_verbose_modules, "");
 CONF_Int32(sys_log_verbose_level, "10");
 // The log buffer level.
 CONF_String(log_buffer_level, "");
+// Whether to show timezone in log prefix.
+CONF_Bool(sys_log_timezone, "false");
 
 // Pull load task dir.
 CONF_String(pull_load_task_dir, "${STARROCKS_HOME}/var/pull_load");

--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -215,8 +215,8 @@ static void failure_function() {
 static std::string get_timezone_offset_string(const google::LogMessageTime& time) {
     // Cache the last offset and its string representation
     static std::mutex cache_mutex;
-    static std::atomic<long> cached_offset_seconds(0);
-    static std::shared_ptr<std::string> cached_tz_str_ptr(std::make_shared<std::string>("+0000"));
+    static std::atomic<long> cached_offset_seconds(-1);
+    static std::shared_ptr<std::string> cached_tz_str_ptr(std::make_shared<std::string>(""));
 
     // Get timezone offset from LogMessageTime
     long offset_seconds = time.gmtoffset().count();

--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -283,10 +283,8 @@ static void custom_prefix_formatter(std::ostream& s, const google::LogMessage& m
     // Timezone offset (calculated dynamically)
     s << ' ' << get_timezone_offset_string(time);
 
-    // Thread ID (simplified, use hash to get a shorter ID)
-    std::hash<std::thread::id> hasher;
-    size_t thread_hash = hasher(message.thread_id());
-    s << ' ' << std::setfill(' ') << std::setw(5) << (thread_hash % 100000) << ' ';
+    // Thread ID
+    s << ' ' << message.thread_id() << ' ';
 
     // File and line
     s << message.basename() << ':' << message.line() << "] ";

--- a/conf/be_test.conf
+++ b/conf/be_test.conf
@@ -13,6 +13,7 @@
 
 # INFO, WARNING, ERROR, FATAL
 sys_log_level = INFO
+sys_log_timezone = true
 # sys_log_verbose_modules = *
 # sys_log_verbose_level = 3
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

1. Output timezone like `+0800` in the be.INFO, controlled by switch `sys_log_timezone`.
2. ~Use a shorter thread_id in the log~

```
I20251121 21:26:32.484570 +0800 67435 tablet_updates.cpp:583]  redo edit version log tablet:113028 version:2 rowsets:0 deltas:0 rows
```


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an optional timezone offset to BE log prefixes controlled by `sys_log_timezone`, installing a custom glog prefix formatter.
> 
> - **Logging**:
>   - **Timezone-aware prefix**: Implement custom glog prefix formatter in `be/src/common/logconfig.cpp` to include timezone offset, thread id, and file:line in log prefix.
>     - Computes offset via `get_timezone_offset_string(...)` with thread-safe caching.
>     - Installs formatter only when `config::sys_log_timezone` is enabled.
>   - **Config**: Introduce `CONF_Bool(sys_log_timezone, "false")` in `be/src/common/config.h`.
>   - **Tests/Config**: Enable `sys_log_timezone = true` in `conf/be_test.conf`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34bae9a96a30872e3560b225f47c4391b6c4d657. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->