### PR TITLE
[Tool] Fix build failure on Ubuntu 24.04 by conditionally linking libsframe

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -612,7 +612,16 @@ FUNCTION(ADD_BE_LIB LIB_NAME)
     set(ALL_BE_LIBS "${ALL_BE_LIBS};${LIB_NAME}" CACHE INTERNAL "All BE libraries")
 ENDFUNCTION()
 
-set (STARROCKS_STATIC_LINK_LIBS ${WL_LINK_STATIC} -lgomp -lbfd)
+# Check if libsframe exists (needed for binutils 2.40+ on newer distros like Ubuntu 24.04)
+find_library(SFRAME_LIB sframe)
+
+if(SFRAME_LIB)
+    message(STATUS "Found libsframe: ${SFRAME_LIB}, linking it explicitly.")
+    set (STARROCKS_STATIC_LINK_LIBS ${WL_LINK_STATIC} -lgomp -lbfd -lsframe)
+else()
+    message(STATUS "libsframe not found, skipping explicit linkage.")
+    set (STARROCKS_STATIC_LINK_LIBS ${WL_LINK_STATIC} -lgomp -lbfd)
+endif()
 
 if (NOT ("${MAKE_TEST}" STREQUAL "ON" AND "${BUILD_FOR_SANITIZE}" STREQUAL "ON"))
     # In other words, turn to dynamic link when MAKE_TEST and BUILD_TYPE == *SAN


### PR DESCRIPTION
## Why I'm doing:

On newer Linux distributions (specifically Ubuntu 24.04 LTS with GCC 12.4.0 and Binutils 2.42), the backend (BE) build fails during the final linking stage of `starrocks_be`.

The error reported is:
`undefined reference to sframe_encoder_write`

This occurs because `libbfd` now has a dependency on `libsframe` in newer binutils versions, but `libsframe` was not included in the linker flags in `be/CMakeLists.txt`.

## What I'm doing:

I have modified `be/CMakeLists.txt` to introduce a conditional check for the `libsframe` library.

- Used `find_library(SFRAME_LIB sframe)` to detect if the library exists on the host system.
- If found (e.g., on Ubuntu 24.04), `-lsframe` is explicitly appended to `STARROCKS_STATIC_LINK_LIBS` after `-lbfd`.
- If not found (e.g., on older CentOS 7 systems), the build proceeds with the original linker flags to ensure backward compatibility.

Fixes #66116

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Conditionally link `libsframe` in `be/CMakeLists.txt` when detected to satisfy newer binutils dependencies.
> 
> - **Build/CMake**:
>   - Detect `libsframe` via `find_library(SFRAME_LIB sframe)` in `be/CMakeLists.txt`.
>   - If found, append `-lsframe` to `STARROCKS_STATIC_LINK_LIBS` (after `-lbfd`); otherwise retain existing linker flags.
>   - Add status messages indicating whether `libsframe` was found and linked.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d66a92533337cbfc0ad4350e8774cfa07ef8c636. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->