### PR TITLE
[Refactor] reduce includes in json.h

### DIFF
--- a/be/src/column/CMakeLists.txt
+++ b/be/src/column/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(Column STATIC
         map_column.cpp
         struct_column.cpp
         stream_chunk.cpp
+        type_traits.cpp
         column_view/column_view_base.cpp
         column_view/column_view_helper.cpp
         variant_column.cpp

--- a/be/src/column/json_column.cpp
+++ b/be/src/column/json_column.cpp
@@ -14,11 +14,10 @@
 
 #include "column/json_column.h"
 
-#include <sstream>
-#include <type_traits>
+#include <velocypack/Slice.h>
 
-#include "column/bytes.h"
-#include "column/column_helper.h"
+#include <sstream>
+
 #include "column/column_view/column_view.h"
 #include "column/nullable_column.h"
 #include "column/vectorized_fwd.h"
@@ -26,7 +25,6 @@
 #include "glog/logging.h"
 #include "gutil/casts.h"
 #include "gutil/strings/substitute.h"
-#include "simd/simd.h"
 #include "types/logical_type.h"
 #include "util/hash_util.hpp"
 #include "util/mysql_row_buffer.h"

--- a/be/src/column/type_traits.cpp
+++ b/be/src/column/type_traits.cpp
@@ -1,0 +1,15 @@
+#include "column/type_traits.h"
+
+#include <velocypack/Slice.h>
+
+namespace starrocks {
+
+JsonValue RunTimeTypeLimits<TYPE_JSON>::min_value() {
+    return JsonValue{vpack::Slice::minKeySlice()};
+}
+
+JsonValue RunTimeTypeLimits<TYPE_JSON>::max_value() {
+    return JsonValue{vpack::Slice::maxKeySlice()};
+}
+
+} // namespace starrocks

--- a/be/src/column/type_traits.cpp
+++ b/be/src/column/type_traits.cpp
@@ -1,3 +1,17 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "column/type_traits.h"
 
 #include <velocypack/Slice.h>

--- a/be/src/column/type_traits.h
+++ b/be/src/column/type_traits.h
@@ -517,8 +517,10 @@ template <>
 struct RunTimeTypeLimits<TYPE_JSON> {
     using value_type = JsonValue;
 
-    static value_type min_value() { return JsonValue{vpack::Slice::minKeySlice()}; }
-    static value_type max_value() { return JsonValue{vpack::Slice::maxKeySlice()}; }
+    // static value_type min_value() { return JsonValue{vpack::Slice::minKeySlice()}; }
+    // static value_type max_value() { return JsonValue{vpack::Slice::maxKeySlice()}; }
+    static value_type min_value();
+    static value_type max_value();
 };
 
 template <>

--- a/be/src/column/type_traits.h
+++ b/be/src/column/type_traits.h
@@ -517,8 +517,6 @@ template <>
 struct RunTimeTypeLimits<TYPE_JSON> {
     using value_type = JsonValue;
 
-    // static value_type min_value() { return JsonValue{vpack::Slice::minKeySlice()}; }
-    // static value_type max_value() { return JsonValue{vpack::Slice::maxKeySlice()}; }
     static value_type min_value();
     static value_type max_value();
 };

--- a/be/src/exec/arrow_to_json_converter.cpp
+++ b/be/src/exec/arrow_to_json_converter.cpp
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <velocypack/Builder.h>
+#include <velocypack/Value.h>
+
 #include <memory>
 #include <string>
 

--- a/be/src/util/json.cpp
+++ b/be/src/util/json.cpp
@@ -39,6 +39,15 @@ Status fromVPackException(const vpack::Exception& e) {
     return Status::JsonFormatError(Slice(e.what()));
 }
 
+template <class Ret, class Fn>
+static inline StatusOr<Ret> callVPack(Fn fn) {
+    try {
+        return fn();
+    } catch (const vpack::Exception& e) {
+        return fromVPackException(e);
+    }
+}
+
 JsonType fromVPackType(vpack::ValueType type) {
     switch (type) {
     case vpack::ValueType::Null:

--- a/be/src/util/json.h
+++ b/be/src/util/json.h
@@ -143,12 +143,6 @@ public:
     int64_t hash() const;
 
 private:
-    template <class Ret, class Fn>
-    StatusOr<Ret> callVPack(Fn fn);
-
-    template <class Ret, class Fn>
-    StatusOr<Ret> callVPack(Fn fn) const;
-
     // serialized binary of json
     // TODO(mofei) store vpack::Slice
     std::string binary_;
@@ -159,24 +153,6 @@ JsonType fromVPackType(vpack::ValueType type);
 vpack::Slice noneJsonSlice();
 vpack::Slice nullJsonSlice();
 vpack::Slice emptyStringJsonSlice();
-
-template <class Ret, class Fn>
-inline StatusOr<Ret> JsonValue::callVPack(Fn fn) {
-    try {
-        return fn();
-    } catch (const std::exception& e) {
-        return Status::JsonFormatError(Slice(e.what()));
-    }
-}
-
-template <class Ret, class Fn>
-inline StatusOr<Ret> JsonValue::callVPack(Fn fn) const {
-    try {
-        return fn();
-    } catch (const std::exception& e) {
-        return Status::JsonFormatError(Slice(e.what()));
-    }
-}
 
 // output
 std::ostream& operator<<(std::ostream& os, const JsonValue& json);

--- a/be/src/util/json.h
+++ b/be/src/util/json.h
@@ -12,8 +12,8 @@
 #include "common/statusor.h"
 #include "fmt/format.h"
 #include "glog/logging.h"
-#include "util/slice.h"
 #include "simdjson.h"
+#include "util/slice.h"
 
 namespace arangodb::velocypack {
 class Slice;
@@ -21,7 +21,6 @@ class Builder;
 class Exception;
 enum class ValueType : uint8_t;
 } // namespace arangodb::velocypack
-
 
 namespace starrocks {
 

--- a/be/src/util/json_converter.h
+++ b/be/src/util/json_converter.h
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <simdjson.h>
+#include <velocypack/Slice.h>
 
 #include "column/column_builder.h"
 #include "column/type_traits.h"
 #include "common/compiler_util.h"
 #include "common/statusor.h"
+#include "simdjson/ondemand.h"
 #include "util/json.h"
 
 namespace starrocks {

--- a/be/test/column/json_column_test.cpp
+++ b/be/test/column/json_column_test.cpp
@@ -30,6 +30,7 @@
 #include "testutil/assert.h"
 #include "testutil/parallel_test.h"
 #include "util/json.h"
+#include "velocypack/vpack.h"
 
 namespace starrocks {
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Move the `velocypack/vpack.h` out of `json.h`, as it's included by `type_traits.h` and a lot of files.

TODO: move `simdjson.h` otu of `json.h`

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Moves VPack-dependent code out of `json.h` into `json.cpp`, implements `RunTimeTypeLimits<TYPE_JSON>`, and updates includes/CMake accordingly.
> 
> - **Refactor: JSON headers**
>   - Forward-declare VPack types in `util/json.h`; move VPack-dependent implementations (e.g., `JsonValue(VSlice)`, `assign(Builder)`, helpers like `fromVPackException`, `fromVPackType`, `noneJsonSlice/nullJsonSlice/emptyStringJsonSlice`) to `util/json.cpp`.
>   - Remove inline VPack utilities from header; keep function declarations only.
> - **Type traits**
>   - Implement `RunTimeTypeLimits<TYPE_JSON>::min_value/max_value` in new `column/type_traits.cpp` using `vpack::Slice::minKeySlice/maxKeySlice`.
>   - Update `column/type_traits.h` to declare these functions.
>   - Add `type_traits.cpp` to `be/src/column/CMakeLists.txt`.
> - **Includes cleanup**
>   - Replace/trim headers: add `velocypack/Slice.h` where needed (`column/json_column.cpp`, `util/json_converter.h`), add `velocypack/Builder.h` and `Value.h` in `exec/arrow_to_json_converter.cpp`.
>   - Switch to `simdjson/ondemand.h` in `util/json_converter.h`; remove broad `simdjson.h` where possible.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8273d90663f833f6762f617cbeb001f5c8185940. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->