### PR TITLE
[Enhancement] merge fragment-profile in runtime

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -340,9 +340,9 @@ public class Config extends ConfigBase {
             "Default is 300 seconds (5 minutes).")
     public static int log_cleaner_check_interval_second = 300;
 
-    @ConfField(mutable = true, comment = "Whether merge the running profile just in time, it can reduce memory " +
+    @ConfField(mutable = true, comment = "Merge the profile in runtime, which can reduce memory " +
             "footprint of profile for a large cluster")
-    public static boolean enable_profile_jit_merge = true;
+    public static boolean enable_profile_runtime_merge = true;
 
     /**
      * Log the COSTS plan, if the query is cancelled due to a crash of the backend or RpcException.

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -310,6 +310,8 @@ public class Config extends ConfigBase {
     @ConfField
     public static boolean enable_profile_log = true;
     @ConfField
+    public static boolean enable_profile_log_compress = false;
+    @ConfField
     public static String profile_log_dir = Config.STARROCKS_HOME_DIR + "/log";
     @ConfField
     public static int profile_log_roll_num = 5;

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -340,6 +340,10 @@ public class Config extends ConfigBase {
             "Default is 300 seconds (5 minutes).")
     public static int log_cleaner_check_interval_second = 300;
 
+    @ConfField(mutable = true, comment = "Whether merge the running profile just in time, it can reduce memory " +
+            "footprint of profile for a large cluster")
+    public static boolean enable_profile_jit_merge = true;
+
     /**
      * Log the COSTS plan, if the query is cancelled due to a crash of the backend or RpcException.
      * It is only effective when enable_collect_query_detail_info is set to false, since the plan will be recorded

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -310,8 +310,6 @@ public class Config extends ConfigBase {
     @ConfField
     public static boolean enable_profile_log = true;
     @ConfField
-    public static boolean enable_profile_log_compress = false;
-    @ConfField
     public static String profile_log_dir = Config.STARROCKS_HOME_DIR + "/log";
     @ConfField
     public static int profile_log_roll_num = 5;

--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/Counter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/Counter.java
@@ -32,7 +32,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package com.starrocks.common.util;
+package com.starrocks.common.profile;
 
 import com.starrocks.thrift.TCounterAggregateType;
 import com.starrocks.thrift.TCounterMergeType;
@@ -44,7 +44,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
-// Counter means indicators field. The counter's name is key, the counter itself is value.  
+// Counter means indicators field. The counter's name is key, the counter itself is value.
 public class Counter {
     private volatile int type;
     private volatile TCounterStrategy strategy;
@@ -112,6 +112,25 @@ public class Counter {
     }
 
     public boolean isSkipMinMax() {
+        return Objects.equals(strategy.min_max_type, TCounterMinMaxType.SKIP_ALL);
+    }
+
+    public static boolean isSum(TCounterStrategy strategy) {
+        return Objects.equals(strategy.aggregate_type, TCounterAggregateType.SUM) ||
+                Objects.equals(strategy.aggregate_type, TCounterAggregateType.AVG_SUM);
+    }
+
+    public static boolean isAvg(TCounterStrategy strategy) {
+        return Objects.equals(strategy.aggregate_type, TCounterAggregateType.AVG)
+                || Objects.equals(strategy.aggregate_type, TCounterAggregateType.SUM_AVG);
+    }
+
+    public static boolean isSkipMerge(TCounterStrategy strategy) {
+        return Objects.equals(strategy.merge_type, TCounterMergeType.SKIP_ALL)
+                || Objects.equals(strategy.merge_type, TCounterMergeType.SKIP_SECOND_MERGE);
+    }
+
+    public static boolean isSkipMinMax(TCounterStrategy strategy) {
         return Objects.equals(strategy.min_max_type, TCounterMinMaxType.SKIP_ALL);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/SummarizationCounter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/SummarizationCounter.java
@@ -36,23 +36,30 @@ public final class SummarizationCounter {
     }
 
     public void merge(TCounter counter, boolean updateSum) {
+        // Use consistent value access to avoid potential issues if getValue() logic changes
+        long counterValue = counter.getValue();
+        
         if (updateSum) {
             if (Counter.isSkipMerge(strategy)) {
-                sum = counter.value;
+                sum = counterValue;
                 cnt = 1;
             } else {
-                sum += counter.value;
+                sum += counterValue;
                 cnt++;
             }
         }
-        min = Long.min(min, counter.getValue());
-        max = Long.max(max, counter.getValue());
+        min = Long.min(min, counterValue);
+        max = Long.max(max, counterValue);
     }
 
     public void finalized(Counter minCounter, Counter maxCounter, Counter mergedCounter) {
         if (cnt == 0) {
             min = 0L;
             max = 0L;
+            // Always update the output counters, even when no data was merged
+            minCounter.setValue(min);
+            maxCounter.setValue(max);
+            mergedCounter.setValue(0L);
             return;
         }
         long mergedValue = Counter.isAvg(strategy) ? sum / cnt : sum;

--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/SummarizationCounter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/SummarizationCounter.java
@@ -1,0 +1,64 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.profile;
+
+import com.starrocks.thrift.TCounter;
+import com.starrocks.thrift.TCounterStrategy;
+import com.starrocks.thrift.TUnit;
+
+/**
+ * Summarize MIN/MAX/SUM/AVG while merging
+ */
+public final class SummarizationCounter {
+
+    public final TUnit unit;
+    public final TCounterStrategy strategy;
+    public long min = Long.MAX_VALUE;
+    public long max = Long.MIN_VALUE;
+    public long sum = 0L;
+    public long cnt = 0L;
+
+    public SummarizationCounter(TUnit unit, TCounterStrategy strategy) {
+        this.unit = unit;
+        this.strategy = strategy;
+    }
+
+    public void merge(TCounter counter, boolean updateSum) {
+        if (updateSum) {
+            if (Counter.isSkipMerge(strategy)) {
+                sum = counter.value;
+                cnt = 1;
+            } else {
+                sum += counter.value;
+                cnt++;
+            }
+        }
+        min = Long.min(min, counter.getValue());
+        max = Long.max(max, counter.getValue());
+    }
+
+    public void finalized(Counter minCounter, Counter maxCounter, Counter mergedCounter) {
+        if (cnt == 0) {
+            min = 0L;
+            max = 0L;
+            return;
+        }
+        long mergedValue = Counter.isAvg(strategy) ? sum / cnt : sum;
+        minCounter.setValue(min);
+        maxCounter.setValue(max);
+        mergedCounter.setValue(mergedValue);
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -133,11 +133,6 @@ public class RuntimeProfile {
         return childMap.get(childName);
     }
 
-    public void removeAllChildren() {
-        childList.clear();
-        childMap.clear();
-    }
-
     public SummarizationCounter getOrAddSummarizationCounter(String name, TUnit unit,
                                                              TCounterStrategy strategy, String parentName) {
         Pair<SummarizationCounter, String> pair = fragmentCounterMap.get(name);
@@ -634,6 +629,18 @@ public class RuntimeProfile {
         formatter.format(this, prefix);
     }
 
+    /**
+     * Clear all counters but keep the info-string
+     */
+    public void clearCounters() {
+        counterMap.clear();
+        childMap.clear();
+        childCounterMap.clear();
+        childList.clear();
+        fragmentCounterMap.clear();
+        counterTotalTime.setValue(0);
+    }
+
     public String toString() {
         ProfileFormatter formater = new DefaultProfileFormatter();
         return formater.format(this);
@@ -727,20 +734,6 @@ public class RuntimeProfile {
         this.childList.addAll(childList);
     }
 
-    public void removeChild(String childName) {
-        RuntimeProfile childProfile = childMap.remove(childName);
-        if (childProfile == null) {
-            return;
-        }
-        childList.removeIf(childPair -> childPair.first == childProfile);
-    }
-
-    // Because the profile of summary and child fragment is not a real parent-child relationship
-    // Each child profile needs to calculate the time proportion consumed by itself
-    public void computeTimeInChildProfile() {
-        childMap.values().forEach(RuntimeProfile::computeTimeInProfile);
-    }
-
     public void computeTimeInProfile() {
         computeTimeInProfile(this.counterTotalTime.getValue());
     }
@@ -777,10 +770,6 @@ public class RuntimeProfile {
 
     public void addInfoString(String key, String value) {
         this.infoStrings.put(key, value);
-    }
-
-    public void removeInfoString(String key) {
-        infoStrings.remove(key);
     }
 
     // Copy all info strings from src profile

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -403,6 +403,7 @@ public class RuntimeProfile {
                 if (pair == null) {
                     SummarizationCounter counter =
                             addSummarizationCounter(tcounter.name, tcounter.type, tcounter.strategy, ROOT_COUNTER);
+                    counter.merge(tcounter, true);
                 } else {
                     Preconditions.checkArgument(pair.first.unit == tcounter.type);
                     pair.first.merge(tcounter, true);

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -368,6 +368,10 @@ public class RuntimeProfile {
                     TCounter tcounter = tCounterMap.get(topName);
                     String parentName = child2ParentMap.get(topName);
 
+                    if (tcounter == null) {
+                        continue;
+                    }
+
                     String target = topName;
                     boolean updateSum = true;
                     // For this kind of special counter, we need to merge them into another target

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfileParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfileParser.java
@@ -15,6 +15,7 @@ package com.starrocks.common.util;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.starrocks.common.profile.Counter;
 import com.starrocks.thrift.TUnit;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -1131,6 +1131,22 @@ public class DefaultCoordinator extends Coordinator {
                     return null; // Return null to continue the chain
                 });
 
+        // Build profiles
+        // 1. Build running profile if necessary
+        queryProfile.updateProfile(execState, params);
+
+        // 2. Either merge into fragment or instance profile:
+        // If the instance is finished, merge it into fragment profile and purge existing instance profiles
+        // If the instance is still running, merge it into instance profiles for use by running profile
+        if (queryProfile.mergeFragmentProfile(execState, params)) {
+            // Purge instance running profile to reduce memory footprint
+            execState.purgeInstanceRunningProfile();
+        } else {
+            // Merge into instance running profile
+            execState.updateInstanceRunningProfile(params);
+        }
+
+        lock();
         try {
             future.get();
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1201,7 +1201,13 @@ public class StmtExecutor {
             summaryProfile.addInfoString(ProfileManager.PROFILE_COLLECT_TIME,
                     DebugUtil.getPrettyStringMs(System.currentTimeMillis() - profileCollectStartTime));
             summaryProfile.addInfoString("IsProfileAsync", String.valueOf(isAsync));
-            profile.addChild(coord.buildQueryProfile(needMerge));
+            try {
+                RuntimeProfile runtimeProfile = coord.buildQueryProfile(needMerge);
+                profile.addChild(runtimeProfile);
+            } catch (Exception e) {
+                LOG.warn("build query runtime profile for query {} failed", executionId, e);
+                return;
+            }
 
             // Update TotalTime to include the Profile Collect Time and the time to build the profile.
             long now = System.currentTimeMillis();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1228,14 +1228,34 @@ public class StmtExecutor {
             if (queryDetail != null) {
                 queryDetail.setProfile(profileContent);
             }
-            QeProcessorImpl.INSTANCE.unMonitorQuery(executionId);
-            QeProcessorImpl.INSTANCE.unregisterQuery(executionId);
-            if (Config.enable_collect_query_detail_info && Config.enable_profile_log) {
-                String jsonString = GSON.toJson(queryDetail);
-                PROFILE_LOG.info(jsonString);
+        };
+        Consumer<Boolean> taskWrapper = (Boolean isAsync) -> {
+            try {
+                task.accept(isAsync);
+            } catch (Exception e) {
+                LOG.warn("process profile async failed", e);
+            } finally {
+                QeProcessorImpl.INSTANCE.unMonitorQuery(executionId);
+                QeProcessorImpl.INSTANCE.unregisterQuery(executionId);
+
+                if (Config.enable_collect_query_detail_info && Config.enable_profile_log && queryDetail != null) {
+                    String jsonString = GSON.toJson(queryDetail);
+                    if (Config.enable_profile_log_compress) {
+                        byte[] jsonBytes;
+                        try {
+                            jsonBytes = CompressionUtils.gzipCompressString(jsonString);
+                            PROFILE_LOG.info(jsonBytes);
+                        } catch (IOException e) {
+                            LOG.warn("Compress queryDetail string failed, length: {}, reason: {}",
+                                    jsonString.length(), e.getMessage());
+                        }
+                    } else {
+                        PROFILE_LOG.info(jsonString);
+                    }
+                }
             }
         };
-        return coord.tryProcessProfileAsync(task);
+        return coord.tryProcessProfileAsync(taskWrapper);
     }
 
     public void registerSubStmtExecutor(StmtExecutor subStmtExecutor) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1240,18 +1240,7 @@ public class StmtExecutor {
 
                 if (Config.enable_collect_query_detail_info && Config.enable_profile_log && queryDetail != null) {
                     String jsonString = GSON.toJson(queryDetail);
-                    if (Config.enable_profile_log_compress) {
-                        byte[] jsonBytes;
-                        try {
-                            jsonBytes = CompressionUtils.gzipCompressString(jsonString);
-                            PROFILE_LOG.info(jsonBytes);
-                        } catch (IOException e) {
-                            LOG.warn("Compress queryDetail string failed, length: {}, reason: {}",
-                                    jsonString.length(), e.getMessage());
-                        }
-                    } else {
-                        PROFILE_LOG.info(jsonString);
-                    }
+                    PROFILE_LOG.info(jsonString);
                 }
             }
         };

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
@@ -168,7 +168,7 @@ public class QueryRuntimeProfile {
             fragmentProfiles.add(profile);
             queryProfile.addChild(profile);
 
-            if (Config.enable_profile_jit_merge) {
+            if (Config.enable_profile_runtime_merge) {
                 RuntimeProfile mergeProfile = new RuntimeProfile("Fragment " + i);
                 mergedFragmentProfiles.add(mergeProfile);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
@@ -15,6 +15,7 @@
 package com.starrocks.qe.scheduler.dag;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.starrocks.common.Status;
 import com.starrocks.common.util.DebugUtil;
@@ -77,6 +78,8 @@ import java.util.stream.Collectors;
 public class FragmentInstanceExecState {
     private static final Logger LOG = LogManager.getLogger(FragmentInstanceExecState.class);
 
+    private static final List<String> PROFILE_BASIC_INFO = ImmutableList.of("Address", "InstanceId");
+
     private volatile State state = State.CREATED;
 
     private final JobSpec jobSpec;
@@ -92,7 +95,7 @@ public class FragmentInstanceExecState {
     private Future<PExecPlanFragmentResult> deployFuture = null;
 
     private final int fragmentIndex;
-    private final RuntimeProfile profile;
+    private RuntimeProfile profile;
 
     private final ComputeNode worker;
     private final TNetworkAddress address;
@@ -330,6 +333,26 @@ public class FragmentInstanceExecState {
         requestToDeploy = null;
         deployFuture = null;
         return new DeploymentResult(code, errMsg, failure);
+    }
+
+    /**
+     * Purse all counters to release memory
+     */
+    public synchronized void purgeInstanceRunningProfile() {
+        RuntimeProfile emptyProfile = new RuntimeProfile(profile.getName());
+        for (String key : PROFILE_BASIC_INFO) {
+            String value = profile.getInfoString(key);
+            if (value != null) {
+                emptyProfile.addInfoString(key, value);
+            }
+        }
+        profile = emptyProfile;
+    }
+
+    public synchronized void updateInstanceRunningProfile(TReportExecStatusParams params) {
+        if (params.isSetProfile()) {
+            profile.update(params.profile);
+        }
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
@@ -339,14 +339,7 @@ public class FragmentInstanceExecState {
      * Purse all counters to release memory
      */
     public synchronized void purgeInstanceRunningProfile() {
-        RuntimeProfile emptyProfile = new RuntimeProfile(profile.getName());
-        for (String key : PROFILE_BASIC_INFO) {
-            String value = profile.getInfoString(key);
-            if (value != null) {
-                emptyProfile.addInfoString(key, value);
-            }
-        }
-        profile = emptyProfile;
+        profile.clearCounters();
     }
 
     public synchronized void updateInstanceRunningProfile(TReportExecStatusParams params) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ExplainAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ExplainAnalyzer.java
@@ -21,7 +21,7 @@ import com.google.common.collect.Sets;
 import com.google.gson.JsonObject;
 import com.starrocks.common.Pair;
 import com.starrocks.common.StarRocksException;
-import com.starrocks.common.util.Counter;
+import com.starrocks.common.profile.Counter;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.ProfilingExecPlan;
 import com.starrocks.common.util.RuntimeProfile;

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileParserTest.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package com.starrocks.common.util;
 
+import com.starrocks.common.profile.Counter;
 import com.starrocks.thrift.TUnit;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/RuntimeProfileTest.java
@@ -620,13 +620,6 @@ public class RuntimeProfileTest {
         Assertions.assertTrue(mergedProfile.getCounterMap().containsKey("__MAX_OF_count1"));
         Assertions.assertEquals(1, mergedProfile.getCounterMap().get("__MAX_OF_count1").getValue());
         Assertions.assertTrue(mergedProfile.getCounterMap().containsKey("count1_sub"));
-        Assertions.assertTrue(mergedProfile.getCounterMap().containsKey("count1"));
-        Assertions.assertEquals(2, mergedProfile.getCounterMap().get("count1").getValue());
-        Assertions.assertTrue(mergedProfile.getCounterMap().containsKey("__MIN_OF_count1"));
-        Assertions.assertEquals(1, mergedProfile.getCounterMap().get("__MIN_OF_count1").getValue());
-        Assertions.assertTrue(mergedProfile.getCounterMap().containsKey("__MAX_OF_count1"));
-        Assertions.assertEquals(1, mergedProfile.getCounterMap().get("__MAX_OF_count1").getValue());
-        Assertions.assertTrue(mergedProfile.getCounterMap().containsKey("count1_sub"));
         Assertions.assertEquals(2, mergedProfile.getCounterMap().get("count1_sub").getValue());
         Assertions.assertTrue(mergedProfile.getCounterMap().containsKey("count2"));
         Assertions.assertEquals(5, mergedProfile.getCounterMap().get("count2").getValue());

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryRuntimeProfileTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryRuntimeProfileTest.java
@@ -14,7 +14,7 @@
 
 package com.starrocks.qe.scheduler;
 
-import com.starrocks.common.util.Counter;
+import com.starrocks.common.profile.Counter;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ExplainAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ExplainAnalyzerTest.java
@@ -14,7 +14,7 @@
 
 package com.starrocks.sql;
 
-import com.starrocks.common.util.Counter;
+import com.starrocks.common.profile.Counter;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.ProfilingExecPlan;
 import com.starrocks.common.util.RuntimeProfile;


### PR DESCRIPTION
## Why I'm doing:

Currently the query profile is generated in a hierarchy way:

1. Each backend would report the profiles in fragment instance level
2. FE would maintain all these profiles in memory before query finish
3. As a result, with more fragments, more backends, this running profile would take more memory
4. For a large-size cluster, this query profile can easily take hundreds MBs of FE memory

The tradeoff:
1. If we want to provide running profile: you have to maintain all instance profiles for running instances
2. If we don't need it, we only need to maintain the fragment-level, then consolidate them into a query profile when finish

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
4. 