### PR TITLE
[Doc] update flatjson default version 4.0

### DIFF
--- a/docs/en/using_starrocks/Flat_json.md
+++ b/docs/en/using_starrocks/Flat_json.md
@@ -30,7 +30,7 @@ Due to the special nature of the JSON type, its performance in queries is not as
 - Redundant data: Queries need to read the entire JSON data, which includes many redundant fields.
 
 StarRocks introduces the Flat JSON feature to improve JSON data query efficiency and reduce the complexity of using JSON.
-- This feature is available from version 3.3.0, disabled by default, and needs to be enabled manually.
+- This feature is available from version 3.3.0. It is disabled by default before v4.0 and needs to be enabled manually. From v4.0 onwards, it is enabled by default.
 
 ## What is Flat JSON
 
@@ -49,13 +49,13 @@ When loading the above JSON data, fields `a` and `b` are present in most JSON da
 
 ## Enable Flat JSON
 
-Flat JSON is enabled globally by default from v3.4 onwards. For versions earlier than v3.4, you must manually enable it.
+Flat JSON is enabled globally by default from v4.0 onwards. For versions earlier than v4.0, you must manually enable it.
 
 From v4.0, this feature can be configured on the table level.
 
-### Enable for versions earlier than v3.4
+### Enable for versions earlier than v4.0
 
-1. Modify BE configuration: `enable_json_flat`, which defaults to `false` before v3.4. For modification methods, refer to
+1. Modify BE configuration: `enable_json_flat`, which defaults to `false` before v4.0. For modification methods, refer to
 [Configure BE parameters](../administration/management/BE_configuration.md#configure-be-parameters).
 2. Enable FE pruning feature:
 

--- a/docs/ja/using_starrocks/Flat_json.md
+++ b/docs/ja/using_starrocks/Flat_json.md
@@ -30,7 +30,7 @@ JSON 型の特性により、クエリのパフォーマンスは標準型（INT
 - 冗長データ：クエリは JSON データ全体を読み取る必要があり、多くの冗長なフィールドを含んでいます。
 
 StarRocks は、JSON データのクエリ効率を向上させ、JSON の使用の複雑さを軽減するために Flat JSON 機能を導入しました。
-- この機能はバージョン 3.3.0 から利用可能で、デフォルトでは無効になっており、手動で有効にする必要があります。
+- この機能はバージョン 3.3.0 から利用可能です。v4.0 より前はデフォルトで無効になっており、手動で有効にする必要があります。v4.0 以降では、デフォルトで有効になっています。
 
 ## Flat JSON とは
 
@@ -49,13 +49,13 @@ Flat JSON の核心原理は、ロード中に JSON データを検出し、JSON
 
 ## Flat JSON 機能の有効化
 
-v3.4 以降では、Flat JSON はデフォルトでグローバルに有効化されています。v3.4 より前のバージョンでは、手動で有効にする必要があります。
+v4.0 以降では、Flat JSON はデフォルトでグローバルに有効化されています。v4.0 より前のバージョンでは、手動で有効にする必要があります。
 
 v4.0 以降では、この機能はテーブルレベルで設定可能です。
 
-### v3.4 より前のバージョンで有効にする
+### v4.0 より前のバージョンで有効にする
 
-1. BE 設定を変更します：`enable_json_flat` はバージョン 3.4 以前はデフォルトで `false` です。変更方法については、[Configure BE parameters](../administration/management/BE_configuration.md#configure-be-parameters) を参照してください。
+1. BE 設定を変更します：`enable_json_flat` はバージョン 4.0 以前はデフォルトで `false` です。変更方法については、[Configure BE parameters](../administration/management/BE_configuration.md#configure-be-parameters) を参照してください。
 2. FE プルーニング機能を有効化します：
 
    ```SQL

--- a/docs/zh/using_starrocks/Flat_json.md
+++ b/docs/zh/using_starrocks/Flat_json.md
@@ -30,7 +30,7 @@ FROM logs;
 - 冗余数据：查询需要读取整个JSON数据，其中包含许多冗余字段。
 
 StarRocks引入了Flat JSON功能，以提高JSON数据查询效率并降低使用JSON的复杂性。
-- 此功能从3.3.0版本开始提供，默认禁用，需要手动启用。
+- 此功能从3.3.0版本开始提供。在 v4.0 之前默认禁用，需要手动启用。从 v4.0 版本起，默认启用。
 
 ## 什么是Flat JSON
 
@@ -49,13 +49,13 @@ Flat JSON的核心原理是在导入时检测JSON数据，并从JSON数据中提
 
 ## 启用 Flat JSON
 
-从 v3.4 版本起，Flat JSON 默认全局启用。对于 v3.4 之前的版本，必须手动启用此功能。
+从 v4.0 版本起，Flat JSON 默认全局启用。对于 v4.0 之前的版本，必须手动启用此功能。
 
 从 v4.0 版本起，此功能可在表级别进行配置。
 
-### 为 v3.4 前版本启用
+### 为 v4.0 前版本启用
 
-1. 修改 BE 配置：`enable_json_flat`，在 v3.4 版本之前默认为 `false`。修改方法参考 [配置 BE 参数](../administration/management/BE_configuration.md#configure-be-parameters)。
+1. 修改 BE 配置：`enable_json_flat`，在 v4.0 版本之前默认为 `false`。修改方法参考 [配置 BE 参数](../administration/management/BE_configuration.md#configure-be-parameters)。
 2. 启用FE分区裁剪功能：
 
    ```SQL


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fix doc: FlatJSON is enabled by default since 4.0, not 3.4.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3