### PR TITLE
[Doc] Add New Deploy FAQ

### DIFF
--- a/docs/en/faq/Deploy_faq.md
+++ b/docs/en/faq/Deploy_faq.md
@@ -30,7 +30,7 @@ This error occurs because the web services port of the BE is occupied. Try to mo
 
 ## What do I do when the error occurs: ERROR 1064 (HY000): Could not initialize class com.starrocks.rpc.BackendServiceProxy?
 
-This error occurs when you run programs in Java Runtime Environment (JRE). To solve this problem, replace JRE with Java Development Kit (JDK). We recommend that you use Oracle's JDK 1.8 or later.
+This error occurs when you run programs in Java Runtime Environment (JRE). To solve this problem, replace JRE with Java Development Kit (JDK). We recommend that you use Oracle's JDK 17 or later.
 
 <!-- ## Why does the error "Failed to Distribute files to node" occur when I deploy StarRocks of Enterprise Edition and configure nodes?
 
@@ -132,3 +132,43 @@ If you do not add the `--helper` option for this FE when starting your cluster f
 ## Why Alive is `false` when an FE is running and prints log `transfer: follower`?
 
 This issue occurs when more than half of memory of Java Virtual Machine (JVM) is used and no checkpoint is marked. In general, a checkpoint will be marked after the system accumulates 50,000 pieces of log. We recommend that you modify the JVM's parameters of each FE and restarting these FEs when they are not heavily loaded.
+
+## Query error: “could not initialize class com.starrocks.rpc.BackendServiceProxy”. How do I resolve this?
+
+- Verify that the environment variable `$JAVA_HOME` points to the correct JDK path.
+- Ensure all nodes use the same JDK version. All nodes must use the identical JDK version.
+
+## What are the MySQL version requirements for installing StarRocks?
+
+MySQL 5.7 or later is recommended to connect to StarRocks.
+
+## If FE and BE are deployed on the same machine, how can I separate them?
+
+It is recommended to scale out a BE node first. After the cluster finishes balancing, you can then scale in the original BE node.
+
+## What should I do when FE fails to start with the error “Replica exceeds max permissible delta:5000ms”?
+
+The clocks between FE nodes are not synchronized. The time difference between FE nodes must be less than 5 seconds.
+
+## If I have five physical machines in a production environment, what is the recommended StarRocks deployment?
+
+A recommended deployment is 3 FE nodes and 5 BE nodes.
+
+## Should I use the root user to install StarRocks?
+
+It is not recommended to use the root user because it has excessive privileges. Create a dedicated user for installing StarRocks.
+
+## Can I install the MySQL client on any machine?
+
+Yes. It is simply a client tool and does not need to run on the same machine as StarRocks. Make sure the MySQL client can access the cluster.
+
+## Is there a limit to the number of tablets on a BE node? For example, for a server with 64 GB RAM and 16 cores, what is the reasonable range of tablet count?
+There is no strict limit for the tablet number. However, for the tablet size, it is recommended to keep each tablet around 1 GB. Proper partitioning and bucketing strategies will help improve query performance. Tablet size planning is important.
+
+## When starting BE, I see the error “error while loading shared libraries: libjvm.so: cannot open shared object file: No such file or directory”. And after manually creating the directory `lib/starrocks_be`, I get a permission denied error. What should I do?
+
+There is an issue with the JDK installation. Please reinstall and properly configure your JDK environment.
+
+## Does StarRocks support running on AMD AVX2? Will mixing Intel and AMD servers cause problems?
+
+StarRocks can run on AMD. Mixing Intel and AMD servers is not recommended because hardware heterogeneity may cause issues. It is suggested to fully test StarRocks on AMD before migrating.

--- a/docs/ja/faq/Deploy_faq.md
+++ b/docs/ja/faq/Deploy_faq.md
@@ -30,7 +30,7 @@ BE をインストールすると、システムは起動エラーを報告し�
 
 ## ERROR 1064 (HY000): Could not initialize class com.starrocks.rpc.BackendServiceProxy というエラーが発生した場合はどうすればよいですか？
 
-このエラーは、Java Runtime Environment (JRE) でプログラムを実行するときに発生します。この問題を解決するには、JRE を Java Development Kit (JDK) に置き換えてください。Oracle の JDK 1.8 以降を使用することをお勧めします。
+このエラーは、Java Runtime Environment (JRE) でプログラムを実行するときに発生します。この問題を解決するには、JRE を Java Development Kit (JDK) に置き換えてください。Oracle の JDK 17 以降を使用することをお勧めします。
 
 ## FE と BE の設定項目を変更して、クラスタを再起動せずに有効にすることはできますか？
 
@@ -111,3 +111,44 @@ OpenSSH Daemon (sshd) が有効になっているか確認してください。�
 ## FE が実行中でログに `transfer: follower` と表示されるときに Alive が `false` になるのはなぜですか？
 
 この問題は、Java Virtual Machine (JVM) のメモリの半分以上が使用され、チェックポイントがマークされていない場合に発生します。通常、システムが 50,000 件のログを蓄積した後にチェックポイントがマークされます。各 FE の JVM パラメータを変更し、これらの FEs が重くロードされていないときに再起動することをお勧めします。
+
+クエリエラー: "could not initialize class com.starrocks.rpc.BackendServiceProxy"。この問題を解決するにはどうすればよいですか？
+
+- 環境変数 `$JAVA_HOME` が正しい JDK パスを指していることを確認してください。
+- すべてのノードが同一のJDKバージョンを使用していることを確認してください。すべてのノードは同一のJDKバージョンを使用する必要があります。
+
+## StarRocks をインストールするための MySQL バージョン要件は何ですか？
+
+StarRocks に接続するには MySQL 5.7 以降を推奨します。
+
+## FE と BE を同じマシンにデプロイした場合、どのように分離できますか？
+
+最初に BE ノードをスケールアウトすることをお勧めします。クラスタのバランスが完了した後、元の BE ノードをスケールインできます。
+
+## FE が「Replica exceeds max permissible delta:5000ms」というエラーで起動に失敗した場合はどうすればよいですか？
+
+FE ノード間のクロックが同期されていません。FE ノード間の時間差は5秒未満である必要があります。
+
+## 本番環境に5台の物理マシンがある場合、推奨される StarRocks のデプロイメントは何ですか？
+
+推奨されるデプロイメントは、3つの FE ノードと5つの BE ノードです。
+
+## StarRocks をインストールする際に root ユーザーを使用すべきですか？
+
+root ユーザーは権限が過剰であるため、使用することは推奨されません。StarRocks をインストールするための専用ユーザーを作成してください。
+
+## MySQL クライアントを任意のマシンにインストールできますか？
+
+はい。これは単なるクライアントツールであり、StarRocks と同じマシンで実行する必要はありません。MySQL クライアントがクラスタにアクセスできることを確認してください。
+
+## BE ノード上の tablet の数に制限はありますか？たとえば、64 GB RAM と 16 コアのサーバーの場合、tablet 数の合理的な範囲はどのくらいですか？
+
+tablet 数に厳密な制限はありません。ただし、tablet サイズについては、各 tablet を約 1 GB に保つことをお勧めします。適切なパーティショニングとバケッティング戦略がクエリパフォーマンスを向上させます。tablet サイズの計画は重要です。
+
+## BE を起動すると「error while loading shared libraries: libjvm.so: cannot open shared object file: No such file or directory」というエラーが表示され、手動で `lib/starrocks_be` ディレクトリを作成すると、許可が拒否されるエラーが発生します。どうすればよいですか？
+
+JDK のインストールに問題があります。JDK 環境を再インストールして適切に構成してください。
+
+## StarRocks は AMD AVX2 での実行をサポートしていますか？Intel と AMD サーバーを混在させると問題が発生しますか？
+
+StarRocks は AMD で実行できます。Intel と AMD サーバーを混在させることは推奨されません。ハードウェアの異質性が問題を引き起こす可能性があるためです。AMD への移行前に StarRocks を十分にテストすることをお勧めします。

--- a/docs/zh/faq/Deploy_faq.md
+++ b/docs/zh/faq/Deploy_faq.md
@@ -142,3 +142,39 @@ netstat  -anp  |grep  port
 
 * 请确认环境变量 `$JAVA_HOME` 是否为正确的 JDK 路径。
 * 请确认所有节点的 JDK 是否是同一个版本，所有节点需要使用相同版本的 JDK。
+
+## 安装 StarRocks 对 MySQL 版本有什么要求？
+
+建议使用 MySQL 5.7 或更高版本连接到 StarRocks。
+
+## 如果 FE 和 BE 部署在同一台机器上，我如何将它们分开？
+
+建议先扩展一个 BE 节点。集群完成平衡后，您可以缩减原始 BE 节点。
+
+## 当 FE 启动失败并出现错误 “Replica exceeds max permissible delta:5000ms” 时，我该怎么办？
+
+FE 节点之间的时钟不同步。FE 节点之间的时间差必须小于 5 秒。
+
+## 如果我在生产环境中有五台物理机器，推荐的 StarRocks 部署是什么？
+
+推荐的部署是 3 个 FE 节点和 5 个 BE 节点。
+
+## 我应该使用 root 用户安装 StarRocks 吗？
+
+不建议使用 root 用户，因为它具有过多的权限。请创建一个专用用户来安装 StarRocks。
+
+## 我可以在任何机器上安装 MySQL 客户端吗？
+
+可以。它只是一个客户端工具，不需要在与 StarRocks 相同的机器上运行。确保 MySQL 客户端可以访问集群。
+
+## BE 节点上的 tablet 数量有限制吗？例如，对于一台具有 64 GB RAM 和 16 核的服务器，合理的 tablet 数量范围是多少？
+
+tablet 数量没有严格限制。然而，对于 tablet 大小，建议保持每个 tablet 大约 1 GB。适当的分区和分桶策略将有助于提高查询性能。tablet 大小规划很重要。
+
+## 启动 BE 时，我看到错误 “error while loading shared libraries: libjvm.so: cannot open shared object file: No such file or directory”。在手动创建目录 `lib/starrocks_be` 后，我收到权限被拒绝的错误。我该怎么办？
+
+JDK 安装存在问题。请重新安装并正确配置您的 JDK 环境。
+
+## StarRocks 支持在 AMD AVX2 上运行吗？混合使用 Intel 和 AMD 服务器会导致问题吗？
+
+StarRocks 可以在 AMD 上运行。不建议混合使用 Intel 和 AMD 服务器，因为硬件异构性可能会导致问题。建议在迁移之前充分测试 StarRocks 在 AMD 上的运行情况。


### PR DESCRIPTION
Signed-off-by: EsoragotoSpirit <wanglichen@starrocks.com>

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands deployment FAQs in en/ja/zh: bump JDK recommendation to 17 and add multiple new troubleshooting and operational Q&As.
> 
> - **Docs**:
>   - **`docs/en/faq/Deploy_faq.md`**:
>     - Update JDK recommendation for `BackendServiceProxy` error to `JDK 17+`.
>     - Add FAQs: verify `$JAVA_HOME` and uniform JDK across nodes; MySQL `5.7+` requirement; separating co-located FE/BE; FE startup clock delta error (<5s); recommended deployment (3 FE, 5 BE for 5 machines); avoid using `root`; MySQL client can run anywhere; BE tablet sizing guidance (~1 GB/tablet); `libjvm.so` load error resolved by reinstalling/configuring JDK; AMD AVX2 support and note on mixing Intel/AMD.
>   - **`docs/ja/faq/Deploy_faq.md`**:
>     - Same JDK update and added FAQs as EN (localized), plus minor formatting adjustments.
>   - **`docs/zh/faq/Deploy_faq.md`**:
>     - Add the same new FAQs and guidance as EN (localized).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98e66c23cd645ac9b9e85e3f875737e6a94dc7a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->