### PR TITLE
[BugFix] fix trim function

### DIFF
--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -2268,6 +2268,11 @@ static const char* skip_trailing_spaces(const char* begin, const char* end, cons
     if (UNLIKELY(begin == nullptr)) {
         return begin;
     }
+    // Nothing to trim when the slice is empty. Avoids walking backwards from
+    // end - 1, which would underflow when begin == end.
+    if (begin == end) {
+        return end;
+    }
     auto p = end;
 #if defined(__SSE2__)
     if constexpr (simd_optimization && trim_single && !trim_utf8) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

```
StarRocks> select trim(" ", "  ");
ERROR 1064 (HY000): Internal error: vector::_M_range_insert: BE:10003
The last optional character was \u1680.
```


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes trimming to safely handle empty slices and adds parameterized tests for Unicode whitespace trimming (e.g., U+1680, U+2009).
> 
> - **Backend (trim)**:
>   - Add empty-slice guard in `skip_trailing_spaces()` to avoid underflow when `begin == end`.
> - **Tests**:
>   - Introduce parameterized tests validating UTF-8 whitespace trimming (e.g., `U+1680` Ogham Space, `U+2009` Hair Space), including mixed and internal character cases.
>   - Minor test includes cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1cc0a8fb1311849f7f9399046a71d64da5c6138b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->