### PR TITLE
[BugFix] fix connector chunk sink bug

### DIFF
--- a/be/src/connector/partition_chunk_writer.cpp
+++ b/be/src/connector/partition_chunk_writer.cpp
@@ -69,6 +69,7 @@ void PartitionChunkWriter::commit_file() {
 }
 
 Status BufferPartitionChunkWriter::init() {
+    RETURN_IF_ERROR(create_file_writer_if_needed());
     return Status::OK();
 }
 
@@ -125,6 +126,7 @@ Status SpillPartitionChunkWriter::init() {
     RETURN_IF_ERROR(_load_spill_block_mgr->init());
     _load_chunk_spiller = std::make_unique<LoadChunkSpiller>(_load_spill_block_mgr.get(),
                                                              _fragment_context->runtime_state()->runtime_profile());
+    RETURN_IF_ERROR(create_file_writer_if_needed());
     return Status::OK();
 }
 

--- a/be/src/formats/orc/orc_file_writer.cpp
+++ b/be/src/formats/orc/orc_file_writer.cpp
@@ -115,7 +115,9 @@ FileWriter::CommitResult ORCFileWriter::commit() {
     FileWriter::CommitResult result{
             .io_status = Status::OK(), .format = ORC, .location = _location, .rollback_action = _rollback_action};
     try {
-        _writer->close();
+        if (_writer != nullptr) {
+            _writer->close();
+        }
     } catch (const std::exception& e) {
         result.io_status.update(Status::IOError(fmt::format("{}: {}", "close file error", e.what())));
     }

--- a/be/src/formats/parquet/parquet_file_writer.cpp
+++ b/be/src/formats/parquet/parquet_file_writer.cpp
@@ -68,7 +68,9 @@ FileWriter::CommitResult ParquetFileWriter::commit() {
     FileWriter::CommitResult result{
             .io_status = Status::OK(), .format = PARQUET, .location = _location, .rollback_action = _rollback_action};
     try {
-        _writer->Close();
+        if (_writer != nullptr) {
+            _writer->Close();
+        }
     } catch (const ::parquet::ParquetStatusException& e) {
         result.io_status.update(Status::IOError(fmt::format("{}: {}", "close file error", e.what())));
     }


### PR DESCRIPTION
## Why I'm doing:
The original question is described in https://github.com/StarRocks/starrocks/pull/65951

But the pr introduces a new problem:
1. the _file_writer in PartitionChunkWriter init failed
2. PartitionChunkWriter is still put into the map
3. PartitionChunkWriter close will also call _file_writer close, but it is nullptr.


## What I'm doing:

Fixes [#10651](https://github.com/StarRocks/StarRocksTest/issues/10651)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
