### PR TITLE
[BugFix] avoid call FragmentCtx::cancel in observer

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -437,8 +437,6 @@ public:
                 return false;
             }
 
-            // TODO(trueeyu): This writing is to ensure that MemTracker will not be destructed before the thread ends.
-            //  This writing method is a bit tricky, and when there is a better way, replace it
             mark_precondition_ready();
 
             RETURN_IF_ERROR(check_short_circuit());
@@ -447,6 +445,40 @@ public:
             }
             // Driver state must be set to a state different from PRECONDITION_BLOCK bellow,
             // to avoid call mark_precondition_ready() and check_short_circuit() multiple times.
+        }
+
+        // OUTPUT_FULL
+        if (!sink_operator()->need_input()) {
+            set_driver_state(DriverState::OUTPUT_FULL);
+            return false;
+        }
+
+        // INPUT_EMPTY
+        if (!source_operator()->is_finished() && !source_operator()->has_output()) {
+            set_driver_state(DriverState::INPUT_EMPTY);
+            return false;
+        }
+
+        return true;
+    }
+
+    // used in event scheduler
+    // check driver is ready for schedule
+    // similar to is_not_blocked but without check short_circuit.
+    bool check_is_ready() {
+        // If the sink operator is finished, the rest operators of this driver needn't be executed anymore.
+        if (sink_operator()->is_finished()) {
+            return true;
+        }
+        if (source_operator()->is_epoch_finished() || sink_operator()->is_epoch_finished()) {
+            return true;
+        }
+
+        if (_state == DriverState::PRECONDITION_BLOCK) {
+            if (is_precondition_block()) {
+                return false;
+            }
+            mark_precondition_ready();
         }
 
         // OUTPUT_FULL

--- a/be/src/exec/pipeline/schedule/event_scheduler.cpp
+++ b/be/src/exec/pipeline/schedule/event_scheduler.cpp
@@ -56,11 +56,7 @@ void EventScheduler::try_schedule(const DriverRawPtr driver) {
     } else if (driver->is_finished()) {
         add_to_ready_queue = true;
     } else {
-        auto status_or_is_not_blocked = driver->is_not_blocked();
-        if (!status_or_is_not_blocked.ok()) {
-            fragment_ctx->cancel(status_or_is_not_blocked.status());
-            add_to_ready_queue = true;
-        } else if (status_or_is_not_blocked.value()) {
+        if (driver->check_is_ready()) {
             driver->set_driver_state(DriverState::READY);
             add_to_ready_queue = true;
         }


### PR DESCRIPTION


## Why I'm doing:

When enabling the event scheduler, `try_schedule` may invoke `FragmentContext::cancel` and `Operator::set_finishing`, potentially triggering recursive calls. Although the observer's notify method is thread-safe, this may lead to unexpected stack recursion. If a query has a high DOP, it could potentially cause a stack overflow. We aim to keep the scheduling code sufficiently simple. Therefore, we no longer allow uncontrolled code within the event scheduler.

## What I'm doing:

In this patch, we removed the `is_not_blocked` logic from the event scheduler. We now perform only the simplest check and no longer execute the `check_short_circuit` check. Since our operator always has `need_input` set to true when in the finished state, there is no performance loss.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce PipelineDriver::check_is_ready and switch event scheduler to use it instead of is_not_blocked, skipping short-circuit logic and cancel path.
> 
> - **Scheduling**:
>   - **PipelineDriver** (`be/src/exec/pipeline/pipeline_driver.h`):
>     - Add `check_is_ready()` to assess schedulability without invoking `check_short_circuit`.
>   - **EventScheduler** (`be/src/exec/pipeline/schedule/event_scheduler.cpp`):
>     - Replace `is_not_blocked()` usage with `check_is_ready()` and set state to `READY` when true.
>     - Remove error-path triggering fragment cancelation from readiness check.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1555fdf652efdd57642411181a63aa558e3f5458. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->