### PR TITLE
[Enhancement] support drop tablet data cache in shared-data

### DIFF
--- a/be/src/fs/fs.h
+++ b/be/src/fs/fs.h
@@ -319,7 +319,9 @@ public:
 
     // Given the path to a remote file, delete the file's cache on the local file system, if any.
     // On success, Status::OK is returned. If there is no cache, Status::NotFound is returned.
-    virtual Status drop_local_cache(const std::string& path) { return Status::NotFound(path); }
+    virtual Status drop_local_cache(const std::string& path, int64_t offset = 0, int64_t size = -1) {
+        return Status::NotFound(path);
+    }
 
     // Batch delete the given files.
     // return ok if all success (not found error ignored), error if any failed and the message indicates the fail message

--- a/be/src/fs/fs_starlet.cpp
+++ b/be/src/fs/fs_starlet.cpp
@@ -585,13 +585,13 @@ public:
         return Status::NotSupported("StarletFileSystem::link_file");
     }
 
-    Status drop_local_cache(const std::string& path) override {
+    Status drop_local_cache(const std::string& path, int64_t offset, int64_t size) override {
         ASSIGN_OR_RETURN(auto pair, parse_starlet_uri(path));
         auto fs_st = get_shard_filesystem(pair.second);
         if (!fs_st.ok()) {
             return to_status(fs_st.status());
         }
-        return to_status((*fs_st)->drop_cache(pair.first, 0 /* offset */, -1 /* size */));
+        return to_status((*fs_st)->drop_cache(pair.first, offset, size));
     }
 
     Status delete_files(std::span<const std::string> paths) override {

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -1496,6 +1496,57 @@ void LakeServiceImpl::abort_compaction(::google::protobuf::RpcController* contro
     st.to_protobuf(response->mutable_status());
 }
 
+void LakeServiceImpl::drop_tablet_cache(::google::protobuf::RpcController* controller,
+                                        const ::starrocks::DropTabletCacheRequest* request,
+                                        ::starrocks::DropTabletCacheResponse* response,
+                                        ::google::protobuf::Closure* done) {
+    brpc::ClosureGuard guard(done);
+    auto cntl = static_cast<brpc::Controller*>(controller);
+
+    if (request->tablets_size() == 0) {
+        cntl->SetFailed("missing tablets");
+        return;
+    }
+
+    auto thread_pool = delete_tablet_thread_pool(_env);
+    if (UNLIKELY(thread_pool == nullptr)) {
+        cntl->SetFailed("no thread pool to run task");
+        return;
+    }
+    Status::OK().to_protobuf(response->mutable_status());
+    auto latch = BThreadCountDownLatch(request->tablets_size());
+    bthread::Mutex response_mtx;
+    for (auto& tablet : request->tablets()) {
+        int64_t tablet_id = tablet.tablet_id();
+        int64_t version = tablet.version();
+        auto task = std::make_shared<CancellableRunnable>(
+                [&, tablet_id, version] {
+                    DeferOp defer([&] { latch.count_down(); });
+                    auto st = lake::drop_tablet_cache(_tablet_mgr, tablet_id, version);
+                    if (!st.ok()) {
+                        std::lock_guard l(response_mtx);
+                        st.to_protobuf(response->mutable_status());
+                    }
+                },
+                [&] {
+                    Status st = Status::Cancelled("drop tablet cache task has been cancelled");
+                    LOG(WARNING) << st;
+                    std::lock_guard l(response_mtx);
+                    st.to_protobuf(response->mutable_status());
+                    latch.count_down();
+                });
+        auto st = thread_pool->submit(std::move(task));
+        if (!st.ok()) {
+            LOG(WARNING) << "Fail to submit drop tablet cache task: " << st;
+            std::lock_guard l(response_mtx);
+            st.to_protobuf(response->mutable_status());
+            latch.count_down();
+        }
+    }
+
+    latch.wait();
+}
+
 void LakeServiceImpl::vacuum(::google::protobuf::RpcController* controller, const ::starrocks::VacuumRequest* request,
                              ::starrocks::VacuumResponse* response, ::google::protobuf::Closure* done) {
     static bthread::Mutex s_mtx;

--- a/be/src/service/service_be/lake_service.h
+++ b/be/src/service/service_be/lake_service.h
@@ -99,6 +99,10 @@ public:
                           const ::starrocks::AbortCompactionRequest* request,
                           ::starrocks::AbortCompactionResponse* response, ::google::protobuf::Closure* done) override;
 
+    void drop_tablet_cache(::google::protobuf::RpcController* controller,
+                           const ::starrocks::DropTabletCacheRequest* request,
+                           ::starrocks::DropTabletCacheResponse* response, ::google::protobuf::Closure* done) override;
+
     void vacuum(::google::protobuf::RpcController* controller, const ::starrocks::VacuumRequest* request,
                 ::starrocks::VacuumResponse* response, ::google::protobuf::Closure* done) override;
 

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -1373,4 +1373,60 @@ StatusOr<int64_t> garbage_file_check(std::string_view root_location) {
     return datafile_gc(root_location, "", 0, false);
 }
 
+Status drop_tablet_cache(TabletManager* tablet_mgr, int64_t tablet_id, int64_t version) {
+    auto drop_cache_func = [&](std::string& path, int64_t offset, int64_t size) {
+        auto fs_or = FileSystem::CreateSharedFromString(path);
+        if (fs_or.ok()) {
+            TEST_SYNC_POINT_CALLBACK("drop_tablet_cache:drop_local_cache", &path);
+            auto result = (*fs_or)->drop_local_cache(path, offset, size);
+            if (!result.ok()) {
+                VLOG(3) << "fail to drop local cache for " << path << ", error: " << result;
+            }
+        } else {
+            VLOG(3) << "fail to get file system for tablet " << tablet_id << ", error: " << fs_or.status();
+        }
+    };
+    while (version > 0) {
+        auto res = tablet_mgr->get_tablet_metadata(tablet_id, version, false /* No need to fill meta cache */,
+                                                   false /* No need to fill data cache */);
+        if (res.status().is_not_found()) {
+            break;
+        } else if (!res.ok()) {
+            return res.status();
+        }
+        auto metadata = std::move(res).value();
+        for (const auto& rowset : metadata->rowsets()) {
+            const auto& segment_cnt = rowset.segments_size();
+            bool has_segment_size = (segment_cnt == rowset.segment_size_size());
+            bool is_bundled_file = (segment_cnt == rowset.bundle_file_offsets_size());
+            for (size_t i = 0; i < segment_cnt; ++i) {
+                std::string segment_path = tablet_mgr->segment_location(tablet_id, rowset.segments().Get(i));
+                int64_t offset = is_bundled_file ? rowset.bundle_file_offsets().Get(i) : 0;
+                int64_t size = has_segment_size ? rowset.segment_size().Get(i) : -1;
+                drop_cache_func(segment_path, offset, size);
+            }
+        }
+
+        for (const auto& [_, file] : metadata->delvec_meta().version_to_file()) {
+            std::string delvec_path = tablet_mgr->delvec_location(tablet_id, file.name());
+            drop_cache_func(delvec_path, 0 /* offset */, file.size());
+        }
+        for (const auto& sst : metadata->sstable_meta().sstables()) {
+            std::string sst_path = tablet_mgr->sst_location(tablet_id, sst.filename());
+            drop_cache_func(sst_path, 0 /* offset */, sst.filesize());
+        }
+        for (const auto& [_, dcg_ver] : metadata->dcg_meta().dcgs()) {
+            for (const auto& filename : dcg_ver.column_files()) {
+                std::string dcg_path = tablet_mgr->segment_location(tablet_id, filename);
+                drop_cache_func(dcg_path, 0 /* offset */, -1 /* unknown size */);
+            }
+        }
+
+        VLOG(3) << "finish drop local cache for tablet " << tablet_id << ", version: " << version;
+        CHECK_LT(metadata->prev_garbage_version(), version);
+        version = metadata->prev_garbage_version();
+    }
+    return Status::OK();
+}
+
 } // namespace starrocks::lake

--- a/be/src/storage/lake/vacuum.h
+++ b/be/src/storage/lake/vacuum.h
@@ -76,4 +76,7 @@ StatusOr<std::map<std::string, DirEntry>> find_orphan_data_files(FileSystem* fs,
 
 Status do_delete_files(FileSystem* fs, const std::vector<std::string>& paths);
 
+// drop tablet data cache, starts from `version`
+Status drop_tablet_cache(TabletManager* tablet_mgr, int64_t tablet_id, int64_t version);
+
 } // namespace starrocks::lake

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -1801,6 +1801,55 @@ TEST_F(LakeServiceTest, test_delete_tablet) {
     EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
 }
 
+TEST_F(LakeServiceTest, test_drop_tablet_cache) {
+    // normal path
+    {
+        DropTabletCacheRequest request;
+        DropTabletCacheResponse response;
+        auto* tablet = request.add_tablets();
+        tablet->set_tablet_id(_tablet_id);
+        tablet->set_version(3);
+        brpc::Controller cntl;
+        CountDownLatch latch(1);
+        auto done = brpc::NewCallback(&latch, &CountDownLatch::count_down);
+        _lake_service.drop_tablet_cache(&cntl, &request, &response, done);
+        latch.wait();
+        ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+        EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+    }
+
+    // missing tablets
+    {
+        brpc::Controller cntl;
+        DropTabletCacheRequest request;
+        DropTabletCacheResponse response;
+        _lake_service.drop_tablet_cache(&cntl, &request, &response, nullptr);
+        ASSERT_TRUE(cntl.Failed());
+        ASSERT_EQ("missing tablets", cntl.ErrorText());
+    }
+
+    // thread pool is null
+    {
+        SyncPoint::GetInstance()->SetCallBack("AgentServer::Impl::get_thread_pool:1",
+                                              [](void* arg) { *(ThreadPool**)arg = nullptr; });
+        SyncPoint::GetInstance()->EnableProcessing();
+        DeferOp defer([]() {
+            SyncPoint::GetInstance()->ClearCallBack("AgentServer::Impl::get_thread_pool:1");
+            SyncPoint::GetInstance()->DisableProcessing();
+        });
+
+        brpc::Controller cntl;
+        DropTabletCacheRequest request;
+        DropTabletCacheResponse response;
+        auto* tablet = request.add_tablets();
+        tablet->set_tablet_id(_tablet_id);
+        tablet->set_version(3);
+        _lake_service.drop_tablet_cache(&cntl, &request, &response, nullptr);
+        ASSERT_TRUE(cntl.Failed());
+        ASSERT_EQ("no thread pool to run task", cntl.ErrorText());
+    }
+}
+
 TEST_F(LakeServiceTest, test_delete_txn_log) {
     // missing tablet_ids
     {

--- a/be/test/storage/lake/vacuum_test.cpp
+++ b/be/test/storage/lake/vacuum_test.cpp
@@ -17,9 +17,12 @@
 #include <gtest/gtest.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <ctime>
 #include <set>
+#include <vector>
 
+#include "base/path/path_util.h"
 #include "base/testutil/assert.h"
 #include "base/testutil/sync_point.h"
 #include "base/uid_util.h"
@@ -2468,6 +2471,101 @@ TEST_P(LakeVacuumTest, test_vacuum_combined_txn_log) {
         ASSERT_EQ(TStatusCode::OK, response.status().status_code());
         EXPECT_FALSE(file_exist(combined_txn_log_filename(1000)));
     }
+}
+
+// NOLINTNEXTLINE
+TEST_P(LakeVacuumTest, test_drop_tablet_cache) {
+    constexpr int64_t kTabletId = 700;
+
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 700,
+        "version": 2,
+        "rowsets": [
+            {
+                "segments": [
+                    "700_seg_c.dat"
+                ],
+                "segment_size": [300],
+                "data_size": 300
+            }
+        ],
+        "delvec_meta": {
+            "version_to_file": [
+                {
+                    "key": 2,
+                    "value": {
+                        "name": "700_delvec.delvec",
+                        "size": 23
+                    }
+                }
+            ]
+        },
+        "sstable_meta": {
+            "sstables": [
+                {
+                    "filename": "700_sst.sst",
+                    "filesize": 333
+                }
+            ]
+        },
+        "dcg_meta": {
+            "dcgs": [
+                {
+                    "key": 0,
+                    "value": {
+                        "column_files": [
+                            "700_col_a.cols",
+                            "700_col_b.cols"
+                        ]
+                    }
+                }
+            ]
+        },
+        "prev_garbage_version": 0
+        }
+        )DEL")));
+
+    ASSERT_OK(_tablet_mgr->put_tablet_metadata(json_to_pb<TabletMetadataPB>(R"DEL(
+        {
+        "id": 700,
+        "version": 3,
+        "rowsets": [
+            {
+                "segments": [
+                    "700_seg_a.dat",
+                    "700_seg_b.dat"
+                ],
+                "segment_size": [100, 200],
+                "bundle_file_offsets": [0, 1000],
+                "data_size": 300
+            }
+        ],
+        "prev_garbage_version": 2
+        }
+        )DEL")));
+
+    std::vector<std::string> dropped;
+    SyncPoint::GetInstance()->SetCallBack("drop_tablet_cache:drop_local_cache", [&](void* arg) {
+        auto* path = reinterpret_cast<const std::string*>(arg);
+        dropped.emplace_back(::starrocks::path_util::base_name(*path));
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([&] {
+        SyncPoint::GetInstance()->ClearCallBack("drop_tablet_cache:drop_local_cache");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    ASSERT_OK(drop_tablet_cache(_tablet_mgr.get(), kTabletId, 3));
+
+    std::vector<std::string> expected{
+            "700_seg_a.dat", "700_seg_b.dat",  "700_seg_c.dat",  "700_delvec.delvec",
+            "700_sst.sst",   "700_col_a.cols", "700_col_b.cols",
+    };
+
+    std::sort(dropped.begin(), dropped.end());
+    std::sort(expected.begin(), expected.end());
+    ASSERT_EQ(expected, dropped);
 }
 
 TEST_P(LakeVacuumTest, test_vacuumed_version) {

--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -3812,6 +3812,16 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: When this item is set to `true`, the system allows Lake tables to use the combined transaction log path for relevant transactions. Available for shared-data clusters only.
 - Introduced in: v3.3.7, v3.4.0, v3.5.0
 
+##### `lake_enable_drop_tablet_cache`
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: In shared-data mode, clears the cache on BE/CN before the underlying data is actually deleted.
+- Introduced in: v4.0
+
+
 ##### `enable_iceberg_commit_queue`
 
 - Default: true

--- a/docs/ja/administration/management/FE_configuration.md
+++ b/docs/ja/administration/management/FE_configuration.md
@@ -3767,6 +3767,17 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Description: ブローカーを使用しない HDFS またはオブジェクトストレージへの直接書き込みに使用される HDFS 書き込みバッファサイズ (KB 単位) を設定します。FE はこの値をバイト (`<< 10`) に変換し、`HdfsFsManager` でローカル書き込みバッファを初期化します。また、Thrift リクエスト (例: TUploadReq、TExportSink、シンクオプション) に伝播され、バックエンド/エージェントが同じバッファサイズを使用するようにします。この値を増やすと、大きなシーケンシャル書き込みのスループットが向上しますが、ライターごとのメモリが増加します。減らすと、ストリームごとのメモリ使用量が減少し、小さな書き込みのレイテンシーが低下する可能性があります。`hdfs_read_buffer_size_kb` と並行して調整し、利用可能なメモリと同時ライターを考慮してください。
 - Introduced in: v3.2.0
 
+
+##### `lake_enable_drop_tablet_cache`
+
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: Yes
+- 説明: shared-data モードで、実データが削除される前に BE/CN 上のキャッシュをクリーンアップします。
+- 導入バージョン: v4.0
+
+
 ##### `lake_batch_publish_max_version_num`
 
 - Default: 10

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -3767,6 +3767,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 描述: 设置用于直接写入 HDFS 或对象存储时（不使用 broker）的 HDFS 写入缓冲区大小（以 KB 为单位）。FE 将此值转换为字节（`<< 10`），并初始化 HdfsFsManager 中的本地写入缓冲区，并在 Thrift 请求中传播（例如 TUploadReq、TExportSink、sink options），以便后端/代理使用相同的缓冲区大小。增加此值可以提高大型顺序写入的吞吐量，但代价是每个写入器占用更多内存；减小此值可以减少每个流的内存使用量，并可能降低小型写入的延迟。与 `hdfs_read_buffer_size_kb` 一起调整，并考虑可用内存和并发写入器。
 - 引入版本: v3.2.0
 
+##### `lake_enable_drop_tablet_cache`
+
+- 默认值：`true`
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：shared-data 模式下，在实际数据被删除前，清理 BE/CN 上的缓存。
+- 引入版本：v4.0
+
 ##### `lake_batch_publish_max_version_num`
 
 - 默认值: 10

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3930,6 +3930,14 @@ public class Config extends ConfigBase {
     @ConfField(mutable = false)
     public static int lake_remove_table_thread_num = 4;
 
+    /**
+     * Enable dropping tablet data cache before removing a table or partition in shared-data mode.
+     * This helps to free up cache space proactively when data is being deleted.
+     * Default: true
+     */
+    @ConfField(mutable = true)
+    public static boolean lake_enable_drop_tablet_cache = true;
+
     @ConfField(mutable = true)
     public static int merge_commit_gc_check_interval_ms = 60000;
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableCleaner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableCleaner.java
@@ -17,7 +17,9 @@ package com.starrocks.lake;
 import com.staros.client.StarClientException;
 import com.staros.proto.ShardInfo;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.common.Config;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
@@ -43,6 +45,14 @@ class LakeTableCleaner {
         Set<String> removedPaths = new HashSet<>();
         ComputeResource computeResource =
                 GlobalStateMgr.getCurrentState().getWarehouseMgr().getBackgroundComputeResource(table.getId());
+        if (Config.lake_enable_drop_tablet_cache) {
+            if (table.getTableProperty() != null && table.getTableProperty().getStorageInfo() != null &&
+                    table.getTableProperty().getStorageInfo().isEnableDataCache()) {
+                for (Partition partition : table.getAllPartitions()) {
+                    LakeTableHelper.dropPartitionCache(partition, computeResource);
+                }
+            }
+        }
         for (PhysicalPartition partition : table.getAllPhysicalPartitions()) {
             try {
                 ShardInfo shardInfo = LakeTableHelper.getAssociatedShardInfo(partition, computeResource).orElse(null);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTableHelper.java
@@ -15,6 +15,7 @@
 package com.starrocks.lake;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import com.staros.client.StarClientException;
 import com.staros.proto.ShardInfo;
 import com.staros.proto.StatusCode;
@@ -29,7 +30,11 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
+import com.starrocks.common.StarRocksException;
 import com.starrocks.proto.DropTableRequest;
+import com.starrocks.proto.DropTabletCacheMeta;
+import com.starrocks.proto.DropTabletCacheRequest;
+import com.starrocks.proto.DropTabletCacheResponse;
 import com.starrocks.proto.StatusPB;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
@@ -40,15 +45,19 @@ import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.Future;
 
 public class LakeTableHelper {
     private static final Logger LOG = LogManager.getLogger(LakeTableHelper.class);
@@ -145,8 +154,101 @@ public class LakeTableHelper {
         return Optional.empty();
     }
 
-    static boolean removePartitionDirectory(Partition partition, ComputeResource computeResource) throws StarClientException {
+    /**
+     * Attempts to drop cache for all tablets in the given partition.
+     * This is a best-effort operation - errors are logged but not propagated.
+     *
+     * @param partition the partition whose tablet caches should be dropped
+     * @param computeResource the compute resource used to locate the tablets
+     */
+    public static void dropPartitionCache(Partition partition, ComputeResource computeResource) {
+        Map<Long, Long> tablets = new HashMap<>();
+        // if we reach here, only catalog recycle bin will touch partition,
+        // so we don't need db or table lock here
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        partition.getSubPartitions().forEach(physicalPartition -> {
+            long visibleVersion = physicalPartition.getVisibleVersion();
+            physicalPartition.getAllMaterializedIndices(MaterializedIndex.IndexExtState.VISIBLE)
+                    .forEach(materializedIndex ->
+                            materializedIndex.getTablets().forEach(tablet ->
+                            tablets.put(tablet.getId(), visibleVersion)));
+        });
+        Map<Long /* beId */, List<Pair<Long /* tabletId */, Long /* version */>>> tabletsByBeMap = new HashMap<>();
+        for (Map.Entry<Long, Long> entry : tablets.entrySet()) {
+            try {
+                long beId = globalStateMgr.getStarOSAgent().getPrimaryComputeNodeIdByShard(
+                        entry.getKey(), computeResource.getWorkerGroupId());
+                tabletsByBeMap.computeIfAbsent(beId,
+                        k -> Lists.newArrayList()).add(Pair.of(entry.getKey(), entry.getValue()));
+            } catch (StarRocksException e) {
+                // still continue, drop cache is a try-at-best behavior
+                LOG.debug("Fail to get replica for tablet {} when drop cache, error: {}.",
+                        entry.getKey(), e.getMessage());
+            }
+        }
+
+        Map<Long, Future<DropTabletCacheResponse>> futureMap = new HashMap<>();
+        for (Map.Entry<Long, List<Pair<Long, Long>>> entry : tabletsByBeMap.entrySet()) {
+            long beId = entry.getKey();
+            ComputeNode node = globalStateMgr.getNodeMgr().getClusterInfo()
+                    .getBackendOrComputeNode(beId);
+            if (node == null) {
+                LOG.debug("Node {} not exist when drop cache.", beId);
+                continue;
+            }
+
+            List<DropTabletCacheMeta> metas = Lists.newArrayList();
+            for (Pair<Long, Long> e : entry.getValue()) {
+                DropTabletCacheMeta meta = new DropTabletCacheMeta();
+                meta.tabletId = e.getKey();
+                meta.version = e.getValue();
+                metas.add(meta);
+            }
+            DropTabletCacheRequest request = new DropTabletCacheRequest();
+            request.tablets = metas;
+            try {
+                LakeService lakeService = BrpcProxy.getLakeService(node.getHost(), node.getBrpcPort());
+                futureMap.put(beId, lakeService.dropTabletCache(request));
+            } catch (Throwable e) {
+                LOG.debug("Fail to send rpc request to node: {} when drop cache, error: {}.",
+                        node.toString(), e.getMessage());
+            }
+        }
+
+        for (Map.Entry<Long, Future<DropTabletCacheResponse>> entry : futureMap.entrySet()) {
+            long beId = entry.getKey();
+            Future<DropTabletCacheResponse> future = entry.getValue();
+            DropTabletCacheResponse response = null;
+            try {
+                response = future.get();
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                LOG.debug("Interrupted while waiting for response from node: {} when drop cache, error: {}.",
+                        beId, exception.getMessage());
+                continue;
+            } catch (Exception e) {
+                LOG.debug("Failed to get response from node: {} when drop cache, error: {}.",
+                        beId, e.getMessage());
+                continue;
+            }
+            if (response != null && response.status != null && response.status.statusCode != 0) {
+                String errorMsg = "";
+                if (response.status.errorMsgs != null && !response.status.errorMsgs.isEmpty()) {
+                    errorMsg = response.status.errorMsgs.get(0);
+                }
+                LOG.debug("Failed to drop cache from node: {}, error: {}.", beId, errorMsg);
+            }
+        }
+    }
+
+    static boolean removePartitionDirectory(Partition partition, ComputeResource computeResource, boolean dropCache)
+            throws StarClientException {
         boolean ret = true;
+
+        if (Config.lake_enable_drop_tablet_cache && dropCache) {
+            dropPartitionCache(partition, computeResource);
+        }
+
         for (PhysicalPartition subPartition : partition.getSubPartitions()) {
             ShardInfo shardInfo = getAssociatedShardInfo(subPartition, computeResource).orElse(null);
             if (shardInfo == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeListPartitionInfo.java
@@ -37,7 +37,8 @@ public class RecycleLakeListPartitionInfo extends RecycleListPartitionInfo {
         try {
             ComputeResource computeResource =
                     GlobalStateMgr.getCurrentState().getWarehouseMgr().getBackgroundComputeResource(tableId);
-            if (LakeTableHelper.removePartitionDirectory(partition, computeResource)) {
+            if (LakeTableHelper.removePartitionDirectory(partition, computeResource,
+                    getDataCacheInfo() != null ? getDataCacheInfo().isEnabled() : false)) {
                 GlobalStateMgr.getCurrentState().getLocalMetastore().onErasePartition(partition);
                 LakeTableHelper.deleteShardGroupMeta(partition);
                 return true;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeRangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeRangePartitionInfo.java
@@ -40,7 +40,8 @@ public class RecycleLakeRangePartitionInfo extends RecycleRangePartitionInfo  {
         try {
             ComputeResource computeResource =
                     GlobalStateMgr.getCurrentState().getWarehouseMgr().getBackgroundComputeResource(tableId);
-            if (LakeTableHelper.removePartitionDirectory(partition, computeResource)) {
+            if (LakeTableHelper.removePartitionDirectory(partition, computeResource,
+                    getDataCacheInfo() != null ? getDataCacheInfo().isEnabled() : false)) {
                 GlobalStateMgr.getCurrentState().getLocalMetastore().onErasePartition(partition);
                 LakeTableHelper.deleteShardGroupMeta(partition);
                 return true;

--- a/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeUnPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/RecycleLakeUnPartitionInfo.java
@@ -39,7 +39,8 @@ public class RecycleLakeUnPartitionInfo extends RecycleUnPartitionInfo {
         try {
             ComputeResource computeResource =
                     GlobalStateMgr.getCurrentState().getWarehouseMgr().getBackgroundComputeResource(tableId);
-            if (LakeTableHelper.removePartitionDirectory(partition, computeResource)) {
+            if (LakeTableHelper.removePartitionDirectory(partition, computeResource,
+                    getDataCacheInfo() != null ? getDataCacheInfo().isEnabled() : false)) {
                 GlobalStateMgr.getCurrentState().getLocalMetastore().onErasePartition(partition);
                 LakeTableHelper.deleteShardGroupMeta(partition);
                 return true;

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
@@ -32,6 +32,8 @@ import com.starrocks.proto.DeleteTxnLogRequest;
 import com.starrocks.proto.DeleteTxnLogResponse;
 import com.starrocks.proto.DropTableRequest;
 import com.starrocks.proto.DropTableResponse;
+import com.starrocks.proto.DropTabletCacheRequest;
+import com.starrocks.proto.DropTabletCacheResponse;
 import com.starrocks.proto.GetTabletMetadatasRequest;
 import com.starrocks.proto.GetTabletMetadatasResponse;
 import com.starrocks.proto.LockTabletMetadataRequest;
@@ -104,6 +106,9 @@ public interface LakeService {
 
     @ProtobufRPC(serviceName = "LakeService", methodName = "drop_table", onceTalkTimeout = TIMEOUT_DROP_TABLE)
     Future<DropTableResponse> dropTable(DropTableRequest request);
+
+    @ProtobufRPC(serviceName = "LakeService", methodName = "drop_tablet_cache", onceTalkTimeout = TIMEOUT_DROP_TABLE)
+    Future<DropTabletCacheResponse> dropTabletCache(DropTabletCacheRequest request);
 
     @ProtobufRPC(serviceName = "LakeService", methodName = "publish_log_version", onceTalkTimeout = TIMEOUT_PUBLISH_LOG_VERSION)
     Future<PublishLogVersionResponse> publishLogVersion(PublishLogVersionRequest request);

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/LakeServiceWithMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/LakeServiceWithMetrics.java
@@ -30,6 +30,8 @@ import com.starrocks.proto.DeleteTxnLogRequest;
 import com.starrocks.proto.DeleteTxnLogResponse;
 import com.starrocks.proto.DropTableRequest;
 import com.starrocks.proto.DropTableResponse;
+import com.starrocks.proto.DropTabletCacheRequest;
+import com.starrocks.proto.DropTabletCacheResponse;
 import com.starrocks.proto.GetTabletMetadatasRequest;
 import com.starrocks.proto.GetTabletMetadatasResponse;
 import com.starrocks.proto.LockTabletMetadataRequest;
@@ -120,6 +122,12 @@ public class LakeServiceWithMetrics implements LakeService {
     public Future<DropTableResponse> dropTable(DropTableRequest request) {
         increaseMetrics();
         return lakeService.dropTable(request);
+    }
+
+    @Override
+    public Future<DropTabletCacheResponse> dropTabletCache(DropTabletCacheRequest request) {
+        increaseMetrics();
+        return lakeService.dropTabletCache(request);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableHelperTest.java
@@ -29,18 +29,29 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.Config;
+import com.starrocks.common.StarRocksException;
+import com.starrocks.proto.DropTabletCacheRequest;
+import com.starrocks.proto.DropTabletCacheResponse;
+import com.starrocks.proto.StatusPB;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.rpc.BrpcProxy;
+import com.starrocks.rpc.LakeService;
+import com.starrocks.rpc.LakeServiceWithMetrics;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.NodeMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.AggregateType;
 import com.starrocks.sql.ast.CreateDbStmt;
 import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.KeysType;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.type.IntegerType;
 import com.starrocks.utframe.UtFrameUtils;
+import com.starrocks.warehouse.cngroup.ComputeResource;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
@@ -54,6 +65,9 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -157,6 +171,165 @@ public class LakeTableHelperTest {
 
         LakeTableHelper.deleteShardGroupMeta(partition);
         Assertions.assertEquals(0, shardGroupInfos.size());
+    }
+
+    @Test
+    public void testDropPartitionCache(@Mocked StarOSAgent starOSAgent,
+                                       @Mocked NodeMgr nodeMgr,
+                                       @Mocked SystemInfoService systemInfoService,
+                                       @Mocked ComputeResource computeResource) {
+        long partitionId = 1001L;
+        long physicalPartitionId = 1002L;
+        long indexId = 1003L;
+        long tabletId = 1004L;
+        long beId = 2001L;
+        long workerGroupId = 3001L;
+
+        DistributionInfo distributionInfo = new HashDistributionInfo(10, Lists.newArrayList());
+        MaterializedIndex index = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
+        Partition partition = new Partition(partitionId, physicalPartitionId, "p1", index, distributionInfo);
+        PhysicalPartition physicalPartition =
+                new PhysicalPartition(physicalPartitionId, partitionId, new MaterializedIndex(indexId,
+                        MaterializedIndex.IndexState.NORMAL));
+        MaterializedIndex materializedIndex = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
+        Tablet tablet = new LakeTablet(tabletId);
+
+        ComputeNode computeNode = new ComputeNode(beId, "127.0.0.1", 9050);
+        computeNode.setBrpcPort(8060);
+
+        DropTabletCacheResponse response = new DropTabletCacheResponse();
+        response.status = new StatusPB();
+        response.status.statusCode = 0;
+
+        final boolean[] nodeExists = {true};
+        final boolean[] throwShardLookup = {false};
+        final boolean[] throwFutureGet = {false};
+        final boolean[] interruptOnGet = {false};
+        final boolean[] nonOkStatus = {false};
+
+        new MockUp<Partition>() {
+            @Mock
+            public Collection<PhysicalPartition> getSubPartitions() {
+                return Lists.newArrayList(physicalPartition);
+            }
+        };
+
+        new MockUp<PhysicalPartition>() {
+            @Mock
+            public long getVisibleVersion() {
+                return 7L;
+            }
+
+            @Mock
+            public List<MaterializedIndex> getAllMaterializedIndices(MaterializedIndex.IndexExtState extState) {
+                return Lists.newArrayList(materializedIndex);
+            }
+        };
+
+        new MockUp<MaterializedIndex>() {
+            @Mock
+            public List<Tablet> getTablets() {
+                return Lists.newArrayList(tablet);
+            }
+        };
+
+        new MockUp<NodeMgr>() {
+            @Mock
+            public SystemInfoService getClusterInfo() {
+                return systemInfoService;
+            }
+        };
+
+        new MockUp<ComputeResource>() {
+            @Mock
+            public long getWorkerGroupId() {
+                return workerGroupId;
+            }
+
+            @Mock
+            public long getWarehouseId() {
+                return 0;
+            }
+        };
+
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public long getPrimaryComputeNodeIdByShard(long shardId, long workerGroup) throws StarRocksException {
+                if (throwShardLookup[0]) {
+                    throw new StarRocksException("lookup failed");
+                }
+                return beId;
+            }
+        };
+
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public ComputeNode getBackendOrComputeNode(long nodeId) {
+                if (!nodeExists[0]) {
+                    return null;
+                }
+                return computeNode;
+            }
+        };
+
+        new MockUp<BrpcProxy>() {
+            @Mock
+            public LakeService getLakeService(String host, int port) {
+                return new LakeServiceWithMetrics(null);
+            }
+        };
+
+        new MockUp<LakeServiceWithMetrics>() {
+            @Mock
+            public Future<DropTabletCacheResponse> dropTabletCache(DropTabletCacheRequest request) {
+                return new CompletableFuture<>() {
+                    @Override
+                    public DropTabletCacheResponse get() throws InterruptedException, ExecutionException {
+                        if (interruptOnGet[0]) {
+                            throw new InterruptedException("interrupted");
+                        }
+                        if (throwFutureGet[0]) {
+                            throw new ExecutionException("future failed", new RuntimeException("future failed"));
+                        }
+                        if (nonOkStatus[0]) {
+                            DropTabletCacheResponse nonOk = new DropTabletCacheResponse();
+                            nonOk.status = new StatusPB();
+                            nonOk.status.statusCode = 1;
+                            nonOk.status.errorMsgs = Lists.newArrayList("bad");
+                            return nonOk;
+                        }
+                        return response;
+                    }
+                };
+            }
+        };
+
+        LakeTableHelper.dropPartitionCache(partition, computeResource);
+
+        // shard lookup throws, should skip sending rpc
+        throwShardLookup[0] = true;
+        LakeTableHelper.dropPartitionCache(partition, computeResource);
+        throwShardLookup[0] = false;
+
+        // node missing, should skip sending rpc
+        nodeExists[0] = false;
+        LakeTableHelper.dropPartitionCache(partition, computeResource);
+        nodeExists[0] = true;
+
+        // future.get interrupted
+        interruptOnGet[0] = true;
+        LakeTableHelper.dropPartitionCache(partition, computeResource);
+        interruptOnGet[0] = false;
+        Thread.interrupted();
+
+        // future.get failed
+        throwFutureGet[0] = true;
+        LakeTableHelper.dropPartitionCache(partition, computeResource);
+        throwFutureGet[0] = false;
+
+        // non-ok status
+        nonOkStatus[0] = true;
+        LakeTableHelper.dropPartitionCache(partition, computeResource);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/lake/RecycleLakePartitionInfoEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/RecycleLakePartitionInfoEditLogTest.java
@@ -111,7 +111,8 @@ public class RecycleLakePartitionInfoEditLogTest {
         // Mock LakeTableHelper using MockUp
         new MockUp<LakeTableHelper>() {
             @Mock
-            public boolean removePartitionDirectory(Partition partition, ComputeResource computeResource) {
+            public boolean removePartitionDirectory(Partition partition, ComputeResource computeResource,
+                    boolean dropCache) {
                 return true;
             }
             
@@ -165,7 +166,8 @@ public class RecycleLakePartitionInfoEditLogTest {
         // 3. Mock LakeTableHelper.removePartitionDirectory to return true
         new MockUp<LakeTableHelper>() {
             @Mock
-            public boolean removePartitionDirectory(Partition partition, ComputeResource computeResource) {
+            public boolean removePartitionDirectory(Partition partition, ComputeResource computeResource,
+                    boolean dropCache) {
                 return true;
             }
             
@@ -218,7 +220,8 @@ public class RecycleLakePartitionInfoEditLogTest {
         // 3. Mock LakeTableHelper.removePartitionDirectory to return true
         new MockUp<LakeTableHelper>() {
             @Mock
-            public boolean removePartitionDirectory(Partition partition, ComputeResource computeResource) {
+            public boolean removePartitionDirectory(Partition partition, ComputeResource computeResource,
+                    boolean dropCache) {
                 return true;
             }
             

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
@@ -41,6 +41,8 @@ import com.starrocks.proto.DeleteTxnLogRequest;
 import com.starrocks.proto.DeleteTxnLogResponse;
 import com.starrocks.proto.DropTableRequest;
 import com.starrocks.proto.DropTableResponse;
+import com.starrocks.proto.DropTabletCacheRequest;
+import com.starrocks.proto.DropTabletCacheResponse;
 import com.starrocks.proto.ExecuteCommandRequestPB;
 import com.starrocks.proto.ExecuteCommandResultPB;
 import com.starrocks.proto.GetTabletMetadatasRequest;
@@ -1165,6 +1167,11 @@ public class PseudoBackend {
 
         @Override
         public Future<DropTableResponse> dropTable(DropTableRequest request) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public Future<DropTabletCacheResponse> dropTabletCache(DropTabletCacheRequest request) {
             return CompletableFuture.completedFuture(null);
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
@@ -36,6 +36,8 @@ import com.starrocks.proto.DeleteTxnLogRequest;
 import com.starrocks.proto.DeleteTxnLogResponse;
 import com.starrocks.proto.DropTableRequest;
 import com.starrocks.proto.DropTableResponse;
+import com.starrocks.proto.DropTabletCacheRequest;
+import com.starrocks.proto.DropTabletCacheResponse;
 import com.starrocks.proto.ExecuteCommandRequestPB;
 import com.starrocks.proto.ExecuteCommandResultPB;
 import com.starrocks.proto.GetTabletMetadatasRequest;
@@ -664,6 +666,11 @@ public class MockedBackend {
 
         @Override
         public Future<DropTableResponse> dropTable(DropTableRequest request) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public Future<DropTabletCacheResponse> dropTabletCache(DropTabletCacheRequest request) {
             return CompletableFuture.completedFuture(null);
         }
 

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -394,6 +394,19 @@ message VacuumFullResponse {
     optional int64 vacuumed_file_size = 3;
 }
 
+message DropTabletCacheMeta {
+    optional int64 tablet_id = 1;
+    optional int64 version = 2;
+}
+
+message DropTabletCacheRequest {
+    repeated DropTabletCacheMeta tablets = 1;
+}
+
+message DropTabletCacheResponse {
+    optional StatusPB status = 1;
+}
+
 message GetTabletMetadatasRequest {
     // all tablets in one physical partition
     repeated int64 tablet_ids = 1;
@@ -467,6 +480,7 @@ service LakeService {
     rpc vacuum(VacuumRequest) returns (VacuumResponse);
     rpc vacuum_full(VacuumFullRequest) returns (VacuumFullResponse);
     rpc aggregate_compact(AggregateCompactRequest) returns (CompactResponse);
+    rpc drop_tablet_cache(DropTabletCacheRequest) returns (DropTabletCacheResponse);
     rpc get_tablet_metadatas(GetTabletMetadatasRequest) returns (GetTabletMetadatasResponse);
     rpc repair_tablet_metadata(RepairTabletMetadataRequest) returns (RepairTabletMetadataResponse);
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

1. introduce FE config `lake_enable_drop_tablet_cache` to control whether delete cache before we delete any partition/table data
2. add `drop_tablet_cache` API for BE/CN, it functions basically the same as Vacuum, except it does not delete data, only delete cache

drop cache is a try-at-best behavior, if error occurred during the drop, the data deletion will proceed anyway.

tested using ssb 10G with 1 FE and 1 BE with PRIMARY key and DUPLICATE key and MV.

<img width="632" height="462" alt="截屏2026-01-28 14 46 34" src="https://github.com/user-attachments/assets/de72b4f9-ad6c-43cc-a8d3-debbf543683a" />

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds tablet cache dropping via new LakeService RPC, invoked by FE before table/partition deletion, and extends FileSystem drop_local_cache to support offset/size.
> 
> - **Backend**:
>   - **LakeService RPC**: Add `drop_tablet_cache` RPC and implementation (`LakeServiceImpl::drop_tablet_cache`) to drop per-tablet caches using thread pool.
>   - **Cache Drop Logic**: Introduce `lake::drop_tablet_cache(TabletManager*, tablet_id, version)` to walk versions and call FS cache drop for `segments` and `delvec` files.
> - **Filesystem**:
>   - **API Update**: Change `FileSystem::drop_local_cache` to accept `offset` and `size` (defaulted); `StarletFileSystem` forwards to underlying `drop_cache`.
> - **Frontend**:
>   - **Trigger on Deletion**: Before removing lake table/partition data, FE groups tablets by BE and calls `LakeService.dropTabletCache`; guarded by new config `Config.lake_enable_drop_tablet_cache` and table/partition data-cache flag.
>   - **Helpers**: Add `LakeTableHelper.dropPartitionCache` and update `removePartitionDirectory` and `LakeTableCleaner.cleanTable` to invoke it.
> - **Protocol/RPC**:
>   - **Protobuf**: Add `DropTabletCache{Meta,Request,Response}` messages and `drop_tablet_cache` to `LakeService`.
>   - **Clients/Tests**: Wire through FE RPC interfaces (`LakeService`, `LakeServiceWithMetrics`) and add stubs in pseudo/mock backends.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5770a0b2c21e834001c8b69acdbc109d39410fdc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->