### PR TITLE
[Enhancement] Add compatiable operation type to support downgrade

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -158,6 +158,11 @@ public class EditLog {
                     globalStateMgr.setNextId(id + 1);
                     break;
                 }
+                case OperationType.OP_SAVE_NEXTID_V2: {
+                    NextIdLog nextIdLog = (NextIdLog) journal.data();
+                    globalStateMgr.setNextId(nextIdLog.getId() + 1);
+                    break;
+                }
                 case OperationType.OP_SAVE_TRANSACTION_ID_V2: {
                     TransactionIdInfo idInfo = (TransactionIdInfo) journal.data();
                     GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getTransactionIDGenerator()

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLogDeserializer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLogDeserializer.java
@@ -270,6 +270,7 @@ public class EditLogDeserializer {
             .put(OperationType.OP_DROP_SPM_BASELINE_LOG, BaselinePlan.Info.class)
             .put(OperationType.OP_UPDATE_TABLET_RESHARD_JOB_LOG, TabletReshardJob.class)
             .put(OperationType.OP_REMOVE_TABLET_RESHARD_JOB_LOG, RemoveTabletReshardJobLog.class)
+            .put(OperationType.OP_SAVE_NEXTID_V2, NextIdLog.class)
             .build();
 
     public static Writable deserialize(Short opCode, DataInput in) throws IOException {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/NextIdLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/NextIdLog.java
@@ -1,0 +1,32 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.persist;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.io.Writable;
+
+public class NextIdLog implements Writable {
+
+    @SerializedName(value = "id")
+    private long id;
+
+    public NextIdLog(long id) {
+        this.id = id;
+    }
+
+    public long getId() {
+        return id;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -646,6 +646,9 @@ public class OperationType {
     @IgnorableOnReplayFailed
     public static final short OP_REMOVE_TABLET_RESHARD_JOB_LOG = 13551;
 
+    // New V2 operations for logEdit to logJsonObject migration
+    public static final short OP_SAVE_NEXTID_V2 = 13552;
+
     @IgnorableOnReplayFailed
     public static final short OP_ALTER_RESOURCE = 13557;
 

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
@@ -238,7 +238,7 @@ public class GsonUtils {
     private static final RuntimeTypeAdapterFactory<com.starrocks.catalog.Type> COLUMN_TYPE_ADAPTER_FACTORY =
             RuntimeTypeAdapterFactory
                     .of(com.starrocks.catalog.Type.class, "clazz")
-                    .registerSubtype(ScalarType.class, "ScalarType")
+                    .registerSubtype(ScalarType.class, "ScalarType", true)
                     .registerSubtype(ArrayType.class, "ArrayType")
                     .registerSubtype(MapType.class, "MapType")
                     .registerSubtype(StructType.class, "StructType")


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This pull request introduces support for a new journal operation type, `OP_SAVE_NEXTID_V2`, to facilitate the migration from logEdit to logJsonObject for next ID persistence. The changes include handling the new operation type in journal loading and deserialization, adding a dedicated log class for next ID, and updating operation type definitions. Additionally, there is a minor improvement in the Gson adapter registration for type serialization.

### Journal operation migration and support

* Added a new operation type constant `OP_SAVE_NEXTID_V2` in `OperationType` to support next ID persistence migration.
* Implemented handling for `OP_SAVE_NEXTID_V2` in `EditLog.loadJournal`, ensuring correct next ID setting during journal replay.
* Registered deserialization logic for `OP_SAVE_NEXTID_V2` in `EditLogDeserializer`, mapping it to the new `NextIdLog` class.
* Introduced the `NextIdLog` class to encapsulate the next ID value for journal operations.

### Serialization improvement

* Updated the Gson adapter registration for `ScalarType` in `GsonUtils` to enable default type handling, improving type serialization/deserialization.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
