### PR TITLE
[Enhancement] Query supports ORDER BY on struct data types

### DIFF
--- a/be/src/exec/chunks_sorter_topn.cpp
+++ b/be/src/exec/chunks_sorter_topn.cpp
@@ -443,6 +443,7 @@ Status ChunksSorterTopn::_build_filter_from_high_low_comparison(const DataSegmen
     // First compare the chunk with last row of this segment.
     const size_t max_value_row_id = _get_number_of_rows_to_sort() - 1;
     const auto& [run, max_rid] = _get_run_by_row_id(max_value_row_id);
+
     get_compare_results_colwise(max_rid, run->orderby, compare_results_array, data_segments, sort_descs);
 
     include_num = 0;

--- a/be/src/exec/sorted_streaming_aggregator.cpp
+++ b/be/src/exec/sorted_streaming_aggregator.cpp
@@ -154,7 +154,29 @@ public:
     }
 
     Status do_visit(const StructColumn& column) {
-        return Status::NotSupported("Unsupported struct column in column wise comparator");
+        size_t num_rows = column.size();
+        if (!_first_column->empty()) {
+            _cmp_vector[0] |= _first_column->compare_at(0, 0, column, 1) != 0;
+        } else {
+            _cmp_vector[0] |= 1;
+        }
+
+        if (!_null_masks.empty()) {
+            DCHECK_EQ(_null_masks.size(), num_rows);
+            for (size_t i = 1; i < num_rows; ++i) {
+                if (_null_masks[i - 1] == 0 && _null_masks[i] == 0) {
+                    _cmp_vector[i] |= column.compare_at(i - 1, i, column, true) != 0;
+                } else {
+                    _cmp_vector[i] |= _null_masks[i - 1] != _null_masks[i];
+                }
+            }
+        } else {
+            for (size_t i = 1; i < num_rows; ++i) {
+                _cmp_vector[i] |= column.compare_at(i - 1, i, column, true) != 0;
+            }
+        }
+
+        return Status::OK();
     }
 
 private:
@@ -251,7 +273,15 @@ public:
     }
 
     Status do_visit(StructColumn* column) {
-        return Status::NotSupported("Unsupported struct column in column wise comparator");
+        auto col = down_cast<StructColumn*>(_column);
+
+        for (size_t i = 0; i < _sel_mask.size(); ++i) {
+            if (_sel_mask[i] == 0) {
+                column->append(*col, i, 1);
+            }
+        }
+
+        return Status::OK();
     }
 
 private:

--- a/be/src/exec/sorting/compare_column.cpp
+++ b/be/src/exec/sorting/compare_column.cpp
@@ -178,8 +178,15 @@ public:
     }
 
     Status do_visit(const StructColumn& column) {
-        //TODO(SmithCruise)
-        return Status::NotSupported("Not support");
+        // Convert the datum to a struct column
+        auto rhs_column = column.clone_empty();
+        rhs_column->append_datum(_rhs_value);
+        auto cmp = [&](int lhs_index) {
+            return column.compare_at(lhs_index, 0, *rhs_column, _null_first) * _sort_order;
+        };
+        _equal_count = compare_column_helper(_cmp_vector, cmp);
+
+        return Status::OK();
     }
 
     template <typename T>
@@ -306,6 +313,7 @@ public:
     Status do_visit(const ArrayColumn& column) { return Status::NotSupported("Not support"); }
     Status do_visit(const MapColumn& column) { return Status::NotSupported("Not support"); }
     Status do_visit(const StructColumn& column) { return Status::NotSupported("Not support"); }
+
     template <typename T>
     Status do_visit(const ObjectColumn<T>& column) {
         return Status::NotSupported("not support");

--- a/be/src/exec/sorting/sort_column.cpp
+++ b/be/src/exec/sorting/sort_column.cpp
@@ -401,8 +401,16 @@ public:
     }
 
     Status do_visit(const StructColumn& column) {
-        // TODO(SmithCruise)
-        return Status::NotSupported("Not support");
+        auto cmp = [&](const PermutationItem& lhs, const PermutationItem& rhs) {
+            auto& lhs_col = _vertical_columns[lhs.chunk_index];
+            auto& rhs_col = _vertical_columns[rhs.chunk_index];
+            return lhs_col->compare_at(lhs.index_in_chunk, rhs.index_in_chunk, *rhs_col, _sort_desc.nan_direction());
+        };
+
+        RETURN_IF_ERROR(sort_and_tie_helper(_cancel, &column, _sort_desc.asc_order(), _permutation, _tie, cmp, _range,
+                                            _build_tie, _limit, &_pruned_limit));
+        _prune_limit();
+        return Status::OK();
     }
 
     template <typename T>

--- a/be/src/runtime/types.cpp
+++ b/be/src/runtime/types.cpp
@@ -276,6 +276,11 @@ bool TypeDescriptor::support_orderby() const {
     if (type == TYPE_ARRAY) {
         return children[0].support_orderby();
     }
+    if (type == TYPE_STRUCT) {
+        bool all_support = std::all_of(children.begin(), children.end(),
+                                       [](const TypeDescriptor& t) { return t.support_orderby(); });
+        return all_support;
+    }
     return type != TYPE_JSON && type != TYPE_OBJECT && type != TYPE_PERCENTILE && type != TYPE_HLL &&
            type != TYPE_MAP && type != TYPE_VARIANT;
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStructTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStructTest.java
@@ -94,7 +94,7 @@ public class AnalyzeStructTest {
     @Test
     public void testInvalidSql() {
         analyzeFail("select b + 1 from struct_a;");
-        analyzeFail("select * from struct_a order by b;");
+        analyzeSuccess("select * from struct_a order by b;");
         analyzeFail("select sum(b) from struct_a;");
         analyzeSuccess("select * from struct_a a join struct_a b on a.b=b.b;");
         analyzeSuccess("select sum(a) from struct_a group by b;");

--- a/fe/fe-type/src/main/java/com/starrocks/type/Type.java
+++ b/fe/fe-type/src/main/java/com/starrocks/type/Type.java
@@ -261,7 +261,17 @@ public abstract class Type implements Cloneable {
         if (isArrayType()) {
             return ((ArrayType) this).getItemType().canOrderBy();
         }
-        return !isOnlyMetricType() && !isJsonType() && !isFunctionType() && !isStructType() &&
+        if (isStructType()) {
+            // Struct can be ordered if all its fields can be ordered
+            StructType structType = (StructType) this;
+            for (StructField field : structType.getFields()) {
+                if (!field.getType().canOrderBy()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return !isOnlyMetricType() && !isJsonType() && !isFunctionType() &&
                 !isMapType() && !isVariantType();
     }
 

--- a/test/sql/test_agg_function/R/test_count_distinct
+++ b/test/sql/test_agg_function/R/test_count_distinct
@@ -47,17 +47,17 @@ insert into test_cc values('c','a', '2022-04-18 03:25:00', 2, 300.3,  null, row(
 insert into test_cc values('c','a', '2022-04-18 03:27:00', 3, 400.3,  [3, 1, 3], null);
 -- result:
 -- !result
-select v2, count(1), count(distinct v1) from test_cc group by v2;
+select v2, count(1), count(distinct v1) from test_cc group by v2 order by v2;
 -- result:
 a	5	2
 b	3	1
 -- !result
-select v2, bitmap_union_count(to_bitmap(v4)), count(distinct v1) from test_cc group by v2;
+select v2, bitmap_union_count(to_bitmap(v4)), count(distinct v1) from test_cc group by v2 order by v2;
 -- result:
-b	3	1
 a	3	2
+b	3	1
 -- !result
-select v2, hll_union_agg(hll_hash(v4)), count(distinct v1) from test_cc group by v2;
+select v2, hll_union_agg(hll_hash(v4)), count(distinct v1) from test_cc group by v2 order by v2;
 -- result:
 a	3	2
 b	3	1
@@ -83,36 +83,37 @@ select count(distinct 1, 2, 3, 4), sum(distinct 1), avg(distinct 1), group_conca
 -- result:
 1	1	1.0	12	[1.3]
 -- !result
-select count(distinct 1, 2, 3, 4), sum(distinct 1), avg(distinct 1), group_concat(distinct 1, 2 order by 1), array_agg(distinct 1.3 order by null) from test_cc group by v2;
+select count(distinct 1, 2, 3, 4), sum(distinct 1), avg(distinct 1), group_concat(distinct 1, 2 order by 1), array_agg(distinct 1.3 order by null) from test_cc group by v2 order by v2;
 -- result:
 1	1	1.0	12	[1.3]
 1	1	1.0	12	[1.3]
 -- !result
-select v2, count(distinct v1), sum(distinct v1), avg(distinct v1), group_concat(distinct 1, 2), array_agg(distinct 1.3 order by null)  from test_cc group by v2;
+select v2, count(distinct v1), sum(distinct v1), avg(distinct v1), group_concat(distinct 1, 2), array_agg(distinct 1.3 order by null)  from test_cc group by v2 order by v2;
 -- result:
-b	1	None	None	12	[1.3]
 a	2	None	None	12	[1.3]
+b	1	None	None	12	[1.3]
 -- !result
-select v2, count(distinct v4), sum(distinct v4), avg(distinct v4), group_concat(distinct 1, 2), array_agg(distinct 1.3 order by null) from test_cc group by v2;
+select v2, count(distinct v4), sum(distinct v4), avg(distinct v4), group_concat(distinct 1, 2), array_agg(distinct 1.3 order by null) from test_cc group by v2 order by v2;
 -- result:
-b	3	6	2.0	12	[1.3]
 a	3	6	2.0	12	[1.3]
+b	3	6	2.0	12	[1.3]
 -- !result
-select v2, count(distinct v5), sum(distinct v5), avg(distinct v5), group_concat(distinct 1, 2), array_agg(distinct 1.3 order by null) from test_cc group by v2;
+select v2, count(distinct v5), sum(distinct v5), avg(distinct v5), group_concat(distinct 1, 2), array_agg(distinct 1.3 order by null) from test_cc group by v2 order by v2;
 -- result:
 a	5	904.40	180.88000000	12	[1.3]
 b	3	104.91	34.97000000	12	[1.3]
 -- !result
-select v2, count(distinct v6), array_agg(distinct v6 order by 1), group_concat(distinct 1, 2), array_agg(distinct 1.3 order by null) from test_cc group by v2;
+select v2, count(distinct v6), array_agg(distinct v6 order by 1), group_concat(distinct 1, 2), array_agg(distinct 1.3 order by null) from test_cc group by v2 order by v2;
 -- result:
 a	3	[null,[1,2,3],[2,2,3],[3,1,3]]	12	[1.3]
 b	3	[[2,1,3],[2,2,3],[3,1,3]]	12	[1.3]
 -- !result
-select v2, count(distinct v7), array_agg(distinct v7 order by 1), group_concat(distinct 1, 2 order by 1), array_agg(distinct 1.3 order by null) from test_cc group by v2;
+select v2, count(distinct v7), array_agg(distinct v7 order by 1), group_concat(distinct 1, 2 order by 1), array_agg(distinct 1.3 order by null) from test_cc group by v2 order by v2;
 -- result:
-E: (1064, "Getting analyzing error from line 1, column 31 to line 1, column 63. Detail message: array_agg can't support order by the 1-th input with type of struct<a bigint(20), b char(20)>.")
+a	3	[null,{"a":1,"b":"a"},{"a":2,"b":"a"},{"a":3,"b":"a"}]	12	[1.3]
+b	2	[{"a":2,"b":"a"},{"a":4,"b":"a"}]	12	[1.3]
 -- !result
-select v2, count(distinct v1, v3, v6), sum(distinct v1), avg(distinct v1), array_agg(v5 order by 1), group_concat(distinct 1, 2), array_agg(distinct 1.3 order by null)  from test_cc group by v2;
+select v2, count(distinct v1, v3, v6), sum(distinct v1), avg(distinct v1), array_agg(v5 order by 1), group_concat(distinct 1, 2), array_agg(distinct 1.3 order by null)  from test_cc group by v2 order by v2;
 -- result:
 a	4	None	None	[1.20,2.30,200.30,300.30,400.30]	12	[1.3]
 b	3	None	None	[1.30,3.31,100.30]	12	[1.3]
@@ -121,39 +122,39 @@ select count(distinct v4, v5), sum(distinct v4), avg(distinct v4), group_concat(
 -- result:
 8	6	2.0	11.202,12.302,1100.302,1200.302,21.302,2300.302,33.312,3400.302	[1.456]
 -- !result
-select v2, count(distinct v4, v5), sum(distinct v5), avg(distinct v5), group_concat(distinct v4, v5, 2 order by 1,2), array_agg(distinct 1.456 order by 1) from test_cc group by v2;
+select v2, count(distinct v4, v5), sum(distinct v5), avg(distinct v5), group_concat(distinct v4, v5, 2 order by 1,2), array_agg(distinct 1.456 order by 1) from test_cc group by v2 order by v2;
 -- result:
 a	5	904.40	180.88000000	11.202,12.302,1200.302,2300.302,3400.302	[1.456]
 b	3	104.91	34.97000000	1100.302,21.302,33.312	[1.456]
 -- !result
-select v2, count(distinct v3, v5), sum(distinct v4), avg(distinct v5), group_concat(distinct v4, v5, 2 order by 1,2), array_agg(distinct 1.456 order by 1) from test_cc group by v2, v3;
+select v2, count(distinct v3, v5), sum(distinct v4), avg(distinct v5), group_concat(distinct v4, v5, 2 order by 1,2), array_agg(distinct 1.456 order by 1) from test_cc group by v2, v3 order by v2, v3;
 -- result:
-a	1	1	200.30000000	1200.302	[1.456]
-a	1	3	400.30000000	3400.302	[1.456]
-b	1	2	1.30000000	21.302	[1.456]
-b	1	1	100.30000000	1100.302	[1.456]
-a	1	1	2.30000000	12.302	[1.456]
-b	1	3	3.31000000	33.312	[1.456]
 a	1	1	1.20000000	11.202	[1.456]
+a	1	1	2.30000000	12.302	[1.456]
 a	1	2	300.30000000	2300.302	[1.456]
+a	1	3	400.30000000	3400.302	[1.456]
+a	1	1	200.30000000	1200.302	[1.456]
+b	1	2	1.30000000	21.302	[1.456]
+b	1	3	3.31000000	33.312	[1.456]
+b	1	1	100.30000000	1100.302	[1.456]
 -- !result
 select count(distinct v4, v5), sum(distinct v4), avg(distinct v4), group_concat(distinct v4, v5, 2 order by 1,2), array_agg(distinct v4 order by 1) from test_cc;
 -- result:
 8	6	2.0	11.202,12.302,1100.302,1200.302,21.302,2300.302,33.312,3400.302	[1,2,3]
 -- !result
-select v2, count(distinct v4, v5), sum(distinct v5), avg(distinct v5), group_concat(distinct v4, v5, 2 order by 1,2), array_agg(distinct v5 order by 1) from test_cc group by v2;
+select v2, count(distinct v4, v5), sum(distinct v5), avg(distinct v5), group_concat(distinct v4, v5, 2 order by 1,2), array_agg(distinct v5 order by 1) from test_cc group by v2 order by v2;
 -- result:
-b	3	104.91	34.97000000	1100.302,21.302,33.312	[1.30,3.31,100.30]
 a	5	904.40	180.88000000	11.202,12.302,1200.302,2300.302,3400.302	[1.20,2.30,200.30,300.30,400.30]
+b	3	104.91	34.97000000	1100.302,21.302,33.312	[1.30,3.31,100.30]
 -- !result
-select v2, count(distinct v3, v5), sum(distinct v4), avg(distinct v5), group_concat(distinct v4, v5, 2 order by 1,2), array_agg(distinct v5 order by 1) from test_cc group by v2, v3;
+select v2, count(distinct v3, v5), sum(distinct v4), avg(distinct v5), group_concat(distinct v4, v5, 2 order by 1,2), array_agg(distinct v5 order by 1) from test_cc group by v2, v3 order by v2, v3;
 -- result:
-b	1	2	1.30000000	21.302	[1.30]
-a	1	2	300.30000000	2300.302	[300.30]
-b	1	1	100.30000000	1100.302	[100.30]
-a	1	3	400.30000000	3400.302	[400.30]
 a	1	1	1.20000000	11.202	[1.20]
 a	1	1	2.30000000	12.302	[2.30]
+a	1	2	300.30000000	2300.302	[300.30]
+a	1	3	400.30000000	3400.302	[400.30]
 a	1	1	200.30000000	1200.302	[200.30]
+b	1	2	1.30000000	21.302	[1.30]
 b	1	3	3.31000000	33.312	[3.31]
+b	1	1	100.30000000	1100.302	[100.30]
 -- !result

--- a/test/sql/test_agg_function/T/test_count_distinct
+++ b/test/sql/test_agg_function/T/test_count_distinct
@@ -32,32 +32,32 @@ insert into test_cc values('c','a', '2022-04-18 03:45:00', 1, 200.3,  [2, 2, 3],
 insert into test_cc values('c','a', '2022-04-18 03:25:00', 2, 300.3,  null, row(2, 'a'));
 insert into test_cc values('c','a', '2022-04-18 03:27:00', 3, 400.3,  [3, 1, 3], null);
 
-select v2, count(1), count(distinct v1) from test_cc group by v2;
-select v2, bitmap_union_count(to_bitmap(v4)), count(distinct v1) from test_cc group by v2;
-select v2, hll_union_agg(hll_hash(v4)), count(distinct v1) from test_cc group by v2;
+select v2, count(1), count(distinct v1) from test_cc group by v2 order by v2;
+select v2, bitmap_union_count(to_bitmap(v4)), count(distinct v1) from test_cc group by v2 order by v2;
+select v2, hll_union_agg(hll_hash(v4)), count(distinct v1) from test_cc group by v2 order by v2;
 
 select count(distinct 1, 2, 3, 4) from test_cc;
 select /*+ new_planner_agg_stage = 3 */ count(distinct 1, 2, 3, 4) from test_cc group by v2;
 select count(distinct 1, v2) from test_cc;
 select /*+ new_planner_agg_stage = 2 */ count(distinct 1, v2) from test_cc;
 select count(distinct 1, 2, 3, 4), sum(distinct 1), avg(distinct 1), group_concat(distinct 1, 2 order by 1), array_agg(distinct 1.3 order by null) from test_cc;
-select count(distinct 1, 2, 3, 4), sum(distinct 1), avg(distinct 1), group_concat(distinct 1, 2 order by 1), array_agg(distinct 1.3 order by null) from test_cc group by v2;
+select count(distinct 1, 2, 3, 4), sum(distinct 1), avg(distinct 1), group_concat(distinct 1, 2 order by 1), array_agg(distinct 1.3 order by null) from test_cc group by v2 order by v2;
 
 
-select v2, count(distinct v1), sum(distinct v1), avg(distinct v1), group_concat(distinct 1, 2), array_agg(distinct 1.3 order by null)  from test_cc group by v2;
-select v2, count(distinct v4), sum(distinct v4), avg(distinct v4), group_concat(distinct 1, 2), array_agg(distinct 1.3 order by null) from test_cc group by v2;
-select v2, count(distinct v5), sum(distinct v5), avg(distinct v5), group_concat(distinct 1, 2), array_agg(distinct 1.3 order by null) from test_cc group by v2;
-select v2, count(distinct v6), array_agg(distinct v6 order by 1), group_concat(distinct 1, 2), array_agg(distinct 1.3 order by null) from test_cc group by v2;
-select v2, count(distinct v7), array_agg(distinct v7 order by 1), group_concat(distinct 1, 2 order by 1), array_agg(distinct 1.3 order by null) from test_cc group by v2;
+select v2, count(distinct v1), sum(distinct v1), avg(distinct v1), group_concat(distinct 1, 2), array_agg(distinct 1.3 order by null)  from test_cc group by v2 order by v2;
+select v2, count(distinct v4), sum(distinct v4), avg(distinct v4), group_concat(distinct 1, 2), array_agg(distinct 1.3 order by null) from test_cc group by v2 order by v2;
+select v2, count(distinct v5), sum(distinct v5), avg(distinct v5), group_concat(distinct 1, 2), array_agg(distinct 1.3 order by null) from test_cc group by v2 order by v2;
+select v2, count(distinct v6), array_agg(distinct v6 order by 1), group_concat(distinct 1, 2), array_agg(distinct 1.3 order by null) from test_cc group by v2 order by v2;
+select v2, count(distinct v7), array_agg(distinct v7 order by 1), group_concat(distinct 1, 2 order by 1), array_agg(distinct 1.3 order by null) from test_cc group by v2 order by v2;
 
-select v2, count(distinct v1, v3, v6), sum(distinct v1), avg(distinct v1), array_agg(v5 order by 1), group_concat(distinct 1, 2), array_agg(distinct 1.3 order by null)  from test_cc group by v2;
+select v2, count(distinct v1, v3, v6), sum(distinct v1), avg(distinct v1), array_agg(v5 order by 1), group_concat(distinct 1, 2), array_agg(distinct 1.3 order by null)  from test_cc group by v2 order by v2;
 select count(distinct v4, v5), sum(distinct v4), avg(distinct v4), group_concat(distinct v4, v5, 2 order by 1,2), array_agg(distinct 1.456 order by 1) from test_cc;
-select v2, count(distinct v4, v5), sum(distinct v5), avg(distinct v5), group_concat(distinct v4, v5, 2 order by 1,2), array_agg(distinct 1.456 order by 1) from test_cc group by v2;
-select v2, count(distinct v3, v5), sum(distinct v4), avg(distinct v5), group_concat(distinct v4, v5, 2 order by 1,2), array_agg(distinct 1.456 order by 1) from test_cc group by v2, v3;
+select v2, count(distinct v4, v5), sum(distinct v5), avg(distinct v5), group_concat(distinct v4, v5, 2 order by 1,2), array_agg(distinct 1.456 order by 1) from test_cc group by v2 order by v2;
+select v2, count(distinct v3, v5), sum(distinct v4), avg(distinct v5), group_concat(distinct v4, v5, 2 order by 1,2), array_agg(distinct 1.456 order by 1) from test_cc group by v2, v3 order by v2, v3;
 
 select count(distinct v4, v5), sum(distinct v4), avg(distinct v4), group_concat(distinct v4, v5, 2 order by 1,2), array_agg(distinct v4 order by 1) from test_cc;
-select v2, count(distinct v4, v5), sum(distinct v5), avg(distinct v5), group_concat(distinct v4, v5, 2 order by 1,2), array_agg(distinct v5 order by 1) from test_cc group by v2;
-select v2, count(distinct v3, v5), sum(distinct v4), avg(distinct v5), group_concat(distinct v4, v5, 2 order by 1,2), array_agg(distinct v5 order by 1) from test_cc group by v2, v3;
+select v2, count(distinct v4, v5), sum(distinct v5), avg(distinct v5), group_concat(distinct v4, v5, 2 order by 1,2), array_agg(distinct v5 order by 1) from test_cc group by v2 order by v2;
+select v2, count(distinct v3, v5), sum(distinct v4), avg(distinct v5), group_concat(distinct v4, v5, 2 order by 1,2), array_agg(distinct v5 order by 1) from test_cc group by v2, v3 order by v2, v3;
 
 
 

--- a/test/sql/test_sort/R/test_array_struct_order_by.sql
+++ b/test/sql/test_sort/R/test_array_struct_order_by.sql
@@ -1,0 +1,249 @@
+-- name: test_array_struct_order_by
+drop database if exists test_array_struct_order_by;
+-- result:
+-- !result
+create database test_array_struct_order_by;
+-- result:
+-- !result
+use test_array_struct_order_by;
+-- result:
+-- !result
+CREATE TABLE IF NOT EXISTS test_array_struct (
+    id INT,
+    tags ARRAY<STRUCT<tag_key STRING, tag_value INT>>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO test_array_struct VALUES
+    (1, [row('a', 1), row('b', 2)]),
+    (2, [row('a', 1), row('b', 1)]),
+    (3, [row('a', 2), row('b', 1)]),
+    (4, [row('a', 1)]),
+    (5, []);
+-- result:
+-- !result
+SELECT * FROM test_array_struct ORDER BY tags;
+-- result:
+5	[]
+4	[{"tag_key":"a","tag_value":1}]
+2	[{"tag_key":"a","tag_value":1},{"tag_key":"b","tag_value":1}]
+1	[{"tag_key":"a","tag_value":1},{"tag_key":"b","tag_value":2}]
+3	[{"tag_key":"a","tag_value":2},{"tag_key":"b","tag_value":1}]
+-- !result
+SELECT * FROM test_array_struct ORDER BY tags DESC;
+-- result:
+3	[{"tag_key":"a","tag_value":2},{"tag_key":"b","tag_value":1}]
+1	[{"tag_key":"a","tag_value":1},{"tag_key":"b","tag_value":2}]
+2	[{"tag_key":"a","tag_value":1},{"tag_key":"b","tag_value":1}]
+4	[{"tag_key":"a","tag_value":1}]
+5	[]
+-- !result
+INSERT INTO test_array_struct VALUES
+    (6, NULL),
+    (7, [row(NULL, 1)]),
+    (8, [row('c', NULL)]);
+-- result:
+-- !result
+SELECT * FROM test_array_struct ORDER BY tags NULLS FIRST;
+-- result:
+6	None
+5	[]
+7	[{"tag_key":null,"tag_value":1}]
+4	[{"tag_key":"a","tag_value":1}]
+2	[{"tag_key":"a","tag_value":1},{"tag_key":"b","tag_value":1}]
+1	[{"tag_key":"a","tag_value":1},{"tag_key":"b","tag_value":2}]
+3	[{"tag_key":"a","tag_value":2},{"tag_key":"b","tag_value":1}]
+8	[{"tag_key":"c","tag_value":null}]
+-- !result
+SELECT * FROM test_array_struct ORDER BY tags NULLS LAST;
+-- result:
+5	[]
+4	[{"tag_key":"a","tag_value":1}]
+2	[{"tag_key":"a","tag_value":1},{"tag_key":"b","tag_value":1}]
+1	[{"tag_key":"a","tag_value":1},{"tag_key":"b","tag_value":2}]
+3	[{"tag_key":"a","tag_value":2},{"tag_key":"b","tag_value":1}]
+8	[{"tag_key":"c","tag_value":null}]
+7	[{"tag_key":null,"tag_value":1}]
+6	None
+-- !result
+CREATE TABLE IF NOT EXISTS test_array_struct_lengths (
+    id INT,
+    items ARRAY<STRUCT<name STRING, score INT>>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO test_array_struct_lengths VALUES
+    (1, [row('Alice', 90)]),
+    (2, [row('Alice', 90), row('Bob', 80)]),
+    (3, [row('Alice', 90), row('Bob', 80), row('Charlie', 85)]),
+    (4, []),
+    (5, [row('Alice', 85)]);
+-- result:
+-- !result
+SELECT * FROM test_array_struct_lengths ORDER BY items;
+-- result:
+4	[]
+5	[{"name":"Alice","score":85}]
+1	[{"name":"Alice","score":90}]
+2	[{"name":"Alice","score":90},{"name":"Bob","score":80}]
+3	[{"name":"Alice","score":90},{"name":"Bob","score":80},{"name":"Charlie","score":85}]
+-- !result
+CREATE TABLE IF NOT EXISTS test_array_struct_complex (
+    id INT,
+    events ARRAY<STRUCT<event_name STRING, timestamp BIGINT, metadata STRUCT<source STRING, priority INT>>>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO test_array_struct_complex VALUES
+    (1, [row('login', 1000, row('web', 1))]),
+    (2, [row('login', 1000, row('mobile', 2))]),
+    (3, [row('login', 999, row('web', 1))]),
+    (4, [row('logout', 1000, row('web', 1))]);
+-- result:
+-- !result
+SELECT * FROM test_array_struct_complex ORDER BY events;
+-- result:
+3	[{"event_name":"login","timestamp":999,"metadata":{"source":"web","priority":1}}]
+2	[{"event_name":"login","timestamp":1000,"metadata":{"source":"mobile","priority":2}}]
+1	[{"event_name":"login","timestamp":1000,"metadata":{"source":"web","priority":1}}]
+4	[{"event_name":"logout","timestamp":1000,"metadata":{"source":"web","priority":1}}]
+-- !result
+SELECT * FROM (
+    VALUES 
+        (1, [row('x', 10)]),
+        (2, [row('y', 20)]),
+        (3, [row('x', 15)])
+) t(id, data) 
+ORDER BY data;
+-- result:
+1	[{"col1":"x","col2":10}]
+3	[{"col1":"x","col2":15}]
+2	[{"col1":"y","col2":20}]
+-- !result
+SELECT * FROM test_array_struct_lengths WHERE id <= 3 ORDER BY items;
+-- result:
+1	[{"name":"Alice","score":90}]
+2	[{"name":"Alice","score":90},{"name":"Bob","score":80}]
+3	[{"name":"Alice","score":90},{"name":"Bob","score":80},{"name":"Charlie","score":85}]
+-- !result
+CREATE TABLE IF NOT EXISTS test_array_struct_join (
+    id INT,
+    categories ARRAY<STRUCT<name STRING, level INT>>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO test_array_struct_join VALUES
+    (1, [row('tech', 1)]),
+    (2, [row('sports', 2)]),
+    (3, [row('tech', 2)]);
+-- result:
+-- !result
+SELECT t1.id, t1.items, t2.categories
+FROM test_array_struct_lengths t1
+JOIN test_array_struct_join t2 ON t1.id = t2.id
+ORDER BY t1.items, t2.categories;
+-- result:
+1	[{"name":"Alice","score":90}]	[{"name":"tech","level":1}]
+2	[{"name":"Alice","score":90},{"name":"Bob","score":80}]	[{"name":"sports","level":2}]
+3	[{"name":"Alice","score":90},{"name":"Bob","score":80},{"name":"Charlie","score":85}]	[{"name":"tech","level":2}]
+-- !result
+SELECT id, items, COUNT(*) as cnt
+FROM (
+    SELECT id, items FROM test_array_struct_lengths
+    UNION ALL
+    SELECT id, items FROM test_array_struct_lengths WHERE id <= 2
+) t
+GROUP BY id, items
+ORDER BY items;
+-- result:
+4	[]	1
+5	[{"name":"Alice","score":85}]	1
+1	[{"name":"Alice","score":90}]	2
+2	[{"name":"Alice","score":90},{"name":"Bob","score":80}]	2
+3	[{"name":"Alice","score":90},{"name":"Bob","score":80},{"name":"Charlie","score":85}]	1
+-- !result
+SELECT * FROM test_array_struct_lengths ORDER BY items LIMIT 3;
+-- result:
+4	[]
+5	[{"name":"Alice","score":85}]
+1	[{"name":"Alice","score":90}]
+-- !result
+INSERT INTO test_array_struct_lengths VALUES (6, NULL);
+-- result:
+-- !result
+SELECT * FROM test_array_struct_lengths WHERE id >= 4 ORDER BY items NULLS FIRST;
+-- result:
+6	None
+4	[]
+5	[{"name":"Alice","score":85}]
+-- !result
+CREATE TABLE IF NOT EXISTS test_array_struct_compare (
+    id INT,
+    pairs ARRAY<STRUCT<first INT, second INT>>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO test_array_struct_compare VALUES
+    (1, [row(1, 2), row(3, 4)]),
+    (2, [row(1, 2), row(3, 3)]),
+    (3, [row(1, 2), row(2, 4)]),
+    (4, [row(1, 2)]);
+-- result:
+-- !result
+SELECT * FROM test_array_struct_compare ORDER BY pairs;
+-- result:
+4	[{"first":1,"second":2}]
+3	[{"first":1,"second":2},{"first":2,"second":4}]
+2	[{"first":1,"second":2},{"first":3,"second":3}]
+1	[{"first":1,"second":2},{"first":3,"second":4}]
+-- !result
+SELECT id, pairs FROM (
+    SELECT * FROM test_array_struct_compare WHERE id <= 3
+) t 
+ORDER BY pairs DESC;
+-- result:
+1	[{"first":1,"second":2},{"first":3,"second":4}]
+2	[{"first":1,"second":2},{"first":3,"second":3}]
+3	[{"first":1,"second":2},{"first":2,"second":4}]
+-- !result
+SELECT * FROM test_array_struct_compare ORDER BY pairs, id DESC;
+-- result:
+4	[{"first":1,"second":2}]
+3	[{"first":1,"second":2},{"first":2,"second":4}]
+2	[{"first":1,"second":2},{"first":3,"second":3}]
+1	[{"first":1,"second":2},{"first":3,"second":4}]
+-- !result
+SELECT pairs FROM test_array_struct_compare WHERE id <= 2
+UNION ALL
+SELECT [row(1, 3), row(3, 3)]
+ORDER BY pairs;
+-- result:
+[{"first":1,"second":2},{"first":3,"second":3}]
+[{"first":1,"second":2},{"first":3,"second":4}]
+[{"first":1,"second":3},{"first":3,"second":3}]
+-- !result
+DROP TABLE test_array_struct FORCE;
+-- result:
+-- !result
+DROP TABLE test_array_struct_lengths FORCE;
+-- result:
+-- !result
+DROP TABLE test_array_struct_complex FORCE;
+-- result:
+-- !result
+DROP TABLE test_array_struct_join FORCE;
+-- result:
+-- !result
+DROP TABLE test_array_struct_compare FORCE;
+-- result:
+-- !result

--- a/test/sql/test_sort/R/test_complex_struct_sort.sql
+++ b/test/sql/test_sort/R/test_complex_struct_sort.sql
@@ -1,0 +1,439 @@
+-- name: test_complex_struct_sort
+drop database if exists test_complex_struct_sort;
+-- result:
+-- !result
+create database test_complex_struct_sort;
+-- result:
+-- !result
+use test_complex_struct_sort;
+-- result:
+-- !result
+CREATE TABLE user_behavior (
+    id BIGINT,
+    user_profile STRUCT<
+        user_id INT,
+        user_name STRING,
+        user_level INT,
+        registration_date DATE,
+        location STRUCT<
+            country STRING,
+            city STRING,
+            coordinates STRUCT<
+                latitude DOUBLE,
+                longitude DOUBLE
+            >
+        >,
+        preferences STRUCT<
+            category STRING,
+            sub_category STRING,
+            score INT
+        >
+    >,
+    event_timestamp DATETIME
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 8
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO user_behavior
+SELECT
+    generate_series AS id,
+    row(
+        CAST(generate_series % 1000000 AS INT),
+        CONCAT('user_', CAST(generate_series % 1000000 AS STRING)),
+        CAST(generate_series % 10 AS INT),
+        DATE_ADD('2020-01-01', INTERVAL (generate_series % 1460) DAY),
+        row(
+            CASE generate_series % 10
+                WHEN 0 THEN 'USA'
+                WHEN 1 THEN 'China'
+                WHEN 2 THEN 'UK'
+                WHEN 3 THEN 'Japan'
+                WHEN 4 THEN 'Germany'
+                WHEN 5 THEN 'France'
+                WHEN 6 THEN 'Canada'
+                WHEN 7 THEN 'Australia'
+                WHEN 8 THEN 'India'
+                ELSE 'Brazil'
+            END,
+            CONCAT('City_', CAST(generate_series % 100 AS STRING)),
+            row(
+                CAST(20.0 + (generate_series % 60) AS DOUBLE),
+                CAST(-180.0 + (generate_series % 360) AS DOUBLE)
+            )
+        ),
+        row(
+            CASE generate_series % 5
+                WHEN 0 THEN 'Electronics'
+                WHEN 1 THEN 'Books'
+                WHEN 2 THEN 'Clothing'
+                WHEN 3 THEN 'Food'
+                ELSE 'Sports'
+            END,
+            CONCAT('Sub_', CAST(generate_series % 20 AS STRING)),
+            CAST(generate_series % 100 AS INT)
+        )
+    ) AS user_profile,
+    date_add(CAST('2024-01-01 00:00:00' AS DATETIME), INTERVAL (generate_series % 86400) SECOND) AS event_timestamp
+FROM TABLE(generate_series(1, 1000000));
+-- result:
+-- !result
+select user_profile from user_behavior order by user_profile limit 10;
+-- result:
+{"user_id":0,"user_name":"user_0","user_level":0,"registration_date":"2023-09-22","location":{"country":"USA","city":"City_0","coordinates":{"latitude":60,"longitude":100}},"preferences":{"category":"Electronics","sub_category":"Sub_0","score":0}}
+{"user_id":1,"user_name":"user_1","user_level":1,"registration_date":"2020-01-02","location":{"country":"China","city":"City_1","coordinates":{"latitude":21,"longitude":-179}},"preferences":{"category":"Books","sub_category":"Sub_1","score":1}}
+{"user_id":2,"user_name":"user_2","user_level":2,"registration_date":"2020-01-03","location":{"country":"UK","city":"City_2","coordinates":{"latitude":22,"longitude":-178}},"preferences":{"category":"Clothing","sub_category":"Sub_2","score":2}}
+{"user_id":3,"user_name":"user_3","user_level":3,"registration_date":"2020-01-04","location":{"country":"Japan","city":"City_3","coordinates":{"latitude":23,"longitude":-177}},"preferences":{"category":"Food","sub_category":"Sub_3","score":3}}
+{"user_id":4,"user_name":"user_4","user_level":4,"registration_date":"2020-01-05","location":{"country":"Germany","city":"City_4","coordinates":{"latitude":24,"longitude":-176}},"preferences":{"category":"Sports","sub_category":"Sub_4","score":4}}
+{"user_id":5,"user_name":"user_5","user_level":5,"registration_date":"2020-01-06","location":{"country":"France","city":"City_5","coordinates":{"latitude":25,"longitude":-175}},"preferences":{"category":"Electronics","sub_category":"Sub_5","score":5}}
+{"user_id":6,"user_name":"user_6","user_level":6,"registration_date":"2020-01-07","location":{"country":"Canada","city":"City_6","coordinates":{"latitude":26,"longitude":-174}},"preferences":{"category":"Books","sub_category":"Sub_6","score":6}}
+{"user_id":7,"user_name":"user_7","user_level":7,"registration_date":"2020-01-08","location":{"country":"Australia","city":"City_7","coordinates":{"latitude":27,"longitude":-173}},"preferences":{"category":"Clothing","sub_category":"Sub_7","score":7}}
+{"user_id":8,"user_name":"user_8","user_level":8,"registration_date":"2020-01-09","location":{"country":"India","city":"City_8","coordinates":{"latitude":28,"longitude":-172}},"preferences":{"category":"Food","sub_category":"Sub_8","score":8}}
+{"user_id":9,"user_name":"user_9","user_level":9,"registration_date":"2020-01-10","location":{"country":"Brazil","city":"City_9","coordinates":{"latitude":29,"longitude":-171}},"preferences":{"category":"Sports","sub_category":"Sub_9","score":9}}
+-- !result
+SELECT user_profile
+FROM (
+    SELECT user_profile
+    FROM user_behavior
+    ORDER BY user_profile
+    LIMIT 1025
+) t
+WHERE user_profile.user_id = 1;
+-- result:
+{"user_id":1,"user_name":"user_1","user_level":1,"registration_date":"2020-01-02","location":{"country":"China","city":"City_1","coordinates":{"latitude":21,"longitude":-179}},"preferences":{"category":"Books","sub_category":"Sub_1","score":1}}
+-- !result
+SELECT COUNT(a.c1), COUNT(a.c2)
+FROM (
+    SELECT
+        id as  c1,
+        row_number() OVER (ORDER BY user_profile) AS c2
+    FROM user_behavior
+) AS a;
+-- result:
+1000000	1000000
+-- !result
+CREATE TABLE transaction_data (
+    id BIGINT,
+    transaction_info STRUCT<
+        card STRUCT<
+            card_details STRUCT<
+                card_bin STRING,
+                card_type STRING,
+                issuer STRING,
+                card_program STRING
+            >,
+            card_tags ARRAY<STRUCT<value STRING>>,
+            version INT
+        >,
+        transaction STRUCT<
+            transaction_id STRING,
+            transaction_details STRUCT<
+                transaction_type STRING,
+                merchant_data STRUCT<
+                    merchant_id STRING,
+                    merchant_name STRING,
+                    merchant_country_code STRING
+                >,
+                posting_date STRING,
+                amount STRUCT<
+                    currency_code STRING
+                >,
+                billing_amount STRUCT<
+                    currency_code STRING
+                >,
+                billing_amount_no_fee DECIMAL(18, 4),
+                conversion_rate DECIMAL(18, 4),
+                ird STRING
+            >
+        >
+    >
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 8
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO transaction_data VALUES
+(1, row(
+    row(
+        row('411111', 'VISA', 'Chase', 'Rewards'),
+        [row('Premium'), row('Verified')],
+        1
+    ),
+    row(
+        'TXN001',
+        row(
+            'PURCHASE',
+            row('MERCH001', 'Amazon', 'US'),
+            '2024-01-15',
+            row('USD'),
+            row('USD'),
+            100.5000,
+            1.0000,
+            'IRD001'
+        )
+    )
+)),
+(2, row(
+    row(
+        row('520000', 'MASTERCARD', 'Citi', 'CashBack'),
+        [row('Standard')],
+        2
+    ),
+    row(
+        'TXN002',
+        row(
+            'REFUND',
+            row('MERCH002', 'Walmart', 'US'),
+            '2024-01-16',
+            row('USD'),
+            row('USD'),
+            50.2500,
+            1.0000,
+            'IRD002'
+        )
+    )
+)),
+(3, row(
+    row(
+        row('370000', 'AMEX', 'American Express', 'Platinum'),
+        [row('Premium'), row('Travel'), row('Insurance')],
+        1
+    ),
+    row(
+        'TXN003',
+        row(
+            'PURCHASE',
+            row('MERCH003', 'Apple Store', 'US'),
+            '2024-01-17',
+            row('USD'),
+            row('EUR'),
+            1200.0000,
+            0.9200,
+            'IRD003'
+        )
+    )
+)),
+(4, row(
+    row(
+        row('411111', 'VISA', 'Bank of America', 'Travel'),
+        [row('Gold')],
+        1
+    ),
+    row(
+        'TXN004',
+        row(
+            'PURCHASE',
+            row('MERCH001', 'Amazon', 'UK'),
+            '2024-01-18',
+            row('GBP'),
+            row('USD'),
+            85.7500,
+            1.2700,
+            'IRD004'
+        )
+    )
+)),
+(5, row(
+    row(
+        row('520000', 'MASTERCARD', 'HSBC', 'Standard'),
+        [row('Basic')],
+        2
+    ),
+    row(
+        'TXN005',
+        row(
+            'WITHDRAWAL',
+            row('MERCH004', 'ATM Network', 'CN'),
+            '2024-01-19',
+            row('CNY'),
+            row('USD'),
+            500.0000,
+            0.1400,
+            'IRD005'
+        )
+    )
+)),
+(6, row(
+    row(
+        row('370000', 'AMEX', 'American Express', 'Gold'),
+        [row('Premium'), row('Concierge')],
+        3
+    ),
+    row(
+        'TXN006',
+        row(
+            'PURCHASE',
+            row('MERCH005', 'Luxury Hotel', 'FR'),
+            '2024-01-20',
+            row('EUR'),
+            row('USD'),
+            2500.0000,
+            1.0800,
+            'IRD006'
+        )
+    )
+)),
+(7, row(
+    row(
+        row('411111', 'VISA', 'Chase', 'Rewards'),
+        [row('Verified')],
+        1
+    ),
+    row(
+        'TXN007',
+        row(
+            'PURCHASE',
+            row('MERCH001', 'Amazon', 'US'),
+            '2024-01-21',
+            row('USD'),
+            row('USD'),
+            45.9900,
+            1.0000,
+            'IRD007'
+        )
+    )
+)),
+(8, row(
+    row(
+        row('520000', 'MASTERCARD', 'Citi', 'CashBack'),
+        [row('Standard'), row('Contactless')],
+        2
+    ),
+    row(
+        'TXN008',
+        row(
+            'PURCHASE',
+            row('MERCH006', 'Grocery Store', 'CA'),
+            '2024-01-22',
+            row('CAD'),
+            row('USD'),
+            75.0000,
+            0.7500,
+            'IRD008'
+        )
+    )
+));
+-- result:
+-- !result
+SELECT transaction_info 
+FROM transaction_data 
+ORDER BY transaction_info 
+LIMIT 5;
+-- result:
+{"card":{"card_details":{"card_bin":"370000","card_type":"AMEX","issuer":"American Express","card_program":"Gold"},"card_tags":[{"value":"Premium"},{"value":"Concierge"}],"version":3},"transaction":{"transaction_id":"TXN006","transaction_details":{"transaction_type":"PURCHASE","merchant_data":{"merchant_id":"MERCH005","merchant_name":"Luxury Hotel","merchant_country_code":"FR"},"posting_date":"2024-01-20","amount":{"currency_code":"EUR"},"billing_amount":{"currency_code":"USD"},"billing_amount_no_fee":2500.0000,"conversion_rate":1.0800,"ird":"IRD006"}}}
+{"card":{"card_details":{"card_bin":"370000","card_type":"AMEX","issuer":"American Express","card_program":"Platinum"},"card_tags":[{"value":"Premium"},{"value":"Travel"},{"value":"Insurance"}],"version":1},"transaction":{"transaction_id":"TXN003","transaction_details":{"transaction_type":"PURCHASE","merchant_data":{"merchant_id":"MERCH003","merchant_name":"Apple Store","merchant_country_code":"US"},"posting_date":"2024-01-17","amount":{"currency_code":"USD"},"billing_amount":{"currency_code":"EUR"},"billing_amount_no_fee":1200.0000,"conversion_rate":0.9200,"ird":"IRD003"}}}
+{"card":{"card_details":{"card_bin":"411111","card_type":"VISA","issuer":"Bank of America","card_program":"Travel"},"card_tags":[{"value":"Gold"}],"version":1},"transaction":{"transaction_id":"TXN004","transaction_details":{"transaction_type":"PURCHASE","merchant_data":{"merchant_id":"MERCH001","merchant_name":"Amazon","merchant_country_code":"UK"},"posting_date":"2024-01-18","amount":{"currency_code":"GBP"},"billing_amount":{"currency_code":"USD"},"billing_amount_no_fee":85.7500,"conversion_rate":1.2700,"ird":"IRD004"}}}
+{"card":{"card_details":{"card_bin":"411111","card_type":"VISA","issuer":"Chase","card_program":"Rewards"},"card_tags":[{"value":"Premium"},{"value":"Verified"}],"version":1},"transaction":{"transaction_id":"TXN001","transaction_details":{"transaction_type":"PURCHASE","merchant_data":{"merchant_id":"MERCH001","merchant_name":"Amazon","merchant_country_code":"US"},"posting_date":"2024-01-15","amount":{"currency_code":"USD"},"billing_amount":{"currency_code":"USD"},"billing_amount_no_fee":100.5000,"conversion_rate":1.0000,"ird":"IRD001"}}}
+{"card":{"card_details":{"card_bin":"411111","card_type":"VISA","issuer":"Chase","card_program":"Rewards"},"card_tags":[{"value":"Verified"}],"version":1},"transaction":{"transaction_id":"TXN007","transaction_details":{"transaction_type":"PURCHASE","merchant_data":{"merchant_id":"MERCH001","merchant_name":"Amazon","merchant_country_code":"US"},"posting_date":"2024-01-21","amount":{"currency_code":"USD"},"billing_amount":{"currency_code":"USD"},"billing_amount_no_fee":45.9900,"conversion_rate":1.0000,"ird":"IRD007"}}}
+-- !result
+SELECT transaction_info 
+FROM transaction_data 
+ORDER BY transaction_info DESC 
+LIMIT 5;
+-- result:
+{"card":{"card_details":{"card_bin":"520000","card_type":"MASTERCARD","issuer":"HSBC","card_program":"Standard"},"card_tags":[{"value":"Basic"}],"version":2},"transaction":{"transaction_id":"TXN005","transaction_details":{"transaction_type":"WITHDRAWAL","merchant_data":{"merchant_id":"MERCH004","merchant_name":"ATM Network","merchant_country_code":"CN"},"posting_date":"2024-01-19","amount":{"currency_code":"CNY"},"billing_amount":{"currency_code":"USD"},"billing_amount_no_fee":500.0000,"conversion_rate":0.1400,"ird":"IRD005"}}}
+{"card":{"card_details":{"card_bin":"520000","card_type":"MASTERCARD","issuer":"Citi","card_program":"CashBack"},"card_tags":[{"value":"Standard"},{"value":"Contactless"}],"version":2},"transaction":{"transaction_id":"TXN008","transaction_details":{"transaction_type":"PURCHASE","merchant_data":{"merchant_id":"MERCH006","merchant_name":"Grocery Store","merchant_country_code":"CA"},"posting_date":"2024-01-22","amount":{"currency_code":"CAD"},"billing_amount":{"currency_code":"USD"},"billing_amount_no_fee":75.0000,"conversion_rate":0.7500,"ird":"IRD008"}}}
+{"card":{"card_details":{"card_bin":"520000","card_type":"MASTERCARD","issuer":"Citi","card_program":"CashBack"},"card_tags":[{"value":"Standard"}],"version":2},"transaction":{"transaction_id":"TXN002","transaction_details":{"transaction_type":"REFUND","merchant_data":{"merchant_id":"MERCH002","merchant_name":"Walmart","merchant_country_code":"US"},"posting_date":"2024-01-16","amount":{"currency_code":"USD"},"billing_amount":{"currency_code":"USD"},"billing_amount_no_fee":50.2500,"conversion_rate":1.0000,"ird":"IRD002"}}}
+{"card":{"card_details":{"card_bin":"411111","card_type":"VISA","issuer":"Chase","card_program":"Rewards"},"card_tags":[{"value":"Verified"}],"version":1},"transaction":{"transaction_id":"TXN007","transaction_details":{"transaction_type":"PURCHASE","merchant_data":{"merchant_id":"MERCH001","merchant_name":"Amazon","merchant_country_code":"US"},"posting_date":"2024-01-21","amount":{"currency_code":"USD"},"billing_amount":{"currency_code":"USD"},"billing_amount_no_fee":45.9900,"conversion_rate":1.0000,"ird":"IRD007"}}}
+{"card":{"card_details":{"card_bin":"411111","card_type":"VISA","issuer":"Chase","card_program":"Rewards"},"card_tags":[{"value":"Premium"},{"value":"Verified"}],"version":1},"transaction":{"transaction_id":"TXN001","transaction_details":{"transaction_type":"PURCHASE","merchant_data":{"merchant_id":"MERCH001","merchant_name":"Amazon","merchant_country_code":"US"},"posting_date":"2024-01-15","amount":{"currency_code":"USD"},"billing_amount":{"currency_code":"USD"},"billing_amount_no_fee":100.5000,"conversion_rate":1.0000,"ird":"IRD001"}}}
+-- !result
+SELECT id, rn
+FROM (
+    SELECT 
+        id,
+        ROW_NUMBER() OVER (ORDER BY transaction_info) AS rn
+    FROM transaction_data
+) t
+WHERE rn <= 5;
+-- result:
+6	1
+3	2
+4	3
+1	4
+7	5
+-- !result
+SELECT transaction_info 
+FROM transaction_data 
+WHERE id <= 5
+ORDER BY transaction_info;
+-- result:
+{"card":{"card_details":{"card_bin":"370000","card_type":"AMEX","issuer":"American Express","card_program":"Platinum"},"card_tags":[{"value":"Premium"},{"value":"Travel"},{"value":"Insurance"}],"version":1},"transaction":{"transaction_id":"TXN003","transaction_details":{"transaction_type":"PURCHASE","merchant_data":{"merchant_id":"MERCH003","merchant_name":"Apple Store","merchant_country_code":"US"},"posting_date":"2024-01-17","amount":{"currency_code":"USD"},"billing_amount":{"currency_code":"EUR"},"billing_amount_no_fee":1200.0000,"conversion_rate":0.9200,"ird":"IRD003"}}}
+{"card":{"card_details":{"card_bin":"411111","card_type":"VISA","issuer":"Bank of America","card_program":"Travel"},"card_tags":[{"value":"Gold"}],"version":1},"transaction":{"transaction_id":"TXN004","transaction_details":{"transaction_type":"PURCHASE","merchant_data":{"merchant_id":"MERCH001","merchant_name":"Amazon","merchant_country_code":"UK"},"posting_date":"2024-01-18","amount":{"currency_code":"GBP"},"billing_amount":{"currency_code":"USD"},"billing_amount_no_fee":85.7500,"conversion_rate":1.2700,"ird":"IRD004"}}}
+{"card":{"card_details":{"card_bin":"411111","card_type":"VISA","issuer":"Chase","card_program":"Rewards"},"card_tags":[{"value":"Premium"},{"value":"Verified"}],"version":1},"transaction":{"transaction_id":"TXN001","transaction_details":{"transaction_type":"PURCHASE","merchant_data":{"merchant_id":"MERCH001","merchant_name":"Amazon","merchant_country_code":"US"},"posting_date":"2024-01-15","amount":{"currency_code":"USD"},"billing_amount":{"currency_code":"USD"},"billing_amount_no_fee":100.5000,"conversion_rate":1.0000,"ird":"IRD001"}}}
+{"card":{"card_details":{"card_bin":"520000","card_type":"MASTERCARD","issuer":"Citi","card_program":"CashBack"},"card_tags":[{"value":"Standard"}],"version":2},"transaction":{"transaction_id":"TXN002","transaction_details":{"transaction_type":"REFUND","merchant_data":{"merchant_id":"MERCH002","merchant_name":"Walmart","merchant_country_code":"US"},"posting_date":"2024-01-16","amount":{"currency_code":"USD"},"billing_amount":{"currency_code":"USD"},"billing_amount_no_fee":50.2500,"conversion_rate":1.0000,"ird":"IRD002"}}}
+{"card":{"card_details":{"card_bin":"520000","card_type":"MASTERCARD","issuer":"HSBC","card_program":"Standard"},"card_tags":[{"value":"Basic"}],"version":2},"transaction":{"transaction_id":"TXN005","transaction_details":{"transaction_type":"WITHDRAWAL","merchant_data":{"merchant_id":"MERCH004","merchant_name":"ATM Network","merchant_country_code":"CN"},"posting_date":"2024-01-19","amount":{"currency_code":"CNY"},"billing_amount":{"currency_code":"USD"},"billing_amount_no_fee":500.0000,"conversion_rate":0.1400,"ird":"IRD005"}}}
+-- !result
+SELECT 
+    id,
+    transaction_info.card.card_details.card_type,
+    transaction_info.card.card_details.issuer
+FROM transaction_data 
+ORDER BY transaction_info 
+LIMIT 5;
+-- result:
+6	AMEX	American Express
+3	AMEX	American Express
+4	VISA	Bank of America
+1	VISA	Chase
+7	VISA	Chase
+-- !result
+SELECT DISTINCT transaction_info.card.card_details.card_type
+FROM transaction_data
+ORDER BY transaction_info.card.card_details.card_type;
+-- result:
+AMEX
+MASTERCARD
+VISA
+-- !result
+SELECT id, transaction_info
+FROM (
+    SELECT * FROM transaction_data WHERE id <= 6
+) t
+ORDER BY transaction_info
+LIMIT 3;
+-- result:
+6	{"card":{"card_details":{"card_bin":"370000","card_type":"AMEX","issuer":"American Express","card_program":"Gold"},"card_tags":[{"value":"Premium"},{"value":"Concierge"}],"version":3},"transaction":{"transaction_id":"TXN006","transaction_details":{"transaction_type":"PURCHASE","merchant_data":{"merchant_id":"MERCH005","merchant_name":"Luxury Hotel","merchant_country_code":"FR"},"posting_date":"2024-01-20","amount":{"currency_code":"EUR"},"billing_amount":{"currency_code":"USD"},"billing_amount_no_fee":2500.0000,"conversion_rate":1.0800,"ird":"IRD006"}}}
+3	{"card":{"card_details":{"card_bin":"370000","card_type":"AMEX","issuer":"American Express","card_program":"Platinum"},"card_tags":[{"value":"Premium"},{"value":"Travel"},{"value":"Insurance"}],"version":1},"transaction":{"transaction_id":"TXN003","transaction_details":{"transaction_type":"PURCHASE","merchant_data":{"merchant_id":"MERCH003","merchant_name":"Apple Store","merchant_country_code":"US"},"posting_date":"2024-01-17","amount":{"currency_code":"USD"},"billing_amount":{"currency_code":"EUR"},"billing_amount_no_fee":1200.0000,"conversion_rate":0.9200,"ird":"IRD003"}}}
+4	{"card":{"card_details":{"card_bin":"411111","card_type":"VISA","issuer":"Bank of America","card_program":"Travel"},"card_tags":[{"value":"Gold"}],"version":1},"transaction":{"transaction_id":"TXN004","transaction_details":{"transaction_type":"PURCHASE","merchant_data":{"merchant_id":"MERCH001","merchant_name":"Amazon","merchant_country_code":"UK"},"posting_date":"2024-01-18","amount":{"currency_code":"GBP"},"billing_amount":{"currency_code":"USD"},"billing_amount_no_fee":85.7500,"conversion_rate":1.2700,"ird":"IRD004"}}}
+-- !result
+SELECT id, transaction_info
+FROM (
+    SELECT 
+        id,
+        transaction_info,
+        ROW_NUMBER() OVER (ORDER BY transaction_info) AS rn
+    FROM transaction_data
+) t
+WHERE rn = 5;
+-- result:
+7	{"card":{"card_details":{"card_bin":"411111","card_type":"VISA","issuer":"Chase","card_program":"Rewards"},"card_tags":[{"value":"Verified"}],"version":1},"transaction":{"transaction_id":"TXN007","transaction_details":{"transaction_type":"PURCHASE","merchant_data":{"merchant_id":"MERCH001","merchant_name":"Amazon","merchant_country_code":"US"},"posting_date":"2024-01-21","amount":{"currency_code":"USD"},"billing_amount":{"currency_code":"USD"},"billing_amount_no_fee":45.9900,"conversion_rate":1.0000,"ird":"IRD007"}}}
+-- !result
+SELECT COUNT(*)
+FROM (
+    SELECT transaction_info 
+    FROM transaction_data 
+    ORDER BY transaction_info 
+    LIMIT 8
+) t;
+-- result:
+8
+-- !result
+SELECT 
+    id,
+    transaction_info.card.version,
+    transaction_info.transaction.transaction_id
+FROM transaction_data
+ORDER BY transaction_info, id;
+-- result:
+6	3	TXN006
+3	1	TXN003
+4	1	TXN004
+1	1	TXN001
+7	1	TXN007
+2	2	TXN002
+8	2	TXN008
+5	2	TXN005
+-- !result
+DROP TABLE transaction_data FORCE;
+-- result:
+-- !result

--- a/test/sql/test_sort/R/test_order_by_struct_comprehensive.sql
+++ b/test/sql/test_sort/R/test_order_by_struct_comprehensive.sql
@@ -1,0 +1,741 @@
+-- name: test_order_by_struct_comprehensive
+DROP DATABASE IF EXISTS test_order_by_struct_comprehensive;
+-- result:
+-- !result
+CREATE DATABASE test_order_by_struct_comprehensive;
+-- result:
+-- !result
+USE test_order_by_struct_comprehensive;
+-- result:
+-- !result
+CREATE TABLE t1_basic (
+    id INT,
+    s STRUCT<a INT, b INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t1_basic VALUES
+(1, row(1, 1)),
+(2, row(1, 2)),
+(3, row(2, 1)),
+(4, row(2, 2)),
+(5, row(1, 1));
+-- result:
+-- !result
+SELECT s FROM t1_basic ORDER BY s ASC;
+-- result:
+{"a":1,"b":1}
+{"a":1,"b":1}
+{"a":1,"b":2}
+{"a":2,"b":1}
+{"a":2,"b":2}
+-- !result
+SELECT s FROM t1_basic ORDER BY s DESC;
+-- result:
+{"a":2,"b":2}
+{"a":2,"b":1}
+{"a":1,"b":2}
+{"a":1,"b":1}
+{"a":1,"b":1}
+-- !result
+SELECT s FROM t1_basic WHERE id IN (1, 2, 5) ORDER BY s;
+-- result:
+{"a":1,"b":1}
+{"a":1,"b":1}
+{"a":1,"b":2}
+-- !result
+SELECT '=== Test 2: NULL Value Handling ===' AS test_name;
+-- result:
+=== Test 2: NULL Value Handling ===
+-- !result
+CREATE TABLE t2_nulls (
+    id INT,
+    s STRUCT<a INT, b INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t2_nulls VALUES
+(1, row(1, 1)),
+(2, row(1, NULL)),
+(3, row(NULL, 1)),
+(4, row(NULL, NULL)),
+(5, NULL);
+-- result:
+-- !result
+SELECT s FROM t2_nulls ORDER BY s ASC NULLS FIRST;
+-- result:
+None
+{"a":null,"b":null}
+{"a":null,"b":1}
+{"a":1,"b":null}
+{"a":1,"b":1}
+-- !result
+SELECT s FROM t2_nulls ORDER BY s ASC NULLS LAST;
+-- result:
+{"a":1,"b":1}
+{"a":1,"b":null}
+{"a":null,"b":1}
+{"a":null,"b":null}
+None
+-- !result
+SELECT s FROM t2_nulls WHERE id BETWEEN 1 AND 4 ORDER BY s;
+-- result:
+{"a":null,"b":null}
+{"a":null,"b":1}
+{"a":1,"b":null}
+{"a":1,"b":1}
+-- !result
+SELECT '=== Test 3: Different Data Types ===' AS test_name;
+-- result:
+=== Test 3: Different Data Types ===
+-- !result
+CREATE TABLE t3_mixed_types (
+    id INT,
+    s STRUCT<name STRING, age INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t3_mixed_types VALUES
+(1, row('Alice', 30)),
+(2, row('Alice', 25)),
+(3, row('Bob', 30)),
+(4, row('Bob', 25)),
+(5, row('Alice', 30));
+-- result:
+-- !result
+SELECT s FROM t3_mixed_types ORDER BY s;
+-- result:
+{"name":"Alice","age":25}
+{"name":"Alice","age":30}
+{"name":"Alice","age":30}
+{"name":"Bob","age":25}
+{"name":"Bob","age":30}
+-- !result
+CREATE TABLE t3_float (
+    id INT,
+    s STRUCT<x DOUBLE, y DOUBLE>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t3_float VALUES
+(1, row(1.1, 2.2)),
+(2, row(1.1, 2.1)),
+(3, row(1.2, 2.2)),
+(4, row(1.0, 2.0));
+-- result:
+-- !result
+SELECT s FROM t3_float ORDER BY s;
+-- result:
+{"x":1,"y":2}
+{"x":1.1,"y":2.1}
+{"x":1.1,"y":2.2}
+{"x":1.2,"y":2.2}
+-- !result
+CREATE TABLE t3_date (
+    id INT,
+    s STRUCT<event_date DATE, event_time DATETIME>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t3_date VALUES
+(1, row('2024-01-01', '2024-01-01 10:00:00')),
+(2, row('2024-01-01', '2024-01-01 09:00:00')),
+(3, row('2024-01-02', '2024-01-02 10:00:00')),
+(4, row('2024-01-01', '2024-01-01 10:00:00'));
+-- result:
+-- !result
+SELECT s FROM t3_date ORDER BY s;
+-- result:
+{"event_date":"2024-01-01","event_time":"2024-01-01 09:00:00"}
+{"event_date":"2024-01-01","event_time":"2024-01-01 10:00:00"}
+{"event_date":"2024-01-01","event_time":"2024-01-01 10:00:00"}
+{"event_date":"2024-01-02","event_time":"2024-01-02 10:00:00"}
+-- !result
+SELECT '=== Test 4: Nested STRUCT ===' AS test_name;
+-- result:
+=== Test 4: Nested STRUCT ===
+-- !result
+CREATE TABLE t4_nested (
+    id INT,
+    s STRUCT<outer1 INT, inner1 STRUCT<a INT, b INT>>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t4_nested VALUES
+(1, row(1, row(1, 1))),
+(2, row(1, row(1, 2))),
+(3, row(1, row(2, 1))),
+(4, row(2, row(1, 1)));
+-- result:
+-- !result
+SELECT s FROM t4_nested ORDER BY s;
+-- result:
+{"outer1":1,"inner1":{"a":1,"b":1}}
+{"outer1":1,"inner1":{"a":1,"b":2}}
+{"outer1":1,"inner1":{"a":2,"b":1}}
+{"outer1":2,"inner1":{"a":1,"b":1}}
+-- !result
+SELECT s FROM t4_nested WHERE id <= 3 ORDER BY s;
+-- result:
+{"outer1":1,"inner1":{"a":1,"b":1}}
+{"outer1":1,"inner1":{"a":1,"b":2}}
+{"outer1":1,"inner1":{"a":2,"b":1}}
+-- !result
+SELECT '=== Test 5: Mixed Column Ordering ===' AS test_name;
+-- result:
+=== Test 5: Mixed Column Ordering ===
+-- !result
+CREATE TABLE t5_mixed_columns (
+    id INT,
+    s STRUCT<a INT, b INT>,
+    score INT
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t5_mixed_columns VALUES
+(1, row(1, 1), 100),
+(2, row(1, 2), 90),
+(3, row(2, 1), 100),
+(4, row(1, 1), 95);
+-- result:
+-- !result
+SELECT s, score FROM t5_mixed_columns ORDER BY s, score;
+-- result:
+{"a":1,"b":1}	95
+{"a":1,"b":1}	100
+{"a":1,"b":2}	90
+{"a":2,"b":1}	100
+-- !result
+SELECT s, score FROM t5_mixed_columns ORDER BY score, s;
+-- result:
+{"a":1,"b":2}	90
+{"a":1,"b":1}	95
+{"a":1,"b":1}	100
+{"a":2,"b":1}	100
+-- !result
+SELECT '=== Test 6: Empty and Single-field STRUCT ===' AS test_name;
+-- result:
+=== Test 6: Empty and Single-field STRUCT ===
+-- !result
+CREATE TABLE t6_single_field (
+    id INT,
+    s STRUCT<value INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t6_single_field VALUES
+(1, row(3)),
+(2, row(1)),
+(3, row(2)),
+(4, row(1));
+-- result:
+-- !result
+SELECT s FROM t6_single_field ORDER BY s;
+-- result:
+{"value":1}
+{"value":1}
+{"value":2}
+{"value":3}
+-- !result
+SELECT '=== Test 7: STRUCT with Many Fields ===' AS test_name;
+-- result:
+=== Test 7: STRUCT with Many Fields ===
+-- !result
+CREATE TABLE t7_many_fields (
+    id INT,
+    s STRUCT<f1 INT, f2 INT, f3 INT, f4 INT, f5 INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t7_many_fields VALUES
+(1, row(1, 1, 1, 1, 1)),
+(2, row(1, 1, 1, 1, 2)),
+(3, row(1, 1, 1, 2, 1)),
+(4, row(1, 1, 2, 1, 1)),
+(5, row(1, 2, 1, 1, 1)),
+(6, row(2, 1, 1, 1, 1));
+-- result:
+-- !result
+SELECT s FROM t7_many_fields ORDER BY s;
+-- result:
+{"f1":1,"f2":1,"f3":1,"f4":1,"f5":1}
+{"f1":1,"f2":1,"f3":1,"f4":1,"f5":2}
+{"f1":1,"f2":1,"f3":1,"f4":2,"f5":1}
+{"f1":1,"f2":1,"f3":2,"f4":1,"f5":1}
+{"f1":1,"f2":2,"f3":1,"f4":1,"f5":1}
+{"f1":2,"f2":1,"f3":1,"f4":1,"f5":1}
+-- !result
+SELECT '=== Test 8: Sort Stability with Same Values ===' AS test_name;
+-- result:
+=== Test 8: Sort Stability with Same Values ===
+-- !result
+CREATE TABLE t8_stability (
+    id INT,
+    s STRUCT<a INT, b INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t8_stability VALUES
+(1, row(1, 1)),
+(2, row(1, 1)),
+(3, row(1, 1)),
+(4, row(2, 2)),
+(5, row(2, 2));
+-- result:
+-- !result
+SELECT id, s FROM t8_stability ORDER BY s, id;
+-- result:
+1	{"a":1,"b":1}
+2	{"a":1,"b":1}
+3	{"a":1,"b":1}
+4	{"a":2,"b":2}
+5	{"a":2,"b":2}
+-- !result
+SELECT id, s FROM t8_stability ORDER BY s, id;
+-- result:
+1	{"a":1,"b":1}
+2	{"a":1,"b":1}
+3	{"a":1,"b":1}
+4	{"a":2,"b":2}
+5	{"a":2,"b":2}
+-- !result
+SELECT '=== Test 9: LIMIT and OFFSET ===' AS test_name;
+-- result:
+=== Test 9: LIMIT and OFFSET ===
+-- !result
+CREATE TABLE t9_limit (
+    id INT,
+    s STRUCT<a INT, b INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t9_limit VALUES
+(1, row(1, 1)),
+(2, row(1, 2)),
+(3, row(2, 1)),
+(4, row(2, 2)),
+(5, row(3, 1)),
+(6, row(3, 2));
+-- result:
+-- !result
+SELECT s FROM t9_limit ORDER BY s LIMIT 3;
+-- result:
+{"a":1,"b":1}
+{"a":1,"b":2}
+{"a":2,"b":1}
+-- !result
+SELECT s FROM t9_limit ORDER BY s LIMIT 3 OFFSET 2;
+-- result:
+{"a":2,"b":1}
+{"a":2,"b":2}
+{"a":3,"b":1}
+-- !result
+SELECT '=== Test 10: Ordering After Aggregation ===' AS test_name;
+-- result:
+=== Test 10: Ordering After Aggregation ===
+-- !result
+CREATE TABLE t10_aggregate (
+    id INT,
+    s STRUCT<a INT, b INT>,
+    value INT
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t10_aggregate VALUES
+(1, row(1, 1), 10),
+(2, row(1, 1), 20),
+(3, row(1, 2), 30),
+(4, row(2, 1), 40);
+-- result:
+-- !result
+SELECT s, SUM(value) AS total
+FROM t10_aggregate
+GROUP BY s
+ORDER BY s;
+-- result:
+{"a":1,"b":1}	30
+{"a":1,"b":2}	30
+{"a":2,"b":1}	40
+-- !result
+SELECT s, SUM(value) AS total
+FROM t10_aggregate
+GROUP BY s
+HAVING SUM(value) > 15
+ORDER BY s;
+-- result:
+{"a":1,"b":1}	30
+{"a":1,"b":2}	30
+{"a":2,"b":1}	40
+-- !result
+SELECT '=== Test 11: Ordering After JOIN ===' AS test_name;
+-- result:
+=== Test 11: Ordering After JOIN ===
+-- !result
+CREATE TABLE t11_left (
+    id INT,
+    s STRUCT<a INT, b INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE t11_right (
+    id INT,
+    s STRUCT<a INT, b INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t11_left VALUES
+(1, row(1, 1)),
+(2, row(1, 2)),
+(3, row(2, 1));
+-- result:
+-- !result
+INSERT INTO t11_right VALUES
+(1, row(1, 1)),
+(2, row(1, 3)),
+(3, row(2, 1));
+-- result:
+-- !result
+SELECT l.s, r.s
+FROM t11_left l
+JOIN t11_right r ON l.id = r.id
+ORDER BY l.s, r.s;
+-- result:
+{"a":1,"b":1}	{"a":1,"b":1}
+{"a":1,"b":2}	{"a":1,"b":3}
+{"a":2,"b":1}	{"a":2,"b":1}
+-- !result
+SELECT '=== Test 12: Ordering After UNION ===' AS test_name;
+-- result:
+=== Test 12: Ordering After UNION ===
+-- !result
+CREATE TABLE t12_union1 (
+    id INT,
+    s STRUCT<a INT, b INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE t12_union2 (
+    id INT,
+    s STRUCT<a INT, b INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t12_union1 VALUES
+(1, row(1, 1)),
+(2, row(2, 1));
+-- result:
+-- !result
+INSERT INTO t12_union2 VALUES
+(3, row(1, 2)),
+(4, row(2, 2));
+-- result:
+-- !result
+SELECT s FROM t12_union1
+UNION ALL
+SELECT s FROM t12_union2
+ORDER BY s;
+-- result:
+{"a":1,"b":1}
+{"a":1,"b":2}
+{"a":2,"b":1}
+{"a":2,"b":2}
+-- !result
+SELECT s FROM t12_union1
+UNION
+SELECT s FROM t12_union2
+ORDER BY s;
+-- result:
+{"a":1,"b":1}
+{"a":1,"b":2}
+{"a":2,"b":1}
+{"a":2,"b":2}
+-- !result
+SELECT '=== Test 13: Ordering in Subqueries ===' AS test_name;
+-- result:
+=== Test 13: Ordering in Subqueries ===
+-- !result
+CREATE TABLE t13_subquery (
+    id INT,
+    s STRUCT<a INT, b INT>,
+    category STRING
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t13_subquery VALUES
+(1, row(1, 1), 'A'),
+(2, row(1, 2), 'A'),
+(3, row(2, 1), 'B'),
+(4, row(2, 2), 'B');
+-- result:
+-- !result
+SELECT * FROM (
+    SELECT s, category FROM t13_subquery ORDER BY s
+) sub
+WHERE category = 'A';
+-- result:
+{"a":1,"b":1}	A
+{"a":1,"b":2}	A
+-- !result
+SELECT 
+    s,
+    ROW_NUMBER() OVER (ORDER BY s) AS rn
+FROM t13_subquery;
+-- result:
+{"a":1,"b":1}	1
+{"a":1,"b":2}	2
+{"a":2,"b":1}	3
+{"a":2,"b":2}	4
+-- !result
+SELECT '=== Test 14: Ordering in CTEs ===' AS test_name;
+-- result:
+=== Test 14: Ordering in CTEs ===
+-- !result
+CREATE TABLE t14_cte (
+    id INT,
+    s STRUCT<a INT, b INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t14_cte VALUES
+(1, row(2, 1)),
+(2, row(1, 2)),
+(3, row(1, 1)),
+(4, row(2, 2));
+-- result:
+-- !result
+WITH sorted_data AS (
+    SELECT s FROM t14_cte ORDER BY s
+)
+SELECT * FROM sorted_data;
+-- result:
+{"a":1,"b":1}
+{"a":1,"b":2}
+{"a":2,"b":1}
+{"a":2,"b":2}
+-- !result
+WITH 
+    cte1 AS (SELECT s FROM t14_cte WHERE id <= 2),
+    cte2 AS (SELECT s FROM t14_cte WHERE id > 2)
+SELECT * FROM cte1
+UNION ALL
+SELECT * FROM cte2
+ORDER BY s;
+-- result:
+{"a":1,"b":1}
+{"a":1,"b":2}
+{"a":2,"b":1}
+{"a":2,"b":2}
+-- !result
+SELECT '=== Test 15: Extreme Values ===' AS test_name;
+-- result:
+=== Test 15: Extreme Values ===
+-- !result
+CREATE TABLE t15_extreme (
+    id INT,
+    s STRUCT<a BIGINT, b BIGINT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t15_extreme VALUES
+(1, row(9223372036854775807, 1)),  -- BIGINT MAX
+(2, row(-9223372036854775808, 1)), -- BIGINT MIN
+(3, row(0, 0)),
+(4, row(1, -9223372036854775808));
+-- result:
+-- !result
+SELECT s FROM t15_extreme ORDER BY s;
+-- result:
+{"a":-9223372036854775808,"b":1}
+{"a":0,"b":0}
+{"a":1,"b":-9223372036854775808}
+{"a":9223372036854775807,"b":1}
+-- !result
+SELECT '=== Test 16: String Ordering (Case Sensitivity) ===' AS test_name;
+-- result:
+=== Test 16: String Ordering (Case Sensitivity) ===
+-- !result
+CREATE TABLE t16_string (
+    id INT,
+    s STRUCT<str1 STRING, str2 STRING>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t16_string VALUES
+(1, row('abc', 'xyz')),
+(2, row('ABC', 'xyz')),
+(3, row('abc', 'XYZ')),
+(4, row('Abc', 'xyz'));
+-- result:
+-- !result
+SELECT s FROM t16_string ORDER BY s;
+-- result:
+{"str1":"ABC","str2":"xyz"}
+{"str1":"Abc","str2":"xyz"}
+{"str1":"abc","str2":"XYZ"}
+{"str1":"abc","str2":"xyz"}
+-- !result
+SELECT '=== Test 17: DISTINCT with ORDER BY ===' AS test_name;
+-- result:
+=== Test 17: DISTINCT with ORDER BY ===
+-- !result
+CREATE TABLE t17_distinct (
+    id INT,
+    s STRUCT<a INT, b INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t17_distinct VALUES
+(1, row(1, 1)),
+(2, row(1, 1)),
+(3, row(1, 2)),
+(4, row(1, 2)),
+(5, row(2, 1));
+-- result:
+-- !result
+SELECT DISTINCT s FROM t17_distinct ORDER BY s;
+-- result:
+{"a":1,"b":1}
+{"a":1,"b":2}
+{"a":2,"b":1}
+-- !result
+SELECT '=== Test 18: Multiple STRUCT Column Ordering ===' AS test_name;
+-- result:
+=== Test 18: Multiple STRUCT Column Ordering ===
+-- !result
+CREATE TABLE t18_multi_struct (
+    id INT,
+    s1 STRUCT<a INT, b INT>,
+    s2 STRUCT<x INT, y INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t18_multi_struct VALUES
+(1, row(1, 1), row(1, 1)),
+(2, row(1, 1), row(1, 2)),
+(3, row(1, 2), row(1, 1)),
+(4, row(1, 1), row(2, 1));
+-- result:
+-- !result
+SELECT s1, s2 FROM t18_multi_struct ORDER BY s1, s2;
+-- result:
+{"a":1,"b":1}	{"x":1,"y":1}
+{"a":1,"b":1}	{"x":1,"y":2}
+{"a":1,"b":1}	{"x":2,"y":1}
+{"a":1,"b":2}	{"x":1,"y":1}
+-- !result
+SELECT s1, s2 FROM t18_multi_struct ORDER BY s2, s1;
+-- result:
+{"a":1,"b":1}	{"x":1,"y":1}
+{"a":1,"b":2}	{"x":1,"y":1}
+{"a":1,"b":1}	{"x":1,"y":2}
+{"a":1,"b":1}	{"x":2,"y":1}
+-- !result
+SELECT '=== Test 19: Performance Test ===' AS test_name;
+-- result:
+=== Test 19: Performance Test ===
+-- !result
+CREATE TABLE t19_performance (
+    id INT,
+    s STRUCT<a INT, b INT, c INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 4
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t19_performance
+SELECT 
+    number,
+    row(
+        number % 100,
+        number % 50,
+        number % 25
+    )
+FROM TABLE(generate_series(1, 10000));
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column 'number' cannot be resolved.")
+-- !result
+SELECT s FROM t19_performance ORDER BY s LIMIT 100;
+-- result:
+-- !result
+SELECT '=== Test 20: STRUCT Comparison in WHERE Clause ===' AS test_name;
+-- result:
+=== Test 20: STRUCT Comparison in WHERE Clause ===
+-- !result
+CREATE TABLE t20_where (
+    id INT,
+    s STRUCT<a INT, b INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t20_where VALUES
+(1, row(1, 1)),
+(2, row(1, 2)),
+(3, row(2, 1)),
+(4, row(2, 2)),
+(5, row(3, 1));
+-- result:
+-- !result
+SELECT s FROM t20_where 
+WHERE s > row(1, 1) 
+ORDER BY s;
+-- result:
+E: (1064, 'Getting analyzing error from line 2, column 6 to line 2, column 18. Detail message: Column type struct<a int(11), b int(11)> does not support binary predicate operation with type struct<col1 tinyint(4), col2 tinyint(4)>.')
+-- !result
+SELECT s FROM t20_where 
+WHERE s = row(2, 1)
+ORDER BY s;
+-- result:
+{"a":2,"b":1}
+-- !result
+SELECT s FROM t20_where 
+WHERE s BETWEEN row(1, 2) AND row(2, 2)
+ORDER BY s;
+-- result:
+E: (1064, "Getting analyzing error from line 2, column 8 to line 2, column 38. Detail message: HLL, BITMAP, PERCENTILE and ARRAY, MAP, STRUCT type couldn't as Predicate.")
+-- !result

--- a/test/sql/test_sort/R/test_struct_order_by_edge_cases.sql
+++ b/test/sql/test_sort/R/test_struct_order_by_edge_cases.sql
@@ -1,0 +1,206 @@
+-- name: test_struct_order_by_edge_cases
+drop database if exists test_struct_order_by_edge_cases;
+-- result:
+-- !result
+create database test_struct_order_by_edge_cases;
+-- result:
+-- !result
+use test_struct_order_by_edge_cases;
+-- result:
+-- !result
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('value', 100)),
+        (2, named_struct('value', 50)),
+        (3, named_struct('value', 75))
+) t(id, info) 
+ORDER BY info;
+-- result:
+2	{"value":50}
+3	{"value":75}
+1	{"value":100}
+-- !result
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('name', NULL, 'age', NULL)),
+        (2, named_struct('name', 'Alice', 'age', 25)),
+        (3, named_struct('name', NULL, 'age', NULL))
+) t(id, info) 
+ORDER BY info;
+-- result:
+1	{"name":null,"age":null}
+3	{"name":null,"age":null}
+2	{"name":"Alice","age":25}
+-- !result
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('flag1', true, 'flag2', false)),
+        (2, named_struct('flag1', false, 'flag2', true)),
+        (3, named_struct('flag1', true, 'flag2', true)),
+        (4, named_struct('flag1', false, 'flag2', false))
+) t(id, info) 
+ORDER BY info;
+-- result:
+4	{"flag1":0,"flag2":0}
+2	{"flag1":0,"flag2":1}
+1	{"flag1":1,"flag2":0}
+3	{"flag1":1,"flag2":1}
+-- !result
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('start_date', DATE '2024-01-01', 'end_date', DATE '2024-12-31')),
+        (2, named_struct('start_date', DATE '2024-01-01', 'end_date', DATE '2024-06-30')),
+        (3, named_struct('start_date', DATE '2023-01-01', 'end_date', DATE '2023-12-31'))
+) t(id, info) 
+ORDER BY info;
+-- result:
+3	{"start_date":"2023-01-01","end_date":"2023-12-31"}
+2	{"start_date":"2024-01-01","end_date":"2024-06-30"}
+1	{"start_date":"2024-01-01","end_date":"2024-12-31"}
+-- !result
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('level1', named_struct('level2', named_struct('level3', 'A')))),
+        (2, named_struct('level1', named_struct('level2', named_struct('level3', 'C')))),
+        (3, named_struct('level1', named_struct('level2', named_struct('level3', 'B'))))
+) t(id, info) 
+ORDER BY info;
+-- result:
+1	{"level1":{"level2":{"level3":"A"}}}
+3	{"level1":{"level2":{"level3":"B"}}}
+2	{"level1":{"level2":{"level3":"C"}}}
+-- !result
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('name', 'Alice', 'age', 25)),
+        (2, NULL),
+        (3, named_struct('name', 'Bob', 'age', 30)),
+        (4, NULL),
+        (5, named_struct('name', 'Charlie', 'age', 20))
+) t(id, info) 
+ORDER BY info NULLS FIRST;
+-- result:
+4	None
+2	None
+1	{"name":"Alice","age":25}
+3	{"name":"Bob","age":30}
+5	{"name":"Charlie","age":20}
+-- !result
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('name', 'Alice', 'age', 25)),
+        (2, NULL),
+        (3, named_struct('name', 'Bob', 'age', 30)),
+        (4, NULL)
+) t(id, info) 
+ORDER BY info NULLS LAST;
+-- result:
+1	{"name":"Alice","age":25}
+3	{"name":"Bob","age":30}
+2	None
+4	None
+-- !result
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('price', CAST(100.50 AS DECIMAL(10,2)), 'quantity', 10)),
+        (2, named_struct('price', CAST(100.50 AS DECIMAL(10,2)), 'quantity', 5)),
+        (3, named_struct('price', CAST(99.99 AS DECIMAL(10,2)), 'quantity', 20))
+) t(id, info) 
+ORDER BY info;
+-- result:
+3	{"price":99.99,"quantity":20}
+2	{"price":100.50,"quantity":5}
+1	{"price":100.50,"quantity":10}
+-- !result
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('description', REPEAT('A', 100), 'id', 1)),
+        (2, named_struct('description', REPEAT('B', 100), 'id', 2)),
+        (3, named_struct('description', REPEAT('A', 100), 'id', 2))
+) t(id, info) 
+ORDER BY info;
+-- result:
+1	{"description":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","id":1}
+3	{"description":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","id":2}
+2	{"description":"BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB","id":2}
+-- !result
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('name', 'Bob', 'age', 30)),
+        (2, named_struct('name', 'Alice', 'age', 25))
+) t(id, info) 
+ORDER BY 2;
+-- result:
+2	{"name":"Alice","age":25}
+1	{"name":"Bob","age":30}
+-- !result
+SELECT id, info as person_info FROM (
+    VALUES 
+        (1, named_struct('name', 'Bob', 'age', 30)),
+        (2, named_struct('name', 'Alice', 'age', 25))
+) t(id, info) 
+ORDER BY person_info;
+-- result:
+2	{"name":"Alice","age":25}
+1	{"name":"Bob","age":30}
+-- !result
+CREATE TABLE IF NOT EXISTS test_struct_edge (
+    id INT,
+    category STRING,
+    info STRUCT<name STRING, score INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO test_struct_edge VALUES
+    (1, 'A', named_struct('name', 'Alice', 'score', 90)),
+    (2, 'A', named_struct('name', 'Bob', 'score', 85)),
+    (3, 'B', named_struct('name', 'Charlie', 'score', 92)),
+    (4, 'B', named_struct('name', 'David', 'score', 88));
+-- result:
+-- !result
+SELECT category, MIN(info) as min_info, MAX(info) as max_info
+FROM test_struct_edge
+GROUP BY category
+ORDER BY min_info;
+-- result:
+E: (1064, 'Getting analyzing error from line 1, column 17 to line 1, column 25. Detail message: No matching function with signature: min(struct<name varchar(65533), score int(11)>).')
+-- !result
+SELECT id, 
+       CASE WHEN id % 2 = 0 
+            THEN named_struct('type', 'even', 'id', id)
+            ELSE named_struct('type', 'odd', 'id', id)
+       END as result
+FROM (VALUES (1), (2), (3), (4)) t(id)
+ORDER BY result;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column 'result' cannot be resolved.")
+-- !result
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('name', 'Alice', 'age', 25)),
+        (2, named_struct('name', 'Bob', 'age', 30)),
+        (3, named_struct('name', 'Charlie', 'age', 20))
+) t(id, info)
+WHERE info > named_struct('name', 'Alice', 'age', 20)
+ORDER BY info;
+-- result:
+E: (1064, 'Getting analyzing error from line 7, column 6 to line 7, column 52. Detail message: Column type struct<name varchar, age tinyint(4)> does not support binary predicate operation with type struct<name varchar, age tinyint(4)>.')
+-- !result
+SELECT DISTINCT info FROM (
+    VALUES 
+        (named_struct('name', 'Alice', 'age', 25)),
+        (named_struct('name', 'Bob', 'age', 30)),
+        (named_struct('name', 'Alice', 'age', 25)),
+        (named_struct('name', 'Charlie', 'age', 20))
+) t(info)
+ORDER BY info;
+-- result:
+{"name":"Alice","age":25}
+{"name":"Bob","age":30}
+{"name":"Charlie","age":20}
+-- !result
+DROP TABLE test_struct_edge FORCE;
+-- result:
+-- !result

--- a/test/sql/test_sort/R/test_struct_topn.sql
+++ b/test/sql/test_sort/R/test_struct_topn.sql
@@ -1,0 +1,144 @@
+-- name: test_struct_topn
+drop database if exists test_struct_topn;
+-- result:
+-- !result
+create database test_struct_topn;
+-- result:
+-- !result
+use test_struct_topn;
+-- result:
+-- !result
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('name', 'Alice', 'score', 95)),
+        (2, named_struct('name', 'Bob', 'score', 88)),
+        (3, named_struct('name', 'Charlie', 'score', 92)),
+        (4, named_struct('name', 'David', 'score', 85)),
+        (5, named_struct('name', 'Eve', 'score', 90))
+) t(id, info) 
+ORDER BY info 
+LIMIT 3;
+-- result:
+1	{"name":"Alice","score":95}
+2	{"name":"Bob","score":88}
+3	{"name":"Charlie","score":92}
+-- !result
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('name', 'Alice', 'score', 95)),
+        (2, named_struct('name', 'Bob', 'score', 88)),
+        (3, named_struct('name', 'Charlie', 'score', 92)),
+        (4, named_struct('name', 'David', 'score', 85)),
+        (5, named_struct('name', 'Eve', 'score', 90))
+) t(id, info) 
+ORDER BY info DESC 
+LIMIT 3;
+-- result:
+5	{"name":"Eve","score":90}
+4	{"name":"David","score":85}
+3	{"name":"Charlie","score":92}
+-- !result
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('name', 'Alice', 'age', 25, 'scores', [90, 85, 88])),
+        (2, named_struct('name', 'Bob', 'age', 30, 'scores', [88, 92, 85])),
+        (3, named_struct('name', 'Charlie', 'age', 22, 'scores', [95, 90, 93]))
+) t(id, info) 
+ORDER BY info 
+LIMIT 2;
+-- result:
+1	{"name":"Alice","age":25,"scores":[90,85,88]}
+2	{"name":"Bob","age":30,"scores":[88,92,85]}
+-- !result
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('name', 'Alice', 'age', 25), named_struct('city', 'Beijing', 'country', 'China')),
+        (2, named_struct('name', 'Bob', 'age', 30), named_struct('city', 'Tokyo', 'country', 'Japan')),
+        (3, named_struct('name', 'Alice', 'age', 30), named_struct('city', 'Beijing', 'country', 'China'))
+) t(id, person, location) 
+ORDER BY person, location 
+LIMIT 2;
+-- result:
+1	{"name":"Alice","age":25}	{"city":"Beijing","country":"China"}
+3	{"name":"Alice","age":30}	{"city":"Beijing","country":"China"}
+-- !result
+WITH data AS (
+    SELECT * FROM (
+        VALUES 
+            (1, named_struct('name', 'Alice', 'dept', 'IT')),
+            (2, named_struct('name', 'Bob', 'dept', 'HR')),
+            (3, named_struct('name', 'Charlie', 'dept', 'IT')),
+            (4, named_struct('name', 'David', 'dept', 'Sales'))
+    ) t(id, employee)
+)
+SELECT * FROM data ORDER BY employee LIMIT 3;
+-- result:
+1	{"name":"Alice","dept":"IT"}
+2	{"name":"Bob","dept":"HR"}
+3	{"name":"Charlie","dept":"IT"}
+-- !result
+CREATE TABLE IF NOT EXISTS test_struct_topn (
+    id INT,
+    info STRUCT<category STRING, value INT, timestamp DATETIME>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO test_struct_topn VALUES
+    (1, named_struct('category', 'A', 'value', 100, 'timestamp', '2024-01-01 10:00:00')),
+    (2, named_struct('category', 'B', 'value', 200, 'timestamp', '2024-01-02 10:00:00')),
+    (3, named_struct('category', 'A', 'value', 150, 'timestamp', '2024-01-03 10:00:00')),
+    (4, named_struct('category', 'C', 'value', 180, 'timestamp', '2024-01-04 10:00:00')),
+    (5, named_struct('category', 'B', 'value', 120, 'timestamp', '2024-01-05 10:00:00')),
+    (6, named_struct('category', 'A', 'value', 100, 'timestamp', '2024-01-06 10:00:00')),
+    (7, named_struct('category', 'C', 'value', 220, 'timestamp', '2024-01-07 10:00:00')),
+    (8, named_struct('category', 'B', 'value', 190, 'timestamp', '2024-01-08 10:00:00')),
+    (9, named_struct('category', 'A', 'value', 110, 'timestamp', '2024-01-09 10:00:00')),
+    (10, named_struct('category', 'C', 'value', 160, 'timestamp', '2024-01-10 10:00:00'));
+-- result:
+-- !result
+SELECT * FROM test_struct_topn ORDER BY info LIMIT 5;
+-- result:
+1	{"category":"A","value":100,"timestamp":"2024-01-01 10:00:00"}
+6	{"category":"A","value":100,"timestamp":"2024-01-06 10:00:00"}
+9	{"category":"A","value":110,"timestamp":"2024-01-09 10:00:00"}
+3	{"category":"A","value":150,"timestamp":"2024-01-03 10:00:00"}
+5	{"category":"B","value":120,"timestamp":"2024-01-05 10:00:00"}
+-- !result
+SELECT * FROM test_struct_topn ORDER BY info DESC LIMIT 5;
+-- result:
+7	{"category":"C","value":220,"timestamp":"2024-01-07 10:00:00"}
+4	{"category":"C","value":180,"timestamp":"2024-01-04 10:00:00"}
+10	{"category":"C","value":160,"timestamp":"2024-01-10 10:00:00"}
+2	{"category":"B","value":200,"timestamp":"2024-01-02 10:00:00"}
+8	{"category":"B","value":190,"timestamp":"2024-01-08 10:00:00"}
+-- !result
+SELECT * FROM test_struct_topn ORDER BY info LIMIT 3 OFFSET 2;
+-- result:
+9	{"category":"A","value":110,"timestamp":"2024-01-09 10:00:00"}
+3	{"category":"A","value":150,"timestamp":"2024-01-03 10:00:00"}
+5	{"category":"B","value":120,"timestamp":"2024-01-05 10:00:00"}
+-- !result
+SELECT * FROM test_struct_topn WHERE id > 3 ORDER BY info LIMIT 4;
+-- result:
+6	{"category":"A","value":100,"timestamp":"2024-01-06 10:00:00"}
+9	{"category":"A","value":110,"timestamp":"2024-01-09 10:00:00"}
+5	{"category":"B","value":120,"timestamp":"2024-01-05 10:00:00"}
+8	{"category":"B","value":190,"timestamp":"2024-01-08 10:00:00"}
+-- !result
+SELECT id, info, 
+       ROW_NUMBER() OVER (ORDER BY info) as rn
+FROM test_struct_topn 
+ORDER BY info 
+LIMIT 5;
+-- result:
+1	{"category":"A","value":100,"timestamp":"2024-01-01 10:00:00"}	1
+6	{"category":"A","value":100,"timestamp":"2024-01-06 10:00:00"}	2
+9	{"category":"A","value":110,"timestamp":"2024-01-09 10:00:00"}	3
+3	{"category":"A","value":150,"timestamp":"2024-01-03 10:00:00"}	4
+5	{"category":"B","value":120,"timestamp":"2024-01-05 10:00:00"}	5
+-- !result
+DROP TABLE test_struct_topn FORCE;
+-- result:
+-- !result

--- a/test/sql/test_sort/T/test_array_struct_order_by.sql
+++ b/test/sql/test_sort/T/test_array_struct_order_by.sql
@@ -1,0 +1,155 @@
+-- name: test_array_struct_order_by
+
+drop database if exists test_array_struct_order_by;
+create database test_array_struct_order_by;
+use test_array_struct_order_by;
+
+-- Create table with ARRAY<STRUCT> column
+CREATE TABLE IF NOT EXISTS test_array_struct (
+    id INT,
+    tags ARRAY<STRUCT<tag_key STRING, tag_value INT>>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+-- Insert test data
+INSERT INTO test_array_struct VALUES
+    (1, [row('a', 1), row('b', 2)]),
+    (2, [row('a', 1), row('b', 1)]),
+    (3, [row('a', 2), row('b', 1)]),
+    (4, [row('a', 1)]),
+    (5, []);
+
+-- Test 1: Basic ORDER BY on ARRAY<STRUCT>
+SELECT * FROM test_array_struct ORDER BY tags;
+
+-- Test 2: ORDER BY DESC
+SELECT * FROM test_array_struct ORDER BY tags DESC;
+
+-- Test 3: ARRAY<STRUCT> with NULL values
+INSERT INTO test_array_struct VALUES
+    (6, NULL),
+    (7, [row(NULL, 1)]),
+    (8, [row('c', NULL)]);
+
+SELECT * FROM test_array_struct ORDER BY tags NULLS FIRST;
+SELECT * FROM test_array_struct ORDER BY tags NULLS LAST;
+
+-- Test 4: Different array lengths
+CREATE TABLE IF NOT EXISTS test_array_struct_lengths (
+    id INT,
+    items ARRAY<STRUCT<name STRING, score INT>>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO test_array_struct_lengths VALUES
+    (1, [row('Alice', 90)]),
+    (2, [row('Alice', 90), row('Bob', 80)]),
+    (3, [row('Alice', 90), row('Bob', 80), row('Charlie', 85)]),
+    (4, []),
+    (5, [row('Alice', 85)]);
+
+SELECT * FROM test_array_struct_lengths ORDER BY items;
+
+-- Test 5: Nested ARRAY<STRUCT> with multiple fields
+CREATE TABLE IF NOT EXISTS test_array_struct_complex (
+    id INT,
+    events ARRAY<STRUCT<event_name STRING, timestamp BIGINT, metadata STRUCT<source STRING, priority INT>>>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO test_array_struct_complex VALUES
+    (1, [row('login', 1000, row('web', 1))]),
+    (2, [row('login', 1000, row('mobile', 2))]),
+    (3, [row('login', 999, row('web', 1))]),
+    (4, [row('logout', 1000, row('web', 1))]);
+
+SELECT * FROM test_array_struct_complex ORDER BY events;
+
+-- Test 6: ARRAY<STRUCT> in VALUES clause
+SELECT * FROM (
+    VALUES 
+        (1, [row('x', 10)]),
+        (2, [row('y', 20)]),
+        (3, [row('x', 15)])
+) t(id, data) 
+ORDER BY data;
+
+-- Test 7: ORDER BY with WHERE clause
+SELECT * FROM test_array_struct_lengths WHERE id <= 3 ORDER BY items;
+
+-- Test 8: ORDER BY with JOIN
+CREATE TABLE IF NOT EXISTS test_array_struct_join (
+    id INT,
+    categories ARRAY<STRUCT<name STRING, level INT>>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO test_array_struct_join VALUES
+    (1, [row('tech', 1)]),
+    (2, [row('sports', 2)]),
+    (3, [row('tech', 2)]);
+
+SELECT t1.id, t1.items, t2.categories
+FROM test_array_struct_lengths t1
+JOIN test_array_struct_join t2 ON t1.id = t2.id
+ORDER BY t1.items, t2.categories;
+
+-- Test 9: ORDER BY with GROUP BY on other columns
+SELECT id, items, COUNT(*) as cnt
+FROM (
+    SELECT id, items FROM test_array_struct_lengths
+    UNION ALL
+    SELECT id, items FROM test_array_struct_lengths WHERE id <= 2
+) t
+GROUP BY id, items
+ORDER BY items;
+
+-- Test 10: ARRAY<STRUCT> with LIMIT
+SELECT * FROM test_array_struct_lengths ORDER BY items LIMIT 3;
+
+-- Test 11: Empty array vs NULL
+INSERT INTO test_array_struct_lengths VALUES (6, NULL);
+SELECT * FROM test_array_struct_lengths WHERE id >= 4 ORDER BY items NULLS FIRST;
+
+-- Test 12: ARRAY<STRUCT> with same first element, different second
+CREATE TABLE IF NOT EXISTS test_array_struct_compare (
+    id INT,
+    pairs ARRAY<STRUCT<first INT, second INT>>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO test_array_struct_compare VALUES
+    (1, [row(1, 2), row(3, 4)]),
+    (2, [row(1, 2), row(3, 3)]),
+    (3, [row(1, 2), row(2, 4)]),
+    (4, [row(1, 2)]);
+
+SELECT * FROM test_array_struct_compare ORDER BY pairs;
+
+-- Test 13: ARRAY<STRUCT> in subquery
+SELECT id, pairs FROM (
+    SELECT * FROM test_array_struct_compare WHERE id <= 3
+) t 
+ORDER BY pairs DESC;
+
+-- Test 14: Multiple ORDER BY columns including ARRAY<STRUCT>
+SELECT * FROM test_array_struct_compare ORDER BY pairs, id DESC;
+
+-- Test 15: ARRAY<STRUCT> with UNION
+SELECT pairs FROM test_array_struct_compare WHERE id <= 2
+UNION ALL
+SELECT [row(1, 3), row(3, 3)]
+ORDER BY pairs;
+
+-- Clean up
+DROP TABLE test_array_struct FORCE;
+DROP TABLE test_array_struct_lengths FORCE;
+DROP TABLE test_array_struct_complex FORCE;
+DROP TABLE test_array_struct_join FORCE;
+DROP TABLE test_array_struct_compare FORCE;
+

--- a/test/sql/test_sort/T/test_complex_struct_sort.sql
+++ b/test/sql/test_sort/T/test_complex_struct_sort.sql
@@ -1,0 +1,381 @@
+-- name: test_complex_struct_sort
+
+drop database if exists test_complex_struct_sort;
+create database test_complex_struct_sort;
+use test_complex_struct_sort;
+
+CREATE TABLE user_behavior (
+    id BIGINT,
+    user_profile STRUCT<
+        user_id INT,
+        user_name STRING,
+        user_level INT,
+        registration_date DATE,
+        location STRUCT<
+            country STRING,
+            city STRING,
+            coordinates STRUCT<
+                latitude DOUBLE,
+                longitude DOUBLE
+            >
+        >,
+        preferences STRUCT<
+            category STRING,
+            sub_category STRING,
+            score INT
+        >
+    >,
+    event_timestamp DATETIME
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 8
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO user_behavior
+SELECT
+    generate_series AS id,
+    row(
+        CAST(generate_series % 1000000 AS INT),
+        CONCAT('user_', CAST(generate_series % 1000000 AS STRING)),
+        CAST(generate_series % 10 AS INT),
+        DATE_ADD('2020-01-01', INTERVAL (generate_series % 1460) DAY),
+        row(
+            CASE generate_series % 10
+                WHEN 0 THEN 'USA'
+                WHEN 1 THEN 'China'
+                WHEN 2 THEN 'UK'
+                WHEN 3 THEN 'Japan'
+                WHEN 4 THEN 'Germany'
+                WHEN 5 THEN 'France'
+                WHEN 6 THEN 'Canada'
+                WHEN 7 THEN 'Australia'
+                WHEN 8 THEN 'India'
+                ELSE 'Brazil'
+            END,
+            CONCAT('City_', CAST(generate_series % 100 AS STRING)),
+            row(
+                CAST(20.0 + (generate_series % 60) AS DOUBLE),
+                CAST(-180.0 + (generate_series % 360) AS DOUBLE)
+            )
+        ),
+        row(
+            CASE generate_series % 5
+                WHEN 0 THEN 'Electronics'
+                WHEN 1 THEN 'Books'
+                WHEN 2 THEN 'Clothing'
+                WHEN 3 THEN 'Food'
+                ELSE 'Sports'
+            END,
+            CONCAT('Sub_', CAST(generate_series % 20 AS STRING)),
+            CAST(generate_series % 100 AS INT)
+        )
+    ) AS user_profile,
+    date_add(CAST('2024-01-01 00:00:00' AS DATETIME), INTERVAL (generate_series % 86400) SECOND) AS event_timestamp
+FROM TABLE(generate_series(1, 1000000));
+
+select user_profile from user_behavior order by user_profile limit 10;
+
+SELECT user_profile
+FROM (
+    SELECT user_profile
+    FROM user_behavior
+    ORDER BY user_profile
+    LIMIT 1025
+) t
+WHERE user_profile.user_id = 1;
+
+SELECT COUNT(a.c1), COUNT(a.c2)
+FROM (
+    SELECT
+        id as  c1,
+        row_number() OVER (ORDER BY user_profile) AS c2
+    FROM user_behavior
+) AS a;
+
+-- ==========================================
+-- Test: Complex Nested Transaction Structure
+-- Card + Transaction with deep nesting
+-- ==========================================
+
+CREATE TABLE transaction_data (
+    id BIGINT,
+    transaction_info STRUCT<
+        card STRUCT<
+            card_details STRUCT<
+                card_bin STRING,
+                card_type STRING,
+                issuer STRING,
+                card_program STRING
+            >,
+            card_tags ARRAY<STRUCT<value STRING>>,
+            version INT
+        >,
+        transaction STRUCT<
+            transaction_id STRING,
+            transaction_details STRUCT<
+                transaction_type STRING,
+                merchant_data STRUCT<
+                    merchant_id STRING,
+                    merchant_name STRING,
+                    merchant_country_code STRING
+                >,
+                posting_date STRING,
+                amount STRUCT<
+                    currency_code STRING
+                >,
+                billing_amount STRUCT<
+                    currency_code STRING
+                >,
+                billing_amount_no_fee DECIMAL(18, 4),
+                conversion_rate DECIMAL(18, 4),
+                ird STRING
+            >
+        >
+    >
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 8
+PROPERTIES ("replication_num" = "1");
+
+-- Insert test data with various card and transaction combinations
+INSERT INTO transaction_data VALUES
+(1, row(
+    row(
+        row('411111', 'VISA', 'Chase', 'Rewards'),
+        [row('Premium'), row('Verified')],
+        1
+    ),
+    row(
+        'TXN001',
+        row(
+            'PURCHASE',
+            row('MERCH001', 'Amazon', 'US'),
+            '2024-01-15',
+            row('USD'),
+            row('USD'),
+            100.5000,
+            1.0000,
+            'IRD001'
+        )
+    )
+)),
+(2, row(
+    row(
+        row('520000', 'MASTERCARD', 'Citi', 'CashBack'),
+        [row('Standard')],
+        2
+    ),
+    row(
+        'TXN002',
+        row(
+            'REFUND',
+            row('MERCH002', 'Walmart', 'US'),
+            '2024-01-16',
+            row('USD'),
+            row('USD'),
+            50.2500,
+            1.0000,
+            'IRD002'
+        )
+    )
+)),
+(3, row(
+    row(
+        row('370000', 'AMEX', 'American Express', 'Platinum'),
+        [row('Premium'), row('Travel'), row('Insurance')],
+        1
+    ),
+    row(
+        'TXN003',
+        row(
+            'PURCHASE',
+            row('MERCH003', 'Apple Store', 'US'),
+            '2024-01-17',
+            row('USD'),
+            row('EUR'),
+            1200.0000,
+            0.9200,
+            'IRD003'
+        )
+    )
+)),
+(4, row(
+    row(
+        row('411111', 'VISA', 'Bank of America', 'Travel'),
+        [row('Gold')],
+        1
+    ),
+    row(
+        'TXN004',
+        row(
+            'PURCHASE',
+            row('MERCH001', 'Amazon', 'UK'),
+            '2024-01-18',
+            row('GBP'),
+            row('USD'),
+            85.7500,
+            1.2700,
+            'IRD004'
+        )
+    )
+)),
+(5, row(
+    row(
+        row('520000', 'MASTERCARD', 'HSBC', 'Standard'),
+        [row('Basic')],
+        2
+    ),
+    row(
+        'TXN005',
+        row(
+            'WITHDRAWAL',
+            row('MERCH004', 'ATM Network', 'CN'),
+            '2024-01-19',
+            row('CNY'),
+            row('USD'),
+            500.0000,
+            0.1400,
+            'IRD005'
+        )
+    )
+)),
+(6, row(
+    row(
+        row('370000', 'AMEX', 'American Express', 'Gold'),
+        [row('Premium'), row('Concierge')],
+        3
+    ),
+    row(
+        'TXN006',
+        row(
+            'PURCHASE',
+            row('MERCH005', 'Luxury Hotel', 'FR'),
+            '2024-01-20',
+            row('EUR'),
+            row('USD'),
+            2500.0000,
+            1.0800,
+            'IRD006'
+        )
+    )
+)),
+(7, row(
+    row(
+        row('411111', 'VISA', 'Chase', 'Rewards'),
+        [row('Verified')],
+        1
+    ),
+    row(
+        'TXN007',
+        row(
+            'PURCHASE',
+            row('MERCH001', 'Amazon', 'US'),
+            '2024-01-21',
+            row('USD'),
+            row('USD'),
+            45.9900,
+            1.0000,
+            'IRD007'
+        )
+    )
+)),
+(8, row(
+    row(
+        row('520000', 'MASTERCARD', 'Citi', 'CashBack'),
+        [row('Standard'), row('Contactless')],
+        2
+    ),
+    row(
+        'TXN008',
+        row(
+            'PURCHASE',
+            row('MERCH006', 'Grocery Store', 'CA'),
+            '2024-01-22',
+            row('CAD'),
+            row('USD'),
+            75.0000,
+            0.7500,
+            'IRD008'
+        )
+    )
+));
+
+-- Test 1: Basic ORDER BY on complex nested structure
+SELECT transaction_info 
+FROM transaction_data 
+ORDER BY transaction_info 
+LIMIT 5;
+
+-- Test 2: ORDER BY DESC
+SELECT transaction_info 
+FROM transaction_data 
+ORDER BY transaction_info DESC 
+LIMIT 5;
+
+-- Test 3: TopN with window function to avoid large output
+SELECT id, rn
+FROM (
+    SELECT 
+        id,
+        ROW_NUMBER() OVER (ORDER BY transaction_info) AS rn
+    FROM transaction_data
+) t
+WHERE rn <= 5;
+
+-- Test 4: ORDER BY with WHERE clause filtering
+SELECT transaction_info 
+FROM transaction_data 
+WHERE id <= 5
+ORDER BY transaction_info;
+
+-- Test 5: Verify specific ordering (card type comparison)
+-- AMEX vs MASTERCARD vs VISA (lexicographical order)
+SELECT 
+    id,
+    transaction_info.card.card_details.card_type,
+    transaction_info.card.card_details.issuer
+FROM transaction_data 
+ORDER BY transaction_info 
+LIMIT 5;
+
+-- Test 6: ORDER BY with DISTINCT
+SELECT DISTINCT transaction_info.card.card_details.card_type
+FROM transaction_data
+ORDER BY transaction_info.card.card_details.card_type;
+
+-- Test 7: Complex struct in subquery
+SELECT id, transaction_info
+FROM (
+    SELECT * FROM transaction_data WHERE id <= 6
+) t
+ORDER BY transaction_info
+LIMIT 3;
+
+-- Test 8: TopN with specific row (only return row 5)
+SELECT id, transaction_info
+FROM (
+    SELECT 
+        id,
+        transaction_info,
+        ROW_NUMBER() OVER (ORDER BY transaction_info) AS rn
+    FROM transaction_data
+) t
+WHERE rn = 5;
+
+-- Test 9: ORDER BY with COUNT aggregation (performance test)
+SELECT COUNT(*)
+FROM (
+    SELECT transaction_info 
+    FROM transaction_data 
+    ORDER BY transaction_info 
+    LIMIT 8
+) t;
+
+-- Test 10: Multiple STRUCT columns ordering
+SELECT 
+    id,
+    transaction_info.card.version,
+    transaction_info.transaction.transaction_id
+FROM transaction_data
+ORDER BY transaction_info, id;
+
+-- Clean up
+DROP TABLE transaction_data FORCE;

--- a/test/sql/test_sort/T/test_order_by_struct_comprehensive.sql
+++ b/test/sql/test_sort/T/test_order_by_struct_comprehensive.sql
@@ -1,0 +1,570 @@
+-- name: test_order_by_struct_comprehensive
+DROP DATABASE IF EXISTS test_order_by_struct_comprehensive;
+CREATE DATABASE test_order_by_struct_comprehensive;
+USE test_order_by_struct_comprehensive;
+
+-- ==========================================
+-- Test 1: Basic Lexicographical Ordering
+-- ==========================================
+CREATE TABLE t1_basic (
+    id INT,
+    s STRUCT<a INT, b INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t1_basic VALUES
+(1, row(1, 1)),
+(2, row(1, 2)),
+(3, row(2, 1)),
+(4, row(2, 2)),
+(5, row(1, 1));
+
+-- Ascending order
+SELECT s FROM t1_basic ORDER BY s ASC;
+
+-- Descending order
+SELECT s FROM t1_basic ORDER BY s DESC;
+
+-- Verify lexicographical order (when first field is same, compare second field)
+SELECT s FROM t1_basic WHERE id IN (1, 2, 5) ORDER BY s;
+
+-- ==========================================
+-- Test 2: NULL Value Handling
+-- ==========================================
+SELECT '=== Test 2: NULL Value Handling ===' AS test_name;
+
+CREATE TABLE t2_nulls (
+    id INT,
+    s STRUCT<a INT, b INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t2_nulls VALUES
+(1, row(1, 1)),
+(2, row(1, NULL)),
+(3, row(NULL, 1)),
+(4, row(NULL, NULL)),
+(5, NULL);
+
+-- NULLS FIRST (default)
+SELECT s FROM t2_nulls ORDER BY s ASC NULLS FIRST;
+
+-- NULLS LAST
+SELECT s FROM t2_nulls ORDER BY s ASC NULLS LAST;
+
+-- Verify ordering of internal NULL fields
+SELECT s FROM t2_nulls WHERE id BETWEEN 1 AND 4 ORDER BY s;
+
+-- ==========================================
+-- Test 3: Different Data Types
+-- ==========================================
+SELECT '=== Test 3: Different Data Types ===' AS test_name;
+
+-- 3.1 String and Integer
+CREATE TABLE t3_mixed_types (
+    id INT,
+    s STRUCT<name STRING, age INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t3_mixed_types VALUES
+(1, row('Alice', 30)),
+(2, row('Alice', 25)),
+(3, row('Bob', 30)),
+(4, row('Bob', 25)),
+(5, row('Alice', 30));
+
+SELECT s FROM t3_mixed_types ORDER BY s;
+
+-- 3.2 Float numbers
+CREATE TABLE t3_float (
+    id INT,
+    s STRUCT<x DOUBLE, y DOUBLE>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t3_float VALUES
+(1, row(1.1, 2.2)),
+(2, row(1.1, 2.1)),
+(3, row(1.2, 2.2)),
+(4, row(1.0, 2.0));
+
+SELECT s FROM t3_float ORDER BY s;
+
+-- 3.3 Date types
+CREATE TABLE t3_date (
+    id INT,
+    s STRUCT<event_date DATE, event_time DATETIME>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t3_date VALUES
+(1, row('2024-01-01', '2024-01-01 10:00:00')),
+(2, row('2024-01-01', '2024-01-01 09:00:00')),
+(3, row('2024-01-02', '2024-01-02 10:00:00')),
+(4, row('2024-01-01', '2024-01-01 10:00:00'));
+
+SELECT s FROM t3_date ORDER BY s;
+
+-- ==========================================
+-- Test 4: Nested STRUCT
+-- ==========================================
+SELECT '=== Test 4: Nested STRUCT ===' AS test_name;
+
+CREATE TABLE t4_nested (
+    id INT,
+    s STRUCT<outer1 INT, inner1 STRUCT<a INT, b INT>>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t4_nested VALUES
+(1, row(1, row(1, 1))),
+(2, row(1, row(1, 2))),
+(3, row(1, row(2, 1))),
+(4, row(2, row(1, 1)));
+
+SELECT s FROM t4_nested ORDER BY s;
+
+-- Verify lexicographical order of nested structures
+SELECT s FROM t4_nested WHERE id <= 3 ORDER BY s;
+
+-- ==========================================
+-- Test 5: Mixed Column Ordering (STRUCT with other columns)
+-- ==========================================
+SELECT '=== Test 5: Mixed Column Ordering ===' AS test_name;
+
+CREATE TABLE t5_mixed_columns (
+    id INT,
+    s STRUCT<a INT, b INT>,
+    score INT
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t5_mixed_columns VALUES
+(1, row(1, 1), 100),
+(2, row(1, 2), 90),
+(3, row(2, 1), 100),
+(4, row(1, 1), 95);
+
+-- Sort by STRUCT first, then by score
+SELECT s, score FROM t5_mixed_columns ORDER BY s, score;
+
+-- Sort by score first, then by STRUCT
+SELECT s, score FROM t5_mixed_columns ORDER BY score, s;
+
+-- ==========================================
+-- Test 6: Empty and Single-field STRUCT
+-- ==========================================
+SELECT '=== Test 6: Empty and Single-field STRUCT ===' AS test_name;
+
+-- Single-field STRUCT
+CREATE TABLE t6_single_field (
+    id INT,
+    s STRUCT<value INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t6_single_field VALUES
+(1, row(3)),
+(2, row(1)),
+(3, row(2)),
+(4, row(1));
+
+SELECT s FROM t6_single_field ORDER BY s;
+
+-- ==========================================
+-- Test 7: STRUCT with Many Fields
+-- ==========================================
+SELECT '=== Test 7: STRUCT with Many Fields ===' AS test_name;
+
+CREATE TABLE t7_many_fields (
+    id INT,
+    s STRUCT<f1 INT, f2 INT, f3 INT, f4 INT, f5 INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t7_many_fields VALUES
+(1, row(1, 1, 1, 1, 1)),
+(2, row(1, 1, 1, 1, 2)),
+(3, row(1, 1, 1, 2, 1)),
+(4, row(1, 1, 2, 1, 1)),
+(5, row(1, 2, 1, 1, 1)),
+(6, row(2, 1, 1, 1, 1));
+
+SELECT s FROM t7_many_fields ORDER BY s;
+
+-- ==========================================
+-- Test 8: Sort Stability with Same Values
+-- ==========================================
+SELECT '=== Test 8: Sort Stability with Same Values ===' AS test_name;
+
+CREATE TABLE t8_stability (
+    id INT,
+    s STRUCT<a INT, b INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t8_stability VALUES
+(1, row(1, 1)),
+(2, row(1, 1)),
+(3, row(1, 1)),
+(4, row(2, 2)),
+(5, row(2, 2));
+
+-- Multiple sorts should yield consistent results
+SELECT id, s FROM t8_stability ORDER BY s, id;
+SELECT id, s FROM t8_stability ORDER BY s, id;
+
+-- ==========================================
+-- Test 9: LIMIT and OFFSET
+-- ==========================================
+SELECT '=== Test 9: LIMIT and OFFSET ===' AS test_name;
+
+CREATE TABLE t9_limit (
+    id INT,
+    s STRUCT<a INT, b INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t9_limit VALUES
+(1, row(1, 1)),
+(2, row(1, 2)),
+(3, row(2, 1)),
+(4, row(2, 2)),
+(5, row(3, 1)),
+(6, row(3, 2));
+
+-- TOP-N optimization
+SELECT s FROM t9_limit ORDER BY s LIMIT 3;
+
+-- OFFSET
+SELECT s FROM t9_limit ORDER BY s LIMIT 3 OFFSET 2;
+
+-- ==========================================
+-- Test 10: Ordering After Aggregation
+-- ==========================================
+SELECT '=== Test 10: Ordering After Aggregation ===' AS test_name;
+
+CREATE TABLE t10_aggregate (
+    id INT,
+    s STRUCT<a INT, b INT>,
+    value INT
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t10_aggregate VALUES
+(1, row(1, 1), 10),
+(2, row(1, 1), 20),
+(3, row(1, 2), 30),
+(4, row(2, 1), 40);
+
+-- Ordering after GROUP BY
+SELECT s, SUM(value) AS total
+FROM t10_aggregate
+GROUP BY s
+ORDER BY s;
+
+-- Ordering after HAVING
+SELECT s, SUM(value) AS total
+FROM t10_aggregate
+GROUP BY s
+HAVING SUM(value) > 15
+ORDER BY s;
+
+-- ==========================================
+-- Test 11: Ordering After JOIN
+-- ==========================================
+SELECT '=== Test 11: Ordering After JOIN ===' AS test_name;
+
+CREATE TABLE t11_left (
+    id INT,
+    s STRUCT<a INT, b INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+CREATE TABLE t11_right (
+    id INT,
+    s STRUCT<a INT, b INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t11_left VALUES
+(1, row(1, 1)),
+(2, row(1, 2)),
+(3, row(2, 1));
+
+INSERT INTO t11_right VALUES
+(1, row(1, 1)),
+(2, row(1, 3)),
+(3, row(2, 1));
+
+-- Ordering after JOIN
+SELECT l.s, r.s
+FROM t11_left l
+JOIN t11_right r ON l.id = r.id
+ORDER BY l.s, r.s;
+
+-- ==========================================
+-- Test 12: Ordering After UNION
+-- ==========================================
+SELECT '=== Test 12: Ordering After UNION ===' AS test_name;
+
+CREATE TABLE t12_union1 (
+    id INT,
+    s STRUCT<a INT, b INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+CREATE TABLE t12_union2 (
+    id INT,
+    s STRUCT<a INT, b INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t12_union1 VALUES
+(1, row(1, 1)),
+(2, row(2, 1));
+
+INSERT INTO t12_union2 VALUES
+(3, row(1, 2)),
+(4, row(2, 2));
+
+-- Ordering after UNION ALL
+SELECT s FROM t12_union1
+UNION ALL
+SELECT s FROM t12_union2
+ORDER BY s;
+
+-- Ordering after UNION (with deduplication)
+SELECT s FROM t12_union1
+UNION
+SELECT s FROM t12_union2
+ORDER BY s;
+
+-- ==========================================
+-- Test 13: Ordering in Subqueries
+-- ==========================================
+SELECT '=== Test 13: Ordering in Subqueries ===' AS test_name;
+
+CREATE TABLE t13_subquery (
+    id INT,
+    s STRUCT<a INT, b INT>,
+    category STRING
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t13_subquery VALUES
+(1, row(1, 1), 'A'),
+(2, row(1, 2), 'A'),
+(3, row(2, 1), 'B'),
+(4, row(2, 2), 'B');
+
+-- Ordering in subquery then filtering
+SELECT * FROM (
+    SELECT s, category FROM t13_subquery ORDER BY s
+) sub
+WHERE category = 'A';
+
+-- Window function
+SELECT 
+    s,
+    ROW_NUMBER() OVER (ORDER BY s) AS rn
+FROM t13_subquery;
+
+-- ==========================================
+-- Test 14: Ordering in CTEs
+-- ==========================================
+SELECT '=== Test 14: Ordering in CTEs ===' AS test_name;
+
+CREATE TABLE t14_cte (
+    id INT,
+    s STRUCT<a INT, b INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t14_cte VALUES
+(1, row(2, 1)),
+(2, row(1, 2)),
+(3, row(1, 1)),
+(4, row(2, 2));
+
+-- CTE with ordering
+WITH sorted_data AS (
+    SELECT s FROM t14_cte ORDER BY s
+)
+SELECT * FROM sorted_data;
+
+-- Multiple CTEs
+WITH 
+    cte1 AS (SELECT s FROM t14_cte WHERE id <= 2),
+    cte2 AS (SELECT s FROM t14_cte WHERE id > 2)
+SELECT * FROM cte1
+UNION ALL
+SELECT * FROM cte2
+ORDER BY s;
+
+-- ==========================================
+-- Test 15: Extreme Values
+-- ==========================================
+SELECT '=== Test 15: Extreme Values ===' AS test_name;
+
+CREATE TABLE t15_extreme (
+    id INT,
+    s STRUCT<a BIGINT, b BIGINT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t15_extreme VALUES
+(1, row(9223372036854775807, 1)),  -- BIGINT MAX
+(2, row(-9223372036854775808, 1)), -- BIGINT MIN
+(3, row(0, 0)),
+(4, row(1, -9223372036854775808));
+
+SELECT s FROM t15_extreme ORDER BY s;
+
+-- ==========================================
+-- Test 16: String Ordering (Case Sensitivity)
+-- ==========================================
+SELECT '=== Test 16: String Ordering (Case Sensitivity) ===' AS test_name;
+
+CREATE TABLE t16_string (
+    id INT,
+    s STRUCT<str1 STRING, str2 STRING>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t16_string VALUES
+(1, row('abc', 'xyz')),
+(2, row('ABC', 'xyz')),
+(3, row('abc', 'XYZ')),
+(4, row('Abc', 'xyz'));
+
+-- Case-sensitive ordering
+SELECT s FROM t16_string ORDER BY s;
+
+-- ==========================================
+-- Test 17: DISTINCT with ORDER BY
+-- ==========================================
+SELECT '=== Test 17: DISTINCT with ORDER BY ===' AS test_name;
+
+CREATE TABLE t17_distinct (
+    id INT,
+    s STRUCT<a INT, b INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t17_distinct VALUES
+(1, row(1, 1)),
+(2, row(1, 1)),
+(3, row(1, 2)),
+(4, row(1, 2)),
+(5, row(2, 1));
+
+-- Ordering after DISTINCT
+SELECT DISTINCT s FROM t17_distinct ORDER BY s;
+
+-- ==========================================
+-- Test 18: Multiple STRUCT Column Ordering
+-- ==========================================
+SELECT '=== Test 18: Multiple STRUCT Column Ordering ===' AS test_name;
+
+CREATE TABLE t18_multi_struct (
+    id INT,
+    s1 STRUCT<a INT, b INT>,
+    s2 STRUCT<x INT, y INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t18_multi_struct VALUES
+(1, row(1, 1), row(1, 1)),
+(2, row(1, 1), row(1, 2)),
+(3, row(1, 2), row(1, 1)),
+(4, row(1, 1), row(2, 1));
+
+-- Order by s1 first, then by s2
+SELECT s1, s2 FROM t18_multi_struct ORDER BY s1, s2;
+
+-- Order by s2 first, then by s1
+SELECT s1, s2 FROM t18_multi_struct ORDER BY s2, s1;
+
+-- ==========================================
+-- Test 19: Performance Test (Large Dataset)
+-- ==========================================
+SELECT '=== Test 19: Performance Test ===' AS test_name;
+
+CREATE TABLE t19_performance (
+    id INT,
+    s STRUCT<a INT, b INT, c INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 4
+PROPERTIES ("replication_num" = "1");
+
+-- Insert 10000 rows
+INSERT INTO t19_performance
+SELECT 
+    number,
+    row(
+        number % 100,
+        number % 50,
+        number % 25
+    )
+FROM TABLE(generate_series(1, 10000));
+
+-- Test sorting performance
+SELECT s FROM t19_performance ORDER BY s LIMIT 100;
+
+-- ==========================================
+-- Test 20: STRUCT Comparison in WHERE Clause
+-- ==========================================
+SELECT '=== Test 20: STRUCT Comparison in WHERE Clause ===' AS test_name;
+
+CREATE TABLE t20_where (
+    id INT,
+    s STRUCT<a INT, b INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t20_where VALUES
+(1, row(1, 1)),
+(2, row(1, 2)),
+(3, row(2, 1)),
+(4, row(2, 2)),
+(5, row(3, 1));
+
+-- STRUCT comparison in WHERE clause
+SELECT s FROM t20_where 
+WHERE s > row(1, 1) 
+ORDER BY s;
+
+-- Equality comparison in WHERE clause
+SELECT s FROM t20_where 
+WHERE s = row(2, 1)
+ORDER BY s;
+
+-- Range query in WHERE clause
+SELECT s FROM t20_where 
+WHERE s BETWEEN row(1, 2) AND row(2, 2)
+ORDER BY s;

--- a/test/sql/test_sort/T/test_struct_order_by_edge_cases.sql
+++ b/test/sql/test_sort/T/test_struct_order_by_edge_cases.sql
@@ -1,0 +1,159 @@
+-- name: test_struct_order_by_edge_cases
+
+drop database if exists test_struct_order_by_edge_cases;
+create database test_struct_order_by_edge_cases;
+use test_struct_order_by_edge_cases;
+
+
+-- Single field struct (should work like ordering by that field)
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('value', 100)),
+        (2, named_struct('value', 50)),
+        (3, named_struct('value', 75))
+) t(id, info) 
+ORDER BY info;
+
+-- Struct with all NULL fields
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('name', NULL, 'age', NULL)),
+        (2, named_struct('name', 'Alice', 'age', 25)),
+        (3, named_struct('name', NULL, 'age', NULL))
+) t(id, info) 
+ORDER BY info;
+
+-- Struct with boolean fields
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('flag1', true, 'flag2', false)),
+        (2, named_struct('flag1', false, 'flag2', true)),
+        (3, named_struct('flag1', true, 'flag2', true)),
+        (4, named_struct('flag1', false, 'flag2', false))
+) t(id, info) 
+ORDER BY info;
+
+-- Struct with date/datetime fields
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('start_date', DATE '2024-01-01', 'end_date', DATE '2024-12-31')),
+        (2, named_struct('start_date', DATE '2024-01-01', 'end_date', DATE '2024-06-30')),
+        (3, named_struct('start_date', DATE '2023-01-01', 'end_date', DATE '2023-12-31'))
+) t(id, info) 
+ORDER BY info;
+
+-- Deeply nested structs (3 levels)
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('level1', named_struct('level2', named_struct('level3', 'A')))),
+        (2, named_struct('level1', named_struct('level2', named_struct('level3', 'C')))),
+        (3, named_struct('level1', named_struct('level2', named_struct('level3', 'B'))))
+) t(id, info) 
+ORDER BY info;
+
+-- Struct with mixed NULL and non-NULL rows
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('name', 'Alice', 'age', 25)),
+        (2, NULL),
+        (3, named_struct('name', 'Bob', 'age', 30)),
+        (4, NULL),
+        (5, named_struct('name', 'Charlie', 'age', 20))
+) t(id, info) 
+ORDER BY info NULLS FIRST;
+
+-- Struct with mixed NULL and non-NULL rows, NULLS LAST
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('name', 'Alice', 'age', 25)),
+        (2, NULL),
+        (3, named_struct('name', 'Bob', 'age', 30)),
+        (4, NULL)
+) t(id, info) 
+ORDER BY info NULLS LAST;
+
+-- Struct with decimal fields
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('price', CAST(100.50 AS DECIMAL(10,2)), 'quantity', 10)),
+        (2, named_struct('price', CAST(100.50 AS DECIMAL(10,2)), 'quantity', 5)),
+        (3, named_struct('price', CAST(99.99 AS DECIMAL(10,2)), 'quantity', 20))
+) t(id, info) 
+ORDER BY info;
+
+-- Struct with very long string fields
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('description', REPEAT('A', 100), 'id', 1)),
+        (2, named_struct('description', REPEAT('B', 100), 'id', 2)),
+        (3, named_struct('description', REPEAT('A', 100), 'id', 2))
+) t(id, info) 
+ORDER BY info;
+
+-- ORDER BY struct column position
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('name', 'Bob', 'age', 30)),
+        (2, named_struct('name', 'Alice', 'age', 25))
+) t(id, info) 
+ORDER BY 2;
+
+-- ORDER BY struct with alias
+SELECT id, info as person_info FROM (
+    VALUES 
+        (1, named_struct('name', 'Bob', 'age', 30)),
+        (2, named_struct('name', 'Alice', 'age', 25))
+) t(id, info) 
+ORDER BY person_info;
+
+-- Struct in HAVING clause with ORDER BY
+CREATE TABLE IF NOT EXISTS test_struct_edge (
+    id INT,
+    category STRING,
+    info STRUCT<name STRING, score INT>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO test_struct_edge VALUES
+    (1, 'A', named_struct('name', 'Alice', 'score', 90)),
+    (2, 'A', named_struct('name', 'Bob', 'score', 85)),
+    (3, 'B', named_struct('name', 'Charlie', 'score', 92)),
+    (4, 'B', named_struct('name', 'David', 'score', 88));
+
+SELECT category, MIN(info) as min_info, MAX(info) as max_info
+FROM test_struct_edge
+GROUP BY category
+ORDER BY min_info;
+
+-- ORDER BY with CASE expression returning struct
+SELECT id, 
+       CASE WHEN id % 2 = 0 
+            THEN named_struct('type', 'even', 'id', id)
+            ELSE named_struct('type', 'odd', 'id', id)
+       END as result
+FROM (VALUES (1), (2), (3), (4)) t(id)
+ORDER BY result;
+
+-- Struct comparison in WHERE clause
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('name', 'Alice', 'age', 25)),
+        (2, named_struct('name', 'Bob', 'age', 30)),
+        (3, named_struct('name', 'Charlie', 'age', 20))
+) t(id, info)
+WHERE info > named_struct('name', 'Alice', 'age', 20)
+ORDER BY info;
+
+-- Struct with DISTINCT
+SELECT DISTINCT info FROM (
+    VALUES 
+        (named_struct('name', 'Alice', 'age', 25)),
+        (named_struct('name', 'Bob', 'age', 30)),
+        (named_struct('name', 'Alice', 'age', 25)),
+        (named_struct('name', 'Charlie', 'age', 20))
+) t(info)
+ORDER BY info;
+
+-- Clean up
+DROP TABLE test_struct_edge FORCE;

--- a/test/sql/test_sort/T/test_struct_topn.sql
+++ b/test/sql/test_sort/T/test_struct_topn.sql
@@ -1,0 +1,102 @@
+-- name: test_struct_topn
+
+drop database if exists test_struct_topn;
+create database test_struct_topn;
+use test_struct_topn;
+
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('name', 'Alice', 'score', 95)),
+        (2, named_struct('name', 'Bob', 'score', 88)),
+        (3, named_struct('name', 'Charlie', 'score', 92)),
+        (4, named_struct('name', 'David', 'score', 85)),
+        (5, named_struct('name', 'Eve', 'score', 90))
+) t(id, info) 
+ORDER BY info 
+LIMIT 3;
+
+-- TOPN with struct DESC
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('name', 'Alice', 'score', 95)),
+        (2, named_struct('name', 'Bob', 'score', 88)),
+        (3, named_struct('name', 'Charlie', 'score', 92)),
+        (4, named_struct('name', 'David', 'score', 85)),
+        (5, named_struct('name', 'Eve', 'score', 90))
+) t(id, info) 
+ORDER BY info DESC 
+LIMIT 3;
+
+-- Struct with complex types
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('name', 'Alice', 'age', 25, 'scores', [90, 85, 88])),
+        (2, named_struct('name', 'Bob', 'age', 30, 'scores', [88, 92, 85])),
+        (3, named_struct('name', 'Charlie', 'age', 22, 'scores', [95, 90, 93]))
+) t(id, info) 
+ORDER BY info 
+LIMIT 2;
+
+-- ORDER BY with multiple struct columns
+SELECT * FROM (
+    VALUES 
+        (1, named_struct('name', 'Alice', 'age', 25), named_struct('city', 'Beijing', 'country', 'China')),
+        (2, named_struct('name', 'Bob', 'age', 30), named_struct('city', 'Tokyo', 'country', 'Japan')),
+        (3, named_struct('name', 'Alice', 'age', 30), named_struct('city', 'Beijing', 'country', 'China'))
+) t(id, person, location) 
+ORDER BY person, location 
+LIMIT 2;
+
+-- ORDER BY struct in CTE
+WITH data AS (
+    SELECT * FROM (
+        VALUES 
+            (1, named_struct('name', 'Alice', 'dept', 'IT')),
+            (2, named_struct('name', 'Bob', 'dept', 'HR')),
+            (3, named_struct('name', 'Charlie', 'dept', 'IT')),
+            (4, named_struct('name', 'David', 'dept', 'Sales'))
+    ) t(id, employee)
+)
+SELECT * FROM data ORDER BY employee LIMIT 3;
+
+-- Struct ordering with large dataset simulation
+CREATE TABLE IF NOT EXISTS test_struct_topn (
+    id INT,
+    info STRUCT<category STRING, value INT, timestamp DATETIME>
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id)
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO test_struct_topn VALUES
+    (1, named_struct('category', 'A', 'value', 100, 'timestamp', '2024-01-01 10:00:00')),
+    (2, named_struct('category', 'B', 'value', 200, 'timestamp', '2024-01-02 10:00:00')),
+    (3, named_struct('category', 'A', 'value', 150, 'timestamp', '2024-01-03 10:00:00')),
+    (4, named_struct('category', 'C', 'value', 180, 'timestamp', '2024-01-04 10:00:00')),
+    (5, named_struct('category', 'B', 'value', 120, 'timestamp', '2024-01-05 10:00:00')),
+    (6, named_struct('category', 'A', 'value', 100, 'timestamp', '2024-01-06 10:00:00')),
+    (7, named_struct('category', 'C', 'value', 220, 'timestamp', '2024-01-07 10:00:00')),
+    (8, named_struct('category', 'B', 'value', 190, 'timestamp', '2024-01-08 10:00:00')),
+    (9, named_struct('category', 'A', 'value', 110, 'timestamp', '2024-01-09 10:00:00')),
+    (10, named_struct('category', 'C', 'value', 160, 'timestamp', '2024-01-10 10:00:00'));
+
+-- TOPN with table
+SELECT * FROM test_struct_topn ORDER BY info LIMIT 5;
+
+-- TOPN DESC with table
+SELECT * FROM test_struct_topn ORDER BY info DESC LIMIT 5;
+
+-- TOPN with OFFSET
+SELECT * FROM test_struct_topn ORDER BY info LIMIT 3 OFFSET 2;
+
+-- TOPN with WHERE clause
+SELECT * FROM test_struct_topn WHERE id > 3 ORDER BY info LIMIT 4;
+
+-- TOPN with window function
+SELECT id, info, 
+       ROW_NUMBER() OVER (ORDER BY info) as rn
+FROM test_struct_topn 
+ORDER BY info 
+LIMIT 5;
+
+-- Clean up
+DROP TABLE test_struct_topn FORCE;

--- a/test/sql/test_sorted_streaming_agg/R/sorted_streaming_agg_spill
+++ b/test/sql/test_sorted_streaming_agg/R/sorted_streaming_agg_spill
@@ -5,6 +5,9 @@ set enable_spill=true;
 set spill_mode="force";
 -- result:
 -- !result
+set enable_agg_spill_preaggregation=false;
+-- result:
+-- !result
 CREATE TABLE `test_basic` (
   `id_int` int(11) NOT NULL COMMENT "",
   `id_tinyint` tinyint(4) NOT NULL COMMENT "",
@@ -89,4 +92,55 @@ select count(*), c_1_0, c_1_1 from t_array group by c_1_0, c_1_1 order by c_1_0,
 1	1	[2]
 1	1	[2,null]
 1	2	[1,2,3]
+-- !result
+CREATE TABLE `t_struct` (
+    `c_1_0` int NULL COMMENT "",
+    `c_1_1` struct<name varchar(20), age int> NULL COMMENT ""
+) ENGINE = OLAP 
+DUPLICATE KEY(`c_1_0`) COMMENT "OLAP" 
+DISTRIBUTED BY HASH(`c_1_0`) BUCKETS 1 PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t_struct values (null, null), (1, row('Alice', 25)), (1, row('Alice', 25)), (1, row('Bob', 30)), (1, null), (null, row('Alice', 25));
+-- result:
+-- !result
+insert into t_struct values (null, null), (1, row('Alice', 25)), (1, row('Alice', 30)), (2, row('Bob', 30)), (1, null), (null, row('Charlie', 35));
+-- result:
+-- !result
+insert into t_struct values (null, null), (1, row('Alice', null)), (1, row('Bob', null)), (1, row('Alice', null));
+-- result:
+-- !result
+select count(*), c_1_0 from t_struct group by c_1_0 order by c_1_0;
+-- result:
+5	None
+10	1
+1	2
+-- !result
+select count(*), c_1_1 from t_struct group by c_1_1 order by c_1_1;
+-- result:
+5	None
+2	{"name":"Alice","age":null}
+4	{"name":"Alice","age":25}
+1	{"name":"Alice","age":30}
+1	{"name":"Bob","age":null}
+2	{"name":"Bob","age":30}
+1	{"name":"Charlie","age":35}
+-- !result
+select count(*), c_1_0, c_1_1 from t_struct group by c_1_0, c_1_1 order by c_1_0, c_1_1;
+-- result:
+3	None	None
+1	None	{"name":"Alice","age":25}
+1	None	{"name":"Charlie","age":35}
+2	1	None
+2	1	{"name":"Alice","age":null}
+3	1	{"name":"Alice","age":25}
+1	1	{"name":"Alice","age":30}
+1	1	{"name":"Bob","age":null}
+1	1	{"name":"Bob","age":30}
+1	2	{"name":"Bob","age":30}
+-- !result
+set enable_agg_spill_preaggregation=true;
+-- result:
 -- !result

--- a/test/sql/test_sorted_streaming_agg/T/sorted_streaming_agg_spill
+++ b/test/sql/test_sorted_streaming_agg/T/sorted_streaming_agg_spill
@@ -1,7 +1,8 @@
 -- name: test_sorted_streaming_agg_spill
 set enable_spill=true;
 set spill_mode="force";
--- 
+set enable_agg_spill_preaggregation=false;
+
 CREATE TABLE `test_basic` (
   `id_int` int(11) NOT NULL COMMENT "",
   `id_tinyint` tinyint(4) NOT NULL COMMENT "",
@@ -54,3 +55,22 @@ insert into t_array values (null, null), (1, [1, null]), (1, [2, null]), (1, [1,
 select count(*), c_1_0 from t_array group by c_1_0 order by c_1_0;
 select count(*), c_1_1 from t_array group by c_1_1 order by c_1_1;
 select count(*), c_1_0, c_1_1 from t_array group by c_1_0, c_1_1 order by c_1_0, c_1_1;
+
+-- test struct
+CREATE TABLE `t_struct` (
+    `c_1_0` int NULL COMMENT "",
+    `c_1_1` struct<name varchar(20), age int> NULL COMMENT ""
+) ENGINE = OLAP 
+DUPLICATE KEY(`c_1_0`) COMMENT "OLAP" 
+DISTRIBUTED BY HASH(`c_1_0`) BUCKETS 1 PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into t_struct values (null, null), (1, row('Alice', 25)), (1, row('Alice', 25)), (1, row('Bob', 30)), (1, null), (null, row('Alice', 25));
+insert into t_struct values (null, null), (1, row('Alice', 25)), (1, row('Alice', 30)), (2, row('Bob', 30)), (1, null), (null, row('Charlie', 35));
+insert into t_struct values (null, null), (1, row('Alice', null)), (1, row('Bob', null)), (1, row('Alice', null));
+
+select count(*), c_1_0 from t_struct group by c_1_0 order by c_1_0;
+select count(*), c_1_1 from t_struct group by c_1_1 order by c_1_1;
+select count(*), c_1_0, c_1_1 from t_struct group by c_1_0, c_1_1 order by c_1_0, c_1_1;
+set enable_agg_spill_preaggregation=true;


### PR DESCRIPTION
## Why I'm doing:

StarRocks previously did not support `ORDER BY` on STRUCT data types. When users attempted to sort queries with STRUCT columns, they would encounter "Not support" errors. 
To enable `ORDER BY` on STRUCT columns, the backend (BE) needed to implement several missing visitor pattern methods for `StructColumn` across different execution contexts (sorting, comparison, aggregation, and spilling).

## What I'm doing:

### Frontend (FE) Changes:
Enable STRUCT orderability at the type system level:

- **`Type.java`**: Modified `canOrderBy()` to support STRUCT types
  
- **`TypeDescriptor.cpp`**: Added `support_orderby()` validation for `TYPE_STRUCT`

### Backend (BE) Changes:
Implemented missing `StructColumn` visitor methods required for `ORDER BY` support:

1. **`ColumnCompare::do_visit(StructColumn)`** in `compare_column.cpp`:

2. **`ColumnSelfComparator::do_visit(StructColumn)`** in `sorted_streaming_aggregator.cpp`:

3. **`AppendWithMask::do_visit(StructColumn)`** in `sorted_streaming_aggregator.cpp`:

4. **`VerticalColumnSorter::do_visit(StructColumn)`** in `sort_column.cpp`:

### Struct Comparison Semantics:
All implementations follow field-by-field comparison:
- Compare fields in order from first to last
- First differing field determines the overall comparison result
- If all fields are equal, the STRUCTs are considered equal

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable ORDER BY on STRUCT by adding StructColumn comparison/sorting support in BE and allowing STRUCT orderability in FE types, with comprehensive tests.
> 
> - **Backend**:
>   - **Sorting/Comparison**:
>     - Implement `StructColumn` in `ColumnCompare::do_visit` (`be/src/exec/sorting/compare_column.cpp`).
>     - Add `StructColumn` handling to `VerticalColumnSorter::do_visit` (`be/src/exec/sorting/sort_column.cpp`).
>     - Support `StructColumn` in `ColumnSelfComparator::do_visit` and `AppendWithMask::do_visit` (`be/src/exec/sorted_streaming_aggregator.cpp`).
>   - **Type System**:
>     - Allow `TYPE_STRUCT` in `TypeDescriptor::support_orderby()` (`be/src/runtime/types.cpp`).
> - **Frontend**:
>   - **Type**: Permit `STRUCT` in `Type.canOrderBy()` (`fe/fe-type/.../Type.java`).
>   - **Analyzer Test**: Update to accept `ORDER BY` on struct (`AnalyzeStructTest.java`).
> - **Tests**:
>   - Add extensive SQL tests for `ORDER BY` on `STRUCT` and `ARRAY<STRUCT>`, including nested, NULLs, TopN, JOIN/UNION/CTE cases, and spill scenarios (`test/sql/test_sort/**/*`, `test/sql/test_sorted_streaming_agg/*`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82f879876428bdeab2b631d13d88b6871e19aeb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->