### PR TITLE
[BugFix] Fix insert failure during concurrent add column with a default value

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -837,20 +837,20 @@ public class InsertPlanner {
 
             // columnIdx >= outputColumns.size() mean this is a new add schema change column
             if (columnIdx >= outputColumns.size()) {
-                ColumnRefOperator columnRefOperator = columnRefFactory.create(
-                        targetColumn.getName(), targetColumn.getType(), targetColumn.isAllowNull());
-                outputColumns.add(columnRefOperator);
-
+                ScalarOperator scalarOperator = null;
                 Column.DefaultValueType defaultValueType = targetColumn.getDefaultValueType();
                 if (defaultValueType == Column.DefaultValueType.NULL) {
-                    columnRefMap.put(columnRefOperator, ConstantOperator.createNull(targetColumn.getType()));
+                    scalarOperator = ConstantOperator.createNull(targetColumn.getType());
                 } else if (defaultValueType == Column.DefaultValueType.CONST) {
-                    columnRefMap.put(columnRefOperator, ConstantOperator.createVarchar(
-                            targetColumn.calculatedDefaultValue()));
+                    scalarOperator = ConstantOperator.createVarchar(targetColumn.calculatedDefaultValue());
                 } else if (defaultValueType == Column.DefaultValueType.VARY) {
                     throw new SemanticException("Column:" + targetColumn.getName() + " has unsupported default value:"
                             + targetColumn.getDefaultExpr().getExpr());
                 }
+                ColumnRefOperator col = columnRefFactory
+                        .create(scalarOperator, scalarOperator.getType(), scalarOperator.isNullable());
+                outputColumns.add(col);
+                columnRefMap.put(col, scalarOperator);
             } else {
                 columnRefMap.put(outputColumns.get(columnIdx), outputColumns.get(columnIdx));
             }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.alter;
 
 import com.google.api.client.util.Lists;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
@@ -34,7 +35,10 @@ import com.starrocks.server.WarehouseManager;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.CreateDbStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.task.AgentBatchTask;
+import com.starrocks.transaction.TransactionState;
 import com.starrocks.utframe.MockedWarehouseManager;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
@@ -45,11 +49,11 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -58,7 +62,6 @@ public class LakeTableSchemaChangeJobTest {
     private static ConnectContext connectContext;
     private static final String DB_NAME = "db_lake_schema_change_test";
     private static Database db;
-    private LakeTableSchemaChangeJob schemaChangeJob;
     private LakeTable table;
 
     public LakeTableSchemaChangeJobTest() {
@@ -103,6 +106,11 @@ public class LakeTableSchemaChangeJobTest {
         return (LakeTableSchemaChangeJob) alterJob;
     }
 
+    private LakeTableSchemaChangeJob alterTableAddColumn() throws Exception {
+        alterTable(connectContext, "ALTER TABLE t0 ADD COLUMN c1 BIGINT key NOT NULL default \"0\"");
+        return getAlterJob(table);
+    }
+
     @BeforeEach
     public void before() throws Exception {
         String createDbStmtStr = "create database " + DB_NAME;
@@ -112,10 +120,6 @@ public class LakeTableSchemaChangeJobTest {
         db = GlobalStateMgr.getServingState().getLocalMetastore().getDb(DB_NAME);
         table = createTable(connectContext, "CREATE TABLE t0(c0 INT) duplicate key(c0) distributed by hash(c0) buckets "
                     + NUM_BUCKETS);
-        Config.enable_fast_schema_evolution_in_share_data_mode = false;
-        alterTable(connectContext, "ALTER TABLE t0 ADD COLUMN c1 BIGINT AS c0 + 2");
-        schemaChangeJob = getAlterJob(table);
-        Config.enable_fast_schema_evolution_in_share_data_mode = true;
     }
 
     @AfterEach
@@ -124,7 +128,8 @@ public class LakeTableSchemaChangeJobTest {
     }
 
     @Test
-    public void testCancelPendingJob() throws IOException {
+    public void testCancelPendingJob() throws Exception {
+        LakeTableSchemaChangeJob schemaChangeJob = alterTableAddColumn();
         TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
         schemaChangeJob.cancel("test");
         Assertions.assertEquals(AlterJobV2.JobState.CANCELLED, schemaChangeJob.getJobState());
@@ -134,15 +139,16 @@ public class LakeTableSchemaChangeJobTest {
     }
 
     @Test
-    public void testDropTableBeforeCancel() {
+    public void testDropTableBeforeCancel() throws Exception {
+        LakeTableSchemaChangeJob schemaChangeJob = alterTableAddColumn();
         db.dropTable(table.getName());
-
         schemaChangeJob.cancel("test");
         Assertions.assertEquals(AlterJobV2.JobState.CANCELLED, schemaChangeJob.getJobState());
     }
 
     @Test
-    public void testPendingJobNoAliveBackend() {
+    public void testPendingJobNoAliveBackend() throws Exception {
+        LakeTableSchemaChangeJob schemaChangeJob = alterTableAddColumn();
         MockedWarehouseManager mockedWarehouseManager = new MockedWarehouseManager();
         new MockUp<GlobalStateMgr>() {
             @Mock
@@ -176,7 +182,8 @@ public class LakeTableSchemaChangeJobTest {
     }
 
     @Test
-    public void testTableDroppedInPending() {
+    public void testTableDroppedInPending() throws Exception {
+        LakeTableSchemaChangeJob schemaChangeJob = alterTableAddColumn();
         new MockUp<Utils>() {
             @Mock
             public Long chooseNodeId(LakeTablet tablet) {
@@ -202,7 +209,8 @@ public class LakeTableSchemaChangeJobTest {
     }
 
     @Test
-    public void testCreateTabletFailed() {
+    public void testCreateTabletFailed() throws Exception {
+        LakeTableSchemaChangeJob schemaChangeJob = alterTableAddColumn();
         new MockUp<LakeTableSchemaChangeJob>() {
             @Mock
             public void sendAgentTaskAndWait(AgentBatchTask batchTask, MarkedCountDownLatch<Long, Long> countDownLatch,
@@ -222,7 +230,8 @@ public class LakeTableSchemaChangeJobTest {
     }
 
     @Test
-    public void testCreateTabletSuccess() throws AlterCancelException {
+    public void testCreateTabletSuccess() throws Exception {
+        LakeTableSchemaChangeJob schemaChangeJob = alterTableAddColumn();
         schemaChangeJob.runPendingJob();
         Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, schemaChangeJob.getJobState());
 
@@ -237,7 +246,8 @@ public class LakeTableSchemaChangeJobTest {
     }
 
     @Test
-    public void testPreviousTxnNotFinished() throws AlterCancelException {
+    public void testPreviousTxnNotFinished() throws Exception {
+        LakeTableSchemaChangeJob schemaChangeJob = alterTableAddColumn();
         new MockUp<LakeTableSchemaChangeJob>() {
             @Mock
             public boolean isPreviousLoadFinished(long dbId, long tableId, long txnId) {
@@ -262,7 +272,8 @@ public class LakeTableSchemaChangeJobTest {
     }
 
     @Test
-    public void testThrowAnalysisExceptionWhileWaitingTxn() throws AlterCancelException {
+    public void testThrowAnalysisExceptionWhileWaitingTxn() throws Exception {
+        LakeTableSchemaChangeJob schemaChangeJob = alterTableAddColumn();
         new MockUp<LakeTableSchemaChangeJob>() {
             @Mock
             public boolean isPreviousLoadFinished(long dbId, long tableId, long txnId) throws AnalysisException {
@@ -288,7 +299,8 @@ public class LakeTableSchemaChangeJobTest {
     }
 
     @Test
-    public void testTableNotExistWhileWaitingTxn() throws AlterCancelException {
+    public void testTableNotExistWhileWaitingTxn() throws Exception {
+        LakeTableSchemaChangeJob schemaChangeJob = alterTableAddColumn();
         schemaChangeJob.runPendingJob();
         Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, schemaChangeJob.getJobState());
 
@@ -316,7 +328,8 @@ public class LakeTableSchemaChangeJobTest {
     }
 
     @Test
-    public void testTableDroppedBeforeRewriting() throws AlterCancelException {
+    public void testTableDroppedBeforeRewriting() throws Exception {
+        LakeTableSchemaChangeJob schemaChangeJob = alterTableAddColumn();
         schemaChangeJob.runPendingJob();
         Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, schemaChangeJob.getJobState());
 
@@ -347,7 +360,8 @@ public class LakeTableSchemaChangeJobTest {
     }
 
     @Test
-    public void testAlterTabletFailed() throws AlterCancelException {
+    public void testAlterTabletFailed() throws Exception {
+        LakeTableSchemaChangeJob schemaChangeJob = alterTableAddColumn();
         new MockUp<LakeTableSchemaChangeJob>() {
             @Mock
             public void sendAgentTask(AgentBatchTask batchTask) {
@@ -377,7 +391,8 @@ public class LakeTableSchemaChangeJobTest {
     }
 
     @Test
-    public void testAlterTabletSuccess() throws AlterCancelException {
+    public void testAlterTabletSuccess() throws Exception {
+        LakeTableSchemaChangeJob schemaChangeJob = alterTableAddColumn();
         new MockUp<LakeTableSchemaChangeJob>() {
             @Mock
             public void sendAgentTask(AgentBatchTask batchTask) {
@@ -418,6 +433,7 @@ public class LakeTableSchemaChangeJobTest {
 
     @Test
     public void testAlterTabletSuccessEnableFileBundling() throws Exception {
+        LakeTableSchemaChangeJob schemaChangeJob = alterTableAddColumn();
         new MockUp<LakeTableSchemaChangeJob>() {
             @Mock
             public void sendAgentTask(AgentBatchTask batchTask) {
@@ -463,6 +479,7 @@ public class LakeTableSchemaChangeJobTest {
 
     @Test
     public void testAlterTabletSuccessDisableFileBundling() throws Exception {
+        LakeTableSchemaChangeJob schemaChangeJob = alterTableAddColumn();
         new MockUp<LakeTableSchemaChangeJob>() {
             @Mock
             public void sendAgentTask(AgentBatchTask batchTask) {
@@ -507,7 +524,8 @@ public class LakeTableSchemaChangeJobTest {
     }
 
     @Test
-    public void testPublishVersion() throws AlterCancelException, InterruptedException {
+    public void testPublishVersion() throws Exception {
+        LakeTableSchemaChangeJob schemaChangeJob = alterTableAddColumn();
         new MockUp<LakeTableSchemaChangeJob>() {
             @Mock
             public void sendAgentTask(AgentBatchTask batchTask) {
@@ -594,6 +612,7 @@ public class LakeTableSchemaChangeJobTest {
 
     @Test
     public void testPublishRetry() throws Exception {
+        LakeTableSchemaChangeJob schemaChangeJob = alterTableAddColumn();
         AtomicInteger numPublishRetry = new AtomicInteger(0);
         new MockUp<LakeTableSchemaChangeJob>() {
             @Mock
@@ -643,7 +662,8 @@ public class LakeTableSchemaChangeJobTest {
     }
 
     @Test
-    public void testTransactionRaceCondition() throws AlterCancelException {
+    public void testTransactionRaceCondition() throws Exception {
+        LakeTableSchemaChangeJob schemaChangeJob = alterTableAddColumn();
         new MockUp<LakeTableSchemaChangeJob>() {
             @Mock
             public void sendAgentTask(AgentBatchTask batchTask) {
@@ -705,6 +725,7 @@ public class LakeTableSchemaChangeJobTest {
 
     @Test
     public void testCancelPendingJobWithFlag() throws Exception {
+        LakeTableSchemaChangeJob schemaChangeJob = alterTableAddColumn();
         schemaChangeJob.setIsCancelling(true);
         schemaChangeJob.runPendingJob();
         schemaChangeJob.setIsCancelling(false);
@@ -712,5 +733,29 @@ public class LakeTableSchemaChangeJobTest {
         schemaChangeJob.setWaitingCreatingReplica(true);
         schemaChangeJob.cancel("");
         schemaChangeJob.setWaitingCreatingReplica(false);
+    }
+
+    @Test
+    public void testInsertConcurrent() throws Exception {
+        TransactionState.TxnCoordinator coordinator = new TransactionState.TxnCoordinator(
+                TransactionState.TxnSourceType.BE, "127.0.0.1");
+        // block the schema change job to simulate concurrent insert
+        GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().beginTransaction(
+                db.getId(), List.of(table.getId()), UUID.randomUUID().toString(), coordinator,
+                TransactionState.LoadJobSourceType.BACKEND_STREAMING, 60000L);
+        LakeTableSchemaChangeJob schemaChangeJob = alterTableAddColumn();
+        Assertions.assertEquals(AlterJobV2.JobState.PENDING, schemaChangeJob.getJobState());
+        schemaChangeJob.run();
+        Assertions.assertEquals(AlterJobV2.JobState.WAITING_TXN, schemaChangeJob.getJobState());
+        ExecPlan execPlan = UtFrameUtils.getPlanAndFragment(connectContext, "insert into t0 values (1)").second;
+        List<Column> fullSchema = table.getFullSchema();
+        Assertions.assertEquals(2, fullSchema.size());
+        Assertions.assertEquals("c0", fullSchema.get(0).getName());
+        Assertions.assertEquals("c1", fullSchema.get(1).getName());
+        List<Expr> outputExprs = execPlan.getOutputExprs();
+        Assertions.assertEquals(fullSchema.size(), outputExprs.size());
+        for (int i = 0; i < fullSchema.size(); i++) {
+            Assertions.assertEquals(fullSchema.get(i).getType(), outputExprs.get(i).getType());
+        }
     }
 }

--- a/test/sql/test_alter_table/R/test_schema_change_and_insert_concurrent
+++ b/test/sql/test_alter_table/R/test_schema_change_and_insert_concurrent
@@ -1,0 +1,62 @@
+-- name: test_schema_change_and_insert_concurrent
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+create table t (
+    c0 int
+) duplicate key (c0)
+distributed by hash (c0) buckets 1
+properties (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t values (1);
+-- result:
+-- !result
+[UC]shell: curl --location-trusted -u root: -H "label:test_txn_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:t" -XPOST ${url}/api/transaction/begin
+-- result:
+0
+{
+    "Status": "OK",
+    "Message": "",
+    "Db": "db_5bd33b14660640aaa6d04122f2d23b6f",
+    "Table": "t",
+    "Label": "test_txn_5bd33b14660640aaa6d04122f2d23b6f",
+    "TxnId": 1004,
+    "BeginTxnTimeMs": 14
+}
+-- !result
+alter table t add column c1 int key NOT NULL default "2";
+-- result:
+-- !result
+function: wait_alter_table_waiting_txn()
+-- result:
+WAITING_TXN
+-- !result
+insert into t values (2);
+-- result:
+-- !result
+[UC]shell: curl --location-trusted -u root: -H "label:test_txn_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -XPOST ${url}/api/transaction/rollback
+-- result:
+0
+{
+    "Status": "OK",
+    "Message": "",
+    "Db": "",
+    "Table": "",
+    "Label": "test_txn_5bd33b14660640aaa6d04122f2d23b6f"
+}
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from t order by c0;
+-- result:
+1	2
+2	2
+-- !result

--- a/test/sql/test_alter_table/T/test_schema_change_and_insert_concurrent
+++ b/test/sql/test_alter_table/T/test_schema_change_and_insert_concurrent
@@ -1,0 +1,29 @@
+-- name: test_schema_change_and_insert_concurrent
+
+create database db_${uuid0};
+use db_${uuid0};
+
+create table t (
+    c0 int
+) duplicate key (c0)
+distributed by hash (c0) buckets 1
+properties (
+    "replication_num" = "1"
+);
+
+insert into t values (1);
+
+[UC]shell: curl --location-trusted -u root: -H "label:test_txn_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -H "table:t" -XPOST ${url}/api/transaction/begin
+
+alter table t add column c1 int key NOT NULL default "2";
+
+function: wait_alter_table_waiting_txn()
+
+insert into t values (2);
+
+[UC]shell: curl --location-trusted -u root: -H "label:test_txn_${uuid0}" -H "Expect:100-continue" -H "db:db_${uuid0}" -XPOST ${url}/api/transaction/rollback
+
+function: wait_alter_table_finish()
+
+select * from t order by c0;
+


### PR DESCRIPTION
## Why I'm doing:
- **Problem**: During `ALTER TABLE ADD COLUMN` with a default value, a concurrent `INSERT` fails with type mismatch
```
create table t (
    c0 int
) duplicate key (c0)
distributed by hash (c0) buckets 1;

alter table t add column c1 int key NOT NULL default "2";

-- insert before the alter finished
insert into t values (2);

-- slot_type 5 is the type INT of the c1 column to add, expr_type 17 is VARCHAR which is the type of default const expr
W20251126 14:19:42.127170 22869312996928 tablet_sink.cpp:272] type of exprs is not match slot's, expr_type=17, slot_type=5, slot_name=c1
```

- **Root cause**: For newly added columns, the default was materialized as a constant with VARCHAR type and didn’t flow through the `ColumnRefOperator` → projection pipeline. As a result, `castOutputColumnsTypeToTargetColumns` didn’t see it, and the sink received a mismatched type.

## What I'm doing:
- **Fix**: In `InsertPlanner.fillShadowColumns`, construct a `ScalarOperator` for the default and wire it to a `ColumnRefOperator` included in `outputColumns`. This ensures the cast phase applies to the new column’s default, aligning types end-to-end.
- **Key code paths**: `InsertPlanner.fillShadowColumns`, `castOutputColumnsTypeToTargetColumns`, `ColumnRefOperator`, `ScalarOperator` (default), `ConstantOperator`.
- **Tests**:
  - UT: `LakeTableSchemaChangeJobTest#testInsertConcurrent`.
  - SQL: `test/sql/test_alter_table/*/test_schema_change_and_insert_concurrent`.


Fixes #issue

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 4.0
  - [X] 3.5
  - [X] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes insert type mismatch during concurrent ADD COLUMN with default by projecting the default as a scalar for shadow columns; adds unit/SQL tests and a test helper.
> 
> - **Planner (FE)**:
>   - In `InsertPlanner.fillShadowColumns`, for newly added `shadow` columns, build a `ScalarOperator` for the column default and create the `ColumnRefOperator` from it, wiring it into `outputColumns` and projection (`columnRefMap`). Ensures later `castOutputColumnsTypeToTargetColumns` applies, preventing type mismatch in sinks.
> - **Tests**:
>   - Java UT: add `LakeTableSchemaChangeJobTest#testInsertConcurrent`; refactor tests to use `alterTableAddColumn()` and broaden `throws Exception` where needed.
>   - SQL: add `test/sql/test_alter_table/*/test_schema_change_and_insert_concurrent` to validate concurrent insert with ADD COLUMN default.
>   - Test lib: add `wait_alter_table_waiting_txn()` in `test/lib/sr_sql_lib.py` for waiting on `WAITING_TXN` state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 830da8216f62c6ef1078debc25433330f46452c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->