### PR TITLE
[BugFix] Fix mv compensation bugs when query contains multi times for the same table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
@@ -576,11 +576,6 @@ public class MaterializationContext {
      * NOTE: This method should be called after mv's compensate has been initialized.
      */
     public MVCompensation getMvCompensation(OptExpression queryExpression) {
-        // if there is only one compensation, return it directly
-        if (queryToMVCompensationMap.size() == 1) {
-            return queryToMVCompensationMap.values().iterator().next();
-        }
-        // otherwise, get the specific compensation for this query expression
         return getOrInitMVCompensation(queryExpression);
     }
 
@@ -592,25 +587,6 @@ public class MaterializationContext {
      * - otherwise return true.
      */
     public boolean isNoRewrite(OptExpression queryExpression) {
-        int score = queryToMVCompensationMap.values()
-                .stream()
-                .map(mvCompensation -> {
-                    if (isMVCompensateNoRewrite(mvCompensation)) {
-                        return 1;
-                    } else {
-                        return 0;
-                    }
-                }).reduce(0, Integer::sum);
-        int compensationSize = queryToMVCompensationMap.size();
-        // if all compensations are no rewrite, return true
-        if (score == compensationSize) {
-            return true;
-        }
-        // if some compensations are no rewrite, return false
-        if (score == 0) {
-            return false;
-        }
-        // mixed case, need to check the specific compensation for this query expression
         MVCompensation mvCompensation = getOrInitMVCompensation(queryExpression);
         return isMVCompensateNoRewrite(mvCompensation);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
@@ -573,14 +573,7 @@ public class MaterializationContext {
     }
 
     public MVCompensation getMvCompensation(OptExpression queryExpression) {
-        if (queryToMVCompensationMap.size() == 1) {
-            return queryToMVCompensationMap.values().iterator().next();
-        }
-        QueryOptProfile queryOptProfile = MVCompensationBuilder.buildQueryOptProfile(mv, queryExpression);
-        MVCompensation mvCompensation = queryToMVCompensationMap.get(queryOptProfile);
-        Preconditions.checkArgument(mvCompensation != null,
-                "MV compensation should be initialized before used");
-        return mvCompensation;
+        return getOrInitMVCompensation(queryExpression);
     }
 
     /**
@@ -606,8 +599,7 @@ public class MaterializationContext {
         if (score == 0) {
             return false;
         }
-        QueryOptProfile queryOptProfile = MVCompensationBuilder.buildQueryOptProfile(mv, queryExpression);
-        MVCompensation mvCompensation = queryToMVCompensationMap.get(queryOptProfile);
+        MVCompensation mvCompensation = getOrInitMVCompensation(queryExpression);
         return isMVCompensateNoRewrite(mvCompensation);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
@@ -572,11 +572,20 @@ public class MaterializationContext {
         }
     }
 
+    /**
+     * NOTE: This method should be called after mv's compensate has been initialized.
+     */
     public MVCompensation getMvCompensation(OptExpression queryExpression) {
+        // if there is only one compensation, return it directly
+        if (queryToMVCompensationMap.size() == 1) {
+            return queryToMVCompensationMap.values().iterator().next();
+        }
+        // otherwise, get the specific compensation for this query expression
         return getOrInitMVCompensation(queryExpression);
     }
 
     /**
+     * NOTE: This method should be called after mv's compensate has been initialized.
      * Check the mv context can be used for rewrite:
      * - if mv compensation's state is no rewrite, return false
      * - if mv compensation's state is unkwown & check mode is checked, return false
@@ -593,12 +602,15 @@ public class MaterializationContext {
                     }
                 }).reduce(0, Integer::sum);
         int compensationSize = queryToMVCompensationMap.size();
+        // if all compensations are no rewrite, return true
         if (score == compensationSize) {
             return true;
         }
+        // if some compensations are no rewrite, return false
         if (score == 0) {
             return false;
         }
+        // mixed case, need to check the specific compensation for this query expression
         MVCompensation mvCompensation = getOrInitMVCompensation(queryExpression);
         return isMVCompensateNoRewrite(mvCompensation);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
@@ -40,6 +40,7 @@ import com.starrocks.sql.optimizer.rule.transformation.materialization.MvPartiti
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.TableScanDesc;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.compensation.MVCompensation;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.compensation.MVCompensationBuilder;
 import org.apache.commons.collections4.SetUtils;
 
 import java.util.Collections;
@@ -47,6 +48,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
@@ -94,11 +96,64 @@ public class MaterializationContext {
 
     //// Caches for the mv rewrite lifecycle
 
+
+    /**
+     * TableOptProfile is used to describe a table's compensation profile for the input query opt expression,
+     * it contains:
+     * 1. table: the table object
+     * 2. partitionIds: the selected partition ids from the query opt expression for this table
+     * 3. partitionPredicates: the partition predicates from the query opt expression for
+     */
+    public record TableOptProfile(Table table, Set<Long> partitionIds, Set<ScalarOperator> partitionPredicates) {
+        @Override
+        public int hashCode() {
+            return Objects.hash(table, partitionIds, partitionPredicates);
+        }
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            TableOptProfile other = (TableOptProfile) obj;
+            return Objects.equals(table, other.table)
+                    && Objects.equals(partitionIds, other.partitionIds)
+                    && Objects.equals(partitionPredicates, other.partitionPredicates);
+        }
+    }
+
+    /**
+     * QueryOptProfile is used to describe a query's compensation profile for the input mv,
+     * it contains:
+     * 1. tableOptProfiles: the set of TableOptProfile for all tables in
+     */
+    public record QueryOptProfile(Set<TableOptProfile> tableOptProfiles) {
+        @Override
+        public int hashCode() {
+            return Objects.hash(tableOptProfiles);
+        }
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            QueryOptProfile other = (QueryOptProfile) obj;
+            return Objects.equals(tableOptProfiles, other.tableOptProfiles);
+        }
+    }
     // Cache whether to need to compensate partition predicates or not, and it's not changed
     // during one query, so it's safe to cache it and be used for each optimizer rule.
     // But it is different for each materialized view, compensate partition predicate from the plan's
     // `selectedPartitionIds`, and check `isNeedCompensatePartitionPredicate` to get more information.
-    private MVCompensation mvCompensation = null;
+    // NOTE:
+    // The same tables with different partition predicates and selected partition ids can lead to different
+    // MV compensation results, so we cache the compensation results for each query optimization profile.
+    private Map<QueryOptProfile, MVCompensation> queryToMVCompensationMap = Maps.newHashMap();
 
     // Cache partition compensates predicates for each ScanNode and isCompensate pair.
     private Map<LogicalScanOperator, List<ScalarOperator>> scanOpToPartitionCompensatePredicates;
@@ -503,15 +558,26 @@ public class MaterializationContext {
      * </p>
      */
     public MVCompensation getOrInitMVCompensation(OptExpression queryExpression) {
-        if (mvCompensation == null) {
+        QueryOptProfile queryOptProfile = MVCompensationBuilder.buildQueryOptProfile(mv, queryExpression);
+        MVCompensation cachedCompensation = queryToMVCompensationMap.get(queryOptProfile);
+        if (cachedCompensation == null) {
             // only set this when `queryExpression` contains ref table, otherwise the cached value maybe dirty.
-            this.mvCompensation = MvPartitionCompensator.getMvCompensation(queryExpression, this);
-            logMVRewrite(mv.getName(), "MV compensation: {}", mvCompensation);
+            MVCompensation mvCompensation = MvPartitionCompensator.getMvCompensation(queryExpression, this);
+            logMVRewrite(mv.getName(), "Construct a new MV compensation: {}", mvCompensation);
+            queryToMVCompensationMap.put(queryOptProfile, mvCompensation);
+            return mvCompensation;
+        } else {
+            logMVRewrite(mv.getName(), "Find a MV compensation: {}", cachedCompensation);
+            return cachedCompensation;
         }
-        return this.mvCompensation;
     }
 
-    public MVCompensation getMvCompensation() {
+    public MVCompensation getMvCompensation(OptExpression queryExpression) {
+        if (queryToMVCompensationMap.size() == 1) {
+            return queryToMVCompensationMap.values().iterator().next();
+        }
+        QueryOptProfile queryOptProfile = MVCompensationBuilder.buildQueryOptProfile(mv, queryExpression);
+        MVCompensation mvCompensation = queryToMVCompensationMap.get(queryOptProfile);
         Preconditions.checkArgument(mvCompensation != null,
                 "MV compensation should be initialized before used");
         return mvCompensation;
@@ -523,7 +589,29 @@ public class MaterializationContext {
      * - if mv compensation's state is unkwown & check mode is checked, return false
      * - otherwise return true.
      */
-    public boolean isNoRewrite() {
+    public boolean isNoRewrite(OptExpression queryExpression) {
+        int score = queryToMVCompensationMap.values()
+                .stream()
+                .map(mvCompensation -> {
+                    if (isMVCompensateNoRewrite(mvCompensation)) {
+                        return 1;
+                    } else {
+                        return 0;
+                    }
+                }).reduce(0, Integer::sum);
+        int compensationSize = queryToMVCompensationMap.size();
+        if (score == compensationSize) {
+            return true;
+        }
+        if (score == 0) {
+            return false;
+        }
+        QueryOptProfile queryOptProfile = MVCompensationBuilder.buildQueryOptProfile(mv, queryExpression);
+        MVCompensation mvCompensation = queryToMVCompensationMap.get(queryOptProfile);
+        return isMVCompensateNoRewrite(mvCompensation);
+    }
+
+    private boolean isMVCompensateNoRewrite(MVCompensation mvCompensation) {
         Preconditions.checkArgument(mvCompensation != null,
                 "MV compensation should be initialized before used");
         if (mvCompensation.getState().isNoRewrite()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -94,7 +94,6 @@ import com.starrocks.sql.optimizer.rule.transformation.UnionToValuesRule;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVCompensationPruneUnionRule;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvRewriteStrategy;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
-import com.starrocks.sql.optimizer.rule.transformation.materialization.compensation.MVCompensation;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.rule.TextMatchBasedRewriteRule;
 import com.starrocks.sql.optimizer.rule.transformation.pruner.CboTablePruneRule;
 import com.starrocks.sql.optimizer.rule.transformation.pruner.PrimaryKeyUpdateTableRule;
@@ -463,14 +462,6 @@ public class QueryOptimizer extends Optimizer {
         if (mvRewriteStrategy.enableViewBasedRewrite && viewBasedMvRuleRewrite(tree, rootTaskContext)) {
             return;
         }
-        for (MaterializationContext mvContext : context.getCandidateMvs()) {
-            if (mvContext.getMv().isView()) {
-                continue;
-            }
-            // initialize query's compensate type based on query and mv's partition refresh status
-            MVCompensation ignored = mvContext.getOrInitMVCompensation(tree);
-        }
-
         if (mvRewriteStrategy.enableForceRBORewrite) {
             // use rule based mv rewrite strategy to do mv rewrite for multi tables query
             if (mvRewriteStrategy.enableMultiTableRewrite) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -1266,7 +1266,7 @@ public class MaterializedViewRewriter implements IMaterializedViewRewriter {
                                                    RewriteContext rewriteContext,
                                                    ColumnRewriter columnRewriter,
                                                    Map<ColumnRefOperator, ScalarOperator> mvColumnRefToScalarOp) {
-        final MVCompensation mvCompensation = materializationContext.getMvCompensation();
+        final MVCompensation mvCompensation = materializationContext.getMvCompensation(rewriteContext.getQueryExpression());
         final LogicalOlapScanOperator mvScanOperator = materializationContext.getScanMvOperator();
         final MaterializedView mv = materializationContext.getMv();
         final List<ColumnRefOperator>  originalOutputColumns = MvUtils.getMvScanOutputColumnRefs(mv, mvScanOperator);
@@ -1313,11 +1313,12 @@ public class MaterializedViewRewriter implements IMaterializedViewRewriter {
                 rewriteContext.getMvPredicateSplit(),
                 true);
         // check mv context again if mv can be applied for rewrite.
-        if (materializationContext.isNoRewrite()) {
+        OptExpression queryOptExpression = rewriteContext.getQueryExpression();
+        if (materializationContext.isNoRewrite(queryOptExpression)) {
             logMVRewrite(mvRewriteContext, "MV cannot be applied for rewrite");
             return null;
         }
-        MVCompensation mvCompensation = materializationContext.getMvCompensation();
+        MVCompensation mvCompensation = materializationContext.getMvCompensation(queryOptExpression);
         boolean isTransparentRewrite = mvCompensation.isTransparentRewrite();
         logMVRewrite(mvRewriteContext, "Get compensation predicates:{}, isTransparentRewrite: {}",
                 compensationPredicates, isTransparentRewrite);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvPartitionCompensator.java
@@ -365,7 +365,7 @@ public class MvPartitionCompensator {
         }
 
         List<ScalarOperator> partitionPredicates = Lists.newArrayList();
-        MVCompensation mvCompensation = mvContext.getMvCompensation();
+        MVCompensation mvCompensation = mvContext.getMvCompensation(queryExpression);
         if (mvCompensation.getState().isNoRewrite()) {
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -156,14 +156,17 @@ public class MvUtils {
         if (tablesToCheck.isEmpty()) {
             return Sets.newTreeSet();
         }
-        SortedSet<MaterializedViewWrapper> mvs = Sets.newTreeSet();
-        getRelatedMvs(connectContext, maxLevel, 0, tablesToCheck, mvs);
-        return mvs;
+        Map<MaterializedView, Integer> mvToLevel = Maps.newHashMap();
+        getRelatedMvs(connectContext, maxLevel, 0, tablesToCheck, mvToLevel);
+        return mvToLevel.entrySet().stream()
+                .map(e -> MaterializedViewWrapper.create(e.getKey(), e.getValue()))
+                .collect(Collectors.toCollection(() -> Sets.newTreeSet()));
     }
 
     public static void getRelatedMvs(ConnectContext connectContext,
                                      int maxLevel, int currentLevel,
-                                     Set<Table> tablesToCheck, Set<MaterializedViewWrapper> mvs) {
+                                     Set<Table> tablesToCheck,
+                                     Map<MaterializedView, Integer> mvs) {
         if (currentLevel >= maxLevel) {
             logMVPrepare("Current level {} is greater than max level {}", currentLevel, maxLevel);
             return;
@@ -197,7 +200,12 @@ public class MvUtils {
                 continue;
             }
             newMvs.add(table);
-            mvs.add(MaterializedViewWrapper.create((MaterializedView) table, currentLevel));
+            MaterializedView curMV = (MaterializedView) table;
+            Integer curLevel = mvs.get(curMV);
+            // update to higher level if a mv is found again
+            if (curLevel == null || curLevel < currentLevel) {
+                mvs.put((MaterializedView) table, currentLevel);
+            }
         }
         getRelatedMvs(connectContext, maxLevel, currentLevel + 1, newMvs, mvs);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/MVCompensationBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/MVCompensationBuilder.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.optimizer.rule.transformation.materialization.compensa
 
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvUpdateInfo;
@@ -27,8 +28,14 @@ import com.starrocks.sql.common.PCellSortedSet;
 import com.starrocks.sql.common.PCellUtils;
 import com.starrocks.sql.optimizer.MaterializationContext;
 import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.operator.ScanOperatorPredicates;
+import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalViewScanOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTransparentState;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvPartitionCompensator;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
@@ -38,7 +45,9 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
@@ -58,6 +67,104 @@ public class MVCompensationBuilder {
         this.mvContext = mvContext;
         this.mvUpdateInfo = mvUpdateInfo;
         this.mv = mvContext.getMv();
+    }
+
+    /**
+     * Build input opt expression query profile for mv compensation. See more details in MaterializationContext.QueryOptProfile.
+     */
+    public static MaterializationContext.QueryOptProfile buildQueryOptProfile(MaterializedView mv,
+                                                                              OptExpression queryPlan) {
+        List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(queryPlan);
+        Set<MaterializationContext.TableOptProfile> tableOptProfiles = Sets.newHashSet();
+        Map<Table, List<Column>> refBaseTablePartitionColumns = mv.getRefBaseTablePartitionColumns();
+        for (LogicalScanOperator scanOperator : scanOperators) {
+            Table refBaseTable = scanOperator.getTable();
+            if (refBaseTable == null) {
+                continue;
+            }
+            // skip if the table is not ref base table
+            if (!refBaseTablePartitionColumns.containsKey(refBaseTable)) {
+                continue;
+            }
+            List<Column> partitionColumns = refBaseTablePartitionColumns.get(refBaseTable);
+
+            Set<ScalarOperator> predicates = Sets.newHashSet();
+            Set<Long> partitionIds = Sets.newHashSet();
+            // only consider predicates with table's partition columns
+            if (refBaseTable.isNativeTableOrMaterializedView()) {
+                LogicalOlapScanOperator olapScanOperator = (LogicalOlapScanOperator) scanOperator;
+
+                // only consider selected partitions ids
+                if (olapScanOperator.getSelectedPartitionId() != null) {
+                    partitionIds.addAll(olapScanOperator.getSelectedPartitionId());
+                }
+                // only consider pruned partition predicates
+                if (olapScanOperator.getPrunedPartitionPredicates() != null) {
+                    predicates.addAll(olapScanOperator.getPrunedPartitionPredicates());
+                }
+                // consider partition predicates
+                if (olapScanOperator.getPredicate() != null) {
+                    ColumnRefSet partitionColumnRefSet = getPartitionColumnRefSet(partitionColumns, scanOperator);
+                    List<ScalarOperator> partitionPredicates = Utils.extractConjuncts(olapScanOperator.getPredicate());
+                    for (ScalarOperator predicate : partitionPredicates) {
+                        if (predicate.getUsedColumns().isIntersect(partitionColumnRefSet)) {
+                            predicates.add(predicate);
+                        }
+                    }
+                }
+                tableOptProfiles.add(new MaterializationContext.TableOptProfile(refBaseTable, partitionIds, predicates));
+            } else {
+                try {
+                    ScanOperatorPredicates scanOperatorPredicates = scanOperator.getScanOperatorPredicates();
+                    if (scanOperatorPredicates == null) {
+                        continue;
+                    }
+                    // only consider selected partitions ids
+                    if (scanOperatorPredicates.getSelectedPartitionIds() != null) {
+                        partitionIds.addAll(scanOperatorPredicates.getSelectedPartitionIds());
+                    }
+                    // consider pruned partition predicates and partition predicates
+                    if (scanOperatorPredicates.getPrunedPartitionConjuncts() != null) {
+                        predicates.addAll(scanOperatorPredicates.getPrunedPartitionConjuncts());
+                    }
+                    if (scanOperatorPredicates.getPartitionConjuncts() != null) {
+                        predicates.addAll(scanOperatorPredicates.getPartitionConjuncts());
+                    }
+                    // for non partition predicates, only consider those related to partition columns
+                    if (scanOperatorPredicates.getNonPartitionConjuncts() != null) {
+                        ColumnRefSet partitionColumnRefSet = getPartitionColumnRefSet(partitionColumns, scanOperator);
+                        List<ScalarOperator> nonPartitionPredicates = scanOperatorPredicates.getNonPartitionConjuncts();
+                        for (ScalarOperator predicate : nonPartitionPredicates) {
+                            if (predicate.getUsedColumns().isIntersect(partitionColumnRefSet)) {
+                                predicates.add(predicate);
+                            }
+                        }
+                    }
+                } catch (Exception e) {
+                    logMVRewrite("Failed to get scan operator predicates for table {}: {}",
+                            refBaseTable.getName(), e.getMessage());
+                }
+                tableOptProfiles.add(new MaterializationContext.TableOptProfile(
+                        refBaseTable, partitionIds, predicates));
+
+            }
+        }
+        return new MaterializationContext.QueryOptProfile(tableOptProfiles);
+    }
+
+    private static ColumnRefSet getPartitionColumnRefSet(List<Column> partitionColumns,
+                                                         LogicalScanOperator scanOperator) {
+        if (partitionColumns.isEmpty()) {
+            return new ColumnRefSet();
+        }
+        Map<Column, ColumnRefOperator> columnColumnRefOperatorMap = scanOperator.getColumnMetaToColRefMap();
+        Set<ColumnRefOperator>  partitionColumnRefs = partitionColumns.stream()
+                .map(columnColumnRefOperatorMap::get)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+        ColumnRefSet partitionColumnRefSet = new ColumnRefSet();
+        partitionColumnRefs.forEach(colRef -> partitionColumnRefSet.union(colRef.getId()));
+        return partitionColumnRefSet;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/MVCompensationBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/MVCompensationBuilder.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
+import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Pair;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.common.PCellSortedSet;
@@ -87,69 +88,84 @@ public class MVCompensationBuilder {
                 continue;
             }
             List<Column> partitionColumns = refBaseTablePartitionColumns.get(refBaseTable);
-
-            Set<ScalarOperator> predicates = Sets.newHashSet();
-            Set<Long> partitionIds = Sets.newHashSet();
             // only consider predicates with table's partition columns
             if (refBaseTable.isNativeTableOrMaterializedView()) {
                 LogicalOlapScanOperator olapScanOperator = (LogicalOlapScanOperator) scanOperator;
-
-                // only consider selected partitions ids
-                if (olapScanOperator.getSelectedPartitionId() != null) {
-                    partitionIds.addAll(olapScanOperator.getSelectedPartitionId());
-                }
-                // only consider pruned partition predicates
-                if (olapScanOperator.getPrunedPartitionPredicates() != null) {
-                    predicates.addAll(olapScanOperator.getPrunedPartitionPredicates());
-                }
-                // consider partition predicates
-                if (olapScanOperator.getPredicate() != null) {
-                    ColumnRefSet partitionColumnRefSet = getPartitionColumnRefSet(partitionColumns, scanOperator);
-                    List<ScalarOperator> partitionPredicates = Utils.extractConjuncts(olapScanOperator.getPredicate());
-                    for (ScalarOperator predicate : partitionPredicates) {
-                        if (predicate.getUsedColumns().isIntersect(partitionColumnRefSet)) {
-                            predicates.add(predicate);
-                        }
-                    }
-                }
-                tableOptProfiles.add(new MaterializationContext.TableOptProfile(refBaseTable, partitionIds, predicates));
+                tableOptProfiles.add(getTableOptProfileOfOlapTable(olapScanOperator, refBaseTable, partitionColumns));
             } else {
-                try {
-                    ScanOperatorPredicates scanOperatorPredicates = scanOperator.getScanOperatorPredicates();
-                    if (scanOperatorPredicates == null) {
-                        continue;
-                    }
-                    // only consider selected partitions ids
-                    if (scanOperatorPredicates.getSelectedPartitionIds() != null) {
-                        partitionIds.addAll(scanOperatorPredicates.getSelectedPartitionIds());
-                    }
-                    // consider pruned partition predicates and partition predicates
-                    if (scanOperatorPredicates.getPrunedPartitionConjuncts() != null) {
-                        predicates.addAll(scanOperatorPredicates.getPrunedPartitionConjuncts());
-                    }
-                    if (scanOperatorPredicates.getPartitionConjuncts() != null) {
-                        predicates.addAll(scanOperatorPredicates.getPartitionConjuncts());
-                    }
-                    // for non partition predicates, only consider those related to partition columns
-                    if (scanOperatorPredicates.getNonPartitionConjuncts() != null) {
-                        ColumnRefSet partitionColumnRefSet = getPartitionColumnRefSet(partitionColumns, scanOperator);
-                        List<ScalarOperator> nonPartitionPredicates = scanOperatorPredicates.getNonPartitionConjuncts();
-                        for (ScalarOperator predicate : nonPartitionPredicates) {
-                            if (predicate.getUsedColumns().isIntersect(partitionColumnRefSet)) {
-                                predicates.add(predicate);
-                            }
-                        }
-                    }
-                } catch (Exception e) {
-                    logMVRewrite("Failed to get scan operator predicates for table {}: {}",
-                            refBaseTable.getName(), e.getMessage());
-                }
-                tableOptProfiles.add(new MaterializationContext.TableOptProfile(
-                        refBaseTable, partitionIds, predicates));
-
+                tableOptProfiles.add(getTableOptProfileOfExternalTable(scanOperator, refBaseTable, partitionColumns));
             }
         }
         return new MaterializationContext.QueryOptProfile(tableOptProfiles);
+    }
+
+    private static MaterializationContext.TableOptProfile getTableOptProfileOfOlapTable(
+            LogicalOlapScanOperator olapScanOperator,
+            Table refBaseTable,
+            List<Column> partitionColumns) {
+        Set<ScalarOperator> predicates = Sets.newHashSet();
+        Set<Long> partitionIds = Sets.newHashSet();
+        // only consider selected partitions ids
+        if (olapScanOperator.getSelectedPartitionId() != null) {
+            partitionIds.addAll(olapScanOperator.getSelectedPartitionId());
+        }
+        // consider pruned partition predicates
+        if (olapScanOperator.getPrunedPartitionPredicates() != null) {
+            predicates.addAll(olapScanOperator.getPrunedPartitionPredicates());
+        }
+        // consider partition predicates
+        if (olapScanOperator.getPredicate() != null) {
+            ColumnRefSet partitionColumnRefSet = getPartitionColumnRefSet(partitionColumns, olapScanOperator);
+            List<ScalarOperator> partitionPredicates = Utils.extractConjuncts(olapScanOperator.getPredicate());
+            for (ScalarOperator predicate : partitionPredicates) {
+                if (predicate.getUsedColumns().isIntersect(partitionColumnRefSet)) {
+                    predicates.add(predicate);
+                }
+            }
+        }
+        return new MaterializationContext.TableOptProfile(refBaseTable, partitionIds, predicates);
+    }
+
+    private static MaterializationContext.TableOptProfile getTableOptProfileOfExternalTable(
+            LogicalScanOperator scanOperator,
+            Table refBaseTable,
+            List<Column> partitionColumns) {
+        Set<ScalarOperator> predicates = Sets.newHashSet();
+        Set<Long> partitionIds = Sets.newHashSet();
+        ScanOperatorPredicates scanOperatorPredicates = null;
+        try {
+            scanOperatorPredicates = scanOperator.getScanOperatorPredicates();
+        } catch (AnalysisException e) {
+            logMVRewrite("Failed to get scan operator predicates for table {}: {}",
+                    refBaseTable.getName(), e.getMessage());
+        }
+        // if failed to get scan operator predicates, return empty profile
+        if (scanOperatorPredicates == null) {
+            return new MaterializationContext.TableOptProfile(refBaseTable, partitionIds, predicates);
+        }
+
+        // consider selected partitions ids
+        if (scanOperatorPredicates.getSelectedPartitionIds() != null) {
+            partitionIds.addAll(scanOperatorPredicates.getSelectedPartitionIds());
+        }
+        // consider pruned partition predicates and partition predicates
+        if (scanOperatorPredicates.getPrunedPartitionConjuncts() != null) {
+            predicates.addAll(scanOperatorPredicates.getPrunedPartitionConjuncts());
+        }
+        if (scanOperatorPredicates.getPartitionConjuncts() != null) {
+            predicates.addAll(scanOperatorPredicates.getPartitionConjuncts());
+        }
+        // for non partition predicates, only consider those related to partition columns
+        if (scanOperatorPredicates.getNonPartitionConjuncts() != null) {
+            ColumnRefSet partitionColumnRefSet = getPartitionColumnRefSet(partitionColumns, scanOperator);
+            List<ScalarOperator> nonPartitionPredicates = scanOperatorPredicates.getNonPartitionConjuncts();
+            for (ScalarOperator predicate : nonPartitionPredicates) {
+                if (predicate.getUsedColumns().isIntersect(partitionColumnRefSet)) {
+                    predicates.add(predicate);
+                }
+            }
+        }
+        return new MaterializationContext.TableOptProfile(refBaseTable, partitionIds, predicates);
     }
 
     private static ColumnRefSet getPartitionColumnRefSet(List<Column> partitionColumns,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/OlapTableCompensation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/compensation/OlapTableCompensation.java
@@ -24,7 +24,6 @@ import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTransparentState;
-import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.List;
@@ -36,6 +35,7 @@ import java.util.stream.Collectors;
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
 
 public final class OlapTableCompensation extends TableCompensation {
+    // olap table's partition ids need to compensate
     private final List<Long> compensations;
 
     public OlapTableCompensation(Table refBaseTable, List<Long> partitionIds) {
@@ -71,7 +71,12 @@ public final class OlapTableCompensation extends TableCompensation {
         }
         StringBuilder sb = new StringBuilder();
         sb.append("size=").append(compensations.size()).append(", ");
-        sb.append(MvUtils.shrinkToSize(compensations, Config.max_mv_task_run_meta_message_values_length));
+        String compensationPartitions = compensations.stream()
+                .limit(Config.max_mv_task_run_meta_message_values_length)
+                .map(id -> refBaseTable.getPartition(id))
+                .map(p -> p != null ? p.getName() : "null")
+                .collect(Collectors.joining(", "));
+        sb.append("[").append(compensationPartitions).append("]");
         return sb.toString();
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
@@ -2152,4 +2152,35 @@ public class MvRefreshAndRewriteIcebergTest extends MVTestBase {
         mvPlanContexts = CachingMvPlanContextBuilder.getInstance().getOrLoadPlanContext(mv2, 3000);
         Assertions.assertTrue(mvPlanContexts.size() == 1);
     }
+
+    @Test
+    public void testIcebergPartialRefreshWithTheSameTables() throws Exception {
+        String mvName = "test_mv1";
+        starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
+                "partition by str2date(d,'%Y-%m-%d') " +
+                "distributed by hash(a) " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\n" +
+                "'replication_num' = '1'" +
+                ") " +
+                "as select  t1.a, t1.b, t1.d " +
+                " from  iceberg0.partitioned_db.part_tbl1 as t1;");
+        // partial refresh
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-01') " +
+                "end ('2023-08-02') force with sync mode");
+        String query = "select count(1) " +
+                " from (select t1.a from iceberg0.partitioned_db.part_tbl1 as t1 where t1.d='2023-08-01' " +
+                " UNION ALL select t1.a from iceberg0.partitioned_db.part_tbl1 as t1 where t1.d='2023-08-02') t;";
+        String plan = getFragmentPlan(query);
+        // for non partial refresh partitions, should still scan base table
+        PlanTestBase.assertContains(plan, "  7:IcebergScanNode\n" +
+                "     TABLE: partitioned_db.part_tbl1\n" +
+                "     PREDICATES: 19: d = '2023-08-02'");
+        // for partial refresh partitions, should scan mv
+        PlanTestBase.assertContains(plan, "  1:OlapScanNode\n" +
+                        "     TABLE: test_mv1\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     partitions=1/1");
+        starRocksAssert.dropMaterializedView(mvName);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
@@ -902,4 +902,40 @@ public class MvRewriteHiveTest extends MVTestBase {
         // - one is for view scan operator
         Assertions.assertTrue(mvPlanContexts.size() == 2);
     }
+
+    @Test
+    public void testHivePartialRefreshWithTheSameTables() throws Exception {
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW `test_mv1`\n" +
+                "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                "PARTITION BY (`l_shipdate`)\n" +
+                "DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 10\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")\n" +
+                "AS SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`\n"  +
+                "FROM `hive0`.`partitioned_db`.`lineitem_par` as a;");
+        // only partial
+        refreshMaterializedViewWithPartition("test", "test_mv1",
+                "1998-01-02", "1998-01-04");
+        String query1 = "SELECT COUNT(1) FROM (" +
+                " SELECT `l_orderkey`, `l_suppkey`, `l_shipdate` FROM `hive0`.`partitioned_db`.`lineitem_par` as a " +
+                "WHERE l_shipdate='1998-01-02'\n UNION ALL " +
+                "SELECT `l_orderkey`, `l_suppkey`, `l_shipdate` FROM `hive0`.`partitioned_db`.`lineitem_par` as a " +
+                "WHERE l_shipdate='1998-01-05') t";
+        String plan = getFragmentPlan(query1);
+        // refresh part can be rewritten
+        PlanTestBase.assertContains(plan, "  2:OlapScanNode\n" +
+                "     TABLE: test_mv1\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     partitions=1/2");
+        // non -refresh part cannot be rewritten
+        PlanTestBase.assertContains(plan, "     TABLE: lineitem_par\n" +
+                        "     PARTITION PREDICATES: 45: l_shipdate = '1998-01-05'," +
+                " (45: l_shipdate IN ('1998-01-01', '1998-01-04', '1998-01-05')) OR (45: l_shipdate IS NULL)\n" +
+                        "     partitions=1/6");
+        dropMv("test", "test_mv1");
+    }
+
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
@@ -1311,7 +1311,16 @@ public class MvRewritePartialPartitionTest extends MVTestBase {
         connectContext.getSessionVariable().setEnableMaterializedViewPushDownRewrite(true);
         {
             String plan = getFragmentPlan(query);
-            PlanTestBase.assertNotContains(plan, "test_mv1", "partitions=0/1");
+            // refresh partition is rewritten by mv
+            PlanTestBase.assertContains(plan, "  5:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1");
+            // non refresh partition is read from base table
+            PlanTestBase.assertContains(plan, "  0:OlapScanNode\n" +
+                    "     TABLE: test_base_table1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/2");
         }
         connectContext.getSessionVariable().setEnableMaterializedViewPushDownRewrite(false);
         starRocksAssert.dropTable("test_base_table1");

--- a/test/sql/test_materialized_view/R/test_nested_mv_rewrite
+++ b/test/sql/test_materialized_view/R/test_nested_mv_rewrite
@@ -242,3 +242,152 @@ explain logical
 -- result:
 []
 -- !result
+-- name: test_nested_mv_with_partial_compensation
+CREATE TABLE t1 (
+    `k1` INT,
+    `v1` INT,
+    `v2` INT)
+DUPLICATE KEY(`k1`)
+PARTITION BY RANGE(`k1`)
+(
+PARTITION `p1` VALUES LESS THAN ('2'),
+PARTITION `p2` VALUES LESS THAN ('3'),
+PARTITION `p3` VALUES LESS THAN ('4'),
+PARTITION `p4` VALUES LESS THAN ('5'),
+PARTITION `p5` VALUES LESS THAN ('6'),
+PARTITION `p6` VALUES LESS THAN ('7')
+)
+DISTRIBUTED BY HASH(k1);
+-- result:
+-- !result
+insert into t1 values (1,1,1),(1,1,2),(1,1,3),(1,2,1),(1,2,2),(1,2,3),(1,3,1),(1,3,2),(1,3,3)
+    ,(2,1,1),(2,1,2),(2,1,3),(2,2,1),(2,2,2),(2,2,3),(2,3,1),(2,3,2),(2,3,3)
+    ,(3,1,1),(3,1,2),(3,1,3),(3,2,1),(3,2,2),(3,2,3),(3,3,1),(3,3,2),(3,3,3);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv1 PARTITION BY k1 DISTRIBUTED BY HASH(k1) BUCKETS 10
+REFRESH DEFERRED MANUAL AS SELECT k1, v1 as k2, v2 as k3 from t1;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW mv2 PARTITION BY k1 DISTRIBUTED BY HASH(k1) BUCKETS 10
+REFRESH DEFERRED MANUAL AS SELECT k1, count(k2) as count_k2, sum(k3) as sum_k3 from mv1 group by k1;
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW mv2 WITH SYNC MODE;
+-- result:
+019aed92-815f-7f22-b30b-b65ccb6c64bf
+-- !result
+select count(1) from (
+    select k1, v1, v2 from mv1 where k1 = 1
+    union all
+    select k1, v1, v2 from t1 where k1 = 2
+    union all
+    select k1, v1, v2 from mv1 where k1 = 3
+    union all
+    select k1, v1, v2 from mv1 where k1 = 4
+) as t;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column 'v1' cannot be resolved.")
+-- !result
+function: print_hit_materialized_views("SELECT k1, count(v1), sum(v2) from t1 group by k1;")
+-- result:
+
+-- !result
+SELECT k1, count(v1), sum(v2) from t1 group by k1;
+-- result:
+2	9	18
+3	9	18
+1	9	18
+-- !result
+[UC]REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+-- result:
+019aed92-887e-7d51-a47d-da3f6a7c3aa7
+-- !result
+select count(1) from (
+    select k1, v1, v2 from mv1 where k1 = 1
+    union all
+    select k1, v1, v2 from t1 where k1 = 2
+    union all
+    select k1, v1, v2 from mv1 where k1 = 3
+    union all
+    select k1, v1, v2 from mv1 where k1 = 4
+) as t;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column 'v1' cannot be resolved.")
+-- !result
+function: print_hit_materialized_views("SELECT k1, count(v1), sum(v2) from t1 group by k1;")
+-- result:
+
+-- !result
+SELECT k1, count(v1), sum(v2) from t1 group by k1;
+-- result:
+3	9	18
+1	9	18
+2	9	18
+-- !result
+insert into t1 values (4,1,1);
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW mv2 WITH SYNC MODE;
+-- result:
+019aed92-982c-7502-ad24-8e7a292be34a
+-- !result
+select count(1) from (
+    select k1, v1, v2 from mv1 where k1 = 1
+    union all
+    select k1, v1, v2 from t1 where k1 = 2
+    union all
+    select k1, v1, v2 from mv1 where k1 = 3
+    union all
+    select k1, v1, v2 from mv1 where k1 = 4
+) as t;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column 'v1' cannot be resolved.")
+-- !result
+function: print_hit_materialized_views("SELECT k1, count(v1), sum(v2) from t1 group by k1;")
+-- result:
+
+-- !result
+SELECT k1, count(v1), sum(v2) from t1 group by k1;
+-- result:
+2	9	18
+3	9	18
+1	9	18
+4	1	1
+-- !result
+[UC]REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+-- result:
+019aed92-a67d-7c4d-9e93-c09e478457c2
+-- !result
+select count(1) from (
+    select k1, v1, v2 from mv1 where k1 = 1
+    union all
+    select k1, v1, v2 from t1 where k1 = 2
+    union all
+    select k1, v1, v2 from mv1 where k1 = 3
+    union all
+    select k1, v1, v2 from mv1 where k1 = 4
+) as t;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Column 'v1' cannot be resolved.")
+-- !result
+function: print_hit_materialized_views("SELECT k1, count(v1), sum(v2) from t1 group by k1;")
+-- result:
+
+-- !result
+SELECT k1, count(v1), sum(v2) from t1 group by k1;
+-- result:
+1	9	18
+2	9	18
+4	1	1
+3	9	18
+-- !result
+drop materialized view mv1;
+-- result:
+-- !result
+drop materialized view mv2;
+-- result:
+-- !result
+drop table t1;  
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/T/test_nested_mv_rewrite
+++ b/test/sql/test_materialized_view/T/test_nested_mv_rewrite
@@ -220,3 +220,94 @@ explain logical
 [UC]select regexp_replace(inspect_related_mv('join_mv1'), '"id":[0-9]+', '"id":0');
 [UC]select regexp_replace(inspect_related_mv('join_mv2'), '"id":[0-9]+', '"id":0');
 [UC]select inspect_related_mv('join_mv3');
+
+-- name: test_nested_mv_with_partial_compensation
+
+CREATE TABLE t1 (
+    `k1` INT,
+    `v1` INT,
+    `v2` INT)
+DUPLICATE KEY(`k1`)
+PARTITION BY RANGE(`k1`)
+(
+PARTITION `p1` VALUES LESS THAN ('2'),
+PARTITION `p2` VALUES LESS THAN ('3'),
+PARTITION `p3` VALUES LESS THAN ('4'),
+PARTITION `p4` VALUES LESS THAN ('5'),
+PARTITION `p5` VALUES LESS THAN ('6'),
+PARTITION `p6` VALUES LESS THAN ('7')
+)
+DISTRIBUTED BY HASH(k1);
+insert into t1 values (1,1,1),(1,1,2),(1,1,3),(1,2,1),(1,2,2),(1,2,3),(1,3,1),(1,3,2),(1,3,3)
+    ,(2,1,1),(2,1,2),(2,1,3),(2,2,1),(2,2,2),(2,2,3),(2,3,1),(2,3,2),(2,3,3)
+    ,(3,1,1),(3,1,2),(3,1,3),(3,2,1),(3,2,2),(3,2,3),(3,3,1),(3,3,2),(3,3,3);
+CREATE MATERIALIZED VIEW mv1 PARTITION BY k1 DISTRIBUTED BY HASH(k1) BUCKETS 10
+REFRESH DEFERRED MANUAL AS SELECT k1, v1 as k2, v2 as k3 from t1;
+
+CREATE MATERIALIZED VIEW mv2 PARTITION BY k1 DISTRIBUTED BY HASH(k1) BUCKETS 10
+REFRESH DEFERRED MANUAL AS SELECT k1, count(k2) as count_k2, sum(k3) as sum_k3 from mv1 group by k1;
+
+-- first refresh mv2
+[UC]REFRESH MATERIALIZED VIEW mv2 WITH SYNC MODE;
+select count(1) from (
+    select k1, v1, v2 from mv1 where k1 = 1
+    union all
+    select k1, v1, v2 from t1 where k1 = 2
+    union all
+    select k1, v1, v2 from mv1 where k1 = 3
+    union all
+    select k1, v1, v2 from mv1 where k1 = 4
+) as t;
+
+function: print_hit_materialized_views("SELECT k1, count(v1), sum(v2) from t1 group by k1;")
+SELECT k1, count(v1), sum(v2) from t1 group by k1;
+
+-- then refresh mv1
+[UC]REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+select count(1) from (
+    select k1, v1, v2 from mv1 where k1 = 1
+    union all
+    select k1, v1, v2 from t1 where k1 = 2
+    union all
+    select k1, v1, v2 from mv1 where k1 = 3
+    union all
+    select k1, v1, v2 from mv1 where k1 = 4
+) as t;
+
+function: print_hit_materialized_views("SELECT k1, count(v1), sum(v2) from t1 group by k1;")
+SELECT k1, count(v1), sum(v2) from t1 group by k1;
+
+insert into t1 values (4,1,1);
+
+-- first refresh mv2
+[UC]REFRESH MATERIALIZED VIEW mv2 WITH SYNC MODE;
+select count(1) from (
+    select k1, v1, v2 from mv1 where k1 = 1
+    union all
+    select k1, v1, v2 from t1 where k1 = 2
+    union all
+    select k1, v1, v2 from mv1 where k1 = 3
+    union all
+    select k1, v1, v2 from mv1 where k1 = 4
+) as t;
+
+function: print_hit_materialized_views("SELECT k1, count(v1), sum(v2) from t1 group by k1;")
+SELECT k1, count(v1), sum(v2) from t1 group by k1;
+
+-- then refresh mv1
+[UC]REFRESH MATERIALIZED VIEW mv1 WITH SYNC MODE;
+select count(1) from (
+    select k1, v1, v2 from mv1 where k1 = 1
+    union all
+    select k1, v1, v2 from t1 where k1 = 2
+    union all
+    select k1, v1, v2 from mv1 where k1 = 3
+    union all
+    select k1, v1, v2 from mv1 where k1 = 4
+) as t;
+function: print_hit_materialized_views("SELECT k1, count(v1), sum(v2) from t1 group by k1;")
+SELECT k1, count(v1), sum(v2) from t1 group by k1;
+
+drop materialized view mv1;
+drop materialized view mv2;
+drop table t1;  


### PR DESCRIPTION


## Why I'm doing:
This is an enhancement  and bugfix for PR: https://github.com/StarRocks/starrocks/pull/66216.

Before, to optimize query rewrite performance, we cache a query OptExpression and associated MV's compensate to avoid duplicated buildings.

But there may be bugs if the same table appears multi times in the query OptExpression with different partition predicates.


## What I'm doing:
- Use a `Map<OptExpression, MVCompensate>` to store different MVCompensate for different OptExpression.

NOTE: we use `QueryOptProfile` to determine a query OptExpression' profile for MV Compensate which we only consider ref base table and its partition infos.


Fixes https://github.com/StarRocks/StarRocksTest/issues/10706

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Cache MV compensation by QueryOptProfile to handle repeated tables with different partitions, update callers, refine related MV discovery, and add partial-refresh tests.
> 
> - **MV Compensation/Context**:
>   - Introduce `TableOptProfile` and `QueryOptProfile`; cache `MVCompensation` per `QueryOptProfile` in `MaterializationContext`.
>   - Replace single `mvCompensation` with `getOrInitMVCompensation(queryExpr)`, `getMvCompensation(queryExpr)`, and `isNoRewrite(queryExpr)`.
> - **Rewrite/Compensation Flow**:
>   - Update `MaterializedViewRewriter` and `MvPartitionCompensator` to fetch compensation using the current `queryExpression`.
>   - `buildMVScanOptExpression` now uses query-scoped compensation.
>   - Remove pre-initialization loop from `QueryOptimizer`.
> - **Compensation Builder**:
>   - Add `MVCompensationBuilder.buildQueryOptProfile` and helpers to collect selected partitions and partition predicates from OLAP/external scans.
> - **Utilities**:
>   - Change `MvUtils.getRelatedMvs` to deduplicate via `Map<MaterializedView,Integer>` and keep highest level.
> - **Logging/Output**:
>   - `OlapTableCompensation.toString()` prints limited partition names instead of IDs.
> - **Tests**:
>   - Add/adjust tests for Iceberg/Hive partial refresh with same tables and nested MV compensation; update expected plans accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5da9bd1bcddac3b8edabab6f44801cb9002358b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->