### PR TITLE
[BugFix] Retry in RPC-level for RuntimeException Unable to validate object

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/rpc/BackendServiceClientTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/rpc/BackendServiceClientTest.java
@@ -1,0 +1,149 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.rpc;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.proto.PCancelPlanFragmentRequest;
+import com.starrocks.proto.PCancelPlanFragmentResult;
+import com.starrocks.proto.PExecPlanFragmentResult;
+import com.starrocks.proto.PPlanFragmentCancelReason;
+import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.thrift.TUniqueId;
+import com.starrocks.utframe.MockedBackend;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class BackendServiceClientTest {
+
+    @Test
+    public void testSendPlanFragmentRetriesOnNoSuchElementSuccess() throws Exception {
+        NoSuchElementException noSuchElementException = new NoSuchElementException("inject fail");
+        RuntimeException runtimeException = new RuntimeException(noSuchElementException);
+        List<RuntimeException> exceptions = ImmutableList.of(noSuchElementException, runtimeException);
+
+        for (RuntimeException ex : exceptions) {
+            RecordingBackendService service = mockBackendService(1, 0, ex);
+            BackendServiceClient client = BackendServiceClient.getInstance();
+            client.execPlanFragmentAsync(new TNetworkAddress("127.0.0.1", 8080), new byte[0], "thrift");
+            Assertions.assertEquals(2, service.execPlanCalls.get());
+        }
+    }
+
+    @Test
+    public void testSendPlanFragmentRetriesOnNoSuchElementFail() throws Exception {
+        NoSuchElementException noSuchElementException = new NoSuchElementException("inject fail");
+        RuntimeException runtimeException = new RuntimeException(noSuchElementException);
+        List<RuntimeException> exceptions = ImmutableList.of(noSuchElementException, runtimeException);
+
+        for (RuntimeException ex : exceptions) {
+            mockBackendService(10, 0, ex);
+            BackendServiceClient client = BackendServiceClient.getInstance();
+            assertThatThrownBy(() -> client.execPlanFragmentAsync(new TNetworkAddress("127.0.0.1", 8080), new byte[0], "thrift"))
+                    .isInstanceOf(RpcException.class)
+                    .hasMessageContaining("inject fail");
+        }
+    }
+
+    @Test
+    public void testCancelPlanFragmentRetriesOnNoSuchElementSuccess() throws Exception {
+        NoSuchElementException noSuchElementException = new NoSuchElementException("inject fail");
+        RuntimeException runtimeException = new RuntimeException(noSuchElementException);
+        List<RuntimeException> exceptions = ImmutableList.of(noSuchElementException, runtimeException);
+
+        for (RuntimeException ex : exceptions) {
+            RecordingBackendService service = mockBackendService(0, 1, ex);
+            BackendServiceClient client = BackendServiceClient.getInstance();
+            client.cancelPlanFragmentAsync(
+                    new TNetworkAddress("127.0.0.1", 8081),
+                    new TUniqueId(1, 2),
+                    new TUniqueId(3, 4),
+                    PPlanFragmentCancelReason.INTERNAL_ERROR,
+                    true);
+            Assertions.assertEquals(2, service.cancelPlanCalls.get());
+        }
+    }
+
+    @Test
+    public void testCancelPlanFragmentRetriesOnNoSuchElementFail() throws Exception {
+        NoSuchElementException noSuchElementException = new NoSuchElementException("inject fail");
+        RuntimeException runtimeException = new RuntimeException(noSuchElementException);
+        List<RuntimeException> exceptions = ImmutableList.of(noSuchElementException, runtimeException);
+
+        for (RuntimeException ex : exceptions) {
+            mockBackendService(0, 10, ex);
+            BackendServiceClient client = BackendServiceClient.getInstance();
+            assertThatThrownBy(() -> client.cancelPlanFragmentAsync(
+                    new TNetworkAddress("127.0.0.1", 8081),
+                    new TUniqueId(1, 2),
+                    new TUniqueId(3, 4),
+                    PPlanFragmentCancelReason.INTERNAL_ERROR,
+                    true))
+                    .isInstanceOf(RpcException.class)
+                    .hasMessageContaining("inject fail");
+        }
+    }
+
+    private RecordingBackendService mockBackendService(int execPlanFailTimes, int cancelPlanFailTimes,
+                                                       RuntimeException exception) {
+        RecordingBackendService service = new RecordingBackendService(execPlanFailTimes, cancelPlanFailTimes, exception);
+        new MockUp<BrpcProxy>() {
+            @Mock
+            public PBackendService getBackendService(TNetworkAddress address) {
+                return service;
+            }
+        };
+        return service;
+    }
+
+    private static class RecordingBackendService extends MockedBackend.MockPBackendService {
+        private final AtomicInteger execPlanCalls = new AtomicInteger();
+        private final AtomicInteger cancelPlanCalls = new AtomicInteger();
+        private final int execPlanFailTimes;
+        private final int cancelPlanFailTimes;
+        private final RuntimeException exception;
+
+        RecordingBackendService(int execPlanFailTimes, int cancelPlanFailTimes, RuntimeException exception) {
+            this.execPlanFailTimes = execPlanFailTimes;
+            this.cancelPlanFailTimes = cancelPlanFailTimes;
+            this.exception = exception;
+        }
+
+        @Override
+        public Future<PExecPlanFragmentResult> execPlanFragmentAsync(PExecPlanFragmentRequest request) {
+            if (execPlanCalls.getAndIncrement() < execPlanFailTimes) {
+                throw exception;
+            }
+            return CompletableFuture.completedFuture(new PExecPlanFragmentResult());
+        }
+
+        @Override
+        public Future<PCancelPlanFragmentResult> cancelPlanFragmentAsync(PCancelPlanFragmentRequest request) {
+            if (cancelPlanCalls.getAndIncrement() < cancelPlanFailTimes) {
+                throw exception;
+            }
+            return CompletableFuture.completedFuture(new PCancelPlanFragmentResult());
+        }
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

When the FE sends bRPC requests `sendPlanFragmentAsync` and `cancelPlanFragmentAsync` to the BE, an RPC-level retry is triggered if a `NoSuchElementException` is thrown. However, for a stale connection (for example, when a BE crashes and quickly comes back up, and the newly added BE has the same IP as before), a `RuntimeException("Unable to validate object")` is thrown instead of `NoSuchElementException`, which we currently do not handle.

The reason for the `RuntimeException("Unable to validate object")` is that jprotobuf catches the `NoSuchElementException("Unable to validate object")` thrown by `GenericObjectPool.borrowObject` and then wraps it inside a `RuntimeException`.
<img width="1318" height="474" alt="img_v3_02sm_b74c88c8-330e-4606-a9b7-5b45843de37g" src="https://github.com/user-attachments/assets/7cb8c09d-f77c-47dd-8bb2-2ea947724036" />
<img width="1012" height="604" alt="img_v3_02sm_e3081946-c9e9-4bbf-8795-0ac1b89ebdfg" src="https://github.com/user-attachments/assets/4a86dc90-3a42-4a5a-9689-2cf4bac46e17" />


## What I'm doing:


We should also perform a retry when encountering a `RuntimeException` whose cause is a `NoSuchElementException`.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Centralizes retry logic for `execPlanFragmentAsync` and `cancelPlanFragmentAsync` to handle `NoSuchElementException` and its `RuntimeException` wrapper; adds unit tests.
> 
> - **RPC client (`fe/fe-core/src/main/java/com/starrocks/rpc/BackendServiceClient.java`)**:
>   - Introduce `retryNoSuchElement` helper with `RETRY_TIMES=2` to retry on `NoSuchElementException` or when wrapped in `RuntimeException` (via `getCause`).
>   - Refactor `sendPlanFragmentAsync` and `cancelPlanFragmentAsync` to use the new retry helper; preserve timing/timeout setup for exec path.
>   - Improve sleep interruption handling by restoring the interrupt flag.
> - **Tests (`fe/fe-core/src/test/java/com/starrocks/rpc/BackendServiceClientTest.java`)**:
>   - Add tests covering retry success/failure for both `execPlanFragmentAsync` and `cancelPlanFragmentAsync`, including cases where `NoSuchElementException` is wrapped in `RuntimeException`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23f70ac0cf9816a4ce41cc8921159002826654b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->