### PR TITLE
[Enhancement] mysql result typed writer

### DIFF
--- a/be/src/exec/data_sinks/mysql_column_writer.h
+++ b/be/src/exec/data_sinks/mysql_column_writer.h
@@ -1,0 +1,108 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "column/column_viewer.h"
+#include "column/mysql_row_buffer.h"
+#include "types/decimalv2_value.h"
+#include "types/decimalv3.h"
+#include "types/logical_type.h"
+#include "types/logical_type_infra.h"
+#include "types/type_descriptor.h"
+
+namespace starrocks {
+
+using MysqlColumnViewer = std::variant<
+#define M(NAME) ColumnViewer<NAME>,
+        APPLY_FOR_ALL_SCALAR_TYPE(M)
+#undef M
+                ColumnViewer<TYPE_NULL>>;
+
+struct MysqlColumnViewerBuilder {
+    template <LogicalType ltype>
+    std::optional<MysqlColumnViewer> operator()(const ColumnPtr& column) const {
+        // JSON/VARIANT need the virtual Column::put_mysql_row_buffer path: it materializes
+        // shredded variant rows via try_get_row_ref/get_row_value and uses push_null(false)
+        // on serialization failure (so binary-protocol _field_pos is not double-incremented).
+        if constexpr (ltype == TYPE_JSON || ltype == TYPE_VARIANT) {
+            return std::nullopt;
+        } else {
+            return MysqlColumnViewer(std::in_place_type<ColumnViewer<ltype>>, column);
+        }
+    }
+};
+
+struct MysqlColumnSerializer {
+    template <LogicalType ltype>
+    static void serialize(const MysqlColumnViewer& viewer, const TypeDescriptor& type_desc, MysqlRowBuffer* buf,
+                          size_t idx, bool is_binary_protocol) {
+        const auto& typed_viewer = std::get<ColumnViewer<ltype>>(viewer);
+        if (typed_viewer.is_null(idx)) {
+            buf->push_null(is_binary_protocol);
+            return;
+        }
+
+        if (is_binary_protocol) {
+            buf->update_field_pos();
+        }
+
+        if constexpr (ltype == TYPE_BOOLEAN) {
+            buf->push_number<int8_t>(typed_viewer.value(idx) ? 1 : 0, is_binary_protocol);
+        } else if constexpr (lt_is_integer<ltype> || ltype == TYPE_LARGEINT) {
+            buf->push_number(typed_viewer.value(idx), is_binary_protocol);
+        } else if constexpr (ltype == TYPE_FLOAT || ltype == TYPE_DOUBLE) {
+            buf->push_number(typed_viewer.value(idx), is_binary_protocol);
+        } else if constexpr (ltype == TYPE_DATE) {
+            buf->push_date(typed_viewer.value(idx), is_binary_protocol);
+        } else if constexpr (ltype == TYPE_DATETIME) {
+            buf->push_timestamp(typed_viewer.value(idx), is_binary_protocol);
+        } else if constexpr (ltype == TYPE_DECIMALV2) {
+            buf->push_decimal(typed_viewer.value(idx).to_string());
+        } else if constexpr (lt_is_decimal<ltype>) {
+            using CppType = RunTimeCppType<ltype>;
+            auto decimal_str =
+                    DecimalV3Cast::to_string<CppType>(typed_viewer.value(idx), type_desc.precision, type_desc.scale);
+            buf->push_decimal(decimal_str);
+        } else if constexpr (lt_is_string<ltype>) {
+            auto slice = typed_viewer.value(idx);
+            buf->push_string(slice.data, slice.size);
+        } else if constexpr (ltype == TYPE_VARBINARY) {
+            auto slice = typed_viewer.value(idx);
+            buf->push_binary(slice.data, slice.size);
+        } else {
+            buf->push_null(is_binary_protocol);
+        }
+    }
+};
+
+using MysqlSerializeFn = void (*)(const MysqlColumnViewer&, const TypeDescriptor&, MysqlRowBuffer*, size_t, bool);
+
+struct MysqlSerializerBuilder {
+    template <LogicalType ltype>
+    MysqlSerializeFn operator()() const {
+        return &MysqlColumnSerializer::serialize<ltype>;
+    }
+};
+
+inline MysqlSerializeFn get_mysql_serializer(LogicalType ltype) {
+    return type_dispatch_basic(ltype, MysqlSerializerBuilder());
+}
+
+} // namespace starrocks

--- a/be/src/exec/data_sinks/mysql_result_writer.cpp
+++ b/be/src/exec/data_sinks/mysql_result_writer.cpp
@@ -36,11 +36,14 @@
 
 #include <column/column_helper.h>
 
+#include <optional>
+
 #include "column/chunk.h"
 #include "column/mysql_row_buffer.h"
 #include "common/statusor.h"
 #include "compute_env/result/buffer_control_block.h"
 #include "exec/data_sinks/buffer_control_result_writer.h"
+#include "exec/data_sinks/mysql_column_writer.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
 #include "runtime/current_thread.h"
@@ -82,6 +85,68 @@ MysqlRowBufferOptions make_mysql_row_buffer_options(const TQueryOptions& query_o
     return options;
 }
 
+struct ColumnSerializeContext {
+    ColumnSerializeContext(MysqlColumnViewer viewer_, MysqlSerializeFn serializer_, const TypeDescriptor& type_desc_)
+            : viewer(std::move(viewer_)), serializer(serializer_), type_desc(type_desc_), use_viewer(true) {}
+
+    explicit ColumnSerializeContext(ColumnPtr column_)
+            : fallback_column(std::move(column_)), serializer(nullptr), use_viewer(false) {}
+
+    std::optional<MysqlColumnViewer> viewer;
+    ColumnPtr fallback_column;
+    MysqlSerializeFn serializer;
+    TypeDescriptor type_desc;
+    bool use_viewer;
+};
+
+inline void serialize_row(MysqlRowBuffer* buf, const std::vector<ColumnSerializeContext>& column_ctxs, int row_idx,
+                          bool is_binary_format) {
+    for (const auto& ctx : column_ctxs) {
+        if (ctx.use_viewer) {
+            ctx.serializer(ctx.viewer.value(), ctx.type_desc, buf, row_idx, is_binary_format);
+        } else {
+            if (is_binary_format && !ctx.fallback_column->is_nullable()) {
+                buf->update_field_pos();
+            }
+            ctx.fallback_column->put_mysql_row_buffer(buf, row_idx, is_binary_format);
+        }
+    }
+}
+
+Status build_column_contexts(const std::vector<ExprContext*>& output_expr_ctxs, Chunk* chunk,
+                             std::vector<ColumnSerializeContext>* column_ctxs, Columns* result_columns) {
+    int num_columns = output_expr_ctxs.size();
+    result_columns->reserve(num_columns);
+    column_ctxs->reserve(num_columns);
+
+    for (int i = 0; i < num_columns; ++i) {
+        ASSIGN_OR_RETURN(ColumnPtr column, output_expr_ctxs[i]->evaluate(chunk));
+        const auto& root_type = output_expr_ctxs[i]->root()->type();
+        TypeDescriptor serializer_type = root_type;
+        LogicalType physical_type = root_type.type;
+        if (root_type.type == TYPE_TIME) {
+            column = ColumnHelper::convert_time_column_from_double_to_str(column);
+            physical_type = TYPE_VARCHAR;
+            serializer_type.type = TYPE_VARCHAR;
+        }
+        // Mark BinaryColumns that carry VARBINARY data so push_binary is used inside nested types.
+        ColumnHelper::mark_binary_columns(column, root_type);
+
+        result_columns->emplace_back(std::move(column));
+        auto& stored_column = result_columns->back();
+
+        auto viewer_opt = type_dispatch_filter(physical_type, std::optional<MysqlColumnViewer>{},
+                                               MysqlColumnViewerBuilder(), stored_column);
+        if (viewer_opt.has_value()) {
+            auto serializer = get_mysql_serializer(physical_type);
+            column_ctxs->emplace_back(std::move(*viewer_opt), serializer, serializer_type);
+        } else {
+            column_ctxs->emplace_back(stored_column);
+        }
+    }
+    return Status::OK();
+}
+
 } // namespace
 
 MysqlResultWriter::MysqlResultWriter(BufferControlBlock* sinker, const std::vector<ExprContext*>& output_expr_ctxs,
@@ -109,6 +174,11 @@ Status MysqlResultWriter::init(RuntimeState* state) {
     }
 
     return Status::OK();
+}
+
+void MysqlResultWriter::_init_profile() {
+    BufferControlResultWriter::_init_profile();
+    _expr_eval_timer = ADD_CHILD_TIMER(_parent_profile, "ExprEvalTime", "AppendChunkTime");
 }
 
 Status MysqlResultWriter::append_chunk(Chunk* chunk) {
@@ -141,45 +211,39 @@ Status MysqlResultWriter::append_chunk(Chunk* chunk) {
 StatusOr<TFetchDataResultPtr> MysqlResultWriter::_process_chunk(Chunk* chunk) {
     SCOPED_TIMER(_append_chunk_timer);
     int num_rows = chunk->num_rows();
+    int num_columns = _output_expr_ctxs.size();
     auto result = std::make_unique<TFetchDataResult>();
     auto& result_rows = result->result_batch.rows;
     result_rows.resize(num_rows);
 
     Columns result_columns;
-    // Step 1: compute expr
-    int num_columns = _output_expr_ctxs.size();
-    result_columns.reserve(num_columns);
-
-    for (int i = 0; i < num_columns; ++i) {
-        ASSIGN_OR_RETURN(ColumnPtr column, _output_expr_ctxs[i]->evaluate(chunk));
-        column = _output_expr_ctxs[i]->root()->type().type == TYPE_TIME
-                         ? ColumnHelper::convert_time_column_from_double_to_str(column)
-                         : column;
-        // Mark BinaryColumns that carry VARBINARY data so that push_binary is
-        // used when they appear inside nested types (ARRAY / MAP / STRUCT).
-        ColumnHelper::mark_binary_columns(column, _output_expr_ctxs[i]->root()->type());
-        result_columns.emplace_back(std::move(column));
+    std::vector<ColumnSerializeContext> column_ctxs;
+    {
+        SCOPED_TIMER(_expr_eval_timer);
+        RETURN_IF_ERROR(build_column_contexts(_output_expr_ctxs, chunk, &column_ctxs, &result_columns));
     }
 
-    // Step 2: convert chunk to mysql row format row by row
     {
         _row_buffer->reserve(128);
         SCOPED_TIMER(_convert_tuple_timer);
+        size_t max_row_len = 0;
         for (int i = 0; i < num_rows; ++i) {
             DCHECK_EQ(0, _row_buffer->length());
             if (_is_binary_format) {
                 _row_buffer->start_binary_row(num_columns);
             }
-            // TODO: codegen here
-            for (auto& result_column : result_columns) {
-                if (_is_binary_format && !result_column->is_nullable()) {
-                    _row_buffer->update_field_pos();
-                }
-                result_column->put_mysql_row_buffer(_row_buffer, i, _is_binary_format);
-            }
+            serialize_row(_row_buffer, column_ctxs, i, _is_binary_format);
             size_t len = _row_buffer->length();
             _row_buffer->move_content(&result_rows[i]);
-            _row_buffer->reserve(len * 1.1);
+            if (len > max_row_len) {
+                max_row_len = len;
+            }
+            // move_content swaps the buffer's storage into result_rows[i], leaving the
+            // buffer at zero capacity. Reserve every row so subsequent pushes don't
+            // reallocate inside the row; +10% headroom to absorb size variance.
+            if (max_row_len > 0) {
+                _row_buffer->reserve(max_row_len + max_row_len / 10);
+            }
         }
     }
     return result;
@@ -188,65 +252,63 @@ StatusOr<TFetchDataResultPtr> MysqlResultWriter::_process_chunk(Chunk* chunk) {
 StatusOr<TFetchDataResultPtrs> MysqlResultWriter::process_chunk(Chunk* chunk) {
     SCOPED_TIMER(_append_chunk_timer);
     int num_rows = chunk->num_rows();
+    int num_columns = _output_expr_ctxs.size();
     std::vector<TFetchDataResultPtr> results;
 
     Columns result_columns;
-    // Step 1: compute expr
-    int num_columns = _output_expr_ctxs.size();
-    result_columns.reserve(num_columns);
-
-    for (int i = 0; i < num_columns; ++i) {
-        ASSIGN_OR_RETURN(ColumnPtr column, _output_expr_ctxs[i]->evaluate(chunk));
-        column = _output_expr_ctxs[i]->root()->type().type == TYPE_TIME
-                         ? ColumnHelper::convert_time_column_from_double_to_str(column)
-                         : column;
-        ColumnHelper::mark_binary_columns(column, _output_expr_ctxs[i]->root()->type());
-        result_columns.emplace_back(std::move(column));
+    std::vector<ColumnSerializeContext> column_ctxs;
+    {
+        SCOPED_TIMER(_expr_eval_timer);
+        RETURN_IF_ERROR(build_column_contexts(_output_expr_ctxs, chunk, &column_ctxs, &result_columns));
     }
 
-    // Step 2: convert chunk to mysql row format row by row
     {
         TRY_CATCH_ALLOC_SCOPE_START()
         _row_buffer->reserve(128);
         size_t current_bytes = 0;
         int current_rows = 0;
+        size_t max_row_len = 0;
         SCOPED_TIMER(_convert_tuple_timer);
         auto result = std::make_unique<TFetchDataResult>();
-        auto& result_rows = result->result_batch.rows;
-        result_rows.resize(num_rows);
+        auto* result_rows = &result->result_batch.rows;
+        result_rows->resize(num_rows);
 
         for (int i = 0; i < num_rows; ++i) {
             DCHECK_EQ(0, _row_buffer->length());
             if (_is_binary_format) {
                 _row_buffer->start_binary_row(num_columns);
             }
-            for (auto& result_column : result_columns) {
-                if (_is_binary_format && !result_column->is_nullable()) {
-                    _row_buffer->update_field_pos();
-                }
-                result_column->put_mysql_row_buffer(_row_buffer, i, _is_binary_format);
-            }
+            serialize_row(_row_buffer, column_ctxs, i, _is_binary_format);
             size_t len = _row_buffer->length();
 
             if (UNLIKELY(current_bytes + len >= _max_row_buffer_size)) {
-                result_rows.resize(current_rows);
+                result_rows->resize(current_rows);
                 results.emplace_back(std::move(result));
 
                 result = std::make_unique<TFetchDataResult>();
-                result_rows = result->result_batch.rows;
-                result_rows.resize(num_rows - i);
+                result_rows = &result->result_batch.rows;
+                result_rows->resize(num_rows - i);
 
                 current_bytes = 0;
                 current_rows = 0;
             }
-            _row_buffer->move_content(&result_rows[current_rows]);
-            _row_buffer->reserve(len * 1.1);
+            _row_buffer->move_content(&(*result_rows)[current_rows]);
+            if (len > max_row_len) {
+                max_row_len = len;
+            }
+            // move_content swaps the buffer's storage into result_rows[current_rows],
+            // leaving the buffer at zero capacity. Reserve every row so subsequent
+            // pushes don't reallocate inside the row; +10% headroom to absorb size
+            // variance.
+            if (max_row_len > 0) {
+                _row_buffer->reserve(max_row_len + max_row_len / 10);
+            }
 
             current_bytes += len;
             current_rows += 1;
         }
         if (current_rows > 0) {
-            result_rows.resize(current_rows);
+            result_rows->resize(current_rows);
             results.emplace_back(std::move(result));
         }
         TRY_CATCH_ALLOC_SCOPE_END()

--- a/be/src/exec/data_sinks/mysql_result_writer.h
+++ b/be/src/exec/data_sinks/mysql_result_writer.h
@@ -58,8 +58,10 @@ public:
 
     StatusOr<TFetchDataResultPtrs> process_chunk(Chunk* chunk) override;
 
+protected:
+    void _init_profile() override;
+
 private:
-    // this function is only used in non-pipeline engine
     StatusOr<TFetchDataResultPtr> _process_chunk(Chunk* chunk);
 
     const std::vector<ExprContext*>& _output_expr_ctxs;
@@ -67,6 +69,8 @@ private:
     bool _is_binary_format;
 
     const size_t _max_row_buffer_size = 1024 * 1024 * 1024;
+
+    RuntimeProfile::Counter* _expr_eval_timer = nullptr;
 };
 
 } // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -297,6 +297,7 @@ set(EXEC_FILES
         ./runtime/merge_cascade_test.cpp
         ./exec/data_sinks/memory_scratch_sink_test_issue_8676.cpp
         ./exec/data_sinks/memory_scratch_sink_test.cpp
+        ./exec/data_sinks/mysql_result_writer_test.cpp
         ./runtime/command_executor_test.cpp
         ./runtime/exec_env_test.cpp
         ./exec/jdbc/type_checker_test.cpp

--- a/be/test/exec/data_sinks/mysql_result_writer_test.cpp
+++ b/be/test/exec/data_sinks/mysql_result_writer_test.cpp
@@ -22,10 +22,10 @@
 #include "column/struct_column.h"
 #include "common/object_pool.h"
 #include "common/runtime_profile.h"
+#include "compute_env/result/buffer_control_block.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
 #include "gen_cpp/Types_types.h"
-#include "runtime/buffer_control_block.h"
 #include "runtime/runtime_state.h"
 #include "types/logical_type.h"
 
@@ -110,6 +110,13 @@ TEST_F(MysqlResultWriterTest, should_set_binary_null_bit_after_fallback_column) 
     MysqlResultWriter writer(&sinker, expr_ctxs, true, &profile);
     RuntimeState dummy_state;
     ASSERT_TRUE(writer.init(&dummy_state).ok());
+
+    // ExprContext::evaluate() DCHECKs that each context was prepared and opened, and
+    // process_chunk() evaluates them, so prepare/open before feeding the writer.
+    for (auto* ctx : expr_ctxs) {
+        ASSERT_TRUE(ctx->prepare(&dummy_state).ok());
+        ASSERT_TRUE(ctx->open(&dummy_state).ok());
+    }
 
     auto result_or = writer.process_chunk(&chunk);
     ASSERT_TRUE(result_or.ok());

--- a/be/test/exec/data_sinks/mysql_result_writer_test.cpp
+++ b/be/test/exec/data_sinks/mysql_result_writer_test.cpp
@@ -1,0 +1,144 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/data_sinks/mysql_result_writer.h"
+
+#include <gtest/gtest.h>
+
+#include "column/chunk.h"
+#include "column/column_helper.h"
+#include "column/nullable_column.h"
+#include "column/struct_column.h"
+#include "common/object_pool.h"
+#include "common/runtime_profile.h"
+#include "exprs/expr.h"
+#include "exprs/expr_context.h"
+#include "gen_cpp/Types_types.h"
+#include "runtime/buffer_control_block.h"
+#include "runtime/runtime_state.h"
+#include "types/logical_type.h"
+
+namespace starrocks {
+
+class ConstColumnExpr final : public Expr {
+public:
+    ConstColumnExpr(const TypeDescriptor& type_desc, ColumnPtr column) : Expr(type_desc), _column(std::move(column)) {}
+
+    Expr* clone(ObjectPool* pool) const override { return pool->add(new ConstColumnExpr(type(), _column)); }
+
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* chunk) override { return _column; }
+
+private:
+    ColumnPtr _column;
+};
+
+class MysqlResultWriterTest : public testing::Test {
+protected:
+    std::vector<ExprContext*> make_expr_ctxs(const std::vector<std::pair<TypeDescriptor, ColumnPtr>>& columns) {
+        std::vector<ExprContext*> ctxs;
+        ctxs.reserve(columns.size());
+        for (const auto& [type, column] : columns) {
+            auto* expr = _pool.add(new ConstColumnExpr(type, column));
+            ctxs.emplace_back(_pool.add(new ExprContext(expr)));
+        }
+        return ctxs;
+    }
+
+    ObjectPool _pool;
+};
+
+TEST_F(MysqlResultWriterTest, should_set_binary_null_bit_after_fallback_column) {
+    constexpr int kNumRows = 2;
+
+    // Typed BIGINT column.
+    auto bigint_col = Int64Column::create();
+    bigint_col->append(11);
+    bigint_col->append(22);
+
+    // Fallback STRUCT column (non-nullable).
+    auto struct_field = BinaryColumn::create();
+    struct_field->append("first");
+    struct_field->append("second");
+    Columns struct_fields{struct_field};
+    std::vector<std::string> field_names{"f"};
+    auto struct_col = StructColumn::create(struct_fields, field_names);
+
+    // Nullable BIGINT column that is NULL for the first row.
+    auto nullable_data = Int64Column::create();
+    nullable_data->append(999);
+    nullable_data->append(888);
+    auto null_flags = NullColumn::create();
+    null_flags->append(1);
+    null_flags->append(0);
+    auto nullable_col = NullableColumn::create(nullable_data, null_flags);
+
+    std::vector<std::pair<TypeDescriptor, ColumnPtr>> expr_columns;
+    expr_columns.emplace_back(TypeDescriptor::from_logical_type(TYPE_BIGINT), bigint_col);
+    expr_columns.emplace_back(
+            TypeDescriptor::create_struct_type(field_names, {TypeDescriptor::from_logical_type(TYPE_VARCHAR)}),
+            struct_col);
+    expr_columns.emplace_back(TypeDescriptor::from_logical_type(TYPE_BIGINT), nullable_col);
+    auto expr_ctxs = make_expr_ctxs(expr_columns);
+
+    // Dummy chunk that only carries row count information.
+    Chunk chunk;
+    auto dummy_col = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_INT), false);
+    dummy_col->append_default();
+    dummy_col->append_default();
+    chunk.append_column(dummy_col, 0);
+    chunk.set_num_rows(kNumRows);
+
+    // Writer setup (binary protocol).
+    TUniqueId query_id;
+    query_id.hi = 0;
+    query_id.lo = 0;
+    BufferControlBlock sinker(query_id, 1024);
+    ASSERT_TRUE(sinker.init().ok());
+
+    RuntimeProfile profile("mysql_result_writer_test");
+    MysqlResultWriter writer(&sinker, expr_ctxs, true, &profile);
+    RuntimeState dummy_state;
+    ASSERT_TRUE(writer.init(&dummy_state).ok());
+
+    auto result_or = writer.process_chunk(&chunk);
+    ASSERT_TRUE(result_or.ok());
+    const auto& result_ptrs = result_or.value();
+    ASSERT_EQ(1, result_ptrs.size());
+
+    const auto& rows = result_ptrs[0]->result_batch.rows;
+    ASSERT_EQ(kNumRows, rows.size());
+
+    auto get_null_byte = [](const std::string& row_bytes) -> uint8_t {
+        CHECK_GE(row_bytes.size(), size_t{2});
+        return static_cast<uint8_t>(row_bytes[1]);
+    };
+
+    // Column indexes: 0 -> bigint, 1 -> struct (fallback), 2 -> nullable bigint
+    const uint8_t struct_bit = 1 << ((1 + 2) & 7);   // bit mask for column index 1
+    const uint8_t nullable_bit = 1 << ((2 + 2) & 7); // bit mask for column index 2
+
+    uint8_t first_row_null_map = get_null_byte(rows[0]);
+    EXPECT_EQ(nullable_bit, first_row_null_map & nullable_bit);
+    EXPECT_EQ(0, first_row_null_map & struct_bit);
+
+    uint8_t second_row_null_map = get_null_byte(rows[1]);
+    EXPECT_EQ(0, second_row_null_map & nullable_bit);
+    EXPECT_EQ(0, second_row_null_map & struct_bit);
+
+    for (auto* ctx : expr_ctxs) {
+        ctx->close(&dummy_state);
+    }
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
MySQL result writer is bottlenecked by per-row virtual dispatch through `Column::put_mysql_row_buffer` for wide chunks / many-row results.

Fixes #73235

## What I'm doing:
Move per-row work out of the virtual call:

1. **Once per chunk:** build a typed `MysqlColumnViewer` (variant over `ColumnViewer<TYPE_*>`) and look up a per-type `MysqlSerializeFn` (template specialization of `MysqlColumnSerializer::serialize<ltype>`).
2. **In the hot row loop:** invoke the function pointer directly — the serializer knows its LogicalType at compile time and emits `push_number<T>` / `push_date` / `push_string` / `push_binary` without virtual dispatch.
3. **Fast path** is `is_scalar_logical_type` minus JSON/VARIANT/TYPE_NULL. STRUCT / ARRAY / MAP / JSON / VARIANT fall back to `Column::put_mysql_row_buffer`. JSON/VARIANT fall back explicitly via `MysqlColumnViewerBuilder` returning `nullopt` so the virtual path materializes shredded variant rows via `try_get_row_ref`/`get_row_value` and uses `push_null(false)` on serialization failure (avoiding double-increment of `_field_pos` in binary protocol).

Additional:
- Dedicated `ExprEvalTime` child timer to separate expression evaluation from MySQL serialization in query profiles.
- Reserve `MysqlRowBuffer` to `max_row_len + 10%` every row. `move_content` swaps the buffer's storage into `result_rows[i]`, so the buffer starts each row at zero capacity; reserving with headroom avoids reallocation inside `push_*` during the row.
- Extracted `build_column_contexts` and `serialize_row` helpers shared by `_process_chunk` / `process_chunk` so the two code paths can't drift.
- Fixed a latent overflow-path bug in `process_chunk` where `result_rows` was a reference that got copy-assigned after `std::move(result)`, causing rows of the second batch to overwrite the first batch. `result_rows` is now a pointer rebound to the new `TFetchDataResult` after the split.
- Added a unit test that exercises the binary-protocol null bitmap when a fallback (non-scalar) column is followed by a nullable scalar column.

## Compatibility with #71346:
- Keep `ColumnHelper::mark_binary_columns` in the expr-eval loop so the fallback path preserves the VARBINARY-in-nested-types fix.
- Top-level VARBINARY in the fast path goes through `MysqlRowBuffer::push_binary` so `BinaryEncodingLevel::ALL` behaves identically to the fallback path.

### Performance

Added `be/src/bench/mysql_result_writer_bench.cpp`, which isolates the change — per-cell virtual `Column::put_mysql_row_buffer` (mode 0) vs the typed `MysqlSerializeFn` path (mode 1) with identical per-row scaffolding. On a wide 9-column scalar chunk:

| rows | protocol | virtual | typed | speedup |
|---|---|---|---|---|
| 4096 | text | 2.44 M/s | 2.54 M/s | +4.0% |
| 65536 | text | 2.35 M/s | 2.45 M/s | +4.4% |
| 4096 | binary | 2.36 M/s | 2.51 M/s | +6.3% |
| 65536 | binary | 2.30 M/s | 2.44 M/s | +6.0% |

So ~4–6% from removing the per-cell dispatch on a mixed chunk (larger for narrow, cheap-to-format results). An earlier "~2×" figure came from a non-isolated end-to-end measurement on branch-3.3 and does not hold as an isolated serialization win on current `main`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5

