### PR TITLE
[Feature] Support virtual column _tablet_id_

### DIFF
--- a/be/src/column/field.h
+++ b/be/src/column/field.h
@@ -90,7 +90,8 @@ public:
               _length(rhs._length),
               _short_key_length(rhs._short_key_length),
               _flags(rhs._flags),
-              _uid(rhs._uid) {}
+              _uid(rhs._uid),
+              _is_virtual(rhs._is_virtual) {}
 
     Field(Field&& rhs) noexcept
             : _id(rhs._id),
@@ -102,7 +103,8 @@ public:
               _length(rhs._length),
               _short_key_length(rhs._short_key_length),
               _flags(rhs._flags),
-              _uid(rhs._uid) {
+              _uid(rhs._uid),
+              _is_virtual(rhs._is_virtual) {
         rhs._sub_fields = nullptr;
     }
 
@@ -119,6 +121,7 @@ public:
             _flags = rhs._flags;
             _sub_fields = rhs._sub_fields ? new std::vector<Field>(*rhs._sub_fields) : nullptr;
             _uid = rhs._uid;
+            _is_virtual = rhs._is_virtual;
         }
         return *this;
     }
@@ -134,6 +137,7 @@ public:
             _short_key_length = rhs._short_key_length;
             _flags = rhs._flags;
             _uid = rhs._uid;
+            _is_virtual = rhs._is_virtual;
             std::swap(_sub_fields, rhs._sub_fields);
         }
         return *this;
@@ -161,6 +165,9 @@ public:
 
     int32_t length() const { return _length; }
     void set_length(int32_t l) { _length = l; }
+
+    bool is_virtual() const { return _is_virtual; }
+    void set_is_virtual(bool is_virtual) { _is_virtual = is_virtual; }
 
     uint8_t short_key_length() const { return _short_key_length; }
     void set_short_key_length(uint8_t n) { _short_key_length = n; }
@@ -221,6 +228,7 @@ private:
     uint8_t _short_key_length;
     uint8_t _flags;
     ColumnUID _uid = -1;
+    bool _is_virtual = false;
 };
 
 inline bool Field::is_nullable() const {

--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -32,6 +32,7 @@
 #include "storage/projection_iterator.h"
 #include "storage/rowset/short_key_range_option.h"
 #include "storage/runtime_range_pruner.hpp"
+#include "storage/virtual_column_utils.h"
 #include "util/starrocks_metrics.h"
 #include "util/string_parser.hpp"
 
@@ -390,6 +391,7 @@ Status LakeDataSource::init_tablet_reader(RuntimeState* runtime_state) {
 
     RETURN_IF_ERROR(get_tablet(_scan_range));
     RETURN_IF_ERROR(_extend_schema_by_access_paths());
+    ASSIGN_OR_RETURN(_tablet_schema, extend_schema_by_virtual_columns(_tablet_schema, *_slots));
     RETURN_IF_ERROR(init_global_dicts(&_params));
     RETURN_IF_ERROR(init_unused_output_columns(thrift_lake_scan_node.unused_output_column_name));
     RETURN_IF_ERROR(init_reader_params(_scanner_ranges));

--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -231,7 +231,7 @@ Status LakeDataSource::init_global_dicts(TabletReaderParams* params) {
 Status LakeDataSource::init_unused_output_columns(const std::vector<std::string>& unused_output_columns) {
     for (const auto& col_name : unused_output_columns) {
         int32_t index = _tablet_schema->field_index(col_name);
-        if (index < 0) {
+        if (index < 0 && !is_virtual_column(col_name)) {
             std::stringstream ss;
             ss << "invalid field name: " << col_name;
             LOG(WARNING) << ss.str();

--- a/be/src/exec/olap_meta_scanner.cpp
+++ b/be/src/exec/olap_meta_scanner.cpp
@@ -21,6 +21,7 @@
 #include "storage/storage_engine.h"
 #include "storage/tablet.h"
 #include "storage/tablet_manager.h"
+#include "storage/virtual_column_utils.h"
 
 namespace starrocks {
 
@@ -101,6 +102,8 @@ Status OlapMetaScanner::_init_meta_reader_params() {
         }
         _reader_params.tablet_schema = tmp_schema;
     }
+
+    ASSIGN_OR_RETURN(_reader_params.tablet_schema, extend_schema_by_virtual_columns(_reader_params.tablet_schema));
     _reader_params.desc_tbl = &_parent->_desc_tbl;
 
     VLOG(2) << "init_meta_reader schema: " << _reader_params.tablet_schema->debug_string();

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -47,6 +47,7 @@
 #include "storage/projection_iterator.h"
 #include "storage/runtime_range_pruner.hpp"
 #include "storage/storage_engine.h"
+#include "storage/virtual_column_utils.h"
 #include "types/logical_type.h"
 #include "util/json.h"
 #include "util/runtime_profile.h"
@@ -356,6 +357,7 @@ Status OlapChunkSource::_init_scanner_columns(std::vector<uint32_t>& scanner_col
     for (auto slot : *_slots) {
         DCHECK(slot->is_materialized());
         int32_t index;
+        // TODO: port vector index column to virtual column
         if (_use_vector_index && !_use_ivfpq && slot->id() == _vector_slot_id) {
             index = _tablet_schema->num_columns();
             _params.vector_search_option->vector_column_id = index;
@@ -405,7 +407,7 @@ Status OlapChunkSource::_init_scanner_columns(std::vector<uint32_t>& scanner_col
 Status OlapChunkSource::_init_unused_output_columns(const std::vector<std::string>& unused_output_columns) {
     for (const auto& col_name : unused_output_columns) {
         int32_t index = _tablet_schema->field_index(col_name);
-        if (index < 0) {
+        if (index < 0 && !is_virtual_column(col_name)) {
             std::stringstream ss;
             ss << "invalid field name: " << col_name;
             LOG(WARNING) << ss.str();
@@ -696,6 +698,7 @@ Status OlapChunkSource::_init_olap_reader(RuntimeState* runtime_state) {
 
     // Extend the tablet_schema with access path columns
     RETURN_IF_ERROR(_extend_schema_by_access_paths());
+    ASSIGN_OR_RETURN(_tablet_schema, extend_schema_by_virtual_columns(_tablet_schema, *_slots));
     RETURN_IF_ERROR(_init_global_dicts(&_params));
     RETURN_IF_ERROR(_init_unused_output_columns(thrift_olap_scan_node.unused_output_column_name));
     RETURN_IF_ERROR(_init_reader_params(_scan_ctx->key_ranges()));

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -63,7 +63,8 @@ SlotDescriptor::SlotDescriptor(SlotId id, std::string name, TypeDescriptor type)
           _slot_size(_type.get_slot_size()),
           _is_materialized(false),
           _is_output_column(false),
-          _is_nullable(true) {}
+          _is_nullable(true),
+          _is_virtual(false) {}
 
 SlotDescriptor::SlotDescriptor(const TSlotDescriptor& tdesc)
         : _id(tdesc.id),
@@ -78,7 +79,10 @@ SlotDescriptor::SlotDescriptor(const TSlotDescriptor& tdesc)
           _is_output_column(tdesc.__isset.isOutputColumn ? tdesc.isOutputColumn : true),
           _is_nullable(tdesc.__isset.isNullable
                                ? tdesc.isNullable
-                               : (tdesc.__isset.nullIndicatorBit ? tdesc.nullIndicatorBit != -1 : true)) {}
+                               : (tdesc.__isset.nullIndicatorBit ? tdesc.nullIndicatorBit != -1 : true)),
+          _is_virtual(tdesc.__isset.is_virtual_column ? tdesc.is_virtual_column : false) {}
+{
+}
 
 SlotDescriptor::SlotDescriptor(const PSlotDescriptor& pdesc)
         : _id(pdesc.id()),
@@ -90,7 +94,8 @@ SlotDescriptor::SlotDescriptor(const PSlotDescriptor& pdesc)
           _slot_size(_type.get_slot_size()),
           _is_materialized(pdesc.is_materialized()),
           _is_output_column(true),
-          _is_nullable(pdesc.has_is_nullable() ? pdesc.is_nullable() : pdesc.null_indicator_bit() != -1) {}
+          _is_nullable(pdesc.has_is_nullable() ? pdesc.is_nullable() : pdesc.null_indicator_bit() != -1),
+          _is_virtual(pdesc.is_virtual()) {}
 
 void SlotDescriptor::to_protobuf(PSlotDescriptor* pslot) const {
     pslot->set_id(_id);
@@ -105,7 +110,11 @@ void SlotDescriptor::to_protobuf(PSlotDescriptor* pslot) const {
     pslot->set_col_name(_col_name);
     pslot->set_slot_idx(_slot_idx);
     pslot->set_is_materialized(_is_materialized);
+<<<<<<< HEAD
     pslot->set_is_nullable(_is_nullable);
+=======
+    pslot->set_is_virtual(_is_virtual);
+>>>>>>> 425a6f65ffa (update 2)
 }
 
 std::string SlotDescriptor::debug_string() const {

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -81,8 +81,6 @@ SlotDescriptor::SlotDescriptor(const TSlotDescriptor& tdesc)
                                ? tdesc.isNullable
                                : (tdesc.__isset.nullIndicatorBit ? tdesc.nullIndicatorBit != -1 : true)),
           _is_virtual(tdesc.__isset.is_virtual_column ? tdesc.is_virtual_column : false) {}
-{
-}
 
 SlotDescriptor::SlotDescriptor(const PSlotDescriptor& pdesc)
         : _id(pdesc.id()),
@@ -110,11 +108,8 @@ void SlotDescriptor::to_protobuf(PSlotDescriptor* pslot) const {
     pslot->set_col_name(_col_name);
     pslot->set_slot_idx(_slot_idx);
     pslot->set_is_materialized(_is_materialized);
-<<<<<<< HEAD
     pslot->set_is_nullable(_is_nullable);
-=======
     pslot->set_is_virtual(_is_virtual);
->>>>>>> 425a6f65ffa (update 2)
 }
 
 std::string SlotDescriptor::debug_string() const {

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -76,12 +76,8 @@ public:
     TupleId parent() const { return _parent; }
     bool is_materialized() const { return _is_materialized; }
     bool is_output_column() const { return _is_output_column; }
-<<<<<<< HEAD
     bool is_nullable() const { return _is_nullable; }
-=======
-    bool is_nullable() const { return _null_indicator_offset.bit_mask != 0; }
     bool is_virtual() const { return _is_virtual; }
->>>>>>> 425a6f65ffa (update 2)
 
     int slot_size() const { return _slot_size; }
 

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -76,7 +76,12 @@ public:
     TupleId parent() const { return _parent; }
     bool is_materialized() const { return _is_materialized; }
     bool is_output_column() const { return _is_output_column; }
+<<<<<<< HEAD
     bool is_nullable() const { return _is_nullable; }
+=======
+    bool is_nullable() const { return _null_indicator_offset.bit_mask != 0; }
+    bool is_virtual() const { return _is_virtual; }
+>>>>>>> 425a6f65ffa (update 2)
 
     int slot_size() const { return _slot_size; }
 
@@ -116,6 +121,8 @@ private:
     const bool _is_output_column;
 
     const bool _is_nullable;
+
+    const bool _is_virtual;
 
     SlotDescriptor(const PSlotDescriptor& pdesc);
 };

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -176,6 +176,7 @@ set(STORAGE_FILES
     compaction_manager.cpp
     horizontal_compaction_task.cpp
     vertical_compaction_task.cpp
+    virtual_column_utils.cpp
     compaction_task_factory.cpp
     default_compaction_policy.cpp
     size_tiered_compaction_policy.cpp

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -122,6 +122,7 @@ Field ChunkHelper::convert_field(ColumnId id, const TabletColumn& c) {
     f.set_is_key(c.is_key());
     f.set_length(c.length());
     f.set_uid(c.unique_id());
+    f.set_is_virtual(c.is_virtual_column());
 
     if (type == TYPE_ARRAY) {
         const TabletColumn& sub_column = c.subcolumn(0);

--- a/be/src/storage/lake_meta_reader.cpp
+++ b/be/src/storage/lake_meta_reader.cpp
@@ -27,6 +27,7 @@
 #include "storage/lake/table_schema_service.h"
 #include "storage/rowset/column_iterator.h"
 #include "storage/rowset/rowset.h"
+#include "storage/virtual_column_utils.h"
 
 namespace starrocks {
 
@@ -76,6 +77,7 @@ Status LakeMetaReader::init(const LakeMetaReaderParams& read_params) {
         tablet_schema = tmp_schema;
     }
 
+    ASSIGN_OR_RETURN(tablet_schema, extend_schema_by_virtual_columns(tablet_schema));
     RETURN_IF_ERROR(_build_collect_context(tablet_schema, read_params));
     RETURN_IF_ERROR(_init_seg_meta_collecters(tablet, read_params));
 

--- a/be/src/storage/meta_reader.h
+++ b/be/src/storage/meta_reader.h
@@ -145,6 +145,7 @@ public:
 private:
     Status _init_return_column_iterators();
     Status _collect(const std::string& name, ColumnId cid, Column* column, LogicalType type);
+    Status _collect_virtual(const std::string& name, const std::string_view col_name, Column* column, LogicalType type);
     Status _collect_dict(ColumnId cid, Column* column, LogicalType type);
     Status _collect_dict_for_flatjson(ColumnId cid, Column* column);
     Status _collect_dict_for_column(ColumnIterator* column_iter, ColumnId cid, Column* column);
@@ -169,6 +170,7 @@ private:
     SegmentSharedPtr _segment;
     std::vector<std::unique_ptr<ColumnIterator>> _column_iterators;
     const SegmentMetaCollecterParams* _params = nullptr;
+    int32_t _tablet_id;
     std::unique_ptr<RandomAccessFile> _read_file;
     OlapReaderStatistics _stats;
     std::unordered_map<std::string, SegmentSharedPtr> _dcg_segments;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1278,7 +1278,6 @@ Status SegmentIterator::_init_column_iterators(const Schema& schema) {
             }
             if (f->is_virtual()) {
                 RETURN_IF_ERROR(_init_virtual_column_iterator(cid, f->name()));
-                continue;
             } else {
                 RETURN_IF_ERROR(_init_column_iterator_by_cid(cid, f->uid(), check_dict_enc));
             }

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -64,6 +64,7 @@
 #include "storage/runtime_range_pruner.hpp"
 #include "storage/types.h"
 #include "storage/update_manager.h"
+#include "storage/virtual_column_utils.h"
 #include "types/array_type_info.h"
 #include "types/logical_type.h"
 #include "util/starrocks_metrics.h"
@@ -419,6 +420,9 @@ private:
     // This function is a unified entry for creating column iterators.
     // `ucid` means unique column id, use it for searching delta column group.
     Status _init_column_iterator_by_cid(const ColumnId cid, const ColumnUID ucid, bool check_dict_enc);
+
+    // init column iterator for virtual column like '_tablet_id_', '_rowid_'
+    Status _init_virtual_column_iterator(const ColumnId cid, const std::string_view col_name);
 
     ColumnAccessPath* _lookup_access_path(ColumnId cid, const TabletColumn& col);
 
@@ -1160,6 +1164,28 @@ ColumnAccessPath* SegmentIterator::_lookup_access_path(ColumnId cid, const Table
     return access_path;
 }
 
+Status SegmentIterator::_init_virtual_column_iterator(const ColumnId cid, const std::string_view col_name) {
+    ColumnIteratorOptions iter_opts;
+    iter_opts.stats = _opts.stats;
+    iter_opts.use_page_cache = _opts.use_page_cache;
+    iter_opts.temporary_data = _opts.temporary_data;
+    iter_opts.check_dict_encoding = false;
+    iter_opts.reader_type = _opts.reader_type;
+    iter_opts.lake_io_opts = _opts.lake_io_opts;
+    iter_opts.has_preaggregation = _opts.has_preaggregation;
+
+    VirtualColumnFactory::Options factory_option;
+    factory_option.tablet_id = _opts.tablet_id;
+    factory_option.segment_id = segment_id();
+    factory_option.num_rows = _segment->num_rows();
+
+    ASSIGN_OR_RETURN(auto iterator, VirtualColumnFactory::create_virtual_column_iterator(factory_option, col_name));
+    _column_iterators[cid].reset(std::move(iterator));
+    RETURN_IF_ERROR(_column_iterators[cid]->init(iter_opts));
+
+    return Status::OK();
+}
+
 Status SegmentIterator::_init_column_iterator_by_cid(const ColumnId cid, const ColumnUID ucid, bool check_dict_enc) {
     ColumnIteratorOptions iter_opts;
     iter_opts.stats = _opts.stats;
@@ -1250,7 +1276,12 @@ Status SegmentIterator::_init_column_iterators(const Schema& schema) {
             } else {
                 check_dict_enc = has_predicate;
             }
-            RETURN_IF_ERROR(_init_column_iterator_by_cid(cid, f->uid(), check_dict_enc));
+            if (f->is_virtual()) {
+                RETURN_IF_ERROR(_init_virtual_column_iterator(cid, f->name()));
+                continue;
+            } else {
+                RETURN_IF_ERROR(_init_column_iterator_by_cid(cid, f->uid(), check_dict_enc));
+            }
 
             if constexpr (check_global_dict) {
                 _column_decoders[cid].set_iterator(_column_iterators[cid].get());
@@ -2019,7 +2050,7 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
                 // after calculation, offset will be 0, and size will be 2MB+123
                 size_t offset = (e.first / buf_size) * buf_size;
                 size_t size = e.second + (e.first % buf_size);
-                while (size > 0) {
+                while (size > 0 && _column_files[cid] != nullptr) {
                     size_t cur_size = std::min(buf_size, size);
                     RETURN_IF_ERROR(_column_files[cid]->touch_cache(offset, cur_size));
                     offset += cur_size;
@@ -3131,7 +3162,7 @@ StatusOr<RowIdSparseRange> SegmentIterator::_sample_by_page() {
     ColumnId cid = _schema.field(0)->id();
     auto& column_iterator = _column_iterators[cid];
     ColumnReader* column_reader = column_iterator->get_column_reader();
-    RETURN_IF(column_reader == nullptr, Status::InvalidArgument("Not support page smaple: no column_reader"));
+    RETURN_IF(column_reader == nullptr, Status::InvalidArgument("Not support page sample: no column_reader"));
     int32_t num_data_pages = column_reader->num_data_pages();
     PageIndexer page_indexer = [&](size_t page_index) { return column_reader->get_page_range(page_index); };
 
@@ -3200,7 +3231,10 @@ Status SegmentIterator::_apply_bitmap_index() {
         SCOPED_RAW_TIMER(&_opts.stats->bitmap_index_iterator_init_ns);
 
         std::unordered_map<ColumnId, ColumnUID> cid_2_ucid;
-        for (auto& field : _schema.fields()) {
+        for (const auto& field : _schema.fields()) {
+            if (field->is_virtual()) {
+                continue;
+            }
             cid_2_ucid[field->id()] = field->uid();
         }
 
@@ -3260,10 +3294,17 @@ Status SegmentIterator::_init_inverted_index_iterators() {
     _inverted_index_ctx->inverted_index_iterators.resize(ChunkHelper::max_column_id(_schema) + 1, nullptr);
     std::unordered_map<ColumnId, ColumnUID> cid_2_ucid;
 
-    for (auto& field : _schema.fields()) {
+    for (const auto& field : _schema.fields()) {
+        if (field->is_virtual()) {
+            continue;
+        }
         cid_2_ucid[field->id()] = field->uid();
     }
     for (const auto& pair : _opts.pred_tree.get_immediate_column_predicate_map()) {
+        if (cid_2_ucid.find(pair.first) == cid_2_ucid.end()) {
+            continue;
+        }
+
         ColumnId cid = pair.first;
         ColumnUID ucid = cid_2_ucid[cid];
 
@@ -3566,8 +3607,10 @@ void SegmentIterator::close() {
 
     for (auto& [cid, rfile] : _column_files) {
         // update statistics before reset column file
-        _update_stats(rfile.get());
-        rfile.reset();
+        if (rfile != nullptr) {
+            _update_stats(rfile.get());
+            rfile.reset();
+        }
     }
 
     STLClearObject(&_selection);

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -124,7 +124,6 @@ public:
     size_t num_rows_per_row_block_with_max_version() const;
     size_t next_unique_id() const;
     size_t field_index_with_max_version(const string& field_name) const;
-    size_t field_index(const string& field_name, const string& extra_column_name) const;
     std::string schema_debug_string() const;
     std::string debug_string() const;
     bool enable_shortcut_compaction() const;
@@ -532,10 +531,6 @@ inline size_t Tablet::next_unique_id() const {
 
 inline size_t Tablet::field_index_with_max_version(const string& field_name) const {
     return tablet_schema()->field_index(field_name);
-}
-
-inline size_t Tablet::field_index(const string& field_name, const string& extra_column_name) const {
-    return tablet_schema()->field_index(field_name, extra_column_name);
 }
 
 inline bool Tablet::enable_shortcut_compaction() const {

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -697,20 +697,6 @@ size_t TabletSchema::field_index(std::string_view field_name) const {
     return -1;
 }
 
-size_t TabletSchema::field_index(std::string_view field_name, std::string_view extra_column_name) const {
-    int ordinal = -1;
-    for (auto& column : _cols) {
-        ordinal++;
-        if (column.name() == field_name) {
-            return ordinal;
-        }
-    }
-    if (field_name == extra_column_name) {
-        return ordinal + 1;
-    }
-    return -1;
-}
-
 int32_t TabletSchema::field_index(int32_t col_unique_id) const {
     const auto& found = _unique_id_to_index.find(col_unique_id);
     return (found == _unique_id_to_index.end()) ? -1 : found->second;

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -74,6 +74,7 @@ class TabletColumn {
         std::string default_value;
         std::vector<TabletColumn> sub_columns;
         bool has_default_value = false;
+        bool is_virtual_column = false;
     };
 
 public:
@@ -167,6 +168,13 @@ public:
         ExtraFields* ext = _get_or_alloc_extra_fields();
         ext->has_default_value = true;
         ext->default_value = std::move(value);
+    }
+
+    bool is_virtual_column() const { return _extra_fields && _extra_fields->is_virtual_column; }
+
+    void set_is_virtual_column(bool is_virtual) {
+        ExtraFields* ext = _get_or_alloc_extra_fields();
+        ext->is_virtual_column = is_virtual;
     }
 
     bool has_agg_state_desc() const { return _agg_state_desc != nullptr; }
@@ -305,7 +313,6 @@ public:
     size_t estimate_row_size(size_t variable_len) const;
     int32_t field_index(int32_t col_unique_id) const;
     size_t field_index(std::string_view field_name) const;
-    size_t field_index(std::string_view field_name, std::string_view extra_column_name) const;
     const TabletColumn& column(size_t ordinal) const;
     const std::vector<TabletColumn>& columns() const;
     const std::vector<ColumnId> sort_key_idxes() const { return _sort_key_idxes; }

--- a/be/src/storage/virtual_column_utils.cpp
+++ b/be/src/storage/virtual_column_utils.cpp
@@ -1,0 +1,150 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/virtual_column_utils.h"
+
+#include <utility>
+
+#include "column/column.h"
+#include "runtime/descriptors.h"
+#include "storage/rowset/default_value_column_iterator.h"
+#include "storage/types.h"
+
+namespace starrocks {
+struct VirtualColumnDefinition;
+using IteratorCreator = ColumnIterator* (*)(const VirtualColumnFactory::Options& options,
+                                            const VirtualColumnDefinition& def);
+using ColumnAppender = Status (*)(const VirtualColumnFactory::Options& options, const VirtualColumnDefinition& def,
+                                  Column* column);
+
+struct VirtualColumnDefinition {
+    VirtualColumnDefinition(std::string name_, LogicalType type_, bool nullable_, IteratorCreator iterator_creator_,
+                            ColumnAppender appender_)
+            : name(std::move(name_)),
+              type(type_),
+              nullable(nullable_),
+              iterator_creator(iterator_creator_),
+              appender(appender_) {}
+    const std::string name;
+    const LogicalType type;
+    bool nullable;
+    IteratorCreator iterator_creator;
+    ColumnAppender appender;
+};
+
+ColumnIterator* create_tablet_iterator(const VirtualColumnFactory::Options& options,
+                                       const VirtualColumnDefinition& def) {
+    std::string tablet_id = std::to_string(options.tablet_id);
+    TypeInfoPtr type_info = get_type_info(def.type);
+    return new DefaultValueColumnIterator(true, tablet_id, def.nullable, type_info, sizeof(int32_t), options.num_rows);
+}
+
+Status append_tablet_column(const VirtualColumnFactory::Options& options, const VirtualColumnDefinition& def,
+                            Column* column) {
+    column->append_datum(Datum(options.tablet_id));
+    return Status::OK();
+}
+
+struct VirtualColumnDefinition VIRTUAL_COLUMNS[] = {
+        VirtualColumnDefinition("_tablet_id_", TYPE_INT, false, create_tablet_iterator, append_tablet_column)};
+
+class SlotDescriptor;
+bool is_virtual_column(const std::string_view col_name) {
+    for (const auto& vc : VIRTUAL_COLUMNS) {
+        if (vc.name == col_name) {
+            return true;
+        }
+    }
+    return false;
+}
+
+StatusOr<TabletSchemaCSPtr> extend_schema_by_virtual_columns(const TabletSchemaCSPtr& schema,
+                                                             const std::vector<SlotDescriptor*>& slots) {
+    bool has_virtual_column = false;
+    has_virtual_column =
+            std::any_of(slots.begin(), slots.end(), [](const SlotDescriptor* slot) { return slot->is_virtual(); });
+    if (!has_virtual_column) {
+        return schema;
+    }
+    TabletSchemaSPtr tmp_schema = TabletSchema::copy(*schema);
+    for (const auto& slot : slots) {
+        const std::string& col_name = slot->col_name();
+        if (slot->is_virtual()) {
+            bool found = false;
+            for (const auto& vc : VIRTUAL_COLUMNS) {
+                if (vc.name == col_name) {
+                    TabletColumn tc;
+                    tc.set_name(vc.name);
+                    tc.set_type(vc.type);
+                    tc.set_is_nullable(vc.nullable);
+                    tc.set_is_virtual_column(true);
+
+                    auto keys_type = schema->keys_type();
+                    if (keys_type == KeysType::UNIQUE_KEYS || keys_type == KeysType::AGG_KEYS) {
+                        tc.set_aggregation(StorageAggregateType::STORAGE_AGGREGATE_REPLACE);
+                    }
+
+                    tmp_schema->append_column(tc);
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                return Status::InternalError(fmt::format("Unknown virtual column: {}", col_name));
+            }
+        }
+    }
+
+    return tmp_schema;
+}
+
+StatusOr<TabletSchemaCSPtr> extend_schema_by_virtual_columns(const TabletSchemaCSPtr& schema) {
+    TabletSchemaSPtr tmp_schema = TabletSchema::copy(*schema);
+    for (const auto& vc : VIRTUAL_COLUMNS) {
+        TabletColumn tc;
+        tc.set_name(vc.name);
+        tc.set_type(vc.type);
+        tc.set_is_nullable(vc.nullable);
+        tc.set_is_virtual_column(true);
+
+        auto keys_type = schema->keys_type();
+        if (keys_type == KeysType::UNIQUE_KEYS || keys_type == KeysType::AGG_KEYS) {
+            tc.set_aggregation(StorageAggregateType::STORAGE_AGGREGATE_REPLACE);
+        }
+
+        tmp_schema->append_column(tc);
+    }
+    return tmp_schema;
+}
+
+StatusOr<ColumnIterator*> VirtualColumnFactory::create_virtual_column_iterator(const Options& options,
+                                                                               const std::string_view col_name) {
+    for (const auto& vc : VIRTUAL_COLUMNS) {
+        if (vc.name == col_name) {
+            return vc.iterator_creator(options, vc);
+        }
+    }
+    return Status::InternalError(fmt::format("unknown virtual column: {}", col_name));
+}
+
+Status VirtualColumnFactory::append_to_column(const Options& options, const std::string_view col_name, Column* column) {
+    for (const auto& vc : VIRTUAL_COLUMNS) {
+        if (vc.name == col_name) {
+            return vc.appender(options, vc, column);
+        }
+    }
+    return Status::InternalError(fmt::format("unknown virtual column: {}", col_name));
+}
+
+} // namespace starrocks

--- a/be/src/storage/virtual_column_utils.cpp
+++ b/be/src/storage/virtual_column_utils.cpp
@@ -14,6 +14,7 @@
 
 #include "storage/virtual_column_utils.h"
 
+#include <memory>
 #include <utility>
 
 #include "column/column.h"
@@ -111,6 +112,15 @@ StatusOr<TabletSchemaCSPtr> extend_schema_by_virtual_columns(const TabletSchemaC
 
 StatusOr<TabletSchemaCSPtr> extend_schema_by_virtual_columns(const TabletSchemaCSPtr& schema) {
     TabletSchemaSPtr tmp_schema = TabletSchema::copy(*schema);
+    // copy extended info from original schema
+    for (size_t i = 0; i < schema->num_columns(); ++i) {
+        const TabletColumn& col = schema->column(i);
+        const TabletColumn& dst_col = tmp_schema->column(i);
+        if (col.extended_info() != nullptr) {
+            const_cast<TabletColumn&>(dst_col).set_extended_info(
+                    std::make_unique<ExtendedColumnInfo>(*col.extended_info()));
+        }
+    }
     for (const auto& vc : VIRTUAL_COLUMNS) {
         TabletColumn tc;
         tc.set_name(vc.name);

--- a/be/src/storage/virtual_column_utils.h
+++ b/be/src/storage/virtual_column_utils.h
@@ -1,0 +1,41 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string_view>
+
+#include "common/status.h"
+#include "storage/tablet_schema.h"
+
+namespace starrocks {
+class SlotDescriptor;
+class ColumnIterator;
+bool is_virtual_column(const std::string_view col_name);
+StatusOr<TabletSchemaCSPtr> extend_schema_by_virtual_columns(const TabletSchemaCSPtr& schema,
+                                                             const std::vector<SlotDescriptor*>& slots);
+StatusOr<TabletSchemaCSPtr> extend_schema_by_virtual_columns(const TabletSchemaCSPtr& schema);
+class VirtualColumnFactory {
+public:
+    struct Options {
+        int32_t tablet_id;
+        int32_t segment_id;
+        int32_t num_rows;
+    };
+    static StatusOr<ColumnIterator*> create_virtual_column_iterator(const Options& options,
+                                                                    const std::string_view col_name);
+    static Status append_to_column(const Options& options, const std::string_view col_name, Column* column);
+};
+
+} // namespace starrocks

--- a/be/test/exec/lake_meta_scanner_test.cpp
+++ b/be/test/exec/lake_meta_scanner_test.cpp
@@ -263,7 +263,7 @@ TEST_F(LakeMetaScannerTest, test_read_schema) {
         ASSERT_EQ(schema->schema_version(), 5);
 
         // Verify schema has 2 columns: c0 (INT, key) and c1 (INT, non-key)
-        ASSERT_EQ(schema->num_columns(), 2);
+        ASSERT_EQ(schema->num_columns(), 3);
 
         // Verify column c0: INT, key
         const auto& col0 = schema->column(0);
@@ -306,7 +306,7 @@ TEST_F(LakeMetaScannerTest, test_read_schema) {
         ASSERT_EQ(schema->schema_version(), 1);
 
         // Verify schema has 1 column: c0 (INT, key)
-        ASSERT_EQ(schema->num_columns(), 1);
+        ASSERT_EQ(schema->num_columns(), 2);
 
         // Verify column c0: INT, key
         const auto& col0 = schema->column(0);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -163,6 +163,9 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
     // Whether this column is a hidden column, hidden columns are used to store some internal data(eg: _ROW_ID).
     @SerializedName(value = "isHidden")
     private boolean isHidden = false;
+    // Whether this column is a virtual column, virtual columns are computed during query execution (eg: _tablet_id_).
+    // Virtual columns are not persisted and only exist during query analysis and planning.
+    private transient boolean isVirtual = false;
 
     // Only for persist
     public Column() {
@@ -449,6 +452,14 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
 
     public void setIsHidden(boolean hidden) {
         isHidden = hidden;
+    }
+
+    public boolean isVirtual() {
+        return isVirtual;
+    }
+
+    public void setIsVirtual(boolean virtual) {
+        isVirtual = virtual;
     }
 
     public boolean isShadowColumn() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -130,7 +130,6 @@ import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
 import com.starrocks.thrift.TWriteQuorumType;
-import com.starrocks.type.IntegerType;
 import com.starrocks.type.PrimitiveType;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
@@ -164,7 +163,6 @@ import javax.annotation.Nullable;
 
 import static com.starrocks.common.util.PropertyAnalyzer.PROPERTIES_STORAGE_TYPE_COLUMN;
 import static com.starrocks.common.util.PropertyAnalyzer.PROPERTIES_STORAGE_TYPE_COLUMN_WITH_ROW;
-import static com.starrocks.thrift.PlanNodesConstants.TABLET_ID_COLUMN_NAME;
 
 /**
  * Internal representation of tableFamilyGroup-related metadata. A
@@ -172,9 +170,6 @@ import static com.starrocks.thrift.PlanNodesConstants.TABLET_ID_COLUMN_NAME;
  */
 public class OlapTable extends Table {
     private static final Logger LOG = LogManager.getLogger(OlapTable.class);
-
-    // Virtual column singleton - lazily initialized
-    private static volatile Column TABLET_ID_VIRTUAL_COLUMN = null;
 
     public enum OlapTableState {
         NORMAL,
@@ -814,48 +809,17 @@ public class OlapTable extends Table {
             return column;
         }
         
-        // Check if this is a virtual column
-        return getVirtualColumn(name);
-    }
-
-    /**
-     * Get or create the singleton tablet_id virtual column.
-     * @return The tablet_id virtual column
-     */
-    private static Column getTabletIdVirtualColumn() {
-        if (TABLET_ID_VIRTUAL_COLUMN == null) {
-            synchronized (OlapTable.class) {
-                if (TABLET_ID_VIRTUAL_COLUMN == null) {
-                    Column col = new Column(TABLET_ID_COLUMN_NAME, IntegerType.BIGINT);
-                    col.setIsVirtual(true);
-                    TABLET_ID_VIRTUAL_COLUMN = col;
-                }
-            }
-        }
-        return TABLET_ID_VIRTUAL_COLUMN;
-    }
-
-    /**
-     * Get virtual column by name. Virtual columns are not persisted but are available during query execution.
-     * @param name The column name
-     * @return The virtual column if it matches a known virtual column name, null otherwise
-     */
-    private Column getVirtualColumn(String name) {
-        if (TABLET_ID_COLUMN_NAME.equalsIgnoreCase(name)) {
-            return getTabletIdVirtualColumn();
-        }
-        return null;
+        // Check if this is a virtual column using registry
+        return VirtualColumnRegistry.getColumn(name);
     }
 
     /**
      * Get all virtual columns for this OLAP table.
-     * @return List of virtual columns
+     * @return List of virtual columns from the registry
      */
     @Override
     public List<Column> getVirtualColumns() {
-        List<Column> virtualColumns = Lists.newArrayList();
-        virtualColumns.add(getTabletIdVirtualColumn());
-        return virtualColumns;
+        return VirtualColumnRegistry.getAllColumns();
     }
 
     public Map<ColumnId, Column> getIdToColumn() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -130,6 +130,7 @@ import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
 import com.starrocks.thrift.TWriteQuorumType;
+import com.starrocks.type.IntegerType;
 import com.starrocks.type.PrimitiveType;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections4.ListUtils;
@@ -163,6 +164,7 @@ import javax.annotation.Nullable;
 
 import static com.starrocks.common.util.PropertyAnalyzer.PROPERTIES_STORAGE_TYPE_COLUMN;
 import static com.starrocks.common.util.PropertyAnalyzer.PROPERTIES_STORAGE_TYPE_COLUMN_WITH_ROW;
+import static com.starrocks.thrift.PlanNodesConstants.TABLET_ID_COLUMN_NAME;
 
 /**
  * Internal representation of tableFamilyGroup-related metadata. A
@@ -799,6 +801,44 @@ public class OlapTable extends Table {
     @Override
     public Column getColumn(ColumnId id) {
         return idToColumn.get(id);
+    }
+
+    @Override
+    public Column getColumn(String name) {
+        // First check regular columns
+        Column column = super.getColumn(name);
+        if (column != null) {
+            return column;
+        }
+        
+        // Check if this is a virtual column
+        return getVirtualColumn(name);
+    }
+
+    /**
+     * Get virtual column by name. Virtual columns are not persisted but are available during query execution.
+     * @param name The column name
+     * @return The virtual column if it matches a known virtual column name, null otherwise
+     */
+    private Column getVirtualColumn(String name) {
+        if (TABLET_ID_COLUMN_NAME.equalsIgnoreCase(name)) {
+            Column tabletIdCol = new Column(TABLET_ID_COLUMN_NAME, IntegerType.BIGINT);
+            tabletIdCol.setIsVirtual(true);
+            return tabletIdCol;
+        }
+        return null;
+    }
+
+    /**
+     * Get all virtual columns for this OLAP table.
+     * @return List of virtual columns
+     */
+    public List<Column> getVirtualColumns() {
+        List<Column> virtualColumns = Lists.newArrayList();
+        Column tabletIdCol = new Column(TABLET_ID_COLUMN_NAME, IntegerType.BIGINT);
+        tabletIdCol.setIsVirtual(true);
+        virtualColumns.add(tabletIdCol);
+        return virtualColumns;
     }
 
     public Map<ColumnId, Column> getIdToColumn() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -173,6 +173,9 @@ import static com.starrocks.thrift.PlanNodesConstants.TABLET_ID_COLUMN_NAME;
 public class OlapTable extends Table {
     private static final Logger LOG = LogManager.getLogger(OlapTable.class);
 
+    // Virtual column singleton - lazily initialized
+    private static volatile Column TABLET_ID_VIRTUAL_COLUMN = null;
+
     public enum OlapTableState {
         NORMAL,
         ROLLUP,
@@ -816,15 +819,30 @@ public class OlapTable extends Table {
     }
 
     /**
+     * Get or create the singleton tablet_id virtual column.
+     * @return The tablet_id virtual column
+     */
+    private static Column getTabletIdVirtualColumn() {
+        if (TABLET_ID_VIRTUAL_COLUMN == null) {
+            synchronized (OlapTable.class) {
+                if (TABLET_ID_VIRTUAL_COLUMN == null) {
+                    Column col = new Column(TABLET_ID_COLUMN_NAME, IntegerType.BIGINT);
+                    col.setIsVirtual(true);
+                    TABLET_ID_VIRTUAL_COLUMN = col;
+                }
+            }
+        }
+        return TABLET_ID_VIRTUAL_COLUMN;
+    }
+
+    /**
      * Get virtual column by name. Virtual columns are not persisted but are available during query execution.
      * @param name The column name
      * @return The virtual column if it matches a known virtual column name, null otherwise
      */
     private Column getVirtualColumn(String name) {
         if (TABLET_ID_COLUMN_NAME.equalsIgnoreCase(name)) {
-            Column tabletIdCol = new Column(TABLET_ID_COLUMN_NAME, IntegerType.BIGINT);
-            tabletIdCol.setIsVirtual(true);
-            return tabletIdCol;
+            return getTabletIdVirtualColumn();
         }
         return null;
     }
@@ -833,11 +851,10 @@ public class OlapTable extends Table {
      * Get all virtual columns for this OLAP table.
      * @return List of virtual columns
      */
+    @Override
     public List<Column> getVirtualColumns() {
         List<Column> virtualColumns = Lists.newArrayList();
-        Column tabletIdCol = new Column(TABLET_ID_COLUMN_NAME, IntegerType.BIGINT);
-        tabletIdCol.setIsVirtual(true);
-        virtualColumns.add(tabletIdCol);
+        virtualColumns.add(getTabletIdVirtualColumn());
         return virtualColumns;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -498,6 +498,16 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
         return fullSchema.stream().filter(c -> c.getUniqueId() == uniqueId).findFirst().orElse(null);
     }
 
+    /**
+     * Get all virtual columns for this table. Virtual columns are not persisted 
+     * but are available during query execution.
+     * Default implementation returns empty list. Subclasses can override to provide virtual columns.
+     * @return List of virtual columns
+     */
+    public List<Column> getVirtualColumns() {
+        return new ArrayList<>();
+    }
+
     public boolean containColumn(String columnName) {
         return nameToColumn.containsKey(columnName);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/VirtualColumnDefinition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/VirtualColumnDefinition.java
@@ -1,0 +1,81 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.starrocks.type.Type;
+
+/**
+ * Definition of a virtual column including its metadata.
+ * Virtual columns are computed at query runtime and not persisted in storage.
+ */
+public class VirtualColumnDefinition {
+    private final String name;
+    private final Type type;
+    private final String description;
+    private final boolean enabled;
+    
+    // Lazy-initialized column instance
+    private volatile Column column = null;
+
+    public VirtualColumnDefinition(String name, Type type, String description) {
+        this(name, type, description, true);
+    }
+
+    public VirtualColumnDefinition(String name, Type type, String description, boolean enabled) {
+        this.name = name;
+        this.type = type;
+        this.description = description;
+        this.enabled = enabled;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Get or create the Column instance for this virtual column definition.
+     * Uses double-checked locking for thread-safe lazy initialization.
+     * @return The Column instance
+     */
+    public Column getColumn() {
+        if (column == null) {
+            synchronized (this) {
+                if (column == null) {
+                    Column col = new Column(name, type);
+                    col.setIsVirtual(true);
+                    column = col;
+                }
+            }
+        }
+        return column;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("VirtualColumn(%s, %s, enabled=%s)", name, type, enabled);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/VirtualColumnRegistry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/VirtualColumnRegistry.java
@@ -1,0 +1,132 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import com.starrocks.type.IntegerType;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.starrocks.thrift.PlanNodesConstants.TABLET_ID_COLUMN_NAME;
+
+/**
+ * Central registry for all virtual columns in StarRocks.
+ * Virtual columns are computed at runtime and not persisted in storage.
+ * 
+ * To add a new virtual column:
+ * 1. Add the column name constant to PlanNodes.thrift
+ * 2. Register the column definition in VIRTUAL_COLUMNS list below
+ * 3. The column will be automatically available in queries
+ */
+public class VirtualColumnRegistry {
+    
+    /**
+     * Registry of all virtual column definitions.
+     * To add a new virtual column, add an entry here with:
+     * - Column name (from PlanNodesConstants)
+     * - Data type
+     * - Description
+     * - Enabled flag (optional, defaults to true)
+     */
+    private static final List<VirtualColumnDefinition> VIRTUAL_COLUMNS = ImmutableList.of(
+            new VirtualColumnDefinition(
+                    TABLET_ID_COLUMN_NAME,
+                    IntegerType.BIGINT,
+                    "Tablet ID of the data block containing this row"
+            )
+            // Future virtual columns - uncomment to enable:
+            // new VirtualColumnDefinition(
+            //         SEGMENT_ID_COLUMN_NAME,
+            //         IntegerType.BIGINT,
+            //         "Segment ID within the tablet"
+            // ),
+            // new VirtualColumnDefinition(
+            //         ROW_ID_COLUMN_NAME,
+            //         IntegerType.BIGINT,
+            //         "Row ID within the segment"
+            // )
+    );
+    
+    // Fast lookup map: column name (case-insensitive) -> definition
+    private static final Map<String, VirtualColumnDefinition> NAME_TO_DEFINITION;
+    
+    static {
+        NAME_TO_DEFINITION = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
+        for (VirtualColumnDefinition def : VIRTUAL_COLUMNS) {
+            if (def.isEnabled()) {
+                NAME_TO_DEFINITION.put(def.getName(), def);
+            }
+        }
+    }
+    
+    /**
+     * Get virtual column definition by name (case-insensitive).
+     * @param name Column name
+     * @return Virtual column definition, or null if not found
+     */
+    public static VirtualColumnDefinition getDefinition(String name) {
+        return NAME_TO_DEFINITION.get(name);
+    }
+    
+    /**
+     * Get virtual column instance by name (case-insensitive).
+     * @param name Column name
+     * @return Column instance, or null if not found
+     */
+    public static Column getColumn(String name) {
+        VirtualColumnDefinition def = getDefinition(name);
+        return def != null ? def.getColumn() : null;
+    }
+    
+    /**
+     * Get all enabled virtual column definitions.
+     * @return List of enabled virtual column definitions
+     */
+    public static List<VirtualColumnDefinition> getAllDefinitions() {
+        return VIRTUAL_COLUMNS.stream()
+                .filter(VirtualColumnDefinition::isEnabled)
+                .collect(Collectors.toList());
+    }
+    
+    /**
+     * Get all enabled virtual column instances.
+     * @return List of enabled virtual columns
+     */
+    public static List<Column> getAllColumns() {
+        return getAllDefinitions().stream()
+                .map(VirtualColumnDefinition::getColumn)
+                .collect(Collectors.toList());
+    }
+    
+    /**
+     * Check if a column name is a registered virtual column (case-insensitive).
+     * @param name Column name
+     * @return True if this is a virtual column, false otherwise
+     */
+    public static boolean isVirtualColumn(String name) {
+        return NAME_TO_DEFINITION.containsKey(name);
+    }
+    
+    /**
+     * Get the number of enabled virtual columns.
+     * @return Count of enabled virtual columns
+     */
+    public static int getCount() {
+        return NAME_TO_DEFINITION.size();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/VirtualColumnRegistry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/VirtualColumnRegistry.java
@@ -46,7 +46,7 @@ public class VirtualColumnRegistry {
     private static final List<VirtualColumnDefinition> VIRTUAL_COLUMNS = ImmutableList.of(
             new VirtualColumnDefinition(
                     TABLET_ID_COLUMN_NAME,
-                    IntegerType.BIGINT,
+                    IntegerType.INT,
                     "Tablet ID of the data block containing this row"
             )
             // Future virtual columns - uncomment to enable:

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3866,6 +3866,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static boolean show_execution_groups = true;
 
+    @ConfField(mutable = true, comment = "Whether enable virtual columns like _tablet_id_")
+    public static boolean enable_virtual_columns = true;
+
     @ConfField(mutable = true)
     public static long max_bucket_number_per_partition = 1024;
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SlotDescriptor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SlotDescriptor.java
@@ -81,6 +81,9 @@ public class SlotDescriptor {
     // if false, this slot cannot be NULL
     private boolean isNullable;
 
+    // if true, this slot represents a virtual column (e.g., _tablet_id_)
+    private boolean isVirtualColumn = false;
+
     // physical layout parameters
     private int byteSize;
     private int byteOffset;  // within tuple
@@ -116,6 +119,7 @@ public class SlotDescriptor {
         this.isOutputColumn = src.isOutputColumn;
         this.column = src.column;
         this.isNullable = src.isNullable;
+        this.isVirtualColumn = src.isVirtualColumn;
         this.byteSize = src.byteSize;
         this.type = src.type;
     }
@@ -172,6 +176,9 @@ public class SlotDescriptor {
         } else {
             this.type = this.originType.clone();
         }
+
+        // Set isVirtualColumn based on the column's virtual column status
+        this.isVirtualColumn = column.isVirtual();
     }
 
     public boolean isMaterialized() {
@@ -264,6 +271,7 @@ public class SlotDescriptor {
         tSlotDescriptor.setIsMaterialized(true);
         tSlotDescriptor.setIsOutputColumn(isOutputColumn);
         tSlotDescriptor.setIsNullable(isNullable);
+        tSlotDescriptor.setIs_virtual_column(isVirtualColumn);
         return tSlotDescriptor;
     }
 
@@ -274,6 +282,7 @@ public class SlotDescriptor {
         return MoreObjects.toStringHelper(this).add("id", id.asInt()).add("parent", parentTupleId)
                 .add("col", colStr).add("type", typeStr).add("materialized", isMaterialized)
                 .add("isOutputColumns", isOutputColumn).add("isNullable", isNullable)
+                .add("isVirtualColumn", isVirtualColumn)
                 .add("byteSize", byteSize).add("byteOffset", byteOffset)
                 .add("slotIdx", slotIdx).toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -785,6 +785,15 @@ public class QueryAnalyzer {
                     columns.put(field, column);
                     fields.add(field);
                 }
+                
+                // Add virtual columns for sync MV queries as well
+                for (Column column : getVirtualColumns(table)) {
+                    SlotRef slot = new SlotRef(tableName, column.getName(), column.getName());
+                    Field field = new Field(column.getName(), column.getType(), tableName, slot, false,
+                            column.isAllowNull());
+                    columns.put(field, column);
+                    fields.add(field);
+                }
             } else {
                 List<Column> fullSchema = table.getFullSchema();
                 Set<Column> baseSchema = new HashSet<>(table.getBaseSchema());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -836,7 +836,8 @@ public class QueryAnalyzer {
                 // Add virtual columns for OLAP tables
                 for (Column column : getVirtualColumns(table)) {
                     SlotRef slot = new SlotRef(tableName, column.getName(), column.getName());
-                    Field field = new Field(column.getName(), column.getType(), tableName, slot, true,
+                    // Virtual columns are not visible in SELECT * but can be explicitly referenced
+                    Field field = new Field(column.getName(), column.getType(), tableName, slot, false,
                             column.isAllowNull());
                     columns.put(field, column);
                     fields.add(field);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -38,6 +38,7 @@ import com.starrocks.catalog.TableFunctionTable;
 import com.starrocks.catalog.TableName;
 import com.starrocks.catalog.View;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
@@ -894,7 +895,7 @@ public class QueryAnalyzer {
         private List<Column> getVirtualColumns(Table table) {
             List<Column> columns = new ArrayList<>();
             // Add _tablet_id_ virtual column for OLAP tables
-            if (table.isNativeTableOrMaterializedView()) {
+            if (table.isNativeTableOrMaterializedView() && Config.enable_virtual_columns) {
                 OlapTable olapTable = (OlapTable) table;
                 columns.addAll(olapTable.getVirtualColumns());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -122,7 +122,6 @@ import static com.starrocks.thrift.PlanNodesConstants.BINLOG_OP_COLUMN_NAME;
 import static com.starrocks.thrift.PlanNodesConstants.BINLOG_SEQ_ID_COLUMN_NAME;
 import static com.starrocks.thrift.PlanNodesConstants.BINLOG_TIMESTAMP_COLUMN_NAME;
 import static com.starrocks.thrift.PlanNodesConstants.BINLOG_VERSION_COLUMN_NAME;
-import static com.starrocks.thrift.PlanNodesConstants.TABLET_ID_COLUMN_NAME;
 
 public class QueryAnalyzer {
     private final ConnectContext session;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -122,6 +122,7 @@ import static com.starrocks.thrift.PlanNodesConstants.BINLOG_OP_COLUMN_NAME;
 import static com.starrocks.thrift.PlanNodesConstants.BINLOG_SEQ_ID_COLUMN_NAME;
 import static com.starrocks.thrift.PlanNodesConstants.BINLOG_TIMESTAMP_COLUMN_NAME;
 import static com.starrocks.thrift.PlanNodesConstants.BINLOG_VERSION_COLUMN_NAME;
+import static com.starrocks.thrift.PlanNodesConstants.TABLET_ID_COLUMN_NAME;
 
 public class QueryAnalyzer {
     private final ConnectContext session;
@@ -831,6 +832,15 @@ public class QueryAnalyzer {
                         fields.add(field);
                     }
                 }
+
+                // Add virtual columns for OLAP tables
+                for (Column column : getVirtualColumns(table)) {
+                    SlotRef slot = new SlotRef(tableName, column.getName(), column.getName());
+                    Field field = new Field(column.getName(), column.getType(), tableName, slot, true,
+                            column.isAllowNull());
+                    columns.put(field, column);
+                    fields.add(field);
+                }
             }
 
             node.setColumns(columns.build());
@@ -869,6 +879,17 @@ public class QueryAnalyzer {
             columns.add(new Column(BINLOG_VERSION_COLUMN_NAME, IntegerType.BIGINT));
             columns.add(new Column(BINLOG_SEQ_ID_COLUMN_NAME, IntegerType.BIGINT));
             columns.add(new Column(BINLOG_TIMESTAMP_COLUMN_NAME, IntegerType.BIGINT));
+            return columns;
+        }
+
+        private List<Column> getVirtualColumns(Table table) {
+            List<Column> columns = new ArrayList<>();
+            // Add _tablet_id_ virtual column for OLAP tables
+            if (table.isNativeTableOrMaterializedView()) {
+                Column tabletIdCol = new Column(TABLET_ID_COLUMN_NAME, IntegerType.BIGINT);
+                tabletIdCol.setIsVirtual(true);
+                columns.add(tabletIdCol);
+            }
             return columns;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -887,9 +887,8 @@ public class QueryAnalyzer {
             List<Column> columns = new ArrayList<>();
             // Add _tablet_id_ virtual column for OLAP tables
             if (table.isNativeTableOrMaterializedView()) {
-                Column tabletIdCol = new Column(TABLET_ID_COLUMN_NAME, IntegerType.BIGINT);
-                tabletIdCol.setIsVirtual(true);
-                columns.add(tabletIdCol);
+                OlapTable olapTable = (OlapTable) table;
+                columns.addAll(olapTable.getVirtualColumns());
             }
             return columns;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -64,6 +64,7 @@ public class SelectStmtTest {
     public static void setUp() throws Exception {
         UtFrameUtils.createMinStarRocksCluster();
         Config.show_execution_groups = false;
+        Config.enable_virtual_columns = false;
         FeConstants.showFragmentCost = false;
         FeConstants.setLengthForVarchar =false;
         String createTblStmtStr = "create table db1.tbl1(k1 varchar(32), k2 varchar(32), k3 varchar(32), k4 int) "

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/UseMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/UseMaterializedViewTest.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
@@ -50,6 +51,7 @@ public class UseMaterializedViewTest {
         UtFrameUtils.createMinStarRocksCluster();
         // create connect context
         connectContext = UtFrameUtils.createDefaultCtx();
+        Config.enable_virtual_columns = false;
 
         // set default config for async mvs
         UtFrameUtils.setDefaultConfigForAsyncMVTest(connectContext);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/VirtualColumnRegistryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/VirtualColumnRegistryTest.java
@@ -1,0 +1,110 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class VirtualColumnRegistryTest {
+    
+    @Test
+    public void testGetDefinition() {
+        // Test case-insensitive lookup
+        VirtualColumnDefinition def1 = VirtualColumnRegistry.getDefinition("_tablet_id_");
+        assertNotNull(def1);
+        assertEquals("_tablet_id_", def1.getName());
+        
+        // Case insensitive
+        VirtualColumnDefinition def2 = VirtualColumnRegistry.getDefinition("_TABLET_ID_");
+        assertNotNull(def2);
+        assertEquals(def1, def2);
+        
+        // Non-existent column
+        VirtualColumnDefinition def3 = VirtualColumnRegistry.getDefinition("_nonexistent_");
+        assertNull(def3);
+    }
+    
+    @Test
+    public void testGetColumn() {
+        // Test getting column instance
+        Column col = VirtualColumnRegistry.getColumn("_tablet_id_");
+        assertNotNull(col);
+        assertEquals("_tablet_id_", col.getName());
+        assertTrue(col.isVirtual());
+        
+        // Test singleton - should return same instance
+        Column col2 = VirtualColumnRegistry.getColumn("_tablet_id_");
+        assertSame(col, col2);
+        
+        // Non-existent column
+        Column col3 = VirtualColumnRegistry.getColumn("_nonexistent_");
+        assertNull(col3);
+    }
+    
+    @Test
+    public void testGetAllDefinitions() {
+        List<VirtualColumnDefinition> defs = VirtualColumnRegistry.getAllDefinitions();
+        assertNotNull(defs);
+        assertFalse(defs.isEmpty());
+        
+        // Should contain tablet_id
+        assertTrue(defs.stream().anyMatch(d -> d.getName().equals("_tablet_id_")));
+    }
+    
+    @Test
+    public void testGetAllColumns() {
+        List<Column> columns = VirtualColumnRegistry.getAllColumns();
+        assertNotNull(columns);
+        assertFalse(columns.isEmpty());
+        
+        // Should contain tablet_id
+        assertTrue(columns.stream().anyMatch(c -> c.getName().equals("_tablet_id_")));
+        
+        // All should be virtual
+        assertTrue(columns.stream().allMatch(Column::isVirtual));
+    }
+    
+    @Test
+    public void testIsVirtualColumn() {
+        assertTrue(VirtualColumnRegistry.isVirtualColumn("_tablet_id_"));
+        assertTrue(VirtualColumnRegistry.isVirtualColumn("_TABLET_ID_")); // case insensitive
+        assertFalse(VirtualColumnRegistry.isVirtualColumn("_nonexistent_"));
+        assertFalse(VirtualColumnRegistry.isVirtualColumn("v1"));
+    }
+    
+    @Test
+    public void testGetCount() {
+        int count = VirtualColumnRegistry.getCount();
+        assertTrue(count > 0);
+        
+        // Should match getAllColumns size
+        assertEquals(VirtualColumnRegistry.getAllColumns().size(), count);
+    }
+    
+    @Test
+    public void testVirtualColumnProperties() {
+        Column col = VirtualColumnRegistry.getColumn("_tablet_id_");
+        assertNotNull(col);
+        
+        // Virtual columns should be marked as virtual
+        assertTrue(col.isVirtual());
+        
+        // Should have correct type
+        assertNotNull(col.getType());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/VirtualColumnRegistryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/VirtualColumnRegistryTest.java
@@ -14,97 +14,96 @@
 
 package com.starrocks.catalog;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 public class VirtualColumnRegistryTest {
-    
+
     @Test
     public void testGetDefinition() {
         // Test case-insensitive lookup
         VirtualColumnDefinition def1 = VirtualColumnRegistry.getDefinition("_tablet_id_");
-        assertNotNull(def1);
-        assertEquals("_tablet_id_", def1.getName());
-        
-        // Case insensitive
+        Assertions.assertNotNull(def1);
+        Assertions.assertEquals("_tablet_id_", def1.getName());
+
+        // Case-insensitive
         VirtualColumnDefinition def2 = VirtualColumnRegistry.getDefinition("_TABLET_ID_");
-        assertNotNull(def2);
-        assertEquals(def1, def2);
-        
+        Assertions.assertNotNull(def2);
+        Assertions.assertEquals(def1, def2);
+
         // Non-existent column
         VirtualColumnDefinition def3 = VirtualColumnRegistry.getDefinition("_nonexistent_");
-        assertNull(def3);
+        Assertions.assertNull(def3);
     }
-    
+
     @Test
     public void testGetColumn() {
         // Test getting column instance
         Column col = VirtualColumnRegistry.getColumn("_tablet_id_");
-        assertNotNull(col);
-        assertEquals("_tablet_id_", col.getName());
-        assertTrue(col.isVirtual());
-        
+        Assertions.assertNotNull(col);
+        Assertions.assertEquals("_tablet_id_", col.getName());
+        Assertions.assertTrue(col.isVirtual());
+
         // Test singleton - should return same instance
         Column col2 = VirtualColumnRegistry.getColumn("_tablet_id_");
-        assertSame(col, col2);
-        
+        Assertions.assertSame(col, col2);
+
         // Non-existent column
         Column col3 = VirtualColumnRegistry.getColumn("_nonexistent_");
-        assertNull(col3);
+        Assertions.assertNull(col3);
     }
-    
+
     @Test
     public void testGetAllDefinitions() {
         List<VirtualColumnDefinition> defs = VirtualColumnRegistry.getAllDefinitions();
-        assertNotNull(defs);
-        assertFalse(defs.isEmpty());
-        
+        Assertions.assertNotNull(defs);
+        Assertions.assertFalse(defs.isEmpty());
+
         // Should contain tablet_id
-        assertTrue(defs.stream().anyMatch(d -> d.getName().equals("_tablet_id_")));
+        Assertions.assertTrue(defs.stream().anyMatch(d -> d.getName().equals("_tablet_id_")));
     }
-    
+
     @Test
     public void testGetAllColumns() {
         List<Column> columns = VirtualColumnRegistry.getAllColumns();
-        assertNotNull(columns);
-        assertFalse(columns.isEmpty());
-        
+        Assertions.assertNotNull(columns);
+        Assertions.assertFalse(columns.isEmpty());
+
         // Should contain tablet_id
-        assertTrue(columns.stream().anyMatch(c -> c.getName().equals("_tablet_id_")));
-        
+        Assertions.assertTrue(columns.stream().anyMatch(c -> c.getName().equals("_tablet_id_")));
+
         // All should be virtual
-        assertTrue(columns.stream().allMatch(Column::isVirtual));
+        Assertions.assertTrue(columns.stream().allMatch(Column::isVirtual));
     }
-    
+
     @Test
     public void testIsVirtualColumn() {
-        assertTrue(VirtualColumnRegistry.isVirtualColumn("_tablet_id_"));
-        assertTrue(VirtualColumnRegistry.isVirtualColumn("_TABLET_ID_")); // case insensitive
-        assertFalse(VirtualColumnRegistry.isVirtualColumn("_nonexistent_"));
-        assertFalse(VirtualColumnRegistry.isVirtualColumn("v1"));
+        Assertions.assertTrue(VirtualColumnRegistry.isVirtualColumn("_tablet_id_"));
+        Assertions.assertTrue(VirtualColumnRegistry.isVirtualColumn("_TABLET_ID_")); // case insensitive
+        Assertions.assertFalse(VirtualColumnRegistry.isVirtualColumn("_nonexistent_"));
+        Assertions.assertFalse(VirtualColumnRegistry.isVirtualColumn("v1"));
     }
-    
+
     @Test
     public void testGetCount() {
         int count = VirtualColumnRegistry.getCount();
-        assertTrue(count > 0);
-        
+        Assertions.assertTrue(count > 0);
+
         // Should match getAllColumns size
-        assertEquals(VirtualColumnRegistry.getAllColumns().size(), count);
+        Assertions.assertEquals(VirtualColumnRegistry.getAllColumns().size(), count);
     }
-    
+
     @Test
     public void testVirtualColumnProperties() {
         Column col = VirtualColumnRegistry.getColumn("_tablet_id_");
-        assertNotNull(col);
-        
+        Assertions.assertNotNull(col);
+
         // Virtual columns should be marked as virtual
-        assertTrue(col.isVirtual());
-        
+        Assertions.assertTrue(col.isVirtual());
+
         // Should have correct type
-        assertNotNull(col.getType());
+        Assertions.assertNotNull(col.getType());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoTestBase.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.connector.parser.trino;
 
+import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.planner.TpchSQL;
@@ -52,6 +53,7 @@ public class TrinoTestBase {
     @BeforeAll
     public static void beforeClass() throws Exception {
         UtFrameUtils.createMinStarRocksCluster();
+        Config.enable_virtual_columns = false;
         FeConstants.enablePruneEmptyOutputScan = false;
         connectContext = UtFrameUtils.createDefaultCtx();
         starRocksAssert = new StarRocksAssert(connectContext);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
@@ -75,6 +75,7 @@ public class MVRewriteTest extends StarRocksTestBase {
         // set default config for async mvs
         UtFrameUtils.setDefaultConfigForAsyncMVTest(connectContext);
 
+        Config.enable_virtual_columns = false;
         Config.alter_scheduler_interval_millisecond = 1;
         FeConstants.runningUnitTest = true;
         UtFrameUtils.createMinStarRocksCluster();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
@@ -144,6 +144,7 @@ public abstract class MVTestBase extends StarRocksTestBase {
     @BeforeAll
     public static void beforeClass() throws Exception {
         FeConstants.runningUnitTest = true;
+        Config.enable_virtual_columns = false;
 
         CachingMvPlanContextBuilder.getInstance().rebuildCache();
         PseudoCluster.getOrCreateWithRandomPort(true, 1);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -81,6 +81,7 @@ public class PlanTestNoneDBBase extends StarRocksTestBase {
     @BeforeAll
     public static void beforeClass() throws Exception {
         Config.show_execution_groups = false;
+        Config.enable_virtual_columns = false;
         // disable checking tablets
         Config.tablet_sched_max_scheduling_tablets = -1;
         Config.alter_scheduler_interval_millisecond = 1;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpForSharedDataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpForSharedDataTest.java
@@ -46,6 +46,7 @@ public class ReplayFromDumpForSharedDataTest extends ReplayFromDumpTestBase {
         connectContext = UtFrameUtils.createDefaultCtx();
         starRocksAssert = new StarRocksAssert(connectContext);
         Config.show_execution_groups = false;
+        Config.enable_virtual_columns = false;
         // Should disable Dynamic Partition in replay dump test
         Config.dynamic_partition_enable = false;
         Config.tablet_sched_disable_colocate_overall_balance = true;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTestBase.java
@@ -60,6 +60,7 @@ public class ReplayFromDumpTestBase extends StarRocksTestBase {
         UtFrameUtils.createMinStarRocksCluster();
         // Should disable Dynamic Partition in replay dump test
         Config.show_execution_groups = false;
+        Config.enable_virtual_columns = false;
         Config.dynamic_partition_enable = false;
         Config.tablet_sched_disable_colocate_overall_balance = true;
         // create connect context

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/VirtualColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/VirtualColumnTest.java
@@ -42,8 +42,7 @@ public class VirtualColumnTest extends PlanTestBase {
         String sql = "select * from t0";
         String plan = getFragmentPlan(sql);
         // Virtual columns should not appear in SELECT * output
-        // This test verifies they're not visible by default
-        System.out.println("SELECT * plan: " + plan);
+        assertNotContains(plan, "_tablet_id_");
     }
     
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/VirtualColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/VirtualColumnTest.java
@@ -16,6 +16,11 @@ package com.starrocks.sql.plan;
 
 import org.junit.jupiter.api.Test;
 
+/**
+ * Test virtual columns functionality.
+ * Virtual columns are dynamically computed metadata columns that exist only during query execution.
+ * They are managed by VirtualColumnRegistry for scalability.
+ */
 public class VirtualColumnTest extends PlanTestBase {
     
     @Test
@@ -52,4 +57,52 @@ public class VirtualColumnTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "_tablet_id_");
     }
+    
+    /**
+     * This test demonstrates the scalability of the virtual column registry.
+     * When new virtual columns like _segment_id_ and _row_id_ are added to the registry,
+     * they will automatically work in queries without any code changes beyond the registry.
+     * 
+     * To enable these tests:
+     * 1. Uncomment the virtual column definitions in VirtualColumnRegistry
+     * 2. Uncomment the constants in PlanNodes.thrift
+     * 3. Uncomment the test methods below
+     */
+    
+    // @Test
+    // public void testSegmentIdVirtualColumn() throws Exception {
+    //     // Test _segment_id_ virtual column (when enabled in registry)
+    //     String sql = "select v1, _segment_id_ from t0";
+    //     String plan = getFragmentPlan(sql);
+    //     assertContains(plan, "_segment_id_");
+    //     
+    //     // Test filtering by segment_id
+    //     sql = "select v1 from t0 where _segment_id_ = 5";
+    //     plan = getFragmentPlan(sql);
+    //     assertContains(plan, "_segment_id_");
+    // }
+    
+    // @Test
+    // public void testRowIdVirtualColumn() throws Exception {
+    //     // Test _row_id_ virtual column (when enabled in registry)
+    //     String sql = "select v1, _row_id_ from t0";
+    //     String plan = getFragmentPlan(sql);
+    //     assertContains(plan, "_row_id_");
+    // }
+    
+    // @Test
+    // public void testMultipleVirtualColumns() throws Exception {
+    //     // Test using multiple virtual columns together (when enabled in registry)
+    //     String sql = "select _tablet_id_, _segment_id_, _row_id_, v1 from t0";
+    //     String plan = getFragmentPlan(sql);
+    //     assertContains(plan, "_tablet_id_");
+    //     assertContains(plan, "_segment_id_");
+    //     assertContains(plan, "_row_id_");
+    //     
+    //     // Test group by multiple virtual columns
+    //     sql = "select _tablet_id_, _segment_id_, count(*) from t0 group by _tablet_id_, _segment_id_";
+    //     plan = getFragmentPlan(sql);
+    //     assertContains(plan, "_tablet_id_");
+    //     assertContains(plan, "_segment_id_");
+    // }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/VirtualColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/VirtualColumnTest.java
@@ -17,7 +17,7 @@ package com.starrocks.sql.plan;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test virtual columns functionality.
+ * Test virtual columns' functionality.
  * Virtual columns are dynamically computed metadata columns that exist only during query execution.
  * They are managed by VirtualColumnRegistry for scalability.
  */
@@ -57,52 +57,4 @@ public class VirtualColumnTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "_tablet_id_");
     }
-    
-    /**
-     * This test demonstrates the scalability of the virtual column registry.
-     * When new virtual columns like _segment_id_ and _row_id_ are added to the registry,
-     * they will automatically work in queries without any code changes beyond the registry.
-     * 
-     * To enable these tests:
-     * 1. Uncomment the virtual column definitions in VirtualColumnRegistry
-     * 2. Uncomment the constants in PlanNodes.thrift
-     * 3. Uncomment the test methods below
-     */
-    
-    // @Test
-    // public void testSegmentIdVirtualColumn() throws Exception {
-    //     // Test _segment_id_ virtual column (when enabled in registry)
-    //     String sql = "select v1, _segment_id_ from t0";
-    //     String plan = getFragmentPlan(sql);
-    //     assertContains(plan, "_segment_id_");
-    //     
-    //     // Test filtering by segment_id
-    //     sql = "select v1 from t0 where _segment_id_ = 5";
-    //     plan = getFragmentPlan(sql);
-    //     assertContains(plan, "_segment_id_");
-    // }
-    
-    // @Test
-    // public void testRowIdVirtualColumn() throws Exception {
-    //     // Test _row_id_ virtual column (when enabled in registry)
-    //     String sql = "select v1, _row_id_ from t0";
-    //     String plan = getFragmentPlan(sql);
-    //     assertContains(plan, "_row_id_");
-    // }
-    
-    // @Test
-    // public void testMultipleVirtualColumns() throws Exception {
-    //     // Test using multiple virtual columns together (when enabled in registry)
-    //     String sql = "select _tablet_id_, _segment_id_, _row_id_, v1 from t0";
-    //     String plan = getFragmentPlan(sql);
-    //     assertContains(plan, "_tablet_id_");
-    //     assertContains(plan, "_segment_id_");
-    //     assertContains(plan, "_row_id_");
-    //     
-    //     // Test group by multiple virtual columns
-    //     sql = "select _tablet_id_, _segment_id_, count(*) from t0 group by _tablet_id_, _segment_id_";
-    //     plan = getFragmentPlan(sql);
-    //     assertContains(plan, "_tablet_id_");
-    //     assertContains(plan, "_segment_id_");
-    // }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/VirtualColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/VirtualColumnTest.java
@@ -14,6 +14,9 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.common.Config;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -23,6 +26,17 @@ import org.junit.jupiter.api.Test;
  */
 public class VirtualColumnTest extends PlanTestBase {
     
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        Config.enable_virtual_columns = true;
+    }
+
+    @AfterAll
+    public static void afterClass() {
+        Config.enable_virtual_columns = false;
+    }
+
     @Test
     public void testTabletIdVirtualColumn() throws Exception {
         // Test that _tablet_id_ is recognized in SELECT clause

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
@@ -1765,15 +1765,18 @@ public class WindowTest extends PlanTestBase {
                 "  |  cardinality: 1");
 
         plan = getDescTbl(sql);
-        assertContains(plan, "TSlotDescriptor(id:11, parent:3, " +
-                "slotType:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType(type:BIGINT))]), " +
-                "columnPos:-1, byteOffset:-1, colName:, slotIdx:-1, " +
-                "isMaterialized:true, isOutputColumn:false, isNullable:false)");
-        assertContains(plan, "TSlotDescriptor(id:11, parent:5, " +
-                "slotType:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType(type:BIGINT))]), " +
-                "columnPos:-1, byteOffset:-1, colName:, slotIdx:-1, " +
-                "isMaterialized:true, isOutputColumn:false, isNullable:false)");
+        assertContains(plan,
+                "TSlotDescriptor(id:11, parent:3, slotType:TTypeDesc(types:[TTypeNode(type:SCALAR, " +
+                        "scalar_type:TScalarType(type:BIGINT))]), columnPos:-1, byteOffset:-1, nullIndicatorByte:-1, " +
+                        "nullIndicatorBit:-1, colName:, slotIdx:-1, isMaterialized:true, isOutputColumn:false, " +
+                        "isNullable:false, is_virtual_column:false)");
+        assertContains(plan,
+                "TSlotDescriptor(id:11, parent:5, slotType:TTypeDesc(types:[TTypeNode(type:SCALAR, " +
+                        "scalar_type:TScalarType(type:BIGINT))]), columnPos:-1, byteOffset:-1, nullIndicatorByte:-1, " +
+                        "nullIndicatorBit:-1, colName:, slotIdx:-1, isMaterialized:true, isOutputColumn:false, " +
+                        "isNullable:false, is_virtual_column:false)");
     }
+
 
     @Test
     public void testPruneSubfieldAfterWindow() throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
@@ -1777,7 +1777,7 @@ public class WindowTest extends PlanTestBase {
                 reached = reached | 2;
             }
         }
-        assertEquals(reached, 3);
+        Assertions.assertEquals(reached, 3);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
@@ -1745,7 +1745,7 @@ public class WindowTest extends PlanTestBase {
                 "  |  \n" +
                 "  1:SORT");
     }
-
+        
     @Test
     public void testWindowOutputColumnNullCheck() throws Exception {
         String sql = "select t1a, t1b, t1c, count(t1d) over (partition by t1d) " +
@@ -1765,18 +1765,20 @@ public class WindowTest extends PlanTestBase {
                 "  |  cardinality: 1");
 
         plan = getDescTbl(sql);
-        assertContains(plan,
-                "TSlotDescriptor(id:11, parent:3, slotType:TTypeDesc(types:[TTypeNode(type:SCALAR, " +
-                        "scalar_type:TScalarType(type:BIGINT))]), columnPos:-1, byteOffset:-1, nullIndicatorByte:-1, " +
-                        "nullIndicatorBit:-1, colName:, slotIdx:-1, isMaterialized:true, isOutputColumn:false, " +
-                        "isNullable:false, is_virtual_column:false)");
-        assertContains(plan,
-                "TSlotDescriptor(id:11, parent:5, slotType:TTypeDesc(types:[TTypeNode(type:SCALAR, " +
-                        "scalar_type:TScalarType(type:BIGINT))]), columnPos:-1, byteOffset:-1, nullIndicatorByte:-1, " +
-                        "nullIndicatorBit:-1, colName:, slotIdx:-1, isMaterialized:true, isOutputColumn:false, " +
-                        "isNullable:false, is_virtual_column:false)");
+        final String[] plans = plan.split("TSlotDescriptor");
+        int reached = 0;
+        for (String detail : plans) {
+            if (detail.contains("id:11, parent:3")) {
+                assertContains("isNullable:false");
+                reached = reached | 1;
+            }
+            if (detail.contains("id:11, parent:5")) {
+                assertContains("isNullable:false");
+                reached = reached | 2;
+            }
+        }
+        assertEquals(reached, 3);
     }
-
 
     @Test
     public void testPruneSubfieldAfterWindow() throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -363,6 +363,7 @@ public class UtFrameUtils {
         Config.tablet_sched_repair_delay_factor_second = 1;
         Config.enable_new_publish_mechanism = true;
         Config.alter_scheduler_interval_millisecond = 100;
+        Config.enable_virtual_columns = false;
 
         try {
             ThriftConnectionPool.beHeartbeatPool = new MockGenericPool.HeatBeatPool("heartbeat");

--- a/gensrc/proto/descriptors.proto
+++ b/gensrc/proto/descriptors.proto
@@ -54,6 +54,7 @@ message PSlotDescriptor {
     repeated string global_dict_words = 11; 
     optional int64 global_dict_version = 12;
     optional bool is_nullable = 13; // replace null_indicator_bit & null_indicator_byte
+    optional bool is_virtual = 14;
 };
 
 message PTupleDescriptor {

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -69,6 +69,7 @@ struct TSlotDescriptor {
   // for example, the physical name of a column in a parquet file.
   // used in delta lake column mapping name mode
   14: optional string col_physical_name
+  15: optional bool is_virtual_column = false
 }
 
 struct TTupleDescriptor {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -1347,6 +1347,9 @@ const string BINLOG_TIMESTAMP_COLUMN_NAME = "_binlog_timestamp";
 
 // virtual column names
 const string TABLET_ID_COLUMN_NAME = "_tablet_id_";
+// Future virtual columns (not yet implemented in BE):
+// const string SEGMENT_ID_COLUMN_NAME = "_segment_id_";
+// const string ROW_ID_COLUMN_NAME = "_row_id_";
 
 struct TBinlogScanNode {
   1: optional Types.TTupleId tuple_id

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -1345,6 +1345,9 @@ const string BINLOG_VERSION_COLUMN_NAME = "_binlog_version";
 const string BINLOG_SEQ_ID_COLUMN_NAME = "_binlog_seq_id";
 const string BINLOG_TIMESTAMP_COLUMN_NAME = "_binlog_timestamp";
 
+// virtual column names
+const string TABLET_ID_COLUMN_NAME = "_tablet_id_";
+
 struct TBinlogScanNode {
   1: optional Types.TTupleId tuple_id
 }

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -2403,7 +2403,23 @@ class StarrocksSQLApiLib(object):
             if str(res["result"]).find("Decode") > 0:
                 return ""
             time.sleep(1)
-
+    
+    def wait_plan_contains(self, query, *expects):
+        """
+        wait plan contains 
+        """
+        timeout = 60
+        interval = 1
+        for _ in range(timeout):
+            res = self.execute_sql("explain " + query, True)
+            print (res)
+            plan_string = "\n".join(" ".join(map(str, item)) for item in res["result"])
+            if all(expect in plan_string for expect in expects):
+                return
+            time.sleep(interval)
+        
+        tools.assert_true(False, "acquire dictionary timeout for 60s")
+        
     def try_collect_dict_N_times(self, column_name, table_name, N):
         """
         try to collect dictionary for N times

--- a/test/sql/test_virtual_column/R/test_virtual_column_tablet_id
+++ b/test/sql/test_virtual_column/R/test_virtual_column_tablet_id
@@ -1,0 +1,138 @@
+-- name: test_virtual_column_tablet_id
+create table olap_table (
+    k1 int,
+    k2 int,
+    v1 string
+)
+duplicate key(k1)
+distributed by hash(k1) buckets 3
+properties("replication_num" = "1");
+-- result:
+-- !result
+insert into olap_table values
+(1, 10, 'a'),
+(2, 20, 'b'),
+(3, 30, 'c'),
+(4, 40, 'd'),
+(5, 50, 'e');
+-- result:
+-- !result
+[UC]select _tablet_id_, k1, k2 from olap_table order by k1;
+-- result:
+3619836	1	10
+3619834	2	20
+3619836	3	30
+3619838	4	40
+3619838	5	50
+-- !result
+select * from olap_table order by k1;
+-- result:
+1	10	a
+2	20	b
+3	30	c
+4	40	d
+5	50	e
+-- !result
+[UC]select _tablet_id_, count(*) as row_count, sum(k2) as sum_k2
+from olap_table
+group by _tablet_id_
+order by _tablet_id_;
+-- result:
+3619834	1	20
+3619836	2	40
+3619838	2	90
+-- !result
+[UC]select _tablet_id_, min(k1) as min_k1, max(k1) as max_k1, count(*) as cnt
+from olap_table
+group by _tablet_id_
+order by _tablet_id_;
+-- result:
+3619834	2	2	1
+3619836	1	3	2
+3619838	4	5	2
+-- !result
+[UC]select k1, k2, _tablet_id_ from olap_table where _tablet_id_ > 0 order by k1;
+-- result:
+1	10	3619836
+2	20	3619834
+3	30	3619836
+4	40	3619838
+5	50	3619838
+-- !result
+desc olap_table;
+-- result:
+k1	int	YES	true	None	
+k2	int	YES	false	None	
+v1	varchar(65533)	YES	false	None	
+-- !result
+show create table olap_table;
+-- result:
+olap_table	CREATE TABLE `olap_table` (
+  `k1` int(11) NULL COMMENT "",
+  `k2` int(11) NULL COMMENT "",
+  `v1` varchar(65533) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3 
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- !result
+[UC]select a._tablet_id_ as tablet_id_a, b._tablet_id_ as tablet_id_b, a.k1, a.k2, b.k2 as k2_b
+from olap_table a
+join olap_table b on a.k1 = b.k1
+order by a.k1
+limit 5;
+-- result:
+3619836	3619836	1	10	10
+3619834	3619834	2	20	20
+3619836	3619836	3	30	30
+3619838	3619838	4	40	40
+3619838	3619838	5	50	50
+-- !result
+[UC]select k1, k2, _tablet_id_ from olap_table order by _tablet_id_, k1;
+-- result:
+2	20	3619834
+1	10	3619836
+3	30	3619836
+4	40	3619838
+5	50	3619838
+-- !result
+[UC]select _tablet_id_, k1, k2 from olap_table order by k1 limit 3;
+-- result:
+3619836	1	10
+3619834	2	20
+3619836	3	30
+-- !result
+CREATE TABLE `t0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 10
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  40960));
+-- result:
+-- !result
+select count(distinct _tablet_id_) from t0;
+-- result:
+10
+-- !result
+select count(*) > 0 from (select max(_tablet_id_) _tablet_id_ from t0 [_META_]) l left join (select _tablet_id_ from t0 order by _tablet_id_ desc) r on l._tablet_id_ = r._tablet_id_ ;
+-- result:
+1
+-- !result
+select count(*) > 0 from (select min(_tablet_id_) _tablet_id_ from t0 [_META_]) l left join (select _tablet_id_ from t0 order by _tablet_id_) r on l._tablet_id_ = r._tablet_id_ ;
+-- result:
+1
+-- !result

--- a/test/sql/test_virtual_column/T/test_virtual_column_tablet_id
+++ b/test/sql/test_virtual_column/T/test_virtual_column_tablet_id
@@ -1,0 +1,78 @@
+-- name: test_virtual_column_tablet_id
+
+-- Create OLAP table (Duplicate Key)
+create table olap_table (
+    k1 int,
+    k2 int,
+    v1 string
+)
+duplicate key(k1)
+distributed by hash(k1) buckets 3
+properties("replication_num" = "1");
+
+-- Insert test data
+insert into olap_table values
+(1, 10, 'a'),
+(2, 20, 'b'),
+(3, 30, 'c'),
+(4, 40, 'd'),
+(5, 50, 'e');
+
+-- Test 1: Select virtual column explicitly
+[UC]select _tablet_id_, k1, k2 from olap_table order by k1;
+
+-- Test 2: Virtual column should not appear in SELECT *
+select * from olap_table order by k1;
+
+-- Test 3: GROUP BY virtual column for data distribution analysis
+[UC]select _tablet_id_, count(*) as row_count, sum(k2) as sum_k2
+from olap_table
+group by _tablet_id_
+order by _tablet_id_;
+
+-- Test 4: Virtual column with aggregation
+[UC]select _tablet_id_, min(k1) as min_k1, max(k1) as max_k1, count(*) as cnt
+from olap_table
+group by _tablet_id_
+order by _tablet_id_;
+
+-- Test 5: Virtual column in WHERE clause (should work)
+[UC]select k1, k2, _tablet_id_ from olap_table where _tablet_id_ > 0 order by k1;
+
+-- Test 6: Virtual column should not appear in DESCRIBE
+desc olap_table;
+
+-- Test 7: Virtual column should not appear in SHOW CREATE TABLE
+show create table olap_table;
+
+-- Test 8: Virtual column with JOIN
+[UC]select a._tablet_id_ as tablet_id_a, b._tablet_id_ as tablet_id_b, a.k1, a.k2, b.k2 as k2_b
+from olap_table a
+join olap_table b on a.k1 = b.k1
+order by a.k1
+limit 5;
+
+-- Test 9: Virtual column with ORDER BY
+[UC]select k1, k2, _tablet_id_ from olap_table order by _tablet_id_, k1;
+
+-- Test 10: Virtual column with LIMIT
+[UC]select _tablet_id_, k1, k2 from olap_table order by k1 limit 3;
+
+CREATE TABLE `t0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 10
+PROPERTIES (
+"replication_num" = "1"
+);
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  40960));
+
+-- test meta scan
+select count(distinct _tablet_id_) from t0;
+select count(*) > 0 from (select max(_tablet_id_) _tablet_id_ from t0 [_META_]) l left join (select _tablet_id_ from t0 order by _tablet_id_ desc) r on l._tablet_id_ = r._tablet_id_ ;
+select count(*) > 0 from (select min(_tablet_id_) _tablet_id_ from t0 [_META_]) l left join (select _tablet_id_ from t0 order by _tablet_id_) r on l._tablet_id_ = r._tablet_id_ ;

--- a/test/sql/test_window_function/R/test_window_skew_rewrite_with_null
+++ b/test/sql/test_window_function/R/test_window_skew_rewrite_with_null
@@ -1,4 +1,4 @@
--- name: test_window_skew_rewrite_with_null
+-- name: test_window_skew_rewrite_with_null @sequential
 DROP TABLE IF EXISTS window_skew_t1;
 -- result:
 -- !result
@@ -42,7 +42,23 @@ shell: sleep 5
 SET enable_split_window_skew_to_union = true;
 -- result:
 -- !result
-function: assert_explain_costs_contains('SELECT pk, v1, row_number() OVER (PARTITION BY pk ORDER BY v1) FROM window_skew_t1', 'UNION', 'ANALYTIC', 'pk, INT, true] IS NOT NULL', 'pk, INT, true] IS NULL')
+SELECT pk, v1, row_number() OVER (PARTITION BY pk ORDER BY v1) FROM window_skew_t1 ORDER BY pk, v1;
+-- result:
+None	4	1
+None	5	2
+None	6	3
+None	7	4
+None	8	5
+None	9	6
+None	10	7
+None	11	8
+None	12	9
+None	13	10
+1	1	1
+2	2	1
+3	3	1
+-- !result
+function: wait_plan_contains('SELECT pk, v1, row_number() OVER (PARTITION BY pk ORDER BY v1) FROM window_skew_t1', 'UNION', 'ANALYTIC')
 -- result:
 None
 -- !result

--- a/test/sql/test_window_function/T/test_window_skew_rewrite_with_null
+++ b/test/sql/test_window_function/T/test_window_skew_rewrite_with_null
@@ -1,4 +1,4 @@
--- name: test_window_skew_rewrite_with_null
+-- name: test_window_skew_rewrite_with_null @sequential
 DROP TABLE IF EXISTS window_skew_t1;
 
 CREATE TABLE window_skew_t1 (
@@ -30,7 +30,8 @@ shell: sleep 5
 -- Plan should contain UNION and two branches
 SET enable_split_window_skew_to_union = true;
 
-function: assert_explain_costs_contains('SELECT pk, v1, row_number() OVER (PARTITION BY pk ORDER BY v1) FROM window_skew_t1', 'UNION', 'ANALYTIC', 'pk, INT, true] IS NOT NULL', 'pk, INT, true] IS NULL')
+SELECT pk, v1, row_number() OVER (PARTITION BY pk ORDER BY v1) FROM window_skew_t1 ORDER BY pk, v1;
+function: wait_plan_contains('SELECT pk, v1, row_number() OVER (PARTITION BY pk ORDER BY v1) FROM window_skew_t1', 'UNION', 'ANALYTIC')
 SELECT pk, v1, row_number() OVER (PARTITION BY pk ORDER BY v1) FROM window_skew_t1 ORDER BY pk, v1;
 
 -- Optimization disabled


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Add a virtual column `_tablet_id_` for data diagnosis.

Fixes #63923

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces hidden, read-only virtual column `_tablet_id_` for OLAP/Lake tables, with FE/BE support, docs, configs, and tests, while preventing pushdown and adjusting planners/optimizations.
> 
> - **Virtual Column Support**
>   - Add hidden, read-only `_tablet_id_` virtual column surfaced in queries but excluded from `SELECT *`, `DESCRIBE`, and `SHOW CREATE TABLE`.
>   - FE: expose virtual column via analyzer/planner; new `enable_virtual_column` config; propagate `is_virtual_column` through SlotDescriptor (Thrift/Proto).
>   - BE: implement `virtual_column.{h,cpp}` and integrate into OLAP/Lake scan paths to populate `_tablet_id_` and map slots; skip predicate pushdown on virtual columns; handle scans with only virtual columns by reading a key column for row count.
> - **Planner/Optimizer Adjustments**
>   - Skip virtual columns in predicate parsing, runtime filters, low-cardinality dict/MinMax stats, and MV rewrite utilities.
> - **APIs/Descriptors**
>   - Extend SlotDescriptor (Thrift/Proto/ProtoBuf) with `is_virtual_column`.
> - **Docs & Tests**
>   - Add docs (EN/JA/ZH) for virtual columns.
>   - Add SQL tests validating `_tablet_id_` behavior and table-defined `_tablet_id_` precedence.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f79a1baf7d643e4bf4536d2925bd181aaeaf65d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->