### PR TITLE
[Enhancement] Add REST API for starmgr diagnostic and support shard group rebalance

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
@@ -92,6 +92,7 @@ import com.starrocks.http.rest.ShowDataAction;
 import com.starrocks.http.rest.ShowMetaInfoAction;
 import com.starrocks.http.rest.ShowProcAction;
 import com.starrocks.http.rest.ShowRuntimeInfoAction;
+import com.starrocks.http.rest.StarManagerHttpServiceAction;
 import com.starrocks.http.rest.StopFeAction;
 import com.starrocks.http.rest.StorageTypeCheckAction;
 import com.starrocks.http.rest.StreamLoadMetaAction;
@@ -110,6 +111,7 @@ import com.starrocks.metric.GaugeMetric;
 import com.starrocks.metric.GaugeMetricImpl;
 import com.starrocks.metric.Metric;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
@@ -249,6 +251,9 @@ public class HttpServer {
         ProcProfileAction.registerAction(controller);
         ProcProfileFileAction.registerAction(controller);
 
+        if (RunMode.isSharedDataMode()) {
+            StarManagerHttpServiceAction.registerAction(controller);
+        }
         // meta service action
         ImageAction.registerAction(controller);
         InfoAction.registerAction(controller);

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/StarManagerHttpServiceAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/StarManagerHttpServiceAction.java
@@ -1,0 +1,93 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest;
+
+import com.starrocks.authorization.AccessDeniedException;
+import com.starrocks.catalog.UserIdentity;
+import com.starrocks.common.DdlException;
+import com.starrocks.http.ActionController;
+import com.starrocks.http.BaseRequest;
+import com.starrocks.http.BaseResponse;
+import com.starrocks.http.IllegalArgException;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.staros.StarMgrServer;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.util.CharsetUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/*
+ * The function is used to retrieve the information of a specific shard by its service info and shard id.
+ * eg:
+ * fe_host:http_port/api/v1/starmgr/service/<serviceid|servicename>/shard/<id>
+ * fe_host:http_port/api/v1/starmgr/service/<serviceid|servicename>/shardgroup/<id>
+ * fe_host:http_port/api/v1/starmgr/service/<serviceid|servicename>/listshardgroup
+ * fe_host:http_port/api/v1/starmgr/service/<serviceid|servicename>/shardgroup/removereplicas
+ * fe_host:http_port/api/v1/starmgr/service/<serviceid|servicename>/worker/<id>
+ * fe_host:http_port/api/v1/starmgr/service/<serviceid|servicename>/workergroup/<id>
+ * fe_host:http_port/api/v1/starmgr/service/<serviceid|servicename>/listworkergroup
+ * fe_host:http_port/api/v1/starmgr/service/<serviceid|servicename>/rebalance
+ */
+public class StarManagerHttpServiceAction extends RestBaseAction {
+    private static final Logger LOG = LogManager.getLogger(StarManagerHttpServiceAction.class);
+    protected static final String SERVICE = "service";
+    private static final String ID = "id";
+
+    public StarManagerHttpServiceAction(ActionController controller) {
+        super(controller);
+    }
+
+    public static void registerAction(ActionController controller) throws IllegalArgException {
+        StarManagerHttpServiceAction action = new StarManagerHttpServiceAction(controller);
+        controller.registerHandler(HttpMethod.GET,
+                "/api/v1/starmgr/service/{" + SERVICE + "}/shard/{" + ID + "}", action);
+        controller.registerHandler(HttpMethod.GET,
+                "/api/v1/starmgr/service/{" + SERVICE + "}/shardgroup/{" + ID + "}", action);
+        controller.registerHandler(HttpMethod.GET,
+                "/api/v1/starmgr/service/{" + SERVICE + "}/listshardgroup", action);
+        controller.registerHandler(HttpMethod.GET,
+                "/api/v1/starmgr/service/{" + SERVICE + "}/worker/{" + ID + "}", action);
+        controller.registerHandler(HttpMethod.GET,
+                "/api/v1/starmgr/service/{" + SERVICE + "}/workergroup/{" + ID + "}", action);
+        controller.registerHandler(HttpMethod.GET,
+                "/api/v1/starmgr/service/{" + SERVICE + "}/listworkergroup", action);
+
+        controller.registerHandler(HttpMethod.POST,
+                "/api/v1/starmgr/service/{" + SERVICE + "}/shardgroup/{" + ID + "}/removereplicas", action);
+        // balance all replicas
+        controller.registerHandler(HttpMethod.POST,
+                "/api/v1/starmgr/service/{" + SERVICE + "}/rebalance", action);
+    }
+
+    @Override
+    public void executeWithoutPassword(BaseRequest request, BaseResponse response)
+            throws DdlException, AccessDeniedException {
+        LOG.info("received star manager http request, {}", request.getRequest().uri());
+        UserIdentity currentUser = ConnectContext.get().getCurrentUserIdentity();
+        checkUserOwnsAdminRole(currentUser);
+        HttpResponse httpResponse = StarMgrServer.getCurrentState().getHttpService().starmgrHttpService(request.getRequest());
+        if (httpResponse instanceof FullHttpResponse) {
+            FullHttpResponse fullResponse = (FullHttpResponse) httpResponse;
+            response.getContent().append(fullResponse.content().toString(CharsetUtil.UTF_8));
+            response.setContentType(httpResponse.headers().get(HttpHeaderNames.CONTENT_TYPE));
+            writeResponse(request, response, httpResponse.status());
+        } else {
+            throw new DdlException("Failed to access star manager's http service");
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/staros/StarMgrServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/staros/StarMgrServer.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.staros;
 
+import com.staros.manager.HttpService;
 import com.staros.manager.StarManager;
 import com.staros.manager.StarManagerServer;
 import com.staros.metrics.MetricsSystem;
@@ -119,6 +120,10 @@ public class StarMgrServer {
 
     public StarOSBDBJEJournalSystem getJournalSystem() {
         return journalSystem;
+    }
+
+    public HttpService getHttpService() {
+        return starMgrServer.getHttpService();
     }
 
     public StateChangeExecution getStateChangeExecution() {

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarManagerHttpServiceActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarManagerHttpServiceActionTest.java
@@ -1,0 +1,138 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http;
+
+import com.staros.manager.HttpService;
+import com.staros.manager.StarManager;
+import com.starrocks.catalog.UserIdentity;
+import com.starrocks.common.DdlException;
+import com.starrocks.http.rest.StarManagerHttpServiceAction;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.staros.StarMgrServer;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class StarManagerHttpServiceActionTest {
+    @Mocked
+    BaseRequest request;
+
+    @BeforeAll
+    public static void setUp() throws IllegalArgException {
+        ActionController controller = new ActionController();
+        StarManagerHttpServiceAction.registerAction(controller);
+    }
+
+    @Test
+    public void testExecuteWithoutPassword() throws Exception {
+
+        StarManagerHttpServiceAction starManagerHttpServiceAction = new StarManagerHttpServiceAction(null);
+
+        BaseResponse response = new BaseResponse();
+
+        ConnectContext connectContext = new ConnectContext();
+        UserIdentity userIdentity = new UserIdentity();
+        StarMgrServer starMgrServer = new StarMgrServer();
+        StarManager starManager = new StarManager();
+        HttpService httpService = new HttpService(starManager);
+
+        new Expectations(request) {
+            {
+                request.getRequest().uri();
+                result = "/v1/test";
+            }
+        };
+
+        new MockUp<ConnectContext>() {
+            @Mock
+            public ConnectContext get() {
+                return connectContext;
+            }
+            public UserIdentity getCurrentUserIdentity() {
+                return userIdentity;
+            }
+        };
+        new MockUp<StarMgrServer>() {
+            @Mock
+            public StarMgrServer getCurrentState() {
+                return starMgrServer;
+            }
+            @Mock
+            public HttpService getHttpService() {
+                return httpService;
+            }
+        };
+        new MockUp<StarManagerHttpServiceAction>() {
+            @Mock
+            public void sendResult(BaseRequest request, BaseResponse response) {}
+
+            @Mock
+            void checkUserOwnsAdminRole(UserIdentity currentUser) {}
+
+            @Mock
+            void writeResponse(BaseRequest request, BaseResponse response, HttpResponseStatus status) {}
+        };
+
+        { // normal case
+            new MockUp<HttpService>() {
+                @Mock
+                public HttpResponse starmgrHttpService(HttpRequest request) {
+                    String str = "content";
+                    FullHttpResponse response = new DefaultFullHttpResponse(
+                            HttpVersion.HTTP_1_1,
+                            HttpResponseStatus.OK,
+                            Unpooled.copiedBuffer(str.getBytes()));
+
+                    response.headers().set(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.TEXT_PLAIN);
+                    response.headers().set(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
+                    return response;
+                }
+                @Mock
+                void writeResponse(BaseRequest request, BaseResponse response, HttpResponseStatus status) {}
+            };
+            starManagerHttpServiceAction.executeWithoutPassword(request, response);
+        }
+
+        { // abnormal case
+            new MockUp<HttpService>() {
+                @Mock
+                public HttpResponse starmgrHttpService(HttpRequest request) {
+                    HttpResponse response = new DefaultHttpResponse(
+                            HttpVersion.HTTP_1_1,
+                            HttpResponseStatus.OK);
+                    response.headers().set("Content-Type", "text/plain; charset=UTF-8");
+                    return response;
+                }
+            };
+            DdlException ddlException = Assertions.<DdlException>assertThrows(DdlException.class, () ->
+                    starManagerHttpServiceAction.executeWithoutPassword(request, response));
+            Assertions.assertEquals("Failed to access star manager's http service", ddlException.getMessage());
+        }
+    }
+}


### PR DESCRIPTION

## Why I'm doing:

## What I'm doing:

support show shard related infos by rest api
curl --location-trusted -u root: "http://127.0.0.1:18030/api/v1/starmgr/service/starrocks/listshardgroup" | python -m json.tool
curl --location-trusted -u root: "http://127.0.0.1:18030/api/v1/starmgr/service/starrocks/shard/11029" | python -m json.tool
...
support shard rebalance by rest api
curl -XPOST -u root: "http://127.0.0.1:18030/api/v1/starmgr/service/starrocks/rebalance"
All api request should send to leader FE.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `/api/v1/starmgr` REST routes proxying StarMgr HTTP service for shard/shardgroup/worker queries and rebalance, registered only in shared-data mode, plus corresponding tests.
> 
> - **REST API (StarManager)**:
>   - Adds `StarManagerHttpServiceAction` with routes under `/api/v1/starmgr/service/{service}/...`:
>     - GET `shard/{id}`, `shardgroup/{id}`, `listshardgroup`, `worker/{id}`, `workergroup/{id}`, `listworkergroup`
>     - POST `shardgroup/{id}/removereplicas`, `rebalance`
>   - Proxies requests to StarMgr `HttpService`; enforces admin role.
> - **Server Integration**:
>   - Registers `StarManagerHttpServiceAction` in `HttpServer` only when `RunMode.isSharedDataMode()`.
>   - Exposes `getHttpService()` in `StarMgrServer` to access StarMgr HTTP service.
> - **Tests**:
>   - Adds `StarManagerHttpServiceActionTest` covering successful proxying and error path for non-full HTTP responses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9aa7bf37af2463e41968061057e0473f1339ef7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->