### PR TITLE
[Refactor] refactor some cluster snapshot code

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotJob.java
@@ -14,8 +14,12 @@
 
 package com.starrocks.lake.snapshot;
 
+import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.Pair;
+import com.starrocks.common.StarRocksException;
 import com.starrocks.common.io.Writable;
+import com.starrocks.leader.CheckpointController;
 import com.starrocks.persist.ClusterSnapshotLog;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TClusterSnapshotJobsItem;
@@ -183,4 +187,127 @@ public class ClusterSnapshotJob implements Writable {
         item.setError_message(errMsg);
         return item;
     }
+
+    /**
+     * Default implementation for meta-only snapshot jobs (ClusterSnapshotJob and ManualClusterSnapshotJob).
+     * FullClusterSnapshotJob should override this method if it needs different initialization logic.
+     */
+    protected void runInitializingJob(SnapshotJobContext context) throws StarRocksException {
+        Preconditions.checkState(state == ClusterSnapshotJobState.INITIALIZING, state);
+        LOG.info("begin to initialize cluster snapshot job. job: {}", getId());
+
+        Pair<Long, Long> consistentIds = context.captureConsistentCheckpointIdBetweenFEAndStarMgr();
+        if (consistentIds == null) {
+            throw new StarRocksException("failed to capture consistent journal id for checkpoint");
+        }
+        setJournalIds(consistentIds.first, consistentIds.second);
+        LOG.info(
+                "Successful capture consistent journal id, FE checkpoint journal Id: {}, StarMgr checkpoint journal Id: {}",
+                consistentIds.first, consistentIds.second);
+
+        setState(ClusterSnapshotJobState.SNAPSHOTING);
+        logJob();
+    }
+
+    /**
+     * Default implementation for meta-only snapshot jobs (ClusterSnapshotJob and ManualClusterSnapshotJob).
+     * FullClusterSnapshotJob should override this method if it needs different snapshotting logic.
+     */
+    protected void runSnapshottingJob(SnapshotJobContext context) throws StarRocksException {
+        Preconditions.checkState(state == ClusterSnapshotJobState.SNAPSHOTING, state);
+        LOG.info("begin to snapshot cluster snapshot job. job: {}", getId());
+
+        CheckpointController feController = context.getFeController();
+        CheckpointController starMgrController = context.getStarMgrController();
+        long feCheckpointJournalId = getFeJournalId();
+        long starMgrCheckpointJournalId = getStarMgrJournalId();
+
+        long feImageJournalId = feController.getImageJournalId();
+        if (feImageJournalId < feCheckpointJournalId) {
+            Pair<Boolean, String> createFEImageRet = feController.runCheckpointControllerWithIds(feImageJournalId,
+                    feCheckpointJournalId, needClusterSnapshotInfo());
+            if (!createFEImageRet.first) {
+                throw new StarRocksException("checkpoint failed for FE image: " + createFEImageRet.second);
+            }
+        } else if (feImageJournalId > feCheckpointJournalId) {
+            throw new StarRocksException("checkpoint journal id for FE is smaller than image version");
+        }
+        LOG.info("Finished create image for FE image, version: {}", feCheckpointJournalId);
+
+        long starMgrImageJournalId = starMgrController.getImageJournalId();
+        if (starMgrImageJournalId < starMgrCheckpointJournalId) {
+            Pair<Boolean, String> createStarMgrImageRet = starMgrController
+                    .runCheckpointControllerWithIds(starMgrImageJournalId, starMgrCheckpointJournalId, false);
+            if (!createStarMgrImageRet.first) {
+                throw new StarRocksException("checkpoint failed for starMgr image: " + createStarMgrImageRet.second);
+            }
+        } else if (starMgrImageJournalId > starMgrCheckpointJournalId) {
+            throw new StarRocksException("checkpoint journal id for starMgr is smaller than image version");
+        }
+        setClusterSnapshotInfo(feController.getClusterSnapshotInfo());
+        setState(ClusterSnapshotJobState.UPLOADING);
+        logJob();
+        LOG.info("Finished create image for starMgr image, version: {}", starMgrCheckpointJournalId);
+    }
+
+    /**
+     * Default implementation for meta-only snapshot jobs (ClusterSnapshotJob and ManualClusterSnapshotJob).
+     * FullClusterSnapshotJob should override this method if it needs different uploading logic.
+     */
+    protected void runUploadingJob(SnapshotJobContext context) throws StarRocksException {
+        Preconditions.checkState(state == ClusterSnapshotJobState.UPLOADING, state);
+        LOG.info("begin to upload cluster snapshot job. job: {}", getId());
+
+        try {
+            ClusterSnapshotUtils.uploadClusterSnapshotToRemote(this);
+        } catch (StarRocksException e) {
+            throw new StarRocksException("upload image failed, err msg: " + e.getMessage());
+        }
+        setState(ClusterSnapshotJobState.FINISHED);
+        logJob();
+        LOG.info(
+                "Finish upload image for Cluster Snapshot, FE checkpoint journal Id: {}, StarMgr checkpoint journal Id: {}",
+                getFeJournalId(), getStarMgrJournalId());
+    }
+
+    protected void runFinishedJob() throws StarRocksException{
+        // Default implementation: do nothing
+    }
+
+    public synchronized void run(SnapshotJobContext context) {
+        try {
+            while (true) {
+                ClusterSnapshotJobState prevState = state;
+                switch (prevState) {
+                    case INITIALIZING:
+                        runInitializingJob(context);
+                        break;
+                    case SNAPSHOTING:
+                        runSnapshottingJob(context);
+                        break;
+                    case UPLOADING:
+                        runUploadingJob(context);
+                        break;
+                    case FINISHED:
+                    case EXPIRED:
+                    case DELETED:
+                    case ERROR:
+                        runFinishedJob();
+                        break;
+                    default:
+                        break;
+                }
+                if (state == prevState) {
+                    break;
+                }
+            }
+        } catch (Exception e) {
+            LOG.warn("failed to run cluster snapshot job {}", getId(), e);
+            setState(ClusterSnapshotJobState.ERROR);
+            setErrMsg(e.getMessage());
+            logJob();
+            return;
+        }
+    }
+
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotJobScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotJobScheduler.java
@@ -21,10 +21,10 @@ import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-// ClusterSnapshotCheckpointScheduler daemon is running on master node. Coordinate two checkpoint controller
+// ClusterSnapshotJobScheduler daemon is running on master node. Coordinate two checkpoint controller
 // together to finish image checkpoint one by one and upload image for backup
-public class ClusterSnapshotCheckpointScheduler extends FrontendDaemon implements SnapshotJobContext {
-    public static final Logger LOG = LogManager.getLogger(ClusterSnapshotCheckpointScheduler.class);
+public class ClusterSnapshotJobScheduler extends FrontendDaemon implements SnapshotJobContext {
+    public static final Logger LOG = LogManager.getLogger(ClusterSnapshotJobScheduler.class);
     private static int CAPTURE_ID_RETRY_TIME = 10;
 
     protected final CheckpointController feController;
@@ -35,7 +35,7 @@ public class ClusterSnapshotCheckpointScheduler extends FrontendDaemon implement
     protected long lastAutomatedJobStartTimeMs;
     protected volatile ClusterSnapshotJob runningJob;
 
-    public ClusterSnapshotCheckpointScheduler(CheckpointController feController,
+    public ClusterSnapshotJobScheduler(CheckpointController feController,
             CheckpointController starMgrController) {
         super("cluster_snapshot_checkpoint_scheduler", 10L);
         this.feController = feController;
@@ -85,13 +85,14 @@ public class ClusterSnapshotCheckpointScheduler extends FrontendDaemon implement
         // skip first run when the scheduler start
         if (lastAutomatedJobStartTimeMs == 0) {
             GlobalStateMgr.getCurrentState().getClusterSnapshotMgr()
-                                            .resetSnapshotJobsStateAfterRestarted(restoredSnapshotInfo);
+                    .resetSnapshotJobsStateAfterRestarted(restoredSnapshotInfo);
             lastAutomatedJobStartTimeMs = System.currentTimeMillis(); // init last start time
             return;
         }
 
         /*
-         * Control the interval of automated cluster snapshot manually instead of by Daemon framework
+         * Control the interval of automated cluster snapshot manually instead of by
+         * Daemon framework
          * for the future purpose.
          */
         if (!GlobalStateMgr.getCurrentState().getClusterSnapshotMgr().canScheduleNextJob(lastAutomatedJobStartTimeMs)

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/ClusterSnapshotMgr.java
@@ -55,7 +55,7 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
     protected volatile String storageVolumeName;
     @SerializedName(value = "automatedSnapshotJobs")
     protected NavigableMap<Long, ClusterSnapshotJob> automatedSnapshotJobs = new ConcurrentSkipListMap<>();
-
+    
     protected ClusterSnapshotCheckpointScheduler clusterSnapshotCheckpointScheduler;
 
     public ClusterSnapshotMgr() {
@@ -140,7 +140,7 @@ public class ClusterSnapshotMgr implements GsonPostProcessable {
         long createTimeMs = System.currentTimeMillis();
         long id = GlobalStateMgr.getCurrentState().getNextId();
         String snapshotName = AUTOMATED_NAME_PREFIX + String.valueOf(createTimeMs);
-        ClusterSnapshotJob job = new ClusterSnapshotJob(id, snapshotName, storageVolumeName, createTimeMs);
+        ClusterSnapshotJob job = new ClusterSnapshotJob(id, snapshotName, storageVolumeName, createTimeMs);   
         job.logJob();
 
         addSnapshotJob(job);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/SnapshotJobContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/snapshot/SnapshotJobContext.java
@@ -1,0 +1,44 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake.snapshot;
+
+import com.starrocks.common.Pair;
+import com.starrocks.leader.CheckpointController;
+
+/**
+ * Context interface for snapshot job execution.
+ * Provides access to external dependencies required by snapshot jobs,
+ * allowing different job types to use different implementations.
+ */
+public interface SnapshotJobContext {
+    /**
+     * Get FE checkpoint controller
+     */
+    CheckpointController getFeController();
+
+    /**
+     * Get StarMgr checkpoint controller
+     */
+    CheckpointController getStarMgrController();
+
+    /**
+     * Capture consistent checkpoint IDs between FE and StarMgr.
+     * This method coordinates the checkpoint process to ensure consistency.
+     * 
+     * @return Pair of (FE journal ID, StarMgr journal ID) if successful, null
+     *         otherwise
+     */
+    Pair<Long, Long> captureConsistentCheckpointIdBetweenFEAndStarMgr();
+}


### PR DESCRIPTION
## Why I'm doing:
refactor some cluster snapshot code
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces SnapshotJobContext and moves checkpoint/upload logic into a state-machine in ClusterSnapshotJob; scheduler now delegates job execution and tests are updated accordingly.
> 
> - **Core Refactor**:
>   - Introduce `SnapshotJobContext` interface to supply controllers and capture consistent checkpoint IDs.
>   - Move checkpointing/upload flow into `ClusterSnapshotJob` with state-machine methods: `runInitializingJob`, `runSnapshottingJob`, `runUploadingJob`, `runFinishedJob`, and orchestrator `run(...)` with error handling and logging.
> - **Scheduler (`ClusterSnapshotCheckpointScheduler`)**:
>   - Implement `SnapshotJobContext`; expose `getFeController`, `getStarMgrController`, and `captureConsistentCheckpointIdBetweenFEAndStarMgr`.
>   - Rename daemon name to `cluster_snapshot_checkpoint_scheduler` and delegate execution via `runningJob.run(this)`; handle unfinished `runningJob` and locking.
> - **Mgr (`ClusterSnapshotMgr`)**:
>   - Minor adjustments; job creation unchanged; supports updated job lifecycle.
> - **Tests**:
>   - Add/expand tests for job state transitions, failure cases, uploading behavior, and scheduler delegation; update existing tests to call `job.run(scheduler)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c69e73f72c66c01607dd4be7e4334a2accade49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->