### PR TITLE
[Feature] Add JSON_SET function

### DIFF
--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -1742,11 +1742,6 @@ StatusOr<ColumnPtr> JsonFunctions::json_set(FunctionContext* context, const Colu
             continue;
         }
 
-        if (json_viewer.value(row)->to_vslice().isNull()) {
-            result.append_null();
-            continue;
-        }
-
         JsonValue current_doc = *json_viewer.value(row);
         bool null_arg = false;
 

--- a/be/src/exprs/json_functions.h
+++ b/be/src/exprs/json_functions.h
@@ -170,6 +170,13 @@ public:
     DEFINE_VECTORIZED_FN(json_remove);
 
     /**
+     * Inserts or updates data in a JSON document at one or more specified JSON paths
+     * @param JSON, JSONPath, Value, [JSONPath, Value, ...]
+     * @return Modified JSON
+     */
+    DEFINE_VECTORIZED_FN(json_set);
+
+    /**
      * Return json built from struct/map
      */
     DEFINE_VECTORIZED_FN(to_json);

--- a/docs/en/sql-reference/sql-functions/json-functions/json-query-and-processing-functions/json_set.md
+++ b/docs/en/sql-reference/sql-functions/json-functions/json-query-and-processing-functions/json_set.md
@@ -1,0 +1,95 @@
+---
+displayed_sidebar: docs
+---
+
+# json_set
+
+Inserts or updates data in a JSON document at one or more specified JSON paths and returns the modified JSON document.
+
+:::tip
+All of the JSON functions and operators are listed in the navigation and on the overview page.
+:::
+
+## Syntax
+
+```SQL
+json_set(json_object_expr, json_path, value[, json_path, value] ...)
+```
+
+## Parameters
+- `json_object_expr`: the expression that represents the JSON object. The object can be a JSON column, or a JSON object that is produced by a JSON constructor function such as **PARSE_JSON**.
+
+- `json_path`: the path to the element in the JSON object that you want to insert or update. The value must be a string. For information about the JSON path syntax that is supported by StarRocks, see Overview of JSON functions and operators.
+
+- `value`: the value to be inserted or updated at the specified path. It can be a string, number, boolean, null, or a JSON object.
+
+## Return value
+Returns the modified JSON document.
+
+> - Returns *NULL* if any argument is *NULL*.
+> - If the path exists in the JSON document, the existing value is updated (replaced).
+> - If the path does not exist, the new value is inserted (Upsert behavior).
+> - Arguments are evaluated from left to right. The result of the first path-value pair becomes the input for the second pair.
+
+## Examples
+
+Example 1: Insert a new key into a JSON object.
+
+```Plaintext
+mysql> SELECT json_set('{"a": 1}', '$.b', 2);
+       -> {"a": 1, "b": 2}
+```
+
+Example 2: Update an existing key in a JSON object.
+
+```Plaintext
+mysql> SELECT json_set('{"a": 1}', '$.a', 10);
+       -> {"a": 10}
+```
+
+Example 3: Perform multiple operations (Update one existing key, Insert one new key).
+
+```Plaintext
+mysql> SELECT json_set('{"a": 1, "b": 2}', '$.a', 10, '$.c', 3);
+       -> {"a": 10, "b": 2, "c": 3}
+```
+
+Example 4: Update a value inside a nested JSON object.
+```Plaintext
+
+mysql> SELECT json_set('{"a": {"x": 1, "y": 2}}', '$.a.x', 100);
+       -> {"a": {"x": 100, "y": 2}}
+```
+
+Example 5: Update an element in an array by index.
+
+```Plaintext
+mysql> SELECT json_set('{"arr": [10, 20, 30]}', '$.arr[1]', 99);
+       -> {"arr": [10, 99, 30]}
+```
+
+Example 6: Append to an array (using an index larger than the array length).
+
+```Plaintext
+mysql> SELECT json_set('{"arr": [10, 20]}', '$.arr[5]', 30);
+       -> {"arr": [10, 20, 30]}
+```
+
+Example 7: Insert different data types (Boolean and JSON Null).
+To insert a JSON `null` value, use `parse_json('null')`. Passing a raw SQL `NULL` will return `NULL` for the entire result.
+
+```plaintext
+mysql> SELECT json_set('{"a": 1}', '$.b', true, '$.c', parse_json('null'));
+       -> {"a": 1, "b": true, "c": null}
+```
+
+## Usage notes
+
+- The `json_set` function follows MySQL-compatible behavior.
+- It operates as an **Upsert** (Update or Insert):
+    - **INSERT:** If the path does not exist, the value is added to the document.
+    - **UPDATE:** If the path already exists, the old value is replaced with the new value.
+- If you specifically want to insert *only* (without updating existing values), use `json_insert`.
+- If you specifically want to update *only* (without inserting new values), use `json_replace`.
+- **Null Handling:** To insert a JSON null value, use parse_json('null'). Passing a raw SQL NULL as an argument will cause the function to return NULL.
+- **Note:** Wildcard characters (e.g., `*` or `**`) and array slices (e.g., `[1:3]`) are not currently supported in `json_path` for modification. If a path contains these, the update for that path will be ignored to ensure safety.

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -272,6 +272,7 @@ public class FunctionSet {
     public static final String GET_JSON_OBJECT = "get_json_object";
     public static final String JSON_LENGTH = "json_length";
     public static final String JSON_REMOVE = "json_remove";
+    public static final String JSON_SET = "json_set";
 
     // Matching functions:
     public static final String ILIKE = "ilike";

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PruneSubfieldRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PruneSubfieldRule.java
@@ -56,7 +56,6 @@ public class PruneSubfieldRule extends TransformationRule {
             .add(FunctionSet.JSON_QUERY)
             .add(FunctionSet.JSON_EXISTS)
             .add(FunctionSet.JSON_LENGTH)
-            .add(FunctionSet.JSON_SET)
             .build();
 
     public static final List<String> PRUNE_FUNCTIONS = ImmutableList.<String>builder()

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PruneSubfieldRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PruneSubfieldRule.java
@@ -56,6 +56,7 @@ public class PruneSubfieldRule extends TransformationRule {
             .add(FunctionSet.JSON_QUERY)
             .add(FunctionSet.JSON_EXISTS)
             .add(FunctionSet.JSON_LENGTH)
+            .add(FunctionSet.JSON_SET)
             .build();
 
     public static final List<String> PRUNE_FUNCTIONS = ImmutableList.<String>builder()

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -881,6 +881,7 @@ vectorized_functions = [
      "JsonFunctions::native_json_path_prepare", "JsonFunctions::native_json_path_close"],
     [110024, "json_remove", False, False, "JSON", ["JSON", "VARCHAR", "..."], "JsonFunctions::json_remove",
      "JsonFunctions::native_json_path_prepare", "JsonFunctions::native_json_path_close"],
+    [110025, "json_set", False, False, "JSON", ["JSON", "JSON", "..."], "JsonFunctions::json_set"],
     [110100, "to_json", False, False, "JSON", ["ANY_MAP"], "JsonFunctions::to_json"],
     [110101, "to_json", False, False, "JSON", ["ANY_STRUCT"], "JsonFunctions::to_json"],
     [110112, "json_contains", False, False, "BOOLEAN", ["JSON", "JSON"], "JsonFunctions::json_contains"],

--- a/test/sql/test_json/R/test_json_set
+++ b/test/sql/test_json/R/test_json_set
@@ -1,0 +1,167 @@
+-- name: test_json_set
+CREATE DATABASE IF NOT EXISTS test_json_set_db;
+-- result:
+-- !result
+
+USE test_json_set_db;
+-- result:
+-- !result
+
+SELECT json_set('{"a": 1, "b": 2}', '$.a', 10) as update_existing;
+-- result:
+{"a": 10, "b": 2}
+-- !result
+
+SELECT json_set('{"a": 1}', '$.b', 2) as insert_new;
+-- result:
+{"a": 1, "b": 2}
+-- !result
+
+SELECT json_set('{"a": 1, "b": 2}', '$.a', 10, '$.c', 3) as mixed_ops;
+-- result:
+{"a": 10, "b": 2, "c": 3}
+-- !result
+
+SELECT json_set('{"a": {"x": 1, "y": 2}}', '$.a.x', 100) as update_nested;
+-- result:
+{"a": {"x": 100, "y": 2}}
+-- !result
+
+SELECT json_set('{"a": {"x": 1}}', '$.a.y', 200) as insert_nested;
+-- result:
+{"a": {"x": 1, "y": 200}}
+-- !result
+
+SELECT json_set('{"level1": {"level2": {"target": "old"}}}', '$.level1.level2.target', "new") as deep_update;
+-- result:
+{"level1": {"level2": {"target": "new"}}}
+-- !result
+
+SELECT json_set('{"arr": [10, 20, 30]}', '$.arr[1]', 99) as update_array_index;
+-- result:
+{"arr": [10, 99, 30]}
+-- !result
+
+SELECT json_set('{"arr": [10, 20]}', '$.arr[100]', 30) as append_array;
+-- result:
+{"arr": [10, 20, 30]}
+-- !result
+
+SELECT json_set('[1, 2, 3]', '$[0]', 9) as root_array_update;
+-- result:
+[9, 2, 3]
+-- !result
+
+SELECT json_set('{"a": 1}', '$.a.b', 2) as set_on_scalar;
+-- result:
+{"a": 1}
+-- !result
+
+SELECT json_set('{"a": 1}', '$.missing_parent.child', 2) as missing_parent;
+-- result:
+{"a": 1}
+-- !result
+
+SELECT json_set('{"a": 1}', '$', '{"new": "doc"}') as replace_root;
+-- result:
+{"new": "doc"}
+-- !result
+
+SELECT if(json_set('{"k": "old"}', '$.k', null) IS NULL, 'NULL_OK', 'FAIL') as set_sql_null;
+-- result:
+NULL_OK
+-- !result
+
+SELECT json_set('{"k": "old"}', '$.k', parse_json('null')) as set_json_null;
+-- result:
+{"k": "null"}
+-- !result
+
+SELECT json_set('{"k": "old"}', '$.k', true) as set_bool;
+-- result:
+{"k": true}
+-- !result
+
+SELECT json_set('{"k": "old"}', '$.k', parse_json('{"sub": "json"}')) as set_json_object;
+-- result:
+{"k": {"sub": "json"}}
+-- !result
+
+SELECT json_set('{"k": "old"}', '$.k', 123.456) as set_double;
+-- result:
+{"k": 123.456}
+-- !result
+
+SELECT json_set('{"a": 1}', '$.a', 10, '$.b', 20, '$.a', 30) as chain_override;
+-- result:
+{"a": 30, "b": 20}
+-- !result
+
+CREATE TABLE json_set_test_table (
+    id INT, 
+    data JSON
+) DUPLICATE KEY(id)
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+
+INSERT INTO json_set_test_table VALUES 
+(1, parse_json('{"name": "Alice", "tags": ["A"]}')),
+(2, parse_json('{"name": "Bob", "score": 10}')),
+(3, NULL),
+(4, parse_json('{}'));
+-- result:
+-- !result
+
+SELECT id, json_set(data, '$.score', 100) FROM json_set_test_table WHERE id = 2;
+-- result:
+2	{"name": "Bob", "score": 100}
+-- !result
+
+SELECT id, json_set(data, '$.city', 'Wonderland') FROM json_set_test_table WHERE id = 1;
+-- result:
+1	{"city": "Wonderland", "name": "Alice", "tags": ["A"]}
+-- !result
+
+SELECT id, json_set(data, '$.tags[1]', 'B') FROM json_set_test_table WHERE id = 1;
+-- result:
+1	{"name": "Alice", "tags": ["A", "B"]}
+-- !result
+
+SELECT id, if(json_set(data, '$.a', 1) IS NULL, 'NULL_OK', 'FAIL') FROM json_set_test_table WHERE id = 3;
+-- result:
+3	NULL_OK
+-- !result
+
+SELECT if(json_set(null, '$.a', 1) IS NULL, 'NULL_OK', 'FAIL') as null_doc;
+-- result:
+NULL_OK
+-- !result
+
+SELECT if(json_set('{"a": 1}', null, 1) IS NULL, 'NULL_OK', 'FAIL') as null_path;
+-- result:
+NULL_OK
+-- !result
+
+SELECT if(json_set('{"a": 1}', '$.a', 1, null, 2) IS NULL, 'NULL_OK', 'FAIL') as null_path_arg2;
+-- result:
+NULL_OK
+-- !result
+
+SELECT json_set('{"a": 1}', '$."key.with.dot"', 2) as escaped_key;
+-- result:
+{"a": 1, "key.with.dot": 2}
+-- !result
+
+SELECT json_set('{"a": [1, 2]}', '$.a[*]', 10);
+-- result:
+{"a": [1, 2]}
+-- !result
+
+DROP TABLE json_set_test_table;
+-- result:
+-- !result
+
+DROP DATABASE test_json_set_db;
+-- result:
+-- !result

--- a/test/sql/test_json/T/test_json_set
+++ b/test/sql/test_json/T/test_json_set
@@ -1,0 +1,68 @@
+-- name: test_json_set
+-- description: Comprehensive test cases for JSON_SET function including edge cases
+
+CREATE DATABASE IF NOT EXISTS test_json_set_db;
+USE test_json_set_db;
+
+-- 1. Basic Functionality
+SELECT json_set('{"a": 1, "b": 2}', '$.a', 10) as update_existing;
+SELECT json_set('{"a": 1}', '$.b', 2) as insert_new;
+SELECT json_set('{"a": 1, "b": 2}', '$.a', 10, '$.c', 3) as mixed_ops;
+
+-- 2. Nested Objects
+SELECT json_set('{"a": {"x": 1, "y": 2}}', '$.a.x', 100) as update_nested;
+SELECT json_set('{"a": {"x": 1}}', '$.a.y', 200) as insert_nested;
+SELECT json_set('{"level1": {"level2": {"target": "old"}}}', '$.level1.level2.target', "new") as deep_update;
+
+-- 3. Array Operations
+SELECT json_set('{"arr": [10, 20, 30]}', '$.arr[1]', 99) as update_array_index;
+SELECT json_set('{"arr": [10, 20]}', '$.arr[100]', 30) as append_array;
+SELECT json_set('[1, 2, 3]', '$[0]', 9) as root_array_update;
+
+-- 4. Edge Cases: Structural Constraints
+SELECT json_set('{"a": 1}', '$.a.b', 2) as set_on_scalar;
+SELECT json_set('{"a": 1}', '$.missing_parent.child', 2) as missing_parent;
+SELECT json_set('{"a": 1}', '$', '{"new": "doc"}') as replace_root;
+
+-- 5. Data Types
+SELECT if(json_set('{"k": "old"}', '$.k', null) IS NULL, 'NULL_OK', 'FAIL') as set_sql_null;
+SELECT json_set('{"k": "old"}', '$.k', parse_json('null')) as set_json_null;
+SELECT json_set('{"k": "old"}', '$.k', true) as set_bool;
+SELECT json_set('{"k": "old"}', '$.k', parse_json('{"sub": "json"}')) as set_json_object;
+SELECT json_set('{"k": "old"}', '$.k', 123.456) as set_double;
+
+-- 6. Multiple/Chained Operations
+SELECT json_set('{"a": 1}', '$.a', 10, '$.b', 20, '$.a', 30) as chain_override;
+
+-- 7. Table Operations
+CREATE TABLE json_set_test_table (
+    id INT, 
+    data JSON
+) DUPLICATE KEY(id)
+PROPERTIES("replication_num" = "1");
+
+-- FIX: Insert SQL NULL for id=3 to test null column handling correctly
+INSERT INTO json_set_test_table VALUES 
+(1, parse_json('{"name": "Alice", "tags": ["A"]}')),
+(2, parse_json('{"name": "Bob", "score": 10}')),
+(3, NULL),
+(4, parse_json('{}'));
+
+SELECT id, json_set(data, '$.score', 100) FROM json_set_test_table WHERE id = 2;
+SELECT id, json_set(data, '$.city', 'Wonderland') FROM json_set_test_table WHERE id = 1;
+SELECT id, json_set(data, '$.tags[1]', 'B') FROM json_set_test_table WHERE id = 1;
+SELECT id, if(json_set(data, '$.a', 1) IS NULL, 'NULL_OK', 'FAIL') FROM json_set_test_table WHERE id = 3;
+
+-- 8. Error/Null Arguments
+SELECT if(json_set(null, '$.a', 1) IS NULL, 'NULL_OK', 'FAIL') as null_doc;
+SELECT if(json_set('{"a": 1}', null, 1) IS NULL, 'NULL_OK', 'FAIL') as null_path;
+SELECT if(json_set('{"a": 1}', '$.a', 1, null, 2) IS NULL, 'NULL_OK', 'FAIL') as null_path_arg2;
+
+-- 9. String escaping
+SELECT json_set('{"a": 1}', '$."key.with.dot"', 2) as escaped_key;
+
+-- 10. Wildcard/Slice
+SELECT json_set('{"a": [1, 2]}', '$.a[*]', 10);
+
+DROP TABLE json_set_test_table;
+DROP DATABASE test_json_set_db;


### PR DESCRIPTION
## Why I'm doing:

StarRocks currently lacks the `JSON_SET()` function, which exists in MySQL and is widely used for manipulating JSON data. This function is essential for "Upsert" operations (Update if exists, Insert if not) on JSON documents.

## What I'm doing:

This PR implements the `JSON_SET` function following MySQL compatibility.

### Function Signature
`JSON_SET(json_doc, path, val[, path, val] ...)`

### Implementation Details
1.  **Frontend:** Registered the function in `FunctionSet.java` and `functions.py`. Added support in `PruneSubfieldRule.java`.
2.  **Backend (C++):** Implemented recursive logic using `arangodb::velocypack::Builder` to traverse and rebuild the JSON document.
    - Handles **Object keys**: Inserts new keys or updates existing ones.
    - Handles **Array indices**: Updates specific indices (e.g., `$.arr[1]`) or appends if the index is out of bounds.
3.  **Documentation:** Added user documentation in `json_set.md`.
4.  **Testing:** Added SQL regression tests covering edge cases (nested paths, type handling, array modification).

### Verification
Verified locally with manual queries.
**Example: Array Index Update**
Query: `SELECT json_set(data, '$.arr[1]', 99) FROM json_set_test_table;`
Result: `{"arr": [10, 99, 30]}` (Correctly updates index 1 instead of replacing the array)

<img width="908" height="410" alt="Screenshot from 2025-12-02 09-59-05" src="https://github.com/user-attachments/assets/c4eea71a-2c91-48eb-867a-5e1b640210be" />


Fixes #66120

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
- [x] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `json_set` to insert/update JSON values by path, with BE implementation, FE registration, documentation, and comprehensive tests.
> 
> - **Backend (C++)**:
>   - Implement `JsonFunctions::json_set` with recursive writers (`_json_set_recursive`, `_json_set_one_path`) to upsert values by `JSONPath`, including array index updates/appends and root replacement.
>   - Integrate into `json_functions.cpp/h` and handle null/argument validation.
> - **Frontend/Registration**:
>   - Register `JSON_SET` in `fe/src/.../FunctionSet.java`.
>   - Map function in `gensrc/script/functions.py` (`id 110025`, signature `JSON, JSON, ...` -> `JsonFunctions::json_set`).
> - **Docs**:
>   - Add `docs/.../json_set.md` covering syntax, parameters, return, examples, and notes.
> - **Tests**:
>   - Add C++ unit tests (`JsonSetTestFixture`) with extensive cases.
>   - Add SQL regression tests `test/sql/test_json/{T,R}/test_json_set`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11a99facb8fc894d5acb2e1c52e408fc15034bfe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->