### PR TITLE
[BugFix] Fix env_macos can not use STARROCKS_THIRDPARTY environment variable in env

### DIFF
--- a/build-mac/build_be.sh
+++ b/build-mac/build_be.sh
@@ -175,13 +175,6 @@ if [[ "$(uname -m)" != "arm64" ]]; then
     exit 1
 fi
 
-# Set default STARROCKS_THIRDPARTY if not set
-if [[ -z "${STARROCKS_THIRDPARTY:-}" ]]; then
-    export STARROCKS_THIRDPARTY="$ROOT_DIR/thirdparty"
-fi
-
-log_info "Third-party directory: $STARROCKS_THIRDPARTY"
-
 # ============================================================================
 # THIRD-PARTY DEPENDENCIES
 # ============================================================================

--- a/build-mac/env_macos.sh
+++ b/build-mac/env_macos.sh
@@ -32,10 +32,15 @@ log_error() {
 # ============================================================================
 export STARROCKS_HOME="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 export STARROCKS_BE_HOME="$STARROCKS_HOME/be"
-export STARROCKS_THIRDPARTY="$STARROCKS_HOME/thirdparty"
 export STARROCKS_BUILD_MAC="$STARROCKS_HOME/build-mac"
 
+# Respect a pre-set STARROCKS_THIRDPARTY so callers can point to a shared deps dir
+if [[ -z "${STARROCKS_THIRDPARTY:-}" ]]; then
+    export STARROCKS_THIRDPARTY="$STARROCKS_HOME/thirdparty"
+fi
+
 log_info "StarRocks home: $STARROCKS_HOME"
+log_info "StarRocks third-party libraries: $STARROCKS_THIRDPARTY"
 
 # ============================================================================
 # SYSTEM VALIDATION


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This pull request updates the environment setup in `build-mac/env_macos.sh` to allow callers to specify a custom location for third-party dependencies by respecting a pre-set `STARROCKS_THIRDPARTY` environment variable. If the variable is not set, it defaults to the standard path.

Environment variable handling:

* Modified the logic for setting `STARROCKS_THIRDPARTY` to check if it is already set in the environment, allowing callers to use a shared dependencies directory. If not set, it defaults to `$STARROCKS_HOME/thirdparty`. A log message is printed when a custom path is used.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Respect pre-set `STARROCKS_THIRDPARTY` in macOS env script and remove redundant handling from the build script.
> 
> - **Environment (macOS)**:
>   - Respect pre-set `STARROCKS_THIRDPARTY` in `build-mac/env_macos.sh`; default to `$STARROCKS_HOME/thirdparty` if unset and log its path.
> - **Build Script**:
>   - Remove redundant `STARROCKS_THIRDPARTY` defaulting/logging from `build-mac/build_be.sh` to centralize dependency path handling in the env script.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b1c396bf5ee77a1143b97d6e0181a11328a068d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->