### PR TITLE
[BugFix] Fix non-existent variable error reporting

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
@@ -99,6 +99,12 @@ public class SetStmtAnalyzer {
             throw new SemanticException("No variable name in set statement.");
         }
 
+        // Validate that the variable exists
+        if (!GlobalStateMgr.getCurrentState().getVariableMgr().containsVariable(variable)) {
+            String similarVars = GlobalStateMgr.getCurrentState().getVariableMgr().findSimilarVarNames(variable);
+            ErrorReport.reportSemanticException(ErrorCode.ERR_UNKNOWN_SYSTEM_VARIABLE, variable, similarVars);
+        }
+
         Expr unResolvedExpression = var.getUnResolvedExpression();
         LiteralExpr resolvedExpression;
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -1629,7 +1629,7 @@ public class PrivilegeCheckerTest extends StarRocksTestBase {
     public void testSetGlobalVar() throws Exception {
         ctxToRoot();
         verifyGrantRevoke(
-                "SET global enable_cbo = true",
+                "SET global enable_cross_join = true",
                 "grant OPERATE on system to test",
                 "revoke OPERATE on system from test",
                 "Access denied; you need (at least one of) the OPERATE privilege(s) on SYSTEM for this operation");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/SetStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/SetStmtTest.java
@@ -403,6 +403,14 @@ public class SetStmtTest {
     }
 
     @Test
+    public void testNonExistentVariable() {
+        SystemVariable setVar = new SystemVariable(SetType.SESSION, "no_exist", new StringLiteral("true"));
+        Throwable exception = assertThrows(SemanticException.class, () ->
+                SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx));
+        assertThat(exception.getMessage(), containsString("Unknown system variable 'no_exist'"));
+    }
+
+    @Test
     public void testCboDisabledRules() {
         {
             SystemVariable setVar = new SystemVariable(SetType.SESSION, SessionVariable.CBO_DISABLED_RULES,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/SetStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/SetStmtTest.java
@@ -407,7 +407,8 @@ public class SetStmtTest {
         SystemVariable setVar = new SystemVariable(SetType.SESSION, "no_exist", new StringLiteral("true"));
         Throwable exception = assertThrows(SemanticException.class, () ->
                 SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx));
-        assertThat(exception.getMessage(), containsString("Unknown system variable 'no_exist'"));
+        assertThat(exception.getMessage(),
+                containsString("Unknown system variable 'no_exist', the most similar variables"));
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:

Previously, setting a non-existent system variable (e.g., `set no_exist = "true";`) would silently succeed, which was a bug introduced by #64150. This PR fixes that by reporting an error.

## What I'm doing:

- Added validation in `SetStmtAnalyzer.analyzeSystemVariable()` to check if a system variable exists using `VariableMgr.containsVariable()`.
- If the variable does not exist, a `SemanticException` with `ERR_UNKNOWN_SYSTEM_VARIABLE` is thrown, including suggestions for similar variable names.
- Added a unit test `testNonExistentVariable()` in `SetStmtTest` to verify this behavior.

Fixes #issue (No specific issue number provided, but relates to #64150)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

---
<a href="https://cursor.com/background-agent?bcId=bc-4d9c9d52-e31d-4abf-8fc3-3f1a2e577800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4d9c9d52-e31d-4abf-8fc3-3f1a2e577800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

