### PR TITLE
[BugFix] avoid libhdfs crash when applied wrong JDK

### DIFF
--- a/be/src/tools/mock_jvm.c
+++ b/be/src/tools/mock_jvm.c
@@ -21,22 +21,21 @@
 // This file is the mock file that helps us get BE started even if we don't have a JAVA_HOME configuration
 
 _JNI_IMPORT_OR_EXPORT_ jint JNICALL JNI_GetDefaultJavaVMInitArgs(void* args) {
-    return 1;
+    return JNI_ERR;
 }
 
 _JNI_IMPORT_OR_EXPORT_ jint JNICALL JNI_CreateJavaVM(JavaVM** pvm, void** penv, void* args) {
-    return 1;
+    return JNI_ERR;
 }
 
 _JNI_IMPORT_OR_EXPORT_ jint JNICALL JNI_GetCreatedJavaVMs(JavaVM** vm, jsize sz, jsize* output) {
     fprintf(stderr, "unsupported call jni function, JAVA_HOME is required\n ");
-    exit(1);
-    return 1;
+    return JNI_ERR;
 }
 
 /* Defined by native libraries. */
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM* vm, void* reserved) {
-    return 1;
+    return JNI_ERR;
 }
 
 JNIEXPORT void JNICALL JNI_OnUnload(JavaVM* vm, void* reserved) {}

--- a/be/src/udf/java/java_udf.cpp
+++ b/be/src/udf/java/java_udf.cpp
@@ -1046,7 +1046,13 @@ Status detect_java_runtime() {
     if (p == nullptr) {
         return Status::RuntimeError("env 'JAVA_HOME' is not set");
     }
-    return Status::OK();
+    auto st = call_hdfs_scan_function_in_pthread([]() {
+        if (getJNIEnv() == nullptr) {
+            return Status::RuntimeError("couldn't get JNIEnv, please check your java runtime");
+        }
+        return Status::OK();
+    });
+    return st->get_future().get();
 }
 
 } // namespace starrocks

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -632,6 +632,7 @@ if [[ -d $TP_SOURCE_DIR/$HADOOPSRC_SOURCE ]] ; then
     cd $TP_SOURCE_DIR/$HADOOPSRC_SOURCE
     if [ ! -f "$PATCHED_MARK" ] && [[ $HADOOPSRC_SOURCE == "hadoop-3.4.2-src" ]] ; then
         patch -p1 < "$TP_PATCH_DIR/hadoop-3.4.2-src.patch"
+        patch -p1 < "$TP_PATCH_DIR/hadoop-3.4.2-src-jni-crash.patch"
         touch "$PATCHED_MARK"
     fi
     cd -

--- a/thirdparty/patches/hadoop-3.4.2-src-jni-crash.patch
+++ b/thirdparty/patches/hadoop-3.4.2-src-jni-crash.patch
@@ -1,0 +1,31 @@
+diff --git a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/exception.c b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/exception.c
+index fec9a103..f1e85c02 100644
+--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/exception.c
++++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/exception.c
+@@ -179,8 +179,12 @@ int printExceptionAndFreeV(JNIEnv *env, jthrowable exc, int noPrintFlags,
+     // pending exception. Instead, use ExceptionUtils.
+     rootCause = getExceptionUtilString(env, exc, "getRootCauseMessage");
+     stackTrace = getExceptionUtilString(env, exc, "getStackTrace");
++    if (rootCause == NULL || stackTrace ==NULL) {
++    	setTLSExceptionStrings(className, "cannot get stack trace");
++    } else {
++    	setTLSExceptionStrings(rootCause, stackTrace);
++    }
+     // Save the exception details in the thread-local state.
+-    setTLSExceptionStrings(rootCause, stackTrace);
+ 
+     if (!noPrint) {
+         vfprintf(stderr, fmt, ap);
+diff --git a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/jni_helper.c b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/jni_helper.c
+index 3c5f5f12..13fe6604 100644
+--- a/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/jni_helper.c
++++ b/hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/jni_helper.c
+@@ -889,7 +889,7 @@ void setTLSExceptionStrings(const char *rootCause, const char *stackTrace)
+     THREAD_LOCAL_STORAGE_GET_QUICK(&state);
+     if (!state) {
+         mutexLock(&jvmMutex);
+-        if (threadLocalStorageGet(&state)) {
++        if (threadLocalStorageGet(&state)||!state) {
+             mutexUnlock(&jvmMutex);
+             return;
+         }


### PR DESCRIPTION
## Why I'm doing:

If the Hadoop compilation version and runtime version do not match, libhdfs will cause a crash.

```
could not find method getStackTrace from class (null) with signature (Ljava/lang/Throwable;)Ljava/lang/String;
UNKNOWN RELEASE (build UNKNOWN distro ubuntu arch x86_64)
*** Aborted at 1763953683 (unix time) try "date -d @1763953683" if you are using GNU date ***
    @     0x7f0b4d381ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @     0x7f0b4e0e5d49 JVM_handle_linux_signal
    @     0x7f0b4e0d91f8 signalHandler(int, siginfo_t*, void*)
    @     0x7f0b4d32a520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @         0x1179be61 setTLSExceptionStrings
    @         0x1179a504 printExceptionAndFreeV
    @         0x1179a59d printExceptionAndFree
    @         0x1179bb60 getJNIEnv
    @          0xe9b8147 thread_proxy
    @     0x7f0b4d37cac3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
    @     0x7f0b4d40e8c0 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x1268bf)
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
