### PR TITLE
[BugFix] Fix mv refresh skipped when iceberg table contains expired snapshots

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.MetadataTableUtils;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionsTable;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.StarRocksIcebergTableScan;
 import org.apache.iceberg.StructLike;
@@ -298,21 +299,19 @@ public interface IcebergCatalog extends MemoryTrackable {
                     CloseableIterable<StructLike> rows = task.asDataTask().rows();
                     for (StructLike row : rows) {
                         // Get the last updated time of the table according to the table schema
-                        long lastUpdated = -1;
-                        try {
-                            lastUpdated = row.get(7, Long.class);
-                        } catch (NullPointerException e) {
-                            // It is a known issue but we do not hanle it right now. If the refresh frequency of
-                            // the materialized view is very high, an excessive number of error logs will be printed.
-                            // Therefore, only brief logs are printed now.
-                            logger.error("The table [{}] snapshot [{}] has been expired", nativeTable.name(), snapshotId);
-                        }
+                        // last_updated_at can be null if the referenced snapshot has been expired.
+                        // Use Long wrapper to avoid NPE during auto-unboxing.
+                        long lastUpdated = getPartitionLastUpdatedTime(icebergTable, row, 7,
+                                EMPTY_PARTITION_NAME, snapshotId);
                         partition = new Partition(lastUpdated);
                         break;
                     }
                 }
                 if (partition == null) {
-                    partition = new Partition(-1);
+                    long tableLastestSnapshotTime = getTableLastestSnapshotTime(icebergTable);
+                    logger.warn("The unpartitioned table [{}] has no partitions in PartitionsTable, " +
+                            "using {} as last updated time", nativeTable.name(), tableLastestSnapshotTime);
+                    partition = new Partition(tableLastestSnapshotTime);
                 }
                 partitionMap.put(EMPTY_PARTITION_NAME, partition);
             } catch (IOException e) {
@@ -343,14 +342,8 @@ public interface IcebergCatalog extends MemoryTrackable {
 
                         String partitionName =
                                 PartitionUtil.convertIcebergPartitionToPartitionName(nativeTable, spec, partitionData);
-
-                        long lastUpdated = -1;
-                        try {
-                            lastUpdated = row.get(9, Long.class);
-                        } catch (NullPointerException e) {
-                            logger.error("The table [{}.{}] snapshot [{}] has been expired", nativeTable.name(), partitionName,
-                                    snapshotId, e);
-                        }
+                        long lastUpdated =
+                                getPartitionLastUpdatedTime(icebergTable, row, 9, partitionName, snapshotId);
                         Partition partition = new Partition(lastUpdated, specId);
                         partitionMap.put(partitionName, partition);
                     }
@@ -360,6 +353,38 @@ public interface IcebergCatalog extends MemoryTrackable {
             }
         }
         return partitionMap;
+    }
+
+    private long getPartitionLastUpdatedTime(IcebergTable icebergTable, StructLike row,
+                                             int columnIndex, String partitionName,
+                                             long snapshotId) {
+        Table nativeTable = icebergTable.getNativeTable();
+        Logger logger = getLogger();
+        // last_updated_at can be null if the referenced snapshot has been expired.
+        // Use Long wrapper to avoid NPE during auto-unboxing.
+        long lastUpdated = -1;
+        try {
+            lastUpdated = row.get(columnIndex, Long.class);
+        } catch (NullPointerException e) {
+            logger.error("The table [{}.{}] snapshot [{}] has been expired", nativeTable.name(), partitionName,
+                    snapshotId, e);
+        }
+        if (lastUpdated ==  -1) {
+            // Fallback to current snapshot's timestamp if last_updated_at is null due to snapshot expiration.
+            lastUpdated = getTableLastestSnapshotTime(icebergTable);
+            logger.warn("The table [{}] last_updated_at is null (snapshot [{}] may have been expired), " +
+                    "using current snapshot timestamp: {}", nativeTable.name(), snapshotId, lastUpdated);
+        }
+        return lastUpdated;
+    }
+
+    private long getTableLastestSnapshotTime(IcebergTable icebergTable) {
+        Table nativeTable = icebergTable.getNativeTable();
+        Snapshot snapshot = nativeTable.currentSnapshot();
+        if (snapshot == null) {
+            throw new StarRocksConnectorException("Table " + nativeTable.name() + " has no snapshot");
+        }
+        return snapshot.timestampMillis();
     }
 
     default List<String> listPartitionNames(IcebergTable icebergTable,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -363,11 +363,13 @@ public interface IcebergCatalog extends MemoryTrackable {
         // last_updated_at can be null if the referenced snapshot has been expired.
         // Use Long wrapper to avoid NPE during auto-unboxing.
         long lastUpdated = -1;
-        try {
-            lastUpdated = row.get(columnIndex, Long.class);
-        } catch (NullPointerException e) {
-            logger.error("The table [{}.{}] snapshot [{}] has been expired", nativeTable.name(), partitionName,
-                    snapshotId, e);
+        if (row != null) {
+            try {
+                lastUpdated = row.get(columnIndex, Long.class);
+            } catch (Exception e) {
+                logger.error("Failed to get last_updated_at for partition [{}] of table [{}] " +
+                                "under snapshot [{}]", partitionName, nativeTable.name(), snapshotId, e);
+            }
         }
         if (lastUpdated ==  -1) {
             // Fallback to current snapshot's timestamp if last_updated_at is null due to snapshot expiration.

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
@@ -257,7 +257,7 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
         // record mv refresh trace info for better debugging
         // TODO: it may be too long, need to optimize it later.
         String mvRefreshInfo = getMVRefreshTraceInfo();
-        Tracers.record("MVRefreshInfo", mvRefreshInfo);
+        Tracers.record("MVRefreshPartitionInfo", mvRefreshInfo);
 
         Throwable lastException = null;
         int lockFailedTimes = 0;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVTaskRunProcessor.java
@@ -46,6 +46,7 @@ import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.common.QueryDebugOptions;
 import com.starrocks.sql.optimizer.QueryMaterializationContext;
+import com.starrocks.sql.optimizer.function.MetaFunctions;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TUniqueId;
@@ -233,12 +234,30 @@ public class MVTaskRunProcessor extends BaseTaskRunProcessor implements MVRefres
     }
 
     /**
+     * Get the trace info for mv refresh for better debugging.
+     * @return current mv refresh trace info about base tables and partitions.
+     */
+    private String getMVRefreshTraceInfo() {
+        try {
+            return MetaFunctions.inspectMVRefreshInfo(db, mv);
+        } catch (Exception e) {
+            logger.warn("failed to inspect mv refresh info for mv: {}", mv.getName(), e);
+        }
+        return "";
+    }
+
+    /**
      * Retry the `doRefreshMaterializedView` method to avoid insert fails in occasional cases.
      */
     private Constants.TaskRunState retryProcessTaskRun(TaskRunContext taskRunContext) throws DmlException {
         // Use current connection variables instead of mvContext's session variables to be better debug.
         int maxRefreshMaterializedViewRetryNum = mvRefreshProcessor.getRetryTimes(taskRunContext.getCtx());
         logger.info("start to refresh mv with retry times:{}", maxRefreshMaterializedViewRetryNum);
+
+        // record mv refresh trace info for better debugging
+        // TODO: it may be too long, need to optimize it later.
+        String mvRefreshInfo = getMVRefreshTraceInfo();
+        Tracers.record("MVRefreshInfo", mvRefreshInfo);
 
         Throwable lastException = null;
         int lockFailedTimes = 0;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -1523,7 +1523,8 @@ public class IcebergMetadataTest extends TableTestBase {
 
         List<PartitionInfo> partitions = metadata.getPartitions(icebergTable, ImmutableList.of("k2=2", "k2=3"));
         Assertions.assertEquals(2, partitions.size());
-        Assertions.assertTrue(partitions.stream().anyMatch(x -> x.getModifiedTime() == -1));
+        // partition's modified time should not be -1 even if snapshot has been expired
+        Assertions.assertTrue(partitions.stream().noneMatch(x -> x.getModifiedTime() == -1));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorIcebergTest.java
@@ -350,12 +350,14 @@ public class PartitionBasedMvRefreshProcessorIcebergTest extends MVTestBase {
                         QueryMaterializationContext.QueryCacheStats queryCacheStats = getQueryCacheStats(runtimeProfile);
                         Assertions.assertTrue(queryCacheStats != null);
                         queryCacheStats.getCounter().forEach((key, value) -> {
-                            if (key.contains("cache_partitionNames")) {
+                            if (key.contains("cache_partitionNames_")) {
                                 Assertions.assertEquals(1L, value.longValue());
-                            } else if (key.contains("cache_getPartitionKeyRange")) {
+                            } else if (key.contains("cache_getPartitionKeyRange_")) {
                                 Assertions.assertEquals(3L, value.longValue());
-                            } else {
+                            } else if (key.contains("cache_getPartitionNameWithPartitionInfo_")) {
                                 Assertions.assertEquals(1L, value.longValue());
+                            } else if (key.contains("cache_getUpdatedPartitionNames_")) {
+                                Assertions.assertEquals(2L, value.longValue());
                             }
                         });
                         Set<String> partitionsToRefresh1 = getPartitionNamesToRefreshForMv(mv);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapPart2Test.java
@@ -285,7 +285,7 @@ public class PartitionBasedMvRefreshProcessorOlapPart2Test extends MVTestBase {
                         String key = String.format("cache_getUpdatedPartitionNames_%s_%s", mv.getId(), table.getId());
                         Assertions.assertTrue(queryCacheStats != null);
                         Assertions.assertTrue(queryCacheStats.getCounter().containsKey(key));
-                        Assertions.assertTrue(queryCacheStats.getCounter().get(key) == 1);
+                        Assertions.assertTrue(queryCacheStats.getCounter().get(key) >= 1);
                     }
 
                     Set<String> partitionsToRefresh1 = getPartitionNamesToRefreshForMv(mv);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -2687,6 +2687,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                             "MVRefreshPrepareRefreshPlan",
                             "MVRefreshParser",
                             "MVRefreshAnalyzer",
+                            "MVRefreshPartitionInfo",
                             "AnalyzeDatabase",
                             "AnalyzeTemporaryTable",
                             "AnalyzeTable",

--- a/test/sql/test_materialized_view/R/test_mv_iceberg_rewrite_with_expired
+++ b/test/sql/test_materialized_view/R/test_mv_iceberg_rewrite_with_expired
@@ -1,0 +1,276 @@
+-- name: test_mv_iceberg_rewrite_with_expired
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_ice_db_${uuid0};
+-- result:
+-- !result
+use mv_ice_db_${uuid0};
+-- result:
+-- !result
+create table mv_ice_tbl_${uuid0} (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt);
+-- result:
+-- !result
+insert into mv_ice_tbl_${uuid0} values 
+  ('1d8cf2a2c0e14fa89d8117792be6eb6f', 2000, '2023-12-01'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2000, '2023-12-01');
+-- result:
+-- !result
+insert into mv_ice_tbl_${uuid0} values 
+  ('abc', 2000, '2023-12-02'),
+  (NULL, 2000, '2023-12-02');
+-- result:
+-- !result
+insert into mv_ice_tbl_${uuid0} values 
+  ('ab1d8cf2a2c0e14fa89d8117792be6eb6f', 2001, '2023-12-03'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2001, '2023-12-03');
+-- result:
+-- !result
+insert into mv_ice_tbl_${uuid0} values 
+  ('abc', 2001, '2023-12-04'),
+  (NULL, 2001, '2023-12-04');
+-- result:
+-- !result
+create table t1 (
+  col_str string,
+  col_int int,
+  dt date
+);
+-- result:
+-- !result
+insert into t1 values 
+  ('1d8cf2a2c0e14fa89d8117792be6eb6f', 2000, '2023-12-01'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2000, '2023-12-01');
+-- result:
+-- !result
+insert into t1 values 
+  ('abc', 2000, '2023-12-02'),
+  (NULL, 2000, '2023-12-02');
+-- result:
+-- !result
+insert into t1 values 
+  ('ab1d8cf2a2c0e14fa89d8117792be6eb6f', 2001, '2023-12-03'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2001, '2023-12-03');
+-- result:
+-- !result
+insert into t1 values 
+  ('abc', 2001, '2023-12-04'),
+  (NULL, 2001, '2023-12-04');
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt 
+REFRESH DEFERRED MANUAL AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
+-- result:
+8
+-- !result
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} execute expire_snapshots(now());
+-- result:
+-- !result
+select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
+-- result:
+8
+-- !result
+[UC]select inspect_mv_refresh_info("test_mv1");
+-- result:
+{"tableToUpdatePartitions":{},"tablePartitionInfos":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":"{\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327221000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150326843000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327795000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327468000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":{"dt\u003d2023-12-02":{"id":-1,"version":1764150327221000,"lastRefreshTime":1764150327221000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1764150326843000,"lastRefreshTime":1764150326843000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1764150327795000,"lastRefreshTime":1764150327795000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1764150327468000,"lastRefreshTime":1764150327468000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+[UC]select inspect_mv_refresh_info("test_mv1");
+-- result:
+{"tableToUpdatePartitions":{},"tablePartitionInfos":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":"{\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327221000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150326843000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327795000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327468000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":{"dt\u003d2023-12-02":{"id":-1,"version":1764150327221000,"lastRefreshTime":1764150327221000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1764150326843000,"lastRefreshTime":1764150326843000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1764150327795000,"lastRefreshTime":1764150327795000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1764150327468000,"lastRefreshTime":1764150327468000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+-- !result
+select count(1) from test_mv1;
+-- result:
+8
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} values ('test', 2002, '2023-12-05');
+-- result:
+-- !result
+[UC]select inspect_mv_refresh_info("test_mv1");
+-- result:
+{"tableToUpdatePartitions":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":["dt\u003d2023-12-05","dt\u003d2023-12-02","dt\u003d2023-12-01","dt\u003d2023-12-03"]},"tablePartitionInfos":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":"{\"dt\u003d2023-12-05\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150333496000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150333496,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150333496,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327795000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150333496,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":{"dt\u003d2023-12-02":{"id":-1,"version":1764150327221000,"lastRefreshTime":1764150327221000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1764150326843000,"lastRefreshTime":1764150326843000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1764150327795000,"lastRefreshTime":1764150327795000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1764150327468000,"lastRefreshTime":1764150327468000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+[UC]select inspect_mv_refresh_info("test_mv1");
+-- result:
+{"tableToUpdatePartitions":{},"tablePartitionInfos":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":"{\"dt\u003d2023-12-05\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150333496000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150333496,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150333496,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327795000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150333496,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":{"dt\u003d2023-12-02":{"id":-1,"version":1764150333496,"lastRefreshTime":1764150333496,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1764150333496,"lastRefreshTime":1764150333496,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1764150327795000,"lastRefreshTime":1764150327795000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1764150333496,"lastRefreshTime":1764150333496,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-05":{"id":-1,"version":1764150333496000,"lastRefreshTime":1764150333496000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+-- !result
+select count(1) from test_mv1;
+-- result:
+9
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} values ('test', 2002, '2023-12-05');
+-- result:
+-- !result
+[UC]select inspect_mv_refresh_info("test_mv1");
+-- result:
+{"tableToUpdatePartitions":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":["dt\u003d2023-12-05","dt\u003d2023-12-02","dt\u003d2023-12-01","dt\u003d2023-12-03"]},"tablePartitionInfos":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":"{\"dt\u003d2023-12-05\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327795000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":{"dt\u003d2023-12-02":{"id":-1,"version":1764150333496,"lastRefreshTime":1764150333496,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1764150333496,"lastRefreshTime":1764150333496,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1764150327795000,"lastRefreshTime":1764150327795000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1764150333496,"lastRefreshTime":1764150333496,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-05":{"id":-1,"version":1764150333496000,"lastRefreshTime":1764150333496000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+[UC]select inspect_mv_refresh_info("test_mv1");
+-- result:
+{"tableToUpdatePartitions":{},"tablePartitionInfos":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":"{\"dt\u003d2023-12-05\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327795000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":{"dt\u003d2023-12-02":{"id":-1,"version":1764150336112,"lastRefreshTime":1764150336112,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1764150336112,"lastRefreshTime":1764150336112,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1764150327795000,"lastRefreshTime":1764150327795000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1764150336112,"lastRefreshTime":1764150336112,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-05":{"id":-1,"version":1764150336112000,"lastRefreshTime":1764150336112000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+-- !result
+select count(1) from test_mv1;
+-- result:
+10
+-- !result
+CREATE MATERIALIZED VIEW test_mv2 
+REFRESH DEFERRED MANUAL AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+select count(1) from test_mv2;
+-- result:
+8
+-- !result
+select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+-- result:
+8
+-- !result
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 execute expire_snapshots(now());
+-- result:
+-- !result
+select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+-- result:
+8
+-- !result
+[UC]select inspect_mv_refresh_info("test_mv2");
+-- result:
+{"tableToUpdatePartitions":{},"tablePartitionInfos":{"t1":"{\"t1\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150329103000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.t1":{"t1":{"id":-1,"version":1764150329103000,"lastRefreshTime":1764150329103000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+-- !result
+REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+[UC]select inspect_mv_refresh_info("test_mv2");
+-- result:
+{"tableToUpdatePartitions":{},"tablePartitionInfos":{"t1":"{\"t1\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150329103000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.t1":{"t1":{"id":-1,"version":1764150329103000,"lastRefreshTime":1764150329103000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+-- !result
+select count(1) from test_mv2;
+-- result:
+8
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('test', 2002, '2023-12-05');
+-- result:
+-- !result
+[UC]select inspect_mv_refresh_info("test_mv2");
+-- result:
+{"tableToUpdatePartitions":{"t1":["t1"]},"tablePartitionInfos":{"t1":"{\"t1\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150338599000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.t1":{"t1":{"id":-1,"version":1764150329103000,"lastRefreshTime":1764150329103000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+-- !result
+REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+[UC]select inspect_mv_refresh_info("test_mv2");
+-- result:
+{"tableToUpdatePartitions":{},"tablePartitionInfos":{"t1":"{\"t1\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150338599000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.t1":{"t1":{"id":-1,"version":1764150338599000,"lastRefreshTime":1764150338599000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+-- !result
+select count(1) from test_mv2;
+-- result:
+9
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('test', 2002, '2023-12-06');
+-- result:
+-- !result
+[UC]select inspect_mv_refresh_info("test_mv2");
+-- result:
+{"tableToUpdatePartitions":{"t1":["t1"]},"tablePartitionInfos":{"t1":"{\"t1\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150339885000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.t1":{"t1":{"id":-1,"version":1764150338599000,"lastRefreshTime":1764150338599000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+-- !result
+REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+[UC]select inspect_mv_refresh_info("test_mv2");
+-- result:
+{"tableToUpdatePartitions":{},"tablePartitionInfos":{"t1":"{\"t1\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150339885000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.t1":{"t1":{"id":-1,"version":1764150339885000,"lastRefreshTime":1764150339885000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+-- !result
+select count(1) from test_mv2;
+-- result:
+10
+-- !result
+CREATE MATERIALIZED VIEW test_mv3 
+REFRESH DEFERRED MANUAL AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
+[UC]select inspect_mv_refresh_info("test_mv3");
+-- result:
+{"tableToUpdatePartitions":{},"tablePartitionInfos":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":"{\"dt\u003d2023-12-05\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327795000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":{"dt\u003d2023-12-02":{"id":-1,"version":1764150336112,"lastRefreshTime":1764150336112,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1764150336112,"lastRefreshTime":1764150336112,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1764150327795000,"lastRefreshTime":1764150327795000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1764150336112,"lastRefreshTime":1764150336112,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-05":{"id":-1,"version":1764150336112000,"lastRefreshTime":1764150336112000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+-- !result
+REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
+[UC]select inspect_mv_refresh_info("test_mv3");
+-- result:
+{"tableToUpdatePartitions":{},"tablePartitionInfos":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":"{\"dt\u003d2023-12-05\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327795000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":{"dt\u003d2023-12-02":{"id":-1,"version":1764150336112,"lastRefreshTime":1764150336112,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1764150336112,"lastRefreshTime":1764150336112,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1764150327795000,"lastRefreshTime":1764150327795000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1764150336112,"lastRefreshTime":1764150336112,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-05":{"id":-1,"version":1764150336112000,"lastRefreshTime":1764150336112000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+-- !result
+select count(1) from test_mv3;
+-- result:
+10
+-- !result
+[UC]select inspect_mv_refresh_info("test_mv3");
+-- result:
+{"tableToUpdatePartitions":{},"tablePartitionInfos":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":"{\"dt\u003d2023-12-05\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327795000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150336112,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":{"dt\u003d2023-12-02":{"id":-1,"version":1764150336112,"lastRefreshTime":1764150336112,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1764150336112,"lastRefreshTime":1764150336112,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1764150327795000,"lastRefreshTime":1764150327795000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1764150336112,"lastRefreshTime":1764150336112,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-05":{"id":-1,"version":1764150336112000,"lastRefreshTime":1764150336112000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} values ('test', 2002, '2023-12-05');
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
+[UC]select inspect_mv_refresh_info("test_mv3");
+-- result:
+{"tableToUpdatePartitions":{},"tablePartitionInfos":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":"{\"dt\u003d2023-12-05\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150342593000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150342593,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150342593,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327795000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150342593,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":{"dt\u003d2023-12-02":{"id":-1,"version":1764150342593,"lastRefreshTime":1764150342593,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1764150342593,"lastRefreshTime":1764150342593,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1764150327795000,"lastRefreshTime":1764150327795000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1764150342593,"lastRefreshTime":1764150342593,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-05":{"id":-1,"version":1764150342593000,"lastRefreshTime":1764150342593000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+-- !result
+select count(1) from test_mv3;
+-- result:
+11
+-- !result
+[UC]select inspect_mv_refresh_info("test_mv3");
+-- result:
+{"tableToUpdatePartitions":{},"tablePartitionInfos":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":"{\"dt\u003d2023-12-05\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150342593000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150342593,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150342593,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327795000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150342593,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":{"dt\u003d2023-12-02":{"id":-1,"version":1764150342593,"lastRefreshTime":1764150342593,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1764150342593,"lastRefreshTime":1764150342593,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1764150327795000,"lastRefreshTime":1764150327795000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1764150342593,"lastRefreshTime":1764150342593,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-05":{"id":-1,"version":1764150342593000,"lastRefreshTime":1764150342593000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+-- !result
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} values ('test', 2002, '2023-12-05');
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
+[UC]select inspect_mv_refresh_info("test_mv3");
+-- result:
+{"tableToUpdatePartitions":{},"tablePartitionInfos":{"mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":"{\"dt\u003d2023-12-05\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150344209000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-02\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150344209,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-01\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150344209,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-04\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150327795000,\"lastFileModifiedTime\":-1,\"fileNumber\":-1},\"dt\u003d2023-12-03\":{\"id\":-1,\"version\":-1,\"lastRefreshTime\":1764150344209,\"lastFileModifiedTime\":-1,\"fileNumber\":-1}}"},"baseOlapTableVisibleVersionMap":{},"baseExternalTableInfoVisibleVersionMap":{"mv_iceberg_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_db_5eabdfddf5424deaab35bc7ffce684b8.mv_ice_tbl_5eabdfddf5424deaab35bc7ffce684b8":{"dt\u003d2023-12-02":{"id":-1,"version":1764150344209,"lastRefreshTime":1764150344209,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-01":{"id":-1,"version":1764150344209,"lastRefreshTime":1764150344209,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-04":{"id":-1,"version":1764150327795000,"lastRefreshTime":1764150327795000,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-03":{"id":-1,"version":1764150344209,"lastRefreshTime":1764150344209,"lastFileModifiedTime":-1,"fileNumber":-1},"dt\u003d2023-12-05":{"id":-1,"version":1764150344209000,"lastRefreshTime":1764150344209000,"lastFileModifiedTime":-1,"fileNumber":-1}}}}
+-- !result
+select count(1) from test_mv3;
+-- result:
+12
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv2;
+-- result:
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv3;
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} force;
+-- result:
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
+-- result:
+-- !result
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/T/test_mv_iceberg_rewrite_with_expired
+++ b/test/sql/test_materialized_view/T/test_mv_iceberg_rewrite_with_expired
@@ -1,0 +1,139 @@
+-- name: test_mv_iceberg_rewrite_with_expired
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog mv_iceberg_${uuid0};
+create database mv_ice_db_${uuid0};
+use mv_ice_db_${uuid0};
+
+create table mv_ice_tbl_${uuid0} (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt);
+insert into mv_ice_tbl_${uuid0} values 
+  ('1d8cf2a2c0e14fa89d8117792be6eb6f', 2000, '2023-12-01'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2000, '2023-12-01');
+insert into mv_ice_tbl_${uuid0} values 
+  ('abc', 2000, '2023-12-02'),
+  (NULL, 2000, '2023-12-02');
+insert into mv_ice_tbl_${uuid0} values 
+  ('ab1d8cf2a2c0e14fa89d8117792be6eb6f', 2001, '2023-12-03'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2001, '2023-12-03');
+insert into mv_ice_tbl_${uuid0} values 
+  ('abc', 2001, '2023-12-04'),
+  (NULL, 2001, '2023-12-04');
+
+create table t1 (
+  col_str string,
+  col_int int,
+  dt date
+);
+insert into t1 values 
+  ('1d8cf2a2c0e14fa89d8117792be6eb6f', 2000, '2023-12-01'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2000, '2023-12-01');
+insert into t1 values 
+  ('abc', 2000, '2023-12-02'),
+  (NULL, 2000, '2023-12-02');
+insert into t1 values 
+  ('ab1d8cf2a2c0e14fa89d8117792be6eb6f', 2001, '2023-12-03'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2001, '2023-12-03');
+insert into t1 values 
+  ('abc', 2001, '2023-12-04'),
+  (NULL, 2001, '2023-12-04');
+
+
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+-- test partitioned mv
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt 
+REFRESH DEFERRED MANUAL AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
+-- select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}$snapshots;
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} execute expire_snapshots(now());
+select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
+-- select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}$snapshots;
+
+[UC]select inspect_mv_refresh_info("test_mv1");
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+[UC]select inspect_mv_refresh_info("test_mv1");
+select count(1) from test_mv1;
+
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} values ('test', 2002, '2023-12-05');
+
+[UC]select inspect_mv_refresh_info("test_mv1");
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+[UC]select inspect_mv_refresh_info("test_mv1");
+select count(1) from test_mv1;
+
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} values ('test', 2002, '2023-12-05');
+[UC]select inspect_mv_refresh_info("test_mv1");
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+[UC]select inspect_mv_refresh_info("test_mv1");
+select count(1) from test_mv1;
+
+-- test non-partitioned mv
+CREATE MATERIALIZED VIEW test_mv2 
+REFRESH DEFERRED MANUAL AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+
+select count(1) from test_mv2;
+select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+alter table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 execute expire_snapshots(now());
+select count(1) from mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1;
+
+[UC]select inspect_mv_refresh_info("test_mv2");
+REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+[UC]select inspect_mv_refresh_info("test_mv2");
+select count(1) from test_mv2;
+
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('test', 2002, '2023-12-05');
+
+[UC]select inspect_mv_refresh_info("test_mv2");
+REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+[UC]select inspect_mv_refresh_info("test_mv2");
+select count(1) from test_mv2;
+
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 values ('test', 2002, '2023-12-06');
+[UC]select inspect_mv_refresh_info("test_mv2");
+REFRESH MATERIALIZED VIEW test_mv2 WITH SYNC MODE;
+[UC]select inspect_mv_refresh_info("test_mv2");
+select count(1) from test_mv2;
+
+-- test partitioned mv
+CREATE MATERIALIZED VIEW test_mv3 
+REFRESH DEFERRED MANUAL AS SELECT * FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
+REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
+
+[UC]select inspect_mv_refresh_info("test_mv3");
+REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
+[UC]select inspect_mv_refresh_info("test_mv3");
+select count(1) from test_mv3;
+
+[UC]select inspect_mv_refresh_info("test_mv3");
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} values ('test', 2002, '2023-12-05');
+REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
+[UC]select inspect_mv_refresh_info("test_mv3");
+select count(1) from test_mv3;
+
+[UC]select inspect_mv_refresh_info("test_mv3");
+insert into mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} values ('test', 2002, '2023-12-05');
+REFRESH MATERIALIZED VIEW test_mv3 WITH SYNC MODE;
+[UC]select inspect_mv_refresh_info("test_mv3");
+select count(1) from test_mv3;
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+drop materialized view default_catalog.db_${uuid0}.test_mv2;
+drop materialized view default_catalog.db_${uuid0}.test_mv3;
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} force;
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.t1 force;
+drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;
+


### PR DESCRIPTION
## Why I'm doing:

I found MV cannot track iceberg's changes after iceberg table meets expired snapshots:
```
2025-11-26 00:10:09.562Z ERROR (starrocks-taskrun-pool-14184|6960727) [IcebergCatalog.getPartitions():273] The table [sei_iceberg.xxxx.cicd_job_runs.integration_id=null/start_time_day=null] snapshot [3481548476149231109] has been expired

```


> How does a mv to define its base table(iceberg)'s updated time?
1. `DefaultTraits#getUpdatedPartitionNames` use `PartitionInfo`'s modifiedTime to determine each partition's latest time.
2.  For an IcebergTable, the partition infos are fetched by `IcebergCatalog#getPartitions` method as below:


But  `IcebergCatalog#getPartitions`  will use `-1` as the partition's modified time if the partition has expired snapshots which will cause MV cannot track the partitions' changes:
```
default Map<String, Partition> getPartitions(IcebergTable icebergTable, long snapshotId, ExecutorService executorService) {


    // TODO: ideally we should know if table is partitioned under a snapshotId.
    // but currently we just did it in a very wild way.
    if (nativeTable.spec().isUnpartitioned()) {
        Partition partition = null;
        try (CloseableIterable<FileScanTask> tasks = tableScan.planFiles()) {
            for (FileScanTask task : tasks) {
                // partitionsTable Table schema :
                // record_count,
                // file_count,
                // total_data_file_size_in_bytes,
                // position_delete_record_count,
                // position_delete_file_count,
                // equality_delete_record_count,
                // equality_delete_file_count,
                // last_updated_at,
                // last_updated_snapshot_id
                CloseableIterable<StructLike> rows = task.asDataTask().rows();
                for (StructLike row : rows) {
                    // Get the last updated time of the table according to the table schema
                    long lastUpdated = -1;
                    try {
                        lastUpdated = row.get(7, Long.class);
                    } catch (NullPointerException e) {
                        // It is a known issue but we do not hanle it right now. If the refresh frequency of
                        // the materialized view is very high, an excessive number of error logs will be printed.
                        // Therefore, only brief logs are printed now.
                        logger.error("The table [{}] snapshot [{}] has been expired", nativeTable.name(), snapshotId);
                    }
                    partition = new Partition(lastUpdated);
                    break;
                }
            }
            if (partition == null) {
                partition = new Partition(-1);
            }
            partitionMap.put(EMPTY_PARTITION_NAME, partition);
        } catch (IOException e) {
            throw new StarRocksConnectorException("Failed to get partitions for table: " + nativeTable.name(), e);
        }
    } else {
        // For partition table, we need to get all partitions from PartitionsTable.
        try (CloseableIterable<FileScanTask> tasks = tableScan.planFiles()) {
            for (FileScanTask task : tasks) {
                // partitionsTable Table schema :
                // partition,
                // spec_id,
                // record_count,
                // file_count,
                // total_data_file_size_in_bytes,
                // position_delete_record_count,
                // position_delete_file_count,
                // equality_delete_record_count,
                // equality_delete_file_count,
                // last_updated_at,
                // last_updated_snapshot_id
                CloseableIterable<StructLike> rows = task.asDataTask().rows();
                for (StructLike row : rows) {
                    // Get the partition data/spec id/last updated time according to the table schema
                    StructProjection partitionData = row.get(0, StructProjection.class);
                    int specId = row.get(1, Integer.class);
                    PartitionSpec spec = nativeTable.specs().get(specId);

                    String partitionName =
                            PartitionUtil.convertIcebergPartitionToPartitionName(nativeTable, spec, partitionData);

                    long lastUpdated = -1;
                    try {
                        lastUpdated = row.get(9, Long.class);
                    } catch (NullPointerException e) {
                        logger.error("The table [{}.{}] snapshot [{}] has been expired", nativeTable.name(), partitionName,
                                snapshotId, e);
                    }
                    Partition partition = new Partition(lastUpdated, specId);
                    partitionMap.put(partitionName, partition);
                }
            }
        } catch (IOException e) {
            throw new StarRocksConnectorException("Failed to get partitions for table: " + nativeTable.name(), e);
        }
    }
    return partitionMap;
}
```
## What I'm doing:
- When  `IcebergCatalog#getPartitions`  meets some exceptions(eg: expired snapshots), use the iceberg table's newest snapshot's timestamp as its modified time.
- Add `baseTablePartitionInfos` into `inspect_mv_refresh_info` for better debugging;
- Add `MVRefreshInfo` into MV's refresh profile for better debugging;

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fallback to current snapshot timestamp when Iceberg partition last_updated_at is null (expired snapshots) and add MV refresh partition/debug info with safer table-level locking; update tests and add SQL cases.
> 
> - **Iceberg Connector**:
>   - Handle expired snapshots in `getPartitions(...)`: if `last_updated_at` is null, fallback to table's current snapshot time instead of `-1` via `getPartitionLastUpdatedTime`/`getTableLastestSnapshotTime`.
>   - Improve logging and warnings; for unpartitioned tables with no rows, use current snapshot timestamp.
> - **MV Refresh**:
>   - Record `MVRefreshPartitionInfo` in refresh tracers by calling `MetaFunctions.inspectMVRefreshInfo(db, mv)`; add helper `getMVRefreshTraceInfo`.
>   - Update runtime profile expected keys to include `MVRefreshPartitionInfo`.
> - **Meta Functions**:
>   - Add `tablePartitionInfos` to `inspect_mv_refresh_info` output; refactor `getTablePartitionInfo` for reuse.
>   - Switch from DB read lock to `lockTableWithIntensiveDbLock` for `inspect_mv_meta`, `inspect_mv_refresh_info`, and `inspect_table_partition_info`.
> - **Tests**:
>   - Ensure Iceberg partition `modifiedTime` is never `-1` after snapshot expiry.
>   - Adjust cache key assertions and expectations; add end-to-end SQL tests `test_mv_iceberg_rewrite_with_expired`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ca064bd2f28523424b2fca0ab1371e7682e2800c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->