### PR TITLE
[Feature] Support data ingestion for range distribution table

### DIFF
--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -39,6 +39,7 @@ set(EXEC_FILES
     tablet_sink_colocate_sender.cpp
     tablet_sink_index_channel.cpp
     tablet_sink_sender.cpp
+    range_tablet_sink_sender.cpp
     write_combined_txn_log.cpp
     multi_olap_table_sink.cpp
     mysql_scanner.cpp
@@ -108,6 +109,7 @@ set(EXEC_FILES
     schema_scan_node.cpp
     dictionary_cache_writer.cpp
     arrow_flight_batch_reader.cpp
+    range_router.cpp
     iceberg/iceberg_delete_builder.cpp
     iceberg/iceberg_delete_file_iterator.cpp
     paimon/paimon_delete_file_builder.cpp

--- a/be/src/exec/range_router.cpp
+++ b/be/src/exec/range_router.cpp
@@ -33,8 +33,7 @@ Status RangeRouter::init(const std::vector<TTabletRange>& tablet_ranges, size_t 
         return Status::InternalError("no tablet ranges for RangeRouter init");
     }
     if (!_upper_boundaries.empty()) {
-        DCHECK((_upper_boundaries[0] == nullptr) ||
-               (_upper_boundaries[0]->size() + 1 == num_ranges));
+        DCHECK((_upper_boundaries[0] == nullptr) || (_upper_boundaries[0]->size() + 1 == num_ranges));
         return Status::OK();
     }
 
@@ -196,11 +195,13 @@ Status RangeRouter::_validate_range(const std::vector<TTabletRange>& tablet_rang
 
         // overlapping or has gap in the boundary
         if ((!prev_upper_inclusive && !curr_lower_inclusive) || (prev_upper_inclusive && curr_lower_inclusive)) {
-            return Status::InternalError("adjacent ranges are overlapping / not complementary for the inclusive/exclusive bound");
+            return Status::InternalError(
+                    "adjacent ranges are overlapping / not complementary for the inclusive/exclusive bound");
         }
 
         if (prev_upper_inclusive && !curr_lower_inclusive) {
-            return Status::InternalError("Invalid range: previous upper bound is inclusive but current lower bound is exclusive");
+            return Status::InternalError(
+                    "Invalid range: previous upper bound is inclusive but current lower bound is exclusive");
         }
 
         // Compare whether adjacent upper and lower bounds are type-compatible
@@ -231,8 +232,8 @@ Status RangeRouter::_validate_range(const std::vector<TTabletRange>& tablet_rang
 size_t RangeRouter::_find_tablet_index_for_row(const ChunkRow& check_row) const {
     DCHECK(!_upper_boundaries.empty());
     DCHECK(_upper_boundaries[0] != nullptr);
-    return std::upper_bound(
-           _upper_boundaries_slice.begin(), _upper_boundaries_slice.end(), check_row, PartionKeyComparator()) -
+    return std::upper_bound(_upper_boundaries_slice.begin(), _upper_boundaries_slice.end(), check_row,
+                            PartionKeyComparator()) -
            _upper_boundaries_slice.begin();
 }
 

--- a/be/src/exec/range_router.cpp
+++ b/be/src/exec/range_router.cpp
@@ -1,0 +1,239 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/range_router.h"
+
+#include <algorithm>
+#include <boost/iterator/counting_iterator.hpp>
+
+#include "column/column_helper.h"
+#include "column/datum_convert.h"
+#include "column/schema.h"
+#include "common/statusor.h"
+#include "fmt/format.h"
+#include "runtime/descriptors.h"
+#include "storage/types.h"
+
+namespace starrocks {
+
+Status RangeRouter::init(const std::vector<TTabletRange>& tablet_ranges, size_t num_columns) {
+    const size_t num_ranges = tablet_ranges.size();
+    if (num_ranges == 0) {
+        return Status::InternalError("no tablet ranges for RangeRouter init");
+    }
+    if (!_upper_boundaries.empty()) {
+        DCHECK((_upper_boundaries[0] == nullptr) ||
+               (_upper_boundaries[0]->size() + 1 == num_ranges));
+        return Status::OK();
+    }
+
+    RETURN_IF_ERROR(_validate_range(tablet_ranges, num_columns));
+
+    _upper_boundaries.resize(num_columns);
+    for (size_t i = 0; i < num_ranges - 1; ++i) {
+        _upper_boundaries_slice.emplace_back(&_upper_boundaries, i);
+    }
+
+    // (-inf, +inf) range, fast return
+    if (num_ranges == 1) {
+        return Status::OK();
+    }
+
+    // Infer TypeDescriptor for each range-distributed column from tablet ranges.
+    // Caller should guarantee that for every column for range distribution, at least one
+    // tablet range provides a concrete type information for lower bound or upper bound.
+    std::vector<std::unique_ptr<TypeDescriptor>> type_descs(num_columns);
+    for (size_t i = 0; i < num_columns; ++i) {
+        for (const auto& tablet_range : tablet_ranges) {
+            const TTuple* lower = tablet_range.__isset.lower_bound ? &tablet_range.lower_bound : nullptr;
+            const TTuple* upper = tablet_range.__isset.upper_bound ? &tablet_range.upper_bound : nullptr;
+            DCHECK(lower != nullptr || upper != nullptr);
+
+            if (lower != nullptr) {
+                DCHECK(i < lower->values.size());
+                type_descs[i] = std::make_unique<TypeDescriptor>(TypeDescriptor::from_thrift(lower->values[i].type));
+                break;
+            }
+
+            if (upper != nullptr) {
+                DCHECK(i < upper->values.size());
+                type_descs[i] = std::make_unique<TypeDescriptor>(TypeDescriptor::from_thrift(upper->values[i].type));
+                break;
+            }
+        }
+    }
+
+    auto parse_bound = [&](const TTuple& bound, MutableColumns& boundary_columns) {
+        for (size_t i = 0; i < num_columns; ++i) {
+            const auto& type_desc = type_descs[i];
+            DCHECK(type_desc != nullptr);
+            MutableColumnPtr& column = boundary_columns[i];
+            if (!column) {
+                column = ColumnHelper::create_column(*type_desc, false);
+                column->reserve(num_ranges);
+            }
+
+            const auto& value = bound.values[i];
+            Datum datum;
+            std::string value_str;
+            auto type_info = get_type_info(type_desc->type, type_desc->precision, type_desc->scale);
+            if (value.__isset.value) {
+                value_str = value.value;
+            } else {
+                return Status::InternalError("Missing value in range bound");
+            }
+            RETURN_IF_ERROR(datum_from_string(type_info.get(), &datum, value_str, nullptr));
+
+            column->append_datum(datum);
+        }
+        return Status::OK();
+    };
+
+    for (size_t range_idx = 0; range_idx < num_ranges - 1; ++range_idx) {
+        const auto& tablet_range = tablet_ranges[range_idx];
+        RETURN_IF_ERROR(parse_bound(tablet_range.upper_bound, _upper_boundaries));
+    }
+
+    return Status::OK();
+}
+
+Status RangeRouter::route_chunk_rows(Chunk* chunk, const std::vector<SlotDescriptor*>& slot_descs,
+                                     const std::vector<uint16_t>& row_indices,
+                                     const std::vector<int64_t>& candidate_dest, std::vector<int64_t>* target_dest) {
+    if (row_indices.empty()) {
+        return Status::OK();
+    }
+    DCHECK(target_dest != nullptr);
+    if (_upper_boundaries.empty()) {
+        return Status::InternalError("RangeRouter::init() must be called before route_chunk_rows()");
+    }
+    if (candidate_dest.empty()) {
+        return Status::InternalError("no candidate destinations routing range");
+    }
+
+    target_dest->clear();
+    target_dest->reserve(row_indices.size());
+    // (-inf, +inf) range, fast return
+    if (_upper_boundaries[0] == nullptr) {
+        const int64_t dest = candidate_dest[0];
+        target_dest->resize(row_indices.size(), dest);
+        return Status::OK();
+    }
+
+    MutableColumns columns(slot_descs.size());
+    for (size_t i = 0; i < slot_descs.size(); ++i) {
+        columns[i] = chunk->get_column_by_slot_id(slot_descs[i]->id())->as_mutable_ptr();
+    }
+
+    ChunkRow cur_check_row(&columns, 0);
+    for (uint16_t row_idx : row_indices) {
+        cur_check_row.index = row_idx;
+        size_t t_idx = _find_tablet_index_for_row(cur_check_row);
+        if (t_idx >= candidate_dest.size()) {
+            return Status::InternalError(fmt::format("tablet index {} out of range for candidate destinations size {}",
+                                                     t_idx, candidate_dest.size()));
+        }
+        target_dest->push_back(candidate_dest[t_idx]);
+    }
+    return Status::OK();
+}
+
+Status RangeRouter::_validate_range(const std::vector<TTabletRange>& tablet_ranges, size_t num_columns) const {
+    // 1. check inf or bounds are set
+    int lower_inf_count = 0;
+    int upper_inf_count = 0;
+    for (const auto& range : tablet_ranges) {
+        if (!range.__isset.lower_bound) {
+            lower_inf_count++;
+        } else {
+            const auto lower_bound = range.lower_bound;
+            RETURN_IF(!lower_bound.__isset.values, Status::InternalError("lower_bound value is required"));
+            RETURN_IF(lower_bound.values.size() != num_columns,
+                      Status::InternalError("lower_bound value size is not equal to column size"));
+        }
+
+        if (!range.__isset.upper_bound) {
+            upper_inf_count++;
+        } else {
+            const auto upper_bound = range.upper_bound;
+            RETURN_IF(!upper_bound.__isset.values, Status::InternalError("upper_bound value is required"));
+            RETURN_IF(upper_bound.values.size() != num_columns,
+                      Status::InternalError("upper_bound value size is not equal to column size"));
+        }
+    }
+    RETURN_IF(lower_inf_count != 1 || upper_inf_count != 1,
+              Status::InternalError("lower_inf_count and upper_inf_count must be 1"));
+    RETURN_IF(tablet_ranges[0].__isset.lower_bound || tablet_ranges[tablet_ranges.size() - 1].__isset.upper_bound,
+              Status::InternalError("-inf/inf range must be set for the first and last tablet range"));
+
+    // 2. check if full range is covered by the tablet ranges and that adjacent
+    //    boundaries are type-consistent and value-equal.
+    auto variant_equal = [](const TVariant& a, const TVariant& b) -> StatusOr<bool> {
+        if (a.__isset.value && b.__isset.value) {
+            return a.value == b.value;
+        }
+        return Status::InternalError("TVariant.value is required for range validation");
+    };
+
+    for (size_t i = 1; i < tablet_ranges.size(); ++i) {
+        const auto& prev = tablet_ranges[i - 1];
+        const auto& curr = tablet_ranges[i];
+        DCHECK(prev.__isset.upper_bound);
+        DCHECK(curr.__isset.lower_bound);
+        const bool prev_upper_inclusive = prev.upper_bound_included;
+        const bool curr_lower_inclusive = curr.lower_bound_included;
+
+        // overlapping or has gap in the boundary
+        if ((!prev_upper_inclusive && !curr_lower_inclusive) || (prev_upper_inclusive && curr_lower_inclusive)) {
+            return Status::InternalError("adjacent ranges are overlapping / not complementary for the inclusive/exclusive bound");
+        }
+
+        if (prev_upper_inclusive && !curr_lower_inclusive) {
+            return Status::InternalError("Invalid range: previous upper bound is inclusive but current lower bound is exclusive");
+        }
+
+        // Compare whether adjacent upper and lower bounds are type-compatible
+        // and equal in value for every column.
+        for (size_t col = 0; col < num_columns; ++col) {
+            const auto& prev_var = prev.upper_bound.values[col];
+            const auto& curr_var = curr.lower_bound.values[col];
+
+            // Type information must be present and identical.
+            if (!prev_var.__isset.type || !curr_var.__isset.type) {
+                return Status::InternalError("TVariant.type is required for range validation");
+            }
+            if (!(prev_var.type == curr_var.type)) {
+                return Status::InternalError(
+                        fmt::format("Type mismatch at column {} between range[{}] and range[{}]", col, i - 1, i));
+            }
+
+            // Then compare the encoded values.
+            ASSIGN_OR_RETURN(auto eq, variant_equal(prev_var, curr_var));
+            if (!eq) {
+                return Status::InternalError(fmt::format("Range[{}] != range[{}] at column {}", i - 1, i, col));
+            }
+        }
+    }
+    return Status::OK();
+}
+
+size_t RangeRouter::_find_tablet_index_for_row(const ChunkRow& check_row) const {
+    DCHECK(!_upper_boundaries.empty());
+    DCHECK(_upper_boundaries[0] != nullptr);
+    return std::upper_bound(
+           _upper_boundaries_slice.begin(), _upper_boundaries_slice.end(), check_row, PartionKeyComparator()) -
+           _upper_boundaries_slice.begin();
+}
+
+} // namespace starrocks

--- a/be/src/exec/range_router.h
+++ b/be/src/exec/range_router.h
@@ -54,7 +54,7 @@ private:
     // For example, if there are 3 tablet ranges : (-inf, 100), [100, 200), [200, +inf)
     // we only save the valid upper boundaries: [100, 200]
     // lower bound must strictly less than upper bound
-    MutableColumns _upper_boundaries;    // size = range column count
+    MutableColumns _upper_boundaries; // size = range column count
     // row-wise view of the upper boundaries
     std::vector<ChunkRow> _upper_boundaries_slice; // size = range count
 };

--- a/be/src/exec/range_router.h
+++ b/be/src/exec/range_router.h
@@ -1,0 +1,62 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "column/chunk.h"
+#include "common/status.h"
+#include "exec/tablet_info.h"
+#include "gen_cpp/Types_types.h"
+#include "runtime/types.h"
+
+namespace starrocks {
+
+class SlotDescriptor;
+
+// RangeRouter is responsible for routing rows will ranges which represent the entire (-inf, +inf)
+class RangeRouter {
+public:
+    RangeRouter() = default;
+
+    ~RangeRouter() = default;
+
+    Status init(const std::vector<TTabletRange>& tablet_ranges, size_t num_columns);
+
+    Status route_chunk_rows(Chunk* chunk, const std::vector<SlotDescriptor*>& slot_descs,
+                            const std::vector<uint16_t>& row_indices, const std::vector<int64_t>& candidate_dest,
+                            std::vector<int64_t>* target_dest);
+
+private:
+    Status _validate_range(const std::vector<TTabletRange>& tablet_ranges, size_t num_columns) const;
+
+    size_t _find_tablet_index_for_row(const ChunkRow& check_row) const;
+
+private:
+    // Compact representation of the entire range (-inf, +inf)
+    // For example, if there are 3 tablet ranges : (-inf, 100), [100, 200), [200, +inf)
+    // we only save the valid upper boundaries: [100, 200]
+    // lower bound must strictly less than upper bound
+    MutableColumns _upper_boundaries;    // size = range column count
+    // row-wise view of the upper boundaries
+    std::vector<ChunkRow> _upper_boundaries_slice; // size = range count
+};
+
+} // namespace starrocks

--- a/be/src/exec/range_tablet_sink_sender.cpp
+++ b/be/src/exec/range_tablet_sink_sender.cpp
@@ -1,0 +1,103 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/range_tablet_sink_sender.h"
+
+#include "column/chunk.h"
+#include "common/statusor.h"
+
+namespace starrocks {
+
+Status RangeTabletSinkSender::send_chunk(const OlapTableSchemaParam* schema,
+                                         const std::vector<OlapTablePartition*>& partitions,
+                                         const std::vector<uint32_t>& record_hashes,
+                                         const std::vector<uint16_t>& validate_select_idx,
+                                         std::unordered_map<int64_t, std::set<int64_t>>& index_id_partition_id,
+                                         Chunk* chunk) {
+    if (validate_select_idx.empty()) {
+        return Status::OK();
+    }
+
+    if (_tablet_ids.size() < chunk->num_rows()) {
+        _tablet_ids.resize(chunk->num_rows());
+    }
+
+    std::unordered_map<int64_t, OlapTablePartition*> partition_map;
+    std::unordered_map<int64_t, std::vector<uint16_t>> partition_row_indices_map;
+
+    // 1. Shuffle rows into batches by partition
+    for (uint16_t i : validate_select_idx) {
+        int64_t partition_id = partitions[i]->id;
+
+        partition_map[partition_id] = partitions[i];
+        auto& row_indices = partition_row_indices_map[partition_id];
+        if (row_indices.empty()) {
+            row_indices.reserve(chunk->num_rows());
+        }
+        row_indices.push_back(i);
+    }
+
+    // 2. Process each index
+    size_t index_size = schema->indexes().size();
+    for (size_t i = 0; i < index_size; ++i) {
+        auto* index_schema = schema->indexes()[i];
+        DCHECK(_partition_params != nullptr && _partition_params->is_range_distribution());
+        DCHECK(_partition_params->distribution_slot_descs().size() <= chunk->num_columns());
+
+        // Process each partition batch
+        for (auto& [part_id, part] : partition_map) {
+            const auto& row_indices = partition_row_indices_map[part_id];
+            // Get or create range router for this partition and index.
+            // Use try_emplace to avoid double lookup
+            auto [router_iter, inserted] = _range_routers[index_schema->index_id].try_emplace(part_id);
+
+            RangeRouter* router_ptr = nullptr;
+            if (inserted) {
+                // New entry, need to initialize router
+                const auto& tablets = part->indexes[i].tablets;
+                std::vector<TTabletRange> tablet_ranges;
+                tablet_ranges.reserve(tablets.size());
+                for (const auto& tablet : tablets) {
+                    DCHECK(tablet.__isset.range);
+                    tablet_ranges.emplace_back(tablet.range);
+                }
+                auto router = std::make_unique<RangeRouter>();
+                RETURN_IF_ERROR(router->init(tablet_ranges, _partition_params->distribution_slot_descs().size()));
+                router_ptr = router.get();
+                router_iter->second = std::move(router);
+            } else {
+                // Entry already exists
+                router_ptr = router_iter->second.get();
+            }
+
+            DCHECK(router_ptr != nullptr);
+            const auto& slot_descs = _partition_params->distribution_slot_descs();
+            const auto& candidate_tablet_ids = part->indexes[i].tablet_ids;
+            RETURN_IF_ERROR(router_ptr->route_chunk_rows(chunk, slot_descs, row_indices, candidate_tablet_ids,
+                                                         &_cur_result_tablet_ids));
+            DCHECK(_cur_result_tablet_ids.size() == row_indices.size());
+            for (size_t j = 0; j < row_indices.size(); ++j) {
+                _tablet_ids[row_indices[j]] = _cur_result_tablet_ids[j];
+            }
+            index_id_partition_id[index_schema->index_id].emplace(part_id);
+        }
+
+        // 3. Send chunk for this index
+        // _send_chunk_by_node uses _tablet_ids and validate_select_idx
+        RETURN_IF_ERROR(_send_chunk_by_node(chunk, _channels[i], validate_select_idx));
+    }
+    return Status::OK();
+}
+
+} // namespace starrocks

--- a/be/src/exec/range_tablet_sink_sender.h
+++ b/be/src/exec/range_tablet_sink_sender.h
@@ -1,0 +1,47 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "exec/range_router.h"
+#include "exec/tablet_sink_sender.h"
+
+namespace starrocks {
+
+// RangeTabletSinkSender specializes TabletSinkSender for range distribution
+class RangeTabletSinkSender : public TabletSinkSender {
+public:
+    RangeTabletSinkSender(PUniqueId load_id, int64_t txn_id, IndexIdToTabletBEMap index_id_to_tablet_be_map,
+                          OlapTablePartitionParam* partition_params, std::vector<IndexChannel*> channels,
+                          std::unordered_map<int64_t, NodeChannel*> node_channels,
+                          std::vector<ExprContext*> output_expr_ctxs, bool enable_replicated_storage,
+                          TWriteQuorumType::type write_quorum_type, int num_repicas)
+            : TabletSinkSender(std::move(load_id), txn_id, std::move(index_id_to_tablet_be_map), partition_params,
+                               std::move(channels), std::move(node_channels), std::move(output_expr_ctxs),
+                               enable_replicated_storage, write_quorum_type, num_repicas) {}
+
+    ~RangeTabletSinkSender() override = default;
+
+    // Override send_chunk to implement range-based routing
+    Status send_chunk(const OlapTableSchemaParam* schema, const std::vector<OlapTablePartition*>& partitions,
+                      const std::vector<uint32_t>& record_hashes, const std::vector<uint16_t>& validate_select_idx,
+                      std::unordered_map<int64_t, std::set<int64_t>>& index_id_partition_id, Chunk* chunk) override;
+
+private:
+    // index_id -> partition_id -> range router
+    std::unordered_map<int64_t, std::unordered_map<int64_t, std::unique_ptr<RangeRouter>>> _range_routers;
+    std::vector<int64_t> _cur_result_tablet_ids;
+};
+
+} // namespace starrocks

--- a/be/src/exec/tablet_info.h
+++ b/be/src/exec/tablet_info.h
@@ -220,6 +220,10 @@ struct PartionKeyComparator {
         return false;
     }
 
+    bool operator()(const ChunkRow& lhs, const ChunkRow& rhs) const {
+        return operator()(&lhs, &rhs);
+    }
+
 private:
     /**
      * @brief Compare left column and right column at l_idx and r_idx which column can be nullable.
@@ -285,6 +289,22 @@ public:
 
     Status test_add_partitions(OlapTablePartition* partition);
 
+    const std::vector<SlotDescriptor*>& distribution_slot_descs() const { return _distributed_slot_descs; }
+
+    bool is_range_distribution() const {
+        return _distribution_type.has_value() && _distribution_type.value() == TOlapTableDistributionType::RANGE;
+    }
+
+    bool is_hash_distribution() const {
+        return ((!_distribution_type.has_value() && !_distributed_slot_descs.empty()) ||
+                (_distribution_type.has_value() && _distribution_type.value() == TOlapTableDistributionType::HASH));
+    }
+
+    bool is_random_distribution() const {
+        return ((!_distribution_type.has_value() && _distributed_slot_descs.empty()) ||
+                (_distribution_type.has_value() && _distribution_type.value() == TOlapTableDistributionType::RANDOM));
+    }
+
 private:
     /**
      * @brief  find tablets with range partition table
@@ -349,6 +369,10 @@ private:
     std::map<ChunkRow*, std::vector<int64_t>, PartionKeyComparator> _partitions_map;
 
     Random _rand{(uint32_t)time(nullptr)};
+
+    // NOTE: Thrift generates enum as `struct TOlapTableDistributionType { enum type { ... }; };`
+    // so we should store the actual enum type `TOlapTableDistributionType::type` here.
+    std::optional<TOlapTableDistributionType::type> _distribution_type;
 };
 
 } // namespace starrocks

--- a/be/src/exec/tablet_info.h
+++ b/be/src/exec/tablet_info.h
@@ -220,9 +220,7 @@ struct PartionKeyComparator {
         return false;
     }
 
-    bool operator()(const ChunkRow& lhs, const ChunkRow& rhs) const {
-        return operator()(&lhs, &rhs);
-    }
+    bool operator()(const ChunkRow& lhs, const ChunkRow& rhs) const { return operator()(&lhs, &rhs); }
 
 private:
     /**

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -50,6 +50,7 @@
 #include "common/statusor.h"
 #include "common/tracer.h"
 #include "exec/pipeline/query_context.h"
+#include "exec/range_tablet_sink_sender.h"
 #include "exec/tablet_sink_colocate_sender.h"
 #include "exprs/expr.h"
 #include "gutil/strings/fastmem.h"
@@ -318,7 +319,11 @@ Status OlapTableSink::prepare(RuntimeState* state) {
                 _load_id, _txn_id, std::move(index_id_to_tablet_be_map), _vectorized_partition,
                 std::move(index_channels), std::move(node_channels), _output_expr_ctxs, _enable_replicated_storage,
                 _write_quorum_type, _num_repicas);
-
+    } else if (_vectorized_partition->is_range_distribution()) {
+        _tablet_sink_sender = std::make_unique<RangeTabletSinkSender>(
+                _load_id, _txn_id, std::move(index_id_to_tablet_be_map), _vectorized_partition,
+                std::move(index_channels), std::move(node_channels), _output_expr_ctxs, _enable_replicated_storage,
+                _write_quorum_type, _num_repicas);
     } else {
         _tablet_sink_sender = std::make_unique<TabletSinkSender>(
                 _load_id, _txn_id, std::move(index_id_to_tablet_be_map), _vectorized_partition,

--- a/be/src/exec/tablet_sink_sender.cpp
+++ b/be/src/exec/tablet_sink_sender.cpp
@@ -46,6 +46,9 @@ Status TabletSinkSender::send_chunk(const OlapTableSchemaParam* schema,
                                     const std::vector<uint16_t>& validate_select_idx,
                                     std::unordered_map<int64_t, std::set<int64_t>>& index_id_partition_id,
                                     Chunk* chunk) {
+    // Range distribution is handled by the base class implementation for RangeTabletSinkSender
+    // Normal hash distribution continues here
+
     size_t num_rows = chunk->num_rows();
     size_t selection_size = validate_select_idx.size();
     if (selection_size == 0) {

--- a/be/src/exec/tablet_sink_sender.h
+++ b/be/src/exec/tablet_sink_sender.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "exec/range_router.h"
 #include "exec/tablet_sink_index_channel.h"
 
 namespace starrocks {
@@ -68,7 +69,9 @@ public:
     }
 
 protected:
-    Status _send_chunk_by_node(Chunk* chunk, IndexChannel* channel, const std::vector<uint16_t>& selection_idx);
+    // Virtual to allow tests or derived senders (e.g. colocate sender) to intercept
+    // how chunks are dispatched to BE nodes.
+    virtual Status _send_chunk_by_node(Chunk* chunk, IndexChannel* channel, const std::vector<uint16_t>& selection_idx);
     Status _write_combined_txn_log();
     void _mark_as_failed(const NodeChannel* ch) { _failed_channels.insert(ch->node_id()); }
     bool _is_failed_channel(const NodeChannel* ch) { return _failed_channels.count(ch->node_id()) != 0; }

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -56,6 +56,7 @@ set(EXEC_FILES
         ./fs/poco_http_client_test.cpp
         ./fs/bundle_file_test.cpp
         ./exec/column_value_range_test.cpp
+        ./exec/range_router_test.cpp
         ./exec/es/es_query_builder_test.cpp
         ./exec/es/es_scan_reader_test.cpp
         ./exec/es/es_scroll_parser_test.cpp
@@ -112,6 +113,7 @@ set(EXEC_FILES
         ./exec/repeat_node_test.cpp
         ./exec/sorting_test.cpp
         ./exec/tablet_sink_index_channel_test.cpp
+        ./exec/tablet_sink_sender_range_test.cpp
         ./exec/table_function_node_test.cpp
         ./exec/olap_scan_prepare_test.cpp
         ./exec/file_scanner/avro_cpp_scanner_test.cpp

--- a/be/test/exec/range_router_test.cpp
+++ b/be/test/exec/range_router_test.cpp
@@ -1,0 +1,771 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/range_router.h"
+
+#include <gtest/gtest.h>
+
+#include <optional>
+#include <tuple>
+#include <vector>
+
+#include "column/binary_column.h"
+#include "column/chunk.h"
+#include "column/field.h"
+#include "column/fixed_length_column.h"
+#include "column/schema.h"
+#include "runtime/descriptors.h"
+#include "runtime/types.h"
+#include "storage/type_utils.h"
+
+namespace starrocks {
+
+// Test fixture providing helpers to construct chunks and tablet ranges
+// in the same way as the FE encodes TVariant / TTabletRange.
+class RangeRouterTest : public ::testing::Test {
+protected:
+    // ---- TVariant helpers ----
+
+    TVariant make_int_variant(int64_t v) {
+        TVariant tv;
+        tv.__set_type(TYPE_INT_DESC.to_thrift());
+        tv.__set_value(std::to_string(v));
+        return tv;
+    }
+
+    TVariant make_varchar_variant(const std::string& v) {
+        TVariant tv;
+        tv.__set_type(TYPE_VARCHAR_DESC.to_thrift());
+        tv.__set_value(v);
+        return tv;
+    }
+
+    TVariant make_datetime_variant(const std::string& v) {
+        TVariant tv;
+        tv.__set_type(TYPE_DATETIME_DESC.to_thrift());
+        tv.__set_value(v);
+        return tv;
+    }
+
+    TVariant make_string_variant(const std::string& v) {
+        TVariant tv;
+        tv.__set_type(TYPE_VARCHAR_DESC.to_thrift());
+        tv.__set_value(v);
+        return tv;
+    }
+
+    TVariant make_hll_variant(const std::string& v) {
+        TVariant tv;
+        TypeDescriptor type_desc = TypeDescriptor::create_hll_type();
+        tv.__set_type(type_desc.to_thrift());
+        tv.__set_value(v);
+        return tv;
+    }
+
+    // ---- Chunk helpers ----
+
+    Chunk make_int_chunk(const std::string& name, const std::vector<int32_t>& values) {
+        auto col = FixedLengthColumn<int32_t>::create();
+        for (int32_t v : values) {
+            col->append(v);
+        }
+        Columns cols;
+        cols.emplace_back(col);
+
+        Fields fields;
+        fields.emplace_back(std::make_shared<Field>(0, name, get_type_info(TYPE_INT), false));
+        auto schema = std::make_shared<Schema>(fields);
+        return Chunk(cols, schema);
+    }
+
+    Chunk make_varchar_chunk(const std::string& name, const std::vector<std::string>& values) {
+        auto col = BinaryColumn::create();
+        for (const auto& v : values) {
+            col->append_string(v);
+        }
+        Columns cols;
+        cols.emplace_back(col);
+
+        Fields fields;
+        fields.emplace_back(std::make_shared<Field>(0, name, get_type_info(TYPE_VARCHAR), false));
+        auto schema = std::make_shared<Schema>(fields);
+        return Chunk(cols, schema);
+    }
+
+    // ---- Single-column TTabletRange helpers ----
+
+    // Helper to build a TTabletRange on a single INT column using long_value.
+    // If lower/upper is std::nullopt, the corresponding bound is treated as -inf / +inf.
+    TTabletRange make_single_long_range(std::optional<int64_t> lower, bool lower_included, std::optional<int64_t> upper,
+                                        bool upper_included) {
+        TTabletRange range;
+        if (lower.has_value()) {
+            TVariant v = make_int_variant(lower.value());
+            TTuple tuple;
+            tuple.__set_values(std::vector<TVariant>{v});
+            range.__set_lower_bound(tuple);
+            range.__set_lower_bound_included(lower_included);
+        }
+        if (upper.has_value()) {
+            TVariant v = make_int_variant(upper.value());
+            TTuple tuple;
+            tuple.__set_values(std::vector<TVariant>{v});
+            range.__set_upper_bound(tuple);
+            range.__set_upper_bound_included(upper_included);
+        }
+        return range;
+    }
+
+    // Helper to build a TTabletRange on a single VARCHAR column using string_value.
+    TTabletRange make_single_string_range(const std::optional<std::string>& lower, bool lower_included,
+                                          const std::optional<std::string>& upper, bool upper_included) {
+        TTabletRange range;
+        if (lower.has_value()) {
+            TVariant v = make_varchar_variant(lower.value());
+            TTuple tuple;
+            tuple.__set_values(std::vector<TVariant>{v});
+            range.__set_lower_bound(tuple);
+            range.__set_lower_bound_included(lower_included);
+        }
+        if (upper.has_value()) {
+            TVariant v = make_varchar_variant(upper.value());
+            TTuple tuple;
+            tuple.__set_values(std::vector<TVariant>{v});
+            range.__set_upper_bound(tuple);
+            range.__set_upper_bound_included(upper_included);
+        }
+        return range;
+    }
+};
+
+// Small helper to assert that an error Status message contains a substring.
+static void assert_status_message_contains(const Status& status, const std::string& needle) {
+    ASSERT_NE(status.message().find(needle), std::string::npos)
+            << "Expected error message to contain '" << needle << "', got: " << status.message();
+}
+
+// ----------------------------------------------------------------------
+// Happy-path routing tests
+// ----------------------------------------------------------------------
+
+// Single (-inf, +inf) tablet range: every row should be routed to the only
+// candidate destination.
+// This also exercises the fast path in route_chunk_rows() when there is only
+// one range.
+// NOLINTNEXTLINE
+TEST_F(RangeRouterTest, SingleInfiniteRangeSelectAll) {
+    std::vector<TTabletRange> ranges(1); // no lower / upper bound set => (-inf, +inf)
+    std::vector<int64_t> tablet_ids{42};
+
+    RangeRouter router;
+    ASSERT_TRUE(router.init(ranges, 1).ok());
+
+    std::vector<int32_t> values{-100, -1, 0, 5, 10, 100};
+    Chunk chunk = make_int_chunk("c1", values);
+
+    SlotDescriptor slot_desc(0, "c1", TypeDescriptor::from_logical_type(TYPE_INT));
+    std::vector<SlotDescriptor*> slot_descs{&slot_desc};
+    chunk.set_slot_id_to_index(slot_desc.id(), 0);
+
+    std::vector<uint16_t> row_indices;
+    for (int i = 0; i < chunk.num_rows(); ++i) {
+        row_indices.emplace_back(i);
+    }
+    std::vector<int64_t> routed_ids;
+
+    ASSERT_TRUE(router.route_chunk_rows(&chunk, slot_descs, row_indices, tablet_ids, &routed_ids).ok());
+    ASSERT_EQ(row_indices.size(), routed_ids.size());
+    for (size_t i = 0; i < row_indices.size(); ++i) {
+        ASSERT_EQ(42, routed_ids[i]) << "row " << row_indices[i] << " mismatch";
+    }
+}
+
+// Three ranges on a single INT column fully covering (-inf, +inf) with left-closed/right-open semantics:
+//   R0: (-inf, 10)
+//   R1: [10, 20)
+//   R2: [20, +inf)
+// NOLINTNEXTLINE
+TEST_F(RangeRouterTest, IntThreeRangesFullCoverage) {
+    std::vector<TTabletRange> ranges;
+    ranges.emplace_back(make_single_long_range(std::nullopt, false, 10, false));  // (-inf, 10)
+    ranges.emplace_back(make_single_long_range(10, true, 20, false));             // [10, 20)
+    ranges.emplace_back(make_single_long_range(20, true, std::nullopt, false));   // [20, +inf)
+
+    std::vector<int64_t> tablet_ids{100, 200, 300};
+
+    RangeRouter router;
+    ASSERT_TRUE(router.init(ranges, 1).ok());
+
+    std::vector<int32_t> values{-5, 0, 5, 10, 11, 19, 20, 21, 100};
+    Chunk chunk = make_int_chunk("c1", values);
+
+    SlotDescriptor slot_desc(0, "c1", TypeDescriptor::from_logical_type(TYPE_INT));
+    std::vector<SlotDescriptor*> slot_descs{&slot_desc};
+    chunk.set_slot_id_to_index(slot_desc.id(), 0);
+
+    std::vector<uint16_t> row_indices;
+    for (int i = 0; i < chunk.num_rows(); ++i) {
+        row_indices.emplace_back(i);
+    }
+    std::vector<int64_t> routed_ids;
+
+    ASSERT_TRUE(router.route_chunk_rows(&chunk, slot_descs, row_indices, tablet_ids, &routed_ids).ok());
+
+    // With left-closed/right-open ranges, value 10 belongs to R1 and value 20 belongs to R2.
+    std::vector<int64_t> expected = {100, 100, 100, 200, 200, 200, 300, 300, 300};
+    ASSERT_EQ(expected.size(), routed_ids.size());
+    for (int i = 0; i < static_cast<int>(expected.size()); ++i) {
+        ASSERT_EQ(expected[i], routed_ids[i]) << "row " << i << " value " << values[i] << " mismatch";
+    }
+}
+
+// Many consecutive ranges to exercise the binary search logic in
+// _find_tablet_index_for_row().
+// Ranges (left-closed/right-open):
+//   R0: (-inf, 0)
+//   R1: [0, 10)
+//   R2: [10, 20)
+//   ...
+//   R7: [60, 70)
+//   R8: [70, +inf)
+// NOLINTNEXTLINE
+TEST_F(RangeRouterTest, ManyRangesBinarySearchFullCoverage) {
+    std::vector<TTabletRange> ranges;
+    std::vector<int64_t> tablet_ids;
+
+    // R0: (-inf, 0)
+    ranges.emplace_back(make_single_long_range(std::nullopt, false, 0, false));
+    tablet_ids.emplace_back(100);
+    // R1..R7: [k*10, (k+1)*10) for k = 0..6 -> values [0,10), ..., [60,70)
+    for (int k = 1; k <= 7; ++k) {
+        ranges.emplace_back(make_single_long_range((k - 1) * 10, true, k * 10, false));
+        tablet_ids.emplace_back(100 + k);
+    }
+    // R8: [70, +inf)
+    ranges.emplace_back(make_single_long_range(70, true, std::nullopt, false));
+    tablet_ids.emplace_back(108);
+
+    RangeRouter router;
+    ASSERT_TRUE(router.init(ranges, 1).ok());
+
+    // For each range, pick two sample points.
+    std::vector<int32_t> values = {
+            -10, 0,  // R0
+            1,   10, // R1
+            11,  20, // R2
+            21,  30, // R3
+            31,  40, // R4
+            41,  50, // R5
+            51,  60, // R6
+            61,  70, // R7
+            71,  100 // R8
+    };
+    Chunk chunk = make_int_chunk("c1", values);
+
+    SlotDescriptor slot_desc(0, "c1", TypeDescriptor::from_logical_type(TYPE_INT));
+    std::vector<SlotDescriptor*> slot_descs{&slot_desc};
+    chunk.set_slot_id_to_index(slot_desc.id(), 0);
+
+    std::vector<uint16_t> row_indices;
+    for (int i = 0; i < chunk.num_rows(); ++i) {
+        row_indices.emplace_back(i);
+    }
+    std::vector<int64_t> routed_ids;
+
+    ASSERT_TRUE(router.route_chunk_rows(&chunk, slot_descs, row_indices, tablet_ids, &routed_ids).ok());
+
+    auto expected_range_idx = [](int v) -> int {
+        if (v < 0) return 0;
+        if (v < 10) return 1;
+        if (v < 20) return 2;
+        if (v < 30) return 3;
+        if (v < 40) return 4;
+        if (v < 50) return 5;
+        if (v < 60) return 6;
+        if (v < 70) return 7;
+        return 8;
+    };
+
+    for (int i = 0; i < chunk.num_rows(); ++i) {
+        int v = values[i];
+        int idx = expected_range_idx(v);
+        ASSERT_EQ(tablet_ids[idx], routed_ids[i]) << "row " << i << " value " << v << " mismatch";
+    }
+}
+
+// Multi-column routing with two ranges fully covering (-inf, +inf) lexicographically.
+// Ranges (left-closed/right-open):
+//   R0: (-inf, -inf) .. (2, 50)
+//   R1: [2, 50) .. (+inf, +inf)
+// NOLINTNEXTLINE
+TEST_F(RangeRouterTest, MultiColumnTwoRangesFullCoverage) {
+    std::vector<TTabletRange> ranges;
+
+    // R0: (-inf, -inf) .. (2, 50)
+    TTabletRange r0;
+    {
+        TVariant v1_up = make_int_variant(2);
+        TVariant v2_up = make_int_variant(50);
+        TTuple upper;
+        upper.__set_values(std::vector<TVariant>{v1_up, v2_up});
+        r0.__set_upper_bound(upper);
+        r0.__set_upper_bound_included(false);
+    }
+
+    // R1: [2, 50) .. (+inf, +inf)
+    TTabletRange r1;
+    {
+        TVariant v1_low = make_int_variant(2);
+        TVariant v2_low = make_int_variant(50);
+        TTuple lower;
+        lower.__set_values(std::vector<TVariant>{v1_low, v2_low});
+        r1.__set_lower_bound(lower);
+        r1.__set_lower_bound_included(true);
+    }
+
+    ranges.push_back(r0);
+    ranges.push_back(r1);
+
+    std::vector<int64_t> tablet_ids{100, 200};
+
+    RangeRouter router;
+    ASSERT_TRUE(router.init(ranges, 2).ok());
+
+    // (c1, c2) tuples:
+    // 0: (1,10)   -> R0
+    // 1: (2,10)   -> R0
+    // 2: (2,50)   -> R1 (lower inclusive)
+    // 3: (3,10)   -> R1
+    // 4: (3,60)   -> R1
+    std::vector<int32_t> col1_vals{1, 2, 2, 3, 3};
+    std::vector<int32_t> col2_vals{10, 10, 50, 10, 60};
+
+    auto c1 = FixedLengthColumn<int32_t>::create();
+    auto c2 = FixedLengthColumn<int32_t>::create();
+    for (auto v : col1_vals) c1->append(v);
+    for (auto v : col2_vals) c2->append(v);
+
+    Chunk chunk;
+    chunk.append_column(c1, 0);
+    chunk.append_column(c2, 1);
+
+    SlotDescriptor slot_desc1(0, "c1", TypeDescriptor::from_logical_type(TYPE_INT));
+    SlotDescriptor slot_desc2(1, "c2", TypeDescriptor::from_logical_type(TYPE_INT));
+    std::vector<SlotDescriptor*> slot_descs{&slot_desc1, &slot_desc2};
+    chunk.set_slot_id_to_index(slot_desc1.id(), 0);
+    chunk.set_slot_id_to_index(slot_desc2.id(), 1);
+
+    std::vector<uint16_t> row_indices;
+    for (int i = 0; i < chunk.num_rows(); ++i) {
+        row_indices.emplace_back(i);
+    }
+    std::vector<int64_t> routed_ids;
+
+    ASSERT_TRUE(router.route_chunk_rows(&chunk, slot_descs, row_indices, tablet_ids, &routed_ids).ok());
+
+    std::vector<int64_t> expected = {100, 100, 200, 200, 200};
+    ASSERT_EQ(expected.size(), routed_ids.size());
+    for (int i = 0; i < static_cast<int>(expected.size()); ++i) {
+        ASSERT_EQ(expected[i], routed_ids[i]) << "row " << i << " mismatch";
+    }
+}
+
+// Multi-column ranges with NULL boundaries (infinite bounds).
+// This test is adapted from the legacy MultiColumnNullBoundaries test to
+// match the current RangeRouter invariants.
+// Ranges:
+//   R0: (-inf, -inf) .. (10, "b")
+//   R1: [10, "b") .. (+inf, +inf)
+// NOLINTNEXTLINE
+TEST_F(RangeRouterTest, MultiColumnNullBoundaries) {
+    std::vector<TTabletRange> ranges;
+
+    // R0: (-inf, -inf) .. (10, "b")
+    TTabletRange r0;
+    r0.upper_bound.values.push_back(make_int_variant(10));
+    r0.upper_bound.values.push_back(make_string_variant("b"));
+    r0.upper_bound.__isset.values = true;
+    r0.upper_bound_included = false;
+    r0.__isset.upper_bound_included = true;
+    r0.__isset.upper_bound = true;
+
+    // R1: [10, "b") .. (+inf, +inf)
+    TTabletRange r1;
+    r1.lower_bound.values.push_back(make_int_variant(10));
+    r1.lower_bound.values.push_back(make_string_variant("b"));
+    r1.lower_bound.__isset.values = true;
+    r1.lower_bound_included = true;
+    r1.__isset.lower_bound_included = true;
+    r1.__isset.lower_bound = true;
+    // No upper_bound means (+inf, +inf)
+
+    ranges.push_back(r0);
+    ranges.push_back(r1);
+
+    std::vector<int64_t> tablet_ids{100, 200};
+
+    RangeRouter router;
+    ASSERT_TRUE(router.init(ranges, 2).ok());
+
+    // Test data: (c1, c2, expected_tablet_id)
+    std::vector<std::tuple<int32_t, std::string, int64_t>> test_data = {
+            {5, "a", 100},  // < (10,"b")
+            {10, "a", 100}, // < (10,"b")
+            {10, "b", 200}, // boundary, goes to R1 (inclusive lower)
+            {10, "c", 200}, // > (10,"b")
+            {20, "a", 200}, // > (10,"b")
+    };
+
+    std::vector<int32_t> col1_values;
+    std::vector<std::string> col2_strings;
+    for (const auto& [v1, v2, expected] : test_data) {
+        (void)expected;
+        col1_values.push_back(v1);
+        col2_strings.push_back(v2);
+    }
+
+    auto col1 = FixedLengthColumn<int32_t>::create();
+    for (auto v : col1_values) {
+        col1->append(v);
+    }
+    auto col2 = BinaryColumn::create();
+    for (const auto& s : col2_strings) {
+        col2->append_string(s);
+    }
+
+    Chunk chunk;
+    chunk.append_column(col1, 0);
+    chunk.append_column(col2, 1);
+
+    SlotDescriptor slot_desc1(0, "c1", TypeDescriptor::from_logical_type(TYPE_INT));
+    SlotDescriptor slot_desc2(1, "c2", TypeDescriptor::from_logical_type(TYPE_VARCHAR));
+    std::vector<SlotDescriptor*> slot_descs{&slot_desc1, &slot_desc2};
+    chunk.set_slot_id_to_index(slot_desc1.id(), 0);
+    chunk.set_slot_id_to_index(slot_desc2.id(), 1);
+
+    std::vector<uint16_t> row_indices;
+    for (size_t i = 0; i < test_data.size(); ++i) {
+        row_indices.emplace_back(i);
+    }
+    std::vector<int64_t> routed_ids;
+
+    ASSERT_TRUE(router.route_chunk_rows(&chunk, slot_descs, row_indices, tablet_ids, &routed_ids).ok());
+    ASSERT_EQ(row_indices.size(), routed_ids.size());
+
+    for (size_t i = 0; i < row_indices.size(); ++i) {
+        const auto& [v1, v2, expected] = test_data[i];
+        ASSERT_EQ(expected, routed_ids[i]) << "Value (" << v1 << ", " << v2 << ") mismatch";
+    }
+}
+
+// VARCHAR ranges with three ranges fully covering (-inf, +inf) with left-closed/right-open semantics:
+//   R0: (-inf, "banana")
+//   R1: ["banana", "date")
+//   R2: ["date", +inf)
+// NOLINTNEXTLINE
+TEST_F(RangeRouterTest, VarcharThreeRangesFullCoverage) {
+    std::vector<TTabletRange> ranges;
+    ranges.emplace_back(make_single_string_range(std::nullopt, false, std::string("banana"), false)); // (-inf, "banana")
+    ranges.emplace_back(
+            make_single_string_range(std::string("banana"), true, std::string("date"), false));       // ["banana","date")
+    ranges.emplace_back(make_single_string_range(std::string("date"), true, std::nullopt, false));    // ["date", +inf)
+
+    std::vector<int64_t> tablet_ids{10, 20, 30};
+
+    RangeRouter router;
+    ASSERT_TRUE(router.init(ranges, 1).ok());
+
+    std::vector<std::string> values = {"apple", "banana", "cherry", "date", "fig"};
+    Chunk chunk = make_varchar_chunk("s1", values);
+
+    SlotDescriptor slot_desc(0, "s1", TypeDescriptor::from_logical_type(TYPE_VARCHAR));
+    std::vector<SlotDescriptor*> slot_descs{&slot_desc};
+    chunk.set_slot_id_to_index(slot_desc.id(), 0);
+
+    std::vector<uint16_t> row_indices;
+    for (int i = 0; i < chunk.num_rows(); ++i) {
+        row_indices.emplace_back(i);
+    }
+    std::vector<int64_t> routed_ids;
+
+    ASSERT_TRUE(router.route_chunk_rows(&chunk, slot_descs, row_indices, tablet_ids, &routed_ids).ok());
+
+    // "apple"           -> R0 (10)
+    // "banana","cherry" -> R1 (20)
+    // "date", "fig"     -> R2 (30)
+    std::vector<int64_t> expected = {10, 20, 20, 30, 30};
+    ASSERT_EQ(expected.size(), routed_ids.size());
+    for (int i = 0; i < static_cast<int>(expected.size()); ++i) {
+        ASSERT_EQ(expected[i], routed_ids[i]) << "row " << i << " value " << values[i] << " mismatch";
+    }
+}
+
+// ----------------------------------------------------------------------
+// Validation tests for _validate_range()
+// ----------------------------------------------------------------------
+
+// Missing -inf/+inf ranges should be rejected.
+// NOLINTNEXTLINE
+TEST_F(RangeRouterTest, ValidateRangeMissingInfiniteBounds) {
+    // Case 1: no -inf and no +inf (both ranges have finite lower/upper)
+    {
+        std::vector<TTabletRange> ranges;
+        ranges.emplace_back(make_single_long_range(0, true, 10, true));   // [0,10]
+        ranges.emplace_back(make_single_long_range(10, false, 20, true)); // (10,20]
+
+        RangeRouter router;
+        auto st = router.init(ranges, 1);
+        ASSERT_FALSE(st.ok());
+        assert_status_message_contains(st, "lower_inf_count and upper_inf_count must be 1");
+    }
+
+    // Case 2: two -inf ranges (both missing lower bound)
+    {
+        std::vector<TTabletRange> ranges;
+        ranges.emplace_back(make_single_long_range(std::nullopt, false, 10, true)); // (-inf,10]
+        ranges.emplace_back(make_single_long_range(std::nullopt, false, 20, true)); // another -inf range
+
+        RangeRouter router;
+        auto st = router.init(ranges, 1);
+        ASSERT_FALSE(st.ok());
+        assert_status_message_contains(st, "lower_inf_count and upper_inf_count must be 1");
+    }
+}
+
+// -inf/+inf ranges must be placed at the first / last tablet range.
+// NOLINTNEXTLINE
+TEST_F(RangeRouterTest, ValidateRangeInfiniteNotAtEdges) {
+    // Case 1: -inf range exists but is not at first position.
+    // We also keep a single +inf range so that lower_inf_count == upper_inf_count == 1,
+    // and the error is triggered by the "at edges" check instead of the count check.
+    {
+        std::vector<TTabletRange> ranges;
+        // finite range at index 0: [0,10)
+        TTabletRange finite = make_single_long_range(0, true, 10, false);
+
+        // r1 has no lower bound => -inf, but appears at index 1.
+        TTabletRange r1;
+        TTuple upper_tuple;
+        upper_tuple.__set_values(std::vector<TVariant>{make_int_variant(20)});
+        r1.__set_upper_bound(upper_tuple);
+        r1.__set_upper_bound_included(false);
+
+        // r2 is the +inf range at the last position: [20,+inf)
+        TTabletRange r2 = make_single_long_range(20, true, std::nullopt, false);
+
+        ranges.push_back(finite);
+        ranges.push_back(r1);
+        ranges.push_back(r2);
+
+        RangeRouter router;
+        auto st = router.init(ranges, 1);
+        ASSERT_FALSE(st.ok());
+        assert_status_message_contains(st, "-inf/inf range must be set for the first and last tablet range");
+    }
+
+    // Case 2: +inf range exists but is not at last position.
+    // Similarly, we keep a single -inf range so that the count check passes first.
+    {
+        std::vector<TTabletRange> ranges;
+
+        // r0 has no lower bound => -inf and is placed at index 0.
+        TTabletRange r0 = make_single_long_range(std::nullopt, false, 10, true); // (-inf,10]
+
+        // r1 has no upper bound => +inf, but it is not the last range.
+        TTabletRange r1 = make_single_long_range(10, true, std::nullopt, false); // [10,+inf)
+
+        // finite range at the last index
+        TTabletRange r2 = make_single_long_range(20, true, 30, false); // [20,30)
+
+        ranges.push_back(r0);
+        ranges.push_back(r1);
+        ranges.push_back(r2);
+
+        RangeRouter router;
+        auto st = router.init(ranges, 1);
+        ASSERT_FALSE(st.ok());
+        assert_status_message_contains(st, "-inf/inf range must be set for the first and last tablet range");
+    }
+}
+
+// Adjacent ranges must have complementary inclusive/exclusive flags on the
+// shared boundary; both-inclusive or both-exclusive should be rejected.
+// NOLINTNEXTLINE
+TEST_F(RangeRouterTest, ValidateRangeAdjacentInclusiveExclusiveOverlap) {
+    // Case 1: both-inclusive at boundary 10: (-inf,10] and [10,+inf)
+    {
+        std::vector<TTabletRange> ranges;
+        ranges.emplace_back(make_single_long_range(std::nullopt, false, 10, true)); // (-inf,10]
+        ranges.emplace_back(make_single_long_range(10, true, std::nullopt, false)); // [10,+inf)
+
+        RangeRouter router;
+        auto st = router.init(ranges, 1);
+        ASSERT_FALSE(st.ok());
+        assert_status_message_contains(
+                st, "adjacent ranges are overlapping / not complementary for the inclusive/exclusive bound");
+    }
+
+    // Case 2: both-exclusive at boundary 10: (-inf,10) and (10,+inf)
+    {
+        std::vector<TTabletRange> ranges;
+        ranges.emplace_back(make_single_long_range(std::nullopt, false, 10, false)); // (-inf,10)
+        ranges.emplace_back(make_single_long_range(10, false, std::nullopt, false)); // (10,+inf)
+
+        RangeRouter router;
+        auto st = router.init(ranges, 1);
+        ASSERT_FALSE(st.ok());
+        assert_status_message_contains(
+                st, "adjacent ranges are overlapping / not complementary for the inclusive/exclusive bound");
+    }
+}
+
+// Type mismatch on adjacent boundaries should be detected.
+// NOLINTNEXTLINE
+TEST_F(RangeRouterTest, ValidateRangeTypeMismatchAtBoundary) {
+    std::vector<TTabletRange> ranges;
+
+    // R0 upper bound uses INT (long_value)
+    TTabletRange r0;
+    {
+        TVariant v_up = make_int_variant(10);
+        TTuple upper;
+        upper.__set_values(std::vector<TVariant>{v_up});
+        r0.__set_upper_bound(upper);
+        r0.__set_upper_bound_included(false);
+    }
+
+    // R1 lower bound uses VARCHAR (string_value) => type mismatch in TVariant payload.
+    TTabletRange r1;
+    {
+        TVariant v_low = make_string_variant("10");
+        TTuple lower;
+        lower.__set_values(std::vector<TVariant>{v_low});
+        r1.__set_lower_bound(lower);
+        r1.__set_lower_bound_included(true);
+    }
+
+    ranges.push_back(r0);
+    ranges.push_back(r1);
+
+    RangeRouter router;
+    auto st = router.init(ranges, 1);
+    ASSERT_FALSE(st.ok());
+    assert_status_message_contains(st, "Type mismatch at column 0 between range[0] and range[1]");
+}
+
+// Adjacent boundaries with different values should be rejected as they would
+// leave a gap or create overlap.
+// NOLINTNEXTLINE
+TEST_F(RangeRouterTest, ValidateRangeEndpointsNotEqual) {
+    std::vector<TTabletRange> ranges;
+
+    // R0: (-inf,10)
+    TTabletRange r0 = make_single_long_range(std::nullopt, false, 10, false);
+    // R1: [20,+inf) -> lower bound 20, which does not equal the previous upper bound 10.
+    TTabletRange r1 = make_single_long_range(20, true, std::nullopt, false);
+
+    ranges.push_back(r0);
+    ranges.push_back(r1);
+
+    RangeRouter router;
+    auto st = router.init(ranges, 1);
+    ASSERT_FALSE(st.ok());
+    assert_status_message_contains(st, "Range[0] != range[1] at column 0");
+}
+
+// ----------------------------------------------------------------------
+// HLL type handling
+// ----------------------------------------------------------------------
+
+// HLL TVariant encoded using string_value only. RangeRouter currently does not
+// support building HLL boundaries via datum_from_string(), but it should fail
+// gracefully with a NotSupported status once _validate_range() passes.
+// NOLINTNEXTLINE
+TEST_F(RangeRouterTest, HllVariantInitNotSupported) {
+    // Build two HLL ranges that satisfy _validate_range():
+    //   R0: (-inf, "boundary"]
+    //   R1: ("boundary", +inf)
+    std::vector<TTabletRange> ranges;
+
+    // R0: (-inf, "boundary")
+    {
+        TTabletRange r0;
+        TTuple upper;
+        upper.__set_values(std::vector<TVariant>{make_hll_variant("boundary")});
+        r0.__set_upper_bound(upper);
+        r0.__set_upper_bound_included(false);
+        ranges.push_back(r0);
+    }
+
+    // R1: ["boundary", +inf)
+    {
+        TTabletRange r1;
+        TTuple lower;
+        lower.__set_values(std::vector<TVariant>{make_hll_variant("boundary")});
+        r1.__set_lower_bound(lower);
+        r1.__set_lower_bound_included(true);
+        ranges.push_back(r1);
+    }
+
+    RangeRouter router;
+    Status st = router.init(ranges, 1);
+    // The exact error code is implementation-defined, but we at least
+    // expect a NotSupported error rather than a crash.
+    ASSERT_TRUE(st.is_not_supported()) << st.to_string();
+}
+
+// ----------------------------------------------------------------------
+// Datetime TVariant with ISO-8601 + nanos format
+// ----------------------------------------------------------------------
+
+// Simulate FE sending a DATETIME boundary encoded as Instant.toString(),
+// e.g. "2024-01-01T00:00:00.123456789Z". RangeRouter should still be able
+// to initialize successfully via the generic datetime parser.
+// NOLINTNEXTLINE
+TEST_F(RangeRouterTest, DateTimeIsoWithNanosInitOk) {
+    std::vector<TTabletRange> ranges;
+
+    // Boundary in ISO-8601 format with 9 fractional digits and 'Z' suffix.
+    const std::string boundary = "2024-01-01T00:00:00.123456789Z";
+
+    // R0: (-inf, boundary)
+    TTabletRange r0;
+    {
+        TVariant v_up = make_datetime_variant(boundary);
+        TTuple upper;
+        upper.__set_values(std::vector<TVariant>{v_up});
+        r0.__set_upper_bound(upper);
+        r0.__set_upper_bound_included(false);
+    }
+
+    // R1: [boundary, +inf)
+    TTabletRange r1;
+    {
+        TVariant v_low = make_datetime_variant(boundary);
+        TTuple lower;
+        lower.__set_values(std::vector<TVariant>{v_low});
+        r1.__set_lower_bound(lower);
+        r1.__set_lower_bound_included(true);
+    }
+
+    ranges.push_back(r0);
+    ranges.push_back(r1);
+
+    RangeRouter router;
+    // If the FE-style ISO-8601 datetime with nanos cannot be parsed, init()
+    // would return an error here. We only care that initialization succeeds.
+    ASSERT_TRUE(router.init(ranges, 1).ok());
+}
+
+} // namespace starrocks

--- a/be/test/exec/range_router_test.cpp
+++ b/be/test/exec/range_router_test.cpp
@@ -198,9 +198,9 @@ TEST_F(RangeRouterTest, SingleInfiniteRangeSelectAll) {
 // NOLINTNEXTLINE
 TEST_F(RangeRouterTest, IntThreeRangesFullCoverage) {
     std::vector<TTabletRange> ranges;
-    ranges.emplace_back(make_single_long_range(std::nullopt, false, 10, false));  // (-inf, 10)
-    ranges.emplace_back(make_single_long_range(10, true, 20, false));             // [10, 20)
-    ranges.emplace_back(make_single_long_range(20, true, std::nullopt, false));   // [20, +inf)
+    ranges.emplace_back(make_single_long_range(std::nullopt, false, 10, false)); // (-inf, 10)
+    ranges.emplace_back(make_single_long_range(10, true, 20, false));            // [10, 20)
+    ranges.emplace_back(make_single_long_range(20, true, std::nullopt, false));  // [20, +inf)
 
     std::vector<int64_t> tablet_ids{100, 200, 300};
 
@@ -476,10 +476,11 @@ TEST_F(RangeRouterTest, MultiColumnNullBoundaries) {
 // NOLINTNEXTLINE
 TEST_F(RangeRouterTest, VarcharThreeRangesFullCoverage) {
     std::vector<TTabletRange> ranges;
-    ranges.emplace_back(make_single_string_range(std::nullopt, false, std::string("banana"), false)); // (-inf, "banana")
     ranges.emplace_back(
-            make_single_string_range(std::string("banana"), true, std::string("date"), false));       // ["banana","date")
-    ranges.emplace_back(make_single_string_range(std::string("date"), true, std::nullopt, false));    // ["date", +inf)
+            make_single_string_range(std::nullopt, false, std::string("banana"), false)); // (-inf, "banana")
+    ranges.emplace_back(
+            make_single_string_range(std::string("banana"), true, std::string("date"), false));    // ["banana","date")
+    ranges.emplace_back(make_single_string_range(std::string("date"), true, std::nullopt, false)); // ["date", +inf)
 
     std::vector<int64_t> tablet_ids{10, 20, 30};
 

--- a/be/test/exec/tablet_sink_sender_range_test.cpp
+++ b/be/test/exec/tablet_sink_sender_range_test.cpp
@@ -1,0 +1,1264 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <limits>
+
+#include "column/chunk.h"
+#include "column/datum.h"
+#include "column/fixed_length_column.h"
+#include "column/schema.h"
+#include "column/type_traits.h"
+#include "exec/range_tablet_sink_sender.h"
+#include "exec/tablet_info.h"
+#include "runtime/types.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+class TestRangeTabletSinkSender : public RangeTabletSinkSender {
+public:
+    TestRangeTabletSinkSender(PUniqueId load_id, int64_t txn_id, IndexIdToTabletBEMap index_id_to_tablet_be_map,
+                              OlapTablePartitionParam* partition_params, std::vector<IndexChannel*> channels,
+                              std::unordered_map<int64_t, NodeChannel*> node_channels,
+                              std::vector<ExprContext*> output_expr_ctxs, bool enable_replicated_storage,
+                              TWriteQuorumType::type write_quorum_type, int num_repicas)
+            : RangeTabletSinkSender(std::move(load_id), txn_id, index_id_to_tablet_be_map, partition_params,
+                                    std::move(channels), std::move(node_channels), std::move(output_expr_ctxs),
+                                    enable_replicated_storage, write_quorum_type, num_repicas),
+              _index_id_to_tablet_be_map_for_test(index_id_to_tablet_be_map),
+              _enable_replicated_storage_for_test(enable_replicated_storage) {}
+
+    // Override to capture routing info instead of real RPC.
+    Status _send_chunk_by_node(Chunk* /*chunk*/, IndexChannel* channel,
+                               const std::vector<uint16_t>& selection_idx) override {
+        SentBatch batch;
+        batch.index_id = channel->index_id();
+        batch.selection_idx = selection_idx;
+        // Snapshot current tablet_ids for selected rows.
+        for (auto idx : selection_idx) {
+            batch.tablet_ids.push_back(_tablet_ids[idx]);
+        }
+        _sent_batches.push_back(std::move(batch));
+
+        // Additionally simulate BE-level routing based on IndexIdToTabletBEMap.
+        auto it = _index_id_to_tablet_be_map_for_test.find(batch.index_id);
+        if (it != _index_id_to_tablet_be_map_for_test.end()) {
+            const auto& tablet_to_bes = it->second;
+            for (auto idx : selection_idx) {
+                auto tablet_it = tablet_to_bes.find(_tablet_ids[idx]);
+                if (tablet_it == tablet_to_bes.end()) {
+                    continue;
+                }
+                const auto& be_ids = tablet_it->second;
+                if (_enable_replicated_storage_for_test) {
+                    if (!be_ids.empty()) {
+                        int64_t primary_be = be_ids[0];
+                        _be_routing[batch.index_id][primary_be].push_back(idx);
+                    }
+                } else {
+                    for (int64_t be_id : be_ids) {
+                        _be_routing[batch.index_id][be_id].push_back(idx);
+                    }
+                }
+            }
+        }
+        return Status::OK();
+    }
+
+    struct SentBatch {
+        int64_t index_id;
+        std::vector<uint16_t> selection_idx;
+        std::vector<int64_t> tablet_ids;
+    };
+
+    const std::vector<SentBatch>& sent_batches() const { return _sent_batches; }
+
+    // index_id -> (be_id -> row indices)
+    const std::unordered_map<int64_t, std::unordered_map<int64_t, std::vector<uint16_t>>>& be_routing() const {
+        return _be_routing;
+    }
+
+private:
+    std::vector<SentBatch> _sent_batches;
+    IndexIdToTabletBEMap _index_id_to_tablet_be_map_for_test;
+    bool _enable_replicated_storage_for_test;
+    std::unordered_map<int64_t, std::unordered_map<int64_t, std::vector<uint16_t>>> _be_routing;
+};
+
+class TabletSinkSenderRangeTest : public testing::Test {
+public:
+    void SetUp() override {
+        _object_pool = std::make_unique<ObjectPool>();
+        _schema_param = _object_pool->add(new OlapTableSchemaParam());
+        _index_id = 100;
+        _table_id = 10;
+        _db_id = 1;
+    }
+
+    void TearDown() override {}
+
+protected:
+    TTabletRange _make_range(int64_t lower, bool lower_included, int64_t upper, bool upper_included) {
+        TTabletRange range;
+
+        TTuple lower_tuple;
+        TVariant lower_var;
+        lower_var.__set_type(TYPE_BIGINT_DESC.to_thrift());
+        lower_var.__set_value(std::to_string(lower));
+        lower_tuple.__set_values({lower_var});
+        range.__set_lower_bound(lower_tuple);
+        range.__set_lower_bound_included(lower_included);
+
+        TTuple upper_tuple;
+        TVariant upper_var;
+        upper_var.__set_type(TYPE_BIGINT_DESC.to_thrift());
+        upper_var.__set_value(std::to_string(upper));
+        upper_tuple.__set_values({upper_var});
+        range.__set_upper_bound(upper_tuple);
+        range.__set_upper_bound_included(upper_included);
+
+        return range;
+    }
+
+    void _init_schema_param(int num_indexes = 1) {
+        TOlapTableSchemaParam tschema;
+        tschema.db_id = _db_id;
+        tschema.table_id = _table_id;
+        tschema.version = 0;
+
+        // Tuple descriptor
+        TTupleDescriptor tuple_desc;
+        tuple_desc.id = 0;
+        tuple_desc.byteSize = 16;
+        tuple_desc.numNullBytes = 0;
+        tuple_desc.tableId = _table_id;
+        tschema.tuple_desc = tuple_desc;
+
+        // Slot descriptors
+        TSlotDescriptor slot1;
+        slot1.id = 0;
+        slot1.parent = 0;
+        slot1.colName = "c1";
+        slot1.slotType.types.emplace_back();
+        slot1.slotType.types.back().__set_type(TTypeNodeType::SCALAR);
+        slot1.slotType.types.back().__set_scalar_type(TScalarType());
+        slot1.slotType.types.back().scalar_type.__set_type(TPrimitiveType::BIGINT);
+        tschema.slot_descs.push_back(slot1);
+
+        for (int i = 0; i < num_indexes; ++i) {
+            // Index schema
+            TOlapTableIndexSchema index_schema;
+            index_schema.id = _index_id + i;
+            index_schema.columns = {"c1"};
+            index_schema.schema_hash = 0;
+
+            TOlapTableColumnParam column_param;
+            TColumn tcol;
+            tcol.column_name = "c1";
+            tcol.column_type.type = TPrimitiveType::BIGINT;
+            tcol.is_key = true;
+            tcol.is_allow_null = false;
+            tcol.col_unique_id = 0;
+            column_param.columns.push_back(tcol);
+            column_param.sort_key_uid.push_back(0); // Set sort key
+
+            // Use thrift setter to correctly populate __isset.column_param,
+            // so BE side `OlapTableSchemaParam::init` will see column_param.
+            index_schema.__set_column_param(column_param);
+            tschema.indexes.push_back(index_schema);
+        }
+
+        ASSERT_OK(_schema_param->init(tschema));
+    }
+
+    void _init_schema_param_two_columns() {
+        TOlapTableSchemaParam tschema;
+        tschema.db_id = _db_id;
+        tschema.table_id = _table_id;
+        tschema.version = 0;
+
+        // Tuple descriptor
+        TTupleDescriptor tuple_desc;
+        tuple_desc.id = 0;
+        tuple_desc.byteSize = 32;
+        tuple_desc.numNullBytes = 0;
+        tuple_desc.tableId = _table_id;
+        tschema.tuple_desc = tuple_desc;
+
+        // Slot descriptor for c1 BIGINT
+        TSlotDescriptor slot1;
+        slot1.id = 0;
+        slot1.parent = 0;
+        slot1.colName = "c1";
+        slot1.slotType.types.emplace_back();
+        slot1.slotType.types.back().__set_type(TTypeNodeType::SCALAR);
+        slot1.slotType.types.back().__set_scalar_type(TScalarType());
+        slot1.slotType.types.back().scalar_type.__set_type(TPrimitiveType::BIGINT);
+        tschema.slot_descs.push_back(slot1);
+
+        // Slot descriptor for c2 BIGINT
+        TSlotDescriptor slot2;
+        slot2.id = 1;
+        slot2.parent = 0;
+        slot2.colName = "c2";
+        slot2.slotType.types.emplace_back();
+        slot2.slotType.types.back().__set_type(TTypeNodeType::SCALAR);
+        slot2.slotType.types.back().__set_scalar_type(TScalarType());
+        slot2.slotType.types.back().scalar_type.__set_type(TPrimitiveType::BIGINT);
+        tschema.slot_descs.push_back(slot2);
+
+        // Single index using (c1,c2)
+        TOlapTableIndexSchema index_schema;
+        index_schema.id = _index_id;
+        index_schema.columns = {"c1", "c2"};
+        index_schema.schema_hash = 0;
+
+        TOlapTableColumnParam column_param;
+        {
+            TColumn tcol1;
+            tcol1.column_name = "c1";
+            tcol1.column_type.type = TPrimitiveType::BIGINT;
+            tcol1.is_key = true;
+            tcol1.is_allow_null = false;
+            tcol1.col_unique_id = 0;
+            column_param.columns.push_back(tcol1);
+            column_param.sort_key_uid.push_back(0);
+        }
+        {
+            TColumn tcol2;
+            tcol2.column_name = "c2";
+            tcol2.column_type.type = TPrimitiveType::BIGINT;
+            tcol2.is_key = true;
+            tcol2.is_allow_null = false;
+            tcol2.col_unique_id = 1;
+            column_param.columns.push_back(tcol2);
+            column_param.sort_key_uid.push_back(1);
+        }
+
+        index_schema.__set_column_param(column_param);
+        tschema.indexes.push_back(index_schema);
+
+        ASSERT_OK(_schema_param->init(tschema));
+    }
+
+    OlapTablePartitionParam* _create_partition_param(const std::vector<std::vector<TTabletRange>>& index_ranges) {
+        TOlapTablePartitionParam tpartition_param;
+        tpartition_param.db_id = _db_id;
+        tpartition_param.table_id = _table_id;
+        tpartition_param.version = 0;
+        tpartition_param.__set_distributed_columns({"c1"});
+        tpartition_param.__set_distribution_type(TOlapTableDistributionType::RANGE);
+
+        TOlapTablePartition tpartition;
+        tpartition.id = 1000;
+
+        for (size_t i = 0; i < index_ranges.size(); ++i) {
+            TOlapTableIndexTablets index_tablets;
+            index_tablets.index_id = _index_id + i;
+            const auto& ranges = index_ranges[i];
+
+            for (size_t j = 0; j < ranges.size(); ++j) {
+                int64_t tablet_id = 10000 + i * 100 + j;
+                index_tablets.tablet_ids.push_back(tablet_id);
+
+                TOlapTableTablet tablet;
+                tablet.id = tablet_id;
+                // Use thrift setter to correctly populate __isset.range.
+                tablet.__set_range(ranges[j]);
+                index_tablets.tablets.push_back(tablet);
+            }
+            tpartition.indexes.push_back(index_tablets);
+        }
+
+        tpartition_param.partitions.push_back(tpartition);
+
+        // Hack for ObjectPool lifecycle
+        return _object_pool->add(new OlapTablePartitionParam(
+                std::shared_ptr<OlapTableSchemaParam>(_schema_param, [](auto*) {}), tpartition_param));
+    }
+
+    ChunkPtr _create_chunk(const std::vector<int64_t>& values) {
+        auto col = FixedLengthColumn<int64_t>::create();
+        for (int64_t v : values) {
+            col->append(v);
+        }
+
+        Columns cols;
+        cols.emplace_back(col);
+
+        // Mock Schema
+        Fields fields;
+        fields.emplace_back(std::make_shared<Field>(0, "c1", get_type_info(TYPE_BIGINT), false));
+        auto schema = std::make_shared<Schema>(fields);
+
+        auto chunk = std::make_shared<Chunk>(cols, schema);
+        // Set slot_id to column index mapping
+        chunk->set_slot_id_to_index(0, 0); // slot_id 0 -> column index 0
+        return chunk;
+    }
+
+    ChunkPtr _create_two_column_chunk(const std::vector<int64_t>& c1_values, const std::vector<int64_t>& c2_values) {
+        DCHECK_EQ(c1_values.size(), c2_values.size());
+        auto c1 = FixedLengthColumn<int64_t>::create();
+        auto c2 = FixedLengthColumn<int64_t>::create();
+        for (size_t i = 0; i < c1_values.size(); ++i) {
+            c1->append(c1_values[i]);
+            c2->append(c2_values[i]);
+        }
+
+        Columns cols;
+        cols.emplace_back(c1);
+        cols.emplace_back(c2);
+
+        Fields fields;
+        fields.emplace_back(std::make_shared<Field>(0, "c1", get_type_info(TYPE_BIGINT), false));
+        fields.emplace_back(std::make_shared<Field>(1, "c2", get_type_info(TYPE_BIGINT), false));
+        auto schema = std::make_shared<Schema>(fields);
+
+        auto chunk = std::make_shared<Chunk>(cols, schema);
+        // Set slot_id to column index mapping
+        chunk->set_slot_id_to_index(0, 0); // slot_id 0 -> column index 0
+        chunk->set_slot_id_to_index(1, 1); // slot_id 1 -> column index 1
+        return chunk;
+    }
+
+    std::unique_ptr<ObjectPool> _object_pool;
+    OlapTableSchemaParam* _schema_param = nullptr;
+    int64_t _index_id;
+    int64_t _table_id;
+    int64_t _db_id;
+};
+
+// NOLINTNEXTLINE
+TEST_F(TabletSinkSenderRangeTest, NormalRouting) {
+    _init_schema_param();
+
+    // Use full-coverage ranges to satisfy RangeRouter invariants while keeping
+    // the same routing semantics for tested values:
+    //   R0: (-inf, 10)   -> 10000
+    //   R1: [10, +inf)   -> 10001
+    std::vector<TTabletRange> ranges;
+    {
+        // R0: (-inf, 10)
+        TTabletRange r0;
+        TTuple upper_tuple;
+        TVariant upper_var;
+        upper_var.__set_type(TYPE_BIGINT_DESC.to_thrift());
+        upper_var.__set_value(std::to_string(10));
+        upper_tuple.__set_values({upper_var});
+        r0.__set_upper_bound(upper_tuple);
+        r0.__set_upper_bound_included(false);
+        ranges.push_back(r0);
+    }
+    {
+        // R1: [10, +inf)
+        TTabletRange r1;
+        TTuple lower_tuple;
+        TVariant lower_var;
+        lower_var.__set_type(TYPE_BIGINT_DESC.to_thrift());
+        lower_var.__set_value(std::to_string(10));
+        lower_tuple.__set_values({lower_var});
+        r1.__set_lower_bound(lower_tuple);
+        r1.__set_lower_bound_included(true);
+        ranges.push_back(r1);
+    }
+
+    auto* partition_param = _create_partition_param({ranges});
+    ASSERT_OK(partition_param->init(nullptr));
+
+    PUniqueId load_id;
+    IndexIdToTabletBEMap index_id_to_tablet_be_map;
+    index_id_to_tablet_be_map[_index_id] = {};
+
+    std::vector<IndexChannel*> channels;
+    channels.push_back(_object_pool->add(new IndexChannel(nullptr, _index_id, nullptr)));
+    std::unordered_map<int64_t, NodeChannel*> node_channels;
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    TestRangeTabletSinkSender sender(load_id, 1, index_id_to_tablet_be_map, partition_param, channels, node_channels,
+                                     output_expr_ctxs, false, TWriteQuorumType::MAJORITY, 1);
+
+    auto chunk = _create_chunk({5, 15, 0, 19});
+
+    std::vector<OlapTablePartition*> partitions;
+    auto* part = partition_param->get_partitions().begin()->second;
+    partitions.resize(4, part);
+
+    std::vector<uint16_t> validate_select_idx = {0, 1, 2, 3};
+    std::unordered_map<int64_t, std::set<int64_t>> index_id_partition_id;
+
+    Status st =
+            sender.send_chunk(_schema_param, partitions, {}, validate_select_idx, index_id_partition_id, chunk.get());
+    ASSERT_OK(st);
+
+    const auto& batches = sender.sent_batches();
+    ASSERT_EQ(1, batches.size());
+    const auto& tablet_ids = batches[0].tablet_ids;
+
+    ASSERT_EQ(4, tablet_ids.size());
+    EXPECT_EQ(10000, tablet_ids[0]);
+    EXPECT_EQ(10001, tablet_ids[1]);
+    EXPECT_EQ(10000, tablet_ids[2]);
+    EXPECT_EQ(10001, tablet_ids[3]);
+
+    // index_id_partition_id should record the single partition for this index.
+    ASSERT_EQ(1, index_id_partition_id[_index_id].size());
+    EXPECT_EQ(1000, *index_id_partition_id[_index_id].begin());
+}
+
+// NOLINTNEXTLINE
+TEST_F(TabletSinkSenderRangeTest, MultiIndexRouting) {
+    _init_schema_param(2); // Two indexes
+
+    // Index 1 (100):
+    //   R0: (-inf, 10)   -> 10000
+    //   R1: [10, +inf)   -> 10001
+    // Index 2 (101):
+    //   R0: (-inf, 5)    -> 10100
+    //   R1: [5, +inf)    -> 10101
+    std::vector<TTabletRange> ranges1;
+    {
+        // Index 1, R0: (-inf, 10)
+        TTabletRange r0;
+        TTuple upper_tuple;
+        TVariant upper_var;
+        upper_var.__set_type(TYPE_BIGINT_DESC.to_thrift());
+        upper_var.__set_value(std::to_string(10));
+        upper_tuple.__set_values({upper_var});
+        r0.__set_upper_bound(upper_tuple);
+        r0.__set_upper_bound_included(false);
+        ranges1.push_back(r0);
+    }
+    {
+        // Index 1, R1: [10, +inf)
+        TTabletRange r1;
+        TTuple lower_tuple;
+        TVariant lower_var;
+        lower_var.__set_type(TYPE_BIGINT_DESC.to_thrift());
+        lower_var.__set_value(std::to_string(10));
+        lower_tuple.__set_values({lower_var});
+        r1.__set_lower_bound(lower_tuple);
+        r1.__set_lower_bound_included(true);
+        ranges1.push_back(r1);
+    }
+
+    std::vector<TTabletRange> ranges2;
+    {
+        // Index 2, R0: (-inf, 5)
+        TTabletRange r0;
+        TTuple upper_tuple;
+        TVariant upper_var;
+        upper_var.__set_type(TYPE_BIGINT_DESC.to_thrift());
+        upper_var.__set_value(std::to_string(5));
+        upper_tuple.__set_values({upper_var});
+        r0.__set_upper_bound(upper_tuple);
+        r0.__set_upper_bound_included(false);
+        ranges2.push_back(r0);
+    }
+    {
+        // Index 2, R1: [5, +inf)
+        TTabletRange r1;
+        TTuple lower_tuple;
+        TVariant lower_var;
+        lower_var.__set_type(TYPE_BIGINT_DESC.to_thrift());
+        lower_var.__set_value(std::to_string(5));
+        lower_tuple.__set_values({lower_var});
+        r1.__set_lower_bound(lower_tuple);
+        r1.__set_lower_bound_included(true);
+        ranges2.push_back(r1);
+    }
+
+    auto* partition_param = _create_partition_param({ranges1, ranges2});
+    ASSERT_OK(partition_param->init(nullptr));
+
+    PUniqueId load_id;
+    IndexIdToTabletBEMap index_id_to_tablet_be_map;
+    index_id_to_tablet_be_map[_index_id] = {};
+    index_id_to_tablet_be_map[_index_id + 1] = {};
+
+    std::vector<IndexChannel*> channels;
+    channels.push_back(_object_pool->add(new IndexChannel(nullptr, _index_id, nullptr)));
+    channels.push_back(_object_pool->add(new IndexChannel(nullptr, _index_id + 1, nullptr)));
+
+    std::unordered_map<int64_t, NodeChannel*> node_channels;
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    TestRangeTabletSinkSender sender(load_id, 1, index_id_to_tablet_be_map, partition_param, channels, node_channels,
+                                     output_expr_ctxs, false, TWriteQuorumType::MAJORITY, 1);
+
+    // Data: 2, 7, 15
+    auto chunk = _create_chunk({2, 7, 15});
+    std::vector<OlapTablePartition*> partitions;
+    auto* part = partition_param->get_partitions().begin()->second;
+    partitions.resize(3, part);
+    std::vector<uint16_t> validate_select_idx = {0, 1, 2};
+    std::unordered_map<int64_t, std::set<int64_t>> index_id_partition_id;
+
+    Status st =
+            sender.send_chunk(_schema_param, partitions, {}, validate_select_idx, index_id_partition_id, chunk.get());
+    ASSERT_OK(st);
+
+    const auto& batches = sender.sent_batches();
+    ASSERT_EQ(2, batches.size());
+
+    // Check Index 1 (Batch 0)
+    // 2 -> [0, 10) -> 10000
+    // 7 -> [0, 10) -> 10000
+    // 15 -> [10, 20) -> 10001
+    EXPECT_EQ(_index_id, batches[0].index_id);
+    EXPECT_EQ(10000, batches[0].tablet_ids[0]);
+    EXPECT_EQ(10000, batches[0].tablet_ids[1]);
+    EXPECT_EQ(10001, batches[0].tablet_ids[2]);
+
+    // Check Index 2 (Batch 1)
+    // 2 -> [0, 5) -> 10100
+    // 7 -> [5, 20) -> 10101
+    // 15 -> [5, 20) -> 10101
+    EXPECT_EQ(_index_id + 1, batches[1].index_id);
+    EXPECT_EQ(10100, batches[1].tablet_ids[0]);
+    EXPECT_EQ(10101, batches[1].tablet_ids[1]);
+    EXPECT_EQ(10101, batches[1].tablet_ids[2]);
+
+    // Both indexes should record the same partition id.
+    ASSERT_EQ(1, index_id_partition_id[_index_id].size());
+    ASSERT_EQ(1, index_id_partition_id[_index_id + 1].size());
+    EXPECT_EQ(1000, *index_id_partition_id[_index_id].begin());
+    EXPECT_EQ(1000, *index_id_partition_id[_index_id + 1].begin());
+}
+
+// NOLINTNEXTLINE
+TEST_F(TabletSinkSenderRangeTest, GapRangeWithPartialMatchAndError) {
+    _init_schema_param();
+
+    // This test verifies that misconfigured ranges (missing -inf/+inf coverage)
+    // are rejected when initializing RangeRouter inside RangeTabletSinkSender.
+    // Tablet 1: [0, 5)
+    // Tablet 2: [10, 20)
+    std::vector<TTabletRange> ranges;
+    ranges.push_back(_make_range(0, true, 5, false));
+    ranges.push_back(_make_range(10, true, 20, false));
+
+    auto* partition_param = _create_partition_param({ranges});
+    ASSERT_OK(partition_param->init(nullptr));
+
+    PUniqueId load_id;
+    IndexIdToTabletBEMap index_id_to_tablet_be_map;
+    index_id_to_tablet_be_map[_index_id] = {};
+    std::vector<IndexChannel*> channels;
+    channels.push_back(_object_pool->add(new IndexChannel(nullptr, _index_id, nullptr)));
+    std::unordered_map<int64_t, NodeChannel*> node_channels;
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    TestRangeTabletSinkSender sender(load_id, 1, index_id_to_tablet_be_map, partition_param, channels, node_channels,
+                                     output_expr_ctxs, false, TWriteQuorumType::MAJORITY, 1);
+
+    // 2 and 12 have matching ranges; 7 falls into the gap [5,10) logically,
+    // but with the new RangeRouter invariants, such a configuration is treated
+    // as invalid at initialization time.
+    auto chunk = _create_chunk({2, 7, 12});
+
+    std::vector<OlapTablePartition*> partitions;
+    auto* part = partition_param->get_partitions().begin()->second;
+    partitions.resize(3, part);
+    std::vector<uint16_t> validate_select_idx = {0, 1, 2};
+    std::unordered_map<int64_t, std::set<int64_t>> index_id_partition_id;
+
+    Status st =
+            sender.send_chunk(_schema_param, partitions, {}, validate_select_idx, index_id_partition_id, chunk.get());
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.message().find("lower_inf_count and upper_inf_count must be 1") != std::string::npos);
+}
+
+// NOLINTNEXTLINE
+TEST_F(TabletSinkSenderRangeTest, MultiColumnRangeRouting) {
+    // Two range columns (c1, c2), both BIGINT
+    _init_schema_param_two_columns();
+
+    // Partition 1000, index 100:
+    // Use two ranges that fully cover the space lexicographically while
+    // preserving the expected routing for tested points:
+    //   R0: (-inf, -inf) .. (3, MAX)   -> 10000
+    //   R1: (3, MAX) .. (+inf, +inf)   -> 10001
+    TOlapTablePartitionParam tpartition_param;
+    tpartition_param.db_id = _db_id;
+    tpartition_param.table_id = _table_id;
+    tpartition_param.version = 0;
+    tpartition_param.__set_distributed_columns({"c1", "c2"});
+    tpartition_param.__set_distribution_type(TOlapTableDistributionType::RANGE);
+
+    TOlapTablePartition tpartition;
+    tpartition.id = 1000;
+
+    TOlapTableIndexTablets index_tablets;
+    index_tablets.index_id = _index_id;
+
+    // Helper to build a 2-column BIGINT tuple.
+    auto make_two_bigint_tuple = [](int64_t v1, int64_t v2) {
+        TVariant var1;
+        var1.__set_type(TYPE_BIGINT_DESC.to_thrift());
+        var1.__set_value(std::to_string(v1));
+        TVariant var2;
+        var2.__set_type(TYPE_BIGINT_DESC.to_thrift());
+        var2.__set_value(std::to_string(v2));
+        TTuple t;
+        t.__set_values(std::vector<TVariant>{var1, var2});
+        return t;
+    };
+
+    // Tablet 10000: (-inf, -inf) .. (3, MAX]
+    {
+        int64_t tablet_id = 10000;
+        index_tablets.tablet_ids.push_back(tablet_id);
+
+        TTabletRange range;
+        // upper bound (3, MAX), no lower bound => (-inf, -inf)..(3, MAX)
+        int64_t max_v = std::numeric_limits<int64_t>::max();
+        range.__set_upper_bound(make_two_bigint_tuple(3, max_v));
+        range.__set_upper_bound_included(false);
+
+        TOlapTableTablet tablet;
+        tablet.id = tablet_id;
+        tablet.__set_range(range);
+        index_tablets.tablets.push_back(tablet);
+    }
+
+    // Tablet 10001: [3, MAX] .. (+inf, +inf)
+    {
+        int64_t tablet_id = 10001;
+        index_tablets.tablet_ids.push_back(tablet_id);
+
+        TTabletRange range;
+        int64_t max_v = std::numeric_limits<int64_t>::max();
+        range.__set_lower_bound(make_two_bigint_tuple(3, max_v));
+        range.__set_lower_bound_included(true);
+
+        TOlapTableTablet tablet;
+        tablet.id = tablet_id;
+        tablet.__set_range(range);
+        index_tablets.tablets.push_back(tablet);
+    }
+
+    tpartition.indexes.push_back(index_tablets);
+    tpartition_param.partitions.push_back(tpartition);
+
+    auto* partition_param = _object_pool->add(new OlapTablePartitionParam(
+            std::shared_ptr<OlapTableSchemaParam>(_schema_param, [](auto*) {}), tpartition_param));
+    ASSERT_OK(partition_param->init(nullptr));
+
+    PUniqueId load_id;
+    IndexIdToTabletBEMap index_id_to_tablet_be_map;
+    index_id_to_tablet_be_map[_index_id] = {};
+    std::vector<IndexChannel*> channels;
+    channels.push_back(_object_pool->add(new IndexChannel(nullptr, _index_id, nullptr)));
+    std::unordered_map<int64_t, NodeChannel*> node_channels;
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    TestRangeTabletSinkSender sender(load_id, 1, index_id_to_tablet_be_map, partition_param, channels, node_channels,
+                                     output_expr_ctxs, false, TWriteQuorumType::MAJORITY, 1);
+
+    // (c1,c2) rows:
+    // idx 0: (2,10)  -> tablet 10000
+    // idx 1: (2,50)  -> tablet 10000
+    // idx 2: (3,10)  -> tablet 10000
+    // idx 3: (3,60)  -> tablet 10000
+    // idx 4: (4,10)  -> tablet 10001
+    // idx 5: (4,50)  -> tablet 10001
+    auto chunk = _create_two_column_chunk({2, 2, 3, 3, 4, 4},        // c1
+                                          {10, 50, 10, 60, 10, 50}); // c2
+
+    std::vector<OlapTablePartition*> partitions;
+    auto* part = partition_param->get_partitions().begin()->second;
+    partitions.resize(chunk->num_rows(), part);
+
+    std::vector<uint16_t> validate_select_idx = {0, 1, 2, 3, 4, 5};
+    std::unordered_map<int64_t, std::set<int64_t>> index_id_partition_id;
+
+    Status st =
+            sender.send_chunk(_schema_param, partitions, {}, validate_select_idx, index_id_partition_id, chunk.get());
+    ASSERT_OK(st);
+
+    const auto& batches = sender.sent_batches();
+    ASSERT_EQ(1, batches.size());
+    const auto& tablet_ids = batches[0].tablet_ids;
+    ASSERT_EQ(6, tablet_ids.size());
+
+    // First four rows should go to tablet 10000, last two to 10001.
+    EXPECT_EQ(10000, tablet_ids[0]);
+    EXPECT_EQ(10000, tablet_ids[1]);
+    EXPECT_EQ(10000, tablet_ids[2]);
+    EXPECT_EQ(10000, tablet_ids[3]);
+    EXPECT_EQ(10001, tablet_ids[4]);
+    EXPECT_EQ(10001, tablet_ids[5]);
+
+    ASSERT_EQ(1, index_id_partition_id[_index_id].size());
+    EXPECT_EQ(1000, *index_id_partition_id[_index_id].begin());
+}
+
+// NOLINTNEXTLINE
+TEST_F(TabletSinkSenderRangeTest, MultiPartitionRoutingSingleIndex) {
+    _init_schema_param();
+
+    // Build partition param with two partitions, each having a single
+    // (-inf, +inf) range. Partition selection is done outside RangeRouter.
+    TOlapTablePartitionParam tpartition_param;
+    tpartition_param.db_id = _db_id;
+    tpartition_param.table_id = _table_id;
+    tpartition_param.version = 0;
+    tpartition_param.__set_distributed_columns({"c1"});
+    tpartition_param.__set_distribution_type(TOlapTableDistributionType::RANGE);
+
+    // Partition 1000
+    {
+        TOlapTablePartition tpartition;
+        tpartition.id = 1000;
+
+        TOlapTableIndexTablets index_tablets;
+        index_tablets.index_id = _index_id;
+
+        // (-inf,+inf) -> tablet 10000
+        int64_t tablet_id = 10000;
+        index_tablets.tablet_ids.push_back(tablet_id);
+        TOlapTableTablet tablet;
+        tablet.id = tablet_id;
+        // No lower/upper bound in the range => (-inf, +inf)
+        {
+            TTabletRange full_range;
+            tablet.__set_range(full_range);
+        }
+        index_tablets.tablets.push_back(tablet);
+
+        tpartition.indexes.push_back(index_tablets);
+        tpartition_param.partitions.push_back(tpartition);
+    }
+
+    // Partition 1001
+    {
+        TOlapTablePartition tpartition;
+        tpartition.id = 1001;
+
+        TOlapTableIndexTablets index_tablets;
+        index_tablets.index_id = _index_id;
+
+        // (-inf,+inf) -> tablet 10001
+        int64_t tablet_id = 10001;
+        index_tablets.tablet_ids.push_back(tablet_id);
+        TOlapTableTablet tablet;
+        tablet.id = tablet_id;
+        // No lower/upper bound in the range => (-inf, +inf)
+        {
+            TTabletRange full_range;
+            tablet.__set_range(full_range);
+        }
+        index_tablets.tablets.push_back(tablet);
+
+        tpartition.indexes.push_back(index_tablets);
+        tpartition_param.partitions.push_back(tpartition);
+    }
+
+    auto* partition_param = _object_pool->add(new OlapTablePartitionParam(
+            std::shared_ptr<OlapTableSchemaParam>(_schema_param, [](auto*) {}), tpartition_param));
+    ASSERT_OK(partition_param->init(nullptr));
+
+    PUniqueId load_id;
+    IndexIdToTabletBEMap index_id_to_tablet_be_map;
+    index_id_to_tablet_be_map[_index_id] = {};
+    std::vector<IndexChannel*> channels;
+    channels.push_back(_object_pool->add(new IndexChannel(nullptr, _index_id, nullptr)));
+    std::unordered_map<int64_t, NodeChannel*> node_channels;
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    TestRangeTabletSinkSender sender(load_id, 1, index_id_to_tablet_be_map, partition_param, channels, node_channels,
+                                     output_expr_ctxs, false, TWriteQuorumType::MAJORITY, 1);
+
+    // Data: 5 (partition 1000), 15 (partition 1001)
+    auto chunk = _create_chunk({5, 15});
+
+    // Partition array is per-row: row0 -> partition 1000, row1 -> partition 1001.
+    std::vector<OlapTablePartition*> partitions;
+    auto it = partition_param->get_partitions().begin();
+    OlapTablePartition* p0 = it->second;
+    ++it;
+    OlapTablePartition* p1 = it->second;
+    partitions.push_back(p0); // row 0
+    partitions.push_back(p1); // row 1
+
+    std::vector<uint16_t> validate_select_idx = {0, 1};
+    std::unordered_map<int64_t, std::set<int64_t>> index_id_partition_id;
+
+    Status st =
+            sender.send_chunk(_schema_param, partitions, {}, validate_select_idx, index_id_partition_id, chunk.get());
+    ASSERT_OK(st);
+
+    const auto& batches = sender.sent_batches();
+    ASSERT_EQ(1, batches.size());
+    ASSERT_EQ(2, batches[0].tablet_ids.size());
+    EXPECT_EQ(10000, batches[0].tablet_ids[0]);
+    EXPECT_EQ(10001, batches[0].tablet_ids[1]);
+
+    // index_id_partition_id should record two partition ids for this index.
+    ASSERT_EQ(2, index_id_partition_id[_index_id].size());
+    EXPECT_TRUE(index_id_partition_id[_index_id].find(1000) != index_id_partition_id[_index_id].end());
+    EXPECT_TRUE(index_id_partition_id[_index_id].find(1001) != index_id_partition_id[_index_id].end());
+}
+
+// NOLINTNEXTLINE
+TEST_F(TabletSinkSenderRangeTest, OverlappingRangesRoutingOrder) {
+    _init_schema_param();
+
+    // Realistic overlap-like scenario with a point range at boundary, but
+    // expressed in a way that satisfies RangeRouter invariants:
+    // Tablet 1: (-inf, 10)      -> 10000
+    // Tablet 2: [10, 11)        -> 10001
+    // Tablet 3: [11, +inf)      -> 10002
+    std::vector<TTabletRange> ranges;
+    {
+        // Tablet 1: (-inf, 10)
+        TTabletRange r0;
+        TTuple upper_tuple;
+        TVariant upper_var;
+        upper_var.__set_type(TYPE_BIGINT_DESC.to_thrift());
+        upper_var.__set_value(std::to_string(10));
+        upper_tuple.__set_values({upper_var});
+        r0.__set_upper_bound(upper_tuple);
+        r0.__set_upper_bound_included(false);
+        ranges.push_back(r0);
+    }
+    {
+        // Tablet 2: [10, 11)
+        ranges.push_back(_make_range(10, true, 11, false));
+    }
+    {
+        // Tablet 3: [11, +inf)
+        TTabletRange r2;
+        TTuple lower_tuple;
+        TVariant lower_var;
+        lower_var.__set_type(TYPE_BIGINT_DESC.to_thrift());
+        lower_var.__set_value(std::to_string(11));
+        lower_tuple.__set_values({lower_var});
+        r2.__set_lower_bound(lower_tuple);
+        r2.__set_lower_bound_included(true);
+        ranges.push_back(r2);
+    }
+
+    auto* partition_param = _create_partition_param({ranges});
+    ASSERT_OK(partition_param->init(nullptr));
+
+    PUniqueId load_id;
+    IndexIdToTabletBEMap index_id_to_tablet_be_map;
+    index_id_to_tablet_be_map[_index_id] = {};
+    std::vector<IndexChannel*> channels;
+    channels.push_back(_object_pool->add(new IndexChannel(nullptr, _index_id, nullptr)));
+    std::unordered_map<int64_t, NodeChannel*> node_channels;
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    TestRangeTabletSinkSender sender(load_id, 1, index_id_to_tablet_be_map, partition_param, channels, node_channels,
+                                     output_expr_ctxs, false, TWriteQuorumType::MAJORITY, 1);
+
+    // Test values: 5 (in range 1), 10 (in range 2), 15 (in range 3)
+    auto chunk = _create_chunk({5, 10, 15});
+
+    std::vector<OlapTablePartition*> partitions;
+    auto* part = partition_param->get_partitions().begin()->second;
+    partitions.resize(3, part);
+    std::vector<uint16_t> validate_select_idx = {0, 1, 2};
+    std::unordered_map<int64_t, std::set<int64_t>> index_id_partition_id;
+
+    Status st =
+            sender.send_chunk(_schema_param, partitions, {}, validate_select_idx, index_id_partition_id, chunk.get());
+    ASSERT_OK(st);
+
+    const auto& batches = sender.sent_batches();
+    ASSERT_EQ(1, batches.size());
+    ASSERT_EQ(3, batches[0].tablet_ids.size());
+    EXPECT_EQ(10000, batches[0].tablet_ids[0]); // 5 -> (0, 10)
+    EXPECT_EQ(10001, batches[0].tablet_ids[1]); // 10 -> [10, 10]
+    EXPECT_EQ(10002, batches[0].tablet_ids[2]); // 15 -> (10, 20]
+}
+
+// NOLINTNEXTLINE
+TEST_F(TabletSinkSenderRangeTest, MultiBENonReplicatedRouting) {
+    _init_schema_param();
+
+    // Tablet 1: (-inf, 10)  -> 10000, replicas on BE 101, 102
+    // Tablet 2: [10, +inf)  -> 10001, replica on BE 102
+    std::vector<TTabletRange> ranges;
+    {
+        TTabletRange r0;
+        TTuple upper_tuple;
+        TVariant upper_var;
+        upper_var.__set_type(TYPE_BIGINT_DESC.to_thrift());
+        upper_var.__set_value(std::to_string(10));
+        upper_tuple.__set_values({upper_var});
+        r0.__set_upper_bound(upper_tuple);
+        r0.__set_upper_bound_included(false);
+        ranges.push_back(r0);
+    }
+    {
+        TTabletRange r1;
+        TTuple lower_tuple;
+        TVariant lower_var;
+        lower_var.__set_type(TYPE_BIGINT_DESC.to_thrift());
+        lower_var.__set_value(std::to_string(10));
+        lower_tuple.__set_values({lower_var});
+        r1.__set_lower_bound(lower_tuple);
+        r1.__set_lower_bound_included(true);
+        ranges.push_back(r1);
+    }
+
+    auto* partition_param = _create_partition_param({ranges});
+    ASSERT_OK(partition_param->init(nullptr));
+
+    PUniqueId load_id;
+    IndexIdToTabletBEMap index_id_to_tablet_be_map;
+    // index 100: tablet -> [be_ids]
+    index_id_to_tablet_be_map[_index_id][10000] = {101, 102};
+    index_id_to_tablet_be_map[_index_id][10001] = {102};
+
+    std::vector<IndexChannel*> channels;
+    channels.push_back(_object_pool->add(new IndexChannel(nullptr, _index_id, nullptr)));
+    std::unordered_map<int64_t, NodeChannel*> node_channels;
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    // enable_replicated_storage = false
+    TestRangeTabletSinkSender sender(load_id, 1, index_id_to_tablet_be_map, partition_param, channels, node_channels,
+                                     output_expr_ctxs, false, TWriteQuorumType::MAJORITY, 1);
+
+    // Rows: 5  -> tablet 10000 -> BE 101,102
+    //       15 -> tablet 10001 -> BE 102
+    auto chunk = _create_chunk({5, 15});
+
+    std::vector<OlapTablePartition*> partitions;
+    auto* part = partition_param->get_partitions().begin()->second;
+    partitions.resize(2, part);
+    std::vector<uint16_t> validate_select_idx = {0, 1};
+    std::unordered_map<int64_t, std::set<int64_t>> index_id_partition_id;
+
+    Status st =
+            sender.send_chunk(_schema_param, partitions, {}, validate_select_idx, index_id_partition_id, chunk.get());
+    ASSERT_OK(st);
+
+    const auto& batches = sender.sent_batches();
+    ASSERT_EQ(1, batches.size());
+    ASSERT_EQ(2, batches[0].tablet_ids.size());
+    EXPECT_EQ(10000, batches[0].tablet_ids[0]);
+    EXPECT_EQ(10001, batches[0].tablet_ids[1]);
+
+    const auto& be_routing = sender.be_routing();
+    auto it_index = be_routing.find(_index_id);
+    ASSERT_NE(it_index, be_routing.end());
+
+    const auto& be_map = it_index->second;
+    auto it_be101 = be_map.find(101);
+    ASSERT_NE(it_be101, be_map.end());
+    std::vector<uint16_t> expected_101 = {0};
+    EXPECT_EQ(expected_101, it_be101->second);
+
+    auto it_be102 = be_map.find(102);
+    ASSERT_NE(it_be102, be_map.end());
+    std::vector<uint16_t> expected_102 = {0, 1};
+    EXPECT_EQ(expected_102, it_be102->second);
+}
+
+// NOLINTNEXTLINE
+TEST_F(TabletSinkSenderRangeTest, MultiBEReplicatedPrimaryOnlyRouting) {
+    _init_schema_param();
+
+    // Tablet 1: (-inf, 10)  -> 10000, replicas on BE 201(primary), 202
+    // Tablet 2: [10, +inf)  -> 10001, replicas on BE 202(primary), 203
+    std::vector<TTabletRange> ranges;
+    {
+        TTabletRange r0;
+        TTuple upper_tuple;
+        TVariant upper_var;
+        upper_var.__set_type(TYPE_BIGINT_DESC.to_thrift());
+        upper_var.__set_value(std::to_string(10));
+        upper_tuple.__set_values({upper_var});
+        r0.__set_upper_bound(upper_tuple);
+        r0.__set_upper_bound_included(false);
+        ranges.push_back(r0);
+    }
+    {
+        TTabletRange r1;
+        TTuple lower_tuple;
+        TVariant lower_var;
+        lower_var.__set_type(TYPE_BIGINT_DESC.to_thrift());
+        lower_var.__set_value(std::to_string(10));
+        lower_tuple.__set_values({lower_var});
+        r1.__set_lower_bound(lower_tuple);
+        r1.__set_lower_bound_included(true);
+        ranges.push_back(r1);
+    }
+
+    auto* partition_param = _create_partition_param({ranges});
+    ASSERT_OK(partition_param->init(nullptr));
+
+    PUniqueId load_id;
+    IndexIdToTabletBEMap index_id_to_tablet_be_map;
+    index_id_to_tablet_be_map[_index_id][10000] = {201, 202};
+    index_id_to_tablet_be_map[_index_id][10001] = {202, 203};
+
+    std::vector<IndexChannel*> channels;
+    channels.push_back(_object_pool->add(new IndexChannel(nullptr, _index_id, nullptr)));
+    std::unordered_map<int64_t, NodeChannel*> node_channels;
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    // enable_replicated_storage = true，只发 primary replica。
+    TestRangeTabletSinkSender sender(load_id, 1, index_id_to_tablet_be_map, partition_param, channels, node_channels,
+                                     output_expr_ctxs, true, TWriteQuorumType::MAJORITY, 2);
+
+    // Rows: 5  -> tablet 10000 -> primary BE 201
+    //       15 -> tablet 10001 -> primary BE 202
+    auto chunk = _create_chunk({5, 15});
+
+    std::vector<OlapTablePartition*> partitions;
+    auto* part = partition_param->get_partitions().begin()->second;
+    partitions.resize(2, part);
+    std::vector<uint16_t> validate_select_idx = {0, 1};
+    std::unordered_map<int64_t, std::set<int64_t>> index_id_partition_id;
+
+    Status st =
+            sender.send_chunk(_schema_param, partitions, {}, validate_select_idx, index_id_partition_id, chunk.get());
+    ASSERT_OK(st);
+
+    const auto& be_routing = sender.be_routing();
+    auto it_index = be_routing.find(_index_id);
+    ASSERT_NE(it_index, be_routing.end());
+
+    const auto& be_map = it_index->second;
+
+    auto it_be201 = be_map.find(201);
+    ASSERT_NE(it_be201, be_map.end());
+    std::vector<uint16_t> expected_201 = {0};
+    EXPECT_EQ(expected_201, it_be201->second);
+
+    auto it_be202 = be_map.find(202);
+    ASSERT_NE(it_be202, be_map.end());
+    std::vector<uint16_t> expected_202 = {1};
+    EXPECT_EQ(expected_202, it_be202->second);
+}
+
+// NOLINTNEXTLINE
+TEST_F(TabletSinkSenderRangeTest, NoMatchError) {
+    _init_schema_param();
+    std::vector<TTabletRange> ranges;
+    // Single finite range [0,10) without -inf/+inf coverage should be rejected
+    // when initializing RangeRouter inside RangeTabletSinkSender.
+    ranges.push_back(_make_range(0, true, 10, false));
+    auto* partition_param = _create_partition_param({ranges});
+    ASSERT_OK(partition_param->init(nullptr));
+
+    PUniqueId load_id;
+    IndexIdToTabletBEMap index_id_to_tablet_be_map;
+    index_id_to_tablet_be_map[_index_id] = {};
+    std::vector<IndexChannel*> channels;
+    channels.push_back(_object_pool->add(new IndexChannel(nullptr, _index_id, nullptr)));
+    std::unordered_map<int64_t, NodeChannel*> node_channels;
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    TestRangeTabletSinkSender sender(load_id, 1, index_id_to_tablet_be_map, partition_param, channels, node_channels,
+                                     output_expr_ctxs, false, TWriteQuorumType::MAJORITY, 1);
+
+    auto chunk = _create_chunk({15});
+    std::vector<OlapTablePartition*> partitions;
+    partitions.push_back(partition_param->get_partitions().begin()->second);
+    std::vector<uint16_t> validate_select_idx = {0};
+    std::unordered_map<int64_t, std::set<int64_t>> index_id_partition_id;
+
+    Status st =
+            sender.send_chunk(_schema_param, partitions, {}, validate_select_idx, index_id_partition_id, chunk.get());
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.message().find("lower_inf_count and upper_inf_count must be 1") != std::string::npos);
+}
+
+// NOLINTNEXTLINE
+TEST_F(TabletSinkSenderRangeTest, BoundaryRoutingAtEdges) {
+    _init_schema_param();
+
+    // Tablet 1: (-inf, 10) -> 10000
+    // Tablet 2: [10, +inf) -> 10001
+    std::vector<TTabletRange> ranges;
+    {
+        TTabletRange r0;
+        TTuple upper_tuple;
+        TVariant upper_var;
+        upper_var.__set_type(TYPE_BIGINT_DESC.to_thrift());
+        upper_var.__set_value(std::to_string(10));
+        upper_tuple.__set_values({upper_var});
+        r0.__set_upper_bound(upper_tuple);
+        r0.__set_upper_bound_included(false);
+        ranges.push_back(r0);
+    }
+    {
+        TTabletRange r1;
+        TTuple lower_tuple;
+        TVariant lower_var;
+        lower_var.__set_type(TYPE_BIGINT_DESC.to_thrift());
+        lower_var.__set_value(std::to_string(10));
+        lower_tuple.__set_values({lower_var});
+        r1.__set_lower_bound(lower_tuple);
+        r1.__set_lower_bound_included(true);
+        ranges.push_back(r1);
+    }
+
+    auto* partition_param = _create_partition_param({ranges});
+    ASSERT_OK(partition_param->init(nullptr));
+
+    PUniqueId load_id;
+    IndexIdToTabletBEMap index_id_to_tablet_be_map;
+    index_id_to_tablet_be_map[_index_id] = {};
+    std::vector<IndexChannel*> channels;
+    channels.push_back(_object_pool->add(new IndexChannel(nullptr, _index_id, nullptr)));
+    std::unordered_map<int64_t, NodeChannel*> node_channels;
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    TestRangeTabletSinkSender sender(load_id, 1, index_id_to_tablet_be_map, partition_param, channels, node_channels,
+                                     output_expr_ctxs, false, TWriteQuorumType::MAJORITY, 1);
+
+    // Values exactly on the boundary: 9, 10, 19
+    auto chunk = _create_chunk({9, 10, 19});
+
+    std::vector<OlapTablePartition*> partitions;
+    auto* part = partition_param->get_partitions().begin()->second;
+    partitions.resize(3, part);
+    std::vector<uint16_t> validate_select_idx = {0, 1, 2};
+    std::unordered_map<int64_t, std::set<int64_t>> index_id_partition_id;
+
+    Status st =
+            sender.send_chunk(_schema_param, partitions, {}, validate_select_idx, index_id_partition_id, chunk.get());
+    ASSERT_OK(st);
+
+    const auto& batches = sender.sent_batches();
+    ASSERT_EQ(1, batches.size());
+    const auto& tablet_ids = batches[0].tablet_ids;
+    ASSERT_EQ(3, tablet_ids.size());
+    // 9  -> tablet 10000 ([0,10))
+    // 10 -> tablet 10001 ([10,20))
+    // 19 -> tablet 10001 ([10,20))
+    EXPECT_EQ(10000, tablet_ids[0]);
+    EXPECT_EQ(10001, tablet_ids[1]);
+    EXPECT_EQ(10001, tablet_ids[2]);
+}
+
+// NOLINTNEXTLINE
+TEST_F(TabletSinkSenderRangeTest, SparseDataRouting) {
+    _init_schema_param();
+    // Ranges:
+    //   R0: (-inf, 101)   -> 10000
+    //   R1: [101, +inf)   -> 10001
+    std::vector<TTabletRange> ranges;
+    {
+        // R0: (-inf, 101)
+        TTabletRange r0;
+        TTuple upper_tuple;
+        TVariant upper_var;
+        upper_var.__set_type(TYPE_BIGINT_DESC.to_thrift());
+        upper_var.__set_value(std::to_string(101));
+        upper_tuple.__set_values({upper_var});
+        r0.__set_upper_bound(upper_tuple);
+        r0.__set_upper_bound_included(false);
+        ranges.push_back(r0);
+    }
+    {
+        // R1: [101, +inf)
+        TTabletRange r1;
+        TTuple lower_tuple;
+        TVariant lower_var;
+        lower_var.__set_type(TYPE_BIGINT_DESC.to_thrift());
+        lower_var.__set_value(std::to_string(101));
+        lower_tuple.__set_values({lower_var});
+        r1.__set_lower_bound(lower_tuple);
+        r1.__set_lower_bound_included(true);
+        ranges.push_back(r1);
+    }
+
+    auto* partition_param = _create_partition_param({ranges});
+    ASSERT_OK(partition_param->init(nullptr));
+
+    PUniqueId load_id;
+    IndexIdToTabletBEMap index_id_to_tablet_be_map;
+    index_id_to_tablet_be_map[_index_id] = {};
+    std::vector<IndexChannel*> channels;
+    channels.push_back(_object_pool->add(new IndexChannel(nullptr, _index_id, nullptr)));
+    std::unordered_map<int64_t, NodeChannel*> node_channels;
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    TestRangeTabletSinkSender sender(load_id, 1, index_id_to_tablet_be_map, partition_param, channels, node_channels,
+                                     output_expr_ctxs, false, TWriteQuorumType::MAJORITY, 1);
+
+    // Construct a large chunk with sparse row indices to ensure routing works
+    // correctly even when validate_select_idx contains large gaps.
+    // Indices: 0, 100, 200.
+    auto col = FixedLengthColumn<int64_t>::create();
+    col->resize(201);
+    col->get_data()[0] = 1;
+    col->get_data()[100] = 2;
+    col->get_data()[200] = 3;
+
+    Columns cols;
+    cols.emplace_back(col);
+    Fields fields;
+    fields.emplace_back(std::make_shared<Field>(0, "c1", get_type_info(TYPE_BIGINT), false));
+    auto schema = std::make_shared<Schema>(fields);
+    auto chunk = std::make_shared<Chunk>(cols, schema);
+    // Set slot_id to column index mapping
+    chunk->set_slot_id_to_index(0, 0); // slot_id 0 -> column index 0
+
+    std::vector<OlapTablePartition*> partitions;
+    auto* part = partition_param->get_partitions().begin()->second;
+    partitions.resize(201, part);
+
+    std::vector<uint16_t> validate_select_idx = {0, 100, 200}; // Sparse selection
+    std::unordered_map<int64_t, std::set<int64_t>> index_id_partition_id;
+
+    Status st =
+            sender.send_chunk(_schema_param, partitions, {}, validate_select_idx, index_id_partition_id, chunk.get());
+    ASSERT_OK(st);
+
+    const auto& batches = sender.sent_batches();
+    ASSERT_EQ(1, batches.size());
+    ASSERT_EQ(3, batches[0].tablet_ids.size());
+    EXPECT_EQ(10000, batches[0].tablet_ids[0]);
+    EXPECT_EQ(10000, batches[0].tablet_ids[1]);
+    EXPECT_EQ(10000, batches[0].tablet_ids[2]);
+}
+
+// NOLINTNEXTLINE
+TEST_F(TabletSinkSenderRangeTest, EmptyInput) {
+    _init_schema_param();
+    std::vector<TTabletRange> ranges;
+    ranges.push_back(_make_range(0, true, 10, false));
+    auto* partition_param = _create_partition_param({ranges});
+
+    PUniqueId load_id;
+    IndexIdToTabletBEMap index_id_to_tablet_be_map;
+    std::vector<IndexChannel*> channels;
+    std::unordered_map<int64_t, NodeChannel*> node_channels;
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    TestRangeTabletSinkSender sender(load_id, 1, index_id_to_tablet_be_map, partition_param, channels, node_channels,
+                                     output_expr_ctxs, false, TWriteQuorumType::MAJORITY, 1);
+
+    std::vector<uint16_t> validate_select_idx; // Empty
+    std::unordered_map<int64_t, std::set<int64_t>> index_id_partition_id;
+    std::vector<OlapTablePartition*> partitions;
+    Chunk chunk;
+
+    Status st = sender.send_chunk(_schema_param, partitions, {}, validate_select_idx, index_id_partition_id, &chunk);
+    ASSERT_OK(st);
+    ASSERT_TRUE(sender.sent_batches().empty());
+}
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/reshard/SplitTabletJob.java
@@ -228,7 +228,7 @@ public class SplitTabletJob extends TabletReshardJob {
                                     TabletRange tabletRange = tabletRanges.get(tabletId);
                                     Preconditions.checkNotNull(tabletRange,
                                             "Range of tablet " + tabletId + " not found");
-                                    newIndex.getTablet(tabletId).setRange(tabletRange.getRange());
+                                    newIndex.getTablet(tabletId).setRange(tabletRange);
                                 }
                             }
                         }
@@ -526,7 +526,7 @@ public class SplitTabletJob extends TabletReshardJob {
                 for (ReshardingMaterializedIndex reshardingIndex : reshardingPhysicalPartition
                         .getReshardingIndexes().values()) {
                     MaterializedIndex newIndex = reshardingIndex.getMaterializedIndex();
-                    if (newIndex.getId() == olapTable.getBaseIndexId()) {
+                    if (newIndex.getId() == olapTable.getBaseIndexMetaId()) {
                         physicalPartition.setBaseIndex(newIndex);
                     } else {
                         physicalPartition.createRollupIndex(newIndex);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/BoolVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/BoolVariant.java
@@ -15,7 +15,9 @@
 package com.starrocks.catalog;
 
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.thrift.TVariant;
 import com.starrocks.type.BooleanType;
+import com.starrocks.type.TypeSerializer;
 
 import java.util.Objects;
 
@@ -51,6 +53,14 @@ public class BoolVariant extends Variant {
     @Override
     public String getStringValue() {
         return value ? "TRUE" : "FALSE";
+    }
+
+    @Override
+    public TVariant toThrift() {
+        TVariant variant = new TVariant();
+        variant.setType(TypeSerializer.toThrift(type));
+        variant.setValue(getStringValue());
+        return variant;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DateVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DateVariant.java
@@ -17,7 +17,9 @@ package com.starrocks.catalog;
 import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.util.DateUtils;
+import com.starrocks.thrift.TVariant;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeSerializer;
 
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -53,6 +55,14 @@ public class DateVariant extends Variant {
     @Override
     public String getStringValue() {
         return Instant.ofEpochSecond(seconds, nanos).toString();
+    }
+
+    @Override
+    public TVariant toThrift() {
+        TVariant variant = new TVariant();
+        variant.setType(TypeSerializer.toThrift(type));
+        variant.setValue(getStringValue());
+        return variant;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IntVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IntVariant.java
@@ -16,7 +16,9 @@ package com.starrocks.catalog;
 
 import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.thrift.TVariant;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeSerializer;
 
 import java.util.Objects;
 
@@ -54,6 +56,14 @@ public class IntVariant extends Variant {
     @Override
     public String getStringValue() {
         return String.valueOf(value);
+    }
+
+    @Override
+    public TVariant toThrift() {
+        TVariant variant = new TVariant();
+        variant.setType(TypeSerializer.toThrift(type));
+        variant.setValue(getStringValue());
+        return variant;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LargeIntVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LargeIntVariant.java
@@ -16,7 +16,9 @@ package com.starrocks.catalog;
 
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.Int128;
+import com.starrocks.thrift.TVariant;
 import com.starrocks.type.IntegerType;
+import com.starrocks.type.TypeSerializer;
 
 import java.math.BigInteger;
 
@@ -53,6 +55,14 @@ public class LargeIntVariant extends Variant {
     @Override
     public String getStringValue() {
         return value.toString();
+    }
+
+    @Override
+    public TVariant toThrift() {
+        TVariant variant = new TVariant();
+        variant.setType(TypeSerializer.toThrift(type));
+        variant.setValue(getStringValue());
+        return variant;
     }
 
     public BigInteger toBigInteger() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StringVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StringVariant.java
@@ -16,7 +16,9 @@ package com.starrocks.catalog;
 
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.util.StringUtils;
+import com.starrocks.thrift.TVariant;
 import com.starrocks.type.Type;
+import com.starrocks.type.TypeSerializer;
 
 /*
  * StringVariant is for type CHAR, VARCHAR, BINARY, VARBINARY and HLL
@@ -39,6 +41,14 @@ public class StringVariant extends Variant {
     @Override
     public String getStringValue() {
         return value;
+    }
+
+    @Override
+    public TVariant toThrift() {
+        TVariant variant = new TVariant();
+        variant.setType(TypeSerializer.toThrift(type));
+        variant.setValue(getStringValue());
+        return variant;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Tablet.java
@@ -35,15 +35,17 @@ public abstract class Tablet extends MetaObject implements Writable {
     /*
      * Add the serialization when the feature is almost finished
      * @SerializedName(value = "range")
-     */
-    protected Range<Tuple> range;
+    */
+    protected TabletRange range = new TabletRange(Range.all());
+
+    public Tablet() {
+    }
 
     public Tablet(long id) {
         this.id = id;
-        this.range = Range.all();
     }
 
-    public Tablet(long id, Range<Tuple> range) {
+    public Tablet(long id, TabletRange range) {
         this.id = id;
         this.range = range;
     }
@@ -52,11 +54,11 @@ public abstract class Tablet extends MetaObject implements Writable {
         return id;
     }
 
-    public Range<Tuple> getRange() {
+    public TabletRange getRange() {
         return range;
     }
 
-    public void setRange(Range<Tuple> range) {
+    public void setRange(TabletRange range) {
         this.range = range;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletRange.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletRange.java
@@ -49,4 +49,18 @@ public class TabletRange {
         boolean upperIncluded = tabletRangePB.upperBoundIncluded != null ? tabletRangePB.upperBoundIncluded : false;
         return new TabletRange(Range.of(lowerBound, upperBound, lowerIncluded, upperIncluded));
     }
+
+    public TTabletRange toThrift() {
+        TTabletRange tRange = new TTabletRange();
+        tRange.setLower_bound_included(range.isLowerBoundIncluded());
+        tRange.setUpper_bound_included(range.isUpperBoundIncluded());
+
+        if (!range.isMinimum()) {
+            tRange.setLower_bound(range.getLowerBound().toThrift());
+        }
+        if (!range.isMaximum()) {
+            tRange.setUpper_bound(range.getUpperBound().toThrift());
+        }
+        return tRange;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Tuple.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Tuple.java
@@ -63,4 +63,10 @@ public class Tuple implements Comparable<Tuple> {
     public static Tuple fromProto(TuplePB tuplePB) {
         return new Tuple(tuplePB.values.stream().map(v -> Variant.fromProto(v)).collect(Collectors.toList()));
     }
+
+    public TTuple toThrift() {
+        TTuple tuple = new TTuple();
+        tuple.setValues(values.stream().map(Variant::toThrift).collect(Collectors.toList()));
+        return tuple;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Variant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Variant.java
@@ -78,10 +78,6 @@ public abstract class Variant implements Comparable<Variant> {
     }
 
     public static Variant fromThrift(TVariant tVariant) {
-        // TVariant encodes all payloads using the `value` field. Older code used to
-        // refer to this field as `string_value` on the Java side, which no longer
-        // exists in the current Thrift IDL. Always read from `value` here to stay
-        // aligned with the Thrift definition.
         return Variant.of(TypeDeserializer.fromThrift(tVariant.type), tVariant.getValue());
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Variant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Variant.java
@@ -42,11 +42,11 @@ public abstract class Variant implements Comparable<Variant> {
         return type;
     }
 
-    public abstract long getLongValue();
-
     public abstract String getStringValue();
 
-    // public abstract TVariant toThrift();
+    public abstract long getLongValue();
+
+    public abstract TVariant toThrift();
 
     // public abstract VariantPB toProto();
 
@@ -115,4 +115,5 @@ public abstract class Variant implements Comparable<Variant> {
         }
         return Integer.compare(key1Length, key2Length);
     }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Variant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Variant.java
@@ -82,7 +82,7 @@ public abstract class Variant implements Comparable<Variant> {
     }
 
     public static Variant fromProto(VariantPB variantPB) {
-        return Variant.of(TypeDeserializer.fromProtobuf(variantPB.type), variantPB.stringValue);
+        return Variant.of(TypeDeserializer.fromProtobuf(variantPB.type), variantPB.value);
     }
 
     public static int compatibleCompare(Variant key1, Variant key2) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Variant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Variant.java
@@ -78,7 +78,11 @@ public abstract class Variant implements Comparable<Variant> {
     }
 
     public static Variant fromThrift(TVariant tVariant) {
-        return Variant.of(TypeDeserializer.fromThrift(tVariant.type), tVariant.string_value);
+        // TVariant encodes all payloads using the `value` field. Older code used to
+        // refer to this field as `string_value` on the Java side, which no longer
+        // exists in the current Thrift IDL. Always read from `value` here to stay
+        // aligned with the Thrift definition.
+        return Variant.of(TypeDeserializer.fromThrift(tVariant.type), tVariant.getValue());
     }
 
     public static Variant fromProto(VariantPB variantPB) {

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -323,6 +323,7 @@ import com.starrocks.thrift.TObjectDependencyRes;
 import com.starrocks.thrift.TOlapTableIndexTablets;
 import com.starrocks.thrift.TOlapTablePartition;
 import com.starrocks.thrift.TOlapTablePartitionParam;
+import com.starrocks.thrift.TOlapTableTablet;
 import com.starrocks.thrift.TPartitionMeta;
 import com.starrocks.thrift.TPartitionMetaRequest;
 import com.starrocks.thrift.TPartitionMetaResponse;
@@ -2035,6 +2036,12 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         }
         for (MaterializedIndex index : physicalPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
             TOlapTableIndexTablets tIndex = new TOlapTableIndexTablets(index.getId(), index.getTabletIdsInOrder());
+            tIndex.setTablets(index.getTablets().stream().map(tablet -> {
+                TOlapTableTablet tTablet = new TOlapTableTablet();
+                tTablet.setId(tablet.getId());
+                tTablet.setRange(tablet.getRange().toThrift());
+                return tTablet;
+            }).collect(Collectors.toList()));
             tPartition.addToIndexes(tIndex);
         }
         partitions.add(tPartition);
@@ -2465,6 +2472,12 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         for (MaterializedIndex index : partition.getDefaultPhysicalPartition()
                 .getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
             TOlapTableIndexTablets tIndex = new TOlapTableIndexTablets(index.getId(), index.getTabletIdsInOrder());
+            tIndex.setTablets(index.getTablets().stream().map(tablet -> {
+                TOlapTableTablet tTablet = new TOlapTableTablet();
+                tTablet.setId(tablet.getId());
+                tTablet.setRange(tablet.getRange().toThrift());
+                return tTablet;
+            }).collect(Collectors.toList()));
             tPartition.addToIndexes(tIndex);
         }
         partitions.add(tPartition);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
@@ -52,6 +52,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class MetaUtils {
 
@@ -244,22 +245,30 @@ public class MetaUtils {
         return result;
     }
 
-    public static List<String> getRangeDistributionColumnNames(OlapTable olapTable) {
-        List<String> columnNames = new ArrayList<>();
+    public static List<Column> getRangeDistributionColumns(OlapTable olapTable) {
+        List<Column> columns = new ArrayList<>();
         MaterializedIndexMeta baseIndexMeta = olapTable.getIndexMetaByIndexId(olapTable.getBaseIndexMetaId());
         List<Column> baseSchema = olapTable.getBaseSchema();
         if (baseIndexMeta.getSortKeyIdxes() != null) {
             for (Integer i : baseIndexMeta.getSortKeyIdxes()) {
-                columnNames.add(baseSchema.get(i).getName());
+                columns.add(baseSchema.get(i));
             }
         } else {
             for (Column column : baseSchema) {
                 if (column.isKey()) {
-                    columnNames.add(column.getName());
+                    columns.add(column);
                 }
             }
         }
-        return columnNames;
+        return columns;
+    }
+
+    public static List<String> getRangeDistributionColumnNames(OlapTable olapTable) {
+        return getRangeDistributionColumns(olapTable).stream().map(Column::getName).collect(Collectors.toList());
+    }
+
+    public static List<String> getRangeDistributionColumnIds(OlapTable olapTable) {
+        return getRangeDistributionColumns(olapTable).stream().map(col -> col.getColumnId().getId()).collect(Collectors.toList());
     }
 
     public static List<String> getColumnNamesByColumnIds(Table table, List<ColumnId> columnIds) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ListPartitionInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ListPartitionInfoTest.java
@@ -156,6 +156,8 @@ public class ListPartitionInfoTest {
                 result = partition;
                 dstTable.getPartitionInfo();
                 result = listPartitionInfo;
+                dstTable.getDefaultDistributionInfo();
+                result = distInfo;
                 dstTable.getIdToColumn();
                 result = idToColumn;
             }};

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TabletRangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TabletRangeTest.java
@@ -1,0 +1,202 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.starrocks.common.Range;
+import com.starrocks.thrift.TTabletRange;
+import com.starrocks.thrift.TTuple;
+import com.starrocks.thrift.TVariant;
+import com.starrocks.type.DateType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+public class TabletRangeTest {
+
+    @Test
+    public void testAllRangeToThrift() {
+        Range<Tuple> all = Range.all();
+        TabletRange tabletRange = new TabletRange(all);
+
+        TTabletRange tRange = tabletRange.toThrift();
+
+        // For all range, no concrete bounds should be set.
+        Assertions.assertFalse(tRange.isSetLower_bound());
+        Assertions.assertFalse(tRange.isSetUpper_bound());
+        // Inclusiveness flags should reflect the underlying Range semantics.
+        Assertions.assertFalse(tRange.isLower_bound_included());
+        Assertions.assertFalse(tRange.isUpper_bound_included());
+    }
+
+    @Test
+    public void testClosedRangeToThrift() {
+        // [ (1, "a"), (5, "z") ]
+        Tuple lower = new Tuple(Arrays.asList(
+                new IntVariant(IntegerType.INT, 1),
+                new StringVariant(VarcharType.VARCHAR, "a")));
+        Tuple upper = new Tuple(Arrays.asList(
+                new IntVariant(IntegerType.INT, 5),
+                new StringVariant(VarcharType.VARCHAR, "z")));
+
+        Range<Tuple> range = Range.gele(lower, upper);
+        TabletRange tabletRange = new TabletRange(range);
+
+        TTabletRange tRange = tabletRange.toThrift();
+        Assertions.assertTrue(tRange.isSetLower_bound());
+        Assertions.assertTrue(tRange.isSetUpper_bound());
+        Assertions.assertTrue(tRange.isLower_bound_included());
+        Assertions.assertTrue(tRange.isUpper_bound_included());
+
+        TTuple tLower = tRange.getLower_bound();
+        TTuple tUpper = tRange.getUpper_bound();
+        Assertions.assertEquals(2, tLower.getValues().size());
+        Assertions.assertEquals(2, tUpper.getValues().size());
+
+        TVariant lowerInt = tLower.getValues().get(0);
+        TVariant lowerStr = tLower.getValues().get(1);
+        TVariant upperInt = tUpper.getValues().get(0);
+        TVariant upperStr = tUpper.getValues().get(1);
+
+        // All Variant values are encoded via the `value` field.
+        Assertions.assertTrue(lowerInt.isSetValue());
+        Assertions.assertEquals("1", lowerInt.getValue());
+        Assertions.assertTrue(lowerStr.isSetValue());
+        Assertions.assertEquals("a", lowerStr.getValue());
+
+        Assertions.assertTrue(upperInt.isSetValue());
+        Assertions.assertEquals("5", upperInt.getValue());
+        Assertions.assertTrue(upperStr.isSetValue());
+        Assertions.assertEquals("z", upperStr.getValue());
+    }
+
+    @Test
+    public void testLowerOnlyRangeToThrift() {
+        // [ (10), +inf )
+        Tuple lower = new Tuple(Arrays.asList(
+                new IntVariant(IntegerType.BIGINT, 10L)));
+        Range<Tuple> range = Range.ge(lower);
+        TabletRange tabletRange = new TabletRange(range);
+
+        TTabletRange tRange = tabletRange.toThrift();
+        Assertions.assertTrue(tRange.isSetLower_bound());
+        Assertions.assertFalse(tRange.isSetUpper_bound());
+        Assertions.assertTrue(tRange.isLower_bound_included());
+        Assertions.assertFalse(tRange.isUpper_bound_included());
+
+        TVariant tv = tRange.getLower_bound().getValues().get(0);
+        Assertions.assertTrue(tv.isSetValue());
+        Assertions.assertEquals("10", tv.getValue());
+    }
+
+    @Test
+    public void testUpperOnlyRangeToThrift() {
+        // (-inf, 100 )
+        Tuple upper = new Tuple(Arrays.asList(
+                new IntVariant(IntegerType.BIGINT, 100L)));
+        Range<Tuple> range = Range.lt(upper);
+        TabletRange tabletRange = new TabletRange(range);
+
+        TTabletRange tRange = tabletRange.toThrift();
+        Assertions.assertFalse(tRange.isSetLower_bound());
+        Assertions.assertTrue(tRange.isSetUpper_bound());
+        Assertions.assertFalse(tRange.isLower_bound_included());
+        Assertions.assertFalse(tRange.isUpper_bound_included());
+
+        TVariant tv = tRange.getUpper_bound().getValues().get(0);
+        Assertions.assertTrue(tv.isSetValue());
+        Assertions.assertEquals("100", tv.getValue());
+    }
+
+    @Test
+    public void testHalfOpenRangeToThrift() {
+        // [ (1),  (5) )
+        Tuple lower = new Tuple(Arrays.asList(
+                new IntVariant(IntegerType.INT, 1)));
+        Tuple upper = new Tuple(Arrays.asList(
+                new IntVariant(IntegerType.INT, 5)));
+
+        Range<Tuple> range = Range.gelt(lower, upper);
+        TabletRange tabletRange = new TabletRange(range);
+
+        TTabletRange tRange = tabletRange.toThrift();
+        Assertions.assertTrue(tRange.isSetLower_bound());
+        Assertions.assertTrue(tRange.isSetUpper_bound());
+        Assertions.assertTrue(tRange.isLower_bound_included());
+        Assertions.assertFalse(tRange.isUpper_bound_included());
+
+        TVariant lowerInt = tRange.getLower_bound().getValues().get(0);
+        TVariant upperInt = tRange.getUpper_bound().getValues().get(0);
+        Assertions.assertTrue(lowerInt.isSetValue());
+        Assertions.assertEquals("1", lowerInt.getValue());
+        Assertions.assertTrue(upperInt.isSetValue());
+        Assertions.assertEquals("5", upperInt.getValue());
+    }
+
+    @Test
+    public void testOpenRangeToThrift() {
+        // ( (1),  (5) )
+        Tuple lower = new Tuple(Arrays.asList(
+                new IntVariant(IntegerType.INT, 1)));
+        Tuple upper = new Tuple(Arrays.asList(
+                new IntVariant(IntegerType.INT, 5)));
+
+        Range<Tuple> range = Range.gtlt(lower, upper);
+        TabletRange tabletRange = new TabletRange(range);
+
+        TTabletRange tRange = tabletRange.toThrift();
+        Assertions.assertTrue(tRange.isSetLower_bound());
+        Assertions.assertTrue(tRange.isSetUpper_bound());
+        Assertions.assertFalse(tRange.isLower_bound_included());
+        Assertions.assertFalse(tRange.isUpper_bound_included());
+
+        TVariant lowerInt = tRange.getLower_bound().getValues().get(0);
+        TVariant upperInt = tRange.getUpper_bound().getValues().get(0);
+        Assertions.assertTrue(lowerInt.isSetValue());
+        Assertions.assertEquals("1", lowerInt.getValue());
+        Assertions.assertTrue(upperInt.isSetValue());
+        Assertions.assertEquals("5", upperInt.getValue());
+    }
+
+    @Test
+    public void testDateRangeToThrift() {
+        // [ date '2024-01-01', date '2024-01-31' ]
+        Tuple lower = new Tuple(Arrays.asList(
+                new DateVariant(DateType.DATE, "2024-01-01")));
+        Tuple upper = new Tuple(Arrays.asList(
+                new DateVariant(DateType.DATE, "2024-01-31")));
+
+        Range<Tuple> range = Range.gele(lower, upper);
+        TabletRange tabletRange = new TabletRange(range);
+
+        TTabletRange tRange = tabletRange.toThrift();
+        Assertions.assertTrue(tRange.isSetLower_bound());
+        Assertions.assertTrue(tRange.isSetUpper_bound());
+
+        TVariant lowerDate = tRange.getLower_bound().getValues().get(0);
+        TVariant upperDate = tRange.getUpper_bound().getValues().get(0);
+
+        // Dates should be encoded via the `value` field.
+        Assertions.assertTrue(lowerDate.isSetValue());
+        Assertions.assertFalse(lowerDate.getValue().isEmpty());
+
+        Assertions.assertTrue(upperDate.isSetValue());
+        Assertions.assertFalse(upperDate.getValue().isEmpty());
+    }
+}
+
+

--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -146,6 +146,8 @@ public class OlapTableSinkTest {
                 result = Lists.newArrayList(partition);
                 dstTable.getPartition(2L);
                 result = partition;
+                dstTable.getDefaultDistributionInfo();
+                result = distInfo;
             }
         };
 
@@ -186,6 +188,8 @@ public class OlapTableSinkTest {
                 result = Lists.newArrayList(p1, p2);
                 dstTable.getPartition(p1.getId());
                 result = p1;
+                dstTable.getDefaultDistributionInfo();
+                result = distInfo;
             }
         };
 
@@ -447,6 +451,8 @@ public class OlapTableSinkTest {
                 result = listPartitionInfo;
                 dstTable.getIdToColumn();
                 result = idToColumn;
+                dstTable.getDefaultDistributionInfo();
+                result = distInfo;
             }
         };
 
@@ -486,6 +492,8 @@ public class OlapTableSinkTest {
                 result = Lists.newArrayList(partition);
                 dstTable.getPartition(2L);
                 result = partition;
+                dstTable.getDefaultDistributionInfo();
+                result = distInfo;
             }
         };
 
@@ -526,6 +534,8 @@ public class OlapTableSinkTest {
                 result = Lists.newArrayList(partition);
                 dstTable.getPartition(2L);
                 result = partition;
+                dstTable.getDefaultDistributionInfo();
+                result = distInfo;
             }
         };
 
@@ -570,6 +580,8 @@ public class OlapTableSinkTest {
                 result = partition;
                 dstTable.getState();
                 result = OlapTable.OlapTableState.SCHEMA_CHANGE;
+                dstTable.getDefaultDistributionInfo();
+                result = distInfo;
             }
         };
 

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -234,8 +234,7 @@ message TransactionStatePB {
 
 message VariantPB {
     optional PTypeDesc type = 1;
-    optional int64 int_value = 2;
-    optional string string_value = 3;
+    optional string value = 2;
 }
 
 message TuplePB {

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -228,6 +228,14 @@ enum TIndexType {
   VECTOR,
 }
 
+// Not define UNKNOWN type for better compatibility with
+// DistributionInfo.DistributionInfoType definition
+enum TOlapTableDistributionType {
+    HASH,
+    RANDOM,
+    RANGE,
+}
+
 // Mapping from names defined by Avro to the enum.
 // We permit gzip and bzip2 in addition.
 const map<string, THdfsCompression> COMPRESSION_MAP = {
@@ -319,6 +327,8 @@ struct TOlapTablePartitionParam {
     8: optional list<Exprs.TExpr> partition_exprs
 
     9: optional bool enable_automatic_partition
+
+    10: optional TOlapTableDistributionType distribution_type
 }
 
 struct TOlapTableColumnParam {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -633,8 +633,7 @@ struct TParquetOptions {
 
 struct TVariant {
     1: optional TTypeDesc type
-    2: optional i64 int_value
-    3: optional string string_value
+    2: optional string value
 }
 
 struct TTuple {


### PR DESCRIPTION
## What I'm doing:
Implement end-to-end range-based routing for range distribution tables on both FE and BE sides:

`FE`:
Add TabletRange and Tuple.toThrift / Variant.toThrift to serialize tablet ranges as TTabletRange/TVariant. OlapTableSink / FrontendServiceImpl now populate range_distributed_columns and per-tablet range in TOlapTablePartitionParam and TOlapTableIndexTablets, and temporarily disable colocate MV index for RANGE distribution tables.

`BE`:
Introduce RangeRouter to route rows to tablets based on TTabletRange, supporting multi-column ranges and various open/closed/±inf intervals; Extend TabletSinkSender with RangeTabletSinkSender.

`Tests`:
Add/extend FE tests (VariantTest, TabletRangeTest) to cover numeric, string, boolean and date/datetime serialization to Thrift. Add BE tests (RangeRouterTest, TabletSinkSenderRangeTest) covering typical routing paths, boundary behavior, sparse selections and error cases.

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements end-to-end range-distribution data routing, adding FE serialization and BE routing/components with protocol updates and extensive tests.
> 
> - **Protocol/IDL**:
>   - Introduce `TOlapTableDistributionType` and per-tablet `range` in `TOlapTableTablet`; switch `TVariant` to a single `value` field; add `TTabletRange`, `TTuple` helpers.
> - **Frontend (FE)**:
>   - Serialize `TabletRange`, `Tuple`, `Variant` to Thrift; include `distribution_type`, range distribution columns, and per-tablet `range` in `TOlapTablePartitionParam`/`TOlapTableIndexTablets`.
>   - `OlapTableSink`: populate new fields, disable colocate MV index for `RANGE` distribution.
>   - `SplitTabletJob`: set tablet `range` using `TabletRange`; fix base-index selection via `getBaseIndexMetaId`.
>   - `MetaUtils`: helpers to get range distribution columns/ids.
> - **Backend (BE)**:
>   - Add `RangeRouter` (parses/validates `TTabletRange`, routes via upper boundaries) and `RangeTabletSinkSender`; integrate in `OlapTableSink` when `is_range_distribution()`.
>   - Extend `OlapTablePartitionParam` to parse `distribution_type`; support hash/random; expose distribution slots; minor comparator overload.
>   - Make `_send_chunk_by_node` virtual.
> - **Tests/Build**:
>   - Add BE tests (`range_router_test`, `tablet_sink_sender_range_test`) and FE tests (`VariantTest`, `TabletRangeTest`, sink tests); update CMake lists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5c7e9315ec15dfdebd585bda4b4c9be34c5267c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->