### PR TITLE
[BugFix] Fix partition expression resolution for MV when view has same name as base table

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -1773,7 +1773,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                                 MaterializedView materializedView =
                                         ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
                                                 .getTable(testDb.getFullName(), mvName));
-                                Assertions.assertEquals(2, materializedView.getPartitionExprMaps().size());
+                                Assertions.assertEquals(1, materializedView.getPartitionExprMaps().size());
 
                                 OlapTable tbl1 = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
                                         .getTable(testDb.getFullName(), "tt1");
@@ -1860,7 +1860,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
                     MaterializedView materializedView =
                             ((MaterializedView) GlobalStateMgr.getCurrentState().getLocalMetastore()
                                     .getTable(testDb.getFullName(), "mv_with_join0"));
-                    Assertions.assertEquals(2, materializedView.getPartitionExprMaps().size());
+                    Assertions.assertEquals(1, materializedView.getPartitionExprMaps().size());
                     TaskRun taskRun = buildMVTaskRun(materializedView, DB_NAME);
 
                     OlapTable tbl1 = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()


### PR DESCRIPTION
## Why I'm doing:

When creating a materialized view based on a VIEW that JOINs multiple tables, if the VIEW name is the same as one of the base table names (but in different databases), the MV creation fails with error:

```
ERROR 1064 (HY000): Getting analyzing error. Detail message: The size of mv partition exprs 
[[MVPartitionExpr{...}], [MVPartitionExpr{...}], [MVPartitionExpr{...}]] should be less or equal 
to the size of partition expr maps: {SlotRef{...}=SlotRef{...}, SlotRef{...}=SlotRef{...}}.
```

Additionally, the final `mvPartitionExprMaps` incorrectly included columns from non-partitioned tables, which should not participate in MV partition expression calculation.

## What I'm doing:

1. Skip VIEW and non-partitioned tables when iterating `baseTableInfos` - they should not participate in partition expression validation
2. Filter `mvPartitionExprMaps` to only keep partition expressions from partitioned tables, excluding columns derived from non-partitioned tables through JOIN conditions

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
