### PR TITLE
[BugFix] fix rowset gc issue when rowset commit fail

### DIFF
--- a/be/src/storage/tablet_meta_manager.cpp
+++ b/be/src/storage/tablet_meta_manager.cpp
@@ -789,7 +789,6 @@ void decode_delta_column_group_key(std::string_view enc_key, TTabletId* tablet_i
 }
 
 DEFINE_FAIL_POINT(tablet_meta_manager_rowset_commit_internal_error);
-
 Status TabletMetaManager::rowset_commit(DataDir* store, TTabletId tablet_id, int64_t logid, EditVersionMetaPB* edit,
                                         const RowsetMetaPB& rowset, const string& rowset_meta_key) {
     FAIL_POINT_TRIGGER_RETURN(tablet_meta_manager_rowset_commit_internal_error,

--- a/be/src/storage/tablet_meta_manager.cpp
+++ b/be/src/storage/tablet_meta_manager.cpp
@@ -788,8 +788,12 @@ void decode_delta_column_group_key(std::string_view enc_key, TTabletId* tablet_i
     *version = INT64_MAX - BigEndian::ToHost64(UNALIGNED_LOAD64(enc_key.data() + 80));
 }
 
+DEFINE_FAIL_POINT(tablet_meta_manager_rowset_commit_internal_error);
+
 Status TabletMetaManager::rowset_commit(DataDir* store, TTabletId tablet_id, int64_t logid, EditVersionMetaPB* edit,
                                         const RowsetMetaPB& rowset, const string& rowset_meta_key) {
+    FAIL_POINT_TRIGGER_RETURN(tablet_meta_manager_rowset_commit_internal_error,
+                              Status::InternalError("inject tablet_meta_manager_rowset_commit_internal_error"));
     WriteBatch batch;
     auto handle = store->get_meta()->handle(META_COLUMN_FAMILY_INDEX);
     string logkey = encode_meta_log_key(tablet_id, logid);

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -715,13 +715,6 @@ Status TabletUpdates::_rowset_commit_unlocked(int64_t version, const RowsetShare
             Tracer::Instance().start_trace_txn_tablet("rowset_commit_unlocked", rowset->txn_id(), _tablet.tablet_id());
     span->SetAttribute("version", version);
     auto scoped = trace::Scope(span);
-    bool add_rowset_succ = false;
-    DeferOp rowset_gc_defer([&]() {
-        // release rowsetid if rowset commit failed
-        if (!add_rowset_succ) {
-            StorageEngine::instance()->release_rowset_id(rowset->rowset_id());
-        }
-    });
     EditVersionMetaPB edit;
     auto edit_version_pb = edit.mutable_version();
     edit_version_pb->set_major_number(version);
@@ -788,7 +781,6 @@ Status TabletUpdates::_rowset_commit_unlocked(int64_t version, const RowsetShare
     {
         std::lock_guard<std::mutex> lg(_rowsets_lock);
         _rowsets[rowsetid] = rowset;
-        add_rowset_succ = true;
     }
     // update stats of the newly added rowset
     {


### PR DESCRIPTION
## Why I'm doing:
When the rowset commit of a PK table fails, the rowset ID is not properly released, which prevents the rowset from being garbage-collected and affects file reclamation.

## What I'm doing:
This pull request adds robust error handling for rowset commit and compaction operations in the storage engine, ensuring that rowset IDs are properly released if these operations fail. It introduces fail points to simulate internal errors and adds comprehensive tests to verify correct resource cleanup in failure scenarios.

**Error handling and resource management improvements:**

* Added logic in `TabletUpdates::_rowset_commit_unlocked` and `TabletUpdates::_commit_compaction` to defer releasing rowset IDs if adding the rowset fails, ensuring no resource leaks occur on commit failures. (`be/src/storage/tablet_updates.cpp` [[1]](diffhunk://#diff-269b48b8e08e9d0910eef0c84ae94a418eb2c7780b2dae5817badbea2a77102cR718-R724) [[2]](diffhunk://#diff-269b48b8e08e9d0910eef0c84ae94a418eb2c7780b2dae5817badbea2a77102cR791) [[3]](diffhunk://#diff-269b48b8e08e9d0910eef0c84ae94a418eb2c7780b2dae5817badbea2a77102cR2189-R2195) [[4]](diffhunk://#diff-269b48b8e08e9d0910eef0c84ae94a418eb2c7780b2dae5817badbea2a77102cR2293)

* Introduced the `tablet_meta_manager_rowset_commit_internal_error` fail point in `TabletMetaManager::rowset_commit` to simulate internal errors for testing commit failure handling. (`be/src/storage/tablet_meta_manager.cpp` [be/src/storage/tablet_meta_manager.cppR791-R796](diffhunk://#diff-ff35e06413eb36584d195c94c82a60de95f094bc854b9eac88fa5cd65908a421R791-R796))

**Testing enhancements:**

* Added two new tests:  
  - `test_rowset_commit_fail_release_rowset_id` to verify that rowset IDs are released after a failed rowset commit.  
  - `test_compaction_commit_fail_release_rowset_id` to ensure rowset IDs are released after a failed compaction commit.  
  Both tests use the new fail point to simulate failures and validate proper cleanup. (`be/test/storage/tablet_updates_test.cpp` [be/test/storage/tablet_updates_test.cppR4172-R4269](diffhunk://#diff-6166ac5aa26092995208c10d107cab4a3dc95449253a74d80f795561766c41e0R4172-R4269))

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure rowset IDs are released when rowset/compaction commit fails by adding deferred cleanup, introduce a fail point for meta commit failure, and add unit tests to verify behavior.
> 
> - **Storage/Meta**:
>   - Add fail point `tablet_meta_manager_rowset_commit_internal_error` and trigger early return in `TabletMetaManager::rowset_commit` for testing injected failures.
> - **TabletUpdates**:
>   - In `TabletUpdates::_rowset_commit_unlocked` and `_commit_compaction`, add deferred cleanup to release `rowset_id` on failure; set `add_rowset_succ` only after successful insertion into `_rowsets`.
> - **Tests** (`be/test/storage/tablet_updates_test.cpp`):
>   - Add `test_rowset_commit_fail_release_rowset_id` to verify rowset ID release on rowset commit failure.
>   - Add `test_compaction_commit_fail_release_rowset_id` to verify rowset ID release/state consistency on compaction commit failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da7f6dc1e6dc9edb36e9c7e8f9d3cb31331b38c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->