### PR TITLE
[Enhancement] Support getting tablet metadatas in frontend

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/TabletRepairHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/TabletRepairHelper.java
@@ -89,7 +89,8 @@ public class TabletRepairHelper {
                         TimeUnit.MILLISECONDS);
 
                 if (response.status.statusCode != 0) {
-                    throw new StarRocksException(response.status.errorMsgs.get(0));
+                    List<String> errMsgs = response.status.errorMsgs;
+                    throw new StarRocksException(errMsgs != null && !errMsgs.isEmpty() ? errMsgs.get(0) : "unknown error");
                 }
 
                 for (TabletMetadatas tm : response.tabletMetadatas) {
@@ -100,7 +101,8 @@ public class TabletRepairHelper {
                         tabletVersionMetadatas.put(tabletId, versionMetadatas);
                     } else if (statusCode != 31) {
                         // status code 31 is not found
-                        throw new StarRocksException(tm.status.errorMsgs.get(0));
+                        List<String> errMsgs = tm.status.errorMsgs;
+                        throw new StarRocksException(errMsgs != null && !errMsgs.isEmpty() ? errMsgs.get(0) : "unknown error");
                     }
                 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/TabletRepairHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/TabletRepairHelper.java
@@ -1,0 +1,127 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.starrocks.common.StarRocksException;
+import com.starrocks.proto.GetTabletMetadatasRequest;
+import com.starrocks.proto.GetTabletMetadatasResponse;
+import com.starrocks.proto.TabletMetadataPB;
+import com.starrocks.proto.TabletMetadatas;
+import com.starrocks.rpc.BrpcProxy;
+import com.starrocks.rpc.LakeService;
+import com.starrocks.rpc.RpcException;
+import com.starrocks.system.ComputeNode;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+public class TabletRepairHelper {
+    private static final Logger LOG = LogManager.getLogger(TabletRepairHelper.class);
+
+    record PhysicalPartitionInfo(
+            long physicalPartitionId,
+            List<Long> allTablets, // all tablets in one physical partition
+            Set<Long> leftTablets, // tablets whose valid metadata still need to be found
+            Map<ComputeNode, Set<Long>> nodeToTablets,
+            long maxVersion,
+            long minVersion
+    ) {
+    }
+
+    private static Map<Long, Map<Long, TabletMetadataPB>> getTabletMetadatas(PhysicalPartitionInfo info, long maxVersion,
+                                                                             long minVersion) throws Exception {
+        long physicalPartitionId = info.physicalPartitionId;
+        Set<Long> leftTablets = info.leftTablets;
+        Map<ComputeNode, Set<Long>> nodeToTablets = info.nodeToTablets;
+
+        List<Future<GetTabletMetadatasResponse>> responses = Lists.newArrayList();
+        List<ComputeNode> nodes = Lists.newArrayList();
+        for (Map.Entry<ComputeNode, Set<Long>> entry : nodeToTablets.entrySet()) {
+            ComputeNode node = entry.getKey();
+            Set<Long> tabletIds = Sets.newHashSet(entry.getValue());
+
+            tabletIds.retainAll(leftTablets);
+            if (tabletIds.isEmpty()) {
+                continue;
+            }
+
+            GetTabletMetadatasRequest request = new GetTabletMetadatasRequest();
+            request.tabletIds = Lists.newArrayList(tabletIds);
+            request.maxVersion = maxVersion;
+            request.minVersion = minVersion;
+
+            try {
+                LakeService lakeService = BrpcProxy.getLakeService(node.getHost(), node.getBrpcPort());
+                Future<GetTabletMetadatasResponse> future = lakeService.getTabletMetadatas(request);
+                responses.add(future);
+                nodes.add(node);
+            } catch (RpcException e) {
+                LOG.warn("Fail to send get tablet metadatas request to node {}, partition: {}, error: {}", node.getId(),
+                        physicalPartitionId, e.getMessage());
+                throw e;
+            }
+        }
+
+        Map<Long, Map<Long, TabletMetadataPB>> tabletVersionMetadatas = Maps.newHashMap();
+        for (int i = 0; i < responses.size(); ++i) {
+            try {
+                GetTabletMetadatasResponse response = responses.get(i).get(LakeService.TIMEOUT_GET_TABLET_STATS,
+                        TimeUnit.MILLISECONDS);
+
+                if (response.status.statusCode != 0) {
+                    throw new StarRocksException(response.status.errorMsgs.get(0));
+                }
+
+                for (TabletMetadatas tm : response.tabletMetadatas) {
+                    long tabletId = tm.tabletId;
+                    int statusCode = tm.status.statusCode;
+                    if (statusCode == 0) {
+                        Map<Long, TabletMetadataPB> versionMetadatas = tm.versionMetadatas;
+                        tabletVersionMetadatas.put(tabletId, versionMetadatas);
+                    } else if (statusCode != 31) {
+                        // status code 31 is not found
+                        throw new StarRocksException(tm.status.errorMsgs.get(0));
+                    }
+                }
+
+                if (LOG.isDebugEnabled()) {
+                    Map<Long, List<Long>> tabletVersions = Maps.newHashMap();
+                    for (TabletMetadatas tm : response.tabletMetadatas) {
+                        if (tm.status.statusCode == 0) {
+                            tabletVersions.put(tm.tabletId, Lists.newArrayList(tm.versionMetadatas.keySet()));
+                        }
+                    }
+                    LOG.debug("Get {} tablet metadatas from node {}, partition: {}, version range: [{}, {}], tablet versions: {}",
+                            tabletVersions.size(), nodes.get(i).getId(), physicalPartitionId, minVersion, maxVersion,
+                            tabletVersions);
+                }
+            } catch (Exception e) {
+                LOG.warn("Fail to get tablet metadatas from node {}, partition: {}, error: {}", nodes.get(i).getId(),
+                        physicalPartitionId, e.getMessage());
+                throw e;
+            }
+        }
+
+        return tabletVersionMetadatas;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
@@ -32,6 +32,8 @@ import com.starrocks.proto.DeleteTxnLogRequest;
 import com.starrocks.proto.DeleteTxnLogResponse;
 import com.starrocks.proto.DropTableRequest;
 import com.starrocks.proto.DropTableResponse;
+import com.starrocks.proto.GetTabletMetadatasRequest;
+import com.starrocks.proto.GetTabletMetadatasResponse;
 import com.starrocks.proto.LockTabletMetadataRequest;
 import com.starrocks.proto.LockTabletMetadataResponse;
 import com.starrocks.proto.PublishLogVersionBatchRequest;
@@ -130,5 +132,8 @@ public interface LakeService {
 
     @ProtobufRPC(serviceName = "LakeService", methodName = "vacuum_full", onceTalkTimeout = TIMEOUT_VACUUM_FULL)
     Future<VacuumFullResponse> vacuumFull(VacuumFullRequest request);
+
+    @ProtobufRPC(serviceName = "LakeService", methodName = "get_tablet_metadatas", onceTalkTimeout = TIMEOUT_GET_TABLET_STATS)
+    Future<GetTabletMetadatasResponse> getTabletMetadatas(GetTabletMetadatasRequest request);
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/LakeServiceWithMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/LakeServiceWithMetrics.java
@@ -30,6 +30,8 @@ import com.starrocks.proto.DeleteTxnLogRequest;
 import com.starrocks.proto.DeleteTxnLogResponse;
 import com.starrocks.proto.DropTableRequest;
 import com.starrocks.proto.DropTableResponse;
+import com.starrocks.proto.GetTabletMetadatasRequest;
+import com.starrocks.proto.GetTabletMetadatasResponse;
 import com.starrocks.proto.LockTabletMetadataRequest;
 import com.starrocks.proto.LockTabletMetadataResponse;
 import com.starrocks.proto.PublishLogVersionBatchRequest;
@@ -176,5 +178,11 @@ public class LakeServiceWithMetrics implements LakeService {
     public Future<VacuumFullResponse> vacuumFull(VacuumFullRequest request) {
         increaseMetrics();
         return lakeService.vacuumFull(request);
+    }
+
+    @Override
+    public Future<GetTabletMetadatasResponse> getTabletMetadatas(GetTabletMetadatasRequest request) {
+        increaseMetrics();
+        return lakeService.getTabletMetadatas(request);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/TabletRepairHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/TabletRepairHelperTest.java
@@ -126,6 +126,19 @@ public class TabletRepairHelperTest {
     }
 
     @Test
+    public void testGetTabletMetadatasResponseNull() {
+        new MockUp<LakeServiceWithMetrics>() {
+            @Mock
+            public Future<GetTabletMetadatasResponse> getTabletMetadatas(GetTabletMetadatasRequest request) {
+                return CompletableFuture.completedFuture(null);
+            }
+        };
+
+        ExceptionChecker.expectThrowsWithMsg(StarRocksException.class, "response is null",
+                () -> Deencapsulation.invoke(TabletRepairHelper.class, "getTabletMetadatas", info, maxVersion, minVersion));
+    }
+
+    @Test
     public void testGetTabletMetadatasRpcLevelStatusFail() {
         new MockUp<LakeServiceWithMetrics>() {
             @Mock

--- a/fe/fe-core/src/test/java/com/starrocks/lake/TabletRepairHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/TabletRepairHelperTest.java
@@ -1,0 +1,182 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.starrocks.common.ExceptionChecker;
+import com.starrocks.common.StarRocksException;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.lake.TabletRepairHelper.PhysicalPartitionInfo;
+import com.starrocks.proto.GetTabletMetadatasRequest;
+import com.starrocks.proto.GetTabletMetadatasResponse;
+import com.starrocks.proto.StatusPB;
+import com.starrocks.proto.TabletMetadataPB;
+import com.starrocks.proto.TabletMetadatas;
+import com.starrocks.rpc.LakeServiceWithMetrics;
+import com.starrocks.rpc.RpcException;
+import com.starrocks.system.ComputeNode;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+public class TabletRepairHelperTest {
+    private final long physicalPartitionId = 100L;
+    private final long tabletId1 = 10001L;
+    private final long tabletId2 = 10002L;
+    private final long maxVersion = 8L;
+    private final long minVersion = 3L;
+
+    private ComputeNode node;
+    private Map<ComputeNode, Set<Long>> nodeToTablets;
+    private PhysicalPartitionInfo info;
+
+    @BeforeEach
+    public void beforeEach() {
+        nodeToTablets = Maps.newHashMap();
+        node = new ComputeNode(1L, "127.0.0.1", 9050);
+        node.setBrpcPort(8060);
+        nodeToTablets.put(node, Sets.newHashSet(tabletId1, tabletId2));
+
+        info = new PhysicalPartitionInfo(physicalPartitionId, Lists.newArrayList(tabletId1, tabletId2),
+                Sets.newHashSet(tabletId1, tabletId2), nodeToTablets, maxVersion, minVersion);
+    }
+
+    @Test
+    public void testGetTabletMetadatas() {
+        new MockUp<LakeServiceWithMetrics>() {
+            @Mock
+            public Future<GetTabletMetadatasResponse> getTabletMetadatas(GetTabletMetadatasRequest request) {
+                GetTabletMetadatasResponse response = new GetTabletMetadatasResponse();
+                response.status = new StatusPB();
+                response.status.statusCode = 0;
+
+                // tablet1 with 2 versions metadata
+                TabletMetadatas tm1 = new TabletMetadatas();
+                tm1.tabletId = tabletId1;
+                tm1.status = new StatusPB();
+                tm1.status.statusCode = 0;
+                tm1.versionMetadatas = Maps.newHashMap();
+
+                TabletMetadataPB meta11 = new TabletMetadataPB();
+                meta11.id = tabletId1;
+                meta11.version = maxVersion;
+                tm1.versionMetadatas.put(maxVersion, meta11);
+
+                TabletMetadataPB meta12 = new TabletMetadataPB();
+                meta12.id = tabletId1;
+                meta12.version = minVersion;
+                tm1.versionMetadatas.put(minVersion, meta12);
+
+                // tablet2 metadata not found
+                TabletMetadatas tm2 = new TabletMetadatas();
+                tm2.tabletId = tabletId2;
+                tm2.status = new StatusPB();
+                tm2.status.statusCode = 31;
+                tm2.versionMetadatas = Maps.newHashMap();
+
+                response.tabletMetadatas = Lists.newArrayList(tm1, tm2);
+
+                return CompletableFuture.completedFuture(response);
+            }
+        };
+
+        Map<Long, Map<Long, TabletMetadataPB>> tabletVersionMetadatas = Deencapsulation.invoke(
+                TabletRepairHelper.class, "getTabletMetadatas", info, maxVersion, minVersion);
+
+        Assertions.assertEquals(1, tabletVersionMetadatas.size());
+        Assertions.assertTrue(tabletVersionMetadatas.containsKey(tabletId1));
+        Assertions.assertEquals(2, tabletVersionMetadatas.get(tabletId1).size());
+        Assertions.assertEquals(maxVersion, tabletVersionMetadatas.get(tabletId1).get(maxVersion).version);
+        Assertions.assertEquals(minVersion, tabletVersionMetadatas.get(tabletId1).get(minVersion).version);
+        Assertions.assertFalse(tabletVersionMetadatas.containsKey(tabletId2));
+    }
+
+    @Test
+    public void testGetTabletMetadatasRpcException() {
+        new MockUp<LakeServiceWithMetrics>() {
+            @Mock
+            public Future<GetTabletMetadatasResponse> getTabletMetadatas(GetTabletMetadatasRequest request) throws RpcException {
+                throw new RpcException("rpc exception");
+            }
+        };
+
+        ExceptionChecker.expectThrowsWithMsg(RpcException.class, "rpc exception",
+                () -> Deencapsulation.invoke(TabletRepairHelper.class, "getTabletMetadatas", info, maxVersion, minVersion));
+    }
+
+    @Test
+    public void testGetTabletMetadatasRpcLevelStatusFail() {
+        new MockUp<LakeServiceWithMetrics>() {
+            @Mock
+            public Future<GetTabletMetadatasResponse> getTabletMetadatas(GetTabletMetadatasRequest request) {
+                GetTabletMetadatasResponse response = new GetTabletMetadatasResponse();
+                response.status = new StatusPB();
+                response.status.statusCode = 1;
+                response.status.errorMsgs = Lists.newArrayList("missing tablet_ids");
+                return CompletableFuture.completedFuture(response);
+            }
+        };
+
+        ExceptionChecker.expectThrowsWithMsg(StarRocksException.class, "missing tablet_ids",
+                () -> Deencapsulation.invoke(TabletRepairHelper.class, "getTabletMetadatas", info, maxVersion, minVersion));
+    }
+
+    @Test
+    public void testGetTabletMetadatasPartialFail() {
+        new MockUp<LakeServiceWithMetrics>() {
+            @Mock
+            public Future<GetTabletMetadatasResponse> getTabletMetadatas(GetTabletMetadatasRequest request) {
+                GetTabletMetadatasResponse response = new GetTabletMetadatasResponse();
+                response.status = new StatusPB();
+                response.status.statusCode = 0;
+
+                // tablet1 with 1 version metadata
+                TabletMetadatas tm1 = new TabletMetadatas();
+                tm1.tabletId = tabletId1;
+                tm1.status = new StatusPB();
+                tm1.status.statusCode = 0;
+                tm1.versionMetadatas = Maps.newHashMap();
+
+                TabletMetadataPB meta11 = new TabletMetadataPB();
+                meta11.id = tabletId1;
+                meta11.version = maxVersion;
+                tm1.versionMetadatas.put(maxVersion, meta11);
+
+                // tablet2 get metadata failed
+                TabletMetadatas tm2 = new TabletMetadatas();
+                tm2.tabletId = tabletId2;
+                tm2.status = new StatusPB();
+                tm2.status.statusCode = 1;
+                tm2.status.errorMsgs = Lists.newArrayList("get tablet metadata failed");
+
+                response.tabletMetadatas = Lists.newArrayList(tm1, tm2);
+
+                return CompletableFuture.completedFuture(response);
+            }
+        };
+
+        ExceptionChecker.expectThrowsWithMsg(StarRocksException.class, "get tablet metadata failed",
+                () -> Deencapsulation.invoke(TabletRepairHelper.class, "getTabletMetadatas", info, maxVersion, minVersion));
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
@@ -43,6 +43,8 @@ import com.starrocks.proto.DropTableRequest;
 import com.starrocks.proto.DropTableResponse;
 import com.starrocks.proto.ExecuteCommandRequestPB;
 import com.starrocks.proto.ExecuteCommandResultPB;
+import com.starrocks.proto.GetTabletMetadatasRequest;
+import com.starrocks.proto.GetTabletMetadatasResponse;
 import com.starrocks.proto.LockTabletMetadataRequest;
 import com.starrocks.proto.LockTabletMetadataResponse;
 import com.starrocks.proto.PCancelPlanFragmentRequest;
@@ -1211,6 +1213,11 @@ public class PseudoBackend {
 
         @Override
         public Future<VacuumFullResponse> vacuumFull(VacuumFullRequest request) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public Future<GetTabletMetadatasResponse> getTabletMetadatas(GetTabletMetadatasRequest request) {
             return CompletableFuture.completedFuture(null);
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/rpc/LakeServiceWithMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/rpc/LakeServiceWithMetricsTest.java
@@ -29,6 +29,8 @@ import com.starrocks.proto.DeleteTxnLogRequest;
 import com.starrocks.proto.DeleteTxnLogResponse;
 import com.starrocks.proto.DropTableRequest;
 import com.starrocks.proto.DropTableResponse;
+import com.starrocks.proto.GetTabletMetadatasRequest;
+import com.starrocks.proto.GetTabletMetadatasResponse;
 import com.starrocks.proto.LockTabletMetadataRequest;
 import com.starrocks.proto.LockTabletMetadataResponse;
 import com.starrocks.proto.PublishLogVersionBatchRequest;
@@ -290,6 +292,19 @@ public class LakeServiceWithMetricsTest {
         };
 
         Future<VacuumResponse> result = lakeServiceWithMetrics.vacuum(new VacuumRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testGetTabletMetadatas() throws Exception {
+        new Expectations() {
+            {
+                lakeService.getTabletMetadatas((GetTabletMetadatasRequest) any);
+                result = CompletableFuture.completedFuture(new GetTabletMetadatasResponse());
+            }
+        };
+
+        Future<GetTabletMetadatasResponse> result = lakeServiceWithMetrics.getTabletMetadatas(new GetTabletMetadatasRequest());
         assertNotNull(result);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
@@ -38,6 +38,8 @@ import com.starrocks.proto.DropTableRequest;
 import com.starrocks.proto.DropTableResponse;
 import com.starrocks.proto.ExecuteCommandRequestPB;
 import com.starrocks.proto.ExecuteCommandResultPB;
+import com.starrocks.proto.GetTabletMetadatasRequest;
+import com.starrocks.proto.GetTabletMetadatasResponse;
 import com.starrocks.proto.LockTabletMetadataRequest;
 import com.starrocks.proto.LockTabletMetadataResponse;
 import com.starrocks.proto.PCancelPlanFragmentRequest;
@@ -715,6 +717,11 @@ public class MockedBackend {
 
         @Override
         public Future<VacuumFullResponse> vacuumFull(VacuumFullRequest request) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public Future<GetTabletMetadatasResponse> getTabletMetadatas(GetTabletMetadatasRequest request) {
             return CompletableFuture.completedFuture(null);
         }
     }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This PR introduces a new helper class for repairing tablet metadata and adds `getTabletMetadatas` method to fetch tablet metadatas from the backends within a version range.

https://github.com/StarRocks/starrocks/issues/66015

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `TabletRepairHelper` and adds `LakeService#getTabletMetadatas` (with metrics wrapper and test/mocks) to fetch tablet metadatas within a version range.
> 
> - **Lake/RPC**:
>   - Add `getTabletMetadatas` RPC to `LakeService` with timeout `TIMEOUT_GET_TABLET_STATS`.
>   - Implement forwarding in `LakeServiceWithMetrics#getTabletMetadatas`.
>   - Update pseudocluster and utframe mocks (`PseudoBackend.PseudoLakeService`, `MockedBackend.MockLakeService`) to stub `getTabletMetadatas`.
> - **Lake**:
>   - Add `TabletRepairHelper` with `PhysicalPartitionInfo` and private `getTabletMetadatas(...)` to fetch per-tablet versioned metadata across nodes, with status handling and debug logging.
> - **Tests**:
>   - Add `TabletRepairHelperTest` covering success, RPC exception, null/failed responses.
>   - Add `LakeServiceWithMetricsTest#testGetTabletMetadatas`.
>   - Adjust pseudocluster/utframe test scaffolding to support the new RPC.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff2f86087de2676b04975ecf31803393b9f74836. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->