### PR TITLE
[BugFix] Multi_distinct_count using Two-level hashset misses updating distinct_size

### DIFF
--- a/be/src/exprs/agg/distinct.h
+++ b/be/src/exprs/agg/distinct.h
@@ -169,6 +169,7 @@ struct AdaptiveSliceHashSet {
                 assert(pos != nullptr);
                 memcpy(pos, key.data, key.size);
                 ctor(pos, key.size, key.hash);
+                distinct_size++;
             });
         }
     }

--- a/test/sql/test_multi_distinct_count_using_two_level_hashset/R/test_multi_distinct_count_using_two_level_hashset
+++ b/test/sql/test_multi_distinct_count_using_two_level_hashset/R/test_multi_distinct_count_using_two_level_hashset
@@ -1,0 +1,29 @@
+-- name: test_multi_distinct_count_using_two_level_hashset
+CREATE TABLE `t0` (
+  `c0` bigint NOT NULL COMMENT "",
+  `c1` datetime NOT NULL COMMENT "",
+  `c2` bigint NOT NULL,
+  `c3` string NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`c0`, `c1`)
+COMMENT "OLAP"
+PARTITION BY date_trunc('DAY', c1)
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1 
+ORDER BY(`c2`, `c1`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t0 select 
+	i as c0, 
+	milliseconds_add('2025-01-01 00:00:00', i%8640000) as c1 ,
+	4000000000 - i as c2,
+	right(concat(repeat('x',512), i),512) as c3
+from table(generate_series(1,69632)) t(i);
+-- result:
+-- !result
+select assert_true(count(distinct c3) = count(1)) from t0;
+-- result:
+1
+-- !result

--- a/test/sql/test_multi_distinct_count_using_two_level_hashset/T/test_multi_distinct_count_using_two_level_hashset
+++ b/test/sql/test_multi_distinct_count_using_two_level_hashset/T/test_multi_distinct_count_using_two_level_hashset
@@ -1,0 +1,24 @@
+-- name: test_multi_distinct_count_using_two_level_hashset
+CREATE TABLE `t0` (
+  `c0` bigint NOT NULL COMMENT "",
+  `c1` datetime NOT NULL COMMENT "",
+  `c2` bigint NOT NULL,
+  `c3` string NOT NULL
+) ENGINE=OLAP 
+PRIMARY KEY(`c0`, `c1`)
+COMMENT "OLAP"
+PARTITION BY date_trunc('DAY', c1)
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1 
+ORDER BY(`c2`, `c1`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into t0 select 
+	i as c0, 
+	milliseconds_add('2025-01-01 00:00:00', i%8640000) as c1 ,
+	4000000000 - i as c2,
+	right(concat(repeat('x',512), i),512) as c3
+from table(generate_series(1,69632)) t(i);
+
+select assert_true(count(distinct c3) = count(1)) from t0;


### PR DESCRIPTION
## Why I'm doing:
when hashset used by multi_distinct_count agg becomes large(rows>=64K and bytes>=32MB), it is converted into two-level hashset. in lazy_emplace_with_hash method of this hashset, distinct_size is not updating when inserting new rows. this method is used by non-group-by agg via update_batch_single_state.
```
  lazy_emplace_with_hash
  └── update_with_hash	[vim be/src/exprs/agg/distinct.h +128]
      └── update_batch_single_state	[vim be/src/exprs/agg/distinct.h +298]
```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure distinct_size updates when inserting into two-level hashset via lazy_emplace_with_hash; add SQL regression test for multi distinct count.
> 
> - **Agg distinct (strings)**:
>   - Increment `distinct_size` when inserting into `two_level_set` in `AdaptiveSliceHashSet::lazy_emplace_with_hash` (`be/src/exprs/agg/distinct.h`).
> - **Tests**:
>   - Add SQL test `test/sql/test_multi_distinct_count_using_two_level_hashset/*` verifying `count(distinct c3)` matches row count after triggering two-level hashset.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e3cc39808b2a5fca1ad327cbb7a09db1fd6f5f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->