### PR TITLE
[Enhancement] support to alter iceberg table partiton spec

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAlterTableExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAlterTableExecutor.java
@@ -492,7 +492,7 @@ public class IcebergAlterTableExecutor extends ConnectorAlterTableExecutor {
     @Override
     public Void visitAddPartitionColumnClause(AddPartitionColumnClause clause, ConnectContext context) {
         actions.add(() -> {
-            UpdatePartitionSpec spec = this.table.updateSpec();
+            UpdatePartitionSpec spec = this.transaction.updateSpec();
             List<Term> terms = clause.getPartitionExprList().stream()
                     .map(this::transformExprToIcebergTerm).toList();
             try {
@@ -510,7 +510,7 @@ public class IcebergAlterTableExecutor extends ConnectorAlterTableExecutor {
     @Override
     public Void visitDropPartitionColumnClause(DropPartitionColumnClause clause, ConnectContext context) {
         actions.add(() -> {
-            UpdatePartitionSpec spec = this.table.updateSpec();
+            UpdatePartitionSpec spec = this.transaction.updateSpec();
             List<Term> terms = clause.getPartitionExprList().stream()
                     .map(this::transformExprToIcebergTerm).toList();
             try {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAlterTableExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAlterTableExecutor.java
@@ -493,12 +493,15 @@ public class IcebergAlterTableExecutor extends ConnectorAlterTableExecutor {
     public Void visitAddPartitionColumnClause(AddPartitionColumnClause clause, ConnectContext context) {
         actions.add(() -> {
             UpdatePartitionSpec spec = this.table.updateSpec();
-            Term term = transformExprToIcebergTerm(clause.getPartitionExpr());
+            List<Term> terms = clause.getPartitionExprList().stream()
+                    .map(this::transformExprToIcebergTerm).toList();
             try {
-                spec.addField(term);
+                for (Term term : terms) {
+                    spec.addField(term);
+                }
                 spec.commit();
             } catch (Exception e) {
-                throw new StarRocksConnectorException("Failed to add partition column: " + clause.getPartitionExpr(), e);
+                throw new StarRocksConnectorException("Failed to execute: " + clause, e);
             }
         });
         return null;
@@ -508,12 +511,15 @@ public class IcebergAlterTableExecutor extends ConnectorAlterTableExecutor {
     public Void visitDropPartitionColumnClause(DropPartitionColumnClause clause, ConnectContext context) {
         actions.add(() -> {
             UpdatePartitionSpec spec = this.table.updateSpec();
-            Term term = transformExprToIcebergTerm(clause.getPartitionExpr());
+            List<Term> terms = clause.getPartitionExprList().stream()
+                    .map(this::transformExprToIcebergTerm).toList();
             try {
-                spec.removeField(term);
+                for (Term term : terms) {
+                    spec.removeField(term);
+                }
                 spec.commit();
             } catch (Exception e) {
-                throw new StarRocksConnectorException("Failed to drop partition column: " + clause.getPartitionExpr(), e);
+                throw new StarRocksConnectorException("Failed to execute： " + clause, e);
             }
         });
         return null;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAlterTableExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAlterTableExecutor.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 package com.starrocks.connector.iceberg;
+
 import com.starrocks.common.DdlException;
 import com.starrocks.connector.ConnectorAlterTableExecutor;
 import com.starrocks.connector.HdfsEnvironment;
@@ -23,6 +24,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.AddColumnClause;
 import com.starrocks.sql.ast.AddColumnsClause;
 import com.starrocks.sql.ast.AddFieldClause;
+import com.starrocks.sql.ast.AddPartitionClause;
 import com.starrocks.sql.ast.AlterTableCommentClause;
 import com.starrocks.sql.ast.AlterTableOperationClause;
 import com.starrocks.sql.ast.AlterTableStmt;
@@ -76,10 +78,10 @@ public class IcebergAlterTableExecutor extends ConnectorAlterTableExecutor {
     private ConnectContext context;
 
     public IcebergAlterTableExecutor(AlterTableStmt stmt,
-            Table table,
-            IcebergCatalog icebergCatalog,
-            ConnectContext context,
-            HdfsEnvironment hdfsEnvironment) {
+                                     Table table,
+                                     IcebergCatalog icebergCatalog,
+                                     ConnectContext context,
+                                     HdfsEnvironment hdfsEnvironment) {
         super(stmt);
         this.table = table;
         this.icebergCatalog = icebergCatalog;
@@ -398,6 +400,11 @@ public class IcebergAlterTableExecutor extends ConnectorAlterTableExecutor {
             }
         });
 
+        return null;
+    }
+
+    @Override
+    public Void visitAddPartitionClause(AddPartitionClause clause, ConnectContext context) {
         return null;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAlterTableExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAlterTableExecutor.java
@@ -25,6 +25,7 @@ import com.starrocks.sql.ast.AddColumnClause;
 import com.starrocks.sql.ast.AddColumnsClause;
 import com.starrocks.sql.ast.AddFieldClause;
 import com.starrocks.sql.ast.AddPartitionClause;
+import com.starrocks.sql.ast.AddPartitionColumnClause;
 import com.starrocks.sql.ast.AlterTableCommentClause;
 import com.starrocks.sql.ast.AlterTableOperationClause;
 import com.starrocks.sql.ast.AlterTableStmt;
@@ -37,6 +38,7 @@ import com.starrocks.sql.ast.CreateOrReplaceTagClause;
 import com.starrocks.sql.ast.DropBranchClause;
 import com.starrocks.sql.ast.DropColumnClause;
 import com.starrocks.sql.ast.DropFieldClause;
+import com.starrocks.sql.ast.DropPartitionColumnClause;
 import com.starrocks.sql.ast.DropTagClause;
 import com.starrocks.sql.ast.ModifyColumnClause;
 import com.starrocks.sql.ast.ModifyTablePropertiesClause;
@@ -438,4 +440,15 @@ public class IcebergAlterTableExecutor extends ConnectorAlterTableExecutor {
         return null;
     }
 
+    @Override
+    public Void visitAddPartitionColumnClause(AddPartitionColumnClause clause, ConnectContext context) {
+        unsupportedException("Not support");
+        return null;
+    }
+
+    @Override
+    public Void visitDropPartitionColumnClause(DropPartitionColumnClause clause, ConnectContext context) {
+        unsupportedException("Not support");
+        return null;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAlterTableExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAlterTableExecutor.java
@@ -501,7 +501,7 @@ public class IcebergAlterTableExecutor extends ConnectorAlterTableExecutor {
                 }
                 spec.commit();
             } catch (Exception e) {
-                throw new StarRocksConnectorException("Failed to execute: " + clause, e);
+                throw new StarRocksConnectorException("Failed to add partition column: " + e.getMessage(), e);
             }
         });
         return null;
@@ -519,7 +519,7 @@ public class IcebergAlterTableExecutor extends ConnectorAlterTableExecutor {
                 }
                 spec.commit();
             } catch (Exception e) {
-                throw new StarRocksConnectorException("Failed to execute： " + clause, e);
+                throw new StarRocksConnectorException("Failed to drop partition column: " + e.getMessage(), e);
             }
         });
         return null;

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -2506,6 +2506,9 @@ public class GlobalStateMgr {
 
     public void refreshOthersFeTable(TableName tableName, List<String> partitions, boolean isSync) throws DdlException {
         List<Frontend> allFrontends = GlobalStateMgr.getCurrentState().getNodeMgr().getFrontends(null);
+        if (allFrontends.size() == 0) {
+            return;
+        }
         Map<String, Future<TStatus>> resultMap = Maps.newHashMapWithExpectedSize(allFrontends.size() - 1);
         for (Frontend fe : allFrontends) {
             if (fe.getHost().equals(GlobalStateMgr.getCurrentState().getNodeMgr().getSelfNode().first)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AddPartitionColumnClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AddPartitionColumnClause.java
@@ -18,17 +18,16 @@ import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.parser.NodePosition;
 
 // clause which is used to add one column to
-public class AddPartitionColumnClause implements ParseNode {
+public class AddPartitionColumnClause extends AlterTableClause {
     private final Expr partitionExpr;
-    private final NodePosition pos;
 
     public Expr getPartitionExpr() {
         return partitionExpr;
     }
 
     public AddPartitionColumnClause(Expr partitionExpr, NodePosition pos) {
+        super(pos);
         this.partitionExpr = partitionExpr;
-        this.pos = pos;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AddPartitionColumnClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AddPartitionColumnClause.java
@@ -27,20 +27,6 @@ public class AddPartitionColumnClause extends AlterTableClause {
         return partitionExprList;
     }
 
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("ADD PARTITION COLUMN (");
-        for (int i = 0; i < partitionExprList.size(); i++) {
-            sb.append(partitionExprList.get(i));
-            if (i != partitionExprList.size() - 1) {
-                sb.append(", ");
-            }
-        }
-        sb.append(")");
-        return sb.toString();
-    }
-
     public AddPartitionColumnClause(List<Expr> partitionExprList, NodePosition pos) {
         super(pos);
         this.partitionExprList = partitionExprList;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AddPartitionColumnClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AddPartitionColumnClause.java
@@ -31,11 +31,6 @@ public class AddPartitionColumnClause extends AlterTableClause {
     }
 
     @Override
-    public NodePosition getPos() {
-        return pos;
-    }
-
-    @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return ((AstVisitorExtendInterface<R, C>) visitor).visitAddPartitionColumnClause(this, context);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AddPartitionColumnClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AddPartitionColumnClause.java
@@ -1,0 +1,43 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.parser.NodePosition;
+
+// clause which is used to add one column to
+public class AddPartitionColumnClause implements ParseNode {
+    private final Expr partitionExpr;
+    private final NodePosition pos;
+
+    public Expr getPartitionExpr() {
+        return partitionExpr;
+    }
+
+    public AddPartitionColumnClause(Expr partitionExpr, NodePosition pos) {
+        this.partitionExpr = partitionExpr;
+        this.pos = pos;
+    }
+
+    @Override
+    public NodePosition getPos() {
+        return pos;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return ((AstVisitorExtendInterface<R, C>) visitor).visitAddPartitionColumnClause(this, context);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AddPartitionColumnClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AddPartitionColumnClause.java
@@ -17,17 +17,33 @@ package com.starrocks.sql.ast;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.parser.NodePosition;
 
+import java.util.List;
+
 // clause which is used to add one column to
 public class AddPartitionColumnClause extends AlterTableClause {
-    private final Expr partitionExpr;
+    private final List<Expr> partitionExprList;
 
-    public Expr getPartitionExpr() {
-        return partitionExpr;
+    public List<Expr> getPartitionExprList() {
+        return partitionExprList;
     }
 
-    public AddPartitionColumnClause(Expr partitionExpr, NodePosition pos) {
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("ADD PARTITION COLUMN (");
+        for (int i = 0; i < partitionExprList.size(); i++) {
+            sb.append(partitionExprList.get(i));
+            if (i != partitionExprList.size() - 1) {
+                sb.append(", ");
+            }
+        }
+        sb.append(")");
+        return sb.toString();
+    }
+
+    public AddPartitionColumnClause(List<Expr> partitionExprList, NodePosition pos) {
         super(pos);
-        this.partitionExpr = partitionExpr;
+        this.partitionExprList = partitionExprList;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitorExtendInterface.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitorExtendInterface.java
@@ -633,6 +633,14 @@ public interface AstVisitorExtendInterface<R, C> extends AstVisitor<R, C> {
         return visitNode(clause, context);
     }
 
+    default R visitAddPartitionColumnClause(AddPartitionColumnClause clause, C context) {
+        return visitNode(clause, context);
+    }
+
+    default R visitDropPartitionColumnClause(DropPartitionColumnClause clause, C context) {
+        return visitNode(clause, context);
+    }
+
     default R visitModifyColumnClause(ModifyColumnClause clause, C context) {
         return visitNode(clause, context);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropPartitionColumnClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropPartitionColumnClause.java
@@ -1,0 +1,43 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.parser.NodePosition;
+
+// clause which is used to drop one partition column
+public class DropPartitionColumnClause implements ParseNode {
+    private final Expr partitionExpr;
+    private final NodePosition pos;
+
+    public Expr getPartitionExpr() {
+        return partitionExpr;
+    }
+
+    public DropPartitionColumnClause(Expr partitionExpr, NodePosition pos) {
+        this.partitionExpr = partitionExpr;
+        this.pos = pos;
+    }
+
+    @Override
+    public NodePosition getPos() {
+        return pos;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return ((AstVisitorExtendInterface<R, C>) visitor).visitDropPartitionColumnClause(this, context);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropPartitionColumnClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropPartitionColumnClause.java
@@ -17,17 +17,33 @@ package com.starrocks.sql.ast;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.parser.NodePosition;
 
+import java.util.List;
+
 // clause which is used to drop one partition column
 public class DropPartitionColumnClause extends AlterTableClause {
-    private final Expr partitionExpr;
+    private final List<Expr> partitionExprList;
 
-    public Expr getPartitionExpr() {
-        return partitionExpr;
+    public List<Expr> getPartitionExprList() {
+        return partitionExprList;
     }
 
-    public DropPartitionColumnClause(Expr partitionExpr, NodePosition pos) {
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("DROP PARTITION COLUMN (");
+        for (int i = 0; i < partitionExprList.size(); i++) {
+            sb.append(partitionExprList.get(i));
+            if (i != partitionExprList.size() - 1) {
+                sb.append(", ");
+            }
+        }
+        sb.append(")");
+        return sb.toString();
+    }
+
+    public DropPartitionColumnClause(List<Expr> partitionExprList, NodePosition pos) {
         super(pos);
-        this.partitionExpr = partitionExpr;
+        this.partitionExprList = partitionExprList;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropPartitionColumnClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropPartitionColumnClause.java
@@ -18,17 +18,16 @@ import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.parser.NodePosition;
 
 // clause which is used to drop one partition column
-public class DropPartitionColumnClause implements ParseNode {
+public class DropPartitionColumnClause extends AlterTableClause {
     private final Expr partitionExpr;
-    private final NodePosition pos;
 
     public Expr getPartitionExpr() {
         return partitionExpr;
     }
 
     public DropPartitionColumnClause(Expr partitionExpr, NodePosition pos) {
+        super(pos);
         this.partitionExpr = partitionExpr;
-        this.pos = pos;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropPartitionColumnClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropPartitionColumnClause.java
@@ -27,20 +27,6 @@ public class DropPartitionColumnClause extends AlterTableClause {
         return partitionExprList;
     }
 
-    @Override
-    public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("DROP PARTITION COLUMN (");
-        for (int i = 0; i < partitionExprList.size(); i++) {
-            sb.append(partitionExprList.get(i));
-            if (i != partitionExprList.size() - 1) {
-                sb.append(", ");
-            }
-        }
-        sb.append(")");
-        return sb.toString();
-    }
-
     public DropPartitionColumnClause(List<Expr> partitionExprList, NodePosition pos) {
         super(pos);
         this.partitionExprList = partitionExprList;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropPartitionColumnClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DropPartitionColumnClause.java
@@ -31,11 +31,6 @@ public class DropPartitionColumnClause extends AlterTableClause {
     }
 
     @Override
-    public NodePosition getPos() {
-        return pos;
-    }
-
-    @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return ((AstVisitorExtendInterface<R, C>) visitor).visitDropPartitionColumnClause(this, context);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -5110,15 +5110,15 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     @Override
     public ParseNode visitAddPartitionColumnClause(
             com.starrocks.sql.parser.StarRocksParser.AddPartitionColumnClauseContext context) {
-        Expr partitionExpr = (Expr) visit(context.expression());
-        return new AddPartitionColumnClause(partitionExpr, createPos(context));
+        List<Expr> partitionExprList = visit(context.expressionList().expression(), Expr.class);
+        return new AddPartitionColumnClause(partitionExprList, createPos(context));
     }
 
     @Override
     public ParseNode visitDropPartitionColumnClause(
             com.starrocks.sql.parser.StarRocksParser.DropPartitionColumnClauseContext context) {
-        Expr partitionExpr = (Expr) visit(context.expression());
-        return new DropPartitionColumnClause(partitionExpr, createPos(context));
+        List<Expr> partitionExprList = visit(context.expressionList().expression(), Expr.class);
+        return new DropPartitionColumnClause(partitionExprList, createPos(context));
     }
 
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -5116,7 +5116,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
 
     @Override
     public ParseNode visitDropPartitionColumnClause(
-            com.starrocks.sql.parser.StarRocksParser.AddPartitionColumnClauseContext context) {
+            com.starrocks.sql.parser.StarRocksParser.DropPartitionColumnClauseContext context) {
         Expr partitionExpr = (Expr) visit(context.expression());
         return new DropPartitionColumnClause(partitionExpr, createPos(context));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -64,6 +64,7 @@ import com.starrocks.sql.ast.AddFieldClause;
 import com.starrocks.sql.ast.AddFollowerClause;
 import com.starrocks.sql.ast.AddObserverClause;
 import com.starrocks.sql.ast.AddPartitionClause;
+import com.starrocks.sql.ast.AddPartitionColumnClause;
 import com.starrocks.sql.ast.AddRollupClause;
 import com.starrocks.sql.ast.AddSqlBlackListStmt;
 import com.starrocks.sql.ast.AdminCancelRepairTableStmt;
@@ -188,6 +189,7 @@ import com.starrocks.sql.ast.DropIndexClause;
 import com.starrocks.sql.ast.DropMaterializedViewStmt;
 import com.starrocks.sql.ast.DropObserverClause;
 import com.starrocks.sql.ast.DropPartitionClause;
+import com.starrocks.sql.ast.DropPartitionColumnClause;
 import com.starrocks.sql.ast.DropPersistentIndexClause;
 import com.starrocks.sql.ast.DropRepositoryStmt;
 import com.starrocks.sql.ast.DropResourceGroupStmt;
@@ -5104,6 +5106,21 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
 
         return new AddColumnClause(columnDef, columnPosition, rollupName, properties, createPos(context));
     }
+
+    @Override
+    public ParseNode visitAddPartitionColumnClause(
+            com.starrocks.sql.parser.StarRocksParser.AddPartitionColumnClauseContext context) {
+        Expr partitionExpr = (Expr) visit(context.expression());
+        return new AddPartitionColumnClause(partitionExpr, createPos(context));
+    }
+
+    @Override
+    public ParseNode visitDropPartitionColumnClause(
+            com.starrocks.sql.parser.StarRocksParser.AddPartitionColumnClauseContext context) {
+        Expr partitionExpr = (Expr) visit(context.expression());
+        return new DropPartitionColumnClause(partitionExpr, createPos(context));
+    }
+
 
     @Override
     public ParseNode visitAddColumnsClause(com.starrocks.sql.parser.StarRocksParser.AddColumnsClauseContext context) {

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -1098,7 +1098,7 @@ addColumnClause
     ;
 
 addPartitionColumnClause
-    : ADD PARTITION COLUMN expression
+    : ADD PARTITION COLUMN expressionList
     ;
 
 addColumnsClause
@@ -1110,7 +1110,7 @@ dropColumnClause
     ;
 
 dropPartitionColumnClause
-    : DROP PARTITION COLUMN expression
+    : DROP PARTITION COLUMN expressionList
     ;
 
 modifyColumnClause

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -949,6 +949,8 @@ alterClause
     | addColumnClause
     | addColumnsClause
     | dropColumnClause
+    | addPartitionColumnClause
+    | dropPartitionColumnClause
     | modifyColumnCommentClause
     | modifyColumnClause
     | columnRenameClause
@@ -1095,12 +1097,20 @@ addColumnClause
     : ADD COLUMN columnDesc (FIRST | AFTER identifier)? ((TO | IN) rollupName=identifier)? properties?
     ;
 
+addPartitionColumnClause
+    : ADD PARTITION COLUMN expression
+    ;
+
 addColumnsClause
     : ADD COLUMN '(' columnDesc (',' columnDesc)* ')' ((TO | IN) rollupName=identifier)? properties?
     ;
 
 dropColumnClause
     : DROP COLUMN identifier (FROM rollupName=identifier)? properties?
+    ;
+
+dropPartitionColumnClause
+    : DROP PARTITION COLUMN expression
     ;
 
 modifyColumnClause

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -3011,6 +3011,18 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
                 "assert expect {} is not found in plan {}".format(expect, res["result"]),
             )
 
+    def assert_query_error_contains(self, query, *expects):
+        """
+        assert error message contains expect string
+        """
+        res = self.execute_sql(query, True)
+        for expect in expects:
+            haystack = str(res["msg"])
+            tools.assert_true(
+                haystack.find(expect) > 0,
+                "assert expect {} is not found in plan {}".format(expect, haystack),
+            )
+
     def assert_explain_contains(self, query, *expects):
         """
         assert explain result contains expect string

--- a/test/sql/test_iceberg/R/test_iceberg_alter_table
+++ b/test/sql/test_iceberg/R/test_iceberg_alter_table
@@ -71,7 +71,7 @@ create table test_part_evo (
 );
 -- result:
 -- !result
-alter table test_part_evo add partition column dt;
+alter table test_part_evo add partition column dt, truncate(value, 10), bucket(id, 10);
 -- result:
 -- !result
 insert into test_part_evo values (1, 'data1', '2023-01-01', 100);
@@ -80,13 +80,7 @@ insert into test_part_evo values (1, 'data1', '2023-01-01', 100);
 insert into test_part_evo values (2, 'data2', '2023-01-02', 200);
 -- result:
 -- !result
-alter table test_part_evo add partition column truncate(value, 10);
--- result:
--- !result
 insert into test_part_evo values (3, 'data3', '2023-01-03', 300);
--- result:
--- !result
-alter table test_part_evo add partition column bucket(id, 10);
 -- result:
 -- !result
 insert into test_part_evo values (4, 'data4', '2023-01-04', 400);
@@ -117,10 +111,7 @@ select * from test_part_evo order by id;
 4	data4	2023-01-04	400
 5	data5	2023-01-05	500
 -- !result
-alter table test_part_evo drop partition column truncate(value, 10);
--- result:
--- !result
-alter table test_part_evo drop partition column bucket(id, 10);
+alter table test_part_evo drop partition column truncate(value, 10), bucket(id, 10);
 -- result:
 -- !result
 function: assert_query_contains("show create table test_part_evo", "PARTITION BY (month(`dt`))")
@@ -134,6 +125,18 @@ select * from test_part_evo order by id;
 3	data3	2023-01-03	300
 4	data4	2023-01-04	400
 5	data5	2023-01-05	500
+-- !result
+function: assert_query_error_contains("alter table test_part_evo add partition column fn(dt)", "Unsupported partition transform")
+-- result:
+None
+-- !result
+function: assert_query_error_contains("alter table test_part_evo add partition column month(dt)", "Failed to execute")
+-- result:
+None
+-- !result
+function: assert_query_error_contains("alter table test_part_evo drop partition column day(dt)", "Failed to execute")
+-- result:
+None
 -- !result
 drop table test_part_evo force;
 -- result:

--- a/test/sql/test_iceberg/R/test_iceberg_alter_table
+++ b/test/sql/test_iceberg/R/test_iceberg_alter_table
@@ -60,7 +60,88 @@ set ('file_format'='orc');
 drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.new_ice_tbl_${uuid0} force;
 -- result:
 -- !result
+use iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+create table test_part_evo (
+  id bigint,
+  data string,
+  dt date,
+  value bigint  
+);
+-- result:
+-- !result
+alter table test_part_evo add partition column dt;
+-- result:
+-- !result
+insert into test_part_evo values (1, 'data1', '2023-01-01', 100);
+-- result:
+-- !result
+insert into test_part_evo values (2, 'data2', '2023-01-02', 200);
+-- result:
+-- !result
+alter table test_part_evo add partition column truncate(value, 10);
+-- result:
+-- !result
+insert into test_part_evo values (3, 'data3', '2023-01-03', 300);
+-- result:
+-- !result
+alter table test_part_evo add partition column bucket(id, 10);
+-- result:
+-- !result
+insert into test_part_evo values (4, 'data4', '2023-01-04', 400);
+-- result:
+-- !result
+function: assert_query_contains("show create table test_part_evo", "PARTITION BY (`dt`, truncate(`value`, 10), bucket(`id`, 10))")
+-- result:
+None
+-- !result
+alter table test_part_evo drop partition column dt;
+-- result:
+-- !result
+alter table test_part_evo add partition column month(dt);
+-- result:
+-- !result
+insert into test_part_evo values (5, 'data5', '2023-01-05', 500);
+-- result:
+-- !result
+function: assert_query_contains("show create table test_part_evo", "PARTITION BY (truncate(`value`, 10), bucket(`id`, 10), month(`dt`))")
+-- result:
+None
+-- !result
+select * from test_part_evo order by id;
+-- result:
+1	data1	2023-01-01	100
+2	data2	2023-01-02	200
+3	data3	2023-01-03	300
+4	data4	2023-01-04	400
+5	data5	2023-01-05	500
+-- !result
+alter table test_part_evo drop partition column truncate(value, 10);
+-- result:
+-- !result
+alter table test_part_evo drop partition column bucket(id, 10);
+-- result:
+-- !result
+function: assert_query_contains("show create table test_part_evo", "PARTITION BY (month(`dt`))")
+-- result:
+None
+-- !result
+select * from test_part_evo order by id;
+-- result:
+1	data1	2023-01-01	100
+2	data2	2023-01-02	200
+3	data3	2023-01-03	300
+4	data4	2023-01-04	400
+5	data5	2023-01-05	500
+-- !result
+drop table test_part_evo force;
+-- result:
+-- !result
 drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+-- result:
+-- !result
+set catalog default_catalog;
 -- result:
 -- !result
 drop catalog iceberg_sql_test_${uuid0};

--- a/test/sql/test_iceberg/R/test_iceberg_alter_table
+++ b/test/sql/test_iceberg/R/test_iceberg_alter_table
@@ -130,11 +130,11 @@ function: assert_query_error_contains("alter table test_part_evo add partition c
 -- result:
 None
 -- !result
-function: assert_query_error_contains("alter table test_part_evo add partition column month(dt)", "Failed to execute")
+function: assert_query_error_contains("alter table test_part_evo add partition column month(dt)", "Failed to add partition column")
 -- result:
 None
 -- !result
-function: assert_query_error_contains("alter table test_part_evo drop partition column day(dt)", "Failed to execute")
+function: assert_query_error_contains("alter table test_part_evo drop partition column day(dt)", "Failed to drop partition column")
 -- result:
 None
 -- !result

--- a/test/sql/test_iceberg/T/test_iceberg_alter_table
+++ b/test/sql/test_iceberg/T/test_iceberg_alter_table
@@ -56,14 +56,10 @@ create table test_part_evo (
   value bigint  
 );
 
-alter table test_part_evo add partition column dt;
+alter table test_part_evo add partition column dt, truncate(value, 10), bucket(id, 10);
 insert into test_part_evo values (1, 'data1', '2023-01-01', 100);
 insert into test_part_evo values (2, 'data2', '2023-01-02', 200);
-
-alter table test_part_evo add partition column truncate(value, 10);
 insert into test_part_evo values (3, 'data3', '2023-01-03', 300);
-
-alter table test_part_evo add partition column bucket(id, 10);
 insert into test_part_evo values (4, 'data4', '2023-01-04', 400);
 
 function: assert_query_contains("show create table test_part_evo", "PARTITION BY (`dt`, truncate(`value`, 10), bucket(`id`, 10))")
@@ -76,12 +72,17 @@ function: assert_query_contains("show create table test_part_evo", "PARTITION BY
 
 select * from test_part_evo order by id;
 
-alter table test_part_evo drop partition column truncate(value, 10);
-alter table test_part_evo drop partition column bucket(id, 10);
+alter table test_part_evo drop partition column truncate(value, 10), bucket(id, 10);
 
 function: assert_query_contains("show create table test_part_evo", "PARTITION BY (month(`dt`))")
 
 select * from test_part_evo order by id;
+
+function: assert_query_error_contains("alter table test_part_evo add partition column fn(dt)", "Unsupported partition transform")
+
+function: assert_query_error_contains("alter table test_part_evo add partition column month(dt)", "Failed to execute")
+
+function: assert_query_error_contains("alter table test_part_evo drop partition column day(dt)", "Failed to execute")
 
 drop table test_part_evo force;
 drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};

--- a/test/sql/test_iceberg/T/test_iceberg_alter_table
+++ b/test/sql/test_iceberg/T/test_iceberg_alter_table
@@ -80,9 +80,9 @@ select * from test_part_evo order by id;
 
 function: assert_query_error_contains("alter table test_part_evo add partition column fn(dt)", "Unsupported partition transform")
 
-function: assert_query_error_contains("alter table test_part_evo add partition column month(dt)", "Failed to execute")
+function: assert_query_error_contains("alter table test_part_evo add partition column month(dt)", "Failed to add partition column")
 
-function: assert_query_error_contains("alter table test_part_evo drop partition column day(dt)", "Failed to execute")
+function: assert_query_error_contains("alter table test_part_evo drop partition column day(dt)", "Failed to drop partition column")
 
 drop table test_part_evo force;
 drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};

--- a/test/sql/test_iceberg/T/test_iceberg_alter_table
+++ b/test/sql/test_iceberg/T/test_iceberg_alter_table
@@ -44,5 +44,47 @@ set ('file_format'='orc');
 
 drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.new_ice_tbl_${uuid0} force;
 
+
+-- partition evolution test
+
+use iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+
+create table test_part_evo (
+  id bigint,
+  data string,
+  dt date,
+  value bigint  
+);
+
+alter table test_part_evo add partition column dt;
+insert into test_part_evo values (1, 'data1', '2023-01-01', 100);
+insert into test_part_evo values (2, 'data2', '2023-01-02', 200);
+
+alter table test_part_evo add partition column truncate(value, 10);
+insert into test_part_evo values (3, 'data3', '2023-01-03', 300);
+
+alter table test_part_evo add partition column bucket(id, 10);
+insert into test_part_evo values (4, 'data4', '2023-01-04', 400);
+
+function: assert_query_contains("show create table test_part_evo", "PARTITION BY (`dt`, truncate(`value`, 10), bucket(`id`, 10))")
+
+alter table test_part_evo drop partition column dt;
+alter table test_part_evo add partition column month(dt);
+insert into test_part_evo values (5, 'data5', '2023-01-05', 500);
+
+function: assert_query_contains("show create table test_part_evo", "PARTITION BY (truncate(`value`, 10), bucket(`id`, 10), month(`dt`))")
+
+select * from test_part_evo order by id;
+
+alter table test_part_evo drop partition column truncate(value, 10);
+alter table test_part_evo drop partition column bucket(id, 10);
+
+function: assert_query_contains("show create table test_part_evo", "PARTITION BY (month(`dt`))")
+
+select * from test_part_evo order by id;
+
+drop table test_part_evo force;
 drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
+
+set catalog default_catalog;
 drop catalog iceberg_sql_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

To support to alter iceberg table partiton spec, you can
- alter table xxx add partition column <expr>
- alter table xxx drop partition column <expr>

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds SQL and executor support to evolve Iceberg table partition specs by adding/dropping partition columns (including transforms) with tests.
> 
> - **SQL/Parser**:
>   - Add AST nodes `AddPartitionColumnClause` and `DropPartitionColumnClause` with visitor hooks in `AstVisitorExtendInterface`.
>   - Extend grammar (`fe-grammar/.../StarRocks.g4`) to parse `ALTER TABLE ... ADD|DROP PARTITION COLUMN <expr>`.
>   - Parse to AST in `AstBuilder` (`visitAddPartitionColumnClause`/`visitDropPartitionColumnClause`).
> - **Iceberg Executor** (`IcebergAlterTableExecutor`):
>   - Implement `visitAddPartitionColumnClause`/`visitDropPartitionColumnClause` using Iceberg `UpdatePartitionSpec`.
>   - Introduce `transformExprToIcebergTerm` to map expressions (`ref`, `year|month|day|hour`, `truncate`, `bucket`, `identity`) to Iceberg partition transforms; validate via `SemanticException`.
> - **Tests**:
>   - Add partition evolution cases in `test/sql/test_iceberg/*/test_iceberg_alter_table` verifying add/drop partition columns and `SHOW CREATE TABLE` output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ef0b5e8a5b943939277a5da6379ec18586bcd5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->