### PR TITLE
[Enhancement] support for enabling/disabling view endpoints in Iceberg REST Catalog

### DIFF
--- a/docs/en/data_source/catalog/iceberg/iceberg_catalog.md
+++ b/docs/en/data_source/catalog/iceberg/iceberg_catalog.md
@@ -306,6 +306,10 @@ If you use REST as metastore, you must specify the metastore type as REST (`"ice
   - Required: No
   - Description: Whether to support querying objects under nested namespace. Default: `false`.
 
+- `iceberg.catalog.rest.view-endpoints-enabled`
+  - Required: No
+  - Description: Whether to enable view endpoints for view-related operations. If set to `false`, view operations like `getView` will be disabled. Default: `true`.
+
 
 The following example creates an Iceberg catalog named `tabular` that uses Tabular as metastore:
 

--- a/docs/ja/data_source/catalog/iceberg/iceberg_catalog.md
+++ b/docs/ja/data_source/catalog/iceberg/iceberg_catalog.md
@@ -306,6 +306,10 @@ REST catalog 用の `MetastoreParams`:
   - 必須: いいえ
   - 説明: 入れ子になった Namespace の下にあるオブジェクトのクエリをサポートするかどうか。デフォルト： `false`。
 
+- `iceberg.catalog.rest.view-endpoints-enabled`
+  - 必須: いいえ
+  - 説明: ビュー関連の操作をサポートするためにビューエンドポイントを有効にするかどうか。`false`に設定すると、`getView`などのビュー操作が無効になります。デフォルト：`true`。
+
 次の例は、Tabular をメタストアとして使用する Iceberg catalog `tabular` を作成します。
 
 ```SQL

--- a/docs/zh/data_source/catalog/iceberg/iceberg_catalog.md
+++ b/docs/zh/data_source/catalog/iceberg/iceberg_catalog.md
@@ -333,6 +333,12 @@ REST catalog 的 `MetastoreParams`：
 
 描述：是否支持查询嵌套命名空间下的对象。默认值：`false`。
 
+##### iceberg.catalog.rest.view-endpoints-enabled
+
+必需：否
+
+描述：是否启用视图端点以支持视图相关操作。如果设置为 `false`，将禁用视图操作（如 `getView`）。默认值：`true`。
+
 以下示例创建了一个名为 `tabular` 的 Iceberg catalog，使用 Tabular 作为元存储：
 
 ```SQL

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -79,12 +79,14 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     public static final String ICEBERG_CATALOG_SECURITY = "iceberg.catalog.security";
     public static final String KEY_NESTED_NAMESPACE_ENABLED = "rest.nested-namespace-enabled";
     public static final String USER_AGENT = "header.User-Agent";
+    public static final String KEY_VIEW_ENDPOINTS_ENABLED = "rest.view-endpoints-enabled";
 
     private String catalogName = null;
     private final Configuration conf;
     private final RESTSessionCatalog delegate;
     private Map<String, String> restCatalogProperties;
     private final boolean nestedNamespaceEnabled;
+    private final boolean viewEndpointsEnabled;
 
 
     public IcebergRESTCatalog(String name, Configuration conf, Map<String, String> properties) {
@@ -112,6 +114,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
                 GlobalStateMgr.getCurrentState().getNodeMgr().getMySelf().getFeVersion());
 
         nestedNamespaceEnabled = PropertyUtil.propertyAsBoolean(restCatalogProperties, KEY_NESTED_NAMESPACE_ENABLED, false);
+        viewEndpointsEnabled = PropertyUtil.propertyAsBoolean(restCatalogProperties, KEY_VIEW_ENDPOINTS_ENABLED, true);
         // setup oauth2
         OAuth2SecurityConfig securityConfig = OAuth2SecurityConfigBuilder.build(restCatalogProperties);
         OAuth2SecurityProperties securityProperties = new OAuth2SecurityProperties(securityConfig);
@@ -134,6 +137,7 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         this.delegate = restCatalog;
         this.conf = conf;
         this.nestedNamespaceEnabled = false;
+        this.viewEndpointsEnabled = true;
     }
 
     @Override
@@ -268,15 +272,20 @@ public class IcebergRESTCatalog implements IcebergCatalog {
         }
 
         List<TableIdentifier> viewIdentifiers = new ArrayList<>();
-        try {
-            viewIdentifiers = delegate.listViews(buildContext(context), ns);
-        } catch (BadRequestException e) {
-            LOG.warn("Failed to list views from {} namespace. Perhaps the server side does not implement the interface. " +
-                    "Ask the user to check it", ns, e);
-        } catch (RESTException re) {
-            LOG.error("Failed to list views using REST Catalog, for dbName {}", dbName, re);
-            throw new StarRocksConnectorException("Failed to list views using REST Catalog",
-                    new RuntimeException("Failed to list views using REST Catalog, exception: " + re.getMessage(), re));
+        if (viewEndpointsEnabled) {
+            try {
+                viewIdentifiers = delegate.listViews(buildContext(context), ns);
+            } catch (BadRequestException e) {
+                LOG.warn("Failed to list views from {} namespace. Perhaps the server side does not implement the interface. " +
+                        "Ask the user to check it, or you can disable view endpoints by setting '{}' to false",
+                        ns, ICEBERG_CUSTOM_PROPERTIES_PREFIX + KEY_VIEW_ENDPOINTS_ENABLED, e);
+            } catch (RESTException re) {
+                LOG.error("Failed to list views using REST Catalog, for dbName {}", dbName, re);
+                throw new StarRocksConnectorException("Failed to list views using REST Catalog",
+                        new RuntimeException("Failed to list views using REST Catalog, exception: " + re.getMessage(), re));
+            }
+        } else {
+            LOG.debug("View endpoints are disabled for catalog, skipping view list operations");
         }
 
         final List<TableIdentifier> finalIdentifiers = ImmutableList.<TableIdentifier>builder()
@@ -351,12 +360,17 @@ public class IcebergRESTCatalog implements IcebergCatalog {
 
     @Override
     public View getView(ConnectContext context, String dbName, String viewName) {
+        if (!viewEndpointsEnabled) {
+            throw new StarRocksConnectorException("View operations are disabled for this catalog. " +
+                    "Set '" + ICEBERG_CUSTOM_PROPERTIES_PREFIX + KEY_VIEW_ENDPOINTS_ENABLED +
+                    "' to true to enable view endpoints");
+        }
         try {
             return delegate.loadView(buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), viewName));
         } catch (RESTException re) {
-            LOG.error("Failed to rename table using REST Catalog, for dbName {} viewName {}", dbName, viewName, re);
-            throw new StarRocksConnectorException("Failed to rename table using REST Catalog",
-                    new RuntimeException("Failed to rename table using REST Catalog, exception: " + re.getMessage(), re));
+            LOG.error("Failed to load view using REST Catalog, for dbName {} viewName {}", dbName, viewName, re);
+            throw new StarRocksConnectorException("Failed to load view using REST Catalog",
+                    new RuntimeException("Failed to load view using REST Catalog, exception: " + re.getMessage(), re));
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:
some rest catalog do not support view operation, we need to disable view operation for these rest catalog 
## What I'm doing:
This pull request introduces a new configuration option to control view-related operations in the Iceberg REST catalog integration. The main change is the addition of the `view-endpoints-enabled` property, allowing users to enable or disable view endpoints for the catalog. The implementation ensures that when view endpoints are disabled, view operations like listing or retrieving views are skipped or blocked, and this behavior is documented in English, Japanese, and Chinese documentation. Unit tests have been added to verify the correct behavior for both enabled and disabled states.

**Configuration and Implementation Changes**
* Added the `rest.view-endpoints-enabled` property to the `IcebergRESTCatalog` class, allowing configuration of view endpoint availability. The property defaults to `true` if not specified. (`fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java`) 
* Updated the logic in `listTables` and `getView` methods to respect the `viewEndpointsEnabled` flag: view operations are performed only if enabled, and clear error messages are provided when disabled. 

**Documentation Updates**
* Documented the new `iceberg.catalog.rest.view-endpoints-enabled` property in English, Japanese, and Chinese Iceberg catalog documentation, explaining its purpose and default value. 


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `iceberg.catalog.rest.view-endpoints-enabled` to enable/disable Iceberg REST view endpoints, updates behavior accordingly, and documents with tests.
> 
> - **FE (Iceberg REST Catalog)**
>   - Adds config `iceberg.catalog.rest.view-endpoints-enabled` (`rest.view-endpoints-enabled`) with default `true`.
>   - `listTables(...)`: conditionally calls `listViews(...)` only when enabled; logs guidance to disable on BadRequest.
>   - `getView(...)`: blocks with clear error when endpoints are disabled; fixes error/log messages to "load view".
>   - Introduces `KEY_VIEW_ENDPOINTS_ENABLED` and wires flag via `PropertyUtil`.
> - **Tests**
>   - Add UTs covering view endpoints enabled/disabled for `listTables` and `getView`.
> - **Docs**
>   - Document new property in `docs/en|ja|zh` Iceberg catalog guides.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1451308d3fa41030e5bed587c64f59b8c4980a4b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->