### PR TITLE
[Enhancement] Support Named Parameters in Scala Functions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -1094,14 +1094,6 @@ public class ExpressionAnalyzer {
             // Handle named arguments reordering before function lookup
             List<String> exprsNames = node.getParams().getExprsNames();
             if (exprsNames != null && !exprsNames.isEmpty()) {
-                // Check for mixed named and positional arguments
-                // Positional arguments have empty string "" as their name in exprsNames
-                boolean hasNamedArg = exprsNames.stream().anyMatch(name -> !name.isEmpty());
-                boolean hasPositionalArg = exprsNames.stream().anyMatch(String::isEmpty);
-                if (hasNamedArg && hasPositionalArg) {
-                    throw new SemanticException("Mixing named and positional arguments is not allowed", node.getPos());
-                }
-
                 // Named arguments are used - we need to find the function first, then reorder
                 Function fn = FunctionAnalyzer.getAnalyzedFunctionForNamedArgs(session, node, argumentTypes, exprsNames);
                 if (fn == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -1094,6 +1094,14 @@ public class ExpressionAnalyzer {
             // Handle named arguments reordering before function lookup
             List<String> exprsNames = node.getParams().getExprsNames();
             if (exprsNames != null && !exprsNames.isEmpty()) {
+                // Check for mixed named and positional arguments
+                // Positional arguments have empty string "" as their name in exprsNames
+                boolean hasNamedArg = exprsNames.stream().anyMatch(name -> !name.isEmpty());
+                boolean hasPositionalArg = exprsNames.stream().anyMatch(String::isEmpty);
+                if (hasNamedArg && hasPositionalArg) {
+                    throw new SemanticException("Mixing named and positional arguments is not allowed", node.getPos());
+                }
+
                 // Named arguments are used - we need to find the function first, then reorder
                 Function fn = FunctionAnalyzer.getAnalyzedFunctionForNamedArgs(session, node, argumentTypes, exprsNames);
                 if (fn == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -1101,13 +1101,11 @@ public class ExpressionAnalyzer {
                     FunctionAnalyzer.throwFriendlyNamedArgError(fnName, argumentTypes, exprsNames);
                     // Fallback to generic error if no specific error was thrown
                     String msg = String.format("No matching function with signature: %s(%s)",
-                            fnName, node.getParams().getNamedArgStr());
+                            fnName, FunctionAnalyzer.getNamedArgStr(node.getParams()));
                     throw new SemanticException(msg, node.getPos());
                 }
-                // Validate named arguments before reordering
-                FunctionAnalyzer.validateNamedArguments(fnName, fn, exprsNames);
                 // Reorder arguments according to function definition
-                node.getParams().reorderNamedArgAndAppendDefaults(fn);
+                FunctionAnalyzer.reorderNamedArgAndAppendDefaults(node.getParams(), fn);
                 // Update children to match reordered params
                 node.clearChildren();
                 node.addChildren(node.getParams().exprs());
@@ -1117,6 +1115,8 @@ public class ExpressionAnalyzer {
                         visit(child, scope);
                     }
                 }
+                // Validate named arguments after reordering (includes NULL checks for required parameters)
+                FunctionAnalyzer.validateNamedArguments(fnName, fn, exprsNames, node);
                 node.setFn(fn);
                 node.setType(fn.getReturnType());
                 FunctionAnalyzer.analyze(node);
@@ -1131,7 +1131,7 @@ public class ExpressionAnalyzer {
                         session, fnName, argumentTypes);
                 if (fn != null) {
                     // Append default values for remaining parameters
-                    node.getParams().appendDefaultsForPositionalArgs(fn);
+                    FunctionAnalyzer.appendDefaultsForPositionalArgs(node.getParams(), fn);
                     // Update children to match the expanded params
                     node.clearChildren();
                     node.addChildren(node.getParams().exprs());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -1090,9 +1090,65 @@ public class ExpressionAnalyzer {
             Type[] argumentTypes = node.getChildren().stream().map(Expr::getType).toArray(Type[]::new);
             // check fn & throw exception direct if analyze failed
             checkFunction(fnName, node, argumentTypes);
+
+            // Handle named arguments reordering before function lookup
+            List<String> exprsNames = node.getParams().getExprsNames();
+            if (exprsNames != null && !exprsNames.isEmpty()) {
+                // Named arguments are used - we need to find the function first, then reorder
+                Function fn = FunctionAnalyzer.getAnalyzedFunctionForNamedArgs(session, node, argumentTypes, exprsNames);
+                if (fn == null) {
+                    // Try to provide a more user-friendly error message
+                    FunctionAnalyzer.throwFriendlyNamedArgError(fnName, argumentTypes, exprsNames);
+                    // Fallback to generic error if no specific error was thrown
+                    String msg = String.format("No matching function with signature: %s(%s)",
+                            fnName, node.getParams().getNamedArgStr());
+                    throw new SemanticException(msg, node.getPos());
+                }
+                // Validate named arguments before reordering
+                FunctionAnalyzer.validateNamedArguments(fnName, fn, exprsNames);
+                // Reorder arguments according to function definition
+                node.getParams().reorderNamedArgAndAppendDefaults(fn);
+                // Update children to match reordered params
+                node.clearChildren();
+                node.addChildren(node.getParams().exprs());
+                // Re-analyze children after reordering
+                for (Expr child : node.getChildren()) {
+                    if (!child.isAnalyzed()) {
+                        visit(child, scope);
+                    }
+                }
+                node.setFn(fn);
+                node.setType(fn.getReturnType());
+                FunctionAnalyzer.analyze(node);
+                return null;
+            }
+
             // get function by function expression and argument types
             Function fn = FunctionAnalyzer.getAnalyzedFunction(session, node, argumentTypes);
             if (fn == null) {
+                // Try to find a function with named arguments that can accept positional arguments
+                fn = FunctionAnalyzer.getAnalyzedFunctionForPositionalCallWithNamedArgs(
+                        session, fnName, argumentTypes);
+                if (fn != null) {
+                    // Append default values for remaining parameters
+                    node.getParams().appendDefaultsForPositionalArgs(fn);
+                    // Update children to match the expanded params
+                    node.clearChildren();
+                    node.addChildren(node.getParams().exprs());
+                    // Re-analyze new children (default values)
+                    for (Expr child : node.getChildren()) {
+                        if (!child.isAnalyzed()) {
+                            visit(child, scope);
+                        }
+                    }
+                    node.setFn(fn);
+                    node.setType(fn.getReturnType());
+                    FunctionAnalyzer.analyze(node);
+                    return null;
+                }
+                // Try to provide a more user-friendly error message for positional calls
+                FunctionAnalyzer.throwFriendlyPositionalArgError(fnName, argumentTypes);
+                // Fallback to generic error if no specific error was thrown
                 String msg = String.format("No matching function with signature: %s(%s)",
                         fnName,
                         node.getParams().isStar() ? "*" : Joiner.on(", ")

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -1104,19 +1104,29 @@ public class ExpressionAnalyzer {
                             fnName, FunctionAnalyzer.getNamedArgStr(node.getParams()));
                     throw new SemanticException(msg, node.getPos());
                 }
+
+                // This prevents confusing IllegalStateException when duplicate parameters exist.
+                // validateNamedArgumentsStructure checks: duplicates, unknown params, missing required params
+                FunctionAnalyzer.validateNamedArgumentsStructure(fnName, fn, exprsNames);
+
                 // Reorder arguments according to function definition
                 FunctionAnalyzer.reorderNamedArgAndAppendDefaults(node.getParams(), fn);
+
                 // Update children to match reordered params
                 node.clearChildren();
                 node.addChildren(node.getParams().exprs());
-                // Re-analyze children after reordering
+
+                // Re-analyze children after reordering (includes default values)
                 for (Expr child : node.getChildren()) {
                     if (!child.isAnalyzed()) {
                         visit(child, scope);
                     }
                 }
-                // Validate named arguments after reordering (includes NULL checks for required parameters)
-                FunctionAnalyzer.validateNamedArguments(fnName, fn, exprsNames, node);
+
+                // Validate NULL constraints AFTER reordering
+                // This must be after reordering because it depends on parameter positions
+                FunctionAnalyzer.validateNullConstraints(fnName, fn, node);
+
                 node.setFn(fn);
                 node.setType(fn.getReturnType());
                 FunctionAnalyzer.analyze(node);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -1456,13 +1456,16 @@ public class FunctionAnalyzer {
      * - No duplicate parameter names
      * - All parameter names are valid
      * - All required parameters (without defaults) are provided
+     * - Required parameters (without defaults) cannot be NULL
      *
      * @param fnName      function name for error messages
      * @param fn          the function definition
      * @param paramNames  list of parameter names provided by user
+     * @param node        function call expression to check argument values
      * @throws SemanticException if validation fails
      */
-    public static void validateNamedArguments(String fnName, Function fn, List<String> paramNames) {
+    public static void validateNamedArguments(String fnName, Function fn, List<String> paramNames,
+                                              FunctionCallExpr node) {
         if (fn == null || !fn.hasNamedArg()) {
             throw new SemanticException(fnName + "() does not support named parameters");
         }
@@ -1498,6 +1501,104 @@ public class FunctionAnalyzer {
                         "%s() required parameter '%s' is missing", fnName, requiredParam));
             }
         }
+
+        // Check required parameters (without defaults) cannot be NULL
+        // Skip NULL validation if node is not provided (for testing)
+        if (node != null) {
+            // Required parameters are those without default values, indicated by index < requiredCount
+            for (int i = 0; i < requiredCount && i < node.getChildren().size(); i++) {
+                com.starrocks.sql.ast.expression.Expr argExpr = node.getChild(i);
+                if (argExpr instanceof com.starrocks.sql.ast.expression.NullLiteral) {
+                    throw new SemanticException(String.format(
+                            "%s() required parameter '%s' cannot be NULL", fnName, validParamNames[i]));
+                }
+            }
+        }
+    }
+
+    /**
+     * Reorder named arguments and append defaults according to function definition.
+     * This method modifies the FunctionParams to match the function's parameter order.
+     *
+     * @param params FunctionParams containing the named arguments
+     * @param fn     Function definition with named arguments
+     */
+    public static void reorderNamedArgAndAppendDefaults(com.starrocks.sql.ast.expression.FunctionParams params, Function fn) {
+        String[] names = fn.getArgNames();
+        List<String> exprsNames = params.getExprsNames();
+        List<com.starrocks.sql.ast.expression.Expr> exprs = params.exprs();
+
+        Preconditions.checkState(names != null && names.length >= exprsNames.size());
+        String[] newNames = new String[names.length];
+        com.starrocks.sql.ast.expression.Expr[] newExprs = new com.starrocks.sql.ast.expression.Expr[names.length];
+        int defaultNum = 0;
+
+        for (int j = 0; j < names.length; j++) {
+            for (int i = 0; i < exprsNames.size(); i++) {
+                if (exprsNames.get(i).equals(names[j])) {
+                    newNames[j] = exprsNames.get(i);
+                    newExprs[j] = exprs.get(i);
+                    break;
+                }
+            }
+            if (newExprs[j] == null) {
+                newExprs[j] = fn.getDefaultNamedExpr(names[j]);
+                newNames[j] = names[j];
+                Preconditions.checkState(newExprs[j] != null);
+                defaultNum++;
+            }
+        }
+        Preconditions.checkState(defaultNum + exprsNames.size() == names.length);
+        params.setExprs(Arrays.asList(newExprs));
+        params.setExprsNames(Arrays.asList(newNames));
+    }
+
+    /**
+     * Append default values for positional arguments.
+     * This method is used when calling a function that has named arguments support
+     * using positional arguments syntax.
+     *
+     * @param params FunctionParams containing positional arguments
+     * @param fn     Function definition with named arguments
+     */
+    public static void appendDefaultsForPositionalArgs(com.starrocks.sql.ast.expression.FunctionParams params, Function fn) {
+        String[] names = fn.getArgNames();
+        List<com.starrocks.sql.ast.expression.Expr> exprs = params.exprs();
+
+        Preconditions.checkState(names != null && names.length >= exprs.size());
+        int providedCount = exprs.size();
+        // Create a new mutable list
+        List<com.starrocks.sql.ast.expression.Expr> newExprs = new java.util.ArrayList<>(exprs);
+        // Append default values for remaining parameters
+        for (int i = providedCount; i < names.length; i++) {
+            com.starrocks.sql.ast.expression.Expr defaultExpr = fn.getDefaultNamedExpr(names[i]);
+            Preconditions.checkState(defaultExpr != null,
+                    "Missing default value for parameter: " + names[i]);
+            newExprs.add(defaultExpr);
+        }
+        params.setExprs(newExprs);
+    }
+
+    /**
+     * Get string representation of named arguments for error messages.
+     *
+     * @param params FunctionParams with named arguments
+     * @return String representation like "param1=>value1,param2=>value2"
+     */
+    public static String getNamedArgStr(com.starrocks.sql.ast.expression.FunctionParams params) {
+        List<com.starrocks.sql.ast.expression.Expr> exprs = params.exprs();
+        List<String> exprsNames = params.getExprsNames();
+
+        Preconditions.checkState(exprs.size() == exprsNames.size());
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < exprs.size(); i++) {
+            if (i != 0) {
+                result.append(",");
+            }
+            result.append(exprsNames.get(i)).append("=>")
+                  .append(com.starrocks.sql.ast.expression.ExprToSql.toSql(exprs.get(i)));
+        }
+        return result.toString();
     }
 
     /**
@@ -1523,7 +1624,7 @@ public class FunctionAnalyzer {
 
         if (fn != null && fn.hasNamedArg()) {
             // Function exists and supports named args - validate to get specific error
-            validateNamedArguments(fnName, fn, paramNames);
+            validateNamedArguments(fnName, fn, paramNames, null);
         }
         // If we reach here, throw generic error (will be handled by caller)
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -1466,9 +1466,13 @@ public class FunctionAnalyzer {
      * Validate named arguments for any function that supports them.
      * This is the main validation entry point that delegates to specialized methods.
      *
+     * IMPORTANT: This method should be called AFTER reordering when node is provided,
+     * because NULL constraints validation relies on parameter positions matching
+     * the function definition order (node.getChild(i) corresponds to fn.getArgNames()[i]).
+     *
      * This method performs validation in two stages:
-     * 1. Structure validation (duplicates, unknown params, missing required) - safe before reordering
-     * 2. NULL constraints validation - requires correct parameter positions after reordering
+     * 1. Structure validation (duplicates, unknown params, missing required)
+     * 2. NULL constraints validation (only if node is provided)
      *
      * @param fnName      function name for error messages
      * @param fn          the function definition
@@ -1478,10 +1482,11 @@ public class FunctionAnalyzer {
      */
     public static void validateNamedArguments(String fnName, Function fn, List<String> paramNames,
                                               FunctionCallExpr node) {
-        // Always validate structure first
+        // Validate structure first
         validateNamedArgumentsStructure(fnName, fn, paramNames);
 
         // Validate NULL constraints only if node is provided
+        // Note: This assumes arguments are already reordered to match function definition order
         if (node != null) {
             validateNullConstraints(fnName, fn, node);
         }
@@ -1508,6 +1513,14 @@ public class FunctionAnalyzer {
     public static void validateNamedArgumentsStructure(String fnName, Function fn, List<String> paramNames) {
         if (fn == null || !fn.hasNamedArg()) {
             throw new SemanticException(fnName + "() does not support named parameters");
+        }
+
+        // Check for mixed named and positional arguments
+        // Positional arguments have empty string "" as their name
+        boolean hasNamedArg = paramNames.stream().anyMatch(name -> !name.isEmpty());
+        boolean hasPositionalArg = paramNames.stream().anyMatch(String::isEmpty);
+        if (hasNamedArg && hasPositionalArg) {
+            throw new SemanticException(fnName + "() mixing named and positional arguments is not allowed");
         }
 
         String[] validParamNames = fn.getArgNames();
@@ -1697,11 +1710,18 @@ public class FunctionAnalyzer {
         Function fn = ExprUtils.getBuiltinFunction(fnName, argumentTypes,
                 Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
 
-        if (fn != null && fn.hasNamedArg()) {
-            // Function exists and supports named args - validate to get specific error
-            validateNamedArguments(fnName, fn, paramNames, null);
+        if (fn != null) {
+            if (fn.hasNamedArg()) {
+                // Function exists and supports named args - validate structure to get specific error
+                // Note: Use validateNamedArgumentsStructure (not validateNamedArguments) because
+                // this is called BEFORE reordering, and NULL validation requires reordered arguments
+                validateNamedArgumentsStructure(fnName, fn, paramNames);
+            } else {
+                // Function exists but does not support named arguments
+                throw new SemanticException(fnName + "() does not support named arguments");
+            }
         }
-        // If we reach here, throw generic error (will be handled by caller)
+        // If we reach here (fn == null), throw generic error (will be handled by caller)
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -77,6 +77,7 @@ import com.starrocks.type.VarcharType;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -1451,21 +1452,48 @@ public class FunctionAnalyzer {
 
     /**
      * Validate named arguments for any function that supports them.
-     * Checks for:
-     * - Function supports named arguments
-     * - No duplicate parameter names
-     * - All parameter names are valid
-     * - All required parameters (without defaults) are provided
-     * - Required parameters (without defaults) cannot be NULL
+     * This is the main validation entry point that delegates to specialized methods.
+     *
+     * This method performs validation in two stages:
+     * 1. Structure validation (duplicates, unknown params, missing required) - safe before reordering
+     * 2. NULL constraints validation - requires correct parameter positions after reordering
      *
      * @param fnName      function name for error messages
      * @param fn          the function definition
      * @param paramNames  list of parameter names provided by user
-     * @param node        function call expression to check argument values
+     * @param node        function call expression to check argument values (null to skip NULL validation)
      * @throws SemanticException if validation fails
      */
     public static void validateNamedArguments(String fnName, Function fn, List<String> paramNames,
                                               FunctionCallExpr node) {
+        // Always validate structure first
+        validateNamedArgumentsStructure(fnName, fn, paramNames);
+
+        // Validate NULL constraints only if node is provided
+        if (node != null) {
+            validateNullConstraints(fnName, fn, node);
+        }
+    }
+
+    /**
+     * Validate named arguments structure before reordering.
+     * This method checks the logical correctness of parameter names without depending on their order.
+     *
+     * IMPORTANT: This must be called BEFORE reordering to catch duplicate parameters early,
+     * preventing confusing IllegalStateException in reorderNamedArgAndAppendDefaults().
+     *
+     * Checks:
+     * - Function supports named arguments
+     * - No duplicate parameter names
+     * - All parameter names are valid (known to the function)
+     * - All required parameters (without defaults) are provided
+     *
+     * @param fnName      function name for error messages
+     * @param fn          the function definition
+     * @param paramNames  list of parameter names provided by user
+     * @throws SemanticException if validation fails
+     */
+    public static void validateNamedArgumentsStructure(String fnName, Function fn, List<String> paramNames) {
         if (fn == null || !fn.hasNamedArg()) {
             throw new SemanticException(fnName + "() does not support named parameters");
         }
@@ -1501,17 +1529,35 @@ public class FunctionAnalyzer {
                         "%s() required parameter '%s' is missing", fnName, requiredParam));
             }
         }
+    }
+
+    /**
+     * Validate NULL constraints after reordering.
+     * This method checks that required parameters are not NULL.
+     *
+     * IMPORTANT: This must be called AFTER reordering because it relies on parameter
+     * positions matching the function definition order (node.getChild(i) corresponds to fn.getArgNames()[i]).
+     *
+     * @param fnName function name for error messages
+     * @param fn     the function definition
+     * @param node   function call expression to check argument values
+     * @throws SemanticException if any required parameter is NULL
+     */
+    public static void validateNullConstraints(String fnName, Function fn, FunctionCallExpr node) {
+        if (node == null || fn == null) {
+            return;
+        }
+
+        String[] validParamNames = fn.getArgNames();
+        int requiredCount = fn.getRequiredArgNum();
 
         // Check required parameters (without defaults) cannot be NULL
-        // Skip NULL validation if node is not provided (for testing)
-        if (node != null) {
-            // Required parameters are those without default values, indicated by index < requiredCount
-            for (int i = 0; i < requiredCount && i < node.getChildren().size(); i++) {
-                com.starrocks.sql.ast.expression.Expr argExpr = node.getChild(i);
-                if (argExpr instanceof com.starrocks.sql.ast.expression.NullLiteral) {
-                    throw new SemanticException(String.format(
-                            "%s() required parameter '%s' cannot be NULL", fnName, validParamNames[i]));
-                }
+        // Required parameters are those without default values, indicated by index < requiredCount
+        for (int i = 0; i < requiredCount && i < node.getChildren().size(); i++) {
+            com.starrocks.sql.ast.expression.Expr argExpr = node.getChild(i);
+            if (argExpr instanceof com.starrocks.sql.ast.expression.NullLiteral) {
+                throw new SemanticException(String.format(
+                        "%s() required parameter '%s' cannot be NULL", fnName, validParamNames[i]));
             }
         }
     }
@@ -1519,6 +1565,10 @@ public class FunctionAnalyzer {
     /**
      * Reorder named arguments and append defaults according to function definition.
      * This method modifies the FunctionParams to match the function's parameter order.
+     *
+     * IMPORTANT: validateNamedArgumentsStructure() should be called BEFORE this method
+     * to ensure no duplicate parameters exist. This method uses HashMap which would silently
+     * overwrite duplicates, but duplicates should already be caught by validation.
      *
      * @param params FunctionParams containing the named arguments
      * @param fn     Function definition with named arguments
@@ -1528,27 +1578,40 @@ public class FunctionAnalyzer {
         List<String> exprsNames = params.getExprsNames();
         List<com.starrocks.sql.ast.expression.Expr> exprs = params.exprs();
 
-        Preconditions.checkState(names != null && names.length >= exprsNames.size());
-        String[] newNames = new String[names.length];
+        Preconditions.checkState(names != null && names.length >= exprsNames.size(),
+                "Function parameter count mismatch");
+
+        // Use HashMap for O(1) lookup instead of O(n²) nested loops
+        // Note: If duplicates exist, this will keep the last value, but validateNamedArgumentsStructure
+        // should have already caught duplicates before this method is called
+        Map<String, com.starrocks.sql.ast.expression.Expr> nameToExpr = new HashMap<>();
+        for (int i = 0; i < exprsNames.size(); i++) {
+            nameToExpr.put(exprsNames.get(i), exprs.get(i));
+        }
+
         com.starrocks.sql.ast.expression.Expr[] newExprs = new com.starrocks.sql.ast.expression.Expr[names.length];
+        String[] newNames = new String[names.length];
         int defaultNum = 0;
 
         for (int j = 0; j < names.length; j++) {
-            for (int i = 0; i < exprsNames.size(); i++) {
-                if (exprsNames.get(i).equals(names[j])) {
-                    newNames[j] = exprsNames.get(i);
-                    newExprs[j] = exprs.get(i);
-                    break;
-                }
-            }
-            if (newExprs[j] == null) {
+            com.starrocks.sql.ast.expression.Expr expr = nameToExpr.get(names[j]);
+            if (expr != null) {
+                newExprs[j] = expr;
+                newNames[j] = names[j];
+            } else {
+                // Parameter not provided - use default value
                 newExprs[j] = fn.getDefaultNamedExpr(names[j]);
                 newNames[j] = names[j];
-                Preconditions.checkState(newExprs[j] != null);
+                Preconditions.checkState(newExprs[j] != null,
+                        "Missing default value for parameter: " + names[j]);
                 defaultNum++;
             }
         }
-        Preconditions.checkState(defaultNum + exprsNames.size() == names.length);
+
+        Preconditions.checkState(defaultNum + exprsNames.size() == names.length,
+                "Parameter count mismatch after reordering: defaultNum=%s, providedNum=%s, totalNum=%s",
+                defaultNum, exprsNames.size(), names.length);
+
         params.setExprs(Arrays.asList(newExprs));
         params.setExprsNames(Arrays.asList(newNames));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -1511,6 +1511,8 @@ public class FunctionAnalyzer {
      * @throws SemanticException if validation fails
      */
     public static void validateNamedArgumentsStructure(String fnName, Function fn, List<String> paramNames) {
+        // hasNamedArg() checks: argNames != null && argNames.length > 0
+        // So if we pass this check, getArgNames() is guaranteed to not return null
         if (fn == null || !fn.hasNamedArg()) {
             throw new SemanticException(fnName + "() does not support named parameters");
         }
@@ -1523,6 +1525,7 @@ public class FunctionAnalyzer {
             throw new SemanticException(fnName + "() mixing named and positional arguments is not allowed");
         }
 
+        // Safe to call: hasNamedArg() above guarantees argNames is not null
         String[] validParamNames = fn.getArgNames();
         Set<String> validParams = new HashSet<>(Arrays.asList(validParamNames));
         Set<String> providedParams = new HashSet<>();
@@ -1546,12 +1549,15 @@ public class FunctionAnalyzer {
         }
 
         // Check all required parameters are provided
-        int requiredCount = fn.getRequiredArgNum();
-        for (int i = 0; i < requiredCount; i++) {
-            String requiredParam = validParamNames[i];
-            if (!providedParams.contains(requiredParam)) {
-                throw new SemanticException(String.format(
-                        "%s() required parameter '%s' is missing", fnName, requiredParam));
+        // A parameter is required if it has no default value (getDefaultNamedExpr returns null)
+        // This approach does not rely on positional ordering assumption
+        for (String paramName : validParamNames) {
+            if (fn.getDefaultNamedExpr(paramName) == null) {
+                // No default value - this is a required parameter
+                if (!providedParams.contains(paramName)) {
+                    throw new SemanticException(String.format(
+                            "%s() required parameter '%s' is missing", fnName, paramName));
+                }
             }
         }
     }
@@ -1574,15 +1580,21 @@ public class FunctionAnalyzer {
         }
 
         String[] validParamNames = fn.getArgNames();
-        int requiredCount = fn.getRequiredArgNum();
+        if (validParamNames == null || validParamNames.length == 0) {
+            return;  // Function doesn't support named arguments
+        }
 
         // Check required parameters (without defaults) cannot be NULL
-        // Required parameters are those without default values, indicated by index < requiredCount
-        for (int i = 0; i < requiredCount && i < node.getChildren().size(); i++) {
-            com.starrocks.sql.ast.expression.Expr argExpr = node.getChild(i);
-            if (argExpr instanceof com.starrocks.sql.ast.expression.NullLiteral) {
-                throw new SemanticException(String.format(
-                        "%s() required parameter '%s' cannot be NULL", fnName, validParamNames[i]));
+        // A parameter is required if it has no default value (getDefaultNamedExpr returns null)
+        // This approach does not rely on positional ordering assumption
+        for (int i = 0; i < validParamNames.length && i < node.getChildren().size(); i++) {
+            if (fn.getDefaultNamedExpr(validParamNames[i]) == null) {
+                // No default value - this is a required parameter
+                com.starrocks.sql.ast.expression.Expr argExpr = node.getChild(i);
+                if (argExpr instanceof com.starrocks.sql.ast.expression.NullLiteral) {
+                    throw new SemanticException(String.format(
+                            "%s() required parameter '%s' cannot be NULL", fnName, validParamNames[i]));
+                }
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -1441,7 +1441,7 @@ public class FunctionAnalyzer {
                                                            FunctionCallExpr node,
                                                            Type[] argumentTypes,
                                                            List<String> exprsNames) {
-        String fnName = node.getFnName().getFunction();
+        String fnName = node.getFunctionName();
         // Find function using named arguments directly
         // Validation is done separately in validateNamedArguments()
         String[] argNames = exprsNames.toArray(new String[0]);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -39,6 +39,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariableConstants;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.OrderByElement;
 import com.starrocks.sql.ast.expression.ArrayExpr;
 import com.starrocks.sql.ast.expression.Expr;
@@ -76,6 +77,7 @@ import com.starrocks.type.VarcharType;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -1422,5 +1424,197 @@ public class FunctionAnalyzer {
             fn = ExprUtils.getBuiltinFunction(fnName, argumentTypes, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
         }
         return fn;
+    }
+
+    // ==================== Named Arguments Support ====================
+
+    /**
+     * Get function for named arguments call.
+     *
+     * @param session       current connect context
+     * @param node          function call expression
+     * @param argumentTypes argument types
+     * @param exprsNames    list of parameter names provided by user
+     * @return function if found, otherwise null
+     */
+    public static Function getAnalyzedFunctionForNamedArgs(ConnectContext session,
+                                                           FunctionCallExpr node,
+                                                           Type[] argumentTypes,
+                                                           List<String> exprsNames) {
+        String fnName = node.getFnName().getFunction();
+        // Find function using named arguments directly
+        // Validation is done separately in validateNamedArguments()
+        String[] argNames = exprsNames.toArray(new String[0]);
+        return ExprUtils.getBuiltinFunction(fnName, argumentTypes, argNames,
+                Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+    }
+
+    /**
+     * Validate named arguments for any function that supports them.
+     * Checks for:
+     * - Function supports named arguments
+     * - No duplicate parameter names
+     * - All parameter names are valid
+     * - All required parameters (without defaults) are provided
+     *
+     * @param fnName      function name for error messages
+     * @param fn          the function definition
+     * @param paramNames  list of parameter names provided by user
+     * @throws SemanticException if validation fails
+     */
+    public static void validateNamedArguments(String fnName, Function fn, List<String> paramNames) {
+        if (fn == null || !fn.hasNamedArg()) {
+            throw new SemanticException(fnName + "() does not support named parameters");
+        }
+
+        String[] validParamNames = fn.getArgNames();
+        Set<String> validParams = new HashSet<>(Arrays.asList(validParamNames));
+        Set<String> providedParams = new HashSet<>();
+
+        // Check for duplicates and unknown parameter names
+        for (String paramName : paramNames) {
+            if (!providedParams.add(paramName)) {
+                throw new SemanticException(String.format(
+                        "%s() duplicate parameter '%s'", fnName, paramName));
+            }
+            if (!validParams.contains(paramName)) {
+                // Check for case-insensitive match and provide hint
+                String suggestion = findSimilarParam(paramName, validParamNames);
+                if (suggestion != null) {
+                    throw new SemanticException(String.format(
+                            "%s() unknown parameter '%s'. Did you mean '%s'?", fnName, paramName, suggestion));
+                }
+                throw new SemanticException(String.format(
+                        "%s() does not support parameter '%s'", fnName, paramName));
+            }
+        }
+
+        // Check all required parameters are provided
+        int requiredCount = fn.getRequiredArgNum();
+        for (int i = 0; i < requiredCount; i++) {
+            String requiredParam = validParamNames[i];
+            if (!providedParams.contains(requiredParam)) {
+                throw new SemanticException(String.format(
+                        "%s() required parameter '%s' is missing", fnName, requiredParam));
+            }
+        }
+    }
+
+    /**
+     * Find a similar parameter name (case-insensitive match).
+     */
+    private static String findSimilarParam(String input, String[] validParams) {
+        for (String valid : validParams) {
+            if (valid.equalsIgnoreCase(input)) {
+                return valid;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Throw a user-friendly error when named arguments function lookup fails.
+     * This is called when getAnalyzedFunctionForNamedArgs returns null.
+     */
+    public static void throwFriendlyNamedArgError(String fnName, Type[] argumentTypes, List<String> paramNames) {
+        // Try to find function ignoring argument names to get better error messages
+        Function fn = ExprUtils.getBuiltinFunction(fnName, argumentTypes,
+                Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+
+        if (fn != null && fn.hasNamedArg()) {
+            // Function exists and supports named args - validate to get specific error
+            validateNamedArguments(fnName, fn, paramNames);
+        }
+        // If we reach here, throw generic error (will be handled by caller)
+    }
+
+    /**
+     * Get function with named arguments support for positional call.
+     * This method is called when regular function lookup fails, to check if
+     * the function supports named arguments and can be called with fewer positional arguments.
+     *
+     * @param session       current connect context
+     * @param fnName        function name
+     * @param argumentTypes argument types provided by the caller
+     * @return function if found and it supports named arguments with defaults, otherwise null
+     */
+    public static Function getAnalyzedFunctionForPositionalCallWithNamedArgs(
+            ConnectContext session, String fnName, Type[] argumentTypes) {
+        // Try to find a function with named arguments by searching with full argument types
+        Function fn = ExprUtils.getBuiltinFunction(fnName, argumentTypes,
+                Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+        if (fn == null || !fn.hasNamedArg()) {
+            return null;
+        }
+
+        int providedArgCount = argumentTypes.length;
+        int requiredArgCount = fn.getRequiredArgNum();
+        int totalArgCount = fn.getNumArgs();
+
+        // Check if provided arguments count is within valid range
+        if (providedArgCount < requiredArgCount || providedArgCount > totalArgCount) {
+            return null;
+        }
+
+        // Verify that provided argument types match the function's expected types
+        Type[] fnArgTypes = fn.getArgs();
+        for (int i = 0; i < providedArgCount; i++) {
+            if (!argumentTypes[i].matchesType(fnArgTypes[i]) &&
+                    !TypeManager.canCastTo(argumentTypes[i], fnArgTypes[i])) {
+                return null;
+            }
+        }
+
+        return fn;
+    }
+
+    /**
+     * Throw a user-friendly error for positional function calls that failed.
+     * This checks if the function supports named arguments and provides helpful error messages
+     * about missing required parameters.
+     *
+     * @param fnName        function name
+     * @param argumentTypes argument types provided by the caller
+     */
+    public static void throwFriendlyPositionalArgError(String fnName, Type[] argumentTypes) {
+        Function fn = null;
+
+        // Try to find a function with named arguments support
+        if (argumentTypes.length > 0) {
+            fn = ExprUtils.getBuiltinFunction(fnName, argumentTypes,
+                    Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+        }
+
+        // If no arguments provided or function not found, try to find by name from FunctionSet
+        if (fn == null) {
+            List<Function> functions = GlobalStateMgr.getCurrentState().getBuiltinFunctions().stream()
+                    .filter(f -> f.functionName().equalsIgnoreCase(fnName) && f.hasNamedArg())
+                    .collect(Collectors.toList());
+            if (!functions.isEmpty()) {
+                fn = functions.get(0);
+            }
+        }
+
+        if (fn == null || !fn.hasNamedArg()) {
+            return; // Let caller handle with generic error
+        }
+
+        int providedArgCount = argumentTypes.length;
+        int requiredArgCount = fn.getRequiredArgNum();
+
+        // Check if not enough arguments provided
+        if (providedArgCount < requiredArgCount) {
+            String[] argNames = fn.getArgNames();
+            StringBuilder missingParams = new StringBuilder();
+            for (int i = providedArgCount; i < requiredArgCount; i++) {
+                if (missingParams.length() > 0) {
+                    missingParams.append(", ");
+                }
+                missingParams.append("'").append(argNames[i]).append("'");
+            }
+            throw new SemanticException(String.format(
+                    "%s() requires at least %d argument(s), but got %d. Missing required parameter(s): %s",
+                    fnName, requiredArgCount, providedArgCount, missingParams));
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -810,7 +810,19 @@ public class FunctionAnalyzer {
         }
 
         // validate argument types
-        for (int i = 0; i < fn.getNumArgs(); i++) {
+        // First check argument count - if mismatched, return null to allow fallback
+        // to named arguments handling in ExpressionAnalyzer
+        if (argumentTypes.length < fn.getNumArgs() && !fn.hasVarArgs()) {
+            // If function supports named args, let ExpressionAnalyzer handle it
+            if (fn.hasNamedArg()) {
+                return null;
+            }
+            // For non-varargs, non-named-args functions, argument count must match exactly
+            // Return null to trigger "No matching function" error
+            return null;
+        }
+        int numArgsToValidate = Math.min(argumentTypes.length, fn.getNumArgs());
+        for (int i = 0; i < numArgsToValidate; i++) {
             if (!argumentTypes[i].matchesType(fn.getArgs()[i]) &&
                     !TypeManager.canCastTo(argumentTypes[i], fn.getArgs()[i])) {
                 String msg = String.format("No matching function with signature: %s(%s)", fnName,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -1517,14 +1517,6 @@ public class FunctionAnalyzer {
             throw new SemanticException(fnName + "() does not support named parameters");
         }
 
-        // Check for mixed named and positional arguments
-        // Positional arguments have empty string "" as their name
-        boolean hasNamedArg = paramNames.stream().anyMatch(name -> !name.isEmpty());
-        boolean hasPositionalArg = paramNames.stream().anyMatch(String::isEmpty);
-        if (hasNamedArg && hasPositionalArg) {
-            throw new SemanticException(fnName + "() mixing named and positional arguments is not allowed");
-        }
-
         // Safe to call: hasNamedArg() above guarantees argNames is not null
         String[] validParamNames = fn.getArgNames();
         Set<String> validParams = new HashSet<>(Arrays.asList(validParamNames));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1759,13 +1759,9 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             return new AlterTableOperationClause(createPos(context), operationName, Collections.emptyList(), where);
         }
 
-        if (tableOperation.argumentList().expressionList() != null) {
-            parameters = visit(tableOperation.argumentList().expressionList().expression(), Expr.class);
-        } else {
-            parameters = visit(tableOperation.argumentList().namedArgumentList().namedArgument(), Expr.class);
-            useNamedArgs = true;
-        }
+        parameters = visit(tableOperation.argumentList().argumentItem(), Expr.class);
         int namedArgNum = parameters.stream().filter(f -> f instanceof NamedArgument).toList().size();
+        useNamedArgs = namedArgNum > 0;
         if (namedArgNum > 0 && namedArgNum < parameters.size()) {
             throw new SemanticException("All arguments must be passed by name or all must be passed positionally");
         }
@@ -1793,13 +1789,9 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             return new CallProcedureStatement(qualifiedName, Collections.emptyList(), createPos(context));
         }
 
-        if (context.argumentList().expressionList() != null) {
-            parameters = visit(context.argumentList().expressionList().expression(), Expr.class);
-        } else {
-            parameters = visit(context.argumentList().namedArgumentList().namedArgument(), Expr.class);
-            useNamedArgs = true;
-        }
+        parameters = visit(context.argumentList().argumentItem(), Expr.class);
         int namedArgNum = parameters.stream().filter(f -> f instanceof NamedArgument).toList().size();
+        useNamedArgs = namedArgNum > 0;
         if (namedArgNum > 0 && namedArgNum < parameters.size()) {
             throw new SemanticException("All arguments must be passed by name or all must be passed positionally");
         }
@@ -6617,11 +6609,25 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         if (name == null || name.isEmpty() || name.equals(" ")) {
             throw new ParsingException(PARSER_ERROR_MSG.unsupportedExpr(" The left of => shouldn't be empty"));
         }
-        Expr node = (Expr) visit(context.expression());
-        if (node == null) {
+        ParseNode parseNode = visit(context.expression());
+        if (parseNode == null) {
             throw new ParsingException(PARSER_ERROR_MSG.unsupportedExpr(" The right of => shouldn't be null"));
         }
-        return new NamedArgument(name, node);
+        if (!(parseNode instanceof Expr)) {
+            throw new ParsingException(PARSER_ERROR_MSG.unsupportedExpr(
+                    " Named argument value must be an expression, got " + parseNode.getClass().getSimpleName()),
+                    createPos(context.expression()));
+        }
+        return new NamedArgument(name, (Expr) parseNode, createPos(context));
+    }
+
+    @Override
+    public ParseNode visitArgumentItem(com.starrocks.sql.parser.StarRocksParser.ArgumentItemContext context) {
+        // argumentItem can be either a namedArgument or an expression
+        if (context.namedArgument() != null) {
+            return visit(context.namedArgument());
+        }
+        return visit(context.expression());
     }
 
     @Override
@@ -6644,12 +6650,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     public ParseNode visitNormalizedTableFunction(
             com.starrocks.sql.parser.StarRocksParser.NormalizedTableFunctionContext context) {
         QualifiedName functionName = getQualifiedName(context.qualifiedName());
-        List<Expr> parameters = null;
-        if (context.argumentList().expressionList() != null) {
-            parameters = visit(context.argumentList().expressionList().expression(), Expr.class);
-        } else {
-            parameters = visit(context.argumentList().namedArgumentList().namedArgument(), Expr.class);
-        }
+        List<Expr> parameters = visit(context.argumentList().argumentItem(), Expr.class);
         int namedArgNum = parameters.stream().filter(f -> f instanceof NamedArgument).collect(toList()).size();
         if (namedArgNum > 0 && namedArgNum < parameters.size()) {
             throw new SemanticException("All arguments must be passed by name or all must be passed positionally");
@@ -7947,6 +7948,44 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         }
     }
 
+    /**
+     * Get all argument expressions from argumentList context.
+     * Supports both positional arguments and named arguments (mixed or not).
+     */
+    private List<Expr> getArgumentExprs(StarRocksParser.ArgumentListContext argumentList) {
+        if (argumentList == null) {
+            return Collections.emptyList();
+        }
+
+        // argumentList now contains argumentItem list which can have either namedArgument or expression
+        return visit(argumentList.argumentItem(), Expr.class);
+    }
+
+    /**
+     * Get the number of argument expressions from argumentList context.
+     */
+    private int getArgumentExprCount(StarRocksParser.ArgumentListContext argumentList) {
+        if (argumentList == null) {
+            return 0;
+        }
+        return argumentList.argumentItem().size();
+    }
+
+    /**
+     * Get a single argument expression at specified index from argumentList context.
+     * For named arguments, extracts the expression value from NamedArgument.
+     */
+    private Expr getArgumentExpr(StarRocksParser.ArgumentListContext argumentList, int index) {
+        if (argumentList == null) {
+            throw new IndexOutOfBoundsException("argumentList is null");
+        }
+        Expr arg = (Expr) visit(argumentList.argumentItem(index));
+        if (arg instanceof NamedArgument) {
+            return ((NamedArgument) arg).getExpr();
+        }
+        return arg;
+    }
+
     @Override
     public ParseNode visitSimpleFunctionCall(com.starrocks.sql.parser.StarRocksParser.SimpleFunctionCallContext context) {
         String fullFunctionName = getQualifiedName(context.qualifiedName()).toString();
@@ -7960,12 +7999,24 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         } else {
             functionName = fullFunctionName.toLowerCase();
         }
+
+        // Check for mixing named and positional arguments early
+        // This validation must happen before special handling which may strip NamedArgument wrappers
+        if (context.argumentList() != null) {
+            List<Expr> allArgs = getArgumentExprs(context.argumentList());
+            boolean hasNamedArg = allArgs.stream().anyMatch(e -> e instanceof NamedArgument);
+            boolean hasPositionalArg = allArgs.stream().anyMatch(e -> !(e instanceof NamedArgument));
+            if (hasNamedArg && hasPositionalArg) {
+                throw new SemanticException("Mixing named and positional arguments is not allowed", pos);
+            }
+        }
+
         if (functionName.equals(FunctionSet.ARRAY_GENERATE)) {
-            if (context.expression().size() == 3) {
-                Expr e3 = (Expr) visit(context.expression(2));
+            if (getArgumentExprCount(context.argumentList()) == 3) {
+                Expr e3 = getArgumentExpr(context.argumentList(), 2);
                 if (e3 instanceof IntervalLiteral) {
-                    Expr e1 = (Expr) visit(context.expression(0));
-                    Expr e2 = (Expr) visit(context.expression(1));
+                    Expr e1 = getArgumentExpr(context.argumentList(), 0);
+                    Expr e2 = getArgumentExpr(context.argumentList(), 1);
                     List<Expr> exprs = Lists.newLinkedList();
                     exprs.add(e1);
                     exprs.add(e2);
@@ -7978,9 +8029,10 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             }
         }
         if (functionName.equals(FunctionSet.TIME_SLICE) || functionName.equals(FunctionSet.DATE_SLICE)) {
-            if (context.expression().size() == 2) {
-                Expr e1 = (Expr) visit(context.expression(0));
-                Expr e2 = (Expr) visit(context.expression(1));
+            int argCount = getArgumentExprCount(context.argumentList());
+            if (argCount == 2) {
+                Expr e1 = getArgumentExpr(context.argumentList(), 0);
+                Expr e2 = getArgumentExpr(context.argumentList(), 1);
                 if (!(e2 instanceof IntervalLiteral)) {
                     e2 = new IntervalLiteral(e2, new UnitIdentifier("DAY"));
                 }
@@ -7990,29 +8042,33 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
                         "floor"), pos);
 
                 return functionCallExpr;
-            } else if (context.expression().size() == 3) {
-                Expr e1 = (Expr) visit(context.expression(0));
-                Expr e2 = (Expr) visit(context.expression(1));
+            } else if (argCount == 3) {
+                Expr e1 = getArgumentExpr(context.argumentList(), 0);
+                Expr e2 = getArgumentExpr(context.argumentList(), 1);
                 if (!(e2 instanceof IntervalLiteral)) {
                     e2 = new IntervalLiteral(e2, new UnitIdentifier("DAY"));
                 }
                 IntervalLiteral intervalLiteral = (IntervalLiteral) e2;
 
-                ParseNode e3 = visit(context.expression(2));
-                if (!(e3 instanceof UnitBoundary)) {
-                    throw new ParsingException(PARSER_ERROR_MSG.wrongTypeOfArgs(functionName), e3.getPos());
+                // e3 may be UnitBoundary which is not an Expr, so use visit directly
+                ParseNode e3Node = visit(context.argumentList().argumentItem(2));
+                if (e3Node instanceof NamedArgument) {
+                    e3Node = ((NamedArgument) e3Node).getExpr();
                 }
-                UnitBoundary unitBoundary = (UnitBoundary) e3;
+                if (!(e3Node instanceof UnitBoundary)) {
+                    throw new ParsingException(PARSER_ERROR_MSG.wrongTypeOfArgs(functionName), e3Node.getPos());
+                }
+                UnitBoundary unitBoundary = (UnitBoundary) e3Node;
                 FunctionCallExpr functionCallExpr = new FunctionCallExpr(fullFunctionName, getArgumentsForTimeSlice(e1,
                         intervalLiteral.getValue(), intervalLiteral.getUnitIdentifier().getDescription().toLowerCase(),
                         unitBoundary.getDescription().toLowerCase()), pos);
 
                 return functionCallExpr;
-            } else if (context.expression().size() == 4) {
-                Expr e1 = (Expr) visit(context.expression(0));
-                Expr e2 = (Expr) visit(context.expression(1));
-                Expr e3 = (Expr) visit(context.expression(2));
-                Expr e4 = (Expr) visit(context.expression(3));
+            } else if (argCount == 4) {
+                Expr e1 = getArgumentExpr(context.argumentList(), 0);
+                Expr e2 = getArgumentExpr(context.argumentList(), 1);
+                Expr e3 = getArgumentExpr(context.argumentList(), 2);
+                Expr e4 = getArgumentExpr(context.argumentList(), 3);
 
                 if (!(e3 instanceof StringLiteral)) {
                     throw new ParsingException(PARSER_ERROR_MSG.wrongTypeOfArgs(functionName), e3.getPos());
@@ -8029,12 +8085,12 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         }
 
         if (DATE_FUNCTIONS.contains(functionName)) {
-            if (context.expression().size() != 2) {
+            if (getArgumentExprCount(context.argumentList()) != 2) {
                 throw new ParsingException(PARSER_ERROR_MSG.wrongNumOfArgs(functionName), pos);
             }
 
-            Expr e1 = (Expr) visit(context.expression(0));
-            Expr e2 = (Expr) visit(context.expression(1));
+            Expr e1 = getArgumentExpr(context.argumentList(), 0);
+            Expr e2 = getArgumentExpr(context.argumentList(), 1);
             if (!(e2 instanceof IntervalLiteral)) {
                 e2 = new IntervalLiteral(e2, new UnitIdentifier("DAY"));
             }
@@ -8045,7 +8101,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         }
 
         if (functionName.equals(FunctionSet.ELEMENT_AT)) {
-            List<Expr> params = visit(context.expression(), Expr.class);
+            List<Expr> params = getArgumentExprs(context.argumentList());
             if (params.size() != 2) {
                 throw new ParsingException(PARSER_ERROR_MSG.wrongNumOfArgs(functionName), pos);
             }
@@ -8053,7 +8109,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         }
 
         if (functionName.equals(FunctionSet.ISNULL)) {
-            List<Expr> params = visit(context.expression(), Expr.class);
+            List<Expr> params = getArgumentExprs(context.argumentList());
             if (params.size() != 1) {
                 throw new ParsingException(PARSER_ERROR_MSG.wrongNumOfArgs(functionName), pos);
             }
@@ -8061,7 +8117,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         }
 
         if (functionName.equals(FunctionSet.ISNOTNULL)) {
-            List<Expr> params = visit(context.expression(), Expr.class);
+            List<Expr> params = getArgumentExprs(context.argumentList());
             if (params.size() != 1) {
                 throw new ParsingException(PARSER_ERROR_MSG.wrongNumOfArgs(functionName), pos);
             }
@@ -8069,12 +8125,13 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         }
 
         if (ArithmeticExpr.isArithmeticExpr(functionName)) {
-            if (context.expression().size() < 1) {
+            int argCount = getArgumentExprCount(context.argumentList());
+            if (argCount < 1) {
                 throw new ParsingException(PARSER_ERROR_MSG.wrongNumOfArgs(functionName), pos);
             }
 
-            Expr e1 = (Expr) visit(context.expression(0));
-            Expr e2 = context.expression().size() > 1 ? (Expr) visit(context.expression(1)) : null;
+            Expr e1 = getArgumentExpr(context.argumentList(), 0);
+            Expr e2 = argCount > 1 ? getArgumentExpr(context.argumentList(), 1) : null;
             return new ArithmeticExpr(ArithmeticExpr.getArithmeticOperator(functionName), e1, e2, pos);
         }
 
@@ -8085,18 +8142,19 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             Expr e2;
             String collectionDelimiter = ",";
             String mapDelimiter = ":";
-            if (context.expression().size() == 1) {
-                e0 = (Expr) visit(context.expression(0));
+            int argCount = getArgumentExprCount(context.argumentList());
+            if (argCount == 1) {
+                e0 = getArgumentExpr(context.argumentList(), 0);
                 e1 = new StringLiteral(collectionDelimiter, pos);
                 e2 = new StringLiteral(mapDelimiter, pos);
-            } else if (context.expression().size() == 2) {
-                e0 = (Expr) visit(context.expression(0));
-                e1 = (Expr) visit(context.expression(1));
+            } else if (argCount == 2) {
+                e0 = getArgumentExpr(context.argumentList(), 0);
+                e1 = getArgumentExpr(context.argumentList(), 1);
                 e2 = new StringLiteral(mapDelimiter, pos);
-            } else if (context.expression().size() == 3) {
-                e0 = (Expr) visit(context.expression(0));
-                e1 = (Expr) visit(context.expression(1));
-                e2 = (Expr) visit(context.expression(2));
+            } else if (argCount == 3) {
+                e0 = getArgumentExpr(context.argumentList(), 0);
+                e1 = getArgumentExpr(context.argumentList(), 1);
+                e2 = getArgumentExpr(context.argumentList(), 2);
             } else {
                 throw new ParsingException(PARSER_ERROR_MSG.wrongNumOfArgs(FunctionSet.STR_TO_MAP));
             }
@@ -8116,31 +8174,27 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         }
 
         if (functionName.equals(FunctionSet.MAP)) {
-            List<Expr> exprs;
-            if (context.expression() != null) {
-                int num = context.expression().size();
-                if (num % 2 == 1) {
-                    throw new ParsingException(PARSER_ERROR_MSG.wrongNumOfArgs(num, "map()",
-                            "Arguments must be in key/value pairs"), pos);
-                }
-                exprs = visit(context.expression(), Expr.class);
-            } else {
-                exprs = Collections.emptyList();
+            List<Expr> exprs = getArgumentExprs(context.argumentList());
+            int num = exprs.size();
+            if (num % 2 == 1) {
+                throw new ParsingException(PARSER_ERROR_MSG.wrongNumOfArgs(num, "map()",
+                        "Arguments must be in key/value pairs"), pos);
             }
             return new MapExpr(AnyMapType.ANY_MAP, exprs, pos);
         }
 
         if (functionName.equals(FunctionSet.SUBSTR) || functionName.equals(FunctionSet.SUBSTRING)) {
             List<Expr> exprs = Lists.newArrayList();
-            if (context.expression().size() == 2) {
-                Expr e1 = (Expr) visit(context.expression(0));
-                Expr e2 = (Expr) visit(context.expression(1));
+            int argCount = getArgumentExprCount(context.argumentList());
+            if (argCount == 2) {
+                Expr e1 = getArgumentExpr(context.argumentList(), 0);
+                Expr e2 = getArgumentExpr(context.argumentList(), 1);
                 exprs.add(e1);
                 addArgumentUseTypeInt(e2, exprs);
-            } else if (context.expression().size() == 3) {
-                Expr e1 = (Expr) visit(context.expression(0));
-                Expr e2 = (Expr) visit(context.expression(1));
-                Expr e3 = (Expr) visit(context.expression(2));
+            } else if (argCount == 3) {
+                Expr e1 = getArgumentExpr(context.argumentList(), 0);
+                Expr e2 = getArgumentExpr(context.argumentList(), 1);
+                Expr e3 = getArgumentExpr(context.argumentList(), 2);
                 exprs.add(e1);
                 addArgumentUseTypeInt(e2, exprs);
                 addArgumentUseTypeInt(e3, exprs);
@@ -8149,9 +8203,10 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         }
 
         if (functionName.equals(FunctionSet.LPAD) || functionName.equals(FunctionSet.RPAD)) {
-            if (context.expression().size() == 2) {
-                Expr e1 = (Expr) visit(context.expression(0));
-                Expr e2 = (Expr) visit(context.expression(1));
+            int argCount = getArgumentExprCount(context.argumentList());
+            if (argCount == 2) {
+                Expr e1 = getArgumentExpr(context.argumentList(), 0);
+                Expr e2 = getArgumentExpr(context.argumentList(), 1);
                 FunctionCallExpr functionCallExpr = new FunctionCallExpr(
                         fullFunctionName, Lists.newArrayList(e1, e2, new StringLiteral(" ")), pos);
                 return functionCallExpr;
@@ -8159,12 +8214,12 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         }
 
         if (functionName.equals(FunctionSet.DICT_MAPPING)) {
-            List<Expr> params = visit(context.expression(), Expr.class);
+            List<Expr> params = getArgumentExprs(context.argumentList());
             return new DictQueryExpr(params);
         }
 
         FunctionCallExpr functionCallExpr = new FunctionCallExpr(fullFunctionName,
-                new FunctionParams(false, visit(context.expression(), Expr.class)), pos);
+                new FunctionParams(false, getArgumentExprs(context.argumentList())), pos);
         if (context.over() != null) {
             return buildOverClause(functionCallExpr, context.over(), pos);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -1759,9 +1759,13 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             return new AlterTableOperationClause(createPos(context), operationName, Collections.emptyList(), where);
         }
 
-        parameters = visit(tableOperation.argumentList().argumentItem(), Expr.class);
+        if (tableOperation.argumentList().expressionList() != null) {
+            parameters = visit(tableOperation.argumentList().expressionList().expression(), Expr.class);
+        } else {
+            parameters = visit(tableOperation.argumentList().namedArgumentList().namedArgument(), Expr.class);
+            useNamedArgs = true;
+        }
         int namedArgNum = parameters.stream().filter(f -> f instanceof NamedArgument).toList().size();
-        useNamedArgs = namedArgNum > 0;
         if (namedArgNum > 0 && namedArgNum < parameters.size()) {
             throw new SemanticException("All arguments must be passed by name or all must be passed positionally");
         }
@@ -1789,9 +1793,13 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             return new CallProcedureStatement(qualifiedName, Collections.emptyList(), createPos(context));
         }
 
-        parameters = visit(context.argumentList().argumentItem(), Expr.class);
+        if (context.argumentList().expressionList() != null) {
+            parameters = visit(context.argumentList().expressionList().expression(), Expr.class);
+        } else {
+            parameters = visit(context.argumentList().namedArgumentList().namedArgument(), Expr.class);
+            useNamedArgs = true;
+        }
         int namedArgNum = parameters.stream().filter(f -> f instanceof NamedArgument).toList().size();
-        useNamedArgs = namedArgNum > 0;
         if (namedArgNum > 0 && namedArgNum < parameters.size()) {
             throw new SemanticException("All arguments must be passed by name or all must be passed positionally");
         }
@@ -6603,50 +6611,34 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         return valuesRelation;
     }
 
-    @Override
-    public ParseNode visitNamedArguments(com.starrocks.sql.parser.StarRocksParser.NamedArgumentsContext context) {
-        String name = ((Identifier) visit(context.identifier())).getValue();
+    private NamedArgument buildNamedArgument(ParserRuleContext identifierCtx,
+                                              ParserRuleContext expressionCtx,
+                                              ParserRuleContext fullCtx) {
+        String name = ((Identifier) visit(identifierCtx)).getValue();
         if (name == null || name.isEmpty() || name.equals(" ")) {
             throw new ParsingException(PARSER_ERROR_MSG.unsupportedExpr(" The left of => shouldn't be empty"));
         }
-        ParseNode parseNode = visit(context.expression());
+        ParseNode parseNode = visit(expressionCtx);
         if (parseNode == null) {
             throw new ParsingException(PARSER_ERROR_MSG.unsupportedExpr(" The right of => shouldn't be null"));
         }
         if (!(parseNode instanceof Expr)) {
             throw new ParsingException(PARSER_ERROR_MSG.unsupportedExpr(
                     " Named argument value must be an expression, got " + parseNode.getClass().getSimpleName()),
-                    createPos(context.expression()));
+                    createPos(expressionCtx));
         }
-        return new NamedArgument(name, (Expr) parseNode, createPos(context));
+        return new NamedArgument(name, (Expr) parseNode, createPos(fullCtx));
+    }
+
+    @Override
+    public ParseNode visitNamedArguments(com.starrocks.sql.parser.StarRocksParser.NamedArgumentsContext context) {
+        return buildNamedArgument(context.identifier(), context.expression(), context);
     }
 
     @Override
     public ParseNode visitFunctionNamedArgument(
             com.starrocks.sql.parser.StarRocksParser.FunctionNamedArgumentContext context) {
-        String name = ((Identifier) visit(context.identifier())).getValue();
-        if (name == null || name.isEmpty() || name.equals(" ")) {
-            throw new ParsingException(PARSER_ERROR_MSG.unsupportedExpr(" The left of => shouldn't be empty"));
-        }
-        ParseNode parseNode = visit(context.expression());
-        if (parseNode == null) {
-            throw new ParsingException(PARSER_ERROR_MSG.unsupportedExpr(" The right of => shouldn't be null"));
-        }
-        if (!(parseNode instanceof Expr)) {
-            throw new ParsingException(PARSER_ERROR_MSG.unsupportedExpr(
-                    " Named argument value must be an expression, got " + parseNode.getClass().getSimpleName()),
-                    createPos(context.expression()));
-        }
-        return new NamedArgument(name, (Expr) parseNode, createPos(context));
-    }
-
-    @Override
-    public ParseNode visitArgumentItem(com.starrocks.sql.parser.StarRocksParser.ArgumentItemContext context) {
-        // argumentItem can be either a namedArgument or an expression
-        if (context.namedArgument() != null) {
-            return visit(context.namedArgument());
-        }
-        return visit(context.expression());
+        return buildNamedArgument(context.identifier(), context.expression(), context);
     }
 
     @Override
@@ -6669,7 +6661,12 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     public ParseNode visitNormalizedTableFunction(
             com.starrocks.sql.parser.StarRocksParser.NormalizedTableFunctionContext context) {
         QualifiedName functionName = getQualifiedName(context.qualifiedName());
-        List<Expr> parameters = visit(context.argumentList().argumentItem(), Expr.class);
+        List<Expr> parameters = null;
+        if (context.argumentList().expressionList() != null) {
+            parameters = visit(context.argumentList().expressionList().expression(), Expr.class);
+        } else {
+            parameters = visit(context.argumentList().namedArgumentList().namedArgument(), Expr.class);
+        }
         int namedArgNum = parameters.stream().filter(f -> f instanceof NamedArgument).collect(toList()).size();
         if (namedArgNum > 0 && namedArgNum < parameters.size()) {
             throw new SemanticException("All arguments must be passed by name or all must be passed positionally");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -6622,6 +6622,25 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
     }
 
     @Override
+    public ParseNode visitFunctionNamedArgument(
+            com.starrocks.sql.parser.StarRocksParser.FunctionNamedArgumentContext context) {
+        String name = ((Identifier) visit(context.identifier())).getValue();
+        if (name == null || name.isEmpty() || name.equals(" ")) {
+            throw new ParsingException(PARSER_ERROR_MSG.unsupportedExpr(" The left of => shouldn't be empty"));
+        }
+        ParseNode parseNode = visit(context.expression());
+        if (parseNode == null) {
+            throw new ParsingException(PARSER_ERROR_MSG.unsupportedExpr(" The right of => shouldn't be null"));
+        }
+        if (!(parseNode instanceof Expr)) {
+            throw new ParsingException(PARSER_ERROR_MSG.unsupportedExpr(
+                    " Named argument value must be an expression, got " + parseNode.getClass().getSimpleName()),
+                    createPos(context.expression()));
+        }
+        return new NamedArgument(name, (Expr) parseNode, createPos(context));
+    }
+
+    @Override
     public ParseNode visitArgumentItem(com.starrocks.sql.parser.StarRocksParser.ArgumentItemContext context) {
         // argumentItem can be either a namedArgument or an expression
         if (context.namedArgument() != null) {
@@ -8179,7 +8198,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         NodePosition pos = createPos(context);
 
         // Extract all named arguments - they will be processed by ExpressionAnalyzer
-        List<Expr> args = visit(context.namedArgumentList().namedArgument(), Expr.class);
+        List<Expr> args = visit(context.functionNamedArgumentList().functionNamedArgument(), Expr.class);
 
         // Create FunctionCallExpr with named arguments preserved
         // ExpressionAnalyzer.reorderNamedArgAndAppendDefaults() will handle reordering

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -7948,44 +7948,6 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         }
     }
 
-    /**
-     * Get all argument expressions from argumentList context.
-     * Supports both positional arguments and named arguments (mixed or not).
-     */
-    private List<Expr> getArgumentExprs(StarRocksParser.ArgumentListContext argumentList) {
-        if (argumentList == null) {
-            return Collections.emptyList();
-        }
-
-        // argumentList now contains argumentItem list which can have either namedArgument or expression
-        return visit(argumentList.argumentItem(), Expr.class);
-    }
-
-    /**
-     * Get the number of argument expressions from argumentList context.
-     */
-    private int getArgumentExprCount(StarRocksParser.ArgumentListContext argumentList) {
-        if (argumentList == null) {
-            return 0;
-        }
-        return argumentList.argumentItem().size();
-    }
-
-    /**
-     * Get a single argument expression at specified index from argumentList context.
-     * For named arguments, extracts the expression value from NamedArgument.
-     */
-    private Expr getArgumentExpr(StarRocksParser.ArgumentListContext argumentList, int index) {
-        if (argumentList == null) {
-            throw new IndexOutOfBoundsException("argumentList is null");
-        }
-        Expr arg = (Expr) visit(argumentList.argumentItem(index));
-        if (arg instanceof NamedArgument) {
-            return ((NamedArgument) arg).getExpr();
-        }
-        return arg;
-    }
-
     @Override
     public ParseNode visitSimpleFunctionCall(com.starrocks.sql.parser.StarRocksParser.SimpleFunctionCallContext context) {
         String fullFunctionName = getQualifiedName(context.qualifiedName()).toString();
@@ -7999,24 +7961,12 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         } else {
             functionName = fullFunctionName.toLowerCase();
         }
-
-        // Check for mixing named and positional arguments early
-        // This validation must happen before special handling which may strip NamedArgument wrappers
-        if (context.argumentList() != null) {
-            List<Expr> allArgs = getArgumentExprs(context.argumentList());
-            boolean hasNamedArg = allArgs.stream().anyMatch(e -> e instanceof NamedArgument);
-            boolean hasPositionalArg = allArgs.stream().anyMatch(e -> !(e instanceof NamedArgument));
-            if (hasNamedArg && hasPositionalArg) {
-                throw new SemanticException("Mixing named and positional arguments is not allowed", pos);
-            }
-        }
-
         if (functionName.equals(FunctionSet.ARRAY_GENERATE)) {
-            if (getArgumentExprCount(context.argumentList()) == 3) {
-                Expr e3 = getArgumentExpr(context.argumentList(), 2);
+            if (context.expression().size() == 3) {
+                Expr e3 = (Expr) visit(context.expression(2));
                 if (e3 instanceof IntervalLiteral) {
-                    Expr e1 = getArgumentExpr(context.argumentList(), 0);
-                    Expr e2 = getArgumentExpr(context.argumentList(), 1);
+                    Expr e1 = (Expr) visit(context.expression(0));
+                    Expr e2 = (Expr) visit(context.expression(1));
                     List<Expr> exprs = Lists.newLinkedList();
                     exprs.add(e1);
                     exprs.add(e2);
@@ -8029,10 +7979,9 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             }
         }
         if (functionName.equals(FunctionSet.TIME_SLICE) || functionName.equals(FunctionSet.DATE_SLICE)) {
-            int argCount = getArgumentExprCount(context.argumentList());
-            if (argCount == 2) {
-                Expr e1 = getArgumentExpr(context.argumentList(), 0);
-                Expr e2 = getArgumentExpr(context.argumentList(), 1);
+            if (context.expression().size() == 2) {
+                Expr e1 = (Expr) visit(context.expression(0));
+                Expr e2 = (Expr) visit(context.expression(1));
                 if (!(e2 instanceof IntervalLiteral)) {
                     e2 = new IntervalLiteral(e2, new UnitIdentifier("DAY"));
                 }
@@ -8042,33 +7991,29 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
                         "floor"), pos);
 
                 return functionCallExpr;
-            } else if (argCount == 3) {
-                Expr e1 = getArgumentExpr(context.argumentList(), 0);
-                Expr e2 = getArgumentExpr(context.argumentList(), 1);
+            } else if (context.expression().size() == 3) {
+                Expr e1 = (Expr) visit(context.expression(0));
+                Expr e2 = (Expr) visit(context.expression(1));
                 if (!(e2 instanceof IntervalLiteral)) {
                     e2 = new IntervalLiteral(e2, new UnitIdentifier("DAY"));
                 }
                 IntervalLiteral intervalLiteral = (IntervalLiteral) e2;
 
-                // e3 may be UnitBoundary which is not an Expr, so use visit directly
-                ParseNode e3Node = visit(context.argumentList().argumentItem(2));
-                if (e3Node instanceof NamedArgument) {
-                    e3Node = ((NamedArgument) e3Node).getExpr();
+                ParseNode e3 = visit(context.expression(2));
+                if (!(e3 instanceof UnitBoundary)) {
+                    throw new ParsingException(PARSER_ERROR_MSG.wrongTypeOfArgs(functionName), e3.getPos());
                 }
-                if (!(e3Node instanceof UnitBoundary)) {
-                    throw new ParsingException(PARSER_ERROR_MSG.wrongTypeOfArgs(functionName), e3Node.getPos());
-                }
-                UnitBoundary unitBoundary = (UnitBoundary) e3Node;
+                UnitBoundary unitBoundary = (UnitBoundary) e3;
                 FunctionCallExpr functionCallExpr = new FunctionCallExpr(fullFunctionName, getArgumentsForTimeSlice(e1,
                         intervalLiteral.getValue(), intervalLiteral.getUnitIdentifier().getDescription().toLowerCase(),
                         unitBoundary.getDescription().toLowerCase()), pos);
 
                 return functionCallExpr;
-            } else if (argCount == 4) {
-                Expr e1 = getArgumentExpr(context.argumentList(), 0);
-                Expr e2 = getArgumentExpr(context.argumentList(), 1);
-                Expr e3 = getArgumentExpr(context.argumentList(), 2);
-                Expr e4 = getArgumentExpr(context.argumentList(), 3);
+            } else if (context.expression().size() == 4) {
+                Expr e1 = (Expr) visit(context.expression(0));
+                Expr e2 = (Expr) visit(context.expression(1));
+                Expr e3 = (Expr) visit(context.expression(2));
+                Expr e4 = (Expr) visit(context.expression(3));
 
                 if (!(e3 instanceof StringLiteral)) {
                     throw new ParsingException(PARSER_ERROR_MSG.wrongTypeOfArgs(functionName), e3.getPos());
@@ -8085,12 +8030,12 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         }
 
         if (DATE_FUNCTIONS.contains(functionName)) {
-            if (getArgumentExprCount(context.argumentList()) != 2) {
+            if (context.expression().size() != 2) {
                 throw new ParsingException(PARSER_ERROR_MSG.wrongNumOfArgs(functionName), pos);
             }
 
-            Expr e1 = getArgumentExpr(context.argumentList(), 0);
-            Expr e2 = getArgumentExpr(context.argumentList(), 1);
+            Expr e1 = (Expr) visit(context.expression(0));
+            Expr e2 = (Expr) visit(context.expression(1));
             if (!(e2 instanceof IntervalLiteral)) {
                 e2 = new IntervalLiteral(e2, new UnitIdentifier("DAY"));
             }
@@ -8101,7 +8046,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         }
 
         if (functionName.equals(FunctionSet.ELEMENT_AT)) {
-            List<Expr> params = getArgumentExprs(context.argumentList());
+            List<Expr> params = visit(context.expression(), Expr.class);
             if (params.size() != 2) {
                 throw new ParsingException(PARSER_ERROR_MSG.wrongNumOfArgs(functionName), pos);
             }
@@ -8109,7 +8054,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         }
 
         if (functionName.equals(FunctionSet.ISNULL)) {
-            List<Expr> params = getArgumentExprs(context.argumentList());
+            List<Expr> params = visit(context.expression(), Expr.class);
             if (params.size() != 1) {
                 throw new ParsingException(PARSER_ERROR_MSG.wrongNumOfArgs(functionName), pos);
             }
@@ -8117,7 +8062,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         }
 
         if (functionName.equals(FunctionSet.ISNOTNULL)) {
-            List<Expr> params = getArgumentExprs(context.argumentList());
+            List<Expr> params = visit(context.expression(), Expr.class);
             if (params.size() != 1) {
                 throw new ParsingException(PARSER_ERROR_MSG.wrongNumOfArgs(functionName), pos);
             }
@@ -8125,13 +8070,12 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         }
 
         if (ArithmeticExpr.isArithmeticExpr(functionName)) {
-            int argCount = getArgumentExprCount(context.argumentList());
-            if (argCount < 1) {
+            if (context.expression().size() < 1) {
                 throw new ParsingException(PARSER_ERROR_MSG.wrongNumOfArgs(functionName), pos);
             }
 
-            Expr e1 = getArgumentExpr(context.argumentList(), 0);
-            Expr e2 = argCount > 1 ? getArgumentExpr(context.argumentList(), 1) : null;
+            Expr e1 = (Expr) visit(context.expression(0));
+            Expr e2 = context.expression().size() > 1 ? (Expr) visit(context.expression(1)) : null;
             return new ArithmeticExpr(ArithmeticExpr.getArithmeticOperator(functionName), e1, e2, pos);
         }
 
@@ -8142,19 +8086,18 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             Expr e2;
             String collectionDelimiter = ",";
             String mapDelimiter = ":";
-            int argCount = getArgumentExprCount(context.argumentList());
-            if (argCount == 1) {
-                e0 = getArgumentExpr(context.argumentList(), 0);
+            if (context.expression().size() == 1) {
+                e0 = (Expr) visit(context.expression(0));
                 e1 = new StringLiteral(collectionDelimiter, pos);
                 e2 = new StringLiteral(mapDelimiter, pos);
-            } else if (argCount == 2) {
-                e0 = getArgumentExpr(context.argumentList(), 0);
-                e1 = getArgumentExpr(context.argumentList(), 1);
+            } else if (context.expression().size() == 2) {
+                e0 = (Expr) visit(context.expression(0));
+                e1 = (Expr) visit(context.expression(1));
                 e2 = new StringLiteral(mapDelimiter, pos);
-            } else if (argCount == 3) {
-                e0 = getArgumentExpr(context.argumentList(), 0);
-                e1 = getArgumentExpr(context.argumentList(), 1);
-                e2 = getArgumentExpr(context.argumentList(), 2);
+            } else if (context.expression().size() == 3) {
+                e0 = (Expr) visit(context.expression(0));
+                e1 = (Expr) visit(context.expression(1));
+                e2 = (Expr) visit(context.expression(2));
             } else {
                 throw new ParsingException(PARSER_ERROR_MSG.wrongNumOfArgs(FunctionSet.STR_TO_MAP));
             }
@@ -8174,27 +8117,31 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         }
 
         if (functionName.equals(FunctionSet.MAP)) {
-            List<Expr> exprs = getArgumentExprs(context.argumentList());
-            int num = exprs.size();
-            if (num % 2 == 1) {
-                throw new ParsingException(PARSER_ERROR_MSG.wrongNumOfArgs(num, "map()",
-                        "Arguments must be in key/value pairs"), pos);
+            List<Expr> exprs;
+            if (context.expression() != null) {
+                int num = context.expression().size();
+                if (num % 2 == 1) {
+                    throw new ParsingException(PARSER_ERROR_MSG.wrongNumOfArgs(num, "map()",
+                            "Arguments must be in key/value pairs"), pos);
+                }
+                exprs = visit(context.expression(), Expr.class);
+            } else {
+                exprs = Collections.emptyList();
             }
             return new MapExpr(AnyMapType.ANY_MAP, exprs, pos);
         }
 
         if (functionName.equals(FunctionSet.SUBSTR) || functionName.equals(FunctionSet.SUBSTRING)) {
             List<Expr> exprs = Lists.newArrayList();
-            int argCount = getArgumentExprCount(context.argumentList());
-            if (argCount == 2) {
-                Expr e1 = getArgumentExpr(context.argumentList(), 0);
-                Expr e2 = getArgumentExpr(context.argumentList(), 1);
+            if (context.expression().size() == 2) {
+                Expr e1 = (Expr) visit(context.expression(0));
+                Expr e2 = (Expr) visit(context.expression(1));
                 exprs.add(e1);
                 addArgumentUseTypeInt(e2, exprs);
-            } else if (argCount == 3) {
-                Expr e1 = getArgumentExpr(context.argumentList(), 0);
-                Expr e2 = getArgumentExpr(context.argumentList(), 1);
-                Expr e3 = getArgumentExpr(context.argumentList(), 2);
+            } else if (context.expression().size() == 3) {
+                Expr e1 = (Expr) visit(context.expression(0));
+                Expr e2 = (Expr) visit(context.expression(1));
+                Expr e3 = (Expr) visit(context.expression(2));
                 exprs.add(e1);
                 addArgumentUseTypeInt(e2, exprs);
                 addArgumentUseTypeInt(e3, exprs);
@@ -8203,10 +8150,9 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         }
 
         if (functionName.equals(FunctionSet.LPAD) || functionName.equals(FunctionSet.RPAD)) {
-            int argCount = getArgumentExprCount(context.argumentList());
-            if (argCount == 2) {
-                Expr e1 = getArgumentExpr(context.argumentList(), 0);
-                Expr e2 = getArgumentExpr(context.argumentList(), 1);
+            if (context.expression().size() == 2) {
+                Expr e1 = (Expr) visit(context.expression(0));
+                Expr e2 = (Expr) visit(context.expression(1));
                 FunctionCallExpr functionCallExpr = new FunctionCallExpr(
                         fullFunctionName, Lists.newArrayList(e1, e2, new StringLiteral(" ")), pos);
                 return functionCallExpr;
@@ -8214,15 +8160,31 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         }
 
         if (functionName.equals(FunctionSet.DICT_MAPPING)) {
-            List<Expr> params = getArgumentExprs(context.argumentList());
+            List<Expr> params = visit(context.expression(), Expr.class);
             return new DictQueryExpr(params);
         }
 
         FunctionCallExpr functionCallExpr = new FunctionCallExpr(fullFunctionName,
-                new FunctionParams(false, getArgumentExprs(context.argumentList())), pos);
+                new FunctionParams(false, visit(context.expression(), Expr.class)), pos);
         if (context.over() != null) {
             return buildOverClause(functionCallExpr, context.over(), pos);
         }
+        return SyntaxSugars.parse(functionCallExpr);
+    }
+
+    @Override
+    public ParseNode visitNamedArgsFunctionCall(
+            com.starrocks.sql.parser.StarRocksParser.NamedArgsFunctionCallContext context) {
+        String fullFunctionName = getQualifiedName(context.qualifiedName()).toString();
+        NodePosition pos = createPos(context);
+
+        // Extract all named arguments - they will be processed by ExpressionAnalyzer
+        List<Expr> args = visit(context.namedArgumentList().namedArgument(), Expr.class);
+
+        // Create FunctionCallExpr with named arguments preserved
+        // ExpressionAnalyzer.reorderNamedArgAndAppendDefaults() will handle reordering
+        FunctionCallExpr functionCallExpr = new FunctionCallExpr(fullFunctionName,
+                new FunctionParams(false, args), pos);
         return SyntaxSugars.parse(functionCallExpr);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeFunctionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeFunctionTest.java
@@ -449,4 +449,62 @@ public class AnalyzeFunctionTest {
         analyzeSuccess("select lead(ta) over() from test_laglead");
         analyzeSuccess("select lag(ta) over() from test_laglead");
     }
+
+    // ========== Named Arguments Tests ==========
+
+    @Test
+    public void testMixingNamedAndPositionalArguments() {
+        // Test mixing named and positional arguments - should fail
+        // This tests ExpressionAnalyzer.java lines 1098-1102
+        analyzeFail("select concat('hello', sep => ', ')",
+                "Mixing named and positional arguments is not allowed");
+
+        // Positional first, then named - should fail
+        analyzeFail("select substr('hello', len => 3)",
+                "Mixing named and positional arguments is not allowed");
+
+        // Named first, then positional - should fail
+        analyzeFail("select substr(str => 'hello', 1)",
+                "Mixing named and positional arguments is not allowed");
+    }
+
+    @Test
+    public void testMixingNamedAndPositionalArgumentsSpecialFunctions() {
+        // Special handler functions should also validate mixing
+
+        // LPAD - special handler in AstBuilder
+        analyzeFail("select lpad('hello', len => 10)",
+                "Mixing named and positional arguments is not allowed");
+
+        // Multiple positional then named
+        analyzeFail("select concat('a', 'b', sep => ',')",
+                "Mixing named and positional arguments is not allowed");
+
+        // RPAD
+        analyzeFail("select rpad('hi', size => 5)",
+                "Mixing named and positional arguments is not allowed");
+    }
+
+    @Test
+    public void testPurePositionalArguments() {
+        // Pure positional arguments should work normally
+        analyzeSuccess("select concat('hello', 'world')");
+        analyzeSuccess("select substr('hello', 1, 3)");
+        analyzeSuccess("select lpad('hi', 5, '*')");
+        analyzeSuccess("select rpad('hi', 5, '*')");
+    }
+
+    @Test
+    public void testPureNamedArgumentsOnUnsupportedFunction() {
+        // For functions WITHOUT special handling in AstBuilder,
+        // pure named arguments should fail with clear error message
+
+        // Note: Functions with special handling (substr, lpad, etc.)
+        // will strip NamedArgument wrappers and treat them as positional,
+        // so they will succeed (by design, for now)
+
+        // array_length has no special handling - should fail with clear message
+        analyzeFail("select array_length(arr => [1,2,3])",
+                "does not support named arguments");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeFunctionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeFunctionTest.java
@@ -455,34 +455,37 @@ public class AnalyzeFunctionTest {
     @Test
     public void testMixingNamedAndPositionalArguments() {
         // Test mixing named and positional arguments - should fail
-        // This tests ExpressionAnalyzer.java lines 1098-1102
+        // With grammar separation, mixing is now a syntax error (not semantic)
+        // namedArgsFunctionCall only accepts namedArgumentList
+        // simpleFunctionCall only accepts expression list
         analyzeFail("select concat('hello', sep => ', ')",
-                "Mixing named and positional arguments is not allowed");
+                "Unexpected input");
 
         // Positional first, then named - should fail
         analyzeFail("select substr('hello', len => 3)",
-                "Mixing named and positional arguments is not allowed");
+                "Unexpected input");
 
-        // Named first, then positional - should fail
+        // Named first, then positional - should fail with syntax error
         analyzeFail("select substr(str => 'hello', 1)",
-                "Mixing named and positional arguments is not allowed");
+                "Unexpected input");
     }
 
     @Test
     public void testMixingNamedAndPositionalArgumentsSpecialFunctions() {
         // Special handler functions should also validate mixing
+        // With grammar separation, mixing is now caught at parse time
 
         // LPAD - special handler in AstBuilder
         analyzeFail("select lpad('hello', len => 10)",
-                "Mixing named and positional arguments is not allowed");
+                "Unexpected input");
 
         // Multiple positional then named
         analyzeFail("select concat('a', 'b', sep => ',')",
-                "Mixing named and positional arguments is not allowed");
+                "Unexpected input");
 
         // RPAD
         analyzeFail("select rpad('hi', size => 5)",
-                "Mixing named and positional arguments is not allowed");
+                "Unexpected input");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/NamedArgumentValidatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/NamedArgumentValidatorTest.java
@@ -18,7 +18,9 @@ import com.starrocks.catalog.FunctionName;
 import com.starrocks.catalog.ScalarFunction;
 import com.starrocks.common.Pair;
 import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.FunctionCallExpr;
 import com.starrocks.sql.ast.expression.IntLiteral;
+import com.starrocks.sql.ast.expression.NullLiteral;
 import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.type.BooleanType;
 import com.starrocks.type.IntegerType;
@@ -81,6 +83,17 @@ public class NamedArgumentValidatorTest {
         return fn;
     }
 
+    /**
+     * Creates a mock FunctionCallExpr with given argument expressions
+     *
+     * @param argExprs List of argument expressions (can include NullLiteral)
+     * @return Mock FunctionCallExpr for testing
+     */
+    private FunctionCallExpr createMockFunctionCallExpr(List<Expr> argExprs) {
+        FunctionCallExpr node = new FunctionCallExpr(new FunctionName("test_function"), argExprs);
+        return node;
+    }
+
     // ========== Test Category 1: Valid Cases ==========
 
     @Test
@@ -97,7 +110,7 @@ public class NamedArgumentValidatorTest {
 
         // Should not throw
         Assertions.assertDoesNotThrow(() -> {
-            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames, null);
         });
     }
 
@@ -115,7 +128,7 @@ public class NamedArgumentValidatorTest {
 
         // Should not throw - order doesn't matter for named args
         Assertions.assertDoesNotThrow(() -> {
-            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames, null);
         });
     }
 
@@ -133,7 +146,7 @@ public class NamedArgumentValidatorTest {
 
         // Should not throw - optional params can be omitted
         Assertions.assertDoesNotThrow(() -> {
-            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames, null);
         });
     }
 
@@ -151,7 +164,7 @@ public class NamedArgumentValidatorTest {
         List<String> paramNames = Arrays.asList("param_a", "param_a");
 
         SemanticException ex = Assertions.assertThrows(SemanticException.class, () -> {
-            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames, null);
         });
 
         Assertions.assertTrue(ex.getMessage().contains("duplicate parameter"),
@@ -172,7 +185,7 @@ public class NamedArgumentValidatorTest {
         List<String> paramNames = Arrays.asList("param_a", "param_b", "param_a");
 
         SemanticException ex = Assertions.assertThrows(SemanticException.class, () -> {
-            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames, null);
         });
 
         Assertions.assertTrue(ex.getMessage().contains("duplicate"),
@@ -193,7 +206,7 @@ public class NamedArgumentValidatorTest {
         List<String> paramNames = Arrays.asList("param_a", "unknown_param");
 
         SemanticException ex = Assertions.assertThrows(SemanticException.class, () -> {
-            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames, null);
         });
 
         Assertions.assertTrue(
@@ -216,7 +229,7 @@ public class NamedArgumentValidatorTest {
         List<String> paramNames = Arrays.asList("PARAM_A", "param_b");
 
         SemanticException ex = Assertions.assertThrows(SemanticException.class, () -> {
-            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames, null);
         });
 
         // Should provide suggestion for case-insensitive match
@@ -238,7 +251,7 @@ public class NamedArgumentValidatorTest {
         List<String> paramNames = Arrays.asList("TIMEOUT_MS", "retry_count");
 
         SemanticException ex = Assertions.assertThrows(SemanticException.class, () -> {
-            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames, null);
         });
 
         Assertions.assertTrue(ex.getMessage().contains("Did you mean 'timeout_ms'"),
@@ -260,7 +273,7 @@ public class NamedArgumentValidatorTest {
         List<String> paramNames = Arrays.asList("method", "timeout");
 
         SemanticException ex = Assertions.assertThrows(SemanticException.class, () -> {
-            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames, null);
         });
 
         Assertions.assertTrue(ex.getMessage().contains("required parameter"),
@@ -282,7 +295,7 @@ public class NamedArgumentValidatorTest {
         List<String> paramNames = Arrays.asList("param_c");
 
         SemanticException ex = Assertions.assertThrows(SemanticException.class, () -> {
-            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames, null);
         });
 
         Assertions.assertTrue(ex.getMessage().contains("required parameter"),
@@ -301,7 +314,7 @@ public class NamedArgumentValidatorTest {
         List<String> paramNames = new ArrayList<>();
 
         SemanticException ex = Assertions.assertThrows(SemanticException.class, () -> {
-            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames, null);
         });
 
         Assertions.assertTrue(ex.getMessage().contains("required parameter"),
@@ -324,7 +337,7 @@ public class NamedArgumentValidatorTest {
         List<String> paramNames = Arrays.asList("param_a");
 
         SemanticException ex = Assertions.assertThrows(SemanticException.class, () -> {
-            FunctionAnalyzer.validateNamedArguments("no_named_args_function", fn, paramNames);
+            FunctionAnalyzer.validateNamedArguments("no_named_args_function", fn, paramNames, null);
         });
 
         Assertions.assertTrue(ex.getMessage().contains("does not support named parameters"),
@@ -336,7 +349,7 @@ public class NamedArgumentValidatorTest {
         List<String> paramNames = Arrays.asList("param_a");
 
         SemanticException ex = Assertions.assertThrows(SemanticException.class, () -> {
-            FunctionAnalyzer.validateNamedArguments("null_function", null, paramNames);
+            FunctionAnalyzer.validateNamedArguments("null_function", null, paramNames, null);
         });
 
         Assertions.assertTrue(ex.getMessage().contains("does not support named parameters"),
@@ -356,7 +369,7 @@ public class NamedArgumentValidatorTest {
         List<String> paramNames = Arrays.asList("single_param");
 
         Assertions.assertDoesNotThrow(() -> {
-            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames, null);
         });
     }
 
@@ -373,7 +386,7 @@ public class NamedArgumentValidatorTest {
         List<String> paramNames = new ArrayList<>();
 
         Assertions.assertDoesNotThrow(() -> {
-            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames, null);
         });
     }
 
@@ -392,7 +405,7 @@ public class NamedArgumentValidatorTest {
         List<String> paramNames = Arrays.asList("url", "method", "timeout_ms");
 
         Assertions.assertDoesNotThrow(() -> {
-            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames, null);
         });
     }
 
@@ -411,10 +424,127 @@ public class NamedArgumentValidatorTest {
         List<String> paramNames = Arrays.asList("method", "timeout_ms");
 
         SemanticException ex = Assertions.assertThrows(SemanticException.class, () -> {
-            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames, null);
         });
 
         Assertions.assertTrue(ex.getMessage().contains("url"),
                 "Expected 'url' in error message: " + ex.getMessage());
+    }
+
+    // ========== Test Category 7: NULL Value Validation ==========
+
+    @Test
+    public void testRequiredParameterCannotBeNull() {
+        // Function: url (required), method (default='GET')
+        String[] names = {"url", "method"};
+        Type[] types = {VarcharType.VARCHAR, VarcharType.VARCHAR};
+        Expr[] defaults = {null, new StringLiteral("GET")};
+
+        ScalarFunction mockFn = createMockFunction(names, types, defaults);
+
+        // Provide NULL for required parameter 'url'
+        List<String> paramNames = Arrays.asList("url", "method");
+        FunctionCallExpr mockNode = createMockFunctionCallExpr(
+                Arrays.asList(new NullLiteral(), new StringLiteral("POST"))
+        );
+
+        SemanticException ex = Assertions.assertThrows(SemanticException.class, () -> {
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames, mockNode);
+        });
+
+        Assertions.assertTrue(ex.getMessage().contains("cannot be NULL"),
+                "Expected 'cannot be NULL' in error message: " + ex.getMessage());
+        Assertions.assertTrue(ex.getMessage().contains("url"),
+                "Expected 'url' in error message: " + ex.getMessage());
+    }
+
+    @Test
+    public void testOptionalParameterCanBeNull() {
+        // Function: url (required), method (default='GET')
+        String[] names = {"url", "method"};
+        Type[] types = {VarcharType.VARCHAR, VarcharType.VARCHAR};
+        Expr[] defaults = {null, new StringLiteral("GET")};
+
+        ScalarFunction mockFn = createMockFunction(names, types, defaults);
+
+        // Provide NULL for optional parameter 'method' - should be allowed
+        List<String> paramNames = Arrays.asList("url", "method");
+        FunctionCallExpr mockNode = createMockFunctionCallExpr(
+                Arrays.asList(new StringLiteral("https://example.com"), new NullLiteral())
+        );
+
+        // Should not throw
+        Assertions.assertDoesNotThrow(() -> {
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames, mockNode);
+        });
+    }
+
+    @Test
+    public void testMultipleRequiredParametersNullCheck() {
+        // Function: url (required), method (required), body (default='')
+        String[] names = {"url", "method", "body"};
+        Type[] types = {VarcharType.VARCHAR, VarcharType.VARCHAR, VarcharType.VARCHAR};
+        Expr[] defaults = {null, null, new StringLiteral("")};
+
+        ScalarFunction mockFn = createMockFunction(names, types, defaults);
+
+        // NULL for second required parameter
+        List<String> paramNames = Arrays.asList("url", "method", "body");
+        FunctionCallExpr mockNode = createMockFunctionCallExpr(
+                Arrays.asList(new StringLiteral("https://example.com"), new NullLiteral(), new StringLiteral("data"))
+        );
+
+        SemanticException ex = Assertions.assertThrows(SemanticException.class, () -> {
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames, mockNode);
+        });
+
+        Assertions.assertTrue(ex.getMessage().contains("method"),
+                "Expected 'method' in error message: " + ex.getMessage());
+    }
+
+    @Test
+    public void testFirstRequiredParameterNull() {
+        // Function: url (required), method (default='GET'), body (default='')
+        String[] names = {"url", "method", "body"};
+        Type[] types = {VarcharType.VARCHAR, VarcharType.VARCHAR, VarcharType.VARCHAR};
+        Expr[] defaults = {null, new StringLiteral("GET"), new StringLiteral("")};
+
+        ScalarFunction mockFn = createMockFunction(names, types, defaults);
+
+        // NULL for first required parameter
+        List<String> paramNames = Arrays.asList("url", "method");
+        FunctionCallExpr mockNode = createMockFunctionCallExpr(
+                Arrays.asList(new NullLiteral(), new StringLiteral("POST"))
+        );
+
+        SemanticException ex = Assertions.assertThrows(SemanticException.class, () -> {
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames, mockNode);
+        });
+
+        Assertions.assertTrue(ex.getMessage().contains("url"),
+                "Expected 'url' in error message: " + ex.getMessage());
+        Assertions.assertTrue(ex.getMessage().contains("cannot be NULL"),
+                "Expected 'cannot be NULL' in error message: " + ex.getMessage());
+    }
+
+    @Test
+    public void testAllOptionalParametersNull() {
+        // Function: url (required), method (default='GET'), body (default='')
+        String[] names = {"url", "method", "body"};
+        Type[] types = {VarcharType.VARCHAR, VarcharType.VARCHAR, VarcharType.VARCHAR};
+        Expr[] defaults = {null, new StringLiteral("GET"), new StringLiteral("")};
+
+        ScalarFunction mockFn = createMockFunction(names, types, defaults);
+
+        // Required parameter provided, optional parameters NULL - should be allowed
+        List<String> paramNames = Arrays.asList("url", "method", "body");
+        FunctionCallExpr mockNode = createMockFunctionCallExpr(
+                Arrays.asList(new StringLiteral("https://example.com"), new NullLiteral(), new NullLiteral())
+        );
+
+        // Should not throw
+        Assertions.assertDoesNotThrow(() -> {
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames, mockNode);
+        });
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/NamedArgumentValidatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/NamedArgumentValidatorTest.java
@@ -90,7 +90,7 @@ public class NamedArgumentValidatorTest {
      * @return Mock FunctionCallExpr for testing
      */
     private FunctionCallExpr createMockFunctionCallExpr(List<Expr> argExprs) {
-        FunctionCallExpr node = new FunctionCallExpr(new FunctionName("test_function"), argExprs);
+        FunctionCallExpr node = new FunctionCallExpr("test_function", argExprs);
         return node;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/NamedArgumentValidatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/NamedArgumentValidatorTest.java
@@ -1,0 +1,420 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.catalog.FunctionName;
+import com.starrocks.catalog.ScalarFunction;
+import com.starrocks.common.Pair;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.IntLiteral;
+import com.starrocks.sql.ast.expression.StringLiteral;
+import com.starrocks.type.BooleanType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.Type;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Vector;
+
+/**
+ * Unit tests for FunctionAnalyzer.validateNamedArguments() method.
+ * These tests verify the common Named Arguments validation logic
+ * without depending on any specific function implementation.
+ */
+public class NamedArgumentValidatorTest {
+
+    // ========== Helper Methods ==========
+
+    /**
+     * Creates a mock ScalarFunction with named arguments support
+     *
+     * @param paramNames   Array of parameter names
+     * @param paramTypes   Array of parameter types
+     * @param defaultExprs Array of default expressions (null for required params)
+     * @return Mock ScalarFunction for testing
+     */
+    private ScalarFunction createMockFunction(String[] paramNames, Type[] paramTypes, Expr[] defaultExprs) {
+        Assertions.assertEquals(paramNames.length, paramTypes.length,
+                "Parameter names and types must have same length");
+        Assertions.assertEquals(paramNames.length, defaultExprs.length,
+                "Parameter names and defaults must have same length");
+
+        // Create function with return type
+        ScalarFunction fn = new ScalarFunction(
+                new FunctionName("test_function"),
+                Arrays.asList(paramTypes),
+                IntegerType.INT,
+                false
+        );
+
+        // Set named argument information - setArgNames expects List<String>
+        fn.setArgNames(Arrays.asList(paramNames));
+
+        // Set default values using Vector<Pair<String, Expr>>
+        // Only add parameters that have default values (non-null)
+        Vector<Pair<String, Expr>> defaultArgs = new Vector<>();
+        for (int i = 0; i < paramNames.length; i++) {
+            if (defaultExprs[i] != null) {
+                defaultArgs.add(new Pair<>(paramNames[i], defaultExprs[i]));
+            }
+        }
+        if (!defaultArgs.isEmpty()) {
+            fn.setDefaultNamedArgs(defaultArgs);
+        }
+
+        return fn;
+    }
+
+    // ========== Test Category 1: Valid Cases ==========
+
+    @Test
+    public void testValidNamedArgumentsInOrder() {
+        // Function: param_a (required), param_b (required), param_c (default=0)
+        ScalarFunction mockFn = createMockFunction(
+                new String[] {"param_a", "param_b", "param_c"},
+                new Type[] {IntegerType.INT, IntegerType.INT, IntegerType.INT},
+                new Expr[] {null, null, new IntLiteral(0)}
+        );
+
+        // All parameters provided in order
+        List<String> paramNames = Arrays.asList("param_a", "param_b", "param_c");
+
+        // Should not throw
+        Assertions.assertDoesNotThrow(() -> {
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+        });
+    }
+
+    @Test
+    public void testValidNamedArgumentsDifferentOrder() {
+        // Function: param_a (required), param_b (required), param_c (default=0)
+        ScalarFunction mockFn = createMockFunction(
+                new String[] {"param_a", "param_b", "param_c"},
+                new Type[] {IntegerType.INT, IntegerType.INT, IntegerType.INT},
+                new Expr[] {null, null, new IntLiteral(0)}
+        );
+
+        // Parameters in different order
+        List<String> paramNames = Arrays.asList("param_c", "param_b", "param_a");
+
+        // Should not throw - order doesn't matter for named args
+        Assertions.assertDoesNotThrow(() -> {
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+        });
+    }
+
+    @Test
+    public void testValidNamedArgumentsOnlyRequired() {
+        // Function: param_a (required), param_b (required), param_c (default=0)
+        ScalarFunction mockFn = createMockFunction(
+                new String[] {"param_a", "param_b", "param_c"},
+                new Type[] {IntegerType.INT, IntegerType.INT, IntegerType.INT},
+                new Expr[] {null, null, new IntLiteral(0)}
+        );
+
+        // Only required parameters provided
+        List<String> paramNames = Arrays.asList("param_a", "param_b");
+
+        // Should not throw - optional params can be omitted
+        Assertions.assertDoesNotThrow(() -> {
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+        });
+    }
+
+    // ========== Test Category 2: Duplicate Parameter ==========
+
+    @Test
+    public void testDuplicateParameterName() {
+        ScalarFunction mockFn = createMockFunction(
+                new String[] {"param_a", "param_b"},
+                new Type[] {IntegerType.INT, IntegerType.INT},
+                new Expr[] {null, null}
+        );
+
+        // Duplicate parameter name
+        List<String> paramNames = Arrays.asList("param_a", "param_a");
+
+        SemanticException ex = Assertions.assertThrows(SemanticException.class, () -> {
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+        });
+
+        Assertions.assertTrue(ex.getMessage().contains("duplicate parameter"),
+                "Expected 'duplicate parameter' in: " + ex.getMessage());
+        Assertions.assertTrue(ex.getMessage().contains("param_a"),
+                "Expected parameter name 'param_a' in: " + ex.getMessage());
+    }
+
+    @Test
+    public void testMultipleDuplicates() {
+        ScalarFunction mockFn = createMockFunction(
+                new String[] {"param_a", "param_b", "param_c"},
+                new Type[] {IntegerType.INT, IntegerType.INT, IntegerType.INT},
+                new Expr[] {null, null, null}
+        );
+
+        // Multiple duplicates - first duplicate should be caught
+        List<String> paramNames = Arrays.asList("param_a", "param_b", "param_a");
+
+        SemanticException ex = Assertions.assertThrows(SemanticException.class, () -> {
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+        });
+
+        Assertions.assertTrue(ex.getMessage().contains("duplicate"),
+                "Expected 'duplicate' in: " + ex.getMessage());
+    }
+
+    // ========== Test Category 3: Unknown Parameter ==========
+
+    @Test
+    public void testUnknownParameterName() {
+        ScalarFunction mockFn = createMockFunction(
+                new String[] {"param_a", "param_b"},
+                new Type[] {IntegerType.INT, IntegerType.INT},
+                new Expr[] {null, null}
+        );
+
+        // Unknown parameter name
+        List<String> paramNames = Arrays.asList("param_a", "unknown_param");
+
+        SemanticException ex = Assertions.assertThrows(SemanticException.class, () -> {
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+        });
+
+        Assertions.assertTrue(
+                ex.getMessage().contains("does not support parameter") ||
+                        ex.getMessage().contains("unknown parameter"),
+                "Expected unknown parameter error in: " + ex.getMessage());
+        Assertions.assertTrue(ex.getMessage().contains("unknown_param"),
+                "Expected parameter name 'unknown_param' in: " + ex.getMessage());
+    }
+
+    @Test
+    public void testCaseSensitiveParameterName() {
+        ScalarFunction mockFn = createMockFunction(
+                new String[] {"param_a", "param_b"},
+                new Type[] {IntegerType.INT, IntegerType.INT},
+                new Expr[] {null, null}
+        );
+
+        // Wrong case - should suggest correct name
+        List<String> paramNames = Arrays.asList("PARAM_A", "param_b");
+
+        SemanticException ex = Assertions.assertThrows(SemanticException.class, () -> {
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+        });
+
+        // Should provide suggestion for case-insensitive match
+        Assertions.assertTrue(ex.getMessage().contains("Did you mean"),
+                "Expected suggestion in: " + ex.getMessage());
+        Assertions.assertTrue(ex.getMessage().contains("param_a"),
+                "Expected correct name 'param_a' in suggestion: " + ex.getMessage());
+    }
+
+    @Test
+    public void testSimilarParameterNameSuggestion() {
+        ScalarFunction mockFn = createMockFunction(
+                new String[] {"timeout_ms", "retry_count"},
+                new Type[] {IntegerType.INT, IntegerType.INT},
+                new Expr[] {null, null}
+        );
+
+        // Wrong case - should suggest similar name
+        List<String> paramNames = Arrays.asList("TIMEOUT_MS", "retry_count");
+
+        SemanticException ex = Assertions.assertThrows(SemanticException.class, () -> {
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+        });
+
+        Assertions.assertTrue(ex.getMessage().contains("Did you mean 'timeout_ms'"),
+                "Expected suggestion for 'timeout_ms' in: " + ex.getMessage());
+    }
+
+    // ========== Test Category 4: Missing Required Parameter ==========
+
+    @Test
+    public void testMissingRequiredParameter() {
+        // url is required, method and timeout have defaults
+        ScalarFunction mockFn = createMockFunction(
+                new String[] {"url", "method", "timeout"},
+                new Type[] {VarcharType.VARCHAR, VarcharType.VARCHAR, IntegerType.INT},
+                new Expr[] {null, new StringLiteral("GET"), new IntLiteral(30000)}
+        );
+
+        // Missing required 'url'
+        List<String> paramNames = Arrays.asList("method", "timeout");
+
+        SemanticException ex = Assertions.assertThrows(SemanticException.class, () -> {
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+        });
+
+        Assertions.assertTrue(ex.getMessage().contains("required parameter"),
+                "Expected 'required parameter' in: " + ex.getMessage());
+        Assertions.assertTrue(ex.getMessage().contains("url"),
+                "Expected parameter name 'url' in: " + ex.getMessage());
+    }
+
+    @Test
+    public void testMissingMultipleRequiredParameters() {
+        // Both param_a and param_b are required
+        ScalarFunction mockFn = createMockFunction(
+                new String[] {"param_a", "param_b", "param_c"},
+                new Type[] {IntegerType.INT, IntegerType.INT, IntegerType.INT},
+                new Expr[] {null, null, new IntLiteral(0)}
+        );
+
+        // Only optional param_c provided
+        List<String> paramNames = Arrays.asList("param_c");
+
+        SemanticException ex = Assertions.assertThrows(SemanticException.class, () -> {
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+        });
+
+        Assertions.assertTrue(ex.getMessage().contains("required parameter"),
+                "Expected 'required parameter' in: " + ex.getMessage());
+    }
+
+    @Test
+    public void testAllRequiredParametersMissing() {
+        ScalarFunction mockFn = createMockFunction(
+                new String[] {"param_a", "param_b"},
+                new Type[] {IntegerType.INT, IntegerType.INT},
+                new Expr[] {null, null}
+        );
+
+        // Empty list - all required params missing
+        List<String> paramNames = new ArrayList<>();
+
+        SemanticException ex = Assertions.assertThrows(SemanticException.class, () -> {
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+        });
+
+        Assertions.assertTrue(ex.getMessage().contains("required parameter"),
+                "Expected 'required parameter' in: " + ex.getMessage());
+    }
+
+    // ========== Test Category 5: Function Without Named Args Support ==========
+
+    @Test
+    public void testFunctionWithoutNamedArgsSupport() {
+        // Create function without named args support
+        ScalarFunction fn = new ScalarFunction(
+                new FunctionName("no_named_args_function"),
+                Arrays.asList(new Type[] {IntegerType.INT}),
+                IntegerType.INT,
+                false
+        );
+        // Don't set argNames or namedArgs
+
+        List<String> paramNames = Arrays.asList("param_a");
+
+        SemanticException ex = Assertions.assertThrows(SemanticException.class, () -> {
+            FunctionAnalyzer.validateNamedArguments("no_named_args_function", fn, paramNames);
+        });
+
+        Assertions.assertTrue(ex.getMessage().contains("does not support named parameters"),
+                "Expected 'does not support named parameters' in: " + ex.getMessage());
+    }
+
+    @Test
+    public void testNullFunction() {
+        List<String> paramNames = Arrays.asList("param_a");
+
+        SemanticException ex = Assertions.assertThrows(SemanticException.class, () -> {
+            FunctionAnalyzer.validateNamedArguments("null_function", null, paramNames);
+        });
+
+        Assertions.assertTrue(ex.getMessage().contains("does not support named parameters"),
+                "Expected 'does not support named parameters' in: " + ex.getMessage());
+    }
+
+    // ========== Test Category 6: Edge Cases ==========
+
+    @Test
+    public void testSingleParameter() {
+        ScalarFunction mockFn = createMockFunction(
+                new String[] {"single_param"},
+                new Type[] {IntegerType.INT},
+                new Expr[] {null}
+        );
+
+        List<String> paramNames = Arrays.asList("single_param");
+
+        Assertions.assertDoesNotThrow(() -> {
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+        });
+    }
+
+    @Test
+    public void testAllOptionalParameters() {
+        // All parameters have defaults
+        ScalarFunction mockFn = createMockFunction(
+                new String[] {"opt_a", "opt_b", "opt_c"},
+                new Type[] {IntegerType.INT, IntegerType.INT, IntegerType.INT},
+                new Expr[] {new IntLiteral(1), new IntLiteral(2), new IntLiteral(3)}
+        );
+
+        // Empty list is valid when all params are optional
+        List<String> paramNames = new ArrayList<>();
+
+        Assertions.assertDoesNotThrow(() -> {
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+        });
+    }
+
+    @Test
+    public void testManyParameters() {
+        // Test with many parameters (8 like http_request)
+        String[] names = {"url", "method", "body", "headers", "timeout_ms", "ssl_verify", "username", "password"};
+        Type[] types = {VarcharType.VARCHAR, VarcharType.VARCHAR, VarcharType.VARCHAR, VarcharType.VARCHAR,
+                IntegerType.INT, BooleanType.BOOLEAN, VarcharType.VARCHAR, VarcharType.VARCHAR};
+        Expr[] defaults = {null, new StringLiteral("GET"), new StringLiteral(""), new StringLiteral("{}"),
+                new IntLiteral(30000), new IntLiteral(1), new StringLiteral(""), new StringLiteral("")};
+
+        ScalarFunction mockFn = createMockFunction(names, types, defaults);
+
+        // Provide only required (url) and some optional
+        List<String> paramNames = Arrays.asList("url", "method", "timeout_ms");
+
+        Assertions.assertDoesNotThrow(() -> {
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+        });
+    }
+
+    @Test
+    public void testManyParametersMissingRequired() {
+        // Same as above but missing required 'url'
+        String[] names = {"url", "method", "body", "headers", "timeout_ms", "ssl_verify", "username", "password"};
+        Type[] types = {VarcharType.VARCHAR, VarcharType.VARCHAR, VarcharType.VARCHAR, VarcharType.VARCHAR,
+                IntegerType.INT, BooleanType.BOOLEAN, VarcharType.VARCHAR, VarcharType.VARCHAR};
+        Expr[] defaults = {null, new StringLiteral("GET"), new StringLiteral(""), new StringLiteral("{}"),
+                new IntLiteral(30000), new IntLiteral(1), new StringLiteral(""), new StringLiteral("")};
+
+        ScalarFunction mockFn = createMockFunction(names, types, defaults);
+
+        // Missing required 'url'
+        List<String> paramNames = Arrays.asList("method", "timeout_ms");
+
+        SemanticException ex = Assertions.assertThrows(SemanticException.class, () -> {
+            FunctionAnalyzer.validateNamedArguments("test_function", mockFn, paramNames);
+        });
+
+        Assertions.assertTrue(ex.getMessage().contains("url"),
+                "Expected 'url' in error message: " + ex.getMessage());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/FunctionParamsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/FunctionParamsTest.java
@@ -369,7 +369,7 @@ public class FunctionParamsTest {
         FunctionParams params = new FunctionParams(false, exprs);
 
         // After reordering, we can get the named arg string representation
-        String argStr = params.getNamedArgStr();
+        String argStr = FunctionAnalyzer.getNamedArgStr(params);
 
         // Should contain both parameters in named format
         Assertions.assertTrue(argStr.contains("url=>"),

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/FunctionParamsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/FunctionParamsTest.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.ast.expression;
 import com.starrocks.catalog.FunctionName;
 import com.starrocks.catalog.ScalarFunction;
 import com.starrocks.common.Pair;
+import com.starrocks.sql.analyzer.FunctionAnalyzer;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.Type;
 import com.starrocks.type.VarcharType;
@@ -184,7 +185,7 @@ public class FunctionParamsTest {
         );
 
         FunctionParams params = new FunctionParams(false, exprs);
-        params.reorderNamedArgAndAppendDefaults(mockFn);
+        FunctionAnalyzer.reorderNamedArgAndAppendDefaults(params, mockFn);
 
         // Verify reordered to match function definition: url, method, timeout_ms
         Assertions.assertEquals(3, params.exprs().size(),
@@ -229,7 +230,7 @@ public class FunctionParamsTest {
         );
 
         FunctionParams params = new FunctionParams(false, exprs);
-        params.reorderNamedArgAndAppendDefaults(mockFn);
+        FunctionAnalyzer.reorderNamedArgAndAppendDefaults(params, mockFn);
 
         // Verify reordered to a, b, c
         Assertions.assertEquals("a", params.getExprsNames().get(0));
@@ -257,7 +258,7 @@ public class FunctionParamsTest {
         );
 
         FunctionParams params = new FunctionParams(false, exprs);
-        params.reorderNamedArgAndAppendDefaults(mockFn);
+        FunctionAnalyzer.reorderNamedArgAndAppendDefaults(params, mockFn);
 
         // Should have all 4 parameters
         Assertions.assertEquals(4, params.exprs().size(),
@@ -294,7 +295,7 @@ public class FunctionParamsTest {
         ));
 
         FunctionParams params = new FunctionParams(false, exprs);
-        params.appendDefaultsForPositionalArgs(mockFn);
+        FunctionAnalyzer.appendDefaultsForPositionalArgs(params, mockFn);
 
         // Should append default for step
         Assertions.assertEquals(3, params.exprs().size(),
@@ -319,7 +320,7 @@ public class FunctionParamsTest {
         List<Expr> exprs = new ArrayList<>(Arrays.asList(new IntLiteral(1)));
 
         FunctionParams params = new FunctionParams(false, exprs);
-        params.appendDefaultsForPositionalArgs(mockFn);
+        FunctionAnalyzer.appendDefaultsForPositionalArgs(params, mockFn);
 
         // Should append all defaults
         Assertions.assertEquals(4, params.exprs().size(),
@@ -348,7 +349,7 @@ public class FunctionParamsTest {
         ));
 
         FunctionParams params = new FunctionParams(false, exprs);
-        params.appendDefaultsForPositionalArgs(mockFn);
+        FunctionAnalyzer.appendDefaultsForPositionalArgs(params, mockFn);
 
         // Should not append anything
         Assertions.assertEquals(2, params.exprs().size(),

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/FunctionParamsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/FunctionParamsTest.java
@@ -1,0 +1,517 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast.expression;
+
+import com.starrocks.catalog.FunctionName;
+import com.starrocks.catalog.ScalarFunction;
+import com.starrocks.common.Pair;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.Type;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Vector;
+
+public class FunctionParamsTest {
+
+    // ========== Helper Methods ==========
+
+    /**
+     * Creates a mock ScalarFunction with named arguments support
+     *
+     * @param paramNames   Array of parameter names
+     * @param paramTypes   Array of parameter types
+     * @param defaultExprs Array of default expressions (null for required params)
+     * @return Mock ScalarFunction for testing
+     */
+    private ScalarFunction createMockFunction(String[] paramNames, Type[] paramTypes, Expr[] defaultExprs) {
+        Assertions.assertEquals(paramNames.length, paramTypes.length,
+                "Parameter names and types must have same length");
+        Assertions.assertEquals(paramNames.length, defaultExprs.length,
+                "Parameter names and defaults must have same length");
+
+        // Create function with return type (doesn't matter for our tests)
+        ScalarFunction fn = new ScalarFunction(
+                new FunctionName("test_function"),
+                Arrays.asList(paramTypes),
+                IntegerType.INT,
+                false
+        );
+
+        // Set named argument information - setArgNames expects List<String>
+        fn.setArgNames(Arrays.asList(paramNames));
+
+        // Set default values using Vector<Pair<String, Expr>>
+        // Only add parameters that have default values (non-null)
+        Vector<Pair<String, Expr>> defaultArgs = new Vector<>();
+        for (int i = 0; i < paramNames.length; i++) {
+            if (defaultExprs[i] != null) {
+                defaultArgs.add(new Pair<>(paramNames[i], defaultExprs[i]));
+            }
+        }
+        if (!defaultArgs.isEmpty()) {
+            fn.setDefaultNamedArgs(defaultArgs);
+        }
+
+        return fn;
+    }
+
+    // ========== Test Category 2.1: FunctionParams Construction ==========
+
+    @Test
+    public void testNamedArgumentExtraction() {
+        // Create named arguments
+        List<Expr> exprs = Arrays.asList(
+                new NamedArgument("url", new StringLiteral("https://example.com")),
+                new NamedArgument("method", new StringLiteral("POST"))
+        );
+
+        FunctionParams params = new FunctionParams(false, exprs);
+
+        // Verify named arguments extracted correctly
+        Assertions.assertEquals(2, params.exprs().size(),
+                "Should have 2 expressions");
+        Assertions.assertNotNull(params.getExprsNames(),
+                "Expression names should not be null");
+        Assertions.assertEquals(2, params.getExprsNames().size(),
+                "Should have 2 expression names");
+        Assertions.assertEquals("url", params.getExprsNames().get(0),
+                "First parameter name should be 'url'");
+        Assertions.assertEquals("method", params.getExprsNames().get(1),
+                "Second parameter name should be 'method'");
+
+        // Verify expressions are extracted (not NamedArgument wrappers)
+        Assertions.assertTrue(params.exprs().get(0) instanceof StringLiteral,
+                "First expression should be StringLiteral, not NamedArgument");
+        Assertions.assertTrue(params.exprs().get(1) instanceof StringLiteral,
+                "Second expression should be StringLiteral, not NamedArgument");
+    }
+
+    @Test
+    public void testPositionalArgumentsNoNames() {
+        // Create positional arguments (no names)
+        List<Expr> exprs = Arrays.asList(
+                new StringLiteral("https://example.com"),
+                new StringLiteral("POST")
+        );
+
+        FunctionParams params = new FunctionParams(false, exprs);
+
+        // Verify no named argument names extracted
+        Assertions.assertNull(params.getExprsNames(),
+                "Expression names should be null for positional arguments");
+        Assertions.assertEquals(2, params.exprs().size(),
+                "Should have 2 expressions");
+    }
+
+    @Test
+    public void testMixedNamedAndPositionalConstruction() {
+        // This tests the constructor behavior when mixing (should extract names for named ones)
+        List<Expr> exprs = Arrays.asList(
+                new NamedArgument("url", new StringLiteral("https://example.com")),
+                new StringLiteral("POST")  // Positional (will have empty name)
+        );
+
+        FunctionParams params = new FunctionParams(false, exprs);
+
+        // Should extract names, with empty string for positional
+        Assertions.assertNotNull(params.getExprsNames(),
+                "Expression names should not be null");
+        Assertions.assertEquals(2, params.getExprsNames().size(),
+                "Should have 2 expression names");
+        Assertions.assertEquals("url", params.getExprsNames().get(0),
+                "First parameter name should be 'url'");
+        Assertions.assertEquals("", params.getExprsNames().get(1),
+                "Second parameter name should be empty for positional");
+    }
+
+    @Test
+    public void testDistinctFlag() {
+        List<Expr> exprs = Arrays.asList(new StringLiteral("value"));
+
+        FunctionParams params1 = new FunctionParams(false, exprs);
+        FunctionParams params2 = new FunctionParams(true, exprs);
+
+        Assertions.assertFalse(params1.isDistinct(),
+                "First params should not be distinct");
+        Assertions.assertTrue(params2.isDistinct(),
+                "Second params should be distinct");
+    }
+
+    @Test
+    public void testStarParam() {
+        FunctionParams params = FunctionParams.createStarParam();
+
+        Assertions.assertTrue(params.isStar(),
+                "Should be star param");
+        Assertions.assertFalse(params.isDistinct(),
+                "Star param should not be distinct by default");
+        Assertions.assertNull(params.exprs(),
+                "Star param should have null exprs");
+    }
+
+    // ========== Test Category 2.2: Reordering Logic ==========
+
+    @Test
+    public void testReorderNamedArgAndAppendDefaults() {
+        // Create mock function with parameters: url (required), method (default=GET), timeout (default=30000)
+        ScalarFunction mockFn = createMockFunction(
+                new String[] {"url", "method", "timeout_ms"},
+                new Type[] {VarcharType.VARCHAR, VarcharType.VARCHAR, IntegerType.INT},
+                new Expr[] {null, new StringLiteral("GET"), new IntLiteral(30000)}
+        );
+
+        // Create params with different order: method, url (missing timeout_ms)
+        List<Expr> exprs = Arrays.asList(
+                new NamedArgument("method", new StringLiteral("POST")),
+                new NamedArgument("url", new StringLiteral("https://example.com"))
+        );
+
+        FunctionParams params = new FunctionParams(false, exprs);
+        params.reorderNamedArgAndAppendDefaults(mockFn);
+
+        // Verify reordered to match function definition: url, method, timeout_ms
+        Assertions.assertEquals(3, params.exprs().size(),
+                "Should have 3 parameters after reordering and defaults");
+        Assertions.assertEquals(3, params.getExprsNames().size(),
+                "Should have 3 parameter names");
+
+        // Verify order: url, method, timeout_ms
+        Assertions.assertEquals("url", params.getExprsNames().get(0),
+                "First parameter should be 'url'");
+        Assertions.assertEquals("method", params.getExprsNames().get(1),
+                "Second parameter should be 'method'");
+        Assertions.assertEquals("timeout_ms", params.getExprsNames().get(2),
+                "Third parameter should be 'timeout_ms'");
+
+        // Verify values
+        Assertions.assertEquals("https://example.com",
+                ((StringLiteral) params.exprs().get(0)).getValue(),
+                "URL value should be preserved");
+        Assertions.assertEquals("POST",
+                ((StringLiteral) params.exprs().get(1)).getValue(),
+                "Method value should be preserved");
+        Assertions.assertEquals(30000L,
+                ((IntLiteral) params.exprs().get(2)).getLongValue(),
+                "Timeout should be default value");
+    }
+
+    @Test
+    public void testReorderingReverseOrder() {
+        // Function params: a, b, c
+        ScalarFunction mockFn = createMockFunction(
+                new String[] {"a", "b", "c"},
+                new Type[] {IntegerType.INT, IntegerType.INT, IntegerType.INT},
+                new Expr[] {null, null, new IntLiteral(0)}  // c has default
+        );
+
+        // Provide in reverse order: c, b, a
+        List<Expr> exprs = Arrays.asList(
+                new NamedArgument("c", new IntLiteral(3)),
+                new NamedArgument("b", new IntLiteral(2)),
+                new NamedArgument("a", new IntLiteral(1))
+        );
+
+        FunctionParams params = new FunctionParams(false, exprs);
+        params.reorderNamedArgAndAppendDefaults(mockFn);
+
+        // Verify reordered to a, b, c
+        Assertions.assertEquals("a", params.getExprsNames().get(0));
+        Assertions.assertEquals("b", params.getExprsNames().get(1));
+        Assertions.assertEquals("c", params.getExprsNames().get(2));
+
+        Assertions.assertEquals(1L, ((IntLiteral) params.exprs().get(0)).getLongValue());
+        Assertions.assertEquals(2L, ((IntLiteral) params.exprs().get(1)).getLongValue());
+        Assertions.assertEquals(3L, ((IntLiteral) params.exprs().get(2)).getLongValue());
+    }
+
+    @Test
+    public void testReorderingWithAllDefaults() {
+        // Function params: start (required), end (required), step (default=1), direction (default='up')
+        ScalarFunction mockFn = createMockFunction(
+                new String[] {"start", "end", "step", "direction"},
+                new Type[] {IntegerType.INT, IntegerType.INT, IntegerType.INT, VarcharType.VARCHAR},
+                new Expr[] {null, null, new IntLiteral(1), new StringLiteral("up")}
+        );
+
+        // Provide only required params in different order
+        List<Expr> exprs = Arrays.asList(
+                new NamedArgument("end", new IntLiteral(10)),
+                new NamedArgument("start", new IntLiteral(1))
+        );
+
+        FunctionParams params = new FunctionParams(false, exprs);
+        params.reorderNamedArgAndAppendDefaults(mockFn);
+
+        // Should have all 4 parameters
+        Assertions.assertEquals(4, params.exprs().size(),
+                "Should have 4 parameters including defaults");
+
+        // Verify correct order
+        Assertions.assertEquals("start", params.getExprsNames().get(0));
+        Assertions.assertEquals("end", params.getExprsNames().get(1));
+        Assertions.assertEquals("step", params.getExprsNames().get(2));
+        Assertions.assertEquals("direction", params.getExprsNames().get(3));
+
+        // Verify values
+        Assertions.assertEquals(1L, ((IntLiteral) params.exprs().get(0)).getLongValue());
+        Assertions.assertEquals(10L, ((IntLiteral) params.exprs().get(1)).getLongValue());
+        Assertions.assertEquals(1L, ((IntLiteral) params.exprs().get(2)).getLongValue());  // default
+        Assertions.assertEquals("up", ((StringLiteral) params.exprs().get(3)).getValue());  // default
+    }
+
+    // ========== Test Category 2.3: Default Value Appending for Positional Args ==========
+
+    @Test
+    public void testAppendDefaultsForPositionalArgs() {
+        // Function params: start, end, step (default=1)
+        ScalarFunction mockFn = createMockFunction(
+                new String[] {"start", "end", "step"},
+                new Type[] {IntegerType.INT, IntegerType.INT, IntegerType.INT},
+                new Expr[] {null, null, new IntLiteral(1)}
+        );
+
+        // Provide positional args: start, end (missing step)
+        List<Expr> exprs = new ArrayList<>(Arrays.asList(
+                new IntLiteral(1),
+                new IntLiteral(10)
+        ));
+
+        FunctionParams params = new FunctionParams(false, exprs);
+        params.appendDefaultsForPositionalArgs(mockFn);
+
+        // Should append default for step
+        Assertions.assertEquals(3, params.exprs().size(),
+                "Should have 3 parameters after appending defaults");
+
+        // Verify values
+        Assertions.assertEquals(1L, ((IntLiteral) params.exprs().get(0)).getLongValue());
+        Assertions.assertEquals(10L, ((IntLiteral) params.exprs().get(1)).getLongValue());
+        Assertions.assertEquals(1L, ((IntLiteral) params.exprs().get(2)).getLongValue());  // default
+    }
+
+    @Test
+    public void testAppendDefaultsForPositionalArgsMultipleDefaults() {
+        // Function params: a (required), b (default=2), c (default=3), d (default=4)
+        ScalarFunction mockFn = createMockFunction(
+                new String[] {"a", "b", "c", "d"},
+                new Type[] {IntegerType.INT, IntegerType.INT, IntegerType.INT, IntegerType.INT},
+                new Expr[] {null, new IntLiteral(2), new IntLiteral(3), new IntLiteral(4)}
+        );
+
+        // Provide only first parameter
+        List<Expr> exprs = new ArrayList<>(Arrays.asList(new IntLiteral(1)));
+
+        FunctionParams params = new FunctionParams(false, exprs);
+        params.appendDefaultsForPositionalArgs(mockFn);
+
+        // Should append all defaults
+        Assertions.assertEquals(4, params.exprs().size(),
+                "Should have 4 parameters after appending defaults");
+
+        // Verify all values
+        Assertions.assertEquals(1L, ((IntLiteral) params.exprs().get(0)).getLongValue());
+        Assertions.assertEquals(2L, ((IntLiteral) params.exprs().get(1)).getLongValue());
+        Assertions.assertEquals(3L, ((IntLiteral) params.exprs().get(2)).getLongValue());
+        Assertions.assertEquals(4L, ((IntLiteral) params.exprs().get(3)).getLongValue());
+    }
+
+    @Test
+    public void testAppendDefaultsForPositionalArgsNoDefaults() {
+        // Function params: all required, no defaults
+        ScalarFunction mockFn = createMockFunction(
+                new String[] {"a", "b"},
+                new Type[] {IntegerType.INT, IntegerType.INT},
+                new Expr[] {null, null}
+        );
+
+        // Provide all parameters
+        List<Expr> exprs = new ArrayList<>(Arrays.asList(
+                new IntLiteral(1),
+                new IntLiteral(2)
+        ));
+
+        FunctionParams params = new FunctionParams(false, exprs);
+        params.appendDefaultsForPositionalArgs(mockFn);
+
+        // Should not append anything
+        Assertions.assertEquals(2, params.exprs().size(),
+                "Should still have 2 parameters");
+    }
+
+    // ========== Test Category 2.4: Edge Cases and Special Scenarios ==========
+
+    @Test
+    public void testGetNamedArgStr() {
+        // Create named arguments
+        List<Expr> exprs = Arrays.asList(
+                new NamedArgument("url", new StringLiteral("https://example.com")),
+                new NamedArgument("method", new StringLiteral("POST"))
+        );
+
+        FunctionParams params = new FunctionParams(false, exprs);
+
+        // After reordering, we can get the named arg string representation
+        String argStr = params.getNamedArgStr();
+
+        // Should contain both parameters in named format
+        Assertions.assertTrue(argStr.contains("url=>"),
+                "Should contain url parameter");
+        Assertions.assertTrue(argStr.contains("method=>"),
+                "Should contain method parameter");
+    }
+
+    @Test
+    public void testEmptyNamedArguments() {
+        // Empty list
+        List<Expr> exprs = new ArrayList<>();
+
+        FunctionParams params = new FunctionParams(false, exprs);
+
+        Assertions.assertEquals(0, params.exprs().size(),
+                "Should have 0 expressions");
+        Assertions.assertNull(params.getExprsNames(),
+                "Expression names should be null for empty list");
+    }
+
+    @Test
+    public void testSingleNamedArgument() {
+        List<Expr> exprs = Arrays.asList(
+                new NamedArgument("value", new IntLiteral(42))
+        );
+
+        FunctionParams params = new FunctionParams(false, exprs);
+
+        Assertions.assertEquals(1, params.exprs().size(),
+                "Should have 1 expression");
+        Assertions.assertNotNull(params.getExprsNames(),
+                "Expression names should not be null");
+        Assertions.assertEquals("value", params.getExprsNames().get(0),
+                "Parameter name should be 'value'");
+        Assertions.assertEquals(42L, ((IntLiteral) params.exprs().get(0)).getLongValue(),
+                "Parameter value should be 42");
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        // Create two identical FunctionParams
+        List<Expr> exprs1 = Arrays.asList(new IntLiteral(1), new IntLiteral(2));
+        List<Expr> exprs2 = Arrays.asList(new IntLiteral(1), new IntLiteral(2));
+
+        FunctionParams params1 = new FunctionParams(false, exprs1);
+        FunctionParams params2 = new FunctionParams(false, exprs2);
+
+        // Note: equals() might not be implemented to compare expr values deeply
+        // This test just verifies the methods don't throw exceptions
+        params1.equals(params2);
+        params1.hashCode();
+        params2.hashCode();
+    }
+
+    // ========== Test Category 2.5: Mixing Named and Positional Detection ==========
+
+    @Test
+    public void testMixingNamedAndPositionalDetection() {
+        // Mixed: first is named, second is positional
+        List<Expr> exprs = Arrays.asList(
+                new NamedArgument("url", new StringLiteral("https://example.com")),
+                new StringLiteral("POST")  // Positional
+        );
+
+        FunctionParams params = new FunctionParams(false, exprs);
+
+        // exprsNames should exist (because at least one named arg exists)
+        Assertions.assertNotNull(params.getExprsNames(),
+                "Expression names should not be null when any named arg exists");
+
+        // Check that mixing can be detected: named args have non-empty names, positional have empty
+        boolean hasNamed = params.getExprsNames().stream().anyMatch(name -> !name.isEmpty());
+        boolean hasPositional = params.getExprsNames().stream().anyMatch(String::isEmpty);
+
+        Assertions.assertTrue(hasNamed, "Should detect named arguments");
+        Assertions.assertTrue(hasPositional, "Should detect positional arguments");
+
+        // This is how mixing detection works
+        boolean isMixed = hasNamed && hasPositional;
+        Assertions.assertTrue(isMixed, "Should detect mixed named and positional");
+    }
+
+    @Test
+    public void testAllNamedNoMixing() {
+        // All named arguments - no mixing
+        List<Expr> exprs = Arrays.asList(
+                new NamedArgument("url", new StringLiteral("https://example.com")),
+                new NamedArgument("method", new StringLiteral("POST"))
+        );
+
+        FunctionParams params = new FunctionParams(false, exprs);
+
+        // All names should be non-empty
+        boolean allNamed = params.getExprsNames().stream().noneMatch(String::isEmpty);
+        Assertions.assertTrue(allNamed, "All parameters should have names");
+    }
+
+    @Test
+    public void testAllPositionalNoMixing() {
+        // All positional arguments - no mixing
+        List<Expr> exprs = Arrays.asList(
+                new StringLiteral("https://example.com"),
+                new StringLiteral("POST")
+        );
+
+        FunctionParams params = new FunctionParams(false, exprs);
+
+        // exprsNames should be null for pure positional
+        Assertions.assertNull(params.getExprsNames(),
+                "Expression names should be null for pure positional arguments");
+    }
+
+    // ========== Test Category 2.6: Complex Expression Values ==========
+
+    @Test
+    public void testComplexExpressionInNamedArgument() {
+        // Named argument with complex expression (arithmetic)
+        // In real code, this would be: func(param => 1 + 2)
+        // For testing, we use IntLiteral as placeholder
+        List<Expr> exprs = Arrays.asList(
+                new NamedArgument("value", new IntLiteral(42))
+        );
+
+        FunctionParams params = new FunctionParams(false, exprs);
+
+        // Verify the expression is extracted correctly
+        Assertions.assertNotNull(params.exprs());
+        Assertions.assertEquals(1, params.exprs().size());
+        Assertions.assertTrue(params.exprs().get(0) instanceof IntLiteral);
+    }
+
+    @Test
+    public void testNullExpressionInNamedArgument() {
+        // Named argument with null literal
+        List<Expr> exprs = Arrays.asList(
+                new NamedArgument("nullable_param", new NullLiteral())
+        );
+
+        FunctionParams params = new FunctionParams(false, exprs);
+
+        Assertions.assertEquals(1, params.exprs().size());
+        Assertions.assertTrue(params.exprs().get(0) instanceof NullLiteral);
+        Assertions.assertEquals("nullable_param", params.getExprsNames().get(0));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/FunctionParamsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/expression/FunctionParamsTest.java
@@ -425,34 +425,6 @@ public class FunctionParamsTest {
         params2.hashCode();
     }
 
-    // ========== Test Category 2.5: Mixing Named and Positional Detection ==========
-
-    @Test
-    public void testMixingNamedAndPositionalDetection() {
-        // Mixed: first is named, second is positional
-        List<Expr> exprs = Arrays.asList(
-                new NamedArgument("url", new StringLiteral("https://example.com")),
-                new StringLiteral("POST")  // Positional
-        );
-
-        FunctionParams params = new FunctionParams(false, exprs);
-
-        // exprsNames should exist (because at least one named arg exists)
-        Assertions.assertNotNull(params.getExprsNames(),
-                "Expression names should not be null when any named arg exists");
-
-        // Check that mixing can be detected: named args have non-empty names, positional have empty
-        boolean hasNamed = params.getExprsNames().stream().anyMatch(name -> !name.isEmpty());
-        boolean hasPositional = params.getExprsNames().stream().anyMatch(String::isEmpty);
-
-        Assertions.assertTrue(hasNamed, "Should detect named arguments");
-        Assertions.assertTrue(hasPositional, "Should detect positional arguments");
-
-        // This is how mixing detection works
-        boolean isMixed = hasNamed && hasPositional;
-        Assertions.assertTrue(isMixed, "Should detect mixed named and positional");
-    }
-
     @Test
     public void testAllNamedNoMixing() {
         // All named arguments - no mixing

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -2776,7 +2776,8 @@ functionCall
     | aggregationFunction filter? over?                                                   #aggregationFunctionCall
     | windowFunction over                                                                 #windowFunctionCall
     | TRANSLATE '(' (expression (',' expression)*)? ')'                                   #translateFunctionCall
-    | qualifiedName '(' argumentList? ')'  over?                                          #simpleFunctionCall
+    | qualifiedName '(' namedArgumentList ')'                                             #namedArgsFunctionCall
+    | qualifiedName '(' (expression (',' expression)*)? ')'  over?                        #simpleFunctionCall
     ;
 
 aggregationFunction

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -2537,6 +2537,14 @@ namedArgument
     | identifier '=' expression                                                         #namedArguments
     ;
 
+functionNamedArgumentList
+    : functionNamedArgument (',' functionNamedArgument)*
+    ;
+
+functionNamedArgument
+    : identifier '=>' expression
+    ;
+
 joinRelation
     : asofJoinType bracketHint?
             rightRelation=relationPrimary joinCriteria
@@ -2777,7 +2785,7 @@ functionCall
     | aggregationFunction filter? over?                                                   #aggregationFunctionCall
     | windowFunction over                                                                 #windowFunctionCall
     | TRANSLATE '(' (expression (',' expression)*)? ')'                                   #translateFunctionCall
-    | qualifiedName '(' namedArgumentList ')'                                             #namedArgsFunctionCall
+    | qualifiedName '(' functionNamedArgumentList ')'                                     #namedArgsFunctionCall
     | qualifiedName '(' (expression (',' expression)*)? ')'  over?                        #simpleFunctionCall
     ;
 

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -2533,8 +2533,8 @@ namedArgumentList
     ;
 
 namedArgument
-    : identifier '=>' expression
-    | identifier '=' expression
+    : identifier '=>' expression                                                        #namedArguments
+    | identifier '=' expression                                                         #namedArguments
     ;
 
 joinRelation

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -2520,12 +2520,8 @@ sampleClause
     ;
 
 argumentList
-    : argumentItem (',' argumentItem)*
-    ;
-
-argumentItem
-    : namedArgument
-    | expression
+    : namedArgumentList
+    | expressionList
     ;
 
 namedArgumentList

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -2534,7 +2534,6 @@ namedArgumentList
 
 namedArgument
     : identifier '=>' expression                                                        #namedArguments
-    | identifier '=' expression                                                         #namedArguments
     ;
 
 joinRelation

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -2533,8 +2533,8 @@ namedArgumentList
     ;
 
 namedArgument
-    : identifier '=>' expression                                                        #namedArguments
-    | identifier '=' expression                                                         #namedArguments
+    : identifier '=>' expression
+    | identifier '=' expression
     ;
 
 joinRelation

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -2520,8 +2520,12 @@ sampleClause
     ;
 
 argumentList
-    : namedArgumentList
-    | expressionList
+    : argumentItem (',' argumentItem)*
+    ;
+
+argumentItem
+    : namedArgument
+    | expression
     ;
 
 namedArgumentList
@@ -2773,7 +2777,7 @@ functionCall
     | aggregationFunction filter? over?                                                   #aggregationFunctionCall
     | windowFunction over                                                                 #windowFunctionCall
     | TRANSLATE '(' (expression (',' expression)*)? ')'                                   #translateFunctionCall
-    | qualifiedName '(' (expression (',' expression)*)? ')'  over?                        #simpleFunctionCall
+    | qualifiedName '(' argumentList? ')'  over?                                          #simpleFunctionCall
     ;
 
 aggregationFunction

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -2534,6 +2534,7 @@ namedArgumentList
 
 namedArgument
     : identifier '=>' expression                                                        #namedArguments
+    | identifier '=' expression                                                         #namedArguments
     ;
 
 joinRelation

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/FunctionParams.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/FunctionParams.java
@@ -107,10 +107,6 @@ public class FunctionParams {
         return exprs;
     }
 
-    public void setExprsNames(List<String> exprsNames) {
-        this.exprsNames = exprsNames;
-    }
-
     public boolean hasNamedArguments() {
         return exprsNames != null && !exprsNames.isEmpty() && exprsNames.stream().anyMatch(name -> !name.isEmpty());
     }
@@ -121,6 +117,10 @@ public class FunctionParams {
 
     public void setExprs(List<Expr> exprs) {
         this.exprs = exprs;
+    }
+
+    public void setExprsNames(List<String> exprsNames) {
+        this.exprsNames = exprsNames;
     }
 
     @Override

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/FunctionParams.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/FunctionParams.java
@@ -107,6 +107,14 @@ public class FunctionParams {
         return exprs;
     }
 
+    public void setExprsNames(List<String> exprsNames) {
+        this.exprsNames = exprsNames;
+    }
+
+    public boolean hasNamedArguments() {
+        return exprsNames != null && !exprsNames.isEmpty() && exprsNames.stream().anyMatch(name -> !name.isEmpty());
+    }
+
     public void setIsDistinct(boolean v) {
         isDistinct = v;
     }

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/NamedArgument.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/NamedArgument.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.ast.expression;
 
 import com.starrocks.sql.ast.AstVisitor;
+import com.starrocks.sql.parser.NodePosition;
 
 public class NamedArgument extends Expr {
     private final String name;
@@ -22,11 +23,19 @@ public class NamedArgument extends Expr {
     private Expr expr;
 
     public NamedArgument(String name, Expr expr) {
+        super(NodePosition.ZERO);
+        this.name = name;
+        this.expr = expr;
+    }
+
+    public NamedArgument(String name, Expr expr, NodePosition pos) {
+        super(pos);
         this.name = name;
         this.expr = expr;
     }
 
     public NamedArgument(NamedArgument other) {
+        super(other.pos);
         this.name = other.name;
         this.expr = other.expr;
     }
@@ -45,7 +54,7 @@ public class NamedArgument extends Expr {
 
     @Override
     public Expr clone() {
-        return new NamedArgument(name, expr);
+        return new NamedArgument(name, expr, pos);
     }
 
     @Override

--- a/gensrc/script/gen_functions.py
+++ b/gensrc/script/gen_functions.py
@@ -54,7 +54,19 @@ ${license}
 
 package com.starrocks.builtins;
 
+import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.ScalarFunction;
+import com.starrocks.sql.ast.expression.BoolLiteral;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.IntLiteral;
+import com.starrocks.sql.ast.expression.StringLiteral;
+import com.starrocks.common.Pair;
+import com.starrocks.type.Type;
+import com.google.common.collect.Lists;
+
+import java.util.List;
+import java.util.Vector;
 
 import static com.starrocks.type.AnyArrayType.ANY_ARRAY;
 import static com.starrocks.type.AnyElementType.ANY_ELEMENT;
@@ -171,13 +183,45 @@ def add_function(fn_data):
         entry["prepare"] = "&" + fn_data[7] if fn_data[7] != "nullptr" else "nullptr"
         entry["close"] = "&" + fn_data[8] if fn_data[8] != "nullptr" else "nullptr"
 
+    # Named Arguments metadata: check if last element is a dict with 'named_args' key
+    entry["named_args"] = []
+    if fn_data and isinstance(fn_data[-1], dict) and 'named_args' in fn_data[-1]:
+        entry["named_args"] = fn_data[-1]['named_args']
+
     function_list.append(entry)
+
+
+def generate_default_value(param, fn_id):
+    """Convert Python value to Java Expr code for Named Arguments default values"""
+    default = param.get('default')
+    name = param['name']
+
+    if 'default' not in param:
+        return None  # required parameter, no default value
+    elif isinstance(default, bool):
+        return f'            defaults{fn_id}.add(new Pair<>("{name}", new BoolLiteral({str(default).lower()})));'
+    elif isinstance(default, int):
+        return f'            defaults{fn_id}.add(new Pair<>("{name}", new IntLiteral({default})));'
+    elif isinstance(default, str):
+        escaped = default.replace('\\', '\\\\').replace('"', '\\"')
+        return f'            defaults{fn_id}.add(new Pair<>("{name}", new StringLiteral("{escaped}")));'
+    return None
 
 
 def generate_fe(path):
     fn_template = Template(
         'functionSet.addVectorizedScalarBuiltin(${id}, "${name}", ${has_vargs}, ${ret}${args_types});'
     )
+
+    fn_named_template = Template('''{
+            List<Type> argTypes${id} = Lists.newArrayList(${args_types_list});
+            Function fn${id} = ScalarFunction.createVectorizedBuiltin(${id}L, "${name}", argTypes${id}, ${has_vargs}, ${ret});
+            fn${id}.setArgNames(Lists.newArrayList(${arg_names}));
+            Vector<Pair<String, Expr>> defaults${id} = new Vector<>();
+${default_values}
+            fn${id}.setDefaultNamedArgs(defaults${id});
+            functionSet.addBuiltin(fn${id});
+        }''')
 
     def gen_fe_fn(fnm):
         fnm["args_types"] = ", " if len(fnm["args"]) > 0 else ""
@@ -186,7 +230,26 @@ def generate_fe(path):
         )
         fnm["has_vargs"] = "true" if "..." in fnm["args"] else "false"
 
-        return fn_template.substitute(fnm)
+        # Check if function has named arguments
+        if fnm.get("named_args"):
+            named_args = fnm["named_args"]
+            arg_names = ', '.join([f'"{p["name"]}"' for p in named_args])
+            default_lines = [generate_default_value(p, fnm["id"]) for p in named_args]
+            default_values = '\n'.join([d for d in default_lines if d])
+            # List of argument types for List<Type> constructor
+            args_types_list = ", ".join([i for i in fnm["args"] if i != "..."])
+
+            return fn_named_template.substitute(
+                id=fnm["id"],
+                name=fnm["name"],
+                has_vargs=fnm["has_vargs"],
+                ret=fnm["ret"],
+                args_types_list=args_types_list,
+                arg_names=arg_names,
+                default_values=default_values
+            )
+        else:
+            return fn_template.substitute(fnm)
 
     value = dict()
     value["license"] = license_string

--- a/gensrc/script/gen_functions.py
+++ b/gensrc/script/gen_functions.py
@@ -211,7 +211,11 @@ def generate_default_value(param, fn_id):
             .replace('\r', '\\r')   # carriage return
             .replace('\t', '\\t'))  # tab
         return f'            defaults{fn_id}.add(new Pair<>("{name}", new StringLiteral("{escaped}")));'
-    return None
+    else:
+        print(f"WARNING: Unsupported default value type '{type(default).__name__}' "
+              f"for parameter '{name}' in function {fn_id}. "
+              f"Parameter will be treated as required.")
+        return None
 
 
 def generate_fe(path):

--- a/gensrc/script/gen_functions.py
+++ b/gensrc/script/gen_functions.py
@@ -203,7 +203,13 @@ def generate_default_value(param, fn_id):
     elif isinstance(default, int):
         return f'            defaults{fn_id}.add(new Pair<>("{name}", new IntLiteral({default})));'
     elif isinstance(default, str):
-        escaped = default.replace('\\', '\\\\').replace('"', '\\"')
+        # Escape all special characters for Java string literals
+        escaped = (default
+            .replace('\\', '\\\\')  # backslash first
+            .replace('"', '\\"')    # double quote
+            .replace('\n', '\\n')   # newline
+            .replace('\r', '\\r')   # carriage return
+            .replace('\t', '\\t'))  # tab
         return f'            defaults{fn_id}.add(new Pair<>("{name}", new StringLiteral("{escaped}")));'
     return None
 


### PR DESCRIPTION
> **Issue**: [#66227](https://github.com/StarRocks/starrocks/issues/66227)  
> **Related PR**: [#66206](https://github.com/StarRocks/starrocks/pull/66206)  
> **Status**: Developing on SSRF (Named Parameter done)  
> **Authors**: @EdwardArchive, with review from @alvin-celerdata
## Why I'm doing:

<html>
<body>
<!--StartFragment--><h1 dir="auto" style="box-sizing: border-box; font-size: 2em; margin-top: 0px !important; margin-right: 0px; margin-bottom: 16px; margin-left: 0px; font-weight: 600; line-height: 1.25; padding-bottom: 0.3em; border-bottom: 1px solid rgba(209, 217, 224, 0.7); color: rgb(31, 35, 40); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Named Arguments Support for Scalar Functions</h1><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; padding-bottom: 0.3em; border-bottom: 1px solid rgba(209, 217, 224, 0.7); color: rgb(31, 35, 40); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h2><p dir="auto" style="box-sizing: border-box; margin-top: 0px; margin-bottom: 16px; color: rgb(31, 35, 40); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">This PR implements<span> </span><strong style="box-sizing: border-box; font-weight: 600;">Named Arguments</strong><span> </span>support for scalar functions in StarRocks, using<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; padding: 0.2em 0.4em; margin: 0px; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px;">http_request()</code><span> </span>as the first function to leverage this feature.</p><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; padding-bottom: 0.3em; border-bottom: 1px solid rgba(209, 217, 224, 0.7); color: rgb(31, 35, 40); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Features</h2><ul dir="auto" style="box-sizing: border-box; padding: 0px; margin-top: 0px; margin-bottom: 16px; position: relative; color: rgb(31, 35, 40); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; margin-left: 24px;"><strong style="box-sizing: border-box; font-weight: 600;">Named Arguments syntax</strong>:<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; padding: 0.2em 0.4em; margin: 0px; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px;">function(param =&gt; value, ...)</code></li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;"><strong style="box-sizing: border-box; font-weight: 600;">Default values</strong>: Optional parameters can be omitted</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;"><strong style="box-sizing: border-box; font-weight: 600;">Positional calls</strong>: Traditional positional syntax still works</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;"><strong style="box-sizing: border-box; font-weight: 600;">User-friendly error messages</strong>: Clear hints for common mistakes</li></ul><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; padding-bottom: 0.3em; border-bottom: 1px solid rgba(209, 217, 224, 0.7); color: rgb(31, 35, 40); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Usage Examples</h2><div class="highlight highlight-source-sql notranslate position-relative overflow-auto" dir="auto" style="box-sizing: border-box; position: relative !important; overflow: visible !important; margin-bottom: 16px; background-color: rgb(255, 255, 255); color: rgb(31, 35, 40); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><pre class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; margin-top: 0px; margin-bottom: 0px; tab-size: 4; overflow-wrap: normal; padding: 16px; overflow: auto; line-height: 1.45; color: rgb(31, 35, 40); background-color: rgb(246, 248, 250); border-radius: 6px; word-break: normal; min-height: 52px;"><span class="pl-c" style="box-sizing: border-box; color: rgb(89, 99, 110);"><span class="pl-c" style="box-sizing: border-box; color: rgb(89, 99, 110);">--</span> Named Arguments (any order, omit optional params)</span>
<span class="pl-k" style="box-sizing: border-box; color: rgb(207, 34, 46);">SELECT</span> http_request(url <span class="pl-k" style="box-sizing: border-box; color: rgb(207, 34, 46);">=&gt;</span> <span class="pl-s" style="box-sizing: border-box; color: rgb(10, 48, 105);"><span class="pl-pds" style="box-sizing: border-box; color: rgb(10, 48, 105);">'</span>https://api.example.com<span class="pl-pds" style="box-sizing: border-box; color: rgb(10, 48, 105);">'</span></span>);
<span class="pl-k" style="box-sizing: border-box; color: rgb(207, 34, 46);">SELECT</span> http_request(url <span class="pl-k" style="box-sizing: border-box; color: rgb(207, 34, 46);">=&gt;</span> <span class="pl-s" style="box-sizing: border-box; color: rgb(10, 48, 105);"><span class="pl-pds" style="box-sizing: border-box; color: rgb(10, 48, 105);">'</span>https://api.example.com<span class="pl-pds" style="box-sizing: border-box; color: rgb(10, 48, 105);">'</span></span>, method <span class="pl-k" style="box-sizing: border-box; color: rgb(207, 34, 46);">=&gt;</span> <span class="pl-s" style="box-sizing: border-box; color: rgb(10, 48, 105);"><span class="pl-pds" style="box-sizing: border-box; color: rgb(10, 48, 105);">'</span>POST<span class="pl-pds" style="box-sizing: border-box; color: rgb(10, 48, 105);">'</span></span>, body <span class="pl-k" style="box-sizing: border-box; color: rgb(207, 34, 46);">=&gt;</span> <span class="pl-s" style="box-sizing: border-box; color: rgb(10, 48, 105);"><span class="pl-pds" style="box-sizing: border-box; color: rgb(10, 48, 105);">'</span>{}<span class="pl-pds" style="box-sizing: border-box; color: rgb(10, 48, 105);">'</span></span>);
<span class="pl-k" style="box-sizing: border-box; color: rgb(207, 34, 46);">SELECT</span> http_request(method <span class="pl-k" style="box-sizing: border-box; color: rgb(207, 34, 46);">=&gt;</span> <span class="pl-s" style="box-sizing: border-box; color: rgb(10, 48, 105);"><span class="pl-pds" style="box-sizing: border-box; color: rgb(10, 48, 105);">'</span>POST<span class="pl-pds" style="box-sizing: border-box; color: rgb(10, 48, 105);">'</span></span>, url <span class="pl-k" style="box-sizing: border-box; color: rgb(207, 34, 46);">=&gt;</span> <span class="pl-s" style="box-sizing: border-box; color: rgb(10, 48, 105);"><span class="pl-pds" style="box-sizing: border-box; color: rgb(10, 48, 105);">'</span>https://api.example.com<span class="pl-pds" style="box-sizing: border-box; color: rgb(10, 48, 105);">'</span></span>);  <span class="pl-c" style="box-sizing: border-box; color: rgb(89, 99, 110);"><span class="pl-c" style="box-sizing: border-box; color: rgb(89, 99, 110);">--</span> order doesn't matter</span>

<span class="pl-c" style="box-sizing: border-box; color: rgb(89, 99, 110);"><span class="pl-c" style="box-sizing: border-box; color: rgb(89, 99, 110);">--</span> Positional Arguments (still supported)</span>
<span class="pl-k" style="box-sizing: border-box; color: rgb(207, 34, 46);">SELECT</span> http_request(<span class="pl-s" style="box-sizing: border-box; color: rgb(10, 48, 105);"><span class="pl-pds" style="box-sizing: border-box; color: rgb(10, 48, 105);">'</span>https://api.example.com<span class="pl-pds" style="box-sizing: border-box; color: rgb(10, 48, 105);">'</span></span>);</pre><div class="zeroclipboard-container position-absolute right-0 top-0" style="box-sizing: border-box; position: absolute !important; top: 0px !important; right: 0px !important;"><clipboard-copy aria-label="Copy" class="ClipboardButton btn js-clipboard-copy m-2 p-0" data-copy-feedback="Copied!" data-tooltip-direction="w" value="-- Named Arguments (any order, omit optional params)
SELECT http_request(url =&gt; 'https://api.example.com');
SELECT http_request(url =&gt; 'https://api.example.com', method =&gt; 'POST', body =&gt; '{}');
SELECT http_request(method =&gt; 'POST', url =&gt; 'https://api.example.com');  -- order doesn't matter

-- Positional Arguments (still supported)
SELECT http_request('https://api.example.com');" tabindex="0" role="button" style="box-sizing: border-box; position: relative; display: inline-block; padding: 0px !important; font-size: 14px; font-weight: 500; line-height: 20px; white-space: nowrap; vertical-align: middle; cursor: pointer; user-select: none; border: 1px solid rgb(209, 217, 224); border-radius: 6px; appearance: none; color: rgb(37, 41, 46); background-color: rgb(246, 248, 250); box-shadow: none; transition: color 80ms cubic-bezier(0.33, 1, 0.68, 1), background-color, box-shadow, border-color; margin: 8px !important;"><svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copy js-clipboard-copy-icon m-2"></svg></clipboard-copy></div></div><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; padding-bottom: 0.3em; border-bottom: 1px solid rgba(209, 217, 224, 0.7); color: rgb(31, 35, 40); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Error Messages</h2><markdown-accessiblity-table data-catalyst="" style="box-sizing: border-box; display: block; color: rgb(31, 35, 40); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">
Scenario | Error Message
-- | --
Missing required param | http_request() required parameter 'url' is missing
Unknown param (with hint) | http_request() unknown parameter 'URL'. Did you mean 'url'?
Duplicate param | http_request() duplicate parameter 'url'
NULL for required param | http_request() required parameter 'url' cannot be NULL
No arguments | http_request() requires at least 1 argument(s). Missing required parameter(s): 'url'

</markdown-accessiblity-table><h3 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.25em; font-weight: 600; line-height: 1.25; color: rgb(31, 35, 40); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Architecture Flow</h3><div class="snippet-clipboard-content notranslate position-relative overflow-auto" style="box-sizing: border-box; position: relative !important; overflow: auto !important; color: rgb(31, 35, 40); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><pre class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; margin-top: 0px; margin-bottom: 16px; tab-size: 4; overflow-wrap: normal; padding: 16px; overflow: auto; line-height: 1.45; color: rgb(31, 35, 40); background-color: rgb(246, 248, 250); border-radius: 6px;"><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; padding: 0px; margin: 0px; white-space: pre; background: rgba(0, 0, 0, 0); border-radius: 6px; word-break: normal; border: 0px; display: inline; overflow: visible; line-height: inherit; overflow-wrap: normal;">SQL: http_request(url =&gt; '...', method =&gt; 'POST')
         │
         ▼
┌─────────────────────────────────────┐
│ 1. Parser (StarRocks.g4)            │
│    Parse `param =&gt; value` syntax    │
└─────────────────────────────────────┘
         │
         ▼
┌─────────────────────────────────────┐
│ 2. AstBuilder.java                  │
│    Create NamedArgument AST nodes   │
└─────────────────────────────────────┘
         │
         ▼
┌─────────────────────────────────────┐
│ 3. FunctionParams.java              │
│    Separate exprs[] + exprsNames[]  │
└─────────────────────────────────────┘
         │
         ▼
┌─────────────────────────────────────┐
│ 4. ExpressionAnalyzer.java          │
│    Branch: Named vs Positional      │
└─────────────────────────────────────┘
         │
         ▼
┌─────────────────────────────────────┐
│ 5. FunctionAnalyzer.java            │
│    Validate &amp; lookup function       │
└─────────────────────────────────────┘
         │
         ▼
┌─────────────────────────────────────┐
│ 6. FunctionParams.java              │
│    Reorder args &amp; append defaults   │
└─────────────────────────────────────┘
         │
         ▼
┌─────────────────────────────────────┐
│ 7. Backend (C++)                    │
│    Receive all 8 columns            │
└─────────────────────────────────────┘
</code></pre><div class="zeroclipboard-container position-absolute right-0 top-0" style="box-sizing: border-box; position: absolute !important; top: 0px !important; right: 0px !important;"><clipboard-copy aria-label="Copy" class="ClipboardButton btn js-clipboard-copy m-2 p-0" data-copy-feedback="Copied!" data-tooltip-direction="w" value="SQL: http_request(url =&gt; '...', method =&gt; 'POST')
         │
         ▼
┌─────────────────────────────────────┐
│ 1. Parser (StarRocks.g4)            │
│    Parse `param =&gt; value` syntax    │
└─────────────────────────────────────┘
         │
         ▼
┌─────────────────────────────────────┐
│ 2. AstBuilder.java                  │
│    Create NamedArgument AST nodes   │
└─────────────────────────────────────┘
         │
         ▼
┌─────────────────────────────────────┐
│ 3. FunctionParams.java              │
│    Separate exprs[] + exprsNames[]  │
└─────────────────────────────────────┘
         │
         ▼
┌─────────────────────────────────────┐
│ 4. ExpressionAnalyzer.java          │
│    Branch: Named vs Positional      │
└─────────────────────────────────────┘
         │
         ▼
┌─────────────────────────────────────┐
│ 5. FunctionAnalyzer.java            │
│    Validate &amp; lookup function       │
└─────────────────────────────────────┘
         │
         ▼
┌─────────────────────────────────────┐
│ 6. FunctionParams.java              │
│    Reorder args &amp; append defaults   │
└─────────────────────────────────────┘
         │
         ▼
┌─────────────────────────────────────┐
│ 7. Backend (C++)                    │
│    Receive all 8 columns            │
└─────────────────────────────────────┘" tabindex="0" role="button" style="box-sizing: border-box; position: relative; display: inline-block; padding: 0px !important; font-size: 14px; font-weight: 500; line-height: 20px; white-space: nowrap; vertical-align: middle; cursor: pointer; user-select: none; border: 1px solid rgb(209, 217, 224); border-radius: 6px; appearance: none; color: rgb(37, 41, 46); background-color: rgb(246, 248, 250); box-shadow: none; transition: color 80ms cubic-bezier(0.33, 1, 0.68, 1), background-color, box-shadow, border-color; margin: 8px !important;"><svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copy js-clipboard-copy-icon m-2"></svg></clipboard-copy></div></div><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; padding-bottom: 0.3em; border-bottom: 1px solid rgba(209, 217, 224, 0.7); color: rgb(31, 35, 40); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Backward Compatibility</h2><ul dir="auto" style="box-sizing: border-box; padding: 0px; margin-top: 0px; margin-bottom: 16px; position: relative; color: rgb(31, 35, 40); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; margin-left: 24px;"><strong style="box-sizing: border-box; font-weight: 600;">No impact on existing functions</strong>: Only functions with<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; padding: 0.2em 0.4em; margin: 0px; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px;">named_args</code><span> </span>defined use this path</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;"><strong style="box-sizing: border-box; font-weight: 600;">Positional calls still work</strong>:<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; padding: 0.2em 0.4em; margin: 0px; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px;">http_request('url')</code><span> </span>works as expected</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;"><strong style="box-sizing: border-box; font-weight: 600;">Varargs functions excluded</strong>: Functions like<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; padding: 0.2em 0.4em; margin: 0px; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px;">concat()</code><span> </span>are not affected</li></ul><h2 dir="auto" style="box-sizing: border-box; margin-top: 24px; margin-bottom: 16px; font-size: 1.5em; font-weight: 600; line-height: 1.25; padding-bottom: 0.3em; border-bottom: 1px solid rgba(209, 217, 224, 0.7); color: rgb(31, 35, 40); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Constraints</h2><ul dir="auto" style="box-sizing: border-box; padding: 0px; margin-top: 0px; margin-bottom: 0px !important; position: relative; color: rgb(31, 35, 40); font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, &quot;Noto Sans&quot;, Helvetica, Arial, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; margin-left: 24px;"><strong style="box-sizing: border-box; font-weight: 600;">No mixed mode</strong>: All arguments must be either named or positional (not both)</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;"><strong style="box-sizing: border-box; font-weight: 600;">Case-sensitive</strong>: Parameter names are case-sensitive (<code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; padding: 0.2em 0.4em; margin: 0px; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px;">url</code><span> </span>≠<span> </span><code class="notranslate" style="box-sizing: border-box; font-family: &quot;Monaspace Neon&quot;, ui-monospace, SFMono-Regular, &quot;SF Mono&quot;, Menlo, Consolas, &quot;Liberation Mono&quot;, monospace; font-size: 11.9px; tab-size: 4; padding: 0.2em 0.4em; margin: 0px; white-space: break-spaces; background-color: rgba(129, 139, 152, 0.12); border-radius: 6px;">URL</code>)</li><li style="box-sizing: border-box; margin-top: 0.25em; margin-left: 24px;"><strong style="box-sizing: border-box; font-weight: 600;">Varargs not supported</strong>: Functions with variable arguments cannot use Named Arguments</li></ul><!--EndFragment-->
</body>
</html>




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces first-class named arguments for scalar functions with robust validation, reordering, and defaults handling.
> 
> - Parser/AST: Extends grammar to accept `argumentItem` and `namedArgsFunctionCall`; `AstBuilder` constructs `NamedArgument` nodes and normalizes argument lists.
> - Analyzer: `ExpressionAnalyzer` detects named vs positional calls, validates structure, reorders to function signature, appends defaults, re-analyzes children, and enforces NULL constraints; supports positional calls against named-arg functions by filling defaults; improved error messaging.
> - Function layer: `FunctionAnalyzer` adds helpers to lookup with named args, validate duplicates/unknown/missing params, check NULLs post-reorder, reorder/apply defaults, and provide friendly errors; adjusts arg-count/type checks to accommodate named args.
> - Parser model updates: `FunctionParams` gains named-arg helpers/setters; `NamedArgument` carries position info and correct cloning.
> - Codegen: `gensrc/script/gen_functions.py` emits FE metadata for named args (arg names and Java default Exprs) into builtins.
> - Tests: New unit tests for validation and params behavior, plus analyzer tests for syntax/mixing/positional paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9939b11d22a7df08423f65ecf4dc1bd64b3ec483. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->






This could lead to runtime errors or unexpected behavior.

## What I'm doing:

This PR adds comprehensive validation for named arguments in scalar functions:
1. Validates that all required parameters (without defaults) are provided
2. Checks for duplicate parameter names
3. Validates that required parameters cannot be NULL
4. Provides user-friendly error messages with suggestions for typos
5. Moves validation logic from `FunctionParams` to `FunctionAnalyzer` to resolve module dependency issues

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

## Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.1 
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
