### PR TITLE
[BugFix] Avoid using fork in sub processes

### DIFF
--- a/be/extension/python-udf/src/flight_server.py
+++ b/be/extension/python-udf/src/flight_server.py
@@ -15,15 +15,16 @@
 # limitations under the License.
 
 import argparse
-import pyarrow as pa
-import pyarrow.flight as flight
-import pyarrow
+import base64
+import json
+import os
 import sys
 import time
-import json
-import base64
 import zipimport
 import ast
+
+import pyarrow as pa
+import pyarrow.flight as flight
 
 class CallStub(object):
     def __init__(self, symbol, output_type, location, content):
@@ -148,8 +149,13 @@ def main(unix_socket_path):
     sys.stdout.flush()
     server.wait()
 
+def build_socket_url(prefix):
+    pid = os.getpid()
+    return prefix + str(pid)
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Run an Arrow Flight echo server over Unix socket.")
     parser.add_argument("unix_socket_path", type=str, help="The path to the Unix socket.")
     args = parser.parse_args()
-    main(args.unix_socket_path)
+    url = build_socket_url(args.unix_socket_path)
+    main(url)

--- a/be/src/common/prof/heap_prof.cpp
+++ b/be/src/common/prof/heap_prof.cpp
@@ -68,8 +68,8 @@ bool dump_snapshot(const std::string& filename) {
                    ("prof.dump", nullptr, nullptr, &fname, sizeof(const char*))) == 0;
 }
 
-// declare exec from script
-std::string exec(const std::string& cmd);
+// declare exec from runtime/exec.cpp
+std::string lite_exec(const std::vector<std::string>& argv_vec, int timeout_ms = 1200000);
 
 void HeapProf::enable_prof() {
 #ifndef __APPLE__
@@ -121,7 +121,7 @@ std::string HeapProf::to_dot_format(const std::string& heapdump_filename) {
 #ifdef __APPLE__
     return "not support on MacOS";
 #else
-    return exec(fmt::format("{} --dot {} {}", jeprof, binary, heapdump_filename));
+    return lite_exec({jeprof, "--dot", binary, heapdump_filename});
 #endif
 }
 

--- a/be/src/exprs/arrow_function_call.cpp
+++ b/be/src/exprs/arrow_function_call.cpp
@@ -128,6 +128,7 @@ std::unique_ptr<UDFCallStub> ArrowFunctionCallExpr::_build_stub(int32_t driver_i
         py_func_desc.input_types = context->get_arg_types();
         py_func_desc.return_type = context->get_return_type();
         py_func_desc.content = _fn.content;
+        py_func_desc.driver_id = driver_id;
         return build_py_call_stub(context, py_func_desc);
     }
 #ifndef __APPLE__

--- a/be/src/runtime/CMakeLists.txt
+++ b/be/src/runtime/CMakeLists.txt
@@ -30,6 +30,7 @@ set(RUNTIME_FILES
     datetime_value.cpp
     descriptors.cpp
     exec_env.cpp
+    exec.cpp
     global_variables.cpp
     user_function_cache.cpp
     jdbc_driver_manager.cpp

--- a/be/src/runtime/exec.cpp
+++ b/be/src/runtime/exec.cpp
@@ -1,4 +1,3 @@
-
 // Copyright 2021-present StarRocks, Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -100,7 +99,7 @@ std::string lite_exec(const std::vector<std::string>& argv_vec, int timeout_ms) 
             timed_out = true;
             break;
         } else {
-            size_t n = read(pipefd[0], buf, sizeof(buf));
+            ssize_t n = read(pipefd[0], buf, sizeof(buf));
             if (n > 0) {
                 output.append(buf, n);
             } else if (n == 0) {

--- a/be/src/runtime/exec.cpp
+++ b/be/src/runtime/exec.cpp
@@ -1,0 +1,147 @@
+
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <fcntl.h>
+#include <spawn.h>
+#include <sys/poll.h>
+#include <sys/time.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <chrono>
+#include <cstring>
+#include <string>
+#include <vector>
+
+extern char** environ;
+
+namespace starrocks {
+std::string lite_exec(const std::vector<std::string>& argv_vec, int timeout_ms) {
+    std::string output;
+
+    std::vector<char*> argv;
+
+    argv.reserve(argv_vec.size() + 1);
+    for (auto& s : argv_vec) {
+        argv.push_back(const_cast<char*>(s.c_str()));
+    }
+    argv.push_back(nullptr);
+
+    // create pipe
+    int pipefd[2];
+    if (pipe(pipefd) != 0) {
+        return std::string("pipe failed: ") + std::strerror(errno);
+    }
+    // make read end non-blocking for robust poll/read
+    int flags = fcntl(pipefd[0], F_GETFL, 0);
+    if (flags != -1) fcntl(pipefd[0], F_SETFL, flags | O_NONBLOCK);
+
+    // spawn file actions
+    posix_spawn_file_actions_t actions;
+    posix_spawn_file_actions_init(&actions);
+
+    // In child:
+    //  - dup pipefd[1] -> STDOUT
+    //  - dup pipefd[1] -> STDERR
+    //  - close pipefd[0] (read end)
+    posix_spawn_file_actions_adddup2(&actions, pipefd[1], STDOUT_FILENO);
+    posix_spawn_file_actions_adddup2(&actions, pipefd[1], STDERR_FILENO);
+    posix_spawn_file_actions_addclose(&actions, pipefd[0]);
+
+    pid_t pid;
+    int rc = posix_spawnp(&pid, argv[0], &actions, nullptr, argv.data(), environ);
+    posix_spawn_file_actions_destroy(&actions);
+
+    // close write end in parent
+    close(pipefd[1]);
+
+    if (rc != 0) {
+        close(pipefd[0]);
+        return std::string("posix_spawnp failed: ") + std::strerror(rc);
+    }
+
+    // poll + read loop with timeout
+    pollfd pfd;
+    pfd.fd = pipefd[0];
+    pfd.events = POLLIN;
+
+    auto start = std::chrono::steady_clock::now();
+    int remaining = timeout_ms;
+    bool timed_out = false;
+    char buf[4096];
+
+    while (true) {
+        int pr = poll(&pfd, 1, remaining);
+        if (pr < 0) {
+            if (errno == EINTR) {
+                auto now = std::chrono::steady_clock::now();
+                remaining =
+                        timeout_ms -
+                        static_cast<int>(std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count());
+                if (remaining < 0) remaining = 0;
+                continue;
+            } else
+                // poll error
+                break;
+        } else if (pr == 0) {
+            timed_out = true;
+            break;
+        } else {
+            size_t n = read(pipefd[0], buf, sizeof(buf));
+            if (n > 0) {
+                output.append(buf, n);
+            } else if (n == 0) {
+                break;
+            } else if (errno != EAGAIN && errno != EINTR) {
+                break;
+            }
+        }
+        auto now = std::chrono::steady_clock::now();
+        remaining = timeout_ms -
+                    static_cast<int>(std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count());
+        if (remaining <= 0) {
+            timed_out = true;
+            break;
+        }
+    }
+
+    if (timed_out) {
+        kill(pid, SIGKILL);
+    }
+
+    int status = 0;
+    if (waitpid(pid, &status, 0) == -1) {
+        close(pipefd[0]);
+        output.append("\nwaitpid failed: " + std::string(strerror(errno)));
+        return output;
+    }
+    close(pipefd[0]);
+
+    if (WIFEXITED(status)) {
+        int code = WEXITSTATUS(status);
+        if (code != 0) output.append("\nexit_code: " + std::to_string(code));
+    } else if (WIFSIGNALED(status)) {
+        int sig = WTERMSIG(status);
+        output.append("\nkilled_by_signal: " + std::to_string(sig));
+    }
+
+    if (timed_out) {
+        output.append("\nexec: timeout");
+    }
+
+    return output;
+}
+} // namespace starrocks

--- a/be/src/udf/python/env.cpp
+++ b/be/src/udf/python/env.cpp
@@ -91,10 +91,11 @@ Status PyWorkerManager::_fork_py_worker(std::unique_ptr<PyWorker>* child_process
         return Status::InternalError(fmt::format("open /proc/self/fd error {}", std::strerror(errno)));
     }
 
-    int dir_fd = dirfd(dir);
-    butil::fd_guard dir_fd_guard(dir_fd);
-    if (dir_fd < 0) {
-        return Status::InternalError(fmt::format("syscall dirfd error {}", std::strerror(errno)));
+    {
+        int dir_fd = dirfd(dir);
+        if (dir_fd < 0) {
+            return Status::InternalError(fmt::format("syscall dirfd error {}", std::strerror(errno)));
+        }
     }
 
     struct dirent* entry;

--- a/be/src/udf/python/env.h
+++ b/be/src/udf/python/env.h
@@ -60,8 +60,8 @@ public:
     void terminate_and_wait() {
         lock_free_call_once(_once, [this]() {
             terminate();
-            wait();
             remove_unix_socket();
+            wait();
         });
     }
     void remove_unix_socket();
@@ -96,6 +96,11 @@ public:
 
     static std::string unix_socket(pid_t pid) {
         std::string unix_socket = fmt::format("grpc+unix://{}/pyworker_{}", config::local_library_dir, pid);
+        return unix_socket;
+    }
+
+    static std::string unix_socket_prefix() {
+        std::string unix_socket = fmt::format("grpc+unix://{}/pyworker_", config::local_library_dir);
         return unix_socket;
     }
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -317,6 +317,7 @@ set(EXEC_FILES
         ./runtime/memory_scratch_sink_test.cpp
         ./runtime/command_executor_test.cpp
         ./runtime/exec_env_test.cpp
+        ./runtime/exec_sub_process_test.cpp
         ./runtime/load_fail_point_test.cpp
         ./runtime/query_statistics_test.cpp
         ./serde/column_array_serde_test.cpp

--- a/be/test/runtime/exec_sub_process_test.cpp
+++ b/be/test/runtime/exec_sub_process_test.cpp
@@ -1,0 +1,37 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "common/logging.h"
+
+namespace starrocks {
+std::string lite_exec(const std::vector<std::string>& argv_vec, int timeout_ms = 1200000);
+
+TEST(TestLiteFork, fork) {
+    {
+        std::vector<std::string> argv = {"/bin/echo", "hello", "world"};
+        auto res = lite_exec(argv);
+        ASSERT_EQ(res, "hello world\n");
+    }
+    {
+        std::vector<std::string> argv = {"/bin/sleep", "3600"};
+        auto res = lite_exec(argv, 1000);
+        ASSERT_TRUE(res.find("timeout") != std::string::npos);
+    }
+}
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

posix_spawnp will not copy page table. Therefore, creating child processes will not cause the BE to become unresponsive.

## What I'm doing:

Fixes #59106

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces fork/exec with posix_spawnp-based helpers, introduces lite_exec, updates Python UDF worker lifecycle and socket handling, switches heap profiling to argv-based exec, and adds unit tests.
> 
> - **Runtime**:
>   - **New `lite_exec`**: Add `be/src/runtime/exec.cpp` providing posix_spawnp-based subprocess execution with timeout; wired into build.
> - **UDF/Python Worker Management**:
>   - Switch worker creation from `fork/exec` to `posix_spawnp`, close extraneous FDs via `posix_spawn_file_actions`, and stream startup logs via pipe.
>   - Add `unix_socket_prefix()`; worker URL now derived in Python using PID; adjust socket cleanup order in `terminate_and_wait`.
>   - Improve lifecycle: mark worker dead on Arrow RPC/init errors; remove dead workers from pool; batch cleanup outside lock using partition.
> - **Profiling**:
>   - Replace string `exec` with `lite_exec({jeprof, "--dot", binary, heapdump})` in `HeapProf::to_dot_format`.
> - **Expressions/UDF**:
>   - Pass `driver_id` to `PyFunctionDescriptor` in `ArrowFunctionCallExpr`.
> - **Python Flight Server** (`be/extension/python-udf/src/flight_server.py`):
>   - Build socket URL by appending PID to provided prefix; minor import cleanup.
> - **Tests**:
>   - Add `runtime/exec_sub_process_test.cpp` validating `lite_exec` output and timeout; include in test CMake.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4beac02b3c288f7e018f73491087e0b79e7fb22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->