### PR TITLE
[Enhancement] support DATE_PART syntax as alias for EXTRACT

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -961,6 +961,79 @@ public class ExpressionAnalyzer {
             }
             String fnName = node.getFnName().getFunction();
 
+            if (fnName.equalsIgnoreCase("date_part")) {
+                if (node.getChildren().size() != 2) {
+                    throw new SemanticException("DATE_PART requires 2 arguments: DATE_PART('unit', date_expr)");
+                }
+
+                Expr unitExpr = node.getChild(0);
+                Expr dateExpr = node.getChild(1);
+
+                if (!(unitExpr instanceof StringLiteral)) {
+                    throw new SemanticException("The first argument of DATE_PART must be a constant string " + 
+                            "literal, e.g., 'year'");
+                }
+
+                String unit = ((StringLiteral) unitExpr).getStringValue().toLowerCase();
+                String targetFunction = "";
+
+                switch (unit) {
+                    case "year":
+                    case "yy":
+                    case "yyyy":
+                        targetFunction = "year";
+                        break;
+                    case "quarter":
+                    case "qq":
+                    case "q":
+                        targetFunction = "quarter";
+                        break;
+                    case "month":
+                    case "mm":
+                    case "m":
+                        targetFunction = "month";
+                        break;
+                    case "day":
+                    case "dd":
+                    case "d":
+                        targetFunction = "day";
+                        break;
+                    case "hour":
+                    case "hh":
+                        targetFunction = "hour";
+                        break;
+                    case "minute":
+                    case "mi":
+                    case "n":
+                        targetFunction = "minute";
+                        break;
+                    case "second":
+                    case "ss":
+                    case "s":
+                        targetFunction = "second";
+                        break;
+                    case "dow": 
+                        targetFunction = "dayofweek";
+                        break;
+                    case "doy":
+                        targetFunction = "dayofyear";
+                        break;
+                    case "week":
+                    case "wk":
+                    case "ww":
+                        targetFunction = "week_iso";
+                        break;
+                    default:
+                        throw new SemanticException("Unsupported unit for DATE_PART: " + unit);
+                }
+
+                node.resetFnName("", targetFunction);
+                node.clearChildren();
+                node.addChild(dateExpr);
+
+                return visitFunctionCall(node, scope);
+            }
+ 
             // Handle backward compatibility parameter conversion
             handleBackwardCompatibleParameterConversion(fnName, node);
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/ExpressionAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/ExpressionAnalyzerTest.java
@@ -245,4 +245,53 @@ public class ExpressionAnalyzerTest extends PlanTestBase {
         Assertions.assertThrows(SemanticException.class, () -> visitor.visitLikePredicate(likePredicate,
                 new Scope(RelationId.anonymous(), new RelationFields())));
     }
+
+    @Test
+    public void testDatePartAnalyzer() {
+        ConnectContext session = new ConnectContext();
+        ExpressionAnalyzer analyzer = new ExpressionAnalyzer(session);
+        AnalyzeState analyzeState = new AnalyzeState();
+        Scope scope = new Scope(RelationId.anonymous(), new RelationFields());
+
+        java.util.function.Consumer<String> verifySuccess = (sql) -> {
+            Expr expr = SqlParser.parseSqlToExpr(sql, session.getSessionVariable().getSqlMode());
+            analyzer.analyze(expr, analyzeState, scope);
+        };
+
+        java.util.function.BiConsumer<String, String> verifyFail = (sql, errorMsg) -> {
+            Expr expr = SqlParser.parseSqlToExpr(sql, session.getSessionVariable().getSqlMode());
+            try {
+                analyzer.analyze(expr, analyzeState, scope);
+                Assertions.fail("Should have failed: " + sql);
+            } catch (SemanticException e) {
+                Assertions.assertTrue(e.getMessage().contains(errorMsg), "Error message mismatch: " + e.getMessage());
+            }
+        };
+
+        verifySuccess.accept("date_part('year', '2023-01-01')");
+        verifySuccess.accept("date_part('quarter', '2023-01-01')");
+        verifySuccess.accept("date_part('month', '2023-01-01')");
+        verifySuccess.accept("date_part('week', '2023-01-01')");
+        verifySuccess.accept("date_part('day', '2023-01-01')");
+        
+        verifySuccess.accept("date_part('hour', '2023-01-01 12:00:00')");
+        verifySuccess.accept("date_part('minute', '2023-01-01 12:00:00')");
+        verifySuccess.accept("date_part('second', '2023-01-01 12:00:00')");
+
+        verifySuccess.accept("date_part('yy', '2023-01-01')");
+        verifySuccess.accept("date_part('qq', '2023-01-01')");
+        verifySuccess.accept("date_part('mm', '2023-01-01')"); 
+        verifySuccess.accept("date_part('wk', '2023-01-01')");
+        verifySuccess.accept("date_part('dd', '2023-01-01')");
+        verifySuccess.accept("date_part('hh', '2023-01-01 12:00:00')");
+        verifySuccess.accept("date_part('mi', '2023-01-01 12:00:00')");
+        verifySuccess.accept("date_part('ss', '2023-01-01 12:00:00')");
+        
+        verifySuccess.accept("date_part('dow', '2023-01-01')");
+        verifySuccess.accept("date_part('doy', '2023-01-01')");
+
+        verifyFail.accept("date_part('year')", "DATE_PART requires 2 arguments");
+        verifyFail.accept("date_part(123, '2023-01-01')", "must be a constant string literal");
+        verifyFail.accept("date_part('invalid_unit', '2023-01-01')", "Unsupported unit for DATE_PART");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:

Many users migrating from PostgreSQL or Snowflake are accustomed to the `DATE_PART(field, source)` syntax. Currently, StarRocks supports `EXTRACT(field FROM source)` or specific functions like `year()`, `month()`, etc.

To improve compatibility and developer experience, this PR adds support for `DATE_PART` as syntactic sugar (alias) for existing extraction functions. This resolves issue #62631.

Fixes #62631

## What I'm doing:

I have modified the `ExpressionAnalyzer.java` to support the `DATE_PART` function syntax. 

**Implementation Details:**
1.  **Interception:** In `visitFunctionCall`, the analyzer now detects if the function name is `date_part`.
2.  **Validation:** It verifies that exactly two arguments are provided and that the first argument is a string literal (the unit).
3.  **AST Rewriting:** It maps the requested unit (e.g., `'year'`, `'dow'`) to the corresponding native StarRocks function (e.g., `year()`, `dayofweek()`) and rewrites the function call internally.

**Supported Units:**
- Standard: `year`, `month`, `day`, `hour`, `minute`, `second`
- Aliases/Postgres-style: `dow` (maps to `dayofweek`), `doy` (maps to `dayofyear`), `quarter`, `week`

**Test Results (Verified Locally):**
I have verified the implementation using a MySQL client connected to the StarRocks FE. Below is a screenshot depicting the successful execution of various `DATE_PART` queries, including year, month, and day of week (dow).

<img width="679" height="516" alt="image" src="https://github.com/user-attachments/assets/0802ca9e-bf62-4c16-81a7-59bc0735fb1c" />

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `DATE_PART('unit', date_expr)` syntax that validates arguments and rewrites to built-in functions (e.g., `year`, `month`, `dayofweek`, `week_iso`), with unit tests.
> 
> - **Analyzer**:
>   - Implement handling of `date_part` in `ExpressionAnalyzer.visitFunctionCall`.
>     - Validate two args and require first to be a string literal.
>     - Map units/aliases to built-ins: `year`, `quarter`, `month`, `day`, `hour`, `minute`, `second`, `dayofweek` (`dow`), `dayofyear` (`doy`), `week_iso` (`week/wk/ww`).
>     - Rewrite AST to target function and re-analyze.
> - **Tests**:
>   - Add `testDatePartAnalyzer` covering success cases for supported units/aliases and failure cases for arity/type/unsupported unit.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba5d326b905fbf1d09023050025789534688acd3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->