### PR TITLE
[Refactor] Unify function ref handling for create/drop/grant operations

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionName.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionName.java
@@ -14,10 +14,7 @@
 
 package com.starrocks.catalog;
 
-import com.google.common.base.Strings;
 import com.google.gson.annotations.SerializedName;
-import com.starrocks.common.ErrorCode;
-import com.starrocks.common.ErrorReport;
 import com.starrocks.common.io.Writable;
 import com.starrocks.thrift.TFunctionName;
 
@@ -94,42 +91,12 @@ public class FunctionName implements Writable {
         return db + "." + fn;
     }
 
-    public void analyze(String defaultDb) {
-        if (fn.length() == 0) {
-            ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "Should order by column");
-        }
-        for (int i = 0; i < fn.length(); ++i) {
-            if (!isValidCharacter(fn.charAt(i))) {
-                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
-                        "Function names must be all alphanumeric or underscore. " +
-                                "Invalid name: " + fn);
-            }
-        }
-        if (Character.isDigit(fn.charAt(0))) {
-            ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
-                    "Function cannot start with a digit: " + fn);
-        }
-        if (db == null) {
-            db = defaultDb;
-            if (Strings.isNullOrEmpty(db)) {
-                ErrorReport.reportSemanticException(ErrorCode.ERR_NO_DB_ERROR);
-            }
-        }
-    }
-
-    private boolean isValidCharacter(char c) {
-        return Character.isLetterOrDigit(c) || c == '_';
-    }
-
     public TFunctionName toThrift() {
         TFunctionName name = new TFunctionName(fn);
         name.setDb_name(db);
         name.setFunction_name(Function.rectifyFunctionName(fn));
         return name;
     }
-
-
-
 
     @Override
     public int hashCode() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateFunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateFunctionAnalyzer.java
@@ -30,6 +30,7 @@ import com.starrocks.common.util.UDFInternalClassLoader;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.CreateFunctionStmt;
 import com.starrocks.sql.ast.FunctionArgsDef;
+import com.starrocks.sql.ast.FunctionRef;
 import com.starrocks.sql.ast.HdfsURI;
 import com.starrocks.sql.ast.expression.TypeDef;
 import com.starrocks.thrift.TFunctionBinaryType;
@@ -70,9 +71,9 @@ public class CreateFunctionAnalyzer {
 
         if (CreateFunctionStmt.TYPE_STARROCKS_JAR.equalsIgnoreCase(langType)) {
             String checksum = computeMd5(stmt);
-            analyzeJavaUDFClass(stmt, checksum);
+            analyzeJavaUDFClass(stmt, checksum, context);
         } else if (CreateFunctionStmt.TYPE_STARROCKS_PYTHON.equalsIgnoreCase(langType)) {
-            analyzePython(stmt);
+            analyzePython(stmt, context);
         } else {
             ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "unknown lang type");
         }
@@ -80,12 +81,12 @@ public class CreateFunctionAnalyzer {
     }
 
     private void analyzeCommon(CreateFunctionStmt stmt, ConnectContext context) {
-        FunctionName functionName = stmt.getFunctionName();
-        functionName.analyze(context.getDatabase());
+        FunctionRef functionRef = stmt.getFunctionRef();
         FunctionArgsDef argsDef = stmt.getArgsDef();
         TypeDef returnType = stmt.getReturnType();
-        // check argument
-        argsDef.analyze();
+        String defaultDb = functionRef.isGlobalFunction() ? FunctionRefAnalyzer.GLOBAL_UDF_DB : context.getDatabase();
+        FunctionRefAnalyzer.analyzeFunctionRef(functionRef, defaultDb);
+        FunctionRefAnalyzer.analyzeArgsDef(argsDef);
         TypeDefAnalyzer.analyze(returnType);
     }
 
@@ -134,7 +135,7 @@ public class CreateFunctionAnalyzer {
         return checksum;
     }
 
-    private void analyzeJavaUDFClass(CreateFunctionStmt stmt, String checksum) {
+    private void analyzeJavaUDFClass(CreateFunctionStmt stmt, String checksum, ConnectContext context) {
         Map<String, String> properties = stmt.getProperties();
         String className = properties.get(CreateFunctionStmt.SYMBOL_KEY);
         if (Strings.isNullOrEmpty(className)) {
@@ -174,11 +175,11 @@ public class CreateFunctionAnalyzer {
 
         Function createdFunction = null;
         if (stmt.isScalar()) {
-            createdFunction = analyzeStarrocksJarUdf(stmt, checksum, handleClass);
+            createdFunction = analyzeStarrocksJarUdf(stmt, checksum, handleClass, context);
         } else if (stmt.isAggregate()) {
-            createdFunction = analyzeStarrocksJarUdaf(stmt, checksum, handleClass, stateClass);
+            createdFunction = analyzeStarrocksJarUdaf(stmt, checksum, handleClass, stateClass, context);
         } else {
-            createdFunction = analyzeStarrocksJarUdtf(stmt, checksum, handleClass);
+            createdFunction = analyzeStarrocksJarUdtf(stmt, checksum, handleClass, context);
         }
 
         stmt.setFunction(createdFunction);
@@ -199,10 +200,13 @@ public class CreateFunctionAnalyzer {
     }
 
     private Function analyzeStarrocksJarUdf(CreateFunctionStmt stmt, String checksum,
-                                            JavaUDFInternalClass handleClass) {
+                                            JavaUDFInternalClass handleClass, ConnectContext context) {
         checkStarrocksJarUdfClass(stmt, handleClass);
 
-        FunctionName functionName = stmt.getFunctionName();
+        FunctionName functionName = FunctionRefAnalyzer.resolveFunctionName(
+                stmt.getFunctionRef(),
+                stmt.getFunctionRef().isGlobalFunction() ? FunctionRefAnalyzer.GLOBAL_UDF_DB
+                        : context.getDatabase());
         FunctionArgsDef argsDef = stmt.getArgsDef();
         TypeDef returnType = stmt.getReturnType();
         String objectFile = stmt.getProperties().get(CreateFunctionStmt.FILE_KEY);
@@ -306,8 +310,12 @@ public class CreateFunctionAnalyzer {
 
     private Function analyzeStarrocksJarUdaf(CreateFunctionStmt stmt, String checksum,
                                              JavaUDFInternalClass mainClass,
-                                             JavaUDFInternalClass udafStateClass) {
-        FunctionName functionName = stmt.getFunctionName();
+                                             JavaUDFInternalClass udafStateClass,
+                                             ConnectContext context) {
+        FunctionName functionName = FunctionRefAnalyzer.resolveFunctionName(
+                stmt.getFunctionRef(),
+                stmt.getFunctionRef().isGlobalFunction() ? FunctionRefAnalyzer.GLOBAL_UDF_DB
+                        : context.getDatabase());
         FunctionArgsDef argsDef = stmt.getArgsDef();
         TypeDef returnType = stmt.getReturnType();
         String objectFile = stmt.getProperties().get(CreateFunctionStmt.FILE_KEY);
@@ -330,8 +338,12 @@ public class CreateFunctionAnalyzer {
     }
 
     private Function analyzeStarrocksJarUdtf(CreateFunctionStmt stmt, String checksum,
-                                             JavaUDFInternalClass mainClass) {
-        FunctionName functionName = stmt.getFunctionName();
+                                             JavaUDFInternalClass mainClass,
+                                             ConnectContext context) {
+        FunctionName functionName = FunctionRefAnalyzer.resolveFunctionName(
+                stmt.getFunctionRef(),
+                stmt.getFunctionRef().isGlobalFunction() ? FunctionRefAnalyzer.GLOBAL_UDF_DB
+                        : context.getDatabase());
         FunctionArgsDef argsDef = stmt.getArgsDef();
         TypeDef returnType = stmt.getReturnType();
         String objectFile = stmt.getProperties().get(CreateFunctionStmt.FILE_KEY);
@@ -567,7 +579,7 @@ public class CreateFunctionAnalyzer {
         }
     }
 
-    private void analyzePython(CreateFunctionStmt stmt) {
+    private void analyzePython(CreateFunctionStmt stmt, ConnectContext context) {
         String content = stmt.getContent();
         Map<String, String> properties = stmt.getProperties();
         boolean isInline = content != null;
@@ -591,7 +603,10 @@ public class CreateFunctionAnalyzer {
             ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "unknown input type:" + inputType);
         }
 
-        FunctionName functionName = stmt.getFunctionName();
+        FunctionName functionName = FunctionRefAnalyzer.resolveFunctionName(
+                stmt.getFunctionRef(),
+                stmt.getFunctionRef().isGlobalFunction() ? FunctionRefAnalyzer.GLOBAL_UDF_DB
+                        : context.getDatabase());
         FunctionArgsDef argsDef = stmt.getArgsDef();
         TypeDef returnType = stmt.getReturnType();
         String isolation = stmt.getProperties().get(CreateFunctionStmt.ISOLATION_KEY);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DropStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DropStmtAnalyzer.java
@@ -44,6 +44,7 @@ import com.starrocks.sql.ast.DropFunctionStmt;
 import com.starrocks.sql.ast.DropTableStmt;
 import com.starrocks.sql.ast.DropTemporaryTableStmt;
 import com.starrocks.sql.ast.FunctionArgsDef;
+import com.starrocks.sql.ast.FunctionRef;
 import com.starrocks.sql.common.MetaUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -202,16 +203,16 @@ public class DropStmtAnalyzer {
 
         @Override
         public Void visitDropFunctionStatement(DropFunctionStmt statement, ConnectContext context) {
-            // analyze function name
-            FunctionName functionName = statement.getFunctionName();
-            functionName.analyze(context.getDatabase());
+            FunctionRef functionRef = statement.getFunctionRef();
+            String defaultDb = functionRef.isGlobalFunction() ? FunctionRefAnalyzer.GLOBAL_UDF_DB : context.getDatabase();
+            FunctionRefAnalyzer.analyzeFunctionRef(functionRef, defaultDb);
+            FunctionName functionName = FunctionRefAnalyzer.resolveFunctionName(functionRef, defaultDb);
             // analyze arguments
             FunctionArgsDef argsDef = statement.getArgsDef();
-            argsDef.analyze();
+            FunctionRefAnalyzer.analyzeArgsDef(argsDef);
 
             FunctionSearchDesc funcDesc = new FunctionSearchDesc(functionName, argsDef.getArgTypes(),
                     argsDef.isVariadic());
-            statement.setFunctionSearchDesc(funcDesc);
 
             // check function existence
             Function func;
@@ -223,7 +224,7 @@ public class DropStmtAnalyzer {
             } else {
                 Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(functionName.getDb());
                 if (db != null) {
-                    func = db.getFunction(statement.getFunctionSearchDesc());
+                    func = db.getFunction(funcDesc);
                     if (func == null) {
                         ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_FUNC_ERROR, funcDesc.toString());
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionRefAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionRefAnalyzer.java
@@ -1,0 +1,99 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer;
+
+import com.google.common.base.Strings;
+import com.starrocks.catalog.FunctionName;
+import com.starrocks.catalog.FunctionSearchDesc;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.ErrorReport;
+import com.starrocks.sql.ast.FunctionArgsDef;
+import com.starrocks.sql.ast.FunctionRef;
+import com.starrocks.sql.ast.expression.TypeDef;
+import com.starrocks.type.Type;
+
+import java.util.List;
+
+public class FunctionRefAnalyzer {
+    public static final String GLOBAL_UDF_DB = FunctionName.GLOBAL_UDF_DB;
+
+    public static void analyzeFunctionRef(FunctionRef functionRef, String defaultDb) {
+        List<String> parts = functionRef.getFnName().getParts();
+        String fullFunctionName = functionRef.getFnName().toString().toLowerCase();
+        if (parts.size() > 2) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                    "Function names must be all alphanumeric or underscore. Invalid name: " + fullFunctionName);
+        }
+        String db = functionRef.getDbName();
+        String fn = functionRef.getFunctionName();
+
+        if (fn.isEmpty()) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "Should order by column");
+        }
+        for (int i = 0; i < fn.length(); ++i) {
+            if (!isValidCharacter(fn.charAt(i))) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                        "Function names must be all alphanumeric or underscore. " +
+                                "Invalid name: " + fn);
+            }
+        }
+        if (Character.isDigit(fn.charAt(0))) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                    "Function cannot start with a digit: " + fn);
+        }
+        if (db == null && Strings.isNullOrEmpty(defaultDb)) {
+            ErrorReport.reportSemanticException(ErrorCode.ERR_NO_DB_ERROR);
+        }
+    }
+
+    public static void analyzeArgsDef(FunctionArgsDef argsDef) {
+        List<TypeDef> argTypeDefs = argsDef.getArgTypeDefs();
+        Type[] argTypes = new Type[argTypeDefs.size()];
+        int i = 0;
+        for (TypeDef typeDef : argTypeDefs) {
+            TypeDefAnalyzer.analyze(typeDef);
+            argTypes[i++] = typeDef.getType();
+        }
+        argsDef.setArgTypes(argTypes);
+    }
+
+    public static FunctionName resolveFunctionName(FunctionRef functionRef, String defaultDb) {
+        FunctionName functionName = FunctionName.createFnName(functionRef.getFnName().toString());
+        if (functionRef.isGlobalFunction()) {
+            if (!Strings.isNullOrEmpty(functionName.getDb())) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                        "Invalid function name: " + functionRef.getFnName().toString().toLowerCase());
+            }
+            functionName.setAsGlobalFunction();
+            return functionName;
+        } else {
+            if (functionName.getDb() == null) {
+                functionName.setDb(defaultDb);
+            }
+        }
+
+        return functionName;
+    }
+
+    public static FunctionSearchDesc buildFunctionSearchDesc(
+            FunctionRef functionRef, FunctionArgsDef argsDef, String defaultDb) {
+        FunctionName functionName = resolveFunctionName(functionRef, defaultDb);
+        return new FunctionSearchDesc(functionName, argsDef.getArgTypes(), argsDef.isVariadic());
+    }
+
+    private static boolean isValidCharacter(char c) {
+        return Character.isLetterOrDigit(c) || c == '_';
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitorExtendInterface.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitorExtendInterface.java
@@ -17,9 +17,7 @@ package com.starrocks.sql.ast;
 import com.starrocks.connector.parser.trino.PlaceholderExpr;
 import com.starrocks.sql.ast.expression.AnalyticExpr;
 import com.starrocks.sql.ast.expression.ArithmeticExpr;
-import com.starrocks.sql.ast.expression.BinaryPredicate;
 import com.starrocks.sql.ast.expression.CastExpr;
-import com.starrocks.sql.ast.expression.CompoundPredicate;
 import com.starrocks.sql.ast.expression.DecimalLiteral;
 import com.starrocks.sql.ast.expression.DefaultValueExpr;
 import com.starrocks.sql.ast.expression.DictQueryExpr;
@@ -29,16 +27,12 @@ import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.FieldReference;
 import com.starrocks.sql.ast.expression.FunctionCallExpr;
 import com.starrocks.sql.ast.expression.GroupingFunctionCallExpr;
-import com.starrocks.sql.ast.expression.InPredicate;
 import com.starrocks.sql.ast.expression.LambdaArgument;
 import com.starrocks.sql.ast.expression.LambdaFunctionExpr;
-import com.starrocks.sql.ast.expression.LargeInPredicate;
 import com.starrocks.sql.ast.expression.LimitElement;
 import com.starrocks.sql.ast.expression.MapExpr;
-import com.starrocks.sql.ast.expression.MultiInPredicate;
 import com.starrocks.sql.ast.expression.Parameter;
 import com.starrocks.sql.ast.expression.PlaceHolderExpr;
-import com.starrocks.sql.ast.expression.SetVarHint;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.ast.expression.SubfieldExpr;
 import com.starrocks.sql.ast.expression.Subquery;
@@ -235,10 +229,6 @@ public interface AstVisitorExtendInterface<R, C> extends AstVisitor<R, C> {
         return visitShowStatement(statement, context);
     }
 
-    default R visitShowCreateRoutineLoadStatement(ShowCreateRoutineLoadStmt statement, C context) {
-        return visitShowStatement(statement, context);
-    }
-
     default R visitShowRoutineLoadTaskStatement(ShowRoutineLoadTaskStmt statement, C context) {
         return visitShowStatement(statement, context);
     }
@@ -252,12 +242,6 @@ public interface AstVisitorExtendInterface<R, C> extends AstVisitor<R, C> {
     default R visitAdminSetReplicaStatusStatement(AdminSetReplicaStatusStmt statement, C context) {
         return visitDDLStatement(statement, context);
     }
-
-
-    default R visitAdminShowReplicaStatusStatement(AdminShowReplicaStatusStmt statement, C context) {
-        return visitShowStatement(statement, context);
-    }
-
 
     default R visitAdminSetPartitionVersionStmt(AdminSetPartitionVersionStmt statement, C context) {
         return visitDDLStatement(statement, context);
@@ -312,14 +296,6 @@ public interface AstVisitorExtendInterface<R, C> extends AstVisitor<R, C> {
 
     // ---------------------------------------- UDF Statement-----------------------------------------------------------
 
-    default R visitShowFunctionsStatement(ShowFunctionsStmt statement, C context) {
-        return visitShowStatement(statement, context);
-    }
-
-    default R visitDropFunctionStatement(DropFunctionStmt statement, C context) {
-        return visitDDLStatement(statement, context);
-    }
-
     default R visitCreateFunctionStatement(CreateFunctionStmt statement, C context) {
         return visitDDLStatement(statement, context);
     }
@@ -357,14 +333,6 @@ public interface AstVisitorExtendInterface<R, C> extends AstVisitor<R, C> {
         return visitShowStatement(statement, context);
     }
 
-    default R visitShowWarningStatement(ShowWarningStmt statement, C context) {
-        return visitShowStatement(statement, context);
-    }
-
-    default R visitShowVariablesStatement(ShowVariablesStmt statement, C context) {
-        return visitShowStatement(statement, context);
-    }
-
     default R visitShowProcStmt(ShowProcStmt statement, C context) {
         return visitShowStatement(statement, context);
     }
@@ -397,23 +365,6 @@ public interface AstVisitorExtendInterface<R, C> extends AstVisitor<R, C> {
         return visitShowStatement(statement, context);
     }
 
-    default R visitShowCollationStatement(ShowCollationStmt statement, C context) {
-        return visitShowStatement(statement, context);
-    }
-
-    default R visitShowCharsetStatement(ShowCharsetStmt statement, C context) {
-        return visitShowStatement(statement, context);
-    }
-
-
-    default R visitShowProcedureStatement(ShowProcedureStmt statement, C context) {
-        return visitShowStatement(statement, context);
-    }
-
-    default R visitShowStatusStatement(ShowStatusStmt statement, C context) {
-        return visitShowStatement(statement, context);
-    }
-
     // ---------------------------------------- Authz Statement ----------------------------------------------------
 
     default R visitGrantRevokePrivilegeStatement(BaseGrantRevokePrivilegeStmt statement, C context) {
@@ -426,11 +377,6 @@ public interface AstVisitorExtendInterface<R, C> extends AstVisitor<R, C> {
     default R visitCancelBackupStatement(CancelBackupStmt statement, C context) {
         return visitDDLStatement(statement, context);
     }
-
-    default R visitShowSnapshotStatement(ShowSnapshotStmt statement, C context) {
-        return visitShowStatement(statement, context);
-    }
-
 
     // ------------------------------- DataCache Management Statement -------------------------------------------------
 
@@ -482,10 +428,6 @@ public interface AstVisitorExtendInterface<R, C> extends AstVisitor<R, C> {
 
     default R visitCreateStorageVolumeStatement(CreateStorageVolumeStmt statement, C context) {
         return visitDDLStatement(statement, context);
-    }
-
-    default R visitShowStorageVolumesStatement(ShowStorageVolumesStmt statement, C context) {
-        return visitShowStatement(statement, context);
     }
 
     default R visitDescStorageVolumeStatement(DescStorageVolumeStmt statement, C context) {
@@ -545,14 +487,6 @@ public interface AstVisitorExtendInterface<R, C> extends AstVisitor<R, C> {
     }
 
     default R visitDropColumnClause(DropColumnClause clause, C context) {
-        return visitNode(clause, context);
-    }
-
-    default R visitAddPartitionColumnClause(AddPartitionColumnClause clause, C context) {
-        return visitNode(clause, context);
-    }
-
-    default R visitDropPartitionColumnClause(DropPartitionColumnClause clause, C context) {
         return visitNode(clause, context);
     }
 
@@ -739,27 +673,7 @@ public interface AstVisitorExtendInterface<R, C> extends AstVisitor<R, C> {
         return visitExpression(node, context);
     }
 
-    default R visitBinaryPredicate(BinaryPredicate node, C context) {
-        return visitPredicate(node, context);
-    }
-
-    default R visitCompoundPredicate(CompoundPredicate node, C context) {
-        return visitPredicate(node, context);
-    }
-
     default R visitExistsPredicate(ExistsPredicate node, C context) {
-        return visitPredicate(node, context);
-    }
-
-    default R visitInPredicate(InPredicate node, C context) {
-        return visitPredicate(node, context);
-    }
-
-    default R visitLargeInPredicate(LargeInPredicate node, C context) {
-        return visitInPredicate(node, context);
-    }
-
-    default R visitMultiInPredicate(MultiInPredicate node, C context) {
         return visitPredicate(node, context);
     }
 
@@ -841,10 +755,6 @@ public interface AstVisitorExtendInterface<R, C> extends AstVisitor<R, C> {
     }
 
     default R visitHintNode(HintNode node, C context) {
-        return visitNode(node, context);
-    }
-
-    default R visitSetVarHint(SetVarHint node, C context) {
         return visitNode(node, context);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/BaseGrantRevokePrivilegeStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/BaseGrantRevokePrivilegeStmt.java
@@ -18,8 +18,6 @@ package com.starrocks.sql.ast;
 import com.starrocks.authorization.ObjectType;
 import com.starrocks.authorization.PEntryObject;
 import com.starrocks.authorization.PrivilegeType;
-import com.starrocks.catalog.FunctionName;
-import com.starrocks.common.Pair;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
@@ -76,8 +74,12 @@ public class BaseGrantRevokePrivilegeStmt extends DdlStmt {
         return objectsUnResolved.getUserPrivilegeObjectList();
     }
 
-    public List<Pair<FunctionName, FunctionArgsDef>> getFunctions() {
-        return objectsUnResolved.getFunctions();
+    public List<FunctionRef> getFunctionRefs() {
+        return objectsUnResolved.getFunctionRefs();
+    }
+
+    public List<FunctionArgsDef> getFunctionArgsDefs() {
+        return objectsUnResolved.getFunctionArgsDefs();
     }
 
     public boolean isGrantOnALL() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateFunctionStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateFunctionStmt.java
@@ -17,7 +17,6 @@ package com.starrocks.sql.ast;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.starrocks.catalog.Function;
-import com.starrocks.catalog.FunctionName;
 import com.starrocks.sql.ast.expression.TypeDef;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.type.PrimitiveType;
@@ -49,7 +48,7 @@ public class CreateFunctionStmt extends DdlStmt {
     public static final String PROCESS_METHOD_NAME = "process";
     public static final String INPUT_TYPE = "input";
 
-    private final FunctionName functionName;
+    private final FunctionRef functionRef;
     private final boolean isAggregate;
     private final boolean isTable;
     private final FunctionArgsDef argsDef;
@@ -76,7 +75,7 @@ public class CreateFunctionStmt extends DdlStmt {
                     .build();
 
     public CreateFunctionStmt(String functionType,
-                              FunctionName functionName,
+                              FunctionRef functionRef,
                               FunctionArgsDef argsDef,
                               TypeDef returnType,
                               Map<String, String> properties,
@@ -84,7 +83,7 @@ public class CreateFunctionStmt extends DdlStmt {
                               boolean shouldReplaceIfExists,
                               boolean createIfNotExists) {
         this(functionType,
-                functionName,
+                functionRef,
                 argsDef,
                 returnType,
                 properties,
@@ -95,11 +94,11 @@ public class CreateFunctionStmt extends DdlStmt {
         );
     }
 
-    public CreateFunctionStmt(String functionType, FunctionName functionName, FunctionArgsDef argsDef,
+    public CreateFunctionStmt(String functionType, FunctionRef functionRef, FunctionArgsDef argsDef,
                               TypeDef returnType, Map<String, String> properties, String content,
                               boolean shouldReplaceIfExists, boolean createIfNotExists, NodePosition pos) {
         super(pos);
-        this.functionName = functionName;
+        this.functionRef = functionRef;
         this.isAggregate = functionType.equalsIgnoreCase("AGGREGATE");
         this.isTable = functionType.equalsIgnoreCase("TABLE");
         this.argsDef = argsDef;
@@ -119,8 +118,8 @@ public class CreateFunctionStmt extends DdlStmt {
         }
     }
 
-    public FunctionName getFunctionName() {
-        return functionName;
+    public FunctionRef getFunctionRef() {
+        return functionRef;
     }
 
     public Function getFunction() {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobMgrEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobMgrEditLogTest.java
@@ -16,13 +16,13 @@ package com.starrocks.alter;
 
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MockedLocalMetaStore;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.View;
 import com.starrocks.persist.AlterViewInfo;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.OperationType;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.transaction.MockedLocalMetaStore;
 import com.starrocks.transaction.MockedMetadataMgr;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.AfterEach;

--- a/fe/fe-core/src/test/java/com/starrocks/authorization/GrantRoleToGroupTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/authorization/GrantRoleToGroupTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.authorization;
 
 import com.starrocks.authentication.AuthenticationMgr;
+import com.starrocks.catalog.MockedLocalMetaStore;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.ErrorReportException;
 import com.starrocks.persist.EditLog;
@@ -39,7 +40,6 @@ import com.starrocks.sql.ast.ShowGrantsStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.sql.parser.SqlParser;
-import com.starrocks.transaction.MockedLocalMetaStore;
 import com.starrocks.transaction.MockedMetadataMgr;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;

--- a/fe/fe-core/src/test/java/com/starrocks/persist/AlterViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/AlterViewTest.java
@@ -19,6 +19,7 @@ package com.starrocks.persist;
 
 import com.starrocks.alter.AlterJobExecutor;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MockedLocalMetaStore;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.View;
 import com.starrocks.journal.JournalEntity;
@@ -30,7 +31,6 @@ import com.starrocks.sql.ast.AlterViewStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.CreateViewStmt;
 import com.starrocks.sql.parser.SqlParser;
-import com.starrocks.transaction.MockedLocalMetaStore;
 import com.starrocks.transaction.MockedMetadataMgr;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.AfterAll;

--- a/fe/fe-core/src/test/java/com/starrocks/qe/RedirectStatusTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/RedirectStatusTest.java
@@ -114,6 +114,8 @@ import com.starrocks.sql.ast.ExecuteAsStmt;
 import com.starrocks.sql.ast.ExecuteScriptStmt;
 import com.starrocks.sql.ast.ExecuteStmt;
 import com.starrocks.sql.ast.ExportStmt;
+import com.starrocks.sql.ast.FunctionArgsDef;
+import com.starrocks.sql.ast.FunctionRef;
 import com.starrocks.sql.ast.GrantPrivilegeStmt;
 import com.starrocks.sql.ast.GrantRevokeClause;
 import com.starrocks.sql.ast.GrantRoleStmt;
@@ -274,6 +276,7 @@ import com.starrocks.sql.ast.warehouse.ShowNodesStmt;
 import com.starrocks.sql.ast.warehouse.ShowWarehousesStmt;
 import com.starrocks.sql.ast.warehouse.SuspendWarehouseStmt;
 import com.starrocks.sql.parser.NodePosition;
+import com.starrocks.type.BooleanType;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.TypeFactory;
 import org.junit.jupiter.api.Assertions;
@@ -1135,8 +1138,11 @@ public class RedirectStatusTest {
 
     @Test
     public void testCreateFunctionStmt() {
-        CreateFunctionStmt stmt = new CreateFunctionStmt("", null, null, null, java.util.Collections.emptyMap(), null, false,
-                false, NodePosition.ZERO);
+        FunctionRef functionRef = new FunctionRef(QualifiedName.of(Lists.newArrayList("db", "fn")),
+                null, NodePosition.ZERO, false);
+        FunctionArgsDef argsDef = new FunctionArgsDef(java.util.Collections.emptyList(), false);
+        CreateFunctionStmt stmt = new CreateFunctionStmt("", functionRef, argsDef, new TypeDef(BooleanType.BOOLEAN),
+                java.util.Collections.emptyMap(), null, false, false, NodePosition.ZERO);
         Assertions.assertEquals(RedirectStatus.FORWARD_WITH_SYNC, RedirectStatus.getRedirectStatus(stmt));
     }
 
@@ -1217,7 +1223,9 @@ public class RedirectStatusTest {
 
     @Test
     public void testDropFunctionStmt() {
-        DropFunctionStmt stmt = new DropFunctionStmt(null, null, NodePosition.ZERO, false);
+        FunctionRef functionRef = new FunctionRef(QualifiedName.of(Lists.newArrayList("db", "fn")),
+                null, NodePosition.ZERO, false);
+        DropFunctionStmt stmt = new DropFunctionStmt(functionRef, null, NodePosition.ZERO, false);
         Assertions.assertEquals(RedirectStatus.FORWARD_WITH_SYNC, RedirectStatus.getRedirectStatus(stmt));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/server/LocalMetastoreEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/LocalMetastoreEditLogTest.java
@@ -14,10 +14,10 @@
 
 package com.starrocks.server;
 
+import com.starrocks.catalog.MockedLocalMetaStore;
 import com.starrocks.persist.AutoIncrementInfo;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.OperationType;
-import com.starrocks.transaction.MockedLocalMetaStore;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/DropStmtAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/DropStmtAnalyzerTest.java
@@ -1,0 +1,199 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.catalog.FunctionName;
+import com.starrocks.catalog.MockedLocalMetaStore;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.DropFunctionStmt;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class DropStmtAnalyzerTest {
+
+    private ConnectContext connectContext;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        MockedLocalMetaStore localMetastore = new MockedLocalMetaStore(
+                globalStateMgr,
+                globalStateMgr.getRecycleBin(),
+                null);
+        globalStateMgr.setLocalMetastore(localMetastore);
+        
+        // Create test database
+        localMetastore.createDb("test");
+        
+        connectContext = UtFrameUtils.createDefaultCtx();
+        connectContext.setDatabase("test");
+    }
+
+    @Test
+    public void testDropFunctionWithExplicitDatabase() throws Exception {
+        // Test DROP FUNCTION with explicit database name
+        // The key test is that the database name is properly parsed
+        StatementBase stmt = com.starrocks.sql.parser.SqlParser.parse(
+                "DROP FUNCTION IF EXISTS test.my_test_func(INT)", 
+                connectContext.getSessionVariable()).get(0);
+        
+        // Before analysis, verify parsing is correct
+        Assertions.assertTrue(stmt instanceof DropFunctionStmt);
+        DropFunctionStmt dropStmt = (DropFunctionStmt) stmt;
+        Assertions.assertEquals("test", dropStmt.getFunctionRef().getDbName());
+        Assertions.assertEquals("my_test_func", dropStmt.getFunctionRef().getFunctionName());
+        Assertions.assertTrue(dropStmt.dropIfExists());
+    }
+
+    @Test
+    public void testDropFunctionWithoutDatabase() throws Exception {
+        // Test DROP FUNCTION without explicit database
+        // This is the bug fix scenario - parser creates FunctionName without db
+        // Analyzer should set the database to current database
+        StatementBase stmt = com.starrocks.sql.parser.SqlParser.parse(
+                "DROP FUNCTION IF EXISTS my_test_func(INT)", 
+                connectContext.getSessionVariable()).get(0);
+        
+        Assertions.assertTrue(stmt instanceof DropFunctionStmt);
+        DropFunctionStmt dropStmt = (DropFunctionStmt) stmt;
+        // Before analysis, function should not have database set
+        Assertions.assertNull(dropStmt.getFunctionRef().getDbName());
+        Assertions.assertEquals("my_test_func", dropStmt.getFunctionRef().getFunctionName());
+    }
+
+    @Test
+    public void testDropGlobalFunction() throws Exception {
+        // Test DROP GLOBAL FUNCTION
+        StatementBase stmt = com.starrocks.sql.parser.SqlParser.parse(
+                "DROP GLOBAL FUNCTION IF EXISTS my_global_func(INT)", 
+                connectContext.getSessionVariable()).get(0);
+        
+        Assertions.assertTrue(stmt instanceof DropFunctionStmt);
+        DropFunctionStmt dropStmt = (DropFunctionStmt) stmt;
+        Assertions.assertTrue(dropStmt.getFunctionRef().isGlobalFunction());
+        Assertions.assertEquals("my_global_func", dropStmt.getFunctionRef().getFunctionName());
+    }
+
+    @Test
+    public void testDropFunctionAnalyzerSetsDatabase() throws Exception {
+        // This test verifies the bug fix: when dropping a non-global function without
+        // explicit database, the analyzer should set the database in the FunctionName
+        
+        // Test case 1: Non-global function without explicit database
+        // Parse the statement - at this point FunctionRef doesn't have database set
+        StatementBase stmt1 = com.starrocks.sql.parser.SqlParser.parse(
+                "DROP FUNCTION IF EXISTS my_func(INT)", 
+                connectContext.getSessionVariable()).get(0);
+        
+        DropFunctionStmt dropStmt1 = (DropFunctionStmt) stmt1;
+        // Before analysis, the function ref doesn't have database
+        Assertions.assertNull(dropStmt1.getFunctionRef().getDbName());
+        
+        // Now test the FunctionRefAnalyzer.resolveFunctionName logic
+        // This is what DropStmtAnalyzer calls internally
+        FunctionName resolvedName1 = FunctionRefAnalyzer.resolveFunctionName(
+                dropStmt1.getFunctionRef(), 
+                connectContext.getDatabase());
+        
+        // After resolution, the database should be set to current database
+        Assertions.assertEquals("test", resolvedName1.getDb());
+        Assertions.assertEquals("my_func", resolvedName1.getFunction());
+        Assertions.assertFalse(resolvedName1.isGlobalFunction());
+        
+        // Test case 2: Non-global function with explicit database
+        StatementBase stmt2 = com.starrocks.sql.parser.SqlParser.parse(
+                "DROP FUNCTION IF EXISTS mydb.my_func(INT)", 
+                connectContext.getSessionVariable()).get(0);
+        
+        DropFunctionStmt dropStmt2 = (DropFunctionStmt) stmt2;
+        Assertions.assertEquals("mydb", dropStmt2.getFunctionRef().getDbName());
+        
+        FunctionName resolvedName2 = FunctionRefAnalyzer.resolveFunctionName(
+                dropStmt2.getFunctionRef(), 
+                connectContext.getDatabase());
+        
+        // Database should remain as explicitly specified
+        Assertions.assertEquals("mydb", resolvedName2.getDb());
+        Assertions.assertEquals("my_func", resolvedName2.getFunction());
+        
+        // Test case 3: Global function
+        StatementBase stmt3 = com.starrocks.sql.parser.SqlParser.parse(
+                "DROP GLOBAL FUNCTION IF EXISTS my_global_func(INT)", 
+                connectContext.getSessionVariable()).get(0);
+        
+        DropFunctionStmt dropStmt3 = (DropFunctionStmt) stmt3;
+        Assertions.assertTrue(dropStmt3.getFunctionRef().isGlobalFunction());
+        
+        FunctionName resolvedName3 = FunctionRefAnalyzer.resolveFunctionName(
+                dropStmt3.getFunctionRef(), 
+                connectContext.getDatabase());
+        
+        // Global function should have special database
+        Assertions.assertEquals(FunctionRefAnalyzer.GLOBAL_UDF_DB, resolvedName3.getDb());
+        Assertions.assertTrue(resolvedName3.isGlobalFunction());
+    }
+
+    @Test
+    public void testDropFunctionIfExists() throws Exception {
+        // Test IF EXISTS clause
+        StatementBase stmt1 = com.starrocks.sql.parser.SqlParser.parse(
+                "DROP FUNCTION IF EXISTS test.my_func(INT)", 
+                connectContext.getSessionVariable()).get(0);
+        Assertions.assertTrue(((DropFunctionStmt) stmt1).dropIfExists());
+        
+        StatementBase stmt2 = com.starrocks.sql.parser.SqlParser.parse(
+                "DROP FUNCTION test.my_func(INT)", 
+                connectContext.getSessionVariable()).get(0);
+        Assertions.assertFalse(((DropFunctionStmt) stmt2).dropIfExists());
+    }
+
+    @Test
+    public void testDropFunctionCaseInsensitive() throws Exception {
+        // Test that function names are case-insensitive (normalized to lowercase)
+        StatementBase stmt = com.starrocks.sql.parser.SqlParser.parse(
+                "DROP FUNCTION IF EXISTS test.MY_TEST_FUNC(INT)", 
+                connectContext.getSessionVariable()).get(0);
+        
+        DropFunctionStmt dropStmt = (DropFunctionStmt) stmt;
+        // Function names should be normalized to lowercase
+        Assertions.assertEquals("my_test_func", dropStmt.getFunctionRef().getFunctionName());
+    }
+
+    @Test
+    public void testDropFunctionWithVariadicArgs() throws Exception {
+        // Test variadic arguments (...)
+        StatementBase stmt = com.starrocks.sql.parser.SqlParser.parse(
+                "DROP FUNCTION IF EXISTS test.my_func(INT, ...)", 
+                connectContext.getSessionVariable()).get(0);
+        
+        DropFunctionStmt dropStmt = (DropFunctionStmt) stmt;
+        Assertions.assertTrue(dropStmt.getArgsDef().isVariadic());
+    }
+
+    @Test
+    public void testDropFunctionArgumentParsing() throws Exception {
+        // Test multiple argument types
+        StatementBase stmt = com.starrocks.sql.parser.SqlParser.parse(
+                "DROP FUNCTION IF EXISTS test.my_func(INT, VARCHAR, DOUBLE)", 
+                connectContext.getSessionVariable()).get(0);
+        
+        DropFunctionStmt dropStmt = (DropFunctionStmt) stmt;
+        Assertions.assertEquals(3, dropStmt.getArgsDef().getArgTypeDefs().size());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/FunctionRefAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/FunctionRefAnalyzerTest.java
@@ -1,0 +1,162 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.catalog.FunctionName;
+import com.starrocks.sql.ast.FunctionRef;
+import com.starrocks.sql.ast.QualifiedName;
+import com.starrocks.sql.parser.NodePosition;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class FunctionRefAnalyzerTest {
+    @Test
+    public void testResolveFunctionNameForGlobalFunction() {
+        // Test resolving global function name
+        QualifiedName funcName = QualifiedName.of(ImmutableList.of("my_func"));
+        FunctionRef functionRef = new FunctionRef(funcName, null, NodePosition.ZERO, true);
+        FunctionName functionName = FunctionRefAnalyzer.resolveFunctionName(functionRef, "test_db");
+
+        Assertions.assertTrue(functionName.isGlobalFunction());
+        Assertions.assertEquals(FunctionRefAnalyzer.GLOBAL_UDF_DB, functionName.getDb());
+        Assertions.assertEquals("my_func", functionName.getFunction());
+    }
+
+    @Test
+    public void testResolveFunctionNameForNonGlobalFunctionWithExplicitDb() {
+        // Test resolving non-global function with explicit database
+        QualifiedName funcName = QualifiedName.of(ImmutableList.of("mydb", "my_func"));
+        FunctionRef functionRef = new FunctionRef(funcName, null, NodePosition.ZERO, false);
+        FunctionName functionName = FunctionRefAnalyzer.resolveFunctionName(functionRef, "default_db");
+
+        Assertions.assertFalse(functionName.isGlobalFunction());
+        Assertions.assertEquals("mydb", functionName.getDb());
+        Assertions.assertEquals("my_func", functionName.getFunction());
+    }
+
+    @Test
+    public void testResolveFunctionNameForNonGlobalFunctionWithoutDb() {
+        // Test resolving non-global function without explicit database
+        // This tests the bug fix scenario
+        QualifiedName funcName = QualifiedName.of(ImmutableList.of("my_func"));
+        FunctionRef functionRef = new FunctionRef(funcName, null, NodePosition.ZERO, false);
+        FunctionName functionName = FunctionRefAnalyzer.resolveFunctionName(functionRef, "test_db");
+
+        Assertions.assertFalse(functionName.isGlobalFunction());
+        Assertions.assertEquals("test_db", functionName.getDb());
+        Assertions.assertEquals("my_func", functionName.getFunction());
+    }
+
+    @Test
+    public void testResolveFunctionNameForGlobalFunctionWithInvalidDb() {
+        // Test that global function should not have database prefix
+        QualifiedName funcName = QualifiedName.of(ImmutableList.of("mydb", "my_func"));
+        FunctionRef functionRef = new FunctionRef(funcName, null, NodePosition.ZERO, true);
+
+        SemanticException exception = Assertions.assertThrows(SemanticException.class, () -> {
+            FunctionRefAnalyzer.resolveFunctionName(functionRef, "test_db");
+        });
+
+        Assertions.assertTrue(exception.getMessage().contains("Invalid function name"));
+    }
+
+    @Test
+    public void testAnalyzeFunctionRefWithValidName() {
+        // Test analyzing function reference with valid name
+        QualifiedName funcName = QualifiedName.of(ImmutableList.of("my_valid_func"));
+        FunctionRef functionRef = new FunctionRef(funcName, null, NodePosition.ZERO, false);
+
+        Assertions.assertDoesNotThrow(() -> {
+            FunctionRefAnalyzer.analyzeFunctionRef(functionRef, "test_db");
+        });
+    }
+
+    @Test
+    public void testAnalyzeFunctionRefWithInvalidNameStartingWithDigit() {
+        // Test analyzing function reference with name starting with digit
+        QualifiedName funcName = QualifiedName.of(ImmutableList.of("1invalid_func"));
+        FunctionRef functionRef = new FunctionRef(funcName, null, NodePosition.ZERO, false);
+
+        SemanticException exception = Assertions.assertThrows(SemanticException.class, () -> {
+            FunctionRefAnalyzer.analyzeFunctionRef(functionRef, "test_db");
+        });
+
+        Assertions.assertTrue(exception.getMessage().contains("Function cannot start with a digit"));
+    }
+
+    @Test
+    public void testAnalyzeFunctionRefWithInvalidCharacters() {
+        // Test analyzing function reference with special characters
+        QualifiedName funcName = QualifiedName.of(ImmutableList.of("my-invalid-func"));
+        FunctionRef functionRef = new FunctionRef(funcName, null, NodePosition.ZERO, false);
+
+        SemanticException exception = Assertions.assertThrows(SemanticException.class, () -> {
+            FunctionRefAnalyzer.analyzeFunctionRef(functionRef, "test_db");
+        });
+
+        Assertions.assertTrue(exception.getMessage().contains(
+                "Function names must be all alphanumeric or underscore"));
+    }
+
+    @Test
+    public void testAnalyzeFunctionRefWithoutDatabaseContext() {
+        // Test analyzing function reference without database context
+        QualifiedName funcName = QualifiedName.of(ImmutableList.of("my_func"));
+        FunctionRef functionRef = new FunctionRef(funcName, null, NodePosition.ZERO, false);
+
+        SemanticException exception = Assertions.assertThrows(SemanticException.class, () -> {
+            FunctionRefAnalyzer.analyzeFunctionRef(functionRef, null);
+        });
+
+        Assertions.assertTrue(exception.getMessage().contains("No database selected"));
+    }
+
+    @Test
+    public void testAnalyzeFunctionRefWithTooManyParts() {
+        // Test analyzing function reference with too many parts (catalog.db.func)
+        QualifiedName funcName = QualifiedName.of(ImmutableList.of("catalog", "mydb", "my_func"));
+        FunctionRef functionRef = new FunctionRef(funcName, null, NodePosition.ZERO, false);
+
+        SemanticException exception = Assertions.assertThrows(SemanticException.class, () -> {
+            FunctionRefAnalyzer.analyzeFunctionRef(functionRef, "test_db");
+        });
+
+        Assertions.assertTrue(exception.getMessage().contains(
+                "Function names must be all alphanumeric or underscore"));
+    }
+
+    @Test
+    public void testFunctionNameCaseInsensitive() {
+        // Test that function names are case-insensitive (normalized to lowercase)
+        QualifiedName funcName1 = QualifiedName.of(ImmutableList.of("MY_FUNC"));
+        QualifiedName funcName2 = QualifiedName.of(ImmutableList.of("my_func"));
+        FunctionRef functionRef1 = new FunctionRef(funcName1, null, NodePosition.ZERO, false);
+        FunctionRef functionRef2 = new FunctionRef(funcName2, null, NodePosition.ZERO, false);
+
+        FunctionName name1 = FunctionRefAnalyzer.resolveFunctionName(functionRef1, "test_db");
+        FunctionName name2 = FunctionRefAnalyzer.resolveFunctionName(functionRef2, "test_db");
+
+        Assertions.assertEquals(name1.getFunction(), name2.getFunction());
+        Assertions.assertEquals("my_func", name1.getFunction());
+    }
+
+    @Test
+    public void testGlobalUdfDbConstant() {
+        // Test that GLOBAL_UDF_DB constant is correctly set
+        Assertions.assertEquals(FunctionName.GLOBAL_UDF_DB, FunctionRefAnalyzer.GLOBAL_UDF_DB);
+        Assertions.assertEquals("__global_udf_db__", FunctionRefAnalyzer.GLOBAL_UDF_DB);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/CreateFunctionStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/CreateFunctionStmtTest.java
@@ -42,8 +42,8 @@ public class CreateFunctionStmtTest {
         CreateFunctionStmt stmt = (CreateFunctionStmt) com.starrocks.sql.parser.SqlParser.parse(
                 createFunctionSql, 32).get(0);
 
-        Assertions.assertEquals("ABC", stmt.getFunctionName().getDb());
-        Assertions.assertEquals("my_udf_json_get", stmt.getFunctionName().getFunction());
+        Assertions.assertEquals("ABC", stmt.getFunctionRef().getDbName());
+        Assertions.assertEquals("my_udf_json_get", stmt.getFunctionRef().getFunctionName());
         Assertions.assertFalse(stmt.shouldReplaceIfExists());
     }
 
@@ -145,8 +145,8 @@ public class CreateFunctionStmtTest {
         CreateFunctionStmt stmt = (CreateFunctionStmt) com.starrocks.sql.parser.SqlParser.parse(
                 createFunctionSql, 32).get(0);
 
-        Assertions.assertEquals("ABC", stmt.getFunctionName().getDb());
-        Assertions.assertEquals("my_udf_json_get", stmt.getFunctionName().getFunction());
+        Assertions.assertEquals("ABC", stmt.getFunctionRef().getDbName());
+        Assertions.assertEquals("my_udf_json_get", stmt.getFunctionRef().getFunctionName());
         Assertions.assertTrue(stmt.shouldReplaceIfExists());
     }
 
@@ -162,8 +162,8 @@ public class CreateFunctionStmtTest {
         CreateFunctionStmt stmt = (CreateFunctionStmt) com.starrocks.sql.parser.SqlParser.parse(
                 createFunctionSql, 32).get(0);
 
-        Assertions.assertEquals("ABC", stmt.getFunctionName().getDb());
-        Assertions.assertEquals("my_udf_json_get", stmt.getFunctionName().getFunction());
+        Assertions.assertEquals("ABC", stmt.getFunctionRef().getDbName());
+        Assertions.assertEquals("my_udf_json_get", stmt.getFunctionRef().getFunctionName());
         Assertions.assertFalse(stmt.shouldReplaceIfExists());
         Assertions.assertTrue(stmt.createIfNotExists());
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/DropFunctionStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/DropFunctionStmtTest.java
@@ -29,8 +29,8 @@ public class DropFunctionStmtTest {
                 dropFunctionSql, 32).get(0);
         // com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
 
-        Assertions.assertEquals("ABC", stmt.getFunctionName().getDb());
-        Assertions.assertEquals("my_udf_json_get", stmt.getFunctionName().getFunction());
+        Assertions.assertEquals("ABC", stmt.getFunctionRef().getDbName());
+        Assertions.assertEquals("my_udf_json_get", stmt.getFunctionRef().getFunctionName());
     }
 
     @Test
@@ -39,8 +39,8 @@ public class DropFunctionStmtTest {
         DropFunctionStmt stmt = (DropFunctionStmt) com.starrocks.sql.parser.SqlParser.parse(
                 dropFunctionSql, 32).get(0);
 
-        Assertions.assertEquals("ABC", stmt.getFunctionName().getDb());
-        Assertions.assertEquals("my_udf_json_get", stmt.getFunctionName().getFunction());
+        Assertions.assertEquals("ABC", stmt.getFunctionRef().getDbName());
+        Assertions.assertEquals("my_udf_json_get", stmt.getFunctionRef().getFunctionName());
         Assertions.assertTrue(stmt.dropIfExists());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/ExplicitTxnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/ExplicitTxnTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.transaction;
 
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MockedLocalMetaStore;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.DdlException;

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -266,6 +266,10 @@ public interface AstVisitor<R, C> {
         return visitShowStatement(statement, context);
     }
 
+    default R visitShowFunctionsStatement(ShowFunctionsStmt statement, C context) {
+        return visitShowStatement(statement, context);
+    }
+
     default R visitShowTriggersStatement(ShowTriggersStmt statement, C context) {
         return visitShowStatement(statement, context);
     }
@@ -527,6 +531,10 @@ public interface AstVisitor<R, C> {
     }
 
     default R visitCreateRepositoryStatement(CreateRepositoryStmt statement, C context) {
+        return visitDDLStatement(statement, context);
+    }
+
+    default R visitDropFunctionStatement(DropFunctionStmt statement, C context) {
         return visitDDLStatement(statement, context);
     }
 

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/DropFunctionStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/DropFunctionStmt.java
@@ -12,48 +12,33 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.ast;
 
-import com.starrocks.catalog.FunctionName;
-import com.starrocks.catalog.FunctionSearchDesc;
 import com.starrocks.sql.parser.NodePosition;
 
 public class DropFunctionStmt extends DdlStmt {
-    private final FunctionName functionName;
-
-    public FunctionArgsDef getArgsDef() {
-        return argsDef;
-    }
-
+    private final FunctionRef functionRef;
     private final FunctionArgsDef argsDef;
-
-    // set after analyzed
-    private FunctionSearchDesc functionSearchDesc;
 
     private final boolean dropIfExists;
 
-    public DropFunctionStmt(FunctionName functionName, FunctionArgsDef argsDef, boolean dropIfExists) {
-        this(functionName, argsDef, NodePosition.ZERO, dropIfExists);
+    public DropFunctionStmt(FunctionRef functionRef, FunctionArgsDef argsDef, boolean dropIfExists) {
+        this(functionRef, argsDef, NodePosition.ZERO, dropIfExists);
     }
 
-    public DropFunctionStmt(FunctionName functionName, FunctionArgsDef argsDef, NodePosition pos, boolean dropIfExists) {
+    public DropFunctionStmt(FunctionRef functionRef, FunctionArgsDef argsDef, NodePosition pos, boolean dropIfExists) {
         super(pos);
-        this.functionName = functionName;
+        this.functionRef = functionRef;
         this.argsDef = argsDef;
         this.dropIfExists = dropIfExists;
     }
 
-    public FunctionName getFunctionName() {
-        return functionName;
+    public FunctionRef getFunctionRef() {
+        return functionRef;
     }
 
-    public FunctionSearchDesc getFunctionSearchDesc() {
-        return functionSearchDesc;
-    }
-
-    public void setFunctionSearchDesc(FunctionSearchDesc functionSearchDesc) {
-        this.functionSearchDesc = functionSearchDesc;
+    public FunctionArgsDef getArgsDef() {
+        return argsDef;
     }
 
     public boolean dropIfExists() {
@@ -62,6 +47,7 @@ public class DropFunctionStmt extends DdlStmt {
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return ((AstVisitorExtendInterface<R, C>) visitor).visitDropFunctionStatement(this, context);
+        return visitor.visitDropFunctionStatement(this, context);
     }
 }
+

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/FunctionArgsDef.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/FunctionArgsDef.java
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.ast;
 
-import com.starrocks.sql.analyzer.TypeDefAnalyzer;
 import com.starrocks.sql.ast.expression.TypeDef;
 import com.starrocks.type.Type;
 
@@ -41,16 +39,11 @@ public class FunctionArgsDef {
         return isVariadic;
     }
 
-    public void analyze() {
-        argTypes = new Type[argTypeDefs.size()];
-        int i = 0;
-        for (TypeDef typeDef : argTypeDefs) {
-            TypeDefAnalyzer.analyze(typeDef);
-            argTypes[i++] = typeDef.getType();
-        }
-    }
-
     public void setArgTypes(Type[] argTypes) {
         this.argTypes = argTypes;
+    }
+
+    public List<TypeDef> getArgTypeDefs() {
+        return argTypeDefs;
     }
 }

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/FunctionRef.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/FunctionRef.java
@@ -28,12 +28,18 @@ public class FunctionRef implements ParseNode {
     private final NodePosition pos;
     private final QualifiedName fnName;
     private final String alias;
+    private final boolean isGlobalFunction;
 
     public FunctionRef(QualifiedName fnName, String alias, NodePosition pos) {
+        this(fnName, alias, pos, false);
+    }
+
+    public FunctionRef(QualifiedName fnName, String alias, NodePosition pos, boolean isGlobalFunction) {
         Preconditions.checkArgument(fnName != null && !fnName.getParts().isEmpty(), "Function name is not valid");
         this.fnName = fnName;
         this.pos = pos;
         this.alias = alias;
+        this.isGlobalFunction = isGlobalFunction;
     }
 
     public QualifiedName getFnName() {
@@ -57,6 +63,10 @@ public class FunctionRef implements ParseNode {
 
     public String getAlias() {
         return this.alias;
+    }
+
+    public boolean isGlobalFunction() {
+        return isGlobalFunction;
     }
 
     @Override

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/GrantRevokePrivilegeObjects.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/GrantRevokePrivilegeObjects.java
@@ -12,11 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.ast;
 
-import com.starrocks.catalog.FunctionName;
-import com.starrocks.common.Pair;
 import com.starrocks.sql.parser.NodePosition;
 
 import java.util.List;
@@ -29,7 +26,8 @@ public class GrantRevokePrivilegeObjects implements ParseNode {
     private List<UserRef> userPrivilegeObjectList;
 
     //UnResolved AST used in syntax grantPrivWithFunc
-    private List<Pair<FunctionName, FunctionArgsDef>> functions;
+    private List<FunctionRef> functionRefs;
+    private List<FunctionArgsDef> functionArgsDefs;
 
     private final NodePosition pos;
 
@@ -40,7 +38,6 @@ public class GrantRevokePrivilegeObjects implements ParseNode {
     public GrantRevokePrivilegeObjects(NodePosition pos) {
         this.pos = pos;
     }
-
 
     public List<List<String>> getPrivilegeObjectNameTokensList() {
         return privilegeObjectNameTokensList;
@@ -58,12 +55,20 @@ public class GrantRevokePrivilegeObjects implements ParseNode {
         this.userPrivilegeObjectList = userPrivilegeObjectList;
     }
 
-    public List<Pair<FunctionName, FunctionArgsDef>> getFunctions() {
-        return functions;
+    public List<FunctionRef> getFunctionRefs() {
+        return functionRefs;
     }
 
-    public void setFunctions(List<Pair<FunctionName, FunctionArgsDef>> functions) {
-        this.functions = functions;
+    public void setFunctionRefs(List<FunctionRef> functionRefs) {
+        this.functionRefs = functionRefs;
+    }
+
+    public List<FunctionArgsDef> getFunctionArgsDefs() {
+        return functionArgsDefs;
+    }
+
+    public void setFunctionArgsDefs(List<FunctionArgsDef> functionArgsDefs) {
+        this.functionArgsDefs = functionArgsDefs;
     }
 
     @Override

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/ShowFunctionsStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/ShowFunctionsStmt.java
@@ -17,8 +17,6 @@ package com.starrocks.sql.ast;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.parser.NodePosition;
 
-import static com.starrocks.common.util.Util.normalizeName;
-
 public class ShowFunctionsStmt extends ShowStmt {
 
     private String dbName;
@@ -74,11 +72,12 @@ public class ShowFunctionsStmt extends ShowStmt {
     }
 
     public void setDbName(String db) {
-        this.dbName = normalizeName(db);
+        this.dbName = db;
     }
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return ((AstVisitorExtendInterface<R, C>) visitor).visitShowFunctionsStatement(this, context);
+        return visitor.visitShowFunctionsStatement(this, context);
     }
 }
+


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces FunctionRefAnalyzer and refactors CREATE/DROP/GRANT UDF flows to use FunctionRef/FunctionArgsDef consistently from parser to analyzers/execution, with comprehensive tests.
> 
> - **Core**:
>   - Add `FunctionRefAnalyzer` to validate, resolve, and build `FunctionSearchDesc` from `FunctionRef`/`FunctionArgsDef`.
>   - Remove validation logic from `FunctionName` (no `analyze()`), centralizing it in the analyzer.
> - **Parser/AST**:
>   - `AstBuilder`: construct `FunctionRef` (incl. global flag) for `CREATE/DROP FUNCTION`; forbid db prefix for global UDFs.
>   - Update AST: `CreateFunctionStmt`, `DropFunctionStmt`, `GrantRevokePrivilegeObjects`, `FunctionArgsDef`, `FunctionRef`; visitor hooks for `ShowFunctionsStmt`/`DropFunctionStmt` moved to base `AstVisitor`.
> - **Analyzers/Execution**:
>   - `CreateFunctionAnalyzer`, `DropStmtAnalyzer`, `AuthorizationAnalyzer`, `AuthorizerStmtVisitor`, `DDLStmtExecutor` now use `FunctionRefAnalyzer` to analyze args, resolve names, and build `FunctionSearchDesc`.
> - **Tests**:
>   - Add `FunctionRefAnalyzerTest`, `DropStmtAnalyzerTest`; update existing UDF/redirect tests to new API.
> - **Misc**:
>   - Move `MockedLocalMetaStore` to `com.starrocks.catalog`; small cleanups and method removals aligning with the refactor.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf5cbeb36d89da70bdc5826ab132de442b00c798. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->