### PR TITLE
[Enhancement] Rapid memory release on AGG/SORT

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -623,8 +623,8 @@ else()
     set (STARROCKS_STATIC_LINK_LIBS ${WL_LINK_STATIC} -lgomp -lbfd)
 endif()
 
-if (NOT ("${MAKE_TEST}" STREQUAL "ON" AND "${BUILD_FOR_SANITIZE}" STREQUAL "ON"))
-    # In other words, turn to dynamic link when MAKE_TEST and BUILD_TYPE == *SAN
+if (NOT ${ENABLE_MULTI_DYNAMIC_LIBS} AND NOT ("${MAKE_TEST}" STREQUAL "ON" AND "${BUILD_FOR_SANITIZE}" STREQUAL "ON"))
+    # In other words, turn to dynamic link when ENABLE_MULTI_DYNAMIC_LIBS or MAKE_TEST and BUILD_TYPE == *SAN
     # otherwise do static link gcc's lib
     set(STARROCKS_STATIC_LINK_LIBS ${STARROCKS_STATIC_LINK_LIBS} -static-libstdc++ -static-libgcc)
 endif()

--- a/be/src/exec/aggregate/agg_hash_variant.cpp
+++ b/be/src/exec/aggregate/agg_hash_variant.cpp
@@ -490,4 +490,7 @@ auto HashVariantResolver<HashVariantType>::instance() -> HashVariantResolver<Has
 template class HashVariantResolver<AggHashSetVariant>;
 template class HashVariantResolver<AggHashMapVariant>;
 
+DEFINE_FAIL_POINT(agg_hash_set_bad_alloc);
+DEFINE_FAIL_POINT(aggregate_build_hash_map_bad_alloc);
+
 } // namespace starrocks

--- a/be/src/exec/chunks_sorter_full_sort.cpp
+++ b/be/src/exec/chunks_sorter_full_sort.cpp
@@ -20,9 +20,12 @@
 #include "exprs/expr.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/runtime_state.h"
+#include "util/defer_op.h"
 #include "util/runtime_profile.h"
 
 namespace starrocks {
+DEFINE_FAIL_POINT(chunks_sorter_full_sort_partial_sort_bad_alloc);
+DEFINE_FAIL_POINT(chunks_sorter_full_sort_done_bad_alloc);
 
 ChunksSorterFullSort::ChunksSorterFullSort(RuntimeState* state, const std::vector<ExprContext*>* sort_exprs,
                                            const std::vector<bool>* is_asc_order,
@@ -47,8 +50,10 @@ void ChunksSorterFullSort::setup_runtime(RuntimeState* state, RuntimeProfile* pr
 }
 
 Status ChunksSorterFullSort::update(RuntimeState* state, const ChunkPtr& chunk) {
+    CancelableDefer defer = [this]() { _reset(); };
     RETURN_IF_ERROR(_merge_unsorted(state, chunk));
     RETURN_IF_ERROR(_partial_sort(state, false));
+    defer.cancel();
 
     return Status::OK();
 }
@@ -100,6 +105,8 @@ Status ChunksSorterFullSort::_partial_sort(RuntimeState* state, bool done) {
     }
     bool reach_limit = _staging_unsorted_rows >= max_buffered_rows || _staging_unsorted_bytes >= max_buffered_bytes;
     if (done || reach_limit) {
+        FAIL_POINT_TRIGGER_EXECUTE(chunks_sorter_full_sort_partial_sort_bad_alloc, { throw std::bad_alloc(); });
+
         _max_num_rows = std::max<int>(_max_num_rows, _staging_unsorted_rows);
         COUNTER_UPDATE(_profiler->input_required_memory, _staging_unsorted_bytes);
         concat_chunks(_unsorted_chunk, _staging_unsorted_chunks, _staging_unsorted_rows);
@@ -143,6 +150,8 @@ Status ChunksSorterFullSort::_merge_sorted(RuntimeState* state) {
         _assign_ordinals();
         RETURN_IF_ERROR(merge_sorted_chunks(_sort_desc, _sort_exprs, _early_materialized_chunks, &_merged_runs));
     }
+
+    FAIL_POINT_TRIGGER_EXECUTE(chunks_sorter_full_sort_done_bad_alloc, { throw std::bad_alloc(); });
 
     return Status::OK();
 }
@@ -251,10 +260,11 @@ starrocks::ChunkPtr ChunksSorterFullSort::_late_materialize_tmpl(const starrocks
     return final_chunk;
 }
 Status ChunksSorterFullSort::do_done(RuntimeState* state) {
+    CancelableDefer defer = [this]() { _reset(); };
     RETURN_IF_ERROR(_partial_sort(state, true));
     _unsorted_chunk.reset();
     RETURN_IF_ERROR(_merge_sorted(state));
-
+    defer.cancel();
     return Status::OK();
 }
 
@@ -287,6 +297,15 @@ size_t ChunksSorterFullSort::get_output_rows() const {
 
 int64_t ChunksSorterFullSort::mem_usage() const {
     return _merged_runs.mem_usage();
+}
+
+void ChunksSorterFullSort::_reset() {
+    _staging_unsorted_chunks.clear();
+    _unsorted_chunk.reset();
+    _sorted_chunks.clear();
+    _late_materialized_chunks.clear();
+    _early_materialized_chunks.clear();
+    _merged_runs.clear();
 }
 
 } // namespace starrocks

--- a/be/src/exec/chunks_sorter_full_sort.h
+++ b/be/src/exec/chunks_sorter_full_sort.h
@@ -80,6 +80,7 @@ private:
 
 protected:
     ChunkPtr _late_materialize(const ChunkPtr& chunk);
+    void _reset();
 
     size_t _total_rows = 0; // Total rows of sorting data
     size_t _staging_unsorted_rows = 0;

--- a/be/src/exec/chunks_sorter_topn.h
+++ b/be/src/exec/chunks_sorter_topn.h
@@ -134,6 +134,8 @@ private:
     // the last two element [4, 5] should be pruned
     void _rank_pruning();
 
+    void _reset();
+
     const MergedRun& _lowest_merged_run() const { return _merged_runs.front(); }
 
     std::pair<const MergedRun*, int> _get_run_by_row_id(size_t rid) const {

--- a/be/src/exec/join/join_hash_table_descriptor.h
+++ b/be/src/exec/join/join_hash_table_descriptor.h
@@ -14,10 +14,6 @@
 
 #pragma once
 
-#include <gen_cpp/PlanNodes_types.h>
-#include <runtime/descriptors.h>
-#include <runtime/runtime_state.h>
-
 #include <coroutine>
 #include <cstdint>
 #include <optional>
@@ -27,8 +23,8 @@
 #include "column/chunk.h"
 #include "column/column_helper.h"
 #include "column/vectorized_fwd.h"
-#include "common/statusor.h"
-#include "exec/sorting/sort_helper.h"
+#include "runtime/descriptors.h"
+#include "runtime/runtime_state.h"
 #include "simd/simd.h"
 #include "util/runtime_profile.h"
 

--- a/be/src/util/failpoint/fail_point.h
+++ b/be/src/util/failpoint/fail_point.h
@@ -127,6 +127,7 @@ private:
 #define DEFINE_FAIL_POINT(NAME)                       \
     starrocks::failpoint::FailPoint fp_##NAME(#NAME); \
     starrocks::failpoint::FailPointRegisterer fpr_##NAME(&fp_##NAME);
+#define DECLARE_FAIL_POINT(NAME) extern starrocks::failpoint::FailPoint fp_##NAME;
 #define DEFINE_SCOPED_FAIL_POINT(NAME)                       \
     starrocks::failpoint::ScopedFailPoint sfp_##NAME(#NAME); \
     starrocks::failpoint::FailPointRegisterer fpr_##NAME(&sfp_##NAME);
@@ -162,6 +163,7 @@ private:
     } while (false)
 #else
 #define DEFINE_FAIL_POINT(NAME)
+#define DECLARE_FAIL_POINT(NAME)
 #define DEFINE_SCOPED_FAIL_POINT(NAME)
 #define FAIL_POINT_SCOPE(NAME)
 #define FAIL_POINT_TRIGGER_EXECUTE(NAME, stmt)

--- a/be/src/util/fixed_hash_map.h
+++ b/be/src/util/fixed_hash_map.h
@@ -123,6 +123,11 @@ public:
 
     size_t dump_bound() { return hash_table_size; }
 
+    void clear() {
+        memset(_hash_table, 0, sizeof(ValueType) * hash_table_size);
+        _size = 0;
+    }
+
 private:
     size_t _size = 0;
     ValueType _hash_table[hash_table_size + 1];
@@ -190,6 +195,11 @@ public:
     size_t size() { return _size; }
 
     size_t capacity() { return hash_table_size; }
+
+    void clear() {
+        memset(_hash_table, 0, sizeof(uint8_t) * hash_table_size);
+        _size = 0;
+    }
 
 private:
     size_t _size = 0;

--- a/test/sql/test_agg/R/test_agg_with_exception
+++ b/test/sql/test_agg/R/test_agg_with_exception
@@ -1,0 +1,49 @@
+-- name: test_agg_with_exception @sequential
+CREATE TABLE `t0` (
+  `c0` int(11) NOT NULL COMMENT "",
+  `c1` varchar(20) NOT NULL COMMENT "",
+  `c2` varchar(200) NOT NULL COMMENT "",
+  `c3` int(11) NOT NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+set enable_group_by_compressed_key=false;
+-- result:
+-- !result
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  40960));
+-- result:
+-- !result
+admin enable failpoint 'agg_hash_set_bad_alloc';
+-- result:
+-- !result
+[UC]select c0 from t0 group by c0;
+-- result:
+E: (1064, 'Mem usage has exceed the limit of BE: BE:10004')
+-- !result
+[UC]select c0 from t0 group by c0 limit 10;
+-- result:
+E: (1064, 'Mem usage has exceed the limit of BE: BE:10004')
+-- !result
+admin disable failpoint 'agg_hash_set_bad_alloc';
+-- result:
+-- !result
+admin enable failpoint 'aggregate_build_hash_map_bad_alloc';
+-- result:
+-- !result
+[UC]select count(*) from t0 group by c0;
+-- result:
+E: (1064, 'Mem usage has exceed the limit of BE: BE:10004')
+-- !result
+[UC]select count(*) from t0 group by c0 limit 10;
+-- result:
+E: (1064, 'Mem usage has exceed the limit of BE: BE:10004')
+-- !result
+admin disable failpoint 'aggregate_build_hash_map_bad_alloc';
+-- result:
+-- !result

--- a/test/sql/test_agg/T/test_agg_with_exception
+++ b/test/sql/test_agg/T/test_agg_with_exception
@@ -1,0 +1,29 @@
+-- name: test_agg_with_exception @sequential
+
+CREATE TABLE `t0` (
+  `c0` int(11) NOT NULL COMMENT "",
+  `c1` varchar(20) NOT NULL COMMENT "",
+  `c2` varchar(200) NOT NULL COMMENT "",
+  `c3` int(11) NOT NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1"
+);
+
+set enable_group_by_compressed_key=false;
+
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  40960));
+
+admin enable failpoint 'agg_hash_set_bad_alloc';
+[UC]select c0 from t0 group by c0;
+[UC]select c0 from t0 group by c0 limit 10;
+admin disable failpoint 'agg_hash_set_bad_alloc';
+
+admin enable failpoint 'aggregate_build_hash_map_bad_alloc';
+[UC]select count(*) from t0 group by c0;
+[UC]select count(*) from t0 group by c0 limit 10;
+admin disable failpoint 'aggregate_build_hash_map_bad_alloc';
+

--- a/test/sql/test_sort/R/test_sort_with_exception
+++ b/test/sql/test_sort/R/test_sort_with_exception
@@ -1,0 +1,45 @@
+-- name: test_sort_with_exception @sequential
+create table t0 (
+    c0 STRING,
+    c1 STRING NOT NULL,
+    c2 int,
+    c3 int NOT NULL
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  100000));
+-- result:
+-- !result
+set pipeline_dop=1;
+-- result:
+-- !result
+admin enable failpoint 'chunks_sorter_full_sort_partial_sort_bad_alloc';
+-- result:
+-- !result
+[UC]select *,row_number() over (partition by c0 order by c1) from t0;
+-- result:
+E: (1064, 'Mem usage has exceed the limit of BE: BE:10004')
+-- !result
+admin disable failpoint 'chunks_sorter_full_sort_partial_sort_bad_alloc';
+-- result:
+-- !result
+admin enable failpoint 'chunks_sorter_full_sort_done_bad_alloc';
+-- result:
+-- !result
+[UC]select *,row_number() over (partition by c0 order by c1) from t0;
+-- result:
+E: (1064, 'Mem usage has exceed the limit of BE: BE:10004')
+-- !result
+admin disable failpoint 'chunks_sorter_full_sort_partial_sort_bad_alloc';
+-- result:
+-- !result
+admin enable failpoint 'chunks_sorter_topn_sort_bad_alloc';
+-- result:
+-- !result
+[UC]select * from t0 order by c1 limit 4096;
+-- result:
+E: (1064, 'Mem usage has exceed the limit of BE: BE:10004')
+-- !result
+admin disable failpoint 'chunks_sorter_topn_sort_bad_alloc';
+-- result:
+-- !result

--- a/test/sql/test_sort/R/test_sort_with_exception
+++ b/test/sql/test_sort/R/test_sort_with_exception
@@ -30,7 +30,7 @@ admin enable failpoint 'chunks_sorter_full_sort_done_bad_alloc';
 -- result:
 E: (1064, 'Mem usage has exceed the limit of BE: BE:10004')
 -- !result
-admin disable failpoint 'chunks_sorter_full_sort_partial_sort_bad_alloc';
+admin disable failpoint 'chunks_sorter_full_sort_done_bad_alloc';
 -- result:
 -- !result
 admin enable failpoint 'chunks_sorter_topn_sort_bad_alloc';

--- a/test/sql/test_sort/T/test_sort_with_exception
+++ b/test/sql/test_sort/T/test_sort_with_exception
@@ -1,0 +1,23 @@
+-- name: test_sort_with_exception @sequential
+
+create table t0 (
+    c0 STRING,
+    c1 STRING NOT NULL,
+    c2 int,
+    c3 int NOT NULL
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  100000));
+
+set pipeline_dop=1;
+
+admin enable failpoint 'chunks_sorter_full_sort_partial_sort_bad_alloc';
+[UC]select *,row_number() over (partition by c0 order by c1) from t0;
+admin disable failpoint 'chunks_sorter_full_sort_partial_sort_bad_alloc';
+
+admin enable failpoint 'chunks_sorter_full_sort_done_bad_alloc';
+[UC]select *,row_number() over (partition by c0 order by c1) from t0;
+admin disable failpoint 'chunks_sorter_full_sort_partial_sort_bad_alloc';
+
+admin enable failpoint 'chunks_sorter_topn_sort_bad_alloc';
+[UC]select * from t0 order by c1 limit 4096;
+admin disable failpoint 'chunks_sorter_topn_sort_bad_alloc';

--- a/test/sql/test_sort/T/test_sort_with_exception
+++ b/test/sql/test_sort/T/test_sort_with_exception
@@ -16,7 +16,7 @@ admin disable failpoint 'chunks_sorter_full_sort_partial_sort_bad_alloc';
 
 admin enable failpoint 'chunks_sorter_full_sort_done_bad_alloc';
 [UC]select *,row_number() over (partition by c0 order by c1) from t0;
-admin disable failpoint 'chunks_sorter_full_sort_partial_sort_bad_alloc';
+admin disable failpoint 'chunks_sorter_full_sort_done_bad_alloc';
 
 admin enable failpoint 'chunks_sorter_topn_sort_bad_alloc';
 [UC]select * from t0 order by c1 limit 4096;


### PR DESCRIPTION
## Why I'm doing:

Continue #65216: Implementing rapid memory release for sort and agg operations in OOM scenarios.

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/10658

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds RAII-based cleanup and failpoints to aggregation and sorting paths to rapidly release memory on allocation failures, plus tests and minor build tweak.
> 
> - **Exec — Aggregation (AGG)**:
>   - Add RAII cleanup (`CancelableDefer`) in `AggHashMapWithKey::*build_hash_map*` and `AggHashSet::*build_hash_set*` to clear underlying containers on exceptions.
>   - Introduce failpoints `aggregate_build_hash_map_bad_alloc` and `agg_hash_set_bad_alloc`; trigger simulated `bad_alloc` during map/set builds.
> - **Exec — Sorting (FullSort/TopN)**:
>   - Add RAII cleanup and `_reset()` to quickly free buffers on errors in `ChunksSorterFullSort` and `ChunksSorterTopn` (`update`, `do_done`, `_sort_chunks`).
>   - Add failpoints `chunks_sorter_full_sort_partial_sort_bad_alloc`, `chunks_sorter_full_sort_done_bad_alloc`, and `chunks_sorter_topn_sort_bad_alloc` to simulate allocation failures.
> - **Utils**:
>   - Add `clear()` to `SmallFixedSizeHashMap/HashSet` and `DECLARE_FAIL_POINT` macro; wire failpoint definitions in `agg_hash_variant.cpp`.
> - **Build**:
>   - Adjust static libstdc++/libgcc linking condition to consider `ENABLE_MULTI_DYNAMIC_LIBS`.
> - **Tests**:
>   - Add SQL tests `test_agg_with_exception` and `test_sort_with_exception` to verify OOM/failpoint behavior and rapid memory release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 12b2f3537d7a6ac574daadca339bebdf23aafa20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->