### PR TITLE
[UT] Add SQL tests for mem_pool property of resource groups

### DIFF
--- a/test/sql/test_resource_group_mem_pool/R/test_create_resource_group_with_mem_pool
+++ b/test/sql/test_resource_group_mem_pool/R/test_create_resource_group_with_mem_pool
@@ -1,0 +1,18 @@
+-- name: test_create_resource_group_with_mem_pool
+
+[UC] drop resource group shared_resource_group_for_test_user;
+
+[UC] create resource group shared_resource_group_for_test_user
+to (user='test_user') 
+with (
+  'cpu_weight' = '12',
+  'mem_limit' = '20%',
+  'mem_pool' = 'test_pool_1'
+);
+
+show verbose resource groups all;
+-- result:
+[REGEX]shared_resource_group_for_test_user.+12.+20(\.\d+)?%.+NORMAL.+\(id=\d+,.+user=test_user\)\s*(test_pool_1)
+-- !result
+
+[UC] drop resource group shared_resource_group_for_test_user;

--- a/test/sql/test_resource_group_mem_pool/R/test_create_resource_group_with_mem_pool_then_try_alter
+++ b/test/sql/test_resource_group_mem_pool/R/test_create_resource_group_with_mem_pool_then_try_alter
@@ -1,0 +1,46 @@
+-- name: test_create_resource_group_with_mem_pool_then_try_alter
+
+[UC] drop resource group shared_resource_group_for_james;
+
+[UC] create resource group shared_resource_group_for_james
+to (user='james') 
+with (
+  'cpu_weight' = '9',
+  'mem_limit' = '66%',
+  'max_cpu_cores' = "8", 
+  'mem_pool' = 'mem_pool_for_james'
+);
+
+show verbose resource groups all;
+-- result:
+[REGEX]shared_resource_group_for_james.+9.+66(\.\d+)?%.+8.+NORMAL.+\(id=\d+,.+user=james\)\s*(mem_pool_for_james)
+-- !result
+
+alter resource group shared_resource_group_for_james with (
+    'mem_limit' = '99%',
+    'mem_pool' = 'other_pool'
+);
+-- result:
+E: (1064, 'Property `mem_pool` cannot be altered [mem_pool_for_james].')
+-- !result
+
+
+alter resource group shared_resource_group_for_james with (
+    'mem_limit' = '99%'
+);
+-- result:
+E: (1064, 'Property `mem_limit` cannot be altered for resource groups with mem_pool [mem_pool_for_james].')
+-- !result
+
+alter resource group shared_resource_group_for_james with (
+    'max_cpu_cores' = "1"
+);
+-- result:
+-- !result
+
+show verbose resource groups all;
+-- result:
+[REGEX]shared_resource_group_for_james.+9.+66(\.\d+)?%.+1.+NORMAL.+\(id=\d+,.+user=james\)\s*(mem_pool_for_james)
+-- !result
+
+[UC] drop resource group shared_resource_group_for_james;

--- a/test/sql/test_resource_group_mem_pool/R/test_create_two_resource_groups_with_mem_pool
+++ b/test/sql/test_resource_group_mem_pool/R/test_create_two_resource_groups_with_mem_pool
@@ -1,0 +1,35 @@
+-- name: test_create_two_resource_groups_with_mem_pool
+
+[UC] drop resource group shared_resource_group_for_john;
+[UC] drop resource group shared_resource_group_for_jane;
+
+[UC] create resource group shared_resource_group_for_john 
+to (user='john') 
+with (
+  'cpu_weight' = '7',
+  'mem_limit' = '55%',
+  'mem_pool' = 'shared_pool_john_and_jane'
+);
+
+
+[UC] create resource group shared_resource_group_for_jane 
+to (user='jane') 
+with (
+  'cpu_weight' = '8',
+  'mem_limit' = '55%',
+  'mem_pool' = 'shared_pool_john_and_jane'
+);
+
+show verbose resource groups all;
+-- result:
+[REGEX]shared_resource_group_for_john.+7.+55(\.\d+)?%.+NORMAL.+\(id=\d+,.+user=john\)\s*shared_pool_john_and_jane
+-- !result
+
+show verbose resource groups all;
+-- result:
+[REGEX]shared_resource_group_for_jane.+8.+55(\.\d+)?%.+NORMAL.+\(id=\d+,.+user=jane\)\s*shared_pool_john_and_jane
+-- !result
+
+
+[UC] drop resource group shared_resource_group_for_john;
+[UC] drop resource group shared_resource_group_for_jane;

--- a/test/sql/test_resource_group_mem_pool/R/test_create_two_resource_groups_with_mem_pool_different_mem_limit
+++ b/test/sql/test_resource_group_mem_pool/R/test_create_two_resource_groups_with_mem_pool_different_mem_limit
@@ -1,0 +1,37 @@
+-- name: test_create_two_resource_groups_with_mem_pool_different_mem_limit
+
+[UC] drop resource group shared_resource_group_for_alex;
+[UC] drop resource group shared_resource_group_for_brad;
+
+[UC] create resource group shared_resource_group_for_alex
+to (user='alex') 
+with (
+  'cpu_weight' = '7',
+  'mem_limit' = '55%',
+  'mem_pool' = 'shared_pool_for_alex_and_brad'
+);
+
+create resource group shared_resource_group_for_brad
+to (user='brad') 
+with (
+  'cpu_weight' = '7',
+  'mem_limit' = '88%',
+  'mem_pool' = 'shared_pool_for_alex_and_brad'
+);
+-- result:
+[REGEX]Property `mem_limit` must be equal for all resource groups using the mem_pool \[shared_pool_for_alex_and_brad\]
+-- !result
+
+show verbose resource groups all;
+-- result:
+[REGEX]shared_resource_group_for_alex.+7.+55(\.\d+)?%.+NORMAL.+\(id=\d+,.+user=alex\)\s*(shared_pool_for_alex_and_brad)
+-- !result
+
+show verbose resource groups all;
+-- result:
+[REGEX][^shared_resource_group_for_brad]
+-- !result
+
+
+[UC] drop resource group shared_resource_group_for_alex;
+[UC] drop resource group shared_resource_group_for_brad;

--- a/test/sql/test_resource_group_mem_pool/R/test_create_two_resource_groups_with_mem_pool_then_try_alter
+++ b/test/sql/test_resource_group_mem_pool/R/test_create_two_resource_groups_with_mem_pool_then_try_alter
@@ -1,0 +1,50 @@
+-- name: test_create_two_resource_groups_with_mem_pool_then_try_alter
+
+[UC] drop resource group shared_resource_group_for_skywalker;
+[UC] drop resource group shared_resource_group_for_vader;
+
+[UC] create resource group shared_resource_group_for_skywalker 
+to (user='skywalker') 
+with (
+  'cpu_weight' = '2',
+  'mem_limit' = '70%',
+  'mem_pool' = 'shared_pool_skywalker_and_vader'
+);
+
+
+[UC] create resource group shared_resource_group_for_vader 
+to (user='vader') 
+with (
+  'cpu_weight' = '2',
+  'mem_limit' = '70%',
+  'mem_pool' = 'shared_pool_skywalker_and_vader'
+);
+
+show verbose resource groups all;
+-- result:
+[REGEX]shared_resource_group_for_skywalker.+2.+70(\.\d+)?%.+NORMAL.+\(id=\d+,.+user=skywalker\)\s*shared_pool_skywalker_and_vader
+-- !result
+
+show verbose resource groups all;
+-- result:
+[REGEX]shared_resource_group_for_vader.+2.+70(\.\d+)?%.+NORMAL.+\(id=\d+,.+user=vader\)\s*shared_pool_skywalker_and_vader
+-- !result
+
+alter resource group shared_resource_group_for_vader with (
+    'mem_limit' = '99%',
+    'mem_pool' = 'other_pool'
+);
+-- result:
+E: (1064, 'Property `mem_pool` cannot be altered [shared_pool_skywalker_and_vader].')
+-- !result
+
+alter resource group shared_resource_group_for_skywalker with (
+    'mem_limit' = '99%',
+    'mem_pool' = 'other_pool'
+);
+-- result:
+E: (1064, 'Property `mem_pool` cannot be altered [shared_pool_skywalker_and_vader].')
+-- !result
+
+[UC] drop resource group shared_resource_group_for_skywalker;
+[UC] drop resource group shared_resource_group_for_vader;

--- a/test/sql/test_resource_group_mem_pool/T/test_create_resource_group_with_mem_pool
+++ b/test/sql/test_resource_group_mem_pool/T/test_create_resource_group_with_mem_pool
@@ -1,0 +1,15 @@
+-- name: test_create_resource_group_with_mem_pool
+
+[UC] drop resource group shared_resource_group_for_test_user;
+
+[UC] create resource group shared_resource_group_for_test_user
+to (user='test_user') 
+with (
+  'cpu_weight' = '12',
+  'mem_limit' = '20%',
+  'mem_pool' = 'test_pool_1'
+);
+
+show verbose resource groups all;
+
+[UC] drop resource group shared_resource_group_for_test_user;

--- a/test/sql/test_resource_group_mem_pool/T/test_create_resource_group_with_mem_pool_then_try_alter
+++ b/test/sql/test_resource_group_mem_pool/T/test_create_resource_group_with_mem_pool_then_try_alter
@@ -1,0 +1,31 @@
+-- name: test_create_resource_group_with_mem_pool_then_try_alter
+
+[UC] drop resource group shared_resource_group_for_james;
+
+[UC] create resource group shared_resource_group_for_james
+to (user='james') 
+with (
+  'cpu_weight' = '9',
+  'mem_limit' = '66%',
+  'max_cpu_cores' = "8", 
+  'mem_pool' = 'mem_pool_for_james'
+);
+
+show verbose resource groups all;
+
+alter resource group shared_resource_group_for_james with (
+    'mem_limit' = '99%',
+    'mem_pool' = 'other_pool'
+);
+
+alter resource group shared_resource_group_for_james with (
+    'mem_limit' = '99%'
+);
+
+alter resource group shared_resource_group_for_james with (
+    'max_cpu_cores' = "1"
+);
+
+show verbose resource groups all;
+
+[UC] drop resource group shared_resource_group_for_james;

--- a/test/sql/test_resource_group_mem_pool/T/test_create_two_resource_groups_with_mem_pool
+++ b/test/sql/test_resource_group_mem_pool/T/test_create_two_resource_groups_with_mem_pool
@@ -1,0 +1,27 @@
+-- name: test_create_two_resource_groups_with_mem_pool
+
+[UC] drop resource group shared_resource_group_for_john;
+[UC] drop resource group shared_resource_group_for_jane;
+
+[UC] create resource group shared_resource_group_for_john 
+to (user='john') 
+with (
+  'cpu_weight' = '7',
+  'mem_limit' = '55%',
+  'mem_pool' = 'shared_pool_john_and_jane'
+);
+
+
+[UC] create resource group shared_resource_group_for_jane 
+to (user='jane') 
+with (
+  'cpu_weight' = '8',
+  'mem_limit' = '55%',
+  'mem_pool' = 'shared_pool_john_and_jane'
+);
+
+show verbose resource groups all;
+show verbose resource groups all;
+
+[UC] drop resource group shared_resource_group_for_john;
+[UC] drop resource group shared_resource_group_for_jane;

--- a/test/sql/test_resource_group_mem_pool/T/test_create_two_resource_groups_with_mem_pool_different_mem_limit
+++ b/test/sql/test_resource_group_mem_pool/T/test_create_two_resource_groups_with_mem_pool_different_mem_limit
@@ -1,0 +1,26 @@
+-- name: test_create_two_resource_groups_with_mem_pool_different_mem_limit
+
+[UC] drop resource group shared_resource_group_for_alex;
+[UC] drop resource group shared_resource_group_for_brad;
+
+[UC] create resource group shared_resource_group_for_alex
+to (user='alex') 
+with (
+  'cpu_weight' = '7',
+  'mem_limit' = '55%',
+  'mem_pool' = 'shared_pool_for_alex_and_brad'
+);
+
+create resource group shared_resource_group_for_brad
+to (user='brad') 
+with (
+  'cpu_weight' = '7',
+  'mem_limit' = '88%',
+  'mem_pool' = 'shared_pool_for_alex_and_brad'
+);
+
+show verbose resource groups all;
+show verbose resource groups all;
+
+[UC] drop resource group shared_resource_group_for_alex;
+[UC] drop resource group shared_resource_group_for_brad;

--- a/test/sql/test_resource_group_mem_pool/T/test_create_two_resource_groups_with_mem_pool_then_try_alter
+++ b/test/sql/test_resource_group_mem_pool/T/test_create_two_resource_groups_with_mem_pool_then_try_alter
@@ -1,0 +1,38 @@
+-- name: test_create_two_resource_groups_with_mem_pool_then_try_alter
+
+[UC] drop resource group shared_resource_group_for_skywalker;
+[UC] drop resource group shared_resource_group_for_vader;
+
+[UC] create resource group shared_resource_group_for_skywalker 
+to (user='skywalker') 
+with (
+  'cpu_weight' = '2',
+  'mem_limit' = '70%',
+  'mem_pool' = 'shared_pool_skywalker_and_vader'
+);
+
+
+[UC] create resource group shared_resource_group_for_vader 
+to (user='vader') 
+with (
+  'cpu_weight' = '2',
+  'mem_limit' = '70%',
+  'mem_pool' = 'shared_pool_skywalker_and_vader'
+);
+
+show verbose resource groups all;
+
+show verbose resource groups all;
+
+alter resource group shared_resource_group_for_vader with (
+    'mem_limit' = '99%',
+    'mem_pool' = 'other_pool'
+);
+
+alter resource group shared_resource_group_for_skywalker with (
+    'mem_limit' = '99%',
+    'mem_pool' = 'other_pool'
+);
+
+[UC] drop resource group shared_resource_group_for_skywalker;
+[UC] drop resource group shared_resource_group_for_vader;


### PR DESCRIPTION
## Why I'm doing:

The mem_pool property for resource groups was recently introduced. 

- https://github.com/StarRocks/starrocks/pull/64111
- https://github.com/StarRocks/starrocks/pull/64112

There are currently no end-to-end SQL test cases for this functionality.

## What I'm doing:

This pull request adds SQL tests, checking the correctness of the behavior under the following scenarios:
- test_create_resource_group_with_mem_pool (should succeed)
- test_create_two_resource_groups_with_mem_pool (should succeed)
- test_create_two_resource_groups_with_mem_pool_then_try_alter (not allowed)
- test_create_two_resource_groups_with_mem_pool_different_mem_limit (not allowed)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add end-to-end SQL tests validating resource group mem_pool creation, sharing, immutability, and mem_limit constraints.
> 
> - **SQL tests for `mem_pool` in resource groups**:
>   - **Creation**: Verify creating a resource group with `mem_pool` succeeds (`test_create_resource_group_with_mem_pool`).
>   - **Shared pool**: Validate two groups can share the same `mem_pool` with matching `mem_limit` (`test_create_two_resource_groups_with_mem_pool`).
>   - **Constraints**:
>     - Reject creating a second group in the same `mem_pool` with a different `mem_limit` (`test_create_two_resource_groups_with_mem_pool_different_mem_limit`).
>     - Disallow altering `mem_pool` and `mem_limit` once set; allow changing `max_cpu_cores` (`test_create_resource_group_with_mem_pool_then_try_alter`, `test_create_two_resource_groups_with_mem_pool_then_try_alter`).
>   - Added corresponding `R/` expected-result files with regex assertions and error codes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f8a6c8ddf03d7aa4d9287d6b499a195e099d603. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->