### PR TITLE
fix the compile error on mac m1

### DIFF
--- a/be/src/gen_cpp/CMakeLists.txt
+++ b/be/src/gen_cpp/CMakeLists.txt
@@ -15,6 +15,16 @@
 set(LIBRARY_OUTPUT_PATH "${BUILD_DIR}/src/gen_cpp")
 
 set (GEN_CPP_DIR ${GENSRC_DIR}/gen_cpp)
+
+# On macOS we bundle pre-generated thrift sources under src/gen_cpp because
+# the gensrc makefiles depend on Linux-only toolchains. When those generated
+# sources are unavailable in ${GENSRC_DIR}/gen_cpp fall back to the checked-in
+# copies so that the build can still link the thrift definitions.
+if (NOT EXISTS "${GEN_CPP_DIR}/AgentService_types.cpp")
+    message(WARNING "Generated thrift sources not found in ${GEN_CPP_DIR}; "
+                    "falling back to ${SRC_DIR}/gen_cpp")
+    set(GEN_CPP_DIR "${SRC_DIR}/gen_cpp")
+endif()
 set(SRC_FILES
     ${SRC_DIR}/gen_cpp/thrift_types_customize_impl.cpp
     ${GEN_CPP_DIR}/AgentService_types.cpp

--- a/be/src/gen_cpp/common/env_config.h
+++ b/be/src/gen_cpp/common/env_config.h
@@ -1,0 +1,24 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+namespace starrocks {
+
+/* #undef HAVE_SCHED_GETCPU */
+
+}

--- a/be/src/util/raw_container.h
+++ b/be/src/util/raw_container.h
@@ -128,7 +128,9 @@ public:
 };
 
 // see details about ABI compatibility issue https://github.com/StarRocks/starrocks/issues/233
-#if _GLIBCXX_USE_CXX11_ABI
+// For libc++ (macOS) `_GLIBCXX_USE_CXX11_ABI` is undefined, but the optimized RawString is still safe.
+// Only guard against the legacy libstdc++ ABI where the macro exists and is 0.
+#if !defined(_GLIBCXX_USE_CXX11_ABI) || _GLIBCXX_USE_CXX11_ABI
 using RawString = std::basic_string<char, std::char_traits<char>, RawAllocator<char, 0>>;
 using RawStringPad16 = std::basic_string<char, std::char_traits<char>, RawAllocator<char, 16>>;
 #else

--- a/build-mac/CMakeLists.txt
+++ b/build-mac/CMakeLists.txt
@@ -101,8 +101,32 @@ set(STARROCKS_THIRDPARTY "$ENV{STARROCKS_THIRDPARTY}")
 set(SRC_DIR "${BASE_DIR}/src")
 set(GENSRC_DIR "${SRC_DIR}/gen_cpp/build")
 set(GENCODE_DIR "${GENSRC_DIR}/gen_cpp")
+set(GEN_THRIFT_SENTINEL "${GENCODE_DIR}/AgentService_types.cpp")
+
+# On macOS we copy pre-generated thrift/protobuf sources into be/src/gen_cpp.
+# When gensrc/build is unavailable (common outside Linux), fall back to the
+# checked-in copies so the linker still sees the thrift symbol definitions.
+if(NOT EXISTS "${GENCODE_DIR}")
+    message(WARNING "Generated C++ sources directory not found at ${GENCODE_DIR}; "
+                    "falling back to ${SRC_DIR}/gen_cpp")
+    set(GENSRC_DIR "${SRC_DIR}/gen_cpp")
+    set(GENCODE_DIR "${GENSRC_DIR}")
+    set(GEN_THRIFT_SENTINEL "${GENCODE_DIR}/AgentService_types.cpp")
+elseif(NOT EXISTS "${GEN_THRIFT_SENTINEL}")
+    message(WARNING "Generated thrift outputs missing in ${GENCODE_DIR}; "
+                    "falling back to ${SRC_DIR}/gen_cpp")
+    set(GENSRC_DIR "${SRC_DIR}/gen_cpp")
+    set(GENCODE_DIR "${GENSRC_DIR}")
+    set(GEN_THRIFT_SENTINEL "${GENCODE_DIR}/AgentService_types.cpp")
+endif()
+
 if(NOT EXISTS "${GENCODE_DIR}")
     message(FATAL_ERROR "Generated C++ sources directory not found: ${GENCODE_DIR}")
+endif()
+
+if(NOT EXISTS "${GEN_THRIFT_SENTINEL}")
+    message(FATAL_ERROR "Unable to locate thrift sources (expected ${GEN_THRIFT_SENTINEL}). "
+                        "Please run gensrc build or sync pre-generated files.")
 endif()
 set(TEST_DIR "${CMAKE_SOURCE_DIR}/test/")
 set(OUTPUT_DIR "${BASE_DIR}/output")


### PR DESCRIPTION
## Why I'm doing:

when I compile the main branch, it occurs some errors.

## What I'm doing:

Please review if the fix is reasonable.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes macOS ARM64 build by falling back to pre-generated thrift/protobuf sources when gensrc is missing and enforcing system binutils across third-party builds; also relaxes RawString ABI guard for libc++.
> 
> - **Build (macOS)**
>   - Fallback to checked-in generated sources when `${GENSRC_DIR}/gen_cpp` or `AgentService_types.cpp` is missing in `be/src/gen_cpp/CMakeLists.txt` and `build-mac/CMakeLists.txt`, with warnings and hard errors if still absent.
>   - Add sentinel checks for thrift outputs and ensure generated dirs exist before proceeding.
> - **Third-party build script (`build-mac/build_thirdparty.sh`)**
>   - Force macOS system binutils (`/usr/bin/ar`, `ranlib`, `strip`) via env and `cmake_toolchain_args`; pass these to all CMake-based builds (gflags, glog, brpc, rocksdb, velocypack, vectorscan, simdutf, fmt, roaring, etc.).
>   - Patch Boost build to use a custom clang toolset and system binutils; adjust `b2` invocation accordingly.
>   - Use system binutils when injecting libc++ `__hash_memory` shims into archives (protobuf, vectorscan, roaring).
> - **C++ source tweaks**
>   - Add `be/src/gen_cpp/common/env_config.h` (generated config stub).
>   - Update `be/src/util/raw_container.h` to allow `RawString` optimization under libc++ by guarding only against legacy libstdc++ ABI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba5b8e5f8b1ea30a4930fb87266154ffd51241b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->