### PR TITLE
[Enhancement] Add overloaded newMessage methods for improved MV log

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/StarRocksLoggerFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/StarRocksLoggerFactory.java
@@ -75,6 +75,21 @@ public class StarRocksLoggerFactory {
         }
 
         @Override
+        public Message newMessage(CharSequence message) {
+            return new ParameterizedMessage(format(message.toString()));
+        }
+
+        @Override
+        public Message newMessage(Object message) {
+            return new ParameterizedMessage(format(Objects.toString(message)));
+        }
+
+        @Override
+        public Message newMessage(String message) {
+            return new ParameterizedMessage(format(message));
+        }
+
+        @Override
         public Message newMessage(final String message, final Object... params) {
             return new ParameterizedMessage(format(message), params);
         }


### PR DESCRIPTION

## Why I'm doing:

```log
[PartitionBasedMvRefreshProcessor.checkMvToRefreshedPartitions():312] no partitions to refresh for materialized view
```
MV name cannot be recorded when logging without using a placeholder.


After modification:
```log
[PartitionBasedMvRefreshProcessor.checkMvToRefreshedPartitions():312]  [mv1] no partitions to refresh for materialized view
```

## What I'm doing:

Added new overloads to the `newMessage` method in the `StarRocksLoggerFactory.java` file, improving how log messages are constructed and formatted.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
