### PR TITLE
[Enhancement] Support table_write_log statistic table

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1755,6 +1755,11 @@ CONF_mBool(enable_lake_compaction_use_partial_segments, "false");
 // chunk size used by lake compaction
 CONF_mInt32(lake_compaction_chunk_size, "4096");
 
+// Enable tablet write log tracking for write amplification analysis
+CONF_mBool(enable_tablet_write_log, "false");
+// Maximum number of log entries to keep in memory buffer (per CN/BE)
+CONF_mInt32(tablet_write_log_buffer_size, "100000");
+
 CONF_mBool(skip_schema_in_rowset_meta, "true");
 
 CONF_mBool(enable_bit_unpack_simd, "true");

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -161,6 +161,7 @@ set(EXEC_FILES
     schema_scanner/schema_be_compactions_scanner.cpp
     schema_scanner/schema_be_bvars_scanner.cpp
     schema_scanner/schema_be_cloud_native_compactions_scanner.cpp
+    schema_scanner/schema_be_tablet_write_log_scanner.cpp
     schema_scanner/schema_pipe_files.cpp
     schema_scanner/schema_pipes.cpp
     schema_scanner/schema_recyclebin_catalogs.cpp

--- a/be/src/exec/schema_scanner.cpp
+++ b/be/src/exec/schema_scanner.cpp
@@ -28,6 +28,7 @@
 #include "exec/schema_scanner/schema_be_datacache_metrics_scanner.h"
 #include "exec/schema_scanner/schema_be_logs_scanner.h"
 #include "exec/schema_scanner/schema_be_metrics_scanner.h"
+#include "exec/schema_scanner/schema_be_tablet_write_log_scanner.h"
 #include "exec/schema_scanner/schema_be_tablets_scanner.h"
 #include "exec/schema_scanner/schema_be_threads_scanner.h"
 #include "exec/schema_scanner/schema_be_txns_scanner.h"
@@ -199,6 +200,8 @@ std::unique_ptr<SchemaScanner> SchemaScanner::create(TSchemaTableType::type type
         return std::make_unique<SchemaBeBvarsScanner>();
     case TSchemaTableType::SCH_BE_CLOUD_NATIVE_COMPACTIONS:
         return std::make_unique<SchemaBeCloudNativeCompactionsScanner>();
+    case TSchemaTableType::SCH_BE_TABLET_WRITE_LOG:
+        return std::make_unique<SchemaBeTabletWriteLogScanner>();
     case TSchemaTableType::STARROCKS_ROLE_EDGES:
         return std::make_unique<StarrocksRoleEdgesScanner>();
     case TSchemaTableType::STARROCKS_GRANT_TO_ROLES:

--- a/be/src/exec/schema_scanner/schema_be_tablet_write_log_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_tablet_write_log_scanner.cpp
@@ -1,0 +1,198 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/schema_scanner/schema_be_tablet_write_log_scanner.h"
+
+#include "column/column_helper.h"
+#include "column/datum.h"
+#include "exec/schema_scanner/schema_helper.h"
+#include "runtime/datetime_value.h"
+#include "runtime/runtime_state.h"
+#include "storage/chunk_helper.h"
+#include "types/logical_type.h"
+
+namespace starrocks {
+
+SchemaScanner::ColumnDesc SchemaBeTabletWriteLogScanner::_s_tbls_columns[] = {
+        {"BE_ID", TypeDescriptor(TYPE_BIGINT), sizeof(int64_t), false},
+        {"BEGIN_TIME", TypeDescriptor(TYPE_DATETIME), sizeof(DateTimeValue), false},
+        {"FINISH_TIME", TypeDescriptor(TYPE_DATETIME), sizeof(DateTimeValue), false},
+        {"TXN_ID", TypeDescriptor(TYPE_BIGINT), sizeof(int64_t), false},
+        {"TABLET_ID", TypeDescriptor(TYPE_BIGINT), sizeof(int64_t), false},
+        {"TABLE_ID", TypeDescriptor(TYPE_BIGINT), sizeof(int64_t), false},
+        {"PARTITION_ID", TypeDescriptor(TYPE_BIGINT), sizeof(int64_t), false},
+        {"LOG_TYPE", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), false},
+        {"INPUT_ROWS", TypeDescriptor(TYPE_BIGINT), sizeof(int64_t), false},
+        {"INPUT_BYTES", TypeDescriptor(TYPE_BIGINT), sizeof(int64_t), false},
+        {"OUTPUT_ROWS", TypeDescriptor(TYPE_BIGINT), sizeof(int64_t), false},
+        {"OUTPUT_BYTES", TypeDescriptor(TYPE_BIGINT), sizeof(int64_t), false},
+        {"INPUT_SEGMENTS", TypeDescriptor(TYPE_INT), sizeof(int32_t), true},
+        {"OUTPUT_SEGMENTS", TypeDescriptor(TYPE_INT), sizeof(int32_t), false},
+        {"LABEL", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), true},
+        {"COMPACTION_SCORE", TypeDescriptor(TYPE_BIGINT), sizeof(int64_t), true},
+        {"COMPACTION_TYPE", TypeDescriptor::create_varchar_type(sizeof(Slice)), sizeof(Slice), true},
+};
+
+SchemaBeTabletWriteLogScanner::SchemaBeTabletWriteLogScanner()
+        : SchemaScanner(_s_tbls_columns, sizeof(_s_tbls_columns) / sizeof(SchemaScanner::ColumnDesc)) {}
+
+SchemaBeTabletWriteLogScanner::~SchemaBeTabletWriteLogScanner() = default;
+
+Status SchemaBeTabletWriteLogScanner::start(RuntimeState* state) {
+    RETURN_IF_ERROR(SchemaScanner::start(state));
+    // Get all logs
+    // TODO: Support predicate pushdown filtering
+    _logs = lake::TabletWriteLogManager::instance()->get_logs();
+    _log_index = 0;
+    _ctz = state->timezone_obj();
+    return Status::OK();
+}
+
+Status SchemaBeTabletWriteLogScanner::get_next(ChunkPtr* chunk, bool* eos) {
+    if (!_is_init) {
+        return Status::InternalError("Used before initialized.");
+    }
+    if (chunk == nullptr || eos == nullptr) {
+        return Status::InternalError("input pointer is nullptr.");
+    }
+    if (_log_index >= _logs.size()) {
+        *eos = true;
+        return Status::OK();
+    }
+    *eos = false;
+    *chunk = ChunkHelper::new_chunk(_slot_descs, _runtime_state->chunk_size());
+
+    size_t i = 0;
+    for (; i < _runtime_state->chunk_size() && _log_index < _logs.size(); ++i, ++_log_index) {
+        const auto& log = _logs[_log_index];
+        size_t col_idx = 0;
+
+        // be_id
+        {
+            Column* col = (Column*)(*chunk)->get_column_by_index(col_idx++).get();
+            ColumnHelper::get_data_column(col)->append_datum(Datum(log.backend_id));
+        }
+        // begin_time
+        {
+            DateTimeValue ts;
+            ts.from_unixtime(log.begin_time / 1000, _ctz); // Convert ms to seconds
+            Column* col = (Column*)(*chunk)->get_column_by_index(col_idx++).get();
+            fill_column_with_slot<TYPE_DATETIME>(col, (void*)&ts);
+        }
+        // finish_time
+        {
+            DateTimeValue ts;
+            ts.from_unixtime(log.finish_time / 1000, _ctz); // Convert ms to seconds
+            Column* col = (Column*)(*chunk)->get_column_by_index(col_idx++).get();
+            fill_column_with_slot<TYPE_DATETIME>(col, (void*)&ts);
+        }
+        // txn_id
+        {
+            Column* col = (Column*)(*chunk)->get_column_by_index(col_idx++).get();
+            ColumnHelper::get_data_column(col)->append_datum(Datum(log.txn_id));
+        }
+        // tablet_id
+        {
+            Column* col = (Column*)(*chunk)->get_column_by_index(col_idx++).get();
+            ColumnHelper::get_data_column(col)->append_datum(Datum(log.tablet_id));
+        }
+        // table_id
+        {
+            Column* col = (Column*)(*chunk)->get_column_by_index(col_idx++).get();
+            ColumnHelper::get_data_column(col)->append_datum(Datum(log.table_id));
+        }
+        // partition_id
+        {
+            Column* col = (Column*)(*chunk)->get_column_by_index(col_idx++).get();
+            ColumnHelper::get_data_column(col)->append_datum(Datum(log.partition_id));
+        }
+        // log_type
+        {
+            std::string type_str = (log.log_type == lake::LogType::LOAD) ? "LOAD" : "COMPACTION";
+            Slice s(type_str);
+            Column* col = (Column*)(*chunk)->get_column_by_index(col_idx++).get();
+            ColumnHelper::get_data_column(col)->append_datum(Datum(s));
+        }
+        // input_rows
+        {
+            Column* col = (Column*)(*chunk)->get_column_by_index(col_idx++).get();
+            ColumnHelper::get_data_column(col)->append_datum(Datum(log.input_rows));
+        }
+        // input_bytes
+        {
+            Column* col = (Column*)(*chunk)->get_column_by_index(col_idx++).get();
+            ColumnHelper::get_data_column(col)->append_datum(Datum(log.input_bytes));
+        }
+        // output_rows
+        {
+            Column* col = (Column*)(*chunk)->get_column_by_index(col_idx++).get();
+            ColumnHelper::get_data_column(col)->append_datum(Datum(log.output_rows));
+        }
+        // output_bytes
+        {
+            Column* col = (Column*)(*chunk)->get_column_by_index(col_idx++).get();
+            ColumnHelper::get_data_column(col)->append_datum(Datum(log.output_bytes));
+        }
+        // input_segments
+        {
+            auto& column = (*chunk)->get_column_by_index(col_idx++);
+            Column* col = (Column*)column.get();
+            if (log.log_type == lake::LogType::COMPACTION) {
+                col->append_datum(Datum(log.input_segments));
+            } else {
+                col->append_nulls(1);
+            }
+        }
+        // output_segments
+        {
+            Column* col = (Column*)(*chunk)->get_column_by_index(col_idx++).get();
+            ColumnHelper::get_data_column(col)->append_datum(Datum(log.output_segments));
+        }
+        // label
+        {
+            auto& column = (*chunk)->get_column_by_index(col_idx++);
+            Column* col = (Column*)column.get();
+            if (log.log_type == lake::LogType::LOAD) {
+                Slice s(log.label);
+                col->append_datum(Datum(s));
+            } else {
+                col->append_nulls(1);
+            }
+        }
+        // compaction_score
+        {
+            auto& column = (*chunk)->get_column_by_index(col_idx++);
+            Column* col = (Column*)column.get();
+            if (log.log_type == lake::LogType::COMPACTION) {
+                col->append_datum(Datum(log.compaction_score));
+            } else {
+                col->append_nulls(1);
+            }
+        }
+        // compaction_type
+        {
+            auto& column = (*chunk)->get_column_by_index(col_idx++);
+            Column* col = (Column*)column.get();
+            if (log.log_type == lake::LogType::COMPACTION) {
+                Slice s(log.compaction_type);
+                col->append_datum(Datum(s));
+            } else {
+                col->append_nulls(1);
+            }
+        }
+    }
+    return Status::OK();
+}
+
+} // namespace starrocks

--- a/be/src/exec/schema_scanner/schema_be_tablet_write_log_scanner.h
+++ b/be/src/exec/schema_scanner/schema_be_tablet_write_log_scanner.h
@@ -1,0 +1,37 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "exec/schema_scanner.h"
+#include "storage/lake/tablet_write_log_manager.h"
+
+namespace starrocks {
+
+class SchemaBeTabletWriteLogScanner : public SchemaScanner {
+public:
+    SchemaBeTabletWriteLogScanner();
+    ~SchemaBeTabletWriteLogScanner() override;
+
+    Status start(RuntimeState* state) override;
+    Status get_next(ChunkPtr* chunk, bool* eos) override;
+
+private:
+    std::vector<lake::TabletWriteLogEntry> _logs;
+    size_t _log_index = 0;
+    cctz::time_zone _ctz;
+    static SchemaScanner::ColumnDesc _s_tbls_columns[];
+};
+
+} // namespace starrocks

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -260,6 +260,7 @@ set(STORAGE_FILES
     lake/persistent_index_sstable.cpp
     lake/lake_primary_key_compaction_conflict_resolver.cpp
     lake/column_mode_partial_update_handler.cpp
+    lake/tablet_write_log_manager.cpp
     sstable/sstable_predicate.cpp
     sstable/sstable_predicate_utils.cpp
     primary_key_dump.cpp

--- a/be/src/storage/lake/compaction_task_context.h
+++ b/be/src/storage/lake/compaction_task_context.h
@@ -68,13 +68,16 @@ struct CompactionTaskStats {
 // Context of a single tablet compaction task.
 struct CompactionTaskContext : public butil::LinkNode<CompactionTaskContext> {
     explicit CompactionTaskContext(int64_t txn_id_, int64_t tablet_id_, int64_t version_, bool force_base_compaction_,
-                                   bool skip_write_txnlog_, std::shared_ptr<CompactionTaskCallback> cb_)
+                                   bool skip_write_txnlog_, std::shared_ptr<CompactionTaskCallback> cb_,
+                                   int64_t table_id_ = 0, int64_t partition_id_ = 0)
             : txn_id(txn_id_),
               tablet_id(tablet_id_),
               version(version_),
               force_base_compaction(force_base_compaction_),
               skip_write_txnlog(skip_write_txnlog_),
-              callback(std::move(cb_)) {}
+              callback(std::move(cb_)),
+              table_id(table_id_),
+              partition_id(partition_id_) {}
 
 #ifndef NDEBUG
     ~CompactionTaskContext() {
@@ -97,6 +100,8 @@ struct CompactionTaskContext : public butil::LinkNode<CompactionTaskContext> {
     std::shared_ptr<CompactionTaskCallback> callback;
     std::unique_ptr<CompactionTaskStats> stats = std::make_unique<CompactionTaskStats>();
     std::shared_ptr<TxnLogPB> txn_log;
+    int64_t table_id;
+    int64_t partition_id;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -20,8 +20,10 @@
 #include <memory>
 #include <utility>
 
+#include "agent/master_info.h"
 #include "column/chunk.h"
 #include "column/column.h"
+#include "common/config.h"
 #include "fs/bundle_file.h"
 #include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
@@ -35,6 +37,7 @@
 #include "storage/lake/spill_mem_table_sink.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_write_log_manager.h"
 #include "storage/lake/tablet_writer.h"
 #include "storage/lake/update_manager.h"
 #include "storage/load_spill_block_manager.h"
@@ -255,6 +258,9 @@ private:
 
     GlobalDictByNameMaps* _global_dicts = nullptr;
     bool _is_multi_statements_txn = false;
+
+    // Record the time when DeltaWriter is opened
+    int64_t _begin_time_ms = 0;
 };
 
 bool DeltaWriterImpl::is_immutable() const {
@@ -444,6 +450,8 @@ Status DeltaWriterImpl::open() {
     if (_bundle_writable_file_context) {
         _bundle_writable_file_context->increase_active_writers();
     }
+    // Record the time when DeltaWriter is opened for write amplification tracking
+    _begin_time_ms = UnixMillis();
     return Status::OK();
 }
 
@@ -489,6 +497,7 @@ Status DeltaWriterImpl::write(const Chunk& chunk, const uint32_t* indexes, uint3
     RETURN_IF_ERROR(check_partial_update_with_sort_key(chunk));
     ADD_COUNTER_RELAXED(_stats.write_count, 1);
     ADD_COUNTER_RELAXED(_stats.row_count, indexes_size);
+    ADD_COUNTER_RELAXED(_stats.input_bytes, chunk.bytes_usage());
     auto start_time = MonotonicNanos();
     DeferOp defer([&]() { ADD_COUNTER_RELAXED(_stats.write_time_ns, MonotonicNanos() - start_time); });
     _last_write_ts = butil::gettimeofday_s();
@@ -737,6 +746,15 @@ StatusOr<TxnLogPtr> DeltaWriterImpl::finish_with_txnlog(DeltaWriterFinishMode mo
     StarRocksMetrics::instance()->delta_writer_pk_preload_duration_us.increment(pk_preload_duration_ns /
                                                                                 NANOSECS_PER_USEC);
     VLOG(2) << "txn_log: " << txn_log->DebugString();
+
+    if (config::enable_tablet_write_log) {
+        int64_t finish_time = UnixMillis();
+        TabletWriteLogManager::instance()->add_load_log(
+                get_backend_id().value_or(0), _txn_id, _tablet_id, _table_id, _partition_id, _stats.row_count,
+                _stats.input_bytes, _tablet_writer->num_rows(), _tablet_writer->data_size(),
+                op_write->rowset().segments_size(), UniqueId(_load_id).to_string(), _begin_time_ms, finish_time);
+    }
+
     return txn_log;
 }
 

--- a/be/src/storage/lake/delta_writer.h
+++ b/be/src/storage/lake/delta_writer.h
@@ -54,6 +54,8 @@ struct DeltaWriterStat {
     std::atomic_int32_t write_count = 0;
     // The number of rows to write
     std::atomic_int32_t row_count = 0;
+    // The number of bytes to write (approximate)
+    std::atomic_int64_t input_bytes = 0;
     // Accumulated time for write()
     std::atomic_int64_t write_time_ns = 0;
     // The number that memtable is full

--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -14,12 +14,15 @@
 
 #include "storage/lake/horizontal_compaction_task.h"
 
+#include "agent/master_info.h"
+#include "common/config.h"
 #include "runtime/current_thread.h"
 #include "runtime/runtime_state.h"
 #include "storage/chunk_helper.h"
 #include "storage/compaction_utils.h"
 #include "storage/lake/rowset.h"
 #include "storage/lake/tablet_reader.h"
+#include "storage/lake/tablet_write_log_manager.h"
 #include "storage/lake/tablet_writer.h"
 #include "storage/lake/txn_log.h"
 #include "storage/lake/update_manager.h"
@@ -28,6 +31,7 @@
 #include "storage/storage_engine.h"
 #include "storage/tablet_reader_params.h"
 #include "util/defer_op.h"
+#include "util/time.h"
 
 namespace starrocks::lake {
 
@@ -142,7 +146,17 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
     }
 
     LOG(INFO) << "Horizontal compaction finished. tablet: " << _tablet.id() << ", txn_id: " << _txn_id
-              << ", statistics: " << _context->stats->to_json_stats();
+              << ", statistics: " << _context->stats->to_json_stats() << ", table_id: " << _context->table_id
+              << ", partition_id: " << _context->partition_id;
+
+    if (config::enable_tablet_write_log) {
+        int64_t begin_time = _context->start_time.load(std::memory_order_relaxed) * 1000; // Convert to ms
+        int64_t finish_time = UnixMillis();
+        TabletWriteLogManager::instance()->add_compaction_log(
+                get_backend_id().value_or(0), _txn_id, _tablet.id(), _context->table_id, _context->partition_id,
+                total_num_rows, input_bytes, writer->num_rows(), writer->data_size(),
+                _context->stats->read_segment_count, writer->files().size(), 0, "horizontal", begin_time, finish_time);
+    }
 
     return Status::OK();
 }

--- a/be/src/storage/lake/tablet_write_log_manager.cpp
+++ b/be/src/storage/lake/tablet_write_log_manager.cpp
@@ -1,0 +1,141 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/tablet_write_log_manager.h"
+
+#include <chrono>
+
+#include "common/config.h"
+#include "gutil/strings/substitute.h"
+#include "util/time.h"
+
+namespace starrocks::lake {
+
+TabletWriteLogManager::TabletWriteLogManager() = default;
+
+TabletWriteLogManager* TabletWriteLogManager::instance() {
+    static TabletWriteLogManager instance;
+    return &instance;
+}
+
+void TabletWriteLogManager::add_load_log(int64_t backend_id, int64_t txn_id, int64_t tablet_id, int64_t table_id,
+                                         int64_t partition_id, int64_t input_rows, int64_t input_bytes,
+                                         int64_t output_rows, int64_t output_bytes, int32_t output_segments,
+                                         const std::string& label, int64_t begin_time, int64_t finish_time) {
+    TabletWriteLogEntry entry;
+    entry.begin_time = begin_time;
+    entry.finish_time = finish_time;
+    entry.backend_id = backend_id;
+    entry.txn_id = txn_id;
+    entry.tablet_id = tablet_id;
+    entry.table_id = table_id;
+    entry.partition_id = partition_id;
+    entry.log_type = LogType::LOAD;
+    entry.input_rows = input_rows;
+    entry.input_bytes = input_bytes;
+    entry.output_rows = output_rows;
+    entry.output_bytes = output_bytes;
+    entry.input_segments = 0; // Load does not need input_segments
+    entry.output_segments = output_segments;
+    entry.label = label;
+    entry.compaction_score = 0;
+    entry.compaction_type = "";
+
+    _add_log(std::move(entry));
+}
+
+void TabletWriteLogManager::add_compaction_log(int64_t backend_id, int64_t txn_id, int64_t tablet_id, int64_t table_id,
+                                               int64_t partition_id, int64_t input_rows, int64_t input_bytes,
+                                               int64_t output_rows, int64_t output_bytes, int32_t input_segments,
+                                               int32_t output_segments, int64_t compaction_score,
+                                               const std::string& compaction_type, int64_t begin_time,
+                                               int64_t finish_time) {
+    TabletWriteLogEntry entry;
+    entry.begin_time = begin_time;
+    entry.finish_time = finish_time;
+    entry.backend_id = backend_id;
+    entry.txn_id = txn_id;
+    entry.tablet_id = tablet_id;
+    entry.table_id = table_id;
+    entry.partition_id = partition_id;
+    entry.log_type = LogType::COMPACTION;
+    entry.input_rows = input_rows;
+    entry.input_bytes = input_bytes;
+    entry.output_rows = output_rows;
+    entry.output_bytes = output_bytes;
+    entry.input_segments = input_segments;
+    entry.output_segments = output_segments;
+    entry.label = "";
+    entry.compaction_score = compaction_score;
+    entry.compaction_type = compaction_type;
+
+    _add_log(std::move(entry));
+}
+
+void TabletWriteLogManager::_add_log(TabletWriteLogEntry entry) {
+    std::lock_guard<std::mutex> lock(_mutex);
+    _log_buffer.push_back(std::move(entry));
+    _total_logs_added.fetch_add(1, std::memory_order_relaxed);
+    _check_buffer_overflow();
+}
+
+void TabletWriteLogManager::_check_buffer_overflow() {
+    // Note: Must hold _mutex when calling this method
+    // Use config directly to support dynamic configuration changes
+    size_t max_size = config::tablet_write_log_buffer_size;
+    if (_log_buffer.size() > max_size) {
+        size_t to_remove = _log_buffer.size() - max_size;
+        _log_buffer.erase(_log_buffer.begin(), _log_buffer.begin() + to_remove);
+        _total_logs_dropped.fetch_add(to_remove, std::memory_order_relaxed);
+    }
+}
+
+std::vector<TabletWriteLogEntry> TabletWriteLogManager::get_logs(int64_t table_id, int64_t partition_id,
+                                                                 int64_t tablet_id, int64_t log_type,
+                                                                 int64_t start_finish_time,
+                                                                 int64_t end_finish_time) const {
+    std::lock_guard<std::mutex> lock(_mutex);
+    std::vector<TabletWriteLogEntry> result;
+    result.reserve(_log_buffer.size());
+
+    for (const auto& entry : _log_buffer) {
+        // Filter conditions
+        if (table_id > 0 && entry.table_id != table_id) continue;
+        if (partition_id > 0 && entry.partition_id != partition_id) continue;
+        if (tablet_id > 0 && entry.tablet_id != tablet_id) continue;
+        if (log_type > 0 && static_cast<int64_t>(entry.log_type) != log_type) continue;
+        if (start_finish_time > 0 && entry.finish_time < start_finish_time) continue;
+        if (end_finish_time > 0 && entry.finish_time > end_finish_time) continue;
+
+        result.push_back(entry);
+    }
+
+    return result;
+}
+
+void TabletWriteLogManager::cleanup_old_logs(int64_t threshold_finish_time) {
+    std::lock_guard<std::mutex> lock(_mutex);
+    auto it = std::remove_if(_log_buffer.begin(), _log_buffer.end(),
+                             [threshold_finish_time](const TabletWriteLogEntry& entry) {
+                                 return entry.finish_time < threshold_finish_time;
+                             });
+    _log_buffer.erase(it, _log_buffer.end());
+}
+
+size_t TabletWriteLogManager::size() const {
+    std::lock_guard<std::mutex> lock(_mutex);
+    return _log_buffer.size();
+}
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_write_log_manager.h
+++ b/be/src/storage/lake/tablet_write_log_manager.h
@@ -1,0 +1,122 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace starrocks::lake {
+
+// Log Type
+enum class LogType : uint8_t {
+    LOAD = 1,      // Data Load (Transaction Commit)
+    COMPACTION = 2 // Compaction
+};
+
+// Single log entry
+struct TabletWriteLogEntry {
+    int64_t begin_time;          // Begin timestamp (ms)
+    int64_t finish_time;         // Finish timestamp (ms)
+    int64_t backend_id;          // Backend ID
+    int64_t txn_id;              // Transaction ID
+    int64_t tablet_id;           // Tablet ID
+    int64_t table_id;            // Table ID
+    int64_t partition_id;        // Partition ID
+    LogType log_type;            // Log Type
+    int64_t input_rows;          // Input rows
+    int64_t input_bytes;         // Input bytes
+    int64_t output_rows;         // Output rows
+    int64_t output_bytes;        // Output bytes
+    int32_t input_segments;      // Input segment count (For Compaction)
+    int32_t output_segments;     // Output segment count
+    std::string label;           // Load label (For Load)
+    int64_t compaction_score;    // Compaction score (For Compaction)
+    std::string compaction_type; // Compaction type (For Compaction)
+
+    TabletWriteLogEntry()
+            : begin_time(0),
+              finish_time(0),
+              backend_id(0),
+              txn_id(0),
+              tablet_id(0),
+              table_id(0),
+              partition_id(0),
+              log_type(LogType::LOAD),
+              input_rows(0),
+              input_bytes(0),
+              output_rows(0),
+              output_bytes(0),
+              input_segments(0),
+              output_segments(0),
+              compaction_score(0) {}
+};
+
+// TabletWriteLogManager: Manages write logs in memory
+// Uses a ring buffer to keep recent log entries (default 30 minutes)
+class TabletWriteLogManager {
+public:
+    TabletWriteLogManager();
+    ~TabletWriteLogManager() = default;
+
+    // Disable copy
+    TabletWriteLogManager(const TabletWriteLogManager&) = delete;
+    TabletWriteLogManager& operator=(const TabletWriteLogManager&) = delete;
+
+    // Record Load log
+    void add_load_log(int64_t backend_id, int64_t txn_id, int64_t tablet_id, int64_t table_id, int64_t partition_id,
+                      int64_t input_rows, int64_t input_bytes, int64_t output_rows, int64_t output_bytes,
+                      int32_t output_segments, const std::string& label, int64_t begin_time, int64_t finish_time);
+
+    // Record Compaction log
+    void add_compaction_log(int64_t backend_id, int64_t txn_id, int64_t tablet_id, int64_t table_id,
+                            int64_t partition_id, int64_t input_rows, int64_t input_bytes, int64_t output_rows,
+                            int64_t output_bytes, int32_t input_segments, int32_t output_segments,
+                            int64_t compaction_score, const std::string& compaction_type, int64_t begin_time,
+                            int64_t finish_time);
+
+    // Get logs (For SchemaScanner query)
+    // Optional filters: table_id, partition_id, tablet_id, log_type, start_finish_time, end_finish_time
+    std::vector<TabletWriteLogEntry> get_logs(int64_t table_id = -1, int64_t partition_id = -1, int64_t tablet_id = -1,
+                                              int64_t log_type = -1, int64_t start_finish_time = 0,
+                                              int64_t end_finish_time = 0) const;
+
+    // Cleanup old logs (finish_time < threshold_time)
+    void cleanup_old_logs(int64_t threshold_finish_time);
+
+    // Get current buffer size
+    size_t size() const;
+
+    // Get singleton instance
+    static TabletWriteLogManager* instance();
+
+private:
+    // Add log to buffer (internal method)
+    void _add_log(TabletWriteLogEntry entry);
+
+    // Check and clean overflowing logs
+    void _check_buffer_overflow();
+
+    mutable std::mutex _mutex;                    // Protects _log_buffer
+    std::deque<TabletWriteLogEntry> _log_buffer;  // Ring buffer
+    std::atomic<uint64_t> _total_logs_added{0};   // Stats: Total logs added
+    std::atomic<uint64_t> _total_logs_dropped{0}; // Stats: Logs dropped due to overflow
+};
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -14,6 +14,8 @@
 
 #include "storage/lake/vertical_compaction_task.h"
 
+#include "agent/master_info.h"
+#include "common/config.h"
 #include "runtime/current_thread.h"
 #include "runtime/runtime_state.h"
 #include "storage/chunk_helper.h"
@@ -21,6 +23,7 @@
 #include "storage/lake/rowset.h"
 #include "storage/lake/tablet_metadata.h"
 #include "storage/lake/tablet_reader.h"
+#include "storage/lake/tablet_write_log_manager.h"
 #include "storage/lake/tablet_writer.h"
 #include "storage/lake/txn_log.h"
 #include "storage/lake/update_manager.h"
@@ -29,6 +32,7 @@
 #include "storage/storage_engine.h"
 #include "storage/tablet_reader_params.h"
 #include "util/defer_op.h"
+#include "util/time.h"
 
 namespace starrocks::lake {
 
@@ -114,7 +118,17 @@ Status VerticalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush
     }
 
     LOG(INFO) << "Vertical compaction finished. tablet: " << _tablet.id() << ", txn_id: " << _txn_id
-              << ", statistics: " << _context->stats->to_json_stats();
+              << ", statistics: " << _context->stats->to_json_stats() << ", table_id: " << _context->table_id
+              << ", partition_id: " << _context->partition_id;
+
+    if (config::enable_tablet_write_log) {
+        int64_t begin_time = _context->start_time.load(std::memory_order_relaxed) * 1000; // Convert to ms
+        int64_t finish_time = UnixMillis();
+        TabletWriteLogManager::instance()->add_compaction_log(
+                get_backend_id().value_or(0), _txn_id, _tablet.id(), _context->table_id, _context->partition_id,
+                _total_num_rows, input_bytes, writer->num_rows(), writer->data_size(),
+                _context->stats->read_segment_count, writer->files().size(), 0, "vertical", begin_time, finish_time);
+    }
 
     return Status::OK();
 }

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -85,6 +85,7 @@ set(EXEC_FILES
         ./exec/schema_fe_tablet_schedules_scanner_test.cpp
         ./exec/schema_materialized_views_scanner_test.cpp
         ./exec/schema_task_runs_scanner_test.cpp
+	    ./exec/schema_scanner/schema_be_tablet_write_log_scanner_test.cpp
         ./exec/sink/connector_sink_operator_test.cpp
         ./exec/sink/sink_io_buffer_test.cpp
         ./exec/stream/mem_state_table_test.cpp
@@ -533,6 +534,7 @@ SET(DW_TEST_FILES
     ./storage/lake/lake_persistent_index_fileset_test.cpp
     ./storage/lake/lake_persistent_index_parallel_compact_mgr_test.cpp
     ./storage/lake/lake_persistent_index_size_tiered_compaction_strategy_test.cpp
+    ./storage/lake/tablet_write_log_manager_test.cpp
     ./storage/load_spill_block_manager_test.cpp
     ./storage/memtable_flush_executor_test.cpp
     ./storage/memtable_test.cpp

--- a/be/test/exec/schema_scanner/schema_be_tablet_write_log_scanner_test.cpp
+++ b/be/test/exec/schema_scanner/schema_be_tablet_write_log_scanner_test.cpp
@@ -1,0 +1,124 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/schema_scanner/schema_be_tablet_write_log_scanner.h"
+
+#include <gtest/gtest.h>
+
+#include "column/column_helper.h"
+#include "runtime/runtime_state.h"
+#include "storage/lake/tablet_write_log_manager.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+class SchemaBeTabletWriteLogScannerTest : public ::testing::Test {
+private:
+    ChunkPtr create_chunk(const std::vector<SlotDescriptor*> slot_descs) {
+        ChunkPtr chunk = std::make_shared<Chunk>();
+        for (const auto* slot_desc : slot_descs) {
+            MutableColumnPtr column = ColumnHelper::create_column(slot_desc->type(), slot_desc->is_nullable());
+            chunk->append_column(std::move(column), slot_desc->id());
+        }
+        return chunk;
+    }
+};
+
+TEST_F(SchemaBeTabletWriteLogScannerTest, test_normal) {
+    SchemaBeTabletWriteLogScanner scanner;
+    SchemaScannerParam params;
+    std::string ip = "127.0.0.1";
+    params.ip = &ip;
+    params.port = 9020;
+    ObjectPool pool;
+    RuntimeState state(TUniqueId(), TQueryOptions(), TQueryGlobals(), nullptr);
+    state.init_instance_mem_tracker();
+
+    // prepare data
+    auto mgr = lake::TabletWriteLogManager::instance();
+    // Clear logs
+    mgr->cleanup_old_logs(std::numeric_limits<int64_t>::max());
+
+    // Add logs
+    mgr->add_load_log(1001, 100, 30, 10, 20, 100, 1000, 100, 2000, 5, "label1", 1686000000000, 1686000010000);
+    mgr->add_compaction_log(1001, 200, 31, 11, 21, 200, 2000, 150, 1500, 10, 5, 80, "base", 1686000020000,
+                            1686000030000);
+
+    // init and start scanner
+    EXPECT_OK(scanner.init(&params, &pool));
+    EXPECT_OK(scanner.start(&state));
+
+    // check get_next
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
+
+    EXPECT_OK(scanner.get_next(&chunk, &eos));
+    EXPECT_FALSE(eos);
+    EXPECT_EQ(2, chunk->num_rows());
+
+    // Verify first row (LOAD)
+    auto row0 = chunk->debug_row(0);
+    EXPECT_TRUE(row0.find("1001") != std::string::npos);   // be_id
+    EXPECT_TRUE(row0.find("LOAD") != std::string::npos);   // log_type
+    EXPECT_TRUE(row0.find("label1") != std::string::npos); // label
+
+    // Verify second row (COMPACTION)
+    auto row1 = chunk->debug_row(1);
+    EXPECT_TRUE(row1.find("1001") != std::string::npos);       // be_id
+    EXPECT_TRUE(row1.find("COMPACTION") != std::string::npos); // log_type
+    EXPECT_TRUE(row1.find("base") != std::string::npos);       // compaction_type
+
+    chunk->reset();
+    EXPECT_OK(scanner.get_next(&chunk, &eos));
+    EXPECT_TRUE(eos);
+}
+
+TEST_F(SchemaBeTabletWriteLogScannerTest, test_get_next_overflow) {
+    SchemaBeTabletWriteLogScanner scanner;
+    SchemaScannerParam params;
+    std::string ip = "127.0.0.1";
+    params.ip = &ip;
+    params.port = 9020;
+    ObjectPool pool;
+    RuntimeState state(TUniqueId(), TQueryOptions(), TQueryGlobals(), nullptr);
+    state.init_instance_mem_tracker();
+
+    // Set chunk size smaller than log count to test multiple batches
+    // Note: Can't easily change chunk size on RuntimeState directly as it defaults to 4096
+    // So we add enough logs or just rely on standard behavior
+
+    auto mgr = lake::TabletWriteLogManager::instance();
+    mgr->cleanup_old_logs(std::numeric_limits<int64_t>::max());
+
+    for (int i = 0; i < 5000; ++i) {
+        mgr->add_load_log(1, i, 1, 1, 1, 1, 1, 1, 1, 1, "l", 0, 0);
+    }
+
+    EXPECT_OK(scanner.init(&params, &pool));
+    EXPECT_OK(scanner.start(&state));
+
+    auto chunk = create_chunk(scanner.get_slot_descs());
+    bool eos = false;
+    int total_rows = 0;
+
+    while (!eos) {
+        chunk->reset();
+        EXPECT_OK(scanner.get_next(&chunk, &eos));
+        total_rows += chunk->num_rows();
+    }
+
+    EXPECT_EQ(5000, total_rows);
+}
+
+} // namespace starrocks

--- a/be/test/storage/lake/tablet_write_log_manager_test.cpp
+++ b/be/test/storage/lake/tablet_write_log_manager_test.cpp
@@ -1,0 +1,118 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/tablet_write_log_manager.h"
+
+#include <gtest/gtest.h>
+
+#include "common/config.h"
+
+namespace starrocks::lake {
+
+class TabletWriteLogManagerTest : public testing::Test {
+public:
+    void SetUp() override {
+        // Clear logs by setting a very future timestamp
+        TabletWriteLogManager::instance()->cleanup_old_logs(std::numeric_limits<int64_t>::max());
+    }
+    void TearDown() override {
+        TabletWriteLogManager::instance()->cleanup_old_logs(std::numeric_limits<int64_t>::max());
+    }
+};
+
+TEST_F(TabletWriteLogManagerTest, test_add_and_get_logs) {
+    auto mgr = TabletWriteLogManager::instance();
+    mgr->add_load_log(1, 100, 200, 300, 400, 10, 1000, 10, 2000, 5, "label1", 10000, 20000);
+
+    auto logs = mgr->get_logs();
+    ASSERT_EQ(1, logs.size());
+    auto& log = logs[0];
+    EXPECT_EQ(1, log.backend_id);
+    EXPECT_EQ(100, log.txn_id);
+    EXPECT_EQ(lake::LogType::LOAD, log.log_type);
+    EXPECT_EQ("label1", log.label);
+    EXPECT_EQ(10, log.input_rows);
+    EXPECT_EQ(1000, log.input_bytes);
+    EXPECT_EQ(0, log.input_segments);
+    EXPECT_EQ(5, log.output_segments);
+}
+
+TEST_F(TabletWriteLogManagerTest, test_buffer_overflow) {
+    auto mgr = TabletWriteLogManager::instance();
+    int32_t original_size = config::tablet_write_log_buffer_size;
+    config::tablet_write_log_buffer_size = 5;
+
+    for (int i = 0; i < 10; ++i) {
+        mgr->add_load_log(1, i, 200, 300, 400, 10, 1000, 10, 2000, 5, "label", 10000 + i, 20000 + i);
+    }
+
+    ASSERT_EQ(5, mgr->size());
+    auto logs = mgr->get_logs();
+    ASSERT_EQ(5, logs.size());
+    // Should contain the last 5 logs (5, 6, 7, 8, 9)
+    EXPECT_EQ(5, logs[0].txn_id);
+    EXPECT_EQ(9, logs[4].txn_id);
+
+    config::tablet_write_log_buffer_size = original_size;
+}
+
+TEST_F(TabletWriteLogManagerTest, test_cleanup_old_logs) {
+    auto mgr = TabletWriteLogManager::instance();
+    mgr->add_load_log(1, 1, 200, 300, 400, 10, 1000, 10, 2000, 5, "label1", 10000, 20000); // finish 20000
+    mgr->add_load_log(1, 2, 200, 300, 400, 10, 1000, 10, 2000, 5, "label2", 30000, 40000); // finish 40000
+
+    mgr->cleanup_old_logs(30000); // Remove logs finished before 30000
+    ASSERT_EQ(1, mgr->size());
+    auto logs = mgr->get_logs();
+    EXPECT_EQ(2, logs[0].txn_id);
+}
+
+TEST_F(TabletWriteLogManagerTest, test_filters) {
+    auto mgr = TabletWriteLogManager::instance();
+    // Log 1: Table 10, Partition 20, Tablet 30, LOAD
+    mgr->add_load_log(1, 1, 30, 10, 20, 10, 1000, 10, 2000, 5, "label1", 10000, 20000);
+    // Log 2: Table 11, Partition 21, Tablet 31, COMPACTION
+    mgr->add_compaction_log(1, 2, 31, 11, 21, 10, 1000, 10, 2000, 5, 5, 100, "base", 30000, 40000);
+
+    // Filter by table_id
+    auto logs = mgr->get_logs(10);
+    ASSERT_EQ(1, logs.size());
+    EXPECT_EQ(1, logs[0].txn_id);
+
+    // Filter by partition_id
+    logs = mgr->get_logs(0, 21);
+    ASSERT_EQ(1, logs.size());
+    EXPECT_EQ(2, logs[0].txn_id);
+
+    // Filter by tablet_id
+    logs = mgr->get_logs(0, 0, 30);
+    ASSERT_EQ(1, logs.size());
+    EXPECT_EQ(1, logs[0].txn_id);
+
+    // Filter by log_type
+    logs = mgr->get_logs(0, 0, 0, (int64_t)lake::LogType::COMPACTION);
+    ASSERT_EQ(1, logs.size());
+    EXPECT_EQ(2, logs[0].txn_id);
+
+    // Filter by time range
+    logs = mgr->get_logs(0, 0, 0, 0, 30000); // start_finish_time = 30000
+    ASSERT_EQ(1, logs.size());
+    EXPECT_EQ(2, logs[0].txn_id);
+
+    logs = mgr->get_logs(0, 0, 0, 0, 0, 30000); // end_finish_time = 30000
+    ASSERT_EQ(1, logs.size());
+    EXPECT_EQ(1, logs[0].txn_id);
+}
+
+} // namespace starrocks::lake

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/SystemId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/SystemId.java
@@ -110,6 +110,8 @@ public class SystemId {
 
     public static final long FE_THREADS_ID = 46L;
 
+    public static final long BE_TABLET_WRITE_LOG_ID = 47L;
+
     public static final long SYS_DB_ID = 100L;
 
     public static final long ROLE_EDGES_ID = 101L;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeTabletWriteLogSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeTabletWriteLogSystemTable.java
@@ -1,0 +1,56 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog.system.information;
+
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.system.SystemId;
+import com.starrocks.catalog.system.SystemTable;
+import com.starrocks.thrift.TSchemaTableType;
+import com.starrocks.type.DateType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.TypeFactory;
+
+import static com.starrocks.catalog.system.SystemTable.builder;
+
+public class BeTabletWriteLogSystemTable {
+    public static final String NAME = "be_tablet_write_log";
+
+    public static SystemTable create() {
+        return new SystemTable(SystemId.BE_TABLET_WRITE_LOG_ID,
+                NAME,
+                Table.TableType.SCHEMA,
+                builder()
+                        .column("BE_ID", IntegerType.BIGINT)
+                        .column("BEGIN_TIME", DateType.DATETIME)
+                        .column("FINISH_TIME", DateType.DATETIME)
+                        .column("TXN_ID", IntegerType.BIGINT)
+                        .column("TABLET_ID", IntegerType.BIGINT)
+                        .column("TABLE_ID", IntegerType.BIGINT)
+                        .column("PARTITION_ID", IntegerType.BIGINT)
+                        .column("LOG_TYPE", TypeFactory.createVarcharType(64))
+                        .column("INPUT_ROWS", IntegerType.BIGINT)
+                        .column("INPUT_BYTES", IntegerType.BIGINT)
+                        .column("OUTPUT_ROWS", IntegerType.BIGINT)
+                        .column("OUTPUT_BYTES", IntegerType.BIGINT)
+                        .column("INPUT_SEGMENTS", IntegerType.INT)
+                        .column("OUTPUT_SEGMENTS", IntegerType.INT)
+                        .column("LABEL", TypeFactory.createVarcharType(1024))
+                        .column("COMPACTION_SCORE", IntegerType.BIGINT)
+                        .column("COMPACTION_TYPE", TypeFactory.createVarcharType(64))
+                        .build(),
+                TSchemaTableType.SCH_BE_TABLET_WRITE_LOG);
+    }
+}
+

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/InfoSchemaDb.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/InfoSchemaDb.java
@@ -95,6 +95,7 @@ public class InfoSchemaDb extends Database {
             super.registerTableUnlocked(WarehouseMetricsSystemTable.create());
             super.registerTableUnlocked(WarehouseQueriesSystemTable.create());
             super.registerTableUnlocked(TabletReshardJobsTable.create());
+            super.registerTableUnlocked(BeTabletWriteLogSystemTable.create());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/TabletWriteLogHistorySyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/TabletWriteLogHistorySyncer.java
@@ -1,0 +1,116 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake;
+
+import com.starrocks.catalog.CatalogUtils;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.qe.SimpleExecutor;
+import com.starrocks.scheduler.history.TableKeeper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class TabletWriteLogHistorySyncer extends FrontendDaemon {
+    private static final Logger LOG = LogManager.getLogger(TabletWriteLogHistorySyncer.class);
+
+    public static final String DB_NAME = "_statistics_";
+    public static final String TABLE_NAME = "tablet_write_log_history";
+
+    // Default retention days: 7
+    private static final int RETAINED_DAYS = 7;
+
+    private static final String TABLE_CREATE =
+            String.format("CREATE TABLE IF NOT EXISTS %s (" +
+                            "be_id bigint NOT NULL, " +
+                            "begin_time datetime NOT NULL, " +
+                            "finish_time datetime NOT NULL, " +
+                            "txn_id bigint, " +
+                            "tablet_id bigint, " +
+                            "table_id bigint, " +
+                            "partition_id bigint, " +
+                            "log_type varchar(64), " +
+                            "input_rows bigint, " +
+                            "input_bytes bigint, " +
+                            "output_rows bigint, " +
+                            "output_bytes bigint, " +
+                            "input_segments int, " +
+                            "output_segments int, " +
+                            "label varchar(1024), " +
+                            "compaction_score bigint, " +
+                            "compaction_type varchar(64)" +
+                            ") " +
+                            "PARTITION BY date_trunc('DAY', finish_time) " +
+                            "DISTRIBUTED BY HASH(tablet_id) BUCKETS 3 " +
+                            "PROPERTIES( " +
+                            "'partition_live_number' = '" + RETAINED_DAYS + "'" +
+                            ")",
+                    TABLE_NAME);
+
+    private static final String SYNC_SQL =
+            "INSERT INTO %s " +
+            "SELECT " +
+            "be_id, begin_time, finish_time, txn_id, tablet_id, table_id, partition_id, log_type, " +
+            "input_rows, input_bytes, output_rows, output_bytes, input_segments, output_segments, " +
+            "label, compaction_score, compaction_type " +
+            "FROM information_schema.be_tablet_write_log " +
+            "WHERE finish_time > (SELECT COALESCE(MAX(finish_time), '0001-01-01 00:00:00') FROM %s) " +
+            "AND finish_time < NOW() - INTERVAL 1 MINUTE";
+
+    private boolean firstSync = true;
+
+    private static final TableKeeper KEEPER =
+            new TableKeeper(DB_NAME, TABLE_NAME, TABLE_CREATE, () -> RETAINED_DAYS);
+
+    public static TableKeeper createKeeper() {
+        return KEEPER;
+    }
+
+    public TabletWriteLogHistorySyncer() {
+        super("TabletWriteLogHistorySyncer", 60 * 1000L); // 60s interval
+    }
+
+    @Override
+    protected void runAfterCatalogReady() {
+        if (FeConstants.runningUnitTest) {
+            return;
+        }
+        try {
+            // wait table keeper to create table
+            if (firstSync) {
+                firstSync = false;
+                return;
+            }
+            syncData();
+        } catch (Throwable e) {
+            LOG.warn("Failed to process one round of TabletWriteLogHistorySyncer with error message {}", e.getMessage(), e);
+        }
+    }
+
+    public void syncData() {
+        // TODO: Can add a switch to control whether to enable synchronization
+        try {
+            SimpleExecutor.getRepoExecutor().executeDML(SQLBuilder.buildSyncSql());
+        } catch (Exception e) {
+            LOG.error("Failed to sync tablet write log history", e);
+        }
+    }
+
+    static class SQLBuilder {
+        public static String buildSyncSql() {
+            String tableName = CatalogUtils.normalizeTableName(DB_NAME, TABLE_NAME);
+            return String.format(SYNC_SQL, tableName, tableName);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
@@ -201,6 +201,7 @@ public class TableKeeper {
 
             keeperList.add(TaskRunHistoryTable.createKeeper());
             keeperList.add(LoadsHistorySyncer.createKeeper());
+            keeperList.add(com.starrocks.lake.TabletWriteLogHistorySyncer.createKeeper());
             keeperList.add(PredicateColumnsStorage.createKeeper());
             // TODO: add FileListPipeRepo
             // TODO: add statistic table

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -137,6 +137,7 @@ import com.starrocks.journal.JournalWriter;
 import com.starrocks.journal.bdbje.Timestamp;
 import com.starrocks.lake.StarMgrMetaSyncer;
 import com.starrocks.lake.StarOSAgent;
+import com.starrocks.lake.TabletWriteLogHistorySyncer;
 import com.starrocks.lake.compaction.CompactionControlScheduler;
 import com.starrocks.lake.compaction.CompactionMgr;
 import com.starrocks.lake.snapshot.ClusterSnapshotMgr;
@@ -408,6 +409,7 @@ public class GlobalStateMgr {
 
     private final LoadTimeoutChecker loadTimeoutChecker;
     private final LoadsHistorySyncer loadsHistorySyncer;
+    private final TabletWriteLogHistorySyncer tabletWriteLogHistorySyncer;
     private final LoadEtlChecker loadEtlChecker;
     private final LoadLoadingChecker loadLoadingChecker;
     private final LockChecker lockChecker;
@@ -739,6 +741,7 @@ public class GlobalStateMgr {
         this.loadMgr = new LoadMgr(loadJobScheduler);
         this.loadTimeoutChecker = new LoadTimeoutChecker(loadMgr);
         this.loadsHistorySyncer = new LoadsHistorySyncer();
+        this.tabletWriteLogHistorySyncer = new TabletWriteLogHistorySyncer();
         this.loadEtlChecker = new LoadEtlChecker(loadMgr);
         this.loadLoadingChecker = new LoadLoadingChecker(loadMgr);
         this.lockChecker = new LockChecker();
@@ -1408,6 +1411,7 @@ public class GlobalStateMgr {
         loadJobScheduler.start();
         loadTimeoutChecker.start();
         loadsHistorySyncer.start();
+        tabletWriteLogHistorySyncer.start();
         loadEtlChecker.start();
         loadLoadingChecker.start();
         // Export checker

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
@@ -230,6 +230,12 @@ public class CompactionSchedulerTest {
             }
         };
 
+        new MockUp<AggregateCompactionTask>() {
+            @Mock
+            public void sendRequest() {
+            }
+        };
+
         CompactionWarehouseInfo info = new CompactionWarehouseInfo("aaa", WarehouseManager.DEFAULT_RESOURCE, 0, 0);
         table.setState(OlapTable.OlapTableState.NORMAL);
         compactionScheduler.startCompaction(snapshot, info);

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -207,6 +207,8 @@ enum TSchemaTableType {
     SCH_RECYCLEBIN_CATALOGS,
 
     SCH_FE_THREADS,
+
+    SCH_BE_TABLET_WRITE_LOG
 }
 
 enum THdfsCompression {


### PR DESCRIPTION
## Why I'm doing:

To provide visibility into tablet write operations (including load and compaction) for monitoring and analyzing write amplification in the storage layer. Without this feature, it is difficult to understand the I/O behavior of tablets and diagnose write amplification issues that can impact storage efficiency and performance.

## What I'm doing:

* Add a new be_tablet_write_log system table in information_schema to expose tablet write operations
Implement TabletWriteLogManager in BE to capture and buffer write logs from both load and compaction tasks, with configurable buffer size and retention time
* Create SchemaBeTabletWriteLogScanner to scan write log entries from memory buffer
* Add TabletWriteLogHistorySyncer in FE to periodically sync write log data from all BEs to a persistent history table (_statistics_.table_write_log)
* Extend CompactRequest protobuf with table_id and partition_id fields to enable complete tracking of compaction operations
* Add new configuration options: enable_tablet_write_log, tablet_write_log_buffer_size (default 100000), and tablet_write_log_retention_time_ms (default 30 minutes)
* The write log tracks key metrics including: txn_id, tablet_id, table_id, partition_id, log_type (LOAD/COMPACTION), input/output rows and bytes, segment counts, and compaction metadata

Fixes #66457

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce tablet write logging across BE load/compaction with an information_schema table and FE sync to a history table, gated by new configs.
> 
> - **Backend (BE)**:
>   - **Write Log Infrastructure**: Add `lake/TabletWriteLogManager` with in-memory ring buffer and filters; expose via new schema scanner `SchemaBeTabletWriteLogScanner` and register `SCH_BE_TABLET_WRITE_LOG`.
>   - **Load/Compaction Logging**: Instrument `DeltaWriter` and horizontal/vertical compaction tasks to record LOAD/COMPACTION logs; track `input_bytes` and operation begin/end times.
>   - **Compaction Context**: Extend `CompactionTaskContext` with `table_id`/`partition_id`; populate from StarOS in `TabletManager::compact`.
>   - **Build**: Wire new sources into CMake.
> - **Frontend (FE)**:
>   - **Information Schema**: Add `information_schema.be_tablet_write_log` table and register in `InfoSchemaDb`/`SystemId`.
>   - **History Sync**: Introduce `TabletWriteLogHistorySyncer` and hook into `GlobalStateMgr` and `TableKeeper` to periodically persist BE logs to `_statistics_.tablet_write_log_history`.
> - **Config**:
>   - Add `enable_tablet_write_log` (off by default) and `tablet_write_log_buffer_size` (default `100000`).
> - **Thrift/Enums**:
>   - Add `SCH_BE_TABLET_WRITE_LOG` to `TSchemaTableType` and factory mapping.
> - **Tests**:
>   - Add unit tests for log manager and schema scanner; update FE compaction tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f68756b203412c93b608b4bcd9a483b70dc6d45f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->