### PR TITLE
[BugFix] trigger statistics collection on UPDATE statement

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/listener/LoadJobStatsListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/listener/LoadJobStatsListener.java
@@ -55,7 +55,7 @@ public class LoadJobStatsListener implements LoadJobListener {
     public void onDMLStmtJobTransactionFinish(TransactionState transactionState, Database db, Table table,
                                               DmlType dmlType) {
         if (dmlType != DmlType.INSERT_OVERWRITE && needTrigger()) {
-            StatisticUtils.triggerCollectionOnFirstLoad(transactionState, db, table, true, true);
+            StatisticUtils.triggerCollectionOnFirstLoad(transactionState, db, table, true, true, dmlType);
         }
     }
 
@@ -110,7 +110,8 @@ public class LoadJobStatsListener implements LoadJobListener {
                     .collect(Collectors.toList());
             for (Table table : tables) {
                 // stream load and broker load do not need lock
-                StatisticUtils.triggerCollectionOnFirstLoad(transactionState, db, table, sync, false);
+                StatisticUtils.triggerCollectionOnFirstLoad(transactionState, db, table, sync, false,
+                        DmlType.INSERT_INTO);
             }
         } catch (Exception t) {
             LOG.warn("refresh mv after publish version failed:", DebugUtil.getStackTrace(t));

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -41,6 +41,7 @@ import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.ConnectorPartitionTraits;
 import com.starrocks.http.HttpConnectContext;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.DmlType;
 import com.starrocks.qe.SimpleExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
@@ -160,7 +161,16 @@ public class StatisticUtils {
                                                     Table table,
                                                     boolean sync,
                                                     boolean useLock) {
-        StatisticsCollectionTrigger.triggerOnFirstLoad(txnState, db, table, sync, useLock);
+        triggerCollectionOnFirstLoad(txnState, db, table, sync, useLock, DmlType.INSERT_INTO);
+    }
+
+    public static void triggerCollectionOnFirstLoad(TransactionState txnState,
+                                                    Database db,
+                                                    Table table,
+                                                    boolean sync,
+                                                    boolean useLock,
+                                                    DmlType dmlType) {
+        StatisticsCollectionTrigger.triggerOnFirstLoad(txnState, db, table, sync, useLock, dmlType);
     }
 
     // check database in black list

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
@@ -298,10 +298,11 @@ public class StatisticsCollectionTrigger {
                     }
                 }
 
-                // TODO: support DELETE
                 if (dmlType == DmlType.UPDATE) {
                     // For UPDATE, collect on touched partitions regardless of version.
                     partitionIds.add(partitionId);
+                    tabletRows.forEach(
+                            (tabletId, rowCount) -> partitionTabletRowCounts.put(partitionId, tabletId, rowCount));
                 } else if (dmlType == DmlType.INSERT_INTO) {
                     // For INSERT, only consider the first load of a partition
                     if (partitionCommitInfo.getVersion() == Partition.PARTITION_INIT_VERSION + 1) {
@@ -309,6 +310,9 @@ public class StatisticsCollectionTrigger {
                         tabletRows.forEach(
                                 (tabletId, rowCount) -> partitionTabletRowCounts.put(partitionId, tabletId, rowCount));
                     }
+                } else {
+                    // TODO: support DELETE
+                    LOG.debug("Statistics collection not triggered for DML type: {}", dmlType);
                 }
             }
         } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectionTrigger.java
@@ -42,7 +42,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectionTriggerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectionTriggerTest.java
@@ -181,7 +181,7 @@ public class StatisticsCollectionTriggerTest extends PlanTestBase {
         TransactionState transactionState = new TransactionState();
         TableCommitInfo commitInfo = new TableCommitInfo(table.getId());
         commitInfo.addPartitionCommitInfo(new PartitionCommitInfo(
-                partition.getDefaultPhysicalPartition().getId(), Partition.PARTITION_INIT_VERSION + 1, 1));
+                partition.getDefaultPhysicalPartition().getId(), Partition.PARTITION_INIT_VERSION + 5, 1));
         transactionState.putIdToTableCommitInfo(table.getId(), commitInfo);
 
         setPartitionStatistics((OlapTable) table, "p1", 1000);

--- a/test/sql/test_analyze_statistics/R/test_update_trigger_statistics
+++ b/test/sql/test_analyze_statistics/R/test_update_trigger_statistics
@@ -1,4 +1,4 @@
--- name: test_update_trigger_statistics
+-- name: test_update_trigger_statistics @sequential
 DROP DATABASE IF EXISTS test_update_trigger_statistics;
 -- result:
 -- !result

--- a/test/sql/test_analyze_statistics/R/test_update_trigger_statistics
+++ b/test/sql/test_analyze_statistics/R/test_update_trigger_statistics
@@ -9,13 +9,11 @@ USE test_update_trigger_statistics;
 -- result:
 -- !result
 CREATE TABLE test_update_stats (
-    k1 int,
     k2 int,
     k3 varchar(20)
 ) 
-PRIMARY KEY (k1)
-PARTITION BY (k1)
-DISTRIBUTED BY HASH(k1) BUCKETS 1
+PRIMARY KEY (k2)
+DISTRIBUTED BY HASH(k2) BUCKETS 1
 PROPERTIES ( "replication_num" = "1");
 -- result:
 -- !result
@@ -36,49 +34,40 @@ order by StartTime desc limit 1;
 delete from _statistics_.column_statistics where table_name='test_update_trigger_statistics.test_update_stats';
 -- result:
 -- !result
-insert into test_update_stats select 1, generate_series, 'data' from table(generate_series(1, 1000000));
+insert into test_update_stats select generate_series, 'data' from table(generate_series(1, 1000000));
 -- result:
 -- !result
 select * from statistic_verify order by column_name;
 -- result:
-k1	p1	1	1	1
-k2	p1	1	999424	999424
-k3	p1	1	data	data
+k2	test_update_stats	1000000	1000000	1
+k3	test_update_stats	1000000	data	data
 -- !result
-update test_update_stats set k3 = 'updated1' where k1 = 1 and k2 < 500;
+update test_update_stats set k3 = '1updated' where k2 < 500;
 -- result:
 -- !result
 select * from statistic_verify order by column_name;
 -- result:
-k1	p1	1	1	1
-k2	p1	1	999424	999424
-k3	p1	1	data	data
+k2	test_update_stats	1000000	1000000	1
+k3	test_update_stats	1000000	data	1updated
 -- !result
-update test_update_stats set k3 = 'updated2' where k2 < 100000;
+update test_update_stats set k3 = '2updated2' where k2 < 10000;
 -- result:
 -- !result
 select * from statistic_verify order by column_name;
 -- result:
-k1	p1	1	1	1
-k2	p1	1	999424	999424
-k3	p1	1	data	data
--- !result
-select * from analyze_status_verify;
--- result:
-test_update_stats	ALL	SAMPLE
--- !result
-update test_update_stats set k3 = 'updated3' where k1 = 1;
--- result:
--- !result
-select * from statistic_verify order by column_name;
--- result:
-k1	p1	1	1	1
-k2	p1	1	999424	999424
-k3	p1	1	updated3	updated3
+k2	test_update_stats	1000000	1000000	1
+k3	test_update_stats	1000000	data	2updated2
 -- !result
 select * from analyze_status_verify;
 -- result:
 test_update_stats	ALL	FULL
+-- !result
+update test_update_stats set k3 = '3updated3' where k2 < 1000000000;
+-- result:
+-- !result
+select * from analyze_status_verify;
+-- result:
+test_update_stats	ALL	SAMPLE
 -- !result
 drop table test_update_stats;
 -- result:

--- a/test/sql/test_analyze_statistics/R/test_update_trigger_statistics
+++ b/test/sql/test_analyze_statistics/R/test_update_trigger_statistics
@@ -1,0 +1,94 @@
+-- name: test_update_trigger_statistics
+DROP DATABASE IF EXISTS test_update_trigger_statistics;
+-- result:
+-- !result
+CREATE DATABASE test_update_trigger_statistics;
+-- result:
+-- !result
+USE test_update_trigger_statistics;
+-- result:
+-- !result
+CREATE TABLE test_update_stats (
+    k1 int,
+    k2 int,
+    k3 varchar(20)
+) 
+PRIMARY KEY (k1)
+PARTITION BY (k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES ( "replication_num" = "1");
+-- result:
+-- !result
+CREATE VIEW statistic_verify AS
+select column_name, partition_name, row_count, max, min 
+from _statistics_.column_statistics 
+where table_name = "test_update_trigger_statistics.test_update_stats" ;
+-- result:
+-- !result
+CREATE VIEW analyze_status_verify AS
+select `Table`, Columns, Type from information_schema.analyze_status
+where 
+    `Database` = 'test_update_trigger_statistics' 
+    and `Table` = "test_update_stats" 
+order by StartTime desc limit 1;
+-- result:
+-- !result
+delete from _statistics_.column_statistics where table_name='test_update_trigger_statistics.test_update_stats';
+-- result:
+-- !result
+insert into test_update_stats select 1, generate_series, 'data' from table(generate_series(1, 1000000));
+-- result:
+-- !result
+select * from statistic_verify order by column_name;
+-- result:
+k1	p1	1	1	1
+k2	p1	1	999424	999424
+k3	p1	1	data	data
+-- !result
+update test_update_stats set k3 = 'updated1' where k1 = 1 and k2 < 500;
+-- result:
+-- !result
+select * from statistic_verify order by column_name;
+-- result:
+k1	p1	1	1	1
+k2	p1	1	999424	999424
+k3	p1	1	data	data
+-- !result
+update test_update_stats set k3 = 'updated2' where k2 < 100000;
+-- result:
+-- !result
+select * from statistic_verify order by column_name;
+-- result:
+k1	p1	1	1	1
+k2	p1	1	999424	999424
+k3	p1	1	data	data
+-- !result
+select * from analyze_status_verify;
+-- result:
+test_update_stats	ALL	SAMPLE
+-- !result
+update test_update_stats set k3 = 'updated3' where k1 = 1;
+-- result:
+-- !result
+select * from statistic_verify order by column_name;
+-- result:
+k1	p1	1	1	1
+k2	p1	1	999424	999424
+k3	p1	1	updated3	updated3
+-- !result
+select * from analyze_status_verify;
+-- result:
+test_update_stats	ALL	FULL
+-- !result
+drop table test_update_stats;
+-- result:
+-- !result
+drop view  statistic_verify;
+-- result:
+-- !result
+drop view  analyze_status_verify;
+-- result:
+-- !result
+delete from _statistics_.column_statistics where table_name='test_update_trigger_statistics.test_update_stats';
+-- result:
+-- !result

--- a/test/sql/test_analyze_statistics/R/test_update_trigger_statistics
+++ b/test/sql/test_analyze_statistics/R/test_update_trigger_statistics
@@ -24,7 +24,8 @@ where table_name = "test_update_trigger_statistics.test_update_stats" ;
 -- result:
 -- !result
 CREATE VIEW analyze_status_verify AS
-select `Table`, Columns, Type from information_schema.analyze_status
+select `Table`, Columns, Type, 
+    IF(StartTime >= @last_analyze, 'new analyze', 'no analyze') as is_new from information_schema.analyze_status
 where 
     `Database` = 'test_update_trigger_statistics' 
     and `Table` = "test_update_stats" 
@@ -42,32 +43,57 @@ select * from statistic_verify order by column_name;
 k2	test_update_stats	1000000	1000000	1
 k3	test_update_stats	1000000	data	data
 -- !result
-update test_update_stats set k3 = '1updated' where k2 < 500;
+set @last_analyze=(select now());
+-- result:
+-- !result
+update test_update_stats set k3 = '1updated' where k2 = 1;
 -- result:
 -- !result
 select * from statistic_verify order by column_name;
 -- result:
 k2	test_update_stats	1000000	1000000	1
-k3	test_update_stats	1000000	data	1updated
+k3	test_update_stats	1000000	data	data
 -- !result
-update test_update_stats set k3 = '2updated2' where k2 < 10000;
+select * from analyze_status_verify;
+-- result:
+test_update_stats	ALL	SAMPLE	no analyze
+-- !result
+update test_update_stats set k3 = '2updated2' where k2 < 1000;
 -- result:
 -- !result
 select * from statistic_verify order by column_name;
 -- result:
 k2	test_update_stats	1000000	1000000	1
-k3	test_update_stats	1000000	data	2updated2
+k3	test_update_stats	1000000	data	data
 -- !result
 select * from analyze_status_verify;
 -- result:
-test_update_stats	ALL	FULL
+test_update_stats	ALL	SAMPLE	no analyze
 -- !result
-update test_update_stats set k3 = '3updated3' where k2 < 1000000000;
+set @last_analyze=(select now());
+-- result:
+-- !result
+update test_update_stats set k3 = '3updated3' where k2 < 200*1000;
+-- result:
+-- !result
+select * from statistic_verify order by column_name;
+-- result:
+k2	test_update_stats	1000000	1000000	1
+k3	test_update_stats	1000000	data	3updated3
+-- !result
+select * from analyze_status_verify;
+-- result:
+test_update_stats	ALL	FULL	new analyze
+-- !result
+set @last_analyze=(select now());
+-- result:
+-- !result
+update test_update_stats set k3 = '4updated4' where k2 < 1000000000;
 -- result:
 -- !result
 select * from analyze_status_verify;
 -- result:
-test_update_stats	ALL	SAMPLE
+test_update_stats	ALL	SAMPLE	new analyze
 -- !result
 drop table test_update_stats;
 -- result:

--- a/test/sql/test_analyze_statistics/T/test_update_trigger_statistics
+++ b/test/sql/test_analyze_statistics/T/test_update_trigger_statistics
@@ -1,4 +1,4 @@
--- name: test_update_trigger_statistics
+-- name: test_update_trigger_statistics @sequential
 
 DROP DATABASE IF EXISTS test_update_trigger_statistics;
 CREATE DATABASE test_update_trigger_statistics;

--- a/test/sql/test_analyze_statistics/T/test_update_trigger_statistics
+++ b/test/sql/test_analyze_statistics/T/test_update_trigger_statistics
@@ -6,13 +6,11 @@ USE test_update_trigger_statistics;
 
 -- Create a partitioned table
 CREATE TABLE test_update_stats (
-    k1 int,
     k2 int,
     k3 varchar(20)
 ) 
-PRIMARY KEY (k1)
-PARTITION BY (k1)
-DISTRIBUTED BY HASH(k1) BUCKETS 1
+PRIMARY KEY (k2)
+DISTRIBUTED BY HASH(k2) BUCKETS 1
 PROPERTIES ( "replication_num" = "1");
 
 CREATE VIEW statistic_verify AS
@@ -32,21 +30,22 @@ order by StartTime desc limit 1;
 delete from _statistics_.column_statistics where table_name='test_update_trigger_statistics.test_update_stats';
 
 -- First load
-insert into test_update_stats select 1, generate_series, 'data' from table(generate_series(1, 1000000));
+insert into test_update_stats select generate_series, 'data' from table(generate_series(1, 1000000));
 select * from statistic_verify order by column_name;
 
 -- UPDATE a few rows
-update test_update_stats set k3 = 'updated1' where k1 = 1 and k2 < 500;
+update test_update_stats set k3 = '1updated' where k2 < 500;
 select * from statistic_verify order by column_name;
 
 -- UPDATE lots of rows
-update test_update_stats set k3 = 'updated2' where k2 < 100000;
+update test_update_stats set k3 = '2updated2' where k2 < 10000;
 select * from statistic_verify order by column_name;
 select * from analyze_status_verify;
 
 -- UPDATE all rows
-update test_update_stats set k3 = 'updated3' where k1 = 1;
-select * from statistic_verify order by column_name;
+update test_update_stats set k3 = '3updated3' where k2 < 1000000000;
+-- sample result is not stable
+-- select * from statistic_verify order by column_name;
 select * from analyze_status_verify;
 
 drop table test_update_stats;

--- a/test/sql/test_analyze_statistics/T/test_update_trigger_statistics
+++ b/test/sql/test_analyze_statistics/T/test_update_trigger_statistics
@@ -1,0 +1,55 @@
+-- name: test_update_trigger_statistics
+
+DROP DATABASE IF EXISTS test_update_trigger_statistics;
+CREATE DATABASE test_update_trigger_statistics;
+USE test_update_trigger_statistics;
+
+-- Create a partitioned table
+CREATE TABLE test_update_stats (
+    k1 int,
+    k2 int,
+    k3 varchar(20)
+) 
+PRIMARY KEY (k1)
+PARTITION BY (k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1
+PROPERTIES ( "replication_num" = "1");
+
+CREATE VIEW statistic_verify AS
+select column_name, partition_name, row_count, max, min 
+from _statistics_.column_statistics 
+where table_name = "test_update_trigger_statistics.test_update_stats" ;
+
+CREATE VIEW analyze_status_verify AS
+select `Table`, Columns, Type from information_schema.analyze_status
+where 
+    `Database` = 'test_update_trigger_statistics' 
+    and `Table` = "test_update_stats" 
+order by StartTime desc limit 1;
+
+
+-- Clear any existing statistics
+delete from _statistics_.column_statistics where table_name='test_update_trigger_statistics.test_update_stats';
+
+-- First load
+insert into test_update_stats select 1, generate_series, 'data' from table(generate_series(1, 1000000));
+select * from statistic_verify order by column_name;
+
+-- UPDATE a few rows
+update test_update_stats set k3 = 'updated1' where k1 = 1 and k2 < 500;
+select * from statistic_verify order by column_name;
+
+-- UPDATE lots of rows
+update test_update_stats set k3 = 'updated2' where k2 < 100000;
+select * from statistic_verify order by column_name;
+select * from analyze_status_verify;
+
+-- UPDATE all rows
+update test_update_stats set k3 = 'updated3' where k1 = 1;
+select * from statistic_verify order by column_name;
+select * from analyze_status_verify;
+
+drop table test_update_stats;
+drop view  statistic_verify;
+drop view  analyze_status_verify;
+delete from _statistics_.column_statistics where table_name='test_update_trigger_statistics.test_update_stats';

--- a/test/sql/test_analyze_statistics/T/test_update_trigger_statistics
+++ b/test/sql/test_analyze_statistics/T/test_update_trigger_statistics
@@ -19,7 +19,9 @@ from _statistics_.column_statistics
 where table_name = "test_update_trigger_statistics.test_update_stats" ;
 
 CREATE VIEW analyze_status_verify AS
-select `Table`, Columns, Type from information_schema.analyze_status
+select `Table`, Columns, Type, 
+    IF(StartTime >= @last_analyze, 'new analyze', 'no analyze') as is_new 
+from information_schema.analyze_status
 where 
     `Database` = 'test_update_trigger_statistics' 
     and `Table` = "test_update_stats" 
@@ -29,21 +31,28 @@ order by StartTime desc limit 1;
 -- Clear any existing statistics
 delete from _statistics_.column_statistics where table_name='test_update_trigger_statistics.test_update_stats';
 
--- First load
+-- First load, 1M rows
 insert into test_update_stats select generate_series, 'data' from table(generate_series(1, 1000000));
 select * from statistic_verify order by column_name;
 
--- UPDATE a few rows
-update test_update_stats set k3 = '1updated' where k2 < 500;
+-- UPDATE a few rows should not trigger statistics collection
+set @last_analyze=(select now());
+update test_update_stats set k3 = '1updated' where k2 = 1;
 select * from statistic_verify order by column_name;
-
--- UPDATE lots of rows
-update test_update_stats set k3 = '2updated2' where k2 < 10000;
+select * from analyze_status_verify;
+update test_update_stats set k3 = '2updated2' where k2 < 1000;
 select * from statistic_verify order by column_name;
 select * from analyze_status_verify;
 
--- UPDATE all rows
-update test_update_stats set k3 = '3updated3' where k2 < 1000000000;
+-- UPDATE lots of rows 
+set @last_analyze=(select now());
+update test_update_stats set k3 = '3updated3' where k2 < 200*1000;
+select * from statistic_verify order by column_name;
+select * from analyze_status_verify;
+
+-- UPDATE all rows 
+set @last_analyze=(select now());
+update test_update_stats set k3 = '4updated4' where k2 < 1000000000;
 -- sample result is not stable
 -- select * from statistic_verify order by column_name;
 select * from analyze_status_verify;


### PR DESCRIPTION
## Why I'm doing:

Currently, only INSERT and INSERT_OVERWRITE operations trigger statistics collection in specific cases. However, the UPDATE statement can also significantly modify data, such as `UPDATE t1 SET c1 = xxxx`. In such cases, the statistics should also be updated to accurately reflect these data changes.

## What I'm doing:

Make the `UPDATE` trigger the statistics collection.

TODO: 
1. support DELETE as well
2. change the background statistics collection healthy calculation

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable statistics collection on UPDATE by propagating DML type through first-load triggers, refine analyze-type decision using stats meta total rows, and add unit/integration tests.
> 
> - **Statistics collection trigger**:
>   - Pass `DmlType` through `triggerCollectionOnFirstLoad(...)` from `LoadJobStatsListener` → `StatisticUtils` → `StatisticsCollectionTrigger`.
>   - Handle `DmlType.UPDATE`: collect on touched partitions regardless of version; keep existing logic for `INSERT_INTO`; log/not supported for DELETE.
>   - Default non-stream/broker paths call with `DmlType.INSERT_INTO`.
> - **Analyze decision logic**:
>   - Use `BasicStatsMeta.getTotalRows()` to compute `totalRows` when deciding FULL vs SAMPLE; fallback to partition row counts.
>   - Preserve/propagate `partitionTabletRowCounts` for SAMPLE where applicable on overwrite.
> - **Tests**:
>   - Add UT `triggerOnUpdate` in `StatisticsCollectionTriggerTest`.
>   - Add SQL regression `test_update_trigger_statistics` verifying no-analyze for small updates, FULL for large, SAMPLE for very large.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bf682f4fb425c07e6ad24fdabefd6468f1766a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->