### PR TITLE
[UT] Auto-detect StarMgr RPC port in UtFrameUtils

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/staros/StarMgrServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/staros/StarMgrServer.java
@@ -180,6 +180,13 @@ public class StarMgrServer {
         // start rpc server
         starMgrServer = new StarManagerServer(journalSystem);
         starMgrServer.start(FrontendOptions.getLocalHostAddress(), com.staros.util.Config.STARMGR_RPC_PORT, grpcExecutor);
+        if (com.staros.util.Config.STARMGR_RPC_PORT == 0) {
+            // get the actual port
+            com.staros.util.Config.STARMGR_RPC_PORT = starMgrServer.getServerPort();
+            // update the configuration to reflect the real port
+            Config.cloud_native_meta_port = com.staros.util.Config.STARMGR_RPC_PORT;
+            LOG.info("star mgr rpc server bind port is set to {}.", com.staros.util.Config.STARMGR_RPC_PORT);
+        }
 
         StarOSAgent starOsAgent = GlobalStateMgr.getCurrentState().getStarOSAgent();
         if (starOsAgent != null && !starOsAgent.init(starMgrServer)) {

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -279,7 +279,7 @@ public class UtFrameUtils {
 
         feConfMap.put("run_mode", runMode.getName());
         if (runMode == RunMode.SHARED_DATA) {
-            feConfMap.put("cloud_native_meta_port", String.valueOf(findValidPort()));
+            feConfMap.put("cloud_native_meta_port", "0"); // auto detect available port
             feConfMap.put("enable_load_volume_from_conf", "true");
             feConfMap.put("cloud_native_storage_type", "S3");
             feConfMap.put("aws_s3_path", "dummy_unittest_bucket/dummy_sub_path");


### PR DESCRIPTION
- Allow tests to set cloud_native_meta_port=0 so the StarMgr RPC server binds an ephemeral port.
- Once the server starts, detect the actual port and feed it back into the in-memory Config to keep StarOS clients aligned.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
