### PR TITLE
[Enhancement] support creating iceberg view with properties (backport #65938)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergView.java
@@ -15,23 +15,28 @@
 package com.starrocks.catalog;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
 import com.starrocks.analysis.TableName;
 import com.starrocks.sql.ast.TableRelation;
 
 import java.util.List;
+import java.util.Map;
 
 public class IcebergView extends ConnectorView {
     private final String defaultCatalogName;
     private final String defaultDbName;
     private final String location;
+    private final Map<String, String> properties;
     public static final String STARROCKS_DIALECT = "starrocks";
 
     public IcebergView(long id, String catalogName, String dbName, String name, List<Column> schema,
-                       String definition, String defaultCatalogName, String defaultDbName, String location) {
+                       String definition, String defaultCatalogName, String defaultDbName,
+                       String location, Map<String, String> properties) {
         super(id, catalogName, dbName, name, schema, definition, TableType.ICEBERG_VIEW);
         this.defaultCatalogName = defaultCatalogName;
         this.defaultDbName = defaultDbName;
         this.location = location;
+        this.properties = properties != null ? properties : Maps.newHashMap();
     }
 
     @Override
@@ -59,5 +64,10 @@ public class IcebergView extends ConnectorView {
     @Override
     public String getTableLocation() {
         return location;
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+        return properties;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorViewDefinition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorViewDefinition.java
@@ -48,7 +48,7 @@ public class ConnectorViewDefinition {
         this.columns = columns;
         this.inlineViewDef = inlineViewDef;
         this.alterDialect = alterDialect;
-        this.properties = properties;
+        this.properties = properties == null ? Maps.newHashMap() : properties;
     }
 
     public static ConnectorViewDefinition fromCreateViewStmt(CreateViewStmt stmt) {
@@ -60,7 +60,7 @@ public class ConnectorViewDefinition {
                 stmt.getColumns(),
                 stmt.getInlineViewDef(),
                 AlterViewStmt.AlterDialectType.NONE,
-                Maps.newHashMap());
+                stmt.getProperties());
     }
 
     public static ConnectorViewDefinition fromAlterViewStmt(AlterViewStmt stmt) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -2032,6 +2032,7 @@ public class AstToStringBuilder {
         try {
             properties = new HashMap<>(table.getProperties());
         } catch (NotImplementedException e) {
+            // hive view does not implement getProperties
         }
 
         // Location
@@ -2064,6 +2065,18 @@ public class AstToStringBuilder {
         }
         sb.append(Joiner.on(", ").join(colDef));
         sb.append(")");
+
+        // Properties
+        Map<String, String> properties = new HashMap<>();
+        try {
+            properties = new HashMap<>(view.getProperties());
+        } catch (NotImplementedException e) {
+        }
+        if (!properties.isEmpty()) {
+            sb.append("\nPROPERTIES (");
+            sb.append(new PrintableMap<>(properties, "=", true, false, true).toString());
+            sb.append(")\n");
+        }
 
         sb.append(" AS ").append(view.getInlineViewDef()).append(";");
         return sb.toString();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateViewStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateViewStmt.java
@@ -15,11 +15,13 @@
 package com.starrocks.sql.ast;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Column;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
+import java.util.Map;
 
 public class CreateViewStmt extends DdlStmt {
     private final TableName tableName;
@@ -33,6 +35,7 @@ public class CreateViewStmt extends DdlStmt {
     //Resolved by Analyzer
     protected List<Column> columns;
     private String inlineViewDef;
+    private Map<String, String> properties;
 
     public CreateViewStmt(boolean ifNotExists,
                           boolean replace,
@@ -42,6 +45,18 @@ public class CreateViewStmt extends DdlStmt {
                           boolean security,
                           QueryStatement queryStmt,
                           NodePosition pos) {
+        this(ifNotExists, replace, tableName, colWithComments, comment, security, queryStmt, pos, Maps.newHashMap());
+    }
+
+    public CreateViewStmt(boolean ifNotExists,
+                          boolean replace,
+                          TableName tableName,
+                          List<ColWithComment> colWithComments,
+                          String comment,
+                          boolean security,
+                          QueryStatement queryStmt,
+                          NodePosition pos,
+                          Map<String, String> properties) {
         super(pos);
         this.ifNotExists = ifNotExists;
         this.replace = replace;
@@ -50,6 +65,7 @@ public class CreateViewStmt extends DdlStmt {
         this.comment = Strings.nullToEmpty(comment);
         this.security = security;
         this.queryStatement = queryStmt;
+        this.properties = properties != null ? properties : Maps.newHashMap();
     }
 
     public String getCatalog() {
@@ -90,6 +106,14 @@ public class CreateViewStmt extends DdlStmt {
 
     public QueryStatement getQueryStatement() {
         return queryStatement;
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public void setProperties(Map<String, String> properties) {
+        this.properties = properties;
     }
 
     public void setColumns(List<Column> columns) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1707,7 +1707,10 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                 colWithComments,
                 context.comment() == null ? null : ((StringLiteral) visit(context.comment())).getStringValue(),
                 isSecurity,
-                (QueryStatement) visit(context.queryStatement()), createPos(context));
+                (QueryStatement) visit(context.queryStatement()),
+                createPos(context),
+                buildProperties(context.properties())
+                );
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -647,6 +647,7 @@ createViewStatement
     ('(' columnNameWithComment (',' columnNameWithComment)* ')')?
     comment?
     (SECURITY (NONE | INVOKER))?
+    properties?
     AS queryStatement
     ;
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergHiveCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergHiveCatalogTest.java
@@ -242,15 +242,11 @@ public class IcebergHiveCatalogTest {
     }
 
     @Test
-    public void testCreateViewPropertiesNotIcebergCatalog(@Mocked GlobalStateMgr mockGsm, @Mocked CatalogMgr mockCatalogMgr) {
+    public void testCreateViewPropertiesNotIcebergCatalog(@Mocked CatalogMgr mockCatalogMgr) {
         final String catalogName = "catalog";
         new Expectations() {
             {
-                GlobalStateMgr.getCurrentState();
-                result = mockGsm;
-                minTimes = 0;
-
-                mockGsm.getCatalogMgr();
+                GlobalStateMgr.getCurrentState().getCatalogMgr();
                 result = mockCatalogMgr;
                 minTimes = 0;
 
@@ -275,15 +271,11 @@ public class IcebergHiveCatalogTest {
     }
 
     @Test
-    public void testCreateViewPropertiesInternalCatalog(@Mocked GlobalStateMgr mockGsm, @Mocked CatalogMgr mockCatalogMgr) {
+    public void testCreateViewPropertiesInternalCatalog(@Mocked CatalogMgr mockCatalogMgr) {
         final String catalogName = "default_catalog";
         new Expectations() {
             {
-                GlobalStateMgr.getCurrentState();
-                result = mockGsm;
-                minTimes = 0;
-
-                mockGsm.getCatalogMgr();
+                GlobalStateMgr.getCurrentState().getCatalogMgr();
                 result = mockCatalogMgr;
                 minTimes = 0;
 
@@ -308,15 +300,11 @@ public class IcebergHiveCatalogTest {
     }
 
     @Test
-    public void testCreateViewPropertiesUnknownCatalog(@Mocked GlobalStateMgr mockGsm, @Mocked CatalogMgr mockCatalogMgr) {
+    public void testCreateViewPropertiesUnknownCatalog(@Mocked CatalogMgr mockCatalogMgr) {
         final String catalogName = "xxx";
         new Expectations() {
             {
-                GlobalStateMgr.getCurrentState();
-                result = mockGsm;
-                minTimes = 0;
-
-                mockGsm.getCatalogMgr();
+                GlobalStateMgr.getCurrentState().getCatalogMgr();
                 result = mockCatalogMgr;
                 minTimes = 0;
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergHiveCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergHiveCatalogTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector.iceberg;
 
 import com.google.common.collect.ImmutableList;
@@ -25,7 +24,12 @@ import com.starrocks.catalog.Table;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.iceberg.hive.IcebergHiveCatalog;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.CatalogMgr;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
+import com.starrocks.sql.analyzer.AstToStringBuilder;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.analyzer.ViewAnalyzer;
 import com.starrocks.sql.ast.AlterViewStmt;
 import com.starrocks.sql.ast.ColWithComment;
 import com.starrocks.sql.ast.CreateViewStmt;
@@ -57,12 +61,11 @@ import static com.starrocks.connector.iceberg.IcebergCatalogProperties.HIVE_META
 import static com.starrocks.connector.iceberg.IcebergCatalogProperties.ICEBERG_CATALOG_TYPE;
 
 public class IcebergHiveCatalogTest {
-    private static final String CATALOG_NAME = "iceberg_hive_catalog";
     public static final Map<String, String> DEFAULT_CONFIG = new HashMap<>();
     public static final IcebergCatalogProperties DEFAULT_CATALOG_PROPERTIES;
-    public static ConnectContext connectContext;
-
     public static final HdfsEnvironment HDFS_ENVIRONMENT = new HdfsEnvironment();
+    private static final String CATALOG_NAME = "iceberg_hive_catalog";
+    public static ConnectContext connectContext;
 
     static {
         DEFAULT_CONFIG.put(HIVE_METASTORE_URIS, "thrift://188.122.12.1:8732"); // non-exist ip, prevent to connect local service
@@ -180,6 +183,160 @@ public class IcebergHiveCatalogTest {
     }
 
     @Test
+    public void testCreateViewWithProperties(@Mocked HiveCatalog hiveCatalog,
+                                             @Mocked BaseView baseView,
+                                             @Mocked ImmutableSQLViewRepresentation representation) throws Exception {
+        IcebergMetadata metadata = buildIcebergMetadata(hiveCatalog);
+
+        new Expectations() {
+            {
+                hiveCatalog.loadNamespaceMetadata(Namespace.of("db"));
+                result = ImmutableMap.of("location", "xxxxx");
+                minTimes = 1;
+            }
+        };
+
+        CreateViewStmt stmt = new CreateViewStmt(false, false, new TableName("catalog", "db", "table"),
+                Lists.newArrayList(new ColWithComment("k1", "", NodePosition.ZERO)), "", false, null,
+                NodePosition.ZERO, ImmutableMap.of("owner", "alex"));
+        stmt.setColumns(Lists.newArrayList(new Column("k1", INT)));
+        metadata.createView(connectContext, stmt);
+
+        new Expectations() {
+            {
+                representation.sql();
+                result = "select * from table";
+                minTimes = 1;
+
+                baseView.sqlFor("starrocks");
+                result = representation;
+                minTimes = 1;
+
+                baseView.properties();
+                result = ImmutableMap.of("owner", "alex");
+                minTimes = 1;
+
+                baseView.schema();
+                result = new Schema(Types.NestedField.optional(1, "k1", Types.IntegerType.get()));
+                minTimes = 1;
+
+                baseView.name();
+                result = "view";
+                minTimes = 1;
+
+                baseView.location();
+                result = "xxx";
+                minTimes = 1;
+
+                hiveCatalog.loadView(TableIdentifier.of("db", "view"));
+                result = baseView;
+                minTimes = 1;
+            }
+        };
+
+        Table table = metadata.getView(connectContext, "db", "view");
+        Assertions.assertEquals(ICEBERG_VIEW, table.getType());
+        Assertions.assertEquals("view", table.getName());
+        IcebergView icebergView = (IcebergView) table;
+        Assertions.assertEquals("alex", icebergView.getProperties().get("owner"));
+    }
+
+    @Test
+    public void testCreateViewPropertiesNotIcebergCatalog(@Mocked GlobalStateMgr mockGsm, @Mocked CatalogMgr mockCatalogMgr) {
+        final String catalogName = "catalog";
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = mockGsm;
+                minTimes = 0;
+
+                mockGsm.getCatalogMgr();
+                result = mockCatalogMgr;
+                minTimes = 0;
+
+                mockCatalogMgr.catalogExists(catalogName);
+                result = true;
+                minTimes = 0;
+
+                mockCatalogMgr.getCatalogType(catalogName);
+                result = "hive";
+                minTimes = 0;
+            }
+        };
+
+        CreateViewStmt stmt = new CreateViewStmt(false, false,
+                new TableName(catalogName, "db", "table"),
+                Lists.newArrayList(new ColWithComment("k1", "", NodePosition.ZERO)),
+                "", false, null, NodePosition.ZERO, ImmutableMap.of("owner", "alex"));
+
+        Assertions.assertThrows(SemanticException.class, () -> {
+            ViewAnalyzer.analyze(stmt, connectContext);
+        });
+    }
+
+    @Test
+    public void testCreateViewPropertiesInternalCatalog(@Mocked GlobalStateMgr mockGsm, @Mocked CatalogMgr mockCatalogMgr) {
+        final String catalogName = "default_catalog";
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = mockGsm;
+                minTimes = 0;
+
+                mockGsm.getCatalogMgr();
+                result = mockCatalogMgr;
+                minTimes = 0;
+
+                mockCatalogMgr.catalogExists(catalogName);
+                result = true;
+                minTimes = 0;
+
+                CatalogMgr.isInternalCatalog(catalogName);
+                result = true;
+                minTimes = 0;
+            }
+        };
+
+        CreateViewStmt stmt = new CreateViewStmt(false, false,
+                new TableName(catalogName, "db", "table"),
+                Lists.newArrayList(new ColWithComment("k1", "", NodePosition.ZERO)),
+                "", false, null, NodePosition.ZERO, ImmutableMap.of("owner", "alex"));
+
+        Assertions.assertThrows(SemanticException.class, () -> {
+            ViewAnalyzer.analyze(stmt, connectContext);
+        });
+    }
+
+    @Test
+    public void testCreateViewPropertiesUnknownCatalog(@Mocked GlobalStateMgr mockGsm, @Mocked CatalogMgr mockCatalogMgr) {
+        final String catalogName = "xxx";
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = mockGsm;
+                minTimes = 0;
+
+                mockGsm.getCatalogMgr();
+                result = mockCatalogMgr;
+                minTimes = 0;
+
+                mockCatalogMgr.catalogExists(catalogName);
+                result = false;
+                minTimes = 0;
+            }
+        };
+
+        CreateViewStmt stmt = new CreateViewStmt(false, false,
+                new TableName(catalogName, "db", "table"),
+                Lists.newArrayList(new ColWithComment("k1", "", NodePosition.ZERO)),
+                "", false, null, NodePosition.ZERO, ImmutableMap.of("owner", "alex"));
+
+        Assertions.assertThrows(SemanticException.class, () -> {
+            ViewAnalyzer.analyze(stmt, connectContext);
+        });
+    }
+
+    @Test
     public void testAlterViewProperties(@Mocked HiveCatalog hiveCatalog, @Mocked BaseView baseView,
                                         @Mocked ImmutableSQLViewRepresentation representation) throws Exception {
         IcebergMetadata metadata = buildIcebergMetadata(hiveCatalog);
@@ -218,5 +375,22 @@ public class IcebergHiveCatalogTest {
 
         Table table = metadata.getView(connectContext, "db", "view");
         Assertions.assertEquals("no comment", table.getComment());
+    }
+
+    @Test
+    public void testExternalCatalogViewDdlPropertiesPrinting() {
+        List<Column> cols = Lists.newArrayList(new Column("k1", INT));
+        Map<String, String> props = ImmutableMap.of(
+                "owner", "alex",
+                "comment", "this is a test view"
+        );
+
+        IcebergView view = new IcebergView(1L, "catalog", "db", "view", cols,
+                "select 1", "catalog", "db", "loc", props);
+
+        String ddl = AstToStringBuilder.getExternalCatalogViewDdlStmt(view);
+        Assertions.assertTrue(ddl.contains("PROPERTIES ("));
+        Assertions.assertTrue(ddl.contains("\"owner\" = \"alex\""));
+        Assertions.assertTrue(ddl.contains("\"comment\" = \"this is a test view\""));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
@@ -210,7 +210,7 @@ public class IcebergRESTCatalogTest {
             Table getTable(ConnectContext context, String dbName, String tblName) {
                 return new IcebergView(1, "iceberg_rest_catalog", "db", "view",
                         Lists.newArrayList(), "mocked", "iceberg_rest_catalog", "db",
-                        "location");
+                        "location", Maps.newHashMap());
             }
         };
 

--- a/test/sql/test_iceberg/R/test_iceberg_view
+++ b/test/sql/test_iceberg/R/test_iceberg_view
@@ -12,6 +12,58 @@ select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_${uuid0}
 drop view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_${uuid0};
 -- result:
 -- !result
+create view if not exists iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0}
+properties ("owner"="alex") as select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+-- result:
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0} order by k1;
+-- result:
+1	beijing	zhangsan
+2	shanghai	lisi
+-- !result
+show create table iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+-- result:
+iceberg_v2_parquet_partitioned_table	CREATE TABLE `iceberg_v2_parquet_partitioned_table` (
+  `k1` int(11) DEFAULT NULL,
+  `k2` varchar(1073741824) DEFAULT NULL,
+  `k3` varchar(1073741824) DEFAULT NULL
+)
+PARTITION BY (`k3`)
+PROPERTIES ("write-format" = "parquet", "location" = "oss://starrocks-ci-test/iceberg_ci_db/iceberg_v2_parquet_partitioned_table", "write.upsert.enabled" = "true");
+-- !result
+show create view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0};
+-- result:
+[REGEX].*"owner" = "alex".*
+-- !result
+drop view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0};
+-- result:
+-- !result
+create view if not exists iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0}
+properties ("owner"="alex", "comment"="this is a test view") as select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+-- result:
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0} order by k1;
+-- result:
+1	beijing	zhangsan
+2	shanghai	lisi
+-- !result
+show create view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0};
+-- result:
+[REGEX].*("owner" = "alex".*"comment" = "this is a test view"|"comment" = "this is a test view".*"owner" = "alex").*
+-- !result
+drop view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0};
+-- result:
+-- !result
+create database default_catalog.test_internal_db_${uuid0};
+-- result:
+-- !result
+create view if not exists default_catalog.test_internal_db_${uuid0}.test_internal_view_${uuid0} properties ("key"="value") as select 1 from dual;
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Setting properties is only supported for Iceberg views.')
+-- !result
+drop database default_catalog.test_internal_db_${uuid0};
+-- result:
+-- !result
 create view if not exists iceberg_sql_test_${uuid0}.iceberg_ci_db.test_alter_iceberg_view_${uuid0} as select k1, k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
 -- result:
 -- !result

--- a/test/sql/test_iceberg/T/test_iceberg_view
+++ b/test/sql/test_iceberg/T/test_iceberg_view
@@ -8,6 +8,32 @@ select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_${uuid0}
 
 drop view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_${uuid0};
 
+create view if not exists iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0}
+properties ("owner"="alex") as select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0} order by k1;
+
+show create table iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+
+show create view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0};
+
+drop view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0};
+
+create view if not exists iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0}
+properties ("owner"="alex", "comment"="this is a test view") as select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+
+select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0} order by k1;
+
+show create view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0};
+
+drop view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0};
+
+create database default_catalog.test_internal_db_${uuid0};
+
+create view if not exists default_catalog.test_internal_db_${uuid0}.test_internal_view_${uuid0} properties ("key"="value") as select 1 from dual;
+
+drop database default_catalog.test_internal_db_${uuid0};
+
 create view if not exists iceberg_sql_test_${uuid0}.iceberg_ci_db.test_alter_iceberg_view_${uuid0} as select k1, k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
 
 select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_alter_iceberg_view_${uuid0} order by k1;


### PR DESCRIPTION
## Why I'm doing:
Iceberg supports tagging properties when creating views. StarRocks should support this as well.

## What I'm doing:

1. support creating iceberg views with properties
2. support showing created iceberg views with properties

grammar
```
CREATE VIEW [IF NOT EXISTS]
[<catalog>.<database>.]<view_name>
(
    <column_name>[ COMMENT 'column comment']
    [, <column_name>[ COMMENT 'column comment'], ...]
)
[COMMENT 'view comment']
[PROPERTIES  ("key" = "value", ...)]
AS <query_statement>;

SHOW CREATE VIEW [<catalog>.<database>.]<view_name>;
+------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| View | Create View                                                                                                                                                                                                                                                                                                                    |
+------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| v1   | CREATE VIEW `ca1.db1.v1` (`c1`)
PROPERTIES ("starrocksVersion" = "xxx", "queryId" = "xxx", "starrocksCatalog" = "xxx")
 AS SELECT `ca1`.`db1`.`t1`.`c1`
FROM `ca1`.`db1`.`t1`; |
+------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


