### PR TITLE
[BugFix] fix iceberg view sql test

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -221,12 +221,10 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         IcebergTableCacheKey key = new IcebergTableCacheKey(icebergTableName, connectContext);
         try {
             return tables.get(key);
+        } catch (NoSuchTableException e) {
+            throw e;
         } catch (Exception e) {
-            Throwable c = e.getCause();
-            if (c instanceof NoSuchTableException) {
-                throw (NoSuchTableException) c;
-            }
-            throw new StarRocksConnectorException("Load table failed: " + dbName + "." + tableName, c);
+            throw new StarRocksConnectorException("Load table failed: " + dbName + "." + tableName, e);
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

The cache exception process logic is changed: fix sql test test_iceberg_ view
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rethrows NoSuchTableException directly during cached table retrieval and wraps other errors without unwrapping causes.
> 
> - **Iceberg Catalog Caching**:
>   - **Exception handling in `CachingIcebergCatalog#getTable`**:
>     - Explicitly catch and rethrow `NoSuchTableException`.
>     - Wrap other exceptions with `StarRocksConnectorException` using the original exception (no cause unwrapping).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48df39d940a3349c25fb19938cae4db6a0502d31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->