### PR TITLE
[Enhancement] Add datacache metrics for memory and disk monitoring

### DIFF
--- a/be/src/cache/CMakeLists.txt
+++ b/be/src/cache/CMakeLists.txt
@@ -22,6 +22,7 @@ set(CACHE_FILES
   disk_space_monitor.cpp
   mem_space_monitor.cpp
   datacache.cpp
+  datacache_metrics.cpp
   datacache_utils.cpp
   data_cache_hit_rate_counter.hpp
   mem_cache/lrucache_engine.cpp

--- a/be/src/cache/datacache_metrics.cpp
+++ b/be/src/cache/datacache_metrics.cpp
@@ -1,0 +1,63 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cache/datacache_metrics.h"
+
+#include "cache/datacache.h"
+
+#ifdef USE_STAROS
+#include "fslib/star_cache_handler.h"
+#endif
+#include "util/starrocks_metrics.h"
+
+namespace starrocks {
+
+#ifndef WITH_STARCACHE
+// empty implementation if WITH_STARCACHE is not enabled
+void register_datacache_metrics(bool) {}
+#else
+static void update_datacache_metrics(bool use_same_instance) {
+    auto* cache_env = DataCache::GetInstance();
+    const auto* local_disk_cache = cache_env->local_disk_cache();
+    DataCacheDiskMetrics disk_metrics{};
+    if (local_disk_cache && local_disk_cache->is_initialized()) {
+        disk_metrics = local_disk_cache->cache_metrics();
+    }
+    const auto* local_mem_cache = cache_env->local_mem_cache();
+    DataCacheMemMetrics mem_metrics{};
+    if (local_mem_cache && local_mem_cache->is_initialized()) {
+        mem_metrics = local_mem_cache->cache_metrics();
+    }
+#ifdef USE_STAROS
+    if (!use_same_instance) {
+        starcache::CacheMetrics starlet_cache_metrics{};
+        staros::starlet::fslib::star_cache_get_metrics(&starlet_cache_metrics);
+        // merge the disk cache metrics
+        disk_metrics.disk_quota_bytes += starlet_cache_metrics.disk_quota_bytes;
+        disk_metrics.disk_used_bytes += starlet_cache_metrics.disk_used_bytes;
+    }
+#endif
+    StarRocksMetrics::instance()->datacache_mem_quota_bytes.set_value(mem_metrics.mem_quota_bytes);
+    StarRocksMetrics::instance()->datacache_mem_used_bytes.set_value(mem_metrics.mem_used_bytes);
+    StarRocksMetrics::instance()->datacache_disk_quota_bytes.set_value(disk_metrics.disk_quota_bytes);
+    StarRocksMetrics::instance()->datacache_disk_used_bytes.set_value(disk_metrics.disk_used_bytes);
+}
+
+void register_datacache_metrics(bool use_same_instance) {
+    StarRocksMetrics::instance()->metrics()->register_hook(
+            "update_datacache_metrics", [use_same = use_same_instance] { update_datacache_metrics(use_same); });
+}
+#endif
+
+} // namespace starrocks

--- a/be/src/cache/datacache_metrics.h
+++ b/be/src/cache/datacache_metrics.h
@@ -1,0 +1,23 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace starrocks {
+
+// Register datacache metrics for monitoring memory and disk usage.
+// @param use_same_instance: true if using unified cache instance (USE_STAROS only)
+extern void register_datacache_metrics(bool use_same_instance);
+
+} // namespace starrocks

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -43,6 +43,7 @@
 #include "service/service_be/lake_service.h"
 #include "storage/lake/tablet_manager.h"
 #endif
+#include "cache/datacache_metrics.h"
 #include "service/staros_worker.h"
 #include "storage/storage_engine.h"
 #include "util/logging.h"
@@ -135,12 +136,14 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     EXIT_IF_ERROR(storage_engine->start_bg_threads());
     LOG(INFO) << process_name << " start step " << start_step++ << ": storage engine start bg threads successfully";
 
+    [[maybe_unused]] bool use_same_datacache_instance = false;
 #ifdef USE_STAROS
 #ifndef __APPLE__
     auto* local_cache = cache_env->local_disk_cache();
     if (config::datacache_unified_instance_enable && local_cache && local_cache->is_initialized()) {
         auto* starcache = reinterpret_cast<StarCacheEngine*>(local_cache);
         init_staros_worker(starcache->starcache_instance());
+        use_same_datacache_instance = true;
     } else {
         init_staros_worker(nullptr);
     }
@@ -149,6 +152,10 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
     init_staros_worker(nullptr);
 #endif
     LOG(INFO) << process_name << " start step " << start_step++ << ": staros worker init successfully";
+#endif
+#ifndef __APPLE__
+    // Register datacache metrics
+    register_datacache_metrics(use_same_datacache_instance);
 #endif
 
     // set up thrift client before providing any service to the external

--- a/be/src/util/starrocks_metrics.cpp
+++ b/be/src/util/starrocks_metrics.cpp
@@ -253,6 +253,12 @@ StarRocksMetrics::StarRocksMetrics() : _metrics(_s_registry_name) {
 
     REGISTER_STARROCKS_METRIC(short_circuit_request_total);
     REGISTER_STARROCKS_METRIC(short_circuit_request_duration_us);
+
+    // data cache metrics
+    REGISTER_STARROCKS_METRIC(datacache_mem_quota_bytes);
+    REGISTER_STARROCKS_METRIC(datacache_mem_used_bytes);
+    REGISTER_STARROCKS_METRIC(datacache_disk_quota_bytes);
+    REGISTER_STARROCKS_METRIC(datacache_disk_used_bytes);
 }
 
 void StarRocksMetrics::initialize(const std::vector<std::string>& paths, bool init_system_metrics,

--- a/be/src/util/starrocks_metrics.h
+++ b/be/src/util/starrocks_metrics.h
@@ -397,6 +397,12 @@ public:
     METRIC_DEFINE_INT_COUNTER(short_circuit_request_total, MetricUnit::REQUESTS);
     METRIC_DEFINE_INT_COUNTER(short_circuit_request_duration_us, MetricUnit::MICROSECONDS);
 
+    // data cache metrics
+    METRIC_DEFINE_INT_GAUGE(datacache_mem_quota_bytes, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_GAUGE(datacache_mem_used_bytes, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_GAUGE(datacache_disk_quota_bytes, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_GAUGE(datacache_disk_used_bytes, MetricUnit::BYTES);
+
     static StarRocksMetrics* instance() {
         static StarRocksMetrics instance;
         return &instance;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -419,6 +419,7 @@ set(EXEC_FILES
         ./service/service_be/internal_service_test.cpp
         ./service/staros_worker_test.cpp
         ./cache/datacache_utils_test.cpp
+        ./cache/datacache_metrics_test.cpp
         ./cache/data_cache_hit_rate_counter_test.cpp
         ./cache/mem_cache/page_cache_test.cpp
         ./cache/peer_cache_test.cpp

--- a/be/test/cache/datacache_metrics_test.cpp
+++ b/be/test/cache/datacache_metrics_test.cpp
@@ -1,0 +1,136 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cache/datacache_metrics.h"
+
+#include <gtest/gtest.h>
+
+#include "cache/datacache.h"
+#include "cache/disk_cache/test_cache_utils.h"
+#include "fs/fs_util.h"
+#include "util/starrocks_metrics.h"
+
+#ifdef WITH_STARCACHE
+#include "cache/disk_cache/starcache_engine.h"
+#include "testutil/assert.h"
+#endif
+
+namespace starrocks {
+
+class DataCacheMetricsTest : public ::testing::Test {
+public:
+    DataCacheMetricsTest() = default;
+    ~DataCacheMetricsTest() override = default;
+
+protected:
+    void SetUp() override {}
+
+    void TearDown() override {}
+};
+
+// Test that register_datacache_metrics can be called without crashing
+TEST_F(DataCacheMetricsTest, test_register_datacache_metrics_basic) {
+    // This should not crash regardless of WITH_STARCACHE
+    ASSERT_NO_THROW(register_datacache_metrics(false));
+    ASSERT_NO_THROW(register_datacache_metrics(true));
+}
+
+#ifdef WITH_STARCACHE
+// Test metrics registration with StarCache enabled
+TEST_F(DataCacheMetricsTest, test_datacache_metrics_registration) {
+    auto instance = StarRocksMetrics::instance();
+    auto metrics = instance->metrics();
+
+    // Verify that datacache metrics are registered
+    ASSERT_NE(nullptr, metrics->get_metric("datacache_mem_quota_bytes"));
+    ASSERT_NE(nullptr, metrics->get_metric("datacache_mem_used_bytes"));
+    ASSERT_NE(nullptr, metrics->get_metric("datacache_disk_quota_bytes"));
+    ASSERT_NE(nullptr, metrics->get_metric("datacache_disk_used_bytes"));
+}
+
+// Test that metrics have correct initial values
+TEST_F(DataCacheMetricsTest, test_datacache_metrics_initial_values) {
+    auto instance = StarRocksMetrics::instance();
+
+    // Initial values should be 0 or positive integers
+    ASSERT_GE(instance->datacache_mem_quota_bytes.value(), 0);
+    ASSERT_GE(instance->datacache_mem_used_bytes.value(), 0);
+    ASSERT_GE(instance->datacache_disk_quota_bytes.value(), 0);
+    ASSERT_GE(instance->datacache_disk_used_bytes.value(), 0);
+}
+
+// Test metrics update through hook mechanism
+TEST_F(DataCacheMetricsTest, test_metrics_update_hook) {
+    auto instance = StarRocksMetrics::instance();
+    auto metrics = instance->metrics();
+
+    // Register the metrics hook
+    register_datacache_metrics(false);
+
+    // Trigger the hook manually
+    metrics->trigger_hook();
+
+    // After hook execution, values should still be non-negative
+    ASSERT_GE(instance->datacache_mem_quota_bytes.value(), 0);
+    ASSERT_GE(instance->datacache_mem_used_bytes.value(), 0);
+    ASSERT_GE(instance->datacache_disk_quota_bytes.value(), 0);
+    ASSERT_GE(instance->datacache_disk_used_bytes.value(), 0);
+
+    // Used bytes should not exceed quota bytes
+    ASSERT_LE(instance->datacache_mem_used_bytes.value(), instance->datacache_mem_quota_bytes.value());
+    ASSERT_LE(instance->datacache_disk_used_bytes.value(), instance->datacache_disk_quota_bytes.value());
+}
+
+// Test metrics types are correct (should be INT_GAUGE)
+TEST_F(DataCacheMetricsTest, test_metrics_types) {
+    auto instance = StarRocksMetrics::instance();
+    auto metrics = instance->metrics();
+
+    auto mem_quota_metric = metrics->get_metric("datacache_mem_quota_bytes");
+    auto mem_used_metric = metrics->get_metric("datacache_mem_used_bytes");
+    auto disk_quota_metric = metrics->get_metric("datacache_disk_quota_bytes");
+    auto disk_used_metric = metrics->get_metric("datacache_disk_used_bytes");
+
+    ASSERT_NE(nullptr, mem_quota_metric);
+    ASSERT_NE(nullptr, mem_used_metric);
+    ASSERT_NE(nullptr, disk_quota_metric);
+    ASSERT_NE(nullptr, disk_used_metric);
+
+    // All should be gauge type metrics (not counters)
+    ASSERT_EQ(MetricType::GAUGE, mem_quota_metric->type());
+    ASSERT_EQ(MetricType::GAUGE, mem_used_metric->type());
+    ASSERT_EQ(MetricType::GAUGE, disk_quota_metric->type());
+    ASSERT_EQ(MetricType::GAUGE, disk_used_metric->type());
+
+    // All should have BYTES unit
+    ASSERT_EQ(MetricUnit::BYTES, mem_quota_metric->unit());
+    ASSERT_EQ(MetricUnit::BYTES, mem_used_metric->unit());
+    ASSERT_EQ(MetricUnit::BYTES, disk_quota_metric->unit());
+    ASSERT_EQ(MetricUnit::BYTES, disk_used_metric->unit());
+}
+
+#else // !WITH_STARCACHE
+
+// Test that without StarCache, registration is a no-op
+TEST_F(DataCacheMetricsTest, test_without_starcache) {
+    // When WITH_STARCACHE is not defined, these should be no-ops
+    ASSERT_NO_THROW(register_datacache_metrics(false));
+    ASSERT_NO_THROW(register_datacache_metrics(true));
+
+    // The function should compile and execute successfully even without StarCache
+}
+
+#endif // WITH_STARCACHE
+
+} // namespace starrocks


### PR DESCRIPTION
Implement comprehensive metrics collection for StarCache data cache, tracking both memory and disk usage with quota and utilization metrics.

Changes:
- Add datacache_metrics.cpp/h to implement metrics collection
- Register 4 new gauge metrics: mem/disk quota/used bytes
- Integrate with StarRocks metrics hook system for automatic updates
- Support both unified and separate cache instance configurations
- Add conditional compilation support for WITH_STARCACHE and USE_STAROS

The metrics are updated via a registered hook and support merging values from both StarCache and Starlet cache instances when running in separate instances.

Metrics exposed:
- starrocks_be_datacache_mem_quota_bytes: Memory quota for cache
- starrocks_be_datacache_mem_used_bytes: Current memory usage
- starrocks_be_datacache_disk_quota_bytes: Disk space quota for cache
- starrocks_be_datacache_disk_used_bytes: Current disk space usage

## Why I'm doing:

## What I'm doing:

Refs #61640

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds datacache mem/disk quota/used gauges, registers periodic update hook, integrates registration in BE startup, and adds tests.
> 
> - **Metrics**:
>   - Register four new gauges in `util/starrocks_metrics.{h,cpp}`: `datacache_mem_quota_bytes`, `datacache_mem_used_bytes`, `datacache_disk_quota_bytes`, `datacache_disk_used_bytes`.
>   - Add `cache/datacache_metrics.{h,cpp}` implementing hook-based updates (merging StarCache/Starlet metrics when applicable).
> - **BE Startup Integration**:
>   - In `service/service_be/starrocks_be.cpp`, register datacache metrics during startup, with `USE_STAROS` unified/separate instance handling.
> - **Build**:
>   - Include `datacache_metrics.cpp` in `be/src/cache/CMakeLists.txt`.
> - **Tests**:
>   - Add `be/test/cache/datacache_metrics_test.cpp` and wire it in `be/test/CMakeLists.txt` to validate registration, initial values, hook updates, and metric types.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15066fb0b65f6850b1842f6b8eb8ab856c67ae01. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->