### PR TITLE
[Feature] Introduce ColumnRange record predicate

### DIFF
--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -278,7 +278,8 @@ set(STORAGE_FILES
     index/vector/tenann/tenann_index_builder.cpp
     index/vector/tenann/tenann_index_utils.cpp
     record_predicate/record_predicate_helper.cpp
-    record_predicate/column_hash_is_congruent.cpp)
+    record_predicate/column_hash_is_congruent.cpp
+    record_predicate/column_range.cpp)
 
 if (NOT BUILD_FORMAT_LIB)
     list(APPEND STORAGE_FILES  lake/starlet_location_provider.cpp)

--- a/be/src/storage/record_predicate/column_hash_is_congruent.cpp
+++ b/be/src/storage/record_predicate/column_hash_is_congruent.cpp
@@ -42,12 +42,12 @@ Status ColumnHashIsCongruent::evaluate(Chunk* chunk, uint8_t* selection, uint16_
 }
 
 Status ColumnHashIsCongruent::init(const RecordPredicatePB& record_predicate_pb) {
-    const auto& column_hash_is_congruent_pb = record_predicate_pb.column_hash_is_congruent();
-    RETURN_IF_ERROR(_check_valid_pb(column_hash_is_congruent_pb));
-    _modulus = column_hash_is_congruent_pb.modulus();
-    _remainder = column_hash_is_congruent_pb.remainder();
-    _column_names.insert(_column_names.end(), column_hash_is_congruent_pb.column_names().begin(),
-                         column_hash_is_congruent_pb.column_names().end());
+    const auto& column_hash_is_congruent_meta = record_predicate_pb.column_hash_is_congruent();
+    RETURN_IF_ERROR(_check_valid_pb(column_hash_is_congruent_meta));
+    _modulus = column_hash_is_congruent_meta.modulus();
+    _remainder = column_hash_is_congruent_meta.remainder();
+    _column_names.insert(_column_names.end(), column_hash_is_congruent_meta.column_names().begin(),
+                         column_hash_is_congruent_meta.column_names().end());
     return Status::OK();
 }
 

--- a/be/src/storage/record_predicate/column_range.cpp
+++ b/be/src/storage/record_predicate/column_range.cpp
@@ -1,0 +1,175 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/record_predicate/column_range.h"
+
+#include <fmt/format.h>
+
+#include "column/chunk.h"
+#include "storage/record_predicate/record_predicate_helper.h"
+
+namespace starrocks {
+
+ColumnRange::ColumnRange(const RecordPredicatePB& record_predicate_pb) :
+        RecordPredicate(record_predicate_pb), _predicate_type(PredicateType::kUnknown) {}
+
+Status ColumnRange::evaluate(Chunk* chunk, uint8_t* selection) const {
+    return evaluate(chunk, selection, 0, chunk->num_rows());
+}
+
+Status ColumnRange::evaluate(Chunk* chunk, uint8_t* selection, uint16_t from, uint16_t to) const {
+    RETURN_IF_ERROR(RecordPredicateHelper::check_valid_schema(*this, *chunk->schema()));
+    RETURN_IF_ERROR(_init_predicates(*chunk->schema()));
+    DCHECK_EQ(_column_names.size(), _selection_vectors.size());
+    std::memset(selection + from, 0, to - from);
+    for (int i = 0; i < _column_names.size(); i++) {
+        if (_selection_vectors[i].size() < to) {
+            _selection_vectors[i].resize(to);
+        }
+        if (_eq_selection_vectors[i].size() < to) {
+            _eq_selection_vectors[i].resize(to);
+        }
+        const auto& column_name = _column_names[i];
+        const auto& column = chunk->get_column_by_name(column_name);
+        RETURN_IF_ERROR(_predicates[i]->evaluate(column.get(), _selection_vectors[i].data(), from, to));
+        RETURN_IF_ERROR(_eq_predicates[i]->evaluate(column.get(), _eq_selection_vectors[i].data(), from, to));
+    }
+
+    for (int i = from; i < to; i++) {
+        for (int j = 0; j < _column_names.size(); j++) {
+            if (_selection_vectors[j][i]) {
+                // For kGE or kLE, if the value is equal to the bound when satisfies the predicate,
+                // we need to check the next column.
+                if (_eq_selection_vectors[j][i]) {
+                    if (j < _column_names.size() - 1) {
+                        continue;
+                    }
+                }
+                selection[i] = 1;
+                break;
+            } else if (!_eq_selection_vectors[j][i]) {
+                // For all type, if the value is not equal to the bound, we need to break.
+                break;
+            }
+
+            // If we reach here, it means the value equals the bound but strictly Range predicate evaluated to false.
+            // This happens for kLT or kGT where equality implies we should check the next column.
+        }
+    }
+    return Status::OK();
+}
+
+Status ColumnRange::init(const RecordPredicatePB& record_predicate_pb) {
+    const auto& column_range_meta = record_predicate_pb.column_range();
+    RETURN_IF_ERROR(_check_valid_pb(column_range_meta));
+    _range = column_range_meta.range();
+    _column_names.insert(_column_names.end(), column_range_meta.column_names().begin(),
+                         column_range_meta.column_names().end());
+    for (int i = 0; i < _column_names.size(); i++) {
+        _selection_vectors.emplace_back(_APPROXIMATE_EVAL_ROWS, 0);
+        _eq_selection_vectors.emplace_back(_APPROXIMATE_EVAL_ROWS, 0);
+    }
+    return Status::OK();
+}
+
+Status ColumnRange::_check_valid_pb(const ColumnRangeMeta& column_range_meta) const {
+    if (column_range_meta.column_names().empty()) {
+        return Status::InternalError("column range predicate has no range columns defined");
+    }
+    for (const auto& column_name : column_range_meta.column_names()) {
+        if (column_name.empty()) {
+            return Status::InternalError("column range predicate has empty range column name");
+        }
+    }
+
+    const TabletRangePB& range = column_range_meta.range();
+    // currently only support the following range types: <, <=, >, >=
+    bool upper_excluded = range.has_upper_bound() && !range.has_lower_bound() && !range.upper_bound_included(); // <
+    bool upper_included = range.has_upper_bound() && !range.has_lower_bound() && range.upper_bound_included();  // <=
+    bool lower_excluded = range.has_lower_bound() && !range.has_upper_bound() && !range.lower_bound_included(); // >
+    bool lower_included = range.has_lower_bound() && !range.has_upper_bound() && range.lower_bound_included();  // >=
+
+    RETURN_IF(!upper_excluded && !upper_included && !lower_excluded && !lower_included,
+              Status::InternalError("column range predicate has invalid range bounds"));
+
+    return Status::OK();
+}
+
+Status ColumnRange::_init_predicates(const Schema& chunk_schema) const {
+    if (!_predicates.empty() && !_eq_predicates.empty() && _predicates.size() == _eq_predicates.size() && 
+        _predicates.size() == _column_names.size()) {
+        return Status::OK();
+    }
+    _predicates.clear();
+    _eq_predicates.clear();
+
+    // Decide predicate type on first use; this is logically const because it depends
+    // only on the protobuf range meta.
+    if (_predicate_type == PredicateType::kUnknown) {
+        const TabletRangePB& range = _range;
+        bool upper_excluded = range.has_upper_bound() && !range.has_lower_bound() && !range.upper_bound_included(); // <
+        bool upper_included = range.has_upper_bound() && !range.has_lower_bound() && range.upper_bound_included();  // <=
+        bool lower_excluded = range.has_lower_bound() && !range.has_upper_bound() && !range.lower_bound_included(); // >
+        bool lower_included = range.has_lower_bound() && !range.has_upper_bound() && range.lower_bound_included();  // >=
+
+        if (upper_excluded) {
+            _predicate_type = PredicateType::kLT;
+        } else if (upper_included) {
+            _predicate_type = PredicateType::kLE;
+        } else if (lower_excluded) {
+            _predicate_type = PredicateType::kGT;
+        } else if (lower_included) {
+            _predicate_type = PredicateType::kGE;
+        } else {
+            return Status::InternalError("column range predicate has invalid range bounds");
+        }
+    }
+
+    const auto& bounds = (_predicate_type == PredicateType::kLT || _predicate_type == PredicateType::kLE)
+                                 ? _range.upper_bound()
+                                 : _range.lower_bound();
+    DCHECK(bounds.values_size() == static_cast<int>(_column_names.size()));
+    for (int i = 0; i < bounds.values_size(); ++i) {
+        const auto& bound = bounds.values(i);
+        const auto& column_name = _column_names[i];
+        auto field = chunk_schema.get_field_by_name(column_name);
+        DCHECK(field != nullptr);
+        DCHECK(bound.has_int_value() || bound.has_string_value());
+
+        std::string bound_str;
+        if (bound.has_int_value()) {
+            bound_str = std::to_string(bound.int_value());
+        } else if (bound.has_string_value()) {
+            bound_str = bound.string_value();
+        }
+        Slice slice(bound_str);
+        ColumnPredicate* pred = new_column_cmp_predicate(_predicate_type, field->type(), field->id(), slice);
+
+        if (pred == nullptr) {
+            return Status::InternalError(
+                    fmt::format("failed to create column predicate for column range predicate, {}", column_name));
+        }
+        _predicates.emplace_back(pred);
+
+        ColumnPredicate* eq_pred = new_column_cmp_predicate(PredicateType::kEQ, field->type(), field->id(), slice);
+        if (eq_pred == nullptr) {
+            return Status::InternalError(
+                    fmt::format("failed to create column eq predicate for column range predicate, {}", column_name));
+        }
+        _eq_predicates.emplace_back(eq_pred);
+    }
+    return Status::OK();
+}
+
+} // namespace starrocks

--- a/be/src/storage/record_predicate/column_range.h
+++ b/be/src/storage/record_predicate/column_range.h
@@ -1,0 +1,72 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+
+#include "google/protobuf/util/message_differencer.h"
+#include "storage/record_predicate/record_predicate.h"
+#include "storage/column_predicate.h"
+
+namespace starrocks {
+
+class Schema;
+
+/*
+ * ColumnRange is used to evaluate a chunk of data as following:
+ * 1. Given the raw value of columns with the specified columns.
+ * 2. Check if the value is in the range or not.
+ * 3. The range is a lexicographic tuple range, which is a range of values that are ordered by the values of the columns.
+ */
+class ColumnRange final : public RecordPredicate {
+public:
+    using ColumnRangeMeta = RecordPredicatePB::ColumnRangePB;
+
+    ColumnRange(const RecordPredicatePB& record_predicate_pb);
+    ~ColumnRange() override = default;
+
+    Status evaluate(Chunk* chunk, uint8_t* selection) const override;
+
+    Status evaluate(Chunk* chunk, uint8_t* selection, uint16_t from, uint16_t to) const override;
+
+    Status init(const RecordPredicatePB& record_predicate_pb) override;
+
+    const std::vector<std::string>* column_names() const override { return &_column_names; }
+
+    bool equals(const RecordPredicate& other) const override {
+        if (typeid(*this) != typeid(other)) {
+            return false;
+        }
+        const auto& other_predicate = static_cast<const ColumnRange&>(other);
+        return _column_names == other_predicate._column_names && 
+               google::protobuf::util::MessageDifferencer::Equals(_range, other_predicate._range);
+    }
+
+private:
+    Status _check_valid_pb(const ColumnRangeMeta& column_range_meta) const;
+
+    Status _init_predicates(const Schema& chunk_schema) const;
+
+    TabletRangePB _range;
+    mutable PredicateType _predicate_type;
+    mutable std::vector<std::unique_ptr<ColumnPredicate>> _predicates;
+    mutable std::vector<std::unique_ptr<ColumnPredicate>> _eq_predicates;
+    std::vector<std::string> _column_names;
+    mutable std::vector<std::vector<uint8_t>> _selection_vectors;
+    mutable std::vector<std::vector<uint8_t>> _eq_selection_vectors;
+    static constexpr size_t _APPROXIMATE_EVAL_ROWS = 4096;
+};
+
+} // namespace starrocks

--- a/be/src/storage/record_predicate/record_predicate.h
+++ b/be/src/storage/record_predicate/record_predicate.h
@@ -27,6 +27,7 @@ class RecordPredicate;
 using RecordPredicateSPtr = std::shared_ptr<RecordPredicate>;
 using RecordPredicateUPtr = std::unique_ptr<RecordPredicate>;
 
+// Record Predicate is non-thread safe
 class RecordPredicate {
 public:
     RecordPredicate(const RecordPredicatePB& record_predicate_pb)

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -540,6 +540,7 @@ SET(DW_TEST_FILES
     ./storage/range_test.cpp
     ./storage/record_predicate/column_hash_is_congruent_test.cpp
     ./storage/record_predicate/record_predicate_helper_test.cpp
+    ./storage/record_predicate/column_range_test.cpp
     ./storage/replication_txn_manager_test.cpp
     ./storage/replication_utils_test.cpp
     ./storage/roaring2range_test.cpp

--- a/be/test/storage/record_predicate/column_range_test.cpp
+++ b/be/test/storage/record_predicate/column_range_test.cpp
@@ -1,0 +1,410 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/record_predicate/column_range.h"
+
+#include <gtest/gtest.h>
+
+#include "gen_cpp/types.pb.h"
+#include "storage/chunk_helper.h"
+#include "storage/record_predicate/record_predicate_helper.h"
+#include "storage/tablet_schema.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+class ColumnRangeTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        TabletSchemaPB schema_pb;
+        schema_pb.set_keys_type(PRIMARY_KEYS);
+        schema_pb.set_num_short_key_columns(1);
+        schema_pb.set_num_rows_per_row_block(5);
+        schema_pb.set_next_column_unique_id(3);
+
+        ColumnPB& col1 = *(schema_pb.add_column());
+        col1.set_unique_id(1);
+        col1.set_name("col1");
+        col1.set_type("INT");
+        col1.set_is_key(true);
+        col1.set_is_nullable(false);
+
+        ColumnPB& col2 = *(schema_pb.add_column());
+        col2.set_unique_id(2);
+        col2.set_name("col2");
+        col2.set_type("INT");
+        col2.set_is_key(true);
+        col2.set_is_nullable(false);
+
+        _table_schema = std::make_shared<const TabletSchema>(schema_pb);
+    }
+
+protected:
+    std::shared_ptr<const TabletSchema> _table_schema;
+};
+
+TEST_F(ColumnRangeTest, InitValidation) {
+    RecordPredicatePB pb;
+    pb.set_type(RecordPredicatePB::COLUMN_RANGE);
+    auto* range_pb = pb.mutable_column_range();
+
+    // Case 1: No columns
+    {
+        auto st = RecordPredicateHelper::create(pb);
+        ASSERT_ERROR(st);
+        EXPECT_TRUE(st.status().to_string().find("no range columns defined") != std::string::npos);
+    }
+
+    // Case 2: Empty column name
+    {
+        range_pb->add_column_names("");
+        auto st = RecordPredicateHelper::create(pb);
+        ASSERT_ERROR(st);
+        EXPECT_TRUE(st.status().to_string().find("empty range column name") != std::string::npos);
+        range_pb->clear_column_names();
+    }
+
+    // Case 3: Invalid range bounds (both empty)
+    {
+        range_pb->add_column_names("col1");
+        auto st = RecordPredicateHelper::create(pb);
+        ASSERT_ERROR(st);
+        EXPECT_TRUE(st.status().to_string().find("invalid range bounds") != std::string::npos);
+    }
+
+    // Case 4: Invalid range bounds (both set)
+    {
+        auto* range = range_pb->mutable_range();
+        range->mutable_lower_bound()->add_values()->set_int_value(1);
+        range->mutable_upper_bound()->add_values()->set_int_value(10);
+        auto st = RecordPredicateHelper::create(pb);
+        ASSERT_ERROR(st);
+        EXPECT_TRUE(st.status().to_string().find("invalid range bounds") != std::string::npos);
+    }
+}
+
+TEST_F(ColumnRangeTest, SingleColumnEvaluate) {
+    auto chunk = ChunkHelper::new_chunk(*_table_schema->schema(), 10);
+    // col1 values: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+    for (int i = 0; i < 10; ++i) {
+        chunk->get_column_by_name("col1")->append_datum(Datum((int32_t)i));
+        chunk->get_column_by_name("col2")->append_datum(Datum((int32_t)i)); // dummy
+    }
+
+    // Test < 5
+    // Boundary check: 4 should match, 5 should not match
+    {
+        RecordPredicatePB pb;
+        pb.set_type(RecordPredicatePB::COLUMN_RANGE);
+        auto* range_pb = pb.mutable_column_range();
+        range_pb->add_column_names("col1");
+        auto* range = range_pb->mutable_range();
+        range->mutable_upper_bound()->add_values()->set_int_value(5);
+        range->set_upper_bound_included(false);
+
+        ASSIGN_OR_ABORT(auto pred, RecordPredicateHelper::create(pb));
+        std::vector<uint8_t> selection(10);
+        ASSERT_OK(pred->evaluate(chunk.get(), selection.data()));
+
+        for (int i = 0; i < 10; ++i) {
+            EXPECT_EQ(selection[i], i < 5 ? 1 : 0);
+        }
+    }
+
+    // Test <= 5
+    // Boundary check: 5 should match, 6 should not match
+    {
+        RecordPredicatePB pb;
+        pb.set_type(RecordPredicatePB::COLUMN_RANGE);
+        auto* range_pb = pb.mutable_column_range();
+        range_pb->add_column_names("col1");
+        auto* range = range_pb->mutable_range();
+        range->mutable_upper_bound()->add_values()->set_int_value(5);
+        range->set_upper_bound_included(true);
+
+        ASSIGN_OR_ABORT(auto pred, RecordPredicateHelper::create(pb));
+        std::vector<uint8_t> selection(10);
+        ASSERT_OK(pred->evaluate(chunk.get(), selection.data()));
+
+        for (int i = 0; i < 10; ++i) {
+            EXPECT_EQ(selection[i], i <= 5 ? 1 : 0);
+        }
+    }
+
+    // Test > 5
+    // Boundary check: 6 should match, 5 should not match
+    {
+        RecordPredicatePB pb;
+        pb.set_type(RecordPredicatePB::COLUMN_RANGE);
+        auto* range_pb = pb.mutable_column_range();
+        range_pb->add_column_names("col1");
+        auto* range = range_pb->mutable_range();
+        range->mutable_lower_bound()->add_values()->set_int_value(5);
+        range->set_lower_bound_included(false);
+
+        ASSIGN_OR_ABORT(auto pred, RecordPredicateHelper::create(pb));
+        std::vector<uint8_t> selection(10);
+        ASSERT_OK(pred->evaluate(chunk.get(), selection.data()));
+
+        for (int i = 0; i < 10; ++i) {
+            EXPECT_EQ(selection[i], i > 5 ? 1 : 0);
+        }
+    }
+
+    // Test >= 5
+    // Boundary check: 5 should match, 4 should not match
+    {
+        RecordPredicatePB pb;
+        pb.set_type(RecordPredicatePB::COLUMN_RANGE);
+        auto* range_pb = pb.mutable_column_range();
+        range_pb->add_column_names("col1");
+        auto* range = range_pb->mutable_range();
+        range->mutable_lower_bound()->add_values()->set_int_value(5);
+        range->set_lower_bound_included(true);
+
+        ASSIGN_OR_ABORT(auto pred, RecordPredicateHelper::create(pb));
+        std::vector<uint8_t> selection(10);
+        ASSERT_OK(pred->evaluate(chunk.get(), selection.data()));
+
+        for (int i = 0; i < 10; ++i) {
+            EXPECT_EQ(selection[i], i >= 5 ? 1 : 0);
+        }
+    }
+}
+
+TEST_F(ColumnRangeTest, MultiColumnEvaluate) {
+    auto chunk = ChunkHelper::new_chunk(*_table_schema->schema(), 10);
+    // col1: 1, 1, 1, 2, 2, 2, 3, 3, 3, 4
+    // col2: 1, 2, 3, 1, 2, 3, 1, 2, 3, 1
+    std::vector<int> c1 = {1, 1, 1, 2, 2, 2, 3, 3, 3, 4};
+    std::vector<int> c2 = {1, 2, 3, 1, 2, 3, 1, 2, 3, 1};
+    
+    for (int i = 0; i < 10; ++i) {
+        chunk->get_column_by_name("col1")->append_datum(Datum((int32_t)c1[i]));
+        chunk->get_column_by_name("col2")->append_datum(Datum((int32_t)c2[i]));
+    }
+
+    // Test < (2, 2)
+    // Expected matches: (1,1), (1,2), (1,3), (2,1)
+    // Boundary: (2,2) should not match. (2,1) matches because 2==2 and 1<2.
+    {
+        RecordPredicatePB pb;
+        pb.set_type(RecordPredicatePB::COLUMN_RANGE);
+        auto* range_pb = pb.mutable_column_range();
+        range_pb->add_column_names("col1");
+        range_pb->add_column_names("col2");
+        auto* range = range_pb->mutable_range();
+        auto* val1 = range->mutable_upper_bound()->add_values();
+        val1->set_int_value(2);
+        auto* val2 = range->mutable_upper_bound()->add_values();
+        val2->set_int_value(2);
+        range->set_upper_bound_included(false);
+
+        ASSIGN_OR_ABORT(auto pred, RecordPredicateHelper::create(pb));
+        std::vector<uint8_t> selection(10);
+        ASSERT_OK(pred->evaluate(chunk.get(), selection.data()));
+
+        for (int i = 0; i < 10; ++i) {
+            bool expected = (c1[i] < 2) || (c1[i] == 2 && c2[i] < 2);
+            EXPECT_EQ(selection[i], expected ? 1 : 0) << "Row " << i << ": (" << c1[i] << "," << c2[i] << ")";
+        }
+    }
+
+    // Test <= (2, 2)
+    // Expected matches: (1,all), (2,1), (2,2)
+    // Boundary: (2,2) should match. (2,3) should not match.
+    {
+        RecordPredicatePB pb;
+        pb.set_type(RecordPredicatePB::COLUMN_RANGE);
+        auto* range_pb = pb.mutable_column_range();
+        range_pb->add_column_names("col1");
+        range_pb->add_column_names("col2");
+        auto* range = range_pb->mutable_range();
+        auto* val1 = range->mutable_upper_bound()->add_values();
+        val1->set_int_value(2);
+        auto* val2 = range->mutable_upper_bound()->add_values();
+        val2->set_int_value(2);
+        range->set_upper_bound_included(true);
+
+        ASSIGN_OR_ABORT(auto pred, RecordPredicateHelper::create(pb));
+        std::vector<uint8_t> selection(10);
+        ASSERT_OK(pred->evaluate(chunk.get(), selection.data()));
+
+        for (int i = 0; i < 10; ++i) {
+            bool expected = (c1[i] < 2) || (c1[i] == 2 && c2[i] <= 2);
+            EXPECT_EQ(selection[i], expected ? 1 : 0) << "Row " << i << ": (" << c1[i] << "," << c2[i] << ")";
+        }
+    }
+
+    // Test > (2, 2)
+    // Expected matches: (2,3), (3,all), (4,all)
+    // Boundary: (2,2) should not match. (2,3) should match.
+    {
+        RecordPredicatePB pb;
+        pb.set_type(RecordPredicatePB::COLUMN_RANGE);
+        auto* range_pb = pb.mutable_column_range();
+        range_pb->add_column_names("col1");
+        range_pb->add_column_names("col2");
+        auto* range = range_pb->mutable_range();
+        auto* val1 = range->mutable_lower_bound()->add_values();
+        val1->set_int_value(2);
+        auto* val2 = range->mutable_lower_bound()->add_values();
+        val2->set_int_value(2);
+        range->set_lower_bound_included(false);
+
+        ASSIGN_OR_ABORT(auto pred, RecordPredicateHelper::create(pb));
+        std::vector<uint8_t> selection(10);
+        ASSERT_OK(pred->evaluate(chunk.get(), selection.data()));
+
+        for (int i = 0; i < 10; ++i) {
+            bool expected = (c1[i] > 2) || (c1[i] == 2 && c2[i] > 2);
+            EXPECT_EQ(selection[i], expected ? 1 : 0) << "Row " << i << ": (" << c1[i] << "," << c2[i] << ")";
+        }
+    }
+
+    // Test >= (2, 2)
+    // Expected matches: (2,2), (2,3), (3,all), (4,all)
+    // Boundary: (2,2) should match. (2,1) should not match.
+    {
+        RecordPredicatePB pb;
+        pb.set_type(RecordPredicatePB::COLUMN_RANGE);
+        auto* range_pb = pb.mutable_column_range();
+        range_pb->add_column_names("col1");
+        range_pb->add_column_names("col2");
+        auto* range = range_pb->mutable_range();
+        auto* val1 = range->mutable_lower_bound()->add_values();
+        val1->set_int_value(2);
+        auto* val2 = range->mutable_lower_bound()->add_values();
+        val2->set_int_value(2);
+        range->set_lower_bound_included(true);
+
+        ASSIGN_OR_ABORT(auto pred, RecordPredicateHelper::create(pb));
+        std::vector<uint8_t> selection(10);
+        ASSERT_OK(pred->evaluate(chunk.get(), selection.data()));
+
+        for (int i = 0; i < 10; ++i) {
+            bool expected = (c1[i] > 2) || (c1[i] == 2 && c2[i] >= 2);
+            EXPECT_EQ(selection[i], expected ? 1 : 0) << "Row " << i << ": (" << c1[i] << "," << c2[i] << ")";
+        }
+    }
+}
+
+TEST_F(ColumnRangeTest, MultiColumnStringEvaluate) {
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(PRIMARY_KEYS);
+    schema_pb.set_num_short_key_columns(2);
+    schema_pb.set_num_rows_per_row_block(5);
+    schema_pb.set_next_column_unique_id(3);
+
+    ColumnPB& col1 = *(schema_pb.add_column());
+    col1.set_unique_id(1);
+    col1.set_name("s1");
+    col1.set_type("VARCHAR");
+    col1.set_is_key(true);
+    col1.set_is_nullable(false);
+
+    ColumnPB& col2 = *(schema_pb.add_column());
+    col2.set_unique_id(2);
+    col2.set_name("s2");
+    col2.set_type("VARCHAR");
+    col2.set_is_key(true);
+    col2.set_is_nullable(false);
+
+    auto schema = std::make_shared<const TabletSchema>(schema_pb);
+    auto chunk = ChunkHelper::new_chunk(*schema->schema(), 5);
+
+    // Data:
+    // 0: ("a", "b")
+    // 1: ("b", "a")
+    // 2: ("b", "b")
+    // 3: ("b", "c")
+    // 4: ("c", "a")
+    std::vector<std::string> s1 = {"a", "b", "b", "b", "c"};
+    std::vector<std::string> s2 = {"b", "a", "b", "c", "a"};
+
+    for (int i = 0; i < 5; ++i) {
+        chunk->get_column_by_name("s1")->append_datum(Datum(Slice(s1[i])));
+        chunk->get_column_by_name("s2")->append_datum(Datum(Slice(s2[i])));
+    }
+
+    // Target: ("b", "b")
+
+    // Test < ("b", "b")
+    // Expect: ("a", "b"), ("b", "a") -> indices 0, 1
+    {
+        RecordPredicatePB pb;
+        pb.set_type(RecordPredicatePB::COLUMN_RANGE);
+        auto* range_pb = pb.mutable_column_range();
+        range_pb->add_column_names("s1");
+        range_pb->add_column_names("s2");
+        auto* range = range_pb->mutable_range();
+        range->mutable_upper_bound()->add_values()->set_string_value("b");
+        range->mutable_upper_bound()->add_values()->set_string_value("b");
+        range->set_upper_bound_included(false);
+
+        ASSIGN_OR_ABORT(auto pred, RecordPredicateHelper::create(pb));
+        std::vector<uint8_t> selection(5);
+        ASSERT_OK(pred->evaluate(chunk.get(), selection.data()));
+
+        EXPECT_EQ(selection[0], 1); // a < b
+        EXPECT_EQ(selection[1], 1); // b == b, a < b
+        EXPECT_EQ(selection[2], 0); // b == b, b < b (False)
+        EXPECT_EQ(selection[3], 0); // b == b, c < b (False)
+        EXPECT_EQ(selection[4], 0); // c < b (False)
+    }
+
+    // Test >= ("b", "b")
+    // Expect: ("b", "b"), ("b", "c"), ("c", "a") -> indices 2, 3, 4
+    {
+        RecordPredicatePB pb;
+        pb.set_type(RecordPredicatePB::COLUMN_RANGE);
+        auto* range_pb = pb.mutable_column_range();
+        range_pb->add_column_names("s1");
+        range_pb->add_column_names("s2");
+        auto* range = range_pb->mutable_range();
+        range->mutable_lower_bound()->add_values()->set_string_value("b");
+        range->mutable_lower_bound()->add_values()->set_string_value("b");
+        range->set_lower_bound_included(true);
+
+        ASSIGN_OR_ABORT(auto pred, RecordPredicateHelper::create(pb));
+        std::vector<uint8_t> selection(5);
+        ASSERT_OK(pred->evaluate(chunk.get(), selection.data()));
+
+        EXPECT_EQ(selection[0], 0);
+        EXPECT_EQ(selection[1], 0);
+        EXPECT_EQ(selection[2], 1); // b == b, b >= b
+        EXPECT_EQ(selection[3], 1); // b == b, c >= b
+        EXPECT_EQ(selection[4], 1); // c > b
+    }
+}
+
+TEST_F(ColumnRangeTest, SchemaMismatch) {
+    RecordPredicatePB pb;
+    pb.set_type(RecordPredicatePB::COLUMN_RANGE);
+    auto* range_pb = pb.mutable_column_range();
+    range_pb->add_column_names("non_existent_col");
+    auto* range = range_pb->mutable_range();
+    range->mutable_upper_bound()->add_values()->set_int_value(5);
+    range->set_upper_bound_included(false);
+
+    ASSIGN_OR_ABORT(auto pred, RecordPredicateHelper::create(pb));
+    auto chunk = ChunkHelper::new_chunk(*_table_schema->schema(), 10);
+    std::vector<uint8_t> selection(10);
+    
+    auto st = pred->evaluate(chunk.get(), selection.data());
+    ASSERT_ERROR(st);
+    EXPECT_TRUE(st.to_string().find("does not contains all columns which record predicate need") != std::string::npos);
+}
+
+} // namespace starrocks

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -186,6 +186,7 @@ message RecordPredicatePB {
     enum RecordPredicateTypePB {
         UNKNOWN = 0;
         COLUMN_HASH_IS_CONGRUENT = 1;
+        COLUMN_RANGE = 2;
     }
 
     message ColumnHashIsCongruentPB {
@@ -194,11 +195,17 @@ message RecordPredicatePB {
         repeated string column_names = 3;
     }
 
+    message ColumnRangePB {
+        optional TabletRangePB range = 1;
+        repeated string column_names = 2;
+    }
+
     optional RecordPredicateTypePB type = 1;
     // set by some type of predicate (RecordPredicateTypePB is AND/OR/NOT...) which will be implemented in the future
     repeated RecordPredicatePB children = 2;
     // The following member should be set one of them by predicate type
     optional ColumnHashIsCongruentPB column_hash_is_congruent = 3;
+    optional ColumnRangePB column_range = 4;
 }
 
 message PersistentIndexSstablePredicatePB {
@@ -230,4 +237,21 @@ message TransactionStatePB {
     optional int64 txn_id = 1;
     optional TransactionStatusPB status = 2;
     optional string reason = 3;
+}
+
+message VariantPB {
+    optional PTypeDesc type = 1;
+    optional int64 int_value = 2;
+    optional string string_value = 3;
+}
+
+message TuplePB {
+    repeated VariantPB values = 1;
+}
+
+message TabletRangePB {
+    optional TuplePB lower_bound = 1;
+    optional TuplePB upper_bound = 2;
+    optional bool lower_bound_included = 3;
+    optional bool upper_bound_included = 4;
 }


### PR DESCRIPTION
## What I'm doing:
In this Pr, i introduce ColumnRange record predicate, which is used to evaluate a chunk of data as following:
1. Given the raw value of columns with the specified columns.
2. Check if the value is in the range or not.
3. The range is a lexicographic tuple range, which is a range of values that are ordered by the values of the columns.

ColumnRange record predicate will be used to evaluate the data of RANGE DISTRIBUTION table for tablet splitting purpose.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
