### PR TITLE
[BugFix] fix bundle meta parse failure when datacache corrupt

### DIFF
--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -663,7 +663,8 @@ StatusOr<TabletMetadataPtr> TabletManager::get_single_tablet_metadata(int64_t ta
     auto metadata = std::make_shared<TabletMetadataPB>();
     std::string_view metadata_str = std::string_view(serialized_string.data() + offset);
     if (!metadata->ParseFromArray(metadata_str.data(), size)) {
-        auto corrupted_status = Status::Corruption(strings::Substitute("deserialized tablet $0 metadata failed", tablet_id));
+        auto corrupted_status =
+                Status::Corruption(strings::Substitute("deserialized tablet $0 metadata failed", tablet_id));
         (void)corrupted_tablet_meta_handler(corrupted_status, path);
         return corrupted_status;
     }

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -527,14 +527,10 @@ StatusOr<BundleTabletMetadataPtr> TabletManager::parse_bundle_tablet_metadata(co
     auto file_size = serialized_string.size();
     auto footer_size = sizeof(uint64_t);
     auto bundle_metadata_size = decode_fixed64_le((uint8_t*)(serialized_string.data() + file_size - footer_size));
-    RETURN_IF(file_size < footer_size + bundle_metadata_size,
+    RETURN_IF(file_size < footer_size + bundle_metadata_size || bundle_metadata_size == 0,
               Status::Corruption(strings::Substitute(
-                      "deserialized shared metadata($0) failed, file_size($1) < bundle_metadata_size($2)", path,
-                      file_size, bundle_metadata_size + footer_size)));
-    RETURN_IF(bundle_metadata_size == 0,
-              Status::Corruption(strings::Substitute("deserialized shared metadata($0) failed, "
-                                                     "bundle_metadata_size is 0",
-                                                     path)));
+                      "deserialized shared metadata($0) failed, file_size($1), bundle_metadata_size($2)", path,
+                      file_size, bundle_metadata_size)));
 
     auto bundle_metadata = std::make_shared<BundleTabletMetadataPB>();
     std::string_view bundle_metadata_str =
@@ -667,9 +663,9 @@ StatusOr<TabletMetadataPtr> TabletManager::get_single_tablet_metadata(int64_t ta
     auto metadata = std::make_shared<TabletMetadataPB>();
     std::string_view metadata_str = std::string_view(serialized_string.data() + offset);
     if (!metadata->ParseFromArray(metadata_str.data(), size)) {
-        std::string err_msg = strings::Substitute("deserialized tablet $0 metadata failed", tablet_id);
-        (void)corrupted_tablet_meta_handler(Status::Corruption(err_msg), path);
-        return Status::Corruption(err_msg);
+        auto corrupted_status = Status::Corruption(strings::Substitute("deserialized tablet $0 metadata failed", tablet_id));
+        (void)corrupted_tablet_meta_handler(corrupted_status, path);
+        return corrupted_status;
     }
 
     FAIL_POINT_TRIGGER_EXECUTE(tablet_schema_not_found_in_bundle_metadata, { tablet_id = 10003; });

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -667,8 +667,7 @@ StatusOr<TabletMetadataPtr> TabletManager::get_single_tablet_metadata(int64_t ta
     auto metadata = std::make_shared<TabletMetadataPB>();
     std::string_view metadata_str = std::string_view(serialized_string.data() + offset);
     if (!metadata->ParseFromArray(metadata_str.data(), size)) {
-        std::string err_msg =
-                strings::Substitute("deserialized tablet $0 metadata failed", tablet_id);
+        std::string err_msg = strings::Substitute("deserialized tablet $0 metadata failed", tablet_id);
         corrupted_tablet_meta_handler(Status::Corruption(err_msg), path);
         return Status::Corruption(err_msg);
     }

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -668,7 +668,7 @@ StatusOr<TabletMetadataPtr> TabletManager::get_single_tablet_metadata(int64_t ta
     std::string_view metadata_str = std::string_view(serialized_string.data() + offset);
     if (!metadata->ParseFromArray(metadata_str.data(), size)) {
         std::string err_msg = strings::Substitute("deserialized tablet $0 metadata failed", tablet_id);
-        corrupted_tablet_meta_handler(Status::Corruption(err_msg), path);
+        (void)corrupted_tablet_meta_handler(Status::Corruption(err_msg), path);
         return Status::Corruption(err_msg);
     }
 

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -880,7 +880,93 @@ TEST_F(LakeTabletManagerTest, get_tablet_metadata_cache_options) {
     EXPECT_TRUE(_tablet_manager->metacache()->lookup_tablet_metadata(path) == nullptr);
 }
 
-TEST_F(LakeTabletManagerTest, get_tablet_metadata) {}
+TEST_F(LakeTabletManagerTest, parse_bundle_tablet_metadata_with_zero_size) {
+    // Create a corrupted bundle metadata file with bundle_metadata_size = 0
+    std::string serialized_string;
+    serialized_string.resize(sizeof(uint64_t));
+    // Set bundle_metadata_size to 0 in the footer
+    encode_fixed64_le((uint8_t*)serialized_string.data(), 0);
+
+    auto res = starrocks::lake::TabletManager::parse_bundle_tablet_metadata("test_path", serialized_string);
+    EXPECT_FALSE(res.ok());
+    EXPECT_TRUE(res.status().is_corruption());
+    EXPECT_TRUE(res.status().message().find("bundle_metadata_size is 0") != std::string::npos);
+}
+
+TEST_F(LakeTabletManagerTest, get_single_tablet_metadata_parse_failure) {
+    // First, create a valid bundle metadata to get the file path
+    auto tablet_id = next_id();
+    std::map<int64_t, TabletMetadataPB> metadatas;
+    TabletSchemaPB schema_pb;
+    {
+        schema_pb.set_id(10);
+        schema_pb.set_num_short_key_columns(1);
+        schema_pb.set_keys_type(DUP_KEYS);
+        schema_pb.set_num_rows_per_row_block(65535);
+        auto c0 = schema_pb.add_column();
+        c0->set_unique_id(0);
+        c0->set_name("c0");
+        c0->set_type("INT");
+        c0->set_is_key(true);
+        c0->set_is_nullable(false);
+    }
+
+    starrocks::TabletMetadataPB metadata1;
+    {
+        metadata1.set_id(tablet_id);
+        metadata1.set_version(2);
+        metadata1.mutable_schema()->CopyFrom(schema_pb);
+        auto& item1 = (*metadata1.mutable_historical_schemas())[10];
+        item1.CopyFrom(schema_pb);
+    }
+
+    metadatas.emplace(tablet_id, metadata1);
+    ASSERT_OK(_tablet_manager->put_bundle_tablet_metadata(metadatas));
+
+    // Read the bundle file and corrupt it
+    auto bundle_path = _tablet_manager->bundle_tablet_metadata_location(tablet_id, 2);
+    auto fs = FileSystem::Default();
+    ASSIGN_OR_ABORT(auto read_file, fs->new_random_access_file(bundle_path));
+    ASSIGN_OR_ABORT(auto content, read_file->read_all());
+
+    // Corrupt the tablet metadata portion by replacing with invalid data
+    // Keep the bundle metadata at the end intact, but corrupt the tablet data
+    // Replace the first part (tablet metadata) with garbage
+    for (size_t i = 0; i < 5; i++) {
+        content[i] = static_cast<char>(0xFF);
+    }
+
+    // Write the corrupted content back
+    ASSERT_OK(fs->delete_file(bundle_path));
+    ASSIGN_OR_ABORT(auto write_file, fs->new_writable_file(bundle_path));
+    ASSERT_OK(write_file->append(content));
+    ASSERT_OK(write_file->close());
+
+    // Clear cache to force reload from disk
+    _tablet_manager->metacache()->prune();
+
+    // Use sync point to mock corrupted_tablet_meta_handler
+    SyncPoint::GetInstance()->EnableProcessing();
+    bool handler_called = false;
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("TabletManager::corrupted_tablet_meta_handler");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    SyncPoint::GetInstance()->SetCallBack("TabletManager::corrupted_tablet_meta_handler", [&](void* arg) {
+        handler_called = true;
+        // Return OK to allow the code to continue, but the parse will still fail
+        *(Status*)arg = Status::OK();
+    });
+
+    // Try to get metadata - should fail with corruption error
+    auto res = _tablet_manager->get_tablet_metadata(tablet_id, 2);
+
+    // Should fail due to parse error
+    EXPECT_FALSE(res.ok());
+    EXPECT_TRUE(res.status().is_corruption());
+    EXPECT_TRUE(handler_called) << "corrupted_tablet_meta_handler should have been called";
+}
 
 namespace {
 class PartitionedLocationProvider : public lake::LocationProvider {

--- a/be/test/storage/lake/tablet_manager_test.cpp
+++ b/be/test/storage/lake/tablet_manager_test.cpp
@@ -890,7 +890,6 @@ TEST_F(LakeTabletManagerTest, parse_bundle_tablet_metadata_with_zero_size) {
     auto res = starrocks::lake::TabletManager::parse_bundle_tablet_metadata("test_path", serialized_string);
     EXPECT_FALSE(res.ok());
     EXPECT_TRUE(res.status().is_corruption());
-    EXPECT_TRUE(res.status().message().find("bundle_metadata_size is 0") != std::string::npos);
 }
 
 TEST_F(LakeTabletManagerTest, get_single_tablet_metadata_parse_failure) {


### PR DESCRIPTION
## Why I'm doing:
When duplicate writes occur for the bundle tablet metadata corresponding to the same path, the serialized metadata cannot be guaranteed to be idempotent, which may cause the data cache to become corrupted. In such cases, the code needs to detect this condition and proactively drop the data cache to handle it automatically.
Call `corrupted_tablet_meta_handler` when tablet meta corruption happen.

## What I'm doing:
This pull request improves error handling and test coverage for tablet metadata parsing in the Lake storage module. The main changes include stricter corruption checks when parsing bundle metadata, invoking a handler on parse failures, and adding new tests to verify these behaviors.

**Error handling improvements:**

* Added a check in `TabletManager::parse_bundle_tablet_metadata` to return a corruption status if `bundle_metadata_size` is zero, preventing further processing of invalid metadata.
* Modified `TabletManager::get_single_tablet_metadata` to call `corrupted_tablet_meta_handler` when parsing fails, ensuring that corruption is handled consistently and explicitly.

**Test coverage enhancements:**

* Added `parse_bundle_tablet_metadata_with_zero_size` test to verify that parsing fails with a clear corruption error when the bundle metadata size is zero.
* Added `get_single_tablet_metadata_parse_failure` test to simulate and validate the handling of corrupted tablet metadata, including ensuring that the `corrupted_tablet_meta_handler` is invoked appropriately.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
