### PR TITLE
[Enhancement] Fast schema evolution jobs keep history schemas until no ingestions use them (backport #65799)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/IndexSchemaInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/IndexSchemaInfo.java
@@ -1,0 +1,47 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.SchemaInfo;
+
+import static java.util.Objects.requireNonNull;
+
+public class IndexSchemaInfo {
+    @SerializedName("indexId")
+    private final long indexId;
+    @SerializedName("indexName")
+    private final String indexName;
+    @SerializedName("schemaInfo")
+    private final SchemaInfo schemaInfo;
+
+    IndexSchemaInfo(long indexId, String indexName, SchemaInfo schemaInfo) {
+        this.indexId = indexId;
+        this.indexName = indexName;
+        this.schemaInfo = requireNonNull(schemaInfo, "schema is null");
+    }
+
+    public long getIndexId() {
+        return indexId;
+    }
+
+    public String getIndexName() {
+        return indexName;
+    }
+
+    public SchemaInfo getSchemaInfo() {
+        return schemaInfo;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
@@ -96,7 +96,7 @@ public class LakeTableAlterMetaJob extends LakeTableAlterMetaJobBase {
     }
 
     @Override
-    protected void updateCatalog(Database db, LakeTable table) {
+    protected void updateCatalog(Database db, LakeTable table, boolean isReplay) {
         if (metaType == TTabletMetaType.ENABLE_PERSISTENT_INDEX) {
             // re-use ENABLE_PERSISTENT_INDEX for both enable index and index's type.
             table.getTableProperty().modifyTableProperties(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX,

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJobBase.java
@@ -128,7 +128,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
     protected abstract TabletMetadataUpdateAgentTask createTask(PhysicalPartition partition,
                                                                 MaterializedIndex index, long nodeId, Set<Long> tablets);
 
-    protected abstract void updateCatalog(Database db, LakeTable table);
+    protected abstract void updateCatalog(Database db, LakeTable table, boolean isReplay);
 
     protected abstract void restoreState(LakeTableAlterMetaJobBase job);
 
@@ -211,7 +211,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.WRITE);
         try {
-            updateCatalog(db, table);
+            updateCatalog(db, table, false);
             this.jobState = JobState.FINISHED;
             this.finishedTimeMs = System.currentTimeMillis();
             GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this);
@@ -526,7 +526,7 @@ public abstract class LakeTableAlterMetaJobBase extends AlterJobV2 {
                 updateNextVersion(table);
             } else if (jobState == JobState.FINISHED) {
                 updateVisibleVersion(table);
-                updateCatalog(db, table);
+                updateCatalog(db, table, true);
                 table.setState(OlapTable.OlapTableState.NORMAL);
             } else if (jobState == JobState.CANCELLED) {
                 table.setState(OlapTable.OlapTableState.NORMAL);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJob.java
@@ -33,12 +33,15 @@ import com.starrocks.task.TabletMetadataUpdateAgentTask;
 import com.starrocks.task.TabletMetadataUpdateAgentTaskFactory;
 import com.starrocks.warehouse.Warehouse;
 import org.apache.commons.collections4.ListUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -56,9 +59,16 @@ import static java.util.Objects.requireNonNull;
  * 8. Finish the transaction
  */
 public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase implements GsonPostProcessable {
+
+    private static final Logger LOG = LogManager.getLogger(LakeTableAsyncFastSchemaChangeJob.class);
+
     // shadow index id -> index schema
     @SerializedName(value = "schemaInfos")
     private List<IndexSchemaInfo> schemaInfos;
+
+    @SerializedName(value = "historySchema")
+    private OlapTableHistorySchema historySchema;
+
     private Set<String> partitionsWithSchemaFile = new HashSet<>();
 
     // for deserialization
@@ -74,8 +84,9 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
     LakeTableAsyncFastSchemaChangeJob(LakeTableAsyncFastSchemaChangeJob other) {
         this(other.getJobId(), other.getDbId(), other.getTableId(), other.getTableName(), other.getTimeoutMs());
         for (IndexSchemaInfo indexSchemaInfo : other.schemaInfos) {
-            setIndexTabletSchema(indexSchemaInfo.indexId, indexSchemaInfo.indexName, indexSchemaInfo.schemaInfo);
+            setIndexTabletSchema(indexSchemaInfo.getIndexId(), indexSchemaInfo.getIndexName(), indexSchemaInfo.getSchemaInfo());
         }
+        this.historySchema = other.historySchema;
         partitionsWithSchemaFile.addAll(other.partitionsWithSchemaFile);
     }
 
@@ -90,12 +101,12 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
         TabletMetadataUpdateAgentTask task = null;
         boolean needUpdateSchema = false;
         for (IndexSchemaInfo info : schemaInfos) {
-            if (info.indexId == index.getId()) {
+            if (info.getIndexId() == index.getId()) {
                 needUpdateSchema = true;
                 // `Set.add()` returns true means this set did not already contain the specified element
                 boolean createSchemaFile = partitionsWithSchemaFile.add(tag);
                 task = TabletMetadataUpdateAgentTaskFactory.createTabletSchemaUpdateTask(nodeId,
-                        new ArrayList<>(tablets), info.schemaInfo.toTabletSchema(), createSchemaFile);
+                        new ArrayList<>(tablets), info.getSchemaInfo().toTabletSchema(), createSchemaFile);
                 break;
             }
         }
@@ -111,18 +122,21 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
     }
 
     @Override
-    protected void updateCatalog(Database db, LakeTable table) {
-        updateCatalogUnprotected(db, table);
+    protected void updateCatalog(Database db, LakeTable table, boolean isReplay) {
+        updateCatalogUnprotected(db, table, isReplay);
     }
 
-    private void updateCatalogUnprotected(Database db, LakeTable table) {
+    private void updateCatalogUnprotected(Database db, LakeTable table, boolean isReplay) {
         Set<String> droppedOrModifiedColumns = Sets.newHashSet();
         boolean hasMv = !table.getRelatedMaterializedViews().isEmpty();
+        OlapTableHistorySchema.Builder historySchemaBuilder = OlapTableHistorySchema.newBuilder();
         for (IndexSchemaInfo indexSchemaInfo : schemaInfos) {
-            SchemaInfo schemaInfo = indexSchemaInfo.schemaInfo;
-            long indexId = indexSchemaInfo.indexId;
+            SchemaInfo schemaInfo = indexSchemaInfo.getSchemaInfo();
+            long indexId = indexSchemaInfo.getIndexId();
             MaterializedIndexMeta indexMeta = requireNonNull(table.getIndexMetaByIndexId(indexId)).shallowCopy();
             List<Column> oldColumns = indexMeta.getSchema();
+            SchemaInfo oldSchemaInfo = SchemaInfo.fromMaterializedIndex(table, indexId, indexMeta);
+            historySchemaBuilder.addIndexSchema(new IndexSchemaInfo(indexId, table.getIndexNameById(indexId), oldSchemaInfo));
 
             Preconditions.checkState(Objects.equals(indexMeta.getKeysType(), schemaInfo.getKeysType()));
             Preconditions.checkState(Objects.equals(ListUtils.emptyIfNull(indexMeta.getSortKeyUniqueIds()),
@@ -145,6 +159,12 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
             table.renameColumnNamePrefix(indexId);
         }
         table.rebuildFullSchema();
+        if (!isReplay) {
+            long txnId = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getTransactionIDGenerator()
+                    .getNextTransactionId();
+            historySchemaBuilder.setHistoryTxnIdThreshold(txnId);
+            this.historySchema = historySchemaBuilder.build();
+        }
 
         // If modified columns are already done, inactive related mv
         AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(table, droppedOrModifiedColumns);
@@ -159,6 +179,7 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
         if (jobSchemaInfos != null && !jobSchemaInfos.isEmpty()) {
             this.schemaInfos = new ArrayList<>(jobSchemaInfos);
         }
+        this.historySchema = ((LakeTableAsyncFastSchemaChangeJob) job).historySchema;
     }
 
     @Override
@@ -171,23 +192,33 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
         return false;
     }
 
-    private static class IndexSchemaInfo {
-        @SerializedName("indexId")
-        private final long indexId;
-        @SerializedName("indexName")
-        private final String indexName;
-        @SerializedName("schemaInfo")
-        private final SchemaInfo schemaInfo;
-
-        IndexSchemaInfo(long indexId, String indexName, SchemaInfo schemaInfo) {
-            this.indexId = indexId;
-            this.indexName = indexName;
-            this.schemaInfo = requireNonNull(schemaInfo, "schema is null");
+    @Override
+    public boolean isExpire() {
+        boolean expiredByTime = super.isExpire();
+        boolean expiredByHistorySchema = true;
+        if (historySchema != null && !historySchema.isExpired()) {
+            try {
+                expiredByHistorySchema = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                    .isPreviousTransactionsFinished(historySchema.getHistoryTxnIdThreshold(), dbId, Lists.newArrayList(tableId));
+            } catch (Exception e) {
+                // As isPreviousTransactionsFinished said, exception happens only when db does not exist,
+                // so could clean the history schema safely
+            }
+            if (expiredByHistorySchema) {
+                historySchema.setExpire();
+                LOG.info("Expire the history schema, jobId: {}, tableName: {}, expireTxnIdThreshold: {}",
+                        jobId, tableName, historySchema.getHistoryTxnIdThreshold());
+            }
         }
+        return expiredByTime && expiredByHistorySchema;
     }
 
     List<SchemaInfo> getSchemaInfoList() {
-        return schemaInfos.stream().map(i -> i.schemaInfo).collect(Collectors.toList());
+        return schemaInfos.stream().map(IndexSchemaInfo::getSchemaInfo).collect(Collectors.toList());
+    }
+
+    public Optional<OlapTableHistorySchema> getHistorySchema() {
+        return Optional.ofNullable(historySchema);
     }
 
     @Override
@@ -203,10 +234,10 @@ public class LakeTableAsyncFastSchemaChangeJob extends LakeTableAlterMetaJobBase
             info.add(tableName);
             info.add(TimeUtils.longToTimeString(createTimeMs));
             info.add(TimeUtils.longToTimeString(finishedTimeMs));
-            info.add(schemaInfo.indexName);
-            info.add(schemaInfo.indexId);
-            info.add(schemaInfo.indexId);
-            info.add(String.format("%d:0", schemaInfo.schemaInfo.getVersion())); // schema version and schema hash
+            info.add(schemaInfo.getIndexName());
+            info.add(schemaInfo.getIndexId());
+            info.add(schemaInfo.getIndexId());
+            info.add(String.format("%d:0", schemaInfo.getSchemaInfo().getVersion())); // schema version and schema hash
             info.add(getWatershedTxnId());
             info.add(jobState.name());
             info.add(errMsg);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableHistorySchema.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/OlapTableHistorySchema.java
@@ -1,0 +1,99 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.SchemaInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class OlapTableHistorySchema {
+
+    // This schema can be used by those transaction ids lower than it
+    @SerializedName(value = "historyTxnIdThreshold")
+    private long historyTxnIdThreshold = -1;
+    // index id -> schema info. not thread safety, can be set to null concurrently
+    @SerializedName(value = "schemaInfos")
+    private volatile List<IndexSchemaInfo> indexSchemaInfos;
+
+    public OlapTableHistorySchema() {
+    }
+
+    private OlapTableHistorySchema(Builder builder) {
+        this.historyTxnIdThreshold = builder.historyTxnIdThreshold;
+        this.indexSchemaInfos = builder.indexSchemaInfos;
+    }
+
+    public long getHistoryTxnIdThreshold() {
+        return historyTxnIdThreshold;
+    }
+
+    public Optional<SchemaInfo> getSchemaByIndexId(long indexId) {
+        return getSchemaInfosSafety().flatMap(
+                    infos -> infos.stream()
+                        .filter(schema -> schema.getIndexId() == indexId)
+                        .findFirst().map(IndexSchemaInfo::getSchemaInfo)
+                );
+    }
+
+    public Optional<SchemaInfo> getSchemaBySchemaId(long schemaId) {
+        return getSchemaInfosSafety().flatMap(
+                infos -> infos.stream()
+                        .filter(schema -> schema.getSchemaInfo().getId() == schemaId)
+                        .findFirst().map(IndexSchemaInfo::getSchemaInfo)
+        );
+    }
+
+    public void setExpire() {
+        this.indexSchemaInfos = null;
+    }
+
+    public boolean isExpired() {
+        return indexSchemaInfos == null;
+    }
+
+    private Optional<List<IndexSchemaInfo>> getSchemaInfosSafety() {
+        List<IndexSchemaInfo> schemaInfos = indexSchemaInfos;
+        return Optional.ofNullable(schemaInfos);
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private long historyTxnIdThreshold = -1;
+        private List<IndexSchemaInfo> indexSchemaInfos = new ArrayList<>();
+
+        public Builder() {
+        }
+
+        public Builder setHistoryTxnIdThreshold(long historyTxnIdThreshold) {
+            this.historyTxnIdThreshold = historyTxnIdThreshold;
+            return this;
+        }
+
+        public Builder addIndexSchema(IndexSchemaInfo schemaInfo) {
+            indexSchemaInfos.add(schemaInfo);
+            return this;
+        }
+
+        public OlapTableHistorySchema build() {
+            return new OlapTableHistorySchema(this);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2970,8 +2970,8 @@ public class SchemaChangeHandler extends AlterHandler {
     //          {c1: int, c2: int, c3: Struct<v1 int, v2 int, v3 int>}
     public void modifyTableAddOrDrop(Database db, OlapTable olapTable,
                                      Map<Long, List<Column>> indexSchemaMap,
-                                     List<Index> indexes, long jobId, long txnId,
-                                     Map<Long, Long> indexToNewSchemaId, boolean isReplay)
+                                     List<Index> indexes, long jobId,
+                                     Map<Long, Long> indexToNewSchemaId, boolean isReplay, long replayedTxnId)
             throws DdlException, NotImplementedException {
         Locker locker = new Locker();
         locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(olapTable.getId()), LockType.WRITE);
@@ -2986,6 +2986,7 @@ public class SchemaChangeHandler extends AlterHandler {
             olapTable.setState(OlapTableState.UPDATING_META);
             SchemaChangeJobV2 schemaChangeJob = new SchemaChangeJobV2(jobId, db.getId(), olapTable.getId(),
                     olapTable.getName(), 1000);
+            OlapTableHistorySchema.Builder historySchemaBuilder = OlapTableHistorySchema.newBuilder();
             // update base index schema
             Set<String> modifiedColumns = Sets.newHashSet();
             boolean hasMv = !olapTable.getRelatedMaterializedViews().isEmpty();
@@ -2995,6 +2996,8 @@ public class SchemaChangeHandler extends AlterHandler {
                 // modify the copied indexMeta and put the update result in the indexIdToMeta
                 MaterializedIndexMeta currentIndexMeta = olapTable.getIndexMetaByIndexId(idx).shallowCopy();
                 List<Column> originSchema = currentIndexMeta.getSchema();
+                SchemaInfo schemaInfo = SchemaInfo.fromMaterializedIndex(olapTable, idx, currentIndexMeta);
+                historySchemaBuilder.addIndexSchema(new IndexSchemaInfo(idx, olapTable.getIndexNameById(idx), schemaInfo));
 
                 if (hasMv) {
                     modifiedColumns.addAll(AlterHelper.collectDroppedOrModifiedColumns(originSchema, indexSchema));
@@ -3038,13 +3041,18 @@ public class SchemaChangeHandler extends AlterHandler {
             // If modified columns are already done, inactive related mv
             AlterMVJobExecutor.inactiveRelatedMaterializedViewsRecursive(olapTable, modifiedColumns);
 
+            long txnId = replayedTxnId;
             if (!isReplay) {
+                txnId = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                        .getTransactionIDGenerator().getNextTransactionId();
                 TableAddOrDropColumnsInfo info = new TableAddOrDropColumnsInfo(db.getId(), olapTable.getId(),
                         indexSchemaMap, indexes, jobId, txnId, indexToNewSchemaId);
                 LOG.debug("logModifyTableAddOrDrop info:{}", info);
                 GlobalStateMgr.getCurrentState().getEditLog().logModifyTableAddOrDrop(info);
             }
 
+            historySchemaBuilder.setHistoryTxnIdThreshold(txnId);
+            schemaChangeJob.setHistorySchema(historySchemaBuilder.build());
             schemaChangeJob.setWatershedTxnId(txnId);
             schemaChangeJob.setJobState(AlterJobV2.JobState.FINISHED);
             schemaChangeJob.setFinishedTimeMs(System.currentTimeMillis());
@@ -3077,8 +3085,7 @@ public class SchemaChangeHandler extends AlterHandler {
         Locker locker = new Locker();
         try {
             locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(olapTable.getId()), LockType.WRITE);
-            modifyTableAddOrDrop(db, olapTable, indexSchemaMap, indexes, jobId, info.getTxnId(),
-                    indexToNewSchemaId, true);
+            modifyTableAddOrDrop(db, olapTable, indexSchemaMap, indexes, jobId, indexToNewSchemaId, true, info.getTxnId());
         } catch (DdlException e) {
             // should not happen
             LOG.warn("failed to replay modify table add or drop columns", e);
@@ -3094,8 +3101,6 @@ public class SchemaChangeHandler extends AlterHandler {
         Preconditions.checkState(RunMode.isSharedNothingMode());
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
         long jobId = globalStateMgr.getNextId();
-        long txnId = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
-                .getTransactionIDGenerator().getNextTransactionId();
         // for schema change add/drop value column optimize, direct modify table meta.
         // when modify this, please also pay attention to the OlapTable#copyOnlyForQuery() operation.
         // try to copy first before modifying, avoiding in-place changes.
@@ -3107,8 +3112,8 @@ public class SchemaChangeHandler extends AlterHandler {
         // when modify this, please also pay attention to the OlapTable#copyOnlyForQuery() operation.
         // try to copy first before modifying, avoiding in-place changes.
         modifyTableAddOrDrop(schemaChangeData.getDatabase(), schemaChangeData.getTable(),
-                schemaChangeData.getNewIndexSchema(), schemaChangeData.getIndexes(), jobId, txnId,
-                indexToNewSchemaId, false);
+                schemaChangeData.getNewIndexSchema(), schemaChangeData.getIndexes(), jobId,
+                indexToNewSchemaId, false, -1);
     }
 
     private AlterJobV2 createFastSchemaEvolutionJobInSharedDataMode(SchemaChangeData schemaChangeData) {

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -179,6 +179,8 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
     // and we need to disable it.
     @SerializedName(value = "disableReplicatedStorageForGIN")
     private boolean disableReplicatedStorageForGIN = false;
+    @SerializedName(value = "historySchema")
+    private OlapTableHistorySchema historySchema;
 
     // save all schema change tasks
     private AgentBatchTask schemaChangeBatchTask = new AgentBatchTask();
@@ -272,6 +274,35 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
 
     public void setDisableReplicatedStorageForGIN(boolean disableReplicatedStorageForGIN) {
         this.disableReplicatedStorageForGIN = disableReplicatedStorageForGIN;
+    }
+
+    public void setHistorySchema(OlapTableHistorySchema historySchema) {
+        this.historySchema = historySchema;
+    }
+
+    public Optional<OlapTableHistorySchema> getHistorySchema() {
+        return Optional.ofNullable(historySchema);
+    }
+
+    @Override
+    public boolean isExpire() {
+        boolean expiredByTime = super.isExpire();
+        boolean expiredByHistorySchema = true;
+        if (historySchema != null && !historySchema.isExpired()) {
+            try {
+                expiredByHistorySchema = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().
+                    isPreviousTransactionsFinished(historySchema.getHistoryTxnIdThreshold(), dbId, Lists.newArrayList(tableId));
+            } catch (Exception e) {
+                // As isPreviousTransactionsFinished said, exception happens only when db does not exist,
+                // so could clean the history schema safely
+            }
+            if (expiredByHistorySchema) {
+                historySchema.setExpire();
+                LOG.info("Expire the history schema, jobId: {}, tableName: {}, expireTxnIdThreshold: {}",
+                        jobId, tableName, historySchema.getHistoryTxnIdThreshold());
+            }
+        }
+        return expiredByTime && expiredByHistorySchema;
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAsyncFastSchemaChangeJobTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.alter;
 
 import com.google.common.collect.Lists;
+import com.google.gson.stream.JsonReader;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndexMeta;
@@ -25,13 +26,19 @@ import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.lake.LakeTable;
+import com.starrocks.persist.ImageWriter;
+import com.starrocks.persist.OperationType;
+import com.starrocks.persist.metablock.SRMetaBlockReader;
+import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.rpc.ThriftConnectionPool;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.LocalMetastore;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.CreateDbStmt;
@@ -42,6 +49,7 @@ import com.starrocks.thrift.TTabletMetaInfo;
 import com.starrocks.thrift.TTabletSchema;
 import com.starrocks.thrift.TTaskType;
 import com.starrocks.thrift.TUpdateTabletMetaInfoReq;
+import com.starrocks.transaction.TransactionState;
 import com.starrocks.utframe.MockGenericPool;
 import com.starrocks.utframe.MockedBackend;
 import com.starrocks.utframe.MockedBackend.MockBeThriftClient;
@@ -56,6 +64,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 public class LakeTableAsyncFastSchemaChangeJobTest extends StarRocksTestBase {
     private static ConnectContext connectContext;
@@ -69,6 +78,8 @@ public class LakeTableAsyncFastSchemaChangeJobTest extends StarRocksTestBase {
         CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseStmtWithNewParser(createDbStmtStr, connectContext);
         GlobalStateMgr.getCurrentState().getLocalMetastore().createDb(createDbStmt.getFullDbName());
         connectContext.setDatabase(DB_NAME);
+        UtFrameUtils.stopBackgroundSchemaChangeHandler(60000);
+        UtFrameUtils.setUpForPersistTest();
     }
 
     private static LakeTable createTable(ConnectContext connectContext, String sql) throws Exception {
@@ -640,5 +651,136 @@ public class LakeTableAsyncFastSchemaChangeJobTest extends StarRocksTestBase {
             thriftClients.forEach(client -> client.setCaptureAgentTask(false));
             thriftClients.forEach(MockBeThriftClient::clearCapturedAgentTasks);
         }
+    }
+
+    @Test
+    public void testHistorySchema() throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeTable table = createTable(connectContext, "CREATE TABLE t_history_schema(c0 INT) DUPLICATE KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 1");
+
+        TransactionState.TxnCoordinator coordinator = new TransactionState.TxnCoordinator(
+                TransactionState.TxnSourceType.BE, "127.0.0.1");
+
+        long baseIndexId = table.getBaseIndexId();
+        MaterializedIndexMeta preAlterIndexMeta1 = table.getIndexMetaByIndexId(baseIndexId).shallowCopy();
+        long runningTxn1 = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().beginTransaction(
+                db.getId(), List.of(table.getId()), UUID.randomUUID().toString(), coordinator,
+                TransactionState.LoadJobSourceType.BACKEND_STREAMING, 60000L);
+        LakeTableAsyncFastSchemaChangeJob job1 = (LakeTableAsyncFastSchemaChangeJob) executeAlterAndWaitFinish(
+                table, "ALTER TABLE t_history_schema ADD COLUMN c1 BIGINT", true);
+        Assertions.assertTrue(isSchemaMatch(db, table, Lists.newArrayList("c0", "c1")));
+        OlapTableHistorySchema historySchema1 = job1.getHistorySchema().orElse(null);
+        Assertions.assertNotNull(historySchema1);
+        Assertions.assertTrue(historySchema1.getHistoryTxnIdThreshold() > runningTxn1);
+        assertHistorySchemaMatches(table, baseIndexId, preAlterIndexMeta1, historySchema1);
+
+        MaterializedIndexMeta preAlterIndexMeta2 = table.getIndexMetaByIndexId(baseIndexId).shallowCopy();
+        long runningTxn2 = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().beginTransaction(
+                db.getId(), List.of(table.getId()), UUID.randomUUID().toString(), coordinator,
+                TransactionState.LoadJobSourceType.BACKEND_STREAMING, 60000L);
+        LakeTableAsyncFastSchemaChangeJob job2 = (LakeTableAsyncFastSchemaChangeJob) executeAlterAndWaitFinish(
+                table, "ALTER TABLE t_history_schema ADD COLUMN c2 BIGINT", true);
+        Assertions.assertTrue(isSchemaMatch(db, table, Lists.newArrayList("c0", "c1", "c2")));
+        OlapTableHistorySchema historySchema2 = job2.getHistorySchema().orElse(null);
+        Assertions.assertNotNull(historySchema2);
+        Assertions.assertTrue(historySchema2.getHistoryTxnIdThreshold() > runningTxn2);
+        assertHistorySchemaMatches(table, baseIndexId, preAlterIndexMeta2, historySchema2);
+
+        SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
+        job1.setFinishedTimeMs(System.currentTimeMillis() / 1000 - Config.alter_table_timeout_second - 100);
+        schemaChangeHandler.runAfterCatalogReady();
+        Assertions.assertSame(job1, schemaChangeHandler.getAlterJobsV2().get(job1.getJobId()));
+        Assertions.assertFalse(job1.getHistorySchema().orElse(null).isExpired());
+        GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(db.getId(), runningTxn1, "fail1");
+        schemaChangeHandler.runAfterCatalogReady();
+        Assertions.assertNull(schemaChangeHandler.getAlterJobsV2().get(job1.getJobId()));
+
+        GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(db.getId(), runningTxn2, "fail2");
+        schemaChangeHandler.runAfterCatalogReady();
+        Assertions.assertSame(job2, schemaChangeHandler.getAlterJobsV2().get(job2.getJobId()));
+        Assertions.assertTrue(job2.getHistorySchema().orElse(null).isExpired());
+        Assertions.assertNull(job2.getHistorySchema().orElse(null).getSchemaByIndexId(baseIndexId).orElse(null));
+        Assertions.assertNull(job2.getHistorySchema().orElse(null)
+                .getSchemaBySchemaId(preAlterIndexMeta2.getSchemaId()).orElse(null));
+        job2.setFinishedTimeMs(System.currentTimeMillis() / 1000 - Config.alter_table_timeout_second - 100);
+        schemaChangeHandler.runAfterCatalogReady();
+        Assertions.assertNull(schemaChangeHandler.getAlterJobsV2().get(job2.getJobId()));
+
+    }
+
+    @Test
+    public void testReplayHistorySchema() throws Exception {
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        LakeTable table = createTable(connectContext, "CREATE TABLE t_history_schema_replay(c0 INT) DUPLICATE KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 1");
+
+        UtFrameUtils.PseudoJournalReplayer.resetFollowerJournalQueue();
+        UtFrameUtils.PseudoImage initialImage = new UtFrameUtils.PseudoImage();
+        ImageWriter imageWriter = initialImage.getImageWriter();
+        GlobalStateMgr.getCurrentState().getLocalMetastore().save(imageWriter);
+        GlobalStateMgr.getCurrentState().getAlterJobMgr().save(imageWriter);
+
+        long baseIndexId = table.getBaseIndexId();
+        MaterializedIndexMeta preAlterIndexMeta = table.getIndexMetaByIndexId(baseIndexId).shallowCopy();
+        LakeTableAsyncFastSchemaChangeJob job = (LakeTableAsyncFastSchemaChangeJob) executeAlterAndWaitFinish(
+                table, "ALTER TABLE t_history_schema_replay ADD COLUMN c1 BIGINT", true);
+        Assertions.assertTrue(isSchemaMatch(db, table, Lists.newArrayList("c0", "c1")));
+        OlapTableHistorySchema historySchema = job.getHistorySchema().orElse(null);
+        Assertions.assertNotNull(historySchema);
+        assertHistorySchemaMatches(table, baseIndexId, preAlterIndexMeta, historySchema);
+
+        LocalMetastore restoredMetastore =
+                new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
+        AlterJobMgr restoredAlterJobMgr =
+                new AlterJobMgr(new SchemaChangeHandler(), new MaterializedViewHandler(), new SystemHandler());
+        JsonReader jsonReader = initialImage.getJsonReader();
+        SRMetaBlockReader blockReader = new SRMetaBlockReaderV2(jsonReader);
+        restoredMetastore.load(blockReader);
+        blockReader.close();
+        blockReader = new SRMetaBlockReaderV2(jsonReader);
+        restoredAlterJobMgr.load(blockReader);
+        blockReader.close();
+        Database restoredDb = restoredMetastore.getDb(DB_NAME);
+        Assertions.assertNotNull(restoredDb, "Restored database not found");
+        LakeTable restoredTable = (LakeTable) restoredMetastore.getTable(DB_NAME, table.getName());
+        Assertions.assertNotNull(restoredTable, "Restored table not found");
+        Assertions.assertEquals(SchemaInfo.fromMaterializedIndex(table, baseIndexId, preAlterIndexMeta),
+                SchemaInfo.fromMaterializedIndex(restoredTable, baseIndexId, restoredTable.getIndexMetaByIndexId(baseIndexId)));
+
+        SchemaChangeHandler restoredHandler = restoredAlterJobMgr.getSchemaChangeHandler();
+        LocalMetastore originalMetastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        try {
+            // restoredHandler can restore state to restoredMetastore
+            GlobalStateMgr.getCurrentState().setLocalMetastore(restoredMetastore);
+            // there is expected 4 edit log in the lifecycle of LakeTableAsyncFastSchemaChangeJob
+            for (int i = 0; i < 4; i++) {
+                AlterJobV2 alterJob = (AlterJobV2)
+                        UtFrameUtils.PseudoJournalReplayer.replayNextJournal(OperationType.OP_ALTER_JOB_V2);
+                Assertions.assertInstanceOf(LakeTableAsyncFastSchemaChangeJob.class, alterJob);
+                Assertions.assertEquals(job.getJobId(), alterJob.getJobId());
+                restoredHandler.replayAlterJobV2(alterJob);
+            }
+        } finally {
+            GlobalStateMgr.getCurrentState().setLocalMetastore(originalMetastore);
+        }
+        Assertions.assertTrue(isSchemaMatch(restoredDb, restoredTable, Lists.newArrayList("c0", "c1")));
+        Assertions.assertEquals(SchemaInfo.fromMaterializedIndex(table, baseIndexId, table.getIndexMetaByIndexId(baseIndexId)),
+                SchemaInfo.fromMaterializedIndex(restoredTable, baseIndexId, restoredTable.getIndexMetaByIndexId(baseIndexId)));
+        AlterJobV2 restoredJob = restoredHandler.getAlterJobsV2().get(job.getJobId());
+        Assertions.assertInstanceOf(LakeTableAsyncFastSchemaChangeJob.class, restoredJob);
+        LakeTableAsyncFastSchemaChangeJob fseJob = (LakeTableAsyncFastSchemaChangeJob) restoredJob;
+        OlapTableHistorySchema restoredHistorySchema = fseJob.getHistorySchema().orElse(null);
+        Assertions.assertNotNull(restoredHistorySchema);
+        Assertions.assertEquals(historySchema.getHistoryTxnIdThreshold(), restoredHistorySchema.getHistoryTxnIdThreshold());
+        assertHistorySchemaMatches(table, baseIndexId, preAlterIndexMeta, restoredHistorySchema);
+    }
+
+    private void assertHistorySchemaMatches(LakeTable table, long indexId, MaterializedIndexMeta originMeta,
+                                      OlapTableHistorySchema historySchema) {
+        SchemaInfo originSchemaInfo = SchemaInfo.fromMaterializedIndex(table, indexId, originMeta);
+        Assertions.assertNotNull(historySchema);
+        Assertions.assertEquals(originSchemaInfo, historySchema.getSchemaByIndexId(indexId).orElse(null));
+        Assertions.assertEquals(originSchemaInfo, historySchema.getSchemaBySchemaId(originMeta.getSchemaId()).orElse(null));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
@@ -71,16 +71,7 @@ public class LakeTableSchemaChangeJobTest {
     public static void setUp() throws Exception {
         UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
         connectContext = UtFrameUtils.createDefaultCtx();
-        // Schema change job is executed manually, so stop the schema change daemon to avoid interfering with the test.
-        SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler();
-        schemaChangeHandler.setStop();
-        schemaChangeHandler.interrupt();
-        long startTime = System.currentTimeMillis();
-        while (schemaChangeHandler.isRunning()) {
-            Thread.sleep(100);
-            Assertions.assertTrue(System.currentTimeMillis() - startTime < 60000,
-                    "Schema change handler is not stopped in 60 seconds");
-        }
+        UtFrameUtils.stopBackgroundSchemaChangeHandler(60000);
     }
 
     private static LakeTable createTable(ConnectContext connectContext, String sql) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
@@ -428,25 +428,25 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         List<Index> newIndexes = tbl.getCopiedIndexes();
 
         Assertions.assertDoesNotThrow(
-                    () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
-                                .modifyTableAddOrDrop(db, tbl, indexSchemaMap, newIndexes, 100, 100,
-                                            indexToNewSchemaId, false));
+                    () -> GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler()
+                                .modifyTableAddOrDrop(db, tbl, indexSchemaMap, newIndexes, 100,
+                                            indexToNewSchemaId, false, -1));
         jobSize++;
         Assertions.assertEquals(jobSize, alterJobs.size());
 
         Assertions.assertDoesNotThrow(
-                    () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
-                                .modifyTableAddOrDrop(db, tbl, indexSchemaMap, newIndexes, 101, 101,
-                                            indexToNewSchemaId, true));
+                    () -> GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler()
+                                .modifyTableAddOrDrop(db, tbl, indexSchemaMap, newIndexes, 101,
+                                            indexToNewSchemaId, true, 101));
         jobSize++;
         Assertions.assertEquals(jobSize, alterJobs.size());
 
         OlapTableState beforeState = tbl.getState();
         tbl.setState(OlapTableState.ROLLUP);
         Assertions.assertThrows(DdlException.class,
-                    () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
-                                .modifyTableAddOrDrop(db, tbl, indexSchemaMap, newIndexes, 102, 102, indexToNewSchemaId,
-                                            false));
+                    () -> GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler()
+                                .modifyTableAddOrDrop(db, tbl, indexSchemaMap, newIndexes, 102, indexToNewSchemaId,
+                                            false, -1));
         tbl.setState(beforeState);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeJobV2Test.java
@@ -35,9 +35,11 @@
 package com.starrocks.alter;
 
 import com.google.common.collect.Lists;
+import com.google.gson.stream.JsonReader;
 import com.starrocks.alter.AlterJobV2.JobState;
 import com.starrocks.analysis.TableName;
 import com.starrocks.backup.CatalogMocker;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DynamicPartitionProperty;
 import com.starrocks.catalog.GlobalStateMgrTestUtil;
@@ -46,14 +48,24 @@ import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.MaterializedIndex.IndexState;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.OlapTable.OlapTableState;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Partition.PartitionState;
 import com.starrocks.catalog.Replica;
+import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.util.ThreadUtil;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
+import com.starrocks.persist.ImageWriter;
+import com.starrocks.persist.OperationType;
+import com.starrocks.persist.TableAddOrDropColumnsInfo;
+import com.starrocks.persist.metablock.SRMetaBlockReader;
+import com.starrocks.persist.metablock.SRMetaBlockReaderV2;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
 import com.starrocks.server.RunMode;
@@ -63,6 +75,7 @@ import com.starrocks.sql.ast.AlterClause;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.ModifyTablePropertiesClause;
 import com.starrocks.sql.ast.ReorderColumnsClause;
+import com.starrocks.transaction.TransactionState;
 import com.starrocks.utframe.MockedWarehouseManager;
 import com.starrocks.utframe.UtFrameUtils;
 import com.starrocks.warehouse.cngroup.ComputeResource;
@@ -73,23 +86,33 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SchemaChangeJobV2Test extends DDLTestBase {
-    private static final String TEST_FILE_NAME = SchemaChangeJobV2Test.class.getCanonicalName();
-    private AlterTableStmt alterTableStmt;
 
     private static final Logger LOG = LogManager.getLogger(SchemaChangeJobV2Test.class);
+    private AlterTableStmt alterTableStmt;
+
+    @BeforeAll
+    public static void setupAll() throws Exception {
+        DDLTestBase.beforeAll();
+        UtFrameUtils.stopBackgroundSchemaChangeHandler(60000);
+        UtFrameUtils.setUpForPersistTest();
+    }
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -450,5 +473,185 @@ public class SchemaChangeJobV2Test extends DDLTestBase {
         schemaChangeJob.setWaitingCreatingReplica(true);
         schemaChangeJob.cancel("");
         schemaChangeJob.setWaitingCreatingReplica(false);
+    }
+
+    @Test
+    public void testFastSchemaEvolutionHistorySchema() throws Exception {
+        Database db = starRocksAssert.getDb(ctx.getDatabase());
+        starRocksAssert.withTable("CREATE TABLE t_history_schema(c0 INT) DUPLICATE KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES ('replication_num' = '1')");
+        OlapTable table = (OlapTable) starRocksAssert.getTable(db.getFullName(), "t_history_schema");
+
+        TransactionState.TxnCoordinator coordinator = new TransactionState.TxnCoordinator(
+                TransactionState.TxnSourceType.BE, "127.0.0.1");
+
+        long baseIndexId = table.getBaseIndexId();
+        MaterializedIndexMeta preAlterIndexMeta1 = table.getIndexMetaByIndexId(baseIndexId).shallowCopy();
+        long runningTxn1 = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().beginTransaction(
+                db.getId(), List.of(table.getId()), UUID.randomUUID().toString(), coordinator,
+                TransactionState.LoadJobSourceType.BACKEND_STREAMING, 60000L);
+        SchemaChangeJobV2 job1 = (SchemaChangeJobV2) executeAlterAndWaitFinish(
+                table, "ALTER TABLE t_history_schema ADD COLUMN c1 BIGINT");
+        Assertions.assertTrue(isSchemaMatch(db, table, Lists.newArrayList("c0", "c1")));
+        OlapTableHistorySchema historySchema1 = job1.getHistorySchema().orElse(null);
+        Assertions.assertNotNull(historySchema1);
+        Assertions.assertTrue(historySchema1.getHistoryTxnIdThreshold() > runningTxn1);
+        assertHistorySchemaMatches(table, baseIndexId, preAlterIndexMeta1, historySchema1);
+
+        MaterializedIndexMeta preAlterIndexMeta2 = table.getIndexMetaByIndexId(baseIndexId).shallowCopy();
+        long runningTxn2 = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().beginTransaction(
+                db.getId(), List.of(table.getId()), UUID.randomUUID().toString(), coordinator,
+                TransactionState.LoadJobSourceType.BACKEND_STREAMING, 60000L);
+        SchemaChangeJobV2 job2 = (SchemaChangeJobV2) executeAlterAndWaitFinish(
+                table, "ALTER TABLE t_history_schema ADD COLUMN c2 BIGINT");
+        Assertions.assertTrue(isSchemaMatch(db, table, Lists.newArrayList("c0", "c1", "c2")));
+        OlapTableHistorySchema historySchema2 = job2.getHistorySchema().orElse(null);
+        Assertions.assertNotNull(historySchema2);
+        Assertions.assertTrue(historySchema2.getHistoryTxnIdThreshold() > runningTxn2);
+        assertHistorySchemaMatches(table, baseIndexId, preAlterIndexMeta2, historySchema2);
+
+        SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getSchemaChangeHandler();
+        job1.setFinishedTimeMs(System.currentTimeMillis() / 1000 - Config.alter_table_timeout_second - 100);
+        schemaChangeHandler.runAfterCatalogReady();
+        Assertions.assertSame(job1, schemaChangeHandler.getAlterJobsV2().get(job1.getJobId()));
+        Assertions.assertFalse(job1.getHistorySchema().orElse(null).isExpired());
+        GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(db.getId(), runningTxn1, "fail1");
+        schemaChangeHandler.runAfterCatalogReady();
+        Assertions.assertNull(schemaChangeHandler.getAlterJobsV2().get(job1.getJobId()));
+
+        GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(db.getId(), runningTxn2, "fail2");
+        schemaChangeHandler.runAfterCatalogReady();
+        Assertions.assertSame(job2, schemaChangeHandler.getAlterJobsV2().get(job2.getJobId()));
+        Assertions.assertTrue(job2.getHistorySchema().orElse(null).isExpired());
+        Assertions.assertNull(job2.getHistorySchema().orElse(null).getSchemaByIndexId(baseIndexId).orElse(null));
+        Assertions.assertNull(job2.getHistorySchema().orElse(null)
+                .getSchemaBySchemaId(preAlterIndexMeta2.getSchemaId()).orElse(null));
+        job2.setFinishedTimeMs(System.currentTimeMillis() / 1000 - Config.alter_table_timeout_second - 100);
+        schemaChangeHandler.runAfterCatalogReady();
+        Assertions.assertNull(schemaChangeHandler.getAlterJobsV2().get(job2.getJobId()));
+    }
+
+    @Test
+    public void testReplayHistorySchema() throws Exception {
+        Database db = starRocksAssert.getDb(ctx.getDatabase());
+        starRocksAssert.withTable("CREATE TABLE t_history_schema_replay(c0 INT) DUPLICATE KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES ('replication_num' = '1')");
+        OlapTable table = (OlapTable) starRocksAssert.getTable(db.getFullName(), "t_history_schema_replay");
+
+        UtFrameUtils.PseudoJournalReplayer.resetFollowerJournalQueue();
+        UtFrameUtils.PseudoImage initialImage = new UtFrameUtils.PseudoImage();
+        ImageWriter imageWriter = initialImage.getImageWriter();
+        GlobalStateMgr.getCurrentState().getLocalMetastore().save(imageWriter);
+        GlobalStateMgr.getCurrentState().getAlterJobMgr().save(imageWriter);
+
+        long baseIndexId = table.getBaseIndexId();
+        MaterializedIndexMeta preAlterIndexMeta = table.getIndexMetaByIndexId(baseIndexId).shallowCopy();
+        SchemaChangeJobV2 job = (SchemaChangeJobV2) executeAlterAndWaitFinish(
+                table, "ALTER TABLE t_history_schema_replay ADD COLUMN c1 BIGINT");
+        Assertions.assertTrue(isSchemaMatch(db, table, Lists.newArrayList("c0", "c1")));
+        OlapTableHistorySchema historySchema = job.getHistorySchema().orElse(null);
+        Assertions.assertNotNull(historySchema);
+        assertHistorySchemaMatches(table, baseIndexId, preAlterIndexMeta, historySchema);
+
+        LocalMetastore restoredMetastore =
+                new LocalMetastore(GlobalStateMgr.getCurrentState(), null, null);
+        AlterJobMgr restoredAlterJobMgr =
+                new AlterJobMgr(new SchemaChangeHandler(), new MaterializedViewHandler(), new SystemHandler());
+        JsonReader jsonReader = initialImage.getJsonReader();
+        SRMetaBlockReader blockReader = new SRMetaBlockReaderV2(jsonReader);
+        restoredMetastore.load(blockReader);
+        blockReader.close();
+        blockReader = new SRMetaBlockReaderV2(jsonReader);
+        restoredAlterJobMgr.load(blockReader);
+        blockReader.close();
+        Database restoredDb = restoredMetastore.getDb(db.getFullName());
+        Assertions.assertNotNull(restoredDb, "Restored database not found");
+        OlapTable restoredTable = (OlapTable) restoredMetastore.getTable(restoredDb.getFullName(), table.getName());
+        Assertions.assertNotNull(restoredTable, "Restored table not found");
+        Assertions.assertEquals(SchemaInfo.fromMaterializedIndex(table, baseIndexId, preAlterIndexMeta),
+                SchemaInfo.fromMaterializedIndex(restoredTable, baseIndexId, restoredTable.getIndexMetaByIndexId(baseIndexId)));
+        Assertions.assertFalse(getLatestAlterJob(restoredTable, restoredAlterJobMgr.getSchemaChangeHandler()).isPresent());
+        isSchemaMatch(restoredDb, restoredTable, Lists.newArrayList("c0"));
+
+        SchemaChangeHandler restoredHandler = restoredAlterJobMgr.getSchemaChangeHandler();
+        LocalMetastore originalMetastore = GlobalStateMgr.getCurrentState().getLocalMetastore();
+        try {
+            // restoredHandler can restore state to restoredMetastore
+            GlobalStateMgr.getCurrentState().setLocalMetastore(restoredMetastore);
+            TableAddOrDropColumnsInfo alterInfo = (TableAddOrDropColumnsInfo)
+                    UtFrameUtils.PseudoJournalReplayer.replayNextJournal(OperationType.OP_MODIFY_TABLE_ADD_OR_DROP_COLUMNS);
+            restoredHandler.replayModifyTableAddOrDrop(alterInfo);
+        } finally {
+            GlobalStateMgr.getCurrentState().setLocalMetastore(originalMetastore);
+        }
+        Assertions.assertTrue(isSchemaMatch(restoredDb, restoredTable, Lists.newArrayList("c0", "c1")));
+        Assertions.assertEquals(SchemaInfo.fromMaterializedIndex(table, baseIndexId, table.getIndexMetaByIndexId(baseIndexId)),
+                SchemaInfo.fromMaterializedIndex(restoredTable, baseIndexId, restoredTable.getIndexMetaByIndexId(baseIndexId)));
+        AlterJobV2 restoredJob = restoredHandler.getAlterJobsV2().get(job.getJobId());
+        Assertions.assertInstanceOf(SchemaChangeJobV2.class, restoredJob);
+        SchemaChangeJobV2 fseJob = (SchemaChangeJobV2) restoredJob;
+        OlapTableHistorySchema restoredHistorySchema = fseJob.getHistorySchema().orElse(null);
+        Assertions.assertNotNull(restoredHistorySchema);
+        Assertions.assertEquals(historySchema.getHistoryTxnIdThreshold(), restoredHistorySchema.getHistoryTxnIdThreshold());
+        assertHistorySchemaMatches(table, baseIndexId, preAlterIndexMeta, restoredHistorySchema);
+    }
+
+    private void assertHistorySchemaMatches(OlapTable table, long indexId, MaterializedIndexMeta originMeta,
+                                            OlapTableHistorySchema historySchema) {
+        SchemaInfo originSchemaInfo = SchemaInfo.fromMaterializedIndex(table, indexId, originMeta);
+        Assertions.assertNotNull(historySchema);
+        SchemaInfo schemaInfo = historySchema.getSchemaByIndexId(indexId).orElse(null);
+        Assertions.assertNotNull(schemaInfo);
+        Assertions.assertEquals(originSchemaInfo, schemaInfo);
+        Assertions.assertEquals(originSchemaInfo.hashCode(), schemaInfo.hashCode());
+        Assertions.assertSame(schemaInfo, historySchema.getSchemaBySchemaId(originMeta.getSchemaId()).orElse(null));
+    }
+
+    private AlterJobV2 executeAlterAndWaitFinish(OlapTable table, String sql) throws Exception {
+        starRocksAssert.alterTable(sql);
+        AlterJobV2 alterJob = getLatestAlterJob(table, GlobalStateMgr.getCurrentState().getSchemaChangeHandler()).orElse(null);
+        Assertions.assertNotNull(alterJob);
+        long startTime = System.currentTimeMillis();
+        long timeoutMs = 10 * 60 * 1000; // 10 minutes timeout
+        while (alterJob.getJobState() != AlterJobV2.JobState.FINISHED
+                || table.getState() != OlapTable.OlapTableState.NORMAL) {
+            long currentTime = System.currentTimeMillis();
+            if (currentTime - startTime > timeoutMs) {
+                throw new RuntimeException(
+                        String.format("Alter job timeout after 10 minutes. Job state: %s, table state: %s",
+                                alterJob.getJobState(), table.getState()));
+            }
+            alterJob.run();
+            Thread.sleep(100);
+        }
+        return alterJob;
+    }
+
+    private Optional<AlterJobV2> getLatestAlterJob(Table table, SchemaChangeHandler schemaChangeHandler) {
+        return schemaChangeHandler.getAlterJobsV2().values()
+                .stream().filter(job -> job.getTableId() == table.getId())
+                .max(Comparator.comparingLong(AlterJobV2::getJobId));
+    }
+
+    private boolean isSchemaMatch(Database db, OlapTable table, List<String> columNames) {
+        Locker locker = new Locker();
+        locker.lockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
+        try {
+            long baseIndexId = table.getBaseIndexId();
+            MaterializedIndexMeta indexMeta = table.getIndexMetaByIndexId(baseIndexId);
+            List<Column> schema = indexMeta.getSchema();
+            if (schema.size() != columNames.size()) {
+                return false;
+
+            }
+            for (int i = 0; i < schema.size(); i++) {
+                if (!schema.get(i).getName().equals(columNames.get(i))) {
+                    return false;
+                }
+            }
+            return true;
+        } finally {
+            locker.unLockTablesWithIntensiveDbLock(db.getId(), Lists.newArrayList(table.getId()), LockType.READ);
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -42,6 +42,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.gson.stream.JsonReader;
 import com.staros.starlet.StarletAgentFactory;
+import com.starrocks.alter.SchemaChangeHandler;
 import com.starrocks.analysis.HintNode;
 import com.starrocks.analysis.SetVarHint;
 import com.starrocks.analysis.StringLiteral;
@@ -67,6 +68,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.NotImplementedException;
 import com.starrocks.common.Pair;
+import com.starrocks.common.TimeoutException;
 import com.starrocks.common.io.DataOutputBuffer;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.profile.Timer;
@@ -1485,5 +1487,22 @@ public class UtFrameUtils {
         Assertions.assertNotNull(optExpression);
         List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(optExpression);
         return scanOperators;
+    }
+
+    public static void stopBackgroundSchemaChangeHandler(long timeoutMs) throws Exception {
+        SchemaChangeHandler schemaChangeHandler = GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler();
+        schemaChangeHandler.setStop();
+        schemaChangeHandler.interrupt();
+        long endTime = System.currentTimeMillis() + timeoutMs;
+        while (schemaChangeHandler.isRunning()) {
+            if (System.currentTimeMillis() > endTime) {
+                throw new TimeoutException(String.format("failed to stop SchemaChangeHandler after %s ms", timeoutMs));
+            }
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                throw new Exception("stopping SchemaChangeHandler is interrupted");
+            }
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:
backport #65799

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [X] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

