### PR TITLE
[Refactor] Split heavy config machinery out of configbase.h

### DIFF
--- a/be/src/common/CMakeLists.txt
+++ b/be/src/common/CMakeLists.txt
@@ -21,6 +21,7 @@ ADD_BE_LIB(Common
   statusor.cpp
   logconfig.cpp
   configbase.cpp
+  config.cpp
   s3_uri.cpp
   tracer.cpp
   process_exit.cpp

--- a/be/src/common/config.cpp
+++ b/be/src/common/config.cpp
@@ -1,0 +1,19 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// clang-format off
+#include "common/configbase_impl.h" // Must precede config.h to turn CONF_* into definitions.
+// clang-format on
+
+#include "common/config.h"

--- a/be/src/common/configbase.cpp
+++ b/be/src/common/configbase.cpp
@@ -26,13 +26,9 @@
 #include <set>
 #include <string>
 
-#define __IN_CONFIGBASE_CPP__
-#include "common/config.h"
-#undef __IN_CONFIGBASE_CPP__
-
-#include <fmt/format.h>
-
+#include "common/configbase_impl.h"
 #include "common/status.h"
+#include "fmt/format.h"
 
 namespace starrocks::config {
 

--- a/be/src/common/configbase.h
+++ b/be/src/common/configbase.h
@@ -18,23 +18,15 @@
 #pragma once
 
 #include <butil/containers/doubly_buffered_data.h>
-#include <fmt/format.h>
 
-#include <iostream>
-#include <map>
-#include <set>
+#include <cstdint>
+#include <iosfwd>
+#include <ostream>
 #include <string>
+#include <utility>
 #include <vector>
 
-#ifdef __IN_CONFIGBASE_CPP__
-
-#include <cassert>
-#include <optional>
-
-#include "gutil/strings/join.h"
-#include "gutil/strings/split.h"
-#include "gutil/strings/strip.h"
-#endif
+#include "fmt/format.h"
 
 namespace starrocks {
 class Status;
@@ -105,199 +97,8 @@ inline std::ostream& operator<<(std::ostream& os, const MutableString& s) {
     return os << s.value();
 }
 
-#ifdef __IN_CONFIGBASE_CPP__
-bool strtox(const std::string& valstr, bool& retval);
-bool strtox(const std::string& valstr, int16_t& retval);
-bool strtox(const std::string& valstr, int32_t& retval);
-bool strtox(const std::string& valstr, int64_t& retval);
-bool strtox(const std::string& valstr, double& retval);
-bool strtox(const std::string& valstr, std::string& retval);
-bool strtox(const std::string& valstr, MutableString& retval);
-
-class Field {
-public:
-    explicit Field(const char* type, const char* name, void* storage, const char* defval, bool valmutable)
-            : _type(type), _name(name), _storage(storage), _defval(defval), _valmutable(valmutable) {
-        _s_field_map.insert(std::make_pair(std::string(_name), this));
-    }
-
-    virtual ~Field() = default;
-
-    // Disallow copy
-    Field(const Field&) = delete;
-    // Disallow assign
-    void operator=(const Field&) = delete;
-    // Disallow move ctor
-    Field(Field&&) = delete;
-    // Disallow move assign
-    void operator=(Field&&) = delete;
-
-    const char* type() const { return _type; }
-
-    const char* name() const { return _name; }
-
-    const char* defval() const { return _defval; }
-
-    bool valmutable() const { return _valmutable; }
-
-    bool set_value(std::string value);
-
-    bool rollback();
-
-    virtual std::string value() const = 0;
-
-    static void clear_fields() { _s_field_map.clear(); }
-
-    static std::map<std::string, Field*>& fields() { return _s_field_map; }
-
-    static std::optional<Field*> get(const std::string& name_or_alias);
-
-protected:
-    inline static std::map<std::string, Field*> _s_field_map{};
-
-    virtual bool parse_value(const std::string& value) = 0;
-
-    const char* _type;
-    const char* _name;
-    void* _storage;
-    const char* _defval;
-    bool _valmutable;
-    std::string _last_set_val;
-    std::string _current_set_val;
-};
-
-template <typename T, typename = void>
-class FieldImpl;
-
-template <typename T>
-class FieldImpl<T> : public Field {
-public:
-    FieldImpl(const char* type, const char* name, void* storage, const char* defval, bool valmutable)
-            : Field(type, name, storage, defval, valmutable) {}
-
-    std::string value() const override { return fmt::format("{}", *reinterpret_cast<T*>(_storage)); }
-
-    bool parse_value(const std::string& valstr) override { return strtox(valstr, *reinterpret_cast<T*>(_storage)); }
-};
-
-//// FieldImpl<std::vector<T>>
-template <typename T>
-class FieldImpl<std::vector<T>> : public Field {
-public:
-    FieldImpl(const char* type, const char* name, void* storage, const char* defval, bool valmutable)
-            : Field(type, name, storage, defval, valmutable) {}
-
-    std::string value() const override {
-        auto as_str = [](const T& v) { return fmt::format("{}", v); };
-        const auto& v = *reinterpret_cast<const std::vector<T>*>(_storage);
-        return JoinMapped(v, as_str, ",");
-    }
-
-    bool parse_value(const std::string& valstr) override {
-        std::vector<T> tmp;
-        std::vector<std::string> parts = strings::Split(valstr, ",");
-        for (auto& part : parts) {
-            T v;
-            StripWhiteSpace(&part);
-            if (part.empty()) {
-                continue;
-            }
-            if (!strtox(part, v)) {
-                return false;
-            }
-            tmp.emplace_back(std::move(v));
-        }
-        auto& value = *reinterpret_cast<std::vector<T>*>(_storage);
-        value.swap(tmp);
-        return true;
-    }
-};
-
-class Alias {
-public:
-    explicit Alias(const char* alias, Field* field) {
-        assert(strcmp(field->name(), alias) != 0);
-        [[maybe_unused]] auto [_, ok] = Field::fields().emplace(std::string(alias), field);
-        if (!ok) {
-            std::cerr << fmt::format("The alias name '{}' for config '{}' already used, please choose another one\n",
-                                     alias, field->name());
-            std::abort();
-        }
-    }
-};
-
-template <typename T>
-class EnumField : public FieldImpl<T> {
-    using Base = FieldImpl<T>;
-
-public:
-    EnumField(const char* type, const char* name, void* storage, const char* defval, bool valmutable,
-              std::string enums_)
-            : FieldImpl<T>(type, name, storage, defval, valmutable), raw_enum_values(std::move(enums_)) {}
-
-    bool parse_value(const std::string& valstr) override {
-        if (enums.empty()) {
-            std::vector<std::string> parts = strings::Split(raw_enum_values, ",");
-            for (auto& part : parts) {
-                StripWhiteSpace(&part);
-                if (!Base::parse_value(part)) {
-                    return false;
-                }
-                auto v = *reinterpret_cast<T*>(Field::_storage);
-                enums.emplace(std::move(v));
-            }
-        }
-        if (!Base::parse_value(valstr)) {
-            return false;
-        }
-        auto value = *reinterpret_cast<T*>(Field::_storage);
-        return enums.find(value) != enums.end();
-    }
-
-private:
-    std::set<T> enums;
-    std::string raw_enum_values;
-};
-
-#endif // __IN_CONFIGBASE_CPP__
-
-#define DEFINE_FIELD(FIELD_TYPE, FIELD_NAME, FIELD_DEFAULT, VALMUTABLE, TYPE_NAME) \
-    FIELD_TYPE FIELD_NAME;                                                         \
-    static FieldImpl<FIELD_TYPE> field_##FIELD_NAME(TYPE_NAME, #FIELD_NAME, &FIELD_NAME, FIELD_DEFAULT, VALMUTABLE);
-
-#define DEFINE_ALIAS(REAL_NAME, ALIAS_NAME) static Alias alias_##ALIAS_NAME(#ALIAS_NAME, &(field_##REAL_NAME));
-
 #define DECLARE_FIELD(FIELD_TYPE, FIELD_NAME) extern FIELD_TYPE FIELD_NAME;
 
-#define DEFINE_ENUM_FIELD(FIELD_TYPE, FIELD_NAME, FIELD_DEFAULT, VALMUTABLE, TYPE_NAME, ENUM_SET)                   \
-    FIELD_TYPE FIELD_NAME;                                                                                          \
-    static EnumField<FIELD_TYPE> field_##FIELD_NAME(TYPE_NAME, #FIELD_NAME, &FIELD_NAME, FIELD_DEFAULT, VALMUTABLE, \
-                                                    ENUM_SET);
-
-#ifdef __IN_CONFIGBASE_CPP__
-// NOTE: alias configs must be defined after the true config, otherwise there will be a compile error
-#define CONF_Alias(name, alias) DEFINE_ALIAS(name, alias)
-#define CONF_Bool(name, defaultstr) DEFINE_FIELD(bool, name, defaultstr, false, "bool")
-#define CONF_Int16(name, defaultstr) DEFINE_FIELD(int16_t, name, defaultstr, false, "int16")
-#define CONF_Int32(name, defaultstr) DEFINE_FIELD(int32_t, name, defaultstr, false, "int32")
-#define CONF_Int64(name, defaultstr) DEFINE_FIELD(int64_t, name, defaultstr, false, "int64")
-#define CONF_Double(name, defaultstr) DEFINE_FIELD(double, name, defaultstr, false, "double")
-#define CONF_String(name, defaultstr) DEFINE_FIELD(std::string, name, defaultstr, false, "string")
-#define CONF_String_enum(name, defaultstr, enums) \
-    DEFINE_ENUM_FIELD(std::string, name, defaultstr, false, "string", enums)
-#define CONF_Bools(name, defaultstr) DEFINE_FIELD(std::vector<bool>, name, defaultstr, false, "list<bool>")
-#define CONF_Int16s(name, defaultstr) DEFINE_FIELD(std::vector<int16_t>, name, defaultstr, false, "list<int16>")
-#define CONF_Int32s(name, defaultstr) DEFINE_FIELD(std::vector<int32_t>, name, defaultstr, false, "list<int32>")
-#define CONF_Int64s(name, defaultstr) DEFINE_FIELD(std::vector<int64_t>, name, defaultstr, false, "list<int64>")
-#define CONF_Doubles(name, defaultstr) DEFINE_FIELD(std::vector<double>, name, defaultstr, false, "list<double>")
-#define CONF_Strings(name, defaultstr) DEFINE_FIELD(std::vector<std::string>, name, defaultstr, false, "list<string>")
-#define CONF_mBool(name, defaultstr) DEFINE_FIELD(bool, name, defaultstr, true, "bool")
-#define CONF_mInt16(name, defaultstr) DEFINE_FIELD(int16_t, name, defaultstr, true, "int16")
-#define CONF_mInt32(name, defaultstr) DEFINE_FIELD(int32_t, name, defaultstr, true, "int32")
-#define CONF_mInt64(name, defaultstr) DEFINE_FIELD(int64_t, name, defaultstr, true, "int64")
-#define CONF_mDouble(name, defaultstr) DEFINE_FIELD(double, name, defaultstr, true, "double")
-#define CONF_mString(name, defaultstr) DEFINE_FIELD(MutableString, name, defaultstr, true, "string")
-#else
 // NOTE: alias configs must be defined after the true config, otherwise there will be a compile error
 #define CONF_Alias(name, alias)
 #define CONF_Bool(name, defaultstr) DECLARE_FIELD(bool, name)
@@ -319,7 +120,6 @@ private:
 #define CONF_mInt64(name, defaultstr) DECLARE_FIELD(int64_t, name)
 #define CONF_mDouble(name, defaultstr) DECLARE_FIELD(double, name)
 #define CONF_mString(name, defaultstr) DECLARE_FIELD(MutableString, name)
-#endif
 
 // Initialize configurations from a config file.
 bool init(const char* filename);

--- a/be/src/common/configbase_impl.h
+++ b/be/src/common/configbase_impl.h
@@ -1,0 +1,236 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// NOTE:
+// Implementation detail for config field definitions.
+// Only include this header from .cpp files (before including config.h)
+// when the translation unit must instantiate the CONF_* entries.
+
+// clang-format off
+#include "common/configbase.h"
+// clang-format on
+
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <map>
+#include <optional>
+#include <set>
+
+#include "gutil/strings/join.h"
+#include "gutil/strings/split.h"
+#include "gutil/strings/strip.h"
+
+namespace starrocks::config {
+
+bool strtox(const std::string& valstr, bool& retval);
+bool strtox(const std::string& valstr, int16_t& retval);
+bool strtox(const std::string& valstr, int32_t& retval);
+bool strtox(const std::string& valstr, int64_t& retval);
+bool strtox(const std::string& valstr, double& retval);
+bool strtox(const std::string& valstr, std::string& retval);
+bool strtox(const std::string& valstr, MutableString& retval);
+
+class Field {
+public:
+    explicit Field(const char* type, const char* name, void* storage, const char* defval, bool valmutable)
+            : _type(type), _name(name), _storage(storage), _defval(defval), _valmutable(valmutable) {
+        _s_field_map.insert(std::make_pair(std::string(_name), this));
+    }
+
+    virtual ~Field() = default;
+
+    Field(const Field&) = delete;
+    void operator=(const Field&) = delete;
+    Field(Field&&) = delete;
+    void operator=(Field&&) = delete;
+
+    const char* type() const { return _type; }
+    const char* name() const { return _name; }
+    const char* defval() const { return _defval; }
+    bool valmutable() const { return _valmutable; }
+
+    bool set_value(std::string value);
+    bool rollback();
+    virtual std::string value() const = 0;
+
+    static void clear_fields() { _s_field_map.clear(); }
+    static std::map<std::string, Field*>& fields() { return _s_field_map; }
+    static std::optional<Field*> get(const std::string& name_or_alias);
+
+protected:
+    inline static std::map<std::string, Field*> _s_field_map{};
+
+    virtual bool parse_value(const std::string& value) = 0;
+
+    const char* _type;
+    const char* _name;
+    void* _storage;
+    const char* _defval;
+    bool _valmutable;
+    std::string _last_set_val;
+    std::string _current_set_val;
+};
+
+template <typename T, typename = void>
+class FieldImpl;
+
+template <typename T>
+class FieldImpl<T> : public Field {
+public:
+    FieldImpl(const char* type, const char* name, void* storage, const char* defval, bool valmutable)
+            : Field(type, name, storage, defval, valmutable) {}
+
+    std::string value() const override { return fmt::format("{}", *reinterpret_cast<T*>(_storage)); }
+
+    bool parse_value(const std::string& valstr) override { return strtox(valstr, *reinterpret_cast<T*>(_storage)); }
+};
+
+template <typename T>
+class FieldImpl<std::vector<T>> : public Field {
+public:
+    FieldImpl(const char* type, const char* name, void* storage, const char* defval, bool valmutable)
+            : Field(type, name, storage, defval, valmutable) {}
+
+    std::string value() const override {
+        auto as_str = [](const T& v) { return fmt::format("{}", v); };
+        const auto& v = *reinterpret_cast<const std::vector<T>*>(_storage);
+        return JoinMapped(v, as_str, ",");
+    }
+
+    bool parse_value(const std::string& valstr) override {
+        std::vector<T> tmp;
+        std::vector<std::string> parts = strings::Split(valstr, ",");
+        for (auto& part : parts) {
+            T v;
+            StripWhiteSpace(&part);
+            if (part.empty()) {
+                continue;
+            }
+            if (!strtox(part, v)) {
+                return false;
+            }
+            tmp.emplace_back(std::move(v));
+        }
+        auto& value = *reinterpret_cast<std::vector<T>*>(_storage);
+        value.swap(tmp);
+        return true;
+    }
+};
+
+class Alias {
+public:
+    explicit Alias(const char* alias, Field* field) {
+        assert(strcmp(field->name(), alias) != 0);
+        [[maybe_unused]] auto [_, ok] = Field::fields().emplace(std::string(alias), field);
+        if (!ok) {
+            std::cerr << fmt::format("The alias name '{}' for config '{}' already used, please choose another one\n",
+                                     alias, field->name());
+            std::abort();
+        }
+    }
+};
+
+template <typename T>
+class EnumField : public FieldImpl<T> {
+    using Base = FieldImpl<T>;
+
+public:
+    EnumField(const char* type, const char* name, void* storage, const char* defval, bool valmutable,
+              std::string enums_)
+            : FieldImpl<T>(type, name, storage, defval, valmutable), raw_enum_values(std::move(enums_)) {}
+
+    bool parse_value(const std::string& valstr) override {
+        if (enums.empty()) {
+            std::vector<std::string> parts = strings::Split(raw_enum_values, ",");
+            for (auto& part : parts) {
+                StripWhiteSpace(&part);
+                if (!Base::parse_value(part)) {
+                    return false;
+                }
+                auto v = *reinterpret_cast<T*>(Field::_storage);
+                enums.emplace(std::move(v));
+            }
+        }
+        if (!Base::parse_value(valstr)) {
+            return false;
+        }
+        auto value = *reinterpret_cast<T*>(Field::_storage);
+        return enums.find(value) != enums.end();
+    }
+
+private:
+    std::set<T> enums;
+    std::string raw_enum_values;
+};
+
+#define DEFINE_FIELD(FIELD_TYPE, FIELD_NAME, FIELD_DEFAULT, VALMUTABLE, TYPE_NAME) \
+    FIELD_TYPE FIELD_NAME;                                                         \
+    static FieldImpl<FIELD_TYPE> field_##FIELD_NAME(TYPE_NAME, #FIELD_NAME, &FIELD_NAME, FIELD_DEFAULT, VALMUTABLE);
+
+#define DEFINE_ENUM_FIELD(FIELD_TYPE, FIELD_NAME, FIELD_DEFAULT, VALMUTABLE, TYPE_NAME, ENUM_SET)                   \
+    FIELD_TYPE FIELD_NAME;                                                                                          \
+    static EnumField<FIELD_TYPE> field_##FIELD_NAME(TYPE_NAME, #FIELD_NAME, &FIELD_NAME, FIELD_DEFAULT, VALMUTABLE, \
+                                                    ENUM_SET);
+
+#define DEFINE_ALIAS(REAL_NAME, ALIAS_NAME) static Alias alias_##ALIAS_NAME(#ALIAS_NAME, &(field_##REAL_NAME));
+
+#undef CONF_Alias
+#undef CONF_Bool
+#undef CONF_Int16
+#undef CONF_Int32
+#undef CONF_Int64
+#undef CONF_Double
+#undef CONF_String
+#undef CONF_String_enum
+#undef CONF_Bools
+#undef CONF_Int16s
+#undef CONF_Int32s
+#undef CONF_Int64s
+#undef CONF_Doubles
+#undef CONF_Strings
+#undef CONF_mBool
+#undef CONF_mInt16
+#undef CONF_mInt32
+#undef CONF_mInt64
+#undef CONF_mDouble
+#undef CONF_mString
+
+// NOTE: alias configs must be defined after the true config, otherwise there will be a compile error
+#define CONF_Alias(name, alias) DEFINE_ALIAS(name, alias)
+#define CONF_Bool(name, defaultstr) DEFINE_FIELD(bool, name, defaultstr, false, "bool")
+#define CONF_Int16(name, defaultstr) DEFINE_FIELD(int16_t, name, defaultstr, false, "int16")
+#define CONF_Int32(name, defaultstr) DEFINE_FIELD(int32_t, name, defaultstr, false, "int32")
+#define CONF_Int64(name, defaultstr) DEFINE_FIELD(int64_t, name, defaultstr, false, "int64")
+#define CONF_Double(name, defaultstr) DEFINE_FIELD(double, name, defaultstr, false, "double")
+#define CONF_String(name, defaultstr) DEFINE_FIELD(std::string, name, defaultstr, false, "string")
+#define CONF_String_enum(name, defaultstr, enums) \
+    DEFINE_ENUM_FIELD(std::string, name, defaultstr, false, "string", enums)
+#define CONF_Bools(name, defaultstr) DEFINE_FIELD(std::vector<bool>, name, defaultstr, false, "list<bool>")
+#define CONF_Int16s(name, defaultstr) DEFINE_FIELD(std::vector<int16_t>, name, defaultstr, false, "list<int16>")
+#define CONF_Int32s(name, defaultstr) DEFINE_FIELD(std::vector<int32_t>, name, defaultstr, false, "list<int32>")
+#define CONF_Int64s(name, defaultstr) DEFINE_FIELD(std::vector<int64_t>, name, defaultstr, false, "list<int64>")
+#define CONF_Doubles(name, defaultstr) DEFINE_FIELD(std::vector<double>, name, defaultstr, false, "list<double>")
+#define CONF_Strings(name, defaultstr) DEFINE_FIELD(std::vector<std::string>, name, defaultstr, false, "list<string>")
+#define CONF_mBool(name, defaultstr) DEFINE_FIELD(bool, name, defaultstr, true, "bool")
+#define CONF_mInt16(name, defaultstr) DEFINE_FIELD(int16_t, name, defaultstr, true, "int16")
+#define CONF_mInt32(name, defaultstr) DEFINE_FIELD(int32_t, name, defaultstr, true, "int32")
+#define CONF_mInt64(name, defaultstr) DEFINE_FIELD(int64_t, name, defaultstr, true, "int64")
+#define CONF_mDouble(name, defaultstr) DEFINE_FIELD(double, name, defaultstr, true, "double")
+#define CONF_mString(name, defaultstr) DEFINE_FIELD(MutableString, name, defaultstr, true, "string")
+
+} // namespace starrocks::config

--- a/be/test/common/config_test.cpp
+++ b/be/test/common/config_test.cpp
@@ -15,9 +15,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#define __IN_CONFIGBASE_CPP__
-#include "common/configbase.h"
-#undef __IN_CONFIGBASE_CPP__
+// clang-format off
+#include "common/configbase_impl.h"
+// clang-format on
 
 #include <gmock/gmock.h> // EXPECT_THAT, ElementsAre
 #include <gtest/gtest.h>


### PR DESCRIPTION
* Add common/configbase_impl.h to host Field/Enum/Alias definitions, strtox helpers, and the defining versions of the CONF_* macros so configbase.h stays lightweight for most includes.
* remove the __IN_CONFIGBASE_CPP__ backdoor implementation

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extract config field machinery into `configbase_impl.h`, add `config.cpp`, and update includes/build to remove the `__IN_CONFIGBASE_CPP__` hack without changing behavior.
> 
> - **Refactor config system**:
>   - Introduce `common/configbase_impl.h` to host `Field`/`EnumField`/`Alias`, `strtox` helpers, and defining versions of `CONF_*` macros.
>   - Add `common/config.cpp` that includes `configbase_impl.h` before `config.h` to instantiate config fields.
> - **Header cleanup**:
>   - Slim down `common/configbase.h` to declarations and declaring `CONF_*` macros only; move implementations out.
>   - Replace `__IN_CONFIGBASE_CPP__` mechanism with direct inclusion of `configbase_impl.h` in `configbase.cpp` and tests.
>   - Adjust includes and minor types/forward declarations for lighter dependencies.
> - **Build**:
>   - Add `config.cpp` to `Common` target in `be/src/common/CMakeLists.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bad57d8a058a6ee542b6a07061357cdcd0ac30ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->