### PR TITLE
[UT] make sqltest more stable 

### DIFF
--- a/test/sql/test_insert_overwrite/R/test_insert_with_profile
+++ b/test/sql/test_insert_overwrite/R/test_insert_with_profile
@@ -1,4 +1,4 @@
--- name: test_insert_with_profile
+-- name: test_insert_with_profile @sequential
 create table t1(k int) 
 distributed by hash(k) buckets 96;
 -- result:
@@ -54,6 +54,6 @@ select count(*) from t2;
 -- result:
 7
 -- !result
-admin enable failpoint 'report_exec_state_failed_status';
+admin disable failpoint 'report_exec_state_failed_status';
 -- result:
 -- !result


### PR DESCRIPTION
## Why I'm doing:
some sqltest use fault error injection without @sequential, and don't disable it at the end, which will make other sqltest fail

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
