### PR TITLE
[Enhancement] Support single-tablet ResultSink optimization in share-data mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -189,6 +189,19 @@ public class PlanFragment extends TreeNode<PlanFragment> {
 
     private List<Integer> collectExecStatsIds;
 
+    // If all scan nodes in the entire plan are OLAP scan nodes and at most one tablet is used,
+    // then all fragments will have at most one instance (running on a single BE).
+    // In this case, there is no need to put the ResultSink in a dedicated gather fragment.
+    //
+    // CN mode(prefer_compute_node is true or share-data mode) needs special handling here, because its strategy for selecting
+    // BE/CN nodes for remote fragments (whose left-deep node is not a scan node) is different from non-CN mode:
+    // - CN mode: selects all CN nodes as instances, which will be more than 1 here,
+    //   causing the fragment that contains the ResultSink to also have more than 1 instance.
+    // - None-CN mode: selects the BE node(s) where the child fragment is running.
+    //
+    // Therefore, if isSingleTabletGatherOutputFragment is true, CN mode should use the same selection strategy as none-CN mode.
+    private boolean isSingleTabletGatherOutputFragment = false;
+
     /**
      * C'tor for fragment with specific partition; the output is by default broadcast.
      */
@@ -1049,4 +1062,11 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         }
     }
 
+    public boolean isSingleTabletGatherOutputFragment() {
+        return isSingleTabletGatherOutputFragment;
+    }
+
+    public void setSingleTabletGatherOutputFragment(boolean singleTabletGatherOutputFragment) {
+        isSingleTabletGatherOutputFragment = singleTabletGatherOutputFragment;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/RemoteFragmentAssignmentStrategy.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/assignment/RemoteFragmentAssignmentStrategy.java
@@ -101,7 +101,8 @@ public class RemoteFragmentAssignmentStrategy implements FragmentAssignmentStrat
         int maxParallelism = 0;
 
         List<Long> selectedComputedNodes = workerProvider.selectAllComputeNodes();
-        if (workerProvider.isPreferComputeNode() && !selectedComputedNodes.isEmpty()) {
+        if (workerProvider.isPreferComputeNode() && !selectedComputedNodes.isEmpty()
+                && !fragment.isSingleTabletGatherOutputFragment()) {
             workerIdSet = adaptiveChooseNodes(fragment, selectedComputedNodes, Sets.newHashSet(selectedComputedNodes));
             // make olapScan maxParallelism equals prefer compute node number
             maxParallelism = workerIdSet.size() * fragment.getParallelExecNum();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -115,7 +115,6 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
-import com.starrocks.server.RunMode;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
@@ -355,12 +354,12 @@ public class PlanFragmentBuilder {
         // We shouldn't set result sink directly to top fragment, because we will hash multi result sink.
         // Note: If enable compute node and the top fragment not GATHER node, the parallelism of top fragment can't
         // be 1, it's error
-        if ((!enableComputeNode(execPlan)
-                && !inputFragment.hashLocalBucketShuffleRightOrFullJoin(inputFragment.getPlanRoot())
+        if ((!inputFragment.hashLocalBucketShuffleRightOrFullJoin(inputFragment.getPlanRoot())
                 && execPlan.getScanNodes().stream().allMatch(d -> d instanceof OlapScanNode)
                 && (execPlan.getScanNodes().stream().map(d -> ((OlapScanNode) d).getScanTabletIds().size())
                 .reduce(Integer::sum).orElse(2) <= 1)) || execPlan.isShortCircuit()) {
             inputFragment.setOutputExprs(outputExprs);
+            inputFragment.setSingleTabletGatherOutputFragment(true);
             return;
         }
 
@@ -373,14 +372,6 @@ public class PlanFragmentBuilder {
 
         exchangeFragment.setOutputExprs(outputExprs);
         execPlan.getFragments().add(exchangeFragment);
-    }
-
-    private static boolean enableComputeNode(ExecPlan execPlan) {
-        boolean preferComputeNode = execPlan.getConnectContext().getSessionVariable().isPreferComputeNode();
-        if (preferComputeNode || RunMode.isSharedDataMode()) {
-            return true;
-        }
-        return false;
     }
 
     private static boolean useQueryCache(ExecPlan execPlan) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -17,9 +17,11 @@ package com.starrocks.sql.plan;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.FeConstants;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.rule.RuleSet;
 import com.starrocks.sql.optimizer.rule.transformation.JoinAssociativityRule;
@@ -2801,16 +2803,57 @@ public class JoinTest extends PlanTestBase {
                 "\n" +
                 "  RESULT SINK");
 
+        sql = "select * from t0 where v1 = 10";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "PLAN FRAGMENT 0\n" +
+                " OUTPUT EXPRS:1: v1 | 2: v2 | 3: v3\n" +
+                "  PARTITION: RANDOM\n" +
+                "\n" +
+                "  RESULT SINK\n" +
+                "\n" +
+                "  0:OlapScanNode");
+
+        sql = "select /*+SET_VAR(prefer_compute_node=true)*/ t0.v1 from t0 join[shuffle] t1 on t0.v2 = t1.v5";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "PLAN FRAGMENT 0\n" +
+                " OUTPUT EXPRS:1: v1\n" +
+                "  PARTITION: HASH_PARTITIONED: 2: v2\n" +
+                "\n" +
+                "  RESULT SINK");
+
+        sql = "select /*+SET_VAR(prefer_compute_node=true)*/ * from t0 where v1 = 10";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "PLAN FRAGMENT 0\n" +
+                " OUTPUT EXPRS:1: v1 | 2: v2 | 3: v3\n" +
+                "  PARTITION: RANDOM\n" +
+                "\n" +
+                "  RESULT SINK\n" +
+                "\n" +
+                "  0:OlapScanNode");
+
+        Config.run_mode = RunMode.SHARED_DATA.getName();
+        RunMode.detectRunMode();
         try {
-            connectContext.getSessionVariable().setPreferComputeNode(true);
+            sql = "select t0.v1 from t0 join[shuffle] t1 on t0.v2 = t1.v5";
             plan = getFragmentPlan(sql);
             assertContains(plan, "PLAN FRAGMENT 0\n" +
                     " OUTPUT EXPRS:1: v1\n" +
-                    "  PARTITION: UNPARTITIONED\n" +
+                    "  PARTITION: HASH_PARTITIONED: 2: v2\n" +
                     "\n" +
                     "  RESULT SINK");
+
+            sql = "select * from t0 where v1 = 10";
+            plan = getFragmentPlan(sql);
+            assertContains(plan, "PLAN FRAGMENT 0\n" +
+                    " OUTPUT EXPRS:1: v1 | 2: v2 | 3: v3\n" +
+                    "  PARTITION: RANDOM\n" +
+                    "\n" +
+                    "  RESULT SINK\n" +
+                    "\n" +
+                    "  0:OlapScanNode");
         } finally {
-            connectContext.getSessionVariable().setPreferComputeNode(false);
+            Config.run_mode = RunMode.SHARED_NOTHING.getName();
+            RunMode.detectRunMode();
         }
     }
 


### PR DESCRIPTION
## Why I'm doing:

If all scan nodes in the entire plan are OLAP scan nodes and at most one tablet is used, then all fragments will have at most one instance (running on a single BE).In this case, there is no need to put the ResultSink in a dedicated gather fragment.

`prefer_compute_node=true` and share-data mode don't support this optimization, because its strategy for selecting BE/CN nodes for remote fragments (whose left-deep node is not a scan node) is different from share-nothing mode:
- `prefer_compute_node=true` and share-data mode: selects all CN nodes as instances, which will be more than 1 here, causing the fragment that contains the ResultSink to also have more than 1 instance.
- share-nothing mode: selects the BE node(s) where the child fragment is running.

This PR supports this optimization for share-data mode and `prefer_compute_node=true`.

Before:
```sql
 explain verbose select count(1) from t1 where k1 != 1
 +---------------------------------------------------------------------------------+
| Explain String                                                                  |
+---------------------------------------------------------------------------------+
| RESOURCE GROUP: default_wg                                                      |
|                                                                                 |
| PLAN COST                                                                       |
|   CPU: 5.247999477496931E7                                                      |
|   Memory: 18.0                                                                  |
|                                                                                 |
| PLAN FRAGMENT 0(F05)                                                            |
|   Fragment Cost: 0.0                                                            |
|   Output Exprs:38: expr                                                         |
|   Input Partition: UNPARTITIONED                                                |
|   RESULT SINK                                                                   |
|                                                                                 |
|   7:EXCHANGE                                                                    |
|      cardinality: 1279999                                                       |
|                                                                                 |
| PLAN FRAGMENT 1(F04)                                                            |
|   Fragment Cost: 3.648004446857622E7                                            |
|                                                                                 |
|   Input Partition: HASH_PARTITIONED: 1: k1                                      |
|   OutPut Partition: UNPARTITIONED                                               |
|   OutPut Exchange Id: 07                                                        |
|                                                                                 |
|   6:Project                                                                     |
|   |  output columns:                                                            |
|   |  38 <-> [38: expr, TINYINT, false]                                          |
|   |  cardinality: 1279999                                                       |
|   |                                                                             |
|   5:HASH JOIN                                                                   |
|   |  join op: INNER JOIN (PARTITIONED)                                          |
|   |  equal join conjunct: [1: k1, BIGINT, true] = [39: cast, BIGINT, false]     |
|   |  build runtime filters:                                                     |
|   |  - filter_id = 0, build_expr = (39: cast), remote = true                    |
|   |  output columns: 38                                                         |
|   |  can local shuffle: false                                                   |
|   |  cardinality: 1279999                                                       |
|   |                                                                             |
|   |----4:EXCHANGE                                                               |
|   |       distribution type: SHUFFLE                                            |
|   |       partition exprs: [39: cast, BIGINT, false]                            |
|   |       cardinality: 2                                                        |
|   |                                                                             |
|   1:EXCHANGE                                                                    |
|      distribution type: SHUFFLE                                                 |
|      partition exprs: [1: k1, BIGINT, true]                                     |
|      cardinality: 1279999                                                       |
|                                                                                 |
| PLAN FRAGMENT 2(F02)                                                            |
|   Fragment Cost: 0.0                                                            |
|                                                                                 |
|   Input Partition: UNPARTITIONED                                                |
|   OutPut Partition: HASH_PARTITIONED: 39: cast                                  |
|   OutPut Exchange Id: 04                                                        |
|                                                                                 |
|   3:Project                                                                     |
|   |  output columns:                                                            |
|   |  38 <-> [38: expr, TINYINT, false]                                          |
|   |  39 <-> cast([38: expr, TINYINT, false] as BIGINT)                          |
|   |  cardinality: 2                                                             |
|   |                                                                             |
|   2:UNION                                                                       |
|      constant exprs:                                                            |
|          1                                                                      |
|          2                                                                      |
|      cardinality: 2                                                             |
|                                                                                 |
| PLAN FRAGMENT 3(F00)                                                            |
|   Fragment Cost: 5119995.978045786                                              |
|                                                                                 |
|   Input Partition: RANDOM                                                       |
|   OutPut Partition: HASH_PARTITIONED: 1: k1                                     |
|   OutPut Exchange Id: 01                                                        |
|                                                                                 |
|   0:OlapScanNode                                                                |
|      table: t1, rollup: t1                                                      |
|      preAggregation: on                                                         |
|      Predicates: [1: k1, BIGINT, true] = 1                                      |
|      partitionsRatio=1/1, tabletsRatio=1/32                                     |
|      tabletList=10406                                                           |
|      actualRows=2560000, avgRowSize=8.0                                         |
|      cardinality: 1279999                                                       |
|      probe runtime filters:                                                     |
|      - filter_id = 0, probe_expr = (1: k1)                                      |
+---------------------------------------------------------------------------------+

explain verbose select count(1) from t1 where k1 = 1
+---------------------------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                                  |
+---------------------------------------------------------------------------------------------------------------------------------+
| RESOURCE GROUP: default_wg                                                                                                      |
|                                                                                                                                 |
| PLAN COST                                                                                                                       |
|   CPU: 1.267200604566332E7                                                                                                      |
|   Memory: 8.8                                                                                                                   |
|                                                                                                                                 |
| PLAN FRAGMENT 0(F01)                                                                                                            |
|   Fragment Cost: 36.0                                                                                                           |
|   Output Exprs:34: count                                                                                                        |
|   Input Partition: UNPARTITIONED                                                                                                |
|   RESULT SINK                                                                                                                   |
|                                                                                                                                 |
|   4:AGGREGATE (merge finalize)                                                                                                  |
|   |  aggregate: count[([34: count, BIGINT, false]); args: TINYINT; result: BIGINT; args nullable: true; result nullable: false] |
|   |  cardinality: 1                                                                                                             |
|   |                                                                                                                             |
|   3:EXCHANGE                                                                                                                    |
|      distribution type: GATHER                                                                                                  |
|      cardinality: 1                                                                                                             |
|                                                                                                                                 |
| PLAN FRAGMENT 1(F00)                                                                                                            |
|   Fragment Cost: 6335996.622831659                                                                                              |
|                                                                                                                                 |
|   Input Partition: RANDOM                                                                                                       |
|   OutPut Partition: UNPARTITIONED                                                                                               |
|   OutPut Exchange Id: 03                                                                                                        |
|                                                                                                                                 |
|   2:AGGREGATE (update serialize)                                                                                                |
|   |  aggregate: count[(1); args: TINYINT; result: BIGINT; args nullable: false; result nullable: false]                         |
|   |  cardinality: 1                                                                                                             |
|   |                                                                                                                             |
|   1:Project                                                                                                                     |
|   |  output columns:                                                                                                            |
|   |  36 <-> 1                                                                                                                   |
|   |  cardinality: 1279999                                                                                                       |
|   |                                                                                                                             |
|   0:OlapScanNode                                                                                                                |
|      table: t1, rollup: t1                                                                                                      |
|      preAggregation: on                                                                                                         |
|      Predicates: [1: k1, BIGINT, true] = 1                                                                                      |
|      partitionsRatio=1/1, tabletsRatio=1/32                                                                                     |
|      tabletList=10406                                                                                                           |
|      actualRows=2560000, avgRowSize=9.0                                                                                         |
|      cardinality: 1279999                                                                                                       |
+---------------------------------------------------------------------------------------------------------------------------------+
```

After:
```sql
 explain verbose with w1 as (select 1 as x union all select 2) select w1.x from t1 join [shuffle] w1 on t1.k1 = w1.x and t1.k1 = 1
+-----------------------------------------------------------------------------+
| Explain String                                                              |
+-----------------------------------------------------------------------------+
| RESOURCE GROUP: default_wg                                                  |
|                                                                             |
| PLAN COST                                                                   |
|   CPU: 59.13172528481641                                                    |
|   Memory: 9.0                                                               |
|                                                                             |
| PLAN FRAGMENT 0(F04)                                                        |
|   Fragment Cost: 65.17227107068034                                          |
|   Output Exprs:38: expr                                                     |
|   Input Partition: HASH_PARTITIONED: 1: k1                                  |
|   RESULT SINK                                                               |
|                                                                             |
|   6:Project                                                                 |
|   |  output columns:                                                        |
|   |  38 <-> [38: expr, TINYINT, false]                                      |
|   |  cardinality: 1                                                         |
|   |                                                                         |
|   5:HASH JOIN                                                               |
|   |  join op: INNER JOIN (PARTITIONED)                                      |
|   |  equal join conjunct: [1: k1, BIGINT, true] = [39: cast, BIGINT, false] |
|   |  build runtime filters:                                                 |
|   |  - filter_id = 0, build_expr = (39: cast), remote = true                |
|   |  output columns: 38                                                     |
|   |  can local shuffle: false                                               |
|   |  cardinality: 1                                                         |
|   |                                                                         |
|   |----4:EXCHANGE                                                           |
|   |       distribution type: SHUFFLE                                        |
|   |       partition exprs: [39: cast, BIGINT, false]                        |
|   |       cardinality: 1                                                    |
|   |                                                                         |
|   1:EXCHANGE                                                                |
|      distribution type: SHUFFLE                                             |
|      partition exprs: [1: k1, BIGINT, true]                                 |
|      cardinality: 1                                                         |
|                                                                             |
| PLAN FRAGMENT 1(F02)                                                        |
|   Fragment Cost: 0.0                                                        |
|                                                                             |
|   Input Partition: UNPARTITIONED                                            |
|   OutPut Partition: HASH_PARTITIONED: 39: cast                              |
|   OutPut Exchange Id: 04                                                    |
|                                                                             |
|   3:Project                                                                 |
|   |  output columns:                                                        |
|   |  38 <-> 1                                                               |
|   |  39 <-> 1                                                               |
|   |  cardinality: 1                                                         |
|   |                                                                         |
|   2:UNION                                                                   |
|      constant exprs:                                                        |
|          NULL                                                               |
|      cardinality: 1                                                         |
|                                                                             |
| PLAN FRAGMENT 2(F00)                                                        |
|   Fragment Cost: 4.021954214136069                                          |
|                                                                             |
|   Input Partition: RANDOM                                                   |
|   OutPut Partition: HASH_PARTITIONED: 1: k1                                 |
|   OutPut Exchange Id: 01                                                    |
|                                                                             |
|   0:OlapScanNode                                                            |
|      table: t1, rollup: t1                                                  |
|      preAggregation: on                                                     |
|      Predicates: [1: k1, BIGINT, true] = 1                                  |
|      partitionsRatio=1/1, tabletsRatio=1/32                                 |
|      tabletList=10406                                                       |
|      actualRows=80000, avgRowSize=8.0                                       |
|      cardinality: 1                                                         |
|      probe runtime filters:                                                 |
|      - filter_id = 0, probe_expr = (1: k1)                                  |
+-----------------------------------------------------------------------------+

explain verbose select count(1) from t1 where k1 = 1
+---------------------------------------------------------------------------------------------------------+
| Explain String                                                                                          |
+---------------------------------------------------------------------------------------------------------+
| RESOURCE GROUP: default_wg                                                                              |
|                                                                                                         |
| PLAN COST                                                                                               |
|   CPU: 18.09879396361231                                                                                |
|   Memory: 8.0                                                                                           |
|                                                                                                         |
| PLAN FRAGMENT 0(F00)                                                                                    |
|   Fragment Cost: 25.049396981806154                                                                     |
|   Output Exprs:34: count                                                                                |
|   Input Partition: RANDOM                                                                               |
|   RESULT SINK                                                                                           |
|                                                                                                         |
|   2:AGGREGATE (update finalize)                                                                         |
|   |  aggregate: count[(1); args: TINYINT; result: BIGINT; args nullable: false; result nullable: false] |
|   |  cardinality: 1                                                                                     |
|   |                                                                                                     |
|   1:Project                                                                                             |
|   |  output columns:                                                                                    |
|   |  36 <-> 1                                                                                           |
|   |  cardinality: 1                                                                                     |
|   |                                                                                                     |
|   0:OlapScanNode                                                                                        |
|      table: t1, rollup: t1                                                                              |
|      preAggregation: on                                                                                 |
|      Predicates: [1: k1, BIGINT, true] = 1                                                              |
|      partitionsRatio=1/1, tabletsRatio=1/32                                                             |
|      tabletList=10406                                                                                   |
|      actualRows=80000, avgRowSize=9.0                                                                   |
|      cardinality: 1                                                                                     |
+---------------------------------------------------------------------------------------------------------+
```


## What I'm doing:


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
