### PR TITLE
[BugFix] fix wrong empty rows result in meta scan

### DIFF
--- a/be/src/storage/meta_reader.cpp
+++ b/be/src/storage/meta_reader.cpp
@@ -100,7 +100,7 @@ void MetaReader::_fill_empty_result(Chunk* chunk) {
         auto slot = _params.desc_tbl->get_slot_descriptor(s_id);
         const auto& field = _collect_context.seg_collecter_params.fields[i];
         ColumnPtr column = chunk->get_column_by_slot_id(slot->id());
-        if (field == "count") {
+        if (field == META_COUNT_COL || field == META_COUNT_ROWS) {
             column->append_datum(int64_t(0));
         } else {
             column->append_nulls(1);

--- a/test/sql/test_agg/R/test_meta_scan_agg
+++ b/test/sql/test_agg/R/test_meta_scan_agg
@@ -6,10 +6,14 @@ create table t0 (
 ) DUPLICATE key (c0) DISTRIBUTED BY HASH(c0) BUCKETS 3 PROPERTIES('replication_num' = '1');
 -- result:
 -- !result
-insert into t0 values ('2024-01-01', 1, 1), ('2024-01-02', 2, 2), ('2024-01-03', 3, 3), ('2024-01-04', 4, 4), ('2024-01-05', 5, 5);
+set enable_rewrite_simple_agg_to_meta_scan=true;
 -- result:
 -- !result
-set enable_rewrite_simple_agg_to_meta_scan=true;
+select count(*) from t0[_META_];
+-- result:
+0
+-- !result
+insert into t0 values ('2024-01-01', 1, 1), ('2024-01-02', 2, 2), ('2024-01-03', 3, 3), ('2024-01-04', 4, 4), ('2024-01-05', 5, 5);
 -- result:
 -- !result
 set enable_exchange_pass_through=false;

--- a/test/sql/test_agg/T/test_meta_scan_agg
+++ b/test/sql/test_agg/T/test_meta_scan_agg
@@ -6,9 +6,12 @@ create table t0 (
     c2 BIGINT
 ) DUPLICATE key (c0) DISTRIBUTED BY HASH(c0) BUCKETS 3 PROPERTIES('replication_num' = '1');
 
-insert into t0 values ('2024-01-01', 1, 1), ('2024-01-02', 2, 2), ('2024-01-03', 3, 3), ('2024-01-04', 4, 4), ('2024-01-05', 5, 5);
 
 set enable_rewrite_simple_agg_to_meta_scan=true;
+select count(*) from t0[_META_];
+
+insert into t0 values ('2024-01-01', 1, 1), ('2024-01-02', 2, 2), ('2024-01-03', 3, 3), ('2024-01-04', 4, 4), ('2024-01-05', 5, 5);
+
 set enable_exchange_pass_through=false;
 select count() from t0;
 select count(c0) from t0;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/10645

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure empty meta scans write 0 for `META_COUNT_COL` and `META_COUNT_ROWS` instead of NULL.
> 
> - **Storage**:
>   - In `MetaReader::_fill_empty_result`, treat `META_COUNT_COL` and `META_COUNT_ROWS` as count fields, appending `0` when no segments; other fields still append `NULL`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b56fc2201f2d68c18880a554f7aba871b1466cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->