### PR TITLE
[BugFix] Fix foreign key constraints lost after FE restart

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1392,6 +1392,11 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         analyzePartitionInfo();
         // analyze mv partition exprs
         analyzePartitionExprs();
+
+        if (tableProperty != null) {
+            tableProperty.buildConstraint();
+        }
+        
         // register constraints from global state manager
         GlobalConstraintManager globalConstraintManager = GlobalStateMgr.getCurrentState().getGlobalConstraintManager();
         globalConstraintManager.registerConstraint(this);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2901,6 +2901,10 @@ public class OlapTable extends Table {
         tryToAssignIndexId();
         updateBaseCompactionForbiddenTimeRanges(false);
 
+        if (tableProperty != null) {
+            tableProperty.buildConstraint();
+        }
+
         // register constraints from global state manager
         GlobalConstraintManager globalConstraintManager = GlobalStateMgr.getCurrentState().getGlobalConstraintManager();
         globalConstraintManager.registerConstraint(this);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateTableStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateTableStmtTest.java
@@ -222,4 +222,74 @@ public class ShowCreateTableStmtTest {
                         .contains("AS dict_mapping('test.dict', k1, k2, k3, k4, k5, TRUE) COMMENT"),
                 resultSet.getResultRows().get(0).get(1));
     }
+
+    @Test
+    public void testShowCreateTableWithUniqueAndForeignKeyConstraints() throws Exception {
+        starRocksAssert.withDatabase("test").useDatabase("test")
+                .withTable("CREATE TABLE test.parent_uk1 (\n" +
+                        "  k1 INT NOT NULL,\n" +
+                        "  k2 VARCHAR(20) NOT NULL\n" +
+                        ") ENGINE=OLAP\n" +
+                        "DUPLICATE KEY(k1)\n" +
+                        "DISTRIBUTED BY HASH(k1) BUCKETS 3\n" +
+                        "PROPERTIES (\n" +
+                        "  \"replication_num\" = \"1\",\n" +
+                        "  \"unique_constraints\" = \"k1,k2\"\n" +
+                        ");")
+                .withTable("CREATE TABLE test.parent_uk2 (\n" +
+                        "  id INT NOT NULL,\n" +
+                        "  name VARCHAR(50) NOT NULL\n" +
+                        ") ENGINE=OLAP\n" +
+                        "DUPLICATE KEY(id)\n" +
+                        "DISTRIBUTED BY HASH(id) BUCKETS 3\n" +
+                        "PROPERTIES (\n" +
+                        "  \"replication_num\" = \"1\",\n" +
+                        "  \"unique_constraints\" = \"id\"\n" +
+                        ");");
+
+        // Test showing unique constraints
+        String showParent1 = "show create table test.parent_uk1";
+        ShowCreateTableStmt stmt1 = (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(showParent1, ctx);
+        ShowResultSet result1 = ShowExecutor.execute(stmt1, ctx);
+        String createTable1 = result1.getResultRows().get(0).get(1);
+        Assertions.assertTrue(createTable1.contains("unique_constraints"),
+                "SHOW CREATE TABLE should include unique_constraints. Got: " + createTable1);
+        Assertions.assertTrue(createTable1.contains("k1") && createTable1.contains("k2"),
+                "unique_constraints should include column names. Got: " + createTable1);
+
+        String showParent2 = "show create table test.parent_uk2";
+        ShowCreateTableStmt stmt2 = (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(showParent2, ctx);
+        ShowResultSet result2 = ShowExecutor.execute(stmt2, ctx);
+        String createTable2 = result2.getResultRows().get(0).get(1);
+        Assertions.assertTrue(createTable2.contains("unique_constraints"),
+                "SHOW CREATE TABLE should include unique_constraints. Got: " + createTable2);
+
+        // Create child table with foreign key constraints
+        starRocksAssert.withTable("CREATE TABLE test.child_fk (\n" +
+                "  id INT,\n" +
+                "  parent1_k1 INT,\n" +
+                "  parent1_k2 VARCHAR(20),\n" +
+                "  parent2_id INT,\n" +
+                "  value VARCHAR(100)\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(id)\n" +
+                "DISTRIBUTED BY HASH(id) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "  \"replication_num\" = \"1\",\n" +
+                "  \"foreign_key_constraints\" = \"(parent1_k1, parent1_k2) REFERENCES parent_uk1(k1, k2);" +
+                "                                 (parent2_id) REFERENCES parent_uk2(id)\"\n" +
+                ");");
+
+        // Test showing foreign key constraints
+        String showChild = "show create table test.child_fk";
+        ShowCreateTableStmt stmt3 = (ShowCreateTableStmt) UtFrameUtils.parseStmtWithNewParser(showChild, ctx);
+        ShowResultSet result3 = ShowExecutor.execute(stmt3, ctx);
+        String createTable3 = result3.getResultRows().get(0).get(1);
+        Assertions.assertTrue(createTable3.contains("foreign_key_constraints"),
+                "SHOW CREATE TABLE should include foreign_key_constraints. Got: " + createTable3);
+        Assertions.assertTrue(createTable3.contains("parent_uk1") && createTable3.contains("parent_uk2"),
+                "foreign_key_constraints should include parent table names. Got: " + createTable3);
+        Assertions.assertTrue(createTable3.contains("parent1_k1") && createTable3.contains("parent1_k2"),
+                "foreign_key_constraints should include child column names. Got: " + createTable3);
+    }
 }


### PR DESCRIPTION

## Why I'm doing:

Foreign key constraints are lost after FE restart due to table loading order issues during image deserialization.

**Root Cause:**

When FE loads tables from image file, each table is deserialized sequentially. During deserialization, `TableProperty.gsonPostProcess()` is automatically called, which invokes `buildMvProperties()` -> `buildConstraint()` to parse foreign key constraints.

The problem is that `buildConstraint()` calls `ForeignKeyConstraint.parse()`, which tries to look up the referenced parent table from `GlobalStateMgr`. However, at this point, the parent table may not have been loaded yet (it might be later in the serialization stream).

When `ForeignKeyConstraint.getTableBaseInfo()` cannot find the parent table, it throws an `IllegalArgumentException`. This exception is caught and silently ignored in `buildConstraint()` (only logs a warning), leaving `foreignKeyConstraints` as `null`.


## What I'm doing:

Add a safety net by calling `tableProperty.buildConstraint()` in `OlapTable.onReload()`, which is invoked after all tables have been loaded into memory.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Rebuild table properties constraints during reload for `OlapTable` and `MaterializedView` to preserve FKs after FE restart, and add tests verifying SHOW CREATE outputs unique/foreign key constraints.
> 
> - **Catalog (reload behavior)**:
>   - `MaterializedView.onReloadImpl()`: call `tableProperty.buildConstraint()` before registering with `GlobalConstraintManager`.
>   - `OlapTable.onReload()`: call `tableProperty.buildConstraint()` before registering with `GlobalConstraintManager`.
> - **Tests**:
>   - Add `testShowCreateTableWithUniqueAndForeignKeyConstraints` in `ShowCreateTableStmtTest` to assert SHOW CREATE includes `unique_constraints` and `foreign_key_constraints` with correct columns and referenced tables.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a0cb2de118543318ac01e0de2280c5294dd0557. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->