### PR TITLE
[Enhancement] Support for MySQL BINARY Columns in External JDBC Catalogs

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
@@ -146,6 +146,10 @@ public class MysqlSchemaResolver extends JDBCSchemaResolver {
             case Types.TIMESTAMP:
                 primitiveType = PrimitiveType.DATETIME;
                 break;
+            case Types.BINARY:
+            case Types.VARBINARY:
+                primitiveType = PrimitiveType.VARBINARY;
+                break;
             default:
                 // The mysql-connector-j will convert the JSON type in MySQL to Types.LONGVARCHAR(1073741824).
                 // However, the mariadb-java-client does not handle the JSON type,

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
@@ -25,6 +25,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.type.DateType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.TypeFactory;
+import com.starrocks.type.VarbinaryType;
 import com.zaxxer.hikari.HikariDataSource;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -50,15 +51,14 @@ public class JDBCMetadataTest {
 
     @Mocked
     Connection connection;
-
+    @Mocked
+    PreparedStatement preparedStatement;
+    MockResultSet partitionsInfoTablesResult;
     private Map<String, String> properties;
     private MockResultSet dbResult;
     private MockResultSet tableResult;
     private MockResultSet columnResult;
-    @Mocked
-    PreparedStatement preparedStatement;
     private MockResultSet partitionsResult;
-    MockResultSet partitionsInfoTablesResult;
 
     @BeforeEach
     public void setUp() throws SQLException {
@@ -70,17 +70,19 @@ public class JDBCMetadataTest {
         columnResult.addColumn("DATA_TYPE",
                 Arrays.asList(Types.INTEGER, Types.DECIMAL, Types.CHAR, Types.VARCHAR, Types.TINYINT, Types.SMALLINT,
                         Types.INTEGER, Types.BIGINT, Types.TINYINT, Types.SMALLINT,
-                        Types.INTEGER, Types.BIGINT, Types.DATE, Types.TIME, Types.TIMESTAMP));
+                        Types.INTEGER, Types.BIGINT, Types.DATE, Types.TIME, Types.TIMESTAMP,
+                        Types.BINARY, Types.VARBINARY));
         columnResult.addColumn("TYPE_NAME",
                 Arrays.asList("INTEGER", "DECIMAL", "CHAR", "VARCHAR", "TINYINT UNSIGNED", "SMALLINT UNSIGNED",
                         "INTEGER UNSIGNED", "BIGINT UNSIGNED", "TINYINT", "SMALLINT",
-                        "INTEGER", "BIGINT", "DATE", "TIME", "TIMESTAMP"));
-        columnResult.addColumn("COLUMN_SIZE", Arrays.asList(4, 10, 10, 10, 1, 2, 4, 8, 1, 2, 4, 8, 8, 8, 8));
-        columnResult.addColumn("DECIMAL_DIGITS", Arrays.asList(0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0));
+                        "INTEGER", "BIGINT", "DATE", "TIME", "TIMESTAMP", "BINARY", "VARBINARY"));
+        columnResult.addColumn("COLUMN_SIZE", Arrays.asList(4, 10, 10, 10, 1, 2, 4, 8, 1, 2, 4, 8, 8, 8, 8, 16, 16));
+        columnResult.addColumn("DECIMAL_DIGITS", Arrays.asList(0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0));
         columnResult.addColumn("COLUMN_NAME",
-                Arrays.asList("a", "b", "c", "d", "e1", "e2", "e4", "e8", "f1", "f2", "f3", "f4", "g1", "g2", "g3"));
+                Arrays.asList("a", "b", "c", "d", "e1", "e2", "e4", "e8", "f1", "f2", "f3", "f4", "g1", "g2", "g3", "h1", "h2"));
         columnResult.addColumn("IS_NULLABLE",
-                Arrays.asList("YES", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO"));
+                Arrays.asList("YES", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO", "NO",
+                        "NO"));
         properties = new HashMap<>();
         properties.put(DRIVER_CLASS, "org.mariadb.jdbc.Driver");
         properties.put(JDBCResource.URI, "jdbc:mariadb://127.0.0.1:3306");
@@ -221,6 +223,8 @@ public class JDBCMetadataTest {
         Assertions.assertTrue(columns.get(12).getType().equals(DateType.DATE));
         Assertions.assertTrue(columns.get(13).getType().equals(DateType.TIME));
         Assertions.assertTrue(columns.get(14).getType().equals(DateType.DATETIME));
+        Assertions.assertTrue(columns.get(15).getType().equals(VarbinaryType.VARBINARY));
+        Assertions.assertTrue(columns.get(16).getType().equals(VarbinaryType.VARBINARY));
     }
 
     @Test

--- a/test/sql/test_jdbc_catalog/R/test_binary_type
+++ b/test/sql/test_jdbc_catalog/R/test_binary_type
@@ -1,0 +1,54 @@
+-- name: test_jdbc_catalog_binary_type
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'create database db_binary_${uuid0};'
+-- result:
+0
+
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use db_binary_${uuid0}; CREATE TABLE t1 (c1 varbinary(16), c2 binary(16));'
+-- result:
+0
+
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use db_binary_${uuid0}; INSERT INTO t1 VALUES (1,1);'
+-- result:
+0
+
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create external catalog jdbc_catalog_${uuid0}
+properties
+(
+    "type"="jdbc",
+    "user"="${external_mysql_user}",
+    "password"="${external_mysql_password}",
+    "jdbc_uri"="jdbc:mysql://${external_mysql_ip}:${external_mysql_port}",
+    "driver_url"="https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar",
+    "driver_class"="com.mysql.cj.jdbc.Driver"
+);
+-- result:
+-- !result
+set catalog jdbc_catalog_${uuid0};
+-- result:
+-- !result
+select hex(c1), hex(c2) from db_binary_${uuid0}.t1;
+-- result:
+31	31000000000000000000000000000000
+-- !result
+desc db_binary_${uuid0}.t1;
+-- result:
+c1	VARBINARY	Yes	false	None		
+c2	VARBINARY	Yes	false	None		
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+drop catalog jdbc_catalog_${uuid0};
+-- result:
+-- !result
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'drop database db_binary_${uuid0};'
+-- result:
+0
+
+-- !result

--- a/test/sql/test_jdbc_catalog/T/test_binary_type
+++ b/test/sql/test_jdbc_catalog/T/test_binary_type
@@ -1,0 +1,28 @@
+-- name: test_jdbc_catalog_binary_type
+-- create mysql table
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'create database db_binary_${uuid0};'
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use db_binary_${uuid0}; CREATE TABLE t1 (c1 varbinary(16), c2 binary(16));'
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'use db_binary_${uuid0}; INSERT INTO t1 VALUES (1,1);'
+
+-- create catalog
+set catalog default_catalog;
+create external catalog jdbc_catalog_${uuid0}
+properties
+(
+    "type"="jdbc",
+    "user"="${external_mysql_user}",
+    "password"="${external_mysql_password}",
+    "jdbc_uri"="jdbc:mysql://${external_mysql_ip}:${external_mysql_port}",
+    "driver_url"="https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.28/mysql-connector-java-8.0.28.jar",
+    "driver_class"="com.mysql.cj.jdbc.Driver"
+);
+
+-- query
+set catalog jdbc_catalog_${uuid0};
+select hex(c1), hex(c2) from db_binary_${uuid0}.t1;
+desc db_binary_${uuid0}.t1;
+set catalog default_catalog;
+drop catalog jdbc_catalog_${uuid0};
+
+-- drop mysql table
+shell: mysql -h${external_mysql_ip} -u${external_mysql_user} -p${external_mysql_password} -P${external_mysql_port} -e 'drop database db_binary_${uuid0};'


### PR DESCRIPTION
## Why I'm doing:
Data migration from MySQL to StarRocks relies on JDBC external catalogs to access source tables directly. However, query failures happened due to unsupported or incorrectly mapped types—specifically, MySQL's BINARY(16).

Current behavior:

- StarRocks maps BINARY(n) columns to VARCHAR (string).
- This causes runtime type mismatch errors when querying, such as:

> ERROR 1064 (HY000): Type mismatches on column[c1], JDBC result type is [B, please set the type to varbinary: BE:10002

## What I'm doing:
Map BINARY(n) and VARBINARY(n) MySQL columns to VARBINARY StarRocks columns.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Maps MySQL BINARY(n)/VARBINARY(n) to StarRocks VARBINARY in JDBC catalogs and adds unit/integration tests to validate.
> 
> - **Connector (MySQL schema resolution)**:
>   - Map `Types.BINARY` and `Types.VARBINARY` to `PrimitiveType.VARBINARY` in `MysqlSchemaResolver.convertColumnType`.
> - **Unit Tests**:
>   - Extend `JDBCMetadataTest` to include binary columns in mock metadata and assert resulting `VarbinaryType.VARBINARY`.
> - **Integration Tests (SQL)**:
>   - Add `test_sql/test_jdbc_catalog/{T,R}/test_binary_type` to verify reading MySQL `VARBINARY(16)` and `BINARY(16)` via JDBC catalog (hex values, `DESC` shows VARBINARY).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fdbb7d2160c49bfd0d26b04b12a37cf2e5116a77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->