### PR TITLE
[Enhancement] optimize information schema table scan

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -457,14 +457,14 @@ public class FrontendServiceImpl implements FrontendService.Iface {
 
         List<String> dbs = new ArrayList<>();
         for (String fullName : dbNames) {
-            try {
-                Authorizer.checkAnyActionOnOrInDb(context, catalogName, fullName);
-            } catch (AccessDeniedException e) {
+            final String db = ClusterNamespace.getNameFromFullName(fullName);
+            if (!PatternMatcher.matchPattern(params.getPattern(), db, matcher, caseSensitive)) {
                 continue;
             }
 
-            final String db = ClusterNamespace.getNameFromFullName(fullName);
-            if (!PatternMatcher.matchPattern(params.getPattern(), db, matcher, caseSensitive)) {
+            try {
+                Authorizer.checkAnyActionOnOrInDb(context, catalogName, fullName);
+            } catch (AccessDeniedException e) {
                 continue;
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1856,6 +1856,21 @@ public class PlanFragmentBuilder {
                                     "only support `regexp` or `rlike` for log grep");
                         }
                     }
+
+                    if (like.getLikeType() == LikePredicateOperator.LikeType.LIKE) {
+                        String pattern = ((ConstantOperator) like.getChild(1)).getVarchar();
+                        if (!pattern.contains("%")) {
+                            switch (columnRefOperator.getName()) {
+                                case "TABLE_SCHEMA":
+                                case "DATABASE_NAME":
+                                    scanNode.setSchemaDb(pattern);
+                                    break;
+                                case "TABLE_NAME":
+                                    scanNode.setSchemaTable(pattern);
+                                    break;
+                            }
+                        }
+                    }
                 }
             }
 
@@ -4325,8 +4340,8 @@ public class PlanFragmentBuilder {
         }
 
         private ScalarOperator extractAndValidateAsofTemporalPredicate(List<ScalarOperator> otherJoin,
-                                                            ColumnRefSet leftColumns,
-                                                            ColumnRefSet rightColumns) {
+                                                                       ColumnRefSet leftColumns,
+                                                                       ColumnRefSet rightColumns) {
             List<ScalarOperator> candidates = new ArrayList<>();
 
             for (ScalarOperator predicate : otherJoin) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1859,16 +1859,14 @@ public class PlanFragmentBuilder {
 
                     if (like.getLikeType() == LikePredicateOperator.LikeType.LIKE) {
                         String pattern = ((ConstantOperator) like.getChild(1)).getVarchar();
-                        if (!pattern.contains("%")) {
-                            switch (columnRefOperator.getName()) {
-                                case "TABLE_SCHEMA":
-                                case "DATABASE_NAME":
-                                    scanNode.setSchemaDb(pattern);
-                                    break;
-                                case "TABLE_NAME":
-                                    scanNode.setSchemaTable(pattern);
-                                    break;
-                            }
+                        switch (columnRefOperator.getName()) {
+                            case "TABLE_SCHEMA":
+                            case "DATABASE_NAME":
+                                scanNode.setSchemaDb(pattern);
+                                break;
+                            case "TABLE_NAME":
+                                scanNode.setSchemaTable(pattern);
+                                break;
                         }
                     }
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1858,7 +1858,7 @@ public class PlanFragmentBuilder {
                     }
 
                     if (like.getLikeType() == LikePredicateOperator.LikeType.LIKE) {
-                        String pattern = ((ConstantOperator) like.getChild(1)).getVarchar();
+                        String pattern = constantOperator.getVarchar();
                         switch (columnRefOperator.getName()) {
                             case "TABLE_SCHEMA":
                             case "DATABASE_NAME":

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ScanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ScanTest.java
@@ -391,6 +391,16 @@ public class ScanTest extends PlanTestBase {
     }
 
     @Test
+    public void testSchemaScanWithLikePattern() throws Exception {
+        String sql = "select column_name from information_schema.columns " +
+                "where table_schema like 'test_%' and table_name like 'my_table%'";
+        ExecPlan plan = getExecPlan(sql);
+        SchemaScanNode scanNode = (SchemaScanNode) plan.getScanNodes().get(0);
+        Assertions.assertEquals("test_%", scanNode.getSchemaDb());
+        Assertions.assertEquals("my_table%", scanNode.getSchemaTable());
+    }
+
+    @Test
     public void testSchemaScanWithWhereConstantFunction() throws Exception {
         String sql = "SELECT TABLE_SCHEMA TABLE_CAT, NULL TABLE_SCHEM, TABLE_NAME, " +
                 "IF(TABLE_TYPE='BASE TABLE' or TABLE_TYPE='SYSTEM VERSIONED', 'TABLE', TABLE_TYPE) as TABLE_TYPE, " +

--- a/test/sql/test_information_schema/R/test_external_catalog_information_schema_pattern
+++ b/test/sql/test_information_schema/R/test_external_catalog_information_schema_pattern
@@ -1,0 +1,77 @@
+-- name: test_external_catalog_information_schema_pattern
+shell: ossutil64 mkdir oss://${oss_bucket}/test_external_catalog_information_schema_pattern/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+create external catalog `ice_hadoop${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_external_catalog_information_schema_pattern/${uuid0}"
+);
+-- result:
+-- !result
+set catalog ice_hadoop${uuid0};
+-- result:
+-- !result
+create database ice_hadoop${uuid0}.ice_hadoop_db1;
+-- result:
+-- !result
+create table ice_hadoop${uuid0}.ice_hadoop_db1.atest (
+    c0 int, 
+    c1 string
+);
+-- result:
+-- !result
+create database ice_hadoop${uuid0}.ice_hadoop_db2;
+-- result:
+-- !result
+create table ice_hadoop${uuid0}.ice_hadoop_db2.btest (
+    c2 int, 
+    c3 string
+);
+-- result:
+-- !result
+select TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, COLUMN_TYPE from information_schema.columns where table_schema like 'ice_hadoop_db%' order by COLUMN_NAME;
+-- result:
+ice_hadoop_db1	atest	c0	int(11)
+ice_hadoop_db1	atest	c1	varchar(1073741824)
+ice_hadoop_db2	btest	c2	int(11)
+ice_hadoop_db2	btest	c3	varchar(1073741824)
+-- !result
+select TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, COLUMN_TYPE from information_schema.columns where table_schema like 'ice_hadoop_db_' order by COLUMN_NAME;
+-- result:
+ice_hadoop_db1	atest	c0	int(11)
+ice_hadoop_db1	atest	c1	varchar(1073741824)
+ice_hadoop_db2	btest	c2	int(11)
+ice_hadoop_db2	btest	c3	varchar(1073741824)
+-- !result
+select TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, COLUMN_TYPE from information_schema.columns where table_schema like 'ice_hadoop_db1' order by COLUMN_NAME;
+-- result:
+ice_hadoop_db1	atest	c0	int(11)
+ice_hadoop_db1	atest	c1	varchar(1073741824)
+-- !result
+select TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, COLUMN_TYPE from information_schema.columns where table_name like '_test' order by COLUMN_NAME;
+-- result:
+ice_hadoop_db1	atest	c0	int(11)
+ice_hadoop_db1	atest	c1	varchar(1073741824)
+ice_hadoop_db2	btest	c2	int(11)
+ice_hadoop_db2	btest	c3	varchar(1073741824)
+-- !result
+select TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, COLUMN_TYPE from information_schema.columns where table_name like 'a_est' order by COLUMN_NAME;
+-- result:
+ice_hadoop_db1	atest	c0	int(11)
+ice_hadoop_db1	atest	c1	varchar(1073741824)
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+drop catalog ice_hadoop${uuid0};
+-- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_external_catalog_information_schema/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_information_schema/T/test_external_catalog_information_schema_pattern
+++ b/test/sql/test_information_schema/T/test_external_catalog_information_schema_pattern
@@ -1,0 +1,40 @@
+-- name: test_external_catalog_information_schema_pattern
+shell: ossutil64 mkdir oss://${oss_bucket}/test_external_catalog_information_schema_pattern/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+create external catalog `ice_hadoop${uuid0}`
+properties (
+"type"  =  "iceberg",
+"iceberg.catalog.type"  =  "hadoop",
+"iceberg.catalog.warehouse"="oss://${oss_bucket}/test_external_catalog_information_schema_pattern/${uuid0}"
+);
+
+set catalog ice_hadoop${uuid0};
+
+create database ice_hadoop${uuid0}.ice_hadoop_db1;
+
+create table ice_hadoop${uuid0}.ice_hadoop_db1.atest (
+    c0 int, 
+    c1 string
+);
+
+create database ice_hadoop${uuid0}.ice_hadoop_db2;
+
+create table ice_hadoop${uuid0}.ice_hadoop_db2.btest (
+    c2 int, 
+    c3 string
+);
+
+select TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, COLUMN_TYPE from information_schema.columns where table_schema like 'ice_hadoop_db%' order by COLUMN_NAME;
+
+select TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, COLUMN_TYPE from information_schema.columns where table_schema like 'ice_hadoop_db_' order by COLUMN_NAME;
+
+select TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, COLUMN_TYPE from information_schema.columns where table_schema like 'ice_hadoop_db1' order by COLUMN_NAME;
+
+select TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, COLUMN_TYPE from information_schema.columns where table_name like '_test' order by COLUMN_NAME;
+
+select TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, COLUMN_TYPE from information_schema.columns where table_name like 'a_est' order by COLUMN_NAME;
+
+set catalog default_catalog;
+drop catalog ice_hadoop${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_external_catalog_information_schema/${uuid0} >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
## Why I'm doing:

SQL from BI tools sometimes looks like

> TABLE_SCHEMA LIKE 'xxx_yyy'

But we don't set pattern if this is a like predicate, which will cause full scan.

However in the another side of code, we support to analyze like pattern

```
    public TGetTablesResult getTableNames(TGetTablesParams params) throws TException {
        LOG.debug("get table name request: {}", params);
        TGetTablesResult result = new TGetTablesResult();
        List<String> tablesResult = Lists.newArrayList();
        result.setTables(tablesResult);
        PatternMatcher matcher = null;
        boolean caseSensitive = CaseSensibility.TABLE.getCaseSensibility();
        if (params.isSetPattern()) {
            try {
                matcher = PatternMatcher.createMysqlPattern(params.getPattern(),
                        CaseSensibility.TABLE.getCaseSensibility());
            } catch (SemanticException e) {
                throw new TException("Pattern is in bad format: " + params.getPattern());
            }
        }
```

## What I'm doing

Set pattern even it's a like predicate.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
