### PR TITLE
[BugFix] Reject conflicting schema-change clauses before side effects

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1990,6 +1990,8 @@ public class SchemaChangeHandler extends AlterHandler {
         List<Index> newIndexes = olapTable.getCopiedIndexes();
         Map<String, String> propertyMap = new HashMap<>();
         Set<String> modifyFieldColumns = new HashSet<>();
+        // NOTE: be very careful with the order of processing alter clauses and early return!!!
+        // It is in a for-loop!
         for (AlterClause alterClause : alterClauses) {
             if (alterClause instanceof AlterTableColumnClause) {
                 if (!propertyMap.isEmpty()) {
@@ -2041,6 +2043,10 @@ public class SchemaChangeHandler extends AlterHandler {
                 // modify column
                 fastSchemaEvolution &= processModifyColumn(modifyColumnClause, olapTable, indexSchemaMap);
             } else if (alterClause instanceof ModifyColumnCommentClause) {
+                // AlterTableStatementAnalyzer.checkAlterOpConflict() allows batch processing SCHEMA_CHANGE clauses.
+                if (alterClauses.size() > 1) {
+                    throw new DdlException("MODIFY COLUMN COMMENT can not be combined with other alter operations");
+                }
                 processModifyColumnComment((ModifyColumnCommentClause) alterClause, db, olapTable, indexSchemaMap);
                 return null;
             } else if (alterClause instanceof AddFieldClause) {
@@ -2074,12 +2080,16 @@ public class SchemaChangeHandler extends AlterHandler {
                 // reorder column
                 fastSchemaEvolution = false;
                 if (changeSortKeyColumn((ReorderColumnsClause) alterClause, olapTable)) {
+                    // AlterTableStatementAnalyzer.checkAlterOpConflict() allows batch processing SCHEMA_CHANGE clauses.
+                    if (alterClauses.size() > 1) {
+                        // This must be checked because it will do early return later.
+                        throw new DdlException("MODIFY SORT KEY COLUMNS can not be combined with other alter operations");
+                    }
                     // do modify sort key column
                     List<Integer> sortKeyIdxes = new ArrayList<>();
                     List<Integer> sortKeyUniqueIds = new ArrayList<>();
                     processModifySortKeyColumn((ReorderColumnsClause) alterClause, olapTable, indexSchemaMap, sortKeyIdxes,
                             sortKeyUniqueIds);
-
                     // If optimized olap table contains related mvs, set those mv state to inactive.
                     AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(olapTable,
                             MaterializedViewExceptions.inactiveReasonForBaseTableReorderColumns(olapTable.getName()), false);
@@ -2102,6 +2112,8 @@ public class SchemaChangeHandler extends AlterHandler {
                 fastSchemaEvolution = false;
                 processDropIndex((DropIndexClause) alterClause, olapTable, newIndexes);
             } else if (alterClause instanceof OptimizeClause) {
+                // AlterTableStatementAnalyzer.checkAlterOpConflict() ensures the OPTIMIZE clause is alone.
+                Preconditions.checkState(alterClauses.size() == 1);
                 return createOptimizeTableJob((OptimizeClause) alterClause, db, olapTable, propertyMap);
             } else {
                 Preconditions.checkState(false);


### PR DESCRIPTION
- detect multi-clause ALTER TABLE statements that include MODIFY COLUMN COMMENT or MODIFY SORT KEY earlier in SchemaChangeHandler, mirroring the analyzer’s conflict rules and preventing partial execution
- add SchemaChangeHandlerTest coverage for combining schema-change clauses and ensure OPTIMIZE-only statements still analyze correctly

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rejects multi-clause ALTER TABLE statements mixing MODIFY COLUMN COMMENT or MODIFY SORT KEY and enforces OPTIMIZE to be alone; adds tests for these conflicts.
> 
> - **FE/Core (SchemaChangeHandler)**:
>   - Enforce conflict checks during clause processing:
>     - `MODIFY COLUMN COMMENT` cannot be combined with other alter operations.
>     - `MODIFY SORT KEY COLUMNS` cannot be combined with other alter operations (validated before early return).
>     - `OPTIMIZE` clause must be alone (strict `Preconditions.checkState`).
>   - Add cautionary comments about processing order/early return in the for-loop.
> - **Tests**:
>   - Add `testAlterTableConflictClauses` in `fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java` covering:
>     - `ADD COLUMN` + `ORDER BY(...)` (sort-key modify) conflict -> `DdlException`.
>     - `ADD COLUMN` + `MODIFY COLUMN ... COMMENT` conflict -> `DdlException`.
>     - `ADD COLUMN` + distribution change analyzed as `OPTIMIZE` conflict -> `SemanticException`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0644dbb2a9d8ab2777ebe74558861d67a81f21fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->