### PR TITLE
[BugFix] fix the behavior of fe_conf.statistic_collect_query_timeout

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalFullStatisticsCollectJob.java
@@ -291,10 +291,7 @@ public class ExternalFullStatisticsCollectJob extends StatisticsCollectJob {
     @Override
     public void collectStatisticSync(String sql, ConnectContext context, AnalyzeStatus analyzeStatus) throws Exception {
         // Calculate and set remaining timeout for this SQL task
-        int remainingTimeout = calculateAndSetRemainingTimeout(context, analyzeStatus);
-        if (remainingTimeout < 0) {
-            throw new DdlException("Analyze job timeout exceeded");
-        }
+        calculateAndSetRemainingTimeout(context, analyzeStatus);
 
         LOG.debug("statistics collect sql : " + sql);
         StatisticExecutor executor = new StatisticExecutor();

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalHistogramStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/ExternalHistogramStatisticsCollectJob.java
@@ -98,7 +98,7 @@ public class ExternalHistogramStatisticsCollectJob extends StatisticsCollectJob 
             }
 
             sql = buildCollectHistogram(db, table, sampleRatio, bucketNum, mostCommonValues, columnName, columnType);
-            collectStatisticSync(sql, context);
+            collectStatisticSync(sql, context, analyzeStatus);
 
             finishedSQLNum++;
             analyzeStatus.setProgress(finishedSQLNum * 100 / totalCollectSQL);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/FullStatisticsCollectJob.java
@@ -187,10 +187,7 @@ public class FullStatisticsCollectJob extends StatisticsCollectJob {
     @Override
     public void collectStatisticSync(String sql, ConnectContext context, AnalyzeStatus analyzeStatus) throws Exception {
         // Calculate and set remaining timeout for this SQL task
-        int remainingTimeout = calculateAndSetRemainingTimeout(context, analyzeStatus);
-        if (remainingTimeout < 0) {
-            throw new DdlException("Analyze job timeout exceeded");
-        }
+        calculateAndSetRemainingTimeout(context, analyzeStatus);
 
         LOG.debug("statistics collect sql : " + sql);
         StatisticExecutor executor = new StatisticExecutor();

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/HistogramStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/HistogramStatisticsCollectJob.java
@@ -133,7 +133,7 @@ public class HistogramStatisticsCollectJob extends StatisticsCollectJob {
                 List<TStatisticData> buckets = statisticExecutor.executeStatisticDQL(context, sql);
                 sql = buildCollectHistogramWithHllNdv(db, table, mostCommonValues, buckets.get(0).histogram, columnName);
             }
-            collectStatisticSync(sql, context);
+            collectStatisticSync(sql, context, analyzeStatus);
 
             finishedSQLNum++;
             analyzeStatus.setProgress(finishedSQLNum * 100 / totalCollectSQL);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/HyperStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/HyperStatisticsCollectJob.java
@@ -107,13 +107,11 @@ public class HyperStatisticsCollectJob extends StatisticsCollectJob {
         long insertFailures = 0;
 
         for (int i = 0; i < queryJobs.size(); i++) {
+            // Calculate and set remaining timeout for this query job
+            calculateAndSetRemainingTimeout(context, analyzeStatus);
+
             HyperQueryJob queryJob = queryJobs.get(i);
             try {
-                // Calculate and set remaining timeout for this query job
-                int remainingTimeout = calculateAndSetRemainingTimeout(context, analyzeStatus);
-                if (remainingTimeout < 0) {
-                    throw new RuntimeException("Analyze job timeout exceeded");
-                }
                 queryJob.queryStatistics();
                 rowsBuffer.addAll(queryJob.getStatisticsData());
                 sqlBuffer.addAll(queryJob.getStatisticsValueSQL());
@@ -160,16 +158,13 @@ public class HyperStatisticsCollectJob extends StatisticsCollectJob {
             return;
         }
 
-        // Calculate and set remaining timeout for this insert task
-        int remainingTimeout = calculateAndSetRemainingTimeout(context, analyzeStatus);
-        if (remainingTimeout < 0) {
-            throw new DdlException("Analyze job timeout exceeded");
-        }
-
         int count = 0;
         int maxRetryTimes = 5;
         StatementBase insertStmt = createInsertStmt();
         do {
+            // Calculate and set remaining timeout for this insert task
+            calculateAndSetRemainingTimeout(context, analyzeStatus);
+
             LOG.debug("statistics insert sql size:" + rowsBuffer.size());
             StmtExecutor executor = StmtExecutor.newInternalExecutor(context, insertStmt);
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/SampleStatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/SampleStatisticsCollectJob.java
@@ -61,7 +61,7 @@ public class SampleStatisticsCollectJob extends StatisticsCollectJob {
                     db.getId(), table.getName(), db.getFullName(), columnSampleManager.getComplexTypeStats());
             context.getSessionVariable().setExprChildrenLimit(
                     Math.max(Config.expr_children_limit, columnSampleManager.getComplexTypeStats().size()));
-            collectStatisticSync(complexTypeColsTask, context);
+            collectStatisticSync(complexTypeColsTask, context, analyzeStatus);
         }
 
         List<List<ColumnStats>> columnStatsBatchList = columnSampleManager.splitPrimitiveTypeStats();
@@ -81,7 +81,7 @@ public class SampleStatisticsCollectJob extends StatisticsCollectJob {
                     db.getId(), table.getName(), db.getFullName(), columnStatsBatch, tabletSampleManager);
             context.getSessionVariable().setExprChildrenLimit(
                     Math.max(Config.expr_children_limit, sampleInfo.getMaxSampleTabletNum()));
-            collectStatisticSync(primitiveTypeColsTask, context);
+            collectStatisticSync(primitiveTypeColsTask, context, analyzeStatus);
 
             double progress = finishedTaskNum * 1.0 / totalTaskNum;
             if (progress >= recordStagePoint) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -520,6 +520,10 @@ public class StatisticExecutor {
 
         try {
             Stopwatch watch = Stopwatch.createStarted();
+            // Set start time if not already set
+            if (analyzeStatus.getStartTime() == null) {
+                analyzeStatus.setStartTime(LocalDateTime.now());
+            }
             statsConnectCtx.getSessionVariable().setEnableProfile(Config.enable_statistics_collect_profile);
             GlobalStateMgr.getCurrentState().getAnalyzeMgr().registerConnection(analyzeStatus.getId(), statsConnectCtx);
             // Only update running status without edit log, make restart job status is failed

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -119,6 +119,10 @@ public class StatisticUtils {
         context.getSessionVariable().setEnableLoadProfile(false);
         context.getSessionVariable().setBigQueryProfileThreshold("0s");
         context.getSessionVariable().setParallelExecInstanceNum(1);
+        // Note: queryTimeoutS and insertTimeoutS will be set dynamically based on remaining job time
+        // in StatisticsCollectJob.calculateAndSetRemainingTimeout() to ensure the total job timeout
+        // is respected across all SQL tasks, not just individual task timeout.
+        // Set a default large value here, but it will be overridden per task.
         context.getSessionVariable().setQueryTimeoutS((int) Config.statistic_collect_query_timeout);
         context.getSessionVariable().setInsertTimeoutS((int) Config.statistic_collect_query_timeout);
         context.getSessionVariable().setEnablePipelineEngine(true);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJob.java
@@ -201,7 +201,8 @@ public abstract class StatisticsCollectJob {
      * @param analyzeStatus The AnalyzeStatus to get start time
      * @return The remaining timeout in seconds, or -1 if timeout has been exceeded
      */
-    protected int calculateAndSetRemainingTimeout(ConnectContext context, AnalyzeStatus analyzeStatus) {
+    protected int calculateAndSetRemainingTimeout(ConnectContext context, AnalyzeStatus analyzeStatus)
+            throws DdlException {
         LocalDateTime startTime = analyzeStatus.getStartTime();
         if (startTime == null) {
             // If start time is not set, use full timeout
@@ -218,7 +219,7 @@ public abstract class StatisticsCollectJob {
 
         // Timeout exceeded
         if (remainingSeconds <= 0) {
-            return -1;
+            throw new DdlException("Analyze job timeout exceeded");
         }
 
         // Use remaining time, but not less than minimum
@@ -233,10 +234,7 @@ public abstract class StatisticsCollectJob {
         int maxRetryTimes = 5;
         do {
             // Calculate and set remaining timeout for this SQL task
-            int remainingTimeout = calculateAndSetRemainingTimeout(context, analyzeStatus);
-            if (remainingTimeout < 0) {
-                throw new DdlException("Analyze job timeout exceeded");
-            }
+            calculateAndSetRemainingTimeout(context, analyzeStatus);
 
             context.setQueryId(UUIDUtil.genUUID());
             LOG.debug("statistics collect sql : {}", sql);

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
@@ -128,7 +128,8 @@ public class StatisticsExecutorTest extends PlanTestBase {
             }
         };
 
-        Assertions.assertThrows(DdlException.class, () -> collectJob.collectStatisticSync(sql, context));
+        AnalyzeStatus analyzeStatus = new NativeAnalyzeStatus();
+        Assertions.assertThrows(DdlException.class, () -> collectJob.collectStatisticSync(sql, context, analyzeStatus));
 
         new Expectations(context) {
             {
@@ -137,7 +138,7 @@ public class StatisticsExecutorTest extends PlanTestBase {
             }
         };
 
-        collectJob.collectStatisticSync(sql, context);
+        collectJob.collectStatisticSync(sql, context, analyzeStatus);
     }
 
     @Test
@@ -320,7 +321,8 @@ public class StatisticsExecutorTest extends PlanTestBase {
         AnalyzeStmt stmt = (AnalyzeStmt) analyzeSuccess(sql);
         StmtExecutor executor = new StmtExecutor(connectContext, stmt);
         AnalyzeStatus analyzeStatus = new NativeAnalyzeStatus(1, 2, 3, Lists.newArrayList(),
-                StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.SCHEDULE, Maps.newHashMap(), LocalDateTime.MIN);
+                StatsConstants.AnalyzeType.FULL, StatsConstants.ScheduleType.SCHEDULE, Maps.newHashMap(),
+                LocalDateTime.now());
 
         Database db = connectContext.getGlobalStateMgr().getMetadataMgr().getDb(connectContext, "default_catalog", "test");
         Table table =


### PR DESCRIPTION
## Why I'm doing:

The `statistic_collect_query_timeout` should be the timeout of the whole `ANALYZE TABLE` job, but actually it's treated as the timeout of a sql task.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces analyze job timeout by computing remaining time and setting per-task query/insert timeouts, updating collect APIs and adding tests.
> 
> - **Core behavior**
>   - Add `calculateAndSetRemainingTimeout(context, analyzeStatus)` in `StatisticsCollectJob` to compute remaining job time and set `queryTimeoutS`/`insertTimeoutS` per SQL/insert task.
>   - `StatisticExecutor.collectStatistics` sets `analyzeStatus.startTime` if missing.
> - **API changes**
>   - Update `collectStatisticSync` signature to `collectStatisticSync(String sql, ConnectContext, AnalyzeStatus)` and invoke timeout calculation before execution in:
>     - `FullStatisticsCollectJob`, `ExternalFullStatisticsCollectJob`, `HistogramStatisticsCollectJob`, `ExternalHistogramStatisticsCollectJob`, `SampleStatisticsCollectJob`.
>   - `HyperStatisticsCollectJob`: compute remaining timeout before each query job and before inserts; update `flushInsertStatisticsData` to accept `AnalyzeStatus`.
> - **Session defaults**
>   - Clarify in `StatisticUtils` that timeouts are dynamically overridden per task, keeping large defaults.
> - **Tests**
>   - Add `testJobTimeout` to verify remaining-time logic and timeout exceptions.
>   - Adjust existing tests to new method signatures and start-time initialization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8beab2136b8003c4f595f7e02e0835f85567022b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->