### PR TITLE
[Enhancement] Add cancellation reason logging for load channels

### DIFF
--- a/be/src/exec/pipeline/sink/olap_table_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/olap_table_sink_operator.cpp
@@ -96,7 +96,9 @@ bool OlapTableSinkOperator::pending_finish() const {
 
 Status OlapTableSinkOperator::set_cancelled(RuntimeState* state) {
     _is_cancelled = true;
-    return _sink->close(state, Status::Cancelled("Cancelled by pipeline engine"));
+    auto final_status = state->fragment_ctx()->final_status();
+    std::string reason = "Cancelled by pipeline engine, reason: " + final_status.to_string();
+    return _sink->close(state, Status::Cancelled(reason));
 }
 
 Status OlapTableSinkOperator::set_finishing(RuntimeState* state) {

--- a/be/src/exec/tablet_sink_index_channel.cpp
+++ b/be/src/exec/tablet_sink_index_channel.cpp
@@ -1105,6 +1105,7 @@ void NodeChannel::_cancel(int64_t index_id, const Status& err_st) {
     request.set_sender_id(_parent->_sender_id);
     request.set_txn_id(_parent->_txn_id);
     request.set_sink_id(_parent->_sink_id);
+    request.set_reason(err_st.to_string());
 
     auto closure = new RefCountClosure<PTabletWriterCancelResult>();
 

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -105,7 +105,7 @@ public:
     void add_segment(brpc::Controller* cntl, const PTabletWriterAddSegmentRequest* request,
                      PTabletWriterAddSegmentResult* response, google::protobuf::Closure* done);
 
-    void cancel();
+    void cancel(const std::string& reason);
 
     void abort();
 
@@ -167,6 +167,8 @@ private:
     bthread::Mutex _lock;
     // key -> tablets channel
     std::map<TabletsChannelKey, std::shared_ptr<TabletsChannel>> _tablets_channels;
+    std::atomic<bool> _cancelled{false};
+    std::string _cancel_reason;
     std::atomic<bool> _closed{false};
 
     Span _span;

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -168,7 +168,6 @@ private:
     // key -> tablets channel
     std::map<TabletsChannelKey, std::shared_ptr<TabletsChannel>> _tablets_channels;
     std::atomic<bool> _cancelled{false};
-    std::string _cancel_reason;
     std::atomic<bool> _closed{false};
 
     Span _span;


### PR DESCRIPTION
## Why I'm doing:

When multiple `OlapTableSink` on multiple BE are involved in one ingestion, if one sink fails and cancels the shared load channel, other sinks attempting to access the same channel may encounter errors like:
- `no associated load channel`
- `AsyncDeltaWriter has been closed`

The problem is that these secondary error messages from later sinks often get returned to FE first, masking the original root cause of the failure. This makes it difficult to identify and fix the actual issue.

This PR adds cancellation reason logging throughout the load channel cancellation flow to help users identify the root
cause when investigating production issues.

Note this is a diagnostic improvement to aid troubleshooting. The actual fix for preventing secondary errors from masking root causes will be addressed in a subsequent PR. This approach minimizes changes to facilitate backporting to previous versions if needed.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 4.0
  - [X] 3.5
  - [X] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Propagates explicit cancellation reasons through sink, channel, and manager paths and logs them when cancelling load channels.
> 
> - **Cancellation reason propagation & logging**:
>   - `OlapTableSinkOperator::set_cancelled` now passes a detailed `Status::Cancelled` with fragment final status.
>   - `NodeChannel::_cancel` sets `PTabletWriterCancelRequest.reason` from error status.
>   - `LoadChannel`:
>     - `cancel` now accepts `reason`, logs it once, and marks `_cancelled` atomically.
>     - Added `_cancelled` flag to track first-time cancel.
>   - `LoadChannelMgr` updates all cancel call sites to pass reasons (manager close, RPC cancel, timeout cleanup, txn abort).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe3c8920cddea9201cb6904ca9e5b978f36cbfd4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->