### PR TITLE
[BugFix] fix PartitionColumnMinMaxRewriteRule cause result wrong

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PartitionColumnMinMaxRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PartitionColumnMinMaxRewriteRule.java
@@ -16,7 +16,6 @@ package com.starrocks.sql.optimizer.rule.transformation;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.FunctionSet;
@@ -34,7 +33,6 @@ import com.starrocks.sql.optimizer.base.Ordering;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
-import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalTopNOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalValuesOperator;
@@ -382,10 +380,7 @@ public class PartitionColumnMinMaxRewriteRule extends TransformationRule {
         List<Ordering> ordering = Lists.newArrayList(new Ordering(columnRefOperator, asc, false));
         LogicalTopNOperator topn = new LogicalTopNOperator(ordering, limit, offset);
 
-        Map<ColumnRefOperator, ScalarOperator> columnRefMap = Maps.newHashMap();
-        columnRefMap.put(entries.get(0).getKey(), columnRefOperator);
-        LogicalProjectOperator project = new LogicalProjectOperator(columnRefMap);
-
-        return OptExpression.create(project, OptExpression.create(topn, optExpression.getInputs().get(0).getInputs()));
+        return OptExpression.create(aggregation,
+                OptExpression.create(topn, optExpression.getInputs().get(0).getInputs()));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
@@ -575,12 +575,14 @@ public class PartitionPruneTest extends PlanTestBase {
         starRocksAssert.ddl("alter table t3_pri add partition p20240104 values less than('2024-01-04') ");
         starRocksAssert.ddl("alter table t3_pri add partition p20240105 values less than('2024-01-05') ");
 
-        starRocksAssert.query("select min(c1) from t3_pri").explainContains("TOP-N", "order by: <slot 1> 1: c1");
-        starRocksAssert.query("select max(c1) from t3_pri").explainContains("TOP-N", "order by: <slot 1> 1: c1 DESC");
+        starRocksAssert.query("select min(c1) from t3_pri")
+                .explainContains("TOP-N", "order by: <slot 1> 1: c1", "AGGREGATE");
+        starRocksAssert.query("select max(c1) from t3_pri")
+                .explainContains("TOP-N", "order by: <slot 1> 1: c1 DESC", "AGGREGATE");
         starRocksAssert.query("select min(c1)+1 from t3_pri")
-                .explainContains("TOP-N", "order by: <slot 1> 1: c1");
+                .explainContains("TOP-N", "order by: <slot 1> 1: c1", "AGGREGATE");
         starRocksAssert.query("select max(c1)+1 from t3_pri")
-                .explainContains("TOP-N", "order by: <slot 1> 1: c1 DESC");
+                .explainContains("TOP-N", "order by: <slot 1> 1: c1 DESC", "AGGREGATE");
 
         // NOT SUPPORTED
         starRocksAssert.query("select max(c1-1)+1 from t3_pri").explainContains("OlapScanNode");


### PR DESCRIPTION
## Why I'm doing:
PartitionColumnMinMaxRewriteRule will rewrite agg->project->scan into project->topn->scan if this is a select max/min(col) from table where xxx  and zonemap can be used to filter data. But if scan has predicate that filter all of the data, then result should be NULL. But if rewrite it into top, result will be Empty set.

## What I'm doing:
rewrite agg->project->scan into agg->topn->project->scan, so if agg's input is empty, it will return NULL


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
