### PR TITLE
[Enhancement] Add compression support for PlanFragment AttachmentRequest

### DIFF
--- a/fe/fe-core/build.gradle.kts
+++ b/fe/fe-core/build.gradle.kts
@@ -291,6 +291,7 @@ dependencies {
     implementation("tools.profiler:async-profiler")
     implementation("com.github.vertical-blank:sql-formatter:2.0.4")
     implementation("at.yawk.lz4:lz4-java")
+    implementation("com.github.luben:zstd-jni:1.5.5-5")
     // dependency sync end
 
     // extra dependencies pom.xml does not have

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -950,6 +950,21 @@ public class Config extends ConfigBase {
     @ConfField
     public static int brpc_min_evictable_idle_time_ms = 120000;
 
+    @ConfField(mutable = true, comment = "Threshold in bytes for compressing thrift plan fragment requests. " +
+            "Requests smaller than this threshold will not be compressed. " +
+            "Set to 0 or negative to disable compression. Default is 64KB.")
+    public static int thrift_plan_fragment_compression_threshold_bytes = 65536;
+
+    @ConfField(mutable = true, comment = "Minimum compression ratio (uncompressed/compressed) required to use compression. " +
+            "If the compression ratio is below this threshold, the uncompressed data will be sent instead. " +
+            "Default is 1.1, meaning compressed data must be at least 10% smaller.")
+    public static double thrift_plan_fragment_compression_ratio_threshold = 1.1;
+
+    @ConfField(mutable = true, comment = "Compression algorithm for thrift plan fragment requests. " +
+            "Supported values: 'lz4' (faster, lower compression ratio) or 'zstd' (slower, better compression ratio). " +
+            "Default is 'lz4' for better performance.")
+    public static String thrift_plan_fragment_compression_algorithm = "lz4";
+
     @ConfField
     public static boolean brpc_short_connection = false;
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitHybridExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitHybridExecutor.java
@@ -108,6 +108,10 @@ public class ShortCircuitHybridExecutor extends ShortCircuitExecutor {
                 PExecShortCircuitRequest pRequest = new PExecShortCircuitRequest();
                 pRequest.setAttachmentProtocol(protocol);
                 pRequest.setRequest(tRequest, protocol);
+                pRequest.setAttachmentCompressionType(pRequest.getCompressionType());
+                if (pRequest.getUncompressedSize() > 0) {
+                    pRequest.setUncompressedSize(pRequest.getUncompressedSize());
+                }
                 watch.start();
                 Future<PExecShortCircuitResult> future = service.execShortCircuit(pRequest);
                 if (null == future) {

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/BackendServiceClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/BackendServiceClient.java
@@ -116,6 +116,10 @@ public class BackendServiceClient {
         final PExecPlanFragmentRequest pRequest = new PExecPlanFragmentRequest();
         pRequest.setAttachmentProtocol(protocol);
         pRequest.setRequest(request);
+        pRequest.setAttachmentCompressionType(pRequest.getCompressionType());
+        if (pRequest.getUncompressedSize() > 0) {
+            pRequest.setUncompressedSize(pRequest.getUncompressedSize());
+        }
         return sendPlanFragmentAsync(address, pRequest);
     }
 
@@ -125,6 +129,10 @@ public class BackendServiceClient {
         final PExecPlanFragmentRequest pRequest = new PExecPlanFragmentRequest();
         pRequest.setAttachmentProtocol(protocol);
         pRequest.setRequest(tRequest, protocol);
+        pRequest.setAttachmentCompressionType(pRequest.getCompressionType());
+        if (pRequest.getUncompressedSize() > 0) {
+            pRequest.setUncompressedSize(pRequest.getUncompressedSize());
+        }
         return sendPlanFragmentAsync(address, pRequest);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/PExecPlanFragmentRequest.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/PExecPlanFragmentRequest.java
@@ -25,7 +25,21 @@ public class PExecPlanFragmentRequest extends AttachmentRequest {
     @Protobuf(order = 1, required = false)
     String attachmentProtocol;
 
+    @Protobuf(order = 2, required = false)
+    String attachmentCompressionType;
+
+    @Protobuf(order = 3, required = false)
+    Long uncompressedSize;
+
     public void setAttachmentProtocol(String attachmentProtocol) {
         this.attachmentProtocol = attachmentProtocol;
+    }
+
+    public void setAttachmentCompressionType(String attachmentCompressionType) {
+        this.attachmentCompressionType = attachmentCompressionType;
+    }
+
+    public void setUncompressedSize(Long uncompressedSize) {
+        this.uncompressedSize = uncompressedSize;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/PExecShortCircuitRequest.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/PExecShortCircuitRequest.java
@@ -25,7 +25,21 @@ public class PExecShortCircuitRequest extends AttachmentRequest {
     @Protobuf(order = 1, required = false)
     String attachmentProtocol;
 
+    @Protobuf(order = 2, required = false)
+    String attachmentCompressionType;
+
+    @Protobuf(order = 3, required = false)
+    Long uncompressedSize;
+
     public void setAttachmentProtocol(String attachmentProtocol) {
         this.attachmentProtocol = attachmentProtocol;
+    }
+
+    public void setAttachmentCompressionType(String attachmentCompressionType) {
+        this.attachmentCompressionType = attachmentCompressionType;
+    }
+
+    public void setUncompressedSize(Long uncompressedSize) {
+        this.uncompressedSize = uncompressedSize;
     }
 }

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -88,6 +88,7 @@ under the License.
         <commons-beanutils.version>1.11.0</commons-beanutils.version>
         <hbase.version>2.6.2</hbase.version>
         <lz4-java.version>1.8.1</lz4-java.version>
+        <zstd-jni.version>1.5.5-5</zstd-jni.version>
         <async-profiler.version>4.0</async-profiler.version>
         <maven.surefire.plugin.version>3.2.5</maven.surefire.plugin.version>
     </properties>
@@ -1561,6 +1562,13 @@ under the License.
                 <groupId>at.yawk.lz4</groupId>
                 <artifactId>lz4-java</artifactId>
                 <version>${lz4-java.version}</version>
+            </dependency>
+
+            <!-- https://mvnrepository.com/artifact/com.github.luben/zstd-jni -->
+            <dependency>
+                <groupId>com.github.luben</groupId>
+                <artifactId>zstd-jni</artifactId>
+                <version>${zstd-jni.version}</version>
             </dependency>
 
         </dependencies>

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -365,6 +365,10 @@ message PLoadDiagnoseResult {
 message PExecPlanFragmentRequest {
     // describe attachment protocol: binary, compact, json
     optional string attachment_protocol = 1;
+    // describe attachment compression type: none, lz4
+    optional string attachment_compression_type = 2;
+    // original uncompressed size for decompression
+    optional int64 uncompressed_size = 3;
 };
 
 message PTabletReaderOpenRequest {
@@ -433,6 +437,10 @@ message PExecPlanFragmentResult {
 };
 
 message PExecBatchPlanFragmentsRequest {
+    // describe attachment compression type: none, lz4
+    optional string attachment_compression_type = 1;
+    // original uncompressed size for decompression
+    optional int64 uncompressed_size = 2;
 };
 
 message PExecBatchPlanFragmentsResult {
@@ -684,6 +692,10 @@ message PExecShortCircuitResult {
 message PExecShortCircuitRequest {
     // describe attachment protocol: binary, compact, json
     optional string attachment_protocol = 1;
+    // describe attachment compression type: none, lz4
+    optional string attachment_compression_type = 2;
+    // original uncompressed size for decompression
+    optional int64 uncompressed_size = 3;
 }
 
 enum PProcessDictionaryCacheRequestType {


### PR DESCRIPTION
## Why I'm doing:
#63697
## What I'm doing:

```
CREATE DATABASE IF NOT EXISTS compression_test;
USE compression_test;

CREATE TABLE IF NOT EXISTS wide_table (
    c1 VARCHAR(255),
    c2 VARCHAR(255),
    c3 VARCHAR(255),
    c4 VARCHAR(255),
    c5 VARCHAR(255),
    c6 VARCHAR(255),
    c7 VARCHAR(255),
    c8 VARCHAR(255),
    c9 VARCHAR(255),
    c10 VARCHAR(255),
    c11 VARCHAR(255),
    c12 VARCHAR(255),
    c13 VARCHAR(255),
    c14 VARCHAR(255),
    c15 VARCHAR(255),
    c16 VARCHAR(255),
    c17 VARCHAR(255),
    c18 VARCHAR(255),
    c19 VARCHAR(255),
    c20 VARCHAR(255),
    c21 VARCHAR(255),
    c22 VARCHAR(255),
    c23 VARCHAR(255),
    c24 VARCHAR(255),
    c25 VARCHAR(255),
    c26 VARCHAR(255),
    c27 VARCHAR(255),
    c28 VARCHAR(255),
    c29 VARCHAR(255),
    c30 VARCHAR(255)
) DISTRIBUTED BY HASH(c1) BUCKETS 3;

INSERT INTO wide_table VALUES 
('a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','aa','bb','cc','dd'),
('a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','aa','bb','cc','dd'),
('a','b','c','d','e','f','g','h','i','j','k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z','aa','bb','cc','dd');

SET enable_profile = true;
SET enable_async_profile = false;
```
---
### LZ4 compression 

```
ADMIN SET FRONTEND CONFIG ("thrift_plan_fragment_compression_algorithm" = "lz4");

ADMIN SET FRONTEND CONFIG ("thrift_plan_fragment_compression_threshold_bytes" = "5000");

ADMIN SET FRONTEND CONFIG ("thrift_plan_fragment_compression_ratio_threshold" = "1.0");

SELECT * FROM compression_test.wide_table WHERE c1 = 'a';

SHOW PROFILELIST LIMIT 1;
```

### ZSTD compression

```
ADMIN SET FRONTEND CONFIG ("thrift_plan_fragment_compression_algorithm" = "zstd");

SELECT * FROM compression_test.wide_table WHERE c1 = 'a';

SHOW PROFILELIST LIMIT 1;
```
### no compression ( setting threshold very high value so preventing compression)
```

ADMIN SET FRONTEND CONFIG ("thrift_plan_fragment_compression_threshold_bytes" = "1000000");

SELECT * FROM compression_test.wide_table WHERE c1 = 'a';

SHOW PROFILELIST LIMIT 1;
```

### Then I took query plans from http://FE_IP:8030/query_profile?query_id=QUERY_ID

LZ4 compression applied plan: 
[019af503-52a9-7cbc-bc00-15060371816cprofile.txt](https://github.com/user-attachments/files/24014412/019af503-52a9-7cbc-bc00-15060371816cprofile.txt)

ZSTD compression applied plan: 
[019af503-db41-7018-b4bd-7f660670a19bprofile.txt](https://github.com/user-attachments/files/24014413/019af503-db41-7018-b4bd-7f660670a19bprofile.txt)

No compression applied plan(original behaviour): 
[019af504-3331-7629-9384-277c85176f0bprofile.txt](https://github.com/user-attachments/files/24014414/019af504-3331-7629-9384-277c85176f0bprofile.txt)

### Here is the comparison plans:

| Metrik | No Compression | LZ4 | ZSTD | İmprovement (LZ4) | İmprovement (ZSTD) |
|--------|----------------|-----|------|-------------------|-------------------|
| DeployDataSize | 14,780 bytes | 3,014 bytes | 1,797 bytes | -79.6% | -87.8% |
| DeployCompressTime | N/A (0ms) | 0ms | 1ms | - | +1ms overhead |
| DeployWaitTime | 0ms | 1ms | 3ms | +1ms | +3ms |
| Total Deploy Time | 2ms | 4ms | 6ms | +2ms | +4ms |
| Compression Ratio | 1.0x | 4.9x | 8.2x | - | - |


Fixes #63697

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional LZ4/ZSTD compression for Thrift plan fragment/short-circuit attachments with BE-side decompression and FE configs for threshold/ratio/algorithm.
> 
> - **RPC/FE**:
>   - Add request attachment compression in `AttachmentRequest` with `lz4`/`zstd`, threshold- and ratio-based enablement; propagate `attachment_compression_type` and `uncompressed_size` via `PExecPlanFragmentRequest` and `PExecShortCircuitRequest`.
>   - Apply compression in send paths: `BackendServiceClient.execPlanFragmentAsync(...)` and `ShortCircuitHybridExecutor`.
> - **RPC/BE**:
>   - Implement `decompress_attachment(...)` and use it in `_exec_plan_fragment`, `_exec_batch_plan_fragments`, and `_exec_short_circuit` to inflate attachments before Thrift deserialization.
> - **Protocol**:
>   - Extend `gensrc/proto/internal_service.proto` to include `attachment_compression_type` and `uncompressed_size` in `PExecPlanFragmentRequest`, `PExecBatchPlanFragmentsRequest`, and `PExecShortCircuitRequest`.
> - **Config (FE)**:
>   - New tunables: `thrift_plan_fragment_compression_threshold_bytes`, `thrift_plan_fragment_compression_ratio_threshold`, `thrift_plan_fragment_compression_algorithm`.
> - **Build**:
>   - Add `com.github.luben:zstd-jni` dependency in Gradle/Maven.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 60c53849c0219987c15f7f8005df6abfabae64c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->