### PR TITLE
[BugFix] Fix the exponential growth in the number of expressions caused by the casewhen function.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CaseWhenOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CaseWhenOperator.java
@@ -76,11 +76,14 @@ public class CaseWhenOperator extends CallOperator {
         incrDepth(arguments);
     }
 
-    private void checkMaxFlatChildren() {
+    @Override
+    public void checkMaxFlatChildren(boolean useCache) {
         if (Config.max_scalar_operator_flat_children > 0 &&
                 getNumFlatChildren() > Config.max_scalar_operator_flat_children) {
             throw new SemanticException(
-                    "The flat children of the case when statement exceeds the FE Config.max_scalar_operator_flat_children");
+                    String.format("Expression CaseWhen too complex, limit: %d. " +
+                                    "Please simplify your expression or increase Config.max_scalar_operator_flat_children.",
+                            Config.max_scalar_operator_flat_children));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
@@ -16,6 +16,8 @@ package com.starrocks.sql.optimizer.operator.scalar;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.starrocks.common.Config;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.LiteralExpr;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
@@ -184,15 +186,40 @@ public abstract class ScalarOperator implements Cloneable {
     }
 
     public int getNumFlatChildren() {
-        if (numberFlatChildren.isPresent()) {
+        return getNumFlatChildren(true);
+    }
+
+    public int getNumFlatChildren(boolean useCache) {
+        if (useCache && numberFlatChildren.isPresent()) {
             return numberFlatChildren.get();
         }
         int numFlatChildren = 1;
         for (ScalarOperator child : getChildren()) {
-            numFlatChildren += child.getNumFlatChildren();
+            numFlatChildren += child.getNumFlatChildren(useCache);
         }
         numberFlatChildren = Optional.of(numFlatChildren);
-        return numberFlatChildren.get();
+        return numFlatChildren;
+    }
+
+    public void checkMaxFlatChildren() {
+        checkMaxFlatChildren(true);
+    }
+
+    /**
+     * Check if the expression complexity exceeds the limit.
+     * 
+     * @param useCache whether to use cached node count. Set to false when the expression
+     *                 structure has been modified without cloning.
+     * @throws SemanticException if the expression is too complex
+     */
+    public void checkMaxFlatChildren(boolean useCache) {
+        if (Config.max_scalar_operator_flat_children > 0 &&
+                getNumFlatChildren(useCache) > Config.max_scalar_operator_flat_children) {
+            throw new SemanticException(
+                    String.format("Expression too complex. Current nodes: %d, Limit: %d. " +
+                            "Please simplify your expression or increase Config.max_scalar_operator_flat_children.",
+                             getNumFlatChildren(useCache), Config.max_scalar_operator_flat_children));
+        }
     }
 
     /**
@@ -242,6 +269,8 @@ public abstract class ScalarOperator implements Cloneable {
             operator.hints = Lists.newArrayList(hints);
             operator.isRedundant = this.isRedundant;
             operator.isPushdown = this.isPushdown;
+            // Clear cache after cloning, as the cloned operator may be modified
+            operator.numberFlatChildren = Optional.empty();
         } catch (CloneNotSupportedException ignored) {
         }
         return operator;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ReplaceColumnRefRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ReplaceColumnRefRewriter.java
@@ -44,14 +44,24 @@ public class ReplaceColumnRefRewriter {
         if (origin == null) {
             return null;
         }
-        return origin.clone().accept(rewriter, null);
+
+        ScalarOperator result = origin.clone().accept(rewriter, null);
+        // Check expression complexity after column reference replacement
+        // Use cached value (true) since clone() has already cleared the cache
+        result.checkMaxFlatChildren(true);
+        return result;
     }
 
     public ScalarOperator rewriteWithoutClone(ScalarOperator origin) {
         if (origin == null) {
             return null;
         }
-        return origin.accept(rewriter, null);
+
+        ScalarOperator result = origin.accept(rewriter, null);
+        // Check expression complexity after column reference replacement
+        // Force recalculation (false) since the expression structure has been modified without cloning
+        result.checkMaxFlatChildren(false);
+        return result;
     }
 
     private class Rewriter extends ScalarOperatorVisitor<ScalarOperator, Void> {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InvalidPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InvalidPlanTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
 import org.junit.jupiter.api.BeforeAll;
@@ -79,6 +80,7 @@ public class InvalidPlanTest extends MVTestBase  {
                 "PROPERTIES (\n" +
                 "\"replication_num\" = \"1\"\n" +
                 ");");
+        Config.max_scalar_operator_flat_children = 30000;
         String sql = ReplayFromDumpTestBase.geContentFromFile("bugs/large_binary_predicate1.sql");
         String plan = getFragmentPlan(sql);
         PlanTestBase.assertContains(plan, " 0:OlapScanNode\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Tracers;
@@ -1026,6 +1027,7 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
 
     @Test
     public void testExpressionReuseTimeout() throws Exception {
+        Config.max_scalar_operator_flat_children = 300000;
         String dumpString = getDumpInfoFromFile("query_dump/expr_reuse_timeout");
         Tracers.register(connectContext);
         Tracers.init(Tracers.Mode.TIMER, Tracers.Module.OPTIMIZER, false, false);

--- a/test/sql/test_case_when/R/test_case_when
+++ b/test/sql/test_case_when/R/test_case_when
@@ -1,10 +1,10 @@
 -- name: test_case_when
- CREATE TABLE `t0` (
-  `region` varchar(128) NOT NULL COMMENT "",
-  `order_date` date NOT NULL COMMENT "",
-  `income` decimal(7, 0) NOT NULL COMMENT "",
-  `ship_mode` int NOT NULL COMMENT "",
-  `ship_code` int) ENGINE=OLAP
+CREATE TABLE `t0` (
+ `region` varchar(128) NOT NULL COMMENT "",
+ `order_date` date NOT NULL COMMENT "",
+ `income` decimal(7, 0) NOT NULL COMMENT "",
+ `ship_mode` int NOT NULL COMMENT "",
+ `ship_code` int) ENGINE=OLAP
 DUPLICATE KEY(`region`, `order_date`)
 COMMENT "OLAP"
 PARTITION BY RANGE(`order_date`)
@@ -3786,7 +3786,7 @@ FROM (
             FROM ads_opt_t_goods_odd_important_kd_di
         ) dataset_table
     ) table_1
-) table_2
+) table_2;
 -- result:
 E: (1064, 'Getting analyzing error. Detail message: Expression CaseWhen too complex, limit: 10000. Please simplify your expression or increase Config.max_scalar_operator_flat_children..')
 -- !result

--- a/test/sql/test_case_when/R/test_case_when
+++ b/test/sql/test_case_when/R/test_case_when
@@ -3596,3 +3596,197 @@ UK	2022-01-04	54321	82	72
 UK	2022-01-04	67890	50	10
 UK	2022-01-04	98765	75	2
 -- !result
+CREATE TABLE `ads_opt_t_goods_odd_important_kd_di` (
+  `region` varchar(128) NOT NULL COMMENT "",
+  `handed_dept_name` int NOT NULL COMMENT "")
+ENGINE=OLAP
+DUPLICATE KEY(`region`)
+COMMENT "OLAP"
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "true",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+SELECT *,
+       CASE
+         WHEN `handling_department_2` LIKE '%Ganzhou Transfer Yard%'
+           THEN REPLACE(`handling_department_2`, 'Ganzhou Transfer Yard', 'Ganzhou Transfer Yard Loading/Unloading Team 1')
+         WHEN `handling_department_2` LIKE '%Guangzhou Fanlong Distribution Station Loading/Unloading Team 1%'
+           THEN REPLACE(`handling_department_2`, 'Guangzhou Fanlong Distribution Station Loading/Unloading Team 1', 'Guangzhou Fanlong Distribution Station Loading/Unloading Team')
+         WHEN `handling_department_2` LIKE '%Jingzhou Transfer Yard Loading/Unloading Department%'
+           THEN REPLACE(`handling_department_2`, 'Jingzhou Transfer Yard Loading/Unloading Department', 'Jingzhou Transfer Yard Loading/Unloading Team')
+         WHEN `handling_department_2` LIKE '%Tangshan Loading/Unloading Team 1%'
+           THEN REPLACE(`handling_department_2`, 'Tangshan Loading/Unloading Team 1', 'Tangshan Loading/Unloading Team')
+         WHEN `handling_department_2` LIKE '%Zhexi Hub Center%'
+           THEN REPLACE(`handling_department_2`, 'Zhexi Hub Center', 'Hangzhou Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Shanghai Hub Center%'
+           THEN REPLACE(`handling_department_2`, 'Shanghai Hub Center', 'Shanghai Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Shunde Hub Center%'
+           THEN REPLACE(`handling_department_2`, 'Shunde Hub Center', 'Shunde Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Sunan Hub Center%'
+           THEN REPLACE(`handling_department_2`, 'Sunan Hub Center', 'Suzhou Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Tianjin Hub Center%'
+           THEN REPLACE(`handling_department_2`, 'Tianjin Hub Center', 'Tianjin Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Wuhan Hub Center%'
+           THEN REPLACE(`handling_department_2`, 'Wuhan Hub Center', 'Wuhan Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Northwest Hub Center%'
+           THEN REPLACE(`handling_department_2`, 'Northwest Hub Center', 'Xi\'an Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Zhengzhou Hub Center%'
+           THEN REPLACE(`handling_department_2`, 'Zhengzhou Hub Center', 'Zhengzhou Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Changzhou Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Changzhou Transfer Center', 'Changzhou Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Chaoshan Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Chaoshan Transfer Center', 'Chaoshan Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Fangshan Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Fangshan Transfer Center', 'Fangshan Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Fuzhou Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Fuzhou Transfer Center', 'Fuzhou Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Guiyang Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Guiyang Transfer Center', 'Guiyang Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Harbin Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Harbin Transfer Center', 'Harbin Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Huaian Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Huaian Transfer Center', 'Huaian Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Jinhua Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Jinhua Transfer Center', 'Jinhua Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Kunming Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Kunming Transfer Center', 'Kunming Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Lanzhou Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Lanzhou Transfer Center', 'Lanzhou Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Luohe Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Luohe Transfer Center', 'Luohe Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Nanchang Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Nanchang Transfer Center', 'Nanchang Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Nanjing Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Nanjing Transfer Center', 'Nanjing Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Nanning Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Nanning Transfer Center', 'Nanning Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Nantong Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Nantong Transfer Center', 'Nantong Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Pudong Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Pudong Transfer Center', 'Pudong Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Quanzhou Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Quanzhou Transfer Center', 'Quanzhou Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Xiamen Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Xiamen Transfer Center', 'Xiamen Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Shenyang Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Shenyang Transfer Center', 'Shenyang Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Taiyuan Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Taiyuan Transfer Center', 'Taiyuan Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Wenzhou Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Wenzhou Transfer Center', 'Wenzhou Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Wuhu Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Wuhu Transfer Center', 'Wuhu Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Xuzhou Shaji Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Xuzhou Shaji Transfer Center', 'Xuzhou Shaji Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Xuzhou Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Xuzhou Transfer Center', 'Xuzhou Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Yantai Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Yantai Transfer Center', 'Yantai Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Yangzhou Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Yangzhou Transfer Center', 'Yangzhou Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Changchun Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Changchun Transfer Center', 'Changchun Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Chongqing Baihe Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Chongqing Baihe Transfer Center', 'Chongqing Baihe Transfer Yard')
+         ELSE `handling_department_2`
+       END AS `handling_department_3`
+FROM (
+    SELECT *,
+           CASE
+             WHEN `handling_department` LIKE '%Ganzhou Transfer Yard%'
+               THEN REPLACE(`handling_department`, 'Ganzhou Transfer Yard', 'Ganzhou Transfer Yard Loading/Unloading Team 1')
+             WHEN `handling_department` LIKE '%Guangzhou Fanlong Distribution Station Loading/Unloading Team 1%'
+               THEN REPLACE(`handling_department`, 'Guangzhou Fanlong Distribution Station Loading/Unloading Team 1', 'Guangzhou Fanlong Distribution Station Loading/Unloading Team')
+             WHEN `handling_department` LIKE '%Jingzhou Transfer Yard Loading/Unloading Department%'
+               THEN REPLACE(`handling_department`, 'Jingzhou Transfer Yard Loading/Unloading Department', 'Jingzhou Transfer Yard Loading/Unloading Team')
+             WHEN `handling_department` LIKE '%Tangshan Loading/Unloading Team 1%'
+               THEN REPLACE(`handling_department`, 'Tangshan Loading/Unloading Team 1', 'Tangshan Loading/Unloading Team')
+             WHEN `handling_department` LIKE '%Zhexi Hub Center%'
+               THEN REPLACE(`handling_department`, 'Zhexi Hub Center', 'Hangzhou Transfer Yard')
+             WHEN `handling_department` LIKE '%Shanghai Hub Center%'
+               THEN REPLACE(`handling_department`, 'Shanghai Hub Center', 'Shanghai Transfer Yard')
+             WHEN `handling_department` LIKE '%Shunde Hub Center%'
+               THEN REPLACE(`handling_department`, 'Shunde Hub Center', 'Shunde Transfer Yard')
+             WHEN `handling_department` LIKE '%Sunan Hub Center%'
+               THEN REPLACE(`handling_department`, 'Sunan Hub Center', 'Suzhou Transfer Yard')
+             WHEN `handling_department` LIKE '%Tianjin Hub Center%'
+               THEN REPLACE(`handling_department`, 'Tianjin Hub Center', 'Tianjin Transfer Yard')
+             WHEN `handling_department` LIKE '%Wuhan Hub Center%'
+               THEN REPLACE(`handling_department`, 'Wuhan Hub Center', 'Wuhan Transfer Yard')
+             WHEN `handling_department` LIKE '%Northwest Hub Center%'
+               THEN REPLACE(`handling_department`, 'Northwest Hub Center', 'Xi\'an Transfer Yard')
+             WHEN `handling_department` LIKE '%Zhengzhou Hub Center%'
+               THEN REPLACE(`handling_department`, 'Zhengzhou Hub Center', 'Zhengzhou Transfer Yard')
+             WHEN `handling_department` LIKE '%Changzhou Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Changzhou Transfer Center', 'Changzhou Transfer Yard')
+             WHEN `handling_department` LIKE '%Chaoshan Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Chaoshan Transfer Center', 'Chaoshan Transfer Yard')
+             WHEN `handling_department` LIKE '%Fangshan Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Fangshan Transfer Center', 'Fangshan Transfer Yard')
+             WHEN `handling_department` LIKE '%Fuzhou Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Fuzhou Transfer Center', 'Fuzhou Transfer Yard')
+             WHEN `handling_department` LIKE '%Guiyang Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Guiyang Transfer Center', 'Guiyang Transfer Yard')
+             WHEN `handling_department` LIKE '%Harbin Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Harbin Transfer Center', 'Harbin Transfer Yard')
+             WHEN `handling_department` LIKE '%Huaian Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Huaian Transfer Center', 'Huaian Transfer Yard')
+             WHEN `handling_department` LIKE '%Jinhua Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Jinhua Transfer Center', 'Jinhua Transfer Yard')
+             WHEN `handling_department` LIKE '%Kunming Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Kunming Transfer Center', 'Kunming Transfer Yard')
+             WHEN `handling_department` LIKE '%Lanzhou Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Lanzhou Transfer Center', 'Lanzhou Transfer Yard')
+             WHEN `handling_department` LIKE '%Luohe Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Luohe Transfer Center', 'Luohe Transfer Yard')
+             WHEN `handling_department` LIKE '%Nanchang Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Nanchang Transfer Center', 'Nanchang Transfer Yard')
+             WHEN `handling_department` LIKE '%Nanjing Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Nanjing Transfer Center', 'Nanjing Transfer Yard')
+             WHEN `handling_department` LIKE '%Nanning Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Nanning Transfer Center', 'Nanning Transfer Yard')
+             WHEN `handling_department` LIKE '%Nantong Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Nantong Transfer Center', 'Nantong Transfer Yard')
+             WHEN `handling_department` LIKE '%Pudong Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Pudong Transfer Center', 'Pudong Transfer Yard')
+             WHEN `handling_department` LIKE '%Quanzhou Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Quanzhou Transfer Center', 'Quanzhou Transfer Yard')
+             WHEN `handling_department` LIKE '%Xiamen Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Xiamen Transfer Center', 'Xiamen Transfer Yard')
+             WHEN `handling_department` LIKE '%Shenyang Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Shenyang Transfer Center', 'Shenyang Transfer Yard')
+             WHEN `handling_department` LIKE '%Taiyuan Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Taiyuan Transfer Center', 'Taiyuan Transfer Yard')
+             WHEN `handling_department` LIKE '%Wenzhou Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Wenzhou Transfer Center', 'Wenzhou Transfer Yard')
+             WHEN `handling_department` LIKE '%Wuhu Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Wuhu Transfer Center', 'Wuhu Transfer Yard')
+             WHEN `handling_department` LIKE '%Xuzhou Shaji Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Xuzhou Shaji Transfer Center', 'Xuzhou Shaji Transfer Yard')
+             WHEN `handling_department` LIKE '%Xuzhou Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Xuzhou Transfer Center', 'Xuzhou Transfer Yard')
+             WHEN `handling_department` LIKE '%Yantai Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Yantai Transfer Center', 'Yantai Transfer Yard')
+             WHEN `handling_department` LIKE '%Yangzhou Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Yangzhou Transfer Center', 'Yangzhou Transfer Yard')
+             WHEN `handling_department` LIKE '%Changchun Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Changchun Transfer Center', 'Changchun Transfer Yard')
+             WHEN `handling_department` LIKE '%Chongqing Baihe Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Chongqing Baihe Transfer Center', 'Chongqing Baihe Transfer Yard')
+             ELSE `handling_department`
+           END AS `handling_department_2`
+    FROM (
+        SELECT CAST(`handling_department` AS STRING) AS `handling_department`
+        FROM (
+            SELECT handed_dept_name AS `handling_department`
+            FROM ads_opt_t_goods_odd_important_kd_di
+        ) dataset_table
+    ) table_1
+) table_2
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Expression CaseWhen too complex, limit: 10000. Please simplify your expression or increase Config.max_scalar_operator_flat_children..')
+-- !result

--- a/test/sql/test_case_when/T/test_case_when
+++ b/test/sql/test_case_when/T/test_case_when
@@ -731,4 +731,4 @@ FROM (
             FROM ads_opt_t_goods_odd_important_kd_di
         ) dataset_table
     ) table_1
-) table_2
+) table_2;

--- a/test/sql/test_case_when/T/test_case_when
+++ b/test/sql/test_case_when/T/test_case_when
@@ -541,3 +541,194 @@ select * from t0 where (case region when 'USA' then 1 when 'UK' then 2 end in (2
 select * from t0 where (case region when 'USA' then 1 when 'UK' then 2 end in (2, 3, null)) is not null order by 1,2,3,4,5;
 select * from t0 where (case when region = 'USA' then 1 when region = 'UK' then 2 else 3 end in (2, 3, null)) is null order by 1,2,3,4,5;
 select * from t0 where (case when region = 'USA' then 1 when region = 'UK' then 2 else 3 end in (2, 3, null)) is not null order by 1,2,3,4,5;
+
+CREATE TABLE `ads_opt_t_goods_odd_important_kd_di` (
+  `region` varchar(128) NOT NULL COMMENT "",
+  `handed_dept_name` int NOT NULL COMMENT "")
+ENGINE=OLAP
+DUPLICATE KEY(`region`)
+COMMENT "OLAP"
+PROPERTIES (
+"replication_num" = "1",
+"enable_persistent_index" = "true",
+"replicated_storage" = "false",
+"compression" = "LZ4"
+);
+
+SELECT *,
+       CASE
+         WHEN `handling_department_2` LIKE '%Ganzhou Transfer Yard%'
+           THEN REPLACE(`handling_department_2`, 'Ganzhou Transfer Yard', 'Ganzhou Transfer Yard Loading/Unloading Team 1')
+         WHEN `handling_department_2` LIKE '%Guangzhou Fanlong Distribution Station Loading/Unloading Team 1%'
+           THEN REPLACE(`handling_department_2`, 'Guangzhou Fanlong Distribution Station Loading/Unloading Team 1', 'Guangzhou Fanlong Distribution Station Loading/Unloading Team')
+         WHEN `handling_department_2` LIKE '%Jingzhou Transfer Yard Loading/Unloading Department%'
+           THEN REPLACE(`handling_department_2`, 'Jingzhou Transfer Yard Loading/Unloading Department', 'Jingzhou Transfer Yard Loading/Unloading Team')
+         WHEN `handling_department_2` LIKE '%Tangshan Loading/Unloading Team 1%'
+           THEN REPLACE(`handling_department_2`, 'Tangshan Loading/Unloading Team 1', 'Tangshan Loading/Unloading Team')
+         WHEN `handling_department_2` LIKE '%Zhexi Hub Center%'
+           THEN REPLACE(`handling_department_2`, 'Zhexi Hub Center', 'Hangzhou Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Shanghai Hub Center%'
+           THEN REPLACE(`handling_department_2`, 'Shanghai Hub Center', 'Shanghai Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Shunde Hub Center%'
+           THEN REPLACE(`handling_department_2`, 'Shunde Hub Center', 'Shunde Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Sunan Hub Center%'
+           THEN REPLACE(`handling_department_2`, 'Sunan Hub Center', 'Suzhou Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Tianjin Hub Center%'
+           THEN REPLACE(`handling_department_2`, 'Tianjin Hub Center', 'Tianjin Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Wuhan Hub Center%'
+           THEN REPLACE(`handling_department_2`, 'Wuhan Hub Center', 'Wuhan Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Northwest Hub Center%'
+           THEN REPLACE(`handling_department_2`, 'Northwest Hub Center', 'Xi\'an Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Zhengzhou Hub Center%'
+           THEN REPLACE(`handling_department_2`, 'Zhengzhou Hub Center', 'Zhengzhou Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Changzhou Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Changzhou Transfer Center', 'Changzhou Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Chaoshan Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Chaoshan Transfer Center', 'Chaoshan Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Fangshan Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Fangshan Transfer Center', 'Fangshan Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Fuzhou Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Fuzhou Transfer Center', 'Fuzhou Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Guiyang Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Guiyang Transfer Center', 'Guiyang Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Harbin Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Harbin Transfer Center', 'Harbin Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Huaian Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Huaian Transfer Center', 'Huaian Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Jinhua Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Jinhua Transfer Center', 'Jinhua Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Kunming Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Kunming Transfer Center', 'Kunming Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Lanzhou Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Lanzhou Transfer Center', 'Lanzhou Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Luohe Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Luohe Transfer Center', 'Luohe Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Nanchang Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Nanchang Transfer Center', 'Nanchang Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Nanjing Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Nanjing Transfer Center', 'Nanjing Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Nanning Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Nanning Transfer Center', 'Nanning Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Nantong Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Nantong Transfer Center', 'Nantong Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Pudong Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Pudong Transfer Center', 'Pudong Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Quanzhou Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Quanzhou Transfer Center', 'Quanzhou Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Xiamen Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Xiamen Transfer Center', 'Xiamen Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Shenyang Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Shenyang Transfer Center', 'Shenyang Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Taiyuan Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Taiyuan Transfer Center', 'Taiyuan Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Wenzhou Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Wenzhou Transfer Center', 'Wenzhou Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Wuhu Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Wuhu Transfer Center', 'Wuhu Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Xuzhou Shaji Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Xuzhou Shaji Transfer Center', 'Xuzhou Shaji Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Xuzhou Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Xuzhou Transfer Center', 'Xuzhou Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Yantai Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Yantai Transfer Center', 'Yantai Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Yangzhou Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Yangzhou Transfer Center', 'Yangzhou Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Changchun Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Changchun Transfer Center', 'Changchun Transfer Yard')
+         WHEN `handling_department_2` LIKE '%Chongqing Baihe Transfer Center%'
+           THEN REPLACE(`handling_department_2`, 'Chongqing Baihe Transfer Center', 'Chongqing Baihe Transfer Yard')
+         ELSE `handling_department_2`
+       END AS `handling_department_3`
+FROM (
+    SELECT *,
+           CASE
+             WHEN `handling_department` LIKE '%Ganzhou Transfer Yard%'
+               THEN REPLACE(`handling_department`, 'Ganzhou Transfer Yard', 'Ganzhou Transfer Yard Loading/Unloading Team 1')
+             WHEN `handling_department` LIKE '%Guangzhou Fanlong Distribution Station Loading/Unloading Team 1%'
+               THEN REPLACE(`handling_department`, 'Guangzhou Fanlong Distribution Station Loading/Unloading Team 1', 'Guangzhou Fanlong Distribution Station Loading/Unloading Team')
+             WHEN `handling_department` LIKE '%Jingzhou Transfer Yard Loading/Unloading Department%'
+               THEN REPLACE(`handling_department`, 'Jingzhou Transfer Yard Loading/Unloading Department', 'Jingzhou Transfer Yard Loading/Unloading Team')
+             WHEN `handling_department` LIKE '%Tangshan Loading/Unloading Team 1%'
+               THEN REPLACE(`handling_department`, 'Tangshan Loading/Unloading Team 1', 'Tangshan Loading/Unloading Team')
+             WHEN `handling_department` LIKE '%Zhexi Hub Center%'
+               THEN REPLACE(`handling_department`, 'Zhexi Hub Center', 'Hangzhou Transfer Yard')
+             WHEN `handling_department` LIKE '%Shanghai Hub Center%'
+               THEN REPLACE(`handling_department`, 'Shanghai Hub Center', 'Shanghai Transfer Yard')
+             WHEN `handling_department` LIKE '%Shunde Hub Center%'
+               THEN REPLACE(`handling_department`, 'Shunde Hub Center', 'Shunde Transfer Yard')
+             WHEN `handling_department` LIKE '%Sunan Hub Center%'
+               THEN REPLACE(`handling_department`, 'Sunan Hub Center', 'Suzhou Transfer Yard')
+             WHEN `handling_department` LIKE '%Tianjin Hub Center%'
+               THEN REPLACE(`handling_department`, 'Tianjin Hub Center', 'Tianjin Transfer Yard')
+             WHEN `handling_department` LIKE '%Wuhan Hub Center%'
+               THEN REPLACE(`handling_department`, 'Wuhan Hub Center', 'Wuhan Transfer Yard')
+             WHEN `handling_department` LIKE '%Northwest Hub Center%'
+               THEN REPLACE(`handling_department`, 'Northwest Hub Center', 'Xi\'an Transfer Yard')
+             WHEN `handling_department` LIKE '%Zhengzhou Hub Center%'
+               THEN REPLACE(`handling_department`, 'Zhengzhou Hub Center', 'Zhengzhou Transfer Yard')
+             WHEN `handling_department` LIKE '%Changzhou Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Changzhou Transfer Center', 'Changzhou Transfer Yard')
+             WHEN `handling_department` LIKE '%Chaoshan Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Chaoshan Transfer Center', 'Chaoshan Transfer Yard')
+             WHEN `handling_department` LIKE '%Fangshan Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Fangshan Transfer Center', 'Fangshan Transfer Yard')
+             WHEN `handling_department` LIKE '%Fuzhou Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Fuzhou Transfer Center', 'Fuzhou Transfer Yard')
+             WHEN `handling_department` LIKE '%Guiyang Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Guiyang Transfer Center', 'Guiyang Transfer Yard')
+             WHEN `handling_department` LIKE '%Harbin Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Harbin Transfer Center', 'Harbin Transfer Yard')
+             WHEN `handling_department` LIKE '%Huaian Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Huaian Transfer Center', 'Huaian Transfer Yard')
+             WHEN `handling_department` LIKE '%Jinhua Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Jinhua Transfer Center', 'Jinhua Transfer Yard')
+             WHEN `handling_department` LIKE '%Kunming Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Kunming Transfer Center', 'Kunming Transfer Yard')
+             WHEN `handling_department` LIKE '%Lanzhou Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Lanzhou Transfer Center', 'Lanzhou Transfer Yard')
+             WHEN `handling_department` LIKE '%Luohe Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Luohe Transfer Center', 'Luohe Transfer Yard')
+             WHEN `handling_department` LIKE '%Nanchang Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Nanchang Transfer Center', 'Nanchang Transfer Yard')
+             WHEN `handling_department` LIKE '%Nanjing Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Nanjing Transfer Center', 'Nanjing Transfer Yard')
+             WHEN `handling_department` LIKE '%Nanning Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Nanning Transfer Center', 'Nanning Transfer Yard')
+             WHEN `handling_department` LIKE '%Nantong Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Nantong Transfer Center', 'Nantong Transfer Yard')
+             WHEN `handling_department` LIKE '%Pudong Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Pudong Transfer Center', 'Pudong Transfer Yard')
+             WHEN `handling_department` LIKE '%Quanzhou Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Quanzhou Transfer Center', 'Quanzhou Transfer Yard')
+             WHEN `handling_department` LIKE '%Xiamen Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Xiamen Transfer Center', 'Xiamen Transfer Yard')
+             WHEN `handling_department` LIKE '%Shenyang Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Shenyang Transfer Center', 'Shenyang Transfer Yard')
+             WHEN `handling_department` LIKE '%Taiyuan Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Taiyuan Transfer Center', 'Taiyuan Transfer Yard')
+             WHEN `handling_department` LIKE '%Wenzhou Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Wenzhou Transfer Center', 'Wenzhou Transfer Yard')
+             WHEN `handling_department` LIKE '%Wuhu Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Wuhu Transfer Center', 'Wuhu Transfer Yard')
+             WHEN `handling_department` LIKE '%Xuzhou Shaji Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Xuzhou Shaji Transfer Center', 'Xuzhou Shaji Transfer Yard')
+             WHEN `handling_department` LIKE '%Xuzhou Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Xuzhou Transfer Center', 'Xuzhou Transfer Yard')
+             WHEN `handling_department` LIKE '%Yantai Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Yantai Transfer Center', 'Yantai Transfer Yard')
+             WHEN `handling_department` LIKE '%Yangzhou Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Yangzhou Transfer Center', 'Yangzhou Transfer Yard')
+             WHEN `handling_department` LIKE '%Changchun Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Changchun Transfer Center', 'Changchun Transfer Yard')
+             WHEN `handling_department` LIKE '%Chongqing Baihe Transfer Center%'
+               THEN REPLACE(`handling_department`, 'Chongqing Baihe Transfer Center', 'Chongqing Baihe Transfer Yard')
+             ELSE `handling_department`
+           END AS `handling_department_2`
+    FROM (
+        SELECT CAST(`handling_department` AS STRING) AS `handling_department`
+        FROM (
+            SELECT handed_dept_name AS `handling_department`
+            FROM ads_opt_t_goods_odd_important_kd_di
+        ) dataset_table
+    ) table_1
+) table_2


### PR DESCRIPTION
## Why I'm doing:
The SQL in Issue 66325 can trigger FE OOM.
Each layer has 40 when/40 then clauses.
```
First-layer expression: N₁ = 1 + (40 × 3) + (40 × 4) + 1
   = 1 + 120 + 160 + 1
   = 282 nodes

N₂ = 282 + 80 × 282
   = 282 + 22,560
   = 22,842

N₃ = 282 + 80 × 22,842
   = 282 + 1,827,360
   = 1,827,642

N₄ = 282 + 80 × 1,827,642
   = 282 + 146,211,360
   = 146,211,642

N₅ = 282 + 80 × 146,211,642
   = 282 + 11,696,931,360
   = 11,696,931,642
```
## What I'm doing:

Fixes #66325


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
