### PR TITLE
[Enhancement] add memory limit for sink buffer

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1485,6 +1485,9 @@ CONF_mInt64(streaming_agg_limited_memory_size, "134217728");
 CONF_mInt64(partition_hash_join_probe_limit_size, "134217728");
 // pipeline streaming aggregate chunk buffer size
 CONF_mInt32(streaming_agg_chunk_buffer_size, "1024");
+// sink buffer memory limit per driver
+CONF_mInt64(sink_buffer_mem_limit_per_driver, "134217728");
+
 CONF_mInt64(wait_apply_time, "6000"); // 6s
 
 // Max size of a binlog file. The default is 512MB.

--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -34,7 +34,7 @@
 #include "runtime/runtime_state.h"
 #include "serde/compress_strategy.h"
 #include "serde/protobuf_serde.h"
-#include "service/brpc.h"
+#include "util/brpc_stub_cache.h"
 #include "util/compression/block_compression.h"
 #include "util/compression/compression_utils.h"
 #include "util/internal_service_recoverable_stub.h"
@@ -76,7 +76,7 @@ public:
     // This function is only used when broadcast, because request can be reused
     // by all the channels.
     Status send_chunk_request(RuntimeState* state, PTransmitChunkParamsPtr chunk_request,
-                              const butil::IOBuf& attachment, int64_t attachment_physical_bytes);
+                              const butil::IOBuf& attachment, size_t request_byte_size);
 
     // Used when doing shuffle.
     // This function will copy selective rows in chunks to batch.
@@ -262,9 +262,9 @@ Status ExchangeSinkOperator::Channel::send_one_chunk(RuntimeState* state, const 
         _chunk_request->set_eos(eos);
         _chunk_request->set_use_pass_through(_use_pass_through);
         butil::IOBuf attachment;
-        int64_t attachment_physical_bytes = _parent->construct_brpc_attachment(_chunk_request, attachment);
+        _parent->construct_brpc_attachment(_chunk_request, attachment);
         TransmitChunkInfo info = {this->_fragment_instance_id, _brpc_stub,     std::move(_chunk_request), attachment,
-                                  attachment_physical_bytes,   _brpc_dest_addr};
+                                  _current_request_bytes,      _brpc_dest_addr};
         RETURN_IF_ERROR(_parent->_buffer->add_request(info));
         _current_request_bytes = 0;
         _chunk_request.reset();
@@ -275,8 +275,7 @@ Status ExchangeSinkOperator::Channel::send_one_chunk(RuntimeState* state, const 
 }
 
 Status ExchangeSinkOperator::Channel::send_chunk_request(RuntimeState* state, PTransmitChunkParamsPtr chunk_request,
-                                                         const butil::IOBuf& attachment,
-                                                         int64_t attachment_physical_bytes) {
+                                                         const butil::IOBuf& attachment, size_t request_byte_size) {
     if (_ignore_local_data) {
         return Status::OK();
     }
@@ -286,7 +285,7 @@ Status ExchangeSinkOperator::Channel::send_chunk_request(RuntimeState* state, PT
     chunk_request->set_eos(false);
     chunk_request->set_use_pass_through(_use_pass_through);
     TransmitChunkInfo info = {this->_fragment_instance_id, _brpc_stub,     std::move(chunk_request), attachment,
-                              attachment_physical_bytes,   _brpc_dest_addr};
+                              request_byte_size,           _brpc_dest_addr};
     RETURN_IF_ERROR(_parent->_buffer->add_request(info));
 
     return Status::OK();
@@ -536,12 +535,12 @@ Status ExchangeSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& chu
             // 3. if request bytes exceede the threshold, send current request
             if (_current_request_bytes > config::max_transmit_batched_bytes) {
                 butil::IOBuf attachment;
-                int64_t attachment_physical_bytes = construct_brpc_attachment(_chunk_request, attachment);
+                construct_brpc_attachment(_chunk_request, attachment);
                 for (auto idx : _channel_indices) {
                     if (!_channels[idx]->use_pass_through()) {
                         PTransmitChunkParamsPtr copy = std::make_shared<PTransmitChunkParams>(*_chunk_request);
                         RETURN_IF_ERROR(
-                                _channels[idx]->send_chunk_request(state, copy, attachment, attachment_physical_bytes));
+                                _channels[idx]->send_chunk_request(state, copy, attachment, _current_request_bytes));
                     }
                 }
                 _current_request_bytes = 0;
@@ -661,10 +660,10 @@ Status ExchangeSinkOperator::set_finishing(RuntimeState* state) {
 
     if (_chunk_request != nullptr) {
         butil::IOBuf attachment;
-        int64_t attachment_physical_bytes = construct_brpc_attachment(_chunk_request, attachment);
+        construct_brpc_attachment(_chunk_request, attachment);
         for (const auto& [_, channel] : _instance_id2channel) {
             PTransmitChunkParamsPtr copy = std::make_shared<PTransmitChunkParams>(*_chunk_request);
-            RETURN_IF_ERROR(channel->send_chunk_request(state, copy, attachment, attachment_physical_bytes));
+            RETURN_IF_ERROR(channel->send_chunk_request(state, copy, attachment, _current_request_bytes));
         }
         _current_request_bytes = 0;
         _chunk_request.reset();

--- a/be/src/exec/pipeline/exchange/local_exchange.h
+++ b/be/src/exec/pipeline/exchange/local_exchange.h
@@ -165,6 +165,8 @@ public:
     int32_t incr_epoch_finished_sinker() { return ++_epoch_finished_sinker; }
 
     size_t get_memory_usage() const { return _memory_manager->get_memory_usage(); }
+    size_t get_peak_memory_usage() const { return _memory_manager->get_peak_memory_usage(); }
+    size_t get_peak_num_rows() const { return _memory_manager->get_peak_num_rows(); }
 
     void attach_sink_observer(RuntimeState* state, pipeline::PipelineObserver* observer) {
         _sink_observable.add_observer(state, observer);

--- a/be/src/exec/pipeline/exchange/local_exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/local_exchange_sink_operator.h
@@ -70,6 +70,7 @@ private:
     bool _is_finished = false;
     const std::shared_ptr<LocalExchanger>& _exchanger;
     RuntimeProfile::HighWaterMarkCounter* _peak_memory_usage_counter = nullptr;
+    RuntimeProfile::HighWaterMarkCounter* _peak_num_rows_counter = nullptr;
     // STREAM MV
     bool _is_epoch_finished = false;
 };

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -16,12 +16,11 @@
 
 #include <bthread/bthread.h>
 
-#include <chrono>
 #include <mutex>
 #include <string_view>
 
-#include "exec/pipeline/schedule/utils.h"
 #include "fmt/core.h"
+#include "util/brpc_stub_cache.h"
 #include "util/defer_op.h"
 #include "util/time.h"
 #include "util/uid_util.h"
@@ -34,6 +33,7 @@ SinkBuffer::SinkBuffer(FragmentContext* fragment_ctx, const std::vector<TPlanFra
           _mem_tracker(fragment_ctx->runtime_state()->instance_mem_tracker()),
           _brpc_timeout_ms(fragment_ctx->runtime_state()->query_options().query_timeout * 1000),
           _is_dest_merge(is_dest_merge),
+          _buffered_mem_usage(std::make_unique<MemTracker>()),
           _rpc_http_min_size(fragment_ctx->runtime_state()->get_rpc_http_min_size()),
           _sent_audit_stats_frequency_upper_limit(
                   std::max((int64_t)64, BitUtil::RoundUpToPowerOfTwo(fragment_ctx->total_dop() * 4))) {
@@ -85,6 +85,7 @@ Status SinkBuffer::add_request(TransmitChunkInfo& request) {
     if (_is_finishing) {
         return Status::OK();
     }
+    _buffered_mem_usage->consume(request.request_byte_size);
     if (!request.attachment.empty()) {
         _bytes_enqueued += request.attachment.size();
         _request_enqueued++;
@@ -123,7 +124,11 @@ bool SinkBuffer::is_full() const {
     for (auto& [_, context] : _sink_ctxs) {
         buffer_size += context->buffer.size();
     }
-    const bool is_full = buffer_size > max_buffer_size;
+    bool is_full = buffer_size > max_buffer_size;
+
+    if (!is_full) {
+        is_full = _buffered_mem_usage->consumption() > config::sink_buffer_mem_limit_per_driver * _sink_ctxs.size();
+    }
 
     int64_t last_full_timestamp = _last_full_timestamp;
     int64_t full_time = _full_time;
@@ -263,6 +268,11 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
     DeferOp decrease_defer([this]() { --_num_sending_rpc; });
     ++_num_sending_rpc;
 
+    // When the driver worker thread sends request and creates the protobuf request,
+    // also use process_mem_tracker to record the memory of the protobuf request.
+    SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
+    // must in the same scope following the above
+
     for (;;) {
         if (_is_finishing) {
             return Status::OK();
@@ -285,6 +295,8 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
         }
 
         TransmitChunkInfo& request = buffer.front();
+        size_t request_byte_size = request.request_byte_size;
+
         bool need_wait = false;
         DeferOp pop_defer([&need_wait, &buffer, mem_tracker = _mem_tracker]() {
             if (need_wait) {
@@ -322,6 +334,7 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
             // ExchangeSourceOperator and eos is sent exactly-once.
             if (context.num_sinker > 1) {
                 if (request.params->chunks_size() == 0) {
+                    _buffered_mem_usage->release(request_byte_size);
                     continue;
                 } else {
                     request.params->set_eos(false);
@@ -363,7 +376,8 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
             _first_send_time = MonotonicNanos();
         }
 
-        closure->addFailedHandler([this](const ClosureContext& ctx, std::string_view rpc_error_msg) noexcept {
+        auto failed_function = [this, request_byte_size](const ClosureContext& ctx,
+                                                         std::string_view rpc_error_msg) noexcept {
             auto query_ctx = _fragment_ctx->runtime_state()->query_ctx();
             auto query_ctx_guard = query_ctx->shared_from_this();
             auto notify = this->defer_notify();
@@ -373,6 +387,7 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
             auto& context = sink_ctx(ctx.instance_id.lo);
             ++context.num_finished_rpcs;
             --context.num_in_flight_rpcs;
+            _buffered_mem_usage->release(request_byte_size);
 
             const auto& dest_addr = context.dest_addrs;
             std::string err_msg =
@@ -381,8 +396,10 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
 
             _fragment_ctx->cancel(Status::ThriftRpcError(err_msg));
             LOG(WARNING) << err_msg;
-        });
-        closure->addSuccessHandler([this](const ClosureContext& ctx, const PTransmitChunkResult& result) noexcept {
+        };
+
+        auto success_function = [this, request_byte_size](const ClosureContext& ctx,
+                                                          const PTransmitChunkResult& result) noexcept {
             auto query_ctx = _fragment_ctx->runtime_state()->query_ctx();
             auto query_ctx_guard = query_ctx->shared_from_this();
             auto notify = this->defer_notify();
@@ -392,6 +409,7 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
             auto& context = sink_ctx(ctx.instance_id.lo);
             ++context.num_finished_rpcs;
             --context.num_in_flight_rpcs;
+            _buffered_mem_usage->release(request_byte_size);
 
             if (!status.ok()) {
                 _is_finishing = true;
@@ -407,31 +425,23 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
                     _process_send_window(ctx.instance_id, ctx.sequence);
                 }));
             }
-        });
+        };
+
+        closure->addFailureHandler(failed_function);
+        closure->addSuccessHandler(success_function);
 
         ++_total_in_flight_rpc;
         ++context.num_in_flight_rpcs;
 
         // Attachment will be released by process_mem_tracker in closure->Run() in bthread, when receiving the response,
         // so decrease the memory usage of attachment from instance_mem_tracker immediately before sending the request.
-        _mem_tracker->release(request.attachment_physical_bytes);
-        GlobalEnv::GetInstance()->process_mem_tracker()->consume(request.attachment_physical_bytes);
+        _mem_tracker->release_without_root(request.attachment.size());
 
         closure->cntl.Reset();
         closure->cntl.set_timeout_ms(_brpc_timeout_ms);
         SET_IGNORE_OVERCROWDED(closure->cntl, query);
 
-        Status st;
-        if (bthread_self()) {
-            st = _send_rpc(closure, request);
-        } else {
-            // When the driver worker thread sends request and creates the protobuf request,
-            // also use process_mem_tracker to record the memory of the protobuf request.
-            SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
-            // must in the same scope following the above
-            st = _send_rpc(closure, request);
-        }
-        return st;
+        return _send_rpc(closure, request);
     }
     return Status::OK();
 }

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -659,7 +659,7 @@ void LocalTabletsChannel::_abort_replica_tablets(
                     << ", load_id: " << print_id(ctx.load_id) << ", replica_node: " << ctx.host
                     << ", tablets: " << ctx.tablets;
         });
-        closure->addFailedHandler([](const Context& ctx, std::string_view rpc_error_msg) {
+        closure->addFailureHandler([](const Context& ctx, std::string_view rpc_error_msg) {
             LOG(ERROR) << "Failed to cancel secondary replicas, txn_id: " << ctx.txn_id
                        << ", load_id: " << print_id(ctx.load_id) << ", replica_node: " << ctx.host
                        << ", error: " << rpc_error_msg << ", tablets: " << ctx.tablets;

--- a/be/src/util/disposable_closure.h
+++ b/be/src/util/disposable_closure.h
@@ -40,7 +40,7 @@ public:
     DisposableClosure(const DisposableClosure& other) = delete;
     DisposableClosure& operator=(const DisposableClosure& other) = delete;
 
-    void addFailedHandler(FailedFunc fn) { _failed_handler = std::move(fn); }
+    void addFailureHandler(FailedFunc fn) { _failed_handler = std::move(fn); }
     void addSuccessHandler(SuccessFunc fn) { _success_handler = fn; }
 
     void Run() noexcept override {

--- a/be/src/util/updater.h
+++ b/be/src/util/updater.h
@@ -1,0 +1,31 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+
+namespace starrocks {
+template <typename AtomicT, typename T>
+inline void atomic_max(AtomicT& atomic_var, const std::atomic<T>& value_source) {
+    T old_val = atomic_var.load(std::memory_order_relaxed);
+    while (true) {
+        T current = value_source.load(std::memory_order_relaxed);
+        if (current <= old_val) break;
+        if (atomic_var.compare_exchange_weak(old_val, current, std::memory_order_release, std::memory_order_relaxed)) {
+            break;
+        }
+    }
+}
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

opt the case like:
```
with cte0 as (
    SELECT
        *
    FROM
        etl_scan_test
    where
        col1 > 0
    limit
        1
), cte1 as (
    SELECT
        *
    FROM
        etl_scan_test
    where
        col1 > 0
    limit
        2100000000
), cte2 as (
    select
        *
    from
        (
            SELECT
                *
            FROM
                cte1
            where
                col2 > 0
            limit
                2100000000
        ) t
    union
    ALL
    select
        *
    from
        cte0
)
select
    *
from
    cte2
limit
    2100000000, 1;
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a per-driver memory limit for exchange sink buffers with precise tracking, propagates request byte sizes, exposes peak memory/rows metrics for local exchange, and renames the RPC closure failure handler.
> 
> - **Config**:
>   - Add `config.h` key `sink_buffer_mem_limit_per_driver` (default `134217728`).
> - **Execution / Exchange Sink**:
>   - `SinkBuffer`: track buffered memory via `MemTracker`, enforce fullness by queue size or `sink_buffer_mem_limit_per_driver * sinks`, and release on RPC completion.
>   - Plumb request sizes: replace `attachment_physical_bytes` with `request_byte_size` in `TransmitChunkInfo`; compute from serialized/passthrough bytes; adjust send paths and HTTP/BRPC handling.
>   - Use `brpc_stub_cache` includes; minor memory tracker adjustments when sending attachments.
> - **Local Exchange**:
>   - `ChunkBufferMemoryManager`: record peak memory usage and peak row count using new `atomic_max` util; expose getters.
>   - `LocalExchange`: expose `get_peak_memory_usage()` / `get_peak_num_rows()`.
>   - `LocalExchangeSinkOperator`: add HighWaterMark counters `LocalExchangePeakMemoryUsage` and `LocalExchangePeakNumRows`; set values on finishing (driver 0).
> - **Utilities**:
>   - New `util/updater.h` with `atomic_max` helper.
>   - `DisposableClosure`: rename `addFailedHandler` -> `addFailureHandler`; update call sites (exchange sink/sink buffer/local tablets channel).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2272e3bd7a0e802f7804ba6ef8e7de43a7949621. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->