### PR TITLE
[BugFix] Fix use-after-free when count down pipeline

### DIFF
--- a/be/src/exec/pipeline/group_execution/execution_group.h
+++ b/be/src/exec/pipeline/group_execution/execution_group.h
@@ -65,13 +65,15 @@ public:
     void attach_driver_executor(DriverExecutor* executor) { _executor = executor; }
 
     void count_down_pipeline(RuntimeState* state) {
-        if (++_num_finished_pipelines == _num_pipelines) {
+        size_t num_pipelines = _num_pipelines;
+        if (++_num_finished_pipelines == num_pipelines) {
             state->fragment_ctx()->count_down_execution_group();
         }
     }
 
     void count_down_epoch_pipeline(RuntimeState* state) {
-        if (++_num_epoch_finished_pipelines == _num_pipelines) {
+        size_t num_pipelines = _num_pipelines;
+        if (++_num_epoch_finished_pipelines == num_pipelines) {
             state->fragment_ctx()->count_down_epoch_pipeline(state);
         }
     }

--- a/be/src/exec/pipeline/group_execution/execution_group.h
+++ b/be/src/exec/pipeline/group_execution/execution_group.h
@@ -65,6 +65,9 @@ public:
     void attach_driver_executor(DriverExecutor* executor) { _executor = executor; }
 
     void count_down_pipeline(RuntimeState* state) {
+        // Cache the member before performing the atomic increment.
+        // This ensures we won't dereference `this` after another thread may
+        // have deleted the object.
         size_t num_pipelines = _num_pipelines;
         if (++_num_finished_pipelines == num_pipelines) {
             state->fragment_ctx()->count_down_execution_group();


### PR DESCRIPTION
## Why I'm doing:

close https://github.com/StarRocks/StarRocksTest/issues/10383

Similar to #38532. This issue only occurs in the Debug version.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reads `_num_pipelines` into a local variable before atomic increments in `ExecutionGroup` countdown methods to prevent use-after-free/data race.
> 
> - **Backend | Pipeline Execution**
>   - In `be/src/exec/pipeline/group_execution/execution_group.h`:
>     - `ExecutionGroup::count_down_pipeline` and `ExecutionGroup::count_down_epoch_pipeline` now cache `_num_pipelines` into a local `num_pipelines` before comparing with incremented counters, preventing races/use-after-free during countdown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27f31fa83a041ec291ae7847889bedafc5749086. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->