### PR TITLE
[BugFix] Fix connector sink hang when writer's initial write fails

### DIFF
--- a/be/src/connector/connector_chunk_sink.cpp
+++ b/be/src/connector/connector_chunk_sink.cpp
@@ -58,9 +58,14 @@ Status ConnectorChunkSink::write_partition_chunk(const std::string& partition,
         writer->set_commit_callback(commit_callback);
         writer->set_error_handler(error_handler);
         writer->set_io_poller(_io_poller);
-        RETURN_IF_ERROR(writer->init());
-        RETURN_IF_ERROR(writer->write(chunk));
+        auto st = writer->init();
+        if (!st.ok()) {
+            set_status(st);
+            return st;
+        }
+        // save the writer to the map, so errors from subsequent write() can be correctly handled.
         _partition_chunk_writers[partition_key] = writer;
+        RETURN_IF_ERROR(writer->write(chunk));
     }
     return Status::OK();
 }

--- a/test/sql/test_files/R/test_insert_into_parquet_files_quick_fail
+++ b/test/sql/test_files/R/test_insert_into_parquet_files_quick_fail
@@ -1,0 +1,13 @@
+-- name: test_insert_into_parquet_files_quick_fail
+set time_zone = '+0800'; -- invalid time zone format
+
+insert into files(
+    "path" = "file:///tmp",
+    "format" = "parquet")
+select NOW() as t;
+-- result:
+[REGEX]E: .*can not find cctz time zone .*
+-- !result
+set time_zone = '+08:00'; -- valid time zone format
+-- result:
+-- !result

--- a/test/sql/test_files/T/test_insert_into_parquet_files_quick_fail
+++ b/test/sql/test_files/T/test_insert_into_parquet_files_quick_fail
@@ -1,0 +1,10 @@
+-- name: test_insert_into_parquet_files_quick_fail
+
+set time_zone = '+0800'; -- invalid time zone format
+
+insert into files(
+    "path" = "file:///tmp",
+    "format" = "parquet")
+select NOW() as t;
+
+set time_zone = '+08:00'; -- valid time zone format


### PR DESCRIPTION
## Why I'm doing:

Fix a race condition in ConnectorChunkSink where writer registration
happened after initialization and writing. If writer->init() or
writer->write() failed, the writer would never be added to the partition
map, causing subsequent operations (error handlers, commit callbacks) to
hang waiting for a writer that was never registered.

Added regression test using invalid timezone format which triggers
writer initialization failure to reproduce the hang condition.

## What I'm doing:

Fixes #65924 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
