### PR TITLE
[BugFix] Fix race condition when exec group submit next driver

### DIFF
--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -77,6 +77,7 @@ set(EXEC_FILES
         ./exec/pipeline/limit_operator_test.cpp
         ./exec/pipeline/local_bucket_shuffle_test.cpp
         ./exec/pipeline/mem_limited_chunk_queue_test.cpp
+        ./exec/pipeline/exec_group_test.cpp
         ./exec/query_cache/query_cache_test.cpp
         ./exec/query_cache/transform_operator.cpp
         ./exec/schema_columns_scanner_test.cpp

--- a/be/test/exec/pipeline/exec_group_test.cpp
+++ b/be/test/exec/pipeline/exec_group_test.cpp
@@ -1,0 +1,98 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "exec/chunk_buffer_memory_manager.h"
+#include "exec/pipeline/exchange/local_exchange_source_operator.h"
+#include "exec/pipeline/group_execution/execution_group.h"
+#include "exec/pipeline/noop_sink_operator.h"
+#include "exec/pipeline/operator.h"
+#include "runtime/runtime_state.h"
+#include "testutil/assert.h"
+#include "util/threadpool.h"
+
+namespace starrocks::pipeline {
+struct GroupTaskRunner : public Runnable {
+    GroupTaskRunner(ColocateExecutionGroup* group) : _group(group) {}
+    ~GroupTaskRunner() override = default;
+    void run() override { _group->submit_active_drivers(); }
+    ColocateExecutionGroup* _group;
+};
+
+class MockedDriverExecutor : public DriverExecutor {
+public:
+    MockedDriverExecutor(ThreadPool* tp, ColocateExecutionGroup* group)
+            : DriverExecutor("mocked"), _tp(tp), _group(group) {}
+    ~MockedDriverExecutor() override = default;
+    void submit(DriverRawPtr driver) override { (void)_tp->submit(std::make_shared<GroupTaskRunner>(_group)); }
+    void cancel(DriverRawPtr driver) override {}
+    void close() override { _tp->shutdown(); }
+
+    void report_exec_state(QueryContext* query_ctx, FragmentContext* fragment_ctx, const Status& status, bool done,
+                           bool attach_profile) override {}
+
+    void report_audit_statistics(QueryContext* query_ctx, FragmentContext* fragment_ctx) override {}
+
+    void iterate_immutable_blocking_driver(const ConstDriverConsumer& call) const override {}
+
+    size_t activate_parked_driver(const ConstDriverPredicator& predicate_func) override { return 0; }
+
+    void report_epoch(ExecEnv* exec_env, QueryContext* query_ctx,
+                      std::vector<FragmentContext*> fragment_ctxs) override {}
+
+    size_t calculate_parked_driver(const ConstDriverPredicator& predicate_func) const override { return 0; }
+
+    void bind_cpus(const CpuUtil::CpuIds& cpuids, const std::vector<CpuUtil::CpuIds>& borrowed_cpuids) override {}
+
+private:
+    ThreadPool* _tp;
+    ColocateExecutionGroup* _group;
+};
+
+TEST(ExecutionGroupTest, SubmitRaceConditionTest) {
+    std::unique_ptr<ThreadPool> tp;
+    ASSERT_OK(ThreadPoolBuilder("mock").set_max_threads(4).build(&tp));
+    RuntimeState dummy;
+    ColocateExecutionGroup group(1);
+    MockedDriverExecutor executor(tp.get(), &group);
+    group.attach_driver_executor(&executor);
+
+    OpFactories factories;
+    auto mem_mgr = std::make_shared<ChunkBufferMemoryManager>(100, 1024);
+    auto source = std::make_shared<LocalExchangeSourceOperatorFactory>(1, 1, mem_mgr);
+    source->set_degree_of_parallelism(100);
+    factories.emplace_back(source);
+    factories.emplace_back(std::make_shared<NoopSinkOperatorFactory>(2, 0));
+    Pipeline pipeline(0, factories, &group);
+
+    for (size_t i = 0; i < 100; ++i) {
+        Operators ops_with_sink;
+        ops_with_sink.emplace_back(factories[0]->create(100, i));
+        ops_with_sink.emplace_back(factories[1]->create(100, i));
+        pipeline.drivers().emplace_back(
+                std::make_shared<PipelineDriver>(ops_with_sink, nullptr, nullptr, &pipeline, -1));
+    }
+
+    group.add_pipeline(&pipeline);
+    // skip prepare step
+    group._submit_drivers = std::make_unique<std::atomic<int>[]>(1);
+
+    group.submit_active_drivers();
+
+    executor.close();
+}
+} // namespace starrocks::pipeline


### PR DESCRIPTION
## Why I'm doing:

```
F20251128 05:57:19.270646 46978825516800 event_scheduler.cpp:28] Check failed: !driver->is_in_blocked()
main RELEASE (build 8af612e distro centos arch x86_64)
query_id:019ac752-1f00-733d-a905-8c825f9a172a, fragment_instance:019ac752-1f00-733d-a905-8c825f9a172c
[1764280639.290][thread: 46978825516800] je_mallctl execute purge success
[1764280639.290][thread: 46978825516800] je_mallctl execute dontdump success
*** Aborted at 1764280644 (unix time) try "date -d @1764280644" if you are using GNU date ***
PC: @     0x2ab9ef910387 __GI_raise
*** SIGABRT (@0x3e800022174) received by PID 139636 (TID 0x2aba1c34f700) LWP(140398) from PID 139636; stack trace: ***
    @     0x2ab9ed50620b __pthread_once_slow
    @          0xe125554 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x2ab9ed50f630 (/usr/lib64/libpthread-2.17.so+0xf62f)
    @     0x2ab9ef910387 __GI_raise
    @     0x2ab9ef911a78 __GI_abort
    @          0x8cfe8d3 starrocks::failure_function()
    @          0xe11a4ad google::LogMessage::Fail()
    @          0xe11b774 google::LogMessageFatal::~LogMessageFatal()
    @          0xa97a0e3 starrocks::pipeline::EventScheduler::add_blocked_driver(starrocks::pipeline::PipelineDriver*)
    @          0x94e8bc4 starrocks::pipeline::ColocateExecutionGroup::submit_active_drivers()
    @          0x9456c81 starrocks::pipeline::FragmentContext::submit_active_drivers(starrocks::pipeline::DriverExecutor*)
    @          0x93825ab starrocks::pipeline::FragmentExecutor::execute(starrocks::ExecEnv*)
    @          0xac08dc4 starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment_by_pipeline(starrocks::TExecPlanFragmentParams const&, starrocks::TExecPlanFragmentParams const&)
    @          0xac0e483 starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(brpc::Controller*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*)
    @          0xac1373c starrocks::PInternalServiceImplBase<starrocks::PInternalService>::_exec_plan_fragment(google::protobuf::RpcController*, starrocks::PExecPlanFragmentRequest const*, starrocks::PExecPlanFragmentResult*, google::protobuf::Closure*)
    @          0x8220a9b starrocks::PriorityThreadPool::work_thread(int)
    @          0xe0e2ac7 thread_proxy
    @     0x2ab9ed507ea5 start_thread
    @     0x2ab9ef9d8b0d __clone
(END)
```



## What I'm doing:

close https://github.com/StarRocks/StarRocksTest/issues/10652

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make initial driver submission two-phase to prevent race with `submit_next_driver()` and add a unit test covering the scenario.
> 
> - **Pipeline/Execution Group**:
>   - `ColocateExecutionGroup::submit_active_drivers()` now performs a two-phase submission:
>     - Publish per-pipeline initial counts to `_submit_drivers`.
>     - Then submit initial drivers using recorded counts to avoid race with `submit_next_driver()`.
>   - Minor: include `<cstddef>` added.
> - **Tests**:
>   - Add `exec/pipeline/exec_group_test.cpp` with a mocked executor to stress concurrent submissions and validate no crash.
>   - Register the test in `be/test/CMakeLists.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59e1e558e40871f60ea2505c8276558f4abe6bec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->