### PR TITLE
[BugFix] Fix global dictionary is not updated under some cases

### DIFF
--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -175,18 +175,7 @@ Status HorizontalGeneralTabletWriter::flush_segment_writer(SegmentPB* segment) {
             segment->set_path(segment_path);
             segment->set_encryption_meta(_seg_writer->encryption_meta());
         }
-        const auto& seg_global_dict_columns_valid_info = _seg_writer->global_dict_columns_valid_info();
-        for (const auto& it : seg_global_dict_columns_valid_info) {
-            if (!it.second) {
-                _global_dict_columns_valid_info[it.first] = false;
-            } else {
-                if (const auto& iter = _global_dict_columns_valid_info.find(it.first);
-                    iter == _global_dict_columns_valid_info.end()) {
-                    _global_dict_columns_valid_info[it.first] = true;
-                }
-            }
-        }
-
+        check_global_dict(_seg_writer.get());
         _seg_writer.reset();
     }
     return Status::OK();

--- a/be/src/storage/lake/pk_tablet_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_writer.cpp
@@ -129,6 +129,7 @@ Status HorizontalPkTabletWriter::flush_segment_writer(SegmentPB* segment) {
             segment->set_path(segment_path);
             segment->set_encryption_meta(_seg_writer->encryption_meta());
         }
+        check_global_dict(_seg_writer.get());
         _seg_writer.reset();
     }
     if (_pk_sst_writer && _pk_sst_writer->has_file_info()) {

--- a/be/src/storage/lake/tablet_writer.cpp
+++ b/be/src/storage/lake/tablet_writer.cpp
@@ -43,4 +43,18 @@ void TabletWriter::try_enable_pk_parallel_execution() {
     }
 }
 
+void TabletWriter::check_global_dict(SegmentWriter* segment_writer) {
+    const auto& seg_global_dict_columns_valid_info = segment_writer->global_dict_columns_valid_info();
+    for (const auto& it : seg_global_dict_columns_valid_info) {
+        if (!it.second) {
+            _global_dict_columns_valid_info[it.first] = false;
+        } else {
+            if (const auto& iter = _global_dict_columns_valid_info.find(it.first);
+                iter == _global_dict_columns_valid_info.end()) {
+                _global_dict_columns_valid_info[it.first] = true;
+            }
+        }
+    }
+}
+
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_writer.cpp
+++ b/be/src/storage/lake/tablet_writer.cpp
@@ -15,6 +15,7 @@
 #include "storage/lake/tablet_writer.h"
 
 #include "storage/lake/tablet_manager.h"
+#include "storage/segment_writer.h"
 
 namespace starrocks::lake {
 

--- a/be/src/storage/lake/tablet_writer.cpp
+++ b/be/src/storage/lake/tablet_writer.cpp
@@ -15,7 +15,7 @@
 #include "storage/lake/tablet_writer.h"
 
 #include "storage/lake/tablet_manager.h"
-#include "storage/segment_writer.h"
+#include "storage/rowset/segment_writer.h"
 
 namespace starrocks::lake {
 

--- a/be/src/storage/lake/tablet_writer.h
+++ b/be/src/storage/lake/tablet_writer.h
@@ -30,6 +30,7 @@ class Chunk;
 class Column;
 class TabletSchema;
 class ThreadPool;
+class SegmentWriter;
 
 struct OlapWriterStatistics;
 

--- a/be/src/storage/lake/tablet_writer.h
+++ b/be/src/storage/lake/tablet_writer.h
@@ -152,6 +152,8 @@ public:
 
     bool enable_pk_parallel_execution() const { return _enable_pk_parallel_execution; }
 
+    void check_global_dict(SegmentWriter* segment_writer);
+
 protected:
     TabletManager* _tablet_mgr;
     int64_t _tablet_id;

--- a/be/src/storage/rowset/horizontal_update_rowset_writer.cpp
+++ b/be/src/storage/rowset/horizontal_update_rowset_writer.cpp
@@ -107,6 +107,8 @@ Status HorizontalUpdateRowsetWriter::flush_chunk(const Chunk& chunk, SegmentPB* 
         _num_uptfile++;
         _total_update_row_size += static_cast<int64_t>(chunk.bytes_usage());
     }
+    // check global_dict
+    _check_global_dict((*segment_writer).get());
     (*segment_writer).reset();
     return Status::OK();
 }
@@ -122,6 +124,8 @@ Status HorizontalUpdateRowsetWriter::flush() {
             std::lock_guard<std::mutex> l(_lock);
             _num_uptfile++;
         }
+        // check global_dict
+        _check_global_dict(_update_file_writer.get());
         _update_file_writer.reset();
     }
     return Status::OK();

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -1176,17 +1176,7 @@ Status HorizontalRowsetWriter::_flush_segment_writer(std::unique_ptr<SegmentWrit
     }
 
     // check global_dict efficacy
-    const auto& seg_global_dict_columns_valid_info = (*segment_writer)->global_dict_columns_valid_info();
-    for (const auto& it : seg_global_dict_columns_valid_info) {
-        if (!it.second) {
-            _global_dict_columns_valid_info[it.first] = false;
-        } else {
-            if (const auto& iter = _global_dict_columns_valid_info.find(it.first);
-                iter == _global_dict_columns_valid_info.end()) {
-                _global_dict_columns_valid_info[it.first] = true;
-            }
-        }
-    }
+    _check_global_dict((*segment_writer).get());
 
     if (seg_info) {
         seg_info->set_data_size(segment_size);
@@ -1214,6 +1204,20 @@ Status HorizontalRowsetWriter::_flush_segment_writer(std::unique_ptr<SegmentWrit
 
     (*segment_writer).reset();
     return Status::OK();
+}
+
+void RowsetWriter::_check_global_dict(SegmentWriter* segment_writer) {
+    const auto& seg_global_dict_columns_valid_info = segment_writer->global_dict_columns_valid_info();
+    for (const auto& it : seg_global_dict_columns_valid_info) {
+        if (!it.second) {
+            _global_dict_columns_valid_info[it.first] = false;
+        } else {
+            if (const auto& iter = _global_dict_columns_valid_info.find(it.first);
+                iter == _global_dict_columns_valid_info.end()) {
+                _global_dict_columns_valid_info[it.first] = true;
+            }
+        }
+    }
 }
 
 VerticalRowsetWriter::VerticalRowsetWriter(const RowsetWriterContext& context) : RowsetWriter(context) {}
@@ -1360,17 +1364,7 @@ Status VerticalRowsetWriter::final_flush() {
         }
 
         // check global_dict efficacy
-        const auto& seg_global_dict_columns_valid_info = segment_writer->global_dict_columns_valid_info();
-        for (const auto& it : seg_global_dict_columns_valid_info) {
-            if (!it.second) {
-                _global_dict_columns_valid_info[it.first] = false;
-            } else {
-                if (const auto& iter = _global_dict_columns_valid_info.find(it.first);
-                    iter == _global_dict_columns_valid_info.end()) {
-                    _global_dict_columns_valid_info[it.first] = true;
-                }
-            }
-        }
+        _check_global_dict(segment_writer.get());
 
         segment_writer.reset();
     }

--- a/be/src/storage/rowset/rowset_writer.h
+++ b/be/src/storage/rowset/rowset_writer.h
@@ -182,6 +182,8 @@ private:
     Status _flush_index_files(const SegmentPB& segment_pb, butil::IOBuf& data);
 
 protected:
+    void _check_global_dict(SegmentWriter* segment_writer);
+
     RowsetWriterContext _context;
     std::shared_ptr<FileSystem> _fs;
     std::unique_ptr<RowsetMetaPB> _rowset_meta_pb;

--- a/be/test/storage/lake/tablet_writer_test.cpp
+++ b/be/test/storage/lake/tablet_writer_test.cpp
@@ -28,6 +28,7 @@
 #include "storage/lake/versioned_tablet.h"
 #include "storage/rowset/segment.h"
 #include "storage/rowset/segment_options.h"
+#include "storage/rowset/segment_writer.h"
 #include "storage/tablet_schema.h"
 #include "test_util.h"
 #include "testutil/assert.h"
@@ -353,17 +354,20 @@ TEST_P(LakeTabletWriterTest, test_write_sdk) {
 
 #endif // USE_STAROS
 
-// Mock SegmentWriter for testing check_global_dict
-class MockSegmentWriter {
+// Helper class for testing check_global_dict by exposing SegmentWriter interface
+class TestSegmentWriterWrapper : public SegmentWriter {
 public:
-    DictColumnsValidMap& global_dict_columns_valid_info() { return _global_dict_columns_valid_info; }
+    TestSegmentWriterWrapper(std::unique_ptr<WritableFile> wfile, uint32_t segment_id, TabletSchemaCSPtr tablet_schema,
+                             SegmentWriterOptions opts)
+            : SegmentWriter(std::move(wfile), segment_id, std::move(tablet_schema), opts) {}
 
+    // Expose method to set global_dict_columns_valid_info for testing
     void set_global_dict_info(const std::string& column_name, bool is_valid) {
         _global_dict_columns_valid_info[column_name] = is_valid;
     }
 
-private:
-    DictColumnsValidMap _global_dict_columns_valid_info;
+    // Access the protected member through public method
+    DictColumnsValidMap& get_global_dict_info() { return _global_dict_columns_valid_info; }
 };
 
 TEST_P(LakeTabletWriterTest, test_check_global_dict_all_valid) {
@@ -371,13 +375,18 @@ TEST_P(LakeTabletWriterTest, test_check_global_dict_all_valid) {
     ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, next_id()));
     ASSERT_OK(writer->open());
 
-    // Create a mock segment writer with all columns marked as valid
-    MockSegmentWriter mock_seg_writer;
-    mock_seg_writer.set_global_dict_info("col1", true);
-    mock_seg_writer.set_global_dict_info("col2", true);
+    // Create a segment writer wrapper with all columns marked as valid
+    ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(kTestDirectory));
+    std::string segment_path = _tablet_mgr->segment_location(_tablet_metadata->id(), "test_segment");
+    ASSIGN_OR_ABORT(auto wfile, fs->new_writable_file(segment_path));
+
+    SegmentWriterOptions opts;
+    auto seg_writer = std::make_unique<TestSegmentWriterWrapper>(std::move(wfile), 0, _tablet_schema, opts);
+    seg_writer->set_global_dict_info("col1", true);
+    seg_writer->set_global_dict_info("col2", true);
 
     // Call check_global_dict
-    writer->check_global_dict(reinterpret_cast<SegmentWriter*>(&mock_seg_writer));
+    writer->check_global_dict(seg_writer.get());
 
     // Verify that all columns are marked as valid
     const auto& dict_info = writer->global_dict_columns_valid_info();
@@ -393,17 +402,28 @@ TEST_P(LakeTabletWriterTest, test_check_global_dict_some_invalid) {
     ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, next_id()));
     ASSERT_OK(writer->open());
 
+    ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(kTestDirectory));
+    SegmentWriterOptions opts;
+
     // First segment: all valid
-    MockSegmentWriter mock_seg_writer1;
-    mock_seg_writer1.set_global_dict_info("col1", true);
-    mock_seg_writer1.set_global_dict_info("col2", true);
-    writer->check_global_dict(reinterpret_cast<SegmentWriter*>(&mock_seg_writer1));
+    {
+        std::string segment_path = _tablet_mgr->segment_location(_tablet_metadata->id(), "test_segment1");
+        ASSIGN_OR_ABORT(auto wfile, fs->new_writable_file(segment_path));
+        auto seg_writer1 = std::make_unique<TestSegmentWriterWrapper>(std::move(wfile), 0, _tablet_schema, opts);
+        seg_writer1->set_global_dict_info("col1", true);
+        seg_writer1->set_global_dict_info("col2", true);
+        writer->check_global_dict(seg_writer1.get());
+    }
 
     // Second segment: col1 becomes invalid
-    MockSegmentWriter mock_seg_writer2;
-    mock_seg_writer2.set_global_dict_info("col1", false);
-    mock_seg_writer2.set_global_dict_info("col2", true);
-    writer->check_global_dict(reinterpret_cast<SegmentWriter*>(&mock_seg_writer2));
+    {
+        std::string segment_path = _tablet_mgr->segment_location(_tablet_metadata->id(), "test_segment2");
+        ASSIGN_OR_ABORT(auto wfile, fs->new_writable_file(segment_path));
+        auto seg_writer2 = std::make_unique<TestSegmentWriterWrapper>(std::move(wfile), 1, _tablet_schema, opts);
+        seg_writer2->set_global_dict_info("col1", false);
+        seg_writer2->set_global_dict_info("col2", true);
+        writer->check_global_dict(seg_writer2.get());
+    }
 
     // Verify that col1 is invalid, col2 is still valid
     const auto& dict_info = writer->global_dict_columns_valid_info();
@@ -419,15 +439,26 @@ TEST_P(LakeTabletWriterTest, test_check_global_dict_once_invalid_always_invalid)
     ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, next_id()));
     ASSERT_OK(writer->open());
 
+    ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(kTestDirectory));
+    SegmentWriterOptions opts;
+
     // First segment: col1 is invalid
-    MockSegmentWriter mock_seg_writer1;
-    mock_seg_writer1.set_global_dict_info("col1", false);
-    writer->check_global_dict(reinterpret_cast<SegmentWriter*>(&mock_seg_writer1));
+    {
+        std::string segment_path = _tablet_mgr->segment_location(_tablet_metadata->id(), "test_segment3");
+        ASSIGN_OR_ABORT(auto wfile, fs->new_writable_file(segment_path));
+        auto seg_writer1 = std::make_unique<TestSegmentWriterWrapper>(std::move(wfile), 0, _tablet_schema, opts);
+        seg_writer1->set_global_dict_info("col1", false);
+        writer->check_global_dict(seg_writer1.get());
+    }
 
     // Second segment: col1 becomes valid again
-    MockSegmentWriter mock_seg_writer2;
-    mock_seg_writer2.set_global_dict_info("col1", true);
-    writer->check_global_dict(reinterpret_cast<SegmentWriter*>(&mock_seg_writer2));
+    {
+        std::string segment_path = _tablet_mgr->segment_location(_tablet_metadata->id(), "test_segment4");
+        ASSIGN_OR_ABORT(auto wfile, fs->new_writable_file(segment_path));
+        auto seg_writer2 = std::make_unique<TestSegmentWriterWrapper>(std::move(wfile), 1, _tablet_schema, opts);
+        seg_writer2->set_global_dict_info("col1", true);
+        writer->check_global_dict(seg_writer2.get());
+    }
 
     // Verify that col1 remains invalid (once invalid, always invalid)
     const auto& dict_info = writer->global_dict_columns_valid_info();
@@ -442,16 +473,27 @@ TEST_P(LakeTabletWriterTest, test_check_global_dict_new_columns_in_later_segment
     ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, next_id()));
     ASSERT_OK(writer->open());
 
+    ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(kTestDirectory));
+    SegmentWriterOptions opts;
+
     // First segment: only col1
-    MockSegmentWriter mock_seg_writer1;
-    mock_seg_writer1.set_global_dict_info("col1", true);
-    writer->check_global_dict(reinterpret_cast<SegmentWriter*>(&mock_seg_writer1));
+    {
+        std::string segment_path = _tablet_mgr->segment_location(_tablet_metadata->id(), "test_segment5");
+        ASSIGN_OR_ABORT(auto wfile, fs->new_writable_file(segment_path));
+        auto seg_writer1 = std::make_unique<TestSegmentWriterWrapper>(std::move(wfile), 0, _tablet_schema, opts);
+        seg_writer1->set_global_dict_info("col1", true);
+        writer->check_global_dict(seg_writer1.get());
+    }
 
     // Second segment: col1 and col2
-    MockSegmentWriter mock_seg_writer2;
-    mock_seg_writer2.set_global_dict_info("col1", true);
-    mock_seg_writer2.set_global_dict_info("col2", true);
-    writer->check_global_dict(reinterpret_cast<SegmentWriter*>(&mock_seg_writer2));
+    {
+        std::string segment_path = _tablet_mgr->segment_location(_tablet_metadata->id(), "test_segment6");
+        ASSIGN_OR_ABORT(auto wfile, fs->new_writable_file(segment_path));
+        auto seg_writer2 = std::make_unique<TestSegmentWriterWrapper>(std::move(wfile), 1, _tablet_schema, opts);
+        seg_writer2->set_global_dict_info("col1", true);
+        seg_writer2->set_global_dict_info("col2", true);
+        writer->check_global_dict(seg_writer2.get());
+    }
 
     // Verify both columns are valid
     const auto& dict_info = writer->global_dict_columns_valid_info();


### PR DESCRIPTION
## Why I'm doing:
In scenarios such as primary key tables under share-data arch and partial column updates in share-nothing arch, the global dict is not being updated correctly.

## What I'm doing:
This pull request refactors and centralizes the logic for checking and updating the validity of global dictionary columns during segment and rowset writing. The main improvement is moving duplicated code into dedicated helper methods, improving maintainability and reducing code repetition across multiple writer classes.

Key changes include:

**Centralization of global dictionary checking logic:**

* Introduced a new `check_global_dict` method in `TabletWriter` and a `_check_global_dict` method in `RowsetWriter` to encapsulate the logic for updating `_global_dict_columns_valid_info` based on segment writer state. [[1]](diffhunk://#diff-83aef32ce1a8ab9fae6291a9219b535da001a1956183015054e270af609b57abR46-R59) [[2]](diffhunk://#diff-0d12a8121fd998a44f71fe7e704037141d625357e8c730378175bf5dd611ed16R1209-R1222) [[3]](diffhunk://#diff-22e40a71efd1ffa705f77ad85728eaa3ec3673afb8d06bbdd9b4d76bd2e74550R155-R156) [[4]](diffhunk://#diff-be1c81f0a2aa50eee3ebf6de9422fd346c2d2f56cbee0bf511bdd6cd68b845b8R185-R186)

**Refactoring to use the new helper methods:**

* Replaced duplicated code in `HorizontalGeneralTabletWriter::flush_segment_writer`, `HorizontalPkTabletWriter::flush_segment_writer`, and `HorizontalUpdateRowsetWriter::flush_chunk` and `flush` with calls to the new `check_global_dict` or `_check_global_dict` methods. [[1]](diffhunk://#diff-3dc155c1f66ca23166df68c90b2dd007553dcdb5614809d09dc669af8d406593L178-R178) [[2]](diffhunk://#diff-a915fbf31d5ce885015bb08d9025089b3f4d6d1d99d4dc034b925d45b1ee2073R132) [[3]](diffhunk://#diff-087963557a97f2260253d5ccb254e6d6405aa9c89a5753012fabb1bb0efb9217R110-R111) [[4]](diffhunk://#diff-087963557a97f2260253d5ccb254e6d6405aa9c89a5753012fabb1bb0efb9217R127-R128)
* Updated `HorizontalRowsetWriter::_flush_segment_writer` and `VerticalRowsetWriter::final_flush` to use `_check_global_dict` instead of inline logic. [[1]](diffhunk://#diff-0d12a8121fd998a44f71fe7e704037141d625357e8c730378175bf5dd611ed16L1179-R1179) [[2]](diffhunk://#diff-0d12a8121fd998a44f71fe7e704037141d625357e8c730378175bf5dd611ed16L1363-R1367)

These changes make the codebase easier to maintain by ensuring that the logic for managing global dictionary column validity is implemented in a single place for each relevant writer class, reducing the risk of inconsistencies and simplifying future updates.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Consolidates global dictionary validity handling into helper methods and replaces duplicated logic across tablet/rowset writers, with new unit tests covering update scenarios.
> 
> - **Storage (writers)**:
>   - Add `TabletWriter::check_global_dict` and `RowsetWriter::_check_global_dict` to update `global_dict_columns_valid_info` from `SegmentWriter` state.
>   - Replace inline global-dict checks with helper calls in:
>     - `HorizontalGeneralTabletWriter::flush_segment_writer`
>     - `HorizontalPkTabletWriter::flush_segment_writer`
>     - `HorizontalRowsetWriter::_flush_segment_writer`
>     - `VerticalRowsetWriter::final_flush`
>     - `HorizontalUpdateRowsetWriter::flush_chunk` and `flush`
>   - Header updates and includes for `SegmentWriter` where needed.
> - **Tests**:
>   - Add unit tests in `be/test/storage/lake/tablet_writer_test.cpp` verifying `check_global_dict` behavior (all valid, partial invalidation, once-invalid-always-invalid, late-added columns).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a304d208818898c592e14b85175cfaaa181ebcb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->