### PR TITLE
[Feature] Enable external catalog discovery for MySQL-compatible clients

### DIFF
--- a/be/src/exec/schema_scanner/schema_schemata_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_schemata_scanner.cpp
@@ -68,8 +68,12 @@ Status SchemaSchemataScanner::fill_chunk(ChunkPtr* chunk) {
             // catalog
             {
                 ColumnPtr column = (*chunk)->get_column_by_slot_id(1);
-                const char* str = "def";
-                Slice value(str, strlen(str));
+                // Use actual catalog name from response if available, otherwise fallback to "def"
+                std::string catalog_name = "def";
+                if (_db_result.__isset.catalogs && _db_index < _db_result.catalogs.size()) {
+                    catalog_name = _db_result.catalogs[_db_index];
+                }
+                Slice value(catalog_name.c_str(), catalog_name.length());
                 fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&value);
             }
             break;

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3614,6 +3614,28 @@ public class Config extends ConfigBase {
     public static boolean enable_show_external_catalog_privilege = true;
 
     /**
+     * When enabled, allows MySQL-compatible tools (DBeaver, Metabase, DataGrip) to discover
+     * and connect to external catalogs via the MySQL protocol.
+     *
+     * Features enabled:
+     * 1. Connect with catalog name in database field: MySQL clients can enter an external
+     *    catalog name (e.g., "hive_catalog") in the "database" connection field to connect
+     *    directly to that catalog and browse its databases.
+     * 2. Cross-catalog SHOW DATABASES: When connected to the internal catalog without
+     *    specifying a database, SHOW DATABASES returns databases from ALL catalogs
+     *    in "catalog.database" format.
+     *
+     * IMPORTANT: If an external catalog has the same name as a database in the internal
+     * catalog (default_catalog), the database takes precedence. For example, if both
+     * exist: external catalog "sales" and internal database "sales", connecting with
+     * database="sales" will use the internal database, not switch to the catalog.
+     * To avoid confusion, ensure external catalog names don't conflict with internal
+     * database names when using this feature.
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_cross_catalog_database_list = false;
+
+    /**
      * Loading or compaction must be stopped for primary_key_disk_schedule_time
      * seconds before it can be scheduled
      */

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -49,6 +49,7 @@ import com.starrocks.authorization.PrivilegeException;
 import com.starrocks.authorization.PrivilegeType;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.cluster.ClusterNamespace;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
@@ -1461,7 +1462,33 @@ public class ConnectContext {
             ErrorReport.reportDdlException(ErrorCode.ERR_BAD_CATALOG_AND_DB_ERROR, identifier);
         }
 
-        if (parts.length == 1) { // use database
+        if (parts.length == 1) { // use database OR catalog (when feature enabled)
+            // When enable_cross_catalog_database_list is enabled, check if identifier is a catalog name.
+            // This allows MySQL clients (DBeaver, Metabase, etc.) to connect with a catalog name 
+            // in the database field, enabling them to browse external catalogs.
+            //
+            // Priority: Database takes precedence over catalog. If a database with this name exists
+            // in the current catalog, it will be used as a database (normal behavior). Only if no
+            // such database exists AND the name matches an external catalog, we switch to that catalog.
+            if (Config.enable_cross_catalog_database_list) {
+                String normalizedName = normalizeName(identifier);
+                // Check: is this an external catalog name AND NOT a database in current catalog?
+                if (catalogMgr.catalogExists(normalizedName) && 
+                    !CatalogMgr.isInternalCatalog(normalizedName) &&
+                    metadataMgr.getDb(this, this.getCurrentCatalog(), normalizedName) == null) {
+                    // It's an external catalog name - switch to it
+                    try {
+                        Authorizer.checkAnyActionOnCatalog(this, normalizedName);
+                    } catch (AccessDeniedException e) {
+                        AccessDeniedException.reportAccessDenied(normalizedName,
+                                this.getCurrentUserIdentity(), this.getCurrentRoleIds(),
+                                PrivilegeType.ANY.name(), ObjectType.CATALOG.name(), normalizedName);
+                    }
+                    this.setCurrentCatalog(normalizedName);
+                    // Don't set a specific database - let user see all databases in this catalog
+                    return;
+                }
+            }
             dbName = identifier;
         } else { // use catalog.database
             String newCatalogName = normalizeName(parts[0]);

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -569,7 +569,12 @@ public class InformationSchemaDataSource {
                     // refer to https://dev.mysql.com/doc/refman/8.0/en/information-schema-tables-table.html
                     // the catalog name is always `def`
                     info.setTable_catalog(DEF);
-                    info.setTable_schema(dbName);
+                    // When cross-catalog discovery is enabled, return catalog.database format
+                    if (Config.enable_cross_catalog_database_list) {
+                        info.setTable_schema(catalogName + "." + dbName);
+                    } else {
+                        info.setTable_schema(dbName);
+                    }
                     info.setTable_name(table.getName());
                     info.setTable_type(table.getMysqlType());
                     info.setEngine(table.getEngine());

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -338,6 +338,9 @@ struct TGetDbsParams {
 // getDbNames returns a list of database names
 struct TGetDbsResult {
   1: list<string> dbs
+  // Optional parallel list: catalogs[i] is the catalog name for dbs[i]
+  // Used when enable_cross_catalog_database_list is enabled
+  2: optional list<string> catalogs
 }
 
 // Arguments to getTableNames, which returns a list of tables that match an


### PR DESCRIPTION
## Changes:

Add opt-in feature (enable_cross_catalog_database_list) that allows MySQL clients like DBeaver, Metabase, DataGrip etc to discover databases across external catalogs (Hive, Polaris, etc.).

Key features:
- Connect with catalog name in database field to browse that catalog
- SHOW DATABASES from default_catalog shows all catalogs in catalog.db format
- information_schema tables work with catalog.database format

IMPORTANT: If an external catalog has the same name as a database in the internal catalog, the database takes precedence. Ensure external catalog names don't conflict with internal database names when using this feature.

All changes gated behind enable_cross_catalog_database_list (default: false) for full backwards compatibility.

## What I'm doing:

Fixes #40287

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.