### PR TITLE
[Doc] Code Block lacks backticks for ending

### DIFF
--- a/docs/ja/administration/management/resource_management/resource_group.md
+++ b/docs/ja/administration/management/resource_management/resource_group.md
@@ -112,6 +112,7 @@ WITH (
     'mem_limit' = '50%',
     'mem_pool' = 'shared_pool'
 );
+```
 
 ##### `spill_mem_limit_threshold`
 

--- a/docs/zh/administration/management/resource_management/resource_group.md
+++ b/docs/zh/administration/management/resource_management/resource_group.md
@@ -112,6 +112,7 @@ WITH (
     'mem_limit' = '50%',
     'mem_pool' = 'shared_pool'
 );
+```
 
 ##### `spill_mem_limit_threshold`
 


### PR DESCRIPTION
the code section have less "```" Document spill_mem_limit_threshold in resource_group.md

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Doc fixes and parameter docs**
> 
> - Fixes missing closing backticks for SQL examples in JA/ZH `resource_group.md` and properly closes the final code fence
> - Adds/clarifies the `spill_mem_limit_threshold` section, detailing value range, defaults, and auto-spill conditions with and without resource groups (`spill_mode=auto`, `query_mem_limit` interactions)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fac0f41e1d34099d791e67d0c0f17d870cc2365. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->