### PR TITLE
[BugFix] Fix mv refresh bug with intersected partitions of multi tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiff.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiff.java
@@ -76,7 +76,7 @@ public class PartitionDiff {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("PartitionDiff{");
+        sb.append("{");
         sb.append("adds=").append(adds);
         sb.append(", deletes=").append(deletes);
         sb.append('}');

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffResult.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffResult.java
@@ -45,11 +45,23 @@ public class PartitionDiffResult {
 
     @Override
     public String toString() {
-        return "{" +
-                "refBaseTableMVPartitionMap=" + refBaseTableMVPartitionMap +
-                ", refBaseTablePartitionMap=" + refBaseTablePartitionMap +
-                ", mvPartitionToCells=" + mvPartitionToCells +
-                ", diff=" + diff +
-                '}';
+        StringBuilder sb = new StringBuilder();
+        String refBaseTableMVPartitionMapStr = refBaseTableMVPartitionMap.entrySet()
+                .stream()
+                .map(e -> e.getKey().getName() + "=" + e.getValue().toString())
+                .reduce((a, b) -> a + ", " + b)
+                .orElse("");
+        String  refBaseTablePartitionMapStr = refBaseTablePartitionMap.entrySet()
+                .stream()
+                .map(e -> e.getKey().getName() + "=" + e.getValue().toString())
+                .reduce((a, b) -> a + ", " + b)
+                .orElse("");
+        sb.append("{")
+                .append("refBaseTableMVPartitionMap:[").append(refBaseTableMVPartitionMapStr).append("]")
+                .append(", refBaseTablePartitionMap:[").append(refBaseTablePartitionMapStr).append("]")
+                .append(", mvPartitionToCells:[").append(mvPartitionToCells).append("]")
+                .append(", diff:[").append(diff).append("]")
+                .append("}");
+        return sb.toString();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -777,7 +777,7 @@ public class MvRewritePreprocessor {
         if (partitionNamesToRefresh.isEmpty()) {
             logMVPrepare(tracers, connectContext, mv, "MV {} has no partitions to refresh", mv.getName());
         } else {
-            logMVPrepare(tracers, mv, "MV' partitions to refresh(size: {}): {}", partitionNamesToRefresh.size(),
+            logMVPrepare(tracers, mv, "MV's partitions to refresh(size: {}): {}", partitionNamesToRefresh.size(),
                     partitionNamesToRefresh);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -170,13 +170,14 @@ public class MvUtils {
         Set<MvId> newMvIds = Sets.newHashSet();
         for (Table table : tablesToCheck) {
             Set<MvId> mvIds = table.getRelatedMaterializedViews();
+            String tableOrMaterializedView = table.isMaterializedView() ? "MaterializedView" : "Table";
             if (mvIds != null && !mvIds.isEmpty()) {
-                logMVPrepare("Table/MaterializedView {} has related materialized views: {}",
-                        table.getName(), mvIds);
+                logMVPrepare("{} {} has related materialized views: {}",
+                        tableOrMaterializedView, table.getName(), mvIds);
                 newMvIds.addAll(mvIds);
             } else if (currentLevel == 0) {
-                logMVPrepare("Table/MaterializedView {} has no related materialized views, " +
-                        "identifier:{}", table.getName(), table.getTableIdentifier());
+                logMVPrepare("{} {} has no related materialized views, " +
+                        "identifier:{}", tableOrMaterializedView, table.getName(), table.getTableIdentifier());
             }
         }
         if (newMvIds.isEmpty()) {

--- a/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_multi_tables
+++ b/test/sql/test_materialized_view_refresh/R/test_mv_refresh_with_multi_tables
@@ -413,3 +413,133 @@ SELECT * FROM test_mv1 ORDER BY dt1 LIMIT 5;
 DROP database db_${uuid0};
 -- result:
 -- !result
+-- name: test_mv_refresh_with_multi_tables5
+CREATE TABLE t1 (dt1 date, int1 int) PARTITION BY date_trunc("day",dt1);
+-- result:
+-- !result
+CREATE TABLE t2 (dt2 date, int2 int) PARTITION BY date_trunc("month",dt2);
+-- result:
+-- !result
+INSERT INTO t1 VALUES ("2020-06-23",1),("2020-07-23",1),("2020-07-23",1),("2020-08-23",1),(null,null);
+-- result:
+-- !result
+INSERT INTO t2 VALUES ("2020-06-23",1),("2020-07-23",1),("2020-07-23",1),("2020-08-23",1),(null,null);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv1 
+PARTITION BY date_trunc("month",dt1) 
+REFRESH DEFERRED MANUAL
+PROPERTIES ("partition_refresh_number"="3") AS
+SELECT dt1,dt2,sum(int1) FROM t1 JOIN t2 ON t1.dt1=t2.dt2 GROUP BY dt1,dt2;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+SELECT * FROM mv1 ORDER BY dt1;
+-- result:
+2020-06-23	2020-06-23	1
+2020-07-23	2020-07-23	4
+2020-08-23	2020-08-23	1
+-- !result
+function: print_hit_materialized_view("SELECT dt1,dt2,sum(int1) FROM t1 JOIN t2 ON t1.dt1=t2.dt2 GROUP BY dt1,dt2 ORDER BY dt1;", "mv1")
+-- result:
+True
+-- !result
+SELECT dt1,dt2,sum(int1) FROM t1 JOIN t2 ON t1.dt1=t2.dt2 GROUP BY dt1,dt2 ORDER BY dt1;
+-- result:
+2020-06-23	2020-06-23	1
+2020-07-23	2020-07-23	4
+2020-08-23	2020-08-23	1
+-- !result
+CREATE MATERIALIZED VIEW mv2 PARTITION BY date_trunc("month",dt1) 
+REFRESH DEFERRED MANUAL 
+PROPERTIES ("partition_refresh_number"="3")
+AS SELECT dt1,sum(int1) from t1 group by dt1 union all
+SELECT dt2,sum(int2) from t2 group by dt2;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW mv2 WITH SYNC MODE;
+SELECT * FROM mv2 ORDER BY dt1;
+-- result:
+None	None
+None	None
+2020-06-23	1
+2020-06-23	1
+2020-07-23	2
+2020-07-23	2
+2020-08-23	1
+2020-08-23	1
+-- !result
+function: print_hit_materialized_view("SELECT dt1,sum(int1) from t1 group by dt1 union all SELECT dt2,sum(int2) from t2 group by dt2 ORDER BY dt1;", "mv2")
+-- result:
+False
+-- !result
+SELECT dt1,sum(int1) from t1 group by dt1 union all SELECT dt2,sum(int2) from t2 group by dt2 ORDER BY dt1;
+-- result:
+None	None
+None	None
+2020-06-23	1
+2020-06-23	1
+2020-07-23	2
+2020-07-23	2
+2020-08-23	1
+2020-08-23	1
+-- !result
+INSERT INTO t1 VALUES ("2020-06-23",1);
+-- result:
+-- !result
+function: print_hit_materialized_view("SELECT dt1,dt2,sum(int1) FROM t1 JOIN t2 ON t1.dt1=t2.dt2 GROUP BY dt1,dt2 ORDER BY dt1;", "mv1")
+-- result:
+True
+-- !result
+SELECT dt1,dt2,sum(int1) FROM t1 JOIN t2 ON t1.dt1=t2.dt2 GROUP BY dt1,dt2 ORDER BY dt1;
+-- result:
+2020-06-23	2020-06-23	2
+2020-07-23	2020-07-23	4
+2020-08-23	2020-08-23	1
+-- !result
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+SELECT * FROM mv1 ORDER BY dt1;
+-- result:
+2020-06-23	2020-06-23	2
+2020-07-23	2020-07-23	4
+2020-08-23	2020-08-23	1
+-- !result
+function: print_hit_materialized_view("SELECT dt1,sum(int1) from t1 group by dt1 union all SELECT dt2,sum(int2) from t2 group by dt2 ORDER BY dt1;", "mv2")
+-- result:
+False
+-- !result
+SELECT dt1,sum(int1) from t1 group by dt1 union all SELECT dt2,sum(int2) from t2 group by dt2 ORDER BY dt1;
+-- result:
+None	None
+None	None
+2020-06-23	1
+2020-06-23	2
+2020-07-23	2
+2020-07-23	2
+2020-08-23	1
+2020-08-23	1
+-- !result
+REFRESH MATERIALIZED VIEW mv2 WITH SYNC MODE;
+SELECT * FROM mv2 ORDER BY dt1;
+-- result:
+None	None
+None	None
+2020-06-23	1
+2020-06-23	2
+2020-07-23	2
+2020-07-23	2
+2020-08-23	1
+2020-08-23	1
+-- !result
+DROP MATERIALIZED VIEW mv1;
+-- result:
+-- !result
+DROP MATERIALIZED VIEW mv2;
+-- result:
+-- !result
+DROP TABLE t1;
+-- result:
+-- !result
+DROP TABLE t2;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_multi_tables
+++ b/test/sql/test_materialized_view_refresh/T/test_mv_refresh_with_multi_tables
@@ -219,3 +219,46 @@ SELECT COUNT(1) FROM test_mv1;
 SELECT * FROM test_mv1 ORDER BY dt1 LIMIT 5;
 
 DROP database db_${uuid0};
+
+-- name: test_mv_refresh_with_multi_tables5
+CREATE TABLE t1 (dt1 date, int1 int) PARTITION BY date_trunc("day",dt1);
+CREATE TABLE t2 (dt2 date, int2 int) PARTITION BY date_trunc("month",dt2);
+INSERT INTO t1 VALUES ("2020-06-23",1),("2020-07-23",1),("2020-07-23",1),("2020-08-23",1),(null,null);
+INSERT INTO t2 VALUES ("2020-06-23",1),("2020-07-23",1),("2020-07-23",1),("2020-08-23",1),(null,null);
+
+CREATE MATERIALIZED VIEW mv1 
+PARTITION BY date_trunc("month",dt1) 
+REFRESH DEFERRED MANUAL
+PROPERTIES ("partition_refresh_number"="3") AS
+SELECT dt1,dt2,sum(int1) FROM t1 JOIN t2 ON t1.dt1=t2.dt2 GROUP BY dt1,dt2;
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+SELECT * FROM mv1 ORDER BY dt1;
+function: print_hit_materialized_view("SELECT dt1,dt2,sum(int1) FROM t1 JOIN t2 ON t1.dt1=t2.dt2 GROUP BY dt1,dt2 ORDER BY dt1;", "mv1")
+SELECT dt1,dt2,sum(int1) FROM t1 JOIN t2 ON t1.dt1=t2.dt2 GROUP BY dt1,dt2 ORDER BY dt1;
+
+CREATE MATERIALIZED VIEW mv2 PARTITION BY date_trunc("month",dt1) 
+REFRESH DEFERRED MANUAL 
+PROPERTIES ("partition_refresh_number"="3")
+AS SELECT dt1,sum(int1) from t1 group by dt1 union all
+SELECT dt2,sum(int2) from t2 group by dt2;
+REFRESH MATERIALIZED VIEW mv2 WITH SYNC MODE;
+SELECT * FROM mv2 ORDER BY dt1;
+function: print_hit_materialized_view("SELECT dt1,sum(int1) from t1 group by dt1 union all SELECT dt2,sum(int2) from t2 group by dt2 ORDER BY dt1;", "mv2")
+SELECT dt1,sum(int1) from t1 group by dt1 union all SELECT dt2,sum(int2) from t2 group by dt2 ORDER BY dt1;
+
+INSERT INTO t1 VALUES ("2020-06-23",1);
+
+function: print_hit_materialized_view("SELECT dt1,dt2,sum(int1) FROM t1 JOIN t2 ON t1.dt1=t2.dt2 GROUP BY dt1,dt2 ORDER BY dt1;", "mv1")
+SELECT dt1,dt2,sum(int1) FROM t1 JOIN t2 ON t1.dt1=t2.dt2 GROUP BY dt1,dt2 ORDER BY dt1;
+REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+SELECT * FROM mv1 ORDER BY dt1;
+
+function: print_hit_materialized_view("SELECT dt1,sum(int1) from t1 group by dt1 union all SELECT dt2,sum(int2) from t2 group by dt2 ORDER BY dt1;", "mv2")
+SELECT dt1,sum(int1) from t1 group by dt1 union all SELECT dt2,sum(int2) from t2 group by dt2 ORDER BY dt1;
+REFRESH MATERIALIZED VIEW mv2 WITH SYNC MODE;
+SELECT * FROM mv2 ORDER BY dt1;
+
+DROP MATERIALIZED VIEW mv1;
+DROP MATERIALIZED VIEW mv2;
+DROP TABLE t1;
+DROP TABLE t2;


### PR DESCRIPTION
## Why I'm doing:

Fix possible exception for intersected(not aligned) partitions of multi base tables in mv refresh:
```
*************************** 2. row ***************************
                                  id: 63274
                       database_name: test_mv_async_db_49aafe53_c92a_11f0_932f_00163e09349d
                                name: mv2
                        refresh_type: MANUAL
                           is_active: true
                     inactive_reason:
                      partition_type: RANGE
                             task_id: 63276
                           task_name: mv-63274
             last_refresh_start_time: 2025-11-25 09:41:38
          last_refresh_finished_time: 2025-11-25 09:41:40
               last_refresh_duration: 1.011
                  last_refresh_state: FAILED
          last_refresh_force_refresh: false
        last_refresh_start_partition: NULL
          last_refresh_end_partition: NULL
last_refresh_base_refresh_partitions: {}
  last_refresh_mv_refresh_partitions: []
             last_refresh_error_code: -1
          last_refresh_error_message: Refresh mv mv2 failed after 1 times, try lock failed: 0, error-msg : com.starrocks.common.DdlException: Range [types: [DATE]; keys: [0000-01-01]; ..types: [DATE]; keys: [0000-02-01]; ) is intersected with range: [types: [DATE]; keys: [0000-01-01]; ..types: [DATE]; keys: [0000-01-02]; )
        at com.starrocks.common.util.RangeUtils.checkRangeIntersect(RangeUtils.java:46)
        at com.starrocks.catalog.RangePartitionInfo.checkNewRange(RangePartitionInfo.java:229)
        at com.starrocks.catalog.RangePartitionInfo.createAndCheckNewRange(RangePartitionInfo.java:201)
        at com.starrocks.catalog.RangePartitionInfo.checkAndCreateRange(RangePartitionInfo.java:158)
        at com.starrocks.catalog.RangePartitionInfo.handleNewRangePartitionDescs(RangePartitionInfo.java:279)
        at com.starrocks.server.LocalMetastore.updatePartitionInfo(LocalMetastore.java:1057)
        at com.starrocks.server.LocalMetastore.addPartitions(LocalMetastore.java:1310)
        at com.starrocks.server.LocalMetastore.addPartitions(LocalMetastore.java:892)
        at com.starrocks.scheduler.mv.pct.MVPCTRefreshRangePartitioner.addRangePartitions(MVPCTRefreshRangePartitioner.java:559)
 [wrapped] com.starrocks.sql.common.DmlException: Expression add partition failed: Range [types: [DATE]; keys: [0000-01-01]; ..types: [DATE]; keys: [0000-02-01]; ) is intersected with range: [types: [DATE]; keys: [0000-01-01]; ..types: [DATE]; keys: [0000-01-02]; ), db: test_mv_async_db_49aafe53_c92a_11f0_932f_00163e09349d, table: mv2
        at com.starrocks.scheduler.mv.pct.MVPCTRefreshRangePartitioner.addRangePartitions(MVPCTRefreshRangePartitioner.java:563)
        at com.starrocks.scheduler.mv.pct.MVPCTRefreshRangePartitioner.syncAddOrDropPartitions(MVPCTRefreshRangePartitioner.java:153)
        at com.starrocks.scheduler.mv.BaseMVRefreshProcessor.syncPartitions(BaseMVRefreshProcessor.java:446)
        at com.starrocks.scheduler.mv.BaseMVRefreshProcessor.syncAndCheckPCTPartitions(BaseMVRefreshProcessor.java:366)
        at com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor.getProcessExecPlan(MVPCTBasedRefreshProcessor.java:97)
        at com.starrocks.scheduler.MVTaskRunProcessor.doProcessTaskRun(MVTaskRunProcessor.java:292)
        at com.starrocks.scheduler.MVTaskRunProcessor.retryProcessTaskRun(MVTaskRunProcessor.java:259)
        at com.starrocks.scheduler.MVTaskRunProcessor.processTaskRun(MVTaskRunProcessor.java:192)
        at com.starrocks.scheduler.TaskRun.doExecuteTaskRun(TaskRun.java:446)
        at com.starrocks.scheduler.TaskRun.executeTaskRun(TaskRun.java:406)
        at com.starrocks.scheduler.TaskRunExecutor.lambda$executeTaskRun$1(TaskRunExecutor.java:66)
        at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)

```
## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/10634

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
