### PR TITLE
[Enhancement] enable shared_scan

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1058,7 +1058,13 @@ CONF_mBool(enable_adjustment_page_cache_skip, "true");
 CONF_Int32(io_coalesce_read_max_buffer_size, "8388608");
 CONF_Int32(io_coalesce_read_max_distance_size, "1048576");
 CONF_mBool(io_coalesce_adaptive_lazy_active, "true");
+// The number of IO tasks per scan operator
 CONF_Int32(io_tasks_per_scan_operator, "4");
+// The number of chunks of each IO task
+CONF_mInt32(io_task_batch_size, "64");
+// Every N chunks, the shared_scan would switch to a new operator
+CONF_mInt32(io_task_shared_scan_step_size, "16");
+
 CONF_Int32(connector_io_tasks_per_scan_operator, "16");
 CONF_Int32(connector_io_tasks_min_size, "2");
 CONF_Int32(connector_io_tasks_adjust_interval_ms, "50");

--- a/be/src/exec/pipeline/scan/balanced_chunk_buffer.cpp
+++ b/be/src/exec/pipeline/scan/balanced_chunk_buffer.cpp
@@ -77,7 +77,11 @@ bool BalancedChunkBuffer::put(int buffer_index, int* actual_buffer, ChunkPtr chu
     // CRITICAL (by satanson)
     // EOS chunks may be empty and must be delivered in order to notify CacheOperator that all chunks of the tablet
     // has been processed.
-    if (!chunk || (!chunk->owner_info().is_last_chunk() && chunk->num_rows() == 0)) return true;
+    if (!chunk || (!chunk->owner_info().is_last_chunk() && chunk->num_rows() == 0)) {
+        // Set actual_buffer to buffer_index for early return case
+        *actual_buffer = buffer_index;
+        return true;
+    }
     bool ret;
     size_t memory_usage = chunk->memory_usage();
     if (_strategy == BalanceStrategy::kDirect) {

--- a/be/src/exec/pipeline/scan/balanced_chunk_buffer.h
+++ b/be/src/exec/pipeline/scan/balanced_chunk_buffer.h
@@ -37,7 +37,7 @@ public:
     size_t size(int buffer_index) const;
     bool empty(int buffer_index) const;
     bool try_get(int buffer_index, ChunkPtr* output_chunk);
-    bool put(int buffer_index, ChunkPtr chunk, ChunkBufferTokenPtr chunk_token);
+    bool put(int buffer_index, int* actual_buffer, ChunkPtr chunk, ChunkBufferTokenPtr chunk_token);
     void close();
     // Mark that it needn't produce any chunk anymore.
     void set_finished(int buffer_index);

--- a/be/src/exec/pipeline/scan/balanced_chunk_buffer.h
+++ b/be/src/exec/pipeline/scan/balanced_chunk_buffer.h
@@ -45,6 +45,7 @@ public:
     ChunkBufferLimiter* limiter() { return _limiter.get(); }
     void update_limiter(Chunk* chunk);
 
+    BalanceStrategy strategy() const { return _strategy; }
     int64_t memory_usage() const { return _memory_usage; }
 
 private:

--- a/be/src/exec/pipeline/scan/balanced_chunk_buffer.h
+++ b/be/src/exec/pipeline/scan/balanced_chunk_buffer.h
@@ -22,7 +22,6 @@
 
 namespace starrocks::pipeline {
 
-// TODO: support hash distribution instead of simple round-robin
 enum BalanceStrategy {
     kDirect,     // Assign chunks from input operator to output operator directly
     kRoundRobin, // Assign chunks from input operator to output with round-robin strategy

--- a/be/src/exec/pipeline/scan/chunk_buffer_limiter.h
+++ b/be/src/exec/pipeline/scan/chunk_buffer_limiter.h
@@ -126,24 +126,13 @@ public:
     ChunkBufferTokenPtr pin(int num_chunks) override;
     void unpin(int num_chunks);
 
-    bool is_full() const override {
-        if (_pinned_chunks_counter >= _capacity) {
-            _returned_full_event.store(true, std::memory_order_release);
-            return true;
-        }
-        return false;
-    }
     size_t size() const override { return _pinned_chunks_counter; }
     size_t capacity() const override { return _capacity; }
     size_t default_capacity() const override { return _default_capacity; }
     void update_mem_limit(int64_t value) override;
-    bool has_full_events() override {
-        if (!_has_full_event.load(std::memory_order_acquire)) {
-            return false;
-        }
-        bool val = true;
-        return _has_full_event.compare_exchange_strong(val, false);
-    }
+
+    bool is_full() const override;
+    bool has_full_events() override;
 
 private:
 private:

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -138,7 +138,7 @@ void ScanOperator::close(RuntimeState* state) {
 
 size_t ScanOperator::_buffer_unplug_threshold() const {
     size_t threshold = buffer_capacity() / _dop / 2;
-    threshold = std::max<size_t>(1, std::min<size_t>(kIOTaskBatchSize, threshold));
+    threshold = std::max<size_t>(1, std::min<size_t>(config::io_task_batch_size, threshold));
     return threshold;
 }
 
@@ -484,7 +484,8 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
             Status status;
 
             if (start_status.ok()) {
-                status = chunk_source->buffer_next_batch_chunks_blocking(state, kIOTaskBatchSize, _workgroup.get());
+                status = chunk_source->buffer_next_batch_chunks_blocking(state, config::io_task_batch_size,
+                                                                         _workgroup.get());
             }
 
             if (!status.ok() && !status.is_end_of_file()) {

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -117,7 +117,13 @@ public:
 
     // notify the operator with the given driver sequence
     auto defer_notify(int& driver_seq) {
-        return DeferOp([this, &driver_seq]() { _source_factory()->observes().notify_source_observer(driver_seq); });
+        return DeferOp([this, &driver_seq]() {
+            if (driver_seq == _driver_sequence) {
+                _observable.notify_source_observers();
+            } else {
+                _source_factory()->observes().notify_source_observer(driver_seq);
+            }
+        });
     }
 
 protected:

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -41,7 +41,7 @@ public:
 
     ~ScanOperator() override;
 
-    static size_t max_buffer_capacity() { return kIOTaskBatchSize; }
+    static size_t max_buffer_capacity() { return config::io_task_batch_size; }
 
     Status prepare(RuntimeState* state) override;
 
@@ -116,8 +116,6 @@ public:
     }
 
 protected:
-    static constexpr size_t kIOTaskBatchSize = 64;
-
     // TODO: remove this to the base ScanContext.
     /// Shared scan
     virtual void attach_chunk_source(int32_t source_index) = 0;

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -115,6 +115,11 @@ public:
         });
     }
 
+    // notify the operator with the given driver sequence
+    auto defer_notify(int& driver_seq) {
+        return DeferOp([this, &driver_seq]() { _source_factory()->observes().notify_source_observer(driver_seq); });
+    }
+
 protected:
     // TODO: remove this to the base ScanContext.
     /// Shared scan
@@ -321,6 +326,11 @@ protected:
 
 inline auto scan_defer_notify(ScanOperator* scan_op) {
     return scan_op->defer_notify([scan_op]() -> bool { return scan_op->need_notify_all(); });
+}
+
+// notify the operator with the given driver sequence
+inline auto scan_defer_notify(ScanOperator* scan_op, int& seq) {
+    return scan_op->defer_notify(seq);
 }
 
 pipeline::OpFactories decompose_scan_node_to_pipeline(std::shared_ptr<ScanOperatorFactory> factory, ScanNode* scan_node,

--- a/be/src/exec/pipeline/schedule/observer.h
+++ b/be/src/exec/pipeline/schedule/observer.h
@@ -117,6 +117,14 @@ public:
             observer->source_trigger();
         }
     }
+    // notify the operator with the given driver sequence
+    // NOTE: The index of _observers directly corresponds to the driver sequence,
+    // because each observer is registered in order during the prepare phase for each operator.
+    // This ensures that observer access by sequence number is safe and consistent.
+    void notify_source_observer(int seq) {
+        DCHECK(seq >= 0 && seq < _observers.size());
+        _observers[seq]->source_trigger();
+    }
     void notify_sink_observers() {
         for (auto* observer : _observers) {
             observer->sink_trigger();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1139,7 +1139,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = TABLET_INTERNAL_PARALLEL_MODE, flag = VariableMgr.INVISIBLE)
     private String tabletInternalParallelMode = "auto";
 
-    @VariableMgr.VarAttr(name = ENABLE_SHARED_SCAN_V2, alias = ENABLE_SHARED_SCAN, show = ENABLE_SHARED_SCAN)
+    @VariableMgr.VarAttr(name = ENABLE_SHARED_SCAN) 
     private boolean enableSharedScan = true;
 
     // max memory used on each fragment instance

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -326,7 +326,6 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String TABLET_INTERNAL_PARALLEL_MODE = "tablet_internal_parallel_mode";
     public static final String ENABLE_SHARED_SCAN = "enable_shared_scan";
-    public static final String ENABLE_SHARED_SCAN_V2 = "enable_shared_scan_v2";
     public static final String PIPELINE_DOP = "pipeline_dop";
     public static final String MAX_PIPELINE_DOP = "max_pipeline_dop";
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -326,6 +326,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String TABLET_INTERNAL_PARALLEL_MODE = "tablet_internal_parallel_mode";
     public static final String ENABLE_SHARED_SCAN = "enable_shared_scan";
+    public static final String ENABLE_SHARED_SCAN_V2 = "enable_shared_scan_v2";
     public static final String PIPELINE_DOP = "pipeline_dop";
     public static final String MAX_PIPELINE_DOP = "max_pipeline_dop";
 
@@ -1138,8 +1139,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = TABLET_INTERNAL_PARALLEL_MODE, flag = VariableMgr.INVISIBLE)
     private String tabletInternalParallelMode = "auto";
 
-    @VariableMgr.VarAttr(name = ENABLE_SHARED_SCAN)
-    private boolean enableSharedScan = false;
+    @VariableMgr.VarAttr(name = ENABLE_SHARED_SCAN_V2, alias = ENABLE_SHARED_SCAN, show = ENABLE_SHARED_SCAN)
+    private boolean enableSharedScan = true;
 
     // max memory used on each fragment instance
     // NOTE: only used for non-pipeline engine and stream_load


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Default-enables shared scan, adds configurable IO task batch size and shared-scan step size, implements grouped round-robin chunk dispatch with targeted driver notifications, and replaces hardcoded batch constants.
> 
> - **Execution/Scan**:
>   - `BalancedChunkBuffer`:
>     - `put()` now returns actual buffer via `int* actual_buffer`; implements grouped round-robin using `config::io_task_shared_scan_step_size`; exposes `strategy()`.
>   - `ChunkSource`/`ScanOperator`:
>     - Replace hardcoded `kIOTaskBatchSize` with `config::io_task_batch_size` and `max_buffer_capacity()` reflects it.
>     - Emit driver-targeted notifications in shared-scan round-robin; adjust EOS/timeout handling and owner flags.
>   - `observer.h`: add `notify_source_observer(int seq)` to notify a specific driver.
> - **Buffer limiter**:
>   - Refactors `DynamicChunkBufferLimiter::is_full()` and `has_full_events()` into .cpp.
> - **Config** (`be/src/common/config.h`):
>   - Add `io_task_batch_size` and `io_task_shared_scan_step_size`; annotate IO task settings.
> - **FE SessionVariable**:
>   - Default `enableSharedScan` set to `true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7e9b58fc4a766631253e57990434e6734e1b20e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->