### PR TITLE
[Refactor] Unify java thread naming style

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/DynamicTabletJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/dynamictablet/DynamicTabletJobMgr.java
@@ -50,7 +50,7 @@ public class DynamicTabletJobMgr extends FrontendDaemon implements GsonPostProce
     protected final Map<Long, DynamicTabletContext> dynamicTabletContexts = Maps.newConcurrentMap();
 
     public DynamicTabletJobMgr() {
-        super("DynamicTabletJobMgr", Config.dynamic_tablet_job_scheduler_interval_ms);
+        super("dynamic-tablet-job-mgr", Config.dynamic_tablet_job_scheduler_interval_ms);
     }
 
     public DynamicTabletJob getDynamicTabletJob(long dynamicJobId) {

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -154,7 +154,7 @@ public class BackupHandler extends FrontendDaemon implements Writable, MemoryTra
     }
 
     public BackupHandler(GlobalStateMgr globalStateMgr) {
-        super("backupHandler", 3000L);
+        super("backup-handler", 3000L);
         this.globalStateMgr = globalStateMgr;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogRecycleBin.java
@@ -119,7 +119,7 @@ public class CatalogRecycleBin extends FrontendDaemon implements Writable {
     protected Set<Long> enableEraseLater;
 
     public CatalogRecycleBin() {
-        super("recycle bin");
+        super("recycle-bin");
         idToDatabase = Maps.newHashMap();
         idToTableInfo = HashBasedTable.create();
         nameToTableInfo = HashBasedTable.create();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DomainResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DomainResolver.java
@@ -65,7 +65,7 @@ public class DomainResolver extends FrontendDaemon {
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
     public DomainResolver(AuthenticationMgr authenticationManager) {
-        super("domain resolver", 10L * 1000);
+        super("domain-resolver", 10L * 1000);
         this.authenticationManager = authenticationManager;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
@@ -89,7 +89,7 @@ public class TabletStatMgr extends FrontendDaemon {
     private LocalDateTime lastWorkTimestamp = LocalDateTime.MIN;
 
     public TabletStatMgr() {
-        super("tablet stat mgr", Config.tablet_stat_update_interval_second * 1000L);
+        super("tablet-stat-mgr", Config.tablet_stat_update_interval_second * 1000L);
     }
 
     public LocalDateTime getLastWorkTimestamp() {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/ColocateTableBalancer.java
@@ -87,7 +87,7 @@ public class ColocateTableBalancer extends FrontendDaemon {
     private static final long CHECK_INTERVAL_MS = 20 * 1000L; // 20 second
 
     private ColocateTableBalancer(long intervalMs) {
-        super("colocate group clone checker", intervalMs);
+        super("colocate-group-clone-checker", intervalMs);
     }
 
     private static ColocateTableBalancer INSTANCE = null;

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
@@ -151,7 +151,7 @@ public class TabletChecker extends FrontendDaemon {
     }
 
     public TabletChecker(TabletScheduler tabletScheduler, TabletSchedulerStat stat) {
-        super("tablet checker", Config.tablet_sched_checker_interval_seconds * 1000L);
+        super("tablet-checker", Config.tablet_sched_checker_interval_seconds * 1000L);
         this.tabletScheduler = tabletScheduler;
         this.stat = stat;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -190,7 +190,7 @@ public class TabletScheduler extends FrontendDaemon {
     }
 
     public TabletScheduler(TabletSchedulerStat stat) {
-        super("tablet scheduler", SCHEDULE_INTERVAL_MS);
+        super("tablet-scheduler", SCHEDULE_INTERVAL_MS);
         this.stat = stat;
         this.rebalancer = new DiskAndTabletLoadReBalancer();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/ConfigWatcher.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ConfigWatcher.java
@@ -41,7 +41,7 @@ public class ConfigWatcher extends Daemon {
     public final Path configPath;
 
     public ConfigWatcher(String configPathStr) {
-        super("config watcher");
+        super("config-watcher");
         Preconditions.checkState(!Strings.isNullOrEmpty(configPathStr));
         configPath = Paths.get(configPathStr);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsRepository.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsRepository.java
@@ -60,7 +60,7 @@ public class EsRepository extends FrontendDaemon {
     private Map<Long, EsRestClient> esClients;
 
     public EsRepository() {
-        super("es repository", Config.es_state_sync_interval_second * 1000);
+        super("es-repository", Config.es_state_sync_interval_second * 1000);
         esTables = Maps.newConcurrentMap();
         esClients = Maps.newConcurrentMap();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/consistency/ConsistencyChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/ConsistencyChecker.java
@@ -111,7 +111,7 @@ public class ConsistencyChecker extends FrontendDaemon {
     private final Map<Long, Integer> creatingTableCounters = new ConcurrentHashMap<>();
 
     public ConsistencyChecker() {
-        super("consistency checker");
+        super("consistency-checker");
 
         jobs = Maps.newHashMap();
         jobsLock = new ReentrantReadWriteLock();

--- a/fe/fe-core/src/main/java/com/starrocks/consistency/LockChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/LockChecker.java
@@ -38,7 +38,7 @@ public class LockChecker extends FrontendDaemon {
     private static final int DEFAULT_STACK_RESERVE_LEVELS = 20;
 
     public LockChecker() {
-        super("DeadlockChecker", 1000 * Config.lock_checker_interval_second);
+        super("deadlock-checker", 1000 * Config.lock_checker_interval_second);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/consistency/MetaRecoveryDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/MetaRecoveryDaemon.java
@@ -53,7 +53,7 @@ public class MetaRecoveryDaemon extends FrontendDaemon {
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
     public MetaRecoveryDaemon() {
-        super("meta_recovery");
+        super("meta-recovery");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/ha/StateChangeExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/ha/StateChangeExecutor.java
@@ -44,7 +44,7 @@ public class StateChangeExecutor extends Daemon {
     }
 
     public StateChangeExecutor() {
-        this("stateChangeExecutor");
+        this("state-change-executor");
     }
 
     public StateChangeExecutor(String name) {

--- a/fe/fe-core/src/main/java/com/starrocks/healthchecker/SafeModeChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/healthchecker/SafeModeChecker.java
@@ -29,7 +29,7 @@ public class SafeModeChecker extends FrontendDaemon {
     private static final Logger LOG = LogManager.getLogger(SafeModeChecker.class);
 
     public SafeModeChecker() {
-        super("safe mode checker", Config.safe_mode_checker_interval_sec * 1000);
+        super("safe-mode-checker", Config.safe_mode_checker_interval_sec * 1000);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/journal/GlobalStateCheckpointWorker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/GlobalStateCheckpointWorker.java
@@ -23,7 +23,7 @@ import com.starrocks.server.GlobalStateMgr;
 public class GlobalStateCheckpointWorker extends CheckpointWorker {
 
     public GlobalStateCheckpointWorker(Journal journal) {
-        super("global_state_checkpoint_worker", journal);
+        super("global-state-checkpoint-worker", journal);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/journal/StarMgrCheckpointWorker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/StarMgrCheckpointWorker.java
@@ -20,7 +20,7 @@ import com.starrocks.staros.StarMgrServer;
 
 public class StarMgrCheckpointWorker extends CheckpointWorker {
     public StarMgrCheckpointWorker(Journal journal) {
-        super("star_os_checkpoint_worker", journal);
+        super("star-os-checkpoint-worker", journal);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -82,7 +82,7 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
     private static final AtomicBoolean IS_METRIC_REGISTERED = new AtomicBoolean(false);
 
     public StarMgrMetaSyncer() {
-        super("StarMgrMetaSyncer", Config.star_mgr_meta_sync_interval_sec * 1000L);
+        super("star-mgr-meta-syncer", Config.star_mgr_meta_sync_interval_sec * 1000L);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
@@ -90,7 +90,7 @@ public class CompactionScheduler extends Daemon {
     CompactionScheduler(@NotNull CompactionMgr compactionManager, @NotNull SystemInfoService systemInfoService,
                         @NotNull GlobalTransactionMgr transactionMgr, @NotNull GlobalStateMgr stateMgr,
                         @NotNull String disableIdsStr) {
-        super("COMPACTION_DISPATCH", LOOP_INTERVAL_MS);
+        super("compaction-dispatch", LOOP_INTERVAL_MS);
         this.compactionManager = compactionManager;
         this.systemInfoService = systemInfoService;
         this.transactionMgr = transactionMgr;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotCheckpointScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotCheckpointScheduler.java
@@ -39,7 +39,7 @@ public class ClusterSnapshotCheckpointScheduler extends FrontendDaemon {
 
     public ClusterSnapshotCheckpointScheduler(CheckpointController feController,
             CheckpointController starMgrController) {
-        super("cluster_snapshot_checkpoint_scheduler", 10L);
+        super("cluster-snapshot-checkpoint-scheduler", 10L);
         this.feController = feController;
         this.starMgrController = starMgrController;
         this.restoredSnapshotInfo = RestoreClusterSnapshotMgr.getRestoredSnapshotInfo();

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -72,7 +72,7 @@ public class AutovacuumDaemon extends FrontendDaemon {
             Config.lake_autovacuum_parallel_partitions, 0, 1, TimeUnit.HOURS, "autovacuum");
 
     public AutovacuumDaemon() {
-        super("autovacuum", 2000);
+        super("auto-vacuum", 2000);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/FullVacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/FullVacuumDaemon.java
@@ -69,7 +69,7 @@ public class FullVacuumDaemon extends FrontendDaemon implements Writable {
 
     public FullVacuumDaemon() {
         // Check every minute if we should run a full vacuum
-        super("FullVacuumDaemon", 1000 * 60);
+        super("full-vacuum-daemon", 1000 * 60);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -209,7 +209,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
     private static final Table<Long, Long, Long> TABLET_TO_DROP_TIME = HashBasedTable.create();
 
     public ReportHandler() {
-        super("ReportHandler");
+        super("report-handler");
         pendingTaskMap.put(ReportType.TABLET_REPORT, Maps.newHashMap());
         pendingTaskMap.put(ReportType.DISK_REPORT, Maps.newHashMap());
         pendingTaskMap.put(ReportType.TASK_REPORT, Maps.newHashMap());

--- a/fe/fe-core/src/main/java/com/starrocks/leader/TabletCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/TabletCollector.java
@@ -41,7 +41,7 @@ public class TabletCollector extends FrontendDaemon {
     private final Set<Long> queuedBeIds;
 
     public TabletCollector() {
-        super("TabletCollector", CHECK_INTERVAL_MS);
+        super("tablet-collector", CHECK_INTERVAL_MS);
         collectQueue = new PriorityQueue<>();
         queuedBeIds = new HashSet<>();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/leader/TaskRunStateSynchronizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/TaskRunStateSynchronizer.java
@@ -37,7 +37,7 @@ public class TaskRunStateSynchronizer extends FrontendDaemon {
     private TaskRunScheduler taskRunScheduler;
 
     public TaskRunStateSynchronizer() {
-        super("TaskRunStateSynchronizer", FeConstants.SYNC_TASK_RUNS_STATE_INTERVAL);
+        super("task-run-state-synchronizer", FeConstants.SYNC_TASK_RUNS_STATE_INTERVAL);
         taskRunManager = GlobalStateMgr.getCurrentState().getTaskManager().getTaskRunManager();
         runningTaskRunProgressMap = new HashMap<>();
         taskRunScheduler = taskRunManager.getTaskRunScheduler();

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportChecker.java
@@ -63,7 +63,7 @@ public final class ExportChecker extends FrontendDaemon {
     private static LeaderTaskExecutor exportingSubTaskExecutor;
 
     private ExportChecker(JobState jobState, long intervalMs) {
-        super("export checker " + jobState.name().toLowerCase(), intervalMs);
+        super("export-checker-" + jobState.name().toLowerCase(), intervalMs);
         this.jobState = jobState;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadEtlChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadEtlChecker.java
@@ -32,7 +32,7 @@ public class LoadEtlChecker extends FrontendDaemon {
     private LoadMgr loadManager;
 
     public LoadEtlChecker(LoadMgr loadManager) {
-        super("Load etl checker", Config.load_checker_interval_second * 1000L);
+        super("load-etl-checker", Config.load_checker_interval_second * 1000L);
         this.loadManager = loadManager;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJobScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJobScheduler.java
@@ -64,7 +64,7 @@ public class LoadJobScheduler extends FrontendDaemon {
     private LinkedBlockingQueue<LoadJob> needScheduleJobs = Queues.newLinkedBlockingQueue();
 
     public LoadJobScheduler() {
-        super("Load job scheduler", Config.load_checker_interval_second * 1000L);
+        super("load-job-scheduler", Config.load_checker_interval_second * 1000L);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingChecker.java
@@ -49,7 +49,7 @@ public class LoadLoadingChecker extends FrontendDaemon {
     private LoadMgr loadManager;
 
     public LoadLoadingChecker(LoadMgr loadManager) {
-        super("Load loading checker", Config.load_checker_interval_second * 1000L);
+        super("load-loading-checker", Config.load_checker_interval_second * 1000L);
         this.loadManager = loadManager;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadTimeoutChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadTimeoutChecker.java
@@ -50,7 +50,7 @@ public class LoadTimeoutChecker extends FrontendDaemon {
     private LoadMgr loadManager;
 
     public LoadTimeoutChecker(LoadMgr loadManager) {
-        super("Load job timeout checker", Config.load_checker_interval_second * 1000L);
+        super("load-job-timeout-checker", Config.load_checker_interval_second * 1000L);
         this.loadManager = loadManager;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadsHistorySyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadsHistorySyncer.java
@@ -94,7 +94,7 @@ public class LoadsHistorySyncer extends FrontendDaemon {
     }
 
     public LoadsHistorySyncer() {
-        super("Load history syncer", Config.loads_history_sync_interval_second * 1000L);
+        super("load-history-syncer", Config.loads_history_sync_interval_second * 1000L);
     }
 
     public void syncData() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/PipeListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/PipeListener.java
@@ -33,7 +33,7 @@ public class PipeListener extends FrontendDaemon {
     private PipeManager pipeManager;
 
     public PipeListener(PipeManager pm) {
-        super("PipeListener", Config.pipe_listener_interval_millis);
+        super("pipe-listener", Config.pipe_listener_interval_millis);
         this.pipeManager = pm;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/PipeScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/PipeScheduler.java
@@ -39,7 +39,7 @@ public class PipeScheduler extends FrontendDaemon {
     private boolean recovered = false;
 
     public PipeScheduler(PipeManager pm) {
-        super("PipeScheduler", Config.pipe_scheduler_interval_millis);
+        super("pipe-scheduler", Config.pipe_scheduler_interval_millis);
         this.pipeManager = pm;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadScheduler.java
@@ -61,7 +61,7 @@ public class RoutineLoadScheduler extends FrontendDaemon {
     }
 
     public RoutineLoadScheduler(RoutineLoadMgr routineLoadManager) {
-        super("Routine load scheduler", Config.routine_load_scheduler_interval_millisecond);
+        super("routine-load-scheduler", Config.routine_load_scheduler_interval_millisecond);
         this.routineLoadManager = routineLoadManager;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
@@ -90,12 +90,12 @@ public class RoutineLoadTaskScheduler extends FrontendDaemon {
 
     @VisibleForTesting
     public RoutineLoadTaskScheduler() {
-        super("Routine load task scheduler", 0);
+        super("routine-load-task-scheduler", 0);
         this.routineLoadManager = GlobalStateMgr.getCurrentState().getRoutineLoadMgr();
     }
 
     public RoutineLoadTaskScheduler(RoutineLoadMgr routineLoadManager) {
-        super("Routine load task scheduler", 0);
+        super("routine-load-task-scheduler", 0);
         this.routineLoadManager = routineLoadManager;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/memory/MemoryUsageTracker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/MemoryUsageTracker.java
@@ -50,7 +50,7 @@ public class MemoryUsageTracker extends FrontendDaemon {
 
     private boolean initialize;
     public MemoryUsageTracker() {
-        super("MemoryUsageTracker", Config.memory_tracker_interval_seconds * 1000L);
+        super("memory-usage-tracker", Config.memory_tracker_interval_seconds * 1000L);
     }
 
     private void initMemoryTracker() {

--- a/fe/fe-core/src/main/java/com/starrocks/memory/ProcProfileCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/memory/ProcProfileCollector.java
@@ -46,7 +46,7 @@ public class ProcProfileCollector extends FrontendDaemon {
     private long lastLogTime = -1;
 
     public ProcProfileCollector() {
-        super("ProcProfileCollector", 1000L);
+        super("proc-profile-collector", 1000L);
         profileLogDir = Config.sys_log_dir + "/proc_profile";
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/HostBlacklist.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/HostBlacklist.java
@@ -241,7 +241,7 @@ public class HostBlacklist {
 
     private class UpdateBlacklistThread extends FrontendDaemon {
         public UpdateBlacklistThread() {
-            super("UpdateBlacklistThread", 1000);
+            super("update-blacklist-thread", 1000);
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationMgr.java
@@ -54,7 +54,7 @@ public class ReplicationMgr extends FrontendDaemon {
     private final Map<Long, ReplicationJob> abortedJobs = Maps.newConcurrentMap(); // Aborted jobs, will retry later
 
     public ReplicationMgr() {
-        super("ReplicationMgr", Config.replication_interval_ms);
+        super("replication-mgr", Config.replication_interval_ms);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
@@ -53,7 +53,7 @@ public class MVActiveChecker extends FrontendDaemon {
     private static final Map<MvId, MvActiveInfo> MV_ACTIVE_INFO = Maps.newConcurrentMap();
 
     public MVActiveChecker() {
-        super("MVActiveChecker", Config.mv_active_checker_interval_seconds * 1000);
+        super("mv-active-checker", Config.mv_active_checker_interval_seconds * 1000);
     }
 
     public static final String MV_BACKUP_INACTIVE_REASON = "it's in backup and will be activated after restore if possible";

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/history/TableKeeper.java
@@ -197,7 +197,7 @@ public class TableKeeper {
         private final List<TableKeeper> keeperList = Lists.newArrayList();
 
         TableKeeperDaemon() {
-            super("TableKeeper", Config.table_keeper_interval_second * 1000L);
+            super("table-keeper", Config.table_keeper_interval_second * 1000L);
 
             keeperList.add(TaskRunHistoryTable.createKeeper());
             keeperList.add(LoadsHistorySyncer.createKeeper());

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVJobExecutor.java
@@ -38,7 +38,7 @@ public class MVJobExecutor extends FrontendDaemon {
     private static final Logger LOG = LogManager.getLogger(MVJobExecutor.class);
 
     public MVJobExecutor() {
-        super("MV Job Executor", EXECUTOR_INTERVAL_MILLIS);
+        super("mv-job-executor", EXECUTOR_INTERVAL_MILLIS);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/server/DatabaseQuotaRefresher.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/DatabaseQuotaRefresher.java
@@ -32,7 +32,7 @@ public class DatabaseQuotaRefresher extends FrontendDaemon {
     private static final Logger LOG = LogManager.getLogger(DatabaseQuotaRefresher.class);
 
     public DatabaseQuotaRefresher() {
-        super("DatabaseQuotaRefresher", Config.db_used_data_quota_update_interval_secs * 1000L);
+        super("database-quota-refresher", Config.db_used_data_quota_update_interval_secs * 1000L);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/service/GroovyUDSServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/GroovyUDSServer.java
@@ -47,7 +47,7 @@ public class GroovyUDSServer extends Daemon {
             (Config.STARROCKS_HOME_DIR == null ? "/tmp" : Config.STARROCKS_HOME_DIR) + "/groovy_debug.sock";
 
     GroovyUDSServer() {
-        super("GroovyUDSServer");
+        super("groovy-uds-server");
     }
 
     public String getSocketPath() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMAutoCapturer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/spm/SPMAutoCapturer.java
@@ -51,7 +51,7 @@ public class SPMAutoCapturer extends FrontendDaemon {
     private ConnectContext connect;
 
     public SPMAutoCapturer() {
-        super("SPMAutoCapturer");
+        super("spm-auto-capturer");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticAutoCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticAutoCollector.java
@@ -46,7 +46,7 @@ public class StatisticAutoCollector extends FrontendDaemon {
     public static final String DEFAULT_JOB_FLAG = "default_job_flag";
 
     public StatisticAutoCollector() {
-        super("AutoStatistic", Config.statistic_collect_interval_sec * 1000);
+        super("auto-statistic", Config.statistic_collect_interval_sec * 1000);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -76,7 +76,7 @@ public class StatisticsMetaManager extends FrontendDaemon {
     private static final Logger LOG = LogManager.getLogger(StatisticsMetaManager.class);
 
     public StatisticsMetaManager() {
-        super("statistics meta manager", 60L * 1000L);
+        super("statistics-meta-manager", 60L * 1000L);
     }
 
     private boolean checkDatabaseExist() {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/columns/PredicateColumnsMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/columns/PredicateColumnsMgr.java
@@ -214,7 +214,7 @@ public class PredicateColumnsMgr {
         private static final DaemonThread INSTANCE = new DaemonThread();
 
         public DaemonThread() {
-            super("PredicateColumnsDaemonThread", Config.statistic_predicate_columns_persist_interval_sec * 1000L);
+            super("predicate-columns-daemon-thread", Config.statistic_predicate_columns_persist_interval_sec * 1000L);
         }
 
         public static DaemonThread getInstance() {

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -89,7 +89,7 @@ public class HeartbeatMgr extends FrontendDaemon {
     private final ExecutorService executor;
 
     public HeartbeatMgr(boolean needRegisterMetric) {
-        super("heartbeat mgr", Config.heartbeat_timeout_second * 1000L);
+        super("heartbeat-mgr", Config.heartbeat_timeout_second * 1000L);
         this.executor = ThreadPoolManager.newDaemonFixedThreadPool(Config.heartbeat_mgr_threads_num,
                 Config.heartbeat_mgr_blocking_queue_size, "heartbeat-mgr-pool", needRegisterMetric);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/system/PortConnectivityChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/PortConnectivityChecker.java
@@ -48,7 +48,7 @@ public class PortConnectivityChecker extends FrontendDaemon {
     }
 
     public PortConnectivityChecker() {
-        super("PortConnectivityChecker");
+        super("port-connectivity-checker");
         executor = ThreadPoolManager.newDaemonFixedThreadPool(4,
                 64, "port-connectivity-checker", true);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -108,7 +108,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
     protected Set<Long> publishingLakeTransactionsBatchTableId;
 
     public PublishVersionDaemon() {
-        super("PUBLISH_VERSION", Config.publish_version_interval_ms);
+        super("publish-version-daemon", Config.publish_version_interval_ms);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/warehouse/WarehouseIdleChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/warehouse/WarehouseIdleChecker.java
@@ -37,7 +37,7 @@ public class WarehouseIdleChecker extends FrontendDaemon {
     private final Map<Long, Long> warehouseIdleTime = new ConcurrentHashMap<>();
 
     public WarehouseIdleChecker() {
-        super("WarehouseIdleChecker", Config.warehouse_idle_check_interval_seconds * 1000);
+        super("warehouse-idle-checker", Config.warehouse_idle_check_interval_seconds * 1000);
     }
 
     @Override


### PR DESCRIPTION
## Why I'm doing:
Thread names changed to follow a consistent kebab-case naming convention (for example: report-handler, tablet-scheduler).

## What I'm doing:
Fixes ##65926

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies FE daemon/thread names to kebab-case across many classes for consistent naming.
> 
> - **Daemon/Thread naming**:
>   - Standardizes thread/daemon names to kebab-case in constructors across many FE components (e.g., schedulers, checkers, managers, services), replacing spaced/mixed-case names like `tablet checker` with `tablet-checker`.
>   - No functional logic changes; only constructor name strings updated for consistency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e521f272996ade705c16fcb113ceda1dc221ac2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->