### PR TITLE
[BugFix] fix iceberg sink decimal bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -431,7 +431,12 @@ public class IcebergApiConverter {
         }
 
         for (Types.NestedField field : nativeTable.schema().columns()) {
-            if (field.type() instanceof Types.DecimalType || field.type() == Types.UUIDType.get()) {
+            // https://apache.googlesource.com/parquet-format/+/HEAD/LogicalTypes.md
+            // the decimal128/uuid data sinked with physical type fixed_len_byte_array will be stored as big endian
+            // decimal64/32 are sinked with physical type int as little endian
+            // iceberg data file's upper/lower bound treat decimal/uuid's byte buffer as big endian.
+            if (dataFile.getFormat().equalsIgnoreCase("PARQUET")
+                    && field.type() instanceof Types.DecimalType && ((Types.DecimalType) field.type()).precision() <= 18) {
                 //change to BigEndian
                 reverseBuffer(lowerBounds.get(field.fieldId()));
                 reverseBuffer(upperBounds.get(field.fieldId()));

--- a/test/sql/test_sink/R/test_iceberg_sink_decimal
+++ b/test/sql/test_sink/R/test_iceberg_sink_decimal
@@ -27,7 +27,34 @@ select * from iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0}.t1 where c1=10.23;
 -- result:
 10.230
 -- !result
+create table iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0}.t2 (
+    c1 decimal(23,3)
+);
+-- result:
+-- !result
+insert into iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0}.t2 values(10);
+-- result:
+-- !result
+select * from iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0}.t2 where c1=10;
+-- result:
+10.000
+-- !result
+insert into iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0}.t2 values(30);
+-- result:
+-- !result
+select * from iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0}.t2 where c1=30;
+-- result:
+30.000
+-- !result
+select * from iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0}.t2 where c1<=30;
+-- result:
+10.000
+30.000
+-- !result
 drop table iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0}.t1 force;
+-- result:
+-- !result
+drop table iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0}.t2 force;
 -- result:
 -- !result
 drop database iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0};

--- a/test/sql/test_sink/T/test_iceberg_sink_decimal
+++ b/test/sql/test_sink/T/test_iceberg_sink_decimal
@@ -21,7 +21,20 @@ insert into iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0}.t1 values(10.23);
 
 select * from iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0}.t1 where c1=10.23;
 
+create table iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0}.t2 (
+    c1 decimal(23,3)
+);
+
+insert into iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0}.t2 values(10);
+select * from iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0}.t2 where c1=10;
+
+insert into iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0}.t2 values(30);
+select * from iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0}.t2 where c1=30;
+
+select * from iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0}.t2 where c1<=30;
+
 drop table iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0}.t1 force;
+drop table iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0}.t2 force;
 
 drop database iceberg_sink_${uuid0}.iceberg_sink_db_${uuid0};
 drop catalog iceberg_sink_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

When sinking decimal128 into iceberg table column, the data file's upper&lower bound meta will be wroten incorrectly.
## What I'm doing:

Fixes [#10646](https://github.com/StarRocks/StarRocksTest/issues/10646)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
