### PR TITLE
[Enhancement] Remove TabletinvertedIndex lock to improve metadata performance

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SystemHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SystemHandler.java
@@ -80,7 +80,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -331,8 +330,8 @@ public class SystemHandler extends AlterHandler {
                 return false;
             }
 
-            Map<Long, Replica> replicas = invertedIndex.getReplicas(tabletId);
-            if (replicas == null) {
+            List<Replica> replicas = invertedIndex.getReplicasByTabletId(tabletId);
+            if (replicas.isEmpty()) {
                 continue;
             }
             // It means the replica can be migrated to retained backends.
@@ -342,7 +341,7 @@ public class SystemHandler extends AlterHandler {
 
             // Make sure there is at least one normal replica on retained backends.
             boolean hasNormalReplica = false;
-            for (Replica replica : replicas.values()) {
+            for (Replica replica : replicas) {
                 if (replica.getState() == ReplicaState.NORMAL && retainedBackendIds.contains(replica.getBackendId())) {
                     hasNormalReplica = true;
                     break;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -35,20 +35,15 @@
 package com.starrocks.catalog;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
-import com.starrocks.common.Config;
-import com.starrocks.common.util.concurrent.QueryableReentrantReadWriteLock;
+import com.starrocks.common.util.concurrent.ConcurrentLong2ObjectHashMap;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.memory.MemoryTrackable;
 import com.starrocks.memory.estimate.Estimator;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TStorageMedium;
-import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
-import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -56,8 +51,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.locks.ReentrantLock;
 
 /*
  * this class stores an inverted index
@@ -73,71 +69,36 @@ public class TabletInvertedIndex implements MemoryTrackable {
     public static final TabletMeta NOT_EXIST_TABLET_META = new TabletMeta(NOT_EXIST_VALUE, NOT_EXIST_VALUE,
             NOT_EXIST_VALUE, NOT_EXIST_VALUE, TStorageMedium.HDD);
 
-    private final QueryableReentrantReadWriteLock lock = new QueryableReentrantReadWriteLock();
-
     // tablet id -> tablet meta
-    private final Map<Long, TabletMeta> tabletMetaMap = new Long2ObjectOpenHashMap<>();
+    private final ConcurrentLong2ObjectHashMap<TabletMeta> tabletMetaMap = new ConcurrentLong2ObjectHashMap<>();
 
-    // replica id -> tablet id
-    private final Map<Long, Long> replicaToTabletMap = new Long2LongOpenHashMap();
+    // tablet id -> replicas
+    private final ConcurrentLong2ObjectHashMap<CopyOnWriteArrayList<Replica>> tabletToReplicaList =
+            new ConcurrentLong2ObjectHashMap<>();
+
+    // backend id -> tablet id list
+    private final ConcurrentLong2ObjectHashMap<Set<Long>> backendToTabletIdList =
+            new ConcurrentLong2ObjectHashMap<>();
 
     // tablet id -> backend set
-    private final Map<Long, Set<Long>> forceDeleteTablets = new Long2ObjectOpenHashMap<>();
+    private final ConcurrentLong2ObjectHashMap<Set<Long>> forceDeleteTablets = new ConcurrentLong2ObjectHashMap<>();
 
-    // tablet id -> (backend id -> replica)
-    private final Map<Long, Map<Long, Replica>> replicaMetaTable = new Long2ObjectOpenHashMap<>();
-    // backing replica table, for visiting backend replicas faster.
-    // backend id -> (tablet id -> replica)
-    private final Map<Long, Map<Long, Replica>> backingReplicaMetaTable = new Long2ObjectOpenHashMap<>();
+    // Protects multi-map mutations; readers rely on higher level synchronization.
+    private final ReentrantLock mutationLock = new ReentrantLock();
 
     public TabletInvertedIndex() {
     }
 
-    public void readLock() {
-        lock.sharedLockDetectingSlowLock(Config.slow_lock_threshold_ms, TimeUnit.MILLISECONDS);
-    }
-
-    public void readUnlock() {
-        lock.sharedUnlock();
-    }
-
-    private void writeLock() {
-        lock.exclusiveLockDetectingSlowLock(Config.slow_lock_threshold_ms, TimeUnit.MILLISECONDS);
-    }
-
-    private void writeUnlock() {
-        lock.exclusiveUnlock();
-    }
-
-    public Long getTabletIdByReplica(long replicaId) {
-        readLock();
-        try {
-            return replicaToTabletMap.get(replicaId);
-        } finally {
-            readUnlock();
-        }
-    }
-
     public TabletMeta getTabletMeta(long tabletId) {
-        readLock();
-        try {
-            return tabletMetaMap.get(tabletId);
-        } finally {
-            readUnlock();
-        }
+        return tabletMetaMap.get(tabletId);
     }
 
     public List<TabletMeta> getTabletMetaList(List<Long> tabletIdList) {
         List<TabletMeta> tabletMetaList = new ArrayList<>(tabletIdList.size());
-        readLock();
-        try {
-            for (Long tabletId : tabletIdList) {
-                tabletMetaList.add(tabletMetaMap.getOrDefault(tabletId, NOT_EXIST_TABLET_META));
-            }
-            return tabletMetaList;
-        } finally {
-            readUnlock();
+        for (Long tabletId : tabletIdList) {
+            tabletMetaList.add(tabletMetaMap.getOrDefault(tabletId, NOT_EXIST_TABLET_META));
         }
+        return tabletMetaList;
     }
 
     // always add tablet before adding replicas
@@ -145,60 +106,39 @@ public class TabletInvertedIndex implements MemoryTrackable {
         if (GlobalStateMgr.isCheckpointThread()) {
             return;
         }
-        writeLock();
+        mutationLock.lock();
         try {
             tabletMetaMap.putIfAbsent(tabletId, tabletMeta);
             LOG.debug("add tablet: {} tabletMeta: {}", tabletId, tabletMeta);
         } finally {
-            writeUnlock();
+            mutationLock.unlock();
         }
     }
 
     @VisibleForTesting
-    public Map<Long, Set<Long>> getForceDeleteTablets() {
-        readLock();
-        try {
-            return forceDeleteTablets;
-        } finally {
-            readUnlock();
-        }
+    public ConcurrentLong2ObjectHashMap<Set<Long>> getForceDeleteTablets() {
+        return forceDeleteTablets;
     }
 
     public boolean tabletForceDelete(long tabletId, long backendId) {
-        readLock();
-        try {
-            if (forceDeleteTablets.containsKey(tabletId)) {
-                return forceDeleteTablets.get(tabletId).contains(backendId);
-            }
+        Set<Long> backendSets = forceDeleteTablets.get(tabletId);
+        if (backendSets != null) {
+            return backendSets.contains(backendId);
+        } else {
             return false;
-        } finally {
-            readUnlock();
         }
     }
 
     public void markTabletForceDelete(long tabletId, long backendId) {
-        writeLock();
-        try {
-            if (forceDeleteTablets.containsKey(tabletId)) {
-                forceDeleteTablets.get(tabletId).add(backendId);
-            } else {
-                forceDeleteTablets.put(tabletId, Sets.newHashSet(backendId));
-            }
-        } finally {
-            writeUnlock();
-        }
+        forceDeleteTablets.computeIfAbsent(tabletId, k -> ConcurrentHashMap.newKeySet()).add(backendId);
     }
 
     public void markTabletForceDelete(long tabletId, Set<Long> backendIds) {
         if (backendIds.isEmpty()) {
             return;
         }
-        writeLock();
-        try {
-            forceDeleteTablets.put(tabletId, backendIds);
-        } finally {
-            writeUnlock();
-        }
+
+        forceDeleteTablets.computeIfAbsent(tabletId, k -> ConcurrentHashMap.newKeySet()).addAll(backendIds);
     }
 
     public void markTabletForceDelete(Tablet tablet) {
@@ -210,62 +150,57 @@ public class TabletInvertedIndex implements MemoryTrackable {
     }
 
     public void eraseTabletForceDelete(long tabletId, long backendId) {
-        writeLock();
-        try {
-            if (forceDeleteTablets.containsKey(tabletId)) {
-                forceDeleteTablets.get(tabletId).remove(backendId);
-                if (forceDeleteTablets.get(tabletId).isEmpty()) {
-                    forceDeleteTablets.remove(tabletId);
-                }
-            }
-        } finally {
-            writeUnlock();
-        }
+        forceDeleteTablets.computeIfPresent(tabletId, (id, backendSets) -> {
+            backendSets.remove(backendId);
+            return backendSets.isEmpty() ? null : backendSets;
+        });
     }
 
     public void deleteTablet(long tabletId) {
         if (GlobalStateMgr.isCheckpointThread()) {
             return;
         }
-        writeLock();
+        mutationLock.lock();
         try {
-            Map<Long, Replica> replicas = replicaMetaTable.remove(tabletId);
+            CopyOnWriteArrayList<Replica> replicas = tabletToReplicaList.remove(tabletId);
             if (replicas != null) {
-                for (Replica replica : replicas.values()) {
-                    replicaToTabletMap.remove(replica.getId());
-                }
-
-                for (long backendId : replicas.keySet()) {
-                    removeReplica(backingReplicaMetaTable, backendId, tabletId);
+                for (Replica replica : replicas) {
+                    Set<Long> tabletIds = backendToTabletIdList.get(replica.getBackendId());
+                    if (tabletIds != null) {
+                        tabletIds.remove(tabletId);
+                    }
                 }
             }
             tabletMetaMap.remove(tabletId);
 
             LOG.debug("delete tablet: {}", tabletId);
         } finally {
-            writeUnlock();
+            mutationLock.unlock();
         }
     }
 
     // Only for test
-    public Map<Long, Map<Long, Replica>> getReplicaMetaTable() {
-        return replicaMetaTable;
+    public ConcurrentLong2ObjectHashMap<CopyOnWriteArrayList<Replica>> getReplicaMetaTable() {
+        return tabletToReplicaList;
     }
 
     public void addReplica(long tabletId, Replica replica) {
         if (GlobalStateMgr.isCheckpointThread()) {
             return;
         }
-        writeLock();
+        mutationLock.lock();
         try {
-            Preconditions.checkState(tabletMetaMap.containsKey(tabletId));
-            setReplica(replicaMetaTable, tabletId, replica.getBackendId(), replica);
-            replicaToTabletMap.put(replica.getId(), tabletId);
-            setReplica(backingReplicaMetaTable, replica.getBackendId(), tabletId, replica);
-            LOG.debug("add replica {} of tablet {} in backend {}",
-                    replica.getId(), tabletId, replica.getBackendId());
+            CopyOnWriteArrayList<Replica> replicas = tabletToReplicaList.computeIfAbsent(tabletId,
+                    k -> new CopyOnWriteArrayList<>());
+            replicas.add(replica);
+
+            Set<Long> tabletIds = backendToTabletIdList.computeIfAbsent(replica.getBackendId(),
+                    k -> ConcurrentHashMap.newKeySet());
+            tabletIds.add(tabletId);
+
+            LOG.debug("add replica {} of tablet {} in backend {}", replica.getId(), tabletId, replica.getBackendId());
         } finally {
-            writeUnlock();
+            mutationLock.unlock();
         }
     }
 
@@ -273,142 +208,129 @@ public class TabletInvertedIndex implements MemoryTrackable {
         if (GlobalStateMgr.isCheckpointThread()) {
             return;
         }
-        writeLock();
+        mutationLock.lock();
         try {
-            if (!tabletMetaMap.containsKey(tabletId)) {
+            if (tabletMetaMap.get(tabletId) == null) {
                 return;
             }
-            if (replicaMetaTable.containsKey(tabletId)) {
-                Replica replica = removeReplica(replicaMetaTable, tabletId, backendId);
-                Preconditions.checkState(replica != null);
-                replicaToTabletMap.remove(replica.getId());
-                removeReplica(backingReplicaMetaTable, backendId, tabletId);
-                LOG.debug("delete replica {} of tablet {} in backend {}",
-                        replica.getId(), tabletId, backendId);
-            } else {
-                // this may happen when fe restart after tablet is empty(bug cause)
-                // add log instead of assertion to observe
-                LOG.error("tablet[{}] contains no replica in inverted index", tabletId);
+            CopyOnWriteArrayList<Replica> replicaList = tabletToReplicaList.get(tabletId);
+            if (replicaList != null) {
+                replicaList.removeIf(replica -> replica.getBackendId() == backendId);
             }
+
+            Set<Long> tabletIds = backendToTabletIdList.get(backendId);
+            if (tabletIds != null) {
+                tabletIds.remove(tabletId);
+            }
+
+            LOG.debug("remove tablet {} in backend {}", tabletId, backendId);
         } finally {
-            writeUnlock();
+            mutationLock.unlock();
         }
     }
 
     public Replica getReplica(long tabletId, long backendId) {
-        readLock();
-        try {
-            return getReplica(replicaMetaTable, tabletId, backendId);
-        } finally {
-            readUnlock();
+        CopyOnWriteArrayList<Replica> replicas = tabletToReplicaList.get(tabletId);
+        if (replicas == null) {
+            return null;
         }
+        for (Replica replica : replicas) {
+            if (replica.getBackendId() == backendId) {
+                return replica;
+            }
+        }
+        return null;
     }
 
     public List<Replica> getReplicasByTabletId(long tabletId) {
-        readLock();
-        try {
-            if (replicaMetaTable.containsKey(tabletId)) {
-                return Lists.newArrayList(replicaMetaTable.get(tabletId).values());
-            }
+        CopyOnWriteArrayList<Replica> replicas = tabletToReplicaList.get(tabletId);
+        if (replicas == null) {
             return Lists.newArrayList();
-        } finally {
-            readUnlock();
         }
+        return Lists.newArrayList(replicas);
     }
 
     /**
-     * For each tabletId in the tablet_id list, get the replica on specified backend or null, return as a list.
+     * Returns replicas that belong to the specified backend among the given tablet ids. Any tablet that does not
+     * have a replica on the backend is ignored. Callers treat {@code null} as "no replica found on this backend".
      *
-     * @param tabletIds tablet_id list
-     * @param backendId backendid
-     * @return list of replica or null if backend not found
+     * @param tabletIds tablet id list to probe
+     * @param backendId backend id whose replicas are required
+     * @return replicas located on {@code backendId}, or {@code null} if the backend does not host any of them
      */
     public List<Replica> getReplicasOnBackendByTabletIds(List<Long> tabletIds, long backendId) {
-        readLock();
-        try {
-            Map<Long, Replica> replicaMetaWithBackend = row(backingReplicaMetaTable, backendId);
-            if (!replicaMetaWithBackend.isEmpty()) {
-                List<Replica> replicas = Lists.newArrayList();
-                for (long tabletId : tabletIds) {
-                    replicas.add(replicaMetaWithBackend.get(tabletId));
-                }
-                return replicas;
+        List<Replica> replicas = Lists.newArrayListWithCapacity(tabletIds.size());
+        for (Long tabletId : tabletIds) {
+            Replica replica = getReplica(tabletId, backendId);
+            if (replica != null) {
+                replicas.add(replica);
             }
-            return null;
-        } finally {
-            readUnlock();
         }
+        if (replicas.isEmpty()) {
+            return null;
+        }
+        return replicas;
     }
 
     public List<Long> getTabletIdsByBackendId(long backendId) {
-        List<Long> tabletIds = Lists.newArrayList();
-        readLock();
-        try {
-            Map<Long, Replica> replicaMetaWithBackend = row(backingReplicaMetaTable, backendId);
-            tabletIds.addAll(replicaMetaWithBackend.keySet());
-        } finally {
-            readUnlock();
+        Set<Long> tabletIds = backendToTabletIdList.get(backendId);
+        if (tabletIds == null) {
+            return Lists.newArrayList();
         }
-        return tabletIds;
+        return Lists.newArrayList(tabletIds);
     }
 
     public List<Long> getTabletIdsByBackendIdAndStorageMedium(long backendId, TStorageMedium storageMedium) {
-        readLock();
-        try {
-            Map<Long, Replica> replicaMetaWithBackend = row(backingReplicaMetaTable, backendId);
-            return replicaMetaWithBackend.keySet().stream()
-                    .filter(id -> tabletMetaMap.get(id).getStorageMedium() == storageMedium)
-                    .collect(Collectors.toList());
-        } finally {
-            readUnlock();
+        List<Long> result = Lists.newArrayList();
+
+        Set<Long> tabletIds = backendToTabletIdList.get(backendId);
+        if (tabletIds == null) {
+            return result;
         }
+        for (Long tabletId : tabletIds) {
+            TabletMeta tabletMeta = tabletMetaMap.get(tabletId);
+            if (tabletMeta == null) {
+                continue;
+            }
+            if (tabletMeta.getStorageMedium() == storageMedium) {
+                result.add(tabletId);
+            }
+        }
+        return result;
     }
 
     public long getTabletNumByBackendId(long backendId) {
-        readLock();
-        try {
-            return row(backingReplicaMetaTable, backendId).size();
-        } finally {
-            readUnlock();
-        }
-    }
-
-    /**
-     * Get the number of tablets on the specified backend and pathHash
-     * @param backendId the ID of the backend
-     * @param pathHash the hash of the path
-     * @return the number of tablets as a long value
-     *
-     * @implNote Linear scan, invoke this interface with caution if the number of replicas is large
-     */
-    public long getTabletNumByBackendIdAndPathHash(long backendId, long pathHash) {
-        readLock();
-        try {
-            Map<Long, Replica> replicaMetaWithBackend = row(backingReplicaMetaTable, backendId);
-            return replicaMetaWithBackend.values().stream().filter(r -> r.getPathHash() == pathHash).count();
-        } finally {
-            readUnlock();
-        }
+        Set<Long> tabletIds = backendToTabletIdList.get(backendId);
+        return tabletIds == null ? 0 : tabletIds.size();
     }
 
     /**
      * Get the number of tablets on the specified backend, grouped by pathHash
+     *
      * @param backendId the ID of the backend
      * @return Map<pathHash, tabletNum> the number of tablets grouped by pathHash
-     *
      * @implNote Linear scan, invoke this interface with caution if the number of replicas is large
      */
     public Map<Long, Long> getTabletNumByBackendIdGroupByPathHash(long backendId) {
         Map<Long, Long> pathHashToTabletNum = Maps.newHashMap();
-        readLock();
-        try {
-            Map<Long, Replica> replicaMetaWithBackend = row(backingReplicaMetaTable, backendId);
-            for (Replica r : replicaMetaWithBackend.values()) {
-                pathHashToTabletNum.compute(r.getPathHash(), (k, v) -> v == null ? 1L : v + 1);
-            }
-        } finally {
-            readUnlock();
+
+        Set<Long> tabletIds = backendToTabletIdList.get(backendId);
+        if (tabletIds == null) {
+            return pathHashToTabletNum;
         }
+        for (Long tabletId : tabletIds) {
+            CopyOnWriteArrayList<Replica> replicas = tabletToReplicaList.get(tabletId);
+            if (replicas == null) {
+                continue;
+            }
+            for (Replica r : replicas) {
+                if (r.getBackendId() == backendId) {
+                    pathHashToTabletNum.compute(r.getPathHash(), (k, v) -> v == null ? 1L : v + 1);
+                    break;
+                }
+            }
+        }
+
         return pathHashToTabletNum;
     }
 
@@ -416,18 +338,22 @@ public class TabletInvertedIndex implements MemoryTrackable {
         Map<TStorageMedium, Long> replicaNumMap = Maps.newHashMap();
         long hddNum = 0;
         long ssdNum = 0;
-        readLock();
-        try {
-            Map<Long, Replica> replicaMetaWithBackend = row(backingReplicaMetaTable, backendId);
-            for (long tabletId : replicaMetaWithBackend.keySet()) {
-                if (tabletMetaMap.get(tabletId).getStorageMedium() == TStorageMedium.HDD) {
-                    hddNum++;
-                } else {
-                    ssdNum++;
-                }
+        Set<Long> tabletIds = backendToTabletIdList.get(backendId);
+        if (tabletIds == null) {
+            replicaNumMap.put(TStorageMedium.HDD, hddNum);
+            replicaNumMap.put(TStorageMedium.SSD, ssdNum);
+            return replicaNumMap;
+        }
+        for (Long tabletId : tabletIds) {
+            TabletMeta tabletMeta = tabletMetaMap.get(tabletId);
+            if (tabletMeta == null) {
+                continue;
             }
-        } finally {
-            readUnlock();
+            if (tabletMeta.getStorageMedium() == TStorageMedium.HDD) {
+                hddNum++;
+            } else {
+                ssdNum++;
+            }
         }
         replicaNumMap.put(TStorageMedium.HDD, hddNum);
         replicaNumMap.put(TStorageMedium.SSD, ssdNum);
@@ -435,104 +361,42 @@ public class TabletInvertedIndex implements MemoryTrackable {
     }
 
     public long getTabletCount() {
-        readLock();
-        try {
-            return this.tabletMetaMap.size();
-        } finally {
-            readUnlock();
-        }
+        return this.tabletMetaMap.size();
     }
 
     public long getReplicaCount() {
-        readLock();
-        try {
-            return this.replicaToTabletMap.size();
-        } finally {
-            readUnlock();
+        long replicaCount = 0;
+        for (CopyOnWriteArrayList<Replica> replicas : tabletToReplicaList.values()) {
+            replicaCount += replicas.size();
         }
-    }
-
-    public Map<Long, Replica> getReplicas(long tabletId) {
-        readLock();
-        try {
-            return this.replicaMetaTable.get(tabletId);
-        } finally {
-            readUnlock();
-        }
-    }
-
-    // The caller should hold readLock.
-    public Map<Long, Replica> getReplicaMetaWithBackend(Long backendId) {
-        return row(backingReplicaMetaTable, backendId);
+        return replicaCount;
     }
 
     // just for test
     public void clear() {
-        writeLock();
+        mutationLock.lock();
         try {
             tabletMetaMap.clear();
-            replicaToTabletMap.clear();
-            replicaMetaTable.clear();
-            backingReplicaMetaTable.clear();
+            tabletToReplicaList.clear();
+            backendToTabletIdList.clear();
+            forceDeleteTablets.clear();
         } finally {
-            writeUnlock();
+            mutationLock.unlock();
         }
     }
 
     @Override
     public Map<String, Long> estimateCount() {
         return ImmutableMap.of("TabletMeta", getTabletCount(),
-                               "TabletCount", getTabletCount(),
-                               "ReplicateCount", getReplicaCount());
+                "TabletCount", getTabletCount(),
+                "ReplicateCount", getReplicaCount());
     }
 
     @Override
     public long estimateSize() {
-        readLock();
-        try {
-            return Estimator.estimate(tabletMetaMap) +
-                   Estimator.estimate(replicaToTabletMap) +
-                   Estimator.estimate(replicaMetaTable) +
-                   Estimator.estimate(backingReplicaMetaTable);
-        } finally {
-            readUnlock();
-        }
-    }
-
-    private static Replica getReplica(Map<Long, Map<Long, Replica>> table, long rowKey, long columnKey) {
-        if (table.containsKey(rowKey)) {
-            return table.get(rowKey).get(columnKey);
-        }
-        return null;
-    }
-
-    private static void setReplica(Map<Long, Map<Long, Replica>> table, long rowKey, long columnKey, Replica replica) {
-        if (table.containsKey(rowKey)) {
-            table.get(rowKey).put(columnKey, replica);
-        } else {
-            Map<Long, Replica> column = new Long2ObjectOpenHashMap<>();
-            column.put(columnKey, replica);
-            table.put(rowKey, column);
-        }
-    }
-
-    private static Replica removeReplica(Map<Long, Map<Long, Replica>> table, long rowKey, long columnKey) {
-        if (table.containsKey(rowKey)) {
-            Map<Long, Replica> row = table.get(rowKey);
-            Replica replica = row.remove(columnKey);
-            if (row.isEmpty()) {
-                table.remove(rowKey);
-            }
-            return replica;
-        }
-        return null;
-    }
-
-    private static Map<Long, Replica> row(Map<Long, Map<Long, Replica>> table, long rowKey) {
-        Map<Long, Replica> row = table.get(rowKey);
-        if (row == null) {
-            row = new Long2ObjectOpenHashMap<>();
-        }
-        return row;
+        return Estimator.estimate(tabletMetaMap) +
+                Estimator.estimate(tabletToReplicaList) +
+                Estimator.estimate(backendToTabletIdList) +
+                Estimator.estimate(forceDeleteTablets);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -1907,6 +1907,12 @@ public class TabletScheduler extends FrontendDaemon {
         // write edit log
         replica.setState(ReplicaState.NORMAL);
         TabletMeta meta = GlobalStateMgr.getCurrentState().getTabletInvertedIndex().getTabletMeta(tabletId);
+        if (meta == null) {
+            LOG.warn("skip finishing create replica task because tablet meta not found, tablet:{} backend:{}",
+                    tabletId, task.getBackendId());
+            finalizeTabletCtx(tabletCtx, TabletSchedCtx.State.CANCELLED, "tablet meta missing");
+            return;
+        }
         ReplicaPersistInfo info = ReplicaPersistInfo.createForAdd(meta.getDbId(),
                 meta.getTableId(), meta.getPhysicalPartitionId(), meta.getIndexId(),
                 tabletId, replica.getBackendId(), replica.getId(), replica.getVersion(),

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/ConcurrentLong2ObjectHashMap.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/ConcurrentLong2ObjectHashMap.java
@@ -1,0 +1,432 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.util.concurrent;
+
+import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * A segmented, thread-safe map that stores long keys, backed by {@link Long2ObjectOpenHashMap} to avoid auto-boxing overhead.
+ * <p>
+ * <b>Concurrency Model:</b>
+ * This implementation uses a two-level locking strategy:
+ * <ol>
+ *     <li><b>Global Table Lock:</b> A {@link ReentrantReadWriteLock} guards the {@code segments} array structure.
+ *         Most operations acquire the <i>read lock</i>. Resizing acquires the <i>write lock</i>,
+ *         which blocks all other operations (Stop-The-World).</li>
+ *     <li><b>Segment Lock:</b> Each segment is guarded by its own {@link ReentrantReadWriteLock}.
+ *         Operations within a segment acquire the appropriate lock (read or write),
+ *         allowing concurrent access to different segments.</li>
+ * </ol>
+ * <p>
+ * <b>Performance Characteristics:</b>
+ * <ul>
+ *     <li><b>Reads:</b> Highly concurrent. Readers only block writers to the same segment (and global resizing).</li>
+ *     <li><b>Writes:</b> Concurrent for different segments.</li>
+ *     <li><b>Resizing:</b> Expensive and blocking. It is recommended to initialize with an appropriate
+ *     {@code segmentCount} and {@code expectedSegmentSize}
+ *         to minimize resizing if the data size is known or predictable.</li>
+ * </ul>
+ * <p>
+ * <b>Limitations & Constraints:</b>
+ * <ul>
+ *     <li><b>Null Values:</b> Null values are <b>not allowed</b> (to ensure accurate size tracking
+ *     and {@code get} semantics).</li>
+ *     <li><b>Map Views:</b> {@link #keySet()} and {@link #values()} return <b>snapshots</b> (copies)
+ *     of the data at the time of call.
+ *         They are weakly consistent and do not reflect subsequent changes.</li>
+ * </ul>
+ *
+ * @param <V> value type stored in the map
+ */
+public class ConcurrentLong2ObjectHashMap<V> {
+    private static final int DEFAULT_SEGMENT_COUNT = 16;
+    private static final int DEFAULT_SEGMENT_INIT_CAPACITY = 4;
+    private static final float DEFAULT_MAX_LOAD_FACTOR = 4.0f;
+
+    private final ReentrantReadWriteLock tableLock = new ReentrantReadWriteLock();
+    private final LongAdder size = new LongAdder();
+    private final int expectedSegmentSize;
+    private final float maxLoadFactor;
+    private final int initialSegmentCount;
+
+    private volatile Segment<V>[] segments;
+    private volatile int segmentMask;
+    private volatile long resizeThreshold;
+
+    public ConcurrentLong2ObjectHashMap() {
+        this(DEFAULT_SEGMENT_COUNT, DEFAULT_SEGMENT_INIT_CAPACITY, DEFAULT_MAX_LOAD_FACTOR);
+    }
+
+    public ConcurrentLong2ObjectHashMap(int segmentCount, int expectedSegmentSize, float maxLoadFactor) {
+        Preconditions.checkArgument(segmentCount > 0, "segment count must be positive");
+        Preconditions.checkArgument(expectedSegmentSize >= 0, "expected segment size must be non-negative");
+        Preconditions.checkArgument(maxLoadFactor > 0, "maxLoadFactor must be positive");
+        this.expectedSegmentSize = expectedSegmentSize;
+        this.maxLoadFactor = maxLoadFactor;
+        int actualSegmentCount = ceilingNextPowerOfTwo(segmentCount);
+        this.initialSegmentCount = actualSegmentCount;
+        initializeSegments(actualSegmentCount);
+    }
+
+    public V get(long key) {
+        tableLock.readLock().lock();
+        try {
+            Segment<V> segment = segmentFor(key);
+            Lock readLock = segment.lock.readLock();
+            readLock.lock();
+            try {
+                return segment.map.get(key);
+            } finally {
+                readLock.unlock();
+            }
+        } finally {
+            tableLock.readLock().unlock();
+        }
+    }
+
+    public V getOrDefault(long key, V defaultValue) {
+        V value = get(key);
+        return value != null ? value : defaultValue;
+    }
+
+    public boolean containsKey(long key) {
+        tableLock.readLock().lock();
+        try {
+            Segment<V> segment = segmentFor(key);
+            Lock readLock = segment.lock.readLock();
+            readLock.lock();
+            try {
+                return segment.map.containsKey(key);
+            } finally {
+                readLock.unlock();
+            }
+        } finally {
+            tableLock.readLock().unlock();
+        }
+    }
+
+    public V put(long key, V value) {
+        Preconditions.checkNotNull(value);
+        boolean inserted = false;
+        V previous;
+        tableLock.readLock().lock();
+        try {
+            Segment<V> segment = segmentFor(key);
+            Lock writeLock = segment.lock.writeLock();
+            writeLock.lock();
+            try {
+                previous = segment.map.put(key, value);
+                if (previous == null) {
+                    inserted = true;
+                    size.increment();
+                }
+            } finally {
+                writeLock.unlock();
+            }
+        } finally {
+            tableLock.readLock().unlock();
+        }
+        if (inserted) {
+            maybeResize();
+        }
+        return previous;
+    }
+
+    public V putIfAbsent(long key, V value) {
+        Preconditions.checkNotNull(value);
+        boolean inserted = false;
+        V existing;
+        tableLock.readLock().lock();
+        try {
+            Segment<V> segment = segmentFor(key);
+            Lock writeLock = segment.lock.writeLock();
+            writeLock.lock();
+            try {
+                existing = segment.map.get(key);
+                if (existing == null) {
+                    segment.map.put(key, value);
+                    inserted = true;
+                    size.increment();
+                }
+            } finally {
+                writeLock.unlock();
+            }
+        } finally {
+            tableLock.readLock().unlock();
+        }
+        if (inserted) {
+            maybeResize();
+        }
+        return existing;
+    }
+
+    public V computeIfAbsent(long key, Function<? super Long, ? extends V> mappingFunction) {
+        Preconditions.checkNotNull(mappingFunction, "mappingFunction is null");
+        boolean inserted = false;
+        V value;
+        tableLock.readLock().lock();
+        try {
+            Segment<V> segment = segmentFor(key);
+            Lock writeLock = segment.lock.writeLock();
+            writeLock.lock();
+            try {
+                value = segment.map.get(key);
+                if (value == null) {
+                    value = mappingFunction.apply(key);
+                    if (value != null) {
+                        segment.map.put(key, value);
+                        inserted = true;
+                        size.increment();
+                    }
+                }
+            } finally {
+                writeLock.unlock();
+            }
+        } finally {
+            tableLock.readLock().unlock();
+        }
+        if (inserted) {
+            maybeResize();
+        }
+        return value;
+    }
+
+    public V computeIfPresent(long key, BiFunction<? super Long, ? super V, ? extends V> remappingFunction) {
+        Preconditions.checkNotNull(remappingFunction, "remappingFunction is null");
+        V newValue = null;
+        boolean removed = false;
+        tableLock.readLock().lock();
+        try {
+            Segment<V> segment = segmentFor(key);
+            Lock writeLock = segment.lock.writeLock();
+            writeLock.lock();
+            try {
+                V oldValue = segment.map.get(key);
+                if (oldValue != null) {
+                    newValue = remappingFunction.apply(key, oldValue);
+                    if (newValue != null) {
+                        segment.map.put(key, newValue);
+                    } else {
+                        segment.map.remove(key);
+                        size.decrement();
+                        removed = true;
+                    }
+                }
+            } finally {
+                writeLock.unlock();
+            }
+        } finally {
+            tableLock.readLock().unlock();
+        }
+        return removed ? null : newValue;
+    }
+
+    public V remove(long key) {
+        V removed;
+        tableLock.readLock().lock();
+        try {
+            Segment<V> segment = segmentFor(key);
+            Lock writeLock = segment.lock.writeLock();
+            writeLock.lock();
+            try {
+                removed = segment.map.remove(key);
+                if (removed != null) {
+                    size.decrement();
+                }
+            } finally {
+                writeLock.unlock();
+            }
+        } finally {
+            tableLock.readLock().unlock();
+        }
+        return removed;
+    }
+
+    public void clear() {
+        tableLock.writeLock().lock();
+        try {
+            initializeSegments(initialSegmentCount);
+            size.reset();
+        } finally {
+            tableLock.writeLock().unlock();
+        }
+    }
+
+    public int size() {
+        return (int) Math.min(Integer.MAX_VALUE, size.sum());
+    }
+
+    public boolean isEmpty() {
+        return size.sum() == 0;
+    }
+
+    public Set<Long> keySet() {
+        tableLock.readLock().lock();
+        try {
+            int expectedSize = (int) Math.min(Integer.MAX_VALUE, size.sum());
+            Set<Long> snapshot = new HashSet<>(expectedSize);
+            for (Segment<V> segment : segments) {
+                Lock readLock = segment.lock.readLock();
+                readLock.lock();
+                try {
+                    snapshot.addAll(segment.map.keySet());
+                } finally {
+                    readLock.unlock();
+                }
+            }
+            return snapshot;
+        } finally {
+            tableLock.readLock().unlock();
+        }
+    }
+
+    /**
+     * Returns a snapshot of values stored in the map. The returned collection is not backed by the map.
+     */
+    public Collection<V> values() {
+        tableLock.readLock().lock();
+        try {
+            int expectedSize = (int) Math.min(Integer.MAX_VALUE, size.sum());
+            List<V> snapshot = new ArrayList<>(expectedSize);
+            for (Segment<V> segment : segments) {
+                Lock readLock = segment.lock.readLock();
+                readLock.lock();
+                try {
+                    snapshot.addAll(segment.map.values());
+                } finally {
+                    readLock.unlock();
+                }
+            }
+            return snapshot;
+        } finally {
+            tableLock.readLock().unlock();
+        }
+    }
+
+    private Segment<V> segmentFor(long key) {
+        return segments[spread(Long.hashCode(key)) & segmentMask];
+    }
+
+    private void maybeResize() {
+        if (size.sum() <= resizeThreshold) {
+            return;
+        }
+        tableLock.writeLock().lock();
+        try {
+            if (size.sum() <= resizeThreshold) {
+                return;
+            }
+            resizeInternal();
+        } finally {
+            tableLock.writeLock().unlock();
+        }
+    }
+
+    private void resizeInternal() {
+        Segment<V>[] oldSegments = this.segments;
+        int newSegmentCount = oldSegments.length << 1;
+        if (newSegmentCount <= 0) {
+            return;
+        }
+
+        // Calculate optimized initial capacity for new segments to avoid internal rehashing
+        long totalSize = size.sum();
+        // We use a load factor of 0.75f which is the default for fastutil maps
+        int expectedItemsPerSegment = (int) (totalSize / newSegmentCount);
+        int initialCapacity = Math.max(expectedSegmentSize, (int) (expectedItemsPerSegment / 0.75f) + 1);
+
+        Segment<V>[] newSegments = createSegments(newSegmentCount, initialCapacity);
+        int newMask = newSegmentCount - 1;
+
+        for (Segment<V> oldSegment : oldSegments) {
+            Lock readLock = oldSegment.lock.readLock();
+            readLock.lock();
+            try {
+                for (Long2ObjectMap.Entry<V> entry : oldSegment.map.long2ObjectEntrySet()) {
+                    Segment<V> target = newSegments[spread(Long.hashCode(entry.getLongKey())) & newMask];
+                    target.map.put(entry.getLongKey(), entry.getValue());
+                }
+            } finally {
+                readLock.unlock();
+            }
+        }
+
+        this.segments = newSegments;
+        this.segmentMask = newMask;
+        this.resizeThreshold = calculateResizeThreshold(newSegmentCount);
+    }
+
+    private void initializeSegments(int segmentCount) {
+        this.segments = createSegments(segmentCount, expectedSegmentSize);
+        this.segmentMask = segmentCount - 1;
+        this.resizeThreshold = calculateResizeThreshold(segmentCount);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Segment<V>[] createSegments(int count, int segmentCapacity) {
+        Segment<V>[] newSegments = (Segment<V>[]) new Segment[count];
+        for (int i = 0; i < count; i++) {
+            newSegments[i] = new Segment<>(segmentCapacity);
+        }
+        return newSegments;
+    }
+
+    private long calculateResizeThreshold(int segmentCount) {
+        return Math.max(1L, (long) (segmentCount * maxLoadFactor));
+    }
+
+    private static int spread(int hash) {
+        // Spreads (XORs) higher bits of hash to lower bits.
+        // This reduces hash collisions when the table size is small, as the index calculation
+        // (hash & (n - 1)) only uses the lower bits. By mixing high bits into low bits,
+        // we ensure that differences in high bits also affect the index.
+        hash ^= (hash >>> 16);
+        return hash;
+    }
+
+    private static int ceilingNextPowerOfTwo(int value) {
+        if (value >= (1 << 30)) {
+            return 1 << 30;
+        }
+        int highestOneBit = Integer.highestOneBit(value - 1);
+        return Math.max(1, highestOneBit << 1);
+    }
+
+    private static final class Segment<V> {
+        private final Long2ObjectOpenHashMap<V> map;
+        private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+        private Segment(int expectedSize) {
+            if (expectedSize > 0) {
+                this.map = new Long2ObjectOpenHashMap<>(expectedSize);
+            } else {
+                this.map = new Long2ObjectOpenHashMap<>();
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -585,163 +585,165 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
         }
 
         TabletInvertedIndex tabletInvertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
-        tabletInvertedIndex.readLock();
         long start = System.currentTimeMillis();
-        try {
-            LOG.debug("begin to do tablet diff with backend[{}]. num: {}", backendId, backendTablets.size());
-            // backingReplicaMetaTable.row(backendId) won't return null
-            Map<Long, Replica> replicaMetaWithBackend = tabletInvertedIndex.getReplicaMetaWithBackend(backendId);
-            // traverse replicas in meta with this backend
-            for (Map.Entry<Long, Replica> entry : replicaMetaWithBackend.entrySet()) {
-                long tabletId = entry.getKey();
-                TabletMeta tabletMeta = tabletInvertedIndex.getTabletMeta(tabletId);
-                Preconditions.checkState(tabletMeta != null);
+        LOG.debug("begin to do tablet diff with backend[{}]. num: {}", backendId, backendTablets.size());
+        List<Long> tabletsId = tabletInvertedIndex.getTabletIdsByBackendId(backendId);
 
-                if (tabletMeta.isLakeTablet()) {
+        // traverse replicas in meta with this backend
+        for (Long tabletId : tabletsId) {
+            TabletMeta tabletMeta = tabletInvertedIndex.getTabletMeta(tabletId);
+            if (tabletMeta == null) {
+                LOG.info("tablet {} no longer exists when diff backend {}, skip it", tabletId, backendId);
+                continue;
+            }
+
+            if (tabletMeta.isLakeTablet()) {
+                continue;
+            }
+
+            if (backendTablets.containsKey(tabletId)) {
+                TTablet backendTablet = backendTablets.get(tabletId);
+                Replica replica = tabletInvertedIndex.getReplica(tabletId, backendId);
+                if (replica == null) {
+                    LOG.info("replica of tablet {} on backend {} no longer exists in FE, skip diff", tabletId, backendId);
                     continue;
                 }
 
-                if (backendTablets.containsKey(tabletId)) {
-                    TTablet backendTablet = backendTablets.get(tabletId);
-                    Replica replica = entry.getValue();
-                    for (TTabletInfo backendTabletInfo : backendTablet.getTablet_infos()) {
-                        if (backendTabletInfo.isSetIs_error_state()) {
-                            replica.setIsErrorState(backendTabletInfo.is_error_state);
-                        }
-                        if (backendTabletInfo.isSetMax_rowset_creation_time()) {
-                            replica.setMaxRowsetCreationTime(backendTabletInfo.max_rowset_creation_time);
-                        }
-                        foundTabletsWithValidSchema.add(tabletId);
-                        // 1. (intersection)
-                        if (needSync(replica, backendTabletInfo)) {
-                            // need sync
-                            tabletSyncMap.put(Pair.create(tabletMeta.getDbId(), tabletMeta.getTableId()), tabletId);
-                        }
+                for (TTabletInfo backendTabletInfo : backendTablet.getTablet_infos()) {
+                    if (backendTabletInfo.isSetIs_error_state()) {
+                        replica.setIsErrorState(backendTabletInfo.is_error_state);
+                    }
+                    if (backendTabletInfo.isSetMax_rowset_creation_time()) {
+                        replica.setMaxRowsetCreationTime(backendTabletInfo.max_rowset_creation_time);
+                    }
+                    foundTabletsWithValidSchema.add(tabletId);
+                    // 1. (intersection)
+                    if (needSync(replica, backendTabletInfo)) {
+                        // need sync
+                        tabletSyncMap.put(Pair.create(tabletMeta.getDbId(), tabletMeta.getTableId()), tabletId);
+                    }
 
-                        // check and set path,
-                        // path info of replica is only saved in Leader FE
-                        if (backendTabletInfo.isSetPath_hash() &&
-                                replica.getPathHash() != backendTabletInfo.getPath_hash()) {
-                            replica.setPathHash(backendTabletInfo.getPath_hash());
-                        }
+                    // check and set path,
+                    // path info of replica is only saved in Leader FE
+                    if (backendTabletInfo.isSetPath_hash() &&
+                            replica.getPathHash() != backendTabletInfo.getPath_hash()) {
+                        replica.setPathHash(backendTabletInfo.getPath_hash());
+                    }
 
-                        if (backendTabletInfo.isSetSchema_hash() && replica.getState() == ReplicaState.NORMAL
-                                && replica.getSchemaHash() != backendTabletInfo.getSchema_hash()) {
-                            // update the schema hash only when replica is normal
-                            replica.setSchemaHash(backendTabletInfo.getSchema_hash());
-                        }
+                    if (backendTabletInfo.isSetSchema_hash() && replica.getState() == ReplicaState.NORMAL
+                            && replica.getSchemaHash() != backendTabletInfo.getSchema_hash()) {
+                        // update the schema hash only when replica is normal
+                        replica.setSchemaHash(backendTabletInfo.getSchema_hash());
+                    }
 
-                        if (!isRestoreReplica(replica, tabletMeta) &&
-                                needRecover(replica, backendTabletInfo)) {
-                            LOG.warn("replica {} of tablet {} on backend {} need recovery. "
-                                            + "replica in FE: {}, report version {}, report schema hash: {},"
-                                            + " is bad: {}",
-                                    replica.getId(), tabletId, backendId,
-                                    replica, backendTabletInfo.getVersion(), backendTabletInfo.getSchema_hash(),
-                                    backendTabletInfo.isSetUsed() ? backendTabletInfo.isUsed() : "unknown");
-                            tabletRecoveryMap.put(tabletMeta.getDbId(), tabletId);
-                        }
+                    if (!isRestoreReplica(replica, tabletMeta) &&
+                            needRecover(replica, backendTabletInfo)) {
+                        LOG.warn("replica {} of tablet {} on backend {} need recovery. "
+                                        + "replica in FE: {}, report version {}, report schema hash: {},"
+                                        + " is bad: {}",
+                                replica.getId(), tabletId, backendId,
+                                replica, backendTabletInfo.getVersion(), backendTabletInfo.getSchema_hash(),
+                                backendTabletInfo.isSetUsed() ? backendTabletInfo.isUsed() : "unknown");
+                        tabletRecoveryMap.put(tabletMeta.getDbId(), tabletId);
+                    }
 
-                        replica.setLastReportVersion(backendTabletInfo.getVersion());
+                    replica.setLastReportVersion(backendTabletInfo.getVersion());
 
-                        // check if tablet needs migration
-                        long physicalPartitionId = tabletMeta.getPhysicalPartitionId();
-                        OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                                .getTable(tabletMeta.getDbId(), tabletMeta.getTableId());
-                        if (olapTable == null) {
-                            continue;
-                        }
-                        PhysicalPartition physicalPartition = olapTable.getPhysicalPartition(physicalPartitionId);
-                        if (physicalPartition == null) {
-                            continue;
-                        }
+                    // check if tablet needs migration
+                    long physicalPartitionId = tabletMeta.getPhysicalPartitionId();
+                    OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                            .getTable(tabletMeta.getDbId(), tabletMeta.getTableId());
+                    if (olapTable == null) {
+                        continue;
+                    }
+                    PhysicalPartition physicalPartition = olapTable.getPhysicalPartition(physicalPartitionId);
+                    if (physicalPartition == null) {
+                        continue;
+                    }
 
-                        TStorageMedium storageMedium = storageMediumMap.get(physicalPartition.getParentId());
-                        if (storageMedium != null && backendTabletInfo.isSetStorage_medium()) {
-                            if (storageMedium != backendTabletInfo.getStorage_medium()) {
-                                // If storage medium is less than 1, there is no need to send migration tasks to BE.
-                                // Because BE will ignore this request.
-                                if (backendStorageTypeCnt <= 1) {
-                                    LOG.debug("available storage medium type count is less than 1, " +
-                                                    "no need to send migrate task. tabletId={}, backendId={}.",
-                                            tabletMeta, backendId);
-                                } else {
-                                    tabletMigrationMap.put(storageMedium, tabletId);
-                                }
-                            }
-                            if (storageMedium != tabletMeta.getStorageMedium()) {
-                                tabletMeta.setStorageMedium(storageMedium);
+                    TStorageMedium storageMedium = storageMediumMap.get(physicalPartition.getParentId());
+                    if (storageMedium != null && backendTabletInfo.isSetStorage_medium()) {
+                        if (storageMedium != backendTabletInfo.getStorage_medium()) {
+                            // If storage medium is less than 1, there is no need to send migration tasks to BE.
+                            // Because BE will ignore this request.
+                            if (backendStorageTypeCnt <= 1) {
+                                LOG.debug("available storage medium type count is less than 1, " +
+                                                "no need to send migrate task. tabletId={}, backendId={}.",
+                                        tabletMeta, backendId);
+                            } else {
+                                tabletMigrationMap.put(storageMedium, tabletId);
                             }
                         }
-                        // check if we should clear transactions
-                        if (backendTabletInfo.isSetTransaction_ids()) {
-                            List<Long> transactionIds = backendTabletInfo.getTransaction_ids();
-                            GlobalTransactionMgr transactionMgr =
-                                    GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
-                            for (Long transactionId : transactionIds) {
-                                TransactionState transactionState =
-                                        transactionMgr.getTransactionState(tabletMeta.getDbId(), transactionId);
-                                if (transactionState == null ||
-                                        transactionState.getTransactionStatus() == TransactionStatus.ABORTED) {
-                                    transactionsToClear.put(transactionId, physicalPartitionId);
-                                    LOG.debug("transaction id [{}] is not valid any more, "
-                                            + "clear it from backend [{}]", transactionId, backendId);
-                                } else if (transactionState.getTransactionStatus() ==
-                                        TransactionStatus.VISIBLE) {
-                                    TableCommitInfo tableCommitInfo =
-                                            transactionState.getTableCommitInfo(tabletMeta.getTableId());
-                                    PartitionCommitInfo partitionCommitInfo =
-                                            tableCommitInfo.getPartitionCommitInfo(physicalPartitionId);
-                                    if (partitionCommitInfo == null) {
-                                        /*
-                                         * This may happen as follows:
-                                         * 1. txn is committed on BE, and report commit info to FE
-                                         * 2. FE received report and begin to assemble partitionCommitInfos.
-                                         * 3. At the same time, some partitions have been dropped, so
-                                         *    partitionCommitInfos does not contain these partitions.
-                                         * 4. So we will not able to get partitionCommitInfo here.
-                                         *
-                                         * Just print a log to observe
-                                         */
-                                        LOG.info(
-                                                "failed to find partition commit info. table: {}, " +
-                                                        "partition: {}, tablet: {}, txn_id: {}",
-                                                tabletMeta.getTableId(), physicalPartitionId, tabletId,
-                                                transactionState.getTransactionId());
-                                    } else {
-                                        TPartitionVersionInfo versionInfo =
-                                                new TPartitionVersionInfo(physicalPartitionId,
-                                                        partitionCommitInfo.getVersion(), 0);
-                                        versionInfo.setGtid(transactionState.getGlobalTransactionId());
-                                        Map<Long, Map<Long, TPartitionVersionInfo>> txnMap =
-                                                transactionsToPublish.computeIfAbsent(
-                                                        transactionState.getDbId(), k -> Maps.newHashMap());
-                                        Map<Long, TPartitionVersionInfo> partitionMap =
-                                                txnMap.computeIfAbsent(transactionId, k -> Maps.newHashMap());
-                                        partitionMap.put(versionInfo.getPartition_id(), versionInfo);
-                                        transactionsToCommitTime.put(transactionId,
-                                                transactionState.getCommitTime());
-                                    }
-                                }
-                            }
-                        } // end for txn id
-
-                        // update replica's version count
-                        // no need to write log, and no need to get db lock.
-                        if (backendTabletInfo.isSetVersion_count()) {
-                            replica.setVersionCount(backendTabletInfo.getVersion_count());
+                        if (storageMedium != tabletMeta.getStorageMedium()) {
+                            tabletMeta.setStorageMedium(storageMedium);
                         }
                     }
-                } else {
-                    // 2. (meta - be)
-                    // may need delete from meta
-                    LOG.debug("backend[{}] does not report tablet[{}-{}]", backendId, tabletId, tabletMeta);
-                    tabletDeleteFromMeta.put(tabletMeta.getDbId(), tabletId);
+                    // check if we should clear transactions
+                    if (backendTabletInfo.isSetTransaction_ids()) {
+                        List<Long> transactionIds = backendTabletInfo.getTransaction_ids();
+                        GlobalTransactionMgr transactionMgr =
+                                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+                        for (Long transactionId : transactionIds) {
+                            TransactionState transactionState =
+                                    transactionMgr.getTransactionState(tabletMeta.getDbId(), transactionId);
+                            if (transactionState == null ||
+                                    transactionState.getTransactionStatus() == TransactionStatus.ABORTED) {
+                                transactionsToClear.put(transactionId, physicalPartitionId);
+                                LOG.debug("transaction id [{}] is not valid any more, "
+                                        + "clear it from backend [{}]", transactionId, backendId);
+                            } else if (transactionState.getTransactionStatus() ==
+                                    TransactionStatus.VISIBLE) {
+                                TableCommitInfo tableCommitInfo =
+                                        transactionState.getTableCommitInfo(tabletMeta.getTableId());
+                                PartitionCommitInfo partitionCommitInfo =
+                                        tableCommitInfo.getPartitionCommitInfo(physicalPartitionId);
+                                if (partitionCommitInfo == null) {
+                                    /*
+                                     * This may happen as follows:
+                                     * 1. txn is committed on BE, and report commit info to FE
+                                     * 2. FE received report and begin to assemble partitionCommitInfos.
+                                     * 3. At the same time, some partitions have been dropped, so
+                                     *    partitionCommitInfos does not contain these partitions.
+                                     * 4. So we will not able to get partitionCommitInfo here.
+                                     *
+                                     * Just print a log to observe
+                                     */
+                                    LOG.info(
+                                            "failed to find partition commit info. table: {}, " +
+                                                    "partition: {}, tablet: {}, txn_id: {}",
+                                            tabletMeta.getTableId(), physicalPartitionId, tabletId,
+                                            transactionState.getTransactionId());
+                                } else {
+                                    TPartitionVersionInfo versionInfo =
+                                            new TPartitionVersionInfo(physicalPartitionId,
+                                                    partitionCommitInfo.getVersion(), 0);
+                                    versionInfo.setGtid(transactionState.getGlobalTransactionId());
+                                    Map<Long, Map<Long, TPartitionVersionInfo>> txnMap =
+                                            transactionsToPublish.computeIfAbsent(
+                                                    transactionState.getDbId(), k -> Maps.newHashMap());
+                                    Map<Long, TPartitionVersionInfo> partitionMap =
+                                            txnMap.computeIfAbsent(transactionId, k -> Maps.newHashMap());
+                                    partitionMap.put(versionInfo.getPartition_id(), versionInfo);
+                                    transactionsToCommitTime.put(transactionId,
+                                            transactionState.getCommitTime());
+                                }
+                            }
+                        }
+                    } // end for txn id
+
+                    // update replica's version count
+                    // no need to write log, and no need to get db lock.
+                    if (backendTabletInfo.isSetVersion_count()) {
+                        replica.setVersionCount(backendTabletInfo.getVersion_count());
+                    }
                 }
-            } // end for replicaMetaWithBackend
-        } finally {
-            tabletInvertedIndex.readUnlock();
-        }
+            } else {
+                // 2. (meta - be)
+                // may need delete from meta
+                LOG.debug("backend[{}] does not report tablet[{}-{}]", backendId, tabletId, tabletMeta);
+                tabletDeleteFromMeta.put(tabletMeta.getDbId(), tabletId);
+            }
+        } // end for replicaMetaWithBackend
 
         long end = System.currentTimeMillis();
         LOG.info("finished to do tablet diff with backend[{}]. sync: {}. metaDel: {}. foundValid: {}. "
@@ -879,7 +881,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
             return;
         }
 
-        backend.updateDisks(backendDisks,  GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
+        backend.updateDisks(backendDisks, GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo());
         long cost = System.currentTimeMillis() - start;
         if (cost > MAX_REPORT_HANDLING_TIME_LOGGING_THRESHOLD_MS) {
             LOG.info("finished to handle disk report from backend {}, cost: {} ms",
@@ -1181,7 +1183,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                             && diskInfo.getState() == DiskInfo.DiskState.ONLINE
                             && backendReportVersion < currentBackendReportVersion) {
                         LOG.warn("report Version from be: {} is outdated, report version in request: {}, " +
-                                "latest report version: {}, ignore tablet: {}",
+                                        "latest report version: {}, ignore tablet: {}",
                                 backendId, backendReportVersion, currentBackendReportVersion, tabletId);
                         continue;
                     } else if (diskInfo == null) {
@@ -1528,7 +1530,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                     continue;
                 }
                 OlapTable table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                            .getTable(db.getId(), tabletMeta.getTableId());
+                        .getTable(db.getId(), tabletMeta.getTableId());
                 if (table == null) {
                     continue;
                 }
@@ -1632,7 +1634,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                     long tabletId = tabletIds.get(i);
                     long tableId = tabletMeta.getTableId();
                     OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                                .getTable(db.getId(), tableId);
+                            .getTable(db.getId(), tableId);
                     if (olapTable == null) {
                         continue;
                     }
@@ -1730,7 +1732,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                 }
 
                 OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                            .getTable(db.getId(), tableId);
+                        .getTable(db.getId(), tableId);
                 if (olapTable == null) {
                     continue;
                 }
@@ -1786,7 +1788,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                 }
 
                 OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                            .getTable(db.getId(), tableId);
+                        .getTable(db.getId(), tableId);
                 if (olapTable == null) {
                     continue;
                 }
@@ -1848,7 +1850,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
                 }
 
                 OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                            .getTable(db.getId(), tableId);
+                        .getTable(db.getId(), tableId);
                 if (olapTable == null) {
                     continue;
                 }
@@ -1981,7 +1983,7 @@ public class ReportHandler extends Daemon implements MemoryTrackable {
 
                 boolean needToCheck = false;
                 OlapTable olapTable = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                            .getTable(db.getId(), tableId);
+                        .getTable(db.getId(), tableId);
                 if (olapTable == null) {
                     continue;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/OlapDeleteJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/OlapDeleteJob.java
@@ -50,7 +50,6 @@ import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
-import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
@@ -415,16 +414,9 @@ public class OlapDeleteJob extends DeleteJob {
     @Override
     protected List<TabletCommitInfo> getTabletCommitInfos() {
         List<TabletCommitInfo> tabletCommitInfos = Lists.newArrayList();
-        TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
-        for (TabletDeleteInfo tDeleteInfo : getTabletDeleteInfo()) {
-            for (Replica replica : tDeleteInfo.getFinishedReplicas()) {
-                // the inverted index contains rolling up replica
-                Long tabletId = invertedIndex.getTabletIdByReplica(replica.getId());
-                if (tabletId == null) {
-                    LOG.warn("could not find tablet id for replica {}, the tablet maybe dropped", replica);
-                    continue;
-                }
-                tabletCommitInfos.add(new TabletCommitInfo(tabletId, replica.getBackendId()));
+        for (TabletDeleteInfo tabletDeleteInfo : getTabletDeleteInfo()) {
+            for (Replica replica : tabletDeleteInfo.getFinishedReplicas()) {
+                tabletCommitInfos.add(new TabletCommitInfo(tabletDeleteInfo.getTabletId(), replica.getBackendId()));
             }
         }
         return tabletCommitInfos;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BinlogConsumeStateVO.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/BinlogConsumeStateVO.java
@@ -22,6 +22,8 @@ import com.starrocks.common.io.Writable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TBinlogOffset;
 import com.starrocks.thrift.TBinlogScanRange;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -35,6 +37,8 @@ import java.util.Objects;
  * NOTE: not thread-safe for updating
  */
 public class BinlogConsumeStateVO implements Writable {
+    private static final Logger LOG = LogManager.getLogger(BinlogConsumeStateVO.class);
+
     @SerializedName("binlogMap")
     private Map<BinlogIdVO, BinlogLSNVO> binlogMap = new HashMap<>();
 
@@ -44,6 +48,9 @@ public class BinlogConsumeStateVO implements Writable {
         binlogMap.forEach((key, value) -> {
             TBinlogScanRange scan = new TBinlogScanRange();
             TabletMeta meta = tabletIndex.getTabletMeta(key.getTabletId());
+            if (meta == null) {
+                throw new RuntimeException("Tablet " + key.getTabletId() + " does not exist");
+            }
             scan.setTable_id(meta.getTableId());
             scan.setTablet_id(key.getTabletId());
             scan.setPartition_id(meta.getPhysicalPartitionId());

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SystemHandlerCanForceDropTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SystemHandlerCanForceDropTest.java
@@ -29,9 +29,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Test class for SystemHandler.canForceDrop method
@@ -304,9 +302,9 @@ public class SystemHandlerCanForceDropTest {
             }
             
             @Mock
-            public Map<Long, Replica> getReplicas(long tabletId) {
-                Map<Long, Replica> replicas = new HashMap<>();
-                replicas.put(1L, new Replica(1L, 1L, 1L, 1, 0L, 0L, Replica.ReplicaState.NORMAL, -1L, 1L));
+            public List<Replica> getReplicasByTabletId(long tabletId) {
+                List<Replica> replicas = new ArrayList<>();
+                replicas.add(new Replica(1L, 1L, 1L, 1, 0L, 0L, Replica.ReplicaState.NORMAL, -1L, 1L));
                 return replicas;
             }
         };
@@ -320,9 +318,9 @@ public class SystemHandlerCanForceDropTest {
             }
             
             @Mock
-            public Map<Long, Replica> getReplicas(long tabletId) {
-                Map<Long, Replica> replicas = new HashMap<>();
-                replicas.put(1L, new Replica(1L, 1L, 1L, 1, 0L, 0L, Replica.ReplicaState.NORMAL, -1L, 1L));
+            public List<Replica> getReplicasByTabletId(long tabletId) {
+                List<Replica> replicas = new ArrayList<>();
+                replicas.add(new Replica(1L, 1L, 1L, 1, 0L, 0L, Replica.ReplicaState.NORMAL, -1L, 1L));
                 return replicas;
             }
         };
@@ -336,10 +334,10 @@ public class SystemHandlerCanForceDropTest {
             }
             
             @Mock
-            public Map<Long, Replica> getReplicas(long tabletId) {
-                Map<Long, Replica> replicas = new HashMap<>();
+            public List<Replica> getReplicasByTabletId(long tabletId) {
+                List<Replica> replicas = new ArrayList<>();
                 // Create replica on non-retained backend (backendId = 2)
-                replicas.put(1L, new Replica(1L, 2L, 1L, 1, 0L, 0L, Replica.ReplicaState.NORMAL, -1L, 1L));
+                replicas.add(new Replica(1L, 2L, 1L, 1, 0L, 0L, Replica.ReplicaState.NORMAL, -1L, 1L));
                 return replicas;
             }
         };
@@ -353,11 +351,11 @@ public class SystemHandlerCanForceDropTest {
             }
             
             @Mock
-            public Map<Long, Replica> getReplicas(long tabletId) {
-                Map<Long, Replica> replicas = new HashMap<>();
+            public List<Replica> getReplicasByTabletId(long tabletId) {
+                List<Replica> replicas = new ArrayList<>();
                 // Create replica on retained backend (backendId = 1)
-                replicas.put(1L, new Replica(1L, 1L, 1L, 1, 0L, 0L, Replica.ReplicaState.NORMAL, -1L, 1L));
-                replicas.put(2L, new Replica(2L, 2L, 1L, 1, 0L, 0L, Replica.ReplicaState.NORMAL, -1L, 1L));
+                replicas.add(new Replica(1L, 1L, 1L, 1, 0L, 0L, Replica.ReplicaState.NORMAL, -1L, 1L));
+                replicas.add(new Replica(2L, 2L, 1L, 1, 0L, 0L, Replica.ReplicaState.NORMAL, -1L, 1L));
                 return replicas;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedCtxTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedCtxTest.java
@@ -82,6 +82,10 @@ public class TabletSchedCtxTest {
 
     @BeforeEach
     public void setUp() {
+        // Clean up any existing tablets from previous test runs
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().deleteTablet(TABLET_ID_1);
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().deleteTablet(TABLET_ID_2);
+        
         // be1
         be1 = new Backend(10001, "192.168.0.1", 9051);
         Map<String, DiskInfo> disks = Maps.newHashMap();

--- a/fe/fe-core/src/test/java/com/starrocks/common/proc/BackendProcNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/proc/BackendProcNodeTest.java
@@ -88,10 +88,6 @@ public class BackendProcNodeTest {
                 GlobalStateMgr.getCurrentState().getTabletInvertedIndex();
                 minTimes = 0;
                 result = tabletInvertedIndex;
-
-                tabletInvertedIndex.getTabletNumByBackendIdAndPathHash(anyLong, anyLong);
-                minTimes = 0;
-                result = 1;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/server/LocalMetastoreSimpleOpsEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/LocalMetastoreSimpleOpsEditLogTest.java
@@ -117,6 +117,9 @@ public class LocalMetastoreSimpleOpsEditLogTest {
             globalStateMgr.setColocateTableIndex(new com.starrocks.catalog.ColocateTableIndex());
         }
 
+        // Clean up any existing tablets from previous test runs
+        globalStateMgr.getTabletInvertedIndex().deleteTablet(TABLET_ID);
+        
         // Create database
         LocalMetastore metastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
         Database db = new Database(DB_ID, DB_NAME);
@@ -1141,6 +1144,9 @@ public class LocalMetastoreSimpleOpsEditLogTest {
         Assertions.assertEquals(ReplicaStatus.BAD, replayInfo.getReplicaStatus());
 
         // Create follower metastore and the same id objects, then replay
+        // First, delete the master replica from TabletInvertedIndex to simulate a clean follower state
+        GlobalStateMgr.getCurrentState().getTabletInvertedIndex().deleteReplica(TABLET_ID, BACKEND_ID);
+        
         LocalMetastore followerMetastore = new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
         Database followerDb = new Database(DB_ID, DB_NAME);
         followerMetastore.unprotectCreateDb(followerDb);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This pull request introduces several improvements and refactorings to how tablet and replica metadata are managed and accessed, as well as some robustness enhancements around tablet state handling. The main themes are API simplification for tablet/replica lookups, improved error handling when tablet metadata is missing, and the addition of a new concurrent map utility.

**Tablet and Replica Metadata API Simplification:**

* Refactored `TabletInvertedIndex` usage across the codebase to replace `Map<Long, Replica>` return types with more direct methods such as `getReplicasByTabletId`, `getTabletIdsByBackendId`, and `getReplica`, simplifying how replicas and tablets are accessed and iterated. This reduces unnecessary map wrapping and improves clarity. [[1]](diffhunk://#diff-c7bc9884ee4f299876f46e65a0c5384c91b0011e3606aac12631f2ed309f7b18L334-R333) [[2]](diffhunk://#diff-c7bc9884ee4f299876f46e65a0c5384c91b0011e3606aac12631f2ed309f7b18L345-R344) [[3]](diffhunk://#diff-8e506bc2b6e93440302f02affa31475e3192c3d35b8cf2c1f7ed3824c7947a30L578-R601) [[4]](diffhunk://#diff-8e506bc2b6e93440302f02affa31475e3192c3d35b8cf2c1f7ed3824c7947a30L732-L734) [[5]](diffhunk://#diff-539cb709034beb058dad765d09d48ae01c3f590f0140a4fee3d031d58c5063e6L408-R409)

**Robustness and Error Handling:**

* Added checks and logging for cases where tablet metadata is missing during replica creation and binlog scan range building, ensuring that such cases are handled gracefully and do not cause failures or inconsistencies. [[1]](diffhunk://#diff-cbfb0bf4c740dd4b26fa0f6093b3119661df21c7e950b68f62b5b4224c9ca95dR1905-R1910) [[2]](diffhunk://#diff-7128e65db8ef34d0256fd83ff0000714a28288e421535bcac7a162c7c3d941b8R51-R54)

**Concurrency Utility Addition:**

* Introduced a new utility class `ConcurrentLong2ObjectHashMap` that provides a segmented, thread-safe map for long keys, improving performance and concurrency for metadata storage. This is backed by `Long2ObjectOpenHashMap` to avoid auto-boxing and supports efficient reads, writes, and resizing.

**Logging Improvements:**

* Added a logger to `BinlogConsumeStateVO` and improved logging for missing tablet scenarios, aiding debugging and operational visibility. [[1]](diffhunk://#diff-7128e65db8ef34d0256fd83ff0000714a28288e421535bcac7a162c7c3d941b8R25-R26) [[2]](diffhunk://#diff-7128e65db8ef34d0256fd83ff0000714a28288e421535bcac7a162c7c3d941b8R40-R41)

**Code Cleanup:**

* Removed unused imports from files that previously referenced the old tablet/replica APIs. [[1]](diffhunk://#diff-c7bc9884ee4f299876f46e65a0c5384c91b0011e3606aac12631f2ed309f7b18L83) [[2]](diffhunk://#diff-539cb709034beb058dad765d09d48ae01c3f590f0140a4fee3d031d58c5063e6L52) [[3]](diffhunk://#diff-56b066b3b46593e4852ca1f60db30cf9578c72924f5fd00ead96d71f36646786R26)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces lock-based TabletInvertedIndex with concurrent data structures and new APIs, updates callers accordingly, adds a concurrent long-key map, and improves missing-metadata handling/logging.
> 
> - **Metadata/Concurrency**:
>   - **TabletInvertedIndex**: Replaced global RW lock and map-of-maps with concurrent structures (`ConcurrentLong2ObjectHashMap`, `CopyOnWriteArrayList`), added mutation lock only for writes. Introduced APIs: `getReplicasByTabletId`, `getReplica`, `getTabletIdsByBackendId`, path-hash grouping, and replica counts; removed replica/id cross maps and read/write lock methods.
>   - **Utility**: Added `ConcurrentLong2ObjectHashMap` (segmented, thread-safe long→object map) to back metadata indexes.
> - **Callers updated to new APIs**:
>   - `ReportHandler`: Reworked tablet diff to iterate `getTabletIdsByBackendId`, use `getReplica`, handle missing `TabletMeta`, and retain migration/txn sync logic; minor logging tweaks.
>   - `SystemHandler`: Uses `getReplicasByTabletId` in decommission-drop checks.
>   - `TabletScheduler`: Validate `TabletMeta` before logging add-replica edit.
>   - `OlapDeleteJob`: Build `TabletCommitInfo` directly from `TabletDeleteInfo` (no inverted-index reverse lookup).
>   - `BinlogConsumeStateVO`: Added logger and explicit error when tablet meta is missing.
> - **Tests**: Updated to new list-based replica APIs and path-hash grouping; adjusted FE test utilities to new replica map type.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61b5112b9d594537a98f9137cd7eb8b1d4370e67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->