### PR TITLE
[BugFix] Fix the crash issue when writing complex data types to the Iceberg by spill writer

### DIFF
--- a/be/src/column/field.cpp
+++ b/be/src/column/field.cpp
@@ -15,6 +15,7 @@
 #include "column/field.h"
 
 #include "column/datum.h"
+#include "runtime/descriptors.h"
 #include "storage/chunk_helper.h"
 #include "storage/key_coder.h"
 #include "storage/types.h"
@@ -61,6 +62,64 @@ FieldPtr Field::convert_to_dict_field(const Field& field) {
         DCHECK(false);
     }
     return nullptr;
+}
+
+FieldPtr Field::convert_from_slot_desc(const SlotDescriptor& slot) {
+    return _build_field_from_type_desc(slot.type(), slot.col_name(), slot.id(), slot.is_nullable());
+}
+
+FieldPtr Field::_build_field_from_type_desc(const TypeDescriptor& type_desc, const std::string& name, int32_t id,
+                                            bool nullable) {
+    TypeInfoPtr type_info = get_type_info(type_desc);
+    DCHECK(type_info != nullptr);
+
+    // Construct field instance directly for basic types
+    if (type_desc.children.empty()) {
+        return std::make_shared<Field>(id, name, type_info, nullable);
+    }
+
+    // Recursively construct subfields of complex types
+    Fields sub_fields;
+
+    switch (type_desc.type) {
+    case TYPE_ARRAY: {
+        // children[0] is element type
+        const TypeDescriptor& item_type = type_desc.children[0];
+        sub_fields.push_back(_build_field_from_type_desc(item_type, name + ".item", id * 10 + 1, true));
+        break;
+    }
+    case TYPE_MAP: {
+        // children[0] key, children[1] value
+        const TypeDescriptor& key_type = type_desc.children[0];
+        const TypeDescriptor& value_type = type_desc.children[1];
+        sub_fields.push_back(_build_field_from_type_desc(key_type, name + ".key", id * 10 + 1, true));
+        sub_fields.push_back(_build_field_from_type_desc(value_type, name + ".value", id * 10 + 2, true));
+        break;
+    }
+    case TYPE_STRUCT: {
+        // children[i] corresponds to field_names[i]
+        for (size_t i = 0; i < type_desc.children.size(); ++i) {
+            const TypeDescriptor& child_type = type_desc.children[i];
+            std::string child_name;
+            if (i < type_desc.field_names.size()) {
+                child_name = type_desc.field_names[i];
+            } else {
+                child_name = name + ".field" + std::to_string(i);
+            }
+            sub_fields.push_back(_build_field_from_type_desc(child_type, child_name, id * 10 + 1 + i, true));
+        }
+        break;
+    }
+    default: {
+        break;
+    }
+    }
+
+    auto field = std::make_shared<Field>(id, name, type_info, nullable);
+    for (auto& sub_field : sub_fields) {
+        field->add_sub_field(*sub_field);
+    }
+    return field;
 }
 
 } // namespace starrocks

--- a/be/src/column/field.h
+++ b/be/src/column/field.h
@@ -31,6 +31,7 @@ namespace starrocks {
 
 class Datum;
 class AggStateDesc;
+class SlotDescriptor;
 
 class Field {
 public:
@@ -200,7 +201,12 @@ public:
 
     static FieldPtr convert_to_dict_field(const Field& field);
 
+    static FieldPtr convert_from_slot_desc(const SlotDescriptor& slot);
+
 private:
+    static FieldPtr _build_field_from_type_desc(const TypeDescriptor& type_desc, const std::string& name, int32_t id,
+                                                bool nullable);
+
     constexpr static int kIsKeyShift = 0;
     constexpr static int kNullableShift = 1;
 

--- a/be/src/connector/partition_chunk_writer.cpp
+++ b/be/src/connector/partition_chunk_writer.cpp
@@ -369,10 +369,9 @@ void SpillPartitionChunkWriter::_handle_err(const Status& st) {
 
 SchemaPtr SpillPartitionChunkWriter::_make_schema() {
     Fields fields;
+    fields.reserve(_tuple_desc->slots().size());
     for (auto& slot : _tuple_desc->slots()) {
-        TypeDescriptor type_desc = slot->type();
-        TypeInfoPtr type_info = get_type_info(type_desc.type, type_desc.precision, type_desc.scale);
-        auto field = std::make_shared<Field>(slot->id(), slot->col_name(), type_info, slot->is_nullable());
+        auto field = Field::convert_from_slot_desc(*slot);
         fields.push_back(field);
     }
 

--- a/be/src/storage/types.h
+++ b/be/src/storage/types.h
@@ -52,6 +52,7 @@ namespace starrocks {
 
 class MemPool;
 class TabletColumn;
+class TypeDescriptor;
 class TypeInfo;
 class ScalarTypeInfo;
 using TypeInfoPtr = std::shared_ptr<TypeInfo>;
@@ -105,6 +106,8 @@ TypeInfoPtr get_type_info(LogicalType field_type);
 TypeInfoPtr get_type_info(const ColumnMetaPB& column_meta_pb);
 
 TypeInfoPtr get_type_info(const TabletColumn& col);
+
+TypeInfoPtr get_type_info(const TypeDescriptor& type_desc);
 
 TypeInfoPtr get_type_info(LogicalType field_type, [[maybe_unused]] int precision, [[maybe_unused]] int scale);
 


### PR DESCRIPTION
## Why I'm doing:
When writing the complex data types to iceberg tables, if the memory is insufficient and spill is triggered, BE crashes may occur due to improper handling of complex types.

```
UNKNOWN RELEASE (build UNKNOWN distro ubuntu arch x86_64)
query_id:019abf64-377e-7e64-802f-0088b3e63256, fragment_instance:019abf64-377e-7e64-802f-0088b3e63257
*** Aborted at 1764147633 (unix time) try "date -d @1764147633" if you are using GNU date ***
PC: @          0xcd2b011 starrocks::ChunkHelper::column_from_field(starrocks::Field const&)
*** SIGSEGV (@0x0) received by PID 32022 (TID 0x14f3e5a37640) LWP(33649) from PID 0; stack trace: ***
    @     0x14f407f59ee8 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x99ee7)
    @          0xea3f686 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x14f4090b0999 PosixSignals::chained_handler(int, siginfo*, void*) [clone .part.0]
    @     0x14f4090b13ee JVM_handle_linux_signal
    @     0x14f407f02520 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    @          0xcd2b011 starrocks::ChunkHelper::column_from_field(starrocks::Field const&)
    @          0xcd2bd40 starrocks::ChunkHelper::new_chunk(starrocks::Schema const&, unsigned long)
    @          0xbd02489 starrocks::connector::SpillPartitionChunkWriter::_create_schema_chunk(std::shared_ptr<starrocks::Chunk> const&, unsigned long)
    @          0xbd029e4 starrocks::connector::SpillPartitionChunkWriter::_merge_chunks()
    @          0xbd03527 starrocks::connector::SpillPartitionChunkWriter::_spill()
    @          0xbd037d5 starrocks::connector::SpillPartitionChunkWriter::flush()
    @          0xbd0d057 starrocks::connector::SinkOperatorMemoryManager::kill_victim()
    @          0xbd0d3ab starrocks::connector::SinkMemoryManager::_apply_on_mem_tracker(starrocks::connector::SinkOperatorMemoryManager*, starrocks::MemTracker*)
    @          0xbd0d6a7 starrocks::connector::SinkMemoryManager::can_accept_more_input(starrocks::connector::SinkOperatorMemoryManager*)
    @          0xd672bd5 starrocks::pipeline::ConnectorSinkOperator::need_input() const
    @          0xa13ed90 starrocks::pipeline::PipelineDriver::process(starrocks::RuntimeState*, int)
    @          0xbe23f40 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0xd8eaca4 starrocks::ThreadPool::dispatch_thread()
    @          0xd8e0b9e starrocks::Thread::supervise_thread(void*)
    @     0x14f407f54ac3 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x94ac2)
    @     0x14f407fe68c0 (/usr/lib/x86_64-linux-gnu/libc.so.6+0x1268bf)
```

## What I'm doing:
Add logic for handling complex types such as arrays, maps, and structs during spill writer operations to ensure the generation of the correct corresponding chunk structures.

Test cases: https://github.com/StarRocks/StarRocksTest/pull/10692

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Build `Schema` for ARRAY/MAP/STRUCT by constructing `Field` and `TypeInfo` from `TypeDescriptor`, and add tests verifying spill/merge with complex types.
> 
> - **Connector (spill writer)**:
>   - Build schema via `Field::convert_from_slot_desc` (supports `ARRAY`/`MAP`/`STRUCT`) instead of scalar-only construction.
> - **Column/Field**:
>   - Add `convert_from_slot_desc` and recursive `_build_field_from_type_desc` to create `Field` hierarchy from `TypeDescriptor` (handles subfields for complex types).
> - **Storage/Types**:
>   - Add `get_type_info(const TypeDescriptor&)` to produce `TypeInfo` for complex types recursively.
> - **Tests**:
>   - Add `spill_writer_for_complex_types` covering ARRAY<INT>, MAP<VARCHAR,INT>, and STRUCT fields through write/flush/spill/merge paths.
> - **Misc**:
>   - Minor optimization reserving `fields` capacity in schema creation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2958c10cdafce3e293f4a6fa9919a8978b3d46c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->