### PR TITLE
[Refactor] Remove temp physical partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/TabletReshardJob.java
@@ -487,7 +487,14 @@ public class TabletReshardJob implements Writable {
                 oldPhysicalPartition.setVisibleVersion(commitVersion, stateStartedTimeMs);
                 newPhysicalPartition.setVisibleVersion(commitVersion, stateStartedTimeMs);
 
-                olapTable.replacePhysicalPartition(oldPhysicalPartition.getId(), newPhysicalPartition, true);
+                // Temporary code, ignore, will be replaced later
+                var partition = olapTable.getPartition(oldPhysicalPartition.getParentId());
+                if (partition != null) {
+                    partition.removeSubPartition(oldPhysicalPartition.getId());
+                    partition.addSubPartition(newPhysicalPartition);
+                    olapTable.removePhysicalPartition(oldPhysicalPartition);
+                    olapTable.addPhysicalPartition(newPhysicalPartition);
+                }
             }
         }
     }
@@ -497,7 +504,8 @@ public class TabletReshardJob implements Writable {
         try (LockedObject<OlapTable> lockedTable = getLockedTable(LockType.WRITE)) {
             OlapTable olapTable = lockedTable.get();
             for (long physicalPartitionId : physicalPartitionContexts.keySet()) {
-                PhysicalPartition physicalPartition = olapTable.removePhysicalPartition(physicalPartitionId);
+                // Temporary code, ignore, will be replaced later
+                PhysicalPartition physicalPartition = olapTable.getPhysicalPartition(physicalPartitionId);
                 if (physicalPartition == null) {
                     continue;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2727,52 +2727,6 @@ public class OlapTable extends Table {
         return !tempPartitions.isEmpty();
     }
 
-    public PhysicalPartition replacePhysicalPartition(long oldPhysicalPartitionId,
-                                                      PhysicalPartition newPhysicalPartition, boolean moveOldToTemp) {
-        Partition partition = getPartition(newPhysicalPartition.getParentId());
-        if (partition == null || partition.getId() != newPhysicalPartition.getParentId()) {
-            return null;
-        }
-
-        PhysicalPartition oldPhysicalPartition = partition.replacePhysicalPartition(oldPhysicalPartitionId,
-                newPhysicalPartition, moveOldToTemp);
-        if (oldPhysicalPartition == null) {
-            return null;
-        }
-
-        physicalPartitionIdToPartitionId.put(newPhysicalPartition.getId(), newPhysicalPartition.getParentId());
-        physicalPartitionNameToPartitionId.put(newPhysicalPartition.getName(), newPhysicalPartition.getParentId());
-
-        if (!moveOldToTemp) {
-            physicalPartitionIdToPartitionId.remove(oldPhysicalPartition.getId());
-            physicalPartitionNameToPartitionId.remove(oldPhysicalPartition.getName());
-        }
-
-        return oldPhysicalPartition;
-    }
-
-    public PhysicalPartition removePhysicalPartition(long physicalPartitionId) {
-        Long partitionId = physicalPartitionIdToPartitionId.get(physicalPartitionId);
-        if (partitionId == null) {
-            return null;
-        }
-
-        Partition partition = getPartition(partitionId);
-        if (partition == null) {
-            return null;
-        }
-
-        PhysicalPartition physicalPartition = partition.removeSubPartition(physicalPartitionId);
-        if (physicalPartition == null) {
-            return null;
-        }
-
-        physicalPartitionIdToPartitionId.remove(physicalPartition.getId());
-        physicalPartitionNameToPartitionId.remove(physicalPartition.getName());
-
-        return physicalPartition;
-    }
-
     public void setCompressionType(TCompressionType compressionType) {
         if (tableProperty == null) {
             tableProperty = new TableProperty(new HashMap<>());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Partition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Partition.java
@@ -82,10 +82,6 @@ public class Partition extends MetaObject implements GsonPostProcessable {
     private Map<Long, PhysicalPartition> idToSubPartition = Maps.newHashMap();
     private Map<String, PhysicalPartition> nameToSubPartition = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
 
-    @SerializedName(value = "idToTempSubPartition")
-    private Map<Long, PhysicalPartition> idToTempSubPartition = Maps.newHashMap();
-    private Map<String, PhysicalPartition> nameToTempSubPartition = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
-
     @SerializedName(value = "distributionInfo")
     private DistributionInfo distributionInfo;
 
@@ -150,8 +146,6 @@ public class Partition extends MetaObject implements GsonPostProcessable {
         partition.defaultPhysicalPartitionId = this.defaultPhysicalPartitionId;
         partition.idToSubPartition = Maps.newHashMap(this.idToSubPartition);
         partition.nameToSubPartition = Maps.newHashMap(this.nameToSubPartition);
-        partition.idToTempSubPartition = Maps.newHashMap(this.idToTempSubPartition);
-        partition.nameToTempSubPartition = Maps.newHashMap(this.nameToTempSubPartition);
         return partition;
     }
 
@@ -205,11 +199,6 @@ public class Partition extends MetaObject implements GsonPostProcessable {
             nameToSubPartition.remove(subPartition.getName());
             return subPartition;
         }
-
-        subPartition = idToTempSubPartition.remove(id);
-        if (subPartition != null) {
-            nameToTempSubPartition.remove(subPartition.getName());
-        }
         return subPartition;
     }
 
@@ -218,19 +207,11 @@ public class Partition extends MetaObject implements GsonPostProcessable {
     }
 
     public PhysicalPartition getSubPartition(long id) {
-        PhysicalPartition physicalPartition = idToSubPartition.get(id);
-        if (physicalPartition != null) {
-            return physicalPartition;
-        }
-        return idToTempSubPartition.get(id);
+        return idToSubPartition.get(id);
     }
 
     public PhysicalPartition getSubPartition(String name) {
-        PhysicalPartition physicalPartition = nameToSubPartition.get(name);
-        if (physicalPartition != null) {
-            return physicalPartition;
-        }
-        return nameToTempSubPartition.get(name);
+        return nameToSubPartition.get(name);
     }
 
     public PhysicalPartition getLatestPhysicalPartition() {
@@ -242,27 +223,6 @@ public class Partition extends MetaObject implements GsonPostProcessable {
 
     public PhysicalPartition getDefaultPhysicalPartition() {
         return idToSubPartition.get(defaultPhysicalPartitionId);
-    }
-
-    public PhysicalPartition replacePhysicalPartition(long oldPhysicalPartitionId,
-            PhysicalPartition newPhysicalPartition, boolean moveOldToTemp) {
-        PhysicalPartition oldPhysicalPartition = removeSubPartition(oldPhysicalPartitionId);
-        if (oldPhysicalPartition == null) {
-            return null;
-        }
-
-        addSubPartition(newPhysicalPartition);
-
-        if (defaultPhysicalPartitionId == oldPhysicalPartitionId) {
-            defaultPhysicalPartitionId = newPhysicalPartition.getId();
-        }
-
-        if (moveOldToTemp) {
-            idToTempSubPartition.put(oldPhysicalPartition.getId(), oldPhysicalPartition);
-            nameToTempSubPartition.put(oldPhysicalPartition.getName(), oldPhysicalPartition);
-        }
-
-        return oldPhysicalPartition;
     }
 
     public boolean hasData() {
@@ -367,13 +327,6 @@ public class Partition extends MetaObject implements GsonPostProcessable {
             }
 
             nameToSubPartition.put(subPartition.getName(), subPartition);
-        }
-
-        for (PhysicalPartition subPartition : idToTempSubPartition.values()) {
-            if (subPartition.getName() == null) {
-                subPartition.setName(generatePhysicalPartitionName(subPartition.getId()));
-            }
-            nameToTempSubPartition.put(subPartition.getName(), subPartition);
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:
Temp physical partition is no longer needed, remove it.

## What I'm doing:
Remove temp physical partition

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes temp physical partition structures/APIs and updates dynamic tablet job to directly replace/remove subpartitions and update table mappings.
> 
> - **Catalog**:
>   - Remove temp physical partition data structures and APIs from `Partition` and `OlapTable` (e.g., delete temp sub-partition maps, `replacePhysicalPartition(...)`, and `removePhysicalPartition(long)`).
>   - Simplify sub-partition lookups in `Partition` to only use formal maps; drop temp-related post-processing.
>   - Add explicit helpers in `OlapTable` to `addPhysicalPartition(...)` and `removePhysicalPartition(PhysicalPartition)` for mapping updates.
> - **Dynamic Tablet**:
>   - In `DynamicTabletJob.replacePhysicalPartitions()`, manually remove old and add new subpartitions on the parent `Partition`, and update `OlapTable` physical partition mappings.
>   - In `removePhysicalPartitions()`, stop removing via table API; only fetch physical partitions and delete their tablets from `TabletInvertedIndex`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37844ce2cbdf1f844ce29a3a5c36981ede5e4f28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->