### PR TITLE
[Enhancement] Support repairing tablet metadata in backend

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -1485,11 +1485,13 @@ void LakeServiceImpl::get_tablet_metadatas(::google::protobuf::RpcController* co
     }
     if (!messages.empty()) {
         LOG(WARNING) << "Get tablet metadatas failed for " << failed_count << " tablets, the first " << messages.size()
-                     << " tablets: " << JoinStrings(messages, "; ");
+                     << " tablets: [" << JoinStrings(messages, "; ") << "]";
     }
 }
 
 // Repair bundling or non-bundling tablet metadata for all tablets in one physical partition.
+// Receieve a list of tablet metadatas sent from FE, and update the metadatas through the tablet manager
+// based on whether file bundling is enabled.
 // This function supports concurrent processing of tablet metadata repair tasks.
 void LakeServiceImpl::repair_tablet_metadata(::google::protobuf::RpcController* controller,
                                              const ::starrocks::RepairTabletMetadataRequest* request,
@@ -1623,7 +1625,8 @@ void LakeServiceImpl::repair_tablet_metadata(::google::protobuf::RpcController* 
     if (!messages.empty()) {
         std::string file_bundling_msg = enable_file_bundling ? "bundling" : "non-bundling";
         LOG(WARNING) << "Repair " << file_bundling_msg << " tablet metadata failed for " << failed_count
-                     << " tablets, the first " << messages.size() << " tablets: " << JoinStrings(messages, "; ");
+                     << " tablets, the first " << messages.size() << " tablets: [" << JoinStrings(messages, "; ")
+                     << "]";
     }
 }
 

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -1530,9 +1530,9 @@ void LakeServiceImpl::repair_tablet_metadata(::google::protobuf::RpcController* 
         }
     }
 
-    auto thread_pool = get_tablet_stats_thread_pool(_env);
+    auto thread_pool = publish_version_thread_pool(_env);
     if (UNLIKELY(thread_pool == nullptr)) {
-        Status::ServiceUnavailable("tablet stats thread pool is null").to_protobuf(response->mutable_status());
+        Status::ServiceUnavailable("publish version thread pool is null").to_protobuf(response->mutable_status());
         return;
     }
 

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -1489,4 +1489,142 @@ void LakeServiceImpl::get_tablet_metadatas(::google::protobuf::RpcController* co
     }
 }
 
+// Repair bundling or non-bundling tablet metadata for all tablets in one physical partition.
+// This function supports concurrent processing of tablet metadata repair tasks.
+void LakeServiceImpl::repair_tablet_metadata(::google::protobuf::RpcController* controller,
+                                             const ::starrocks::RepairTabletMetadataRequest* request,
+                                             ::starrocks::RepairTabletMetadataResponse* response,
+                                             ::google::protobuf::Closure* done) {
+    brpc::ClosureGuard guard(done);
+
+    if (request->tablet_metadatas_size() == 0) {
+        Status::InvalidArgument("missing tablet_metadatas").to_protobuf(response->mutable_status());
+        return;
+    }
+
+    // check tablet metadatas
+    int64_t version = 0;
+    std::unordered_set<int64_t> tablet_ids;
+    for (const auto& metadata_pb : request->tablet_metadatas()) {
+        // check metadata have the same version
+        if (version == 0) {
+            version = metadata_pb.version();
+            if (version <= 0) {
+                Status::InvalidArgument(fmt::format("invalid version: {}", version))
+                        .to_protobuf(response->mutable_status());
+                return;
+            }
+        } else if (version != metadata_pb.version()) {
+            Status::InvalidArgument("tablet metadatas should have the same version")
+                    .to_protobuf(response->mutable_status());
+            return;
+        }
+
+        // check duplicated tablet
+        if (!tablet_ids.insert(metadata_pb.id()).second) {
+            Status::InvalidArgument(fmt::format("duplicated tablet id: {}", metadata_pb.id()))
+                    .to_protobuf(response->mutable_status());
+            return;
+        }
+    }
+
+    auto thread_pool = get_tablet_stats_thread_pool(_env);
+    if (UNLIKELY(thread_pool == nullptr)) {
+        Status::ServiceUnavailable("tablet stats thread pool is null").to_protobuf(response->mutable_status());
+        return;
+    }
+
+    Status::OK().to_protobuf(response->mutable_status());
+
+    bool enable_file_bundling = request->has_enable_file_bundling() && request->enable_file_bundling();
+    if (enable_file_bundling) {
+        // bundling tablet metadata
+        std::map<int64_t, TabletMetadata> tablet_metadatas;
+        for (const auto& metadata_pb : request->tablet_metadatas()) {
+            tablet_metadatas.emplace(metadata_pb.id(), metadata_pb);
+        }
+
+        auto* repair_status = response->add_tablet_repair_statuses();
+        // set tablet_id to 0 for bundling metadata
+        repair_status->set_tablet_id(0);
+
+        // submit one put bundling tablet metadata task
+        auto latch = BThreadCountDownLatch(1);
+        auto task = std::make_shared<CancellableRunnable>(
+                [&, repair_status] {
+                    DeferOp defer([&] { latch.count_down(); });
+                    auto st = _tablet_mgr->put_bundle_tablet_metadata(tablet_metadatas);
+                    st.to_protobuf(repair_status->mutable_status());
+                },
+                [&, version, repair_status] {
+                    auto st = Status::Cancelled(fmt::format(
+                            "repair bundling tablet metadata task has been cancelled. version: {}", version));
+                    st.to_protobuf(repair_status->mutable_status());
+                    latch.count_down();
+                });
+
+        auto st = thread_pool->submit(std::move(task));
+        if (!st.ok()) {
+            st.to_protobuf(repair_status->mutable_status());
+            latch.count_down();
+        }
+
+        latch.wait();
+    } else {
+        // non-bundling tablet metadata
+        // traverse each tablet metadata and submit put tablet metadata task
+        auto latch = BThreadCountDownLatch(request->tablet_metadatas_size());
+        response->mutable_tablet_repair_statuses()->Reserve(request->tablet_metadatas_size());
+        for (const auto& metadata_pb : request->tablet_metadatas()) {
+            auto tablet_id = metadata_pb.id();
+            auto* repair_status = response->add_tablet_repair_statuses();
+            repair_status->set_tablet_id(tablet_id);
+
+            auto task = std::make_shared<CancellableRunnable>(
+                    [&, metadata_pb, repair_status] {
+                        DeferOp defer([&] { latch.count_down(); });
+                        auto metadata_ptr = std::make_shared<const TabletMetadataPB>(metadata_pb);
+                        auto st = _tablet_mgr->put_tablet_metadata(metadata_ptr);
+                        st.to_protobuf(repair_status->mutable_status());
+                    },
+                    [&, tablet_id, repair_status] {
+                        auto st = Status::Cancelled(
+                                fmt::format("repair tablet metadata task has been cancelled. tablet: {}", tablet_id));
+                        st.to_protobuf(repair_status->mutable_status());
+                        latch.count_down();
+                    });
+
+            auto st = thread_pool->submit(std::move(task));
+            if (!st.ok()) {
+                st.to_protobuf(repair_status->mutable_status());
+                latch.count_down();
+            }
+        }
+
+        latch.wait();
+    }
+
+    // add a warning log if any tablets fail, at most 10 failed tablets
+    std::vector<std::string> messages;
+    size_t failed_count = 0;
+    for (const auto& tr : response->tablet_repair_statuses()) {
+        if (tr.status().status_code() != 0) {
+            ++failed_count;
+            if (messages.size() < 10) {
+                std::string error_msg;
+                for (const auto& msg : tr.status().error_msgs()) {
+                    error_msg += msg;
+                }
+                messages.emplace_back(fmt::format("tablet_id: {}, status_code: {}, error_msg: {}", tr.tablet_id(),
+                                                  tr.status().status_code(), error_msg));
+            }
+        }
+    }
+    if (!messages.empty()) {
+        std::string file_bundling_msg = enable_file_bundling ? "bundling" : "non-bundling";
+        LOG(WARNING) << "Repair " << file_bundling_msg << " tablet metadata failed for " << failed_count
+                     << " tablets, the first " << messages.size() << " tablets: " << JoinStrings(messages, "; ");
+    }
+}
+
 } // namespace starrocks

--- a/be/src/service/service_be/lake_service.h
+++ b/be/src/service/service_be/lake_service.h
@@ -109,6 +109,11 @@ public:
                               ::starrocks::GetTabletMetadatasResponse* response,
                               ::google::protobuf::Closure* done) override;
 
+    void repair_tablet_metadata(::google::protobuf::RpcController* controller,
+                                const ::starrocks::RepairTabletMetadataRequest* request,
+                                ::starrocks::RepairTabletMetadataResponse* response,
+                                ::google::protobuf::Closure* done) override;
+
 private:
     void _submit_publish_log_version_task(const int64_t* tablet_ids, size_t tablet_size,
                                           std::span<const TxnInfoPB> txn_infos, const int64_t* log_versions,

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -326,6 +326,7 @@ DEFINE_FAIL_POINT(tablet_meta_not_found);
 // NOTE: tablet_metas is non-const and we will clear schemas for optimization.
 // Callers should ensure thread safety.
 Status TabletManager::put_bundle_tablet_metadata(std::map<int64_t, TabletMetadataPB>& tablet_metas) {
+    TEST_ERROR_POINT("TabletManager::put_bundle_tablet_metadata");
     if (tablet_metas.empty()) {
         return Status::InternalError("tablet_metas cannot be empty");
     }

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -3145,7 +3145,7 @@ TEST_F(LakeServiceTest, test_repair_tablet_metadata) {
         _lake_service.repair_tablet_metadata(&cntl, &request, &response, nullptr);
         ASSERT_FALSE(cntl.Failed());
         ASSERT_EQ(TStatusCode::SERVICE_UNAVAILABLE, response.status().status_code());
-        ASSERT_TRUE(MatchPattern(response.status().error_msgs(0), "tablet stats thread pool is null"));
+        ASSERT_TRUE(MatchPattern(response.status().error_msgs(0), "publish version thread pool is null"));
     }
 
     // 3. successful repair of non-bundling tablet metadata

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -402,6 +402,25 @@ message GetTabletMetadatasResponse {
     repeated TabletMetadatas tablet_metadatas = 2;
 }
 
+message RepairTabletMetadataRequest {
+    // all tablet metadatas with the same version in one physical partition
+    repeated TabletMetadataPB tablet_metadatas = 1;
+    // whether enable file bundling
+    optional bool enable_file_bundling = 2;
+}
+
+message TabletMetadataRepairStatus {
+    optional int64 tablet_id = 1;
+    // tablet-level status
+    optional StatusPB status = 2;
+}
+
+message RepairTabletMetadataResponse {
+    // rpc-level status
+    optional StatusPB status = 1;
+    repeated TabletMetadataRepairStatus tablet_repair_statuses = 2;
+}
+
 service LakeService {
     rpc publish_version(PublishVersionRequest) returns (PublishVersionResponse);
     rpc aggregate_publish_version(AggregatePublishVersionRequest) returns (PublishVersionResponse);
@@ -424,5 +443,6 @@ service LakeService {
     rpc aggregate_compact(AggregateCompactRequest) returns (CompactResponse);
     rpc find_split_point(FindSplitPointRequest) returns (FindSplitPointResponse);
     rpc get_tablet_metadatas(GetTabletMetadatasRequest) returns (GetTabletMetadatasResponse);
+    rpc repair_tablet_metadata(RepairTabletMetadataRequest) returns (RepairTabletMetadataResponse);
 }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This PR introduces a new RPC method `repair_tablet_metadata` in the LakeService, allowing FE to repair individual and bundled tablets metadata.

https://github.com/StarRocks/starrocks/issues/66015

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a LakeService RPC to repair tablet metadata (bundled and non-bundled), updates TabletManager support, and adds comprehensive tests and proto definitions.
> 
> - **Backend (LakeService)**:
>   - **New RPC**: `repair_tablet_metadata` to repair tablet metadata for a partition.
>     - Validates inputs (same version, no duplicates) and uses the publish-version thread pool.
>     - Supports bundling (single task via `_tablet_mgr->put_bundle_tablet_metadata`) and non-bundling (per-tablet `put_tablet_metadata`).
>     - Returns per-tablet repair statuses and logs summarized failures.
>   - Minor log tweak in `get_tablet_metadatas` warning formatting.
> - **Storage (TabletManager)**:
>   - Add failpoint and pathway for `put_bundle_tablet_metadata` used by repair.
> - **Protocol (Proto)**:
>   - Add `RepairTabletMetadataRequest`, `RepairTabletMetadataResponse`, `TabletMetadataRepairStatus` and service method `repair_tablet_metadata`.
> - **Tests**:
>   - Add extensive UTs covering validation errors, thread-pool unavailability, success (bundled and non-bundled), injected failures, and task cancellation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 02e7202b1c7fe44741c17071470d6e4b707afaac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->