### PR TITLE
[UT] Remove potentially buggy SQL test case for mem_pool property of resource groups

### DIFF
--- a/test/sql/test_resource_group_mem_pool/R/test_create_two_resource_groups_with_mem_pool_different_mem_limit
+++ b/test/sql/test_resource_group_mem_pool/R/test_create_two_resource_groups_with_mem_pool_different_mem_limit
@@ -27,11 +27,5 @@ show verbose resource groups all;
 [REGEX]shared_resource_group_for_alex.+7.+55(\.\d+)?%.+NORMAL.+\(id=\d+,.+user=alex\)\s*(shared_pool_for_alex_and_brad)
 -- !result
 
-show verbose resource groups all;
--- result:
-[REGEX][^shared_resource_group_for_brad]
--- !result
-
-
 [UC] drop resource group shared_resource_group_for_alex;
 [UC] drop resource group shared_resource_group_for_brad;

--- a/test/sql/test_resource_group_mem_pool/T/test_create_two_resource_groups_with_mem_pool_different_mem_limit
+++ b/test/sql/test_resource_group_mem_pool/T/test_create_two_resource_groups_with_mem_pool_different_mem_limit
@@ -20,7 +20,6 @@ with (
 );
 
 show verbose resource groups all;
-show verbose resource groups all;
 
 [UC] drop resource group shared_resource_group_for_alex;
 [UC] drop resource group shared_resource_group_for_brad;


### PR DESCRIPTION
## Why I'm doing:

I recently added E2E SQL test cases for testing the mem_pool property. 
- https://github.com/StarRocks/starrocks/pull/65859

One of the test cases has an incorrect regex.
```
show verbose resource groups all;
-- result:
[REGEX][^shared_resource_group_for_brad]
-- !result
```
The intention was to assert that the expression cannot be matched in the result.
It instead tries to match a single character that is not present in the brackets.
The correct regex should use a negative lookahead to implement the intended behavior. 

The test case, however, does not fail, as the result coincidentally does not start with any of these characters.

## What I'm doing:
The check is actually redundant, as we already assert that the resource group was not created in the previous check. 
Instead of adding another complicated regex with negative lookaheads, I am simply removing it.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes an incorrect regex-based assertion and a duplicate `show verbose resource groups all` call from the mem_pool resource group test.
> 
> - **Tests (SQL mem_pool resource groups)**:
>   - Remove invalid regex assertion block from `R/test_create_two_resource_groups_with_mem_pool_different_mem_limit` that attempted to verify absence in `show verbose resource groups all` output.
>   - Simplify `T/test_create_two_resource_groups_with_mem_pool_different_mem_limit` by removing a duplicate `show verbose resource groups all` call, leaving a single invocation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eef6213e903121c664d0738027491931db875794. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->