### PR TITLE
[BugFix] Fix null result caused by incorrect mv compensation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -94,6 +94,7 @@ import com.starrocks.sql.optimizer.rule.transformation.UnionToValuesRule;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVCompensationPruneUnionRule;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvRewriteStrategy;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.compensation.MVCompensation;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.rule.TextMatchBasedRewriteRule;
 import com.starrocks.sql.optimizer.rule.transformation.pruner.CboTablePruneRule;
 import com.starrocks.sql.optimizer.rule.transformation.pruner.PrimaryKeyUpdateTableRule;
@@ -461,6 +462,13 @@ public class QueryOptimizer extends Optimizer {
         // view rewrite can handle single table and multi tables query rewrite, no need extra rules to further optimization
         if (mvRewriteStrategy.enableViewBasedRewrite && viewBasedMvRuleRewrite(tree, rootTaskContext)) {
             return;
+        }
+        for (MaterializationContext mvContext : context.getCandidateMvs()) {
+            if (mvContext.getMv().isView()) {
+                continue;
+            }
+            // initialize query's compensate type based on query and mv's partition refresh status
+            MVCompensation ignored = mvContext.getOrInitMVCompensation(tree);
         }
 
         if (mvRewriteStrategy.enableForceRBORewrite) {


### PR DESCRIPTION
## Why I'm doing:

 In particular sql pattern, `partitions=0/1` is used if mv lacks some partitions due to incorrect mv compensation timing.

``` sql
CREATE TABLE `test_pt` (
  `id` int(11) NULL COMMENT "id",
  `pt` date NOT NULL COMMENT "",
  `gmv` int(11) NULL COMMENT "gmv"
) ENGINE=OLAP
DUPLICATE KEY(`id`)
COMMENT "OLAP"
PARTITION BY date_trunc('day', pt)
DISTRIBUTED BY HASH(`pt`) buckets 1
PROPERTIES (
"replication_num" = "1"
);
insert into test_pt values(2,'2023-03-07',10);

CREATE MATERIALIZED VIEW `test_pt_mv` 
PARTITION BY (`pt`)
DISTRIBUTED BY HASH(`pt`) buckets 1
REFRESH ASYNC START("2024-03-08 03:00:00") EVERY(INTERVAL 1 DAY)
PROPERTIES (
"query_rewrite_consistency" = "CHECKED",
"auto_refresh_partitions_limit"="1",
"partition_refresh_number" = "1",
"replication_num" = "1"
)
AS SELECT `pt`, `id`, sum(gmv) AS `sum_gmv`
FROM `test_pt`
GROUP BY `pt`, `id`;

select sleep(5);
# p20230308 exist in test_pt but not in test_pt_mv
insert into test_pt values(2,'2023-03-08',10);

explain
SELECT  *
FROM
(
	SELECT  SUM(gmv) AS sumGmv
	FROM test_pt
	WHERE pt = '20230308' 
) a
CROSS JOIN
(
	SELECT  SUM(gmv) AS sumGmv
	FROM test_pt
	WHERE pt = '20230307' 
) b;

```

The result is `NULL,10`, while the expected result is `10,10`


## What I'm doing:

In this case, test_pt_mv1 's compensaction is **inited** to sub-query as NO_COMPENSATION due to mv partition `p20230307` exists in test_pt_mv1
```sql
	SELECT  SUM(gmv) AS sumGmv
	FROM test_pt
	WHERE pt = '20230307' 
```

then sub-query
```sql
	SELECT  SUM(gmv) AS sumGmv
	FROM test_pt
	WHERE pt = '20230308' 
```
reuse the **cached** compensation, and incorrectly set **non-exsited** mv partition `p20230308` as NO_COMPENSATION which should be NO_REWRITE.


This patch move mv compensation timing before where mv rewrite rules actually are executed but after partition prune rules are applied, so that compensation can see the **entire** sql expression instead of sub-query expression to build correct mv compensation, which is NO_REWRITE in this case.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Initialize MV compensation for candidate materialized views before applying rule-based MV rewrite; add a test to prevent incorrect rewrites when MV partitions are missing.
> 
> - **Optimizer**:
>   - Initialize MV compensation per candidate MV in `QueryOptimizer#doRuleBasedMaterializedViewRewrite` using `MaterializationContext#getOrInitMVCompensation(tree)` (skip views) before executing MV rewrite rules.
>   - Add import for `materialization.compensation.MVCompensation`.
> - **Tests**:
>   - Add `testMVPartitionRefreshRewrite2` in `MvRewritePartialPartitionTest` to verify MV is not used (avoids `partitions=0/1`) when MV lacks refreshed partitions during push-down rewrite.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2dbe1d84490bf9a53c901f01c34a39131bb0b5df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->