### PR TITLE
[Tool] Exit if GTEST_PARALLEL is not set in running all be tests

### DIFF
--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -334,10 +334,19 @@ test_files=`find ${STARROCKS_TEST_BINARY_DIR} -type f -perm -111 -name "*test" \
 
 echo "[INFO] gtest_filter: $TEST_NAME"
 
+
+# If TEST_NAME is "*", GTEST_PARALLEL must be set, otherwise exit with an error
+# Run cases in gunit test in parallel if has gtest-parallel script.
+# Reference: https://github.com/google/gtest-parallel
+if [[ "$TEST_NAME" == "*" ]]; then
+    if [ ! -x "${GTEST_PARALLEL}" ]; then
+        echo "[ERROR] Running all tests (gtest_filter=*) requires GTEST_PARALLEL to be set and executable, please set GTEST_PARALLEL in your environment, for example: export GTEST_PARALLEL=/path/to/gtest-parallel/gtest-parallel"
+        exit 1
+    fi
+fi
+
 run_test_module() {
     TARGET=$1
-    # run cases in gunit test in parallel if has gtest-parallel script.
-    # reference: https://github.com/google/gtest-parallel
     if [[ $TEST_MODULE == '.*'  || $TEST_MODULE == $TARGET ]]; then
         echo "Run test: ${STARROCKS_TEST_BINARY_DIR}/$TARGET"
         if [ ${DRY_RUN} -eq 0 ]; then


### PR DESCRIPTION
## Why I'm doing:
Without `gtest_parallel`, be uts cannot be runned sucessfully, eixt it if it is not set.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
