### PR TITLE
[BugFix] cancel MemoryScratchSinkOperator when RecordBatchQueue shutdown

### DIFF
--- a/be/src/exec/pipeline/sink/memory_scratch_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/memory_scratch_sink_operator.cpp
@@ -59,7 +59,7 @@ bool MemoryScratchSinkOperator::pending_finish() const {
     // After set_finishing, there may be data that has not been sent.
     // We need to ensure that all remaining data are put into the queue.
     const_cast<MemoryScratchSinkOperator*>(this)->try_to_put_sentinel();
-    return !(_is_finished && _pending_result == nullptr && _has_put_sentinel);
+    return !(_is_finished && ((_pending_result == nullptr && _has_put_sentinel) || _queue->is_shutdown()));
 }
 
 Status MemoryScratchSinkOperator::set_cancelled(RuntimeState* state) {

--- a/be/src/runtime/record_batch_queue.h
+++ b/be/src/runtime/record_batch_queue.h
@@ -50,6 +50,8 @@ public:
 
     bool try_put(const std::shared_ptr<arrow::RecordBatch>& val) { return _queue.try_put(val); }
 
+    bool is_shutdown() const { return _queue.is_shutdown(); }
+
     // Shut down the queue. Wakes up all threads waiting on blocking_get or blocking_put.
     void shutdown();
 

--- a/be/src/util/blocking_queue.hpp
+++ b/be/src/util/blocking_queue.hpp
@@ -195,6 +195,11 @@ public:
         return true;
     }
 
+    bool is_shutdown() const {
+        std::lock_guard<Lock> guard(_lock);
+        return _shutdown;
+    }
+
     // Shutdown the queue, this will wake up all waiting threads.
     void shutdown() {
         std::lock_guard<Lock> guard(_lock);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

When SparkSQL exits due to a limit or query error, the RecordBatchQueue will shut down. At this point, `try_put` will continuously fail, and `_has_put_sentinel` will not be updated, causing the operator to remain in a pending_finish state. In this situation, we should allow the operator to terminate.

```cpp
    bool try_put(const T& val) {
        std::unique_lock<Lock> l(_lock);
        if (_items.size() >= _capacity || _shutdown) {
            return false;
        }
        _items.emplace_back(val);
        _not_empty.notify_one();
        return true;
    }

void MemoryScratchSinkOperator::try_to_put_sentinel() {
    // NOTE: Must be implemented idempotent!
    if (_pending_result != nullptr) {
        if (!_queue->try_put(_pending_result)) {
            return;
        }
        _pending_result.reset();
    }
    // the result queue uses nullptr as a sentinel to indicate that no new data is generated.
    if (!_has_put_sentinel && _queue->try_put(nullptr)) {
        _has_put_sentinel = true;
    }
}
```
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `MemoryScratchSinkOperator::pending_finish()` completes when the underlying `RecordBatchQueue` is shutdown by exposing `is_shutdown()` on both `RecordBatchQueue` and `BlockingQueue`.
> 
> - **Execution/Sink**
>   - Update `MemoryScratchSinkOperator::pending_finish()` to treat `_queue->is_shutdown()` as a completion condition.
> - **Runtime**
>   - Add `RecordBatchQueue::is_shutdown()` delegating to underlying queue.
> - **Util**
>   - Add thread-safe `BlockingQueue::is_shutdown()` for shutdown state checks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 27b5f4c32cd84bf9bb87afed851793e35985848b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->