### PR TITLE
[BugFix] Fix push down distinct limit cause data lose

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AggregationNode.java
@@ -98,6 +98,9 @@ public class AggregationNode extends PlanNode implements RuntimeFilterBuildNode 
 
     private boolean withLocalShuffle = false;
 
+    // direct set limit will introduce a limit on ExchangeNode
+    private long localLimit = -1;
+
     // identicallyDistributed meanings the PlanNode above OlapScanNode are cases as follows:
     // 1. bucket shuffle join,
     // 2. colocate join,
@@ -174,6 +177,10 @@ public class AggregationNode extends PlanNode implements RuntimeFilterBuildNode 
         this.usePerBucketOptimize = usePerBucketOptimize;
     }
 
+    public void setLocalLimit(long localLimit) {
+        this.localLimit = localLimit;
+    }
+
     public void setGroupByMinMaxStats(List<Pair<ConstantOperator, ConstantOperator>> groupByMinMaxStats) {
         this.groupByMinMaxStats = groupByMinMaxStats;
     }
@@ -246,6 +253,10 @@ public class AggregationNode extends PlanNode implements RuntimeFilterBuildNode 
         }
         msg.agg_node.setUse_sort_agg(useSortAgg);
         msg.agg_node.setUse_per_bucket_optimize(usePerBucketOptimize);
+        if (localLimit > 0) {
+            Preconditions.checkState(!hasLimit());
+            msg.limit = localLimit;
+        }
 
         List<Expr> groupingExprs = aggInfo.getGroupingExprs();
         if (groupingExprs != null) {
@@ -363,6 +374,9 @@ public class AggregationNode extends PlanNode implements RuntimeFilterBuildNode 
 
         if (withLocalShuffle) {
             output.append(detailPrefix).append("withLocalShuffle: true\n");
+        }
+        if (localLimit > 0) {
+            output.append(detailPrefix).append("limit: ").append(localLimit).append("\n");
         }
 
         if (detailLevel == TExplainLevel.VERBOSE) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -2186,6 +2186,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public long cboPushDownDistinctLimit() {
         return cboPushDownDistinctLimit;
     }
+    public void setCboPushDownDistinctLimit(long cboPushDownDistinctLimit) {
+        this.cboPushDownDistinctLimit = cboPushDownDistinctLimit;
+    }
 
     public void setCboPushDownTopNLimit(long cboPushDownTopNLimit) {
         this.cboPushDownTopNLimit = cboPushDownTopNLimit;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalAggregationOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalAggregationOperator.java
@@ -68,6 +68,14 @@ public class LogicalAggregationOperator extends LogicalOperator {
     // forced to pre-aggregate because the data has to be fully reduced before evaluating the topN.
     private boolean topNLocalAgg = false;
 
+    // only used in streaming aggregate
+    // eg: select distinct a from table limit 100;
+    // In this query, we can push the LIMIT down to the streaming distinct operator.
+    // However, no LIMIT should be inserted between the global and local operators.
+    // may cause incorrect final results, because the LIMIT between the local-distinct and global-distinct
+    // operators can truncate overlapping data produced by the local-distinct stage.
+    private long localLimit = DEFAULT_LIMIT;
+
     // If the AggType is not GLOBAL, it means we have split the agg hence the isSplit should be true.
     // `this.isSplit = !type.isGlobal() || isSplit;` helps us do the work.
     // If you want to manually set this value, you could invoke setOnlyLocalAggregate().
@@ -148,6 +156,10 @@ public class LogicalAggregationOperator extends LogicalOperator {
 
     public void setTopNLocalAgg(boolean topNLocalAgg) {
         this.topNLocalAgg = topNLocalAgg;
+    }
+
+    public long getLocalLimit() {
+        return localLimit;
     }
 
     public boolean checkGroupByCountDistinct() {
@@ -317,6 +329,7 @@ public class LogicalAggregationOperator extends LogicalOperator {
             builder.isSplit = aggregationOperator.isSplit;
             builder.distinctColumnDataSkew = aggregationOperator.distinctColumnDataSkew;
             builder.topNLocalAgg = aggregationOperator.topNLocalAgg;
+            builder.localLimit = aggregationOperator.localLimit;
             return this;
         }
 
@@ -328,6 +341,11 @@ public class LogicalAggregationOperator extends LogicalOperator {
         public Builder setGroupingKeys(
                 List<ColumnRefOperator> groupingKeys) {
             builder.groupingKeys = ImmutableList.copyOf(groupingKeys);
+            return this;
+        }
+
+        public Builder setLocalLimit(long localLimit) {
+            builder.localLimit = localLimit;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashAggregateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashAggregateOperator.java
@@ -78,6 +78,8 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
 
     private boolean withLocalShuffle = false;
 
+    private long localLimit = DEFAULT_LIMIT;
+
     private List<Pair<ConstantOperator, ConstantOperator>> groupByMinMaxStatistic = Lists.newArrayList();
 
     public PhysicalHashAggregateOperator(AggType type,
@@ -116,6 +118,7 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
         this.distinctColumnDataSkew = aggregateOperator.distinctColumnDataSkew;
         this.groupByMinMaxStatistic = aggregateOperator.groupByMinMaxStatistic;
         this.withLocalShuffle = aggregateOperator.withLocalShuffle;
+        this.localLimit = aggregateOperator.localLimit;
     }
 
     public List<ColumnRefOperator> getGroupBys() {
@@ -211,8 +214,16 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
         return withoutColocateRequirement;
     }
 
+    public long getLocalLimit() {
+        return localLimit;
+    }
+
     public void setWithoutColocateRequirement(boolean withoutColocateRequirement) {
         this.withoutColocateRequirement = withoutColocateRequirement;
+    }
+
+    public void setLocalLimit(long localLimit) {
+        this.localLimit = localLimit;
     }
 
     public void setUsePerBucketOptmize(boolean usePerBucketOptmize) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/HashAggImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/HashAggImplementationRule.java
@@ -45,6 +45,7 @@ public class HashAggImplementationRule extends ImplementationRule {
                 logical.getProjection());
         physical.setDistinctColumnDataSkew(logical.getDistinctColumnDataSkew());
         physical.setTopNLocalAgg(logical.isTopNLocalAgg());
+        physical.setLocalLimit(logical.getLocalLimit());
         OptExpression result = OptExpression.create(physical, input.getInputs());
         return Lists.newArrayList(result);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitTwoPhaseAggRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitTwoPhaseAggRule.java
@@ -103,7 +103,8 @@ public class SplitTwoPhaseAggRule extends SplitAggregateRule {
                 .setAggregations(createNormalAgg(AggType.LOCAL, newAggMap))
                 .setSplit()
                 .setPredicate(null)
-                .setLimit(localAggLimit)
+                .setLocalLimit(localAggLimit)
+                .setLimit(Operator.DEFAULT_LIMIT)
                 .setProjection(null)
                 .build();
         OptExpression localOptExpression = OptExpression.create(local, input.getInputs());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/AddDecodeNodeForDictStringRule.java
@@ -778,6 +778,7 @@ public class AddDecodeNodeForDictStringRule implements TreeRewriteRule {
             newHashAggregator.setUseSortAgg(aggOperator.isUseSortAgg());
             newHashAggregator.setUsePerBucketOptmize(aggOperator.isUsePerBucketOptmize());
             newHashAggregator.setWithoutColocateRequirement(aggOperator.isWithoutColocateRequirement());
+            newHashAggregator.setLocalLimit(aggOperator.getLocalLimit());
             return newHashAggregator;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -240,6 +240,8 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
         op.setMergedLocalAgg(aggregate.isMergedLocalAgg());
         op.setUseSortAgg(aggregate.isUseSortAgg());
         op.setUsePerBucketOptmize(aggregate.isUsePerBucketOptmize());
+        op.setWithoutColocateRequirement(aggregate.isWithoutColocateRequirement());
+        op.setLocalLimit(aggregate.getLocalLimit());
         return rewriteOptExpression(optExpression, op, info.outputStringColumns);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -2395,6 +2395,7 @@ public class PlanFragmentBuilder {
 
             aggregationNode.setUseSortAgg(node.isUseSortAgg());
             aggregationNode.setUsePerBucketOptimize(node.isUsePerBucketOptmize());
+            aggregationNode.setLocalLimit(node.getLocalLimit());
             aggregationNode.setStreamingPreaggregationMode(node.getNeededPreaggregationMode());
             aggregationNode.setHasNullableGenerateChild();
             aggregationNode.computeStatistics(optExpr.getStatistics());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -3169,6 +3169,12 @@ public class AggregateTest extends PlanTestBase {
                 "  |  STREAMING\n" +
                 "  |  group by: 4: expr\n" +
                 "  |  limit: 10");
+        assertNotContains(plan, "  4:AGGREGATE (merge finalize)\n" +
+                "  |  group by: 4: expr\n" +
+                "  |  limit: 10\n" +
+                "  |  \n" +
+                "  3:EXCHANGE\n" +
+                "     limit: 10");
         FeConstants.runningUnitTest = false;
     }
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

close #66012

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Apply per-node local LIMIT for streaming/group-by distinct aggregation and propagate it through planning to avoid LIMIT crossing exchanges and causing data loss.
> 
> - **Optimizer/Aggregation**:
>   - Introduce per-node `localLimit` on `LogicalAggregationOperator` and `PhysicalHashAggregateOperator`; propagate via `HashAggImplementationRule` and through dict decode rewriters.
>   - In `SplitTwoPhaseAggRule`, push LIMIT to local streaming distinct by setting `localLimit` and clear global LIMIT to avoid truncation across `EXCHANGE`.
> - **Planner/Execution**:
>   - `AggregationNode` now supports a local limit (serialized as thrift `limit` when set; shown in EXPLAIN); `PlanFragmentBuilder` sets it from physical agg.
> - **Session Variables**:
>   - Add setter for `cboPushDownDistinctLimit`.
> - **Tests**:
>   - Add UT ensuring LIMIT appears only on local AGG (not on global AGG/EXCHANGE).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bb8b255dcd56633e47bb5dd69d6485dc40b82d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->