### PR TITLE
[Refactor] remove binutils-dev dependency

### DIFF
--- a/docker/dockerfiles/allin1/allin1-ubuntu.Dockerfile
+++ b/docker/dockerfiles/allin1/allin1-ubuntu.Dockerfile
@@ -33,7 +33,7 @@ ARG DEPLOYDIR=/data/deploy
 ENV SR_HOME=${DEPLOYDIR}/starrocks
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
-        binutils-dev openjdk-17-jdk python2 mysql-client curl vim tree net-tools less tzdata linux-tools-common linux-tools-generic supervisor nginx netcat locales tini && \
+        openjdk-17-jdk python2 mysql-client curl vim tree net-tools less tzdata linux-tools-common linux-tools-generic supervisor nginx netcat locales tini && \
         ln -fs /usr/share/zoneinfo/UTC /etc/localtime && \
         dpkg-reconfigure -f noninteractive tzdata && \
         locale-gen en_US.UTF-8 && \

--- a/docker/dockerfiles/be/be-ubuntu.Dockerfile
+++ b/docker/dockerfiles/be/be-ubuntu.Dockerfile
@@ -44,7 +44,7 @@ ARG GROUP=starrocks
 ARG MINIMAL
 
 # TODO: switch to `openjdk-##-jre` when the starrocks core is ready.
-RUN OPTIONAL_PKGS="" && if [ "x$MINIMAL" = "xfalse" ] ; then OPTIONAL_PKGS="binutils-dev openjdk-17-jdk curl vim tree net-tools less pigz inotify-tools rclone gdb" ; fi && \
+RUN OPTIONAL_PKGS="" && if [ "x$MINIMAL" = "xfalse" ] ; then OPTIONAL_PKGS="openjdk-17-jdk curl vim tree net-tools less pigz inotify-tools rclone gdb" ; fi && \
         apt-get update -y && apt-get install -y --no-install-recommends \
         openjdk-17-jdk mysql-client tzdata locales tini $OPTIONAL_PKGS && \
         ln -fs /usr/share/zoneinfo/UTC /etc/localtime && \

--- a/docker/dockerfiles/toolchains/toolchains-centos7.Dockerfile
+++ b/docker/dockerfiles/toolchains/toolchains-centos7.Dockerfile
@@ -75,7 +75,7 @@ LABEL com.starrocks.commit=${COMMIT_ID}
 
 RUN yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && yum install -y gh && \
         yum install -y ${EPEL_RPM_URL} && yum install -y wget unzip bzip2 patch bison byacc flex autoconf automake make \
-        libtool which git ccache binutils-devel python3 file less psmisc && \
+        libtool which git ccache python3 file less psmisc && \
         localedef --no-archive -i en_US -f UTF-8 en_US.UTF-8 && \
         yum clean all && rm -rf /var/cache/yum
 

--- a/docker/dockerfiles/toolchains/toolchains-ubuntu.Dockerfile
+++ b/docker/dockerfiles/toolchains/toolchains-ubuntu.Dockerfile
@@ -36,7 +36,7 @@ LABEL com.starrocks.commit=${COMMIT_ID}
 # Install common libraries and tools that are needed for dev environment
 RUN apt-get update -y && \
     apt-get install --no-install-recommends -y \
-    automake binutils-dev bison byacc ccache flex libiberty-dev libtool maven zip python3 python-is-python3 make openjdk-17-jdk git patch lld bzip2 \
+    automake bison byacc ccache flex libiberty-dev libtool maven zip python3 python-is-python3 make openjdk-17-jdk git patch lld bzip2 \
     wget unzip curl vim tree net-tools openssh-client xz-utils gh locales && \
     DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get -y install tzdata && \
     locale-gen en_US.UTF-8 && \

--- a/docs/en/developers/build-starrocks/build_starrocks_on_ubuntu.md
+++ b/docs/en/developers/build-starrocks/build_starrocks_on_ubuntu.md
@@ -17,7 +17,7 @@ sudo apt-get update
 ```
 
 ```
-sudo apt-get install automake binutils-dev bison byacc ccache flex libiberty-dev libtool maven zip python3 python-is-python3 bzip2 -y
+sudo apt-get install automake bison byacc ccache flex libiberty-dev libtool maven zip python3 python-is-python3 bzip2 -y
 ```
 
 ### Install Compiler

--- a/docs/en/developers/development-environment/ide-setup.md
+++ b/docs/en/developers/development-environment/ide-setup.md
@@ -79,7 +79,7 @@ sudo apt update
 ```
 
 ```bash
-sudo apt install gcc g++ maven openjdk-17-jdk python3 python-is-python3 unzip cmake bzip2 ccache byacc ccache flex automake libtool bison binutils-dev libiberty-dev build-essential ninja-build curl
+sudo apt install gcc g++ maven openjdk-17-jdk python3 python-is-python3 unzip cmake bzip2 ccache byacc ccache flex automake libtool bison libiberty-dev build-essential ninja-build curl
 ```
 
 Setup `JAVA_HOME` env

--- a/docs/ja/developers/build-starrocks/build_starrocks_on_ubuntu.md
+++ b/docs/ja/developers/build-starrocks/build_starrocks_on_ubuntu.md
@@ -17,7 +17,7 @@ sudo apt-get update
 ```
 
 ```
-sudo apt-get install automake binutils-dev bison byacc ccache flex libiberty-dev libtool maven zip python3 python-is-python3 bzip2 -y
+sudo apt-get install automake bison byacc ccache flex libiberty-dev libtool maven zip python3 python-is-python3 bzip2 -y
 ```
 
 ### コンパイラのインストール

--- a/docs/ja/developers/development-environment/ide-setup.md
+++ b/docs/ja/developers/development-environment/ide-setup.md
@@ -81,7 +81,7 @@ sudo apt update
 ```
 
 ```bash
-sudo apt install gcc g++ maven openjdk-11-jdk python3 python-is-python3 unzip cmake bzip2 ccache byacc ccache flex automake libtool bison binutils-dev libiberty-dev build-essential ninja-build curl
+sudo apt install gcc g++ maven openjdk-11-jdk python3 python-is-python3 unzip cmake bzip2 ccache byacc ccache flex automake libtool bison libiberty-dev build-essential ninja-build curl
 ```
 
 `JAVA_HOME` 環境のセットアップ

--- a/docs/zh/developers/build-starrocks/build_starrocks_on_ubuntu.md
+++ b/docs/zh/developers/build-starrocks/build_starrocks_on_ubuntu.md
@@ -17,7 +17,7 @@ sudo apt-get update
 ```
 
 ```bash
-sudo apt-get install automake binutils-dev bison byacc ccache flex libiberty-dev libtool maven zip python3 python-is-python3 bzip2 -y
+sudo apt-get install automake bison byacc ccache flex libiberty-dev libtool maven zip python3 python-is-python3 bzip2 -y
 ```
 
 ### 安装编译器


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Followup #https://github.com/StarRocks/starrocks/pull/66211

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes binutils(-dev/-devel) from Docker images and Ubuntu/CentOS setup docs, keeping other dependencies unchanged.
> 
> - **Dockerfiles**:
>   - `docker/dockerfiles/be/be-ubuntu.Dockerfile`: Drop `binutils-dev` from optional packages.
>   - `docker/dockerfiles/allin1/allin1-ubuntu.Dockerfile`: Remove `binutils-dev` from base apt installs.
>   - `docker/dockerfiles/toolchains/toolchains-ubuntu.Dockerfile`: Remove `binutils-dev` from apt installs.
>   - `docker/dockerfiles/toolchains/toolchains-centos7.Dockerfile`: Remove `binutils-devel` from yum installs.
> - **Docs**:
>   - Update Ubuntu dependency commands (EN/JA/ZH) to omit `binutils-dev`.
>   - Update IDE setup (EN/JA) to omit `binutils-dev` from apt installs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 14b72cb773aec2387a40e957c045eb78355667c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->