### PR TITLE
[BugFix] Set RocksDB log file options

### DIFF
--- a/be/src/storage/kv_store.cpp
+++ b/be/src/storage/kv_store.cpp
@@ -115,9 +115,13 @@ int64_t KVStore::calc_rocksdb_write_buffer_size(MemTracker* mem_tracker) {
 Status KVStore::init(bool read_only) {
     DBOptions options;
     options.IncreaseParallelism();
-    std::string db_path = _root_path + META_POSTFIX;
-
+    // 256MB. default is 0, which means all logs will be written to one log file
+    options.max_log_file_size = 268435456;
+    // default is 1000
+    options.keep_log_file_num = 10;
     RETURN_IF_ERROR(rocksdb::GetDBOptionsFromString(options, config::rocksdb_db_options_string, &options));
+
+    std::string db_path = _root_path + META_POSTFIX;
 
     ColumnFamilyOptions meta_cf_options;
     RETURN_IF_ERROR(rocksdb::GetColumnFamilyOptionsFromString(meta_cf_options, config::rocksdb_cf_options_string,


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Set RocksDB options `max_log_file_size` to 256MB and `keep_log_file_num` to 10  for better log files management.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configure RocksDB log rotation by setting `max_log_file_size` to 256MB and `keep_log_file_num` to 10 in `KVStore::init`.
> 
> - **Storage / RocksDB configuration**:
>   - In `be/src/storage/kv_store.cpp` `KVStore::init`:
>     - Set `options.max_log_file_size = 268435456` (256MB).
>     - Set `options.keep_log_file_num = 10`.
>     - Initialize these before applying `config::rocksdb_db_options_string` and opening DB at `db_path`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf91aba3f98044f4df7f2bac68e20b4470a63034. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->