### PR TITLE
[Feature] Add index_size meta function to query column index sizes

### DIFF
--- a/be/src/storage/meta_reader.h
+++ b/be/src/storage/meta_reader.h
@@ -107,6 +107,7 @@ static const std::string META_FLAT_JSON_META = "flat_json_meta";
 static const std::string META_COUNT_COL = "count";
 static const std::string META_COLUMN_SIZE = "column_size";
 static const std::string META_COLUMN_COMPRESSED_SIZE = "column_compressed_size";
+static const std::string META_INDEX_SIZE = "index_size";
 
 class SegmentMetaCollecter {
 public:
@@ -139,12 +140,14 @@ private:
     Status _collect_flat_json(ColumnId cid, Column* column);
     Status _collect_column_size(ColumnId cid, Column* column, LogicalType type);
     Status _collect_column_compressed_size(ColumnId cid, Column* column, LogicalType type);
+    Status _collect_index_size(ColumnId cid, Column* column, LogicalType type, const std::string& index_type);
     template <bool is_max>
     Status __collect_max_or_min(ColumnId cid, Column* column, LogicalType type);
 
     // Recursive helper methods for collecting column sizes
     size_t _collect_column_size_recursive(ColumnReader* col_reader);
     int64_t _collect_column_compressed_size_recursive(ColumnReader* col_reader);
+    int64_t _collect_index_size_recursive(ColumnReader* col_reader, const std::string& index_type);
     SegmentSharedPtr _segment;
     std::vector<std::unique_ptr<ColumnIterator>> _column_iterators;
     const SegmentMetaCollecterParams* _params = nullptr;

--- a/be/src/storage/rowset/column_reader.h
+++ b/be/src/storage/rowset/column_reader.h
@@ -139,6 +139,11 @@ public:
         return _bloom_filter_index != nullptr && _segment->tablet_schema().has_index(_column_unique_id, NGRAMBF);
     }
 
+    // Get index size in bytes for the specified index type.
+    // index_type can be: "BITMAP", "BLOOM", "ZONEMAP", "ALL"
+    // Returns 0 if the specified index does not exist.
+    int64_t get_index_size(const std::string& index_type) const;
+
     ZoneMapPB* segment_zone_map() const { return _segment_zone_map.get(); }
 
     PagePointer get_dict_page_pointer() const { return _dict_page_pointer; }

--- a/docs/en/sql-reference/sql-functions/utility-functions/index_size.md
+++ b/docs/en/sql-reference/sql-functions/utility-functions/index_size.md
@@ -1,0 +1,57 @@
+---
+displayed_sidebar: docs
+---
+
+# index_size
+
+Returns the size of column indexes in bytes for storage analysis and optimization. This function works with the `[_META_]` hint to inspect segment file metadata.
+
+## Syntax
+
+```SQL
+-- Do not omit the brackets [] in the hint.
+SELECT index_size(column_name [, index_type]) FROM table_name [_META_];
+```
+
+## Parameters
+
+- `column_name`: The name of the column for which you want to get the index size.
+- `index_type` (optional): The type of index to query. Valid values are:
+  - `'BITMAP'`: Bitmap index size
+  - `'BLOOM'`: Bloom filter index size
+  - `'ZONEMAP'`: Zone map index size
+  - `'ALL'` (default): Total size of all indexes
+
+## Return value
+
+Returns the index size in bytes as a BIGINT value. Returns 0 if the specified index does not exist for the column.
+
+## Usage notes
+
+- This function must be used with the `[_META_]` hint to access metadata information.
+- The function scans the metadata of underlying segment files using the META_SCAN operator.
+- For complex data types (JSON, ARRAY, MAP, STRUCT), the function recursively calculates the index size of all sub-columns.
+- If no `index_type` is specified, `'ALL'` is used by default, which returns the total size of all indexes.
+- The function returns 0 for columns that do not have the specified index type.
+
+## Examples
+
+```sql
+-- Get the total index size for all indexes on a column
+SELECT index_size(city) FROM locations [_META_];
+
+-- Get specific index type sizes
+SELECT 
+    index_size(city, 'BITMAP') as bitmap_index_size,
+    index_size(city, 'BLOOM') as bloom_filter_size,
+    index_size(city, 'ZONEMAP') as zonemap_size,
+    index_size(city, 'ALL') as total_index_size
+FROM locations [_META_];
+
+-- Compare index sizes across multiple columns
+SELECT 
+    index_size(name) as name_index_size,
+    index_size(description) as desc_index_size,
+    index_size(category, 'BITMAP') as category_bitmap_size
+FROM products [_META_];
+```

--- a/docs/zh/sql-reference/sql-functions/utility-functions/index_size.md
+++ b/docs/zh/sql-reference/sql-functions/utility-functions/index_size.md
@@ -1,0 +1,57 @@
+---
+displayed_sidebar: docs
+---
+
+# index_size
+
+返回列索引的字节大小，用于存储分析和优化。此函数需要与 `[_META_]` 提示一起使用来检查段文件元数据。
+
+## 语法
+
+```SQL
+-- 不要省略提示中的方括号 []。
+SELECT index_size(column_name [, index_type]) FROM table_name [_META_];
+```
+
+## 参数
+
+- `column_name`：要获取索引大小的列名。
+- `index_type`（可选）：要查询的索引类型。有效值包括：
+  - `'BITMAP'`：位图索引大小
+  - `'BLOOM'`：布隆过滤器索引大小
+  - `'ZONEMAP'`：区域映射索引大小
+  - `'ALL'`（默认）：所有索引的总大小
+
+## 返回值
+
+返回索引大小（以字节为单位）作为 BIGINT 值。如果列不存在指定的索引，则返回 0。
+
+## 使用说明
+
+- 此函数必须与 `[_META_]` 提示一起使用才能访问元数据信息。
+- 该函数使用 META_SCAN 操作符扫描底层段文件的元数据。
+- 对于复杂数据类型（JSON、ARRAY、MAP、STRUCT），该函数递归计算所有子列的索引大小。
+- 如果未指定 `index_type`，默认使用 `'ALL'`，返回所有索引的总大小。
+- 对于没有指定索引类型的列，函数返回 0。
+
+## 示例
+
+```sql
+-- 获取列所有索引的总大小
+SELECT index_size(city) FROM locations [_META_];
+
+-- 获取特定索引类型的大小
+SELECT 
+    index_size(city, 'BITMAP') as bitmap_index_size,
+    index_size(city, 'BLOOM') as bloom_filter_size,
+    index_size(city, 'ZONEMAP') as zonemap_size,
+    index_size(city, 'ALL') as total_index_size
+FROM locations [_META_];
+
+-- 比较多个列的索引大小
+SELECT 
+    index_size(name) as name_index_size,
+    index_size(description) as desc_index_size,
+    index_size(category, 'BITMAP') as category_bitmap_size
+FROM products [_META_];
+```

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -355,6 +355,7 @@ public class FunctionSet {
     public static final String FLAT_JSON_META = "flat_json_meta";
     public static final String COLUMN_SIZE = "column_size";
     public static final String COLUMN_COMPRESSED_SIZE = "column_compressed_size";
+    public static final String INDEX_SIZE = "index_size";
     public static final String MANN_WHITNEY_U_TEST = "mann_whitney_u_test";
 
     // Bitmap functions:
@@ -1539,6 +1540,12 @@ public class FunctionSet {
         addBuiltin(AggregateFunction.createBuiltin(COLUMN_SIZE, Lists.newArrayList(AnyElementType.ANY_ELEMENT),
                 IntegerType.BIGINT, IntegerType.BIGINT, false, false, false));
         addBuiltin(AggregateFunction.createBuiltin(COLUMN_COMPRESSED_SIZE, Lists.newArrayList(AnyElementType.ANY_ELEMENT),
+                IntegerType.BIGINT, IntegerType.BIGINT, false, false, false));
+        // index_size(column_ref) - returns total index size of all index types
+        addBuiltin(AggregateFunction.createBuiltin(INDEX_SIZE, Lists.newArrayList(AnyElementType.ANY_ELEMENT),
+                IntegerType.BIGINT, IntegerType.BIGINT, false, false, false));
+        // index_size(column_ref, index_type) - returns index size for specific index type (BITMAP, BLOOM, ZONEMAP, ALL)
+        addBuiltin(AggregateFunction.createBuiltin(INDEX_SIZE, Lists.newArrayList(AnyElementType.ANY_ELEMENT, VarcharType.VARCHAR),
                 IntegerType.BIGINT, IntegerType.BIGINT, false, false, false));
 
         Consumer<Type> registerLeadLagFunctions = t -> {

--- a/test/sql/test_meta_scan/R/test_meta_scan
+++ b/test/sql/test_meta_scan/R/test_meta_scan
@@ -236,6 +236,43 @@ SELECT column_size(s) > 0, column_compressed_size(s) > 0 FROM meta_nested_types 
 -- result:
 1	1
 -- !result
+-- name: test_meta_index_size_functions
+CREATE TABLE meta_index_table (
+    k1 int,
+    k2 varchar(20),
+    k3 int
+)
+DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES ("replication_num" = "1", "bloom_filter_columns" = "k2");
+-- result:
+-- !result
+INSERT INTO meta_index_table VALUES
+(1, 'value1', 100),
+(2, 'value2', 200),
+(3, 'value3', 300);
+-- result:
+-- !result
+SELECT index_size(k1) >= 0 FROM meta_index_table [_META_];
+-- result:
+1
+-- !result
+SELECT index_size(k1, 'ZONEMAP') >= 0 FROM meta_index_table [_META_];
+-- result:
+1
+-- !result
+SELECT index_size(k1, 'ALL') >= 0 FROM meta_index_table [_META_];
+-- result:
+1
+-- !result
+SELECT index_size(k2, 'BLOOM') >= 0 FROM meta_index_table [_META_];
+-- result:
+1
+-- !result
+SELECT index_size(k3, 'BITMAP') >= 0 FROM meta_index_table [_META_];
+-- result:
+1
+-- !result
 -- name: test_update_table_on_meta_scan
 CREATE TABLE `update_table_with_null_partition` (
     `k1` date,

--- a/test/sql/test_meta_scan/T/test_meta_scan
+++ b/test/sql/test_meta_scan/T/test_meta_scan
@@ -107,6 +107,28 @@ SELECT column_size(a) > 0, column_compressed_size(a) > 0 FROM meta_nested_types 
 SELECT column_size(m) > 0, column_compressed_size(m) > 0 FROM meta_nested_types [_META_];
 SELECT column_size(s) > 0, column_compressed_size(s) > 0 FROM meta_nested_types [_META_];
 
+-- name: test_meta_index_size_functions
+CREATE TABLE meta_index_table (
+    k1 int,
+    k2 varchar(20),
+    k3 int
+)
+DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES ("replication_num" = "1", "bloom_filter_columns" = "k2");
+
+INSERT INTO meta_index_table VALUES
+(1, 'value1', 100),
+(2, 'value2', 200),
+(3, 'value3', 300);
+
+-- test index_size function with different index types
+SELECT index_size(k1) >= 0 FROM meta_index_table [_META_];
+SELECT index_size(k1, 'ZONEMAP') >= 0 FROM meta_index_table [_META_];
+SELECT index_size(k1, 'ALL') >= 0 FROM meta_index_table [_META_];
+SELECT index_size(k2, 'BLOOM') >= 0 FROM meta_index_table [_META_];
+SELECT index_size(k3, 'BITMAP') >= 0 FROM meta_index_table [_META_];
+
 -- name: test_update_table_on_meta_scan
 CREATE TABLE `update_table_with_null_partition` (
     `k1` date,


### PR DESCRIPTION
## Why I'm doing:

This PR implements the feature requested in [https://github.com/StarRocks/starrocks/issues/62680](https://github.com/StarRocks/starrocks/issues/62680) to provide a meta function for querying column index sizes.

Users need a way to analyze and monitor the size of various indexes (BITMAP, BLOOM, ZONEMAP) on their table columns for storage optimization and troubleshooting purposes.

## What I'm doing:

Fixes [https://github.com/StarRocks/starrocks/issues/62680](https://github.com/StarRocks/starrocks/issues/62680). Add a new `index_size()` meta function that works with the `[_META_]` hint to query the size of column indexes.

### Syntax

```sql
SELECT index_size(column_ref [, index_type]) FROM table_name [_META_];
```

### Parameters

- `column_ref`: The column to check index size for
- `index_type` (optional): The type of index to query
  - `'BITMAP'`: Bitmap index size
  - `'BLOOM'`: Bloom filter index size
  - `'ZONEMAP'`: Zone map index size
  - `'ALL'` (default): Total size of all indexes

### Examples

```sql
-- Get total index size for column k1
SELECT index_size(k1) FROM my_table [_META_];

-- Get only ZONEMAP index size
SELECT index_size(k1, 'ZONEMAP') FROM my_table [_META_];

-- Get BLOOM filter index size
SELECT index_size(k2, 'BLOOM') FROM my_table [_META_];
```

## Changes Made

### Backend (C++)
- `be/src/storage/rowset/column_reader.h/cpp`: Added `get_index_size()` method to retrieve index sizes from metadata
- `be/src/storage/meta_reader.h/cpp`: Added `META_INDEX_SIZE` constant and `_collect_index_size()` function

### Frontend (Java)
- `fe/.../FunctionSet.java`: Registered `INDEX_SIZE` as builtin aggregate function
- `fe/.../PushDownAggToMetaScanRule.java`: Added support for index_size in meta scan push down
- `fe/.../RewriteSimpleAggToMetaScanRule.java`: Added support for index_size in simple agg rewrite

### Tests
- Added test cases in `test/sql/test_meta_scan/`

### Documentation
- Added function documentation in `docs/en/` and `docs/zh/`

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

N/A - New feature

## Checklist:

- [x] I have added test cases for my code
- [x] I have added documentation for my code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces index_size(column[, 'BITMAP'|'BLOOM'|'ZONEMAP'|'ALL']) for META_SCAN, with planner pushdown/rewrite, backend collectors, docs, and tests.
> 
> - **Backend (BE)**:
>   - Add `META_INDEX_SIZE` and support in `SegmentMetaCollecter` (special parsing `index_size_<TYPE>_<COL>`, BIGINT output).
>   - Implement `_collect_index_size` (recursive) and `ColumnReader::get_index_size()` to sum BITMAP/BLOOM/ZONEMAP metadata sizes.
>   - Treat `index_size` like size counters when building result chunks.
> - **Frontend/Planner (FE)**:
>   - Register builtin `index_size` (1-arg total, 2-arg typed) in `FunctionSet`.
>   - Extend `PushDownAggToMetaScanRule` and `RewriteSimpleAggToMetaScanRule` to support `index_size`, encode meta column names (`index_size_<TYPE>_<COL>`), and rewrite to `SUM`.
> - **Docs**:
>   - Add EN/ZH docs for `index_size` usage and semantics.
> - **Tests**:
>   - Add META_SCAN SQL tests covering `index_size` for ALL/ZONEMAP/BLOOM/BITMAP.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4592f9c004351346a8260cbd6f1d83bc0140e341. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->