### PR TITLE
[BugFix] Fix warehouse field NULL in loads table for stream loads

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -53,6 +53,7 @@ import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.rpc.ThriftConnectionPool;
 import com.starrocks.rpc.ThriftRPCRequestExecutor;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.LoadPlanner;
@@ -73,6 +74,7 @@ import com.starrocks.transaction.TransactionException;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TransactionState.TxnCoordinator;
 import com.starrocks.transaction.TxnCommitAttachment;
+import com.starrocks.warehouse.Warehouse;
 import com.starrocks.warehouse.WarehouseIdleChecker;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import io.netty.handler.codec.http.HttpHeaders;
@@ -1689,6 +1691,20 @@ public class StreamLoadTask extends AbstractStreamLoadTask {
             info.setLoad_finish_time(TimeUtils.longToTimeString(endTimeMs));
 
             info.setType(getStringByType());
+
+            // warehouse
+            if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+                try {
+                    Warehouse warehouse = GlobalStateMgr.getCurrentState().getWarehouseMgr().getWarehouse(warehouseId);
+                    info.setWarehouse(warehouse.getName());
+                } catch (Exception e) {
+                    LOG.warn("Failed to get warehouse for stream load task {}, error: {}", id, e.getMessage());
+                    info.setWarehouse("");
+                }
+            } else {
+                info.setWarehouse("");
+            }
+
             return Lists.newArrayList(info);
         } finally {
             readUnlock();

--- a/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadTaskTest.java
@@ -23,6 +23,7 @@ import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.Status;
 import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.common.util.TimeUtils;
 import com.starrocks.http.rest.TransactionResult;
 import com.starrocks.load.loadv2.LoadJob;
 import com.starrocks.load.loadv2.ManualLoadTxnCommitAttachment;
@@ -30,14 +31,19 @@ import com.starrocks.load.routineload.RLTaskTxnCommitAttachment;
 import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.qe.scheduler.Coordinator;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.task.LoadEtlTask;
 import com.starrocks.thrift.TLoadInfo;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.TransactionState;
+import com.starrocks.warehouse.Warehouse;
 import com.starrocks.warehouse.WarehouseIdleChecker;
 import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
 import mockit.Mocked;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,6 +51,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.Map;
+import java.util.TimeZone;
 
 import static com.starrocks.common.ErrorCode.ERR_NO_PARTITIONS_HAVE_DATA_LOAD;
 import static org.mockito.ArgumentMatchers.any;
@@ -449,5 +456,102 @@ public class StreamLoadTaskTest {
         Deencapsulation.setField(task, "loadId", null);
         task.gsonPostProcess();
         Assertions.assertEquals(id.getHi(), task.getTUniqueId().getHi());
+    }
+
+    @Test
+    public void testToThriftWarehouseFieldInSharedDataMode(@Mocked GlobalStateMgr globalStateMgr,
+                                                            @Mocked WarehouseManager warehouseManager,
+                                                            @Mocked Warehouse warehouse) {
+        StreamLoadTask task = new StreamLoadTask(1017, new Database(), new OlapTable(), "t_label18", "u", "127.0.0.1",
+                10000, 1, 0, System.currentTimeMillis(), WarehouseManager.DEFAULT_RESOURCE);
+
+        new MockUp<RunMode>() {
+            @Mock
+            public RunMode getCurrentRunMode() {
+                return RunMode.SHARED_DATA;
+            }
+        };
+
+        new MockUp<TimeUtils>() {
+            @Mock
+            public TimeZone getTimeZone() {
+                return TimeZone.getDefault();
+            }
+        };
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+
+                globalStateMgr.getWarehouseMgr();
+                result = warehouseManager;
+
+                warehouseManager.getWarehouse(anyLong);
+                result = warehouse;
+
+                warehouse.getName();
+                result = "test_warehouse";
+            }
+        };
+
+        TLoadInfo loadInfo = task.toThrift().get(0);
+        Assertions.assertTrue(loadInfo.isSetWarehouse());
+        Assertions.assertEquals("test_warehouse", loadInfo.getWarehouse());
+    }
+
+    @Test
+    public void testToThriftWarehouseFieldInNonSharedDataMode() {
+        StreamLoadTask task = new StreamLoadTask(1018, new Database(), new OlapTable(), "t_label19", "u", "127.0.0.1",
+                10000, 1, 0, System.currentTimeMillis(), WarehouseManager.DEFAULT_RESOURCE);
+
+        new MockUp<RunMode>() {
+            @Mock
+            public RunMode getCurrentRunMode() {
+                return RunMode.SHARED_NOTHING;
+            }
+        };
+
+        TLoadInfo loadInfo = task.toThrift().get(0);
+        Assertions.assertTrue(loadInfo.isSetWarehouse());
+        Assertions.assertEquals("", loadInfo.getWarehouse());
+    }
+
+    @Test
+    public void testToThriftWarehouseFieldWhenWarehouseNotFound(@Mocked GlobalStateMgr globalStateMgr,
+                                                                 @Mocked WarehouseManager warehouseManager) {
+        StreamLoadTask task = new StreamLoadTask(1019, new Database(), new OlapTable(), "t_label20", "u", "127.0.0.1",
+                10000, 1, 0, System.currentTimeMillis(), WarehouseManager.DEFAULT_RESOURCE);
+
+        new MockUp<RunMode>() {
+            @Mock
+            public RunMode getCurrentRunMode() {
+                return RunMode.SHARED_DATA;
+            }
+        };
+
+        new MockUp<TimeUtils>() {
+            @Mock
+            public TimeZone getTimeZone() {
+                return TimeZone.getDefault();
+            }
+        };
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+
+                globalStateMgr.getWarehouseMgr();
+                result = warehouseManager;
+
+                warehouseManager.getWarehouse(anyLong);
+                result = new RuntimeException("Warehouse not found");
+            }
+        };
+
+        TLoadInfo loadInfo = task.toThrift().get(0);
+        Assertions.assertTrue(loadInfo.isSetWarehouse());
+        Assertions.assertEquals("", loadInfo.getWarehouse());
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Problem:
The warehouse column in information_schema.loads table shows NULL for stream load tasks, while it is correctly populated for other load types (broker load, insert load, etc.).

Root Cause:
StreamLoadTask.toThrift() method was missing the logic to set the warehouse field in TLoadInfo, while LoadJob.toThrift() has this logic.

## What I'm doing:

- Add warehouse field setting logic in StreamLoadTask.toThrift() to match the behavior of LoadJob.toThrift()
- In SHARED_DATA mode, fetch and set the warehouse name
- In non-SHARED_DATA mode, set warehouse to empty string
- Handle exceptions gracefully by setting warehouse to empty string

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
