### PR TITLE
[BugFix] Forward runtime filter transmit options to receivers

### DIFF
--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -869,9 +869,13 @@ void RuntimeFilterWorker::receive_runtime_filter(const PTransmitRuntimeFilterPar
     }
     if (params.has_transmit_timeout_ms()) {
         ev.transmit_timeout_ms = params.transmit_timeout_ms();
+    } else {
+        ev.transmit_timeout_ms = config::send_rpc_runtime_filter_timeout_ms;
     }
     if (params.has_transmit_via_http_min_size()) {
         ev.transmit_via_http_min_size = params.transmit_via_http_min_size();
+    } else {
+        ev.transmit_via_http_min_size = config::send_runtime_filter_via_http_rpc_min_size;
     }
     ev.query_id.hi = params.query_id().hi();
     ev.query_id.lo = params.query_id().lo();

--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -181,6 +181,8 @@ void RuntimeFilterPort::publish_runtime_filters(const std::list<RuntimeFilterBui
 
         // rf metadata
         PTransmitRuntimeFilterParams params;
+        params.set_transmit_timeout_ms(timeout_ms);
+        params.set_transmit_via_http_min_size(rpc_http_min_size);
         prepare_params(params, state, rf_desc);
 
         // print before setting data, otherwise it's too big.
@@ -224,7 +226,19 @@ void RuntimeFilterPort::publish_skew_boradcast_join_key_columns(RuntimeFilterBui
 
     if (!need_sender_grf) return;
 
+    int timeout_ms = config::send_rpc_runtime_filter_timeout_ms;
+    if (state->query_options().__isset.runtime_filter_send_timeout_ms) {
+        timeout_ms = state->query_options().runtime_filter_send_timeout_ms;
+    }
+
+    int64_t rpc_http_min_size = config::send_runtime_filter_via_http_rpc_min_size;
+    if (state->query_options().__isset.runtime_filter_rpc_http_min_size) {
+        rpc_http_min_size = state->query_options().runtime_filter_rpc_http_min_size;
+    }
+
     PTransmitRuntimeFilterParams params;
+    params.set_transmit_timeout_ms(timeout_ms);
+    params.set_transmit_via_http_min_size(rpc_http_min_size);
     prepare_params(params, state, rf_desc);
 
     VLOG_FILE << "RuntimeFilterPort::publish_runtime_filters for skew join's boradcast site. join filter_id="
@@ -241,15 +255,6 @@ void RuntimeFilterPort::publish_skew_boradcast_join_key_columns(RuntimeFilterBui
     RETURN_IF(!actual_size.status().ok(), (void)nullptr);
     rf_data->resize(actual_size.value());
     *(params.mutable_columntype()) = type_desc.to_protobuf();
-    int timeout_ms = config::send_rpc_runtime_filter_timeout_ms;
-    if (state->query_options().__isset.runtime_filter_send_timeout_ms) {
-        timeout_ms = state->query_options().runtime_filter_send_timeout_ms;
-    }
-
-    int64_t rpc_http_min_size = config::send_runtime_filter_via_http_rpc_min_size;
-    if (state->query_options().__isset.runtime_filter_rpc_http_min_size) {
-        rpc_http_min_size = state->query_options().runtime_filter_rpc_http_min_size;
-    }
     state->exec_env()->runtime_filter_worker()->send_part_runtime_filter(std::move(params), rf_desc->merge_nodes(),
                                                                          timeout_ms, rpc_http_min_size,
                                                                          EventType::SEND_SKEW_JOIN_BROADCAST_RF);
@@ -618,6 +623,10 @@ void RuntimeFilterMerger::_send_total_runtime_filter(int rf_version, int32_t fil
         rpc_http_min_size = _query_options.runtime_filter_rpc_http_min_size;
     }
 
+    // we pass this options to the receiver, and receiver can use this option to forward rf to others.
+    request.set_transmit_timeout_ms(timeout_ms);
+    request.set_transmit_via_http_min_size(rpc_http_min_size);
+
     int64_t now = UnixMillis();
     status->broadcast_filter_ts = now;
 
@@ -857,6 +866,12 @@ void RuntimeFilterWorker::receive_runtime_filter(const PTransmitRuntimeFilterPar
     } else {
         _exec_env->add_rf_event({params.query_id(), params.filter_id(), "", "RECV_TOTAL_RF"});
         ev.type = RECEIVE_TOTAL_RF;
+    }
+    if (params.has_transmit_timeout_ms()) {
+        ev.transmit_timeout_ms = params.transmit_timeout_ms();
+    }
+    if (params.has_transmit_via_http_min_size()) {
+        ev.transmit_via_http_min_size = params.transmit_via_http_min_size();
     }
     ev.query_id.hi = params.query_id().hi();
     ev.query_id.lo = params.query_id().lo();

--- a/be/src/runtime/runtime_filter_worker.h
+++ b/be/src/runtime/runtime_filter_worker.h
@@ -198,8 +198,8 @@ struct RuntimeFilterWorkerEvent {
     // For SEND_PART_RF.
     std::vector<TNetworkAddress> transmit_addrs;
     std::vector<TRuntimeFilterDestination> destinations;
-    int transmit_timeout_ms;
-    int64_t transmit_via_http_min_size = 64L * 1024 * 1024;
+    int transmit_timeout_ms = config::send_rpc_runtime_filter_timeout_ms;
+    int64_t transmit_via_http_min_size = config::send_runtime_filter_via_http_rpc_min_size;
     // For SEND_PART_RF, RECEIVE_PART_RF, and RECEIVE_TOTAL_RF.
     PTransmitRuntimeFilterParams transmit_rf_request;
 };

--- a/be/src/runtime/runtime_filter_worker.h
+++ b/be/src/runtime/runtime_filter_worker.h
@@ -198,8 +198,8 @@ struct RuntimeFilterWorkerEvent {
     // For SEND_PART_RF.
     std::vector<TNetworkAddress> transmit_addrs;
     std::vector<TRuntimeFilterDestination> destinations;
-    int transmit_timeout_ms = config::send_rpc_runtime_filter_timeout_ms;
-    int64_t transmit_via_http_min_size = config::send_runtime_filter_via_http_rpc_min_size;
+    int transmit_timeout_ms;
+    int64_t transmit_via_http_min_size;
     // For SEND_PART_RF, RECEIVE_PART_RF, and RECEIVE_TOTAL_RF.
     PTransmitRuntimeFilterParams transmit_rf_request;
 };

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -135,6 +135,9 @@ message PTransmitRuntimeFilterParams {
     optional bool is_skew_broadcast_join = 12;
     optional PTypeDesc columnType = 13;
     optional int32 skew_shuffle_filter_id = 14;
+
+    optional int32 transmit_timeout_ms = 15;
+    optional int64 transmit_via_http_min_size = 16;
 };
 
 message PTransmitRuntimeFilterResult {


### PR DESCRIPTION
## Why I'm doing:

Runtime filter forwarding drops custom timeout and HTTP RPC size settings, so receivers fall back to defaults and may forward with inconsistent parameters.

## What I'm doing:

  - Adds transmit timeout and HTTP size threshold to PTransmitRuntimeFilterParams so sender settings survive forwarding.
  - Propagates these options when publishing skew broadcast runtime filters and when merging total filters.
  - Defaults worker event fields to config values and records received options for safer forwarding and observability.

Fixes #66393

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `transmit_timeout_ms` and `transmit_via_http_min_size` to runtime filter params and plumbs them through send/receive/forward paths to preserve sender settings.
> 
> - **Proto**:
>   - Add `optional int32 transmit_timeout_ms` and `optional int64 transmit_via_http_min_size` to `PTransmitRuntimeFilterParams`.
> - **Runtime filter send paths**:
>   - Set `params.set_transmit_timeout_ms(...)` and `params.set_transmit_via_http_min_size(...)` when publishing filters (normal and skew broadcast) in `runtime_filter_worker.cpp`.
>   - In `RuntimeFilterMerger::_send_total_runtime_filter`, include these fields in the broadcast `request`.
> - **Receive/forward paths**:
>   - In `RuntimeFilterWorker::receive_runtime_filter`, read the two fields (fallback to config if absent) and store in `RuntimeFilterWorkerEvent`.
>   - Use `ev.transmit_timeout_ms` and `ev.transmit_via_http_min_size` when forwarding/relaying/passthrough delivery and local receive (`_receive_total_runtime_filter`, `_deliver_*`).
> - **Event struct**:
>   - Update `RuntimeFilterWorkerEvent` (`runtime_filter_worker.h`): keep `int64_t transmit_via_http_min_size` (no inline default); ensure propagation throughout send cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c53cc01fe079c05ec2b18f84ce9fe70e791278b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->