### PR TITLE
[BugFix] Fix array_map expr get wrong result from constant unary expr

### DIFF
--- a/be/src/exprs/array_map_expr.cpp
+++ b/be/src/exprs/array_map_expr.cpp
@@ -202,6 +202,13 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_lambda_expr(ExprContext* context, Chu
         ColumnPtr tmp_col;
         if (!cur_chunk->has_columns()) {
             ASSIGN_OR_RETURN(tmp_col, context->evaluate(_children[0], nullptr));
+            DCHECK_EQ(tmp_col->size(), 1);
+            // Now we cannot guarantee that a const column input will return a const column.
+            if (tmp_col->has_null()) {
+                tmp_col = ColumnHelper::create_const_null_column(1);
+            } else {
+                tmp_col = ConstColumn::create(ColumnHelper::get_data_column(tmp_col.get()), 1);
+            }
         } else {
             ASSIGN_OR_RETURN(tmp_col, context->evaluate(_children[0], cur_chunk.get()));
         }

--- a/be/src/exprs/java_function_call_expr.h
+++ b/be/src/exprs/java_function_call_expr.h
@@ -42,6 +42,6 @@ private:
     RuntimeState* _runtime_state = nullptr;
     std::shared_ptr<JavaUDFContext> _func_desc;
     std::shared_ptr<UDFFunctionCallHelper> _call_helper;
-    bool _is_returning_random_value;
+    bool _is_returning_random_value = false;
 };
 } // namespace starrocks

--- a/test/sql/test_udf/R/test_jvm_udf
+++ b/test/sql/test_udf/R/test_jvm_udf
@@ -309,3 +309,30 @@ select id, sum_map(data) from map_table group by id order by id;
 1	{"a":30,"b":20,"c":20}
 2	{null:40,"d":50,"e":30}
 -- !result
+CREATE FUNCTION echoint(int)
+RETURNS int
+symbol = "Echoint"
+type = "StarrocksJar"
+file = "${udf_url}/starrocks-jdbc/udf.jar";
+-- result:
+-- !result
+CREATE TABLE `t1` (
+  `c0` int DEFAULT NULL,
+  `c1` int DEFAULT NULL,
+  `c2` array<int> DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1 SELECT generate_series, 4096 - generate_series, [generate_series] FROM TABLE(generate_series(1,  40960));
+-- result:
+-- !result
+select count(*) from (select * from t1 where any_match((x)->cast(echoint(1) as boolean), c2)) t;
+-- result:
+40960
+-- !result

--- a/test/sql/test_udf/T/test_jvm_udf
+++ b/test/sql/test_udf/T/test_jvm_udf
@@ -194,3 +194,23 @@ insert into map_table values (1, map{"a": 10, "b": 20}), (1, map{"a": 20, "c": 2
 select id, data from map_table order by id;
 select id, sum_map(data) from map_table group by id order by id;
 
+CREATE FUNCTION echoint(int)
+RETURNS int
+symbol = "Echoint"
+type = "StarrocksJar"
+file = "${udf_url}/starrocks-jdbc/udf.jar";
+
+CREATE TABLE `t1` (
+  `c0` int DEFAULT NULL,
+  `c1` int DEFAULT NULL,
+  `c2` array<int> DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into t1 SELECT generate_series, 4096 - generate_series, [generate_series] FROM TABLE(generate_series(1,  40960));
+select count(*) from (select * from t1 where any_match((x)->cast(echoint(1) as boolean), c2)) t;


### PR DESCRIPTION
## Why I'm doing:

see reproduce case

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fix array_map evaluation for independent lambdas with constant input, initialize Java UDF random-value flag, and add SQL tests validating UDF usage with any_match.
> 
> - **Exprs**:
>   - **array_map**: When evaluating independent lambdas without input columns, ensure the lambda result is treated as a single-row const (or const-null) column before replication; aligns return types and prevents incorrect results from constant unary expressions (`be/src/exprs/array_map_expr.cpp`).
>   - **Java UDF**: Initialize `_is_returning_random_value` to `false` to avoid uninitialized state (`be/src/exprs/java_function_call_expr.h`).
> - **Tests**:
>   - Add UDF `echoint`, table `t1`, data load via `generate_series`, and query using `any_match((x)->cast(echoint(1) as boolean), c2)` with expected count `40960` (`test/sql/test_udf/T|R/test_jvm_udf`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a51ce5fb594e1d64350baf23396d24ec81df8be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->