### PR TITLE
[BugFix] fix audit log's scan statistics uncorrect when filter has good selectivity

### DIFF
--- a/be/src/exec/pipeline/scan/balanced_chunk_buffer.cpp
+++ b/be/src/exec/pipeline/scan/balanced_chunk_buffer.cpp
@@ -105,6 +105,10 @@ void BalancedChunkBuffer::set_finished(int buffer_index) {
 
 void BalancedChunkBuffer::update_limiter(Chunk* chunk) {
     static constexpr int UPDATE_AVG_ROW_BYTES_FREQUENCY = 8;
+    if (chunk == nullptr || chunk->num_rows() == 0) {
+        return;
+    }
+
     // Update local counters.
     LimiterContext& ctx = _limiter_context;
     ctx.local_sum_row_bytes += chunk->memory_usage();

--- a/be/src/exec/pipeline/scan/chunk_buffer_limiter.cpp
+++ b/be/src/exec/pipeline/scan/chunk_buffer_limiter.cpp
@@ -22,6 +22,10 @@ namespace starrocks::pipeline {
 
 void DynamicChunkBufferLimiter::update_avg_row_bytes(size_t added_sum_row_bytes, size_t added_num_rows,
                                                      size_t max_chunk_rows) {
+    if (max_chunk_rows == 0) {
+        return;
+    }
+
     std::lock_guard<std::mutex> lock(_mutex);
 
     _sum_row_bytes += added_sum_row_bytes;

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -719,7 +719,9 @@ void OlapChunkSource::_update_realtime_counter(Chunk* chunk) {
         _runtime_state->update_num_bytes_load_from_source(bytes_usage);
     }
 
-    _chunk_buffer.update_limiter(chunk);
+    if (chunk != nullptr && num_rows > 0) {
+        _chunk_buffer.update_limiter(chunk);
+    }
 }
 
 void OlapChunkSource::_update_counter() {

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -3598,7 +3598,7 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
         # Validate scanBytes
         actual_scan_bytes = query_detail.get("scanBytes")
         tools.assert_true(
-            actual_scan_bytes > 0,
+            actual_scan_bytes >= 0,
             f"scanBytes is negative: {actual_scan_bytes}"
         )
         # print(f"✓ scanBytes validation passed: {actual_scan_bytes}")

--- a/test/sql/test_files/R/test_query_detail_api
+++ b/test/sql/test_files/R/test_query_detail_api
@@ -1,4 +1,4 @@
--- name: test_query_detail_api
+-- name: test_query_detail_api @sequential
 create database db_${uuid0};
 -- result:
 -- !result
@@ -19,6 +19,10 @@ insert into test_table values (1, 'test1', 10.5), (2, 'test2', 20.5), (3, 'test3
 -- result:
 -- !result
 function: query_detail_check("select * from test_table", 3, 3)
+-- result:
+{'success': True}
+-- !result
+function: query_detail_check("select * from test_table where value > 100", 3, 0)
 -- result:
 {'success': True}
 -- !result

--- a/test/sql/test_files/T/test_query_detail_api
+++ b/test/sql/test_files/T/test_query_detail_api
@@ -1,4 +1,4 @@
--- name: test_query_detail_api
+-- name: test_query_detail_api @sequential
 
 create database db_${uuid0};
 use db_${uuid0};
@@ -17,6 +17,7 @@ create table test_table (
 insert into test_table values (1, 'test1', 10.5), (2, 'test2', 20.5), (3, 'test3', 30.5);
 
 function: query_detail_check("select * from test_table", 3, 3)
+function: query_detail_check("select * from test_table where value > 100", 3, 0)
 
 function: query_detail_check("insert into test_table select * from test_table", 3, 0)
 


### PR DESCRIPTION
## Why I'm doing:
for one chunk source, if predicate can filter most of data, then it will return eos when call get_next(), then it won't update realtime counter, which cause this chunk source's scan statistics missing.


## What I'm doing:
always call _update_realtime_counter in OlapChunkSource::_read_chunk_from_storage

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure scan stats are recorded on iterator EOF/error and skip limiter updates for null/empty chunks; adjust tests and add query-detail case for highly selective filter.
> 
> - **Backend / Scan**:
>   - `be/src/exec/pipeline/scan/olap_chunk_source.cpp`:
>     - Call `_update_realtime_counter(chunk)` when `_prj_iter->get_next` returns EOF/error.
>     - Only update chunk buffer limiter when `chunk != nullptr` and `num_rows > 0`.
>   - `be/src/exec/pipeline/scan/balanced_chunk_buffer.cpp`:
>     - `update_limiter` early-return for `nullptr` or empty chunks.
>   - `be/src/exec/pipeline/scan/chunk_buffer_limiter.cpp`:
>     - `update_avg_row_bytes` no-op when `max_chunk_rows == 0`.
> - **Tests**:
>   - `test/lib/sr_sql_lib.py`: relax `scanBytes` assertion to `>= 0`.
>   - `test/sql/test_files/*/test_query_detail_api`: mark as `@sequential`; add check for filtered query (`value > 100`) expecting `scanRows=3`, `returnRows=0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b2561f0326b719ca8a04a483ec975cb1ac5b159. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->