### PR TITLE
[Enhancement] add concatenating iterator for sstable files

### DIFF
--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -233,6 +233,7 @@ set(STORAGE_FILES
     sstable/iterator.cpp
     sstable/options.cpp
     sstable/merger.cpp
+    sstable/concatenating_iterator.cpp
     lake/lake_delvec_loader.cpp
     binlog_util.cpp
     binlog_file_writer.cpp

--- a/be/src/storage/sstable/concatenating_iterator.cpp
+++ b/be/src/storage/sstable/concatenating_iterator.cpp
@@ -152,7 +152,7 @@ public:
 private:
     IteratorWrapper* children_;
     int n_;
-    int current_index_;
+    int current_index_{-1};
 };
 } // namespace
 

--- a/be/src/storage/sstable/concatenating_iterator.cpp
+++ b/be/src/storage/sstable/concatenating_iterator.cpp
@@ -75,11 +75,7 @@ public:
         // If current iterator becomes invalid, move to next iterator
         if (!children_[current_index_].Valid()) {
             for (int i = current_index_ + 1; i < n_; i++) {
-                if (children_[i].Valid()) {
-                    current_index_ = i;
-                    return;
-                }
-                // Try to seek to first in case the iterator hasn't been initialized
+                // Always seek to first to ensure we don't use stale positions
                 children_[i].SeekToFirst();
                 if (children_[i].Valid()) {
                     current_index_ = i;

--- a/be/src/storage/sstable/concatenating_iterator.cpp
+++ b/be/src/storage/sstable/concatenating_iterator.cpp
@@ -1,0 +1,160 @@
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+// (https://developers.google.com/open-source/licenses/bsd)
+
+#include "storage/sstable/concatenating_iterator.h"
+
+#include "storage/sstable/iterator.h"
+#include "storage/sstable/iterator_wrapper.h"
+
+namespace starrocks::sstable {
+
+namespace {
+class ConcatenatingIterator : public Iterator {
+public:
+    ConcatenatingIterator(Iterator** children, int n) : children_(new IteratorWrapper[n]), n_(n), current_index_(-1) {
+        for (int i = 0; i < n; i++) {
+            children_[i].Set(children[i]);
+        }
+    }
+
+    ~ConcatenatingIterator() override { delete[] children_; }
+
+    bool Valid() const override { return current_index_ >= 0 && current_index_ < n_ && children_[current_index_].Valid(); }
+
+    void SeekToFirst() override {
+        for (int i = 0; i < n_; i++) {
+            children_[i].SeekToFirst();
+            if (children_[i].Valid()) {
+                current_index_ = i;
+                return;
+            }
+        }
+        current_index_ = -1;
+    }
+
+    void SeekToLast() override {
+        for (int i = n_ - 1; i >= 0; i--) {
+            children_[i].SeekToLast();
+            if (children_[i].Valid()) {
+                current_index_ = i;
+                return;
+            }
+        }
+        current_index_ = -1;
+    }
+
+    void Seek(const Slice& target) override {
+        // Find the first child that might contain the target
+        for (int i = 0; i < n_; i++) {
+            children_[i].Seek(target);
+            if (children_[i].Valid()) {
+                current_index_ = i;
+                return;
+            }
+        }
+        current_index_ = -1;
+    }
+
+    void Next() override {
+        assert(Valid());
+        children_[current_index_].Next();
+
+        // If current iterator becomes invalid, move to next iterator
+        if (!children_[current_index_].Valid()) {
+            for (int i = current_index_ + 1; i < n_; i++) {
+                if (children_[i].Valid()) {
+                    current_index_ = i;
+                    return;
+                }
+                // Try to seek to first in case the iterator hasn't been initialized
+                children_[i].SeekToFirst();
+                if (children_[i].Valid()) {
+                    current_index_ = i;
+                    return;
+                }
+            }
+            current_index_ = -1;
+        }
+    }
+
+    void Prev() override {
+        assert(Valid());
+        children_[current_index_].Prev();
+
+        // If current iterator becomes invalid, move to previous iterator's last element
+        if (!children_[current_index_].Valid()) {
+            for (int i = current_index_ - 1; i >= 0; i--) {
+                children_[i].SeekToLast();
+                if (children_[i].Valid()) {
+                    current_index_ = i;
+                    return;
+                }
+            }
+            current_index_ = -1;
+        }
+    }
+
+    Slice key() const override {
+        assert(Valid());
+        return children_[current_index_].key();
+    }
+
+    Slice value() const override {
+        assert(Valid());
+        return children_[current_index_].value();
+    }
+
+    Status status() const override {
+        // Check all children for errors
+        for (int i = 0; i < n_; i++) {
+            Status s = children_[i].status();
+            if (!s.ok()) {
+                return s;
+            }
+        }
+        return Status::OK();
+    }
+
+    uint64_t max_rss_rowid() const override {
+        assert(Valid());
+        return children_[current_index_].max_rss_rowid();
+    }
+
+    SstablePredicateSPtr predicate() const override {
+        assert(Valid());
+        return children_[current_index_].predicate();
+    }
+
+    uint32_t shared_rssid() const override {
+        assert(Valid());
+        return children_[current_index_].shared_rssid();
+    }
+
+    int64_t shared_version() const override {
+        assert(Valid());
+        return children_[current_index_].shared_version();
+    }
+
+    DelVectorPtr delvec() const override {
+        assert(Valid());
+        return children_[current_index_].delvec();
+    }
+
+private:
+    IteratorWrapper* children_;
+    int n_;
+    int current_index_;
+};
+} // namespace
+
+Iterator* NewConcatenatingIterator(Iterator** children, int n) {
+    assert(n >= 0);
+    if (n == 0) {
+        return NewEmptyIterator();
+    } else {
+        return new ConcatenatingIterator(children, n);
+    }
+}
+
+} // namespace starrocks::sstable

--- a/be/src/storage/sstable/concatenating_iterator.cpp
+++ b/be/src/storage/sstable/concatenating_iterator.cpp
@@ -22,7 +22,7 @@ namespace starrocks::sstable {
 namespace {
 class ConcatenatingIterator : public Iterator {
 public:
-    ConcatenatingIterator(Iterator** children, int n) : children_(new IteratorWrapper[n]), n_(n), current_index_(-1) {
+    ConcatenatingIterator(Iterator** children, int n) : children_(new IteratorWrapper[n]), n_(n) {
         for (int i = 0; i < n; i++) {
             children_[i].Set(children[i]);
         }

--- a/be/src/storage/sstable/concatenating_iterator.cpp
+++ b/be/src/storage/sstable/concatenating_iterator.cpp
@@ -1,6 +1,16 @@
-// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license.
-// (https://developers.google.com/open-source/licenses/bsd)
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #include "storage/sstable/concatenating_iterator.h"
 
@@ -20,7 +30,9 @@ public:
 
     ~ConcatenatingIterator() override { delete[] children_; }
 
-    bool Valid() const override { return current_index_ >= 0 && current_index_ < n_ && children_[current_index_].Valid(); }
+    bool Valid() const override {
+        return current_index_ >= 0 && current_index_ < n_ && children_[current_index_].Valid();
+    }
 
     void SeekToFirst() override {
         for (int i = 0; i < n_; i++) {

--- a/be/src/storage/sstable/concatenating_iterator.h
+++ b/be/src/storage/sstable/concatenating_iterator.h
@@ -1,6 +1,16 @@
-// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license.
-// (https://developers.google.com/open-source/licenses/bsd)
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #pragma once
 

--- a/be/src/storage/sstable/concatenating_iterator.h
+++ b/be/src/storage/sstable/concatenating_iterator.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license.
+// (https://developers.google.com/open-source/licenses/bsd)
+
+#pragma once
+
+namespace starrocks::sstable {
+
+class Iterator;
+
+// Return an iterator that concatenates the data in children[0,n-1].
+// Takes ownership of the child iterators and will delete them when
+// the result iterator is deleted.
+//
+// REQUIRES: The keys in children[i] are all less than the keys in children[i+1]
+// for all i in [0, n-2]. In other words, the files are already ordered
+// and no merging is needed.
+//
+// REQUIRES: n >= 0
+Iterator* NewConcatenatingIterator(Iterator** children, int n);
+
+} // namespace starrocks::sstable

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -588,6 +588,7 @@ SET(DW_TEST_FILES
     ./storage/size_tiered_compaction_policy_test.cpp
     ./storage/snapshot_meta_test.cpp
     ./storage/sstable/sstable_predicate_test.cpp
+    ./storage/sstable/concatenating_iterator_test.cpp
     ./storage/storage_engine_test.cpp
     ./storage/storage_types_test.cpp
     ./storage/table_reader_remote_test.cpp

--- a/be/test/storage/sstable/concatenating_iterator_test.cpp
+++ b/be/test/storage/sstable/concatenating_iterator_test.cpp
@@ -120,6 +120,10 @@ TEST_F(ConcatenatingIteratorTest, SingleIterator) {
 
     Iterator* children[1] = {new VectorIterator(data)};
     std::unique_ptr<Iterator> iter(NewConcatenatingIterator(children, 1));
+    iter->SeekToFirst();
+    EXPECT_EQ(iter->max_rss_rowid(), 0);
+    EXPECT_EQ(iter->shared_rssid(), 0);
+    EXPECT_EQ(iter->shared_version(), 0);
 
     auto keys = CollectKeys(iter.get());
     ASSERT_EQ(3, keys.size());

--- a/be/test/storage/sstable/concatenating_iterator_test.cpp
+++ b/be/test/storage/sstable/concatenating_iterator_test.cpp
@@ -1,0 +1,313 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/sstable/concatenating_iterator.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "storage/sstable/comparator.h"
+#include "storage/sstable/iterator.h"
+#include "testutil/assert.h"
+#include "util/slice.h"
+
+namespace starrocks::sstable {
+
+// A simple in-memory iterator for testing
+class VectorIterator : public Iterator {
+public:
+    VectorIterator(const std::vector<std::pair<std::string, std::string>>& data) : _data(data), _index(-1) {}
+
+    bool Valid() const override { return _index >= 0 && _index < static_cast<int>(_data.size()); }
+
+    void SeekToFirst() override { _index = _data.empty() ? -1 : 0; }
+
+    void SeekToLast() override { _index = _data.empty() ? -1 : static_cast<int>(_data.size()) - 1; }
+
+    void Seek(const Slice& target) override {
+        for (size_t i = 0; i < _data.size(); i++) {
+            if (_data[i].first >= target.to_string()) {
+                _index = i;
+                return;
+            }
+        }
+        _index = -1;
+    }
+
+    void Next() override {
+        assert(Valid());
+        _index++;
+        if (_index >= static_cast<int>(_data.size())) {
+            _index = -1;
+        }
+    }
+
+    void Prev() override {
+        assert(Valid());
+        _index--;
+    }
+
+    Slice key() const override {
+        assert(Valid());
+        return Slice(_data[_index].first);
+    }
+
+    Slice value() const override {
+        assert(Valid());
+        return Slice(_data[_index].second);
+    }
+
+    Status status() const override { return Status::OK(); }
+
+private:
+    std::vector<std::pair<std::string, std::string>> _data;
+    int _index;
+};
+
+class ConcatenatingIteratorTest : public ::testing::Test {
+protected:
+    void SetUp() override {}
+    void TearDown() override {}
+
+    // Helper function to collect all keys from an iterator
+    std::vector<std::string> CollectKeys(Iterator* iter) {
+        std::vector<std::string> keys;
+        iter->SeekToFirst();
+        while (iter->Valid()) {
+            keys.push_back(iter->key().to_string());
+            iter->Next();
+        }
+        return keys;
+    }
+
+    // Helper function to collect all keys in reverse order
+    std::vector<std::string> CollectKeysReverse(Iterator* iter) {
+        std::vector<std::string> keys;
+        iter->SeekToLast();
+        while (iter->Valid()) {
+            keys.push_back(iter->key().to_string());
+            iter->Prev();
+        }
+        return keys;
+    }
+};
+
+TEST_F(ConcatenatingIteratorTest, EmptyIterators) {
+    Iterator* children[0] = {};
+    std::unique_ptr<Iterator> iter(NewConcatenatingIterator(children, 0));
+
+    ASSERT_FALSE(iter->Valid());
+    iter->SeekToFirst();
+    ASSERT_FALSE(iter->Valid());
+}
+
+TEST_F(ConcatenatingIteratorTest, SingleIterator) {
+    std::vector<std::pair<std::string, std::string>> data = {{"a", "1"}, {"c", "2"}, {"e", "3"}};
+
+    Iterator* children[1] = {new VectorIterator(data)};
+    std::unique_ptr<Iterator> iter(NewConcatenatingIterator(children, 1));
+
+    auto keys = CollectKeys(iter.get());
+    ASSERT_EQ(3, keys.size());
+    EXPECT_EQ("a", keys[0]);
+    EXPECT_EQ("c", keys[1]);
+    EXPECT_EQ("e", keys[2]);
+}
+
+TEST_F(ConcatenatingIteratorTest, MultipleIteratorsSeekToFirst) {
+    std::vector<std::pair<std::string, std::string>> data1 = {{"a", "1"}, {"c", "2"}, {"e", "3"}};
+    std::vector<std::pair<std::string, std::string>> data2 = {{"g", "4"}, {"i", "5"}, {"k", "6"}};
+    std::vector<std::pair<std::string, std::string>> data3 = {{"m", "7"}, {"o", "8"}, {"q", "9"}};
+
+    Iterator* children[3] = {new VectorIterator(data1), new VectorIterator(data2), new VectorIterator(data3)};
+    std::unique_ptr<Iterator> iter(NewConcatenatingIterator(children, 3));
+
+    auto keys = CollectKeys(iter.get());
+    ASSERT_EQ(9, keys.size());
+    EXPECT_EQ("a", keys[0]);
+    EXPECT_EQ("c", keys[1]);
+    EXPECT_EQ("e", keys[2]);
+    EXPECT_EQ("g", keys[3]);
+    EXPECT_EQ("i", keys[4]);
+    EXPECT_EQ("k", keys[5]);
+    EXPECT_EQ("m", keys[6]);
+    EXPECT_EQ("o", keys[7]);
+    EXPECT_EQ("q", keys[8]);
+}
+
+TEST_F(ConcatenatingIteratorTest, MultipleIteratorsSeekToLast) {
+    std::vector<std::pair<std::string, std::string>> data1 = {{"a", "1"}, {"c", "2"}, {"e", "3"}};
+    std::vector<std::pair<std::string, std::string>> data2 = {{"g", "4"}, {"i", "5"}, {"k", "6"}};
+    std::vector<std::pair<std::string, std::string>> data3 = {{"m", "7"}, {"o", "8"}, {"q", "9"}};
+
+    Iterator* children[3] = {new VectorIterator(data1), new VectorIterator(data2), new VectorIterator(data3)};
+    std::unique_ptr<Iterator> iter(NewConcatenatingIterator(children, 3));
+
+    auto keys = CollectKeysReverse(iter.get());
+    ASSERT_EQ(9, keys.size());
+    EXPECT_EQ("q", keys[0]);
+    EXPECT_EQ("o", keys[1]);
+    EXPECT_EQ("m", keys[2]);
+    EXPECT_EQ("k", keys[3]);
+    EXPECT_EQ("i", keys[4]);
+    EXPECT_EQ("g", keys[5]);
+    EXPECT_EQ("e", keys[6]);
+    EXPECT_EQ("c", keys[7]);
+    EXPECT_EQ("a", keys[8]);
+}
+
+TEST_F(ConcatenatingIteratorTest, SeekToTarget) {
+    std::vector<std::pair<std::string, std::string>> data1 = {{"a", "1"}, {"c", "2"}, {"e", "3"}};
+    std::vector<std::pair<std::string, std::string>> data2 = {{"g", "4"}, {"i", "5"}, {"k", "6"}};
+    std::vector<std::pair<std::string, std::string>> data3 = {{"m", "7"}, {"o", "8"}, {"q", "9"}};
+
+    Iterator* children[3] = {new VectorIterator(data1), new VectorIterator(data2), new VectorIterator(data3)};
+    std::unique_ptr<Iterator> iter(NewConcatenatingIterator(children, 3));
+
+    // Seek to a key in the first iterator
+    iter->Seek(Slice("b"));
+    ASSERT_TRUE(iter->Valid());
+    EXPECT_EQ("c", iter->key().to_string());
+
+    // Seek to a key in the second iterator
+    iter->Seek(Slice("h"));
+    ASSERT_TRUE(iter->Valid());
+    EXPECT_EQ("i", iter->key().to_string());
+
+    // Seek to a key in the third iterator
+    iter->Seek(Slice("n"));
+    ASSERT_TRUE(iter->Valid());
+    EXPECT_EQ("o", iter->key().to_string());
+
+    // Seek to exact key
+    iter->Seek(Slice("k"));
+    ASSERT_TRUE(iter->Valid());
+    EXPECT_EQ("k", iter->key().to_string());
+
+    // Seek beyond all keys
+    iter->Seek(Slice("z"));
+    ASSERT_FALSE(iter->Valid());
+}
+
+TEST_F(ConcatenatingIteratorTest, WithEmptyChildren) {
+    std::vector<std::pair<std::string, std::string>> data1 = {{"a", "1"}, {"c", "2"}};
+    std::vector<std::pair<std::string, std::string>> data2; // empty
+    std::vector<std::pair<std::string, std::string>> data3 = {{"m", "7"}, {"o", "8"}};
+
+    Iterator* children[3] = {new VectorIterator(data1), new VectorIterator(data2), new VectorIterator(data3)};
+    std::unique_ptr<Iterator> iter(NewConcatenatingIterator(children, 3));
+
+    auto keys = CollectKeys(iter.get());
+    ASSERT_EQ(4, keys.size());
+    EXPECT_EQ("a", keys[0]);
+    EXPECT_EQ("c", keys[1]);
+    EXPECT_EQ("m", keys[2]);
+    EXPECT_EQ("o", keys[3]);
+}
+
+TEST_F(ConcatenatingIteratorTest, NextAcrossBoundaries) {
+    std::vector<std::pair<std::string, std::string>> data1 = {{"a", "1"}};
+    std::vector<std::pair<std::string, std::string>> data2 = {{"b", "2"}};
+    std::vector<std::pair<std::string, std::string>> data3 = {{"c", "3"}};
+
+    Iterator* children[3] = {new VectorIterator(data1), new VectorIterator(data2), new VectorIterator(data3)};
+    std::unique_ptr<Iterator> iter(NewConcatenatingIterator(children, 3));
+
+    iter->SeekToFirst();
+    ASSERT_TRUE(iter->Valid());
+    EXPECT_EQ("a", iter->key().to_string());
+    EXPECT_EQ("1", iter->value().to_string());
+
+    iter->Next();
+    ASSERT_TRUE(iter->Valid());
+    EXPECT_EQ("b", iter->key().to_string());
+    EXPECT_EQ("2", iter->value().to_string());
+
+    iter->Next();
+    ASSERT_TRUE(iter->Valid());
+    EXPECT_EQ("c", iter->key().to_string());
+    EXPECT_EQ("3", iter->value().to_string());
+
+    iter->Next();
+    ASSERT_FALSE(iter->Valid());
+}
+
+TEST_F(ConcatenatingIteratorTest, PrevAcrossBoundaries) {
+    std::vector<std::pair<std::string, std::string>> data1 = {{"a", "1"}};
+    std::vector<std::pair<std::string, std::string>> data2 = {{"b", "2"}};
+    std::vector<std::pair<std::string, std::string>> data3 = {{"c", "3"}};
+
+    Iterator* children[3] = {new VectorIterator(data1), new VectorIterator(data2), new VectorIterator(data3)};
+    std::unique_ptr<Iterator> iter(NewConcatenatingIterator(children, 3));
+
+    iter->SeekToLast();
+    ASSERT_TRUE(iter->Valid());
+    EXPECT_EQ("c", iter->key().to_string());
+
+    iter->Prev();
+    ASSERT_TRUE(iter->Valid());
+    EXPECT_EQ("b", iter->key().to_string());
+
+    iter->Prev();
+    ASSERT_TRUE(iter->Valid());
+    EXPECT_EQ("a", iter->key().to_string());
+
+    iter->Prev();
+    ASSERT_FALSE(iter->Valid());
+}
+
+TEST_F(ConcatenatingIteratorTest, ForwardAndBackwardMixed) {
+    std::vector<std::pair<std::string, std::string>> data1 = {{"a", "1"}, {"b", "2"}};
+    std::vector<std::pair<std::string, std::string>> data2 = {{"c", "3"}, {"d", "4"}};
+
+    Iterator* children[2] = {new VectorIterator(data1), new VectorIterator(data2)};
+    std::unique_ptr<Iterator> iter(NewConcatenatingIterator(children, 2));
+
+    iter->SeekToFirst();
+    EXPECT_EQ("a", iter->key().to_string());
+
+    iter->Next();
+    EXPECT_EQ("b", iter->key().to_string());
+
+    iter->Next();
+    EXPECT_EQ("c", iter->key().to_string());
+
+    iter->Prev();
+    EXPECT_EQ("b", iter->key().to_string());
+
+    iter->Prev();
+    EXPECT_EQ("a", iter->key().to_string());
+
+    iter->Next();
+    iter->Next();
+    iter->Next();
+    EXPECT_EQ("d", iter->key().to_string());
+}
+
+TEST_F(ConcatenatingIteratorTest, StatusCheck) {
+    std::vector<std::pair<std::string, std::string>> data1 = {{"a", "1"}};
+    std::vector<std::pair<std::string, std::string>> data2 = {{"b", "2"}};
+
+    Iterator* children[2] = {new VectorIterator(data1), new VectorIterator(data2)};
+    std::unique_ptr<Iterator> iter(NewConcatenatingIterator(children, 2));
+
+    ASSERT_TRUE(iter->status().ok());
+    iter->SeekToFirst();
+    ASSERT_TRUE(iter->status().ok());
+}
+
+} // namespace starrocks::sstable


### PR DESCRIPTION
## Why I'm doing:
This is a prerequisite change for upcoming supporting ordered filesets in the cloud-native persistent index.

## What I'm doing:
Fix #66457

This pull request introduces a new `ConcatenatingIterator` implementation for the SSTable storage layer, which enables sequential iteration across multiple ordered child iterators without merging. The changes include the implementation, header, build system integration, and comprehensive unit tests to ensure correctness and robustness.

### SSTable Iterator Enhancements

* Added a new source file `sstable/concatenating_iterator.cpp` implementing the `ConcatenatingIterator`, which allows seamless forward and backward traversal across multiple ordered iterators. This iterator takes ownership of child iterators and handles boundary conditions between them.
* Introduced the corresponding header `sstable/concatenating_iterator.h` declaring the `NewConcatenatingIterator` factory function and documenting usage requirements.

### Build System Integration

* Registered `sstable/concatenating_iterator.cpp` in the storage build files (`be/src/storage/CMakeLists.txt`) to ensure it is compiled as part of the storage module.
* Added the new test file `concatenating_iterator_test.cpp` to the test build configuration (`be/test/CMakeLists.txt`).

### Testing

* Added `concatenating_iterator_test.cpp`, a comprehensive unit test suite that verifies correct behavior for empty, single, and multiple iterators, boundary traversal, seeking, and error/status handling.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `ConcatenatingIterator` to traverse multiple ordered SSTable iterators sequentially, with build integration and unit tests.
> 
> - **Storage/SSTable**:
>   - Implement `ConcatenatingIterator` (`sstable/concatenating_iterator.cpp`, `sstable/concatenating_iterator.h`) to sequentially traverse multiple ordered child `Iterator`s (supports `Seek`, `Next`, `Prev`, and propagates status/metadata).
> - **Build**:
>   - Register `sstable/concatenating_iterator.cpp` in `be/src/storage/CMakeLists.txt`.
> - **Tests**:
>   - Add `storage/sstable/concatenating_iterator_test.cpp` and include in `be/test/CMakeLists.txt` (covers empty/single/multiple iterators, boundary traversal, seeking, and status).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da1b35d78d473ebbb99e10e59d2682c49113fc34. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->