### PR TITLE
[BugFix] Fix memory leak in CachingIcebergCatalog cache invalidation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -449,11 +449,13 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         tables.invalidate(new IcebergTableCacheKey(key, new ConnectContext()));
         // will invalidate all snapshots of this table
         partitionCache.invalidate(key);
-        Set<String> paths = metaFileCacheMap.get(key);
+        tableLatestAccessTime.remove(key);
+        tableLatestRefreshTime.remove(key);
+
+        Set<String> paths = metaFileCacheMap.remove(key);
         if (paths != null && !paths.isEmpty()) {
             dataFileCache.invalidateAll(paths);
             deleteFileCache.invalidateAll(paths);
-            paths.clear();
         }
     }
 


### PR DESCRIPTION
## Changes:
Clean up tableLatestAccessTime and tableLatestRefreshTime maps when invalidating cache entries to prevent unbounded growth. Also use atomic remove instead of get+clear for metaFileCacheMap cleanup.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Invalidate table cache now also removes latest access/refresh entries and atomically removes `metaFileCacheMap` paths to prevent memory growth.
> 
> - **Caching/Invalidation in `CachingIcebergCatalog`**:
>   - Remove `tableLatestAccessTime` and `tableLatestRefreshTime` entries when invalidating a table (`invalidateCache`).
>   - Replace `metaFileCacheMap.get(key)` with atomic `metaFileCacheMap.remove(key)`; drop `paths.clear()`.
>   - Continue to invalidate `dataFileCache` and `deleteFileCache` for the removed `paths`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cfaa884ab497d495d4aee007da4482dc6930b1a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->