### PR TITLE
xxxx

### DIFF
--- a/be/src/column/struct_column.cpp
+++ b/be/src/column/struct_column.cpp
@@ -342,13 +342,21 @@ int StructColumn::compare_at(size_t left, size_t right, const Column& rhs, int n
     auto rsize = rhs_struct._fields.size();
     auto size = std::min(lsize, rsize);
 
+    LOG(INFO) << "[STRUCT_COMPARE_AT] Comparing structs: left_row=" << left 
+              << ", right_row=" << right << ", fields=" << size 
+              << ", lsize=" << lsize << ", rsize=" << rsize;
+
     for (int i = 0; i < size; ++i) {
         auto cmp = _fields[i]->compare_at(left, right, *rhs_struct._fields[i].get(), nan_direction_hint);
         if (cmp != 0) {
+            LOG(INFO) << "[STRUCT_COMPARE_AT] Difference found at field " << i << ": cmp=" << cmp;
             return cmp;
         }
     }
-    return lsize < rsize ? -1 : (lsize == rsize ? 0 : 1);
+    
+    int result = lsize < rsize ? -1 : (lsize == rsize ? 0 : 1);
+    LOG(INFO) << "[STRUCT_COMPARE_AT] All fields equal, result=" << result;
+    return result;
 }
 
 int StructColumn::equals(size_t left, const Column& rhs, size_t right, bool safe_eq) const {

--- a/be/src/runtime/types.cpp
+++ b/be/src/runtime/types.cpp
@@ -276,6 +276,13 @@ bool TypeDescriptor::support_orderby() const {
     if (type == TYPE_ARRAY) {
         return children[0].support_orderby();
     }
+    if (type == TYPE_STRUCT) {
+        bool all_support = std::all_of(children.begin(), children.end(),
+                           [](const TypeDescriptor& t) { return t.support_orderby(); });
+        LOG(ERROR) << "[TRACE] TypeDescriptor::support_orderby() - TYPE_STRUCT with " << children.size() 
+                   << " children, all_support=" << all_support;
+        return all_support;
+    }
     return type != TYPE_JSON && type != TYPE_OBJECT && type != TYPE_PERCENTILE && type != TYPE_HLL &&
            type != TYPE_MAP && type != TYPE_VARIANT;
 }

--- a/fe/fe-type/src/main/java/com/starrocks/type/Type.java
+++ b/fe/fe-type/src/main/java/com/starrocks/type/Type.java
@@ -261,7 +261,17 @@ public abstract class Type implements Cloneable {
         if (isArrayType()) {
             return ((ArrayType) this).getItemType().canOrderBy();
         }
-        return !isOnlyMetricType() && !isJsonType() && !isFunctionType() && !isStructType() &&
+        if (isStructType()) {
+            // Struct can be ordered if all its fields can be ordered
+            StructType structType = (StructType) this;
+            for (StructField field : structType.getFields()) {
+                if (!field.getType().canOrderBy()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return !isOnlyMetricType() && !isJsonType() && !isFunctionType() &&
                 !isMapType() && !isVariantType();
     }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements STRUCT column comparison/sorting across BE (sorting, aggregators) and enables ORDER BY on STRUCT in both BE and FE when all fields are orderable.
> 
> - **Execution/Sorting (BE)**:
>   - Add `StructColumn` support in column-wise compare (`CompareColumn`), tie-building, and vertical sorting (`VerticalColumnSorter`), using `compare_at` for field-wise comparison.
>   - Support `StructColumn` in streaming aggregator utilities: self-compare and append-with-mask paths.
> - **Column**:
>   - Enhance `StructColumn::compare_at` with result handling (no logic change) and add diagnostics.
> - **Type system**:
>   - BE `TypeDescriptor.support_orderby()`: allow `TYPE_STRUCT` if all child types support ORDER BY.
>   - FE `Type.canOrderBy()`: allow struct ORDER BY when all fields are orderable.
> - **Logging**:
>   - Add trace/info logs around struct comparisons and sorting paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5192a75cab723f3bd4d95368523df2bb53ddfadd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->