### PR TITLE
[BugFix] Fix sample scan range index overflow in files schema detection

### DIFF
--- a/be/src/exec/file_scanner/file_scanner.cpp
+++ b/be/src/exec/file_scanner/file_scanner.cpp
@@ -411,8 +411,13 @@ void FileScanner::sample_files(size_t total_file_count, int64_t sample_file_coun
     } else {
         step = static_cast<double>(total_file_count - 1) / (sample_file_count - 1);
     }
-    for (size_t i = 0; i < sample_file_count - 1; ++i) {
-        sample_file_indexes->emplace_back(std::round(i * step));
+
+    double next_index = 0;
+    size_t i = 0;
+    while (i < total_file_count - 1) {
+        sample_file_indexes->emplace_back(i);
+        next_index += step;
+        i = static_cast<size_t>(std::round(next_index));
     }
     sample_file_indexes->emplace_back(total_file_count - 1);
 }

--- a/be/test/exec/file_scanner/file_scanner_test.cpp
+++ b/be/test/exec/file_scanner/file_scanner_test.cpp
@@ -185,17 +185,11 @@ TEST_F(FileScannerTest, select_sample_files) {
         ASSERT_TRUE(sample_file_indexes.empty());
     }
 
+    // total file count >= sample file count
     {
         std::vector<size_t> sample_file_indexes;
         FileScanner::sample_files(10, 1, &sample_file_indexes);
         std::vector<size_t> expect = {9};
-        ASSERT_EQ(expect, sample_file_indexes);
-    }
-
-    {
-        std::vector<size_t> sample_file_indexes;
-        FileScanner::sample_files(1, 10, &sample_file_indexes);
-        std::vector<size_t> expect = {0};
         ASSERT_EQ(expect, sample_file_indexes);
     }
 
@@ -241,7 +235,14 @@ TEST_F(FileScannerTest, select_sample_files) {
         ASSERT_EQ(expect, sample_file_indexes);
     }
 
-    // sample file count > total file count
+    // total file count < sample file count
+    {
+        std::vector<size_t> sample_file_indexes;
+        FileScanner::sample_files(1, 10, &sample_file_indexes);
+        std::vector<size_t> expect = {0};
+        ASSERT_EQ(expect, sample_file_indexes);
+    }
+
     {
         std::vector<size_t> sample_file_indexes;
         FileScanner::sample_files(2, 8, &sample_file_indexes);

--- a/be/test/exec/file_scanner/file_scanner_test.cpp
+++ b/be/test/exec/file_scanner/file_scanner_test.cpp
@@ -240,6 +240,21 @@ TEST_F(FileScannerTest, select_sample_files) {
         std::vector<size_t> expect = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         ASSERT_EQ(expect, sample_file_indexes);
     }
+
+    // sample file count > total file count
+    {
+        std::vector<size_t> sample_file_indexes;
+        FileScanner::sample_files(2, 8, &sample_file_indexes);
+        std::vector<size_t> expect = {0, 1};
+        ASSERT_EQ(expect, sample_file_indexes);
+    }
+
+    {
+        std::vector<size_t> sample_file_indexes;
+        FileScanner::sample_files(10, 100, &sample_file_indexes);
+        std::vector<size_t> expect = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+        ASSERT_EQ(expect, sample_file_indexes);
+    }
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

```
query_id:00000000-0000-0000-0000-000000000000, fragment_instance:00000000-0000-0000-0000-000000000000
*** Aborted at 1763218936 (unix time) try "date -d @1763218936" if you are using GNU date ***
PC: @     0xff99a2202008 (/usr/lib/aarch64-linux-gnu/libc.so.6+0x82007)
*** SIGABRT (@0x3e800231281) received by PID 2298497 (TID 0xff993e4100c0) from PID 2298497; stack trace: ***
    @     0xff99a22053dc (/usr/lib/aarch64-linux-gnu/libc.so.6+0x853db)
    @          0xe481198 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0xff99a36588f8 ([vdso]+0x8f7)
    @     0xff99a2202008 (/usr/lib/aarch64-linux-gnu/libc.so.6+0x82007)
    @     0xff99a21ba83c raise
    @     0xff99a21a7134 abort
    @         0x105ac7cc __gnu_cxx::__verbose_terminate_handler()
    @         0x105aac6c __cxxabiv1::__terminate(void (*)())
    @         0x105aacd0 std::terminate()
    @         0x105aae64 __cxa_throw
    @         0x105ab3a8 operator new(unsigned long)
    @          0x77292b0 std::__cxx11::basic_string, std::allocator >::_M_assign(std::__cxx11::basic_string, std::allocator > const&)
    @          0xb0cbabc starrocks::TBrokerRangeDesc::TBrokerRangeDesc(starrocks::TBrokerRangeDesc const&)
    @          0xa5559b8 starrocks::FileScanner::sample_schema(starrocks::RuntimeState*, starrocks::TBrokerScanRange const&, std::vector >*)
    @          0xaa96680 starrocks::PInternalServiceImplBase::_get_file_schema(google::protobuf::RpcController*, starrocks::PGetFileSchemaRequest const*, starrocks::PGetFileSchemaResult*, google::protobuf::Closure*)
    @          0xac1fce4 starrocks::ThreadPool::dispatch_thread()
    @          0xac1658c starrocks::Thread::supervise_thread(void*)
    @     0xff99a2200398 (/usr/lib/aarch64-linux-gnu/libc.so.6+0x80397)
    @     0xff99a2269e9c (/usr/lib/aarch64-linux-gnu/libc.so.6+0xe9e9b)
```

## What I'm doing:

sample scan range index is overflow when `sample file count` is smaller than `total file count`.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Revamps `sample_files` to a bounded incremental selection to avoid overflow and correctly handle `sample >= total`, and updates unit tests with cases where total files are fewer than requested samples.
> 
> - **Backend**:
>   - **File sampling logic**: Reworks `FileScanner::sample_files` to iterate with an incremental rounded index, ensuring indices stay within `[0, total-1]`, always include the last file, and sample all files when `sample_file_count >= total_file_count`.
> - **Tests**:
>   - **`FileScannerTest::select_sample_files`**: Adjusts expectations and adds coverage for cases where `total_file_count < sample_file_count` (e.g., `1/10`, `2/8`, `10/100`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 821015203f3d90bb875e907b80398d63dd8310f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->