### PR TITLE
[Enhancement] support creating iceberg view with properties

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergView.java
@@ -26,7 +26,7 @@ public class IcebergView extends ConnectorView {
     private final String defaultCatalogName;
     private final String defaultDbName;
     private final String location;
-    private Map<String, String> properties;
+    private final Map<String, String> properties;
     public static final String STARROCKS_DIALECT = "starrocks";
 
     public IcebergView(long id, String catalogName, String dbName, String name, List<Column> schema,

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergView.java
@@ -15,6 +15,7 @@
 package com.starrocks.catalog;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
 import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.ast.expression.TableName;
 
@@ -35,7 +36,7 @@ public class IcebergView extends ConnectorView {
         this.defaultCatalogName = defaultCatalogName;
         this.defaultDbName = defaultDbName;
         this.location = location;
-        this.properties = properties;
+        this.properties = properties != null ? properties : Maps.newHashMap();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergView.java
@@ -19,19 +19,23 @@ import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.ast.expression.TableName;
 
 import java.util.List;
+import java.util.Map;
 
 public class IcebergView extends ConnectorView {
     private final String defaultCatalogName;
     private final String defaultDbName;
     private final String location;
+    private Map<String, String> properties;
     public static final String STARROCKS_DIALECT = "starrocks";
 
     public IcebergView(long id, String catalogName, String dbName, String name, List<Column> schema,
-                       String definition, String defaultCatalogName, String defaultDbName, String location) {
+                       String definition, String defaultCatalogName, String defaultDbName,
+                       String location, Map<String, String> properties) {
         super(id, catalogName, dbName, name, schema, definition, TableType.ICEBERG_VIEW);
         this.defaultCatalogName = defaultCatalogName;
         this.defaultDbName = defaultDbName;
         this.location = location;
+        this.properties = properties;
     }
 
     @Override
@@ -59,5 +63,10 @@ public class IcebergView extends ConnectorView {
     @Override
     public String getTableLocation() {
         return location;
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return properties;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorViewDefinition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorViewDefinition.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.connector;
 
+import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
 import com.starrocks.sql.ast.AlterViewClause;
 import com.starrocks.sql.ast.AlterViewStmt;
@@ -47,7 +48,7 @@ public class ConnectorViewDefinition {
         this.columns = columns;
         this.inlineViewDef = inlineViewDef;
         this.alterDialect = alterDialect;
-        this.properties = properties;
+        this.properties = properties == null ? Maps.newHashMap() : properties;
     }
 
     public static ConnectorViewDefinition fromCreateViewStmt(CreateViewStmt stmt) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorViewDefinition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorViewDefinition.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.connector;
 
-import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
 import com.starrocks.sql.ast.AlterViewClause;
 import com.starrocks.sql.ast.AlterViewStmt;
@@ -60,7 +59,7 @@ public class ConnectorViewDefinition {
                 stmt.getColumns(),
                 stmt.getInlineViewDef(),
                 AlterViewStmt.AlterDialectType.NONE,
-                Maps.newHashMap());
+                stmt.getProperties());
     }
 
     public static ConnectorViewDefinition fromAlterViewStmt(AlterViewStmt stmt) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -643,17 +643,15 @@ public class IcebergApiConverter {
         String queryId = connectContext.getQueryId().toString();
 
         Map<String, String> properties = new HashMap<>();
-        properties.put("queryId", queryId);
-        properties.put("starrocksCatalog", catalogName);
-        properties.put("starrocksVersion", GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf().getFeVersion());
-
         if (!Strings.isNullOrEmpty(definition.getComment())) {
             properties.put(IcebergMetadata.COMMENT, definition.getComment());
         }
-
         if (!MapUtils.isEmpty(definition.getProperties())) {
             properties.putAll(definition.getProperties());
         }
+        properties.put("queryId", queryId);
+        properties.put("starrocksCatalog", catalogName);
+        properties.put("starrocksVersion", GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf().getFeVersion());
 
         return properties;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -48,6 +48,7 @@ import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
 import com.starrocks.type.UnknownType;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.FileFormat;
@@ -650,7 +651,7 @@ public class IcebergApiConverter {
             properties.put(IcebergMetadata.COMMENT, definition.getComment());
         }
 
-        if (definition.getProperties() != null && !definition.getProperties().isEmpty()) {
+        if (!MapUtils.isEmpty(definition.getProperties())) {
             properties.putAll(definition.getProperties());
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -510,7 +510,7 @@ public class IcebergApiConverter {
         String viewName = icebergView.name();
         String location = icebergView.location();
         IcebergView view = new IcebergView(CONNECTOR_ID_GENERATOR.getNextId().asInt(), catalogName, dbName, viewName,
-                columns, sqlView.sql(), defaultCatalogName, defaultDbName, location);
+                columns, sqlView.sql(), defaultCatalogName, defaultDbName, location, icebergView.properties());
         view.setComment(comment);
         return view;
     }
@@ -641,13 +641,17 @@ public class IcebergApiConverter {
 
         String queryId = connectContext.getQueryId().toString();
 
-        Map<String, String> properties = com.google.common.collect.ImmutableMap.of(
-                "queryId", queryId,
-                "starrocksCatalog", catalogName,
-                "starrocksVersion", GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf().getFeVersion());
+        Map<String, String> properties = new HashMap<>();
+        properties.put("queryId", queryId);
+        properties.put("starrocksCatalog", catalogName);
+        properties.put("starrocksVersion", GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf().getFeVersion());
 
         if (!Strings.isNullOrEmpty(definition.getComment())) {
             properties.put(IcebergMetadata.COMMENT, definition.getComment());
+        }
+
+        if (definition.getProperties() != null && !definition.getProperties().isEmpty()) {
+            properties.putAll(definition.getProperties());
         }
 
         return properties;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -457,6 +457,7 @@ public class AstToStringBuilder {
         try {
             properties = new HashMap<>(table.getProperties());
         } catch (NotImplementedException e) {
+            // hive view does not implement getProperties
         }
 
         // Location

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -490,6 +490,18 @@ public class AstToStringBuilder {
         sb.append(Joiner.on(", ").join(colDef));
         sb.append(")");
 
+        // Properties
+        Map<String, String> properties = new HashMap<>();
+        try {
+            properties = new HashMap<>(view.getProperties());
+        } catch (NotImplementedException e) {
+        }
+        if (!properties.isEmpty()) {
+            sb.append("\nPROPERTIES (");
+            sb.append(new PrintableMap<>(properties, "=", true, false, true).toString());
+            sb.append(")\n");
+        }
+
         sb.append(" AS ").append(view.getInlineViewDef()).append(";");
         return sb.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateViewStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateViewStmt.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.ast;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
 import com.starrocks.catalog.Column;
 import com.starrocks.sql.ast.expression.TableName;
 import com.starrocks.sql.parser.NodePosition;
@@ -44,7 +45,7 @@ public class CreateViewStmt extends DdlStmt {
                           boolean security,
                           QueryStatement queryStmt,
                           NodePosition pos) {
-        this(ifNotExists, replace, tableName, colWithComments, comment, security, queryStmt, pos, null);
+        this(ifNotExists, replace, tableName, colWithComments, comment, security, queryStmt, pos, Maps.newHashMap());
     }
 
     public CreateViewStmt(boolean ifNotExists,
@@ -64,7 +65,7 @@ public class CreateViewStmt extends DdlStmt {
         this.comment = Strings.nullToEmpty(comment);
         this.security = security;
         this.queryStatement = queryStmt;
-        this.properties = properties;
+        this.properties = properties != null ? properties : Maps.newHashMap();
     }
 
     public String getCatalog() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateViewStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateViewStmt.java
@@ -20,6 +20,7 @@ import com.starrocks.sql.ast.expression.TableName;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
+import java.util.Map;
 
 public class CreateViewStmt extends DdlStmt {
     private final TableName tableName;
@@ -33,6 +34,7 @@ public class CreateViewStmt extends DdlStmt {
     //Resolved by Analyzer
     protected List<Column> columns;
     private String inlineViewDef;
+    private Map<String, String> properties;
 
     public CreateViewStmt(boolean ifNotExists,
                           boolean replace,
@@ -42,6 +44,18 @@ public class CreateViewStmt extends DdlStmt {
                           boolean security,
                           QueryStatement queryStmt,
                           NodePosition pos) {
+        this(ifNotExists, replace, tableName, colWithComments, comment, security, queryStmt, pos, null);
+    }
+
+    public CreateViewStmt(boolean ifNotExists,
+                          boolean replace,
+                          TableName tableName,
+                          List<ColWithComment> colWithComments,
+                          String comment,
+                          boolean security,
+                          QueryStatement queryStmt,
+                          NodePosition pos,
+                          Map<String, String> properties) {
         super(pos);
         this.ifNotExists = ifNotExists;
         this.replace = replace;
@@ -50,6 +64,7 @@ public class CreateViewStmt extends DdlStmt {
         this.comment = Strings.nullToEmpty(comment);
         this.security = security;
         this.queryStatement = queryStmt;
+        this.properties = properties;
     }
 
     public String getCatalog() {
@@ -90,6 +105,14 @@ public class CreateViewStmt extends DdlStmt {
 
     public QueryStatement getQueryStatement() {
         return queryStatement;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
     }
 
     public void setColumns(List<Column> columns) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1823,15 +1823,6 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             }
         }
 
-        Map<String, String> properties = null;
-        if (context.properties() != null) {
-            properties = new HashMap<>();
-            List<Property> propertyList = visit(context.properties().property(), Property.class);
-            for (Property property : propertyList) {
-                properties.put(property.getKey(), property.getValue());
-            }
-        }
-
         return new CreateViewStmt(
                 context.IF() != null,
                 context.REPLACE() != null,
@@ -1841,7 +1832,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
                 isSecurity,
                 (QueryStatement) visit(context.queryStatement()),
                 createPos(context),
-                properties
+                buildProperties(context.properties())
                 );
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1823,6 +1823,15 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             }
         }
 
+        Map<String, String> properties = null;
+        if (context.properties() != null) {
+            properties = new HashMap<>();
+            List<Property> propertyList = visit(context.properties().property(), Property.class);
+            for (Property property : propertyList) {
+                properties.put(property.getKey(), property.getValue());
+            }
+        }
+
         return new CreateViewStmt(
                 context.IF() != null,
                 context.REPLACE() != null,
@@ -1830,7 +1839,10 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
                 colWithComments,
                 context.comment() == null ? null : ((StringLiteral) visit(context.comment())).getStringValue(),
                 isSecurity,
-                (QueryStatement) visit(context.queryStatement()), createPos(context));
+                (QueryStatement) visit(context.queryStatement()),
+                createPos(context),
+                properties
+                );
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergHiveCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergHiveCatalogTest.java
@@ -26,6 +26,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
+import com.starrocks.sql.analyzer.AstToStringBuilder;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.analyzer.ViewAnalyzer;
 import com.starrocks.sql.ast.AlterViewStmt;
@@ -290,7 +291,7 @@ public class IcebergHiveCatalogTest {
                 result = true;
                 minTimes = 0;
 
-                mockCatalogMgr.isInternalCatalog(catalogName);
+                CatalogMgr.isInternalCatalog(catalogName);
                 result = true;
                 minTimes = 0;
             }
@@ -374,5 +375,22 @@ public class IcebergHiveCatalogTest {
 
         Table table = metadata.getView(connectContext, "db", "view");
         Assertions.assertEquals("no comment", table.getComment());
+    }
+
+    @Test
+    public void testExternalCatalogViewDdlPropertiesPrinting() {
+        List<Column> cols = Lists.newArrayList(new Column("k1", INT));
+        Map<String, String> props = ImmutableMap.of(
+                "owner", "alex",
+                "comment", "this is a test view"
+        );
+
+        IcebergView view = new IcebergView(1L, "catalog", "db", "view", cols,
+                "select 1", "catalog", "db", "loc", props);
+
+        String ddl = AstToStringBuilder.getExternalCatalogViewDdlStmt(view);
+        Assertions.assertTrue(ddl.contains("PROPERTIES ("));
+        Assertions.assertTrue(ddl.contains("\"owner\" = \"alex\""));
+        Assertions.assertTrue(ddl.contains("\"comment\" = \"this is a test view\""));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
@@ -210,7 +210,7 @@ public class IcebergRESTCatalogTest {
             Table getTable(ConnectContext context, String dbName, String tblName) {
                 return new IcebergView(1, "iceberg_rest_catalog", "db", "view",
                         Lists.newArrayList(), "mocked", "iceberg_rest_catalog", "db",
-                        "location");
+                        "location", Maps.newHashMap());
             }
         };
 

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -650,6 +650,7 @@ createViewStatement
     ('(' columnNameWithComment (',' columnNameWithComment)* ')')?
     comment?
     (SECURITY (NONE | INVOKER))?
+    properties?
     AS queryStatement
     ;
 

--- a/test/sql/test_iceberg/R/test_iceberg_view
+++ b/test/sql/test_iceberg/R/test_iceberg_view
@@ -49,9 +49,19 @@ select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_pro
 -- !result
 show create view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0};
 -- result:
-[REGEX].*"owner" = "alex".*"comment" = "this is a test view".*
+[REGEX].*("owner" = "alex".*"comment" = "this is a test view"|"comment" = "this is a test view".*"owner" = "alex").*
 -- !result
 drop view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0};
+-- result:
+-- !result
+create database default_catalog.test_internal_db_${uuid0};
+-- result:
+-- !result
+create view if not exists default_catalog.test_internal_db_${uuid0}.test_internal_view_${uuid0} properties ("key"="value") as select 1 from dual;
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Setting properties is only supported for Iceberg views.')
+-- !result
+drop database default_catalog.test_internal_db_${uuid0};
 -- result:
 -- !result
 create view if not exists iceberg_sql_test_${uuid0}.iceberg_ci_db.test_alter_iceberg_view_${uuid0} as select k1, k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;

--- a/test/sql/test_iceberg/R/test_iceberg_view
+++ b/test/sql/test_iceberg/R/test_iceberg_view
@@ -12,6 +12,48 @@ select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_${uuid0}
 drop view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_${uuid0};
 -- result:
 -- !result
+create view if not exists iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0}
+properties ("owner"="alex") as select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+-- result:
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0} order by k1;
+-- result:
+1	beijing	zhangsan
+2	shanghai	lisi
+-- !result
+show create table iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+-- result:
+iceberg_v2_parquet_partitioned_table	CREATE TABLE `iceberg_v2_parquet_partitioned_table` (
+  `k1` int(11) DEFAULT NULL,
+  `k2` varchar(1073741824) DEFAULT NULL,
+  `k3` varchar(1073741824) DEFAULT NULL
+)
+PARTITION BY (`k3`)
+PROPERTIES ("write-format" = "parquet", "location" = "oss://starrocks-ci-test/iceberg_ci_db/iceberg_v2_parquet_partitioned_table", "write.upsert.enabled" = "true");
+-- !result
+show create view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0};
+-- result:
+[REGEX].*"owner" = "alex".*
+-- !result
+drop view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0};
+-- result:
+-- !result
+create view if not exists iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0}
+properties ("owner"="alex", "comment"="this is a test view") as select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+-- result:
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0} order by k1;
+-- result:
+1	beijing	zhangsan
+2	shanghai	lisi
+-- !result
+show create view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0};
+-- result:
+[REGEX].*"owner" = "alex".*"comment" = "this is a test view".*
+-- !result
+drop view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0};
+-- result:
+-- !result
 create view if not exists iceberg_sql_test_${uuid0}.iceberg_ci_db.test_alter_iceberg_view_${uuid0} as select k1, k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
 -- result:
 -- !result

--- a/test/sql/test_iceberg/T/test_iceberg_view
+++ b/test/sql/test_iceberg/T/test_iceberg_view
@@ -8,6 +8,26 @@ select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_${uuid0}
 
 drop view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_${uuid0};
 
+create view if not exists iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0}
+properties ("owner"="alex") as select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0} order by k1;
+
+show create table iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+
+show create view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0};
+
+drop view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0};
+
+create view if not exists iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0}
+properties ("owner"="alex", "comment"="this is a test view") as select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0} order by k1;
+
+show create view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0};
+
+drop view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0};
+
 create view if not exists iceberg_sql_test_${uuid0}.iceberg_ci_db.test_alter_iceberg_view_${uuid0} as select k1, k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
 
 select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_alter_iceberg_view_${uuid0} order by k1;

--- a/test/sql/test_iceberg/T/test_iceberg_view
+++ b/test/sql/test_iceberg/T/test_iceberg_view
@@ -28,6 +28,12 @@ show create view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_
 
 drop view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0};
 
+create database default_catalog.test_internal_db_${uuid0};
+
+create view if not exists default_catalog.test_internal_db_${uuid0}.test_internal_view_${uuid0} properties ("key"="value") as select 1 from dual;
+
+drop database default_catalog.test_internal_db_${uuid0};
+
 create view if not exists iceberg_sql_test_${uuid0}.iceberg_ci_db.test_alter_iceberg_view_${uuid0} as select k1, k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
 
 select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_alter_iceberg_view_${uuid0} order by k1;


### PR DESCRIPTION
## Why I'm doing:
Iceberg supports tagging properties when creating views. StarRocks should support this as well.

## What I'm doing:

1. support creating iceberg views with properties
2. support showing created iceberg views with properties

grammar
```
CREATE VIEW [IF NOT EXISTS]
[<catalog>.<database>.]<view_name>
(
    <column_name>[ COMMENT 'column comment']
    [, <column_name>[ COMMENT 'column comment'], ...]
)
[COMMENT 'view comment']
[PROPERTIES  ("key" = "value", ...)]
AS <query_statement>;

SHOW CREATE VIEW [<catalog>.<database>.]<view_name>;
+------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| View | Create View                                                                                                                                                                                                                                                                                                                    |
+------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| v1   | CREATE VIEW `ca1.db1.v1` (`c1`)
PROPERTIES ("starrocksVersion" = "xxx", "queryId" = "xxx", "starrocksCatalog" = "xxx")
 AS SELECT `ca1`.`db1`.`t1`.`c1`
FROM `ca1`.`db1`.`t1`; |
+------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support to create Iceberg views with properties, prints them in SHOW CREATE VIEW, and restricts property usage to Iceberg catalogs.
> 
> - **SQL/Parser & AST**:
>   - Extend grammar to allow `PROPERTIES` in `CREATE VIEW`.
>   - Add properties to `CreateViewStmt`; parse via `AstBuilder`; propagate through `ConnectorViewDefinition`.
> - **Catalog/Connector**:
>   - `IcebergView` now stores/exposes `properties`; constructor updated and used in converters/tests.
>   - `IcebergApiConverter`: include view properties when converting; build view properties by merging user props/comment with `queryId`, `starrocksCatalog`, and `starrocksVersion`.
> - **Analyzer/Validation**:
>   - `ViewAnalyzer`: allow setting properties only for non-internal Iceberg catalogs; validate catalog existence/type.
> - **DDL/Display**:
>   - `AstToStringBuilder`: include view `PROPERTIES (...)` in external catalog view DDL; safely fetch table/view properties and location.
> - **Tests & SQL**:
>   - New/updated unit and SQL tests for creating Iceberg views with properties, SHOW CREATE output, and rejection on non-Iceberg/internal/unknown catalogs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c59d4b22d11188cc34d0dea3d69afb90e05cef6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->