### PR TITLE
[BugFix] Fix shadow partition being dropped when dropping partitions by expression

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
@@ -328,6 +328,18 @@ public class RangePartitionInfo extends PartitionInfo {
         }
     }
 
+    // return ranges without empty ranges, like shadow partition range
+    public Map<Long, Range<PartitionKey>> getNonEmptyRanges(boolean isTemp) {
+        Set<Map.Entry<Long, Range<PartitionKey>>> entrySet = null;
+        if (isTemp) {
+            entrySet = idToTempRange.entrySet();
+        } else {
+            entrySet = idToRange.entrySet();
+        }
+        return entrySet.stream().filter(x -> !x.getValue().isEmpty())
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
     public Range<PartitionKey> getRange(long partitionId) {
         Range<PartitionKey> range = idToRange.get(partitionId);
         if (range == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/partition/PartitionSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/partition/PartitionSelector.java
@@ -532,7 +532,7 @@ public class PartitionSelector {
                                                          boolean isDropPartitionCondition,
                                                          Map<Long, PCell> inputCells) {
         // clone it to avoid changing the original map
-        Map<Long, Range<PartitionKey>> keyRangeById = Maps.newHashMap(rangePartitionInfo.getIdToRange(false));
+        Map<Long, Range<PartitionKey>> keyRangeById = rangePartitionInfo.getNonEmptyRanges(false);
         if (inputCells != null && !inputCells.isEmpty()) {
             // mock partition ids since input cells has not been added into olapTable yet.
             inputCells.entrySet().stream()

--- a/test/sql/test_drop_partition/R/test_drop_partition_range_table_with_where
+++ b/test/sql/test_drop_partition/R/test_drop_partition_range_table_with_where
@@ -130,6 +130,56 @@ select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uu
 drop table t1;
 -- result:
 -- !result
+
+CREATE TABLE t1
+(
+    k1 date,
+    k2 string,
+    v1 int
+)
+PARTITION BY date_trunc('day', k1)
+DISTRIBUTED BY HASH(k2) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%';
+-- result:
+1
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name = '$shadow_automatic_partition';
+-- result:
+1
+-- !result
+insert into t1 values('2020-01-01','2020-02-02', 1);
+-- result:
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%';
+-- result:
+2
+-- !result
+ALTER TABLE t1 DROP PARTITIONS WHERE k1 >= '2020-01-01';
+-- result:
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%';
+-- result:
+1
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name = '$shadow_automatic_partition';
+-- result:
+1
+-- !result
+insert into t1 values('2020-01-01','2020-02-02', 1);
+-- result:
+-- !result
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%';
+-- result:
+2
+-- !result
+drop table t1;
+-- result:
+-- !result
+
 drop database db_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_drop_partition/T/test_drop_partition_range_table_with_where
+++ b/test/sql/test_drop_partition/T/test_drop_partition_range_table_with_where
@@ -63,6 +63,28 @@ ALTER TABLE t1 DROP PARTITIONS WHERE  k1 is null;
 select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
 ALTER TABLE t1 DROP PARTITIONS WHERE k1 <= current_date();
 select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name != '$shadow_automatic_partition';
-
 drop table t1;
+
+-- test shadow partition should not be dropped
+CREATE TABLE t1
+(
+    k1 date,
+    k2 string,
+    v1 int 
+)
+PARTITION BY date_trunc('day', k1)
+DISTRIBUTED BY HASH(k2) BUCKETS 3
+PROPERTIES('replication_num' = '1');
+
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%';
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name = '$shadow_automatic_partition';
+insert into t1 values('2020-01-01','2020-02-02', 1);
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%';
+ALTER TABLE t1 DROP PARTITIONS WHERE k1 >= '2020-01-01';
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%';
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%' and partition_name = '$shadow_automatic_partition';
+insert into t1 values('2020-01-01','2020-02-02', 1);
+select COUNT(1) from INFORMATION_SCHEMA.PARTITIONS_META where db_name = 'db_${uuid0}' and table_name like '%t1%';
+drop table t1;
+
 drop database db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

Expression-partitioned table can not be inserted after dropping partitions.
```
ALTER TABLE t1 DROP PARTITIONS WHERE k1 >= '2020-01-01';

insert into t1 values('2020-01-01','2020-02-02', 1);
ERROR 1064 (HY000): Getting analyzing error. Detail message: data cannot be inserted into table with empty partition.Use SHOW PARTITIONS FROM t1 to see the currently partitions of this table.
```

## What I'm doing:

This issue is caused by shadow partition being incorrectly dropped.

Fixes https://github.com/StarRocks/starrocks/issues/66172

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Exclude empty (shadow) partition ranges from range-partition pruning to prevent shadow partitions being dropped; add tests to verify behavior.
> 
> - **Partition pruning (range)**:
>   - Add `RangePartitionInfo.getNonEmptyRanges(boolean)` to filter out empty ranges (e.g., shadow partitions).
>   - Use `getNonEmptyRanges(false)` in `PartitionSelector.getRangePartitionIdsByExpr` to avoid considering shadow partitions during drop-by-expression pruning.
> - **Tests**:
>   - Extend `test/sql/test_drop_partition/*/test_drop_partition_range_table_with_where` to validate that shadow partitions are preserved when dropping by expressions and verify partition counts across operations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99a1aea777c14a255770488eaea3deabd4abefa9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->