### PR TITLE
[UT] PseudoFrontend retries when query port conflict

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeService.java
@@ -58,5 +58,15 @@ public class QeService {
         }
         LOG.info("QE service start.");
     }
+
+    public boolean tryStart() {
+        if (mysqlServer.start()) {
+            LOG.info("QE service started.");
+            return true;
+        } else {
+            LOG.error("mysql server start failed");
+            return false;
+        }
+    }
 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoFrontendFailTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoFrontendFailTest.java
@@ -1,0 +1,66 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.pseudocluster;
+
+import com.starrocks.mysql.MysqlServer;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Invocation;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Separate the failure test from PseudoFrontendTest to avoid interference with other tests
+ */
+public class PseudoFrontendFailTest {
+    @AfterAll
+    public static void tearDown() {
+        PseudoCluster instance = PseudoCluster.getInstance();
+        if (instance != null) {
+            instance.shutdown();
+        }
+    }
+
+    @Test
+    public void testQueryPortConflictAutoRetryFailWithMaxAttempts() throws Exception {
+        // NOTE: max attempts set to 3 inside PseudoFrontend
+        AtomicInteger mockFails = new AtomicInteger(3);
+        new MockUp<MysqlServer>() {
+            @Mock
+            public boolean start(Invocation invocation) throws Exception {
+                if (mockFails.decrementAndGet() >= 0) {
+                    return false;
+                } else {
+                    Boolean result = invocation.proceed();
+                    return result != null && result;
+                }
+            }
+        };
+
+        int queryPort = UtFrameUtils.findValidPort();
+        boolean fakeJournal = true;
+        int numBackends = 1;
+        // Must throw exception after all attempts fail
+        ExecutionException exception = Assertions.assertThrows(ExecutionException.class, () ->
+                PseudoCluster.getOrCreate("pseudo_cluster_" + queryPort, fakeJournal, queryPort, numBackends));
+        Assertions.assertTrue(exception.getMessage().contains("QE service start failed after 3 attempts"),
+                exception.getMessage());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoFrontendTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoFrontendTest.java
@@ -1,0 +1,61 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.pseudocluster;
+
+import com.starrocks.common.Config;
+import com.starrocks.mysql.MysqlServer;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Invocation;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class PseudoFrontendTest {
+    @AfterAll
+    public static void tearDown() {
+        PseudoCluster instance = PseudoCluster.getInstance();
+        if (instance != null) {
+            instance.shutdown();
+        }
+    }
+
+    @Test
+    public void testQueryPortConflictAutoRetrySuccess() throws Exception {
+        // first attempt fails, second attempt succeeds
+        AtomicInteger mockFails = new AtomicInteger(1);
+        new MockUp<MysqlServer>() {
+            @Mock
+            public boolean start(Invocation invocation) throws Exception {
+                if (mockFails.decrementAndGet() >= 0) {
+                    return false;
+                } else {
+                    Boolean result = invocation.proceed();
+                    return result != null && result;
+                }
+            }
+        };
+
+        int queryPort = UtFrameUtils.findValidPort();
+        boolean fakeJournal = true;
+        int numBackends = 1;
+        PseudoCluster.getOrCreate("pseudo_cluster_" + queryPort, fakeJournal, queryPort, numBackends);
+        int actualQueryPort = Config.query_port;
+        Assertions.assertNotEquals(queryPort, actualQueryPort);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -453,7 +453,7 @@ public class UtFrameUtils {
                     continue;
                 }
 
-                System.out.println("find valid port " + port + new Date());
+                System.out.println("find valid port " + port + " at " + new Date());
                 return port;
             } catch (Exception e) {
                 e.printStackTrace();


### PR DESCRIPTION
When running multiple unit tests in parallel, PseudoCluster instances could fail to start because the configured query port was already in use by another test instance. This caused intermittent test failures in CI/CD pipelines.

This PR implements automatic port conflict resolution for the PseudoCluster test framework:

1. **Added QeService.tryStart()**: A non-fatal variant of start() that returns success/failure instead of calling System.exit(-1), enabling retry logic.

2. **Implemented auto-retry mechanism**: PseudoFrontend now attempts up to 3 times to start the QE service, automatically selecting a new port via UtFrameUtils.findValidPort() when conflicts occur.

3. **Dynamic port detection**: PseudoCluster initialization now waits for the actual query port from PseudoFrontend (via CompletableFuture) before configuring the JDBC datasource, ensuring the correct port is used.

## Why I'm doing:

A very common unstable Frontend UT fails as the following error
```
2025-12-07T02:30:07.9528063Z [ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.2.5:test (default-test) on project fe-core: 
2025-12-07T02:30:07.9528188Z [ERROR] 
2025-12-07T02:30:07.9528564Z [ERROR] Please refer to /root/starrocks/fe/fe-core/target/surefire-reports for the individual test results.
2025-12-07T02:30:07.9528992Z [ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
2025-12-07T02:30:07.9529406Z [ERROR] ExecutionException The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
2025-12-07T02:30:07.9531841Z [ERROR] Command was /bin/sh -c cd '/root/starrocks/fe/fe-core' && '/var/local/env/jdk17.0.8/bin/java' '-javaagent:/var/local/env/.m2/repository/com/github/hazendaz/jmockit/jmockit/1.49.4/jmockit-1.49.4.jar' '-Xmx3072m' '-XX:TieredStopAtLevel=1' '-XX:CICompilerCount=1' '-XX:-BackgroundCompilation' '-XX:+UseSerialGC' '-Duser.timezone=Asia/Shanghai' '-Djacoco-agent.destfile=/root/starrocks/fe/fe-core/target/jacoco.exec' 'org.apache.maven.surefire.booter.ForkedBooter' '/root/starrocks/fe/fe-core/target/surefire' '2025-12-07T02-11-15_760-jvmRun9' 'surefire-20251207021610180_5178tmp' 'surefire_1195-20251207021610180_5180tmp'
2025-12-07T02:30:07.9532085Z [ERROR] Error occurred in starting fork, check output in log
2025-12-07T02:30:07.9532225Z [ERROR] Process Exit Code: 255
2025-12-07T02:30:07.9532878Z [ERROR] org.apache.maven.surefire.booter.SurefireBooterForkException: ExecutionException The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
2025-12-07T02:30:07.9535056Z [ERROR] Command was /bin/sh -c cd '/root/starrocks/fe/fe-core' && '/var/local/env/jdk17.0.8/bin/java' '-javaagent:/var/local/env/.m2/repository/com/github/hazendaz/jmockit/jmockit/1.49.4/jmockit-1.49.4.jar' '-Xmx3072m' '-XX:TieredStopAtLevel=1' '-XX:CICompilerCount=1' '-XX:-BackgroundCompilation' '-XX:+UseSerialGC' '-Duser.timezone=Asia/Shanghai' '-Djacoco-agent.destfile=/root/starrocks/fe/fe-core/target/jacoco.exec' 'org.apache.maven.surefire.booter.ForkedBooter' '/root/starrocks/fe/fe-core/target/surefire' '2025-12-07T02-11-15_760-jvmRun9' 'surefire-20251207021610180_5178tmp' 'surefire_1195-20251207021610180_5180tmp'
2025-12-07T02:30:07.9535301Z [ERROR] Error occurred in starting fork, check output in log
2025-12-07T02:30:07.9535438Z [ERROR] Process Exit Code: 255
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds non-fatal `QeService.tryStart()` and makes `PseudoFrontend` auto-retry QE startup with new ports, updating `PseudoCluster` to use the detected port; includes success/failure tests.
> 
> - **UT framework (PseudoCluster/PseudoFrontend)**
>   - Implement auto-retry (max 3) for QE startup on port conflicts in `PseudoFrontend` using `QeService.tryStart()` and `UtFrameUtils.findValidPort()`.
>   - Expose actual query port via `CompletableFuture` (`getQueryPort()`) and configure `BasicDataSource` in `PseudoCluster` with the detected port.
>   - Minor loop/sleep and logging tweaks during FE thread run.
> - **QE service**
>   - Add `QeService.tryStart()` returning boolean instead of exiting on failure.
> - **Tests**
>   - Add `PseudoFrontendTest` (retry success) and `PseudoFrontendFailTest` (retry fails after 3 attempts).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1deea607b08bc061bc54d367453e5ed98797ced. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->