### PR TITLE
[BugFix] Preserve ephemeral flag across thrift conversion

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/authentication/UserIdentityUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/authentication/UserIdentityUtils.java
@@ -56,6 +56,7 @@ public class UserIdentityUtils {
         tUserIdent.setHost(userIdentity.getHost());
         tUserIdent.setUsername(userIdentity.getUser());
         tUserIdent.setIs_domain(userIdentity.isDomain());
+        tUserIdent.setIs_ephemeral(userIdentity.isEphemeral());
         return tUserIdent;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/UserIdentityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/mysql/privilege/UserIdentityTest.java
@@ -19,6 +19,7 @@ package com.starrocks.mysql.privilege;
 
 import com.starrocks.authentication.UserIdentityUtils;
 import com.starrocks.catalog.UserIdentity;
+import com.starrocks.thrift.TUserIdentity;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -41,4 +42,16 @@ public class UserIdentityTest {
         Assertions.assertEquals(str2, userIdent.toString());
     }
 
+    @Test
+    public void testEphemeralFlagRoundTrip() {
+        UserIdentity ephemeralIdentity = UserIdentity.createEphemeralUserIdent("ldap_user", "10.0.%");
+
+        TUserIdentity thriftIdentity = UserIdentityUtils.toThrift(ephemeralIdentity);
+        Assertions.assertTrue(thriftIdentity.isSetIs_ephemeral());
+        Assertions.assertTrue(thriftIdentity.isIs_ephemeral());
+
+        UserIdentity roundTrip = UserIdentityUtils.fromThrift(thriftIdentity);
+        Assertions.assertEquals(ephemeralIdentity.toString(), roundTrip.toString());
+        Assertions.assertTrue(roundTrip.isEphemeral());
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This pull request enhances support for ephemeral user identities by updating the Thrift serialization logic and adding comprehensive unit tests to verify correct handling of the ephemeral flag.

**Ephemeral user identity support:**

* Updated `UserIdentityUtils.toThrift` to set the `is_ephemeral` field when converting a `UserIdentity` to its Thrift representation, ensuring the ephemeral status is preserved in serialization.

**Testing improvements:**

* Added a new unit test `testEphemeralFlagRoundTrip` in `UserIdentityTest.java` to verify that the ephemeral flag is correctly set, serialized, and deserialized in round-trip conversions between `UserIdentity` and `TUserIdentity`.
* Imported the necessary `TUserIdentity` class in the test file to support the new test logic.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure UserIdentity.isEphemeral is preserved during Thrift serialization/deserialization and add a unit test to verify it.
> 
> - **Auth/Serialization**:
>   - Update `UserIdentityUtils.toThrift` to set `is_ephemeral` on `TUserIdentity`.
> - **Tests**:
>   - Add `testEphemeralFlagRoundTrip` in `UserIdentityTest` to validate `is_ephemeral` round-trip via Thrift.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1796a8c468df78124fed6071cea766977996a49c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->