### PR TITLE
[Doc] docs(fe_config): update en, zh, ja documentation

### DIFF
--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -3489,7 +3489,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: When enabled, StarRocks allows Lake tables to use the combined transaction log path for relevant transactions. This flag is only considered when the cluster is running in shared-data mode (`RunMode.isSharedDataMode()`). With `lake_use_combined_txn_log = true`, loading transactions of types BACKEND_STREAMING, ROUTINE_LOAD_TASK, INSERT_STREAMING and BATCH_LOAD_JOB will be eligible to use combined txn logs (see `LakeTableHelper.supportCombinedTxnLog`). Code paths that also include compaction check combined-log support via isTransactionSupportCombinedTxnLog. If disabled or when not in shared-data mode, combined transaction log behavior is not used.
+- Description: When enabled, StarRocks allows Lake tables to use the combined transaction log path for relevant transactions. Available only for shared-data clusters.
 - Introduced in: v3.3.7, v3.4.0, v3.5.0
 
 ### Other

--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -3489,7 +3489,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: When enabled, StarRocks allows Lake tables to use the combined transaction log path for relevant transactions. This flag is only considered when the cluster is running in shared-data mode (RunMode.isSharedDataMode()). With `lake_use_combined_txn_log = true`, loading transactions of types BACKEND_STREAMING, ROUTINE_LOAD_TASK, INSERT_STREAMING and BATCH_LOAD_JOB will be eligible to use combined txn logs (see LakeTableHelper.supportCombinedTxnLog). Code paths that also include compaction check combined-log support via isTransactionSupportCombinedTxnLog. If disabled or when not in shared-data mode, combined transaction log behavior is not used.
+- Description: When enabled, StarRocks allows Lake tables to use the combined transaction log path for relevant transactions. This flag is only considered when the cluster is running in shared-data mode (`RunMode.isSharedDataMode()`). With `lake_use_combined_txn_log = true`, loading transactions of types BACKEND_STREAMING, ROUTINE_LOAD_TASK, INSERT_STREAMING and BATCH_LOAD_JOB will be eligible to use combined txn logs (see `LakeTableHelper.supportCombinedTxnLog`). Code paths that also include compaction check combined-log support via isTransactionSupportCombinedTxnLog. If disabled or when not in shared-data mode, combined transaction log behavior is not used.
 - Introduced in: v3.3.7, v3.4.0, v3.5.0
 
 ### Other

--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -3489,7 +3489,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: When enabled, StarRocks allows Lake tables to use the combined transaction log path for relevant transactions. Available only for shared-data clusters.
+- Description: When this item is set to `true`, the system allows Lake tables to use the combined transaction log path for relevant transactions. Available for shared-data clusters only.
 - Introduced in: v3.3.7, v3.4.0, v3.5.0
 
 ### Other

--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -115,12 +115,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### bdbje_log_level
 
-- Default: `INFO`
+- Default: INFO
 - Type: String
 - Unit: -
 - Is mutable: No
 - Description: Controls the logging level used by Berkeley DB Java Edition (BDB JE) in StarRocks. During BDB environment initialization BDBEnvironment.initConfigs() applies this value to the Java logger for the `com.sleepycat.je` package and to the BDB JE environment file logging level (EnvironmentConfig.FILE_LOGGING_LEVEL). Accepts standard java.util.logging.Level names such as SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST, ALL, OFF. Setting to ALL enables all log messages. Increasing verbosity will raise log volume and may impact disk I/O and performance; the value is read when the BDB environment is initialized, so it takes effect only after environment (re)initialization.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### big_query_log_delete_age
 
@@ -535,7 +535,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### brpc_inner_reuse_pool
 
-- Default: `true`
+- Default: true
 - Type: boolean
 - Unit: -
 - Is mutable: No
@@ -544,21 +544,21 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### brpc_min_evictable_idle_time_ms
 
-- Default: `120000`
+- Default: 120000
 - Type: Int
 - Unit: Milliseconds
 - Is mutable: No
 - Description: Time in milliseconds that an idle BRPC connection must remain in the connection pool before it becomes eligible for eviction. Applied to the RpcClientOptions used by `BrpcProxy` (via RpcClientOptions.setMinEvictableIdleTime). Raise this value to keep idle connections longer (reducing reconnect churn); lower it to free unused sockets faster (reducing resource usage). Tune together with `brpc_connection_pool_size` and `brpc_idle_wait_max_time` to balance connection reuse, pool growth, and eviction behavior.
-- Introduced in: `v3.3.11, v3.4.1, v3.5.0`
+- Introduced in: v3.3.11, v3.4.1, v3.5.0
 
 ##### brpc_reuse_addr
 
-- Default: `true`
+- Default: true
 - Type: Boolean
 - Unit: -
 - Is mutable: No
 - Description: When true, StarRocks sets the socket option to allow local address reuse for client sockets created by the brpc RpcClient (via RpcClientOptions.setReuseAddress). Enabling this reduces bind failures and allows faster rebinding of local ports after sockets are closed, which is helpful for high-rate connection churn or rapid restarts. When false, address/port reuse is disabled, which can reduce the chance of unintended port sharing but may increase transient bind errors. This option interacts with connection behavior configured by `brpc_connection_pool_size` and `brpc_short_connection` because it affects how rapidly client sockets can be rebound and reused.
-- Introduced in: `v3.3.11, v3.4.1, v3.5.0`
+- Introduced in: v3.3.11, v3.4.1, v3.5.0
 
 ##### cluster_name
 
@@ -580,12 +580,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### enable_http_validate_headers
 
-- Default: `false`
+- Default: false
 - Type: Boolean
 - Unit: -
 - Is mutable: No
 - Description: Controls whether Netty's HttpServerCodec performs strict HTTP header validation. The value is passed to HttpServerCodec when the HTTP pipeline is initialized in `HttpServer` (see UseLocations). Default is false for backward compatibility because newer netty versions enforce stricter header rules (https://github.com/netty/netty/pull/12760). Set to true to enforce RFC-compliant header checks; doing so may cause malformed or nonconforming requests from legacy clients or proxies to be rejected. Change requires a restart of the HTTP server to take effect.
-- Introduced in: `v3.3.0, v3.4.0, v3.5.0`
+- Introduced in: v3.3.0, v3.4.0, v3.5.0
 
 ##### enable_https
 
@@ -630,25 +630,25 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Unit: Bytes
 - Is mutable: No
 - Description: Sets the maximum allowed size (in bytes) of a single HTTP chunk handled by Netty's HttpServerCodec in the FE HTTP server. It is passed as the third argument to HttpServerCodec and limits the length of chunks during chunked transfer or streaming requests/responses. If an incoming chunk exceeds this value, Netty will raise a frame-too-large error (e.g., TooLongFrameException) and the request may be rejected. Increase this for legitimate large chunked uploads; keep it small to reduce memory pressure and surface area for DoS attacks. This setting is used alongside `http_max_initial_line_length`, `http_max_header_size`, and `enable_http_validate_headers`.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### http_max_header_size
 
-- Default: `32768`
+- Default: 32768
 - Type: Int
 - Unit: Bytes
 - Is mutable: No
 - Description: Maximum allowed size in bytes for the HTTP request header block parsed by Netty's `HttpServerCodec`. StarRocks passes this value to `HttpServerCodec` (as `Config.http_max_header_size`); if an incoming request's headers (names and values combined) exceed this limit, the codec will reject the request (decoder exception) and the connection/request will fail. Increase only when clients legitimately send very large headers (large cookies or many custom headers); larger values increase per-connection memory use. Tune in conjunction with `http_max_initial_line_length` and `http_max_chunk_size`. Changes require FE restart.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### http_max_initial_line_length
 
-- Default: `4096`
+- Default: 4096
 - Type: Int
 - Unit: Bytes
 - Is mutable: No
 - Description: Sets the maximum allowed length (in bytes) of the HTTP initial request line (method + request-target + HTTP version) accepted by the Netty `HttpServerCodec` used in HttpServer. The value is passed to Netty's decoder and requests with an initial line longer than this will be rejected (TooLongFrameException). Increase this only when you must support very long request URIs; larger values increase memory use and may raise exposure to malformed/request-abuse. Tune together with `http_max_header_size` and `http_max_chunk_size`.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### http_port
 
@@ -661,12 +661,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### http_web_page_display_hardware
 
-- Default: `true`
+- Default: true
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
 - Description: When true, the HTTP index page (/index) will include a hardware information section populated via the oshi library (CPU, memory, processes, disks, filesystems, network, etc.). oshi may invoke system utilities or read system files indirectly (for example, it can execute commands such as `getent passwd`), which can surface sensitive system data. If you require stricter security or want to avoid executing those indirect commands on the host, set this configuration to false to disable collection and display of hardware details on the web UI.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### http_worker_threads_num
 
@@ -826,12 +826,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### thrift_rpc_max_body_size
 
-- Default: `-1`
+- Default: -1
 - Type: Int
 - Unit: Bytes
 - Is mutable: No
 - Description: Controls the maximum allowed Thrift RPC message body size (in bytes) used when constructing the server's Thrift protocol (passed to TBinaryProtocol.Factory in `ThriftServer`). A value of `-1` disables the limit (unbounded). Setting a positive value enforces an upper bound so that messages larger than this are rejected by the Thrift layer, which helps limit memory usage and mitigate oversized-request or DoS risks. Set this to a size large enough for expected payloads (large structs or batched data) to avoid rejecting legitimate requests.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### thrift_server_max_worker_threads
 
@@ -855,21 +855,21 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### alter_max_worker_queue_size
 
-- Default: `4096`
+- Default: 4096
 - Type: Int
 - Unit: Tasks
 - Is mutable: No
 - Description: Controls the capacity of the internal worker thread pool queue used by the alter subsystem. It is passed to `ThreadPoolManager.newDaemonCacheThreadPool` in `AlterHandler` together with `alter_max_worker_threads`. When the number of pending alter tasks exceeds `alter_max_worker_queue_size`, new submissions will be rejected and a `RejectedExecutionException` can be thrown (see `AlterHandler.handleFinishAlterTask`). Tune this value to balance memory usage and the amount of backlog you permit for concurrent alter tasks.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### alter_max_worker_threads
 
-- Default: `4`
+- Default: 4
 - Type: Int
 - Unit: Threads
 - Is mutable: No
 - Description: Sets the maximum number of worker threads in the AlterHandler's thread pool. The AlterHandler constructs the executor with this value to run and finalize alter-related tasks (e.g., submitting `AlterReplicaTask` via handleFinishAlterTask). This value bounds concurrent execution of alter operations; raising it increases parallelism and resource usage, lowering it limits concurrent alters and may become a bottleneck. The executor is created together with `alter_max_worker_queue_size`, and the handler scheduling uses `alter_scheduler_interval_millisecond`.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### automated_cluster_snapshot_interval_seconds
 
@@ -900,12 +900,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### bdbje_cleaner_threads
 
-- Default: `1`
+- Default: 1
 - Type: Int
 - Unit: -
 - Is mutable: No
 - Description: Number of background cleaner threads for the Berkeley DB Java Edition (JE) environment used by StarRocks journal. This value is read during environment initialization in `BDBEnvironment.initConfigs` and applied to `EnvironmentConfig.CLEANER_THREADS` using `Config.bdbje_cleaner_threads`. It controls parallelism for JE log cleaning and space reclamation; increasing it can speed up cleaning at the cost of additional CPU and I/O interference with foreground operations. Changes take effect only when the BDB environment is (re)initialized, so a frontend restart is required to apply a new value.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### bdbje_heartbeat_timeout_second
 
@@ -932,7 +932,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Unit: Percent
 - Is mutable: No
 - Description: Sets the relative cost (as a percentage) of replaying transactions from a BDB JE log versus obtaining the same data via a network restore. The value is supplied to the underlying JE replication parameter REPLAY_COST_PERCENT and is typically >100 to indicate that replay is usually more expensive than a network restore. When deciding whether to retain cleaned log files for potential replay, the system compares replay cost multiplied by log size against the cost of a network restore; files will be removed if network restore is judged more efficient. A value of 0 disables retention based on this cost comparison. Log files required for replicas within `REP_STREAM_TIMEOUT` or for any active replication are always retained.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### bdbje_replica_ack_timeout_second
 
@@ -945,12 +945,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### bdbje_reserved_disk_size
 
-- Default: `512L * 1024 * 1024` (536870912)
+- Default: 512 * 1024 * 1024 (536870912)
 - Type: Long
 - Unit: Bytes
 - Is mutable: No
 - Description: Limits the number of bytes Berkeley DB JE will reserve as "unprotected" (deletable) log/data files. StarRocks passes this value to JE via `EnvironmentConfig.RESERVED_DISK` in BDBEnvironment; JE's built-in default is 0 (unlimited). The StarRocks default (512 MiB) prevents JE from reserving excessive disk space for unprotected files while allowing safe cleanup of obsolete files. Tune this value on disk-constrained systems: decreasing it lets JE free more files sooner, increasing it lets JE retain more reserved space. Changes require restarting the process to take effect.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### bdbje_reset_election_group
 
@@ -981,21 +981,21 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### brpc_connection_pool_size
 
-- Default: `16`
+- Default: 16
 - Type: Int
 - Unit: Connections
 - Is mutable: No
 - Description: The maximum number of pooled BRPC connections per endpoint used by the FE's BrpcProxy. This value is applied to RpcClientOptions via `setMaxTotoal` and `setMaxIdleSize`, so it directly limits concurrent outgoing BRPC requests because each request must borrow a connection from the pool. In high-concurrency scenarios increase this to avoid request queuing; increasing it raises socket and memory usage and may increase remote server load. When tuning, consider related settings such as `brpc_idle_wait_max_time`, `brpc_short_connection`, `brpc_inner_reuse_pool`, `brpc_reuse_addr`, and `brpc_min_evictable_idle_time_ms`. Changing this value is not hot-reloadable and requires a restart.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### brpc_short_connection
 
-- Default: `false`
+- Default: false
 - Type: boolean
 - Unit: -
 - Is mutable: No
 - Description: Controls whether the underlying brpc RpcClient uses short-lived connections. When enabled (`true`), RpcClientOptions.setShortConnection is set and connections are closed after a request completes, reducing the number of long-lived sockets at the cost of higher connection setup overhead and increased latency. When disabled (`false`, the default) persistent connections and connection pooling are used. Enabling this option affects connection-pool behavior and should be considered together with `brpc_connection_pool_size`, `brpc_idle_wait_max_time`, `brpc_min_evictable_idle_time_ms`, `brpc_reuse_addr`, and `brpc_inner_reuse_pool`. Keep it disabled for typical high-throughput deployments; enable only to limit socket lifetime or when short connections are required by network policy.
-- Introduced in: `v3.3.11, v3.4.1, v3.5.0`
+- Introduced in: v3.3.11, v3.4.1, v3.5.0
 
 ##### catalog_try_lock_timeout_ms
 
@@ -1008,21 +1008,21 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### checkpoint_only_on_leader
 
-- Default: `false`
+- Default: false
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
 - Description: When `true`, the CheckpointController will only select the leader FE as the checkpoint worker; when `false`, the controller may pick any frontend and prefers nodes with lower heap usage. With `false`, workers are sorted by recent failure time and `heapUsedPercent` (the leader is treated as having infinite usage to avoid selecting it). For operations that require cluster snapshot metadata, the controller already forces leader selection regardless of this flag. Enabling `true` centralizes checkpoint work on the leader (simpler but increases leader CPU/memory and network load); keeping it `false` distributes checkpoint load to less-loaded FEs. This setting affects worker selection and interaction with timeouts such as `checkpoint_timeout_seconds` and RPC settings like `thrift_rpc_timeout_ms`.
-- Introduced in: `v3.4.0, v3.5.0`
+- Introduced in: v3.4.0, v3.5.0
 
 ##### checkpoint_timeout_seconds
 
-- Default: `24 * 3600`
+- Default: 24 * 3600
 - Type: Long
 - Unit: Seconds
 - Is mutable: Yes
 - Description: Maximum time (in seconds) the leader's CheckpointController will wait for a checkpoint worker to complete a checkpoint. The controller converts this value to nanoseconds and polls the worker result queue; if no successful completion is received within this timeout the checkpoint is treated as failed and createImage returns failure. Increasing this value accommodates longer-running checkpoints but delays failure detection and subsequent image propagation; decreasing it causes faster failover/retries but can produce false timeouts for slow workers. This setting only controls the waiting period in `CheckpointController` during checkpoint creation and does not change the worker's internal checkpointing behavior.
-- Introduced in: `v3.4.0, v3.5.0`
+- Introduced in: v3.4.0, v3.5.0
 
 ##### db_used_data_quota_update_interval_secs
 
@@ -1128,7 +1128,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### enable_task_history_archive
 
-- Default: `true`
+- Default: true
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
@@ -1272,21 +1272,21 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### start_with_incomplete_meta
 
-- Default: `false`
+- Default: false
 - Type: boolean
 - Unit: -
 - Is mutable: No
 - Description: When true, the FE will allow startup when image data exists but Berkeley DB JE (BDB) log files are missing or corrupted. `MetaHelper.checkMetaDir()` uses this flag to bypass the safety check that otherwise prevents starting from an image without corresponding BDB logs; starting this way can produce stale or inconsistent metadata and should only be used for emergency recovery. `RestoreClusterSnapshotMgr` temporarily sets this flag to true while restoring a cluster snapshot and then rolls it back; that component also toggles `bdbje_reset_election_group` during restore. Do not enable in normal operation — enable only when recovering from corrupted BDB data or when explicitly restoring an image-based snapshot.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### table_keeper_interval_second
 
-- Default: `30`
+- Default: 30
 - Type: Int
 - Unit: Seconds
 - Is mutable: Yes
 - Description: Interval, in seconds, between executions of the TableKeeper daemon. The TableKeeperDaemon uses this value (multiplied by 1000) to set its internal timer and periodically runs keeper tasks that ensure history tables exist, correct table properties (replication number) and update partition TTLs. The daemon only performs work on the leader node and updates its runtime interval via setInterval when `table_keeper_interval_second` changes. Increase to reduce scheduling frequency and load; decrease for faster reaction to missing or stale history tables.
-- Introduced in: `v3.3.1, v3.4.0, v3.5.0`
+- Introduced in: v3.3.1, v3.4.0, v3.5.0
 
 ##### task_runs_ttl_second
 
@@ -1308,7 +1308,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### thrift_rpc_retry_times
 
-- Default: `3`
+- Default: 3
 - Type: Int
 - Unit: -
 - Is mutable: Yes
@@ -1317,21 +1317,21 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### thrift_rpc_strict_mode
 
-- Default: `true`
+- Default: true
 - Type: Boolean
 - Unit: -
 - Is mutable: No
 - Description: Controls the TBinaryProtocol "strict read" mode used by the Thrift server. This value is passed as the first argument to org.apache.thrift.protocol.TBinaryProtocol.Factory in the Thrift server stack and affects how incoming Thrift messages are parsed and validated. When `true` (default), the server enforces strict Thrift encoding/version checks and honors the configured `thrift_rpc_max_body_size` limit; when `false`, the server accepts non-strict (legacy/lenient) message formats, which can improve compatibility with older clients but may bypass some protocol validations. Use caution changing this on a running cluster because it is not mutable and affects interoperability and parsing safety.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### thrift_rpc_timeout_ms
 
-- Default: `10000`
+- Default: 10000
 - Type: Int
 - Unit: Milliseconds
 - Is mutable: Yes
 - Description: Timeout (in milliseconds) used as the default network/socket timeout for Thrift RPC calls. It is passed to TSocket when creating Thrift clients in `ThriftConnectionPool` (used by the frontend and backend pools) and is also added to an operation's execution timeout (e.g., ExecTimeout*1000 + `thrift_rpc_timeout_ms`) when computing RPC call timeouts in places such as `ConfigBase`, `LeaderOpExecutor`, `GlobalStateMgr`, `NodeMgr`, `VariableMgr`, and `CheckpointWorker`. Increasing this value makes RPC calls tolerate longer network or remote processing delays; decreasing it causes faster failover on slow networks. Changing this value affects connection creation and request deadlines across the FE code paths that perform Thrift RPCs.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### txn_latency_metric_report_groups
 
@@ -1384,12 +1384,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### brpc_send_plan_fragment_timeout_ms
 
-- Default: `60000`
+- Default: 60000
 - Type: Int
 - Unit: Milliseconds
 - Is mutable: Yes
 - Description: Timeout in milliseconds applied to the BRPC TalkTimeoutController before sending a plan fragment. `BackendServiceClient.sendPlanFragmentAsync` sets this value prior to calling the backend `execPlanFragmentAsync`. It governs how long BRPC will wait when borrowing an idle connection from the connection pool and while performing the send; if exceeded, the RPC will fail and may trigger the method's retry logic. Set this lower to fail fast under contention, or raise it to tolerate transient pool exhaustion or slow networks. Be cautious: very large values can delay failure detection and block request threads.
-- Introduced in: `v3.3.11, v3.4.1, v3.5.0`
+- Introduced in: v3.3.11, v3.4.1, v3.5.0
 
 ##### connector_table_query_trigger_analyze_large_table_interval
 
@@ -1633,7 +1633,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Unit: -
 - Is mutable: No
 - Description: When true, switches the FE slot-based query scheduler to Query Queue V2. The flag is read by the slot manager and trackers (for example, `BaseSlotManager.isEnableQueryQueueV2` and `SlotTracker#createSlotSelectionStrategy`) to choose `SlotSelectionStrategyV2` instead of the legacy strategy. `query_queue_v2_xxx` configuration options and `QueryQueueOptions` take effect only when this flag is enabled. Because the value is static at runtime, enablement requires restarting the leader FE to take effect and may change query scheduling, concurrency limits, and queueing behavior cluster-wide.
-- Introduced in: `v3.3.4, v3.4.0, v3.5.0`
+- Introduced in: v3.3.4, v3.4.0, v3.5.0
 
 ##### enable_sql_blacklist
 
@@ -1815,12 +1815,12 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 
 ##### max_query_queue_history_slots_number
 
-- Default: `0`
+- Default: 0
 - Type: Int
 - Unit: Slots
 - Is mutable: Yes
 - Description: Controls how many recently released (history) allocated slots are retained per query queue for monitoring and observability. When `max_query_queue_history_slots_number` is set to a value &gt; 0, BaseSlotTracker keeps up to that many most-recently released LogicalSlot entries in an in-memory queue, evicting the oldest when the limit is exceeded. Enabling this causes getSlots() to include these history entries (newest first), allows BaseSlotTracker to attempt registering slots with the ConnectContext for richer ExtraMessage data, and lets LogicalSlot.ConnectContextListener attach query finish metadata to history slots. When `max_query_queue_history_slots_number` &lt;= 0 the history mechanism is disabled (no extra memory used). Use a reasonable value to balance observability and memory overhead.
-- Introduced in: `v3.5.0`
+- Introduced in: v3.5.0
 
 ##### max_query_retry_time
 
@@ -1878,16 +1878,16 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 
 ##### query_queue_slots_estimator_strategy
 
-- Default: `SlotEstimatorFactory.EstimatorPolicy.createDefault().name()` (resolves to `MAX`)
+- Default: MAX
 - Type: String
 - Unit: -
 - Is mutable: Yes
 - Description: Selects the slot estimation strategy used for queue-based queries when `enable_query_queue_v2` is true. Valid values: MBE (memory-based), PBE (parallelism-based), MAX (take max of MBE and PBE) and MIN (take min of MBE and PBE). MBE estimates slots from predicted memory or plan costs divided by the per-slot memory target and is capped by `totalSlots`. PBE derives slots from fragment parallelism (scan range counts or cardinality / rows-per-slot) and a CPU-cost based calculation (using CPU costs per slot), then bounds the result within [numSlots/2, numSlots]. MAX and MIN combine MBE and PBE by taking their maximum or minimum respectively. If the configured value is invalid, the default (`MAX`) is used.
-- Introduced in: `v3.5.0`
+- Introduced in: v3.5.0
 
 ##### query_queue_v2_concurrency_level
 
-- Default: `4`
+- Default: 4
 - Type: Int
 - Unit: -
 - Is mutable: Yes
@@ -1896,7 +1896,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 
 ##### query_queue_v2_cpu_costs_per_slot
 
-- Default: `1000000000`
+- Default: 1000000000
 - Type: Long
 - Unit: planner CPU cost units
 - Is mutable: Yes
@@ -1914,12 +1914,12 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 
 ##### query_queue_v2_schedule_strategy
 
-- Default: `QueryQueueOptions.SchedulePolicy.createDefault().name()`
+- Default: SWRR
 - Type: String
 - Unit: -
 - Is mutable: Yes
 - Description: Selects the scheduling policy used by Query Queue V2 to order pending queries. Supported values (case-insensitive) are `SWRR` (Smooth Weighted Round Robin) — the default, suitable for mixed/hybrid workloads that need fair weighted sharing — and `SJF` (Short Job First + Aging) — prioritizes short jobs while using aging to avoid starvation. The value is parsed with case-insensitive enum lookup; an unrecognized value is logged as an error and the default policy is used. This configuration only affects behavior when Query Queue V2 is enabled and interacts with V2 sizing settings such as `query_queue_v2_concurrency_level`.
-- Introduced in: `v3.3.12, v3.4.2, v3.5.0`
+- Introduced in: v3.3.12, v3.4.2, v3.5.0
 
 ##### semi_sync_collect_statistic_await_seconds
 
@@ -2049,12 +2049,12 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 
 ##### task_min_schedule_interval_s
 
-- Default: `10`
+- Default: 10
 - Type: Int
 - Unit: Seconds
 - Is mutable: Yes
 - Description: Minimum allowed schedule interval (in seconds) for task schedules checked by the SQL layer. When a task is submitted, TaskAnalyzer converts the schedule period to seconds and rejects the submission with ERR_INVALID_PARAMETER if the period is smaller than `task_min_schedule_interval_s`. This prevents creating tasks that run too frequently and protects the scheduler from high-frequency tasks. If a schedule has no explicit start time, TaskAnalyzer sets the start time to the current epoch seconds.
-- Introduced in: `v3.3.0, v3.4.0, v3.5.0`
+- Introduced in: v3.3.0, v3.4.0, v3.5.0
 
 ### Loading and unloading
 
@@ -2244,7 +2244,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 
 ##### load_parallel_instance_num
 
-- Default: `1`
+- Default: 1
 - Type: Int
 - Unit: -
 - Is mutable: Yes
@@ -2466,7 +2466,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Unit: Seconds
 - Is mutable: No
 - Description: Maximum time in seconds to wait for a YARN response after submitting a Spark application. `SparkLauncherMonitor.LogMonitor` converts this value to milliseconds and will stop monitoring and forcibly kill the spark launcher process if the job remains in UNKNOWN/CONNECTED/SUBMITTED longer than this timeout. `SparkLoadJob` reads this configuration as the default and allows a per-load override via the `LoadStmt.SPARK_LOAD_SUBMIT_TIMEOUT` property. Set it high enough to accommodate YARN queueing delays; setting it too low may abort legitimately queued jobs, while setting it too high may delay failure handling and resource cleanup.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### spark_resource_path
 
@@ -2488,7 +2488,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 
 ##### stream_load_max_txn_num_per_be
 
-- Default: `-1`
+- Default: -1
 - Type: Int
 - Unit: Transactions
 - Is mutable: Yes
@@ -2652,12 +2652,12 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 
 ##### enable_online_optimize_table
 
-- Default: `true`
+- Default: true
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
 - Description: Controls whether StarRocks will use the non-blocking online optimization path when creating an optimize job. When `enable_online_optimize_table` is true and the target table meets compatibility checks (no partition/keys/sort specification, distribution is not `RandomDistributionDesc`, storage type is not `COLUMN_WITH_ROW`, replicated storage enabled, and the table is not a cloud-native table or materialized view), the planner creates an `OnlineOptimizeJobV2` to perform optimization without blocking writes. If false or any compatibility condition fails, StarRocks falls back to `OptimizeJobV2`, which may block write operations during optimization.
-- Introduced in: `v3.3.3, v3.4.0, v3.5.0`
+- Introduced in: v3.3.3, v3.4.0, v3.5.0
 
 ##### enable_strict_storage_medium_check
 
@@ -3223,12 +3223,12 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 
 ##### hdfs_file_system_expire_seconds
 
-- Default: `300`
+- Default: 300
 - Type: Int
 - Unit: Seconds
 - Is mutable: Yes
 - Description: Time-to-live in seconds for an unused cached HDFS/ObjectStore FileSystem managed by HdfsFsManager. The FileSystemExpirationChecker (runs every 60s) calls each HdfsFs.isExpired(...) using this value; when expired the manager closes the underlying FileSystem and removes it from the cache. Accessor methods (for example `HdfsFs.getDFSFileSystem`, `getUserName`, `getConfiguration`) update the last-access timestamp, so expiry is based on inactivity. Lower values reduce idle resource holding but increase reopen overhead; higher values keep handles longer and may consume more resources.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### lake_autovacuum_grace_period_minutes
 
@@ -3422,43 +3422,43 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 
 ##### files_enable_insert_push_down_schema
 
-- Default: `true`
+- Default: true
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
 - Description: When enabled, the analyzer will attempt to push the target table schema into the `files()` table function for INSERT ... FROM files() operations. This only applies when the source is a FileTableFunctionRelation, the target is a native table, and the SELECT list contains corresponding slot-ref columns (or *). The analyzer will match select columns to target columns (counts must match), lock the target table briefly, and replace file-column types with deep-copied target column types for non-complex types (complex types such as parquet json -> array&lt;varchar&gt; are skipped). Column names from the original files table are preserved. This reduces type-mismatch and looseness from file-based type inference during ingestion.
-- Introduced in: `v3.4.0, v3.5.0`
+- Introduced in: v3.4.0, v3.5.0
 
 ##### hdfs_read_buffer_size_kb
 
-- Default: `8192`
+- Default: 8192
 - Type: Int
 - Unit: Kilobytes
 - Is mutable: Yes
-- Description: Size of the HDFS read buffer in kilobytes. StarRocks converts this value to bytes (<< 10) and uses it to initialize HDFS read buffers in `HdfsFsManager` and to populate the thrift field `hdfs_read_buffer_size_kb` sent to BE tasks (e.g., `TBrokerScanRangeParams`, `TDownloadReq`) when broker access is not used. Increasing `hdfs_read_buffer_size_kb` can improve sequential read throughput and reduce syscall overhead at the cost of higher per-stream memory usage; decreasing it reduces memory footprint but may lower IO efficiency. Consider workload (many small streams vs. few large sequential reads) when tuning.
-- Introduced in: `v3.2.0`
+- Description: Size of the HDFS read buffer in kilobytes. StarRocks converts this value to bytes (`<< 10`) and uses it to initialize HDFS read buffers in `HdfsFsManager` and to populate the thrift field `hdfs_read_buffer_size_kb` sent to BE tasks (e.g., `TBrokerScanRangeParams`, `TDownloadReq`) when broker access is not used. Increasing `hdfs_read_buffer_size_kb` can improve sequential read throughput and reduce syscall overhead at the cost of higher per-stream memory usage; decreasing it reduces memory footprint but may lower IO efficiency. Consider workload (many small streams vs. few large sequential reads) when tuning.
+- Introduced in: v3.2.0
 
 ##### hdfs_write_buffer_size_kb
 
-- Default: `1024`
+- Default: 1024
 - Type: Int
 - Unit: Kilobytes
 - Is mutable: Yes
 - Description: Sets the HDFS write buffer size (in KB) used for direct writes to HDFS or object stores when not using a broker. The FE converts this value to bytes (<< 10) and initializes the local write buffer in HdfsFsManager, and it is propagated in Thrift requests (e.g., TUploadReq, TExportSink, sink options) so backends/agents use the same buffer size. Increasing this value can improve throughput for large sequential writes at the cost of more memory per writer; decreasing it reduces per-stream memory usage and may lower latency for small writes. Tune alongside `hdfs_read_buffer_size_kb` and consider available memory and concurrent writers.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### lake_batch_publish_max_version_num
 
-- Default: `10`
+- Default: 10
 - Type: Int
 - Unit: Count
 - Is mutable: Yes
 - Description: Sets the upper bound on how many consecutive transaction versions may be grouped together when building a publish batch for lake (cloud‑native) tables. The value is passed to the transaction graph batching routine (see getReadyToPublishTxnListBatch) and works together with `lake_batch_publish_min_version_num` to determine the candidate range size for a TransactionStateBatch. Larger values can increase publish throughput by batching more commits, but increase the scope of an atomic publish (longer visibility latency and larger rollback surface) and may be limited at runtime when versions are not consecutive. Tune according to workload and visibility/latency requirements.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### lake_batch_publish_min_version_num
 
-- Default: `1`
+- Default: 1
 - Type: Int
 - Unit: -
 - Is mutable: Yes
@@ -3467,30 +3467,30 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 
 ##### lake_enable_batch_publish_version
 
-- Default: `true`
+- Default: true
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
 - Description: When enabled, PublishVersionDaemon batches ready transactions for the same Lake (shared-data) table/partition and publishes their versions together instead of issuing per-transaction publishes. In RunMode shared-data, the daemon calls getReadyPublishTransactionsBatch() and uses publishVersionForLakeTableBatch(...) to perform grouped publish operations (reducing RPCs and improving throughput). When disabled, the daemon falls back to per-transaction publishing via publishVersionForLakeTable(...). The implementation coordinates in-flight work using internal sets to avoid duplicate publishes when the switch is toggled and is affected by the thread pool sizing via `lake_publish_version_max_threads`.
-- Introduced in: `v3.2.0`
+- Introduced in: v3.2.0
 
 ##### lake_enable_tablet_creation_optimization
 
-- Default: `false`
+- Default: false
 - Type: boolean
 - Unit: -
 - Is mutable: Yes
 - Description: When enabled, StarRocks optimizes tablet creation for cloud-native tables and materialized views in shared-data mode by creating a single shared tablet metadata for all tablets under a physical partition instead of distinct metadata per tablet. This reduces the number of tablet creation tasks and metadata/files produced during table creation, rollup, and schema-change jobs. The optimization is applied only for cloud-native tables/materialized views and is combined with `file_bundling` (the latter reuses the same optimization logic). Note: schema-change and rollup jobs explicitly disable the optimization for tables using `file_bundling` to avoid overwriting files with identical names. Enable cautiously — it changes the granularity of created tablet metadata and can affect how replica creation and file naming behave.
-- Introduced in: `v3.3.1, v3.4.0, v3.5.0`
+- Introduced in: v3.3.1, v3.4.0, v3.5.0
 
 ##### lake_use_combined_txn_log
 
-- Default: `false`
+- Default: false
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
 - Description: When enabled, StarRocks allows Lake tables to use the combined transaction log path for relevant transactions. This flag is only considered when the cluster is running in shared-data mode (RunMode.isSharedDataMode()). With `lake_use_combined_txn_log = true`, loading transactions of types BACKEND_STREAMING, ROUTINE_LOAD_TASK, INSERT_STREAMING and BATCH_LOAD_JOB will be eligible to use combined txn logs (see LakeTableHelper.supportCombinedTxnLog). Code paths that also include compaction check combined-log support via isTransactionSupportCombinedTxnLog. If disabled or when not in shared-data mode, combined transaction log behavior is not used.
-- Introduced in: `v3.3.7, v3.4.0, v3.5.0`
+- Introduced in: v3.3.7, v3.4.0, v3.5.0
 
 ### Other
 

--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -2586,7 +2586,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Type: double
 - Unit: Fraction (0.0–1.0)
 - Is mutable: Yes
-- Description: The high-water threshold of disk capacity used percent (fraction of total capacity) used when computing backend load scores. `BackendLoadStatistic.calcSore` uses `capacity_used_percent_high_water` to set `LoadScore.capacityCoefficient`: if a backend's used percent < 0.5 the coefficient = 0.5; if used percent > `capacity_used_percent_high_water` the coefficient = 1.0; otherwise the coefficient transitions linearly with used percent via (2 * usedPercent - 0.5). When the coefficient is 1.0, the load score is driven entirely by capacity proportion; lower values increase the weight of replica count. Adjusting this value changes how aggressively the balancer penalizes backends with high disk utilization.
+- Description: The high-water threshold of disk capacity used percent (fraction of total capacity) used when computing backend load scores. `BackendLoadStatistic.calcSore` uses `capacity_used_percent_high_water` to set `LoadScore.capacityCoefficient`: if a backend's used percent less than 0.5 the coefficient equal to 0.5; if used percent > `capacity_used_percent_high_water` the coefficient = 1.0; otherwise the coefficient transitions linearly with used percent via (2 * usedPercent - 0.5). When the coefficient is 1.0, the load score is driven entirely by capacity proportion; lower values increase the weight of replica count. Adjusting this value changes how aggressively the balancer penalizes backends with high disk utilization.
 - Introduced in: v3.2.0
 
 ##### catalog_trash_expire_second
@@ -3444,7 +3444,7 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Type: Int
 - Unit: Kilobytes
 - Is mutable: Yes
-- Description: Sets the HDFS write buffer size (in KB) used for direct writes to HDFS or object stores when not using a broker. The FE converts this value to bytes (<< 10) and initializes the local write buffer in HdfsFsManager, and it is propagated in Thrift requests (e.g., TUploadReq, TExportSink, sink options) so backends/agents use the same buffer size. Increasing this value can improve throughput for large sequential writes at the cost of more memory per writer; decreasing it reduces per-stream memory usage and may lower latency for small writes. Tune alongside `hdfs_read_buffer_size_kb` and consider available memory and concurrent writers.
+- Description: Sets the HDFS write buffer size (in KB) used for direct writes to HDFS or object stores when not using a broker. The FE converts this value to bytes (`<< 10`) and initializes the local write buffer in HdfsFsManager, and it is propagated in Thrift requests (e.g., TUploadReq, TExportSink, sink options) so backends/agents use the same buffer size. Increasing this value can improve throughput for large sequential writes at the cost of more memory per writer; decreasing it reduces per-stream memory usage and may lower latency for small writes. Tune alongside `hdfs_read_buffer_size_kb` and consider available memory and concurrent writers.
 - Introduced in: v3.2.0
 
 ##### lake_batch_publish_max_version_num

--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -113,6 +113,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Description: The maximum number of audit log files that can be retained within each retention period specified by the `audit_log_roll_interval` parameter.
 - Introduced in: -
 
+##### bdbje_log_level
+
+- Default: `INFO`
+- Type: String
+- Unit: -
+- Is mutable: No
+- Description: Controls the logging level used by Berkeley DB Java Edition (BDB JE) in StarRocks. During BDB environment initialization BDBEnvironment.initConfigs() applies this value to the Java logger for the `com.sleepycat.je` package and to the BDB JE environment file logging level (EnvironmentConfig.FILE_LOGGING_LEVEL). Accepts standard java.util.logging.Level names such as SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST, ALL, OFF. Setting to ALL enables all log messages. Increasing verbosity will raise log volume and may impact disk I/O and performance; the value is read when the BDB environment is initialized, so it takes effect only after environment (re)initialization.
+- Introduced in: `v3.2.0`
+
 ##### big_query_log_delete_age
 
 - Default: 7d
@@ -205,6 +214,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Description: The maximum number of dump log files that can be retained within each retention period specified by the `dump_log_roll_interval` parameter.
 - Introduced in: -
 
+##### edit_log_write_slow_log_threshold_ms
+
+- Default: 2000
+- Type: Int
+- Unit: Milliseconds
+- Is mutable: Yes
+- Description: Threshold (in ms) used by JournalWriter to detect and log slow edit-log batch writes. After a batch commit, if the batch duration exceeds this value, JournalWriter emits a WARN with batch size, duration and current journal queue size (rate-limited to once every ~2s). This setting only controls logging/alerts for potential IO or replication latency on the FE leader; it does not change commit or roll behavior (see `edit_log_roll_num` and commit-related settings). Metric updates still occur regardless of this threshold.
+- Introduced in: v3.2.3
+
 ##### enable_audit_sql
 
 - Default: true
@@ -222,15 +240,6 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Is mutable: No
 - Description: Whether to enable profile logging. When this feature is enabled, the FE writes per-query profile logs (the serialized `queryDetail` JSON produced by `ProfileManager`) to the profile log sink. This logging is performed only if `enable_collect_query_detail_info` is also enabled; when `enable_profile_log_compress` is enabled, the JSON may be gzipped before logging. Profile log files are managed by `profile_log_dir`, `profile_log_roll_num`, `profile_log_roll_interval` and rotated/deleted according to `profile_log_delete_age` (supports formats like `7d`, `10h`, `60m`, `120s`). Disabling this feature stops writing profile logs (reducing disk I/O, compression CPU and storage usage).
 - Introduced in: v3.2.5
-
-##### enable_profile_log_compress
-
-- Default: false
-- Type: Boolean
-- Unit: -
-- Is mutable: No
-- Description: Whether to enable compression for profile logging. When this feature is enabled, the JSON query profile produced by ProfileManager is GZIP-compressed via `CompressionUtils.gzipCompressString` before being written to profile logs. This compression only takes effect when both `enable_collect_query_detail_info` and `enable_profile_log` are set to `true`. Compression reduces log volume and I/O at the cost of CPU; consumers of profile logs must decompress the GZIP payload to read query details. If compression fails, a warning is logged and the compressed profile is not written.
-- Introduced in: v3.2.7
 
 ##### enable_qe_slow_log
 
@@ -524,6 +533,33 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Description: The maximum length of time for which bRPC clients wait as in the idle state.
 - Introduced in: -
 
+##### brpc_inner_reuse_pool
+
+- Default: `true`
+- Type: boolean
+- Unit: -
+- Is mutable: No
+- Description: Controls whether the underlying BRPC client uses an internal shared reuse pool for connections/channels. StarRocks reads `brpc_inner_reuse_pool` in BrpcProxy when constructing RpcClientOptions (via `rpcOptions.setInnerResuePool(...)`). When enabled (true) the RPC client reuses internal pools to reduce per-call connection creation, lowering connection churn, memory and file-descriptor usage for FE-to-BE / LakeService RPCs. When disabled (false) the client may create more isolated pools (increasing concurrency isolation at the cost of higher resource usage). Changing this value requires restarting the process to take effect.
+- Introduced in: v3.3.11, v3.4.1, v3.5.0
+
+##### brpc_min_evictable_idle_time_ms
+
+- Default: `120000`
+- Type: Int
+- Unit: Milliseconds
+- Is mutable: No
+- Description: Time in milliseconds that an idle BRPC connection must remain in the connection pool before it becomes eligible for eviction. Applied to the RpcClientOptions used by `BrpcProxy` (via RpcClientOptions.setMinEvictableIdleTime). Raise this value to keep idle connections longer (reducing reconnect churn); lower it to free unused sockets faster (reducing resource usage). Tune together with `brpc_connection_pool_size` and `brpc_idle_wait_max_time` to balance connection reuse, pool growth, and eviction behavior.
+- Introduced in: `v3.3.11, v3.4.1, v3.5.0`
+
+##### brpc_reuse_addr
+
+- Default: `true`
+- Type: Boolean
+- Unit: -
+- Is mutable: No
+- Description: When true, StarRocks sets the socket option to allow local address reuse for client sockets created by the brpc RpcClient (via RpcClientOptions.setReuseAddress). Enabling this reduces bind failures and allows faster rebinding of local ports after sockets are closed, which is helpful for high-rate connection churn or rapid restarts. When false, address/port reuse is disabled, which can reduce the chance of unintended port sharing but may increase transient bind errors. This option interacts with connection behavior configured by `brpc_connection_pool_size` and `brpc_short_connection` because it affects how rapidly client sockets can be rebound and reused.
+- Introduced in: `v3.3.11, v3.4.1, v3.5.0`
+
 ##### cluster_name
 
 - Default: StarRocks Cluster
@@ -541,6 +577,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Is mutable: Yes
 - Description: Whether to allow the system to process HTTP requests asynchronously. If this feature is enabled, an HTTP request received by Netty worker threads will then be submitted to a separate thread pool for service logic handling to avoid blocking the HTTP server. If disabled, Netty workers will handle the service logic.
 - Introduced in: 4.0.0
+
+##### enable_http_validate_headers
+
+- Default: `false`
+- Type: Boolean
+- Unit: -
+- Is mutable: No
+- Description: Controls whether Netty's HttpServerCodec performs strict HTTP header validation. The value is passed to HttpServerCodec when the HTTP pipeline is initialized in `HttpServer` (see UseLocations). Default is false for backward compatibility because newer netty versions enforce stricter header rules (https://github.com/netty/netty/pull/12760). Set to true to enforce RFC-compliant header checks; doing so may cause malformed or nonconforming requests from legacy clients or proxies to be rejected. Change requires a restart of the HTTP server to take effect.
+- Introduced in: `v3.3.0, v3.4.0, v3.5.0`
 
 ##### enable_https
 
@@ -578,6 +623,33 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Description: The length of the backlog queue held by the HTTP server in the FE node.
 - Introduced in: -
 
+##### http_max_chunk_size
+
+- Default: 8192
+- Type: Int
+- Unit: Bytes
+- Is mutable: No
+- Description: Sets the maximum allowed size (in bytes) of a single HTTP chunk handled by Netty's HttpServerCodec in the FE HTTP server. It is passed as the third argument to HttpServerCodec and limits the length of chunks during chunked transfer or streaming requests/responses. If an incoming chunk exceeds this value, Netty will raise a frame-too-large error (e.g., TooLongFrameException) and the request may be rejected. Increase this for legitimate large chunked uploads; keep it small to reduce memory pressure and surface area for DoS attacks. This setting is used alongside `http_max_initial_line_length`, `http_max_header_size`, and `enable_http_validate_headers`.
+- Introduced in: `v3.2.0`
+
+##### http_max_header_size
+
+- Default: `32768`
+- Type: Int
+- Unit: Bytes
+- Is mutable: No
+- Description: Maximum allowed size in bytes for the HTTP request header block parsed by Netty's `HttpServerCodec`. StarRocks passes this value to `HttpServerCodec` (as `Config.http_max_header_size`); if an incoming request's headers (names and values combined) exceed this limit, the codec will reject the request (decoder exception) and the connection/request will fail. Increase only when clients legitimately send very large headers (large cookies or many custom headers); larger values increase per-connection memory use. Tune in conjunction with `http_max_initial_line_length` and `http_max_chunk_size`. Changes require FE restart.
+- Introduced in: `v3.2.0`
+
+##### http_max_initial_line_length
+
+- Default: `4096`
+- Type: Int
+- Unit: Bytes
+- Is mutable: No
+- Description: Sets the maximum allowed length (in bytes) of the HTTP initial request line (method + request-target + HTTP version) accepted by the Netty `HttpServerCodec` used in HttpServer. The value is passed to Netty's decoder and requests with an initial line longer than this will be rejected (TooLongFrameException). Increase this only when you must support very long request URIs; larger values increase memory use and may raise exposure to malformed/request-abuse. Tune together with `http_max_header_size` and `http_max_chunk_size`.
+- Introduced in: `v3.2.0`
+
 ##### http_port
 
 - Default: 8030
@@ -586,6 +658,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Is mutable: No
 - Description: The port on which the HTTP server in the FE node listens.
 - Introduced in: -
+
+##### http_web_page_display_hardware
+
+- Default: `true`
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: When true, the HTTP index page (/index) will include a hardware information section populated via the oshi library (CPU, memory, processes, disks, filesystems, network, etc.). oshi may invoke system utilities or read system files indirectly (for example, it can execute commands such as `getent passwd`), which can surface sensitive system data. If you require stricter security or want to avoid executing those indirect commands on the host, set this configuration to false to disable collection and display of hardware details on the web UI.
+- Introduced in: `v3.2.0`
 
 ##### http_worker_threads_num
 
@@ -743,6 +824,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Description: The length of time after which idle client connections time out.
 - Introduced in: -
 
+##### thrift_rpc_max_body_size
+
+- Default: `-1`
+- Type: Int
+- Unit: Bytes
+- Is mutable: No
+- Description: Controls the maximum allowed Thrift RPC message body size (in bytes) used when constructing the server's Thrift protocol (passed to TBinaryProtocol.Factory in `ThriftServer`). A value of `-1` disables the limit (unbounded). Setting a positive value enforces an upper bound so that messages larger than this are rejected by the Thrift layer, which helps limit memory usage and mitigate oversized-request or DoS risks. Set this to a size large enough for expected payloads (large structs or batched data) to avoid rejecting legitimate requests.
+- Introduced in: `v3.2.0`
+
 ##### thrift_server_max_worker_threads
 
 - Default: 4096
@@ -762,6 +852,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Introduced in: -
 
 ### Metadata and cluster management
+
+##### alter_max_worker_queue_size
+
+- Default: `4096`
+- Type: Int
+- Unit: Tasks
+- Is mutable: No
+- Description: Controls the capacity of the internal worker thread pool queue used by the alter subsystem. It is passed to `ThreadPoolManager.newDaemonCacheThreadPool` in `AlterHandler` together with `alter_max_worker_threads`. When the number of pending alter tasks exceeds `alter_max_worker_queue_size`, new submissions will be rejected and a `RejectedExecutionException` can be thrown (see `AlterHandler.handleFinishAlterTask`). Tune this value to balance memory usage and the amount of backlog you permit for concurrent alter tasks.
+- Introduced in: `v3.2.0`
+
+##### alter_max_worker_threads
+
+- Default: `4`
+- Type: Int
+- Unit: Threads
+- Is mutable: No
+- Description: Sets the maximum number of worker threads in the AlterHandler's thread pool. The AlterHandler constructs the executor with this value to run and finalize alter-related tasks (e.g., submitting `AlterReplicaTask` via handleFinishAlterTask). This value bounds concurrent execution of alter operations; raising it increases parallelism and resource usage, lowering it limits concurrent alters and may become a bottleneck. The executor is created together with `alter_max_worker_queue_size`, and the handler scheduling uses `alter_scheduler_interval_millisecond`.
+- Introduced in: `v3.2.0`
 
 ##### automated_cluster_snapshot_interval_seconds
 
@@ -790,6 +898,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Description: The expiration time of a Hive metadata cache refresh task. For the Hive catalog that has been accessed, if it has not been accessed for more than the specified time, StarRocks stops refreshing its cached metadata. For the Hive catalog that has not been accessed, StarRocks will not refresh its cached metadata.
 - Introduced in: v2.5.5
 
+##### bdbje_cleaner_threads
+
+- Default: `1`
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: Number of background cleaner threads for the Berkeley DB Java Edition (JE) environment used by StarRocks journal. This value is read during environment initialization in `BDBEnvironment.initConfigs` and applied to `EnvironmentConfig.CLEANER_THREADS` using `Config.bdbje_cleaner_threads`. It controls parallelism for JE log cleaning and space reclamation; increasing it can speed up cleaning at the cost of additional CPU and I/O interference with foreground operations. Changes take effect only when the BDB environment is (re)initialized, so a frontend restart is required to apply a new value.
+- Introduced in: `v3.2.0`
+
 ##### bdbje_heartbeat_timeout_second
 
 - Default: 30
@@ -808,6 +925,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Description: The amount of time after which a lock in the BDB JE-based FE times out.
 - Introduced in: -
 
+##### bdbje_replay_cost_percent
+
+- Default: 150
+- Type: Int
+- Unit: Percent
+- Is mutable: No
+- Description: Sets the relative cost (as a percentage) of replaying transactions from a BDB JE log versus obtaining the same data via a network restore. The value is supplied to the underlying JE replication parameter REPLAY_COST_PERCENT and is typically >100 to indicate that replay is usually more expensive than a network restore. When deciding whether to retain cleaned log files for potential replay, the system compares replay cost multiplied by log size against the cost of a network restore; files will be removed if network restore is judged more efficient. A value of 0 disables retention based on this cost comparison. Log files required for replicas within `REP_STREAM_TIMEOUT` or for any active replication are always retained.
+- Introduced in: `v3.2.0`
+
 ##### bdbje_replica_ack_timeout_second
 
 - Default: 10
@@ -816,6 +942,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Is mutable: No
 - Description: The maximum amount of time for which the leader FE can wait for ACK messages from a specified number of follower FEs when metadata is written from the leader FE to the follower FEs. Unit: second. If a large amount of metadata is being written, the follower FEs require a long time before they can return ACK messages to the leader FE, causing ACK timeout. In this situation, metadata writes fail, and the FE process exits. We recommend that you increase the value of this parameter to prevent this situation.
 - Introduced in: -
+
+##### bdbje_reserved_disk_size
+
+- Default: `512L * 1024 * 1024` (536870912)
+- Type: Long
+- Unit: Bytes
+- Is mutable: No
+- Description: Limits the number of bytes Berkeley DB JE will reserve as "unprotected" (deletable) log/data files. StarRocks passes this value to JE via `EnvironmentConfig.RESERVED_DISK` in BDBEnvironment; JE's built-in default is 0 (unlimited). The StarRocks default (512 MiB) prevents JE from reserving excessive disk space for unprotected files while allowing safe cleanup of obsolete files. Tune this value on disk-constrained systems: decreasing it lets JE free more files sooner, increasing it lets JE retain more reserved space. Changes require restarting the process to take effect.
+- Introduced in: `v3.2.0`
 
 ##### bdbje_reset_election_group
 
@@ -844,6 +979,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Description: The time duration for retaining historical connection failures of BE nodes in the BE Blacklist. If a BE node is added to the BE Blacklist automatically, StarRocks will assess its connectivity and judge whether it can be removed from the BE Blacklist. Within `black_host_history_sec`, only if a blacklisted BE node has fewer connection failures than the threshold set in `black_host_connect_failures_within_time`, it can be removed from the BE Blacklist.
 - Introduced in: v3.3.0
 
+##### brpc_connection_pool_size
+
+- Default: `16`
+- Type: Int
+- Unit: Connections
+- Is mutable: No
+- Description: The maximum number of pooled BRPC connections per endpoint used by the FE's BrpcProxy. This value is applied to RpcClientOptions via `setMaxTotoal` and `setMaxIdleSize`, so it directly limits concurrent outgoing BRPC requests because each request must borrow a connection from the pool. In high-concurrency scenarios increase this to avoid request queuing; increasing it raises socket and memory usage and may increase remote server load. When tuning, consider related settings such as `brpc_idle_wait_max_time`, `brpc_short_connection`, `brpc_inner_reuse_pool`, `brpc_reuse_addr`, and `brpc_min_evictable_idle_time_ms`. Changing this value is not hot-reloadable and requires a restart.
+- Introduced in: `v3.2.0`
+
+##### brpc_short_connection
+
+- Default: `false`
+- Type: boolean
+- Unit: -
+- Is mutable: No
+- Description: Controls whether the underlying brpc RpcClient uses short-lived connections. When enabled (`true`), RpcClientOptions.setShortConnection is set and connections are closed after a request completes, reducing the number of long-lived sockets at the cost of higher connection setup overhead and increased latency. When disabled (`false`, the default) persistent connections and connection pooling are used. Enabling this option affects connection-pool behavior and should be considered together with `brpc_connection_pool_size`, `brpc_idle_wait_max_time`, `brpc_min_evictable_idle_time_ms`, `brpc_reuse_addr`, and `brpc_inner_reuse_pool`. Keep it disabled for typical high-throughput deployments; enable only to limit socket lifetime or when short connections are required by network policy.
+- Introduced in: `v3.3.11, v3.4.1, v3.5.0`
+
 ##### catalog_try_lock_timeout_ms
 
 - Default: 5000
@@ -852,6 +1005,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Is mutable: Yes
 - Description: The timeout duration to obtain the global lock.
 - Introduced in: -
+
+##### checkpoint_only_on_leader
+
+- Default: `false`
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: When `true`, the CheckpointController will only select the leader FE as the checkpoint worker; when `false`, the controller may pick any frontend and prefers nodes with lower heap usage. With `false`, workers are sorted by recent failure time and `heapUsedPercent` (the leader is treated as having infinite usage to avoid selecting it). For operations that require cluster snapshot metadata, the controller already forces leader selection regardless of this flag. Enabling `true` centralizes checkpoint work on the leader (simpler but increases leader CPU/memory and network load); keeping it `false` distributes checkpoint load to less-loaded FEs. This setting affects worker selection and interaction with timeouts such as `checkpoint_timeout_seconds` and RPC settings like `thrift_rpc_timeout_ms`.
+- Introduced in: `v3.4.0, v3.5.0`
+
+##### checkpoint_timeout_seconds
+
+- Default: `24 * 3600`
+- Type: Long
+- Unit: Seconds
+- Is mutable: Yes
+- Description: Maximum time (in seconds) the leader's CheckpointController will wait for a checkpoint worker to complete a checkpoint. The controller converts this value to nanoseconds and polls the worker result queue; if no successful completion is received within this timeout the checkpoint is treated as failed and createImage returns failure. Increasing this value accommodates longer-running checkpoints but delays failure detection and subsequent image propagation; decreasing it causes faster failover/retries but can produce false timeouts for slow workers. This setting only controls the waiting period in `CheckpointController` during checkpoint creation and does not change the worker's internal checkpointing behavior.
+- Introduced in: `v3.4.0, v3.5.0`
 
 ##### db_used_data_quota_update_interval_secs
 
@@ -955,6 +1126,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
   - Currently, this feature does not support JDBC catalog and table names. Do not enable this feature if you want to perform case-insensitive processing on JDBC or ODBC data sources.
 - Introduced in: v4.0
 
+##### enable_task_history_archive
+
+- Default: `true`
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: When enabled, finished task-run records are archived to the persistent task-run history table and recorded to the edit log so lookups (e.g., `lookupHistory`, `lookupHistoryByTaskNames`, `lookupLastJobOfTasks`) include archived results. Archiving is performed by the FE leader and is skipped during unit tests (`FeConstants.runningUnitTest`). When enabled, in-memory expiration and forced-GC paths are bypassed (the code returns early from `removeExpiredRuns` and `forceGC`), so retention/eviction is handled by the persistent archive instead of `task_runs_ttl_second` and `task_runs_max_history_number`. When disabled, history stays in memory and is pruned by those configurations.
+- Introduced in: v3.3.1, v3.4.0, v3.5.0
+
+##### enable_task_run_fe_evaluation
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: When enabled, the FE will perform local evaluation for the system table `task_runs` in `TaskRunsSystemTable.supportFeEvaluation`. FE-side evaluation is only allowed for conjunctive equality predicates comparing a column to a constant and is limited to the columns `QUERY_ID` and `TASK_NAME`. Enabling this improves performance for targeted lookups by avoiding broader scans or additional remote processing; disabling it forces the planner to skip FE evaluation for `task_runs`, which may reduce predicate pruning and affect query latency for those filters.
+- Introduced in: v3.3.13, v3.4.3, v3.5.0
+
 ##### heartbeat_mgr_blocking_queue_size
 
 - Default: 1024
@@ -990,6 +1179,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Is mutable: Yes
 - Description: Whether non-Leader FEs ignore the metadata gap from the Leader FE. If the value is TRUE, non-Leader FEs ignore the metadata gap from the Leader FE and continue providing data reading services. This parameter ensures continuous data reading services even when you stop the Leader FE for a long period of time. If the value is FALSE, non-Leader FEs do not ignore the metadata gap from the Leader FE and stop providing data reading services.
 - Introduced in: -
+
+##### lock_checker_interval_second
+
+- Default: 30
+- Type: long
+- Unit: Seconds
+- Is mutable: Yes
+- Description: Interval, in seconds, between executions of the LockChecker frontend daemon (named "deadlock-checker"). The daemon performs deadlock detection and slow-lock scanning; the configured value is multiplied by 1000 to set the timer in milliseconds. Decreasing this value reduces detection latency but increases scheduling and CPU overhead; increasing it reduces overhead but delays detection and slow-lock reporting. Changes take effect at runtime because the daemon resets its interval each run. This setting interacts with `lock_checker_enable_deadlock_check` (enables deadlock checks) and `slow_lock_threshold_ms` (defines what constitutes a slow lock).
+- Introduced in: v3.2.0
 
 ##### master_sync_policy
 
@@ -1072,6 +1270,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
   - `WRITE_NO_SYNC`: When a transaction is committed, a log entry is generated simultaneously but is not flushed to disk.
 - Introduced in: -
 
+##### start_with_incomplete_meta
+
+- Default: `false`
+- Type: boolean
+- Unit: -
+- Is mutable: No
+- Description: When true, the FE will allow startup when image data exists but Berkeley DB JE (BDB) log files are missing or corrupted. `MetaHelper.checkMetaDir()` uses this flag to bypass the safety check that otherwise prevents starting from an image without corresponding BDB logs; starting this way can produce stale or inconsistent metadata and should only be used for emergency recovery. `RestoreClusterSnapshotMgr` temporarily sets this flag to true while restoring a cluster snapshot and then rolls it back; that component also toggles `bdbje_reset_election_group` during restore. Do not enable in normal operation — enable only when recovering from corrupted BDB data or when explicitly restoring an image-based snapshot.
+- Introduced in: `v3.2.0`
+
+##### table_keeper_interval_second
+
+- Default: `30`
+- Type: Int
+- Unit: Seconds
+- Is mutable: Yes
+- Description: Interval, in seconds, between executions of the TableKeeper daemon. The TableKeeperDaemon uses this value (multiplied by 1000) to set its internal timer and periodically runs keeper tasks that ensure history tables exist, correct table properties (replication number) and update partition TTLs. The daemon only performs work on the leader node and updates its runtime interval via setInterval when `table_keeper_interval_second` changes. Increase to reduce scheduling frequency and load; decrease for faster reaction to missing or stale history tables.
+- Introduced in: `v3.3.1, v3.4.0, v3.5.0`
+
 ##### task_runs_ttl_second
 
 - Default: 7 * 24 * 3600
@@ -1089,6 +1305,33 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Is mutable: Yes
 - Description: Time-to-live (TTL) for tasks. For manual tasks (when no schedule is set), TaskBuilder uses this value to compute the task's `expireTime` (`expireTime = now + task_ttl_second * 1000L`). TaskRun also uses this value as an upper bound when computing a run's execute timeout — the effective execute timeout is `min(task_runs_timeout_second, task_runs_ttl_second, task_ttl_second)`. Adjusting this value changes how long manually created tasks remain valid and can indirectly limit the maximum allowed execution time of task runs.
 - Introduced in: v3.2.0
+
+##### thrift_rpc_retry_times
+
+- Default: `3`
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: Controls the total number of attempts a Thrift RPC call will make. This value is used by `ThriftRPCRequestExecutor` (and callers such as `NodeMgr` and `VariableMgr`) as the loop count for retries — i.e., a value of 3 allows up to three attempts including the initial try. On `TTransportException` the executor will try to reopen the connection and retry up to this count; it will not retry when the cause is a `SocketTimeoutException` or when reopen fails. Each attempt is subject to the per-attempt timeout configured by `thrift_rpc_timeout_ms`. Increasing this value improves resilience to transient connection failures but can increase overall RPC latency and resource usage.
+- Introduced in: v3.2.0
+
+##### thrift_rpc_strict_mode
+
+- Default: `true`
+- Type: Boolean
+- Unit: -
+- Is mutable: No
+- Description: Controls the TBinaryProtocol "strict read" mode used by the Thrift server. This value is passed as the first argument to org.apache.thrift.protocol.TBinaryProtocol.Factory in the Thrift server stack and affects how incoming Thrift messages are parsed and validated. When `true` (default), the server enforces strict Thrift encoding/version checks and honors the configured `thrift_rpc_max_body_size` limit; when `false`, the server accepts non-strict (legacy/lenient) message formats, which can improve compatibility with older clients but may bypass some protocol validations. Use caution changing this on a running cluster because it is not mutable and affects interoperability and parsing safety.
+- Introduced in: `v3.2.0`
+
+##### thrift_rpc_timeout_ms
+
+- Default: `10000`
+- Type: Int
+- Unit: Milliseconds
+- Is mutable: Yes
+- Description: Timeout (in milliseconds) used as the default network/socket timeout for Thrift RPC calls. It is passed to TSocket when creating Thrift clients in `ThriftConnectionPool` (used by the frontend and backend pools) and is also added to an operation's execution timeout (e.g., ExecTimeout*1000 + `thrift_rpc_timeout_ms`) when computing RPC call timeouts in places such as `ConfigBase`, `LeaderOpExecutor`, `GlobalStateMgr`, `NodeMgr`, `VariableMgr`, and `CheckpointWorker`. Increasing this value makes RPC calls tolerate longer network or remote processing delays; decreasing it causes faster failover on slow networks. Changing this value affects connection creation and request deadlines across the FE code paths that perform Thrift RPCs.
+- Introduced in: `v3.2.0`
 
 ##### txn_latency_metric_report_groups
 
@@ -1110,6 +1353,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ### User, role, and privilege
 
+##### enable_task_info_mask_credential
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: When true, StarRocks redacts credentials from task SQL definitions before returning them in information_schema.tasks and information_schema.task_runs by applying SqlCredentialRedactor.redact to the DEFINITION column. In `information_schema.task_runs` the same redaction is applied whether the definition comes from the task run status or, when empty, from the task definition lookup. When false, raw task definitions are returned (may expose credentials). Masking is CPU/string-processing work and can be time-consuming when the number of tasks or task_runs is large; disable only if you need unredacted definitions and accept the security risk.
+- Introduced in: v3.5.6
+
 ##### privilege_max_role_depth
 
 - Default: 16
@@ -1129,6 +1381,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Introduced in: v3.0.0
 
 ### Query engine
+
+##### brpc_send_plan_fragment_timeout_ms
+
+- Default: `60000`
+- Type: Int
+- Unit: Milliseconds
+- Is mutable: Yes
+- Description: Timeout in milliseconds applied to the BRPC TalkTimeoutController before sending a plan fragment. `BackendServiceClient.sendPlanFragmentAsync` sets this value prior to calling the backend `execPlanFragmentAsync`. It governs how long BRPC will wait when borrowing an idle connection from the connection pool and while performing the send; if exceeded, the RPC will fail and may trigger the method's retry logic. Set this lower to fail fast under contention, or raise it to tolerate transient pool exhaustion or slow networks. Be cautious: very large values can delay failure detection and block request threads.
+- Introduced in: `v3.3.11, v3.4.1, v3.5.0`
 
 ##### connector_table_query_trigger_analyze_large_table_interval
 
@@ -1365,6 +1626,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: Whether to enable predicate columns collection. If disabled, predicate columns will not be recorded during query optimization.
 - Introduced in: -
 
+##### enable_query_queue_v2
+
+- Default: false
+- Type: boolean
+- Unit: -
+- Is mutable: No
+- Description: When true, switches the FE slot-based query scheduler to Query Queue V2. The flag is read by the slot manager and trackers (for example, `BaseSlotManager.isEnableQueryQueueV2` and `SlotTracker#createSlotSelectionStrategy`) to choose `SlotSelectionStrategyV2` instead of the legacy strategy. `query_queue_v2_xxx` configuration options and `QueryQueueOptions` take effect only when this flag is enabled. Because the value is static at runtime, enablement requires restarting the leader FE to take effect and may change query scheduling, concurrency limits, and queueing behavior cluster-wide.
+- Introduced in: `v3.3.4, v3.4.0, v3.5.0`
+
 ##### enable_sql_blacklist
 
 - Default: false
@@ -1480,6 +1750,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: If the response time for an HTTP request exceeds the value specified by this parameter, a log is generated to track this request.
 - Introduced in: v2.5.15, v3.1.5
 
+##### lock_checker_enable_deadlock_check
+
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: When enabled, the LockChecker thread performs JVM-level deadlock detection using ThreadMXBean.findDeadlockedThreads() and logs the offending threads' stack traces. The check runs inside the LockChecker daemon (whose frequency is controlled by `lock_checker_interval_second`) and writes detailed stack information to the log, which may be CPU- and I/O-intensive. Enable this option only for troubleshooting live or reproducible deadlock issues; leaving it enabled in normal operation can increase overhead and log volume.
+- Introduced in: v3.2.0
+
 ##### low_cardinality_threshold
 
 - Default: 255
@@ -1534,6 +1813,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: The maximum number of times that the optimizer can rewrite a scalar operator.
 - Introduced in: -
 
+##### max_query_queue_history_slots_number
+
+- Default: `0`
+- Type: Int
+- Unit: Slots
+- Is mutable: Yes
+- Description: Controls how many recently released (history) allocated slots are retained per query queue for monitoring and observability. When `max_query_queue_history_slots_number` is set to a value &gt; 0, BaseSlotTracker keeps up to that many most-recently released LogicalSlot entries in an in-memory queue, evicting the oldest when the limit is exceeded. Enabling this causes getSlots() to include these history entries (newest first), allows BaseSlotTracker to attempt registering slots with the ConnectContext for richer ExtraMessage data, and lets LogicalSlot.ConnectContextListener attach query finish metadata to history slots. When `max_query_queue_history_slots_number` &lt;= 0 the history mechanism is disabled (no extra memory used). Use a reasonable value to balance observability and memory overhead.
+- Introduced in: `v3.5.0`
+
 ##### max_query_retry_time
 
 - Default: 2
@@ -1587,6 +1875,51 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Is mutable: No
 - Description: The time interval at which release validation tasks are issued.
 - Introduced in: -
+
+##### query_queue_slots_estimator_strategy
+
+- Default: `SlotEstimatorFactory.EstimatorPolicy.createDefault().name()` (resolves to `MAX`)
+- Type: String
+- Unit: -
+- Is mutable: Yes
+- Description: Selects the slot estimation strategy used for queue-based queries when `enable_query_queue_v2` is true. Valid values: MBE (memory-based), PBE (parallelism-based), MAX (take max of MBE and PBE) and MIN (take min of MBE and PBE). MBE estimates slots from predicted memory or plan costs divided by the per-slot memory target and is capped by `totalSlots`. PBE derives slots from fragment parallelism (scan range counts or cardinality / rows-per-slot) and a CPU-cost based calculation (using CPU costs per slot), then bounds the result within [numSlots/2, numSlots]. MAX and MIN combine MBE and PBE by taking their maximum or minimum respectively. If the configured value is invalid, the default (`MAX`) is used.
+- Introduced in: `v3.5.0`
+
+##### query_queue_v2_concurrency_level
+
+- Default: `4`
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: Controls how many logical concurrency "layers" are used when computing the system's total query slots. In shared-nothing mode the total slots = `query_queue_v2_concurrency_level` * number_of_BEs * cores_per_BE (derived from BackendResourceStat). In multi-warehouse mode the effective concurrency is scaled down to max(1, `query_queue_v2_concurrency_level` / 4). If the configured value is non-positive it is treated as `4`. Changing this value increases or decreases totalSlots (and therefore concurrent query capacity) and affects per-slot resources: memBytesPerSlot is derived by dividing per-worker memory by (cores_per_worker * concurrency), and CPU accounting uses `query_queue_v2_cpu_costs_per_slot`. Set it proportional to cluster size; very large values may reduce per-slot memory and cause resource fragmentation. 
+- Introduced in: v3.3.4, v3.4.0, v3.5.0
+
+##### query_queue_v2_cpu_costs_per_slot
+
+- Default: `1000000000`
+- Type: Long
+- Unit: planner CPU cost units
+- Is mutable: Yes
+- Description: Per-slot CPU cost threshold used to estimate how many slots a query needs from its planner CPU cost. The scheduler computes slots as integer(plan_cpu_costs / `query_queue_v2_cpu_costs_per_slot`) and then clamps the result to the range [1, totalSlots] (totalSlots is derived from the query queue V2 `V2` parameters). The V2 code normalizes non-positive settings to 1 (Math.max(1, value)), so a non-positive value effectively becomes `1`. Increasing this value reduces slots allocated per query (favoring fewer, larger-slot queries); decreasing it increases slots per query. Tune together with `query_queue_v2_num_rows_per_slot` and concurrency settings to control parallelism vs. resource granularity.
+- Introduced in: v3.3.4, v3.4.0, v3.5.0
+
+##### query_queue_v2_num_rows_per_slot
+
+- Default: 4096
+- Type: Int
+- Unit: Rows
+- Is mutable: Yes
+- Description: The target number of source-row records assigned to a single scheduling slot when estimating per-query slot count. StarRocks computes estimated_slots = (cardinality of the Source Node) / `query_queue_v2_num_rows_per_slot`, then clamps the result to the range [1, totalSlots] and enforces a minimum of 1 if the computed value is non-positive. totalSlots is derived from available resources (roughly DOP * `query_queue_v2_concurrency_level` * number_of_workers/BE) and therefore depends on cluster/core counts. Increase this value to reduce slot count (each slot handles more rows) and lower scheduling overhead; decrease it to increase parallelism (more, smaller slots), up to the resource limit.
+- Introduced in: v3.3.4, v3.4.0, v3.5.0
+
+##### query_queue_v2_schedule_strategy
+
+- Default: `QueryQueueOptions.SchedulePolicy.createDefault().name()`
+- Type: String
+- Unit: -
+- Is mutable: Yes
+- Description: Selects the scheduling policy used by Query Queue V2 to order pending queries. Supported values (case-insensitive) are `SWRR` (Smooth Weighted Round Robin) — the default, suitable for mixed/hybrid workloads that need fair weighted sharing — and `SJF` (Short Job First + Aging) — prioritizes short jobs while using aging to avoid starvation. The value is parsed with case-insensitive enum lookup; an unrecognized value is logged as an error and the default policy is used. This configuration only affects behavior when Query Queue V2 is enabled and interacts with V2 sizing settings such as `query_queue_v2_concurrency_level`.
+- Introduced in: `v3.3.12, v3.4.2, v3.5.0`
 
 ##### semi_sync_collect_statistic_await_seconds
 
@@ -1713,6 +2046,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Is mutable: Yes
 - Description: Interval between executions of task background jobs. GlobalStateMgr uses this value to schedule the TaskCleaner FrontendDaemon which invokes `doTaskBackgroundJob()`; the value is multiplied by 1000 to set the daemon interval in milliseconds. Decreasing the value makes background maintenance (task cleanup, checks) run more frequently and react faster but increases CPU/IO overhead; increasing it reduces overhead but delays cleanup and detection of stale tasks. Tune this value to balance maintenance responsiveness and resource usage.
 - Introduced in: v3.2.0
+
+##### task_min_schedule_interval_s
+
+- Default: `10`
+- Type: Int
+- Unit: Seconds
+- Is mutable: Yes
+- Description: Minimum allowed schedule interval (in seconds) for task schedules checked by the SQL layer. When a task is submitted, TaskAnalyzer converts the schedule period to seconds and rejects the submission with ERR_INVALID_PARAMETER if the period is smaller than `task_min_schedule_interval_s`. This prevents creating tasks that run too frequently and protects the scheduler from high-frequency tasks. If a schedule has no explicit start time, TaskAnalyzer sets the start time to the current epoch seconds.
+- Introduced in: `v3.3.0, v3.4.0, v3.5.0`
 
 ### Loading and unloading
 
@@ -1899,6 +2241,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Is mutable: No
 - Description: The time interval at which load jobs are processed on a rolling basis.
 - Introduced in: -
+
+##### load_parallel_instance_num
+
+- Default: `1`
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: Controls the number of parallel load fragment instances created on a single host for broker and stream loads. LoadPlanner uses this value as the per-host degree of parallelism unless the session enables adaptive sink DOP; if the session variable `enable_adaptive_sink_dop` is true, the session`s `sink_degree_of_parallelism` overrides this configuration. When shuffle is required, this value is applied to fragment parallel execution (scan fragment and sink fragment parallel exec instances). When no shuffle is needed, it is used as the sink pipeline DOP. Note: loads from local files are forced to a single instance (pipeline DOP = 1, parallel exec = 1) to avoid local disk contention. Increasing this number raises per-host concurrency and throughput but may increase CPU, memory and I/O contention.
+- Introduced in: v3.2.0
 
 ##### load_straggler_wait_second
 
@@ -2108,6 +2459,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: The timeout duration for each Spark Load job.
 - Introduced in: -
 
+##### spark_load_submit_timeout_second
+
+- Default: 300
+- Type: long
+- Unit: Seconds
+- Is mutable: No
+- Description: Maximum time in seconds to wait for a YARN response after submitting a Spark application. `SparkLauncherMonitor.LogMonitor` converts this value to milliseconds and will stop monitoring and forcibly kill the spark launcher process if the job remains in UNKNOWN/CONNECTED/SUBMITTED longer than this timeout. `SparkLoadJob` reads this configuration as the default and allows a per-load override via the `LoadStmt.SPARK_LOAD_SUBMIT_TIMEOUT` property. Set it high enough to accommodate YARN queueing delays; setting it too low may abort legitimately queued jobs, while setting it too high may delay failure handling and resource cleanup.
+- Introduced in: `v3.2.0`
+
 ##### spark_resource_path
 
 - Default: Empty string
@@ -2125,6 +2485,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Is mutable: Yes
 - Description: The default timeout duration for each Stream Load job.
 - Introduced in: -
+
+##### stream_load_max_txn_num_per_be
+
+- Default: `-1`
+- Type: Int
+- Unit: Transactions
+- Is mutable: Yes
+- Description: Limits the number of concurrent stream-load transactions accepted from a single BE (backend) host. When set to a non-negative integer, FrontendServiceImpl checks the current transaction count for the BE (by client IP) and rejects new stream-load begin requests if the count >= this limit. A value of &lt; 0 disables the limit (unlimited). This check occurs during stream load begin and may cause a `streamload txn num per be exceeds limit` error when exceeded. Related runtime behavior uses `stream_load_default_timeout_second` for request timeout fallback.
+- Introduced in: v3.3.0, v3.4.0, v3.5.0
 
 ##### stream_load_task_keep_max_num
 
@@ -2189,6 +2558,17 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: The directory that stores the Yarn configuration file.
 - Introduced in: -
 
+### Statistic report
+
+##### enable_http_detail_metrics
+
+- Default: false
+- Type: boolean
+- Unit: -
+- Is mutable: Yes
+- Description: When true, the HTTP server computes and exposes detailed HTTP worker metrics (notably the `HTTP_WORKER_PENDING_TASKS_NUM` gauge). Enabling this causes the server to iterate over Netty worker executors and call `pendingTasks()` on each `NioEventLoop` to sum pending task counts; when disabled the gauge returns 0 to avoid that cost. This extra collection can be CPU- and latency-sensitive — enable only for debugging or detailed investigation.
+- Introduced in: v3.2.3
+
 ### Storage
 
 ##### alter_table_timeout_second
@@ -2199,6 +2579,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Is mutable: Yes
 - Description: The timeout duration for the schema change operation (ALTER TABLE).
 - Introduced in: -
+
+##### capacity_used_percent_high_water
+
+- Default: 0.75
+- Type: double
+- Unit: Fraction (0.0–1.0)
+- Is mutable: Yes
+- Description: The high-water threshold of disk capacity used percent (fraction of total capacity) used when computing backend load scores. `BackendLoadStatistic.calcSore` uses `capacity_used_percent_high_water` to set `LoadScore.capacityCoefficient`: if a backend's used percent < 0.5 the coefficient = 0.5; if used percent > `capacity_used_percent_high_water` the coefficient = 1.0; otherwise the coefficient transitions linearly with used percent via (2 * usedPercent - 0.5). When the coefficient is 1.0, the load score is driven entirely by capacity proportion; lower values increase the weight of replica count. Adjusting this value changes how aggressively the balancer penalizes backends with high disk utilization.
+- Introduced in: v3.2.0
 
 ##### catalog_trash_expire_second
 
@@ -2260,6 +2649,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 >
 > - StarRocks shared-data clusters supports this parameter from v3.3.0.
 > - If you need to configure the fast schema evolution for a specific table, such as disabling fast schema evolution for a specific table, you can set the table property [`fast_schema_evolution`](../../sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md#set-fast-schema-evolution) at table creation.
+
+##### enable_online_optimize_table
+
+- Default: `true`
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Controls whether StarRocks will use the non-blocking online optimization path when creating an optimize job. When `enable_online_optimize_table` is true and the target table meets compatibility checks (no partition/keys/sort specification, distribution is not `RandomDistributionDesc`, storage type is not `COLUMN_WITH_ROW`, replicated storage enabled, and the table is not a cloud-native table or materialized view), the planner creates an `OnlineOptimizeJobV2` to perform optimization without blocking writes. If false or any compatibility condition fails, StarRocks falls back to `OptimizeJobV2`, which may block write operations during optimization.
+- Introduced in: `v3.3.3, v3.4.0, v3.5.0`
 
 ##### enable_strict_storage_medium_check
 
@@ -2823,6 +3221,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: Whether to use the Service Account that is bound to your Compute Engine.
 - Introduced in: v3.5.1
 
+##### hdfs_file_system_expire_seconds
+
+- Default: `300`
+- Type: Int
+- Unit: Seconds
+- Is mutable: Yes
+- Description: Time-to-live in seconds for an unused cached HDFS/ObjectStore FileSystem managed by HdfsFsManager. The FileSystemExpirationChecker (runs every 60s) calls each HdfsFs.isExpired(...) using this value; when expired the manager closes the underlying FileSystem and removes it from the cache. Accessor methods (for example `HdfsFs.getDFSFileSystem`, `getUserName`, `getConfiguration`) update the last-access timestamp, so expiry is based on inactivity. Lower values reduce idle resource holding but increase reopen overhead; higher values keep handles longer and may consume more resources.
+- Introduced in: `v3.2.0`
+
 ##### lake_autovacuum_grace_period_minutes
 
 - Default: 30
@@ -3010,6 +3417,80 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Is mutable: Yes
 - Description:
 - Introduced in: -
+
+### Data Lake
+
+##### files_enable_insert_push_down_schema
+
+- Default: `true`
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: When enabled, the analyzer will attempt to push the target table schema into the `files()` table function for INSERT ... FROM files() operations. This only applies when the source is a FileTableFunctionRelation, the target is a native table, and the SELECT list contains corresponding slot-ref columns (or *). The analyzer will match select columns to target columns (counts must match), lock the target table briefly, and replace file-column types with deep-copied target column types for non-complex types (complex types such as parquet json -> array&lt;varchar&gt; are skipped). Column names from the original files table are preserved. This reduces type-mismatch and looseness from file-based type inference during ingestion.
+- Introduced in: `v3.4.0, v3.5.0`
+
+##### hdfs_read_buffer_size_kb
+
+- Default: `8192`
+- Type: Int
+- Unit: Kilobytes
+- Is mutable: Yes
+- Description: Size of the HDFS read buffer in kilobytes. StarRocks converts this value to bytes (<< 10) and uses it to initialize HDFS read buffers in `HdfsFsManager` and to populate the thrift field `hdfs_read_buffer_size_kb` sent to BE tasks (e.g., `TBrokerScanRangeParams`, `TDownloadReq`) when broker access is not used. Increasing `hdfs_read_buffer_size_kb` can improve sequential read throughput and reduce syscall overhead at the cost of higher per-stream memory usage; decreasing it reduces memory footprint but may lower IO efficiency. Consider workload (many small streams vs. few large sequential reads) when tuning.
+- Introduced in: `v3.2.0`
+
+##### hdfs_write_buffer_size_kb
+
+- Default: `1024`
+- Type: Int
+- Unit: Kilobytes
+- Is mutable: Yes
+- Description: Sets the HDFS write buffer size (in KB) used for direct writes to HDFS or object stores when not using a broker. The FE converts this value to bytes (<< 10) and initializes the local write buffer in HdfsFsManager, and it is propagated in Thrift requests (e.g., TUploadReq, TExportSink, sink options) so backends/agents use the same buffer size. Increasing this value can improve throughput for large sequential writes at the cost of more memory per writer; decreasing it reduces per-stream memory usage and may lower latency for small writes. Tune alongside `hdfs_read_buffer_size_kb` and consider available memory and concurrent writers.
+- Introduced in: `v3.2.0`
+
+##### lake_batch_publish_max_version_num
+
+- Default: `10`
+- Type: Int
+- Unit: Count
+- Is mutable: Yes
+- Description: Sets the upper bound on how many consecutive transaction versions may be grouped together when building a publish batch for lake (cloud‑native) tables. The value is passed to the transaction graph batching routine (see getReadyToPublishTxnListBatch) and works together with `lake_batch_publish_min_version_num` to determine the candidate range size for a TransactionStateBatch. Larger values can increase publish throughput by batching more commits, but increase the scope of an atomic publish (longer visibility latency and larger rollback surface) and may be limited at runtime when versions are not consecutive. Tune according to workload and visibility/latency requirements.
+- Introduced in: `v3.2.0`
+
+##### lake_batch_publish_min_version_num
+
+- Default: `1`
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: Sets the minimum number of consecutive transaction versions required to form a publish batch for lake tables. DatabaseTransactionMgr.getReadyToPublishTxnListBatch passes this value to transactionGraph.getTxnsWithTxnDependencyBatch together with `lake_batch_publish_max_version_num` to select dependent transactions. A value of `1` allows single-transaction publishes (no batching). Values &gt;1 require at least that many consecutively-versioned, single-table, non-replication transactions to be available; batching is aborted if versions are non-consecutive, a replication transaction appears, or a schema change consumes a version. Increasing this value can improve publish throughput by grouping commits but may delay publishing while waiting for enough consecutive transactions.
+- Introduced in: v3.2.0
+
+##### lake_enable_batch_publish_version
+
+- Default: `true`
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: When enabled, PublishVersionDaemon batches ready transactions for the same Lake (shared-data) table/partition and publishes their versions together instead of issuing per-transaction publishes. In RunMode shared-data, the daemon calls getReadyPublishTransactionsBatch() and uses publishVersionForLakeTableBatch(...) to perform grouped publish operations (reducing RPCs and improving throughput). When disabled, the daemon falls back to per-transaction publishing via publishVersionForLakeTable(...). The implementation coordinates in-flight work using internal sets to avoid duplicate publishes when the switch is toggled and is affected by the thread pool sizing via `lake_publish_version_max_threads`.
+- Introduced in: `v3.2.0`
+
+##### lake_enable_tablet_creation_optimization
+
+- Default: `false`
+- Type: boolean
+- Unit: -
+- Is mutable: Yes
+- Description: When enabled, StarRocks optimizes tablet creation for cloud-native tables and materialized views in shared-data mode by creating a single shared tablet metadata for all tablets under a physical partition instead of distinct metadata per tablet. This reduces the number of tablet creation tasks and metadata/files produced during table creation, rollup, and schema-change jobs. The optimization is applied only for cloud-native tables/materialized views and is combined with `file_bundling` (the latter reuses the same optimization logic). Note: schema-change and rollup jobs explicitly disable the optimization for tables using `file_bundling` to avoid overwriting files with identical names. Enable cautiously — it changes the granularity of created tablet metadata and can affect how replica creation and file naming behave.
+- Introduced in: `v3.3.1, v3.4.0, v3.5.0`
+
+##### lake_use_combined_txn_log
+
+- Default: `false`
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: When enabled, StarRocks allows Lake tables to use the combined transaction log path for relevant transactions. This flag is only considered when the cluster is running in shared-data mode (RunMode.isSharedDataMode()). With `lake_use_combined_txn_log = true`, loading transactions of types BACKEND_STREAMING, ROUTINE_LOAD_TASK, INSERT_STREAMING and BATCH_LOAD_JOB will be eligible to use combined txn logs (see LakeTableHelper.supportCombinedTxnLog). Code paths that also include compaction check combined-log support via isTransactionSupportCombinedTxnLog. If disabled or when not in shared-data mode, combined transaction log behavior is not used.
+- Introduced in: `v3.3.7, v3.4.0, v3.5.0`
 
 ### Other
 

--- a/docs/ja/administration/management/FE_configuration.md
+++ b/docs/ja/administration/management/FE_configuration.md
@@ -418,12 +418,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### http_max_initial_line_length
 
-- デフォルト: `4096`
+- デフォルト: 4096
 - タイプ: Int
 - 単位: Bytes
 - 変更可能: No
 - 説明: HttpServer で使用される Netty の `HttpServerCodec` が受け付ける HTTP 初期リクエスト行（メソッド + request-target + HTTP バージョン）の最大許容長（バイト単位）を設定します。この値は Netty のデコーダに渡され、初期行がこの長さを超えるリクエストは拒否されます（TooLongFrameException）。非常に長いリクエスト URI をサポートする必要がある場合にのみ増やしてください。値を大きくするとメモリ使用量が増え、誤った形式やリクエスト悪用に対する露出が増える可能性があります。`http_max_header_size`、`http_max_chunk_size` と合わせて調整してください。
-- 導入バージョン: `v3.2.0`
+- 導入バージョン: v3.2.0
 
 ##### http_port
 
@@ -583,12 +583,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### thrift_rpc_max_body_size
 
-- デフォルト: `-1`
+- デフォルト: -1
 - タイプ: Int
 - 単位: Bytes
 - 変更可能: No
 - 説明: サーバの Thrift プロトコルを構築する際（`ThriftServer` の TBinaryProtocol.Factory に渡される）に使用される、許可される Thrift RPC メッセージ本文の最大サイズ（バイト単位）を制御します。値 `-1` は制限を無効にします（無制限）。正の値を設定すると上限が強制され、それより大きいメッセージは Thrift 層で拒否されます。これによりメモリ使用量を制限し、過大なリクエストや DoS のリスクを緩和するのに役立ちます。正当なリクエスト（大きな struct やバッチ化されたデータなど）が拒否されないように、期待されるペイロードに十分な大きさに設定してください。
-- 導入バージョン: `v3.2.0`
+- 導入バージョン: v3.2.0
 
 ##### thrift_server_max_worker_threads
 
@@ -612,12 +612,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### alter_max_worker_queue_size
 
-- デフォルト: `4096`
+- デフォルト: 4096
 - タイプ: Int
 - 単位: Tasks
 - 変更可能: No
 - 説明: alter サブシステムで使用される内部ワーカースレッドプールのキューの容量を制御します。`AlterHandler` 内で `alter_max_worker_threads` とともに `ThreadPoolManager.newDaemonCacheThreadPool` に渡されます。保留中の alter タスク数が `alter_max_worker_queue_size` を超えると、新しい送信は拒否され、`RejectedExecutionException` がスローされる可能性があります（`AlterHandler.handleFinishAlterTask` を参照）。この値を調整して、メモリ使用量と同時実行される alter タスクのバックログ許容量のバランスを取ってください。
-- 導入バージョン: `v3.2.0`
+- 導入バージョン: v3.2.0
 
 ##### automated_cluster_snapshot_interval_seconds
 
@@ -675,12 +675,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### bdbje_reserved_disk_size
 
-- デフォルト: `512L * 1024 * 1024` (536870912)
+- デフォルト: 512L * 1024 * 1024 (536870912)
 - タイプ: Long
 - 単位: Bytes
 - 変更可能: いいえ
 - 説明: Berkeley DB JE が「保護されていない」（削除可能な）ログ/データファイルとして予約するバイト数の上限を制限します。StarRocks はこの値を BDBEnvironment の `EnvironmentConfig.RESERVED_DISK` を介して JE に渡します。JE の組み込みデフォルトは 0（無制限）です。StarRocks のデフォルト（512 MiB）は、JE が保護されていないファイルに過剰なディスク領域を予約するのを防ぎつつ、不要ファイルの安全なクリーンアップを可能にします。ディスク制約のあるシステムではこの値を調整してください：値を小さくすると JE はより早くファイルを解放でき、値を大きくすると JE はより多くの予約領域を保持します。変更はプロセスの再起動が必要です。
-- 導入バージョン: `v3.2.0`
+- 導入バージョン: v3.2.0
 
 ##### bdbje_reset_election_group
 
@@ -711,12 +711,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### brpc_connection_pool_size
 
-- デフォルト: `16`
+- デフォルト: 16
 - タイプ: Int
 - 単位: Connections
 - 変更可能: No
 - 説明: FE の BrpcProxy がエンドポイントごとにプールする BRPC 接続の最大数です。この値は `RpcClientOptions` に対して `setMaxTotoal` と `setMaxIdleSize` を通じて適用されるため、各リクエストがプールから接続を借用する必要があるため、同時発生する送信 BRPC リクエスト数を直接制限します。高同時実行のシナリオではリクエストの待ち行列を避けるためにこの値を増やしてください。ただし増やすとソケットやメモリ使用量が増え、リモートサーバの負荷も高まる可能性があります。チューニング時は `brpc_idle_wait_max_time`, `brpc_short_connection`, `brpc_inner_reuse_pool`, `brpc_reuse_addr`, `brpc_min_evictable_idle_time_ms` などの関連設定も考慮してください。この値の変更はホットリロード不可で、プロセスの再起動が必要です。
-- 導入バージョン: `v3.2.0`
+- 導入バージョン: v3.2.0
 
 ##### catalog_try_lock_timeout_ms
 
@@ -729,12 +729,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### checkpoint_timeout_seconds
 
-- デフォルト: `24 * 3600`
+- デフォルト: 24 * 3600
 - タイプ: Long
 - 単位: Seconds
 - 変更可能: はい
 - 説明: リーダーの CheckpointController がチェックポイントワーカーのチェックポイント完了を待つ最大時間（秒）です。コントローラはこの値をナノ秒に変換してワーカーの結果キューをポーリングします；このタイムアウト内に成功完了が受信されない場合、チェックポイントは失敗とみなされ、createImage は失敗を返します。値を増やすと長時間実行されるチェックポイントに対応できますが、失敗検出とその後のイメージ伝播が遅れます。値を減らすとフェイルオーバー/再試行は速くなりますが、遅いワーカーに対して誤ったタイムアウトが発生する可能性があります。この設定はチェックポイント作成中の `CheckpointController` における待機期間のみを制御し、ワーカー内部のチェックポイント動作を変更するものではありません。
-- 導入バージョン: `v3.4.0, v3.5.0`
+- 導入バージョン: v3.4.0, v3.5.0
 
 ##### db_used_data_quota_update_interval_secs
 
@@ -840,7 +840,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### enable_task_history_archive
 
-- デフォルト: `true`
+- デフォルト: true
 - タイプ: Boolean
 - 単位: -
 - 変更可能: Yes
@@ -1481,7 +1481,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### query_queue_v2_cpu_costs_per_slot
 
-- デフォルト: `1000000000`
+- デフォルト: 1000000000
 - タイプ: Long
 - 単位: planner CPU cost units
 - 変更可能: Yes
@@ -2139,12 +2139,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### enable_online_optimize_table
 
-- デフォルト: `true`
+- デフォルト: true
 - タイプ: Boolean
 - 単位: -
 - 変更可能: Yes
 - 説明: StarRocks が optimize ジョブを作成する際に、書き込みをブロックしないオンライン最適化パスを使用するかどうかを制御します。`enable_online_optimize_table` が true で、対象テーブルが互換性チェックを満たす場合（パーティション/キー/ソート指定がなく、distribution が `RandomDistributionDesc` でない、ストレージタイプが `COLUMN_WITH_ROW` でない、レプリケートされたストレージが有効で、テーブルがクラウドネイティブテーブルやマテリアライズドビューでない）、プランナーは書き込みをブロックせずに最適化を行うために `OnlineOptimizeJobV2` を作成します。false の場合、またはいずれかの互換性条件を満たさない場合、最適化中に書き込みをブロックする可能性のある `OptimizeJobV2` にフォールバックします。
-- 導入バージョン: `v3.3.3, v3.4.0, v3.5.0`
+- 導入バージョン: v3.3.3, v3.4.0, v3.5.0
 
 ##### enable_strict_storage_medium_check
 
@@ -2891,7 +2891,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### lake_batch_publish_min_version_num
 
-- デフォルト: `1`
+- デフォルト: 1
 - タイプ: Int
 - 単位: -
 - 変更可能: Yes
@@ -2900,12 +2900,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### lake_use_combined_txn_log
 
-- デフォルト: `false`
+- デフォルト: false
 - タイプ: Boolean
 - 単位: -
 - 変更可能: Yes
 - 説明: 有効にすると、Lake テーブルは関連するトランザクションで combined transaction log パスを使用することを許可します。このフラグはクラスタが shared-data モード（RunMode.isSharedDataMode()）で動作している場合にのみ考慮されます。`lake_use_combined_txn_log = true` のとき、BACKEND_STREAMING、ROUTINE_LOAD_TASK、INSERT_STREAMING、BATCH_LOAD_JOB タイプのロードトランザクションは combined txn log を使用する対象になります（詳細は LakeTableHelper.supportCombinedTxnLog を参照）。compaction を含むコードパスは isTransactionSupportCombinedTxnLog を通じて combined-log のサポートを確認します。無効化されているか shared-data モードでない場合は、combined transaction log の動作は使用されません。
-- 導入バージョン: `v3.3.7, v3.4.0, v3.5.0`
+- 導入バージョン: v3.3.7, v3.4.0, v3.5.0
 
 ### その他
 

--- a/docs/ja/administration/management/FE_configuration.md
+++ b/docs/ja/administration/management/FE_configuration.md
@@ -104,6 +104,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明: FE が big query ダンプログを書き込むディレクトリ（ファイル名: fe.big_query.log）。Log4j の設定はこのパスを使用して `fe.big_query.log` とローテートされたファイル用の RollingFile appender を作成します。ローテーションと保持は `big_query_log_roll_interval`（時間ベースのサフィックス）、`log_roll_size_mb`（サイズトリガー）、`big_query_log_roll_num`（最大ファイル数）、および `big_query_log_delete_age`（年齢ベースの削除）によって制御されます。big-query レコードは `big_query_log_cpu_second_threshold`、`big_query_log_scan_rows_threshold`、`big_query_log_scan_bytes_threshold` のようなユーザー定義の閾値を超えたクエリについて出力されます。どのモジュールがこのファイルにログを出力するかは `big_query_log_modules` で制御してください。
 - 導入バージョン: v3.2.0
 
+##### big_query_log_modules
+
+- デフォルト: `{"query"}`
+- タイプ: String[]
+- 単位: -
+- 変更可能: No
+- 説明: モジュール単位の big query ログを有効にするモジュール名サフィックスの一覧です。典型的な値は論理コンポーネント名です。たとえばデフォルトの `query` は `big_query.query` を生成します。
+- 導入バージョン: v3.2.0
+
 ##### big_query_log_roll_num
 
 - デフォルト: 10
@@ -169,14 +178,23 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明: true の場合、Frontend の監査サブシステムは ConnectProcessor によって処理される FE の監査ログ (fe.audit.log) にステートメントの SQL テキストを記録します。格納されるステートメントは他の制御を尊重します：暗号化されたステートメントは (AuditEncryptionChecker により) マスキングされ、認証情報は enable_sql_desensitize_in_log が設定されていると赤字化または脱感作される可能性があり、ダイジェストの記録は enable_sql_digest で制御されます。false の場合、ConnectProcessor は監査イベント内のステートメントテキストを "?" に置き換えます — 他の監査フィールド（user、host、duration、status、qe_slow_log_ms によるスロークエリ検出、メトリクス）は引き続き記録されます。SQL 監査を有効にするとフォレンジックやトラブルシューティングの可視性は向上しますが、機密性の高い SQL 内容が露出したりログの量および I/O が増加したりする可能性があります。無効にすると監査ログでの完全なステートメントの可視性を失う代わりにプライバシーが向上します。このオプションはランタイムで変更できません。
 - 導入バージョン: -
 
-##### enable_profile_log_compress
+##### internal_log_delete_age
 
-- デフォルト: false
-- タイプ: Boolean
+- デフォルト: 7d
+- タイプ: String
 - 単位: -
 - 変更可能: No
-- 説明: 有効にすると、ProfileManager が生成する JSON クエリプロファイルを PROFILE_LOG に書き込む前に `CompressionUtils.gzipCompressString` を使って GZIP 圧縮します。この圧縮は `enable_collect_query_detail_info` と `enable_profile_log` の両方が true の場合にのみ有効です。圧縮によりログ量と I/O は削減されますが CPU 負荷が増加します。PROFILE_LOG の消費者はクエリ詳細を読むために GZIP ペイロードを解凍する必要があります。圧縮が失敗した場合、コードは警告をログに出力し、圧縮されたプロファイルは書き込まれません。
-- 導入バージョン: v3.2.7
+- 説明: FE の内部ログファイル（`internal_log_dir` に書き込まれる）の保持期間を指定します。値は期間文字列で、サフィックスとして `d`（日）、`h`（時間）、`m`（分）、`s`（秒）をサポートします。例: `7d`（7日）、`10h`（10時間）、`60m`（60分）、`120s`（120秒）。この項目は log4j 設定内の `<IfLastModified age="..."/>` 述語（RollingFile Delete ポリシーで使用）に代入されます。最終更新時刻がこの期間より前のファイルはロールオーバー時に削除されます。内部のマテリアライズドビューや統計ログを長く保持したい場合は値を小さくするのではなく、逆に保持期間を延長してください。ディスク容量を早く確保したい場合はこの値を短くしてください。
+- 導入バージョン: v3.2.4
+
+##### internal_log_modules
+
+- デフォルト: `{"base", "statistic"}`
+- タイプ: String[]
+- 単位: -
+- 変更可能: No
+- 説明: 専用の内部ログを受け取るモジュール識別子のリスト。各エントリ X に対して、Log4j はレベル INFO かつ additivity="false" のロガー `internal.<X>` を作成します。これらのロガーは internal appender（`fe.internal.log` に書き込まれる）または `sys_log_to_console` が有効な場合はコンソールにルーティングされます。必要に応じて短い名前やパッケージの断片を使用してください — 正確なロガー名は `internal.` + 設定した文字列になります。内部ログファイルのローテーションと保持は `internal_log_dir`、`internal_log_roll_num`、`internal_log_delete_age`、`internal_log_roll_interval`、`log_roll_size_mb` に従います。モジュールを追加すると、そのランタイムメッセージが内部ロガーストリームに分離され、デバッグや監査が容易になります。
+- 導入バージョン: v3.2.4
 
 ##### log_roll_size_mb
 
@@ -204,6 +222,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 変更可能: はい
 - 説明: クエリがスロークエリであるかどうかを判断するために使用されるしきい値。クエリの応答時間がこのしきい値を超える場合、**fe.audit.log** にスロークエリとして記録されます。
 - 導入バージョン: -
+
+##### slow_lock_log_every_ms
+
+- デフォルト: 3000L
+- タイプ: Long
+- 単位: Milliseconds
+- 変更可能: Yes
+- 説明: 同じ SlowLockLogStats インスタンスに対して別の「slow lock」警告を出力するまでに待機する最小間隔（ms）。ロック待機が slow_lock_threshold_ms を超えた後、LockUtils はこの値をチェックし、最後にログに記録されたスローロックイベントから slow_lock_log_every_ms ミリ秒が経過するまでは追加の警告を抑制します。長時間の競合でログ量を減らしたい場合は大きな値を、より頻繁に診断情報を得たい場合は小さな値を使用してください。変更はランタイムで次回以降のチェックに反映されます。
+- 導入バージョン: v3.2.0
 
 ##### slow_lock_threshold_ms
 
@@ -240,6 +267,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 変更可能: いいえ
 - 説明: この項目が `true` に設定されていると、システムはローテートされたシステムログファイル名に ".gz" の後置を付け、Log4j によって gzip 圧縮されたローテート済み FE システムログ（例: fe.log.*）が出力されるようになります。この値は Log4j 設定生成時（Log4jConfig.initLogging / generateActiveLog4jXmlConfig）に読み取られ、RollingFile の filePattern で使用される `sys_file_postfix` プロパティを制御します。この機能を有効にすると保持ログのディスク使用量は減少しますが、ロールオーバー時の CPU と I/O が増加し、ログファイル名が変更されるためログを読むツールやスクリプトが .gz ファイルを扱える必要があります。なお、監査ログは圧縮に別の設定（`audit_log_enable_compress`）を使用します。
 - 導入バージョン: v3.2.12
+
+##### sys_log_format
+
+- デフォルト: "plaintext"
+- タイプ: String
+- 単位: -
+- 変更可能: No
+- 説明: FE ログに使用する Log4j レイアウトを選択します。有効な値: `"plaintext"`（デフォルト）および `"json"`。大文字小文字は区別されません。`"plaintext"` は PatternLayout を設定し、人間が読みやすいタイムスタンプ、レベル、スレッド、class.method:line および WARN/ERROR のスタックトレースを出力します。`"json"` は JsonTemplateLayout を設定し、ログ集約ツール（ELK、Splunk 等）向けの構造化された JSON イベント（UTC タイムスタンプ、level、thread id/name、ソースファイル/メソッド/行、message、例外の stackTrace）を出力します。JSON 出力は最大文字列長に関して `sys_log_json_max_string_length` および `sys_log_json_profile_max_string_length` を順守します。
+- 導入バージョン: v3.2.10
 
 ##### sys_log_json_max_string_length
 
@@ -287,6 +323,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 変更可能: いいえ
 - 説明: `sys_log_roll_interval` パラメータで指定された保持期間内に保持できるシステムログファイルの最大数。
 - 導入バージョン: -
+
+##### sys_log_to_console
+
+- デフォルト: false (unless the environment variable `SYS_LOG_TO_CONSOLE` is set to "1")
+- タイプ: Boolean
+- 単位: -
+- 変更可能: No
+- 説明: この項目を `true` に設定すると、システムは Log4j を構成してファイルベースの appender の代わりにすべてのログをコンソール（ConsoleErr appender）に送るようにします。この値は、アクティブな Log4j XML 設定を生成する際に読み込まれ（root logger とモジュールごとの logger の appender 選択に影響します）、プロセス起動時に環境変数 `SYS_LOG_TO_CONSOLE` から取得されます。ランタイムで変更しても効果はありません。本設定は、ログをファイルに書き込む代わりに stdout/stderr の収集が好まれるコンテナ化環境や CI 環境で一般的に使用されます。
+- 導入バージョン: v3.2.0
 
 ##### sys_log_verbose_modules
 
@@ -370,6 +415,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 変更可能: いいえ
 - 説明: FE ノード内の HTTP サーバーが保持するバックログキューの長さ。
 - 導入バージョン: -
+
+##### http_max_initial_line_length
+
+- デフォルト: `4096`
+- タイプ: Int
+- 単位: Bytes
+- 変更可能: No
+- 説明: HttpServer で使用される Netty の `HttpServerCodec` が受け付ける HTTP 初期リクエスト行（メソッド + request-target + HTTP バージョン）の最大許容長（バイト単位）を設定します。この値は Netty のデコーダに渡され、初期行がこの長さを超えるリクエストは拒否されます（TooLongFrameException）。非常に長いリクエスト URI をサポートする必要がある場合にのみ増やしてください。値を大きくするとメモリ使用量が増え、誤った形式やリクエスト悪用に対する露出が増える可能性があります。`http_max_header_size`、`http_max_chunk_size` と合わせて調整してください。
+- 導入バージョン: `v3.2.0`
 
 ##### http_port
 
@@ -527,6 +581,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明: アイドル状態のクライアント接続がタイムアウトするまでの時間。
 - 導入バージョン: -
 
+##### thrift_rpc_max_body_size
+
+- デフォルト: `-1`
+- タイプ: Int
+- 単位: Bytes
+- 変更可能: No
+- 説明: サーバの Thrift プロトコルを構築する際（`ThriftServer` の TBinaryProtocol.Factory に渡される）に使用される、許可される Thrift RPC メッセージ本文の最大サイズ（バイト単位）を制御します。値 `-1` は制限を無効にします（無制限）。正の値を設定すると上限が強制され、それより大きいメッセージは Thrift 層で拒否されます。これによりメモリ使用量を制限し、過大なリクエストや DoS のリスクを緩和するのに役立ちます。正当なリクエスト（大きな struct やバッチ化されたデータなど）が拒否されないように、期待されるペイロードに十分な大きさに設定してください。
+- 導入バージョン: `v3.2.0`
+
 ##### thrift_server_max_worker_threads
 
 - デフォルト: 4096
@@ -546,6 +609,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 導入バージョン: -
 
 ### メタデータとクラスタ管理
+
+##### alter_max_worker_queue_size
+
+- デフォルト: `4096`
+- タイプ: Int
+- 単位: Tasks
+- 変更可能: No
+- 説明: alter サブシステムで使用される内部ワーカースレッドプールのキューの容量を制御します。`AlterHandler` 内で `alter_max_worker_threads` とともに `ThreadPoolManager.newDaemonCacheThreadPool` に渡されます。保留中の alter タスク数が `alter_max_worker_queue_size` を超えると、新しい送信は拒否され、`RejectedExecutionException` がスローされる可能性があります（`AlterHandler.handleFinishAlterTask` を参照）。この値を調整して、メモリ使用量と同時実行される alter タスクのバックログ許容量のバランスを取ってください。
+- 導入バージョン: `v3.2.0`
 
 ##### automated_cluster_snapshot_interval_seconds
 
@@ -601,6 +673,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明: メタデータがリーダー FE からフォロワー FEs に書き込まれるときに、リーダー FE が指定された数のフォロワー FEs からの ACK メッセージを待つことができる最大時間。単位: 秒。大量のメタデータが書き込まれている場合、フォロワー FEs はリーダー FE に ACK メッセージを返すまでに長い時間がかかり、ACK タイムアウトが発生します。この状況を防ぐために、このパラメータの値を増やすことをお勧めします。
 - 導入バージョン: -
 
+##### bdbje_reserved_disk_size
+
+- デフォルト: `512L * 1024 * 1024` (536870912)
+- タイプ: Long
+- 単位: Bytes
+- 変更可能: いいえ
+- 説明: Berkeley DB JE が「保護されていない」（削除可能な）ログ/データファイルとして予約するバイト数の上限を制限します。StarRocks はこの値を BDBEnvironment の `EnvironmentConfig.RESERVED_DISK` を介して JE に渡します。JE の組み込みデフォルトは 0（無制限）です。StarRocks のデフォルト（512 MiB）は、JE が保護されていないファイルに過剰なディスク領域を予約するのを防ぎつつ、不要ファイルの安全なクリーンアップを可能にします。ディスク制約のあるシステムではこの値を調整してください：値を小さくすると JE はより早くファイルを解放でき、値を大きくすると JE はより多くの予約領域を保持します。変更はプロセスの再起動が必要です。
+- 導入バージョン: `v3.2.0`
+
 ##### bdbje_reset_election_group
 
 - デフォルト: false
@@ -628,6 +709,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明: BE ブラックリスト内の BE ノードの過去の接続失敗を保持する時間。BE ノードが自動的に BE ブラックリストに追加されると、StarRocks はその接続性を評価し、BE ブラックリストから削除できるかどうかを判断します。`black_host_history_sec` 内で、ブラックリストに登録された BE ノードが `black_host_connect_failures_within_time` に設定されたしきい値よりも少ない接続失敗を持っている場合にのみ、BE ブラックリストから削除できます。
 - 導入バージョン: v3.3.0
 
+##### brpc_connection_pool_size
+
+- デフォルト: `16`
+- タイプ: Int
+- 単位: Connections
+- 変更可能: No
+- 説明: FE の BrpcProxy がエンドポイントごとにプールする BRPC 接続の最大数です。この値は `RpcClientOptions` に対して `setMaxTotoal` と `setMaxIdleSize` を通じて適用されるため、各リクエストがプールから接続を借用する必要があるため、同時発生する送信 BRPC リクエスト数を直接制限します。高同時実行のシナリオではリクエストの待ち行列を避けるためにこの値を増やしてください。ただし増やすとソケットやメモリ使用量が増え、リモートサーバの負荷も高まる可能性があります。チューニング時は `brpc_idle_wait_max_time`, `brpc_short_connection`, `brpc_inner_reuse_pool`, `brpc_reuse_addr`, `brpc_min_evictable_idle_time_ms` などの関連設定も考慮してください。この値の変更はホットリロード不可で、プロセスの再起動が必要です。
+- 導入バージョン: `v3.2.0`
+
 ##### catalog_try_lock_timeout_ms
 
 - デフォルト: 5000
@@ -636,6 +726,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 変更可能: はい
 - 説明: グローバルロックを取得するためのタイムアウト期間。
 - 導入バージョン: -
+
+##### checkpoint_timeout_seconds
+
+- デフォルト: `24 * 3600`
+- タイプ: Long
+- 単位: Seconds
+- 変更可能: はい
+- 説明: リーダーの CheckpointController がチェックポイントワーカーのチェックポイント完了を待つ最大時間（秒）です。コントローラはこの値をナノ秒に変換してワーカーの結果キューをポーリングします；このタイムアウト内に成功完了が受信されない場合、チェックポイントは失敗とみなされ、createImage は失敗を返します。値を増やすと長時間実行されるチェックポイントに対応できますが、失敗検出とその後のイメージ伝播が遅れます。値を減らすとフェイルオーバー/再試行は速くなりますが、遅いワーカーに対して誤ったタイムアウトが発生する可能性があります。この設定はチェックポイント作成中の `CheckpointController` における待機期間のみを制御し、ワーカー内部のチェックポイント動作を変更するものではありません。
+- 導入バージョン: `v3.4.0, v3.5.0`
 
 ##### db_used_data_quota_update_interval_secs
 
@@ -738,6 +837,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
   - この機能はクラスターを作成する際にのみ有効にできます。**クラスターが起動された後、この設定項目の値はどのような手段でも変更できません**。この設定を変更しようとするとエラーが発生します。FE は、この設定項目の値がクラスターが最初に起動された際の値と一致しない場合、起動に失敗します。  
   - 現在は、この機能は JDBC カタログ名とテーブル名をサポートしていません。JDBC または ODBC データソースで大文字小文字を区別しない処理を実行したい場合は、この機能を有効にしないでください。
 - 導入バージョン: v4.0
+
+##### enable_task_history_archive
+
+- デフォルト: `true`
+- タイプ: Boolean
+- 単位: -
+- 変更可能: Yes
+- 説明: 有効にすると、終了した task-run レコードが永続的な task-run history テーブルにアーカイブされ、edit log に記録されるため、ルックアップ（例: `lookupHistory`, `lookupHistoryByTaskNames`, `lookupLastJobOfTasks`）にアーカイブされた結果が含まれます。アーカイブ処理は FE リーダーによって実行され、ユニットテスト中（`FeConstants.runningUnitTest`）はスキップされます。有効時はインメモリの有効期限処理および強制 GC の経路がバイパスされ（`removeExpiredRuns` および `forceGC` から早期に戻る）、保持/追放は `task_runs_ttl_second` や `task_runs_max_history_number` の代わりに永続的なアーカイブで管理されます。無効にすると、履歴はメモリ内に留まり、これらの設定によって剪定されます。
+- 導入バージョン: v3.3.1, v3.4.0, v3.5.0
+
+##### enable_task_run_fe_evaluation
+
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: Yes
+- 説明: 有効にすると、FE はシステムテーブル `task_runs` に対して `TaskRunsSystemTable.supportFeEvaluation` 内でローカル評価を行います。FE 側評価は列と定数を比較する結合された等価述語（conjunctive equality predicates）のみ許可され、対象列は `QUERY_ID` と `TASK_NAME` に制限されます。これを有効にすると、広範なスキャンや追加のリモート処理を回避してターゲットを絞ったルックアップのパフォーマンスが向上します。無効にするとプランナーは `task_runs` の FE 評価をスキップするため、述語の刈り込みが減少し、これらのフィルターに対するクエリレイテンシに影響を与える可能性があります。
+- 導入バージョン: v3.3.13, v3.4.3, v3.5.0
 
 ##### heartbeat_mgr_blocking_queue_size
 
@@ -1362,6 +1479,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明: リリース検証タスクが発行される時間間隔。
 - 導入バージョン: -
 
+##### query_queue_v2_cpu_costs_per_slot
+
+- デフォルト: `1000000000`
+- タイプ: Long
+- 単位: planner CPU cost units
+- 変更可能: Yes
+- 説明: プランナーの CPU コストからクエリが必要とするスロット数を推定するために使用される、スロットあたりの CPU コスト閾値です。スケジューラはスロット数を integer(plan_cpu_costs / `query_queue_v2_cpu_costs_per_slot`) として計算し、その結果を [1, totalSlots] の範囲にクランプします（totalSlots はクエリキュー V2 の `V2` パラメータから導出されます）。V2 のコードは非正の設定を 1 に正規化します（Math.max(1, value)）ので、非正の値は実質的に `1` になります。この値を増やすとクエリあたりに割り当てられるスロット数が減り（少数の大きなスロットを持つクエリが有利になります）、逆に減らすとクエリあたりのスロット数が増えます。並列度とリソース粒度を制御するために、`query_queue_v2_num_rows_per_slot` や同時実行設定と併せてチューニングしてください。
+- 導入バージョン: v3.3.4, v3.4.0, v3.5.0
+
 ##### semi_sync_collect_statistic_await_seconds
 
 - デフォルト: 30
@@ -1674,6 +1800,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明: BE レプリカによって許容される最大ロード遅延。この値を超えると、他のレプリカからデータをクローンするためにクローンが実行されます。
 - 導入バージョン: -
 
+##### loads_history_retained_days
+
+- デフォルト: 30
+- タイプ: Int
+- 単位: Days
+- 変更可能: Yes
+- 説明: 内部テーブル `_statistics_.loads_history` におけるロード履歴の保持日数。この値はテーブル作成時にテーブルプロパティ `partition_live_number` を設定するために使用され、`TableKeeper` に渡され（日数は最小1にクランプされます）、保持する日別パーティション数を決定します。この値を増減すると完了したロードジョブが日別パーティションにどの程度残るかが調整されます；新規テーブル作成とTableKeeperの削除挙動に影響しますが、過去のパーティションを自動的に再作成することはありません。`LoadsHistorySyncer` はロード履歴のライフサイクル管理にこの保持設定を利用します；同期の頻度は `loads_history_sync_interval_second` によって制御されます。
+- 導入バージョン: v3.3.6, v3.4.0, v3.5.0
+
 ##### max_broker_load_job_concurrency
 
 - デフォルト: 5
@@ -1873,6 +2008,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 説明: 各 Stream Load ジョブのデフォルトタイムアウト期間。
 - 導入バージョン: -
 
+##### stream_load_task_keep_max_num
+
+- デフォルト: 1000
+- タイプ: Int
+- 単位: -
+- 変更可能: Yes
+- 説明: StreamLoadMgrがメモリ内で保持するStream Loadタスクの最大数（全データベースに跨るグローバルな設定）。追跡中のタスク数（`idToStreamLoadTask`）がこの閾値を超えると、StreamLoadMgrはまず `cleanSyncStreamLoadTasks()` を呼び出して完了した同期ストリームロードタスクを削除します；それでもサイズがこの閾値の半分より大きいままの場合、`cleanOldStreamLoadTasks(true)` を呼び出して古いまたは終了したタスクを強制的に削除します。メモリ内により多くのタスク履歴を保持したい場合はこの値を増やし、メモリ使用量を減らしてクリーンアップをより積極的に行いたい場合はこの値を減らしてください。この値はメモリ内での保持にのみ影響し、永続化／リプレイされたタスクには影響しません。
+- 導入バージョン: v3.2.0
+
 ##### transaction_clean_interval_second
 
 - デフォルト: 30
@@ -1918,6 +2062,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 変更可能: いいえ
 - 説明: Yarn 設定ファイルを保存するディレクトリ。
 - 導入バージョン: -
+
+### 統計レポート
 
 ### ストレージ
 
@@ -1990,6 +2136,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 >
 > - StarRocks 共有データクラスタは v3.3.0 からこのパラメータをサポートしています。
 > - 特定のテーブルに対して高速スキーマ進化を設定する必要がある場合、たとえば特定のテーブルに対して高速スキーマ進化を無効にする場合、テーブル作成時にテーブルプロパティ [`fast_schema_evolution`](../../sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md#set-fast-schema-evolution) を設定できます。
+
+##### enable_online_optimize_table
+
+- デフォルト: `true`
+- タイプ: Boolean
+- 単位: -
+- 変更可能: Yes
+- 説明: StarRocks が optimize ジョブを作成する際に、書き込みをブロックしないオンライン最適化パスを使用するかどうかを制御します。`enable_online_optimize_table` が true で、対象テーブルが互換性チェックを満たす場合（パーティション/キー/ソート指定がなく、distribution が `RandomDistributionDesc` でない、ストレージタイプが `COLUMN_WITH_ROW` でない、レプリケートされたストレージが有効で、テーブルがクラウドネイティブテーブルやマテリアライズドビューでない）、プランナーは書き込みをブロックせずに最適化を行うために `OnlineOptimizeJobV2` を作成します。false の場合、またはいずれかの互換性条件を満たさない場合、最適化中に書き込みをブロックする可能性のある `OptimizeJobV2` にフォールバックします。
+- 導入バージョン: `v3.3.3, v3.4.0, v3.5.0`
 
 ##### enable_strict_storage_medium_check
 
@@ -2731,6 +2886,26 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 変更可能: Yes
 - 説明:
 - 導入バージョン: -
+
+### データレイク
+
+##### lake_batch_publish_min_version_num
+
+- デフォルト: `1`
+- タイプ: Int
+- 単位: -
+- 変更可能: Yes
+- 説明: Lake テーブルの publish バッチを形成するために必要な連続したトランザクションバージョンの最小数を設定します。DatabaseTransactionMgr.getReadyToPublishTxnListBatch は、この値を `lake_batch_publish_max_version_num` とともに transactionGraph.getTxnsWithTxnDependencyBatch に渡して依存トランザクションを選択します。値が `1` の場合は単一トランザクションの publish（バッチ化なし）を許可します。`1` より大きい値は、少なくともその数だけ連続するバージョンを持つ、単一テーブルかつレプリケーションでないトランザクションが利用可能であることを要求します。バージョンが連続していない場合、レプリケーショントランザクションが現れた場合、またはスキーマ変更がバージョンを消費した場合はバッチ化が中止されます。この値を大きくするとコミットをグループ化して publish スループットを改善できる一方、十分な連続トランザクションを待つために公開が遅延する可能性があります。
+- 導入バージョン: v3.2.0
+
+##### lake_use_combined_txn_log
+
+- デフォルト: `false`
+- タイプ: Boolean
+- 単位: -
+- 変更可能: Yes
+- 説明: 有効にすると、Lake テーブルは関連するトランザクションで combined transaction log パスを使用することを許可します。このフラグはクラスタが shared-data モード（RunMode.isSharedDataMode()）で動作している場合にのみ考慮されます。`lake_use_combined_txn_log = true` のとき、BACKEND_STREAMING、ROUTINE_LOAD_TASK、INSERT_STREAMING、BATCH_LOAD_JOB タイプのロードトランザクションは combined txn log を使用する対象になります（詳細は LakeTableHelper.supportCombinedTxnLog を参照）。compaction を含むコードパスは isTransactionSupportCombinedTxnLog を通じて combined-log のサポートを確認します。無効化されているか shared-data モードでない場合は、combined transaction log の動作は使用されません。
+- 導入バージョン: `v3.3.7, v3.4.0, v3.5.0`
 
 ### その他
 

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -143,6 +143,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述：每个 `dump_log_roll_interval` 时间内，允许保留的 Dump 日志文件的最大数目。
 - 引入版本：-
 
+##### internal_log_dir
+
+- 默认值: `Config.STARROCKS_HOME_DIR + "/log"`
+- 类型: String
+- 単位: -
+- 是否可变: No
+- 描述: FE 日志子系统用于存放内部日志（`fe.internal.log`）的目录。此配置会被替换到 Log4j 配置中，用于决定 InternalFile appender 将内部/物化视图/统计日志写入何处，以及 `internal.<module>` 下的各模块 logger 将其文件放置到哪里。请确保该目录存在、可写且有足够的磁盘空间。该目录中文件的日志轮转与保留由 `log_roll_size_mb`、`internal_log_roll_num`、`internal_log_delete_age` 和 `internal_log_roll_interval` 控制。如果启用了 `sys_log_to_console`，内部日志可能会写到控制台而不是该目录。
+- 引入版本: v3.2.4
+
 ##### internal_log_modules
 
 - 默认值: `{"base", "statistic"}`
@@ -161,6 +170,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 控制 FE 内部日志 appender 的基于时间的滚动间隔。接受（不区分大小写）的值为 `HOUR` 和 `DAY`。`HOUR` 生成每小时的文件模式 (`"%d{yyyyMMddHH}"`)，`DAY` 生成每日的文件模式 (`"%d{yyyyMMdd}"`)，这些模式由 RollingFile TimeBasedTriggeringPolicy 用于命名旋转后的 `fe.internal.log` 文件。无效的值会导致初始化失败（在构建活动 Log4j 配置时会抛出 IOException）。滚动行为还取决于相关设置，例如 `internal_log_dir`、`internal_roll_maxsize`、`internal_log_roll_num` 和 `internal_log_delete_age`。
 - 引入版本: v3.2.4
 
+##### internal_log_roll_num
+
+- 默认值: 90
+- 类型: Int
+- 単位: -
+- 是否可变: No
+- 描述: 内部 appender（`fe.internal.log`）保留的最大已滚动内部 FE 日志文件数。该值作为 Log4j DefaultRolloverStrategy 的 `max` 属性使用；在发生滚动时，StarRocks 会保留最多 `internal_log_roll_num` 个归档文件并删除更旧的文件（也受 `internal_log_delete_age` 控制）。较低的值可减少磁盘使用但缩短日志历史；较高的值可保留更多历史内部日志。该项与 `internal_log_dir`、`internal_log_roll_interval` 和 `internal_roll_maxsize` 配合工作。
+- 引入版本: v3.2.4
+
 ##### log_roll_size_mb
 
 - 默认值：1024
@@ -169,6 +187,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 是否动态：否
 - 描述：单个系统日志或审计日志文件的大小上限。
 - 引入版本：-
+
+##### profile_log_delete_age
+
+- 默认值: 1d
+- 类型: String
+- 単位: -
+- 是否可变: 否
+- 描述: 控制 FE profile 日志文件在可删除之前保留的时长。该值被注入到 Log4j 的 `&lt;IfLastModified age="..."/&gt;` 策略（通过 `Log4jConfig`）中，并与诸如 `profile_log_roll_interval` 和 `profile_log_roll_num` 的轮转设置一起生效。支持的后缀：`d`（天）、`h`（小时）、`m`（分钟）、`s`（秒）。例如：`7d`（7 天）、`10h`（10 小时）、`60m`（60 分钟）、`120s`（120 秒）。
+- 引入版本: v3.2.5
 
 ##### profile_log_dir
 
@@ -186,6 +213,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 单位: Number of files
 - 是否可变: No
 - 描述: 指定 Log4j 的 DefaultRolloverStrategy 为 profile logger 保留的最大轮换 profile 日志文件数。该值会作为 `${profile_log_roll_num}` 注入到日志 XML 中（例如 `&lt;DefaultRolloverStrategy max="${profile_log_roll_num}" fileIndex="min"&gt;`）。轮换由 `profile_log_roll_size_mb` 或 `profile_log_roll_interval` 触发；发生轮换时，Log4j 最多保留这么多带索引的文件，较旧的索引文件将成为可删除对象。磁盘上的实际保留还受 `profile_log_delete_age` 和 `profile_log_dir` 位置的影响。较低的值可降低磁盘使用，但限制可保留的历史；较高的值则保留更多历史 profile 日志。
+- 引入版本: v3.2.5
+
+##### profile_log_roll_size_mb
+
+- 默认值: 1024
+- 类型: Int
+- 単位: MB
+- 是否可变: 否
+- 描述: 设置触发基于大小的 FE profile 日志文件滚动的阈值（以兆字节为单位）。该值被 Log4j 的 RollingFile SizeBasedTriggeringPolicy 用于 `ProfileFile` appender；当 profile 日志超过 `profile_log_roll_size_mb` 时会发生轮转。达到 `profile_log_roll_interval` 时也会按时间发生轮转 —— 任一条件满足都会触发轮转。结合 `profile_log_roll_num` 和 `profile_log_delete_age` 使用，该项控制保留多少历史 profile 文件以及何时删除旧文件。轮转文件的压缩由 `enable_profile_log_compress` 控制。
 - 引入版本: v3.2.5
 
 ##### qe_slow_log_ms
@@ -242,6 +278,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 当此项设置为 `true` 时，系统会在轮转的系统日志文件名后追加 ".gz" 后缀，从而使 Log4j 在轮转时生成 gzip 压缩的 FE 系统日志（例如，`fe.log.*`）。此值在生成 Log4j 配置时读取（Log4jConfig.initLogging / generateActiveLog4jXmlConfig），并控制用于 RollingFile filePattern 的 `sys_file_postfix` 属性。启用此功能可减少保留日志的磁盘占用，但会在轮转期间增加 CPU 和 I/O 开销，并改变日志文件名，因此读取日志的工具或脚本必须能够处理 .gz 文件。注意，审计日志使用单独的压缩配置，即 `audit_log_enable_compress`。
 - 引入版本: v3.2.12
 
+##### sys_log_format
+
+- 默认值: "plaintext"
+- 类型: String
+- 单位: -
+- 是否可变: No
+- 描述: 选择用于 FE 日志的 Log4j layout。有效值：`"plaintext"`（默认）和 `"json"`。值不区分大小写。`"plaintext"` 配置 PatternLayout，包含可读的时间戳、级别、线程、class.method:line 以及 WARN/ERROR 的堆栈跟踪。`"json"` 配置 JsonTemplateLayout，输出结构化 JSON 事件（UTC 时间戳、级别、线程 id/name、源文件/方法/行、消息、异常 stackTrace），适合日志聚合器（ELK、Splunk）。JSON 输出遵守 `sys_log_json_max_string_length` 和 `sys_log_json_profile_max_string_length` 关于最大字符串长度的限制。
+- 引入版本: v3.2.10
+
 ##### sys_log_json_max_string_length
 
 - 默认值: 1048576
@@ -288,6 +333,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 是否动态：否
 - 描述：每个 `sys_log_roll_interval` 时间段内，允许保留的系统日志文件的最大数目。
 - 引入版本：-
+
+##### sys_log_to_console
+
+- 默认值: false (除非环境变量 `SYS_LOG_TO_CONSOLE` 被设置为 "1")
+- 类型: Boolean
+- 单位: -
+- 是否可变: No
+- 描述: 当此项设置为 `true` 时，系统会配置 Log4j 将所有日志发送到控制台（ConsoleErr appender），而不是基于文件的 appender。该值在生成活动的 Log4j XML 配置时读取（影响 root logger 和按模块的 logger appender 选择）。其值在进程启动时从环境变量 `SYS_LOG_TO_CONSOLE` 捕获。运行时更改不会生效。该配置常用于容器化或 CI 环境，在这些环境中更偏向于通过 stdout/stderr 收集日志而不是写入日志文件。
+- 引入版本: v3.2.0
 
 ##### sys_log_verbose_modules
 
@@ -371,6 +425,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 是否动态：否
 - 描述：HTTP 服务器支持的 Backlog 队列长度。
 - 引入版本：-
+
+##### http_max_initial_line_length
+
+- 默认值: `4096`
+- 类型: Int
+- 単位: Bytes
+- 是否可变: 否
+- 描述: 设置由 HttpServer 中使用的 Netty `HttpServerCodec` 接受的 HTTP 初始请求行（method + request-target + HTTP version）的最大允许长度（字节）。该值会传递给 Netty 的解码器，初始行长度超过此值的请求将被拒绝（TooLongFrameException）。仅在必须支持非常长的请求 URI 时才增大此值；更大的值会增加内存使用并可能提高对畸形请求或滥用请求的暴露面。应与 `http_max_header_size` 和 `http_max_chunk_size` 一起调整。
+- 引入版本: `v3.2.0`
 
 ##### http_port
 
@@ -528,6 +591,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述：Thrift 客户端链接的空闲超时时间，即链接超过该时间无新请求后则将链接断开。
 - 引入版本：-
 
+##### thrift_rpc_max_body_size
+
+- 默认值: `-1`
+- 类型: Int
+- 单位: Bytes
+- 是否可变: No
+- 描述: 控制在构造服务器的 Thrift 协议（传递给 `ThriftServer` 中的 TBinaryProtocol.Factory）时允许的最大 Thrift RPC 消息体大小（以字节为单位）。值为 `-1` 表示禁用限制（无界）。设置为正值会强制上限，使得超过该大小的消息会被 Thrift 层拒绝，这有助于限制内存使用并降低超大请求或 DoS 风险。请将此值设置为足够大的大小以容纳预期的有效载荷（大型 struct 或批量数据），以避免拒绝合法请求。
+- 引入版本: `v3.2.0`
+
 ##### thrift_server_max_worker_threads
 
 - 默认值：4096
@@ -547,6 +619,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 引入版本：-
 
 ### 元数据与集群管理
+
+##### alter_max_worker_queue_size
+
+- 默认值: `4096`
+- 类型: Int
+- 单位: Tasks
+- 是否可变: No
+- 描述: 控制 alter 子系统使用的内部工作线程池队列的容量。该值与 `alter_max_worker_threads` 一起在 `AlterHandler` 中传递给 `ThreadPoolManager.newDaemonCacheThreadPool`。当待处理的 alter 任务数量超过 `alter_max_worker_queue_size` 时，新提交的任务将被拒绝，可能会抛出 `RejectedExecutionException`（参见 `AlterHandler.handleFinishAlterTask`）。调整此值以在内存使用与允许的并发 alter 任务积压量之间取得平衡。
+- 引入版本: `v3.2.0`
 
 ##### automated_cluster_snapshot_interval_seconds
 
@@ -602,6 +683,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述：FE 所在 StarRocks 集群中，元数据从 Leader FE 写入到多个 Follower FE 时，Leader FE 等待足够多的 Follower FE 发送 ACK 消息的超时时间。当写入的元数据较多时，可能返回 ACK 的时间较长，进而导致等待超时。如果超时，会导致写元数据失败，FE 进程退出，此时可以适当地调大该参数取值。
 - 引入版本：-
 
+##### bdbje_reserved_disk_size
+
+- 默认值: `512L * 1024 * 1024` (536870912)
+- 类型: Long
+- 単位: Bytes
+- 是否可变: No
+- 描述: 限制 Berkeley DB JE 将被保留为“未保护”（可删除）的日志/数据文件的字节数。StarRocks 通过 BDBEnvironment 中的 `EnvironmentConfig.RESERVED_DISK` 将此值传递给 JE；JE 的内置默认值为 0（无限制）。StarRocks 的默认值（512 MiB）可防止 JE 为未保护文件保留过多磁盘空间，同时允许安全清理过期文件。在磁盘受限的系统上调整此值：减小它可以让 JE 更早释放文件，增大它可以让 JE 保留更多保留空间。更改需要重启进程才能生效。
+- 引入版本: `v3.2.0`
+
 ##### bdbje_reset_election_group
 
 - 默认值：false
@@ -629,6 +719,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述：黑名单中 BE 节点连接失败记录的保留时长。如果一个 BE 节点被自动添加到 BE 黑名单中，StarRocks 将评估其连接状态，并判断是否可以将其从 BE 黑名单中移除。在 `black_host_history_sec` 内，只有当黑名单中的 BE 节点的连接失败次数少于 `black_host_connect_failures_within_time` 中设置的阈值时，StarRocks 才会将其从 BE 黑名单中移除。
 - 引入版本：v3.3.0
 
+##### brpc_connection_pool_size
+
+- 默认值: `16`
+- 类型: Int
+- 单位: Connections
+- 是否可变: No
+- 描述: FE 的 BrpcProxy 为每个端点使用的最大池化 BRPC 连接数。此值通过 `setMaxTotoal` 和 `setMaxIdleSize` 应用到 RpcClientOptions，因此它直接限制了并发的出站 BRPC 请求数，因为每个请求都必须从连接池借用一个连接。在高并发场景下增加此值以避免请求排队；增加会提高 socket 和内存使用，并可能增加远端服务器负载。调优时需考虑相关设置，例如 `brpc_idle_wait_max_time`、`brpc_short_connection`、`brpc_inner_reuse_pool`、`brpc_reuse_addr` 和 `brpc_min_evictable_idle_time_ms`。更改此值不会热重载，需要重启生效。
+- 引入版本: `v3.2.0`
+
 ##### catalog_try_lock_timeout_ms
 
 - 默认值：5000
@@ -637,6 +736,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 是否动态：是
 - 描述：全局锁（Global Lock）获取的超时时长。
 - 引入版本：-
+
+##### checkpoint_timeout_seconds
+
+- 默认值: `24 * 3600`
+- 类型: Long
+- 単位: Seconds
+- 是否可变: Yes
+- 描述: leader 的 CheckpointController 在等待某个 checkpoint worker 完成 checkpoint 时的最长等待时间（单位：秒）。控制器会将该值转换为纳秒并轮询 worker 的结果队列；如果在此超时时间内未收到成功完成，则将该 checkpoint 视为失败，createImage 返回失败。增大此值可以容纳运行时间更长的 checkpoint，但会延迟失败检测及随后镜像传播；减小此值可以更快触发故障转移/重试，但可能对较慢的 worker 产生误超时。此设置仅控制 CheckpointController 在创建 checkpoint 时的等待时长，不会改变 worker 的内部 checkpoint 行为。
+- 引入版本: `v3.4.0, v3.5.0`
 
 ##### db_used_data_quota_update_interval_secs
 
@@ -730,6 +838,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
   - 您只能在创建集群时启用此功能。**集群启动后，此配置项的值无法通过任何方式修改**。任何修改尝试均会导致错误。当 FE 检测到此配置项的值与集群首次启动时不一致时，FE 将无法启动。  
   - 目前，此功能不支持 JDBC Catalog 和表名。若需对 JDBC 或 ODBC 数据源进行大小写不敏感处理，请勿启用此功能。
 - 引入版本：v4.0
+
+##### enable_task_history_archive
+
+- 默认值: `true`
+- 类型: Boolean
+- 単位: -
+- 是否可变: Yes
+- 描述: 启用后，已完成的 task-run 记录会归档到持久化的 task-run history 表，并记录到 edit log，这样查找（例如 `lookupHistory`、`lookupHistoryByTaskNames`、`lookupLastJobOfTasks`）会包含归档结果。归档由 FE leader 执行，在单元测试期间会跳过（`FeConstants.runningUnitTest`）。启用时，会绕过内存过期和强制 GC 路径（代码会在 `removeExpiredRuns` 和 `forceGC` 中提前返回），因此保留/驱逐由持久化归档处理，而不是由 `task_runs_ttl_second` 和 `task_runs_max_history_number` 控制。禁用时，历史保留在内存中并由这些配置进行裁剪。
+- 引入版本: v3.3.1, v3.4.0, v3.5.0
+
+##### enable_task_run_fe_evaluation
+
+- 默认值: true
+- 类型: Boolean
+- 単位: -
+- 是否可变: Yes
+- 描述: 启用后，FE 将在 `TaskRunsSystemTable.supportFeEvaluation` 中对系统表 `task_runs` 执行本地评估。FE 端评估仅允许对列与常量进行的合取等值谓词，并且仅限于列 `QUERY_ID` 和 `TASK_NAME`。启用此项可通过避免更广泛的扫描或额外的远程处理来提高针对性查找的性能；禁用会强制 planner 跳过对 `task_runs` 的 FE 评估，可能降低谓词裁剪效果并影响这些过滤条件的查询延迟。
+- 引入版本: v3.3.13, v3.4.3, v3.5.0
 
 ##### heartbeat_mgr_blocking_queue_size
 
@@ -1346,6 +1472,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述：两个版本发布操作之间的时间间隔。
 - 引入版本：-
 
+##### query_queue_v2_cpu_costs_per_slot
+
+- 默认值: `1000000000`
+- 类型: Long
+- 単位: planner CPU cost units
+- 是否可变: 是
+- 描述: 每个 slot 的 CPU 成本阈值，用于根据查询的 planner CPU cost 估算该查询需要多少 slot。调度器将以 integer(plan_cpu_costs / `query_queue_v2_cpu_costs_per_slot`) 的方式计算 slot 数量，然后将结果限定在 [1, totalSlots] 范围内（totalSlots 来源于查询队列 V2 的 `V2` 参数）。V2 代码会将非正值规范化为 1（Math.max(1, value)），因此非正值实际上等同于 `1`。增大此值会减少每个查询分配的 slot（偏向更少但每个占用更多 slot 的查询）；减小此值会增加每个查询的 slot。应与 `query_queue_v2_num_rows_per_slot` 及并发设置一起调整，以在并行度与资源粒度之间取得平衡。
+- 引入版本: v3.3.4, v3.4.0, v3.5.0
+
 ##### semi_sync_collect_statistic_await_seconds
 
 - 默认值：30
@@ -1920,6 +2055,8 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述：Yarn 配置文件的保存目录。
 - 引入版本：-
 
+### 统计信息
+
 ### 存储
 
 ##### alter_table_timeout_second
@@ -1992,6 +2129,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 >
 > - StarRocks 存算分离集群自 v3.3.0 起支持该参数。
 > - 如果您需要为某张表设置该配置，例如关闭该表的 fast schema evolution，则可以在建表时设置表属性 [`fast_schema_evolution`](../../sql-reference/sql-statements/table_bucket_part_index/CREATE_TABLE.md#设置-fast-schema-evolution)。
+
+##### enable_online_optimize_table
+
+- 默认值: `true`
+- 类型: Boolean
+- 单位: -
+- 是否可变: Yes
+- 描述: 控制在创建优化（optimize）任务时 StarRocks 是否使用非阻塞的在线优化路径。当 `enable_online_optimize_table` 为 true 且目标表满足兼容性检查（没有分区/键/排序规范，分发方式不是 `RandomDistributionDesc`，存储类型不是 `COLUMN_WITH_ROW`，启用了副本存储，并且该表不是云原生表或物化视图）时，planner 会创建 `OnlineOptimizeJobV2` 来执行优化而不阻塞写入。如果为 false 或任一兼容性条件不满足，StarRocks 将回退到 `OptimizeJobV2`，在优化期间可能会阻塞写操作。
+- 引入版本: `v3.3.3, v3.4.0, v3.5.0`
 
 ##### enable_strict_storage_medium_check
 
@@ -2722,6 +2868,26 @@ Compaction Score 代表了一个表分区是否值得进行 Compaction 的评分
 - 描述：存算分离集群下 FE 与 StarMgr 定期同步元数据的时间间隔。
 - 引入版本：-
 
+### 数据湖
+
+##### lake_batch_publish_min_version_num
+
+- 默认值: `1`
+- 类型: Int
+- 単位: -
+- 是否可变: 是
+- 描述: 设置形成 lake 表发布批次所需的连续事务版本的最小数量。DatabaseTransactionMgr.getReadyToPublishTxnListBatch 将此值与 `lake_batch_publish_max_version_num` 一起传递给 transactionGraph.getTxnsWithTxnDependencyBatch 用于选择依赖事务。值为 `1` 允许单事务发布（不进行批处理）。值 >1 要求至少有该数量的连续版本、单表、非复制事务可用；如果版本不连续、出现复制事务，或架构变更消耗了某个版本，则中止批处理。增大此值可以通过将提交分组来提高发布吞吐，但在等待足够数量的连续事务时可能会延迟发布。
+- 引入版本: v3.2.0
+
+##### lake_use_combined_txn_log
+
+- 默认值: `false`
+- 类型: Boolean
+- 単位: -
+- 是否可变: 是
+- 描述: 启用时，StarRocks 允许 Lake 表对相关事务使用 combined transaction log 路径。仅在集群以 shared-data 模式运行（RunMode.isSharedDataMode()）时此标志才会被考虑。设置 `lake_use_combined_txn_log = true` 时，类型为 BACKEND_STREAMING、ROUTINE_LOAD_TASK、INSERT_STREAMING 和 BATCH_LOAD_JOB 的加载事务将有资格使用 combined txn logs（参见 LakeTableHelper.supportCombinedTxnLog）。包含 compaction 的代码路径通过 isTransactionSupportCombinedTxnLog 检查 combined-log 支持。如果禁用或不在 shared-data 模式下，则不使用 combined transaction log 行为。
+- 引入版本: `v3.3.7, v3.4.0, v3.5.0`
+
 ### 其他
 
 ##### agent_task_resend_wait_time_ms
@@ -2813,6 +2979,15 @@ Compaction Score 代表了一个表分区是否值得进行 Compaction 的评分
 - 是否动态：是
 - 描述：Backup 作业的超时时间。
 - 引入版本：-
+
+##### enable_collect_tablet_num_in_show_proc_backend_disk_path
+
+- 默认值: true
+- 类型: Boolean
+- 单位: -
+- 是否可变: 是
+- 描述: 是否在 `SHOW PROC /BACKENDS/{id}` 命令中启用对每个磁盘的 tablet 数量的采集
+- 引入版本: v4.0.1, v3.5.8
 
 ##### enable_colocate_restore
 
@@ -3290,6 +3465,15 @@ Compaction Score 代表了一个表分区是否值得进行 Compaction 的评分
 - 是否动态：否
 - 描述：小文件的根目录。
 - 引入版本：-
+
+##### task_runs_max_history_number
+
+- 默认值: 10000
+- 类型: Int
+- 单位: -
+- 是否可变: 是
+- 描述: 内存中保留的任务运行记录的最大数量，并在查询归档的 task-run 历史时用作默认的 LIMIT。当 `enable_task_history_archive` 为 false 时，此值约束内存中的历史：Force GC 会修剪较旧的条目，使得只保留最新的 `task_runs_max_history_number` 条记录。当查询归档历史（且未提供显式 LIMIT）时，如果该值大于 0，`TaskRunHistoryTable.lookup` 会使用 `"ORDER BY create_time DESC LIMIT <value>"`。注意：将此值设置为 0 会禁用查询侧的 LIMIT（无限制），但会导致内存中的历史被截断为零（除非启用了归档）。
+- 引入版本: v3.2.0
 
 ##### tmp_dir
 


### PR DESCRIPTION

## Why I'm doing:

## What I'm doing:  

    EXECUTION SUMMARY
    Document Type: fe_config
    Duration: 2766.39 seconds
    Command: /home/seaven/documents/workspace/DocsAgent/src/docsagent/main.py -g -t fe_config --force_search_code -tv -l 100 --pr
    Arguments:
      ├─ ci: False
      ├─ force_search_code: True
      ├─ generate: True
      ├─ include_miss_usage: False
      ├─ limit: 100
      ├─ meta: False
      ├─ name: None
      ├─ pr: True
      ├─ track_version: True
      ├─ type: fe_config
      ├─ without_llm: False
    
    ITEM EXTRACTION:
      ├─ Items from meta files: 728
      ├─ Items from code parsing: 0
      └─ Total unique items: 0
    
    DOCUMENT GENERATION:
      ├─ EN: 54 documents
      ├─ JA: 10 documents
      ├─ ZH: 10 documents
      └─ Total: 74 documents
    
    AGENT INVOCATIONS:
      ├─ ConfigDocAgent: 58 calls
      ├─ TranslationAgent_ja: 10 calls
      ├─ TranslationAgent_zh: 10 calls
      └─ Total: 78 calls
    
    TOOL INVOCATIONS:
      ├─ read_file: 78 calls
      ├─ search_code: 8 calls
      └─ Total: 86 calls
    
    GENERATED ITEMS:
      ├─ Total: 54 items
      ├─ task_min_schedule_interval_s
      ├─ table_keeper_interval_second
      ├─ enable_task_history_archive
      ├─ enable_task_run_fe_evaluation
      ├─ enable_task_info_mask_credential
      ├─ edit_log_write_slow_log_threshold_ms
      ├─ hdfs_read_buffer_size_kb
      ├─ hdfs_write_buffer_size_kb
      ├─ hdfs_file_system_expire_seconds
      ├─ bdbje_log_level
      ├─ bdbje_cleaner_threads
      ├─ bdbje_replay_cost_percent
      ├─ bdbje_reserved_disk_size
      ├─ checkpoint_timeout_seconds
      ├─ checkpoint_only_on_leader
      ├─ start_with_incomplete_meta
      ├─ enable_query_queue_v2
      ├─ query_queue_v2_concurrency_level
      ├─ query_queue_v2_schedule_strategy
      ├─ query_queue_slots_estimator_strategy
      ├─ max_query_queue_history_slots_number
      ├─ query_queue_v2_num_rows_per_slot
      ├─ query_queue_v2_cpu_costs_per_slot
      ├─ http_max_initial_line_length
      ├─ http_max_header_size
      ├─ http_max_chunk_size
      ├─ enable_http_validate_headers
      ├─ http_web_page_display_hardware
      ├─ enable_http_detail_metrics
      ├─ thrift_rpc_timeout_ms
      ├─ thrift_rpc_retry_times
      ├─ thrift_rpc_strict_mode
      ├─ thrift_rpc_max_body_size
      ├─ brpc_connection_pool_size
      ├─ brpc_send_plan_fragment_timeout_ms
      ├─ brpc_reuse_addr
      ├─ brpc_min_evictable_idle_time_ms
      ├─ brpc_short_connection
      ├─ brpc_inner_reuse_pool
      ├─ lake_enable_batch_publish_version
      ├─ lake_batch_publish_max_version_num
      ├─ lake_batch_publish_min_version_num
      ├─ lake_use_combined_txn_log
      ├─ lake_enable_tablet_creation_optimization
      ├─ lock_checker_interval_second
      ├─ lock_checker_enable_deadlock_check
      ├─ spark_load_submit_timeout_second
      ├─ stream_load_max_txn_num_per_be
      ├─ files_enable_insert_push_down_schema
      ├─ capacity_used_percent_high_water
      ├─ alter_max_worker_threads
      ├─ alter_max_worker_queue_size
      ├─ enable_online_optimize_table
      └─ load_parallel_instance_num
    
    TRANSLATED ITEMS:
      ├─ Total: 100 items
      ├─ capacity_used_percent_high_water
      ├─ load_parallel_instance_num
      ├─ big_query_log_delete_age
      ├─ big_query_log_roll_num
      ├─ profile_log_delete_age
      ├─ alter_max_worker_threads
      ├─ big_query_log_modules
      ├─ stream_load_max_txn_num_per_be
      ├─ mysql_service_kill_after_disconnect
      ├─ task_check_interval_second
      ├─ hdfs_write_buffer_size_kb
      ├─ brpc_reuse_addr
      ├─ enable_task_run_fe_evaluation
      ├─ task_runs_ttl_second
      ├─ hdfs_file_system_expire_seconds
      ├─ starmgr_grpc_server_max_worker_threads
      ├─ lock_checker_interval_second
      ├─ alter_max_worker_queue_size
      ├─ max_task_consecutive_fail_count
      ├─ task_runs_max_history_number
      ├─ enable_http_validate_headers
      ├─ files_enable_insert_push_down_schema
      ├─ lake_enable_batch_publish_version
      ├─ query_queue_v2_concurrency_level
      ├─ enable_qe_slow_log
      ├─ start_with_incomplete_meta
      ├─ thrift_rpc_strict_mode
      ├─ big_query_log_roll_interval
      ├─ log_register_and_unregister_query_id
      ├─ lake_batch_publish_max_version_num
      ├─ enable_materialized_view_concurrent_prepare
      ├─ enable_sql_desensitize_in_log
      ├─ enable_online_optimize_table
      ├─ profile_log_roll_interval
      ├─ profile_log_roll_size_mb
      ├─ task_runs_timeout_second
      ├─ loads_history_sync_interval_second
      ├─ thrift_rpc_retry_times
      ├─ thrift_rpc_max_body_size
      ├─ big_query_log_dir
      ├─ bdbje_replay_cost_percent
      ├─ http_web_page_display_hardware
      ├─ thrift_rpc_timeout_ms
      ├─ lake_enable_tablet_creation_optimization
      ├─ internal_log_dir
      ├─ http_max_header_size
      ├─ enable_internal_sql
      ├─ query_queue_v2_num_rows_per_slot
      ├─ enable_audit_sql
      ├─ brpc_inner_reuse_pool
      ├─ enable_task_history_archive
      ├─ enable_profile_log
      ├─ loads_history_retained_days
      ├─ brpc_connection_pool_size
      ├─ brpc_min_evictable_idle_time_ms
      ├─ checkpoint_timeout_seconds
      ├─ slow_lock_stack_trace_reserve_levels
      ├─ table_keeper_interval_second
      ├─ spark_load_submit_timeout_second
      ├─ slow_lock_log_every_ms
      ├─ http_max_chunk_size
      ├─ lake_batch_publish_min_version_num
      ├─ brpc_send_plan_fragment_timeout_ms
      ├─ brpc_short_connection
      ├─ sys_log_format
      ├─ profile_log_dir
      ├─ profile_log_roll_num
      ├─ sys_log_to_console
      ├─ enable_http_detail_metrics
      ├─ enable_query_queue_v2
      ├─ log_plan_cancelled_by_crash_be
      ├─ bdbje_log_level
      ├─ internal_log_modules
      ├─ audit_log_enable_compress
      ├─ stream_load_task_keep_max_num
      ├─ task_ttl_second
      ├─ lock_checker_enable_deadlock_check
      ├─ query_queue_v2_schedule_strategy
      ├─ internal_log_roll_num
      ├─ bdbje_cleaner_threads
      ├─ internal_log_roll_interval
      ├─ max_dynamic_partition_num
      ├─ hdfs_read_buffer_size_kb
      ├─ stream_load_task_keep_max_second
      ├─ audit_log_json_format
      ├─ slow_lock_print_stack
      ├─ query_queue_slots_estimator_strategy
      ├─ enable_task_info_mask_credential
      ├─ enable_collect_tablet_num_in_show_proc_backend_disk_path
      ├─ bdbje_reserved_disk_size
      ├─ internal_log_json_format
      ├─ http_max_initial_line_length
      ├─ max_query_queue_history_slots_number
      ├─ query_queue_v2_cpu_costs_per_slot
      ├─ task_min_schedule_interval_s
      ├─ lake_use_combined_txn_log
      ├─ edit_log_write_slow_log_threshold_ms
      ├─ checkpoint_only_on_leader
      ├─ internal_log_delete_age
      └─ starmgr_grpc_timeout_seconds
    
    ERRORS:
      ├─ Generation failed for internal_log_json_format: 'NoneType' object is not iterable
      ├─ Generation failed for max_task_consecutive_fail_count: 'NoneType' object is not iterable
      ├─ Generation failed for task_runs_timeout_second: 'NoneType' object is not iterable
      ├─ Generation failed for mysql_service_kill_after_disconnect: 'NoneType' object is not iterable
    

This Pr is generated by [DocsAgent](https://github.com/StarRocks/DocsAgent)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3