### PR TITLE
[Enhancement] Support getting tablet metadatas in backend

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -1394,6 +1394,10 @@ void LakeServiceImpl::get_tablet_metadatas(::google::protobuf::RpcController* co
         cntl->SetFailed("missing min_version");
         return;
     }
+    if (request->max_version() < request->min_version()) {
+        cntl->SetFailed("max_version should be >= min_version");
+        return;
+    }
 
     auto thread_pool = get_tablet_stats_thread_pool(_env);
     if (UNLIKELY(thread_pool == nullptr)) {

--- a/be/src/service/service_be/lake_service.h
+++ b/be/src/service/service_be/lake_service.h
@@ -104,6 +104,11 @@ public:
     void vacuum_full(::google::protobuf::RpcController* controller, const ::starrocks::VacuumFullRequest* request,
                      ::starrocks::VacuumFullResponse* response, ::google::protobuf::Closure* done) override;
 
+    void get_tablet_metadatas(::google::protobuf::RpcController* controller,
+                              const ::starrocks::GetTabletMetadatasRequest* request,
+                              ::starrocks::GetTabletMetadatasResponse* response,
+                              ::google::protobuf::Closure* done) override;
+
 private:
     void _submit_publish_log_version_task(const int64_t* tablet_ids, size_t tablet_size,
                                           std::span<const TxnInfoPB> txn_infos, const int64_t* log_versions,

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -456,6 +456,7 @@ StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(int64_t tablet_id
 StatusOr<TabletMetadataPtr> TabletManager::get_tablet_metadata(int64_t tablet_id, int64_t version,
                                                                const CacheOptions& cache_opts, int64_t expected_gtid,
                                                                const std::shared_ptr<FileSystem>& fs) {
+    TEST_ERROR_POINT("TabletManager::get_tablet_metadata");
     StatusOr<TabletMetadataPtr> tablet_metadata_or;
     auto cache_key = _location_provider->real_location(tablet_metadata_root_location(tablet_id));
     if (cache_key.ok() && _metacache->lookup_aggregation_partition(*cache_key)) {

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -2836,6 +2836,18 @@ TEST_F(LakeServiceTest, test_get_tablet_metadatas) {
         ASSERT_EQ("missing min_version", cntl.ErrorText());
     }
 
+    {
+        brpc::Controller cntl;
+        GetTabletMetadatasRequest request;
+        GetTabletMetadatasResponse response;
+        request.add_tablet_ids(_tablet_id);
+        request.set_max_version(3);
+        request.set_min_version(4);
+        _lake_service.get_tablet_metadatas(&cntl, &request, &response, nullptr);
+        ASSERT_TRUE(cntl.Failed());
+        ASSERT_EQ("max_version should be >= min_version", cntl.ErrorText());
+    }
+
     // thread pool is null
     {
         SyncPoint::GetInstance()->SetCallBack("AgentServer::Impl::get_thread_pool:1",

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -389,14 +389,17 @@ message GetTabletMetadatasRequest {
 }
 
 message TabletMetadatas {
-    optional StatusPB status = 1;
-    optional int64 tablet_id = 2;
+    optional int64 tablet_id = 1;
+    // tablet-level status
+    optional StatusPB status = 2;
     // version -> tablet metadata
     map<int64, TabletMetadataPB> version_metadatas = 3;
 }
 
 message GetTabletMetadatasResponse {
-    repeated TabletMetadatas tablet_metadatas = 1;
+    // rpc-level status
+    optional StatusPB status = 1;
+    repeated TabletMetadatas tablet_metadatas = 2;
 }
 
 service LakeService {

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -379,6 +379,26 @@ message FindSplitPointResponse {
     repeated TabletSplitResult tablet_split_results = 2;
 }
 
+message GetTabletMetadatasRequest {
+    // all tablets in one physical partition
+    repeated int64 tablet_ids = 1;
+    // included
+    optional int64 max_version = 2;
+    // included
+    optional int64 min_version = 3;
+}
+
+message TabletMetadatas {
+    // version -> tablet metadata
+    map<int64, TabletMetadataPB> version_metadatas = 1;
+}
+
+message GetTabletMetadatasResponse {
+    optional StatusPB status = 1;
+    // tablet id -> TabletMetadatas
+    map<int64, TabletMetadatas> tablet_metadatas = 2;
+}
+
 service LakeService {
     rpc publish_version(PublishVersionRequest) returns (PublishVersionResponse);
     rpc aggregate_publish_version(AggregatePublishVersionRequest) returns (PublishVersionResponse);
@@ -400,5 +420,6 @@ service LakeService {
     rpc vacuum_full(VacuumFullRequest) returns (VacuumFullResponse);
     rpc aggregate_compact(AggregateCompactRequest) returns (CompactResponse);
     rpc find_split_point(FindSplitPointRequest) returns (FindSplitPointResponse);
+    rpc get_tablet_metadatas(GetTabletMetadatasRequest) returns (GetTabletMetadatasResponse);
 }
 

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -389,14 +389,14 @@ message GetTabletMetadatasRequest {
 }
 
 message TabletMetadatas {
+    optional StatusPB status = 1;
+    optional int64 tablet_id = 2;
     // version -> tablet metadata
-    map<int64, TabletMetadataPB> version_metadatas = 1;
+    map<int64, TabletMetadataPB> version_metadatas = 3;
 }
 
 message GetTabletMetadatasResponse {
-    optional StatusPB status = 1;
-    // tablet id -> TabletMetadatas
-    map<int64, TabletMetadatas> tablet_metadatas = 2;
+    repeated TabletMetadatas tablet_metadatas = 1;
 }
 
 service LakeService {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This PR introduces a new RPC method `get_tablet_metadatas` in the LakeService, allowing FE to fetch metadatas for multiple tablets across a specified version range. 

https://github.com/StarRocks/starrocks/issues/66015

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `get_tablet_metadatas` RPC to concurrently fetch per-tablet metadata over a specified version range, with validation, error handling, and comprehensive tests.
> 
> - **LakeService (backend)**:
>   - Adds `get_tablet_metadatas` RPC in `LakeServiceImpl` to concurrently retrieve tablet metadatas within `[min_version, max_version]` using `get_tablet_stats_thread_pool`.
>   - Validates inputs, aggregates results as `version -> TabletMetadataPB`, sets per-tablet status on errors, and logs summarized failures.
>   - Declares the new method in `service_be/lake_service.h`.
> - **Proto/API**:
>   - Defines `GetTabletMetadatasRequest`, `TabletMetadatas`, and `GetTabletMetadatasResponse` in `gensrc/proto/lake_service.proto` and registers `rpc get_tablet_metadatas`.
> - **Storage**:
>   - Adds test failpoint `TEST_ERROR_POINT("TabletManager::get_tablet_metadata")` in `tablet_manager.cpp` to facilitate error injection.
> - **Tests**:
>   - Adds `test_get_tablet_metadatas` covering argument validation, null thread pool, normal retrieval, partial/missing versions, not-found tablets, injected IO errors, thread pool full, and task cancellation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a38768ad70a22820c6a256116b69eee8a8c570a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->