### PR TITLE
[Enhancement] let pagecache use a separated arena

### DIFF
--- a/be/src/cache/CMakeLists.txt
+++ b/be/src/cache/CMakeLists.txt
@@ -26,6 +26,7 @@ set(CACHE_FILES
   data_cache_hit_rate_counter.hpp
   mem_cache/lrucache_engine.cpp
   mem_cache/page_cache.cpp
+  mem_cache/pagecache_arena.cpp
   disk_cache/block_cache.cpp
   disk_cache/io_buffer.cpp
 )

--- a/be/src/cache/mem_cache/page_cache.h
+++ b/be/src/cache/mem_cache/page_cache.h
@@ -38,6 +38,7 @@
 #include <utility>
 
 #include "cache/datacache.h"
+#include "cache/mem_cache/pagecache_arena.h"
 
 namespace starrocks {
 
@@ -88,6 +89,10 @@ public:
     // concurrently, this function can assure that only one page is cached.
     // The in_memory page will have higher priority.
     Status insert(const std::string& key, std::vector<uint8_t>* data, const MemCacheWriteOptions& opts,
+                  PageCacheHandle* handle);
+
+    // Insert using PageCacheVector (uses pagecache arena)
+    Status insert(const std::string& key, PageCacheVector* data, const MemCacheWriteOptions& opts,
                   PageCacheHandle* handle);
 
     Status insert(const std::string& key, void* data, int64_t size, MemCacheDeleter deleter,

--- a/be/src/cache/mem_cache/pagecache_arena.cpp
+++ b/be/src/cache/mem_cache/pagecache_arena.cpp
@@ -1,0 +1,176 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cache/mem_cache/pagecache_arena.h"
+
+#include <cstring>
+
+#include "glog/logging.h"
+#include "jemalloc/jemalloc.h"
+
+namespace starrocks {
+
+PageCacheArena* PageCacheArena::instance() {
+    static PageCacheArena arena;
+    return &arena;
+}
+
+// Helper function for allocator to avoid incomplete type issues
+PageCacheArena* get_pagecache_arena_instance() {
+    return PageCacheArena::instance();
+}
+
+// Helper functions to check initialization and allocate/deallocate
+// These are needed because allocator template is instantiated before PageCacheArena is fully defined
+bool pagecache_arena_is_initialized(PageCacheArena* arena) {
+    return arena->is_initialized();
+}
+
+void* pagecache_arena_allocate(PageCacheArena* arena, size_t size) {
+    return arena->allocate(size);
+}
+
+void pagecache_arena_deallocate(PageCacheArena* arena, void* ptr, size_t size) {
+    arena->deallocate(ptr, size);
+}
+
+bool PageCacheArena::init() {
+    if (_initialized) {
+        return true;
+    }
+
+    // Create a new arena
+    size_t arena_index_size = sizeof(unsigned);
+    int ret = je_mallctl("arenas.create", &_arena_index, &arena_index_size, nullptr, 0);
+    if (ret != 0) {
+        LOG(ERROR) << "Failed to create jemalloc arena for pagecache, error: " << ret;
+        return false;
+    }
+
+    // Configure aggressive decay settings to minimize memory fragmentation
+    // Use shorter decay times: 1000ms (1 second) for both dirty and muzzy pages
+    // This is more aggressive than the default 5000ms
+    uint64_t dirty_decay_ms = 1000;
+    uint64_t muzzy_decay_ms = 1000;
+
+    char dirty_decay_key[64];
+    snprintf(dirty_decay_key, sizeof(dirty_decay_key), "arena.%u.dirty_decay_ms", _arena_index);
+    size_t sz = sizeof(dirty_decay_ms);
+    ret = je_mallctl(dirty_decay_key, nullptr, nullptr, &dirty_decay_ms, sz);
+    if (ret != 0) {
+        LOG(WARNING) << "Failed to set dirty_decay_ms for pagecache arena, error: " << ret;
+    }
+
+    char muzzy_decay_key[64];
+    snprintf(muzzy_decay_key, sizeof(muzzy_decay_key), "arena.%u.muzzy_decay_ms", _arena_index);
+    sz = sizeof(muzzy_decay_ms);
+    ret = je_mallctl(muzzy_decay_key, nullptr, nullptr, &muzzy_decay_ms, sz);
+    if (ret != 0) {
+        LOG(WARNING) << "Failed to set muzzy_decay_ms for pagecache arena, error: " << ret;
+    }
+
+    // Enable background thread for automatic decay
+    // This helps release memory more aggressively
+    char background_thread_key[64];
+    snprintf(background_thread_key, sizeof(background_thread_key), "arena.%u.background_thread", _arena_index);
+    bool background_thread = true;
+    sz = sizeof(background_thread);
+    ret = je_mallctl(background_thread_key, nullptr, nullptr, &background_thread, sz);
+    if (ret != 0) {
+        LOG(WARNING) << "Failed to enable background_thread for pagecache arena, error: " << ret;
+    }
+
+    _initialized = true;
+    LOG(INFO) << "PageCacheArena initialized with arena index " << _arena_index << ", dirty_decay_ms=" << dirty_decay_ms
+              << ", muzzy_decay_ms=" << muzzy_decay_ms;
+    return true;
+}
+
+void* PageCacheArena::allocate(size_t size) {
+    if (!_initialized) {
+        LOG(ERROR) << "PageCacheArena not initialized";
+        return nullptr;
+    }
+
+    // Use MALLOCX_ARENA to allocate from the specific arena
+    int flags = MALLOCX_ARENA(_arena_index) | MALLOCX_TCACHE_NONE;
+    void* ptr = je_mallocx(size, flags);
+    return ptr;
+}
+
+void PageCacheArena::deallocate(void* ptr, size_t size) {
+    if (ptr == nullptr) {
+        return;
+    }
+
+    if (!_initialized) {
+        LOG(ERROR) << "PageCacheArena not initialized";
+        return;
+    }
+
+    // Use dallocx with arena flag to free from the specific arena
+    int flags = MALLOCX_ARENA(_arena_index) | MALLOCX_TCACHE_NONE;
+    je_dallocx(ptr, flags);
+}
+
+bool PageCacheArena::get_stats(ArenaStats* stats) {
+    if (!_initialized || stats == nullptr) {
+        return false;
+    }
+
+    // Update epoch to refresh stats
+    uint64_t epoch = 1;
+    size_t sz = sizeof(epoch);
+    je_mallctl("epoch", &epoch, &sz, &epoch, sz);
+
+    // Get arena-specific stats
+    char allocated_key[64];
+    snprintf(allocated_key, sizeof(allocated_key), "stats.arenas.%u.allocated", _arena_index);
+    sz = sizeof(stats->allocated);
+    if (je_mallctl(allocated_key, &stats->allocated, &sz, nullptr, 0) != 0) {
+        return false;
+    }
+
+    char active_key[64];
+    snprintf(active_key, sizeof(active_key), "stats.arenas.%u.active", _arena_index);
+    sz = sizeof(stats->active);
+    if (je_mallctl(active_key, &stats->active, &sz, nullptr, 0) != 0) {
+        return false;
+    }
+
+    char resident_key[64];
+    snprintf(resident_key, sizeof(resident_key), "stats.arenas.%u.resident", _arena_index);
+    sz = sizeof(stats->resident);
+    if (je_mallctl(resident_key, &stats->resident, &sz, nullptr, 0) != 0) {
+        return false;
+    }
+
+    char mapped_key[64];
+    snprintf(mapped_key, sizeof(mapped_key), "stats.arenas.%u.mapped", _arena_index);
+    sz = sizeof(stats->mapped);
+    if (je_mallctl(mapped_key, &stats->mapped, &sz, nullptr, 0) != 0) {
+        return false;
+    }
+
+    char retained_key[64];
+    snprintf(retained_key, sizeof(retained_key), "stats.arenas.%u.retained", _arena_index);
+    sz = sizeof(stats->retained);
+    if (je_mallctl(retained_key, &stats->retained, &sz, nullptr, 0) != 0) {
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace starrocks

--- a/be/src/cache/mem_cache/pagecache_arena.cpp
+++ b/be/src/cache/mem_cache/pagecache_arena.cpp
@@ -119,9 +119,13 @@ void PageCacheArena::deallocate(void* ptr, size_t size) {
         return;
     }
 
-    // Use dallocx with arena flag to free from the specific arena
-    int flags = MALLOCX_ARENA(_arena_index) | MALLOCX_TCACHE_NONE;
-    je_dallocx(ptr, flags);
+    // Use je_free instead of je_dallocx to let jemalloc automatically detect
+    // which arena the pointer belongs to. This is safer because:
+    // 1. je_free automatically detects the arena from the pointer metadata
+    // 2. je_dallocx with MALLOCX_ARENA requires the pointer to be from that specific arena,
+    //    which may not always be true if allocation fell back to default jemalloc
+    (void)size; // size parameter is not used by je_free
+    je_free(ptr);
 }
 
 bool PageCacheArena::get_stats(ArenaStats* stats) {

--- a/be/src/cache/mem_cache/pagecache_arena.h
+++ b/be/src/cache/mem_cache/pagecache_arena.h
@@ -1,0 +1,183 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "common/config.h"
+#include "jemalloc/jemalloc.h"
+
+namespace starrocks {
+
+// Forward declaration
+class PageCacheArena;
+
+// Helper function declarations to avoid incomplete type issues in allocator
+PageCacheArena* get_pagecache_arena_instance();
+bool pagecache_arena_is_initialized(PageCacheArena* arena);
+void* pagecache_arena_allocate(PageCacheArena* arena, size_t size);
+void pagecache_arena_deallocate(PageCacheArena* arena, void* ptr, size_t size);
+
+// Custom allocator for std::vector that uses the pagecache arena
+template <typename T>
+class PageCacheArenaAllocator {
+public:
+    using value_type = T;
+    using pointer = T*;
+    using const_pointer = const T*;
+    using reference = T&;
+    using const_reference = const T&;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+
+    template <typename U>
+    struct rebind {
+        using other = PageCacheArenaAllocator<U>;
+    };
+
+    PageCacheArenaAllocator() = default;
+    ~PageCacheArenaAllocator() = default;
+
+    template <typename U>
+    PageCacheArenaAllocator(const PageCacheArenaAllocator<U>&) {}
+
+    pointer allocate(size_type n) {
+        if (n == 0) {
+            return nullptr;
+        }
+
+        const size_t bytes = n * sizeof(T);
+
+        // Check config first - if arena is disabled, use default jemalloc
+        if (!config::enable_pagecache_arena) {
+            // Use jemalloc directly (which is the default allocator in StarRocks)
+            void* ptr = je_malloc(bytes);
+            return static_cast<pointer>(ptr);
+        }
+
+        // Arena is enabled, try to use pagecache arena
+        auto* arena = get_pagecache_arena_instance();
+        if (arena != nullptr && pagecache_arena_is_initialized(arena)) {
+            void* ptr = pagecache_arena_allocate(arena, bytes);
+            if (ptr != nullptr) {
+                return static_cast<pointer>(ptr);
+            }
+            // If arena allocation fails, fallback to default jemalloc
+        }
+
+        // Fallback to default jemalloc
+        void* ptr = je_malloc(bytes);
+        return static_cast<pointer>(ptr);
+    }
+
+    void deallocate(pointer p, size_type n) {
+        if (p == nullptr) {
+            return;
+        }
+
+        const size_t bytes = n * sizeof(T);
+
+        // Check config first - if arena is disabled, use default jemalloc
+        if (!config::enable_pagecache_arena) {
+            je_free(p);
+            return;
+        }
+
+        // Arena is enabled, try to use pagecache arena
+        auto* arena = get_pagecache_arena_instance();
+        if (arena != nullptr && pagecache_arena_is_initialized(arena)) {
+            // Try to deallocate from arena first
+            // Note: We need to check if the pointer belongs to the arena
+            // For simplicity, we always try arena deallocation first, then fallback
+            pagecache_arena_deallocate(arena, p, bytes);
+            return;
+        }
+
+        // Fallback to default jemalloc
+        je_free(p);
+    }
+
+    template <typename U, typename... Args>
+    void construct(U* p, Args&&... args) {
+        ::new (static_cast<void*>(p)) U(std::forward<Args>(args)...);
+    }
+
+    template <typename U>
+    void destroy(U* p) {
+        p->~U();
+    }
+
+    bool operator==(const PageCacheArenaAllocator&) const { return true; }
+    bool operator!=(const PageCacheArenaAllocator&) const { return false; }
+};
+
+// Type alias for vector using pagecache arena allocator.
+// The allocator internally checks config::enable_pagecache_arena:
+// - If enabled: uses pagecache arena for all allocations (initial and resize)
+// - If disabled: uses default jemalloc for all allocations
+// This ensures consistent allocation behavior throughout the vector's lifetime.
+using PageCacheVector = std::vector<uint8_t, PageCacheArenaAllocator<uint8_t>>;
+
+// Manages a separate jemalloc arena dedicated to pagecache memory allocations.
+// This arena is configured with aggressive decay settings to minimize memory fragmentation.
+class PageCacheArena {
+public:
+    // Get the singleton instance
+    static PageCacheArena* instance();
+
+    // Initialize the arena with aggressive decay settings
+    // Returns true on success, false on failure
+    bool init();
+
+    // Get the arena index
+    unsigned get_arena_index() const { return _arena_index; }
+
+    // Check if the arena is initialized
+    bool is_initialized() const { return _initialized; }
+
+    // Allocate memory from the pagecache arena
+    void* allocate(size_t size);
+
+    // Free memory allocated from the pagecache arena
+    void deallocate(void* ptr, size_t size);
+
+    // Get arena statistics
+    struct ArenaStats {
+        size_t allocated = 0; // Bytes allocated
+        size_t active = 0;    // Active bytes
+        size_t resident = 0;  // Resident bytes
+        size_t mapped = 0;    // Mapped bytes
+        size_t retained = 0;  // Retained bytes
+    };
+
+    // Retrieve current arena statistics
+    bool get_stats(ArenaStats* stats);
+
+    // Delete copy constructor and assignment operator
+    PageCacheArena(const PageCacheArena&) = delete;
+    PageCacheArena& operator=(const PageCacheArena&) = delete;
+
+private:
+    PageCacheArena() = default;
+    ~PageCacheArena() = default;
+
+    unsigned _arena_index = 0;
+    bool _initialized = false;
+};
+
+} // namespace starrocks

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -333,6 +333,8 @@ CONF_mBool(enable_zero_copy_from_page_cache, "true");
 CONF_mString(storage_page_cache_limit, "-1");
 // whether to disable page cache feature in storage
 CONF_mBool(disable_storage_page_cache, "false");
+// whether to use separate jemalloc arena for pagecache to reduce memory fragmentation
+CONF_mBool(enable_pagecache_arena, "true");
 // whether to enable the bitmap index memory cache
 CONF_mBool(enable_bitmap_index_memory_page_cache, "true");
 // whether to enable the zonemap index memory cache

--- a/be/src/formats/parquet/page_reader.cpp
+++ b/be/src/formats/parquet/page_reader.cpp
@@ -21,7 +21,6 @@
 #include <vector>
 
 #include "cache/datacache.h"
-#include "cache/mem_cache/pagecache_arena.h"
 #include "common/compiler_util.h"
 #include "common/config.h"
 #include "common/status.h"
@@ -53,9 +52,8 @@ PageReader::PageReader(io::SeekableInputStream* stream, size_t start_offset, siz
         _cache = DataCache::GetInstance()->page_cache();
         _init_page_cache_key();
     }
-    // Use PageCacheVector if arena is enabled, otherwise use std::vector<uint8_t>
-    _compressed_buf = make_pagecache_vector();
-    _uncompressed_buf = make_pagecache_vector();
+    _compressed_buf = std::make_unique<std::vector<uint8_t>>();
+    _uncompressed_buf = std::make_unique<std::vector<uint8_t>>();
 }
 
 Status PageReader::next_page() {
@@ -117,13 +115,10 @@ Status PageReader::_read_and_deserialize_header(bool need_fill_cache) {
     BufferPtr tmp_page_buffer;
     std::vector<uint8_t>* page_buffer;
     if (need_fill_cache) {
-        // Use PageCacheVector if arena is enabled, otherwise use std::vector<uint8_t>
-        tmp_page_buffer = make_pagecache_vector();
         DCHECK(_cache_buf);
         page_buffer = _cache_buf;
     } else {
-        // Use PageCacheVector - allocator internally handles config switch
-        tmp_page_buffer = std::make_unique<PageCacheVector>();
+        tmp_page_buffer = std::make_unique<std::vector<uint8_t>>();
         page_buffer = tmp_page_buffer.get();
     }
 

--- a/be/src/storage/rowset/page_handle_fwd.h
+++ b/be/src/storage/rowset/page_handle_fwd.h
@@ -25,6 +25,11 @@ class FileMetaData;
 template <class PageType>
 class PageHandleTmpl;
 
-using PageHandle = PageHandleTmpl<std::vector<uint8_t>>;
+template <class T>
+class PageCacheArenaAllocator;
+using PageBuffer = std::vector<uint8_t, PageCacheArenaAllocator<uint8_t>>;
+using PageBufferPtr = std::unique_ptr<PageBuffer>;
+
+using PageHandle = PageHandleTmpl<PageBuffer>;
 using FileFooterHandle = PageHandleTmpl<std::shared_ptr<parquet::FileMetaData>*>;
 } // namespace starrocks

--- a/be/src/storage/rowset/page_pointer.h
+++ b/be/src/storage/rowset/page_pointer.h
@@ -37,7 +37,6 @@
 #include <cstdint>
 #include <string>
 
-#include "gen_cpp/segment.pb.h"
 #include "util/coding.h"
 #include "util/faststring.h"
 

--- a/be/src/storage/rowset/storage_page_decoder.h
+++ b/be/src/storage/rowset/storage_page_decoder.h
@@ -18,7 +18,7 @@
 
 #include "common/status.h"
 #include "gen_cpp/segment.pb.h"
-#include "storage/rowset/common.h"
+#include "storage/rowset/page_handle_fwd.h"
 #include "util/slice.h"
 
 namespace starrocks {
@@ -33,15 +33,15 @@ public:
     virtual void reserve_head(uint8_t head_size) {}
 
     virtual Status decode_page_data(PageFooterPB* footer, uint32_t footer_size, EncodingTypePB encoding,
-                                    std::unique_ptr<std::vector<uint8_t>>* page, Slice* page_slice) {
+                                    PageBufferPtr* page, Slice* page_slice) {
         return Status::OK();
     }
 };
 
 class StoragePageDecoder {
 public:
-    static Status decode_page(PageFooterPB* footer, uint32_t footer_size, EncodingTypePB encoding,
-                              std::unique_ptr<std::vector<uint8_t>>* page, Slice* page_slice);
+    static Status decode_page(PageFooterPB* footer, uint32_t footer_size, EncodingTypePB encoding, PageBufferPtr* page,
+                              Slice* page_slice);
 };
 
 } // namespace starrocks

--- a/be/src/util/system_metrics.h
+++ b/be/src/util/system_metrics.h
@@ -72,6 +72,12 @@ public:
     METRIC_DEFINE_INT_GAUGE(compaction_mem_bytes, MetricUnit::BYTES);
     METRIC_DEFINE_INT_GAUGE(schema_change_mem_bytes, MetricUnit::BYTES);
     METRIC_DEFINE_INT_GAUGE(storage_page_cache_mem_bytes, MetricUnit::BYTES);
+    // PageCache arena metrics
+    METRIC_DEFINE_INT_GAUGE(pagecache_arena_allocated_bytes, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_GAUGE(pagecache_arena_active_bytes, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_GAUGE(pagecache_arena_resident_bytes, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_GAUGE(pagecache_arena_mapped_bytes, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_GAUGE(pagecache_arena_retained_bytes, MetricUnit::BYTES);
     METRIC_DEFINE_INT_GAUGE(jit_cache_mem_bytes, MetricUnit::BYTES);
     METRIC_DEFINE_INT_GAUGE(update_mem_bytes, MetricUnit::BYTES);
     METRIC_DEFINE_INT_GAUGE(passthrough_mem_bytes, MetricUnit::BYTES);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

**Why let pagecache use a separated arena?**
- The lifecycle of pagecache significantly exceeds that of an ephemeral query, and mixing these lifecycles can exacerbate internal fragmentation issues.
- Pagecache typically occupies 20% of memory, which is significant; however, there is a lack of metrics regarding its fragmentation.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3