### PR TITLE
[BugFix] Fix counter profile not update min/max correctly

### DIFF
--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -144,7 +144,9 @@ public:
         virtual double double_value() const { return bit_cast<double>(_value.load(std::memory_order_relaxed)); }
 
         virtual void set_min(int64_t min) { _min_value.emplace(min); }
+        virtual void clear_min() { _min_value.reset(); }
         virtual void set_max(int64_t max) { _max_value.emplace(max); }
+        virtual void clear_max() { _max_value.reset(); }
         virtual std::optional<int64_t> min_value() const { return _min_value; }
         virtual std::optional<int64_t> max_value() const { return _max_value; }
 

--- a/be/test/util/runtime_profile_test.cpp
+++ b/be/test/util/runtime_profile_test.cpp
@@ -542,25 +542,25 @@ TEST(TestRuntimeProfile, testUpdateMinMax) {
     auto profile = std::make_shared<RuntimeProfile>("base_profile");
     auto* base_c1 =
             profile->add_counter("counter1", TUnit::UNIT, RuntimeProfile::Counter::create_strategy(TUnit::UNIT));
-    base_c1->set(4);
+    COUNTER_SET(base_c1, int64_t(4));
     base_c1->set_min(1);
     base_c1->set_max(7);
     auto* base_c2 =
             profile->add_counter("counter2", TUnit::UNIT, RuntimeProfile::Counter::create_strategy(TUnit::UNIT));
-    base_c2->set(5);
+    COUNTER_SET(base_c2, int64_t(5));
 
     auto update_profile = std::make_shared<RuntimeProfile>("update_profile");
     auto* update_c1 =
             update_profile->add_counter("counter1", TUnit::UNIT, RuntimeProfile::Counter::create_strategy(TUnit::UNIT));
-    update_c1->set(6);
+    COUNTER_SET(update_c1, int64_t(6));
     auto* update_c2 =
             update_profile->add_counter("counter2", TUnit::UNIT, RuntimeProfile::Counter::create_strategy(TUnit::UNIT));
-    update_c2->set(8);
+    COUNTER_SET(update_c2, int64_t(8));
     update_c2->set_min(4);
     update_c2->set_max(12);
     auto* update_c3 =
             update_profile->add_counter("counter3", TUnit::UNIT, RuntimeProfile::Counter::create_strategy(TUnit::UNIT));
-    update_c3->set(10);
+    COUNTER_SET(update_c3, int64_t(10));
     update_c3->set_min(5);
     update_c3->set_max(15);
 
@@ -569,18 +569,18 @@ TEST(TestRuntimeProfile, testUpdateMinMax) {
 
     profile->update(update_tree);
     ASSERT_EQ(6, base_c1->value());
-    ASSERT_FALSE(base_c1->min_value().has_value())
-    ASSERT_FALSE(base_c1->max_value().has_value())
+    ASSERT_FALSE(base_c1->min_value().has_value());
+    ASSERT_FALSE(base_c1->max_value().has_value());
     ASSERT_EQ(8, base_c2->value());
-    ASSERT_TRUE(base_c2->min_value().has_value())
-    ASSERT_EQ(4, base_c2->min_value().value())
-    ASSERT_TRUE(base_c2->max_value().has_value())
-    ASSERT_EQ(12, base_c2->max_value().value())
+    ASSERT_TRUE(base_c2->min_value().has_value());
+    ASSERT_EQ(4, base_c2->min_value().value());
+    ASSERT_TRUE(base_c2->max_value().has_value());
+    ASSERT_EQ(12, base_c2->max_value().value());
     ASSERT_EQ(10, base_c3->value());
-    ASSERT_TRUE(base_c3->min_value().has_value())
-    ASSERT_EQ(5, base_c3->min_value().value())
-    ASSERT_TRUE(base_c3->max_value().has_value())
-    ASSERT_EQ(15, base_c3->max_value().value())
+    ASSERT_TRUE(base_c3->min_value().has_value());
+    ASSERT_EQ(5, base_c3->min_value().value());
+    ASSERT_TRUE(base_c3->max_value().has_value());
+    ASSERT_EQ(15, base_c3->max_value().value());
 }
 
 TEST(TestRuntimeProfile, testRaceMergeProfiles) {

--- a/be/test/util/runtime_profile_test.cpp
+++ b/be/test/util/runtime_profile_test.cpp
@@ -538,6 +538,51 @@ TEST(TestRuntimeProfile, testUpdateWithOldAndNewProfile) {
     ASSERT_EQ(2, child_profile->get_version());
 }
 
+TEST(TestRuntimeProfile, testUpdateMinMax) {
+    auto profile = std::make_shared<RuntimeProfile>("base_profile");
+    auto* base_c1 =
+            profile->add_counter("counter1", TUnit::UNIT, RuntimeProfile::Counter::create_strategy(TUnit::UNIT));
+    base_c1->set(4);
+    base_c1->set_min(1);
+    base_c1->set_max(7);
+    auto* base_c2 =
+            profile->add_counter("counter2", TUnit::UNIT, RuntimeProfile::Counter::create_strategy(TUnit::UNIT));
+    base_c2->set(5);
+
+    auto update_profile = std::make_shared<RuntimeProfile>("update_profile");
+    auto* update_c1 =
+            update_profile->add_counter("counter1", TUnit::UNIT, RuntimeProfile::Counter::create_strategy(TUnit::UNIT));
+    update_c1->set(6);
+    auto* update_c2 =
+            update_profile->add_counter("counter2", TUnit::UNIT, RuntimeProfile::Counter::create_strategy(TUnit::UNIT));
+    update_c2->set(8);
+    update_c2->set_min(4);
+    update_c2->set_max(12);
+    auto* update_c3 =
+            update_profile->add_counter("counter3", TUnit::UNIT, RuntimeProfile::Counter::create_strategy(TUnit::UNIT));
+    update_c3->set(10);
+    update_c3->set_min(5);
+    update_c3->set_max(15);
+
+    TRuntimeProfileTree update_tree;
+    update_profile->to_thrift(&update_tree);
+
+    profile->update(update_tree);
+    ASSERT_EQ(6, base_c1->value());
+    ASSERT_FALSE(base_c1->min_value().has_value())
+    ASSERT_FALSE(base_c1->max_value().has_value())
+    ASSERT_EQ(8, base_c2->value());
+    ASSERT_TRUE(base_c2->min_value().has_value())
+    ASSERT_EQ(4, base_c2->min_value().value())
+    ASSERT_TRUE(base_c2->max_value().has_value())
+    ASSERT_EQ(12, base_c2->max_value().value())
+    ASSERT_EQ(10, base_c3->value());
+    ASSERT_TRUE(base_c3->min_value().has_value())
+    ASSERT_EQ(5, base_c3->min_value().value())
+    ASSERT_TRUE(base_c3->max_value().has_value())
+    ASSERT_EQ(15, base_c3->max_value().value())
+}
+
 TEST(TestRuntimeProfile, testRaceMergeProfiles) {
     ObjectPool pool;
     std::vector<RuntimeProfile*> profiles;

--- a/be/test/util/runtime_profile_test.cpp
+++ b/be/test/util/runtime_profile_test.cpp
@@ -576,6 +576,8 @@ TEST(TestRuntimeProfile, testUpdateMinMax) {
     ASSERT_EQ(4, base_c2->min_value().value());
     ASSERT_TRUE(base_c2->max_value().has_value());
     ASSERT_EQ(12, base_c2->max_value().value());
+    auto* base_c3 = profile->get_counter("counter3");
+    ASSERT_TRUE(base_c3 != nullptr);
     ASSERT_EQ(10, base_c3->value());
     ASSERT_TRUE(base_c3->min_value().has_value());
     ASSERT_EQ(5, base_c3->min_value().value());

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/Counter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/Counter.java
@@ -72,8 +72,16 @@ public class Counter {
         this.minValue = Optional.of(minValue);
     }
 
+    public void clearMinValue() {
+        this.minValue = Optional.empty();
+    }
+
     public void setMaxValue(long maxValue) {
         this.maxValue = Optional.of(maxValue);
+    }
+
+    public void clearMaxValue() {
+        this.maxValue = Optional.empty();
     }
 
     public void update(long increment) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -330,9 +330,13 @@ public class RuntimeProfile {
                         // Running profile will report multiple times, we only need the last time value
                         if (tcounter.isSetMin_value()) {
                             counter.setMinValue(tcounter.getMin_value());
+                        } else {
+                            counter.clearMinValue();
                         }
                         if (tcounter.isSetMax_value()) {
                             counter.setMaxValue(tcounter.getMax_value());
+                        } else {
+                            counter.clearMaxValue();
                         }
                         tCounterMap.remove(topName);
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -372,9 +372,13 @@ public class RuntimeProfile {
                 // Running profile will report multiple times, we only need the last time value
                 if (tcounter.isSetMin_value()) {
                     counter.setMinValue(tcounter.getMin_value());
+                } else {
+                    counter.clearMinValue();
                 }
                 if (tcounter.isSetMax_value()) {
                     counter.setMaxValue(tcounter.getMax_value());
+                } else {
+                    counter.clearMaxValue();
                 }
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileTest.java
@@ -858,4 +858,46 @@ public class RuntimeProfileTest {
             Assertions.assertEquals(11L, c1.getMaxValue().get().longValue());
         }
     }
+
+    @Test
+    public void testUpdateMinMax() {
+        RuntimeProfile baseProfile = new RuntimeProfile("base_profile");
+        Counter baseC1 = baseProfile.addCounter("counter1", TUnit.UNIT, null);
+        baseC1.setValue(4);
+        baseC1.setMinValue(1);
+        baseC1.setMaxValue(7);
+        Counter baseC2 = baseProfile.addCounter("counter2", TUnit.UNIT, null);
+        baseC2.setValue(5);
+
+        RuntimeProfile updateProfile = new RuntimeProfile("update_profile");
+        Counter updateC1 = updateProfile.addCounter("counter1", TUnit.UNIT, null);
+        updateC1.setValue(6);
+        Counter updateC2 = updateProfile.addCounter("counter2", TUnit.UNIT, null);
+        updateC2.setValue(8);
+        updateC2.setMinValue(4);
+        updateC2.setMaxValue(12);
+        Counter updateC3 = updateProfile.addCounter("counter3", TUnit.UNIT, null);
+        updateC3.setValue(10);
+        updateC3.setMinValue(5);
+        updateC3.setMaxValue(15);
+
+        TRuntimeProfileTree updateTree = updateProfile.toThrift();
+
+        baseProfile.update(updateTree);
+        Assertions.assertEquals(6, baseC1.getValue());
+        Assertions.assertFalse(baseC1.getMinValue().isPresent());
+        Assertions.assertFalse(baseC1.getMaxValue().isPresent());
+        Assertions.assertEquals(8, baseC2.getValue());
+        Assertions.assertTrue(baseC2.getMinValue().isPresent());
+        Assertions.assertEquals(4, baseC2.getMinValue().get().longValue());
+        Assertions.assertTrue(baseC2.getMaxValue().isPresent());
+        Assertions.assertEquals(12, baseC2.getMaxValue().get().longValue());
+        Counter baseC3 = baseProfile.getCounter("counter3");
+        Assertions.assertNotNull(baseC3);
+        Assertions.assertEquals(10, baseC3.getValue());
+        Assertions.assertTrue(baseC3.getMinValue().isPresent());
+        Assertions.assertEquals(5, baseC3.getMinValue().get().longValue());
+        Assertions.assertTrue(baseC3.getMaxValue().isPresent());
+        Assertions.assertEquals(15, baseC3.getMaxValue().get().longValue());
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
introduced by #53759
* on BE, `RuntimeProfile::update` does not update counter min/max
* on FE, `RuntimeProfile::update` doest not reset min/max if the new update does not have min/max

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 4.0
  - [X] 3.5
  - [X] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure RuntimeProfile counter min/max are updated when provided and cleared when absent across BE/FE, adding clear APIs and tests.
> 
> - **Backend (BE)**:
>   - `RuntimeProfile::update(...)` now sets `min/max` for counters when present in `TRuntimeProfileNode` and clears them when absent.
>   - Initialize new counters without value, then set value and `min/max` explicitly.
>   - Add `Counter::clear_min()` and `clear_max()` in `runtime_profile.h`.
> - **Frontend (FE)**:
>   - `Counter`: add `clearMinValue()` and `clearMaxValue()`; expose via `RuntimeProfile.update(...)` to reset `min/max` when not provided.
>   - `RuntimeProfile.update(...)`: when processing counters, set `min/max` if present; otherwise clear them. Also ensure strategy is set on newly added counters.
> - **Tests**:
>   - Add `testUpdateMinMax` in BE and FE to validate updating and clearing `min/max` and creation of new counters with `min/max` from updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8df8b44fb96f14198a45f41f82d65b4e9a63040b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->