### PR TITLE
[BugFix] Fix sample scan range index overflow in files schema detection (backport #65894)

### DIFF
--- a/be/src/exec/file_scanner.cpp
+++ b/be/src/exec/file_scanner.cpp
@@ -412,8 +412,13 @@ void FileScanner::sample_files(size_t total_file_count, int64_t sample_file_coun
     } else {
         step = static_cast<double>(total_file_count - 1) / (sample_file_count - 1);
     }
-    for (size_t i = 0; i < sample_file_count - 1; ++i) {
-        sample_file_indexes->emplace_back(std::round(i * step));
+
+    double next_index = 0;
+    size_t i = 0;
+    while (i < total_file_count - 1) {
+        sample_file_indexes->emplace_back(i);
+        next_index += step;
+        i = static_cast<size_t>(std::round(next_index));
     }
     sample_file_indexes->emplace_back(total_file_count - 1);
 }

--- a/be/test/exec/file_scanner_test.cpp
+++ b/be/test/exec/file_scanner_test.cpp
@@ -185,17 +185,11 @@ TEST_F(FileScannerTest, select_sample_files) {
         ASSERT_TRUE(sample_file_indexes.empty());
     }
 
+    // total file count >= sample file count
     {
         std::vector<size_t> sample_file_indexes;
         FileScanner::sample_files(10, 1, &sample_file_indexes);
         std::vector<size_t> expect = {9};
-        ASSERT_EQ(expect, sample_file_indexes);
-    }
-
-    {
-        std::vector<size_t> sample_file_indexes;
-        FileScanner::sample_files(1, 10, &sample_file_indexes);
-        std::vector<size_t> expect = {0};
         ASSERT_EQ(expect, sample_file_indexes);
     }
 
@@ -237,6 +231,28 @@ TEST_F(FileScannerTest, select_sample_files) {
     {
         std::vector<size_t> sample_file_indexes;
         FileScanner::sample_files(10, 10, &sample_file_indexes);
+        std::vector<size_t> expect = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+        ASSERT_EQ(expect, sample_file_indexes);
+    }
+
+    // total file count < sample file count
+    {
+        std::vector<size_t> sample_file_indexes;
+        FileScanner::sample_files(1, 10, &sample_file_indexes);
+        std::vector<size_t> expect = {0};
+        ASSERT_EQ(expect, sample_file_indexes);
+    }
+
+    {
+        std::vector<size_t> sample_file_indexes;
+        FileScanner::sample_files(2, 8, &sample_file_indexes);
+        std::vector<size_t> expect = {0, 1};
+        ASSERT_EQ(expect, sample_file_indexes);
+    }
+
+    {
+        std::vector<size_t> sample_file_indexes;
+        FileScanner::sample_files(10, 100, &sample_file_indexes);
         std::vector<size_t> expect = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
         ASSERT_EQ(expect, sample_file_indexes);
     }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

https://github.com/StarRocks/starrocks/pull/65894

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [x] 3.4
  - [ ] 3.3

