### PR TITLE
[UT] Fix unstable mock ut

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -108,11 +108,14 @@ public class PlanFragmentWithCostTest extends PlanWithCostTestBase {
 
     // still choose two stage agg even it's a high cardinality scene to cover bad case when statistics is uncorrect
     @Test
-    public void testAggWithHighCardinality(@Mocked MockTpchStatisticStorage mockedStatisticStorage) throws Exception {
-        new Expectations() {
-            {
-                mockedStatisticStorage.getColumnStatistics((Table) any, Lists.newArrayList("v2"));
-                result = ImmutableList.of(new ColumnStatistic(0.0, 100, 0.0, 10, 7000));
+    public void testAggWithHighCardinality() throws Exception {
+        new MockUp<MockTpchStatisticStorage>() {
+            @Mock
+            public List<ColumnStatistic> getColumnStatistics(Table table, List<String> columns) {
+                if (columns.size() == 1 && columns.contains("v2")) {
+                    return ImmutableList.of(new ColumnStatistic(0.0, 100, 0.0, 10, 7000));
+                }
+                return List.of();
             }
         };
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors `testAggWithHighCardinality` to use `MockUp<MockTpchStatisticStorage>` instead of parameterized `@Mocked` expectations, defining `getColumnStatistics` behavior directly.
> 
> - **Tests**:
>   - Update `fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java`:
>     - Refactor `testAggWithHighCardinality`:
>       - Remove `@Mocked MockTpchStatisticStorage` parameter; use `MockUp<MockTpchStatisticStorage>` to override `getColumnStatistics`.
>       - Return specific stats for `"v2"` and empty list otherwise.
>     - Keeps SQL and assertions for two-stage aggregation unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b3bd837666d579350fbbefebdb7066e7c3c5e52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->