### PR TITLE
[BugFix] Refresh mv's metadata in getting mvs by ast keys

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
@@ -357,13 +357,28 @@ public class CachingMvPlanContextBuilder {
     }
 
     /**
+     * NOTE: This method will refresh the metadata of mvs to avoid using stale mv.
      * @return: null if parseNode is null or astToMvsMap doesn't contain this ast, otherwise return the mvs
      */
     public Set<MaterializedView> getMvsByAst(AstKey ast) {
         if (ast == null) {
             return null;
         }
-        return AST_TO_MV_MAP.get(ast);
+        Set<MaterializedView> candidateMVs = AST_TO_MV_MAP.get(ast);
+        // check & refresh mv's metadata to avoid using stale mv
+        if (candidateMVs == null) {
+            return Sets.newHashSet();
+        }
+        Set<MaterializedView> validMVs = Sets.newHashSet();
+        for (MaterializedView mv : candidateMVs) {
+            MaterializedView curMV = GlobalStateMgr.getCurrentState().getLocalMetastore().getMaterializedView(mv.getMvId());
+            if (curMV == null) {
+                LOG.warn("mv {} is not found in metastore, skip it.", mv.getName());
+                continue;
+            }
+            validMVs.add(curMV);
+        }
+        return validMVs;
     }
 
     /**


### PR DESCRIPTION
## Why I'm doing:
`ast` to `mv` mapping is static and used for finding the mv of the specific `ast tree` using text-based mv rewrite.

But if the MV is outdated, the rewritten plan may use outdated tablets.


## What I'm doing:
- Get the current MV object from `GlobalStateMananger` for each fetching mvs of the `ast` keys.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3
