### PR TITLE
[BugFix] Fix automatic partition creation failure on duplicate partition values

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -1404,8 +1404,19 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
                         .collect(Collectors.toList());
                 PartitionDescAnalyzer.analyze(partitionDesc, columnDefList, cloneProperties);
                 if (!existPartitionNameSet.contains(partitionDesc.getPartitionName())) {
-                    CatalogUtils.checkPartitionValuesExistForAddListPartition(olapTable, partitionDesc,
-                            addPartitionClause.isTempPartition());
+                    boolean isDuplicate = CatalogUtils.checkPartitionValuesExistForAddListPartition(olapTable,
+                            partitionDesc, addPartitionClause.isTempPartition());
+                    if (isDuplicate) {
+                        if (partitionDesc.isSystem()) {
+                            // For system-created partitions (automatic partition), skip if values already exist.
+                            // duplicate partition will be ignored in create partition phase
+                            continue;
+                        } else {
+                            // For user-created partitions, throw error
+                            throw new DdlException("Duplicate partition values exist for partition: " +
+                                    partitionDesc.getPartitionName());
+                        }
+                    }
                 }
             } else {
                 throw new DdlException("Only support adding partition to range/list partitioned table");

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogUtilsTest.java
@@ -14,16 +14,11 @@
 
 package com.starrocks.catalog;
 
-import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AlterTableStmt;
-import com.starrocks.sql.ast.ColumnDef;
-import com.starrocks.sql.ast.SingleItemListPartitionDesc;
-import com.starrocks.sql.ast.expression.TypeDef;
-import com.starrocks.type.TypeFactory;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.StarRocksTestBase;
 import com.starrocks.utframe.UtFrameUtils;
@@ -35,7 +30,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -338,52 +332,5 @@ public class CatalogUtilsTest extends StarRocksTestBase {
 
         // Clean up
         starRocksAssert.dropTable("test_catalog_utils4.tbl_list4");
-    }
-
-    @Test
-    public void testCheckPartitionValuesExistForAddListPartition_DirectMethodCall() throws Exception {
-        // Create a list partition table for direct method testing
-        starRocksAssert.withDatabase("test_catalog_utils5").useDatabase("test_catalog_utils5")
-                .withTable("CREATE TABLE test_catalog_utils5.tbl_list5(\n" +
-                        "    id bigint not null,\n" +
-                        "    province varchar(20) not null\n" +
-                        ") ENGINE=OLAP\n" +
-                        "DUPLICATE KEY(id)\n" +
-                        "PARTITION BY LIST (province) (\n" +
-                        "   PARTITION p_bj VALUES IN (\"beijing\"),\n" +
-                        "   PARTITION p_gd VALUES IN (\"shenzhen\")\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(`id`) BUCKETS 10 \n" +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\"\n" +
-                        ");");
-
-        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test_catalog_utils5");
-        OlapTable table = (OlapTable) db.getTable("tbl_list5");
-
-        // Create a SingleItemListPartitionDesc for testing
-        SingleItemListPartitionDesc partitionDesc = new SingleItemListPartitionDesc(
-                false, "tp_test", Arrays.asList("hangzhou"), null);
-        // Set column def list for the partition desc
-        List<ColumnDef> columnDefList = new ArrayList<>();
-        columnDefList.add(new ColumnDef("province", new TypeDef(TypeFactory.createVarchar(20))));
-        partitionDesc.setColumnDefList(columnDefList);
-
-        // Test: temp partition should not throw exception for value not in formal partitions
-        Assertions.assertDoesNotThrow(() -> {
-            CatalogUtils.checkPartitionValuesExistForAddListPartition(table, partitionDesc, true);
-        });
-
-        // Test: formal partition with duplicate value should throw exception
-        SingleItemListPartitionDesc dupPartitionDesc = new SingleItemListPartitionDesc(
-                false, "p_test", Arrays.asList("beijing"), null);
-        dupPartitionDesc.setColumnDefList(columnDefList);
-
-        Assertions.assertThrows(DdlException.class, () -> {
-            CatalogUtils.checkPartitionValuesExistForAddListPartition(table, dupPartitionDesc, false);
-        });
-
-        // Clean up
-        starRocksAssert.dropTable("test_catalog_utils5.tbl_list5");
     }
 }

--- a/test/sql/test_automatic_partition/R/test_automatic_partition_reuse
+++ b/test/sql/test_automatic_partition/R/test_automatic_partition_reuse
@@ -1,0 +1,38 @@
+-- name: test_automatic_partition_reuse
+-- This test verifies that automatic partition creation is idempotent for partition reuse,
+-- meaning re-inserting data with existing partition values won't fail with "Duplicate values" error.
+-- Note: This does NOT test data deduplication - duplicate data rows are expected in the result.
+CREATE TABLE t_idempotent (
+    c1 date NOT NULL,
+    c2 varchar(20),
+    c3 boolean NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(c1, c2)
+PARTITION BY (c1, c3)
+DISTRIBUTED BY HASH(c1)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t_idempotent values ("2025-12-01", "1", true), ("2025-12-01", "0", false);
+-- result:
+-- !result
+select * from t_idempotent order by c2;
+-- result:
+2025-12-01	0	0
+2025-12-01	1	1
+-- !result
+admin set frontend config ("max_load_initial_open_partition_number"="1");
+-- result:
+-- !result
+insert into t_idempotent values ("2025-12-01", "1", true), ("2025-12-01", "0", false);
+-- result:
+-- !result
+select * from t_idempotent order by c2;
+-- result:
+2025-12-01	0	0
+2025-12-01	0	0
+2025-12-01	1	1
+2025-12-01	1	1
+-- !result

--- a/test/sql/test_automatic_partition/T/test_automatic_partition_reuse
+++ b/test/sql/test_automatic_partition/T/test_automatic_partition_reuse
@@ -1,0 +1,25 @@
+-- name: test_automatic_partition_reuse
+-- This test verifies that automatic partition creation is idempotent for partition reuse,
+-- meaning re-inserting data with existing partition values won't fail with "Duplicate values" error.
+-- Note: This does NOT test data deduplication - duplicate data rows are expected in the result.
+CREATE TABLE t_idempotent (
+    c1 date NOT NULL,
+    c2 varchar(20),
+    c3 boolean NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(c1, c2)
+PARTITION BY (c1, c3)
+DISTRIBUTED BY HASH(c1)
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+insert into t_idempotent values ("2025-12-01", "1", true), ("2025-12-01", "0", false);
+
+select * from t_idempotent order by c2;
+
+admin set frontend config ("max_load_initial_open_partition_number"="1");
+
+insert into t_idempotent values ("2025-12-01", "1", true), ("2025-12-01", "0", false);
+
+select * from t_idempotent order by c2;


### PR DESCRIPTION
## Why I'm doing:

When `max_load_initial_open_partition_number` is set to a small value, automatic partition tables fail on subsequent inserts with same partition values, reporting "Duplicate values" error. This happens because:
1. First insert creates partitions successfully
2. Second insert triggers BE to request partition creation from FE
3. FE detects partition values already exist and throws error

For automatic partitioning, the behavior should be idempotent: if partition values already exist, skip creation and return existing partition info to BE.

## What I'm doing:

- Add partition value existence check in AnalyzerUtils.getAddPartitionClauseFromPartitionValues
- Skip duplicate value check for system-created partitions in AlterTableClauseAnalyzer.analyzeAddPartition

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make automatic list-partition creation idempotent by detecting duplicate values and skipping system-created duplicates, while still erroring for user-created ones; add supporting tests.
> 
> - **Partition handling (CatalogUtils)**:
>   - Change `checkPartitionValuesExistForAddListPartition` to return `boolean` (true on duplicates) instead of throwing; update logic to check temp/formal scopes and reuse existing values.
>   - Replace throwing path for multi-item checks with `isItemValuesExist(...)` returning `boolean`.
>   - Add `extractTxnPrefix(String)` to scope temp partition duplicate checks per txn.
> - **Analyzer behavior (AlterTableClauseAnalyzer)**:
>   - Use the boolean duplicate check; if duplicates and `partitionDesc.isSystem()` (automatic), skip creation; otherwise throw `DdlException`.
> - **Tests**:
>   - Add/adjust UTs to cover txn-prefixed vs non-txn temp partitions and formal/temp interactions; test `extractTxnPrefix`.
>   - Add SQL tests `test_automatic_partition_reuse` validating idempotent automatic partition reuse under constrained `max_load_initial_open_partition_number`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46df5755f2ae85c50c6e7bbd8c72ebe194630b0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->