### PR TITLE
[Enhancement] make JWT security in IcebergRESTCatalog case-insensitive

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -252,6 +252,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
                     new RuntimeException("Failed to get database using REST Catalog exception:" + re.getMessage(), re));
         }
     }
+
     @Override
     public List<String> listTables(ConnectContext context, String dbName) {
         Namespace ns = convertDbNameToNamespace(dbName);
@@ -396,7 +397,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
             Table table = delegate.registerTable(buildContext(context), tableIdentifier, metadataFileLocation);
             return table != null;
         } catch (RESTException re) {
-            LOG.error("Failed to register table using REST Catalog, for dbName {} tableName {} metadataFileLocation {}", 
+            LOG.error("Failed to register table using REST Catalog, for dbName {} tableName {} metadataFileLocation {}",
                     dbName, tableName, metadataFileLocation, re);
             throw new StarRocksConnectorException("Failed to register table using REST Catalog",
                     new RuntimeException("Failed to register table using REST Catalog, exception: " + re.getMessage(), re));
@@ -433,10 +434,10 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         if (Strings.isNullOrEmpty(context.getAuthToken())) {
             return SessionCatalog.SessionContext.createEmpty();
         } else {
-            ImmutableMap.Builder mapBuilder = ImmutableMap.<String, String>builder()
+            ImmutableMap.Builder<String, String> mapBuilder = ImmutableMap.<String, String>builder()
                     .put(OAuth2Properties.ACCESS_TOKEN_TYPE, context.getAuthToken());
 
-            if (Security.JWT.name().equals(restCatalogProperties.getOrDefault(ICEBERG_CATALOG_SECURITY, "NONE"))) {
+            if (Security.JWT.name().equalsIgnoreCase(restCatalogProperties.getOrDefault(ICEBERG_CATALOG_SECURITY, "NONE"))) {
                 mapBuilder.put(OAuth2Properties.TOKEN, context.getAuthToken());
             }
             credentials = mapBuilder.buildOrThrow();


### PR DESCRIPTION
## Why I'm doing:
Fix https://github.com/StarRocks/starrocks/issues/65944
## What I'm doing:
This pull request makes improvements to the `IcebergRESTCatalog` implementation and its corresponding tests, primarily focusing on enhancing security handling and test coverage. The most notable changes are the addition of case-insensitive security property handling and new unit tests to verify JWT security context construction.

**Security handling improvements:**

* Changed the comparison for the `ICEBERG_CATALOG_SECURITY` property from case-sensitive to case-insensitive using `equalsIgnoreCase`, ensuring that both "JWT" and "Jwt" are handled correctly in `IcebergRESTCatalog.java`.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
