### PR TITLE
[BugFix] Fix SHOW VERBOSE RESOURCE GROUP ALL displays NULL for existing resource groups

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
@@ -407,6 +407,9 @@ public class ResourceGroup {
     public String getMemPool() {
         return memPool;
     }
+    public boolean hasDefaultMemPool() {
+        return memPool == null || memPool.equals(DEFAULT_MEM_POOL);
+    }
 
     public void setMemPool(String memPool) {
         this.memPool = memPool;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
@@ -129,7 +129,7 @@ public class ResourceGroup {
                     (rg, classifier) -> classifier.toString()),
             new ColumnMeta(
                     new Column(MEM_POOL, TypeFactory.createVarchar(200)),
-                    (rg, classifier) -> rg.getMemPool(), false)
+                    (rg, classifier) -> Objects.requireNonNullElse(rg.getMemPool(), DEFAULT_MEM_POOL), false)
     );
 
     public static final ShowResultSetMetaData META_DATA;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
@@ -386,7 +386,7 @@ public class ResourceGroupMgr implements Writable {
 
                 String memPool = wg.getMemPool();
                 if (wg.hasDefaultMemPool()) {
-                   memPool = ResourceGroup.DEFAULT_MEM_POOL;
+                    memPool = ResourceGroup.DEFAULT_MEM_POOL;
                 }
 
                 if (exclusiveCpuCores != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
@@ -388,8 +388,6 @@ public class ResourceGroupMgr implements Writable {
                     alterResourceGroupLog.setMemPool(ResourceGroup.DEFAULT_MEM_POOL);
                 }
 
-                wg.normalizeCpuWeight();
-
                 if (exclusiveCpuCores != null) {
                     alterResourceGroupLog.setExclusiveCpuCores(exclusiveCpuCores);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
@@ -164,7 +164,7 @@ public class ResourceGroupMgr implements Writable {
                 classifier.setId(GlobalStateMgr.getCurrentState().getNextId());
             }
 
-            if (!ResourceGroup.DEFAULT_MEM_POOL.equals(wg.getMemPool()) && !resourceGroupInMemPoolHaveSameMemLimit(wg)) {
+            if (!wg.hasDefaultMemPool() && !resourceGroupInMemPoolHaveSameMemLimit(wg)) {
                 throw new DdlException(
                         "Property `mem_limit` must be equal for all resource groups using the mem_pool [" + wg.getMemPool() +
                                 "].");
@@ -203,7 +203,7 @@ public class ResourceGroupMgr implements Writable {
     }
 
     private boolean resourceGroupInMemPoolHaveSameMemLimit(ResourceGroup wg) {
-        if (wg.getMemPool() == null) {
+        if (wg.hasDefaultMemPool()) {
             return true;
         }
         return resourceGroupMap.entrySet().stream().allMatch(entry -> !wg.getMemPool().equals(entry.getValue().getMemPool()) ||
@@ -384,6 +384,12 @@ public class ResourceGroupMgr implements Writable {
                     alterResourceGroupLog.setCpuWeight(cpuWeight);
                 }
 
+                if (wg.hasDefaultMemPool()) {
+                    alterResourceGroupLog.setMemPool(ResourceGroup.DEFAULT_MEM_POOL);
+                }
+
+                wg.normalizeCpuWeight();
+
                 if (exclusiveCpuCores != null) {
                     alterResourceGroupLog.setExclusiveCpuCores(exclusiveCpuCores);
                 }
@@ -395,7 +401,7 @@ public class ResourceGroupMgr implements Writable {
                 if (changedProperties.getMemPool() != null && !changedProperties.getMemPool().equals(wg.getMemPool())) {
                     throw new DdlException("Property `mem_pool` cannot be altered [" + wg.getMemPool() + "].");
                 }
-                if (wg.getMemPool() != null && !ResourceGroup.DEFAULT_MEM_POOL.equals(wg.getMemPool()) &&
+                if (!wg.hasDefaultMemPool() &&
                         changedProperties.getMemLimit() != null &&
                         !wg.getMemLimit().equals(changedProperties.getMemLimit())) {
                     throw new DdlException(

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
@@ -384,8 +384,9 @@ public class ResourceGroupMgr implements Writable {
                     alterResourceGroupLog.setCpuWeight(cpuWeight);
                 }
 
+                String memPool = wg.getMemPool();
                 if (wg.hasDefaultMemPool()) {
-                    alterResourceGroupLog.setMemPool(ResourceGroup.DEFAULT_MEM_POOL);
+                   memPool = ResourceGroup.DEFAULT_MEM_POOL;
                 }
 
                 if (exclusiveCpuCores != null) {
@@ -396,7 +397,7 @@ public class ResourceGroupMgr implements Writable {
                 if (maxCpuCores != null) {
                     alterResourceGroupLog.setMaxCpuCores(maxCpuCores);
                 }
-                if (changedProperties.getMemPool() != null && !changedProperties.getMemPool().equals(wg.getMemPool())) {
+                if (changedProperties.getMemPool() != null && !changedProperties.getMemPool().equals(memPool)) {
                     throw new DdlException("Property `mem_pool` cannot be altered [" + wg.getMemPool() + "].");
                 }
                 if (!wg.hasDefaultMemPool() &&

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
@@ -395,7 +395,7 @@ public class ResourceGroupMgr implements Writable {
                 if (changedProperties.getMemPool() != null && !changedProperties.getMemPool().equals(wg.getMemPool())) {
                     throw new DdlException("Property `mem_pool` cannot be altered [" + wg.getMemPool() + "].");
                 }
-                if (!ResourceGroup.DEFAULT_MEM_POOL.equals(wg.getMemPool()) &&
+                if (wg.getMemPool() != null && !ResourceGroup.DEFAULT_MEM_POOL.equals(wg.getMemPool()) &&
                         changedProperties.getMemLimit() != null &&
                         !wg.getMemLimit().equals(changedProperties.getMemLimit())) {
                     throw new DdlException(


### PR DESCRIPTION
## Why I'm doing:
`SHOW VERBOSE RESOURCE GROUP ALL;` will display "NULL" instead of "default_mem_pool" if a resource group was created on a StarRocks version before `mem_pool` property was introduced.
## What I'm doing:
Fixing the issue by using a default value. Also adding an additional NULL check to make sure altering the mem_limit works as expected for existing resource groups.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Show `default_mem_pool` instead of `NULL` for legacy resource groups and normalize `mem_pool` handling in create/alter validations; add a unit test.
> 
> - **Catalog / Display**:
>   - In `ResourceGroup`, show `DEFAULT_MEM_POOL` when `mem_pool` is `null` in verbose output.
>   - Add `hasDefaultMemPool()` to detect default/unspecified pool.
> - **Validation / DDL logic**:
>   - In `ResourceGroupMgr`, use `hasDefaultMemPool()` for mem-pool consistency checks during create.
>   - Normalize `mem_pool` to default when comparing on alter; forbid changing `mem_pool` and `mem_limit` when non-default pool is used.
>   - Treat `null` `mem_pool` as default in `resourceGroupInMemPoolHaveSameMemLimit`.
> - **Tests**:
>   - Add `testShowDefaultMemPoolForOldResourceGroup` to verify verbose output shows `default_mem_pool` for legacy groups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a82cc11ab8ffe1f1f4b3cce26e01ee6394db45b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->