### PR TITLE
[BugFix] Fix the concurrency issue between primary key index compaction and apply

### DIFF
--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -42,8 +42,11 @@ Status LakePrimaryIndex::lake_load(TabletManager* tablet_mgr, const TabletMetada
                                    const MetaFileBuilder* builder) {
     TRACE_COUNTER_SCOPE_LATENCY_US("primary_index_load_latency_us");
     std::lock_guard<std::mutex> lg(_lock);
-    if (_loaded) {
+    if (_loaded && !need_rebuild()) {
         return _status;
+    }
+    if (need_rebuild()) {
+        unload();
     }
     _status = _do_lake_load(tablet_mgr, metadata, base_version, builder);
     TEST_SYNC_POINT_CALLBACK("lake_index_load.1", &_status);

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -46,7 +46,7 @@ Status LakePrimaryIndex::lake_load(TabletManager* tablet_mgr, const TabletMetada
         return _status;
     }
     if (need_rebuild()) {
-        unload();
+        unload_without_lock();
     }
     _status = _do_lake_load(tablet_mgr, metadata, base_version, builder);
     TEST_SYNC_POINT_CALLBACK("lake_index_load.1", &_status);

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -34,6 +34,7 @@
 #include "storage/tablet_meta_manager.h"
 #include "storage/tablet_updates.h"
 #include "storage/update_manager.h"
+#include "testutil/sync_point.h"
 #include "util/bit_util.h"
 #include "util/coding.h"
 #include "util/crc32c.h"
@@ -5129,8 +5130,7 @@ Status PersistentIndex::major_compaction(DataDir* data_dir, int64_t tablet_id, s
         RETURN_IF_ERROR(TabletMetaManager::write_persistent_index_meta(data_dir, tablet_id, index_meta));
         // reload new l2 versions
         auto st = _reload(index_meta);
-        FAIL_POINT_TRIGGER_EXECUTE(persistent_index_major_compaction_reload_fail,
-                                   { st = Status::InternalError("injected major compaction reload failure"); });
+        TEST_SYNC_POINT_CALLBACK("persistent_index_major_compaction_reload_fail", &st);
         if (!st.ok()) {
             _set_need_rebuild(true);
             return st;

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -1167,7 +1167,6 @@ public:
 };
 
 DEFINE_FAIL_POINT(phmap_try_consume_mem_failed);
-DEFINE_FAIL_POINT(persistent_index_major_compaction_reload_fail);
 class SliceMutableIndex : public MutableIndex {
 public:
     using KeyType = std::string;

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -5127,7 +5127,6 @@ Status PersistentIndex::major_compaction(DataDir* data_dir, int64_t tablet_id, s
         RETURN_IF_ERROR(modify_l2_versions(l2_versions, new_l2_version, index_meta));
         RETURN_IF_ERROR(TabletMetaManager::write_persistent_index_meta(data_dir, tablet_id, index_meta));
         // reload new l2 versions
-        RETURN_IF_ERROR(_reload(index_meta));
         auto st = _reload(index_meta);
         if (!st.ok()) {
             _set_need_rebuild(true);

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -5128,6 +5128,11 @@ Status PersistentIndex::major_compaction(DataDir* data_dir, int64_t tablet_id, s
         RETURN_IF_ERROR(TabletMetaManager::write_persistent_index_meta(data_dir, tablet_id, index_meta));
         // reload new l2 versions
         RETURN_IF_ERROR(_reload(index_meta));
+        auto st = _reload(index_meta);
+        if (!st.ok()) {
+            _set_need_rebuild(true);
+            return st;
+        }
         // delete useless files
         const MutableIndexMetaPB& l0_meta = index_meta.l0_meta();
         EditVersion l0_version = l0_meta.snapshot().version();

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -956,7 +956,7 @@ private:
     // Re-calculated when commit end
     std::atomic<size_t> _memory_usage{0};
 
-    bool _need_rebuild = false;
+    std::atomic<bool> _need_rebuild{false};
 };
 
 } // namespace starrocks

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -827,6 +827,8 @@ public:
 
     void test_force_dump();
 
+    bool need_rebuild() const { return _need_rebuild; }
+
 protected:
     Status _delete_expired_index_file(const EditVersion& l0_version, const EditVersion& l1_version,
                                       const EditVersionWithMerge& min_l2_version);
@@ -905,6 +907,8 @@ private:
 
     size_t _get_encoded_fixed_size(const Schema& schema);
 
+    void _set_need_rebuild(bool need_rebuild) { _need_rebuild = need_rebuild; }
+
 protected:
     // index storage directory
     std::string _path;
@@ -951,6 +955,8 @@ private:
     int64_t _latest_compaction_time = 0;
     // Re-calculated when commit end
     std::atomic<size_t> _memory_usage{0};
+
+    bool _need_rebuild = false;
 };
 
 } // namespace starrocks

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1082,7 +1082,7 @@ Status PrimaryIndex::load(Tablet* tablet) {
         return _status;
     }
     if (need_rebuild()) {
-        _unload_without_lock();
+        unload_without_lock();
     }
     _status = _do_load(tablet);
     _loaded = true;
@@ -1099,10 +1099,10 @@ Status PrimaryIndex::load(Tablet* tablet) {
 
 void PrimaryIndex::unload() {
     std::lock_guard<std::mutex> lg(_lock);
-    _unload_without_lock();
+    unload_without_lock();
 }
 
-void PrimaryIndex::_unload_without_lock() {
+void PrimaryIndex::unload_without_lock() {
     if (!_loaded) {
         return;
     }

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -53,6 +53,7 @@ public:
     //
     // [thread-safe]
     void unload();
+    void unload_without_lock();
 
     // Whether index is normally loaded
     bool is_loaded();
@@ -202,8 +203,6 @@ private:
                                                 const std::vector<uint32_t>& replace_indexes, const Column& pks);
 
     void _calc_memory_usage();
-
-    void _unload_without_lock();
 
 protected:
     std::mutex _lock;

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -169,6 +169,8 @@ public:
     static const Slice* build_persistent_keys(const Column& pks, size_t key_size, uint32_t idx_begin, uint32_t idx_end,
                                               std::vector<Slice>* key_slices);
 
+    bool need_rebuild();
+
 protected:
     void _set_schema(const Schema& pk_schema);
 

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -169,7 +169,7 @@ public:
     static const Slice* build_persistent_keys(const Column& pks, size_t key_size, uint32_t idx_begin, uint32_t idx_end,
                                               std::vector<Slice>* key_slices);
 
-    bool need_rebuild();
+    bool need_rebuild() const;
 
 protected:
     void _set_schema(const Schema& pk_schema);
@@ -202,6 +202,8 @@ private:
                                                 const std::vector<uint32_t>& replace_indexes, const Column& pks);
 
     void _calc_memory_usage();
+
+    void _unload_without_lock();
 
 protected:
     std::mutex _lock;

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -467,6 +467,69 @@ TEST_F(TabletUpdatesTest, test_pk_index_write_amp_score) {
     config::l0_max_mem_usage = old_l0_max_mem_usage;
 }
 
+TEST_F(TabletUpdatesTest, test_pk_index_major_compaction_reload_fail) {
+    srand(GetCurrentTimeMicros());
+    _tablet = create_tablet(rand(), rand());
+    _tablet->set_enable_persistent_index(true);
+    // write
+    const int N = 8000;
+    std::vector<int64_t> keys;
+    std::vector<int64_t> keys2;
+    std::vector<int64_t> keys3;
+    std::vector<int64_t> keys4;
+    for (int i = 0; i < N; i++) {
+        keys.push_back(i);
+        keys2.push_back(i + N);
+        keys3.push_back(i + N * 2);
+        keys4.push_back(i + N * 3);
+    }
+    const int64_t old_l0_max_mem_usage = config::l0_max_mem_usage;
+    // make sure generate l1
+    config::l0_max_mem_usage = 10;
+    auto rs0 = create_rowset(_tablet, keys);
+    ASSERT_TRUE(_tablet->rowset_commit(2, rs0).ok());
+    // read
+    ASSERT_EQ(N, read_tablet(_tablet, 2));
+    // check score
+    ASSERT_TRUE(_tablet->updates()->get_pk_index_write_amp_score() == 0);
+    ASSERT_EQ(2, _tablet->updates()->max_version());
+    auto rs1 = create_rowset(_tablet, keys2);
+    ASSERT_TRUE(_tablet->rowset_commit(3, rs1).ok());
+    ASSERT_EQ(3, _tablet->updates()->max_version());
+    auto rs2 = create_rowset(_tablet, keys3);
+    ASSERT_TRUE(_tablet->rowset_commit(4, rs2).ok());
+    ASSERT_EQ(4, _tablet->updates()->max_version());
+    auto rs3 = create_rowset(_tablet, keys4);
+    ASSERT_TRUE(_tablet->rowset_commit(5, rs3).ok());
+    ASSERT_EQ(5, _tablet->updates()->max_version());
+    // read
+    ASSERT_EQ(N * 4, read_tablet(_tablet, 5));
+    // check score
+    ASSERT_TRUE(_tablet->updates()->get_pk_index_write_amp_score() > 0);
+
+    // inject reload failure after major compaction writes new meta
+    PFailPointTriggerMode trigger_mode;
+    trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);
+    auto fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get(
+            "persistent_index_major_compaction_reload_fail");
+    fp->setMode(trigger_mode);
+
+    auto st = _tablet->updates()->pk_index_major_compaction();
+    ASSERT_FALSE(st.ok());
+
+    trigger_mode.set_mode(FailPointTriggerModeType::DISABLE);
+    fp->setMode(trigger_mode);
+    config::l0_max_mem_usage = old_l0_max_mem_usage;
+
+    // verify primary index is marked need_rebuild
+    auto manager = StorageEngine::instance()->update_manager();
+    auto index_entry = manager->index_cache().get(_tablet->tablet_id());
+    ASSERT_NE(index_entry, nullptr);
+    auto& index = index_entry->value();
+    ASSERT_TRUE(index.need_rebuild());
+    manager->index_cache().release(index_entry);
+}
+
 TEST_F(TabletUpdatesTest, writeread_with_sort_key) {
     srand(GetCurrentTimeMicros());
     _tablet = create_tablet_with_sort_key(rand(), rand(), {1});


### PR DESCRIPTION
## Why I'm doing:
1. Pk index do major compaction, load index success
2. new ingestion generate new snapshot file but corruption
3. major compaction finished, reload pk index but find corruption
4. major compaction return directly but not roll back the memory modify
4. new ingestion will get wrong pk index

## What I'm doing:
rebuild the pk index if compaction found corruption

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Mark persistent index as need_rebuild on major compaction reload failure and make (Lake)PrimaryIndex unload/reload accordingly; add UT with sync points.
> 
> - **Storage (PersistentIndex)**:
>   - On major compaction, if reloading new L2 metadata fails, set `_need_rebuild = true` and return the error instead of proceeding.
>   - Add `_need_rebuild` flag with getter/setter to signal rebuild requirement.
> - **Storage (PrimaryIndex / LakePrimaryIndex)**:
>   - Add `need_rebuild()` check in `load()`; if set, `unload_without_lock()` then reload to recover.
>   - Add `unload_without_lock()` helper.
> - **Tests**:
>   - Add `test_pk_index_major_compaction_reload_fail` using sync point `persistent_index_major_compaction_reload_fail` to inject reload failure and verify `need_rebuild()` is true.
> - **Misc**:
>   - Include `testutil/sync_point.h` where needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8131eb6759bc8e57f576205c176d9b9709d230f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->