### PR TITLE
[BugFix]Fix the calculation logic of the query error rate metrics

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
@@ -101,20 +101,20 @@ public class MetricCalculator extends TimerTask {
         // internal err rate
         long currentInternalErrCounter = MetricRepo.COUNTER_QUERY_INTERNAL_ERR.getValue();
         double internalErrRate = (double) (currentInternalErrCounter - lastQueryInternalErrCounter) / interval;
-        MetricRepo.GAUGE_QUERY_INTERNAL_ERR_RATE.setValue(errRate < 0 ? 0.0 : internalErrRate);
-        lastQueryInternalErrCounter = currentErrCounter;
+        MetricRepo.GAUGE_QUERY_INTERNAL_ERR_RATE.setValue(internalErrRate < 0 ? 0.0 : internalErrRate);
+        lastQueryInternalErrCounter = currentInternalErrCounter;
 
         // analysis error rate
         long currentAnalysisErrCounter = MetricRepo.COUNTER_QUERY_ANALYSIS_ERR.getValue();
         double analysisErrRate = (double) (currentAnalysisErrCounter - lastQueryAnalysisErrCounter) / interval;
-        MetricRepo.GAUGE_QUERY_ANALYSIS_ERR_RATE.setValue(errRate < 0 ? 0.0 : analysisErrRate);
-        lastQueryAnalysisErrCounter = currentErrCounter;
+        MetricRepo.GAUGE_QUERY_ANALYSIS_ERR_RATE.setValue(analysisErrRate < 0 ? 0.0 : analysisErrRate);
+        lastQueryAnalysisErrCounter = currentAnalysisErrCounter;
 
         // query timeout rate
         long currentTimeoutErrCounter = MetricRepo.COUNTER_QUERY_TIMEOUT.getValue();
         double timeoutErrRate = (double) (currentTimeoutErrCounter - lastQueryTimeOutCounter) / interval;
-        MetricRepo.GAUGE_QUERY_TIMEOUT_RATE.setValue(errRate < 0 ? 0.0 : timeoutErrRate);
-        lastQueryTimeOutCounter = currentErrCounter;
+        MetricRepo.GAUGE_QUERY_TIMEOUT_RATE.setValue(timeoutErrRate < 0 ? 0.0 : timeoutErrRate);
+        lastQueryTimeOutCounter = currentTimeoutErrCounter;
 
         lastTs = currentTs;
 


### PR DESCRIPTION
## Why I'm doing:
Got the negative number 
```
# HELP starrocks_fe_query_err_rate query error rate
# TYPE starrocks_fe_query_err_rate gauge
starrocks_fe_query_err_rate 0.0
# HELP starrocks_fe_query_internal_err_rate query internal error rate
# TYPE starrocks_fe_query_internal_err_rate gauge
starrocks_fe_query_internal_err_rate -139.4375
# HELP starrocks_fe_query_analysis_err_rate query analysis error rate
# TYPE starrocks_fe_query_analysis_err_rate gauge
starrocks_fe_query_analysis_err_rate -10.1875
# HELP starrocks_fe_query_timeout_rate query timeout rate
# TYPE starrocks_fe_query_timeout_rate gauge
starrocks_fe_query_timeout_rate -144.5
``` 

## What I'm doing:
Correct it

Fixes #65890

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes incorrect variable usage in error-rate metrics by using the proper rates and counters for internal, analysis, and timeout errors.
> 
> - **Metrics (FE)**:
>   - Corrects gauge updates to use the proper per-metric rates: `GAUGE_QUERY_INTERNAL_ERR_RATE`, `GAUGE_QUERY_ANALYSIS_ERR_RATE`, `GAUGE_QUERY_TIMEOUT_RATE` now clamp based on their own computed rates instead of `errRate`.
>   - Fixes last-counter tracking to use the corresponding current counters: `lastQueryInternalErrCounter`, `lastQueryAnalysisErrCounter`, `lastQueryTimeOutCounter`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a20587bc1d81ce0dd7442cedb9995e870d7cab75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->