### PR TITLE
[Enhancement] support dump pipeline status when query timeout

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -935,6 +935,7 @@ CONF_Int64(pipeline_sink_brpc_dop, "64");
 // exceeds it*pipeline_exec_thread_pool_thread_num.
 CONF_Int64(pipeline_max_num_drivers_per_exec_thread, "10240");
 CONF_mBool(pipeline_print_profile, "false");
+CONF_mBool(pipeline_timeout_diagnostic, "false");
 
 // The arguments of multilevel feedback pipeline_driver_queue. It prioritizes small queries over larger ones,
 // when the value of level_time_slice_base_ns is smaller and queue_ratio_of_adjacent_queue is larger.

--- a/be/src/exec/pipeline/fragment_context.cpp
+++ b/be/src/exec/pipeline/fragment_context.cpp
@@ -189,13 +189,13 @@ void FragmentContext::set_final_status(const Status& status) {
         _driver_token.reset();
 
         auto detailed_message = _s_status.detailed_message();
-        // These statuses indicate that the query completed successfully.
-        bool is_finished_cancel = detailed_message == "QueryFinished" || detailed_message == "LimitReach";
+        bool is_timeout = detailed_message == "TimeOut";
         if (_s_status.is_cancelled()) {
             std::string cancel_msg =
                     fmt::format("[Driver] Canceled, query_id={}, instance_id={}, reason={}", print_id(_query_id),
                                 print_id(_fragment_instance_id), detailed_message);
-            if (is_finished_cancel || detailed_message == "UserCancel" || detailed_message == "TimeOut") {
+            if (detailed_message == "QueryFinished" || detailed_message == "LimitReach" ||
+                detailed_message == "UserCancel" || is_timeout) {
                 LOG(INFO) << cancel_msg;
             } else {
                 LOG(WARNING) << cancel_msg;
@@ -209,11 +209,11 @@ void FragmentContext::set_final_status(const Status& status) {
         }
 
         // cancel drivers in event scheduler
-        iterate_drivers([detailed_message, is_finished_cancel](const DriverPtr& driver) {
+        iterate_drivers([is_timeout](const DriverPtr& driver) {
             driver->set_need_check_reschedule(true);
             if (driver->is_in_blocked()) {
-                LOG_IF(WARNING, config::pipeline_timeout_diagnostic && is_finished_cancel)
-                        << "[Driver] " << detailed_message << " " << driver->to_readable_string();
+                LOG_IF(WARNING, config::pipeline_timeout_diagnostic && is_timeout)
+                        << "[Driver] Timeout" << driver->to_readable_string();
                 driver->observer()->cancel_trigger();
             }
         });

--- a/be/src/exec/pipeline/schedule/timeout_tasks.cpp
+++ b/be/src/exec/pipeline/schedule/timeout_tasks.cpp
@@ -29,7 +29,7 @@ void CheckFragmentTimeout::Run() {
     _fragment_ctx->iterate_drivers([](const DriverPtr& driver) {
         driver->set_need_check_reschedule(true);
         if (driver->is_in_blocked()) {
-            LOG(WARNING) << "[Driver] Timeout " << driver->to_readable_string();
+            LOG_IF(WARNING, config::pipeline_timeout_diagnostic) << "[Driver] Timeout " << driver->to_readable_string();
             driver->observer()->cancel_trigger();
         }
     });

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -733,7 +733,7 @@ public class DefaultCoordinator extends Coordinator {
             throws StarRocksException, RpcException {
         switch (Objects.requireNonNull(status.getErrorCode())) {
             case TIMEOUT:
-                cancelInternal(PPlanFragmentCancelReason.INTERNAL_ERROR);
+                cancelInternal(PPlanFragmentCancelReason.TIMEOUT);
                 throw new StarRocksException("query timeout. backend id: " + execution.getWorker().getId());
             case THRIFT_RPC_ERROR:
                 cancelInternal(PPlanFragmentCancelReason.INTERNAL_ERROR);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a flag to enable detailed driver diagnostics on timeouts/finished cancels and updates FE to cancel with TIMEOUT reason on timeout errors.
> 
> - **Execution diagnostics (BE)**:
>   - Add `config::pipeline_timeout_diagnostic` flag to toggle detailed timeout diagnostics.
>   - `fragment_context.cpp`: when finalizing and drivers are blocked, conditionally log driver details for finished-cancel states (`QueryFinished`/`LimitReach`) when enabled; minor refactor extracting `detailed_message` and `is_finished_cancel`.
>   - `timeout_tasks.cpp`: conditionally log blocked driver details on query timeout when enabled.
> - **Coordinator behavior (FE)**:
>   - On `TIMEOUT` error code, invoke `cancelInternal(PPlanFragmentCancelReason.TIMEOUT)` instead of `INTERNAL_ERROR`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2841597474c7c8d233403c863009d043919feab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->