### PR TITLE
[BugFix] fix iceberg table cache bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -17,11 +17,6 @@ package com.starrocks.connector.iceberg;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.github.benmanes.caffeine.cache.Weigher;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
-import com.google.common.cache.RemovalNotification;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.IcebergTable;
@@ -65,7 +60,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 
-import static com.google.common.cache.CacheLoader.asyncReloading;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class CachingIcebergCatalog implements IcebergCatalog {
@@ -76,8 +70,8 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     private static final int MEMORY_FILE_SAMPLES = 100;
     private final String catalogName;
     private final IcebergCatalog delegate;
-    private final LoadingCache<IcebergTableCacheKey, Table> tables;
-    private final Cache<String, Database> databases;
+    private final com.github.benmanes.caffeine.cache.LoadingCache<IcebergTableCacheKey, Table> tables;
+    private final com.github.benmanes.caffeine.cache.Cache<String, Database> databases;
     private final ExecutorService backgroundExecutor;
 
     private final IcebergCatalogProperties icebergProperties;
@@ -87,7 +81,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     private final Map<IcebergTableName, Long> tableLatestAccessTime = new ConcurrentHashMap<>();
     private final Map<IcebergTableName, Long> tableLatestRefreshTime = new ConcurrentHashMap<>();
 
-    private final LoadingCache<IcebergTableName, Map<String, Partition>> partitionCache;
+    private final com.github.benmanes.caffeine.cache.LoadingCache<IcebergTableName, Map<String, Partition>> partitionCache;
 
     public CachingIcebergCatalog(String catalogName, IcebergCatalog delegate, IcebergCatalogProperties icebergProperties,
                                  ExecutorService executorService) {
@@ -98,30 +92,39 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         boolean enableTableCache = icebergProperties.isEnableIcebergTableCache();
         this.databases = newCacheBuilder(icebergProperties.getIcebergMetaCacheTtlSec(), NEVER_CACHE,
                 enableCache ? DEFAULT_CACHE_NUM : NEVER_CACHE).build();
-        this.tables = newCacheBuilder(icebergProperties.getIcebergMetaCacheTtlSec(),
+        this.tables = newCacheBuilder(
+                icebergProperties.getIcebergMetaCacheTtlSec(),
                 icebergProperties.getIcebergTableCacheRefreshIntervalSec(),
                 enableTableCache ? DEFAULT_CACHE_NUM : NEVER_CACHE)
-                .removalListener((RemovalNotification<IcebergTableCacheKey, Table> n) -> {
-                    LOG.debug("iceberg table cache removal: {}.{}, cause={}, evicted={}",
-                            n.getKey().icebergTableName.dbName, n.getKey().icebergTableName.tableName,
-                            n.getCause(), n.wasEvicted());
+                .executor(executorService)
+                .removalListener((IcebergTableCacheKey key, Table value, RemovalCause cause) -> {
+                    if (key != null) {
+                        LOG.debug("iceberg table cache removal: {}.{}, cause={}, evicted={}",
+                                key.icebergTableName.dbName, key.icebergTableName.tableName,
+                                cause, cause.wasEvicted());
+                    }
                 })
-                .build(asyncReloading(CacheLoader.from(key -> {
-                    LOG.debug("Loading iceberg table {}.{} from remote catalog",
-                                    key.icebergTableName.dbName, key.icebergTableName.tableName);
-                    return delegate.getTable(key.connectContext, 
-                                    key.icebergTableName.dbName, key.icebergTableName.tableName);
-                }), executorService));  
+                .build(new com.github.benmanes.caffeine.cache.CacheLoader<IcebergTableCacheKey, Table>() {
+                    @Override
+                    public Table load(IcebergTableCacheKey key) throws Exception {
+                        LOG.debug("Loading iceberg table {}.{} from remote catalog",
+                                key.icebergTableName.dbName, key.icebergTableName.tableName);
+                        return delegate.getTable(key.connectContext, key.icebergTableName.dbName,
+                                key.icebergTableName.tableName);
+                    }
+                });
         this.partitionCache = newCacheBuilder(icebergProperties.getIcebergMetaCacheTtlSec(), NEVER_CACHE,
                 enableCache ? DEFAULT_CACHE_NUM : NEVER_CACHE).build(
-                CacheLoader.from(key -> {
-                    Table nativeTable = getTable(new ConnectContext(), key.dbName, key.tableName);
-                    IcebergTable icebergTable =
-                            IcebergTable.builder().setCatalogDBName(key.dbName).setCatalogTableName(key.tableName)
-                                    .setNativeTable(nativeTable).build();
-                    return delegate.getPartitions(icebergTable, key.snapshotId, null);
-                }));
-
+                    new com.github.benmanes.caffeine.cache.CacheLoader<IcebergTableName, Map<String, Partition>>() {
+                        @Override
+                        public Map<String, Partition> load(IcebergTableName key) throws Exception {
+                            Table nativeTable = getTable(new ConnectContext(), key.dbName, key.tableName);
+                            IcebergTable icebergTable =
+                                    IcebergTable.builder().setCatalogDBName(key.dbName).setCatalogTableName(key.tableName)
+                                            .setNativeTable(nativeTable).build();
+                            return delegate.getPartitions(icebergTable, key.snapshotId, null);
+                        }
+                    });
         long dataFileCacheSize = Math.round(Runtime.getRuntime().maxMemory() *
                 icebergProperties.getIcebergDataFileCacheMemoryUsageRatio());
         long deleteFileCacheSize = Math.round(Runtime.getRuntime().maxMemory() *
@@ -210,8 +213,8 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         }
 
         // do not cache if jwt or oauth2 is not used OR if it is not a REST Catalog.
-        boolean cacheAllowed = Strings.isNullOrEmpty(connectContext.getAuthToken())
-                       || !(delegate instanceof IcebergRESTCatalog);
+        boolean cacheAllowed = icebergProperties.isEnableIcebergTableCache() && 
+                (Strings.isNullOrEmpty(connectContext.getAuthToken()) || !(delegate instanceof IcebergRESTCatalog));
         if (!cacheAllowed) {
             return delegate.getTable(connectContext, dbName, tableName);
         }
@@ -291,7 +294,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                                                 ExecutorService executorService) {
         IcebergTableName key =
                 new IcebergTableName(icebergTable.getCatalogDBName(), icebergTable.getCatalogTableName(), snapshotId);
-        return partitionCache.getUnchecked(key);
+        return partitionCache.get(key);
     }
 
     @Override
@@ -368,7 +371,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         long updatedSnapshotId = updatedTable.currentSnapshot().snapshotId();
         IcebergTableName baseIcebergTableName = new IcebergTableName(dbName, tableName, baseSnapshotId);
         IcebergTableName updatedIcebergTableName = new IcebergTableName(dbName, tableName, updatedSnapshotId);
-        IcebergTableCacheKey baseKey = new IcebergTableCacheKey(baseIcebergTableName, ctx);
+        IcebergTableCacheKey keyWithoutSnap = new IcebergTableCacheKey(new IcebergTableName(dbName, tableName), ctx);
         IcebergTableCacheKey updateKey = new IcebergTableCacheKey(updatedIcebergTableName, ctx);
         long latestRefreshTime = tableLatestRefreshTime.computeIfAbsent(new IcebergTableName(dbName, tableName), ignore -> -1L);
 
@@ -376,11 +379,11 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         // so when refreshing partition cache, `getTables` can return the latest one.
         // another way to fix is to call `delegate.getTables` when refreshing partition cache.
         synchronized (this) {
-            tables.put(updateKey, updatedTable);
+            tables.put(keyWithoutSnap, updatedTable);
         }
 
         partitionCache.invalidate(baseIcebergTableName);
-        partitionCache.getUnchecked(updatedIcebergTableName);
+        partitionCache.get(updatedIcebergTableName);
 
         TableMetadata updatedTableMetadata = updatedTable.operations().current();
         List<ManifestFile> manifestFiles = updatedTable.currentSnapshot().dataManifests(updatedTable.io()).stream()
@@ -443,16 +446,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     }
 
     private void invalidateCache(IcebergTableName key) {
-        if (key.ignoreSnapshotId) {
-            // invalidate all snapshots of this table if snapshotId is not specified
-            tables.asMap().keySet().stream()
-                    .filter(k -> k.icebergTableName.dbName.equals(key.dbName) &&
-                            k.icebergTableName.tableName.equals(key.tableName))
-                    .forEach(tables::invalidate);
-        } else {
-            // only invalidate the specified snapshot
-            tables.invalidate(new IcebergTableCacheKey(key, new ConnectContext()));
-        }
+        tables.invalidate(new IcebergTableCacheKey(key, new ConnectContext()));
         // will invalidate all snapshots of this table
         partitionCache.invalidate(key);
         Set<String> paths = metaFileCacheMap.get(key);
@@ -475,8 +469,9 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         return delegate.getTableScan(table, scanContext);
     }
 
-    private CacheBuilder<Object, Object> newCacheBuilder(long expiresAfterWriteSec, long refreshInterval, long maximumSize) {
-        CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder();
+    private Caffeine<Object, Object> newCacheBuilder(long expiresAfterWriteSec, long refreshInterval,
+                                                         long maximumSize) {
+        Caffeine<Object, Object> cacheBuilder = Caffeine.newBuilder();
         if (expiresAfterWriteSec >= 0) {
             cacheBuilder.expireAfterWrite(expiresAfterWriteSec, SECONDS);
         }
@@ -578,7 +573,7 @@ public class CachingIcebergCatalog implements IcebergCatalog {
                         .stream()
                         .limit(MEMORY_META_SAMPLES)
                         .collect(Collectors.toList()),
-                databases.size());
+                databases.estimatedSize());
 
         List<List<String>> partitionNames = getAllCachedPartitionNames();
         List<Object> partitions = partitionNames
@@ -619,8 +614,8 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     public Map<String, Long> estimateCount() {
         Map<String, Long> counter = new HashMap<>();
         List<List<String>> partitionNames = getAllCachedPartitionNames();
-        counter.put("Database", databases.size());
-        counter.put("Table", tables.size());
+        counter.put("Database", databases.estimatedSize());
+        counter.put("Table", tables.estimatedSize());
         counter.put("PartitionNames", partitionNames
                 .stream()
                 .mapToLong(List::size)


### PR DESCRIPTION
## Why I'm doing:
<img width="1536" height="826" alt="image" src="https://github.com/user-attachments/assets/8c331f70-033d-4855-9a91-18bad013d967" />

In our Iceberg catalog, we observed that Guava’s LocalCache can enter a weird state. Specifically:
	1.	cache.size() becomes 0, indicating that the cache believes it contains no active entries.
	2.	However, some Segment in the cache still retains stale StrongAccessWriteEntry objects, which remain in memory for over 10 hours.
	3.	A call for get(key) will return the value associated with this stale entry via LoadingValueReference.futureValue.
while getIfPresent(key) returns null, because the entry is already considered inactive by the cache’s bookkeeping.

This condition leads to two major issues:
	1.	Refresh becomes ineffective, since refresh will call getIfPresent to judge if continue.
	2.	Reads always return stale results, and async reload judge the value is loading, become ineffective too.

Some unusual behaviors of the CachingIcebergCatalog may have triggered this cache bug:
	1.	Iceberg caches multiple table entries for different snapshots of the same table,
while IcebergTableName.equals() does not strictly satisfy the commutative property,
which may cause the Guava bugs.
	2.	Guava’s cache appears to suffer from several long-standing concurrency issues that still persist today, as referenced in
https://github.com/google/guava/issues/1881 and https://github.com/google/guava/issues/2971.

## What I'm doing:

1.	The table cache should store only the newest object per table. The snapshotId does not necessarily need to be part of the cache key.
2.	Migrate the Guava cache implementation to Caffeine.

Fixes [#65827](https://github.com/StarRocks/starrocks/issues/65827)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x]  3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces Guava caches with Caffeine, caches only the latest table per name (no snapshot in key), refines refresh/invalidation and counting, and adds tests including REST catalog auth-token bypass.
> 
> - **Iceberg cache migration (Caffeine)**
>   - Replace Guava `Cache/LoadingCache` with Caffeine equivalents across `CachingIcebergCatalog`.
>   - Add executor-backed loaders and removal listeners; use `estimatedSize()` where applicable.
>   - Implement weighted caches for data/delete files with Caffeine `weigher` and logging.
> - **Table cache semantics**
>   - Cache only the latest `Table` per `db.table` (exclude snapshotId from key for table lookups).
>   - Update refresh flow to put updated table under snapshot-agnostic key; adjust partition cache refresh (`get` vs `getUnchecked`).
>   - Simplify invalidation to a single key; remove snapshot-scoped invalidation logic.
> - **Behavioral guards**
>   - Bypass table cache when using `IcebergRESTCatalog` with auth token.
> - **Metrics/estimation**
>   - Use `estimatedSize()` for `Database`/`Table` counts; sample methods updated accordingly.
> - **Tests**
>   - Update existing tests for Caffeine behavior differences and add tests for count estimation and REST catalog cache-bypass.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2adb5fac98ec7038265c0c8a7b9d2eb334d690e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->