### PR TITLE
[Enhancement] Add column statistic labels to explain statement

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1028,6 +1028,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_PRE_AGG_TOP_N_PUSH_DOWN = "enable_pre_agg_top_n_push_down";
 
+    public static final String ENABLE_LABELED_COLUMN_STATISTIC_OUTPUT = "enable_labeled_column_statistic_output";
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(MAX_EXECUTION_TIME)
@@ -2131,6 +2133,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_PRE_AGG_TOP_N_PUSH_DOWN, flag = VariableMgr.INVISIBLE)
     private boolean enablePreAggTopNPushDown = true;
+
+    @VarAttr(name = ENABLE_LABELED_COLUMN_STATISTIC_OUTPUT)
+    private boolean enableLabeledColumnStatisticOutput = false;
 
     public int getCboPruneJsonSubfieldDepth() {
         return cboPruneJsonSubfieldDepth;
@@ -5621,6 +5626,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnablePreAggTopNPushDown() {
         return enablePreAggTopNPushDown;
+    }
+
+    public void setEnableLabeledColumnStatisticOutput(boolean flag) {
+        this.enableLabeledColumnStatisticOutput = flag;
+    }
+
+    public boolean isEnableLabeledColumnStatisticOutput() {
+        return this.enableLabeledColumnStatisticOutput;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnStatistic.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.optimizer.statistics;
 
 import com.google.common.base.Preconditions;
+import com.starrocks.qe.ConnectContext;
 
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
@@ -173,14 +174,28 @@ public class ColumnStatistic {
     @Override
     public String toString() {
         String separator = ", ";
-        return "[MIN: " + minValue + separator
-                + "MAX: " + maxValue + separator
-                + "NULLS: " + nullsFraction + separator
-                + "ROS: " + averageRowSize + separator
-                + "NDV: " + distinctValuesCount + "] "
-                + (collectionSize == DEFAULT_COLLECTION_SIZE ? "" : "COS: " + collectionSize + " ")
-                + (histogram == null ? "" : histogram.getMcvString() + " ")
-                + type;
+        boolean enableLabeledColumnStatisticOutput =
+                ConnectContext.get() != null && ConnectContext.get().getSessionVariable() != null &&
+                        ConnectContext.get().getSessionVariable().isEnableLabeledColumnStatisticOutput();
+        if (enableLabeledColumnStatisticOutput) {
+            return "[MIN: " + minValue + separator
+                    + "MAX: " + maxValue + separator
+                    + "NULLS: " + nullsFraction + separator
+                    + "ROS: " + averageRowSize + separator
+                    + "NDV: " + distinctValuesCount + "] "
+                    + (collectionSize == DEFAULT_COLLECTION_SIZE ? "" : "COS: " + collectionSize + " ")
+                    + (histogram == null ? "" : histogram.getMcvString() + " ")
+                    + type;
+        } else {
+            return "[" + minValue + separator
+                    + maxValue + separator
+                    + nullsFraction + separator
+                    + averageRowSize + separator
+                    + distinctValuesCount + "] "
+                    + (collectionSize == DEFAULT_COLLECTION_SIZE ? "" : "COS: " + collectionSize + " ")
+                    + (histogram == null ? "" : histogram.getMcvString() + " ")
+                    + type;
+        }
     }
 
     public static Builder buildFrom(ColumnStatistic other) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnStatistic.java
@@ -173,11 +173,11 @@ public class ColumnStatistic {
     @Override
     public String toString() {
         String separator = ", ";
-        return "[" + minValue + separator
-                + maxValue + separator
-                + nullsFraction + separator
-                + averageRowSize + separator
-                + distinctValuesCount + "] "
+        return "[MIN: " + minValue + separator
+                + "MAX: " + maxValue + separator
+                + "NULLS: " + nullsFraction + separator
+                + "ROS: " + averageRowSize + separator
+                + "NDV: " + distinctValuesCount + "] "
                 + (collectionSize == DEFAULT_COLLECTION_SIZE ? "" : "COS: " + collectionSize + " ")
                 + (histogram == null ? "" : histogram.getMcvString() + " ")
                 + type;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExplainTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExplainTest.java
@@ -35,7 +35,7 @@ public class ExplainTest extends PlanTestBase {
                 + "                        Estimates: {row: 1, cpu: ?, memory: ?, network: ?, cost: 4.0}\n"
                 + "                        partitionRatio: 0/1, tabletRatio: 0/0");
 
-        Explain explain = new Explain(true, true, " ", " |");
+        Explain explain = new Explain(true, false, " ", " |");
         String plan2 = explain.print(execPlan.getPhysicalPlan(), execPlan.getOutputColumns());
         System.out.println("plan2" + plan2);
         assertContains(plan2, "- Output => [1:v1]\n"
@@ -61,5 +61,69 @@ public class ExplainTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         assertContains(plan, "min(pow(CAST(1: v1 AS DOUBLE), ?))");
 
+    }
+
+    @Test
+    public void testExplainCosts() throws Exception {
+        String sql = "SELECT DISTINCT t0.v1 FROM t0 LEFT JOIN t1 ON t0.v1 = t1.v4";
+        String plan = getCostExplain(sql);
+        Assertions.assertTrue(plan.contains("3:AGGREGATE (merge finalize)\n" +
+                "  |  group by: [1: v1, BIGINT, true]\n" +
+                "  |  cardinality: 1\n" +
+                "  |  column statistics: \n" +
+                "  |  * v1-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN\n" +
+                "  |  \n" +
+                "  2:EXCHANGE\n" +
+                "     distribution type: SHUFFLE\n" +
+                "     partition exprs: [1: v1, BIGINT, true]\n" +
+                "     cardinality: 1"), plan);
+        Assertions.assertTrue(plan.contains("1:AGGREGATE (update serialize)\n" +
+                "  |  STREAMING\n" +
+                "  |  group by: [1: v1, BIGINT, true]\n" +
+                "  |  cardinality: 1\n" +
+                "  |  column statistics: \n" +
+                "  |  * v1-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN\n" +
+                "  |  \n" +
+                "  0:OlapScanNode\n" +
+                "     table: t0, rollup: t0\n" +
+                "     preAggregation: on\n" +
+                "     partitionsRatio=0/1, tabletsRatio=0/0\n" +
+                "     tabletList=\n" +
+                "     actualRows=0, avgRowSize=1.0\n" +
+                "     cardinality: 1\n" +
+                "     column statistics: \n" +
+                "     * v1-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN"), plan);
+    }
+
+    @Test
+    public void testExplainCostsWithLabels() throws Exception {
+        String sql = "SELECT DISTINCT t0.v1 FROM t0 LEFT JOIN t1 ON t0.v1 = t1.v4";
+        String plan = getCostExplainWithLabels(sql);
+        Assertions.assertTrue(plan.contains("3:AGGREGATE (merge finalize)\n" +
+                "  |  group by: [1: v1, BIGINT, true]\n" +
+                "  |  cardinality: 1\n" +
+                "  |  column statistics: \n" +
+                "  |  * v1-->[MIN: -Infinity, MAX: Infinity, NULLS: 0.0, ROS: 1.0, NDV: 1.0] UNKNOWN\n" +
+                "  |  \n" +
+                "  2:EXCHANGE\n" +
+                "     distribution type: SHUFFLE\n" +
+                "     partition exprs: [1: v1, BIGINT, true]\n" +
+                "     cardinality: 1"), plan);
+        Assertions.assertTrue(plan.contains("1:AGGREGATE (update serialize)\n" +
+                "  |  STREAMING\n" +
+                "  |  group by: [1: v1, BIGINT, true]\n" +
+                "  |  cardinality: 1\n" +
+                "  |  column statistics: \n" +
+                "  |  * v1-->[MIN: -Infinity, MAX: Infinity, NULLS: 0.0, ROS: 1.0, NDV: 1.0] UNKNOWN\n" +
+                "  |  \n" +
+                "  0:OlapScanNode\n" +
+                "     table: t0, rollup: t0\n" +
+                "     preAggregation: on\n" +
+                "     partitionsRatio=0/1, tabletsRatio=0/0\n" +
+                "     tabletList=\n" +
+                "     actualRows=0, avgRowSize=1.0\n" +
+                "     cardinality: 1\n" +
+                "     column statistics: \n" +
+                "     * v1-->[MIN: -Infinity, MAX: Infinity, NULLS: 0.0, ROS: 1.0, NDV: 1.0] UNKNOWN"), plan);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExplainTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExplainTest.java
@@ -35,7 +35,7 @@ public class ExplainTest extends PlanTestBase {
                 + "                        Estimates: {row: 1, cpu: ?, memory: ?, network: ?, cost: 4.0}\n"
                 + "                        partitionRatio: 0/1, tabletRatio: 0/0");
 
-        Explain explain = new Explain(true, false, " ", " |");
+        Explain explain = new Explain(true, true, " ", " |");
         String plan2 = explain.print(execPlan.getPhysicalPlan(), execPlan.getOutputColumns());
         System.out.println("plan2" + plan2);
         assertContains(plan2, "- Output => [1:v1]\n"

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExplainTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExplainTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.plan;
 
 import com.starrocks.sql.Explain;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class ExplainTest extends PlanTestBase {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -313,6 +313,14 @@ public class PlanTestNoneDBBase extends StarRocksTestBase {
                 getExplainString(TExplainLevel.COSTS);
     }
 
+    public String getCostExplainWithLabels(String sql) throws Exception {
+        connectContext.getSessionVariable().setEnableLabeledColumnStatisticOutput(true);
+        String plan = UtFrameUtils.getPlanAndFragment(connectContext, sql).second.
+                getExplainString(TExplainLevel.COSTS);
+        connectContext.getSessionVariable().setEnableLabeledColumnStatisticOutput(false);
+        return plan;
+    }
+
     public String getDumpString(String sql) throws Exception {
         UtFrameUtils.getPlanAndFragment(connectContext, sql);
         return GsonUtils.GSON.toJson(connectContext.getDumpInfo());


### PR DESCRIPTION
## Why I'm doing:

Minor quality of life improvement to make explain output more understandable. ColumnStatistic is outputed as a list where it's not obvious what each value represents if you don't know them by heart.

## What I'm doing:

Adding labels to the ColumnStatistic array that explains what each value means.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
