### PR TITLE
[Enhancement] Add page cache stats to http api: datacache/stat

### DIFF
--- a/be/src/http/action/datacache_action.cpp
+++ b/be/src/http/action/datacache_action.cpp
@@ -77,9 +77,9 @@ void DataCacheAction::_handle(HttpRequest* req, const std::function<void(rapidjs
     HttpChannel::send_reply(req, HttpStatus::OK, strbuf.GetString());
 }
 
-double DataCacheAction::_calc_rate(size_t quota, size_t used) {
-    if (quota > 0) {
-        return std::round(static_cast<double>(used) / static_cast<double>(quota) * 100.0) / 100.0;
+double DataCacheAction::_calc_rate(size_t total, size_t count) {
+    if (total > 0) {
+        return std::round(static_cast<double>(count) / static_cast<double>(total) * 100.0) / 100.0;
     }
     return 0;
 }

--- a/be/src/http/action/datacache_action.h
+++ b/be/src/http/action/datacache_action.h
@@ -46,6 +46,7 @@ private:
     void _handle_stat(HttpRequest* req);
     void _handle_app_stat(HttpRequest* req);
     void _handle_error(HttpRequest* req, const std::string& error_msg);
+    static double _calc_rate(size_t quota, size_t used);
 
     LocalDiskCacheEngine* _disk_cache;
     LocalMemCacheEngine* _mem_cache;

--- a/be/src/http/action/datacache_action.h
+++ b/be/src/http/action/datacache_action.h
@@ -46,7 +46,7 @@ private:
     void _handle_stat(HttpRequest* req);
     void _handle_app_stat(HttpRequest* req);
     void _handle_error(HttpRequest* req, const std::string& error_msg);
-    static double _calc_rate(size_t quota, size_t used);
+    static double _calc_rate(size_t total, size_t count);
 
     LocalDiskCacheEngine* _disk_cache;
     LocalMemCacheEngine* _mem_cache;

--- a/be/test/http/datacache_action_test.cpp
+++ b/be/test/http/datacache_action_test.cpp
@@ -83,7 +83,7 @@ TEST_F(DataCacheActionTest, stat_success) {
 
     rapidjson::Document doc;
     doc.Parse(k_response_str.c_str());
-    ASSERT_STREQ("NORMAL", doc["status"].GetString());
+    ASSERT_STREQ("NORMAL", doc["block_cache_status"].GetString());
 }
 
 TEST_F(DataCacheActionTest, app_stat_success) {


### PR DESCRIPTION
## Why I'm doing:

Similar to https://github.com/StarRocks/starrocks/pull/65341, DataCache consists of two components: Block Cache and Page Cache. Therefore, I have added new page-cache-related metrics to the HTTP API api/datacache/stat and renamed the block-cache-related metrics.

curl -XGET http://127.0.0.1:8040/api/datacache/stat

```
{
    "page_cache_mem_quota_bytes": 10679976935,
    "page_cache_mem_used_bytes": 10663052377,
    "page_cache_mem_used_rate": 1.0,
    "page_cache_hit_count": 276890,
    "page_cache_miss_count": 153126,
    "page_cache_hit_rate": 0.64,
    "page_cache_hit_count_last_minute": 11196,
    "page_cache_miss_count_last_minute": 9982,
    "page_cache_hit_rate_last_minute": 0.53,
    "block_cache_status": "NORMAL",
    "block_cache_disk_quota_bytes": 214748364800,
    "block_cache_disk_used_bytes": 11371020288,
    "block_cache_disk_used_rate": 0.05,
    "block_cache_disk_spaces": "/home/disk1/sr/be/storage/datacache:107374182400;/home/disk1/sr/be/storage_ssd/datacache:107374182400",
    "block_cache_meta_used_bytes": 11756727,
    "block_cache_hit_count": 57707,
    "block_cache_miss_count": 2556,
    "block_cache_hit_rate": 0.96,
    "block_cache_hit_bytes": 15126253744,
    "block_cache_miss_bytes": 620687633,
    "block_cache_hit_count_last_minute": 18108,
    "block_cache_miss_count_last_minute": 2449,
    "block_cache_hit_bytes_last_minute": 4745613488,
    "block_cache_miss_bytes_last_minute": 607536783,
    "block_cache_read_disk_bytes": 15126253744,
    "block_cache_write_bytes": 11338218093,
    "block_cache_write_success_count": 43377,
    "block_cache_write_fail_count": 36394,
    "block_cache_remove_bytes": 0,
    "block_cache_remove_success_count": 0,
    "block_cache_remove_fail_count": 0,
    "block_cache_current_reading_count": 0,
    "block_cache_current_writing_count": 0,
    "block_cache_current_removing_count": 0
}
```

## What I'm doing:

Add page cache stats to http api: datacache/stat

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
