### PR TITLE
[BugFix] If the operator is AND, return the predicates that are not null for paimon

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonPredicateContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonPredicateContext.java
@@ -1,0 +1,29 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.connector.paimon;
+
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
+
+public class PaimonPredicateContext {
+    private CompoundPredicateOperator parentPredicateOperator;
+
+    public CompoundPredicateOperator getParentPredicateOperator() {
+        return parentPredicateOperator;
+    }
+
+    public void setParentPredicateOperator(
+            CompoundPredicateOperator parentPredicateOperator) {
+        this.parentPredicateOperator = parentPredicateOperator;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonPredicateConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonPredicateConverter.java
@@ -109,6 +109,11 @@ public class PaimonPredicateConverter extends ScalarOperatorVisitor<Predicate, V
             if (left != null && right != null) {
                 return (op == CompoundPredicateOperator.CompoundType.OR) ? PredicateBuilder.or(left, right) :
                         PredicateBuilder.and(left, right);
+            } else if (left != null && op == CompoundPredicateOperator.CompoundType.AND) {
+                //if op=and, return the predicates that are not null.
+                return left;
+            } else if (right != null && op == CompoundPredicateOperator.CompoundType.AND) {
+                return right;
             }
         }
         return null;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonPredicateConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonPredicateConverterTest.java
@@ -417,7 +417,8 @@ public class PaimonPredicateConverterTest {
                 BinaryType.EQ, F0, ConstantOperator.createInt(44));
         CaseWhenOperator caseWhenOperator = new CaseWhenOperator(IntegerType.INT, op2, null,
                 Lists.newArrayList(op2, ConstantOperator.createVarchar("test")));
-        BinaryPredicateOperator test = new BinaryPredicateOperator(BinaryType.EQ, caseWhenOperator, ConstantOperator.createVarchar("test"));
+        BinaryPredicateOperator test =
+                new BinaryPredicateOperator(BinaryType.EQ, caseWhenOperator, ConstantOperator.createVarchar("test"));
         ScalarOperator op20 = new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.AND, op2,
                 test.clone());
 
@@ -445,8 +446,13 @@ public class PaimonPredicateConverterTest {
         // return null
         ScalarOperator op40 = new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.OR, test.clone(),
                 op21.clone());
-        CompoundPredicate convert1 = (CompoundPredicate) CONVERTER.convert(op40);
+        CompoundPredicate convert1 = (CompoundPredicate) CONVERTER.convert(op40.clone());
         Assertions.assertTrue(convert1 == null);
 
+        // NOT (f0 <= 46 and (case when f0 = 44 then 'test' end) = 'test')
+        // return null
+        ScalarOperator op52 = new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.NOT, op21.clone());
+        Predicate convert2 = CONVERTER.convert(op52);
+        Assertions.assertTrue(convert2 == null);
     }
 }


### PR DESCRIPTION
## Why I'm doing:
For the following predicate:
f0 = 44 and (case when f0 = 44 then f1 else f2) = 33,
Paimon cannot parse the predicate (case when f0 = 44 then f1 else f2) = 33, and the predicate conversion returns null.
Normally, the predicate f0 = 44 should be retained.
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves Paimon predicate conversion robustness and partial-predicate preservation.
> 
> - Add `PaimonPredicateContext` to track parent `CompoundPredicateOperator`
> - Update `PaimonPredicateConverter` to accept `PaimonPredicateContext` and propagate it to children
> - For `AND`, return the non-null predicate when one side is unconvertible; under parent `NOT`, return `null` to avoid invalid partials; keep NOT over `LIKE` unsupported
> - Update visitor method signatures to use the new context
> - Add `testOrWithFunction` validating mixed `OR`/`AND`/`NOT` with `CASE WHEN` and `LIKE`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b92c31f6f803e29dd6b810e3ac1e5470d4cf729. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->