### PR TITLE
[BugFix] set ExecTimeout for ANALYZE

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2246,7 +2246,9 @@ public class Config extends ConfigBase {
     public static int statistic_analyze_task_pool_size = 3;
 
     /**
-     * statistic collect query timeout
+     * statistic collect query timeout (in seconds)
+     * This is the total timeout for the entire analyze job, not for individual SQL tasks.
+     * Each SQL task within the job will use the remaining time based on the job start time.
      */
     @ConfField(mutable = true)
     public static long statistic_collect_query_timeout = 3600; // 1h

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1687,10 +1687,7 @@ public class StmtExecutor {
             if (!analyzeStmt.isAsync()) {
                 // sync statistics collection doesn't be interrupted by query timeout, but
                 // will print warning log if timeout, so we update timeout temporarily to avoid
-                // warning log.
-                // Note: The actual timeout for each SQL task within the analyze job is controlled
-                // by StatisticsCollectJob.calculateAndSetRemainingTimeout() which ensures the
-                // total job timeout (statistic_collect_query_timeout) is respected across all tasks.
+                // warning log
                 context.getSessionVariable().setQueryTimeoutS((int) Config.statistic_collect_query_timeout);
                 context.getSessionVariable().setInsertTimeoutS((int) Config.statistic_collect_query_timeout);
                 cancelableTask.get();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -546,6 +546,12 @@ public class StmtExecutor {
         return null;
     }
 
+    /**
+     * The execution timeout varies among different statements:
+     * 1. SELECT: use query_timeout
+     * 2. DML: use insert_timeout or statement-specified timeout
+     * 3. ANALYZE: use fe_conf.statistic_collect_query_timeout
+     */
     public int getExecTimeout() {
         if (parsedStmt instanceof CreateTableAsSelectStmt ctas) {
             Map<String, String> properties = ctas.getInsertStmt().getProperties();
@@ -567,6 +573,8 @@ public class StmtExecutor {
                 }
             }
             return ConnectContext.get().getSessionVariable().getInsertTimeoutS();
+        } else if (parsedStmt instanceof AnalyzeStmt) {
+            return (int) Config.statistic_collect_query_timeout;
         } else {
             return ConnectContext.get().getSessionVariable().getQueryTimeoutS();
         }
@@ -1679,7 +1687,10 @@ public class StmtExecutor {
             if (!analyzeStmt.isAsync()) {
                 // sync statistics collection doesn't be interrupted by query timeout, but
                 // will print warning log if timeout, so we update timeout temporarily to avoid
-                // warning log
+                // warning log.
+                // Note: The actual timeout for each SQL task within the analyze job is controlled
+                // by StatisticsCollectJob.calculateAndSetRemainingTimeout() which ensures the
+                // total job timeout (statistic_collect_query_timeout) is respected across all tasks.
                 context.getSessionVariable().setQueryTimeoutS((int) Config.statistic_collect_query_timeout);
                 context.getSessionVariable().setInsertTimeoutS((int) Config.statistic_collect_query_timeout);
                 cancelableTask.get();

--- a/fe/fe-core/src/test/java/com/starrocks/qe/StmtExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/StmtExecutorTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.qe;
 
+import com.starrocks.common.Config;
 import com.starrocks.common.jmockit.Deencapsulation;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.common.util.RuntimeProfile;
@@ -161,5 +162,28 @@ public class StmtExecutorTest {
         Assertions.assertNotNull(summaryProfile);
         Assertions.assertEquals("Running", summaryProfile.getInfoString(ProfileManager.QUERY_STATE));
         Assertions.assertEquals("default_warehouse", summaryProfile.getInfoString(ProfileManager.WAREHOUSE_CNGROUP));
+    }
+
+    @Test
+    public void testExecTimeout() {
+        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
+        ConnectContext.threadLocalInfo.set(ctx);
+
+        {
+            StatementBase stmt = SqlParser.parseSingleStatement("select * from t1", SqlModeHelper.MODE_DEFAULT);
+            StmtExecutor executor = new StmtExecutor(new ConnectContext(), stmt);
+            Assertions.assertEquals(ctx.getSessionVariable().getQueryTimeoutS(), executor.getExecTimeout());
+        }
+        {
+            StatementBase stmt = SqlParser.parseSingleStatement("analyze table t1", SqlModeHelper.MODE_DEFAULT);
+            StmtExecutor executor = new StmtExecutor(new ConnectContext(), stmt);
+            Assertions.assertEquals(Config.statistic_collect_query_timeout, executor.getExecTimeout());
+        }
+        {
+            StatementBase stmt = SqlParser.parseSingleStatement("create table t2 as select * from t1",
+                    SqlModeHelper.MODE_DEFAULT);
+            StmtExecutor executor = new StmtExecutor(new ConnectContext(), stmt);
+            Assertions.assertEquals(ctx.getSessionVariable().getInsertTimeoutS(), executor.getExecTimeout());
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

The `StmtExecutor::getExecTimeout` impacts query execution and query forwarding (RPC timeout) and varies depending on the type of statement. The `ANALYZE TABLE` statement does not adhere to `query_timeout`, so this behavior should be accounted for in the function.

Without the fix, when executing `ANALYZE TABLE` on follower FE, the RPC timeout will be set to `query_timeout`, even if the `statistic_collect_query_timeout` is much longer than `query_timeout`.

## What I'm doing:



Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Exec timeout for ANALYZE now uses `Config.statistic_collect_query_timeout`; added unit tests and clarified config doc.
> 
> - **QE/Execution**:
>   - Update `StmtExecutor.getExecTimeout()` to return `Config.statistic_collect_query_timeout` for `ANALYZE` statements.
>   - Add brief docs on timeout selection for SELECT/DML/ANALYZE in method comment.
> - **Config**:
>   - Clarify `statistic_collect_query_timeout` docs (units=seconds; total job timeout semantics).
> - **Tests**:
>   - Add `StmtExecutorTest.testExecTimeout` asserting timeouts for `SELECT`, `ANALYZE`, and `CTAS`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8dc5dd414a6f5f5ba0ac67a3bee4eaac9cea5e2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->