### PR TITLE
[BugFix] make set_collector call once only

### DIFF
--- a/be/src/exec/pipeline/runtime_filter_types.h
+++ b/be/src/exec/pipeline/runtime_filter_types.h
@@ -121,9 +121,12 @@ private:
 class RuntimeFilterHolder {
 public:
     void set_collector(RuntimeFilterCollectorPtr&& collector) {
-        DCHECK(_collector.load(std::memory_order_acquire) == nullptr);
-        _collector_ownership = std::move(collector);
-        _collector.store(_collector_ownership.get(), std::memory_order_release);
+        RuntimeFilterCollector* expected = nullptr;
+
+        if (_collector.compare_exchange_strong(expected, collector.get(), std::memory_order_release,
+                                               std::memory_order_acquire)) {
+            _collector_ownership = std::move(collector);
+        }
     }
     RuntimeFilterCollector* get_collector() { return _collector.load(std::memory_order_acquire); }
     bool is_ready() { return get_collector() != nullptr; }


### PR DESCRIPTION
## Why I'm doing:

#61497 will push down a local topN (no merge partition_sort_sink). It will cause set_collector multi times

## What I'm doing:

```
F20251202 12:13:45.001712 47614933886720 runtime_filter_types.h:124] Check failed: _collector.load(std::memory_order_acquire) == nullptr F20251202 12:13:45.001895 47614975174400 runtime_filter_types.h:124] Check failed: _collector.load(std::memory_order_acquire) == nullptr 
PC: @     0x2b4d1385c387 __GI_raise
*** SIGABRT (@0x3e80002848e) received by PID 165006 (TID 0x2b4e44586700) LWP(166298) from PID 165006; stack trace: ***
F00000000 00:00:00.000000 47615250425600 logging.cc:1962] RAW: Check data_->num_chars_to_log_ > 0 && data_->message_text_[data_->num_chars_to_log_ - 1] == '\n' failed: 
    @         0x27447787 google::(anonymous namespace)::HandleSignal(int, siginfo_t*, void*)
    @     0x2b4d1178020b __pthread_once_slow
    @         0x27446f94 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x2b4d11789630 (/usr/lib64/libpthread-2.17.so+0xf62f)
    @     0x2b4d1385c387 __GI_raise
    @     0x2b4d1385da78 __GI_abort
    @         0x1d408b94 starrocks::failure_function()
    @         0x2743bd8a google::LogMessage::Fail()
    @         0x2743d7c4 google::LogMessageFatal::~LogMessageFatal()
    @         0x1eea279e starrocks::pipeline::RuntimeFilterHolder::set_collector(std::unique_ptr<starrocks::pipeline::RuntimeFilterCollector, std::default_delete<starrocks::pipeline::RuntimeFilterCollector> >&&)
    @         0x1eea293e starrocks::pipeline::RuntimeFilterHub::set_collector(int, std::unique_ptr<starrocks::pipeline::RuntimeFilterCollector, std::default_delete<starrocks::pipeline::RuntimeFilterCollector> >&&)
```


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
