### PR TITLE
[BugFix] Fix the core dump caused by empty row groups in parquet files

### DIFF
--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -285,6 +285,10 @@ Status FileReader::_init_group_readers() {
             continue;
         }
 
+        if (_file_metadata->t_metadata().row_groups[i].num_rows == 0) {
+            continue;
+        }
+
         auto row_group_reader = std::make_shared<GroupReader>(_group_reader_param, i, _skip_rows_ctx,
                                                               row_group_first_row, row_group_first_row_id);
         RETURN_IF_ERROR(row_group_reader->init());


### PR DESCRIPTION
## Why I'm doing:
```
*** SIGSEGV (@0x0) received by PID 8 (TID 0x7fbe66013700) from PID 0; stack trace: ***
    @         0x1b874483 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x7fbfae40620b __pthread_once_slow
    @         0x1b873dc0 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x7fbfae40f630 (/usr/lib64/libpthread-2.17.so+0xf62f)
    @          0xd07ad2b __gnu_cxx::__normal_iterator<std::shared_ptr<starrocks::Column>*, std::vector<std::shared_ptr<starrocks::Column>, std::allocator<std::shared_ptr<starrocks::Column> > > >::__normal_iterator(std::shared_ptr<starrocks::Column>* const&)
    @          0xd07a659 std::vector<std::shared_ptr<starrocks::Column>, std::allocator<std::shared_ptr<starrocks::Column> > >::begin()
    @          0xe66148f starrocks::Chunk::reset()
    @         0x1a3da0f2 starrocks::parquet::GroupReader::get_next(std::shared_ptr<starrocks::Chunk>*, unsigned long*)
    @         0x1a2c88f1 starrocks::parquet::FileReader::get_next(std::shared_ptr<starrocks::Chunk>*)
    @         0x19ca556f starrocks::HdfsParquetScanner::do_get_next(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*)
    @         0x19c4dda4 starrocks::HdfsScanner::get_next(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*)
    @         0x19ad07b6 starrocks::connector::HiveDataSource::get_next(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*)
    @          0xfc7b474 starrocks::pipeline::ConnectorChunkSource::_read_chunk(starrocks::RuntimeState*, std::shared_ptr<starrocks::Chunk>*)
    @         0x10d5fcc8 starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking(starrocks::RuntimeState*, unsigned long, starrocks::workgroup::WorkGroup const*)
    @          0xfc083ad auto starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}::operator()<starrocks::workgroup::YieldContext>(starrocks::workgroup::YieldContext&) const
    @          0xfc0f45b void std::__invoke_impl<void, starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}&, starrocks::workgroup::YieldContext&>(std::__invoke_other, starrocks::pipeline::ScanOperator::_trigger_next_scan(starroh      <96>z
    @          0xfc0f0a9 std::enable_if<is_invocable_r_v<void, starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}&, starrocks::workgroup::YieldContext&>, void>::type std::__invoke_r<void, starrocks::pipeline::ScanOperator::_trh      <96>z
    @          0xfc0ecc5 std::_Function_handler<void (starrocks::workgroup::YieldContext&), starrocks::pipeline::ScanOperator::_trigger_next_scan(starrocks::RuntimeState*, int)::{lambda(auto:1&)#1}>::_M_invoke(std::_Any_data const&, starrocks::workgroup::YieldContext&)
    @         0x100c735d std::function<void (starrocks::workgroup::YieldContext&)>::operator()(starrocks::workgroup::YieldContext&) const
    @         0x100c5fc5 starrocks::workgroup::ScanTask::run()
```

caused by

```
End of file:
be/src/formats/parquet/column_chunk_reader cpp_page_reader->next_header()
be/src/formats/parquet/column_chunk_reader cpp_parse_page_header()
be/src/formats/parquet/column_chunk_reader h_try_load_dictionary()
be/src/formats/parquet/column_reader.cpp reader->get_dict_values(dict_value_column.get())
be/src/formats/parquet/group_reader.cpp _column_readers[slot_id]->rewrite_conjunct_ctxs_to_predicate(is_group_filtered, sub_field_path, 0), row_group_first_row=1049677
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skips parquet row groups with zero rows during initialization to avoid crashes when reading.
> 
> - **Backend · Parquet**:
>   - **FileReader (`be/src/formats/parquet/file_reader.cpp`)**: In `_init_group_readers`, add a guard to skip row groups with `num_rows == 0` before creating `GroupReader` and filtering, avoiding processing of empty groups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 550bfdb2eeca272cd588af2fc9b1a6e09b95ab80. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->