### PR TITLE
[Doc] Add New Privilege FAQ

### DIFF
--- a/docs/en/administration/user_privs/authorization/privilege_faq.md
+++ b/docs/en/administration/user_privs/authorization/privilege_faq.md
@@ -43,3 +43,71 @@ GRANT SELECT ON ALL TABLES IN DATABASE <db_name> TO USER <user_identity>;
 ```
 
 The statement above is equivalent to `GRANT select_priv ON db.* TO <user_identity>;` used in versions earlier than v3.0.
+
+## What privileges are required to access the StarRocks Web Console `http://<fe_ip>:<fe_http_port>`?
+
+The user must have the `cluster_admin` role.
+
+## How did the privilege retention mechanism change before and after StarRocks v3.0?
+
+Before v3.0, after a user is granted privileges on a table, the privileges would still remain even if the table was dropped and recreated. Starting from v3.0, privileges will no longer be retained after a table is dropped and recreated.
+
+## How to query users and granted privileges in StarRocks?
+
+You can obtain the full user list via querying the system view `sys.grants_to_users` or executing SHOW USERS, and then query each user individually using `SHOW GRANTS FOR <user_identity>`.
+
+## What is the impact on FE resources when querying system views on privilege metadata of large numbers of users and tables?
+
+When the number of users or tables is very large, queries on system views `sys.grants_to_users`, `sys.grants_to_roles`, and `sys.role_edges` may take a long time. These views are computed in real time, consuming a proportion of FE resources. Therefore, it is not recommended to run such operations frequently at large scale.
+
+## Will recreating a catalog cause permission loss? How should privileges be backed up and restored?
+
+Yes. Recreating a catalog will cause its relative privileges to be lost. You should back up all user privileges first and restore them after the catalog is recreated.
+
+## Is there a tool that supports automatic permission migration?
+
+Not at the moment. Users must manually back up and restore permissions using SHOW GRANTS for each user.
+
+## Are there restrictions on using the KILL command? Can it be restricted to only killing a user’s own queries?
+
+Yes. The KILL command now requires the OPERATE privilege, and a user can only kill queries that were initiated by themselves.
+
+## Why do the granted privileges change after renaming or deleting a table? Can the system retain old permissions while adding permissions for the renamed table?
+
+For native tables, privileges are tied to the table ID, not the table name. This ensures data security, as table names can change arbitrarily. If privileges were to follow table names, it could cause data leakage. Similarly, when a table is dropped, its permissions are removed because the object no longer exists.
+
+For external tables, historical versions behaved the same as internal tables. However, because external table metadata is not managed by StarRocks, delays or privilege loss can occur. To address this, future versions will use table-name–based permission management for external tables, which aligns with the expected behavior.
+
+## How to back up user privileges?
+
+Below is a sample script for backing up the user privilege information in the cluster.
+
+```Bash
+#!/bin/bash
+
+# MySQL connection info
+HOST=""
+PORT="9030"
+USER="root"
+PASSWORD=""  
+OUTPUT_FILE="user_privileges.txt"
+
+# Clear output file
+> $OUTPUT_FILE
+
+# Get user list
+users=$(mysql -h$HOST -P$PORT -u$USER -p$PASSWORD -e "SHOW USERS;" | sed -e '1d' -e '/^+/d')
+
+# Loop through users and get privileges
+for user in $users; do
+    echo "Privileges for $user:" >> $OUTPUT_FILE
+    mysql -h$HOST -P$PORT -u$USER -p$PASSWORD -e "SHOW GRANTS FOR $user;" >> $OUTPUT_FILE
+    echo "" >> $OUTPUT_FILE
+done
+
+echo "All user privileges have been written to $OUTPUT_FILE"
+```
+
+## Why does granting USAGE on a normal function produce the error “Unexpected input 'IN', the most similar input is {'TO'}.”? What is the correct way to grant permissions on functions?
+
+Normal functions cannot be granted using IN ALL DATABASES; they can only be granted within the current database. While global functions are granted on the ALL DATABASES scale.

--- a/docs/ja/administration/user_privs/authorization/privilege_faq.md
+++ b/docs/ja/administration/user_privs/authorization/privilege_faq.md
@@ -43,3 +43,71 @@ GRANT SELECT ON ALL TABLES IN DATABASE <db_name> TO USER <user_identity>;
 ```
 
 上記のステートメントは、v3.0 より前のバージョンで使用されていた `GRANT select_priv ON db.* TO <user_identity>;` と同等です。
+
+## StarRocks Web Console `http://<fe_ip>:<fe_http_port>` にアクセスするために必要な権限は何ですか？
+
+ユーザーは `cluster_admin` ロールを持っている必要があります。
+
+## StarRocks v3.0 の前後で権限保持メカニズムはどのように変わりましたか？
+
+v3.0 より前は、ユーザーがテーブルに対して権限を付与された後、そのテーブルが削除され再作成されても権限は保持されていました。v3.0 以降、テーブルが削除され再作成された場合、権限は保持されなくなります。
+
+## StarRocks でユーザーと付与された権限をどのように照会しますか？
+
+システムビュー `sys.grants_to_users` を照会するか、SHOW USERS を実行して完全なユーザーリストを取得し、その後、`SHOW GRANTS FOR <user_identity>` を使用して各ユーザーを個別に照会できます。
+
+## 多数のユーザーとテーブルの権限メタデータに関するシステムビューを照会する際の FE リソースへの影響は何ですか？
+
+ユーザーやテーブルの数が非常に多い場合、システムビュー `sys.grants_to_users`、`sys.grants_to_roles`、および `sys.role_edges` のクエリは時間がかかることがあります。これらのビューはリアルタイムで計算され、FE リソースの一部を消費します。したがって、大規模に頻繁にこのような操作を実行することは推奨されません。
+
+## catalog を再作成すると権限が失われますか？権限をどのようにバックアップおよび復元しますか？
+
+はい。catalog を再作成すると、その関連する権限が失われます。まずすべてのユーザー権限をバックアップし、catalog を再作成した後に復元する必要があります。
+
+## 自動権限移行をサポートするツールはありますか？
+
+現時点ではありません。ユーザーは各ユーザーに対して SHOW GRANTS を使用して手動で権限をバックアップおよび復元する必要があります。
+
+## KILL コマンドの使用に制限はありますか？ユーザー自身のクエリのみを終了させるように制限できますか？
+
+はい。KILL コマンドは現在 OPERATE 権限を必要とし、ユーザーは自分自身が開始したクエリのみを終了させることができます。
+
+## テーブルの名前変更や削除後に付与された権限が変わるのはなぜですか？システムは古い権限を保持しながら、名前変更されたテーブルに対する権限を追加できますか？
+
+内部テーブルの場合、権限はテーブル名ではなくテーブル ID に結び付けられています。これにより、テーブル名が任意に変更される可能性があるため、データのセキュリティが確保されます。権限がテーブル名に従うと、データ漏洩が発生する可能性があります。同様に、テーブルが削除されると、そのオブジェクトが存在しなくなるため、権限も削除されます。
+
+外部テーブルの場合、過去のバージョンでは内部テーブルと同様に動作していました。しかし、外部テーブルのメタデータは StarRocks によって管理されていないため、遅延や権限の喪失が発生する可能性があります。これに対処するため、将来のバージョンでは外部テーブルに対してテーブル名に基づく権限管理が使用され、期待される動作に一致します。
+
+## ユーザー権限をどのようにバックアップしますか？
+
+以下は、クラスタ内のユーザー権限情報をバックアップするためのサンプルスクリプトです。
+
+```Bash
+#!/bin/bash
+
+# MySQL connection info
+HOST=""
+PORT="9030"
+USER="root"
+PASSWORD=""  
+OUTPUT_FILE="user_privileges.txt"
+
+# Clear output file
+> $OUTPUT_FILE
+
+# Get user list
+users=$(mysql -h$HOST -P$PORT -u$USER -p$PASSWORD -e "SHOW USERS;" | sed -e '1d' -e '/^+/d')
+
+# Loop through users and get privileges
+for user in $users; do
+    echo "Privileges for $user:" >> $OUTPUT_FILE
+    mysql -h$HOST -P$PORT -u$USER -p$PASSWORD -e "SHOW GRANTS FOR $user;" >> $OUTPUT_FILE
+    echo "" >> $OUTPUT_FILE
+done
+
+echo "All user privileges have been written to $OUTPUT_FILE"
+```
+
+## 通常の関数に USAGE を付与すると「Unexpected input 'IN', the most similar input is {'TO'}」というエラーが発生するのはなぜですか？関数に対する権限を付与する正しい方法は何ですか？
+
+通常の関数は IN ALL DATABASES を使用して付与することはできません。現在のデータベース内でのみ付与できます。一方、グローバル関数は ALL DATABASES スケールで付与されます。


### PR DESCRIPTION
Signed-off-by: EsoragotoSpirit <wanglichen@starrocks.com>

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands the Privilege FAQ (EN/JA/ZH) with new guidance on access roles, privilege retention, querying/FE impact, catalog recreation, KILL restrictions, rename/delete behavior, function grants, and adds a backup script.
> 
> - **Docs (EN/JA/ZH)**: Expand `privilege_faq.md` with new FAQs and guidance
>   - Web Console access requirement: `cluster_admin` role
>   - Privilege retention change since v3.0 (no retain after drop/recreate)
>   - How to query users/privileges (`sys.grants_to_*`, `SHOW USERS/GRANTS`) and FE resource impact
>   - Catalog recreation causes permission loss; recommend backup/restore
>     - Add sample Bash script to back up user privileges via `SHOW USERS` and `SHOW GRANTS`
>   - No tool for automatic permission migration
>   - KILL command restrictions: requires `OPERATE`; can only kill own queries
>   - Permission behavior on table rename/delete (native tables by ID; external tables note and future name-based policy)
>   - Correct scope for granting USAGE on functions (normal vs global)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit acee7f2ae6898fc1d0c05b9bf8ba0fde468f9c91. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->