### PR TITLE
[BugFix] Fix BE still reported as alive on SIGSEGV

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -88,7 +88,7 @@ void HeartbeatServer::heartbeat(THeartbeatResult& heartbeat_result, const TMaste
 
     StatusOr<CmpResult> res;
     // reject master's heartbeat when exit
-    if (process_exit_in_progress()) {
+    if (process_exit_in_progress() || is_process_crashing()) {
         res = Status::Shutdown("BE is shutting down");
     } else {
         res = compare_master_info(master_info);

--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -18,6 +18,8 @@
 #include <glog/logging.h>
 #include <glog/vlog_is_on.h>
 #include <jemalloc/jemalloc.h>
+
+#include "common/process_exit.h"
 #ifdef __APPLE__
 #include <mach/mach_init.h>
 #include <mach/mach_port.h>
@@ -188,6 +190,8 @@ static void dontdump_unused_pages() {
 static void failure_handler_after_output_log() {
     static bool start_dump = false;
     if (!start_dump && config::enable_core_file_size_optimization && base::get_cur_core_file_limit() != 0) {
+        set_process_is_crashing();
+
         ExecEnv::GetInstance()->try_release_resource_before_core_dump();
 #ifndef __APPLE__
         DataCache::GetInstance()->try_release_resource_before_core_dump();

--- a/be/src/common/process_exit.h
+++ b/be/src/common/process_exit.h
@@ -54,4 +54,8 @@ bool is_frontend_aware_of_exit();
 // clear the flag of frontend awareness of the shutdown.
 void clear_frontend_aware_of_exit();
 
+void set_process_is_crashing();
+
+bool is_process_crashing();
+
 } // namespace starrocks


### PR DESCRIPTION

## Why I'm doing:

This patch fixes an issue where the BE could still be reported as `alive` after a fatal signal such as SIGSEGV. In such cases, the BE process enters the crash handler path, but the frontend (FE) may continue to receive successful heartbeat responses before the process fully exits, leading to an inconsistent state where the crashed BE appears healthy.

To address this, a new flag `k_starrocks_be_crashing` is introduced and set at the beginning of the fatal-signal crash handler. Once this flag is set, the heartbeat server rejects incoming FE heartbeats with a `Status::Shutdown`, ensuring that the FE marks the BE as not alive immediately instead of waiting for timeout-based detection.

This change improves the correctness of FE/BE state synchronization and prevents cases in which the BE crash is masked by jemalloc or logging paths that continue to function briefly during the crash handling.

This PR helps prevent the frontend from selecting problematic nodes in this state.

![img_v3_02sj_a51ed579-c2f2-4156-adb1-9d5a5594643g](https://github.com/user-attachments/assets/b7577f7a-10b9-43a5-a608-cdc0d1793472)


## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/10690

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Marks BE as crashing on fatal signals and makes heartbeat return Shutdown so FE immediately treats the node as not alive.
> 
> - **Heartbeat handling (`be/src/agent/heartbeat_server.cpp`)**:
>   - Rejects FE heartbeats when `process_exit_in_progress()` or new `is_process_crashing()` is true, returning `Status::Shutdown`.
> - **Process state (`be/src/common/process_exit.{h,cpp}`)**:
>   - Adds `k_starrocks_be_crashing` flag with APIs `set_process_is_crashing()` and `is_process_crashing()`.
> - **Crash handler (`be/src/common/logconfig.cpp`)**:
>   - Calls `set_process_is_crashing()` at start of fatal-signal handling path to mark BE as crashing before resource release and jemalloc tweaks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2fa8ce4319e05e0f6b6296602dd00dd9789ecb0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->