### PR TITLE
[BugFix] Fix bugs of Arrow Flight SQL

### DIFF
--- a/be/src/exec/arrow_flight_batch_reader.cpp
+++ b/be/src/exec/arrow_flight_batch_reader.cpp
@@ -25,21 +25,21 @@ ArrowFlightBatchReader::ArrowFlightBatchReader(ResultBufferMgr* result_buffer_mg
 arrow::Status ArrowFlightBatchReader::init() {
     _schema = _result_buffer_mgr->get_arrow_schema(_query_id);
     if (_schema == nullptr) {
-        return arrow::Status::ExecutionError("Failed to fetch schema for query ID", print_id(_query_id));
+        return arrow::Status::ExecutionError("Failed to fetch schema for query ID: ", print_id(_query_id));
     }
     return arrow::Status::OK();
 }
 
 arrow::Status ArrowFlightBatchReader::ReadNext(std::shared_ptr<arrow::RecordBatch>* out) {
     if (!_schema) {
-        return arrow::Status::IOError("Failed to fetch schema for query ID ", print_id(_query_id));
+        return arrow::Status::IOError("Failed to fetch schema for query ID: ", print_id(_query_id));
     }
 
     *out = nullptr;
     auto status = ExecEnv::GetInstance()->result_mgr()->fetch_arrow_data(_query_id, out);
     if (!status.ok()) {
-        return arrow::Status::IOError("Failed to fetch arrow data for query ID ", print_id(_query_id), ": ",
-                                      status.to_string());
+        return arrow::Status::IOError("Failed to fetch arrow data for query ID: ", print_id(_query_id),
+                                      ", error: ", status.to_string());
     }
 
     return arrow::Status::OK();

--- a/be/src/exec/arrow_type_traits.h
+++ b/be/src/exec/arrow_type_traits.h
@@ -49,6 +49,7 @@ M_ArrowTypeIdToTypeStruct(ArrowTypeId::FIXED_SIZE_BINARY, arrow::FixedSizeBinary
 M_ArrowTypeIdToTypeStruct(ArrowTypeId::LARGE_BINARY, arrow::LargeBinaryType);
 M_ArrowTypeIdToTypeStruct(ArrowTypeId::LARGE_STRING, arrow::LargeStringType);
 M_ArrowTypeIdToTypeStruct(ArrowTypeId::DECIMAL, arrow::Decimal128Type);
+M_ArrowTypeIdToTypeStruct(ArrowTypeId::DECIMAL256, arrow::Decimal256Type);
 M_ArrowTypeIdToTypeStruct(ArrowTypeId::DATE32, arrow::Date32Type);
 M_ArrowTypeIdToTypeStruct(ArrowTypeId::DATE64, arrow::Date64Type);
 M_ArrowTypeIdToTypeStruct(ArrowTypeId::TIMESTAMP, arrow::TimestampType);
@@ -81,6 +82,10 @@ struct ArrowTypeIdToCppTypeStruct<AT, BinaryATGuard<AT>> {
 };
 template <>
 struct ArrowTypeIdToCppTypeStruct<ArrowTypeId::DECIMAL, guard::Guard> {
+    using type = const uint8_t*;
+};
+template <>
+struct ArrowTypeIdToCppTypeStruct<ArrowTypeId::DECIMAL256, guard::Guard> {
     using type = const uint8_t*;
 };
 template <>

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -259,6 +259,10 @@ Status FragmentExecutor::_prepare_runtime_state(ExecEnv* exec_env, const Unified
     runtime_state->set_func_version(func_version);
     runtime_state->init_mem_trackers(query_mem_tracker);
     runtime_state->set_be_number(request.backend_num());
+    const int arrow_flight_sql_version = request.common().__isset.arrow_flight_sql_version
+                                                 ? request.common().arrow_flight_sql_version
+                                                 : TArrowFlightSQLVersion::type::V0;
+    runtime_state->set_arrow_flight_sql_version(arrow_flight_sql_version);
 
     // RuntimeFilterWorker::open_query is idempotent
     const TRuntimeFilterParams* runtime_filter_params = nullptr;

--- a/be/src/runtime/arrow_result_writer.cpp
+++ b/be/src/runtime/arrow_result_writer.cpp
@@ -63,8 +63,9 @@ Status ArrowResultWriter::init(RuntimeState* state) {
     }
 
     std::unordered_map<int64_t, std::string> temp_id_to_col_name;
+
     RETURN_IF_ERROR(convert_to_arrow_schema(_row_desc, temp_id_to_col_name, &_arrow_schema, _output_expr_ctxs,
-                                            &_output_column_names));
+                                            &_output_column_names, state->arrow_flight_sql_version()));
 
     state->exec_env()->result_mgr()->set_arrow_schema(state->fragment_instance_id(), _arrow_schema);
 
@@ -96,6 +97,8 @@ StatusOr<TFetchDataResultPtrs> ArrowResultWriter::process_chunk(Chunk* chunk) {
     RETURN_IF_ERROR(convert_chunk_to_arrow_batch(chunk, _output_expr_ctxs, _arrow_schema, arrow::default_memory_pool(),
                                                  &result));
     RETURN_IF_ERROR(_sinker->add_arrow_batch(result));
+
+    _written_rows += chunk->num_rows();
 
     return TFetchDataResultPtrs{};
 }

--- a/be/src/runtime/result_buffer_mgr.cpp
+++ b/be/src/runtime/result_buffer_mgr.cpp
@@ -123,8 +123,8 @@ Status ResultBufferMgr::fetch_arrow_data(const TUniqueId& query_id, std::shared_
     if (cb == nullptr) {
         return Status::InternalError("no result for this query");
     }
-    RETURN_IF_ERROR(cb->get_arrow_batch(result));
-    return Status::OK();
+
+    return cb->get_arrow_batch(result);
 }
 
 void ResultBufferMgr::set_arrow_schema(const TUniqueId& query_id, const std::shared_ptr<arrow::Schema>& arrow_schema) {

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -503,6 +503,8 @@ public:
 
     void set_func_version(int func_version) { this->_func_version = func_version; }
     int func_version() const { return this->_func_version; }
+    void set_arrow_flight_sql_version(int version) { this->_arrow_flight_sql_version = version; }
+    int arrow_flight_sql_version() const { return this->_arrow_flight_sql_version; }
 
     void set_enable_pipeline_engine(bool enable_pipeline_engine) { _enable_pipeline_engine = enable_pipeline_engine; }
     bool enable_pipeline_engine() const { return _enable_pipeline_engine; }
@@ -603,6 +605,7 @@ private:
 
     // An aggregation function may have multiple versions of implementation, func_version determines the chosen version.
     int _func_version = 0;
+    int _arrow_flight_sql_version = 0;
 
     DescriptorTbl* _desc_tbl = nullptr;
 

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -660,6 +660,12 @@ void PInternalServiceImplBase<T>::_cancel_plan_fragment(google::protobuf::RpcCon
     Status st;
     auto reason_string =
             request->has_cancel_reason() ? cancel_reason_to_string(request->cancel_reason()) : "UnknownReason";
+
+    // Use error_message if provided (for INTERNAL_ERROR with actual error details)
+    if (request->has_error_message() && !request->error_message().empty()) {
+        reason_string = request->error_message();
+    }
+
     bool cancel_query_ctx = tid.hi == 0 && tid.lo == 0;
     // Only log cancellations for exceptional reasons (errors, timeouts, user cancels).
     // Skip logging for normal cancellations (LIMIT_REACH, QUERY_FINISHED) to reduce log noise.

--- a/be/src/types/date_value.h
+++ b/be/src/types/date_value.h
@@ -49,6 +49,8 @@ public:
 
     int64_t to_unixtime() const;
 
+    int32_t to_days_since_unix_epoch() const;
+
     void from_date_literal(int64_t date_literal);
 
     bool from_date_literal_with_check(int64_t date_literal);
@@ -129,6 +131,10 @@ DateValue DateValue::from_days_since_unix_epoch(int days_since_unix_epoch) {
     DateValue dv;
     dv._julian = days_since_unix_epoch + date::UNIX_EPOCH_JULIAN;
     return dv;
+}
+
+inline int32_t DateValue::to_days_since_unix_epoch() const {
+    return _julian - date::UNIX_EPOCH_JULIAN;
 }
 
 template <TimeUnit UNIT>

--- a/be/src/types/timestamp_value.cpp
+++ b/be/src/types/timestamp_value.cpp
@@ -838,6 +838,16 @@ int64_t TimestampValue::to_unix_second() const {
 }
 
 // return microseconds since epoch.
+int64_t TimestampValue::to_unix_microsecond() const {
+    int64_t result = timestamp::to_julian(_timestamp);
+    result *= SECS_PER_DAY;
+    result -= timestamp::UNIX_EPOCH_SECONDS;
+    result *= USECS_PER_SEC;
+    result += timestamp::to_time(_timestamp);
+    return result;
+}
+
+// return milliseconds since epoch.
 int64_t TimestampValue::to_unixtime() const {
     int64_t result = timestamp::to_julian(_timestamp);
     result *= SECS_PER_DAY;

--- a/be/src/types/timestamp_value.h
+++ b/be/src/types/timestamp_value.h
@@ -124,6 +124,7 @@ public:
     bool from_string(const char* date_str, size_t len);
 
     int64_t to_unix_second() const;
+    int64_t to_unix_microsecond() const;
     int64_t to_unixtime() const;
     int64_t to_unixtime(const cctz::time_zone& ctz) const;
 

--- a/be/src/util/arrow/row_batch.h
+++ b/be/src/util/arrow/row_batch.h
@@ -64,7 +64,12 @@ Status convert_to_arrow_schema(const RowDescriptor& row_desc,
                                const std::unordered_map<int64_t, std::string>& id_to_col_name,
                                std::shared_ptr<arrow::Schema>* result,
                                const std::vector<ExprContext*>& output_expr_ctxs,
-                               const std::vector<std::string>* output_column_names = nullptr);
+                               const std::vector<std::string>* output_column_names = nullptr,
+                               int32_t flight_sql_version = 0);
+
+Status convert_to_arrow_type_for_flight_sql(const TypeDescriptor& type, std::shared_ptr<arrow::DataType>* result);
+Status convert_to_arrow_field_for_flight_sql(const TypeDescriptor& desc, const std::string& col_name, bool is_nullable,
+                                             std::shared_ptr<arrow::Field>* field, int32_t version);
 
 Status serialize_record_batch(const arrow::RecordBatch& record_batch, std::string* result);
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3869,6 +3869,11 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int arrow_max_service_task_threads_num = 4096;
 
+    // Maximum time in milliseconds that a subsequent query on the same Arrow Flight SQL connection will wait
+    // for the previous query to finish before returning an error.
+    @ConfField(mutable = true)
+    public static long arrow_flight_sql_connection_query_wait_timeout_ms = 10_000;
+
     @ConfField(mutable = false)
     public static int query_deploy_threadpool_size = max(50, getRuntime().availableProcessors() * 10);
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ArrowUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ArrowUtil.java
@@ -27,7 +27,6 @@ public class ArrowUtil {
     private static final BufferAllocator ALLOCATOR = new RootAllocator(Long.MAX_VALUE);
 
     private ArrowUtil() {
-        throw new UnsupportedOperationException("ArrowUtil cannot be instantiated");
     }
 
     public static VectorSchemaRoot createSingleSchemaRoot(String fieldName, String fieldValue) {

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlChannel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlChannel.java
@@ -132,7 +132,10 @@ public class MysqlChannel {
             return;
         }
         try {
-            conn.close();
+            // Non-MySQL connection may have null conn.
+            if (conn != null) {
+                conn.close();
+            }
         } catch (IOException e) {
             LOG.warn("Close channel exception, ignore.");
         } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -71,6 +71,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
+import com.starrocks.service.arrow.flight.sql.ArrowFlightSqlConnectContext;
 import com.starrocks.sql.analyzer.Authorizer;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.CleanTemporaryTableStmt;
@@ -739,7 +740,7 @@ public class ConnectContext {
         return endTime;
     }
 
-    public void updateReturnRows(int returnRows) {
+    public void updateReturnRows(long returnRows) {
         this.returnRows += returnRows;
     }
 
@@ -801,6 +802,10 @@ public class ConnectContext {
 
     public void setState(QueryState state) {
         this.state = state;
+    }
+
+    public boolean isArrowFlightSql() {
+        return this instanceof ArrowFlightSqlConnectContext;
     }
 
     public String getNormalizedErrorCode() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectScheduler.java
@@ -156,7 +156,7 @@ public class ConnectScheduler {
             currentConnAtomic.incrementAndGet();
             connectionMap.put((long) ctx.getConnectionId(), ctx);
 
-            if (ctx instanceof ArrowFlightSqlConnectContext) {
+            if (ctx.isArrowFlightSql()) {
                 ArrowFlightSqlConnectContext context = (ArrowFlightSqlConnectContext) ctx;
                 arrowFlightSqlConnectContextMap.put(context.getArrowFlightSqlToken(), context);
             }
@@ -237,7 +237,7 @@ public class ConnectScheduler {
                         ctx.getQualifiedUser(), conns != null ? Integer.toString(conns.get()) : "nil");
             }
 
-            if (ctx instanceof ArrowFlightSqlConnectContext) {
+            if (ctx.isArrowFlightSql()) {
                 ArrowFlightSqlConnectContext context = (ArrowFlightSqlConnectContext) ctx;
                 arrowFlightSqlConnectContextMap.remove(context.getArrowFlightSqlToken());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -1057,7 +1057,8 @@ public class DefaultCoordinator extends Coordinator {
     private void cancelInternal(PPlanFragmentCancelReason cancelReason) {
         jobSpec.getSlotProvider().cancelSlotRequirement(slot);
         if (!isInternalCancel(cancelReason) && StringUtils.isEmpty(connectContext.getState().getErrorMessage())) {
-            connectContext.getState().setError(cancelReason.toString());
+            String errorMsg = String.format("[reason=%s] [msg=%s]", cancelReason, queryStatus.getErrorMsg());
+            connectContext.getState().setError(errorMsg);
         }
         if (null != receiver) {
             receiver.cancel();
@@ -1085,16 +1086,27 @@ public class DefaultCoordinator extends Coordinator {
 
     // For phased schedule execution, we cancel the query context. (BE will cancel the relevant fragment internally)
     private void cancelRemoteQueryContext(PPlanFragmentCancelReason cancelReason) {
-        executionDAG.cancelQueryContext(cancelReason);
+        // Get the actual error message to propagate to BEs
+        String errorMessage = null;
+        if (cancelReason == PPlanFragmentCancelReason.INTERNAL_ERROR && !queryStatus.ok()) {
+            errorMessage = queryStatus.getErrorMsg();
+        }
+        executionDAG.cancelQueryContext(cancelReason, errorMessage);
     }
 
     private void cancelRemoteFragmentsAsync(PPlanFragmentCancelReason cancelReason) {
         scheduler.cancel();
+        // Get the actual error message to propagate to BEs
+        String errorMessage = null;
+        if (cancelReason == PPlanFragmentCancelReason.INTERNAL_ERROR && !queryStatus.ok()) {
+            errorMessage = queryStatus.getErrorMsg();
+        }
+        
         for (FragmentInstanceExecState execState : executionDAG.getExecutions()) {
             // If the execState fails to be cancelled, and it has been finished or not been deployed,
             // count down the profileDoneSignal of this execState immediately,
             // because the profile report will not arrive anymore for the finished or non-deployed execState.
-            if (!execState.cancelFragmentInstance(cancelReason) &&
+            if (!execState.cancelFragmentInstance(cancelReason, errorMessage) &&
                     (!execState.hasBeenDeployed() || execState.isFinished())) {
                 queryProfile.finishInstance(execState.getInstanceId());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -128,11 +128,14 @@ import com.starrocks.qe.feedback.skeleton.SkeletonBuilder;
 import com.starrocks.qe.feedback.skeleton.SkeletonNode;
 import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.qe.scheduler.FeExecuteCoordinator;
+import com.starrocks.qe.scheduler.dag.ExecutionFragment;
+import com.starrocks.qe.scheduler.dag.FragmentInstance;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.GracefulExitFlag;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.service.ExecuteEnv;
 import com.starrocks.service.arrow.flight.sql.ArrowFlightSqlConnectContext;
+import com.starrocks.service.arrow.flight.sql.ArrowFlightSqlResultDescriptor;
 import com.starrocks.sql.ExplainAnalyzer;
 import com.starrocks.sql.PrepareStmtPlanner;
 import com.starrocks.sql.StatementPlanner;
@@ -232,6 +235,7 @@ import com.starrocks.statistic.StatisticExecutor;
 import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.statistic.StatisticsCollectJobFactory;
 import com.starrocks.statistic.StatsConstants;
+import com.starrocks.system.ComputeNode;
 import com.starrocks.system.Frontend;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.task.LoadEtlTask;
@@ -254,6 +258,7 @@ import com.starrocks.transaction.TransactionStmtExecutor;
 import com.starrocks.transaction.VisibleStateWaiter;
 import com.starrocks.type.TypeFactory;
 import com.starrocks.warehouse.WarehouseIdleChecker;
+import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -275,6 +280,7 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.RejectedExecutionException;
@@ -286,6 +292,7 @@ import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
 import static com.starrocks.common.ErrorCode.ERR_NO_ROWS_IMPORTED;
+import static com.starrocks.service.arrow.flight.sql.ArrowFlightSqlServiceImpl.buildSchema;
 import static com.starrocks.sql.parser.ErrorMsgProxy.PARSER_ERROR_MSG;
 import static com.starrocks.statistic.AnalyzeMgr.IS_MULTI_COLUMN_STATS;
 
@@ -321,8 +328,15 @@ public class StmtExecutor {
     private PrepareStmtContext prepareStmtContext = null;
     private boolean isInternalStmt = false;
 
+    private final CompletableFuture<ArrowFlightSqlResultDescriptor> deploymentFinished;
+
     public StmtExecutor(ConnectContext ctx, StatementBase parsedStmt) {
         this(ctx, parsedStmt, false);
+    }
+
+    public StmtExecutor(ConnectContext ctx, StatementBase parsedStmt,
+                        CompletableFuture<ArrowFlightSqlResultDescriptor> deploymentFinished) {
+        this(ctx, parsedStmt, false, deploymentFinished);
     }
 
     public static StmtExecutor newInternalExecutor(ConnectContext ctx, StatementBase parsedStmt) {
@@ -334,12 +348,18 @@ public class StmtExecutor {
     }
 
     private StmtExecutor(ConnectContext ctx, StatementBase parsedStmt, boolean isInternalStmt) {
+        this(ctx, parsedStmt, isInternalStmt, null);
+    }
+
+    private StmtExecutor(ConnectContext ctx, StatementBase parsedStmt, boolean isInternalStmt,
+                         CompletableFuture<ArrowFlightSqlResultDescriptor> deploymentFinished) {
         this.context = ctx;
         this.parsedStmt = Preconditions.checkNotNull(parsedStmt);
         this.originStmt = parsedStmt.getOrigStmt();
         this.serializer = context.getSerializer();
         this.isProxy = false;
         this.isInternalStmt = isInternalStmt;
+        this.deploymentFinished = deploymentFinished;
     }
 
     public void setProxy() {
@@ -792,7 +812,7 @@ public class StmtExecutor {
                     } catch (Exception e) {
                         // For Arrow Flight SQL, FE doesn't know whether the client has already pull data from BE.
                         // So FE cannot decide whether it is able to retry.
-                        if (i == retryTime - 1 || context instanceof ArrowFlightSqlConnectContext) {
+                        if (i == retryTime - 1 || context.isArrowFlightSql()) {
                             throw e;
                         }
                         ExecuteExceptionHandler.handle(e, retryContext);
@@ -1186,7 +1206,8 @@ public class StmtExecutor {
         }
         try {
             context.incPendingForwardRequest();
-            leaderOpExecutor = new LeaderOpExecutor(parsedStmt, originStmt, context, redirectStatus, isInternalStmt);
+            leaderOpExecutor =
+                    new LeaderOpExecutor(parsedStmt, originStmt, context, redirectStatus, isInternalStmt, deploymentFinished);
             LOG.debug("need to transfer to Leader. stmt: {}", context.getStmtId());
             leaderOpExecutor.execute();
         } finally {
@@ -1471,7 +1492,7 @@ public class StmtExecutor {
 
         // TODO(liuzihe): support execute in FE for Arrow Flight SQL.
         boolean executeInFe = !isExplainAnalyze && !isSchedulerExplain && !isOutfileQuery
-                && canExecuteInFe(context, execPlan.getPhysicalPlan()) && !(context instanceof ArrowFlightSqlConnectContext);
+                && canExecuteInFe(context, execPlan.getPhysicalPlan()) && !(context.isArrowFlightSql());
 
         if (isExplainAnalyze) {
             context.getSessionVariable().setEnableProfile(true);
@@ -1525,13 +1546,27 @@ public class StmtExecutor {
         RowBatch batch = null;
         if (context instanceof HttpConnectContext) {
             batch = httpResultSender.sendQueryResult(coord, execPlan, parsedStmt.getOrigStmt().getOrigStmt());
-        } else if (context instanceof ArrowFlightSqlConnectContext) {
-            ArrowFlightSqlConnectContext ctx = (ArrowFlightSqlConnectContext) context;
-            ctx.setReturnResultFromFE(false);
-            ctx.setDeploymentFinished(coord);
         } else {
-            boolean needSendResult = !isPlanAdvisorAnalyze && !isExplainAnalyze
-                    && !context.getSessionVariable().isEnableExecutionOnly();
+            final boolean isArrowFlight = context.isArrowFlightSql() && deploymentFinished != null;
+            if (isArrowFlight && !isExplainAnalyze && !isOutfileQuery) {
+                Preconditions.checkState(coord instanceof DefaultCoordinator,
+                        "Coordinator is not DefaultCoordinator, cannot proceed with BE execution.");
+                DefaultCoordinator defaultCoordinator = (DefaultCoordinator) coord;
+
+                ExecutionFragment rootFragment = defaultCoordinator.getExecutionDAG().getRootFragment();
+                FragmentInstance rootFragmentInstance = rootFragment.getInstances().get(0);
+                ComputeNode worker = rootFragmentInstance.getWorker();
+                TUniqueId rootFragmentInstanceId = rootFragmentInstance.getInstanceId();
+                Schema schema = buildSchema(execPlan);
+
+                ArrowFlightSqlResultDescriptor backendResultDesc =
+                        new ArrowFlightSqlResultDescriptor(worker.getId(), rootFragmentInstanceId, schema);
+
+                deploymentFinished.complete(backendResultDesc);
+            }
+
+            final boolean needSendResult = !isPlanAdvisorAnalyze && !isExplainAnalyze
+                    && !context.getSessionVariable().isEnableExecutionOnly() && !isArrowFlight;
             // send mysql result
             // 1. If this is a query with OUTFILE clause, eg: select * from tbl1 into outfile xxx,
             //    We will not send real query result to client. Instead, we only send OK to client with
@@ -1568,21 +1603,15 @@ public class StmtExecutor {
                             channel.sendOnePacket(row);
                         }
                     }
+                }
+                if (batch.getBatch() != null) {
                     context.updateReturnRows(batch.getBatch().getRows().size());
                 }
             } while (!batch.isEos());
-            if (!isSendFields && !isOutfileQuery && !isExplainAnalyze && !isPlanAdvisorAnalyze) {
+
+            if (!isSendFields && !isOutfileQuery && !isExplainAnalyze && !isPlanAdvisorAnalyze && !isArrowFlight) {
                 sendFields(colNames, outputExprs);
             }
-        }
-
-        if (context instanceof ArrowFlightSqlConnectContext) {
-            coord.join(context.getSessionVariable().getQueryTimeoutS());
-            if (!isOutfileQuery) {
-                context.getState().setEof();
-            }
-            // TODO(liuzihe): process query statistics for Arrow Flight SQL. For now query statistics is passed by the final
-            //  batch, so we need to change the implementation to support Arrow Flight SQL.
         }
 
         processQueryStatisticsFromResult(batch, execPlan, isOutfileQuery);
@@ -1601,12 +1630,16 @@ public class StmtExecutor {
                 context.getState().setOk(statisticsForAuditLog.returnedRows, 0, "");
             }
 
-            if (null != statisticsForAuditLog) {
-                analyzePlanWithExecStats(execPlan);
+            if (null == statisticsForAuditLog) {
+                return;
             }
 
-            if (null == statisticsForAuditLog || null == statisticsForAuditLog.statsItems ||
-                    statisticsForAuditLog.statsItems.isEmpty()) {
+            analyzePlanWithExecStats(execPlan);
+            if (context.isArrowFlightSql()) {
+                context.updateReturnRows(statisticsForAuditLog.getReturnedRows());
+            }
+
+            if (null == statisticsForAuditLog.statsItems || statisticsForAuditLog.statsItems.isEmpty()) {
                 return;
             }
 
@@ -2159,7 +2192,7 @@ public class StmtExecutor {
         }
 
         // Send result set for Arrow Flight SQL.
-        if (context instanceof ArrowFlightSqlConnectContext) {
+        if (context.isArrowFlightSql()) {
             ArrowFlightSqlConnectContext ctx = (ArrowFlightSqlConnectContext) context;
             ctx.addShowResult(DebugUtil.printId(ctx.getExecutionId()), resultSet);
             context.getState().setEof();
@@ -2203,33 +2236,37 @@ public class StmtExecutor {
     }
 
     private void handleExplainStmt(String explainString) throws IOException {
-        if (context instanceof HttpConnectContext) {
-            httpResultSender.sendExplainResult(explainString);
-            return;
-        }
 
         if (context.getQueryDetail() != null) {
             context.getQueryDetail().setExplain(explainString);
         }
 
-        ShowResultSetMetaData metaData =
-                ShowResultSetMetaData.builder()
-                        .addColumn(new Column("Explain String", TypeFactory.createVarcharType(20)))
-                        .build();
-        sendMetaData(metaData);
-
-        if (isProxy) {
-            proxyResultSet = new ShowResultSet(metaData,
-                    Arrays.stream(explainString.split("\n")).map(Collections::singletonList).collect(
-                            Collectors.toList()));
+        if (context instanceof HttpConnectContext) {
+            httpResultSender.sendExplainResult(explainString);
+        } else if (context.isArrowFlightSql()) {
+            ArrowFlightSqlConnectContext ctx = (ArrowFlightSqlConnectContext) context;
+            ctx.addExplainResult(DebugUtil.printId(ctx.getExecutionId()), explainString);
         } else {
-            // Send result set.
-            for (String item : explainString.split("\n")) {
-                serializer.reset();
-                serializer.writeLenEncodedString(item);
-                context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
+            ShowResultSetMetaData metaData =
+                    ShowResultSetMetaData.builder()
+                            .addColumn(new Column("Explain String", TypeFactory.createVarcharType(20)))
+                            .build();
+            sendMetaData(metaData);
+
+            if (isProxy) {
+                proxyResultSet = new ShowResultSet(metaData,
+                        Arrays.stream(explainString.split("\n")).map(Collections::singletonList).collect(
+                                Collectors.toList()));
+            } else {
+                // Send result set.
+                for (String item : explainString.split("\n")) {
+                    serializer.reset();
+                    serializer.writeLenEncodedString(item);
+                    context.getMysqlChannel().sendOnePacket(serializer.toByteBuffer());
+                }
             }
         }
+
         context.getState().setEof();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/TFragmentInstanceFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/TFragmentInstanceFactory.java
@@ -28,6 +28,7 @@ import com.starrocks.qe.scheduler.dag.JobSpec;
 import com.starrocks.sql.common.QueryDebugOptions;
 import com.starrocks.thrift.InternalServiceVersion;
 import com.starrocks.thrift.TAdaptiveDopParam;
+import com.starrocks.thrift.TArrowFlightSQLVersion;
 import com.starrocks.thrift.TDescriptorTable;
 import com.starrocks.thrift.TExecPlanFragmentParams;
 import com.starrocks.thrift.TFunctionVersion;
@@ -120,6 +121,7 @@ public class TFragmentInstanceFactory {
         result.setFragment(fragment.toThrift());
         result.setDesc_tbl(descTable);
         result.setFunc_version(TFunctionVersion.RUNTIME_FILTER_SERIALIZE_VERSION_3.getValue());
+        result.setArrow_flight_sql_version(TArrowFlightSQLVersion.V1.getValue());
         result.setCoord(coordAddress);
 
         result.setParams(new TPlanFragmentExecParams());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionDAG.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionDAG.java
@@ -615,10 +615,10 @@ public class ExecutionDAG {
         instanceIdToInstance.put(instanceId, instance);
     }
 
-    public void cancelQueryContext(PPlanFragmentCancelReason cancelReason) {
+    public void cancelQueryContext(PPlanFragmentCancelReason cancelReason, String errorMessage) {
         if (LOG.isDebugEnabled()) {
-            LOG.debug("cancel query context id:{} reason:{}", DebugUtil.printId(jobSpec.getQueryId()),
-                    cancelReason.name());
+            LOG.debug("cancel query context id:{} reason:{} error:{}", DebugUtil.printId(jobSpec.getQueryId()),
+                    cancelReason.name(), errorMessage);
         }
 
         Set<ComputeNode> workers = Sets.newHashSet();
@@ -634,7 +634,7 @@ public class ExecutionDAG {
             try {
                 BackendServiceClient.getInstance().cancelPlanFragmentAsync(brpcAddress,
                         jobSpec.getQueryId(), dummyInstanceId, cancelReason,
-                        jobSpec.isEnablePipeline());
+                        jobSpec.isEnablePipeline(), errorMessage);
             } catch (RpcException e) {
                 LOG.warn("cancel plan fragment get a exception, address={}:{}", brpcAddress.getHostname(),
                         brpcAddress.getPort(), e);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
@@ -374,16 +374,17 @@ public class FragmentInstanceExecState {
     }
 
     /**
-     * Cancel the fragment instance.
+     * Cancel the fragment instance with error message.
      *
      * @param cancelReason The cancel reason.
+     * @param errorMessage The detailed error message (used for INTERNAL_ERROR).
      * @return true if cancel succeeds. Otherwise, return false.
      */
-    public synchronized boolean cancelFragmentInstance(PPlanFragmentCancelReason cancelReason) {
+    public synchronized boolean cancelFragmentInstance(PPlanFragmentCancelReason cancelReason, String errorMessage) {
         if (LOG.isDebugEnabled()) {
             LOG.debug(
-                    "cancelRemoteFragments state={}  backend: {}, fragment instance id={}, reason: {}",
-                    state, worker.getId(), DebugUtil.printId(instanceId), cancelReason.name());
+                    "cancelRemoteFragments state={}  backend: {}, fragment instance id={}, reason: {}, error: {}",
+                    state, worker.getId(), DebugUtil.printId(instanceId), cancelReason.name(), errorMessage);
         }
 
         switch (state) {
@@ -402,7 +403,7 @@ public class FragmentInstanceExecState {
         try {
             BackendServiceClient.getInstance().cancelPlanFragmentAsync(brpcAddress,
                     jobSpec.getQueryId(), instanceId, cancelReason,
-                    jobSpec.isEnablePipeline());
+                    jobSpec.isEnablePipeline(), errorMessage);
         } catch (RpcException e) {
             LOG.warn("cancel plan fragment get a exception, address={}:{}", brpcAddress.getHostname(),
                     brpcAddress.getPort(), e);

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/BackendServiceClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/BackendServiceClient.java
@@ -157,7 +157,7 @@ public class BackendServiceClient {
 
     public Future<PCancelPlanFragmentResult> cancelPlanFragmentAsync(
             TNetworkAddress address, TUniqueId queryId, TUniqueId finstId, PPlanFragmentCancelReason cancelReason,
-            boolean isPipeline) throws RpcException {
+            boolean isPipeline, String errorMessage) throws RpcException {
         final PCancelPlanFragmentRequest pRequest = new PCancelPlanFragmentRequest();
         PUniqueId uid = new PUniqueId();
         uid.hi = finstId.hi;
@@ -169,6 +169,10 @@ public class BackendServiceClient {
         qid.hi = queryId.hi;
         qid.lo = queryId.lo;
         pRequest.queryId = qid;
+        // Set error message for INTERNAL_ERROR to propagate actual error to BE
+        if (errorMessage != null && !errorMessage.isEmpty()) {
+            pRequest.errorMessage = errorMessage;
+        }
         try {
             final PBackendService service = BrpcProxy.getBackendService(address);
             return service.cancelPlanFragmentAsync(pRequest);

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -155,6 +155,10 @@ import com.starrocks.server.LocalMetastore;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.server.TemporaryTableMgr;
 import com.starrocks.server.WarehouseManager;
+import com.starrocks.service.arrow.flight.sql.ArrowFlightSqlConnectContext;
+import com.starrocks.service.arrow.flight.sql.ArrowFlightSqlConnectProcessor;
+import com.starrocks.service.arrow.flight.sql.ArrowFlightSqlProxyQueryManager;
+import com.starrocks.service.arrow.flight.sql.ArrowFlightSqlResultDescriptor;
 import com.starrocks.sql.analyzer.AlterTableClauseAnalyzer;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.Authorizer;
@@ -312,6 +316,8 @@ import com.starrocks.thrift.TMergeCommitRequest;
 import com.starrocks.thrift.TMergeCommitResult;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TNodesInfo;
+import com.starrocks.thrift.TNotifyForwardDeploymentFinishedRequest;
+import com.starrocks.thrift.TNotifyForwardDeploymentFinishedRespone;
 import com.starrocks.thrift.TObjectDependencyReq;
 import com.starrocks.thrift.TObjectDependencyRes;
 import com.starrocks.thrift.TOlapTableIndexTablets;
@@ -382,6 +388,7 @@ import com.starrocks.warehouse.Warehouse;
 import com.starrocks.warehouse.WarehouseInfo;
 import com.starrocks.warehouse.cngroup.CRAcquireContext;
 import com.starrocks.warehouse.cngroup.ComputeResource;
+import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -389,6 +396,7 @@ import org.apache.thrift.TException;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -522,7 +530,7 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                 if (!PatternMatcher.matchPattern(params.getPattern(), tableName, matcher, caseSensitive)) {
                     continue;
                 }
-                
+
                 try {
                     tbl = metadataMgr.getTable(context, catalogName, params.db, tableName);
                 } catch (Exception e) {
@@ -1019,18 +1027,24 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     @Override
     public TMasterOpResult forward(TMasterOpRequest params) throws TException {
         TNetworkAddress clientAddr = getClientAddr();
+        Frontend fe = null;
         if (clientAddr != null) {
-            Frontend fe = GlobalStateMgr.getCurrentState().getNodeMgr().getFeByHost(clientAddr.getHostname());
+            fe = GlobalStateMgr.getCurrentState().getNodeMgr().getFeByHost(clientAddr.getHostname());
             if (fe == null) {
                 LOG.warn("reject request from invalid host. client: {}", clientAddr);
                 throw new TException("request from invalid host was rejected.");
             }
         }
 
+        if (fe == null && params.isIs_arrow_flight_sql()) {
+            throw new TException("Arrow Flight SQL request must be with valid FE host info.");
+        }
+
         // add this log so that we can track this stmt
         LOG.info("receive forwarded stmt {} from FE: {}",
                 params.getStmt_id(), clientAddr != null ? clientAddr.getHostname() : "unknown");
-        ConnectContext context = new ConnectContext(null);
+        ConnectContext context = !params.isIs_arrow_flight_sql() ? new ConnectContext(null) :
+                new ArrowFlightSqlConnectContext("");
         String hostname = "";
         if (clientAddr != null) {
             hostname = clientAddr.getHostname();
@@ -1040,14 +1054,30 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         final int connectionId = params.getConnectionId();
 
         try (var guard = proxyContextManager.guard(hostname, connectionId, context, addToProxyManager)) {
-            ConnectProcessor processor = new ConnectProcessor(context);
-            return processor.proxyExecute(params);
+            ConnectProcessor processor = !params.isIs_arrow_flight_sql() ? new ConnectProcessor(context) :
+                    new ArrowFlightSqlConnectProcessor(context, params.getSql());
+            return processor.proxyExecute(params, fe);
         } catch (Exception e) {
             LOG.warn("unreachable path:", e);
             final TMasterOpResult result = new TMasterOpResult();
             result.setErrorMsg(e.getMessage());
             return result;
         }
+    }
+
+    @Override
+    public TNotifyForwardDeploymentFinishedRespone notifyForwardDeploymentFinished(
+            TNotifyForwardDeploymentFinishedRequest request) throws TException {
+        long backendId = request.getArrow_flight_sql_result_backend_id();
+        TUniqueId fragmentId = request.getArrow_flight_sql_result_fragment_id();
+        byte[] schemaBytes = request.getArrow_flight_sql_result_schema();
+        Schema schema = Schema.deserializeMessage(ByteBuffer.wrap(schemaBytes));
+        ArrowFlightSqlResultDescriptor resultDesc = new ArrowFlightSqlResultDescriptor(backendId, fragmentId, schema);
+
+        ArrowFlightSqlProxyQueryManager.getInstance().notifyBackendResult(request.getQuery_id(), resultDesc);
+
+        TStatus status = new TStatus(TStatusCode.OK);
+        return new TNotifyForwardDeploymentFinishedRespone().setStatus(status);
     }
 
     private void checkPasswordAndLoadPriv(String user, String passwd, String db, String tbl,

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectProcessor.java
@@ -66,8 +66,10 @@ public class ArrowFlightSqlConnectProcessor extends ConnectProcessor {
 
     public ArrowFlightSqlResultDescriptor execute() throws InterruptedException, StarRocksException, ExecutionException {
         ArrowFlightSqlConnectContext arrowCtx = (ArrowFlightSqlConnectContext) ctx;
-        if (!arrowCtx.acquireRunningToken(arrowCtx.getSessionVariable().getQueryTimeoutS() * 1000L)) {
-            throw new StarRocksException("Query already in progress on this connection");
+        long waitTimeoutMs = Math.max(0, Config.arrow_flight_sql_connection_query_wait_timeout_ms);
+        if (!arrowCtx.acquireRunningToken(waitTimeoutMs)) {
+            throw new StarRocksException(
+                    "Another query is already in progress on this connection (waited " + waitTimeoutMs + " ms)");
         }
         arrowCtx.resetForStatement();
 

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectProcessor.java
@@ -14,27 +14,149 @@
 
 package com.starrocks.service.arrow.flight.sql;
 
+import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
+import com.starrocks.common.util.DebugUtil;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.mysql.MysqlCommand;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ConnectProcessor;
 import com.starrocks.qe.QueryState;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.qe.ShowResultSet;
 import com.starrocks.qe.StmtExecutor;
+import com.starrocks.rpc.ThriftConnectionPool;
+import com.starrocks.rpc.ThriftRPCRequestExecutor;
 import com.starrocks.sql.ast.KillStmt;
+import com.starrocks.sql.ast.OriginStatement;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.common.LargeInPredicateException;
+import com.starrocks.system.Frontend;
+import com.starrocks.thrift.TMasterOpRequest;
+import com.starrocks.thrift.TMasterOpResult;
+import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.thrift.TNotifyForwardDeploymentFinishedRequest;
+import org.apache.arrow.vector.VectorSchemaRoot;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.thrift.TException;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 // inherit ConnectProcessor to record the audit log and Query Detail
 public class ArrowFlightSqlConnectProcessor extends ConnectProcessor {
     private static final Logger LOG = LogManager.getLogger(ArrowFlightSqlConnectProcessor.class);
 
-    public ArrowFlightSqlConnectProcessor(ConnectContext context) {
+    private final String originStmt;
+
+    private final CompletableFuture<ArrowFlightSqlResultDescriptor> deploymentFinished = new CompletableFuture<>();
+    CompletableFuture<Void> processorFinished = new CompletableFuture<>();
+
+    public ArrowFlightSqlConnectProcessor(ConnectContext context, String originStmt) {
         super(context);
+        this.originStmt = originStmt;
+    }
+
+    public ArrowFlightSqlResultDescriptor execute() throws InterruptedException, StarRocksException, ExecutionException {
+        ArrowFlightSqlConnectContext arrowCtx = (ArrowFlightSqlConnectContext) ctx;
+        if (!arrowCtx.acquireRunningToken(arrowCtx.getSessionVariable().getQueryTimeoutS() * 1000L)) {
+            throw new StarRocksException("Query already in progress on this connection");
+        }
+        arrowCtx.resetForStatement();
+
+        try {
+            ArrowFlightSqlServiceImpl.submitTask(() -> {
+                final boolean prevUseLowCardOptimizeOnLake = arrowCtx.getSessionVariable().isUseLowCardinalityOptimizeOnLake();
+                try {
+                    // The Lake low-cardinality optimization relies on a retry mechanism on the FE side: when the BE discovers at
+                    // execution time that the dictionary cannot be used, it reports this to the FE, and the FE re-plans the query.
+                    // However, with Arrow Flight SQL the client talks directly to the BE, so this retry mechanism is not available.
+                    arrowCtx.getSessionVariable().setUseLowCardinalityOptimizeOnLake(false);
+                    arrowCtx.setThreadLocalInfo();
+
+                    processOnce();
+
+                    deploymentFinished.complete(null);
+                    processorFinished.complete(null);
+                } catch (Throwable t) {
+                    deploymentFinished.completeExceptionally(t);
+                    processorFinished.completeExceptionally(t);
+                } finally {
+                    arrowCtx.getSessionVariable().setUseLowCardinalityOptimizeOnLake(prevUseLowCardOptimizeOnLake);
+                    arrowCtx.releaseRunningToken();
+                }
+            });
+        } catch (Exception t) {
+            // Task submission failed, ensure state is cleaned up so callers don't hang.
+            deploymentFinished.completeExceptionally(t);
+            processorFinished.completeExceptionally(t);
+            arrowCtx.releaseRunningToken();
+            throw t;
+        }
+
+        // Wait util deployment finished or the whole process finished.
+        ArrowFlightSqlResultDescriptor backendResult = deploymentFinished.get();
+
+        // Query task will wait until deployment to BE is finished and return BE as endpoint.
+        if (backendResult != null) {
+            if (ctx.getState().isError()) {
+                reportError(ctx);
+            }
+            return backendResult;
+        }
+
+        // FE task will return FE as endpoint.
+        processorFinished.get(); // Wait `processor.processOnce()` to finish.
+
+        if (ctx.getState().isError()) {
+            reportError(ctx);
+        }
+
+        if (executor != null && executor.isForwardToLeader()) {
+            ShowResultSet showResultSet = executor.getShowResultSet();
+            if (showResultSet != null) {
+                arrowCtx.addShowResult(DebugUtil.printId(arrowCtx.getExecutionId()), showResultSet);
+            }
+        }
+
+        String queryId = DebugUtil.printId(arrowCtx.getExecutionId());
+        VectorSchemaRoot result = arrowCtx.getResult(queryId);
+        if (result == null) {
+            arrowCtx.setEmptyResultIfNotExist(queryId);
+            result = arrowCtx.getResult(queryId);
+        }
+
+        return new ArrowFlightSqlResultDescriptor(result.getSchema());
+    }
+
+    @Override
+    public void processOnce() {
+        // Set status of query to OK.
+        ctx.getState().reset();
+        executor = null;
+
+        // Only handle query，so no need to dispatch
+        ctx.setCommand(MysqlCommand.COM_QUERY);
+        ctx.setStartTime();
+        ctx.setResourceGroup(null);
+        ctx.resetErrorCode();
+
+        this.handleQuery();
+
+        ctx.setLastQueryId(ctx.getQueryId());
+        ctx.setQueryId(null);
+
+        // Set command as sleep, so timeCheck will close the connection.
+        // When client's last query is long long ago (controlled by waitTimeout session variable).
+        ctx.setStartTime();
+        ctx.setCommand(MysqlCommand.COM_SLEEP);
     }
 
     @Override
@@ -51,30 +173,23 @@ public class ArrowFlightSqlConnectProcessor extends ConnectProcessor {
                 .setCatalog(ctx.getCurrentCatalog());
         Tracers.register(ctx);
 
-        StatementBase parsedStmt = ((ArrowFlightSqlConnectContext) ctx).getStatement();
-        String sql = parsedStmt.getOrigStmt().originStmt;
-
-        executor = new StmtExecutor(ctx, parsedStmt);
-        ctx.setExecutor(executor);
-        ctx.setIsLastStmt(true);
-
+        StatementBase parsedStmt = null;
         try {
-            executor.addRunningQueryDetail(parsedStmt);
-            executor.execute();
+            parsedStmt = runWithParserStageRetry();
         } catch (IOException e) {
             // Client failed.
             LOG.warn("Process one query failed because IOException: ", e);
             ctx.getState().setError("StarRocks process failed");
             ctx.getState().setErrType(QueryState.ErrType.IO_ERR);
         } catch (StarRocksException e) {
-            LOG.warn("Process one query failed. SQL: " + sql + ", because.", e);
+            LOG.warn("Process one query failed. SQL: {}, because ", originStmt, e);
             ctx.getState().setError(e.getMessage());
             // set is as ANALYSIS_ERR so that it won't be treated as a query failure.
             ctx.getState().setErrType(QueryState.ErrType.ANALYSIS_ERR);
         } catch (Throwable e) {
             // Catch all throwable.
             // If reach here, maybe StarRocks bug.
-            LOG.warn("Process one query failed. SQL: " + sql + ", because unknown reason: ", e);
+            LOG.warn("Process one query failed. SQL: {}, because unknown reason: ", originStmt, e);
             ctx.getState().setError("Unexpected exception: " + e.getMessage());
             if (parsedStmt instanceof KillStmt) {
                 // ignore kill stmt execute err(not monitor it)
@@ -86,26 +201,152 @@ public class ArrowFlightSqlConnectProcessor extends ConnectProcessor {
             Tracers.close();
         }
 
-        auditAfterExec(sql, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog());
-        executor.addFinishedQueryDetail();
+        setResultFromLeaderIfForwarded();
+
+        if (executor != null) {
+            auditAfterExec(originStmt, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog());
+            executor.addFinishedQueryDetail();
+        } else {
+            auditAfterExec(originStmt, parsedStmt, null);
+        }
     }
 
     @Override
-    public void processOnce() {
-        // Set status of query to OK.
-        ctx.getState().reset();
-        executor = null;
+    protected StmtExecutor doProxyExecute(TMasterOpResult result, TMasterOpRequest request, StatementBase statement,
+                                          Frontend requestFE) throws Exception {
+        if (request.isIsInternalStmt()) {
+            throw new IllegalArgumentException("Arrow Flight SQL does not support internal statement");
+        }
 
-        // Only handle query，so no need to dispatch
-        ctx.setCommand(MysqlCommand.COM_QUERY);
-        ctx.setStartTime();
-        ctx.setResourceGroup(null);
-        ctx.resetErrorCode();
-        this.handleQuery();
+        StmtExecutor executor = new StmtExecutor(ctx, statement, deploymentFinished);
+        ctx.setExecutor(executor);
+        executor.setProxy();
+        executor.addRunningQueryDetail(statement);
 
-        // Set command as sleep, so timeCheck will close the connection.
-        // When client's last query is long long ago (controlled by waitTimeout session variable).
-        ctx.setStartTime();
-        ctx.setCommand(MysqlCommand.COM_SLEEP);
+        try {
+            ArrowFlightSqlServiceImpl.submitTask(() -> {
+                final boolean prevUseLowCardinalityOptimizeOnLake = ctx.getSessionVariable().isUseLowCardinalityOptimizeOnLake();
+                try {
+                    ctx.getSessionVariable().setUseLowCardinalityOptimizeOnLake(false);
+                    ctx.setThreadLocalInfo();
+                    executor.execute();
+                    deploymentFinished.complete(null);
+                    processorFinished.complete(null);
+                } catch (Exception e) {
+                    deploymentFinished.completeExceptionally(e);
+                    processorFinished.completeExceptionally(e);
+                } finally {
+                    ctx.getSessionVariable().setUseLowCardinalityOptimizeOnLake(prevUseLowCardinalityOptimizeOnLake);
+                }
+            });
+
+            ArrowFlightSqlResultDescriptor backendResult = deploymentFinished.get();
+            if (backendResult == null || ctx.getState().isError()) {
+                return executor;
+            }
+
+            notifyForwardDeploymentFinished(requestFE, backendResult);
+            return executor;
+        } catch (Exception e) {
+            LOG.warn("Process one query failed. SQL: {}", originStmt, e);
+            ctx.kill(true, "Proxy execute one query failed. SQL: " + originStmt + ", error: " + e.getMessage());
+            throw e;
+        } finally {
+            processorFinished.get(); // Wait for `executor.execute()` to finish
+        }
     }
+
+    private void notifyForwardDeploymentFinished(Frontend requestFE, ArrowFlightSqlResultDescriptor backendResult)
+            throws TException {
+        TNetworkAddress address = new TNetworkAddress(requestFE.getHost(), requestFE.getRpcPort());
+        int timeoutMs = ctx.getExecTimeout() * 1000 + Config.thrift_rpc_timeout_ms;
+        if (timeoutMs < 0) {
+            timeoutMs = ctx.getExecTimeout() * 1000;
+        }
+
+        TNotifyForwardDeploymentFinishedRequest request = new TNotifyForwardDeploymentFinishedRequest();
+
+        request.setQuery_id(UUIDUtil.toTUniqueId(ctx.getQueryId()));
+        request.setArrow_flight_sql_result_backend_id(backendResult.getBackendId());
+        request.setArrow_flight_sql_result_fragment_id(backendResult.getFragmentInstanceId());
+        request.setArrow_flight_sql_result_schema(backendResult.getSchema().serializeAsMessage());
+
+        ThriftRPCRequestExecutor.call(
+                ThriftConnectionPool.frontendPool,
+                address,
+                timeoutMs,
+                client -> client.notifyForwardDeploymentFinished(request));
+    }
+
+    private void reportError(ConnectContext ctx) throws StarRocksException {
+        String errMsg = ctx.getState().getErrorMessage();
+        if (StringUtils.isEmpty(errMsg)) {
+            errMsg = "Unknown error";
+        }
+        throw new StarRocksException(String.format("failed to process query [queryID=%s] [error=%s]",
+                DebugUtil.printId(ctx.getExecutionId()), errMsg));
+    }
+
+    private StatementBase runWithParserStageRetry() throws Exception {
+        try {
+            return executeQueryAttempt();
+        } catch (LargeInPredicateException e) {
+            final boolean originalEnableLargeInPredicate = ctx.getSessionVariable().enableLargeInPredicate();
+            try {
+                ctx.getSessionVariable().setEnableLargeInPredicate(false);
+                LOG.warn("Retrying query with enable_large_in_predicate=false");
+                Tracers.record(Tracers.Module.BASE, "retry_with_large_in_predicate_exception", "true");
+                ((ArrowFlightSqlConnectContext) ctx).resetForStatement();
+                return executeQueryAttempt();
+            } finally {
+                ctx.getSessionVariable().setEnableLargeInPredicate(originalEnableLargeInPredicate);
+            }
+        }
+    }
+
+    private StatementBase executeQueryAttempt() throws Exception {
+        StatementBase parsedStmt = parse(originStmt, ctx.getSessionVariable());
+        Tracers.init(ctx, parsedStmt.getTraceMode(), parsedStmt.getTraceModule());
+
+        executor = new StmtExecutor(ctx, parsedStmt, deploymentFinished);
+        ctx.setIsLastStmt(true);
+        ctx.setExecutor(executor);
+
+        executor.addRunningQueryDetail(parsedStmt);
+        executor.execute();
+
+        return parsedStmt;
+    }
+
+    private StatementBase parse(String sql, SessionVariable sessionVariables) throws StarRocksException {
+        List<StatementBase> stmts;
+        try (Timer ignored = Tracers.watchScope(Tracers.Module.PARSER, "Parser")) {
+            stmts = com.starrocks.sql.parser.SqlParser.parse(sql, sessionVariables);
+        }
+
+        if (stmts.size() > 1) {
+            throw new StarRocksException("arrow flight sql query does not support execute multiple query");
+        }
+
+        StatementBase parsedStmt = stmts.get(0);
+        parsedStmt.setOrigStmt(new OriginStatement(sql));
+        return parsedStmt;
+    }
+
+    private void setResultFromLeaderIfForwarded() {
+        ArrowFlightSqlConnectContext arrowCtx = (ArrowFlightSqlConnectContext) ctx;
+        if (executor == null || !executor.isForwardToLeader()) {
+            return;
+        }
+
+        if (arrowCtx.getState().getStateType() == QueryState.MysqlStateType.ERR) {
+            return;
+        }
+
+        ShowResultSet resultSet = executor.getShowResultSet();
+        if (resultSet != null) {
+            arrowCtx.addShowResult(DebugUtil.printId(arrowCtx.getExecutionId()), resultSet);
+        }
+    }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectProcessor.java
@@ -203,8 +203,6 @@ public class ArrowFlightSqlConnectProcessor extends ConnectProcessor {
             Tracers.close();
         }
 
-        setResultFromLeaderIfForwarded();
-
         if (executor != null) {
             auditAfterExec(originStmt, executor.getParsedStmt(), executor.getQueryStatisticsForAuditLog());
             executor.addFinishedQueryDetail();
@@ -333,22 +331,6 @@ public class ArrowFlightSqlConnectProcessor extends ConnectProcessor {
         StatementBase parsedStmt = stmts.get(0);
         parsedStmt.setOrigStmt(new OriginStatement(sql));
         return parsedStmt;
-    }
-
-    private void setResultFromLeaderIfForwarded() {
-        ArrowFlightSqlConnectContext arrowCtx = (ArrowFlightSqlConnectContext) ctx;
-        if (executor == null || !executor.isForwardToLeader()) {
-            return;
-        }
-
-        if (arrowCtx.getState().getStateType() == QueryState.MysqlStateType.ERR) {
-            return;
-        }
-
-        ShowResultSet resultSet = executor.getShowResultSet();
-        if (resultSet != null) {
-            arrowCtx.addShowResult(DebugUtil.printId(arrowCtx.getExecutionId()), resultSet);
-        }
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlProxyQueryManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlProxyQueryManager.java
@@ -1,0 +1,59 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.service.arrow.flight.sql;
+
+import com.google.common.collect.Maps;
+import com.starrocks.thrift.TUniqueId;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * The manager for queries that are forwarded from the follower to the leader is stored in the manager
+ * while the forward-to-leader request is in progress.
+ */
+public class ArrowFlightSqlProxyQueryManager {
+    private final Map<TUniqueId, QueryInfo> queryIdToInfo = Maps.newConcurrentMap();
+
+    private static final ArrowFlightSqlProxyQueryManager INSTANCE = new ArrowFlightSqlProxyQueryManager();
+
+    public static ArrowFlightSqlProxyQueryManager getInstance() {
+        return INSTANCE;
+    }
+
+    public void register(TUniqueId queryId, CompletableFuture<ArrowFlightSqlResultDescriptor> backendResultFuture) {
+        QueryInfo queryInfo = new QueryInfo(backendResultFuture);
+        queryIdToInfo.put(queryId, queryInfo);
+    }
+
+    public void deregister(TUniqueId queryId) {
+        queryIdToInfo.remove(queryId);
+    }
+
+    public void notifyBackendResult(TUniqueId queryId, ArrowFlightSqlResultDescriptor backendResult) {
+        QueryInfo queryInfo = queryIdToInfo.get(queryId);
+        if (queryInfo != null) {
+            queryInfo.backendResultFuture.complete(backendResult);
+        }
+    }
+
+    public static class QueryInfo {
+        private final CompletableFuture<ArrowFlightSqlResultDescriptor> backendResultFuture;
+
+        public QueryInfo(CompletableFuture<ArrowFlightSqlResultDescriptor> backendResultFuture) {
+            this.backendResultFuture = backendResultFuture;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlResultDescriptor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlResultDescriptor.java
@@ -1,0 +1,58 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.service.arrow.flight.sql;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.thrift.TUniqueId;
+import org.apache.arrow.vector.types.pojo.Schema;
+
+import javax.annotation.Nullable;
+
+public class ArrowFlightSqlResultDescriptor {
+    private final Schema schema;
+    @Nullable
+    private final BackendResultDescriptor backendResultDescriptor;
+
+    public ArrowFlightSqlResultDescriptor(long backendId, TUniqueId fragmentInstanceId, Schema schema) {
+        this.backendResultDescriptor = new BackendResultDescriptor(backendId, fragmentInstanceId);
+        this.schema = schema;
+    }
+
+    public ArrowFlightSqlResultDescriptor(Schema schema) {
+        this.backendResultDescriptor = null;
+        this.schema = schema;
+    }
+
+    public Schema getSchema() {
+        return schema;
+    }
+
+    public boolean isBackendResultDescriptor() {
+        return backendResultDescriptor != null;
+    }
+
+    public long getBackendId() {
+        Preconditions.checkArgument(backendResultDescriptor != null, "backend result not found");
+        return backendResultDescriptor.backendId();
+    }
+
+    public TUniqueId getFragmentInstanceId() {
+        Preconditions.checkArgument(backendResultDescriptor != null, "backend result not found");
+        return backendResultDescriptor.fragmentInstanceId();
+    }
+
+    public record BackendResultDescriptor(long backendId, TUniqueId fragmentInstanceId) {
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
@@ -125,16 +125,16 @@ public class ArrowFlightSqlServiceImpl implements FlightSqlProducer, AutoCloseab
      *
      * <p> JDBC and ADBC always use prepared statements to execute queries, even if the simple Statement::execute() is called.
      * The RPC sequence for Statement::execute() is:
-     *    createPreparedStatement -> getFlightInfoPreparedStatement-> getStreamStatement.
+     * createPreparedStatement -> getFlightInfoPreparedStatement-> getStreamStatement.
      * The RPC for Statement::close() is closePreparedStatement.
      *
      * <p> For a single connection, multiple prepared statements may be created.
      * When executing a query with a cursor, if the query is identical to the previous one, the existing preparedStmtId is reused
      * instead of creating a new one via createPreparedStatement. Specifically:
      * - If the current query is identical to the previous one, the RPC sequence for Statement::execute() is:
-     *     getFlightInfoPreparedStatement -> getStreamStatement.
+     * getFlightInfoPreparedStatement -> getStreamStatement.
      * - Otherwise, the RPC sequence for Statement::execute() is:
-     *     closePreparedStatement(prevPreparedStmtId) -> getFlightInfoPreparedStatement -> getStreamStatement.
+     * closePreparedStatement(prevPreparedStmtId) -> createPreparedStatement->getFlightInfoPreparedStatement->getStreamStatement.
      */
     @Override
     public void createPreparedStatement(FlightSql.ActionCreatePreparedStatementRequest request, CallContext context,

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlServiceImpl.java
@@ -24,7 +24,6 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.util.ArrowUtil;
 import com.starrocks.common.util.DebugUtil;
-import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.arrow.flight.sql.session.ArrowFlightSqlSessionManager;
 import com.starrocks.sql.ast.expression.Expr;

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowUtils.java
@@ -16,10 +16,13 @@ package com.starrocks.service.arrow.flight.sql;
 
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.MapType;
+import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
+import org.apache.arrow.vector.types.DateUnit;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
+import org.apache.arrow.vector.types.TimeUnit;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
@@ -37,6 +40,12 @@ public final class ArrowUtils {
         if (type.isScalarType()) {
             ScalarType scalarType = (ScalarType) type;
             ArrowType arrowType = convertToScalarArrowType(scalarType);
+
+            PrimitiveType primitiveType = type.getPrimitiveType();
+            if (primitiveType == PrimitiveType.HLL || primitiveType == PrimitiveType.BITMAP ||
+                    primitiveType == PrimitiveType.PERCENTILE || primitiveType == PrimitiveType.VARIANT) {
+                nullable = true;
+            }
             return new Field(colName, new FieldType(nullable, arrowType, null), Collections.emptyList());
         } else if (type.isArrayType()) {
             ArrayType arrayType = (ArrayType) type;
@@ -86,20 +95,30 @@ public final class ArrowUtils {
             case DOUBLE:
             case TIME:
                 return new ArrowType.FloatingPoint(FloatingPointPrecision.DOUBLE);
+            case LARGEINT:
+                return new ArrowType.Decimal(38, 0, 128);
+            case DATE:
+                return new ArrowType.Date(DateUnit.DAY);
+            case DATETIME:
+                return new ArrowType.Timestamp(TimeUnit.MICROSECOND, "UTC");
             case VARCHAR:
             case CHAR:
-            case HLL:
-            case LARGEINT:
-            case DATE:
-            case DATETIME:
             case JSON:
                 return new ArrowType.Utf8();
+            case VARBINARY:
+            case HLL:
+            case BITMAP:
+            case PERCENTILE:
+                // HLL,BITMAP,PERCENTILE are always converted to utf8 with null values, which is the same as MySQL output.
+                return new ArrowType.Binary();
             case DECIMALV2:
                 return new ArrowType.Decimal(27, 9, 128);
             case DECIMAL32:
             case DECIMAL64:
             case DECIMAL128:
                 return new ArrowType.Decimal(type.decimalPrecision(), type.decimalScale(), 128);
+            case DECIMAL256:
+                return new ArrowType.Decimal(type.decimalPrecision(), type.decimalScale(), 256);
             default:
                 throw new UnsupportedOperationException("Unknown scalar type: " + type);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowUtils.java
@@ -43,7 +43,7 @@ public final class ArrowUtils {
 
             PrimitiveType primitiveType = type.getPrimitiveType();
             if (primitiveType == PrimitiveType.HLL || primitiveType == PrimitiveType.BITMAP ||
-                    primitiveType == PrimitiveType.PERCENTILE || primitiveType == PrimitiveType.VARIANT) {
+                    primitiveType == PrimitiveType.PERCENTILE) {
                 nullable = true;
             }
             return new Field(colName, new FieldType(nullable, arrowType, null), Collections.emptyList());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -40,7 +40,6 @@ import com.starrocks.planner.ResultSink;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.FrontendOptions;
-import com.starrocks.service.arrow.flight.sql.ArrowFlightSqlConnectContext;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.Authorizer;
@@ -102,7 +101,7 @@ public class StatementPlanner {
     public static ExecPlan plan(StatementBase stmt, ConnectContext session) {
         if (session instanceof HttpConnectContext) {
             return plan(stmt, session, TResultSinkType.HTTP_PROTOCAL);
-        } else if (session instanceof ArrowFlightSqlConnectContext) {
+        } else if (session.isArrowFlightSql()) {
             return plan(stmt, session, TResultSinkType.ARROW_FLIGHT_PROTOCAL);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowBasicStatsMetaStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowBasicStatsMetaStmt.java
@@ -87,7 +87,7 @@ public class ShowBasicStatsMetaStmt extends ShowStmt {
 
     public static List<String> showExternalBasicStatsMeta(ConnectContext context,
                                                           ExternalBasicStatsMeta basicStatsMeta) throws MetaNotFoundException {
-        List<String> row = Lists.newArrayList("", "", "ALL", "", "", "", "", "", "", "", "", "");
+        List<String> row = Lists.newArrayList("", "", "ALL", "", "", "", "", "", "", "", "");
         String catalogName = basicStatsMeta.getCatalogName();
         String dbName = basicStatsMeta.getDbName();
         String tableName = basicStatsMeta.getTableName();

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ConnectProcessorTest.java
@@ -796,7 +796,7 @@ public class ConnectProcessorTest extends DDLTestBase {
             }
         };
 
-        TMasterOpResult result = processor.proxyExecute(request);
+        TMasterOpResult result = processor.proxyExecute(request, null);
         Assertions.assertNotNull(result);
     }
 
@@ -824,7 +824,7 @@ public class ConnectProcessorTest extends DDLTestBase {
             }
         };
 
-        TMasterOpResult result = processor.proxyExecute(request);
+        TMasterOpResult result = processor.proxyExecute(request, null);
         Assertions.assertNotNull(result);
         Assertions.assertTrue(context.getState().isError());
     }
@@ -837,91 +837,91 @@ public class ConnectProcessorTest extends DDLTestBase {
         // Create a prepared statement packet for COM_STMT_EXECUTE
         ByteBuffer executePacket = createExecutePacket(1, new ArrayList<>());
         ConnectContext ctx = initMockContext(mockChannel(executePacket), GlobalStateMgr.getCurrentState());
-        
+
         // Create a prepared statement context with a query statement
         PrepareStmt prepareStmt = createMockPrepareStmt("SELECT 1 + 2");
         PrepareStmtContext prepareCtx = new PrepareStmtContext(prepareStmt, ctx, null);
         ctx.putPreparedStmt("1", prepareCtx);
-        
+
         ConnectProcessor processor = new ConnectProcessor(ctx);
-        
+
         // Track method calls
         AtomicReference<Boolean> tracersRegistered = new AtomicReference<>(false);
         AtomicReference<Boolean> tracersInitialized = new AtomicReference<>(false);
-        
+
         // Mock Tracers
         new MockUp<Tracers>() {
             @Mock
             public void register(ConnectContext context) {
                 tracersRegistered.set(true);
             }
-            
+
             @Mock
             public void init(ConnectContext context, String traceMode, String traceModule) {
                 tracersInitialized.set(true);
             }
         };
-        
+
         // Mock StmtExecutor
         new MockUp<StmtExecutor>() {
             @Mock
             public void execute() throws Exception {
                 // Do nothing for test
             }
-            
+
             @Mock
             public PQueryStatistics getQueryStatisticsForAuditLog() {
                 return statistics;
             }
-            
+
             @Mock
             public StatementBase getParsedStmt() {
                 return prepareStmt;
             }
         };
-        
+
         processor.processOnce();
-        
+
         // Verify that tracers are properly initialized for query statements
         Assertions.assertTrue(tracersRegistered.get(), "Tracers should be registered for query statements");
         Assertions.assertTrue(tracersInitialized.get(), "Tracers should be initialized for query statements");
         Assertions.assertEquals(MysqlCommand.COM_STMT_EXECUTE, myContext.getCommand());
         Assertions.assertEquals("SELECT 1 + 2 AS `1 + 2`", processor.executor.getOriginStmtInString());
     }
-    
+
     /**
      * Helper method to create a COM_STMT_EXECUTE packet
      */
     private ByteBuffer createExecutePacket(int stmtId, List<Object> params) {
         MysqlSerializer serializer = MysqlSerializer.newInstance();
-        
+
         // Command type COM_STMT_EXECUTE (0x17 = 23)
         serializer.writeInt1(23);
-        
+
         // Statement ID
         serializer.writeInt4(stmtId);
-        
+
         // Flags (0 = CURSOR_TYPE_NO_CURSOR)
         serializer.writeInt1(0);
-        
+
         // Iteration count (always 1)
         serializer.writeInt4(1);
-        
+
         // NULL bitmap (empty for no parameters)
         int nullBitmapLength = (params.size() + 7) / 8;
         if (nullBitmapLength > 0) {
             byte[] nullBitmap = new byte[nullBitmapLength];
             serializer.writeBytes(nullBitmap);
         }
-        
+
         // new_params_bind_flag (0 = types not included)
         if (params.size() > 0) {
             serializer.writeInt1(0);
         }
-        
+
         return serializer.toByteBuffer().order(ByteOrder.LITTLE_ENDIAN);
     }
-    
+
     /**
      * Helper method to create a mock PrepareStmt
      */

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ForwardTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ForwardTest.java
@@ -18,6 +18,7 @@ import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.ExecuteEnv;
 import com.starrocks.service.FrontendServiceImpl;
+import com.starrocks.system.Frontend;
 import com.starrocks.thrift.TMasterOpRequest;
 import com.starrocks.thrift.TMasterOpResult;
 import com.starrocks.thrift.TNetworkAddress;
@@ -74,6 +75,9 @@ public class ForwardTest {
         Assertions.assertEquals(result.errorMsg, "Unknown thread id: 1");
     }
 
+    /**
+     * Mockup {@link ConnectProcessor#proxyExecute(TMasterOpRequest, Frontend)}.
+     */
     @Test
     public void testKillWithUnknownException() throws Exception {
         final FrontendServiceImpl service = new FrontendServiceImpl(ExecuteEnv.getInstance());
@@ -96,12 +100,12 @@ public class ForwardTest {
 
         new MockUp<ConnectProcessor>() {
             @Mock
-            public TMasterOpResult proxyExecute(TMasterOpRequest request) {
+            public TMasterOpResult proxyExecute(TMasterOpRequest request, Frontend requestFE) {
                 throw new RuntimeException("unknown exception");
             }
         };
 
         final TMasterOpResult result = service.forward(request);
-        Assertions.assertEquals(result.errorMsg, "unknown exception");
+        Assertions.assertEquals("unknown exception", result.errorMsg);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/LeaderOpExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/LeaderOpExecutorTest.java
@@ -93,7 +93,8 @@ public class LeaderOpExecutorTest {
         String sql = "insert into t1 select * from t1";
         StatementBase stmtBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         LeaderOpExecutor executor =
-                new LeaderOpExecutor(stmtBase, stmtBase.getOrigStmt(), connectContext, RedirectStatus.FORWARD_NO_SYNC, false);
+                new LeaderOpExecutor(stmtBase, stmtBase.getOrigStmt(), connectContext, RedirectStatus.FORWARD_NO_SYNC, false,
+                        null);
 
         mockFrontendService(new MockFrontendServiceClient());
         executor.execute();
@@ -174,7 +175,8 @@ public class LeaderOpExecutorTest {
                             -> ThriftRPCRequestExecutor.call(Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any()))
                     .thenReturn(tMasterOpResult);
             LeaderOpExecutor executor =
-                    new LeaderOpExecutor(stmtBase, stmtBase.getOrigStmt(), connectContext, RedirectStatus.FORWARD_NO_SYNC, false);
+                    new LeaderOpExecutor(stmtBase, stmtBase.getOrigStmt(), connectContext, RedirectStatus.FORWARD_NO_SYNC, false,
+                            null);
             executor.execute();
 
             Assertions.assertEquals(1, connectContext.getTxnId());

--- a/fe/fe-core/src/test/java/com/starrocks/qe/VariablePriorityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/VariablePriorityTest.java
@@ -333,7 +333,7 @@ public class VariablePriorityTest {
         // mock context
         ConnectContext ctx = new ConnectContext();
         ConnectProcessor processor = new ConnectProcessor(ctx);
-        TMasterOpResult result = processor.proxyExecute(request);
+        TMasterOpResult result = processor.proxyExecute(request, null);
         Assertions.assertNotNull(result);
         Assertions.assertEquals(300, ctx.getSessionVariable().getQueryTimeoutS());
 
@@ -352,7 +352,7 @@ public class VariablePriorityTest {
         // mock context
         ctx = new ConnectContext();
         processor = new ConnectProcessor(ctx);
-        result = processor.proxyExecute(request);
+        result = processor.proxyExecute(request, null);
         Assertions.assertNotNull(result);
         Assertions.assertEquals(10, ctx.getSessionVariable().getQueryTimeoutS());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/SchedulerTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/SchedulerTestBase.java
@@ -39,6 +39,8 @@ import com.starrocks.thrift.FrontendService;
 import com.starrocks.thrift.TFinishSlotRequirementRequest;
 import com.starrocks.thrift.TFinishSlotRequirementResponse;
 import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.thrift.TNotifyForwardDeploymentFinishedRequest;
+import com.starrocks.thrift.TNotifyForwardDeploymentFinishedRespone;
 import com.starrocks.thrift.TReleaseSlotRequest;
 import com.starrocks.thrift.TReleaseSlotResponse;
 import com.starrocks.thrift.TRequireSlotRequest;
@@ -47,6 +49,7 @@ import com.starrocks.thrift.TWorkGroup;
 import com.starrocks.utframe.MockGenericPool;
 import mockit.Mock;
 import mockit.MockUp;
+import org.apache.thrift.TException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
@@ -297,6 +300,12 @@ public class SchedulerTestBase extends SchedulerTestNoneDBBase {
         public TFinishSlotRequirementResponse finishSlotRequirement(TFinishSlotRequirementRequest request)
                 throws org.apache.thrift.TException {
             return frontendService.finishSlotRequirement(request);
+        }
+
+        @Override
+        public TNotifyForwardDeploymentFinishedRespone notifyForwardDeploymentFinished(
+                TNotifyForwardDeploymentFinishedRequest request) throws TException {
+            return frontendService.notifyForwardDeploymentFinished(request);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectContextTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectContextTest.java
@@ -16,35 +16,21 @@ package com.starrocks.service.arrow.flight.sql;
 
 import com.starrocks.catalog.Column;
 import com.starrocks.common.util.ArrowUtil;
-import com.starrocks.mysql.MysqlChannel;
-import com.starrocks.qe.ConnectContext;
-import com.starrocks.qe.ConnectScheduler;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.qe.ShowResultSetMetaData;
-import com.starrocks.qe.StmtExecutor;
-import com.starrocks.qe.scheduler.Coordinator;
-import com.starrocks.service.ExecuteEnv;
-import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.type.TypeFactory;
-import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
-import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeoutException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
@@ -53,7 +39,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 public class ArrowFlightSqlConnectContextTest {
 
@@ -66,67 +51,9 @@ public class ArrowFlightSqlConnectContextTest {
     }
 
     @Test
-    public void testConstructor() {
-        assertEquals(token, context.getArrowFlightSqlToken());
-        assertEquals("", context.getQuery());
-        assertTrue(context.returnFromFE());
-    }
-
-    @Test
-    public void testSetAndGetStatement() {
-        StatementBase mockStatement = mock(StatementBase.class);
-        context.setStatement(mockStatement);
-        assertEquals(mockStatement, context.getStatement());
-    }
-
-    @Test
     public void testReset() {
-        context.initWithStatement("SELECT 1");
-        assertEquals("SELECT 1", context.getQuery());
+        context.resetForStatement();
         assertNotNull(context.getQueryId());
-    }
-
-    @Test
-    public void testResetThrowsWhenQueryAlreadySet() {
-        // First reset should succeed
-        context.initWithStatement("SELECT 1");
-        assertEquals("SELECT 1", context.getQuery());
-        
-        // Second reset should throw IllegalStateException
-        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> {
-            context.initWithStatement("SELECT 2");
-        });
-        
-        assertTrue(exception.getMessage().contains("Query already in progress"));
-    }
-
-    @Test
-    public void testResetAfterClearQuery() {
-        context.initWithStatement("SELECT 1");
-        context.reset();
-        
-        // Should not throw since query was cleared
-        context.initWithStatement("SELECT 2");
-        assertEquals("SELECT 2", context.getQuery());
-    }
-
-    @Test
-    public void testClearQuery() {
-        context.initWithStatement("SELECT 1");
-        assertEquals("SELECT 1", context.getQuery());
-        
-        context.reset();
-        assertEquals("", context.getQuery());
-        
-        // After clearing, reset should work again
-        context.initWithStatement("SELECT 2");
-        assertEquals("SELECT 2", context.getQuery());
-    }
-
-    @Test
-    public void testSetReturnResultFromFE() {
-        context.setReturnResultFromFE(false);
-        assertFalse(context.returnFromFE());
     }
 
     @Test
@@ -185,7 +112,6 @@ public class ArrowFlightSqlConnectContextTest {
         }
     }
 
-
     @Test
     public void testRemoveAllResults() {
         try (var mocked = mockStatic(ArrowUtil.class)) {
@@ -202,84 +128,10 @@ public class ArrowFlightSqlConnectContextTest {
     }
 
     @Test
-    public void testIsArrowFlightSQL() {
-        assertTrue(context instanceof ArrowFlightSqlConnectContext);
-    }
-
-    @Test
-    public void testIsFromFECoordinator() {
-        assertTrue(context.isFromFECoordinator());
-    }
-
-    @Test
     public void testCancelQuery() {
         var mockExecutor = mock(com.starrocks.qe.StmtExecutor.class);
         context.setStmtExecutor(mockExecutor);
         context.cancelQuery();
         verify(mockExecutor, times(1)).cancel("Arrow Flight SQL client disconnected");
-    }
-
-    @Test
-    public void testSetDeploymentFinishedAndWaitSuccess() throws Exception {
-        Coordinator coordinator = mock(Coordinator.class);
-        context.setDeploymentFinished(coordinator);
-        Coordinator result = context.waitForDeploymentFinished(1000);
-        assertEquals(coordinator, result);
-    }
-
-    @Test
-    public void testWaitForDeploymentFinishedTimeout() {
-        assertThrows(TimeoutException.class, () -> {
-            context.waitForDeploymentFinished(1);
-        });
-    }
-
-    @Test
-    public void testKill() throws Exception {
-        ArrowFlightSqlConnectContext context = new ArrowFlightSqlConnectContext("token");
-
-        // mock executor
-        StmtExecutor executor = mock(StmtExecutor.class);
-        Field executorField = ConnectContext.class.getDeclaredField("executor");
-        executorField.setAccessible(true);
-        executorField.set(context, executor);
-
-        // mock coordinator
-        Coordinator coordinator = mock(Coordinator.class);
-        CompletableFuture<Coordinator> future = new CompletableFuture<>();
-        future.complete(coordinator);
-        Field futureField = ArrowFlightSqlConnectContext.class.getDeclaredField("coordinatorFuture");
-        futureField.setAccessible(true);
-        futureField.set(context, future);
-
-        // mock allocator
-        BufferAllocator allocator = mock(BufferAllocator.class);
-        Field allocatorField = ArrowFlightSqlConnectContext.class.getDeclaredField("allocator");
-        allocatorField.setAccessible(true);
-        allocatorField.set(context, allocator);
-
-        MysqlChannel mysqlChannel = mock(MysqlChannel.class);
-        Field mysqlChannelField = ConnectContext.class.getDeclaredField("mysqlChannel");
-        mysqlChannelField.setAccessible(true);
-        mysqlChannelField.set(context, mysqlChannel);
-
-        // mock ExecuteEnv.getInstance().getScheduler().unregisterConnection(this);
-        ConnectScheduler scheduler = mock(ConnectScheduler.class);
-        ExecuteEnv mockEnv = mock(ExecuteEnv.class);
-        when(mockEnv.getScheduler()).thenReturn(scheduler);
-
-        try (MockedStatic<ExecuteEnv> mocked = mockStatic(ExecuteEnv.class)) {
-            mocked.when(ExecuteEnv::getInstance).thenReturn(mockEnv);
-
-            context.kill(true, "cancelled");
-
-            verify(mysqlChannel).close();
-
-            verify(executor).cancel("cancelled");
-
-            verify(coordinator).cancel("cancelled");
-
-            verify(scheduler).unregisterConnection(context);
-        }
     }
 }

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -458,6 +458,10 @@ message PCancelPlanFragmentRequest {
     optional PPlanFragmentCancelReason cancel_reason = 2;
     optional bool is_pipeline = 10;
     optional PUniqueId query_id = 11;
+    // Detailed error message when cancel_reason is INTERNAL_ERROR
+    // This allows propagating the actual error (e.g., "exceed big query cpu limit")
+    // instead of just "InternalError"
+    optional string error_message = 12;
 };
 
 message PCancelPlanFragmentResult {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -840,7 +840,20 @@ struct TMasterOpRequest {
     37: optional i64 txn_id;
     38: optional bool isInternalStmt;
 
+    39: optional bool is_arrow_flight_sql;
+
     101: optional i64 warehouse_id    // begin from 101, in case of conflict with other's change
+}
+
+struct TNotifyForwardDeploymentFinishedRequest {
+    1: optional Types.TUniqueId query_id
+    2: optional Types.TUniqueId arrow_flight_sql_result_fragment_id;
+    3: optional i64 arrow_flight_sql_result_backend_id;
+    4: optional binary arrow_flight_sql_result_schema;
+}
+
+struct TNotifyForwardDeploymentFinishedRespone {
+    1: optional Status.TStatus status
 }
 
 struct TColumnDefinition {
@@ -2296,6 +2309,7 @@ service FrontendService {
 
     //NOTE: Do not add numbers to the parameters, otherwise it will cause compatibility problems
     TMasterOpResult forward(TMasterOpRequest params)
+    TNotifyForwardDeploymentFinishedRespone notifyForwardDeploymentFinished(TNotifyForwardDeploymentFinishedRequest request)
 
     TListTableStatusResult listTableStatus(1:TGetTablesParams params)
     TListMaterializedViewStatusResult listMaterializedViewStatus(1:TGetTablesParams params)

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -54,6 +54,11 @@ enum TFunctionVersion {
     RUNTIME_FILTER_SERIALIZE_VERSION_3 = 8,
 }
 
+enum TArrowFlightSQLVersion {
+  V0 = 0,
+  V1 = 1,
+}
+
 enum TQueryType {
     SELECT,
     LOAD,
@@ -523,6 +528,8 @@ struct TExecPlanFragmentParams {
   60: optional TPredicateTreeParams pred_tree_params
 
   61: optional list<i32> exec_stats_node_ids;
+
+  62: optional i32 arrow_flight_sql_version;
 }
 
 struct TExecPlanFragmentResult {

--- a/test/lib/arrow_sql_lib.py
+++ b/test/lib/arrow_sql_lib.py
@@ -131,7 +131,7 @@ class ArrowSqlLib(BaseConnectionLib):
             elif char == ';' and not in_single_quote and not in_double_quote:
                 # Statement terminator (only if not in any string)
                 current_stmt.append(char)
-                stmt = ''.join(current_stmt).strip()
+                stmt = ''.join(current_stmt)
                 if stmt and stmt != ';':  # Ignore empty statements
                     statements.append(stmt)
                 current_stmt = []
@@ -141,9 +141,16 @@ class ArrowSqlLib(BaseConnectionLib):
 
         # Handle remaining statement (if any)
         if current_stmt:
-            stmt = ''.join(current_stmt).strip()
+            stmt = ''.join(current_stmt)
             if stmt:  # Ignore empty statements
                 statements.append(stmt)
+
+        for i, raw_statement in enumerate(statements):
+            statement = raw_statement.strip()
+            if statement.startswith('--') and '\n' not in statement:
+                statements[i - 1] += raw_statement
+                statements[i] = ''
+        statements = [s for s in statements if s]
 
         return statements if statements else [sql]  # Return original if no split occurred
 

--- a/test/lib/arrow_sql_lib.py
+++ b/test/lib/arrow_sql_lib.py
@@ -21,26 +21,403 @@ arrow_sql_lib.py
 @Time : 2024/11/13
 @Author : liubotao
 """
+import json
+import math
+import warnings
+from decimal import Decimal
+from typing import Tuple, Any
+
+from cup import log
 
 import adbc_driver_manager
 import adbc_driver_flightsql.dbapi as flight_sql
+import pyarrow
+import pyarrow.compute as pc
+from dbutils.pooled_db import PooledDB
+from pyarrow import types as T
+
+from lib.connection_base_lib import BaseConnectionLib, SQLRawResult
 
 
-class ArrowSqlLib(object):
-    """ArrowSqlLib class"""
-
-    def __init__(self):
-        self.connector = None
+class ArrowSqlLib(BaseConnectionLib):
+    def __init__(self, conn=None):
+        self.connector: flight_sql.Connection = conn
 
     def connect(self, query_dict):
-        self.connector = flight_sql.connect(uri=f"grpc://{query_dict['host']}:{int(query_dict['arrow_port'])}",
-                                            db_kwargs={
-                                                adbc_driver_manager.DatabaseOptions.USERNAME.value: query_dict["user"],
-                                                adbc_driver_manager.DatabaseOptions.PASSWORD.value: query_dict[
-                                                    "password"],
-                                            })
+        # Filter the autocommit warning from ADBC driver
+        warnings.filterwarnings('ignore', message='Cannot disable autocommit.*')
+        self.connector = flight_sql.connect(
+            uri=f"grpc://{query_dict['host']}:{int(query_dict['arrow_port'])}",
+            db_kwargs={
+                adbc_driver_manager.DatabaseOptions.USERNAME.value: query_dict["user"],
+                adbc_driver_manager.DatabaseOptions.PASSWORD.value: query_dict["password"],
+            })
 
     def close(self):
         if self.connector:
             self.connector.close()
             self.connector = None
+
+    def execute(self, sql: str) -> SQLRawResult:
+        sql_statements = self._split_sql(sql)
+
+        try:
+            if len(sql_statements) == 1:
+                return self._execute_single(sql_statements[0])
+
+            # If multiple SQL statements, execute each and return query result
+            results = []
+            for stmt in sql_statements:
+                result = self._execute_single(stmt)
+                if not result.status:
+                    return result  # Return immediately on error
+                results.append(result)
+
+            # Select the result to return (prioritize query results)
+            return self._select_result(results)
+        except adbc_driver_manager.DatabaseError as e:
+            return SQLRawResult(status=False, result=(), msg=str(e), desc=None)
+
+    def wrapper(self, conn):
+        return ArrowSqlLib(conn)
+
+    def create_pool(self, host: str, mysql_port: int, arrow_port: int, user: str, password: str) -> PooledDB:
+        # Filter the autocommit warning from ADBC driver
+        warnings.filterwarnings('ignore', message='Cannot disable autocommit.*')
+        return PooledDB(
+            creator=flight_sql,
+            mincached=3,
+            blocking=True,
+            uri=f"grpc://{host}:{arrow_port}",
+            db_kwargs={
+                adbc_driver_manager.DatabaseOptions.USERNAME.value: user,
+                adbc_driver_manager.DatabaseOptions.PASSWORD.value: password,
+            },
+        )
+
+    def _split_sql(self, sql: str) -> list:
+        """
+        Split SQL string into multiple SQL statements.
+        A statement ends with ';' that is not inside a string literal.
+        Handles single quotes ('), double quotes ("), and backslash escaping.
+        """
+        statements = []
+        current_stmt = []
+        in_single_quote = False
+        in_double_quote = False
+        escaped = False
+
+        for char in sql:
+            if escaped:
+                # Previous character was a backslash, current character is escaped
+                current_stmt.append(char)
+                escaped = False
+                continue
+
+            if char == '\\':
+                # Backslash escapes the next character
+                current_stmt.append(char)
+                escaped = True
+                continue
+
+            if char == "'" and not in_double_quote:
+                # Toggle single quote state (only if not in double quote)
+                in_single_quote = not in_single_quote
+                current_stmt.append(char)
+            elif char == '"' and not in_single_quote:
+                # Toggle double quote state (only if not in single quote)
+                in_double_quote = not in_double_quote
+                current_stmt.append(char)
+            elif char == ';' and not in_single_quote and not in_double_quote:
+                # Statement terminator (only if not in any string)
+                current_stmt.append(char)
+                stmt = ''.join(current_stmt).strip()
+                if stmt and stmt != ';':  # Ignore empty statements
+                    statements.append(stmt)
+                current_stmt = []
+            else:
+                # Regular character
+                current_stmt.append(char)
+
+        # Handle remaining statement (if any)
+        if current_stmt:
+            stmt = ''.join(current_stmt).strip()
+            if stmt:  # Ignore empty statements
+                statements.append(stmt)
+
+        return statements if statements else [sql]  # Return original if no split occurred
+
+    def _execute_single(self, sql: str) -> SQLRawResult:
+        """Execute a single SQL statement."""
+        with self.connector.cursor() as cursor:
+            cursor.execute(sql)
+            arrow_table = cursor.fetch_arrow_table()
+            res = convert_arrow_table_to_mysql_rows(arrow_table)
+            return SQLRawResult(status=True, result=res, msg="OK", desc=cursor.description)
+
+    def _is_query_result(self, result: SQLRawResult) -> bool:
+        """
+        Check if the result is a query result.
+        Non-query result: cursor.description has only one column named 'StatusResult' with string type.
+        """
+        if not result.desc:
+            return False
+
+        if len(result.desc) != 1:
+            return True  # More than one column, it's a query
+
+        # Check if it's StatusResult column
+        col_name = result.desc[0][0]
+        col_type = str(result.desc[0][1])  # Convert to string for comparison
+
+        # Check if it's a StatusResult (non-query result)
+        if col_name == 'StatusResult' and 'string' in col_type.lower():
+            return False
+
+        return True
+
+    def _select_result(self, results: list) -> SQLRawResult:
+        """
+        Select which result to return from multiple results.
+        Prioritize query results over non-query results.
+        """
+        # Try to find a query result
+        for result in results:
+            if self._is_query_result(result):
+                return result
+
+        # If no query result found, return the last result
+        return results[-1] if results else SQLRawResult(status=True, result=(), msg="OK")
+
+
+def convert_arrow_table_to_mysql_rows(arrow_table) -> Tuple[Tuple[Any, ...], ...]:
+    if arrow_table.num_rows == 0:
+        return tuple()
+
+    rows = arrow_table_to_py(arrow_table)
+    new_rows = []
+    for row in rows:
+        new_row = []
+        for col in row:
+            if isinstance(col, (dict, list)):
+                new_col = serialize_to_json(col)
+            elif isinstance(col, bytes):
+                try:
+                    new_col = col.decode()
+                except UnicodeDecodeError as e:
+                    log.info("decode sql result by utf-8 error, try str")
+                    new_col = str(col)
+            else:
+                new_col = col
+            new_row.append(new_col)
+        new_rows.append(tuple(new_row))
+
+    return tuple(new_rows)
+
+
+def serialize_to_json(item, deep=0) -> str:
+    """
+    Convert the data into the same format as MySQL's result set. The main focus is on handling Array, Map, and Struct
+    types (which correspond to Python's list/tuple and dict).
+    Note that when a key is an int, its serialized form must not be wrapped in quotes.
+    For example: {1: "value"} -> {1:"value"} instead of {"1":"value"}
+    """
+    if item is None:
+        return "null"
+    elif isinstance(item, bool):
+        return "true" if item else "false"
+    elif isinstance(item, (int, Decimal)):
+        return str(item)
+    elif isinstance(item, float):
+        # In array/map/struct, MySQL displays integer-valued floats without .0
+        # e.g., 6.0 -> "6", but 1.1 -> "1.1"
+        if deep != 0 and not math.isnan(item) and item == int(item):  # Check it's an integer value and not NaN
+            return str(int(item))
+        return str(item)
+    elif isinstance(item, str):
+        escaped = json.dumps(item, ensure_ascii=False)
+        return escaped
+    elif isinstance(item, dict):
+        if not item:
+            return "{}"
+        items = []
+        for k, v in item.items():
+            # For integer keys, don't add quotes
+            if isinstance(k, int):
+                key_str = str(k)
+            else:
+                key_str = json.dumps(str(k), ensure_ascii=False)
+            value_str = serialize_to_json(v, deep + 1)
+            items.append(f"{key_str}:{value_str}")
+        return "{" + ",".join(items) + "}"
+    elif isinstance(item, (list, tuple)):
+        if not item:
+            return "[]"
+        items = [serialize_to_json(item, deep + 1) for item in item]
+        return "[" + ",".join(items) + "]"
+    else:
+        # Fallback to standard JSON serialization
+        return json.dumps(item, ensure_ascii=False, separators=(',', ':'))
+
+
+def arrow_table_to_py(table: pyarrow.Table):
+    """
+    Given a pyarrow.Table, return a List[List[...]].
+    """
+    num_cols = table.num_columns
+    num_rows = table.num_rows
+
+    col_converters = []
+    columns = []
+    for col_i in range(num_cols):
+        col = table.column(col_i)
+        columns.append(col.combine_chunks())
+        col_converters.append(_build_arrow_to_py_converter(col.type))
+
+    rows = []
+    for row_i in range(num_rows):
+        new_columns = []
+        for col_i in range(num_cols):
+            item = columns[col_i][row_i]
+            try:
+                py_value = item.as_py()  # may contain nested list/map/struct
+            except UnicodeDecodeError:
+                # Handle non-UTF8 bytes in string columns
+                # Get the raw bytes and represent them as bytes object
+                if hasattr(item, 'as_buffer'):
+                    raw_bytes = item.as_buffer().to_pybytes()
+                    py_value = raw_bytes
+                else:
+                    # Fallback: try to get bytes representation
+                    py_value = bytes(item)
+            except OverflowError:
+                col_type = columns[col_i].type
+                if T.is_date32(col_type):
+                    # Some dates (e.g. year 0000) cannot be converted to Python date; format via Arrow.
+                    py_value = pc.strftime(item, format="%Y-%m-%d").as_py()
+                elif T.is_timestamp(col_type):
+                    # Use Arrow formatting to avoid Python datetime limits.
+                    py_value = pc.strftime(item, format="%Y-%m-%d %H:%M:%S.%f").as_py()
+                else:
+                    raise
+            new_columns.append(col_converters[col_i](py_value))
+        rows.append(new_columns)
+
+    return rows
+
+
+def _build_arrow_to_py_converter(dtype: pyarrow.DataType):
+    """
+    Build a Python-side converter function based on an Arrow DataType.
+    The converter will recursively turn any map-typed values (including nested)
+    from list-of-tuples form into Python dict.
+    """
+    # 1. MapType: value is [(key, value), ...]
+    if T.is_map(dtype):
+        key_conv = _build_arrow_to_py_converter(dtype.key_type)
+        value_conv = _build_arrow_to_py_converter(dtype.item_type)
+
+        def conv_map(value):
+            if value is None:
+                return None
+            # Default Python representation of map is [(k, v), ...]
+            return {key_conv(k): value_conv(v) for (k, v) in value}
+
+        return conv_map
+
+    # 2. List / LargeList / FixedSizeList: recursively convert each element
+    if T.is_list(dtype) or T.is_large_list(dtype) or T.is_fixed_size_list(dtype):
+        elem_conv = _build_arrow_to_py_converter(dtype.value_type)
+
+        def conv_list(value):
+            if value is None:
+                return None
+            return [elem_conv(v) for v in value]
+
+        return conv_list
+
+    # 3. Struct: value is a dict {field_name: field_value, ...}
+    if T.is_struct(dtype):
+        field_convs = {
+            field.name: _build_arrow_to_py_converter(field.type)
+            for field in dtype
+        }
+
+        def conv_struct(value):
+            if value is None:
+                return None
+            # value is a dict: field name -> Python value
+            return {
+                name: field_convs[name](value.get(name))
+                for name in field_convs
+            }
+
+        return conv_struct
+
+    # 4. Date32: convert to YYYY-MM-DD string
+    if T.is_date32(dtype):
+        def conv_date32(value):
+            if value is None:
+                return None
+            if isinstance(value, str):
+                return value
+            return f"{value.year:04d}-{value.month:02d}-{value.day:02d}"
+
+        return conv_date32
+
+    # 5. Timestamp (datetime): convert to string, append .uuuuuu when microsecond > 0
+    if T.is_timestamp(dtype):
+        def conv_timestamp(value):
+            if value is None:
+                return None
+            if isinstance(value, str):
+                return value
+            base = (f"{value.year:04d}-{value.month:02d}-{value.day:02d} "
+                    f"{value.hour:02d}:{value.minute:02d}:{value.second:02d}")
+            if value.microsecond > 0:
+                return f"{base}.{value.microsecond:06d}"
+            return base
+
+        return conv_timestamp
+
+    # 6. Boolean type: convert True/False to 1/0
+    if T.is_boolean(dtype):
+        def conv_bool(value):
+            if value is None:
+                return None
+            return 1 if value else 0
+
+        return conv_bool
+
+    # 7. Float32 type: handle precision to match MySQL/Ryu behavior
+    if T.is_float32(dtype):
+        import struct
+
+        def conv_float32(value):
+            if value is None:
+                return None
+
+            # Round-trip through float32 to preserve only float32 precision
+            float32_bytes = struct.pack('f', value)
+            float32_value = struct.unpack('f', float32_bytes)[0]
+
+            # Implement Ryu-like algorithm: find shortest representation that round-trips
+            # Try from FLT_DIG (6) to FLT_DIG + 2 (8) significant digits
+            for digits in [6, 7, 8]:
+                formatted = f'{float32_value:.{digits}g}'
+                try:
+                    reparsed = struct.unpack('f', struct.pack('f', float(formatted)))[0]
+                    if reparsed == float32_value:
+                        return float(formatted)
+                except (ValueError, struct.error):
+                    pass
+
+            # Fallback: use 8 digits if nothing worked
+            formatted = f'{float32_value:.8g}'
+            return float(formatted)
+
+        return conv_float32
+
+    # 6. Other complex types (dictionary/union/extension/etc.) can be added here.
+    #    By default, return the Python value as-is.
+    return lambda v: v

--- a/test/lib/arrow_sql_lib.py
+++ b/test/lib/arrow_sql_lib.py
@@ -150,7 +150,7 @@ class ArrowSqlLib(BaseConnectionLib):
             if statement.startswith('--') and '\n' not in statement:
                 statements[i - 1] += raw_statement
                 statements[i] = ''
-        statements = [s for s in statements if s]
+        statements = [s for s in statements if s.strip() and s.strip() != ';']
 
         return statements if statements else [sql]  # Return original if no split occurred
 

--- a/test/lib/choose_cases.py
+++ b/test/lib/choose_cases.py
@@ -45,7 +45,7 @@ LOG_FILTERED_WARN = "You can use `--log_filtered` to show the details..."
 
 class ChooseCase(object):
     class CaseTR(object):
-        def __init__(self, ctx, name, file, sql, result, info, cleanup=None):
+        def __init__(self, ctx, name, file, sql, result, info, cleanup=None, tags=None):
             """init"""
             super().__init__()
             self.ctx = ctx
@@ -57,6 +57,8 @@ class ChooseCase(object):
             self.result: List = result
             # custom cleanup commands
             self.cleanup: List = cleanup or []
+            # case tags (e.g., @arrow_flight_sql, @sequential)
+            self.tags: List = tags or []
 
             # # get db from lines
             # self.db = set()
@@ -422,6 +424,7 @@ class ChooseCase(object):
                                 copy.deepcopy(tmp_res),
                                 info,
                                 cleanup=copy.deepcopy(tmp_cleanup_stat),
+                                tags=copy.deepcopy(tags),
                             )
                         )
 
@@ -618,6 +621,7 @@ class ChooseCase(object):
                         copy.deepcopy(tmp_res),
                         info,
                         cleanup=copy.deepcopy(tmp_cleanup_stat),
+                        tags=copy.deepcopy(tags),
                     )
                 )
 

--- a/test/lib/connection_base_lib.py
+++ b/test/lib/connection_base_lib.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# -- coding: utf-8 --
+###########################################################################
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###########################################################################
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Union, Optional
+
+from dbutils.pooled_db import PooledDB
+
+
+@dataclass
+class SQLRawResult:
+    status: bool
+    msg: str
+    result: Optional[Union[list, tuple]] = None
+    desc: Optional[str] = None
+
+class BaseConnectionLib(ABC):
+    @abstractmethod
+    def connect(self, query_dict):
+        pass
+
+    @abstractmethod
+    def close(self):
+        pass
+
+    @abstractmethod
+    def execute(self, sql) -> SQLRawResult:
+        pass
+
+    @abstractmethod
+    def wrapper(self, conn):
+        pass
+
+    def create_pool(self, host: str, mysql_port: int, arrow_port: int, user: str, password: str) -> PooledDB:
+        pass

--- a/test/lib/mysql_lib.py
+++ b/test/lib/mysql_lib.py
@@ -21,18 +21,22 @@ mysql_lib.py
 @Time : 2022/11/03 10:34
 @Author : Brook.Ye
 """
-
+import pymysql
 import pymysql as _mysql
+from dbutils.pooled_db import PooledDB
 from pymysql.constants import CLIENT
 
+from cup import log
+
 from lib import close_conn
+from lib.connection_base_lib import BaseConnectionLib, SQLRawResult
 
 
-class MysqlLib(object):
+class MysqlLib(BaseConnectionLib):
     """MysqlLib class"""
 
-    def __init__(self):
-        self.connector = ""
+    def __init__(self, conn=""):
+        self.connector = conn
 
     def connect(self, query_dict):
         if "database" not in query_dict:
@@ -56,3 +60,40 @@ class MysqlLib(object):
         if self.connector != "":
             close_conn(self.connector, "MySQL")
             self.connector = ""
+
+    def execute(self, sql) -> SQLRawResult:
+        with self.connector.cursor() as cursor:
+            cursor.execute(sql)
+            result = cursor.fetchall()
+
+            if isinstance(result, tuple):
+                result = list(result)
+                for row_i, row in enumerate(result):
+                    row = list(row)
+                    # type to str
+                    for col_i, col_data in enumerate(row):
+                        if isinstance(col_data, bytes):
+                            try:
+                                row[col_i] = col_data.decode()
+                            except UnicodeDecodeError as e:
+                                log.info("decode sql result by utf-8 error, try str")
+                                row[col_i] = str(col_data)
+
+                    result[row_i] = tuple(row)
+                result = tuple(result)
+
+            return SQLRawResult(status=True, result=result, msg=cursor._result.message, desc=cursor.description)
+
+    def wrapper(self, conn):
+        return MysqlLib(conn)
+
+    def create_pool(self, host: str, mysql_port: int, arrow_port: int, user: str, password: str) -> PooledDB:
+        return PooledDB(
+            creator=pymysql,
+            mincached=3,
+            blocking=True,
+            host=host,
+            port=mysql_port,
+            user=user,
+            password=password,
+        )

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -22,4 +22,4 @@ adbc-driver-flightsql==1.2.0
 # Relaxed pyarrow version constraint to >=17.0.0 to support the variant_query feature,
 # which requires features introduced after 17.0.0. As of this writing, no known compatibility
 # issues have been observed with newer pyarrow versions, but please verify compatibility if upgrading.
-pyarrow>=17.0.0
+pyarrow>=21.0.0

--- a/test/run.py
+++ b/test/run.py
@@ -196,8 +196,6 @@ if __name__ == "__main__":
         print("In alive mode, set concurrency=1 in default!")
         concurrency = 1
 
-    arrow_mode = True # TODO(lzh): remove this
-
     # Auto-exclude no_arrow_flight_sql cases in arrow mode
     if arrow_mode:
         if attr:

--- a/test/run.py
+++ b/test/run.py
@@ -196,6 +196,15 @@ if __name__ == "__main__":
         print("In alive mode, set concurrency=1 in default!")
         concurrency = 1
 
+    arrow_mode = True # TODO(lzh): remove this
+
+    # Auto-exclude no_arrow_flight_sql cases in arrow mode
+    if arrow_mode:
+        if attr:
+            attr = attr + ",!no_arrow_flight_sql"
+        else:
+            attr = "!no_arrow_flight_sql"
+
     # set environment
     os.environ.update(
         {
@@ -210,6 +219,7 @@ if __name__ == "__main__":
             "log_filtered": str(log_filtered),
             "check_status": str(check_status),
             "case_timeout": str(timeout),
+            "arrow_mode": "true" if arrow_mode else "false",
         }
     )
 

--- a/test/sql/test_array_fn/R/test_array_fn
+++ b/test/sql/test_array_fn/R/test_array_fn
@@ -1,4 +1,4 @@
--- name: test_array_functions @mac
+-- name: test_array_functions @mac @no_arrow_flight_sql
 CREATE TABLE array_test ( 
 pk bigint not null ,
 s_1   Array<String>, 

--- a/test/sql/test_array_fn/R/test_array_min_max
+++ b/test/sql/test_array_fn/R/test_array_min_max
@@ -1,4 +1,4 @@
--- name: test_array_min_max_all_type @mac
+-- name: test_array_min_max_all_type @mac @no_arrow_flight_sql
 CREATE TABLE test_array_min_max (
     id INT,
     array_boolean ARRAY<BOOLEAN>,

--- a/test/sql/test_array_fn/R/test_array_remove
+++ b/test/sql/test_array_fn/R/test_array_remove
@@ -1,4 +1,4 @@
--- name: test_array_remove_all_type @mac
+-- name: test_array_remove_all_type @mac @no_arrow_flight_sql
 CREATE TABLE test_array_remove (
     id INT,
     array_boolean ARRAY<BOOLEAN>,

--- a/test/sql/test_array_fn/R/test_array_sum_avg
+++ b/test/sql/test_array_fn/R/test_array_sum_avg
@@ -1,4 +1,4 @@
--- name: test_array_sum_avg @mac
+-- name: test_array_sum_avg @mac @no_arrow_flight_sql
 CREATE TABLE test_array_functions (
     id INT,
     array_boolean ARRAY<BOOLEAN>,

--- a/test/sql/test_array_fn/R/test_array_top_n
+++ b/test/sql/test_array_fn/R/test_array_top_n
@@ -1,4 +1,4 @@
--- name: test_array_top_n_all_types
+-- name: test_array_top_n_all_types @no_arrow_flight_sql
 CREATE TABLE test_array_top_n (
     id INT,
     array_int ARRAY<INT>,

--- a/test/sql/test_array_fn/T/test_array_fn
+++ b/test/sql/test_array_fn/T/test_array_fn
@@ -1,4 +1,4 @@
--- name: test_array_functions @mac
+-- name: test_array_functions @mac @no_arrow_flight_sql
 CREATE TABLE array_test ( 
 pk bigint not null ,
 s_1   Array<String>, 

--- a/test/sql/test_array_fn/T/test_array_min_max
+++ b/test/sql/test_array_fn/T/test_array_min_max
@@ -1,4 +1,4 @@
--- name: test_array_min_max_all_type @mac
+-- name: test_array_min_max_all_type @mac @no_arrow_flight_sql
 
 CREATE TABLE test_array_min_max (
     id INT,

--- a/test/sql/test_array_fn/T/test_array_remove
+++ b/test/sql/test_array_fn/T/test_array_remove
@@ -1,4 +1,4 @@
--- name: test_array_remove_all_type @mac
+-- name: test_array_remove_all_type @mac @no_arrow_flight_sql
 CREATE TABLE test_array_remove (
     id INT,
     array_boolean ARRAY<BOOLEAN>,

--- a/test/sql/test_array_fn/T/test_array_sum_avg
+++ b/test/sql/test_array_fn/T/test_array_sum_avg
@@ -1,4 +1,4 @@
--- name: test_array_sum_avg @mac
+-- name: test_array_sum_avg @mac @no_arrow_flight_sql
 CREATE TABLE test_array_functions (
     id INT,
     array_boolean ARRAY<BOOLEAN>,

--- a/test/sql/test_array_fn/T/test_array_top_n
+++ b/test/sql/test_array_fn/T/test_array_top_n
@@ -1,4 +1,4 @@
--- name: test_array_top_n_all_types
+-- name: test_array_top_n_all_types @no_arrow_flight_sql
 
 CREATE TABLE test_array_top_n (
     id INT,

--- a/test/sql/test_arrow/R/test_arrow_flight_1
+++ b/test/sql/test_arrow/R/test_arrow_flight_1
@@ -1,38 +1,38 @@
--- name: test_arrow_flight_1
-arrow: DROP DATABASE IF EXISTS arrow_demo;
+-- name: test_arrow_flight_1 @arrow_flight_sql
+DROP DATABASE IF EXISTS arrow_demo;
 -- result:
 -- !result
-arrow: CREATE DATABASE arrow_demo;
+CREATE DATABASE arrow_demo;
 -- result:
 -- !result
-arrow: USE arrow_demo;
+USE arrow_demo;
 -- result:
 -- !result
-arrow: CREATE TABLE arrow_demo.students (     id INT NOT NULL,    name VARCHAR(255) NOT NULL,    age INT NOT NULL,    enrollment_date DATE ) ENGINE=OLAP  PRIMARY KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 10 PROPERTIES (    'replication_num' = '1',    'in_memory' = 'false',    'enable_persistent_index' = 'true',    'replicated_storage' = 'true',    'fast_schema_evolution' = 'true',    'compression' = 'LZ4');
+CREATE TABLE arrow_demo.students (     id INT NOT NULL,    name VARCHAR(255) NOT NULL,    age INT NOT NULL,    enrollment_date DATE ) ENGINE=OLAP  PRIMARY KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 10 PROPERTIES (    'replication_num' = '1',    'in_memory' = 'false',    'enable_persistent_index' = 'true',    'replicated_storage' = 'true',    'fast_schema_evolution' = 'true',    'compression' = 'LZ4');
 -- result:
 -- !result
-arrow: INSERT INTO arrow_demo.students (id, name, age, enrollment_date) VALUES (1, 'John Doe', 20, '2024-01-10'),(2, 'Jane Smith', 22, '2024-01-11'),(3, 'Emily Davis', 21, '2024-01-12');
+INSERT INTO arrow_demo.students (id, name, age, enrollment_date) VALUES (1, 'John Doe', 20, '2024-01-10'),(2, 'Jane Smith', 22, '2024-01-11'),(3, 'Emily Davis', 21, '2024-01-12');
 -- result:
 -- !result
-arrow: SELECT * FROM arrow_demo.students order by id asc;
+SELECT * FROM arrow_demo.students order by id asc;
 -- result:
 1	John Doe	20	2024-01-10
 2	Jane Smith	22	2024-01-11
 3	Emily Davis	21	2024-01-12
 -- !result
-arrow: UPDATE arrow_demo.students SET age = 23 WHERE id = 1;
+UPDATE arrow_demo.students SET age = 23 WHERE id = 1;
 -- result:
 -- !result
-arrow: SELECT * FROM arrow_demo.students order by id asc;
+SELECT * FROM arrow_demo.students order by id asc;
 -- result:
 1	John Doe	23	2024-01-10
 2	Jane Smith	22	2024-01-11
 3	Emily Davis	21	2024-01-12
 -- !result
-arrow: DELETE FROM arrow_demo.students WHERE id = 3;
+DELETE FROM arrow_demo.students WHERE id = 3;
 -- result:
 -- !result
-arrow: SELECT * FROM arrow_demo.students order by id asc;
+SELECT * FROM arrow_demo.students order by id asc;
 -- result:
 1	John Doe	23	2024-01-10
 2	Jane Smith	22	2024-01-11

--- a/test/sql/test_arrow/R/test_arrow_flight_2
+++ b/test/sql/test_arrow/R/test_arrow_flight_2
@@ -1,33 +1,33 @@
--- name: test_arrow_flight_2
-arrow: DROP DATABASE IF EXISTS flight_demo;
+-- name: test_arrow_flight_2 @arrow_flight_sql
+DROP DATABASE IF EXISTS flight_demo;
 -- result:
 -- !result
 
-arrow: CREATE DATABASE flight_demo;
+CREATE DATABASE flight_demo;
 -- result:
 -- !result
 
-arrow: USE flight_demo;
+USE flight_demo;
 -- result:
 -- !result
 
-arrow: CREATE TABLE flight_demo.test (id INT, name STRING) ENGINE=OLAP PRIMARY KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ('replication_num' = '1');
+CREATE TABLE flight_demo.test (id INT, name STRING) ENGINE=OLAP PRIMARY KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ('replication_num' = '1');
 -- result:
 -- !result
 
-arrow: INSERT INTO flight_demo.test VALUES (1, 'Alice'), (2, 'Bob');
+INSERT INTO flight_demo.test VALUES (1, 'Alice'), (2, 'Bob');
 -- result:
 -- !result
 
-arrow: INSERT INTO flight_demo.test VALUES (1, 'Alice'), (2, 'Bob');
+INSERT INTO flight_demo.test VALUES (1, 'Alice'), (2, 'Bob');
 -- result:
 -- !result
 
-arrow: INSERT INTO flight_demo.test VALUES (3, 'Zac'), (4, 'Tom');
+INSERT INTO flight_demo.test VALUES (3, 'Zac'), (4, 'Tom');
 -- result:
 -- !result
 
-arrow: SELECT * FROM flight_demo.test order by id asc;
+SELECT * FROM flight_demo.test order by id asc;
 -- result:
 1	Alice
 2	Bob
@@ -35,23 +35,11 @@ arrow: SELECT * FROM flight_demo.test order by id asc;
 4	Tom
 -- !result
 
-arrow: UPDATE flight_demo.test SET name = 'Charlie' WHERE id = 1;
+UPDATE flight_demo.test SET name = 'Charlie' WHERE id = 1;
 -- result:
 -- !result
 
-arrow: SELECT * FROM flight_demo.test order by id asc;
--- result:
-1	Charlie
-2	Bob
-3	Zac
-4	Tom
--- !result
-
-arrow: UPDATE flight_demo.test SET name = 'Charlie' WHERE id = 1;
--- result:
--- !result
-
-arrow: SELECT * FROM flight_demo.test order by id asc;
+SELECT * FROM flight_demo.test order by id asc;
 -- result:
 1	Charlie
 2	Bob
@@ -59,28 +47,40 @@ arrow: SELECT * FROM flight_demo.test order by id asc;
 4	Tom
 -- !result
 
-arrow: DELETE FROM flight_demo.test WHERE id = 2;
+UPDATE flight_demo.test SET name = 'Charlie' WHERE id = 1;
 -- result:
 -- !result
 
-arrow: ALTER TABLE flight_demo.test ADD COLUMN age INT;
+SELECT * FROM flight_demo.test order by id asc;
+-- result:
+1	Charlie
+2	Bob
+3	Zac
+4	Tom
+-- !result
+
+DELETE FROM flight_demo.test WHERE id = 2;
 -- result:
 -- !result
 
-arrow: ALTER TABLE flight_demo.test MODIFY COLUMN name STRING;
+ALTER TABLE flight_demo.test ADD COLUMN age INT;
 -- result:
 -- !result
 
-arrow: INSERT INTO flight_demo.test (id, name, age) VALUES (5, 'Eve', 30);
+ALTER TABLE flight_demo.test MODIFY COLUMN name STRING;
 -- result:
 -- !result
 
-arrow: SELECT * FROM flight_demo.test WHERE id = 5;
+INSERT INTO flight_demo.test (id, name, age) VALUES (5, 'Eve', 30);
+-- result:
+-- !result
+
+SELECT * FROM flight_demo.test WHERE id = 5;
 -- result:
 5	Eve	30
 -- !result
 
-arrow: SELECT * FROM flight_demo.test order by id asc;
+SELECT * FROM flight_demo.test order by id asc;
 -- result:
 1	Charlie	None
 3	Zac	None
@@ -88,19 +88,19 @@ arrow: SELECT * FROM flight_demo.test order by id asc;
 5	Eve	30
 -- !result
 
-arrow: SHOW CREATE TABLE flight_demo.test;
+SHOW CREATE TABLE flight_demo.test;
 -- result:
 -- !result
 
-arrow: CREATE TABLE flight_demo.test2 (id INT, age INT) ENGINE=OLAP PRIMARY KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ('replication_num' = '1');
+CREATE TABLE flight_demo.test2 (id INT, age INT) ENGINE=OLAP PRIMARY KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ('replication_num' = '1');
 -- result:
 -- !result
 
-arrow: INSERT INTO flight_demo.test2 VALUES (1, 18), (2, 20);
+INSERT INTO flight_demo.test2 VALUES (1, 18), (2, 20);
 -- result:
 -- !result
 
-arrow: SELECT * FROM (SELECT id, name FROM flight_demo.test) AS sub WHERE id = 1;
+SELECT * FROM (SELECT id, name FROM flight_demo.test) AS sub WHERE id = 1;
 -- result:
 1	Charlie
 -- !result

--- a/test/sql/test_arrow/R/test_arrow_flight_3
+++ b/test/sql/test_arrow/R/test_arrow_flight_3
@@ -1,89 +1,206 @@
--- name: test_arrow_flight_3
-arrow: CREATE DATABASE arrow_flight_${uuid0};
+-- name: test_arrow_flight_3 @arrow_flight_sql
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
 -- result:
 0
 -- !result
-arrow: USE arrow_flight_${uuid0};
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
 -- result:
 0
 -- !result
-arrow: CREATE TABLE arrow_flight_${uuid0}.__row_util_base ( k1 bigint NULL ) DISTRIBUTED BY HASH(`k1`) BUCKETS 64 PROPERTIES ( "replication_num" = "1" );
+insert into __row_util_base select * from __row_util_base;
 -- result:
 0
 -- !result
-arrow: insert into arrow_flight_${uuid0}.__row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+insert into __row_util_base select * from __row_util_base;
 -- result:
 0
 -- !result
-arrow: insert into arrow_flight_${uuid0}.__row_util_base select * from arrow_flight_${uuid0}.__row_util_base;
+insert into __row_util_base select * from __row_util_base;
 -- result:
 0
 -- !result
-arrow: insert into arrow_flight_${uuid0}.__row_util_base select * from arrow_flight_${uuid0}.__row_util_base;
+insert into __row_util_base select * from __row_util_base;
 -- result:
 0
 -- !result
-arrow: insert into arrow_flight_${uuid0}.__row_util_base select * from arrow_flight_${uuid0}.__row_util_base;
+CREATE TABLE __row_util (
+  idx bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
 -- result:
 0
 -- !result
-arrow: insert into arrow_flight_${uuid0}.__row_util_base select * from arrow_flight_${uuid0}.__row_util_base;
+insert into __row_util select row_number() over() as idx from __row_util_base;
 -- result:
 0
 -- !result
-arrow: CREATE TABLE arrow_flight_${uuid0}.__row_util ( idx bigint NULL ) DISTRIBUTED BY HASH(`idx`) BUCKETS 64 PROPERTIES ( "replication_num" = "1" );
+CREATE TABLE t1 (
+    k1 bigint NULL,
+    c_boolean boolean NULL,
+    c_tinyint tinyint NULL,
+    c_smallint smallint NULL,
+    c_int int NULL,
+    c_bigint bigint NULL,
+    c_largeint largeint NULL,
+    c_float float NULL,
+    c_double double NULL,
+    c_decimalv2 DECIMAL NULL,
+    c_decimal32 DECIMAL(9, 1) NULL,
+    c_decimal64 DECIMAL(18, 1) NULL,
+    c_decimal128 DECIMAL(38, 1) NULL,
+    c_decimal256 DECIMAL(76, 1) NULL,
+    c_date date NULL,
+    c_datetime datetime NULL,
+    c_varchar string NULL,
+    c_char char(64) NULL,
+    c_json JSON NULL,
+    c_array_json ARRAY<JSON> NULL,
+    c_array_int ARRAY<INT> NULL,
+    c_array_largeint ARRAY<LARGEINT> NULL,
+    c_map MAP<INT, STRING> NULL,
+    c_struct STRUCT<k1 INT, k2 STRING> NULL
+) DISTRIBUTED BY HASH(`k1`) BUCKETS 64 PROPERTIES ("replication_num" = "1");
 -- result:
 0
 -- !result
-arrow: insert into arrow_flight_${uuid0}.__row_util select row_number() over() as idx from arrow_flight_${uuid0}.__row_util_base;
+insert into t1 SELECT 
+    idx, idx % 2 = 0, cast(idx % 128 as tinyint), cast(idx % 32768 as smallint), cast(idx as int), cast(idx as bigint), cast(idx * 1000000000000 as largeint), 
+    cast(idx as float), cast(idx as double), 
+    cast(idx + 0.1 as DECIMAL), cast(idx + 0.1 as DECIMAL(9, 1)), cast(idx + 0.1 as DECIMAL(18, 1)), cast(idx + 0.1 as DECIMAL(38, 1)), cast(idx + 0.1 as DECIMAL(76, 1)), 
+    date_add('2020-01-01', interval idx day), date_add('2020-01-01 00:00:00', interval idx hour), 
+    cast(concat('varchar_', idx) as string), cast(concat('char_', idx) as char(64)), 
+    json_object('k1', idx, 'k2', concat('str_', idx)), [json_object('k1', idx, 'k2', concat('str_', idx))],
+    [idx, idx + 1, idx + 2], [idx, idx + 1, idx + 2], 
+    map{0: concat('str_', idx), 1: concat('str_', idx + 1)}, struct(idx, concat('str_', idx)) FROM __row_util;
 -- result:
 0
 -- !result
-arrow: CREATE TABLE arrow_flight_${uuid0}.t1 ( k1 bigint NULL, c_boolean boolean NULL, c_tinyint tinyint NULL, c_smallint smallint NULL, c_int int NULL, c_bigint bigint NULL, c_largeint largeint NULL, c_float float NULL, c_double double NULL, c_decimalv2 DECIMAL NULL, c_decimal32 DECIMAL(9, 1) NULL, c_decimal64 DECIMAL(18, 1) NULL, c_decimal128 DECIMAL(38, 1) NULL, c_date date NULL, c_datetime datetime NULL, c_varchar string NULL, c_char char(64) NULL, c_json JSON NULL, c_array_int ARRAY<INT> NULL, c_map MAP<INT, STRING> NULL, c_struct STRUCT<k1 INT, k2 STRING> NULL ) DISTRIBUTED BY HASH(`k1`) BUCKETS 64 PROPERTIES ( "replication_num" = "1" );
+insert into t1(k1) select idx + 1600000 from __row_util where idx <= 10000;
 -- result:
 0
 -- !result
-arrow: insert into arrow_flight_${uuid0}.t1 SELECT idx, idx % 2 = 0, cast(idx % 128 as tinyint), cast(idx % 32768 as smallint), cast(idx as int), cast(idx as bigint), cast(idx * 1000000000000 as largeint), cast(idx as float), cast(idx as double), cast(idx + 0.1 as DECIMAL), cast(idx + 0.1 as DECIMAL(9, 1)), cast(idx + 0.1 as DECIMAL(18, 1)), cast(idx + 0.1 as DECIMAL(38, 1)), date_add('2020-01-01', interval idx day), date_add('2020-01-01 00:00:00', interval idx hour), cast(concat('varchar_', idx) as string), cast(concat('char_', idx) as char(64)), json_object('k1', idx, 'k2', concat('str_', idx)), [idx, idx + 1, idx + 2], map{0: concat('str_', idx), 1: concat('str_', idx + 1)}, struct(idx, concat('str_', idx)) FROM arrow_flight_${uuid0}.__row_util;
+select * from t1 order by k1 limit 10;
 -- result:
-0
+1	0	1	1	1	1	1000000000000	1.0	1.0	1	1.1	1.1	1.1	1.1	2020-01-02	2020-01-01 01:00:00	varchar_1	char_1	{"k1": 1, "k2": "str_1"}	["{\"k1\": 1, \"k2\": \"str_1\"}"]	[1,2,3]	[1,2,3]	{0:"str_1",1:"str_2"}	{"k1":1,"k2":"str_1"}
+2	1	2	2	2	2	2000000000000	2.0	2.0	2	2.1	2.1	2.1	2.1	2020-01-03	2020-01-01 02:00:00	varchar_2	char_2	{"k1": 2, "k2": "str_2"}	["{\"k1\": 2, \"k2\": \"str_2\"}"]	[2,3,4]	[2,3,4]	{0:"str_2",1:"str_3"}	{"k1":2,"k2":"str_2"}
+3	0	3	3	3	3	3000000000000	3.0	3.0	3	3.1	3.1	3.1	3.1	2020-01-04	2020-01-01 03:00:00	varchar_3	char_3	{"k1": 3, "k2": "str_3"}	["{\"k1\": 3, \"k2\": \"str_3\"}"]	[3,4,5]	[3,4,5]	{0:"str_3",1:"str_4"}	{"k1":3,"k2":"str_3"}
+4	1	4	4	4	4	4000000000000	4.0	4.0	4	4.1	4.1	4.1	4.1	2020-01-05	2020-01-01 04:00:00	varchar_4	char_4	{"k1": 4, "k2": "str_4"}	["{\"k1\": 4, \"k2\": \"str_4\"}"]	[4,5,6]	[4,5,6]	{0:"str_4",1:"str_5"}	{"k1":4,"k2":"str_4"}
+5	0	5	5	5	5	5000000000000	5.0	5.0	5	5.1	5.1	5.1	5.1	2020-01-06	2020-01-01 05:00:00	varchar_5	char_5	{"k1": 5, "k2": "str_5"}	["{\"k1\": 5, \"k2\": \"str_5\"}"]	[5,6,7]	[5,6,7]	{0:"str_5",1:"str_6"}	{"k1":5,"k2":"str_5"}
+6	1	6	6	6	6	6000000000000	6.0	6.0	6	6.1	6.1	6.1	6.1	2020-01-07	2020-01-01 06:00:00	varchar_6	char_6	{"k1": 6, "k2": "str_6"}	["{\"k1\": 6, \"k2\": \"str_6\"}"]	[6,7,8]	[6,7,8]	{0:"str_6",1:"str_7"}	{"k1":6,"k2":"str_6"}
+7	0	7	7	7	7	7000000000000	7.0	7.0	7	7.1	7.1	7.1	7.1	2020-01-08	2020-01-01 07:00:00	varchar_7	char_7	{"k1": 7, "k2": "str_7"}	["{\"k1\": 7, \"k2\": \"str_7\"}"]	[7,8,9]	[7,8,9]	{0:"str_7",1:"str_8"}	{"k1":7,"k2":"str_7"}
+8	1	8	8	8	8	8000000000000	8.0	8.0	8	8.1	8.1	8.1	8.1	2020-01-09	2020-01-01 08:00:00	varchar_8	char_8	{"k1": 8, "k2": "str_8"}	["{\"k1\": 8, \"k2\": \"str_8\"}"]	[8,9,10]	[8,9,10]	{0:"str_8",1:"str_9"}	{"k1":8,"k2":"str_8"}
+9	0	9	9	9	9	9000000000000	9.0	9.0	9	9.1	9.1	9.1	9.1	2020-01-10	2020-01-01 09:00:00	varchar_9	char_9	{"k1": 9, "k2": "str_9"}	["{\"k1\": 9, \"k2\": \"str_9\"}"]	[9,10,11]	[9,10,11]	{0:"str_9",1:"str_10"}	{"k1":9,"k2":"str_9"}
+10	1	10	10	10	10	10000000000000	10.0	10.0	10	10.1	10.1	10.1	10.1	2020-01-11	2020-01-01 10:00:00	varchar_10	char_10	{"k1": 10, "k2": "str_10"}	["{\"k1\": 10, \"k2\": \"str_10\"}"]	[10,11,12]	[10,11,12]	{0:"str_10",1:"str_11"}	{"k1":10,"k2":"str_10"}
 -- !result
-arrow: insert into arrow_flight_${uuid0}.t1(k1) select idx + 1600000 from arrow_flight_${uuid0}.__row_util where idx <= 10000;
+select * from t1 order by k1 DESC limit 10;
 -- result:
-0
+1610000	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None
+1609999	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None
+1609998	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None
+1609997	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None
+1609996	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None
+1609995	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None
+1609994	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None
+1609993	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None
+1609992	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None
+1609991	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None
 -- !result
-arrow: select * from arrow_flight_${uuid0}.t1 order by k1 limit 10;
+select * from t1 where c_boolean is not null order by k1 DESC limit 10;
 -- result:
-1	False	1	1	1	1	1000000000000	1.0	1.0	1	1.1	1.1	1.1	2020-01-02	2020-01-01 01:00:00	varchar_1	char_1	{"k1": 1, "k2": "str_1"}	[1, 2, 3]	[(0, 'str_1'), (1, 'str_2')]	{'k1': 1, 'k2': 'str_1'}
-2	True	2	2	2	2	2000000000000	2.0	2.0	2	2.1	2.1	2.1	2020-01-03	2020-01-01 02:00:00	varchar_2	char_2	{"k1": 2, "k2": "str_2"}	[2, 3, 4]	[(0, 'str_2'), (1, 'str_3')]	{'k1': 2, 'k2': 'str_2'}
-3	False	3	3	3	3	3000000000000	3.0	3.0	3	3.1	3.1	3.1	2020-01-04	2020-01-01 03:00:00	varchar_3	char_3	{"k1": 3, "k2": "str_3"}	[3, 4, 5]	[(0, 'str_3'), (1, 'str_4')]	{'k1': 3, 'k2': 'str_3'}
-4	True	4	4	4	4	4000000000000	4.0	4.0	4	4.1	4.1	4.1	2020-01-05	2020-01-01 04:00:00	varchar_4	char_4	{"k1": 4, "k2": "str_4"}	[4, 5, 6]	[(0, 'str_4'), (1, 'str_5')]	{'k1': 4, 'k2': 'str_4'}
-5	False	5	5	5	5	5000000000000	5.0	5.0	5	5.1	5.1	5.1	2020-01-06	2020-01-01 05:00:00	varchar_5	char_5	{"k1": 5, "k2": "str_5"}	[5, 6, 7]	[(0, 'str_5'), (1, 'str_6')]	{'k1': 5, 'k2': 'str_5'}
-6	True	6	6	6	6	6000000000000	6.0	6.0	6	6.1	6.1	6.1	2020-01-07	2020-01-01 06:00:00	varchar_6	char_6	{"k1": 6, "k2": "str_6"}	[6, 7, 8]	[(0, 'str_6'), (1, 'str_7')]	{'k1': 6, 'k2': 'str_6'}
-7	False	7	7	7	7	7000000000000	7.0	7.0	7	7.1	7.1	7.1	2020-01-08	2020-01-01 07:00:00	varchar_7	char_7	{"k1": 7, "k2": "str_7"}	[7, 8, 9]	[(0, 'str_7'), (1, 'str_8')]	{'k1': 7, 'k2': 'str_7'}
-8	True	8	8	8	8	8000000000000	8.0	8.0	8	8.1	8.1	8.1	2020-01-09	2020-01-01 08:00:00	varchar_8	char_8	{"k1": 8, "k2": "str_8"}	[8, 9, 10]	[(0, 'str_8'), (1, 'str_9')]	{'k1': 8, 'k2': 'str_8'}
-9	False	9	9	9	9	9000000000000	9.0	9.0	9	9.1	9.1	9.1	2020-01-10	2020-01-01 09:00:00	varchar_9	char_9	{"k1": 9, "k2": "str_9"}	[9, 10, 11]	[(0, 'str_9'), (1, 'str_10')]	{'k1': 9, 'k2': 'str_9'}
-10	True	10	10	10	10	10000000000000	10.0	10.0	10	10.1	10.1	10.1	2020-01-11	2020-01-01 10:00:00	varchar_10	char_10	{"k1": 10, "k2": "str_10"}	[10, 11, 12]	[(0, 'str_10'), (1, 'str_11')]	{'k1': 10, 'k2': 'str_10'}
+160000	1	0	28928	160000	160000	160000000000000000	160000.0	160000.0	160000	160000.1	160000.1	160000.1	160000.1	2458-01-24	2038-04-02 16:00:00	varchar_160000	char_160000	{"k1": 160000, "k2": "str_160000"}	["{\"k1\": 160000, \"k2\": \"str_160000\"}"]	[160000,160001,160002]	[160000,160001,160002]	{0:"str_160000",1:"str_160001"}	{"k1":160000,"k2":"str_160000"}
+159999	0	127	28927	159999	159999	159999000000000000	159999.0	159999.0	159999	159999.1	159999.1	159999.1	159999.1	2458-01-23	2038-04-02 15:00:00	varchar_159999	char_159999	{"k1": 159999, "k2": "str_159999"}	["{\"k1\": 159999, \"k2\": \"str_159999\"}"]	[159999,160000,160001]	[159999,160000,160001]	{0:"str_159999",1:"str_160000"}	{"k1":159999,"k2":"str_159999"}
+159998	1	126	28926	159998	159998	159998000000000000	159998.0	159998.0	159998	159998.1	159998.1	159998.1	159998.1	2458-01-22	2038-04-02 14:00:00	varchar_159998	char_159998	{"k1": 159998, "k2": "str_159998"}	["{\"k1\": 159998, \"k2\": \"str_159998\"}"]	[159998,159999,160000]	[159998,159999,160000]	{0:"str_159998",1:"str_159999"}	{"k1":159998,"k2":"str_159998"}
+159997	0	125	28925	159997	159997	159997000000000000	159997.0	159997.0	159997	159997.1	159997.1	159997.1	159997.1	2458-01-21	2038-04-02 13:00:00	varchar_159997	char_159997	{"k1": 159997, "k2": "str_159997"}	["{\"k1\": 159997, \"k2\": \"str_159997\"}"]	[159997,159998,159999]	[159997,159998,159999]	{0:"str_159997",1:"str_159998"}	{"k1":159997,"k2":"str_159997"}
+159996	1	124	28924	159996	159996	159996000000000000	159996.0	159996.0	159996	159996.1	159996.1	159996.1	159996.1	2458-01-20	2038-04-02 12:00:00	varchar_159996	char_159996	{"k1": 159996, "k2": "str_159996"}	["{\"k1\": 159996, \"k2\": \"str_159996\"}"]	[159996,159997,159998]	[159996,159997,159998]	{0:"str_159996",1:"str_159997"}	{"k1":159996,"k2":"str_159996"}
+159995	0	123	28923	159995	159995	159995000000000000	159995.0	159995.0	159995	159995.1	159995.1	159995.1	159995.1	2458-01-19	2038-04-02 11:00:00	varchar_159995	char_159995	{"k1": 159995, "k2": "str_159995"}	["{\"k1\": 159995, \"k2\": \"str_159995\"}"]	[159995,159996,159997]	[159995,159996,159997]	{0:"str_159995",1:"str_159996"}	{"k1":159995,"k2":"str_159995"}
+159994	1	122	28922	159994	159994	159994000000000000	159994.0	159994.0	159994	159994.1	159994.1	159994.1	159994.1	2458-01-18	2038-04-02 10:00:00	varchar_159994	char_159994	{"k1": 159994, "k2": "str_159994"}	["{\"k1\": 159994, \"k2\": \"str_159994\"}"]	[159994,159995,159996]	[159994,159995,159996]	{0:"str_159994",1:"str_159995"}	{"k1":159994,"k2":"str_159994"}
+159993	0	121	28921	159993	159993	159993000000000000	159993.0	159993.0	159993	159993.1	159993.1	159993.1	159993.1	2458-01-17	2038-04-02 09:00:00	varchar_159993	char_159993	{"k1": 159993, "k2": "str_159993"}	["{\"k1\": 159993, \"k2\": \"str_159993\"}"]	[159993,159994,159995]	[159993,159994,159995]	{0:"str_159993",1:"str_159994"}	{"k1":159993,"k2":"str_159993"}
+159992	1	120	28920	159992	159992	159992000000000000	159992.0	159992.0	159992	159992.1	159992.1	159992.1	159992.1	2458-01-16	2038-04-02 08:00:00	varchar_159992	char_159992	{"k1": 159992, "k2": "str_159992"}	["{\"k1\": 159992, \"k2\": \"str_159992\"}"]	[159992,159993,159994]	[159992,159993,159994]	{0:"str_159992",1:"str_159993"}	{"k1":159992,"k2":"str_159992"}
+159991	0	119	28919	159991	159991	159991000000000000	159991.0	159991.0	159991	159991.1	159991.1	159991.1	159991.1	2458-01-15	2038-04-02 07:00:00	varchar_159991	char_159991	{"k1": 159991, "k2": "str_159991"}	["{\"k1\": 159991, \"k2\": \"str_159991\"}"]	[159991,159992,159993]	[159991,159992,159993]	{0:"str_159991",1:"str_159992"}	{"k1":159991,"k2":"str_159991"}
 -- !result
-arrow: select * from arrow_flight_${uuid0}.t1 where false;
+select cast(c_varchar as VARBINARY) from t1 order by k1 limit 10;
+-- result:
+varchar_1
+varchar_2
+varchar_3
+varchar_4
+varchar_5
+varchar_6
+varchar_7
+varchar_8
+varchar_9
+varchar_10
+-- !result
+select hll_hash(k1) from t1 where k1 is not null order by k1 limit 10;
+-- result:
+None
+None
+None
+None
+None
+None
+None
+None
+None
+None
+-- !result
+select PERCENTILE_HASH(c_double) from t1 where c_double is not null order by k1 limit 10;
+-- result:
+None
+None
+None
+None
+None
+None
+None
+None
+None
+None
+-- !result
+select BITMAP_HASH(c_bigint) from t1 where c_bigint is not null order by k1 limit 10;
+-- result:
+None
+None
+None
+None
+None
+None
+None
+None
+None
+None
+-- !result
+select * from t1 where false;
 -- result:
 -- !result
-arrow: select * from arrow_flight_${uuid0}.t1 where k1 < 0;
+select * from t1 where k1 < 0;
 -- result:
 -- !result
-arrow: select distinct k1, c_boolean, c_tinyint, c_smallint, c_int, c_bigint, c_largeint, c_float, c_double, c_decimalv2, c_decimal32, c_decimal64, c_decimal128, c_date, c_datetime, c_varchar, c_char from arrow_flight_${uuid0}.t1 order by k1 limit 10;
+select distinct k1, c_boolean, c_tinyint, c_smallint, c_int, c_bigint, c_largeint, c_float, c_double, c_decimalv2, c_decimal32, c_decimal64, c_decimal128, c_date, c_datetime, c_varchar, c_char from t1 order by k1 limit 10;
 -- result:
-1	False	1	1	1	1	1000000000000	1.0	1.0	1	1.1	1.1	1.1	2020-01-02	2020-01-01 01:00:00	varchar_1	char_1
-2	True	2	2	2	2	2000000000000	2.0	2.0	2	2.1	2.1	2.1	2020-01-03	2020-01-01 02:00:00	varchar_2	char_2
-3	False	3	3	3	3	3000000000000	3.0	3.0	3	3.1	3.1	3.1	2020-01-04	2020-01-01 03:00:00	varchar_3	char_3
-4	True	4	4	4	4	4000000000000	4.0	4.0	4	4.1	4.1	4.1	2020-01-05	2020-01-01 04:00:00	varchar_4	char_4
-5	False	5	5	5	5	5000000000000	5.0	5.0	5	5.1	5.1	5.1	2020-01-06	2020-01-01 05:00:00	varchar_5	char_5
-6	True	6	6	6	6	6000000000000	6.0	6.0	6	6.1	6.1	6.1	2020-01-07	2020-01-01 06:00:00	varchar_6	char_6
-7	False	7	7	7	7	7000000000000	7.0	7.0	7	7.1	7.1	7.1	2020-01-08	2020-01-01 07:00:00	varchar_7	char_7
-8	True	8	8	8	8	8000000000000	8.0	8.0	8	8.1	8.1	8.1	2020-01-09	2020-01-01 08:00:00	varchar_8	char_8
-9	False	9	9	9	9	9000000000000	9.0	9.0	9	9.1	9.1	9.1	2020-01-10	2020-01-01 09:00:00	varchar_9	char_9
-10	True	10	10	10	10	10000000000000	10.0	10.0	10	10.1	10.1	10.1	2020-01-11	2020-01-01 10:00:00	varchar_10	char_10
+1	0	1	1	1	1	1000000000000	1.0	1.0	1	1.1	1.1	1.1	2020-01-02	2020-01-01 01:00:00	varchar_1	char_1
+2	1	2	2	2	2	2000000000000	2.0	2.0	2	2.1	2.1	2.1	2020-01-03	2020-01-01 02:00:00	varchar_2	char_2
+3	0	3	3	3	3	3000000000000	3.0	3.0	3	3.1	3.1	3.1	2020-01-04	2020-01-01 03:00:00	varchar_3	char_3
+4	1	4	4	4	4	4000000000000	4.0	4.0	4	4.1	4.1	4.1	2020-01-05	2020-01-01 04:00:00	varchar_4	char_4
+5	0	5	5	5	5	5000000000000	5.0	5.0	5	5.1	5.1	5.1	2020-01-06	2020-01-01 05:00:00	varchar_5	char_5
+6	1	6	6	6	6	6000000000000	6.0	6.0	6	6.1	6.1	6.1	2020-01-07	2020-01-01 06:00:00	varchar_6	char_6
+7	0	7	7	7	7	7000000000000	7.0	7.0	7	7.1	7.1	7.1	2020-01-08	2020-01-01 07:00:00	varchar_7	char_7
+8	1	8	8	8	8	8000000000000	8.0	8.0	8	8.1	8.1	8.1	2020-01-09	2020-01-01 08:00:00	varchar_8	char_8
+9	0	9	9	9	9	9000000000000	9.0	9.0	9	9.1	9.1	9.1	2020-01-10	2020-01-01 09:00:00	varchar_9	char_9
+10	1	10	10	10	10	10000000000000	10.0	10.0	10	10.1	10.1	10.1	2020-01-11	2020-01-01 10:00:00	varchar_10	char_10
 -- !result
-arrow: select distinct k1, c_boolean, c_tinyint, c_smallint, c_int, c_bigint, c_largeint, c_float, c_double, c_decimalv2, c_decimal32, c_decimal64, c_decimal128, c_date, c_datetime, c_varchar, c_char from arrow_flight_${uuid0}.t1 order by k1 DESC limit 10;
+select distinct k1, c_boolean, c_tinyint, c_smallint, c_int, c_bigint, c_largeint, c_float, c_double, c_decimalv2, c_decimal32, c_decimal64, c_decimal128, c_date, c_datetime, c_varchar, c_char from t1 order by k1 DESC limit 10;
 -- result:
 1610000	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None
 1609999	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None
@@ -96,17 +213,21 @@ arrow: select distinct k1, c_boolean, c_tinyint, c_smallint, c_int, c_bigint, c_
 1609992	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None
 1609991	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None	None
 -- !result
-arrow: select distinct k1, c_boolean, c_tinyint, c_smallint, c_int, c_bigint, c_largeint, c_float, c_double, c_decimalv2, c_decimal32, c_decimal64, c_decimal128, c_date, c_datetime, c_varchar, c_char from arrow_flight_${uuid0}.t1 where false order by k1 limit 10;
+select distinct k1, c_boolean, c_tinyint, c_smallint, c_int, c_bigint, c_largeint, c_float, c_double, c_decimalv2, c_decimal32, c_decimal64, c_decimal128, c_date, c_datetime, c_varchar, c_char from t1 where false order by k1 limit 10;
 -- result:
 -- !result
-arrow: select distinct k1, c_boolean, c_tinyint, c_smallint, c_int, c_bigint, c_largeint, c_float, c_double, c_decimalv2, c_decimal32, c_decimal64, c_decimal128, c_date, c_datetime, c_varchar, c_char from arrow_flight_${uuid0}.t1 where k1 < 0 order by k1 limit 10;
+select distinct k1, c_boolean, c_tinyint, c_smallint, c_int, c_bigint, c_largeint, c_float, c_double, c_decimalv2, c_decimal32, c_decimal64, c_decimal128, c_date, c_datetime, c_varchar, c_char from t1 where k1 < 0 order by k1 limit 10;
 -- result:
 -- !result
-arrow: select 1;
+select 1;
 -- result:
 1
 -- !result
-arrow: drop database arrow_flight_${uuid0} force;
+select map{null:1};
 -- result:
-0
+[REGEX].*Can't convert data to arrow because the map key can be null, but arrow does not allow null key.*
+-- !result
+select map{1:null};
+-- result:
+{1:null}
 -- !result

--- a/test/sql/test_arrow/T/test_arrow_flight_1
+++ b/test/sql/test_arrow/T/test_arrow_flight_1
@@ -1,22 +1,22 @@
--- name: test_arrow_flight_1
-arrow: DROP DATABASE IF EXISTS arrow_demo;
+-- name: test_arrow_flight_1 @arrow_flight_sql
+DROP DATABASE IF EXISTS arrow_demo;
 
-arrow: CREATE DATABASE arrow_demo;
+CREATE DATABASE arrow_demo;
 
-arrow: USE arrow_demo;
+USE arrow_demo;
 
-arrow: CREATE TABLE arrow_demo.students (     id INT NOT NULL,    name VARCHAR(255) NOT NULL,    age INT NOT NULL,    enrollment_date DATE ) ENGINE=OLAP  PRIMARY KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 10 PROPERTIES (    'replication_num' = '1',    'in_memory' = 'false',    'enable_persistent_index' = 'true',    'replicated_storage' = 'true',    'fast_schema_evolution' = 'true',    'compression' = 'LZ4');
+CREATE TABLE arrow_demo.students (     id INT NOT NULL,    name VARCHAR(255) NOT NULL,    age INT NOT NULL,    enrollment_date DATE ) ENGINE=OLAP  PRIMARY KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 10 PROPERTIES (    'replication_num' = '1',    'in_memory' = 'false',    'enable_persistent_index' = 'true',    'replicated_storage' = 'true',    'fast_schema_evolution' = 'true',    'compression' = 'LZ4');
 
-arrow: INSERT INTO arrow_demo.students (id, name, age, enrollment_date) VALUES (1, 'John Doe', 20, '2024-01-10'),(2, 'Jane Smith', 22, '2024-01-11'),(3, 'Emily Davis', 21, '2024-01-12');
+INSERT INTO arrow_demo.students (id, name, age, enrollment_date) VALUES (1, 'John Doe', 20, '2024-01-10'),(2, 'Jane Smith', 22, '2024-01-11'),(3, 'Emily Davis', 21, '2024-01-12');
 
-arrow: SELECT * FROM arrow_demo.students order by id asc;
+SELECT * FROM arrow_demo.students order by id asc;
 
-arrow: UPDATE arrow_demo.students SET age = 23 WHERE id = 1;
+UPDATE arrow_demo.students SET age = 23 WHERE id = 1;
 
-arrow: SELECT * FROM arrow_demo.students order by id asc;
+SELECT * FROM arrow_demo.students order by id asc;
 
-arrow: DELETE FROM arrow_demo.students WHERE id = 3;
+DELETE FROM arrow_demo.students WHERE id = 3;
 
-arrow: SELECT * FROM arrow_demo.students order by id asc;
+SELECT * FROM arrow_demo.students order by id asc;
 
 

--- a/test/sql/test_arrow/T/test_arrow_flight_2
+++ b/test/sql/test_arrow/T/test_arrow_flight_2
@@ -1,44 +1,44 @@
--- name: test_arrow_flight_2
-arrow: DROP DATABASE IF EXISTS flight_demo;
+-- name: test_arrow_flight_2 @arrow_flight_sql
+DROP DATABASE IF EXISTS flight_demo;
 
-arrow: CREATE DATABASE flight_demo;
+CREATE DATABASE flight_demo;
 
-arrow: USE flight_demo;
+USE flight_demo;
 
-arrow: CREATE TABLE flight_demo.test (id INT, name STRING) ENGINE=OLAP PRIMARY KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ('replication_num' = '1');
+CREATE TABLE flight_demo.test (id INT, name STRING) ENGINE=OLAP PRIMARY KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ('replication_num' = '1');
 
-arrow: INSERT INTO flight_demo.test VALUES (1, 'Alice'), (2, 'Bob');
+INSERT INTO flight_demo.test VALUES (1, 'Alice'), (2, 'Bob');
 
-arrow: INSERT INTO flight_demo.test VALUES (1, 'Alice'), (2, 'Bob');
+INSERT INTO flight_demo.test VALUES (1, 'Alice'), (2, 'Bob');
 
-arrow: INSERT INTO flight_demo.test VALUES (3, 'Zac'), (4, 'Tom');
+INSERT INTO flight_demo.test VALUES (3, 'Zac'), (4, 'Tom');
 
-arrow: SELECT * FROM flight_demo.test order by id asc;
+SELECT * FROM flight_demo.test order by id asc;
 
-arrow: UPDATE flight_demo.test SET name = 'Charlie' WHERE id = 1;
+UPDATE flight_demo.test SET name = 'Charlie' WHERE id = 1;
 
-arrow: SELECT * FROM flight_demo.test order by id asc;
+SELECT * FROM flight_demo.test order by id asc;
 
-arrow: UPDATE test SET name = 'Charlie' WHERE id = 1;
+UPDATE test SET name = 'Charlie' WHERE id = 1;
 
-arrow: SELECT * FROM flight_demo.test order by id asc;
+SELECT * FROM flight_demo.test order by id asc;
 
-arrow: DELETE FROM flight_demo.test WHERE id = 2;
+DELETE FROM flight_demo.test WHERE id = 2;
 
-arrow: ALTER TABLE flight_demo.test ADD COLUMN age INT;
+ALTER TABLE flight_demo.test ADD COLUMN age INT;
 
-arrow: ALTER TABLE flight_demo.test MODIFY COLUMN name STRING;
+ALTER TABLE flight_demo.test MODIFY COLUMN name STRING;
 
-arrow: INSERT INTO flight_demo.test (id, name, age) VALUES (5, 'Eve', 30);
+INSERT INTO flight_demo.test (id, name, age) VALUES (5, 'Eve', 30);
 
-arrow: SELECT * FROM flight_demo.test WHERE id = 5;
+SELECT * FROM flight_demo.test WHERE id = 5;
 
-arrow: SELECT * FROM flight_demo.test order by id asc;
+SELECT * FROM flight_demo.test order by id asc;
 
-arrow: SHOW CREATE TABLE flight_demo.test;
+SHOW CREATE TABLE flight_demo.test;
 
-arrow: CREATE TABLE flight_demo.test2 (id INT, age INT) ENGINE=OLAP PRIMARY KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ('replication_num' = '1');
+CREATE TABLE flight_demo.test2 (id INT, age INT) ENGINE=OLAP PRIMARY KEY (id) DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES ('replication_num' = '1');
 
-arrow: INSERT INTO flight_demo.test2 VALUES (1, 18), (2, 20);
+INSERT INTO flight_demo.test2 VALUES (1, 18), (2, 20);
 
-arrow: SELECT * FROM (SELECT id, name FROM flight_demo.test) AS sub WHERE id = 1;
+SELECT * FROM (SELECT id, name FROM flight_demo.test) AS sub WHERE id = 1;

--- a/test/sql/test_arrow/T/test_arrow_flight_3
+++ b/test/sql/test_arrow/T/test_arrow_flight_3
@@ -1,39 +1,90 @@
--- name: test_arrow_flight_3
+-- name: test_arrow_flight_3 @arrow_flight_sql
 
-arrow: CREATE DATABASE arrow_flight_${uuid0};
-arrow: USE arrow_flight_${uuid0};
-arrow: CREATE TABLE arrow_flight_${uuid0}.__row_util_base ( k1 bigint NULL ) DISTRIBUTED BY HASH(`k1`) BUCKETS 64 PROPERTIES ( "replication_num" = "1" );
-arrow: insert into arrow_flight_${uuid0}.__row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
-arrow: insert into arrow_flight_${uuid0}.__row_util_base select * from arrow_flight_${uuid0}.__row_util_base;
-arrow: insert into arrow_flight_${uuid0}.__row_util_base select * from arrow_flight_${uuid0}.__row_util_base;
-arrow: insert into arrow_flight_${uuid0}.__row_util_base select * from arrow_flight_${uuid0}.__row_util_base;
-arrow: insert into arrow_flight_${uuid0}.__row_util_base select * from arrow_flight_${uuid0}.__row_util_base;
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+insert into __row_util_base select * from __row_util_base;
+insert into __row_util_base select * from __row_util_base;
+insert into __row_util_base select * from __row_util_base;
+insert into __row_util_base select * from __row_util_base;
 
-arrow: CREATE TABLE arrow_flight_${uuid0}.__row_util ( idx bigint NULL ) DISTRIBUTED BY HASH(`idx`) BUCKETS 64 PROPERTIES ( "replication_num" = "1" );
-arrow: insert into arrow_flight_${uuid0}.__row_util select row_number() over() as idx from arrow_flight_${uuid0}.__row_util_base;
+CREATE TABLE __row_util (
+  idx bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util select row_number() over() as idx from __row_util_base;
+
+CREATE TABLE t1 (
+    k1 bigint NULL,
+    c_boolean boolean NULL,
+    c_tinyint tinyint NULL,
+    c_smallint smallint NULL,
+    c_int int NULL,
+    c_bigint bigint NULL,
+    c_largeint largeint NULL,
+    c_float float NULL,
+    c_double double NULL,
+    c_decimalv2 DECIMAL NULL,
+    c_decimal32 DECIMAL(9, 1) NULL,
+    c_decimal64 DECIMAL(18, 1) NULL,
+    c_decimal128 DECIMAL(38, 1) NULL,
+    c_decimal256 DECIMAL(76, 1) NULL,
+    c_date date NULL,
+    c_datetime datetime NULL,
+    c_varchar string NULL,
+    c_char char(64) NULL,
+    c_json JSON NULL,
+    c_array_json ARRAY<JSON> NULL,
+    c_array_int ARRAY<INT> NULL,
+    c_array_largeint ARRAY<LARGEINT> NULL,
+    c_map MAP<INT, STRING> NULL,
+    c_struct STRUCT<k1 INT, k2 STRING> NULL
+) DISTRIBUTED BY HASH(`k1`) BUCKETS 64 PROPERTIES ("replication_num" = "1");
+
+insert into t1 SELECT 
+    idx, idx % 2 = 0, cast(idx % 128 as tinyint), cast(idx % 32768 as smallint), cast(idx as int), cast(idx as bigint), cast(idx * 1000000000000 as largeint), 
+    cast(idx as float), cast(idx as double), 
+    cast(idx + 0.1 as DECIMAL), cast(idx + 0.1 as DECIMAL(9, 1)), cast(idx + 0.1 as DECIMAL(18, 1)), cast(idx + 0.1 as DECIMAL(38, 1)), cast(idx + 0.1 as DECIMAL(76, 1)), 
+    date_add('2020-01-01', interval idx day), date_add('2020-01-01 00:00:00', interval idx hour), 
+    cast(concat('varchar_', idx) as string), cast(concat('char_', idx) as char(64)), 
+    json_object('k1', idx, 'k2', concat('str_', idx)), [json_object('k1', idx, 'k2', concat('str_', idx))],
+    [idx, idx + 1, idx + 2], [idx, idx + 1, idx + 2], 
+    map{0: concat('str_', idx), 1: concat('str_', idx + 1)}, struct(idx, concat('str_', idx)) FROM __row_util;
+
+insert into t1(k1) select idx + 1600000 from __row_util where idx <= 10000;
+
+select * from t1 order by k1 limit 10;
+select * from t1 order by k1 DESC limit 10;
+select * from t1 where c_boolean is not null order by k1 DESC limit 10;
+
+select cast(c_varchar as VARBINARY) from t1 order by k1 limit 10;
+select hll_hash(k1) from t1 where k1 is not null order by k1 limit 10;
+select PERCENTILE_HASH(c_double) from t1 where c_double is not null order by k1 limit 10;
+select BITMAP_HASH(c_bigint) from t1 where c_bigint is not null order by k1 limit 10;
+
+select * from t1 where false;
+select * from t1 where k1 < 0;
+
+select distinct k1, c_boolean, c_tinyint, c_smallint, c_int, c_bigint, c_largeint, c_float, c_double, c_decimalv2, c_decimal32, c_decimal64, c_decimal128, c_date, c_datetime, c_varchar, c_char from t1 order by k1 limit 10;
+
+select distinct k1, c_boolean, c_tinyint, c_smallint, c_int, c_bigint, c_largeint, c_float, c_double, c_decimalv2, c_decimal32, c_decimal64, c_decimal128, c_date, c_datetime, c_varchar, c_char from t1 order by k1 DESC limit 10;
+
+select distinct k1, c_boolean, c_tinyint, c_smallint, c_int, c_bigint, c_largeint, c_float, c_double, c_decimalv2, c_decimal32, c_decimal64, c_decimal128, c_date, c_datetime, c_varchar, c_char from t1 where false order by k1 limit 10;
+
+select distinct k1, c_boolean, c_tinyint, c_smallint, c_int, c_bigint, c_largeint, c_float, c_double, c_decimalv2, c_decimal32, c_decimal64, c_decimal128, c_date, c_datetime, c_varchar, c_char from t1 where k1 < 0 order by k1 limit 10;
 
 
-arrow: CREATE TABLE arrow_flight_${uuid0}.t1 ( k1 bigint NULL, c_boolean boolean NULL, c_tinyint tinyint NULL, c_smallint smallint NULL, c_int int NULL, c_bigint bigint NULL, c_largeint largeint NULL, c_float float NULL, c_double double NULL, c_decimalv2 DECIMAL NULL, c_decimal32 DECIMAL(9, 1) NULL, c_decimal64 DECIMAL(18, 1) NULL, c_decimal128 DECIMAL(38, 1) NULL, c_date date NULL, c_datetime datetime NULL, c_varchar string NULL, c_char char(64) NULL, c_json JSON NULL, c_array_int ARRAY<INT> NULL, c_map MAP<INT, STRING> NULL, c_struct STRUCT<k1 INT, k2 STRING> NULL ) DISTRIBUTED BY HASH(`k1`) BUCKETS 64 PROPERTIES ( "replication_num" = "1" );
+select 1;
 
-arrow: insert into arrow_flight_${uuid0}.t1 SELECT idx, idx % 2 = 0, cast(idx % 128 as tinyint), cast(idx % 32768 as smallint), cast(idx as int), cast(idx as bigint), cast(idx * 1000000000000 as largeint), cast(idx as float), cast(idx as double), cast(idx + 0.1 as DECIMAL), cast(idx + 0.1 as DECIMAL(9, 1)), cast(idx + 0.1 as DECIMAL(18, 1)), cast(idx + 0.1 as DECIMAL(38, 1)), date_add('2020-01-01', interval idx day), date_add('2020-01-01 00:00:00', interval idx hour), cast(concat('varchar_', idx) as string), cast(concat('char_', idx) as char(64)), json_object('k1', idx, 'k2', concat('str_', idx)), [idx, idx + 1, idx + 2], map{0: concat('str_', idx), 1: concat('str_', idx + 1)}, struct(idx, concat('str_', idx)) FROM arrow_flight_${uuid0}.__row_util;
-
-arrow: insert into arrow_flight_${uuid0}.t1(k1) select idx + 1600000 from arrow_flight_${uuid0}.__row_util where idx <= 10000;
-
-arrow: select * from arrow_flight_${uuid0}.t1 order by k1 limit 10;
---arrow: select hll_hash(k1) from arrow_flight_${uuid0}.t1 where k1 is not null order by k1 limit 10;
-
-arrow: select * from arrow_flight_${uuid0}.t1 where false;
-arrow: select * from arrow_flight_${uuid0}.t1 where k1 < 0;
-
-arrow: select distinct k1, c_boolean, c_tinyint, c_smallint, c_int, c_bigint, c_largeint, c_float, c_double, c_decimalv2, c_decimal32, c_decimal64, c_decimal128, c_date, c_datetime, c_varchar, c_char from arrow_flight_${uuid0}.t1 order by k1 limit 10;
-
-arrow: select distinct k1, c_boolean, c_tinyint, c_smallint, c_int, c_bigint, c_largeint, c_float, c_double, c_decimalv2, c_decimal32, c_decimal64, c_decimal128, c_date, c_datetime, c_varchar, c_char from arrow_flight_${uuid0}.t1 order by k1 DESC limit 10;
-
-arrow: select distinct k1, c_boolean, c_tinyint, c_smallint, c_int, c_bigint, c_largeint, c_float, c_double, c_decimalv2, c_decimal32, c_decimal64, c_decimal128, c_date, c_datetime, c_varchar, c_char from arrow_flight_${uuid0}.t1 where false order by k1 limit 10;
-
-arrow: select distinct k1, c_boolean, c_tinyint, c_smallint, c_int, c_bigint, c_largeint, c_float, c_double, c_decimalv2, c_decimal32, c_decimal64, c_decimal128, c_date, c_datetime, c_varchar, c_char from arrow_flight_${uuid0}.t1 where k1 < 0 order by k1 limit 10;
-
-
-arrow: select 1;
-
-arrow: drop database arrow_flight_${uuid0} force;
+select map{null:1};
+select map{1:null};

--- a/test/sql/test_cast/R/test_cast_json_to_map
+++ b/test/sql/test_cast/R/test_cast_json_to_map
@@ -1,4 +1,4 @@
--- name: test_cast_json_to_map
+-- name: test_cast_json_to_map @no_arrow_flight_sql
 CREATE TABLE t (
     c1 int,
     c2 json

--- a/test/sql/test_cast/R/test_cast_json_to_struct
+++ b/test/sql/test_cast/R/test_cast_json_to_struct
@@ -1,4 +1,4 @@
--- name: test_cast_json_to_struct
+-- name: test_cast_json_to_struct @no_arrow_flight_sql
 select cast(PARSE_JSON('[1,2,3]') as struct<col1 int, col2 int, col3 int>);
 -- result:
 {"col1":1,"col2":2,"col3":3}

--- a/test/sql/test_cast/T/test_cast_json_to_map
+++ b/test/sql/test_cast/T/test_cast_json_to_map
@@ -1,4 +1,4 @@
--- name: test_cast_json_to_map
+-- name: test_cast_json_to_map @no_arrow_flight_sql
 CREATE TABLE t (
     c1 int,
     c2 json

--- a/test/sql/test_cast/T/test_cast_json_to_struct
+++ b/test/sql/test_cast/T/test_cast_json_to_struct
@@ -1,4 +1,4 @@
--- name: test_cast_json_to_struct
+-- name: test_cast_json_to_struct @no_arrow_flight_sql
 
 select cast(PARSE_JSON('[1,2,3]') as struct<col1 int, col2 int, col3 int>);
 select cast(PARSE_JSON('[1,2,3]') as struct<col1 int, col2 int>);

--- a/test/sql/test_collect_statistics/R/test_array_stats
+++ b/test/sql/test_collect_statistics/R/test_array_stats
@@ -1,4 +1,4 @@
--- name: test_array_stats @sequential
+-- name: test_array_stats @sequential @no_arrow_flight_sql
 DROP DATABASE IF EXISTS test_array_stats;
 -- result:
 -- !result

--- a/test/sql/test_collect_statistics/T/test_array_stats
+++ b/test/sql/test_collect_statistics/T/test_array_stats
@@ -1,4 +1,4 @@
--- name: test_array_stats @sequential
+-- name: test_array_stats @sequential @no_arrow_flight_sql
 
 DROP DATABASE IF EXISTS test_array_stats;
 CREATE DATABASE test_array_stats;

--- a/test/sql/test_column_with_row/R/test_column_with_row_variable
+++ b/test/sql/test_column_with_row/R/test_column_with_row_variable
@@ -1,4 +1,4 @@
--- name: test_column_with_row_variable
+-- name: test_column_with_row_variable @no_arrow_flight_sql
 ADMIN SET FRONTEND CONFIG ("enable_experimental_rowstore" = "true");
 -- result:
 -- !result

--- a/test/sql/test_column_with_row/T/test_column_with_row_variable
+++ b/test/sql/test_column_with_row/T/test_column_with_row_variable
@@ -1,4 +1,4 @@
--- name: test_column_with_row_variable
+-- name: test_column_with_row_variable @no_arrow_flight_sql
 ADMIN SET FRONTEND CONFIG ("enable_experimental_rowstore" = "true");
 --创建行存表
 DROP TABLE IF EXISTS t1_var;

--- a/test/sql/test_conf/R/test_configure
+++ b/test/sql/test_conf/R/test_configure
@@ -1,4 +1,4 @@
--- name: test_configure @sequential
+-- name: test_configure @sequential @no_arrow_flight_sql
 admin set frontend config ("thrift_max_message_size"="10485760");
 -- result:
 -- !result

--- a/test/sql/test_conf/T/test_configure
+++ b/test/sql/test_conf/T/test_configure
@@ -1,4 +1,4 @@
--- name: test_configure @sequential
+-- name: test_configure @sequential @no_arrow_flight_sql
 admin set frontend config ("thrift_max_message_size"="10485760");
 set group_concat_max_len = 1073741824;
 CREATE table tab1 (

--- a/test/sql/test_decimal/R/test_decimal256_complex_types
+++ b/test/sql/test_decimal/R/test_decimal256_complex_types
@@ -1,4 +1,4 @@
--- name: test_decimal256_complex_types
+-- name: test_decimal256_complex_types @no_arrow_flight_sql
 DROP DATABASE IF EXISTS test_decimal256_complex;
 -- result:
 -- !result

--- a/test/sql/test_decimal/T/test_decimal256_complex_types.sql
+++ b/test/sql/test_decimal/T/test_decimal256_complex_types.sql
@@ -1,4 +1,4 @@
--- name: test_decimal256_complex_types
+-- name: test_decimal256_complex_types @no_arrow_flight_sql
 
 DROP DATABASE IF EXISTS test_decimal256_complex;
 CREATE DATABASE test_decimal256_complex;

--- a/test/sql/test_execute_in_fe/R/test_execute_in_fe
+++ b/test/sql/test_execute_in_fe/R/test_execute_in_fe
@@ -1,4 +1,4 @@
--- name: test_execute_in_fe
+-- name: test_execute_in_fe @no_arrow_flight_sql
 set enable_constant_execute_in_fe = true;
 -- result:
 -- !result

--- a/test/sql/test_execute_in_fe/T/test_execute_in_fe
+++ b/test/sql/test_execute_in_fe/T/test_execute_in_fe
@@ -1,4 +1,4 @@
--- name: test_execute_in_fe
+-- name: test_execute_in_fe @no_arrow_flight_sql
 -- execute in fe
 set enable_constant_execute_in_fe = true;
 select 1, -1, 1.23456, cast(1.123 as float), cast(1.123 as double), cast(10 as bigint), cast(100 as largeint),

--- a/test/sql/test_function/R/test_translate
+++ b/test/sql/test_function/R/test_translate
@@ -568,40 +568,48 @@ insert into t1 values ('placeholder', 'a', 'b');
 -- !result
 SELECT ifnull(sum(murmur_hash3_32(
     TRANSLATE(REPEAT('a', 1024*1024), from_str, to_str)
-)), 0) from t1;  
-truncate table t1;
+)), 0) from t1;
 -- result:
 1624733713
+-- !result
+truncate table t1;
+-- result:
 -- !result
 insert into t1 values ('placeholder', '膨', 'p');
 -- result:
 -- !result
 SELECT ifnull(sum(murmur_hash3_32(
     TRANSLATE(CONCAT(REPEAT('a', 1024*1024-1024*3), REPEAT('膨', 1024)), from_str, to_str)
-)), 0) from t1; 
-truncate table t1;
+)), 0) from t1;
 -- result:
 -308607422
+-- !result
+truncate table t1;
+-- result:
 -- !result
 insert into t1 values ('placeholder', 'a', '膨');
 -- result:
 -- !result
 SELECT ifnull(sum(murmur_hash3_32(
     TRANSLATE(CONCAT('a', REPEAT('b', 1024*1024 - 1 - 2)), from_str, to_str)
-)), 0) from t1; 
-truncate table t1;
+)), 0) from t1;
 -- result:
 777398045
+-- !result
+truncate table t1;
+-- result:
 -- !result
 insert into t1 values ('placeholder', 'a', '膨');
 -- result:
 -- !result
 SELECT ifnull(sum(murmur_hash3_32(
     TRANSLATE(REPEAT('a', 1024*1024), from_str, to_str)
-)), 0) from t1; 
-truncate table t1;
+)), 0) from t1;
 -- result:
 0
+-- !result
+truncate table t1;
+-- result:
 -- !result
 -- name: test_translate_multiple_chunks
 CREATE TABLE `t1` (

--- a/test/sql/test_global_dict/R/dict_lake_period_version
+++ b/test/sql/test_global_dict/R/dict_lake_period_version
@@ -1,4 +1,4 @@
--- name: test_dict_lake_period_version
+-- name: test_dict_lake_period_version @no_arrow_flight_sql
 set low_cardinality_optimize_on_lake = true;
 -- result:
 -- !result

--- a/test/sql/test_global_dict/T/dict_lake_period_version
+++ b/test/sql/test_global_dict/T/dict_lake_period_version
@@ -1,4 +1,4 @@
--- name: test_dict_lake_period_version
+-- name: test_dict_lake_period_version @no_arrow_flight_sql
 
 set low_cardinality_optimize_on_lake = true;
 set always_collect_low_card_dict_on_lake = true;

--- a/test/sql/test_iceberg/R/test_iceberg_catalog_time_type
+++ b/test/sql/test_iceberg/R/test_iceberg_catalog_time_type
@@ -1,4 +1,4 @@
--- name: test_iceberg_catalog_time_type
+-- name: test_iceberg_catalog_time_type @no_arrow_flight_sql
 create external catalog ice_cat_${uuid0}
 properties
 (

--- a/test/sql/test_iceberg/R/test_timetravel
+++ b/test/sql/test_iceberg/R/test_timetravel
@@ -1,4 +1,4 @@
--- name: test_timetravel @sequential
+-- name: test_timetravel @sequential @no_arrow_flight_sql
 create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
 -- result:
 -- !result

--- a/test/sql/test_iceberg/T/test_iceberg_catalog_time_type
+++ b/test/sql/test_iceberg/T/test_iceberg_catalog_time_type
@@ -1,4 +1,4 @@
--- name: test_iceberg_catalog_time_type
+-- name: test_iceberg_catalog_time_type @no_arrow_flight_sql
 create external catalog ice_cat_${uuid0}
 properties
 (

--- a/test/sql/test_iceberg/T/test_timetravel
+++ b/test/sql/test_iceberg/T/test_timetravel
@@ -1,4 +1,4 @@
--- name: test_timetravel @sequential
+-- name: test_timetravel @sequential @no_arrow_flight_sql
 
 create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
 

--- a/test/sql/test_join/R/test_join_map
+++ b/test/sql/test_join/R/test_join_map
@@ -1,4 +1,4 @@
--- name: test_join_map
+-- name: test_join_map @no_arrow_flight_sql
 CREATE TABLE map_test (
 pk bigint not null ,
 map0  map<Int,string>,

--- a/test/sql/test_join/R/test_join_struct
+++ b/test/sql/test_join/R/test_join_struct
@@ -1,4 +1,4 @@
--- name: test_join_struct
+-- name: test_join_struct @no_arrow_flight_sql
 CREATE TABLE struct_test (
 pk bigint not null,
 s0  struct<c0 int,c1 string>,

--- a/test/sql/test_join/T/test_join_fixed_size
+++ b/test/sql/test_join/T/test_join_fixed_size
@@ -160,3 +160,6 @@ from t1 join t1 t2 on t1.c_bigint_null = t2.c_bigint_null and t1.c_int = t2.c_in
 
 select count(1)
 from t1 join t1 t2 on t1.c_datetime = t2.c_datetime and cast(t1.c_int as string) = cast(t2.c_int as string);
+
+select named_struct('a', json_object("a", 1, "b", "b1"));
+select named_struct('a', "str");

--- a/test/sql/test_join/T/test_join_map
+++ b/test/sql/test_join/T/test_join_map
@@ -1,4 +1,4 @@
--- name: test_join_map
+-- name: test_join_map @no_arrow_flight_sql
 CREATE TABLE map_test (
 pk bigint not null ,
 map0  map<Int,string>,

--- a/test/sql/test_join/T/test_join_struct
+++ b/test/sql/test_join/T/test_join_struct
@@ -1,4 +1,4 @@
--- name: test_join_struct
+-- name: test_join_struct @no_arrow_flight_sql
 CREATE TABLE struct_test (
 pk bigint not null,
 s0  struct<c0 int,c1 string>,

--- a/test/sql/test_materialized_view/R/test_create_mv_with_user
+++ b/test/sql/test_materialized_view/R/test_create_mv_with_user
@@ -1,4 +1,4 @@
--- name: test_create_mv_with_user
+-- name: test_create_mv_with_user @no_arrow_flight_sql
 drop database if exists test_create_mv_with_user;
 -- result:
 -- !result

--- a/test/sql/test_materialized_view/T/test_create_mv_with_user
+++ b/test/sql/test_materialized_view/T/test_create_mv_with_user
@@ -1,4 +1,4 @@
--- name: test_create_mv_with_user
+-- name: test_create_mv_with_user @no_arrow_flight_sql
 
 drop database if exists test_create_mv_with_user;
 create database test_create_mv_with_user;

--- a/test/sql/test_semi/R/test_flat_json_dict
+++ b/test/sql/test_semi/R/test_flat_json_dict
@@ -56,7 +56,7 @@ select dict_merge(get_json_string(c1, 'f3'), 255) from js2 [_META_];
 -- !result
 select dict_merge(get_json_string(c1, 'f4'), 255) from js2 [_META_];
 -- result:
-[REGEX]E: \(1064, 'global dict size:500 greater than low_cardinality_threshold:255: BE:.*'\)
+[REGEX].*global dict size:500 greater than low_cardinality_threshold:255: BE:.*
 -- !result
 select dict_merge(get_json_string(c1, 'f5'), 255) from js2 [_META_];
 -- result:
@@ -89,7 +89,7 @@ select dict_merge(get_json_string(c1, 'f3'), 255) from js2 [_META_];
 -- !result
 select dict_merge(get_json_string(c1, 'f4'), 255) from js2 [_META_];
 -- result:
-[REGEX]E: \(1064, 'global dict size:500 greater than low_cardinality_threshold:255: BE:.*'\)
+[REGEX].*global dict size:500 greater than low_cardinality_threshold:255: BE:.*
 -- !result
 select dict_merge(get_json_string(c1, 'f5'), 255) from js2 [_META_];
 -- result:

--- a/test/sql/test_short_circuit/R/test_short_circuit
+++ b/test/sql/test_short_circuit/R/test_short_circuit
@@ -1,4 +1,4 @@
--- name: testShortCircuit
+-- name: testShortCircuit @no_arrow_flight_sql
 set enable_short_circuit=true;
 -- result:
 -- !result

--- a/test/sql/test_short_circuit/T/test_short_circuit
+++ b/test/sql/test_short_circuit/T/test_short_circuit
@@ -1,4 +1,4 @@
--- name: testShortCircuit
+-- name: testShortCircuit @no_arrow_flight_sql
 set enable_short_circuit=true;
 set enable_profile=true;
 

--- a/test/sql/test_sink/R/test_files_sink_parquet_json
+++ b/test/sql/test_sink/R/test_files_sink_parquet_json
@@ -1,4 +1,4 @@
--- name: test_files_sink_parquet_json
+-- name: test_files_sink_parquet_json @no_arrow_flight_sql
 
 create database db_${uuid0};
 use db_${uuid0};

--- a/test/sql/test_sink/T/test_files_sink_parquet_json
+++ b/test/sql/test_sink/T/test_files_sink_parquet_json
@@ -1,4 +1,4 @@
--- name: test_files_sink_parquet_json
+-- name: test_files_sink_parquet_json @no_arrow_flight_sql
 
 create database db_${uuid0};
 use db_${uuid0};

--- a/test/sql/test_time_fn/R/test_to_date
+++ b/test/sql/test_time_fn/R/test_to_date
@@ -89,7 +89,7 @@ select to_tera_timestamp("1988/04/08 02 pm:3:4","yyyy/mm/dd hh pm:mi:ss");
 -- !result
 select to_tera_date(";198804:08",";YYYYmm:dd");
 -- result:
-[REGEX].*'The format parameter ;YYYYmm:dd is invalid .*'
+[REGEX].*The format parameter ;YYYYmm:dd is invalid .*
 -- !result
 select to_tera_date("1988/04/08","yy/mm/dd");
 -- result:
@@ -97,7 +97,7 @@ None
 -- !result
 select to_tera_date("1988/04/08","xyz/mm/dd");
 -- result:
-[REGEX].*'The format parameter xyz/mm/dd is invalid .*'
+[REGEX].*The format parameter xyz/mm/dd is invalid.*
 -- !result
 select to_tera_timestamp("1988/04/0800 02 pm:3:4","yyyy/mm/dd hh am:mi:ss");
 -- result:

--- a/test/sql/test_udf/R/test_jvm_udf
+++ b/test/sql/test_udf/R/test_jvm_udf
@@ -1,4 +1,4 @@
--- name: test_jvm_udf
+-- name: test_jvm_udf @no_arrow_flight_sql
 set enable_group_execution = true;
 -- result:
 -- !result

--- a/test/sql/test_udf/T/test_jvm_udf
+++ b/test/sql/test_udf/T/test_jvm_udf
@@ -1,4 +1,4 @@
--- name: test_jvm_udf
+-- name: test_jvm_udf @no_arrow_flight_sql
 
 set enable_group_execution = true;
 


### PR DESCRIPTION
## Sequence between client and FE/BE

### Sequence diagrams for interactions between client and FE/BE

For native Arrow Flight SQL clients, such as `FlightSqlClient` in Java:

1. `getFlightInfoStatement`: Send SQL to the FE. The FE generates the plan, dispatches fragment instances to BEs, and returns the endpoint from which results can be fetched.
   - For queries: the endpoint is the address of the BE that hosts the result sink.
   - For non-queries: the endpoint is the address of the FE itself.
2. `getStreamStatement`: The client pulls results from the endpoint.

<img width="60%" alt="image" src="https://github.com/user-attachments/assets/b2e7e709-e85a-4a42-9aa6-23efb5cd6f3d" />

For ADBC/JDBC drivers, SQL is executed using the following sequence:

1. `createPreparedStatement`: Create a prepared statement and return a handle (`preparedStmtId`) to the client as its identifier.
2. Execute the query. Note that a single connection can hold multiple prepared statements at the same time.
   1. `acceptPutStatement`: Update the parameter values of a prepared statement.
      - We currently do not implement this RPC, so only non-parameterized SQL is supported.
   2. `getFlightInfoPreparedStatement`: The FE starts executing the query associated with the given handle. The FE generates the plan, dispatches fragment instances to BEs, and returns the endpoint from which results can be fetched.
      - For queries: the endpoint is the address of the BE that hosts the result sink.
      - For non-queries: the endpoint is the address of the FE itself.
   3. `getStreamStatement`: Fetch results from the endpoint returned in the previous step.
3. `closePreparedStatement`: Close a prepared statement.

On the client side, a single cursor only maintains one prepared statement. For the same cursor, when calling `cursor.execute(SQL)`:

- If the SQL is the same as the previous one, it directly runs the three “execute query” steps.
- Otherwise, it first issues `closePreparedStatement`, then creates a new prepared statement via `acceptPutStatement`.

<img width="60%" alt="image" src="https://github.com/user-attachments/assets/b9ae46cc-cfe4-4c99-a027-7c7d7163b001" />



### FE/BE Internal Execution Flow

There are four different execution flows, determined by two dimensions:

- Whether the request is forwarded to the leader.
- Whether it is a query or a non-query.

#### Non-forward Query

1. The client sends a `getFlightInfoPreparedStatement` RPC to the FE. After the FE generates the plan and dispatches fragment instances to BEs, it returns the result sink BE endpoint to the client.
2. The client uses the endpoint to send a `getStreamStatement` RPC to the BE and pulls results from the BE.

<img width="2120" height="1130" alt="image" src="https://github.com/user-attachments/assets/9f421f57-9209-44f5-b759-c4cb530ffb73" />


#### Non-forward Non-Query

1. The client sends a `getFlightInfoPreparedStatement` RPC to the FE. The FE’s behavior:
   - For `SHOW xxx` statements, the FE executes everything locally; there is no BE-side execution.
   - For DDL and DML, execution must run on BEs. The FE waits until execution fully completes, and only then returns to the client.
2. The client uses the endpoint to send `getStreamStatement` to the FE and fetch results from the FE.


<img width="2078" height="1130" alt="image" src="https://github.com/user-attachments/assets/61db1875-f2f5-4e92-9e95-a6887a1fbd8d" />

#### Forward Query

1. The follower FE executes in a dedicated executor thread, forwards the request to the leader FE, blocks waiting for the response, and then writes `audit.log` and query detail.
2. After the leader FE finishes deploying fragment instances to BEs, it notifies the follower FE via a new RPC. The follower FE immediately returns the result sink BE endpoint to the client without waiting for step 1’s forward flow to complete.

<img width="2632" height="1114" alt="image" src="https://github.com/user-attachments/assets/b08a1d40-f704-489e-a474-874afce41dce" />

#### Forward Non-Query

1. The follower FE executes in a dedicated executor thread, forwards the request to the leader FE, blocks waiting for the response, and then writes `audit.log` and query detail.
2. The follower FE waits until step 1 fully completes, writes the result into its local cache, and then returns its own FE endpoint to the client.


<img width="2562" height="1090" alt="image" src="https://github.com/user-attachments/assets/a2e751f2-2286-4c62-8034-faf5e98d16de" />



## Issues

### 1. Column type conversion

| SR Type           | Arrow-Before | Arrow-PR                                        |
|-------------------|--------------|-------------------------------------------------|
| `TYPE_LARGEINT`   | utf8         | `Decimal128Type(38, 0)`                         |
| `TYPE_DATE`       | utf8         | `date32`                                        |
| `TYPE_DATETIME`   | utf8         | `timestamp(arrow::TimeUnit::MICRO, "UTC")`      |
| `TYPE_VARBINARY`  | unsupported  | `binary`                                        |
| `TYPE_DECIMAL256` | unsupported  | `Decimal256`                                    |
| `TYPE_HLL`        | utf8         | `binary` (always returns `NULL`, same as MySQL) |
| `TYPE_OBJECT(BITMAP)` | unsupported | `binary` (always returns `NULL`, same as MySQL) |
| `TYPE_PERCENTILE` | unsupported  | `binary` (always returns `NULL`, same as MySQL) |

The mapping from SR types to Arrow types is used not only by Arrow Flight SQL, but also by import/export. For compatibility reasons, only Arrow Flight SQL changes the mapping above.

See `row_batch.h/cpp`, `starrocks_column_to_arrow.cpp`.

### 2. A single connection cannot handle multiple queries concurrently

**Problem**

Our `ConnectContext` is not thread-safe.

There are two scenarios where a single connection can be handling multiple queries at once:

- First, the ADBC driver allows a single connection to initiate multiple queries concurrently, as long as each cursor is only executing one query at a time.
- Second, even if the client issues queries serially, this can still occur because the client and the FE do not consider a query “finished” at exactly the same time. A query executes as follows:
  1. The client sends a `getFlightInfoPreparedStatement` RPC to the FE. The FE generates a plan and deploys it to BEs, then returns the result sink BE endpoint to the client.
  2. The client sends a `getStreamStatement` RPC to the BE and pulls results directly from the BE.
  3. After finishing result fetching, the client issues the next query. However, at this point the FE may still not have received all BE profile reports. As a result, two queries may be using the same `ConnectContext` simultaneously.

**Fix**

Ideally, we would split `ConnectContext` into `ConnectContext` and `StatementContext`. Only a small subset of `ConnectContext` fields would need to be thread-safe, while `StatementContext` would not.

However, this change would be too large; `ConnectContext` is used in hundreds of places. Therefore, the current approach is: each `ConnectContext` can execute only one SQL at a time, and subsequent SQLs wait up to `arrow_flight_sql_connection_query_wait_timeout_ms` before timing out.

Implementation-wise, we maintain a `RunningToken` (a semaphore) that can be held by only one owner at a time. Others block and wait for up to `arrow_flight_sql_connection_query_wait_timeout_ms`. If it times out, an error is returned.

- Before a SQL starts, acquire the `RunningToken`.
- After the SQL fully completes, release the `RunningToken`. “Fully completes” means `StmtExecutor::execute` finishes, including the extra 2 seconds waiting for profile reports and writing audit logs and query detail.

See `ArrowFlightSqlConnectProcessor::execute`.

### 3. No statistics collected for BE execution

**Problem**

BE fragments report statistics when `ResultSink` finishes (on `ResultSink::close`), piggybacked on the last batch sent to the FE. However, Arrow Flight SQL doesn’t have a `ResultSink` between FE and BE.

**Fix**

We still let the FE issue a `fetch_data` RPC to the BE’s `ResultSink`. When `ResultSink::close` is called, the BE responds to this `fetch_data` RPC and sends the statistics to the FE.

This also implicitly lets the FE know that the query has finished.

### 4. One `ConnectionContext` maintaining multiple prepared queries

The client’s RPC sequence for a single query is:

`[createPreparedStatement] -> [getFlightInfoPreparedStatement(preparedStmtId) -> getStreamStatement]`

1. `createPreparedStatement`: Send the query to the FE, and the FE returns a `preparedStmtId`.
2. `getFlightInfoPreparedStatement(preparedStmtId)`: Send a request to the FE to execute the query corresponding to the provided `preparedStmtId`. The FE returns the endpoint from which results can be fetched (BE for queries, FE for others).
3. `getStreamStatement`: Fetch query results from the FE or BE.

**Problem**

`ArrowFlightSQLConnectionContext` currently stores only a single `query` field. In reality, a single `ArrowFlightSQLConnectionContext` may hold multiple different prepared statements at the same time.

More specifically, each client cursor maintains one prepared statement. For a given cursor:

- If `cursor.execute(sql)` uses the same SQL as before, it reuses the existing prepared statement and issues `getFlightInfoPreparedStatement(preparedStmtId) -> getStreamStatement`.
- Otherwise, it first closes the previous prepared statement and then creates a new one, issuing `closePreparedStatement(prevPreparedStmtId) -> getFlightInfoPreparedStatement -> getStreamStatement`.

**Fix**

`ArrowFlightSQLConnectionContext` should store a collection of `preparedStatements` instead of a single `query`.

### 5. Forwarding to the leader for execution

**Flow changes**

- For non-queries, the flow is the same as the MySQL protocol: wait for the response from the RPC forwarded to the leader, and then set the result.
- For queries, since the client fetches results directly from BEs, we cannot wait for the leader FE to return results to the follower FE. Instead, once the leader FE finishes deploying fragment instances to BEs, it sends a `notifyForwardDeploymentFinished` RPC (including BE information) to the follower FE. The follower FE directly returns this information to the client.

**Kill-related fixes**

- For MySQL, when canceling a query, it automatically sends a `KILL connection_id` command. The follower FE forwards this `KILL connection_id` to the leader FE.
- For Arrow Flight SQL, there are two ways to cancel, both requiring the FE to actively send a `KILL connection_id` command to the leader FE:
  - Closing the connection: `closeSession` RPC.
  - Canceling the connection/query: `cancelFlightInfo` RPC (not yet implemented).

### 6. Passing the cancel reason to the BE

**Problem**

When one fragment fails, it passes the error message to the FE. The FE then cancels the other fragments, but only sends an `INTERNAL_ERROR` without the error message.

However, since the client pulls data directly from BEs, it cannot obtain the error message from the FE. It only sees `INTERNAL_ERROR` from the BE.

**Fix**

When the FE cancels other fragments, it also passes along the error message.

### 7. Other issues

**FE**

1. Exceptions thrown when closing a connection prevented the connection context from being released.
2. `showExternalBasicStatsMeta` has one more column than `StatsMeta` for internal tables. MySQL results ignore this extra column, so there is no issue.
3. Parser retry does not support large `IN` value lists.

**BE**

1. The map from `query_id` to schema has unsynchronized read/write access (no locking).
2. The `get_arrow_batch` method had incorrect checks on the terminal state `_status`, causing occasional deadlocks.


## SQL Test
- Adding `--arrow` to `python run.py` will run the cases using the Arrow Flight SQL protocol.
- Adding `@no_arrow_flight_sql` to a case will cause that case to be skipped when running with `--arrow`.
- Adding `@arrow_flight_sql` to a case will make that case run using the Arrow Flight SQL protocol even when `--arrow` is not specified.

## TODO

1. Parameterized prepared SQL is not supported.
2. A single connection cannot initiate multiple SQLs concurrently.
3. SQL retries are not supported, especially when BEs restart/fail.
   - Since the client pulls data directly from BEs, the FE cannot re-plan and retry. Once we support fetching data via an FE proxy, we can consider adding this feature.
4. `enable_short_circuit` is not supported.
5. `enable_constant_execute_in_fe` is not supported.


## Why I'm doing:


## What I'm doing:


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes Arrow Flight SQL by adding correct Arrow type mappings, FE/BE execution and leader-forwarding flows with error propagation, connection concurrency control, and comprehensive test/client updates.
> 
> - **Arrow Flight SQL execution (FE/BE)**:
>   - Add `ArrowFlightSqlConnectContext/Processor`, `LeaderOpExecutor` enhancements, `ArrowFlightSqlResultDescriptor`, and `ArrowFlightSqlProxyQueryManager` for endpoint return and forward-to-leader deployment notification (`notifyForwardDeploymentFinished`).
>   - Enforce single in-flight query per connection via `RunningToken` with configurable timeout `arrow_flight_sql_connection_query_wait_timeout_ms`.
>   - Support FE-returned results for non-queries; BE endpoint for queries; handle explain and SHOW.
> - **Type mapping and Arrow conversions**:
>   - Implement Arrow Flight SQL–specific schema/field conversions: `DATE→date32`, `DATETIME→timestamp(micro,UTC)`, `VARBINARY→binary`, `LARGEINT→Decimal128(38,0)`, `DECIMAL256` support; map `HLL/OBJECT/PERCENTILE→binary` (always null).
>   - Extend row/column converters (date/timestamp units, decimal128/256, varbinary), and add guards for unsupported MAP null keys.
> - **Runtime/IO fixes**:
>   - Propagate cancel error messages to BEs (`PCancelPlanFragmentRequest.error_message`) and through FE (`DefaultCoordinator`, `ExecutionDAG`, `BackendServiceClient`).
>   - Fix `BufferControlBlock::get_arrow_batch` status handling to avoid deadlocks; `ResultBufferMgr` returns underlying status.
>   - Track written rows in `ArrowResultWriter`; carry `arrow_flight_sql_version` via `RuntimeState` and fragment params.
> - **Core utilities**:
>   - Add `DateValue::to_days_since_unix_epoch` and `TimestampValue::to_unix_microsecond`.
>   - Add `DECIMAL256` to arrow type traits.
> - **FE service/proxy**:
>   - Update `FrontendServiceImpl.forward` to handle Arrow Flight SQL sessions and deployment-finished callback; improve cancel/log messages.
>   - Make `ConnectContext` Arrow-aware (`isArrowFlightSql`, `updateReturnRows` uses long).
> - **Tests and tooling**:
>   - Introduce Python Arrow Flight SQL client/helpers and connection pooling; upgrade `pyarrow>=21`.
>   - Add arrow-mode test runner flags, tagging (`@arrow_flight_sql`, `@no_arrow_flight_sql`), and numerous SQL test adjustments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 964ff4357525e2d9296e84c22ab18414f17484b0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->