### PR TITLE
[BugFix] Fix CVE-2025-12183 by upgrading lz4-java to 1.8.1

### DIFF
--- a/fe/build.gradle.kts
+++ b/fe/build.gradle.kts
@@ -75,6 +75,7 @@ subprojects {
         set("spark.version", "3.5.5")
         set("staros.version", "4.0.0")
         set("tomcat.version", "8.5.70")
+        set("lz4-java.version", "1.8.1")
         // var sync end
     }
 
@@ -232,7 +233,25 @@ subprojects {
             implementation("org.xerial.snappy:snappy-java:1.1.10.5")
             implementation("software.amazon.awssdk:bundle:${project.ext["aws-v2-sdk.version"]}")
             implementation("tools.profiler:async-profiler:${project.ext["async-profiler.version"]}")
+            implementation("at.yawk.lz4:lz4-java:${project.ext["lz4-java.version"]}")
             // dependency sync end
+        }
+    }
+
+    // https://nvd.nist.gov/vuln/detail/CVE-2025-12183
+    // Resolve capability conflicts: at.yawk.lz4:lz4-java replaces org.lz4:lz4-java and org.lz4:lz4-pure-java
+    configurations.all {
+        resolutionStrategy.capabilitiesResolution {
+            withCapability("org.lz4:lz4-java") {
+                select("at.yawk.lz4:lz4-java:${project.ext["lz4-java.version"]}")
+                because("CVE-2025-12183: Use at.yawk.lz4:lz4-java instead of vulnerable org.lz4:lz4-java")
+            }
+        }
+        resolutionStrategy.dependencySubstitution {
+            substitute(module("org.lz4:lz4-java")).using(module("at.yawk.lz4:lz4-java:${project.ext["lz4-java.version"]}"))
+                .because("CVE-2025-12183: Replace vulnerable org.lz4:lz4-java with at.yawk.lz4:lz4-java")
+            substitute(module("org.lz4:lz4-pure-java")).using(module("at.yawk.lz4:lz4-java:${project.ext["lz4-java.version"]}"))
+                .because("CVE-2025-12183: Replace vulnerable org.lz4:lz4-pure-java with at.yawk.lz4:lz4-java")
         }
     }
 

--- a/fe/fe-core/build.gradle.kts
+++ b/fe/fe-core/build.gradle.kts
@@ -67,9 +67,13 @@ dependencies {
         exclude(group = "org.codehaus.jackson", module = "jackson-mapper-asl")
         exclude(group = "org.ini4j", module = "ini4j")
         exclude(group = "org.antlr", module = "antlr4")
+        // https://nvd.nist.gov/vuln/detail/CVE-2025-12183
+        exclude(group = "org.lz4", module = "lz4-java")
     }
     implementation("com.aliyun.odps:odps-sdk-table-api") {
         exclude(group = "org.antlr", module = "antlr4")
+        // https://nvd.nist.gov/vuln/detail/CVE-2025-12183
+        exclude(group = "org.lz4", module = "lz4-pure-java")
     }
     implementation("com.azure:azure-identity")
     implementation("com.azure:azure-storage-blob")
@@ -194,6 +198,8 @@ dependencies {
         exclude(group = "io.netty", module = "*")
         exclude(group = "org.glassfish", module = "javax.el")
         exclude(group = "org.apache.zookeeper", module = "zookeeper")
+        // https://nvd.nist.gov/vuln/detail/CVE-2025-12183
+        exclude(group = "org.lz4", module = "lz4-java")
     }
     implementation("org.apache.hudi:hudi-hadoop-mr") {
         exclude(group = "org.glassfish", module = "javax.el")
@@ -216,7 +222,10 @@ dependencies {
     implementation("org.apache.logging.log4j:log4j-core")
     implementation("org.apache.logging.log4j:log4j-layout-template-json")
     implementation("org.apache.logging.log4j:log4j-slf4j-impl")
-    implementation("org.apache.paimon:paimon-bundle")
+    implementation("org.apache.paimon:paimon-bundle") {
+        // https://nvd.nist.gov/vuln/detail/CVE-2025-12183
+        exclude(group = "org.lz4", module = "lz4-java")
+    }
     implementation("org.apache.paimon:paimon-oss")
     implementation("org.apache.paimon:paimon-s3")
     implementation("org.apache.parquet:parquet-avro")
@@ -248,6 +257,8 @@ dependencies {
         exclude(group = "org.eclipse.jetty", module = "jetty-servlet")
         exclude(group = "org.eclipse.jetty", module = "jetty-client")
         exclude(group = "org.eclipse.jetty", module = "jetty-security")
+        // https://nvd.nist.gov/vuln/detail/CVE-2025-12183
+        exclude(group = "org.lz4", module = "lz4-java")
     }
     implementation("org.apache.spark:spark-launcher_2.12")
     compileOnly("org.apache.spark:spark-sql_2.12")
@@ -279,6 +290,7 @@ dependencies {
     implementation("software.amazon.awssdk:bundle")
     implementation("tools.profiler:async-profiler")
     implementation("com.github.vertical-blank:sql-formatter:2.0.4")
+    implementation("at.yawk.lz4:lz4-java")
     // dependency sync end
 
     // extra dependencies pom.xml does not have

--- a/fe/plugin/spark-dpp/build.gradle.kts
+++ b/fe/plugin/spark-dpp/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     implementation("com.google.code.gson:gson")
     implementation("io.netty:netty-handler")
     implementation("org.roaringbitmap:RoaringBitmap")
+    implementation("at.yawk.lz4:lz4-java")
 
     // Provided scope dependencies - equivalent to compileOnly in Gradle
     compileOnly("commons-codec:commons-codec")

--- a/fe/plugin/spark-dpp/pom.xml
+++ b/fe/plugin/spark-dpp/pom.xml
@@ -94,6 +94,12 @@ under the License.
             <artifactId>RoaringBitmap</artifactId>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/at.yawk.lz4/lz4-java -->
+        <dependency>
+            <groupId>at.yawk.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+        </dependency>
+
         <!-- spark -->
         <!-- https://mvnrepository.com/artifact/org.apache.spark/spark-core_2.12 -->
         <dependency>

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -87,6 +87,7 @@ under the License.
         <fastutil.version>8.5.15</fastutil.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <hbase.version>2.6.2</hbase.version>
+        <lz4-java.version>1.8.1</lz4-java.version>
         <async-profiler.version>4.0</async-profiler.version>
         <maven.surefire.plugin.version>3.2.5</maven.surefire.plugin.version>
     </properties>
@@ -741,6 +742,12 @@ under the License.
                         <groupId>org.eclipse.jetty</groupId>
                         <artifactId>jetty-security</artifactId>
                     </exclusion>
+                    <!-- https://nvd.nist.gov/vuln/detail/CVE-2025-12183 -->
+                    <exclusion>
+                        <artifactId>lz4-java</artifactId>
+                        <groupId>org.lz4</groupId>
+                    </exclusion>
+
                 </exclusions>
             </dependency>
 
@@ -1063,6 +1070,11 @@ under the License.
                         <groupId>org.apache.zookeeper</groupId>
                         <artifactId>zookeeper</artifactId>
                     </exclusion>
+                    <!-- https://nvd.nist.gov/vuln/detail/CVE-2025-12183 -->
+                    <exclusion>
+                        <groupId>org.lz4</groupId>
+                        <artifactId>lz4-java</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -1233,6 +1245,11 @@ under the License.
                         <groupId>org.ini4j</groupId>
                         <artifactId>ini4j</artifactId>
                     </exclusion>
+                    <!-- https://nvd.nist.gov/vuln/detail/CVE-2025-12183 -->
+                    <exclusion>
+                        <groupId>org.lz4</groupId>
+                        <artifactId>lz4-pure-java</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -1326,6 +1343,13 @@ under the License.
                 <groupId>org.apache.paimon</groupId>
                 <artifactId>paimon-bundle</artifactId>
                 <version>${paimon.version}</version>
+                <!-- https://nvd.nist.gov/vuln/detail/CVE-2025-12183 -->
+                <exclusions>
+                    <exclusion>
+                        <artifactId>lz4-java</artifactId>
+                        <groupId>org.lz4</groupId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -1531,6 +1555,14 @@ under the License.
                 <artifactId>async-profiler</artifactId>
                 <version>${async-profiler.version}</version>
             </dependency>
+
+            <!-- https://mvnrepository.com/artifact/at.yawk.lz4/lz4-java -->
+            <dependency>
+                <groupId>at.yawk.lz4</groupId>
+                <artifactId>lz4-java</artifactId>
+                <version>${lz4-java.version}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/java-extensions/hudi-reader/pom.xml
+++ b/java-extensions/hudi-reader/pom.xml
@@ -59,6 +59,12 @@
             <artifactId>junit-jupiter</artifactId>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/at.yawk.lz4/lz4-java -->
+        <dependency>
+            <groupId>at.yawk.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/org.apache.hudi/hudi-common -->
         <dependency>
             <groupId>org.apache.hudi</groupId>
@@ -80,6 +86,11 @@
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <!-- https://nvd.nist.gov/vuln/detail/CVE-2025-12183 -->
+                <exclusion>
+                    <artifactId>lz4-java</artifactId>
+                    <groupId>org.lz4</groupId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/java-extensions/jdbc-bridge/pom.xml
+++ b/java-extensions/jdbc-bridge/pom.xml
@@ -32,12 +32,12 @@
             <version>${hikaricp.version}</version>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/org.lz4/lz4-java -->
         <!-- we need lz4 because clickhouse return data compressed in lz4. -->
+        <!-- https://mvnrepository.com/artifact/at.yawk.lz4/lz4-java -->
         <dependency>
-            <groupId>org.lz4</groupId>
+            <groupId>at.yawk.lz4</groupId>
             <artifactId>lz4-java</artifactId>
-            <version>1.8.0</version>
+            <version>1.8.1</version>
         </dependency>
     </dependencies>
 

--- a/java-extensions/odps-reader/pom.xml
+++ b/java-extensions/odps-reader/pom.xml
@@ -44,6 +44,12 @@
             <artifactId>log4j-core</artifactId>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/at.yawk.lz4/lz4-java -->
+        <dependency>
+            <groupId>at.yawk.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>com.aliyun.odps</groupId>
             <artifactId>odps-sdk-table-api</artifactId>
@@ -80,6 +86,11 @@
                 <exclusion>
                     <groupId>org.ini4j</groupId>
                     <artifactId>ini4j</artifactId>
+                </exclusion>
+                <!-- https://nvd.nist.gov/vuln/detail/CVE-2025-12183 -->
+                <exclusion>
+                    <artifactId>lz4-pure-java</artifactId>
+                    <groupId>org.lz4</groupId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/java-extensions/paimon-reader/pom.xml
+++ b/java-extensions/paimon-reader/pom.xml
@@ -63,10 +63,23 @@
             <version>0.20.0</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/at.yawk.lz4/lz4-java -->
+        <dependency>
+            <groupId>at.yawk.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.paimon</groupId>
             <artifactId>paimon-bundle</artifactId>
             <version>${paimon.version}</version>
+            <exclusions>
+                <!-- https://nvd.nist.gov/vuln/detail/CVE-2025-12183 -->
+                <exclusion>
+                    <artifactId>lz4-java</artifactId>
+                    <groupId>org.lz4</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/java-extensions/pom.xml
+++ b/java-extensions/pom.xml
@@ -59,6 +59,7 @@
         <luben.zstd.jni.version>1.5.4-2</luben.zstd.jni.version>
         <kryo.version>4.0.2</kryo.version>
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
+        <lz4-java.version>1.8.1</lz4-java.version>
     </properties>
 
     <dependencyManagement>
@@ -476,6 +477,14 @@
                 <artifactId>bundle</artifactId>
                 <version>${aws-v2-sdk.version}</version>
             </dependency>
+
+            <!-- https://mvnrepository.com/artifact/at.yawk.lz4/lz4-java -->
+            <dependency>
+                <groupId>at.yawk.lz4</groupId>
+                <artifactId>lz4-java</artifactId>
+                <version>${lz4-java.version}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Replace vulnerable org.lz4:lz4-java and org.lz4:lz4-pure-java dependencies with at.yawk.lz4:lz4-java version 1.8.1 across all affected modules to address security vulnerability CVE-2025-12183.

The at.yawk.lz4 fork provides the security fix while maintaining API compatibility with existing code.

## Why I'm doing:

## What I'm doing:

Fixes #66352

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
