### PR TITLE
[Enhancement] enhance Dump API for prevent DoS attacks

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/meta/OperationRateLimiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/meta/OperationRateLimiter.java
@@ -1,0 +1,57 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.meta;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class OperationRateLimiter {
+    private final long minIntervalMs;
+    private final AtomicBoolean isRunning = new AtomicBoolean(false);
+    private final AtomicLong lastOperationTime = new AtomicLong(0);
+
+    public OperationRateLimiter(long minIntervalMs) {
+        this.minIntervalMs = minIntervalMs;
+    }
+
+    public long getRemainingCooldownSeconds() {
+        long elapsed = System.currentTimeMillis() - lastOperationTime.get();
+        if (elapsed < minIntervalMs) {
+            return (minIntervalMs - elapsed) / 1000;
+        }
+        return 0;
+    }
+
+    public boolean isInCooldown() {
+        return getRemainingCooldownSeconds() > 0;
+    }
+
+    public boolean tryAcquire() {
+        if (isInCooldown()) {
+            return false;
+        }
+        return isRunning.compareAndSet(false, true);
+    }
+
+    public void release() {
+        lastOperationTime.set(System.currentTimeMillis());
+        isRunning.set(false);
+    }
+
+    public boolean isRunning() {
+        return isRunning.get();
+    }
+}
+


### PR DESCRIPTION
## Why I'm doing:
The /dump and /dump_starmgr endpoints might vulnerable to DoS attacks. These endpoints execute heavy operations that lock all databases and write image files to disk. Without protection, an attacker (even with valid admin credentials) could overwhelm the system by repeatedly calling these endpoints.
## What I'm doing:
Rate Limiting - Enforces a 60-second minimum interval between requests. Subsequent requests within this window are rejected with HTTP 429 TOO_MANY_REQUESTS.
Concurrent Execution Preventation - Uses AtomicBoolean to ensure only one dump operation runs at a time. If a dump is already in progress, new requests are rejected immediately
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add rate limiting and single-operation guard to `/dump` and `/dump_starmgr`, returning 429 on frequent or concurrent requests.
> 
> - **HTTP meta**:
>   - **New utility**: Add `OperationRateLimiter` to control operation frequency and concurrency.
>   - **Endpoints**:
>     - `GET /dump` and `GET /dump_starmgr`:
>       - Enforce 60s cooldown via `RATE_LIMITER`; respond with `429` when requests are too frequent.
>       - Block concurrent executions; reject if another dump is running with `429`.
>       - Adjust response flow (early returns, explicit status codes) and ensure `writeResponse` is called appropriately.
>     - `GET /dump_starmgr`: early return for unsupported run mode before proceeding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 927cc6a62f49606f8cc96ff61ef13f44e6662490. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->