### PR TITLE
[BugFix] fix FE NULL pointer in resetDecommStatForSingleReplicaTabletUnlocked

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -400,6 +400,9 @@ public class TabletScheduler extends FrontendDaemon {
      */
     public static void resetDecommStatForSingleReplicaTabletUnlocked(long tabletId, List<Replica> replicas) {
         TabletScheduler tabletScheduler = GlobalStateMgr.getCurrentState().getTabletScheduler();
+        if (tabletScheduler == null) {
+            return;
+        }
         TabletSchedCtx tabletSchedCtx = tabletScheduler.getTabletSchedCtx(tabletId);
         if (tabletSchedCtx != null) {
             Replica decommissionedReplica = tabletSchedCtx.getDecommissionedReplica();

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -406,9 +406,10 @@ public class TabletScheduler extends FrontendDaemon {
             for (Replica replica : replicas) {
                 if (replica.getState() == Replica.ReplicaState.DECOMMISSION && replica.getLastFailedVersion() < 0
                         && decommissionedReplica != null && replica.getId() == decommissionedReplica.getId()) {
+                    String replicaInfo = tabletSchedCtx.getTablet() != null ?
+                            tabletSchedCtx.getTablet().getReplicaInfos() : "tablet is null";
                     tabletScheduler.finalizeTabletCtx(tabletSchedCtx, TabletSchedCtx.State.CANCELLED,
-                            "src replica of rebalance need to reset state, replicas: " +
-                                    tabletSchedCtx.getTablet().getReplicaInfos());
+                            "src replica of rebalance need to reset state, replicas: " + replicaInfo);
                     break;
                 }
             }

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
@@ -656,9 +656,6 @@ public class TabletSchedulerTest {
 
         // This should not throw NullPointerException even though ctx.getTablet() returns null
         TabletScheduler.resetDecommStatForSingleReplicaTabletUnlocked(tabletId, replicas);
-
-        // Verify the method completed without exception
-        Assertions.assertEquals(TabletSchedCtx.State.PENDING, ctx.getState());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
@@ -672,11 +672,10 @@ public class TabletSchedulerTest {
         Replica decommissionedReplica = new Replica(replicaId, beId, -1, Replica.ReplicaState.DECOMMISSION);
         List<Replica> replicas = Lists.newArrayList(decommissionedReplica);
 
-        new Expectations() {
-            {
-                globalStateMgr.getTabletScheduler();
-                minTimes = 0;
-                result = null;
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public TabletScheduler getTabletScheduler() {
+                return null;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
@@ -644,11 +644,10 @@ public class TabletSchedulerTest {
 
         TabletScheduler tabletScheduler = new TabletScheduler(new TabletSchedulerStat());
 
-        new Expectations() {
-            {
-                globalStateMgr.getTabletScheduler();
-                minTimes = 0;
-                result = tabletScheduler;
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public TabletScheduler getTabletScheduler() {
+                return tabletScheduler;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
@@ -626,4 +626,64 @@ public class TabletSchedulerTest {
                 "unable to delete any colocate redundant replicas. replicas: 10001:-1/-1/-1/0:NORMAL:NIL,, backend set: [10001]",
                 () -> Deencapsulation.invoke(tabletScheduler, "handleColocateRedundant", ctx));
     }
+
+    @Test
+    public void testResetDecommStatForSingleReplicaTabletWithNullTablet() {
+        long tabletId = 10006L;
+        long replicaId = 10007L;
+        long beId = 10001L;
+
+        // Create a replica with DECOMMISSION state
+        Replica decommissionedReplica = new Replica(replicaId, beId, -1, Replica.ReplicaState.DECOMMISSION);
+        List<Replica> replicas = Lists.newArrayList(decommissionedReplica);
+
+        // Create a TabletSchedCtx but don't set the tablet (getTablet() will return null)
+        TabletSchedCtx ctx = new TabletSchedCtx(TabletSchedCtx.Type.BALANCE,
+                10002L, 10003L, 10004L, 10005L, tabletId, System.currentTimeMillis());
+        ctx.setDecommissionedReplica(decommissionedReplica);
+
+        TabletScheduler tabletScheduler = new TabletScheduler(new TabletSchedulerStat());
+
+        new Expectations() {
+            {
+                globalStateMgr.getTabletScheduler();
+                minTimes = 0;
+                result = tabletScheduler;
+            }
+        };
+
+        // Add the context to scheduler so getTabletSchedCtx can find it
+        Deencapsulation.invoke(tabletScheduler, "addToPendingTablets", ctx);
+
+        // This should not throw NullPointerException even though ctx.getTablet() returns null
+        TabletScheduler.resetDecommStatForSingleReplicaTabletUnlocked(tabletId, replicas);
+
+        // Verify the method completed without exception
+        Assertions.assertEquals(TabletSchedCtx.State.PENDING, ctx.getState());
+    }
+
+    @Test
+    public void testResetDecommStatForSingleReplicaTabletWithNullTabletScheduler() {
+        long tabletId = 10006L;
+        long replicaId = 10007L;
+        long beId = 10001L;
+
+        // Create a replica with DECOMMISSION state
+        Replica decommissionedReplica = new Replica(replicaId, beId, -1, Replica.ReplicaState.DECOMMISSION);
+        List<Replica> replicas = Lists.newArrayList(decommissionedReplica);
+
+        new Expectations() {
+            {
+                globalStateMgr.getTabletScheduler();
+                minTimes = 0;
+                result = null;
+            }
+        };
+
+        // This should not throw NullPointerException even though getTabletScheduler() returns null
+        TabletScheduler.resetDecommStatForSingleReplicaTabletUnlocked(tabletId, replicas);
+
+        // If we reach here without exception, the test passes
+        Assertions.assertTrue(true);
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
`tabletSchedCtx.getTablet()` could return null and lead to :
```
2025-11-19 11:55:04.091+01:00 ERROR (PUBLISH_VERSION|25) [PublishVersionDaemon.runAfterCatalogReady():117] errors while publish version to all backends
java.lang.NullPointerException: null
        at com.starrocks.clone.TabletScheduler.resetDecommStatForSingleReplicaTabletUnlocked(TabletScheduler.java:389) ~[starrocks-fe.jar:?]
        at com.starrocks.transaction.OlapTableTxnLogApplier.applyVisibleLog(OlapTableTxnLogApplier.java:151) ~[starrocks-fe.jar:?]
        at com.starrocks.transaction.DatabaseTransactionMgr.updateCatalogAfterVisible(DatabaseTransactionMgr.java:1504) ~[starrocks-fe.jar:?]
        at com.starrocks.transaction.DatabaseTransactionMgr.finishTransaction(DatabaseTransactionMgr.java:1025) ~[starrocks-fe.jar:?]
        at com.starrocks.transaction.GlobalTransactionMgr.finishTransaction(GlobalTransactionMgr.java:607) ~[starrocks-fe.jar:?]
        at com.starrocks.transaction.PublishVersionDaemon.publishVersionForOlapTable(PublishVersionDaemon.java:274) ~[starrocks-fe.jar:?]
        at com.starrocks.transaction.PublishVersionDaemon.runAfterCatalogReady(PublishVersionDaemon.java:112) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.FrontendDaemon.runOneCycle(FrontendDaemon.java:72) ~[starrocks-fe.jar:?]
        at com.starrocks.common.util.Daemon.run(Daemon.java:107) ~[starrocks-fe.jar:?]
```

## What I'm doing:
This pull request improves the robustness of the `TabletScheduler` by handling cases where certain objects may be null, and adds corresponding unit tests to ensure these scenarios are covered. The changes prevent potential `NullPointerException`s and verify the correct behavior through new tests.

**Robustness improvements:**

* Updated `resetDecommStatForSingleReplicaTabletUnlocked` to safely handle cases where `tabletSchedCtx.getTablet()` may return null, preventing possible `NullPointerException`s by checking for null before accessing `getReplicaInfos()` and providing a fallback message.

**Testing enhancements:**

* Added two new unit tests in `TabletSchedulerTest`:
  * `testResetDecommStatForSingleReplicaTabletWithNullTablet` verifies that the method works correctly when the `TabletSchedCtx`'s tablet is null.
  * `testResetDecommStatForSingleReplicaTabletWithNullTabletScheduler` verifies that the method does not throw an exception when the `TabletScheduler` itself is null.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds null-safety to `resetDecommStatForSingleReplicaTabletUnlocked` and introduces tests to ensure no NPE when `TabletScheduler` or `TabletSchedCtx.getTablet()` is null.
> 
> - **Robustness**
>   - Update `resetDecommStatForSingleReplicaTabletUnlocked` to:
>     - Return early if `GlobalStateMgr.getTabletScheduler()` is null.
>     - Safely build replica info message when `tabletSchedCtx.getTablet()` is null.
> - **Tests**
>   - Add `testResetDecommStatForSingleReplicaTabletWithNullTablet` to verify no NPE when `getTablet()` is null.
>   - Add `testResetDecommStatForSingleReplicaTabletWithNullTabletScheduler` to verify no NPE when scheduler is null.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d661594cf8ddf27b8e8b4b736db72e7cc5c2069f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->