### PR TITLE
[BugFix] Fix post-warehouse-deletion failures in load metadata and SQL execution

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -897,8 +897,12 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
             jobInfo.add(loadingStatus.getLoadStatistic().toShowInfoStr());
             // warehouse
             if (RunMode.isSharedDataMode()) {
-                Warehouse warehouse = GlobalStateMgr.getCurrentState().getWarehouseMgr().getWarehouse(warehouseId);
-                jobInfo.add(warehouse.getName());
+                Warehouse warehouse = GlobalStateMgr.getCurrentState().getWarehouseMgr().getWarehouseAllowNull(warehouseId);
+                if (warehouse != null) {
+                    jobInfo.add(warehouse.getName());
+                } else {
+                    jobInfo.add(String.format("Warehouse id: %d not exist.", warehouseId));
+                }
             } else {
                 jobInfo.add("");
             }
@@ -1061,12 +1065,11 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
             info.setNum_scan_bytes(loadingStatus.getLoadStatistic().sourceScanBytes());
             // warehouse
             if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
-                try {
-                    Warehouse warehouse = GlobalStateMgr.getCurrentState().getWarehouseMgr().getWarehouse(warehouseId);
+                Warehouse warehouse = GlobalStateMgr.getCurrentState().getWarehouseMgr().getWarehouseAllowNull(warehouseId);
+                if (warehouse != null) {
                     info.setWarehouse(warehouse.getName());
-                } catch (Exception e) {
-                    LOG.warn("Failed to get warehouse for job {}, error: {}", id, e.getMessage());
-                    info.setWarehouse("");
+                } else {
+                    info.setWarehouse(String.format("Warehouse id: %d not exist.", warehouseId));
                 }
             } else {
                 info.setWarehouse("");

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -970,7 +970,7 @@ public class ConnectContext {
         this.sessionVariable.setCatalog(currentCatalog);
     }
 
-    public long getCurrentWarehouseId() {
+    public Long getCurrentWarehouseIdAllowNull() {
         String warehouseName = this.sessionVariable.getWarehouseName();
         if (warehouseName.equalsIgnoreCase(WarehouseManager.DEFAULT_WAREHOUSE_NAME)) {
             return WarehouseManager.DEFAULT_WAREHOUSE_ID;
@@ -978,9 +978,17 @@ public class ConnectContext {
 
         Warehouse warehouse = globalStateMgr.getWarehouseMgr().getWarehouseAllowNull(warehouseName);
         if (warehouse == null) {
-            throw new SemanticException("Warehouse " + warehouseName + " not exist");
+            return null;
         }
         return warehouse.getId();
+    }
+
+    public long getCurrentWarehouseId() {
+        Long warehouseId = getCurrentWarehouseIdAllowNull();
+        if (warehouseId == null) {
+            throw new SemanticException("Warehouse " + this.sessionVariable.getWarehouseName() + " not exist");
+        }
+        return warehouseId;
     }
 
     public String getCurrentWarehouseName() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -664,8 +664,8 @@ public class StmtExecutor {
         }
 
         final boolean shouldMarkIdleCheck = shouldMarkIdleCheck(parsedStmt);
-        final long originWarehouseId = context.getCurrentWarehouseId();
-        if (shouldMarkIdleCheck) {
+        final Long originWarehouseId = context.getCurrentWarehouseIdAllowNull();
+        if (shouldMarkIdleCheck && originWarehouseId != null) {
             WarehouseIdleChecker.increaseRunningSQL(originWarehouseId);
         }
 
@@ -952,7 +952,7 @@ public class StmtExecutor {
             // restore session variable in connect context
             context.setSessionVariable(sessionVariableBackup);
 
-            if (shouldMarkIdleCheck) {
+            if (shouldMarkIdleCheck && originWarehouseId != null) {
                 WarehouseIdleChecker.decreaseRunningSQL(originWarehouseId);
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadJobTest.java
@@ -372,7 +372,7 @@ public class LoadJobTest {
                 minTimes = 0;
                 result = warehouseManager;
 
-                warehouseManager.getWarehouse(anyLong);
+                warehouseManager.getWarehouseAllowNull(anyLong);
                 minTimes = 0;
                 result = warehouse;
 
@@ -402,6 +402,49 @@ public class LoadJobTest {
     }
 
     @Test
+    public void testGetShowInfoMissingWarehouse() throws DdlException {
+        TimeZone tz = TimeZone.getTimeZone(ZoneId.of("Asia/Shanghai"));
+        new MockUp<TimeUtils>() {
+            @Mock
+            public TimeZone getTimeZone() {
+                return tz;
+            }
+        };
+
+        new MockUp<RunMode>() {
+            @Mock
+            public RunMode getCurrentRunMode() {
+                return RunMode.SHARED_DATA;
+            }
+        };
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                minTimes = 0;
+                result = globalStateMgr;
+
+                globalStateMgr.getWarehouseMgr();
+                minTimes = 0;
+                result = warehouseManager;
+
+                warehouseManager.getWarehouseAllowNull(anyLong);
+                minTimes = 0;
+                result = null;
+            }
+        };
+
+        LoadJob loadJob = new BrokerLoadJob();
+        loadJob.setWarehouseId(1L);
+
+        List<Comparable> showInfo = loadJob.getShowInfo();
+        Assertions.assertEquals("Warehouse id: 1 not exist.", showInfo.get(showInfo.size() - 1));
+
+        TLoadInfo loadInfo = loadJob.toThrift();
+        Assertions.assertEquals("Warehouse id: 1 not exist.", loadInfo.getWarehouse());
+    }
+
+    @Test
     public void testToThrift() {
         LoadJob loadJob = new BrokerLoadJob();
 
@@ -422,7 +465,7 @@ public class LoadJobTest {
                 minTimes = 0;
                 result = warehouseManager;
 
-                warehouseManager.getWarehouse(anyLong);
+                warehouseManager.getWarehouseAllowNull(anyLong);
                 minTimes = 0;
                 result = warehouse;
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetVarTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetVarTest.java
@@ -204,4 +204,16 @@ public class SetVarTest extends PlanTestBase {
         }
     }
 
+    @Test
+    public void testMissingWarehouse() throws Exception {
+        // Simulate that after setting the warehouse, this warehouse is deleted.
+        starRocksAssert.getCtx().getSessionVariable().setWarehouseName("no_exist_warehouse");
+
+        String sql = "set warehouse = default_warehouse";
+        StatementBase stmt = SqlParser.parse(sql, starRocksAssert.getCtx().getSessionVariable()).get(0);
+        StmtExecutor executor = new StmtExecutor(starRocksAssert.getCtx(), stmt);
+        executor.execute();
+        assertEquals("default_warehouse", starRocksAssert.getCtx().getSessionVariable().getWarehouseName());
+    }
+
 }


### PR DESCRIPTION
## Why I'm doing:

After a warehouse is deleted, there are still two places where the deleted warehouse is accessed:
1. When running `SHOW LOAD` or `SELECT * FROM information_schema.loads` to retrieve load information, the system still tries to fetch metadata for that warehouse.
2. Before executing any SQL statement, the system tries to obtain information about the current warehouse.

This leads to two issues:
1. Executing `SHOW LOAD` or `SELECT * FROM information_schema.loads` in any session fails with an error.
2. In an existing session whose current warehouse is `deleted_warehouse`, no SQL can be executed at all, including updating the warehouse via `SET warehouse = default_warehouse`.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
