### PR TITLE
[Feature] Support for builtin inverted index

### DIFF
--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -305,6 +305,13 @@ Status LakeDataSource::init_reader_params(const std::vector<OlapScanRange*>& key
     _params.splitted_scan_rows = _provider->get_splitted_scan_rows();
     _params.scan_dop = _provider->get_scan_dop();
 
+    if (thrift_lake_scan_node.__isset.enable_prune_column_after_index_filter) {
+        _params.prune_column_after_index_filter = thrift_lake_scan_node.enable_prune_column_after_index_filter;
+    }
+    if (thrift_lake_scan_node.__isset.enable_gin_filter) {
+        _params.enable_gin_filter = thrift_lake_scan_node.enable_gin_filter;
+    }
+
     ASSIGN_OR_RETURN(auto pred_tree, _conjuncts_manager->get_predicate_tree(parser, _predicate_free_pool));
     _params.enable_join_runtime_filter_pushdown = _runtime_state->enable_join_runtime_filter_pushdown();
     if (_params.enable_join_runtime_filter_pushdown) {
@@ -635,6 +642,8 @@ void LakeDataSource::init_counter(RuntimeState* state) {
     _bi_filter_timer = ADD_CHILD_TIMER(_runtime_profile, "BitmapIndexFilter", segment_init_name);
     _bi_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "BitmapIndexFilterRows", TUnit::UNIT, segment_init_name);
     _bf_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "BloomFilterFilterRows", TUnit::UNIT, segment_init_name);
+    _gin_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "GinFilterRows", TUnit::UNIT, segment_init_name);
+    _gin_filtered_timer = ADD_CHILD_TIMER(_runtime_profile, "GinFilter", segment_init_name);
     _seg_zm_filtered_counter =
             ADD_CHILD_COUNTER(_runtime_profile, "SegmentZoneMapFilterRows", TUnit::UNIT, segment_init_name);
     _seg_rt_filtered_counter =
@@ -778,6 +787,8 @@ void LakeDataSource::update_counter(RuntimeState* state) {
 
     COUNTER_UPDATE(_bi_filtered_counter, _reader->stats().rows_bitmap_index_filtered);
     COUNTER_UPDATE(_bi_filter_timer, _reader->stats().bitmap_index_filter_timer);
+    COUNTER_UPDATE(_gin_filtered_counter, _reader->stats().rows_gin_filtered);
+    COUNTER_UPDATE(_gin_filtered_timer, _reader->stats().gin_index_filter_ns);
     COUNTER_UPDATE(_block_seek_counter, _reader->stats().block_seek_num);
 
     COUNTER_UPDATE(_rowsets_read_count, _reader->stats().rowsets_read_count);

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -160,6 +160,8 @@ private:
     RuntimeProfile::Counter* _block_fetch_timer = nullptr;
     RuntimeProfile::Counter* _bi_filtered_counter = nullptr;
     RuntimeProfile::Counter* _bi_filter_timer = nullptr;
+    RuntimeProfile::Counter* _gin_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _gin_filtered_timer = nullptr;
     RuntimeProfile::Counter* _pushdown_predicates_counter = nullptr;
     RuntimeProfile::Counter* _non_pushdown_predicates_counter = nullptr;
     RuntimeProfile::Counter* _rowsets_read_count = nullptr;

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -287,7 +287,12 @@ set(STORAGE_FILES
     index/vector/tenann/tenann_index_utils.cpp
     record_predicate/record_predicate_helper.cpp
     record_predicate/column_hash_is_congruent.cpp
-    lake/table_schema_service.cpp)
+    lake/table_schema_service.cpp
+    index/inverted/builtin/builtin_plugin.cpp
+    index/inverted/builtin/builtin_inverted_writer.cpp
+    index/inverted/builtin/builtin_inverted_reader.cpp
+    index/inverted/builtin/builtin_inverted_index_iterator.cpp
+    index/inverted/builtin/builtin_simple_analyzer.cpp)
 
 if (NOT BUILD_FORMAT_LIB)
     list(APPEND STORAGE_FILES  lake/starlet_location_provider.cpp)

--- a/be/src/storage/column_expr_predicate.cpp
+++ b/be/src/storage/column_expr_predicate.cpp
@@ -337,7 +337,7 @@ Status ColumnExprPredicate::seek_inverted_index(const std::string& column_name, 
     }
     std::string str_v = padded_value.to_string();
     InvertedIndexQueryType query_type = InvertedIndexQueryType::UNKNOWN_QUERY;
-    bool has_wildcard = str_v.find('*') != std::string::npos || str_v.find('%') != std::string::npos;
+    bool has_wildcard = str_v.find('%') != std::string::npos;
 
     // TODO: The logic for determining query_type will be abstracted into a separate method in the future.
     if (valid_match && expr->op() == TExprOpcode::MATCH_ANY) {

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.cpp
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.cpp
@@ -1,0 +1,209 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/index/inverted/builtin/builtin_inverted_index_iterator.h"
+
+#include <CLucene.h>
+
+#include <memory>
+
+#include "exprs/function_context.h"
+#include "exprs/like_predicate.h"
+#include "storage/chunk_helper.h"
+
+namespace starrocks {
+std::string get_next_prefix(const Slice& prefix_s) {
+    std::string next_prefix = prefix_s.to_string();
+
+    for (int i = next_prefix.length() - 1; i >= 0; i--) {
+        if (static_cast<unsigned char>(next_prefix[i]) != 0xFF) {
+            next_prefix[i]++;
+            next_prefix.resize(i + 1);
+            return next_prefix;
+        }
+    }
+    return "";
+}
+
+Status BuiltinInvertedIndexIterator::close() {
+    if (!_like_context) {
+        return Status::OK();
+    }
+    Status st = LikePredicate::like_close(_like_context.get(), FunctionContext::FunctionStateScope::THREAD_LOCAL);
+    _like_context.reset(nullptr);
+    return st;
+}
+
+Status BuiltinInvertedIndexIterator::_equal_query(const Slice* search_query, roaring::Roaring* bitmap) {
+    bool exact_match = false;
+    Status st = _bitmap_itr->seek_dictionary(search_query, &exact_match);
+    if (st.ok() && exact_match) {
+        rowid_t ordinal = _bitmap_itr->current_ordinal();
+        RETURN_IF_ERROR(_bitmap_itr->read_bitmap(ordinal, bitmap));
+    } else if (!st.ok() && !st.is_not_found()) {
+        return st;
+    }
+    return Status::OK();
+}
+
+Status BuiltinInvertedIndexIterator::_wildcard_query(const Slice* search_query, roaring::Roaring* bitmap) {
+    auto first_wildcard_pos = search_query->to_string().find('%');
+    if (first_wildcard_pos == std::string::npos) {
+        return Status::InternalError("invalid wildcard query for builtin inverted index");
+    }
+
+    rowid_t lower_rowid = 0;
+    rowid_t upper_rowid = _bitmap_itr->has_null_bitmap() ? _bitmap_itr->bitmap_nums() - 1 : _bitmap_itr->bitmap_nums();
+    std::pair<rowid_t, std::string> lower = std::make_pair(lower_rowid, Slice::min_value().to_string());
+    std::pair<rowid_t, std::string> upper = std::make_pair(upper_rowid, Slice::max_value().to_string());
+
+    if (first_wildcard_pos != 0) {
+        Slice prefix_s(search_query->data, first_wildcard_pos);
+        std::string next_prefix = get_next_prefix(prefix_s);
+
+        auto seek = [&](const Slice& bound) -> StatusOr<std::pair<rowid_t, std::string>> {
+            bool exact_match;
+            auto st = _bitmap_itr->seek_dictionary(&bound, &exact_match);
+            auto cur_ordinal = _bitmap_itr->current_ordinal();
+            if (st.is_not_found()) {
+                // hit the end of dictionary set
+                return std::make_pair(upper_rowid, Slice::max_value().to_string());
+            } else if (!st.ok()) {
+                return st;
+            } else {
+                auto column = ChunkHelper::column_from_field_type(TYPE_VARCHAR, false);
+                size_t read_num = 1;
+                RETURN_IF_ERROR(_bitmap_itr->next_batch_dictionary(&read_num, column.get()));
+                Slice s = down_cast<BinaryColumn*>(column.get())->get_data()[0];
+                return std::make_pair(cur_ordinal, s.to_string());
+            }
+        };
+
+        ASSIGN_OR_RETURN(lower, seek(prefix_s));
+        if (!next_prefix.empty()) {
+            Slice next_prefix_s(next_prefix);
+            ASSIGN_OR_RETURN(upper, seek(next_prefix_s));
+        }
+
+        if (lower.first >= upper.first) {
+            // prefix not found
+            return Status::OK();
+        }
+
+        if (first_wildcard_pos == search_query->size - 1) {
+            // pure prefix query
+            Buffer<rowid_t> hit_rowids(upper.first - lower.first);
+            std::iota(hit_rowids.begin(), hit_rowids.end(), lower.first);
+            RETURN_IF_ERROR(_bitmap_itr->read_union_bitmap(hit_rowids, bitmap));
+            return Status::OK();
+        }
+    }
+
+    RETURN_IF_ERROR(_init_like_context(*search_query));
+    auto predicate = [this](const Column& value_column) -> StatusOr<ColumnPtr> {
+        Columns cols;
+        cols.push_back(&value_column);
+        cols.push_back(this->_like_context->get_constant_column(1));
+        return LikePredicate::like(this->_like_context.get(), cols);
+    };
+    Slice from_value = Slice(lower.second);
+    size_t search_size = upper.first - lower.first;
+    auto res = _bitmap_itr->seek_dictionary_by_predicate(predicate, from_value, search_size);
+    Status st = res.status();
+    if (st.ok()) {
+        auto hit_rowids = std::move(res.value());
+        RETURN_IF_ERROR(_bitmap_itr->read_union_bitmap(hit_rowids, bitmap));
+    } else if (!st.ok() && !st.is_not_found()) {
+        return st;
+    }
+    return Status::OK();
+}
+
+Status BuiltinInvertedIndexIterator::_init_like_context(const Slice& s) {
+    if (_like_context) {
+        RETURN_IF_ERROR(
+                LikePredicate::like_close(_like_context.get(), FunctionContext::FunctionStateScope::THREAD_LOCAL));
+        _like_context.reset(nullptr);
+    }
+
+    _like_context = std::make_unique<FunctionContext>();
+    auto ptr = BinaryColumn::create();
+    ptr->append_datum(Datum(s));
+    (void)ptr->get_data();
+    Columns cols;
+    cols.push_back(nullptr);
+    cols.push_back(ConstColumn::create(std::move(ptr), 1));
+    _like_context->set_constant_columns(cols);
+    Status st = LikePredicate::like_prepare(_like_context.get(), FunctionContext::FunctionStateScope::THREAD_LOCAL);
+    if (!st.ok()) {
+        (void)LikePredicate::like_close(_like_context.get(), FunctionContext::FunctionStateScope::THREAD_LOCAL);
+        _like_context.reset(nullptr);
+    }
+    return st;
+}
+
+Status BuiltinInvertedIndexIterator::read_from_inverted_index(const std::string& column_name, const void* query_value,
+                                                              InvertedIndexQueryType query_type,
+                                                              roaring::Roaring* bitmap) {
+    const auto* search_query = reinterpret_cast<const Slice*>(query_value);
+    switch (query_type) {
+    case InvertedIndexQueryType::EQUAL_QUERY: {
+        RETURN_IF_ERROR(_equal_query(search_query, bitmap));
+        break;
+    }
+    case InvertedIndexQueryType::MATCH_WILDCARD_QUERY: {
+        RETURN_IF_ERROR(_wildcard_query(search_query, bitmap));
+        break;
+    }
+    case InvertedIndexQueryType::MATCH_ALL_QUERY:
+    case InvertedIndexQueryType::MATCH_ANY_QUERY: {
+        std::string search_query_str = search_query->to_string();
+        std::istringstream iss(search_query_str);
+        std::string cur_predicate;
+        bool first = true;
+        roaring::Roaring roaring;
+        while (iss >> cur_predicate) {
+            roaring.clear();
+            Slice s(cur_predicate);
+            if (cur_predicate.find('%') != std::string::npos) {
+                RETURN_IF_ERROR(_wildcard_query(&s, &roaring));
+            } else {
+                RETURN_IF_ERROR(_equal_query(&s, &roaring));
+            }
+
+            if (first) {
+                *bitmap = std::move(roaring);
+                first = false;
+            } else if (query_type == InvertedIndexQueryType::MATCH_ALL_QUERY) {
+                *bitmap &= roaring;
+            } else if (query_type == InvertedIndexQueryType::MATCH_ANY_QUERY) {
+                *bitmap |= roaring;
+            } else {
+                DCHECK(false) << "do not support query type";
+            }
+            cur_predicate.clear();
+        }
+        break;
+    }
+    default:
+        return Status::InvalidArgument("do not support query type");
+    }
+    return Status::OK();
+}
+
+Status BuiltinInvertedIndexIterator::read_null(const std::string& column_name, roaring::Roaring* bitmap) {
+    return Status::InternalError("Unsupported");
+}
+
+} // namespace starrocks

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.h
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_index_iterator.h
@@ -1,0 +1,52 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "storage/index/inverted/inverted_index_iterator.h"
+#include "storage/rowset/bitmap_index_reader.h"
+#include "util/slice.h"
+
+namespace starrocks {
+class FunctionContext;
+
+std::string get_next_prefix(const Slice& prefix_s);
+
+class BuiltinInvertedIndexIterator final : public InvertedIndexIterator {
+public:
+    BuiltinInvertedIndexIterator(const std::shared_ptr<TabletIndex>& index_meta, InvertedReader* reader,
+                                 std::unique_ptr<BitmapIndexIterator>& bitmap_itr)
+            : InvertedIndexIterator(index_meta, reader), _bitmap_itr(std::move(bitmap_itr)), _like_context(nullptr) {}
+
+    ~BuiltinInvertedIndexIterator() override = default;
+
+    Status read_from_inverted_index(const std::string& column_name, const void* query_value,
+                                    InvertedIndexQueryType query_type, roaring::Roaring* bit_map) override;
+
+    Status read_null(const std::string& column_name, roaring::Roaring* bit_map) override;
+
+    Status close() override;
+
+private:
+    Status _equal_query(const Slice* search_query, roaring::Roaring* bit_map);
+
+    Status _wildcard_query(const Slice* search_query, roaring::Roaring* bit_map);
+
+    Status _init_like_context(const Slice& s);
+
+    std::unique_ptr<BitmapIndexIterator> _bitmap_itr;
+    std::unique_ptr<FunctionContext> _like_context;
+};
+
+} // namespace starrocks

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_reader.cpp
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_reader.cpp
@@ -1,0 +1,59 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/index/inverted/builtin/builtin_inverted_reader.h"
+
+#include <fmt/format.h>
+
+#include "storage/index/index_descriptor.h"
+#include "storage/index/inverted/builtin/builtin_inverted_index_iterator.h"
+#include "types/logical_type.h"
+
+namespace starrocks {
+
+Status BuiltinInvertedReader::new_iterator(const std::shared_ptr<TabletIndex> index_meta,
+                                           InvertedIndexIterator** iterator, const IndexReadOptions& index_opt) {
+    BitmapIndexIterator* iter;
+    RETURN_IF_ERROR(_bitmap_index->new_iterator(index_opt, &iter));
+    std::unique_ptr<BitmapIndexIterator> bitmap_itr;
+    bitmap_itr.reset(iter);
+    *iterator = new BuiltinInvertedIndexIterator(index_meta, this, bitmap_itr);
+    return Status::OK();
+}
+
+Status BuiltinInvertedReader::create(const std::shared_ptr<TabletIndex>& tablet_index, LogicalType field_type,
+                                     std::unique_ptr<InvertedReader>* res) {
+    if (is_string_type(field_type)) {
+        *res = std::make_unique<BuiltinInvertedReader>(tablet_index->index_id());
+        return Status::OK();
+    } else {
+        return Status::InvalidArgument(fmt::format("Not supported type {}", field_type));
+    }
+}
+
+Status BuiltinInvertedReader::load(const IndexReadOptions& opt, void* meta) {
+    if (meta == nullptr) {
+        return Status::InvalidArgument("Invalid argument for loading builtin inverted index");
+    }
+    const BitmapIndexPB bitmap_index_meta = reinterpret_cast<BuiltinInvertedIndexPB*>(meta)->bitmap_index();
+    _bitmap_index = std::make_unique<BitmapIndexReader>();
+
+    ASSIGN_OR_RETURN(auto first_load, _bitmap_index->load(opt, bitmap_index_meta));
+    if (!first_load) {
+        return Status::InternalError("loading builtin inverted index more than once");
+    }
+    return Status::OK();
+}
+
+} // namespace starrocks

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_reader.h
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_reader.h
@@ -1,0 +1,65 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <CLucene.h>
+
+#include <utility>
+
+#include "storage/index/inverted/inverted_reader.h"
+#include "storage/rowset/bitmap_index_reader.h"
+
+namespace starrocks {
+
+class InvertedIndexIterator;
+enum class InvertedIndexQueryType;
+enum class InvertedIndexReaderType;
+class IndexReadOptions;
+class FunctionContext;
+
+class BuiltinInvertedReader : public InvertedReader {
+public:
+    explicit BuiltinInvertedReader(const uint32_t index_id) : InvertedReader("", index_id), _bitmap_index(nullptr) {}
+
+    ~BuiltinInvertedReader() override {}
+
+    static Status create(const std::shared_ptr<TabletIndex>& tablet_index, LogicalType field_type,
+                         std::unique_ptr<InvertedReader>* res);
+
+    Status new_iterator(const std::shared_ptr<TabletIndex> index_meta, InvertedIndexIterator** iterator,
+                        const IndexReadOptions& index_opt) override;
+
+    Status load(const IndexReadOptions& opt, void* meta) override;
+
+    /*
+       Implemented in BuiltinInvertedIndexIterator. For builtin inverted index, we have to define bitmap index iterator in BuiltinInvertedIndexIterator.
+       Because BuiltinInvertedReader may be accessed by multiple threads, and bitmap index iterator is not thread-safe.
+    */
+    Status query(OlapReaderStatistics* stats, const std::string& column_name, const void* query_value,
+                 InvertedIndexQueryType query_type, roaring::Roaring* bit_map) override {
+        return Status::InternalError("Unreachable");
+    }
+
+    Status query_null(OlapReaderStatistics* stats, const std::string& column_name, roaring::Roaring* bit_map) override {
+        return Status::InternalError("Unreachable");
+    }
+
+    InvertedIndexReaderType get_inverted_index_reader_type() override { return InvertedIndexReaderType::TEXT; }
+
+private:
+    std::unique_ptr<BitmapIndexReader> _bitmap_index;
+};
+
+} // namespace starrocks

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_writer.cpp
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_writer.cpp
@@ -1,0 +1,158 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/index/inverted/builtin/builtin_inverted_writer.h"
+
+#include <CLucene.h>
+#include <CLucene/analysis/LanguageBasedAnalyzer.h>
+#include <CLucene/util/Misc.h>
+#include <fmt/format.h>
+
+#include <boost/locale/encoding_utf.hpp>
+#include <vector>
+
+#include "common/status.h"
+#include "gen_cpp/segment.pb.h"
+#include "storage/index/inverted/builtin/builtin_simple_analyzer.h"
+#include "storage/index/inverted/inverted_index_option.h"
+#include "storage/rowset/bitmap_index_writer.h"
+#include "storage/tablet_index.h"
+#include "storage/type_traits.h"
+#include "types/logical_type.h"
+
+namespace starrocks {
+
+template <LogicalType field_type>
+class BuiltinInvertedWriterImpl : public BuiltinInvertedWriter {
+public:
+    using CppType = typename CppTypeTraits<field_type>::CppType;
+
+    explicit BuiltinInvertedWriterImpl(std::unique_ptr<BitmapIndexWriter>& writer, const TabletIndex* inverted_index)
+            : _builtin_writer(std::move(writer)) {
+        static_assert(field_type == TYPE_CHAR || field_type == TYPE_VARCHAR);
+        _parser_type = get_inverted_index_parser_type_from_string(
+                get_parser_string_from_properties(inverted_index->index_properties()));
+        DCHECK(_parser_type != InvertedIndexParserType::PARSER_UNKNOWN);
+    }
+
+    Status init() override;
+
+    void add_values(const void* values, size_t count) override;
+
+    void add_nulls(uint32_t count) override { _builtin_writer->add_nulls(count); }
+
+    Status finish(WritableFile* wfile, ColumnMetaPB* meta) override;
+
+    uint64_t size() const override { return _builtin_writer->size(); }
+
+private:
+    std::unique_ptr<BitmapIndexWriter> _builtin_writer;
+    std::unique_ptr<lucene::analysis::Analyzer> _analyzer{};
+    std::unique_ptr<lucene::util::StringReader> _char_string_reader{};
+
+    std::unique_ptr<SimpleAnalyzer> _builtin_analyzer{};
+
+    InvertedIndexParserType _parser_type;
+};
+
+template <LogicalType field_type>
+Status BuiltinInvertedWriterImpl<field_type>::init() {
+    // init tokenizer relative context
+    _char_string_reader = std::make_unique<lucene::util::StringReader>(L"");
+    if (_parser_type == InvertedIndexParserType::PARSER_STANDARD) {
+        _analyzer = std::make_unique<lucene::analysis::standard::StandardAnalyzer>();
+    } else if (_parser_type == InvertedIndexParserType::PARSER_ENGLISH) {
+        _builtin_analyzer = std::make_unique<SimpleAnalyzer>();
+    } else if (_parser_type == InvertedIndexParserType::PARSER_CHINESE) {
+        auto chinese_analyzer = _CLNEW lucene::analysis::LanguageBasedAnalyzer();
+        chinese_analyzer->setLanguage(L"cjk");
+        _analyzer.reset(chinese_analyzer);
+    }
+    return Status::OK();
+}
+
+template <LogicalType field_type>
+void BuiltinInvertedWriterImpl<field_type>::add_values(const void* values, size_t count) {
+    const Slice* val = static_cast<const Slice*>(values);
+    for (int i = 0; i < count; ++i) {
+        const char* s = val->data;
+        size_t size = val->size;
+        if (_parser_type == InvertedIndexParserType::PARSER_NONE) {
+            _builtin_writer->add_value_with_current_rowid((void*)val);
+        } else if (_parser_type == InvertedIndexParserType::PARSER_ENGLISH) {
+            std::string mutable_text(val->data, val->size);
+            std::vector<SliceToken> tokens;
+            _builtin_analyzer->tokenize(mutable_text.data(), mutable_text.length(), tokens);
+            for (const auto& token : tokens) {
+                _builtin_writer->add_value_with_current_rowid((void*)&(token.text));
+            }
+        } else {
+            // For all kinds of CLucene analyzers, we need to process the text as follows:
+            // 1. Convert the text to wstring
+            // 2. Tokenize the wstring
+            // 3. Convert the tokens to string
+            // 4. Add the string to the bitmap index
+            std::wstring tchar = boost::locale::conv::utf_to_utf<TCHAR>(s, s + size);
+
+            _char_string_reader->init(tchar.c_str(), tchar.size(), false);
+            auto stream = _analyzer->reusableTokenStream(L"", _char_string_reader.get());
+            lucene::analysis::Token token;
+            while (stream->next(&token)) {
+                if (token.termLength() != 0) {
+                    std::string str = boost::locale::conv::utf_to_utf<char>(token.termBuffer(),
+                                                                            token.termBuffer() + token.termLength());
+                    Slice s(str);
+                    _builtin_writer->add_value_with_current_rowid((void*)&s);
+                }
+            }
+        }
+
+        ++val;
+        _builtin_writer->incre_rowid();
+    }
+}
+
+template <LogicalType field_type>
+Status BuiltinInvertedWriterImpl<field_type>::finish(WritableFile* wfile, ColumnMetaPB* meta) {
+    ColumnIndexMetaPB* index_meta = meta->add_indexes();
+    index_meta->set_type(BUILTIN_INVERTED_INDEX);
+    BuiltinInvertedIndexPB* inverted_index_meta = index_meta->mutable_builtin_inverted_index();
+    BitmapIndexPB* bitmap_index_meta = inverted_index_meta->mutable_bitmap_index();
+    return _builtin_writer->finish(wfile, bitmap_index_meta);
+}
+
+Status BuiltinInvertedWriter::create(const TypeInfoPtr& typeinfo, TabletIndex* tablet_index,
+                                     std::unique_ptr<InvertedWriter>* res) {
+    std::unique_ptr<BitmapIndexWriter> writer;
+    RETURN_IF_ERROR(BitmapIndexWriter::create(typeinfo, &writer));
+    writer->set_dictionary_compression(CompressionTypePB::ZSTD);
+
+    LogicalType type = typeinfo->type();
+    switch (type) {
+    case LogicalType::TYPE_CHAR: {
+        *res = std::make_unique<BuiltinInvertedWriterImpl<LogicalType::TYPE_CHAR>>(writer, tablet_index);
+        break;
+    }
+    case LogicalType::TYPE_VARCHAR: {
+        *res = std::make_unique<BuiltinInvertedWriterImpl<LogicalType::TYPE_VARCHAR>>(writer, tablet_index);
+        break;
+    }
+    default:
+        return Status::NotSupported(
+                strings::Substitute("Unsupported type for inverted index: $0", type_to_string_v2(type)));
+    }
+    return Status::OK();
+}
+
+} // namespace starrocks

--- a/be/src/storage/index/inverted/builtin/builtin_inverted_writer.h
+++ b/be/src/storage/index/inverted/builtin/builtin_inverted_writer.h
@@ -14,29 +14,22 @@
 
 #pragma once
 
-#include "common/status.h"
-#include "storage/collection.h"
+#include "storage/index/inverted/inverted_writer.h"
+#include "storage/types.h"
 
 namespace starrocks {
-class WritableFile;
-class ColumnMetaPB;
-
-class InvertedWriter {
+class TabletIndex;
+class BuiltinInvertedWriter : public InvertedWriter {
 public:
-    InvertedWriter() = default;
+    static Status create(const TypeInfoPtr& typeinfo, TabletIndex* tablet_index, std::unique_ptr<InvertedWriter>* res);
 
-    InvertedWriter(InvertedWriter&& other_writer) noexcept = default;
+    BuiltinInvertedWriter(const BuiltinInvertedWriter&) = delete;
 
-    virtual ~InvertedWriter() = default;
+    const BuiltinInvertedWriter& operator=(const BuiltinInvertedWriter&) = delete;
 
-    virtual Status init() = 0;
+    BuiltinInvertedWriter() = default;
 
-    virtual void add_values(const void* values, size_t count) = 0;
-
-    virtual void add_nulls(uint32_t count) = 0;
-
-    virtual Status finish(WritableFile* wfile, ColumnMetaPB* meta) = 0;
-
-    virtual uint64_t size() const = 0;
+    ~BuiltinInvertedWriter() override = default;
 };
+
 } // namespace starrocks

--- a/be/src/storage/index/inverted/builtin/builtin_plugin.cpp
+++ b/be/src/storage/index/inverted/builtin/builtin_plugin.cpp
@@ -1,0 +1,32 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/index/inverted/builtin/builtin_plugin.h"
+
+#include "storage/index/inverted/builtin/builtin_inverted_reader.h"
+#include "storage/index/inverted/builtin/builtin_inverted_writer.h"
+
+namespace starrocks {
+
+Status BuiltinPlugin::create_inverted_index_writer(TypeInfoPtr typeinfo, std::string field_name, std::string path,
+                                                   TabletIndex* tablet_index, std::unique_ptr<InvertedWriter>* res) {
+    return BuiltinInvertedWriter::create(typeinfo, tablet_index, res);
+}
+
+Status BuiltinPlugin::create_inverted_index_reader(std::string path, const std::shared_ptr<TabletIndex>& tablet_index,
+                                                   LogicalType field_type, std::unique_ptr<InvertedReader>* res) {
+    return BuiltinInvertedReader::create(tablet_index, field_type, res);
+}
+
+} // namespace starrocks

--- a/be/src/storage/index/inverted/builtin/builtin_plugin.h
+++ b/be/src/storage/index/inverted/builtin/builtin_plugin.h
@@ -1,0 +1,41 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "storage/index/inverted/inverted_plugin.h"
+
+namespace starrocks {
+
+class BuiltinPlugin : public InvertedPlugin {
+public:
+    static BuiltinPlugin& get_instance() {
+        static BuiltinPlugin instance;
+        return instance;
+    }
+
+    BuiltinPlugin(BuiltinPlugin const&) = delete;
+    void operator=(BuiltinPlugin const&) = delete;
+
+    Status create_inverted_index_writer(TypeInfoPtr typeinfo, std::string field_name, std::string path,
+                                        TabletIndex* tablet_index, std::unique_ptr<InvertedWriter>* res) override;
+
+    Status create_inverted_index_reader(std::string path, const std::shared_ptr<TabletIndex>& tablet_index,
+                                        LogicalType field_type, std::unique_ptr<InvertedReader>* res) override;
+
+private:
+    BuiltinPlugin() {}
+};
+
+} // namespace starrocks

--- a/be/src/storage/index/inverted/builtin/builtin_simple_analyzer.cpp
+++ b/be/src/storage/index/inverted/builtin/builtin_simple_analyzer.cpp
@@ -1,0 +1,77 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "storage/index/inverted/builtin/builtin_simple_analyzer.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+
+namespace starrocks {
+
+SimpleAnalyzer::SimpleAnalyzer(bool normalize_case) : _normalize_case(normalize_case) {
+    // Initialize lookup tables based on ASCII character classification
+    for (size_t i = 0; i < LOOKUP_SIZE; ++i) {
+        char c = static_cast<char>(i);
+
+        // Token character table: alphanumeric characters
+        _token_char_table[i] = std::isalnum(static_cast<unsigned char>(c)) != 0;
+
+        // Normalize table: convert uppercase to lowercase
+        _normalize_table[i] = std::tolower(static_cast<unsigned char>(c));
+    }
+}
+
+void SimpleAnalyzer::tokenize(char* mutable_text, size_t text_size, std::vector<SliceToken>& tokens) const {
+    tokens.clear();
+
+    if (mutable_text == nullptr || text_size == 0) {
+        return;
+    }
+    tokens.reserve(text_size);
+
+    size_t offset = 0;
+    size_t position = 0;
+
+    while (offset < text_size) {
+        char c = mutable_text[offset];
+
+        // Skip non-token characters
+        if (!_is_token_char(c)) {
+            ++offset;
+            continue;
+        }
+
+        // Found start of token
+        size_t token_start = offset;
+        size_t token_length = 0;
+
+        // Find end of token
+        while (offset < text_size && _is_token_char(mutable_text[offset])) {
+            ++offset;
+            ++token_length;
+        }
+
+        // Create token if we have content
+        if (token_length > 0) {
+            if (_normalize_case) {
+                for (size_t i = 0; i < token_length; ++i) {
+                    mutable_text[token_start + i] = _normalize(mutable_text[token_start + i]);
+                }
+            }
+            tokens.emplace_back(mutable_text + token_start, token_length, position++);
+        }
+    }
+}
+
+} // namespace starrocks

--- a/be/src/storage/index/inverted/builtin/builtin_simple_analyzer.h
+++ b/be/src/storage/index/inverted/builtin/builtin_simple_analyzer.h
@@ -1,0 +1,101 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "util/slice.h"
+
+namespace starrocks {
+
+/**
+ * @brief Represents a token extracted from text with its position information.
+ */
+struct SliceToken {
+    Slice text;      // Token text data
+    size_t position; // Position of this token in the sequence
+
+    SliceToken() : text(), position(0) {}
+
+    // Constructor for raw char buffer
+    SliceToken(const char* data, size_t len, size_t pos) : text(data, len), position(pos) {}
+
+    bool empty() const { return text.empty(); }
+
+    // Get string_view for efficient access
+    std::string_view view() const { return std::string_view(text.data, text.size); }
+
+    // Comparison operators
+    bool operator==(const SliceToken& other) const { return text == other.text; }
+};
+
+/**
+ * @brief Core tokenizer implementation for simple text analysis
+ * Simplified version of CLucene's CharTokenizer using Slice-based tokens
+ */
+class SimpleAnalyzer {
+public:
+    /**
+     * @brief Constructor
+     * @param normalize_case Whether to normalize case (default: false for maximum performance)
+     */
+    SimpleAnalyzer(bool normalize_case = true);
+    ~SimpleAnalyzer() = default;
+
+    /**
+     * @brief Tokenize text and output tokens to provided vector
+     * @param mutable_text Input text buffer (will be modified for case normalization)
+     * @param text_size Size of input text
+     * @param tokens Output vector to store tokens with their positions
+     */
+    void tokenize(char* mutable_text, size_t text_size, std::vector<SliceToken>& tokens) const;
+
+private:
+    static const size_t LOOKUP_SIZE = 256;
+
+    /**
+     * @brief Check if character should be included in token
+     * @param c Character to check
+     * @return true if character is part of token
+     */
+    inline bool _is_token_char(char c) const {
+        size_t index = static_cast<unsigned char>(c);
+        if (index >= LOOKUP_SIZE) {
+            return false; // Non-isalnum characters are not considered token chars
+        }
+        return _token_char_table[index];
+    }
+
+    /**
+     * @brief Normalize character (e.g., convert to lowercase)
+     * @param c Character to normalize
+     * @return Normalized character
+     */
+    inline char _normalize(char c) const {
+        size_t index = static_cast<unsigned char>(c);
+        if (index >= LOOKUP_SIZE) {
+            return c; // Return unchanged for non-ASCII
+        }
+        return _normalize_table[index];
+    }
+
+    bool _normalize_case;
+    bool _token_char_table[LOOKUP_SIZE];
+    char _normalize_table[LOOKUP_SIZE];
+};
+
+} // namespace starrocks

--- a/be/src/storage/index/inverted/clucene/clucene_inverted_reader.cpp
+++ b/be/src/storage/index/inverted/clucene/clucene_inverted_reader.cpp
@@ -29,7 +29,7 @@
 namespace starrocks {
 
 Status CLuceneInvertedReader::new_iterator(const std::shared_ptr<TabletIndex> index_meta,
-                                           InvertedIndexIterator** iterator) {
+                                           InvertedIndexIterator** iterator, const IndexReadOptions& index_opt) {
     *iterator = new InvertedIndexIterator(index_meta, this);
     return Status::OK();
 }

--- a/be/src/storage/index/inverted/clucene/clucene_inverted_reader.h
+++ b/be/src/storage/index/inverted/clucene/clucene_inverted_reader.h
@@ -61,7 +61,8 @@ public:
     static Status create(const std::string& path, const std::shared_ptr<TabletIndex>& tablet_index,
                          LogicalType field_type, std::unique_ptr<InvertedReader>* res);
 
-    Status new_iterator(const std::shared_ptr<TabletIndex> index_meta, InvertedIndexIterator** iterator) override;
+    Status new_iterator(const std::shared_ptr<TabletIndex> index_meta, InvertedIndexIterator** iterator,
+                        const IndexReadOptions& index_opt) override;
 };
 
 class FullTextCLuceneInvertedReader : public CLuceneInvertedReader {

--- a/be/src/storage/index/inverted/clucene/clucene_inverted_writer.cpp
+++ b/be/src/storage/index/inverted/clucene/clucene_inverted_writer.cpp
@@ -51,11 +51,7 @@ public:
         _field_name = std::wstring(field_name.begin(), field_name.end());
     }
 
-    uint64_t size() const override { return _index_writer->numRamDocs(); }
-
-    uint64_t estimate_buffer_size() const override { return _index_writer->ramSizeInBytes(); }
-
-    uint64_t total_mem_footprint() const override { return _index_writer->ramSizeInBytes(); }
+    uint64_t size() const override { return _index_writer->ramSizeInBytes(); }
 
     Status init() override {
         try {
@@ -190,7 +186,7 @@ public:
         }
     }
 
-    Status finish() override {
+    Status finish(WritableFile* wfile, ColumnMetaPB* meta) override {
         lucene::store::Directory* dir = nullptr;
         lucene::store::IndexOutput* null_bitmap_out = nullptr;
         lucene::store::IndexOutput* data_out = nullptr;

--- a/be/src/storage/index/inverted/inverted_index_common.h
+++ b/be/src/storage/index/inverted/inverted_index_common.h
@@ -21,6 +21,7 @@ namespace starrocks {
 enum class InvertedImplementType {
     UNKNOWN = 0,
     CLUCENE = 1,
+    BUILTIN = 2,
 };
 
 enum class InvertedIndexParserType {
@@ -33,6 +34,7 @@ enum class InvertedIndexParserType {
 
 const std::string INVERTED_IMP_KEY = "imp_lib";
 const std::string TYPE_CLUCENE = "clucene";
+const std::string TYPE_BUILTIN = "builtin";
 const std::string INVERTED_INDEX_PARSER_KEY = "parser";
 const std::string INVERTED_INDEX_PARSER_UNKNOWN = "unknown";
 const std::string INVERTED_INDEX_PARSER_NONE = "none";

--- a/be/src/storage/index/inverted/inverted_index_iterator.h
+++ b/be/src/storage/index/inverted/inverted_index_iterator.h
@@ -32,18 +32,22 @@ public:
                 get_parser_string_from_properties(_index_meta->index_properties()));
     }
 
-    Status read_from_inverted_index(const std::string& column_name, const void* query_value,
-                                    InvertedIndexQueryType query_type, roaring::Roaring* bit_map);
+    virtual ~InvertedIndexIterator() = default;
 
-    Status read_null(const std::string& column_name, roaring::Roaring* bit_map);
+    virtual Status read_from_inverted_index(const std::string& column_name, const void* query_value,
+                                            InvertedIndexQueryType query_type, roaring::Roaring* bit_map);
 
-    InvertedIndexParserType get_inverted_index_analyser_type() const;
+    virtual Status read_null(const std::string& column_name, roaring::Roaring* bit_map);
 
-    InvertedIndexReaderType get_inverted_index_reader_type() const;
+    virtual InvertedIndexParserType get_inverted_index_analyser_type() const;
 
-    bool is_untokenized() const { return _analyser_type == InvertedIndexParserType::PARSER_NONE; }
+    virtual InvertedIndexReaderType get_inverted_index_reader_type() const;
 
-private:
+    virtual bool is_untokenized() const { return _analyser_type == InvertedIndexParserType::PARSER_NONE; }
+
+    virtual Status close() { return Status::OK(); }
+
+protected:
     const std::shared_ptr<TabletIndex> _index_meta;
     OlapReaderStatistics* _stats;
     InvertedReader* _reader;

--- a/be/src/storage/index/inverted/inverted_index_option.cpp
+++ b/be/src/storage/index/inverted/inverted_index_option.cpp
@@ -24,6 +24,8 @@ StatusOr<InvertedImplementType> get_inverted_imp_type(const TabletIndex& tablet_
         const auto& imp_type = inverted_imp_prop->second;
         if (boost::algorithm::to_lower_copy(imp_type) == TYPE_CLUCENE) {
             return InvertedImplementType::CLUCENE;
+        } else if (boost::algorithm::to_lower_copy(imp_type) == TYPE_BUILTIN) {
+            return InvertedImplementType::BUILTIN;
         } else {
             return Status::InvalidArgument("Do not support imp_type : " + imp_type);
         }

--- a/be/src/storage/index/inverted/inverted_plugin_factory.cpp
+++ b/be/src/storage/index/inverted/inverted_plugin_factory.cpp
@@ -15,6 +15,7 @@
 #include "storage/index/inverted/inverted_plugin_factory.h"
 
 #include "common/statusor.h"
+#include "storage/index/inverted/builtin/builtin_plugin.h"
 #include "storage/index/inverted/clucene/clucene_plugin.h"
 
 namespace starrocks {
@@ -22,6 +23,8 @@ StatusOr<InvertedPlugin*> InvertedPluginFactory::get_plugin(InvertedImplementTyp
     switch (imp_type) {
     case InvertedImplementType::CLUCENE:
         return &CLucenePlugin::get_instance();
+    case InvertedImplementType::BUILTIN:
+        return &BuiltinPlugin::get_instance();
     default:
         return Status::InternalError("Invalid implement of inverted type");
     }

--- a/be/src/storage/index/inverted/inverted_reader.h
+++ b/be/src/storage/index/inverted/inverted_reader.h
@@ -28,6 +28,7 @@ namespace starrocks {
 class InvertedIndexIterator;
 enum class InvertedIndexReaderType;
 enum class InvertedIndexQueryType;
+class IndexReadOptions;
 
 class InvertedReader {
 public:
@@ -37,7 +38,8 @@ public:
     virtual ~InvertedReader() = default;
 
     // create a new column iterator. Client should delete returned iterator
-    virtual Status new_iterator(const std::shared_ptr<TabletIndex> index_meta, InvertedIndexIterator** iterator) = 0;
+    virtual Status new_iterator(const std::shared_ptr<TabletIndex> index_meta, InvertedIndexIterator** iterator,
+                                const IndexReadOptions& index_opt) = 0;
 
     virtual Status query(OlapReaderStatistics* stats, const std::string& column_name, const void* query_value,
                          InvertedIndexQueryType query_type, roaring::Roaring* bit_map) = 0;
@@ -46,6 +48,8 @@ public:
                               roaring::Roaring* bit_map) = 0;
 
     virtual InvertedIndexReaderType get_inverted_index_reader_type() = 0;
+
+    virtual Status load(const IndexReadOptions& opt, void* meta) { return Status::OK(); }
 
     bool index_exists(const std::string& index_file_path) { return fs::path_exist(index_file_path); }
 

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -234,6 +234,9 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
     if (_metadata->has_record_predicate()) {
         ASSIGN_OR_RETURN(seg_options.record_predicate, RecordPredicateHelper::create(_metadata->record_predicate()));
     }
+    seg_options.enable_gin_filter = options.enable_gin_filter;
+    seg_options.prune_column_after_index_filter = options.prune_column_after_index_filter;
+    seg_options.has_preaggregation = options.has_preaggregation;
 
     std::unique_ptr<Schema> segment_schema_guard;
     auto* segment_schema = const_cast<Schema*>(&schema);

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -343,6 +343,8 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     rs_opts.runtime_range_pruner = params.runtime_range_pruner;
     rs_opts.lake_io_opts = params.lake_io_opts;
     rs_opts.enable_join_runtime_filter_pushdown = params.enable_join_runtime_filter_pushdown;
+    rs_opts.prune_column_after_index_filter = params.prune_column_after_index_filter;
+    rs_opts.enable_gin_filter = params.enable_gin_filter;
 
     if (keys_type == KeysType::PRIMARY_KEYS) {
         rs_opts.is_primary_keys = true;

--- a/be/src/storage/rowset/bitmap_index_reader.cpp
+++ b/be/src/storage/rowset/bitmap_index_reader.cpp
@@ -40,6 +40,8 @@
 
 #include "column/column_helper.h"
 #include "column/column_viewer.h"
+#include "exprs/function_context.h"
+#include "exprs/like_predicate.h"
 #include "runtime/exec_env.h"
 #include "storage/chunk_helper.h"
 #include "storage/range.h"
@@ -104,6 +106,35 @@ Status BitmapIndexIterator::seek_dictionary(const void* value, bool* exact_match
     return Status::OK();
 }
 
+Status BitmapIndexIterator::next_batch_dictionary(size_t* n, Column* column) {
+    RETURN_IF_ERROR(_dict_column_iter->next_batch(n, column));
+    _current_rowid += *n;
+    return Status::OK();
+}
+
+StatusOr<Buffer<rowid_t>> BitmapIndexIterator::seek_dictionary_by_predicate(const DictPredicate& predicate,
+                                                                            const Slice& from_value,
+                                                                            size_t search_size) {
+    if (_reader->type_info()->type() != TYPE_VARCHAR && _reader->type_info()->type() != TYPE_CHAR) {
+        return Status::NotSupported("predicate seek for dictionary only support string/char type bitmap index");
+    }
+    auto column = ChunkHelper::column_from_field_type(TYPE_VARCHAR, false);
+    bool exact_match;
+    RETURN_IF_ERROR(seek_dictionary(&from_value, &exact_match));
+    size_t beg_rowid = _current_rowid;
+    RETURN_IF_ERROR(next_batch_dictionary(&search_size, column.get()));
+    ASSIGN_OR_RETURN(auto ret, predicate(*column));
+
+    const auto* hit_column = down_cast<const BooleanColumn*>(ret.get());
+    Buffer<rowid_t> hit_rowids;
+    for (int i = 0; i < hit_column->size(); ++i) {
+        if (hit_column->get_data()[i]) {
+            hit_rowids.push_back(beg_rowid + i);
+        }
+    }
+    return hit_rowids;
+}
+
 Status BitmapIndexIterator::read_bitmap(rowid_t ordinal, Roaring* result) {
     DCHECK(0 <= ordinal && ordinal < _reader->bitmap_nums());
 
@@ -136,6 +167,15 @@ Status BitmapIndexIterator::read_union_bitmap(const SparseRange<>& range, Roarin
     for (size_t i = 0; i < range.size(); i++) { // NOLINT
         const Range<>& r = range[i];
         RETURN_IF_ERROR(read_union_bitmap(r.begin(), r.end(), result));
+    }
+    return Status::OK();
+}
+
+Status BitmapIndexIterator::read_union_bitmap(const Buffer<rowid_t>& rowids, Roaring* result) {
+    for (const auto& rowid : rowids) {
+        Roaring bitmap;
+        RETURN_IF_ERROR(read_bitmap(rowid, &bitmap));
+        *result |= bitmap;
     }
     return Status::OK();
 }

--- a/be/src/storage/rowset/bitmap_index_reader.h
+++ b/be/src/storage/rowset/bitmap_index_reader.h
@@ -36,6 +36,7 @@
 
 #include <roaring/roaring.hh>
 
+#include "column/column_helper.h"
 #include "common/status.h"
 #include "fs/fs.h"
 #include "gen_cpp/segment.pb.h"
@@ -107,6 +108,8 @@ private:
 
 class BitmapIndexIterator {
 public:
+    using DictPredicate = std::function<StatusOr<ColumnPtr>(const Column&)>;
+
     BitmapIndexIterator(BitmapIndexReader* reader, std::unique_ptr<IndexedColumnIterator> dict_iter,
                         std::unique_ptr<IndexedColumnIterator> bitmap_iter, bool has_null, rowid_t num_bitmap)
             : _reader(reader),
@@ -126,6 +129,11 @@ public:
     // Returns NotFound when no such value exists (all values in dictionary < `value`).
     // Returns other error status otherwise.
     Status seek_dictionary(const void* value, bool* exact_match);
+
+    StatusOr<Buffer<rowid_t>> seek_dictionary_by_predicate(const DictPredicate& predicate, const Slice& from_value,
+                                                           size_t search_size);
+
+    Status next_batch_dictionary(size_t* n, Column* column);
 
     // Read bitmap at the given ordinal into `result`.
     Status read_bitmap(rowid_t ordinal, Roaring* result);
@@ -148,6 +156,8 @@ public:
     //     read_union_bitmap(range[i].begin(), range[i].end(), &result);
     // }
     Status read_union_bitmap(const SparseRange<>& range, Roaring* result);
+
+    Status read_union_bitmap(const Buffer<rowid_t>& rowids, Roaring* result);
 
     rowid_t bitmap_nums() const { return _num_bitmap; }
 

--- a/be/src/storage/rowset/bitmap_index_writer.cpp
+++ b/be/src/storage/rowset/bitmap_index_writer.cpp
@@ -48,7 +48,10 @@
 #include "storage/type_traits.h"
 #include "storage/types.h"
 #include "util/faststring.h"
+#include "util/phmap/btree.h"
+#include "util/phmap/phmap.h"
 #include "util/slice.h"
+#include "util/xxh3.h"
 
 namespace starrocks {
 
@@ -58,8 +61,13 @@ class BitmapUpdateContext {
     static const size_t estimate_size_threshold = 1024;
 
 public:
-    explicit BitmapUpdateContext(rowid_t rid) : _roaring(Roaring::bitmapOf(1, rid)){};
-    explicit BitmapUpdateContext(rowid_t rid0, rowid_t rid1) : _roaring(Roaring::bitmapOfList({rid0, rid1})){};
+    explicit BitmapUpdateContext(rowid_t rid, MemPool* pool) : _roaring(Roaring::bitmapOf(1, rid)) {
+        _pending_adds = reinterpret_cast<uint32_t*>(pool->allocate(sizeof(uint32_t) * _ADD_BATCH_SIZE));
+    }
+    explicit BitmapUpdateContext(rowid_t rid0, rowid_t rid1, MemPool* pool)
+            : _roaring(Roaring::bitmapOfList({rid0, rid1})) {
+        _pending_adds = reinterpret_cast<uint32_t*>(pool->allocate(sizeof(uint32_t) * _ADD_BATCH_SIZE));
+    }
 
     Roaring* roaring() { return &_roaring; }
 
@@ -73,6 +81,23 @@ public:
 
     static void init_estimate_size(uint64_t* reverted_index_size) {
         *reverted_index_size += BitmapUpdateContext::estimate_size(1);
+    }
+
+    void add_and_flush_if_needed(rowid_t rid) {
+        if (_pending_adds_size != 0 && _pending_adds[_pending_adds_size - 1] == rid) {
+            return;
+        }
+        _pending_adds[_pending_adds_size++] = rid;
+        if (_pending_adds_size == _ADD_BATCH_SIZE) {
+            flush_pending_adds();
+        }
+    }
+
+    void flush_pending_adds() {
+        if (_pending_adds_size != 0) {
+            _roaring.addMany(_pending_adds_size, _pending_adds);
+            _pending_adds_size = 0;
+        }
     }
 
     // When _element_count is less than estimate_size_threshold, update the estimate size
@@ -114,6 +139,9 @@ private:
     uint64_t _previous_size{0};
     uint32_t _element_count{1};
     bool _size_changed{false};
+    uint32_t* _pending_adds{nullptr};
+    size_t _pending_adds_size{0};
+    static const size_t _ADD_BATCH_SIZE = 64;
 };
 
 // if last bit is 0 it is std::unique_ptr<BitmapUpdateContext>
@@ -121,6 +149,22 @@ private:
 class BitmapUpdateContextRefOrSingleValue {
 public:
     BitmapUpdateContextRefOrSingleValue(const BitmapUpdateContextRefOrSingleValue& rhs) = delete;
+    BitmapUpdateContextRefOrSingleValue& operator=(const BitmapUpdateContextRefOrSingleValue& rhs) = delete;
+    BitmapUpdateContextRefOrSingleValue(BitmapUpdateContextRefOrSingleValue&& rhs) noexcept {
+        _value = rhs._value;
+        rhs._value = 1; // make sure not delete when rhs is destroyed
+    }
+    BitmapUpdateContextRefOrSingleValue& operator=(BitmapUpdateContextRefOrSingleValue&& rhs) noexcept {
+        if (this == &rhs) {
+            return *this;
+        }
+        if (is_context()) {
+            delete context();
+        }
+        _value = rhs._value;
+        rhs._value = 1; // make sure not delete when rhs is destroyed
+        return *this;
+    }
     BitmapUpdateContextRefOrSingleValue(uint32_t value) { _value = (value << 1) | 1; }
     ~BitmapUpdateContextRefOrSingleValue() {
         if (is_context()) {
@@ -132,11 +176,14 @@ public:
     BitmapUpdateContext* context() const {
         return reinterpret_cast<BitmapUpdateContext*>(_value); // NOLINT
     }
-    void add(rowid_t rid) {
+    void add(rowid_t rid, MemPool* pool) {
         if (is_context()) {
-            context()->roaring()->add(rid);
+            context()->add_and_flush_if_needed(rid);
         } else {
-            auto* context = new BitmapUpdateContext(value(), rid);
+            if (value() == rid) {
+                return;
+            }
+            auto* context = new BitmapUpdateContext(value(), rid, pool);
             _value = reinterpret_cast<uint64_t>(context); // NOLINT
         }
     }
@@ -149,7 +196,7 @@ public:
     }
 
     bool update_estimate_size(uint64_t* reverted_index_size) {
-        if (context()) {
+        if (is_context()) {
             return context()->update_estimate_size(reverted_index_size);
         } else {
             return false;
@@ -162,18 +209,31 @@ public:
         }
     }
 
+    void flush_pending_adds() {
+        if (is_context()) {
+            context()->flush_pending_adds();
+        }
+    }
+
 private:
     uint64_t _value;
 };
 
+struct BitmapIndexSliceHash {
+    inline size_t operator()(const Slice& v) const { return XXH3_64bits(v.data, v.size); }
+};
+
 template <typename CppType>
 struct BitmapIndexTraits {
-    using MemoryIndexType = std::map<CppType, BitmapUpdateContextRefOrSingleValue>;
+    using UnorderedMemoryIndexType = phmap::flat_hash_map<CppType, BitmapUpdateContextRefOrSingleValue>;
+    using OrderedMemoryIndexType = std::map<CppType, BitmapUpdateContextRefOrSingleValue>;
 };
 
 template <>
 struct BitmapIndexTraits<Slice> {
-    using MemoryIndexType = std::map<Slice, BitmapUpdateContextRefOrSingleValue, Slice::Comparator>;
+    using UnorderedMemoryIndexType = phmap::flat_hash_map<Slice, BitmapUpdateContextRefOrSingleValue,
+                                                          BitmapIndexSliceHash, std::equal_to<Slice>>;
+    using OrderedMemoryIndexType = std::map<Slice, BitmapUpdateContextRefOrSingleValue, Slice::Comparator>;
 };
 
 // Builder for bitmap index. Bitmap index is comprised of two parts
@@ -193,7 +253,8 @@ template <LogicalType field_type>
 class BitmapIndexWriterImpl : public BitmapIndexWriter {
 public:
     using CppType = typename CppTypeTraits<field_type>::CppType;
-    using MemoryIndexType = typename BitmapIndexTraits<CppType>::MemoryIndexType;
+    using UnorderedMemoryIndexType = typename BitmapIndexTraits<CppType>::UnorderedMemoryIndexType;
+    using OrderedMemoryIndexType = typename BitmapIndexTraits<CppType>::OrderedMemoryIndexType;
 
     explicit BitmapIndexWriterImpl(TypeInfoPtr type_info) : _typeinfo(std::move(type_info)) {}
 
@@ -202,22 +263,26 @@ public:
     void add_values(const void* values, size_t count) override {
         auto p = reinterpret_cast<const CppType*>(values);
         for (size_t i = 0; i < count; ++i) {
-            const CppType& value = unaligned_load<CppType>(p);
-            auto it = _mem_index.find(value);
-            if (it != _mem_index.end()) {
-                it->second.add(_rid);
-                if (it->second.update_estimate_size(&_reverted_index_size)) {
-                    _late_update_context_vector.push_back(&(it->second));
-                }
-            } else {
-                // new value, copy value and insert new key->bitmap pair
-                CppType new_value;
-                _typeinfo->deep_copy(&new_value, &value, &_pool);
-                _mem_index.emplace(new_value, _rid);
-                BitmapUpdateContext::init_estimate_size(&_reverted_index_size);
-            }
+            add_value_with_current_rowid(p);
             _rid++;
             p++;
+        }
+    }
+
+    inline void add_value_with_current_rowid(const void* vptr) override {
+        const CppType& value = *(reinterpret_cast<const CppType*>(vptr));
+        auto it = _mem_index.find(value);
+        if (it != _mem_index.end()) {
+            it->second.add(_rid, &_pool);
+            if (it->second.update_estimate_size(&_reverted_index_size)) {
+                _late_update_context_vector.push_back(it->second.context());
+            }
+        } else {
+            // new value, copy value and insert new key->bitmap pair
+            CppType new_value;
+            _typeinfo->deep_copy(&new_value, &value, &_pool);
+            _mem_index.emplace(new_value, _rid);
+            BitmapUpdateContext::init_estimate_size(&_reverted_index_size);
         }
     }
 
@@ -229,27 +294,39 @@ public:
     Status finish(WritableFile* wfile, ColumnIndexMetaPB* index_meta) override {
         index_meta->set_type(BITMAP_INDEX);
         BitmapIndexPB* meta = index_meta->mutable_bitmap_index();
+        return finish(wfile, meta);
+    }
+
+    Status finish(WritableFile* wfile, BitmapIndexPB* meta) override {
+        _late_update_context_vector.clear();
+        _reverted_index_size = 0;
 
         meta->set_bitmap_type(BitmapIndexPB::ROARING_BITMAP);
         meta->set_has_null(!_null_bitmap.isEmpty());
+
+        OrderedMemoryIndexType ordered_mem_index;
+        for (auto& p : _mem_index) {
+            p.second.flush_pending_adds();
+            ordered_mem_index.insert(std::move(p));
+        }
 
         { // write dictionary
             IndexedColumnWriterOptions options;
             options.write_ordinal_index = false;
             options.write_value_index = true;
             options.encoding = EncodingInfo::get_default_encoding(_typeinfo->type(), true);
-            options.compression = CompressionTypePB::LZ4;
+            options.compression = _dictionary_compression;
 
             IndexedColumnWriter dict_column_writer(options, _typeinfo, wfile);
             RETURN_IF_ERROR(dict_column_writer.init());
-            for (auto const& it : _mem_index) {
+            for (auto const& it : ordered_mem_index) {
                 RETURN_IF_ERROR(dict_column_writer.add(&(it.first)));
             }
             RETURN_IF_ERROR(dict_column_writer.finish(meta->mutable_dict_column()));
         }
         { // write bitmaps
             std::vector<BitmapUpdateContextRefOrSingleValue*> bitmaps;
-            for (auto& it : _mem_index) {
+            for (auto& it : ordered_mem_index) {
                 bitmaps.push_back(&(it.second));
             }
 
@@ -304,13 +381,16 @@ public:
             }
             RETURN_IF_ERROR(bitmap_column_writer.finish(meta->mutable_bitmap_column()));
         }
+        _mem_index.clear();
+        _null_bitmap.clear();
         return Status::OK();
     }
 
     uint64_t size() const override {
         uint64_t size = 0;
         size += _null_bitmap.getSizeInBytes(false);
-        for (BitmapUpdateContextRefOrSingleValue* update_context : _late_update_context_vector) {
+        for (BitmapUpdateContext* update_context : _late_update_context_vector) {
+            update_context->flush_pending_adds();
             update_context->late_update_size(&_reverted_index_size);
         }
         _late_update_context_vector.clear();
@@ -320,6 +400,8 @@ public:
         return size;
     }
 
+    inline void incre_rowid() override { _rid++; }
+
 private:
     TypeInfoPtr _typeinfo;
     rowid_t _rid = 0;
@@ -327,12 +409,14 @@ private:
     // row id list for null value
     Roaring _null_bitmap;
     // unique value to its row id list
-    MemoryIndexType _mem_index;
+    // Use UnorderedMemoryIndexType during loading and sort it when finish is more efficient than only
+    // use OrderedMemoryIndexType. Especially for the case of built-in inverted index workload.
+    UnorderedMemoryIndexType _mem_index;
     MemPool _pool;
 
     // roaring bitmap size
     mutable uint64_t _reverted_index_size = 0;
-    mutable std::vector<BitmapUpdateContextRefOrSingleValue*> _late_update_context_vector;
+    mutable std::vector<BitmapUpdateContext*> _late_update_context_vector;
 };
 
 struct BitmapIndexWriterBuilder {

--- a/be/src/storage/rowset/bitmap_index_writer.h
+++ b/be/src/storage/rowset/bitmap_index_writer.h
@@ -55,13 +55,23 @@ public:
     BitmapIndexWriter() = default;
     virtual ~BitmapIndexWriter() = default;
 
+    virtual void add_value_with_current_rowid(const void* vptr) = 0;
+
     virtual void add_values(const void* values, size_t count) = 0;
 
     virtual void add_nulls(uint32_t count) = 0;
 
     virtual Status finish(WritableFile* file, ColumnIndexMetaPB* index_meta) = 0;
+    virtual Status finish(WritableFile* file, BitmapIndexPB* meta) = 0;
 
     virtual uint64_t size() const = 0;
+
+    virtual void incre_rowid() = 0;
+
+    void set_dictionary_compression(CompressionTypePB compression) { _dictionary_compression = compression; }
+
+protected:
+    CompressionTypePB _dictionary_compression = LZ4;
 
 private:
     BitmapIndexWriter(const BitmapIndexWriter&) = delete;

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -119,6 +119,9 @@ ColumnReader::~ColumnReader() {
                                  _bloom_filter_index_meta->SpaceUsedLong());
         _bloom_filter_index_meta.reset(nullptr);
     }
+    if (_builtin_inverted_index_meta != nullptr) {
+        _builtin_inverted_index_meta.reset(nullptr);
+    }
     MEM_TRACKER_SAFE_RELEASE(GlobalEnv::GetInstance()->column_metadata_mem_tracker(), sizeof(ColumnReader));
 }
 
@@ -201,6 +204,9 @@ Status ColumnReader::_init(ColumnMetaPB* meta, const TabletColumn* column) {
                                          _bloom_filter_index_meta->SpaceUsedLong());
                 _meta_mem_usage.fetch_add(_bloom_filter_index_meta->SpaceUsedLong(), std::memory_order_relaxed);
                 _bloom_filter_index = std::make_unique<BloomFilterIndexReader>();
+                break;
+            case BUILTIN_INVERTED_INDEX:
+                _builtin_inverted_index_meta.reset(index_meta->release_builtin_inverted_index());
                 break;
             case UNKNOWN_INDEX_TYPE:
                 return Status::Corruption(fmt::format("Bad file {}: unknown index type", file_name()));
@@ -531,16 +537,16 @@ Status ColumnReader::_load_bloom_filter_index(const IndexReadOptions& opts) {
 }
 
 Status ColumnReader::new_inverted_index_iterator(const std::shared_ptr<TabletIndex>& index_meta,
-                                                 InvertedIndexIterator** iterator, const SegmentReadOptions& opts) {
-    RETURN_IF_ERROR(_load_inverted_index(index_meta, opts));
-    RETURN_IF_ERROR(_inverted_index->new_iterator(index_meta, iterator));
+                                                 InvertedIndexIterator** iterator, const SegmentReadOptions& opts,
+                                                 const IndexReadOptions& index_opt) {
+    RETURN_IF_ERROR(_load_inverted_index(index_meta, opts, index_opt));
+    RETURN_IF_ERROR(_inverted_index->new_iterator(index_meta, iterator, index_opt));
     return Status::OK();
 }
 
 Status ColumnReader::_load_inverted_index(const std::shared_ptr<TabletIndex>& index_meta,
-                                          const SegmentReadOptions& opts) {
-    if (_inverted_index && index_meta && _inverted_index->get_index_id() == index_meta->index_id() &&
-        _inverted_index_loaded()) {
+                                          const SegmentReadOptions& opts, const IndexReadOptions& index_opt) {
+    if (index_meta == nullptr || _inverted_index_loaded()) {
         return Status::OK();
     }
 
@@ -562,7 +568,10 @@ Status ColumnReader::_load_inverted_index(const std::shared_ptr<TabletIndex>& in
                             ASSIGN_OR_RETURN(auto inverted_plugin, InvertedPluginFactory::get_plugin(imp_type));
                             RETURN_IF_ERROR(inverted_plugin->create_inverted_index_reader(index_path, index_meta, type,
                                                                                           &_inverted_index));
-
+                            RETURN_IF_ERROR(_inverted_index->load(index_opt, _builtin_inverted_index_meta.get()));
+                            if (_builtin_inverted_index_meta != nullptr) {
+                                _builtin_inverted_index_meta.reset();
+                            }
                             return Status::OK();
                         })
             .status();

--- a/be/src/storage/rowset/column_reader.h
+++ b/be/src/storage/rowset/column_reader.h
@@ -188,7 +188,7 @@ public:
     Status load_ordinal_index(const IndexReadOptions& opts);
 
     Status new_inverted_index_iterator(const std::shared_ptr<TabletIndex>& index_meta, InvertedIndexIterator** iterator,
-                                       const SegmentReadOptions& opts);
+                                       const SegmentReadOptions& opts, const IndexReadOptions& index_opt);
 
     uint32_t num_rows() const { return _segment->num_rows(); }
 
@@ -241,7 +241,8 @@ private:
                             std::unordered_set<uint32_t>* del_partial_filtered_pages, std::vector<uint32_t>* pages,
                             const Range<>* src_range);
 
-    Status _load_inverted_index(const std::shared_ptr<TabletIndex>& index_meta, const SegmentReadOptions& opts);
+    Status _load_inverted_index(const std::shared_ptr<TabletIndex>& index_meta, const SegmentReadOptions& opts,
+                                const IndexReadOptions& index_opt);
 
     NgramBloomFilterReaderOptions _get_reader_options_for_ngram() const;
 
@@ -269,6 +270,7 @@ private:
     std::unique_ptr<OrdinalIndexPB> _ordinal_index_meta;
     std::unique_ptr<BitmapIndexPB> _bitmap_index_meta;
     std::unique_ptr<BloomFilterIndexPB> _bloom_filter_index_meta;
+    std::unique_ptr<BuiltinInvertedIndexPB> _builtin_inverted_index_meta;
 
     std::unique_ptr<ZoneMapIndexReader> _zonemap_index;
     std::unique_ptr<OrdinalIndexReader> _ordinal_index;

--- a/be/src/storage/rowset/column_writer.cpp
+++ b/be/src/storage/rowset/column_writer.cpp
@@ -577,7 +577,7 @@ Status ScalarColumnWriter::write_bloom_filter_index() {
 Status ScalarColumnWriter::write_inverted_index() {
 #ifndef __APPLE__
     if (_inverted_index_builder != nullptr) {
-        return _inverted_index_builder->finish();
+        return _inverted_index_builder->finish(_wfile, _opts.meta);
     }
 #endif
     return Status::OK();

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -347,15 +347,16 @@ StatusOr<ChunkIteratorPtr> Segment::new_iterator(const Schema& schema, const Seg
     return _new_iterator(schema, read_options);
 }
 
-Status Segment::new_inverted_index_iterator(uint32_t ucid, InvertedIndexIterator** iter,
-                                            const SegmentReadOptions& opts) {
+Status Segment::new_inverted_index_iterator(uint32_t ucid, InvertedIndexIterator** iter, const SegmentReadOptions& opts,
+                                            const IndexReadOptions& index_opt) {
     auto column_reader_iter = _column_readers.find(ucid);
 
     if (column_reader_iter != _column_readers.end()) {
         std::shared_ptr<TabletIndex> index_meta;
         RETURN_IF_ERROR(_tablet_schema->get_indexes_for_column(ucid, GIN, index_meta));
         if (index_meta.get() != nullptr) {
-            return column_reader_iter->second->new_inverted_index_iterator(index_meta, iter, std::move(opts));
+            return column_reader_iter->second->new_inverted_index_iterator(index_meta, iter, std::move(opts),
+                                                                           index_opt);
         }
     }
     return Status::OK();

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -200,7 +200,8 @@ public:
     Status load_index(const LakeIOOptions& lake_io_opts = {});
     bool has_loaded_index() const;
 
-    Status new_inverted_index_iterator(uint32_t cid, InvertedIndexIterator** iter, const SegmentReadOptions& opts);
+    Status new_inverted_index_iterator(uint32_t cid, InvertedIndexIterator** iter, const SegmentReadOptions& opts,
+                                       const IndexReadOptions& index_opt);
 
     const ShortKeyIndexDecoder* decoder() const { return _sk_index_decoder.get(); }
 

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -2459,9 +2459,16 @@ Status SegmentIterator::_init_inverted_index_iterators() {
         ColumnId cid = pair.first;
         ColumnUID ucid = cid_2_ucid[cid];
 
+        IndexReadOptions index_opts;
+        index_opts.use_page_cache =
+                !_opts.temporary_data && _opts.use_page_cache && !config::disable_storage_page_cache;
+        index_opts.lake_io_opts = _opts.lake_io_opts;
+        index_opts.read_file = _column_files[cid].get();
+        index_opts.stats = _opts.stats;
+
         if (_inverted_index_ctx->inverted_index_iterators[cid] == nullptr) {
             RETURN_IF_ERROR(_segment->new_inverted_index_iterator(
-                    ucid, &_inverted_index_ctx->inverted_index_iterators[cid], _opts));
+                    ucid, &_inverted_index_ctx->inverted_index_iterators[cid], _opts, index_opts));
             _inverted_index_ctx->has_inverted_index |= (_inverted_index_ctx->inverted_index_iterators[cid] != nullptr);
         }
     }
@@ -2525,6 +2532,12 @@ Status SegmentIterator::_apply_inverted_index() {
                 // inverted index filtering.These columns may can be pruned.
                 _inverted_index_ctx->prune_cols_candidate_by_inverted_index.insert(cid);
             }
+        }
+    }
+
+    for (auto* iter : _inverted_index_ctx->inverted_index_iterators) {
+        if (iter != nullptr) {
+            RETURN_IF_ERROR(iter->close());
         }
     }
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -497,6 +497,7 @@ SET(DW_TEST_FILES
     ./storage/hll_test.cpp
     ./storage/index/vector_index_test.cpp
     ./storage/index/vector_search_test.cpp
+    ./storage/index/builtin_inverted_index_test.cpp
     ./storage/key_coder_test.cpp
     ./storage/kv_store_test.cpp
     ./storage/lake/alter_tablet_meta_test.cpp

--- a/be/test/storage/index/builtin_inverted_index_test.cpp
+++ b/be/test/storage/index/builtin_inverted_index_test.cpp
@@ -1,0 +1,819 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "fs/fs_memory.h"
+#include "gen_cpp/segment.pb.h"
+#include "roaring/roaring.hh"
+#include "storage/index/inverted/builtin/builtin_inverted_index_iterator.h"
+#include "storage/index/inverted/builtin/builtin_inverted_reader.h"
+#include "storage/index/inverted/builtin/builtin_inverted_writer.h"
+#include "storage/index/inverted/builtin/builtin_simple_analyzer.h"
+#include "storage/index/inverted/inverted_index_common.h"
+#include "storage/rowset/bitmap_index_reader.h"
+#include "storage/tablet_index.h"
+#include "storage/types.h"
+#include "testutil/assert.h"
+#include "util/slice.h"
+
+namespace starrocks {
+
+class BuiltinInvertedIndexTest : public testing::Test {
+public:
+    const std::string kTestDir = "/builtin_inverted_index_test";
+
+protected:
+    void SetUp() override {
+        _fs = std::make_shared<MemoryFileSystem>();
+        ASSERT_TRUE(_fs->create_dir(kTestDir).ok());
+
+        _opts.use_page_cache = true;
+        _opts.stats = &_stats;
+    }
+
+    void TearDown() override {}
+
+protected:
+    std::shared_ptr<MemoryFileSystem> _fs;
+    IndexReadOptions _opts;
+    OlapReaderStatistics _stats;
+};
+
+// Basic sanity test for parser=none: builtin inverted index should behave like a normal
+// string bitmap index where each distinct whole value maps to a posting list of rowids.
+TEST_F(BuiltinInvertedIndexTest, test_parser_none_equal_query) {
+    // Prepare test data: "apple" appears twice, "banana" once.
+    std::vector<std::string> values = {"apple", "banana", "apple"};
+    std::vector<Slice> slices;
+    slices.reserve(values.size());
+    for (auto& v : values) {
+        slices.emplace_back(v.data(), v.size());
+    }
+
+    // Configure a TabletIndex with parser=none.
+    TabletIndex tablet_index;
+    tablet_index.add_index_properties(INVERTED_INDEX_PARSER_KEY, INVERTED_INDEX_PARSER_NONE);
+
+    TypeInfoPtr type_info = get_type_info(TYPE_VARCHAR);
+
+    std::string file_name = kTestDir + "/parser_none";
+    ColumnMetaPB meta;
+    {
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+
+        std::unique_ptr<InvertedWriter> writer;
+        ASSERT_OK(BuiltinInvertedWriter::create(type_info, &tablet_index, &writer));
+        ASSERT_OK(writer->init());
+
+        writer->add_values(slices.data(), slices.size());
+        writer->add_nulls(0);
+        ASSERT_OK(writer->finish(wfile.get(), &meta));
+        ASSERT_TRUE(wfile->close().ok());
+    }
+
+    ASSERT_EQ(1, meta.indexes_size());
+    const auto& index_meta = meta.indexes(0);
+    ASSERT_EQ(BUILTIN_INVERTED_INDEX, index_meta.type());
+    ASSERT_TRUE(index_meta.has_builtin_inverted_index());
+    const auto& builtin_meta = index_meta.builtin_inverted_index();
+    ASSERT_TRUE(builtin_meta.has_bitmap_index());
+
+    // Load builtin inverted index via BuiltinInvertedReader.
+    ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(file_name));
+    _opts.read_file = rfile.get();
+
+    auto tablet_index_sp = std::make_shared<TabletIndex>(tablet_index);
+    std::unique_ptr<InvertedReader> reader;
+    ASSERT_OK(BuiltinInvertedReader::create(tablet_index_sp, TYPE_VARCHAR, &reader));
+
+    // BuiltinInvertedReader::load expects a non-null meta pointer.
+    BuiltinInvertedIndexPB builtin_meta_copy = builtin_meta;
+    ASSERT_OK(reader->load(_opts, &builtin_meta_copy));
+
+    InvertedIndexIterator* iter = nullptr;
+    ASSERT_OK(reader->new_iterator(tablet_index_sp, &iter, _opts));
+
+    // Query "apple" with EQUAL_QUERY. Should hit rowids 0 and 2.
+    roaring::Roaring bitmap;
+    Slice query("apple");
+    ASSERT_OK(iter->read_from_inverted_index("c0", &query, InvertedIndexQueryType::EQUAL_QUERY, &bitmap));
+    ASSERT_EQ(2, bitmap.cardinality());
+    ASSERT_TRUE(bitmap.contains(0));
+    ASSERT_TRUE(bitmap.contains(2));
+
+    delete iter;
+}
+
+// Test tokenized english parser: verify equality and prefix wildcard behaviour.
+TEST_F(BuiltinInvertedIndexTest, test_english_parser_queries) {
+    // Values:
+    //  row0: "hello world"
+    //  row1: "hello"
+    //  row2: "world"
+    //  row3: "other"
+    std::vector<std::string> values = {"hello world", "hello", "world", "other"};
+    std::vector<Slice> slices;
+    slices.reserve(values.size());
+    for (auto& v : values) {
+        slices.emplace_back(v.data(), v.size());
+    }
+
+    TabletIndex tablet_index;
+    tablet_index.add_index_properties(INVERTED_INDEX_PARSER_KEY, INVERTED_INDEX_PARSER_ENGLISH);
+
+    TypeInfoPtr type_info = get_type_info(TYPE_VARCHAR);
+
+    std::string file_name = kTestDir + "/english";
+    ColumnMetaPB meta;
+    {
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+
+        std::unique_ptr<InvertedWriter> writer;
+        ASSERT_OK(BuiltinInvertedWriter::create(type_info, &tablet_index, &writer));
+        ASSERT_OK(writer->init());
+
+        writer->add_values(slices.data(), slices.size());
+        writer->add_nulls(0);
+        ASSERT_OK(writer->finish(wfile.get(), &meta));
+        ASSERT_TRUE(wfile->close().ok());
+    }
+
+    ASSERT_EQ(1, meta.indexes_size());
+    const auto& index_meta = meta.indexes(0);
+    ASSERT_EQ(BUILTIN_INVERTED_INDEX, index_meta.type());
+    const auto& builtin_meta = index_meta.builtin_inverted_index();
+
+    ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(file_name));
+    _opts.read_file = rfile.get();
+
+    auto tablet_index_sp = std::make_shared<TabletIndex>(tablet_index);
+    std::unique_ptr<InvertedReader> reader;
+    ASSERT_OK(BuiltinInvertedReader::create(tablet_index_sp, TYPE_VARCHAR, &reader));
+
+    BuiltinInvertedIndexPB builtin_meta_copy = builtin_meta;
+    ASSERT_OK(reader->load(_opts, &builtin_meta_copy));
+
+    InvertedIndexIterator* iter = nullptr;
+    ASSERT_OK(reader->new_iterator(tablet_index_sp, &iter, _opts));
+
+    // EQUAL_QUERY "hello" should hit rows 0 and 1.
+    {
+        roaring::Roaring bitmap;
+        Slice query("hello");
+        ASSERT_OK(iter->read_from_inverted_index("c0", &query, InvertedIndexQueryType::EQUAL_QUERY, &bitmap));
+        ASSERT_EQ(2, bitmap.cardinality());
+        ASSERT_TRUE(bitmap.contains(0));
+        ASSERT_TRUE(bitmap.contains(1));
+    }
+
+    // MATCH_WILDCARD_QUERY "he%" should behave like a prefix query on terms starting with "he".
+    {
+        roaring::Roaring bitmap;
+        Slice query("he%");
+        ASSERT_OK(iter->read_from_inverted_index("c0", &query, InvertedIndexQueryType::MATCH_WILDCARD_QUERY, &bitmap));
+        ASSERT_EQ(2, bitmap.cardinality());
+        ASSERT_TRUE(bitmap.contains(0));
+        ASSERT_TRUE(bitmap.contains(1));
+    }
+
+    delete iter;
+}
+
+// Test MATCH_ANY and MATCH_ALL semantics for english parser, with and without wildcard tokens.
+TEST_F(BuiltinInvertedIndexTest, test_english_parser_match_any_all_queries) {
+    // Values:
+    //  row0: "hello world"
+    //  row1: "hello"
+    //  row2: "world"
+    //  row3: "other"
+    std::vector<std::string> values = {"hello world", "hello", "world", "other"};
+    std::vector<Slice> slices;
+    slices.reserve(values.size());
+    for (auto& v : values) {
+        slices.emplace_back(v.data(), v.size());
+    }
+
+    TabletIndex tablet_index;
+    tablet_index.add_index_properties(INVERTED_INDEX_PARSER_KEY, INVERTED_INDEX_PARSER_ENGLISH);
+
+    TypeInfoPtr type_info = get_type_info(TYPE_VARCHAR);
+
+    std::string file_name = kTestDir + "/english_match_any_all";
+    ColumnMetaPB meta;
+    {
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+
+        std::unique_ptr<InvertedWriter> writer;
+        ASSERT_OK(BuiltinInvertedWriter::create(type_info, &tablet_index, &writer));
+        ASSERT_OK(writer->init());
+
+        writer->add_values(slices.data(), slices.size());
+        writer->add_nulls(0);
+        ASSERT_OK(writer->finish(wfile.get(), &meta));
+        ASSERT_TRUE(wfile->close().ok());
+    }
+
+    ASSERT_EQ(1, meta.indexes_size());
+    const auto& index_meta = meta.indexes(0);
+    ASSERT_EQ(BUILTIN_INVERTED_INDEX, index_meta.type());
+    const auto& builtin_meta = index_meta.builtin_inverted_index();
+
+    ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(file_name));
+    _opts.read_file = rfile.get();
+
+    auto tablet_index_sp = std::make_shared<TabletIndex>(tablet_index);
+    std::unique_ptr<InvertedReader> reader;
+    ASSERT_OK(BuiltinInvertedReader::create(tablet_index_sp, TYPE_VARCHAR, &reader));
+
+    BuiltinInvertedIndexPB builtin_meta_copy = builtin_meta;
+    ASSERT_OK(reader->load(_opts, &builtin_meta_copy));
+
+    InvertedIndexIterator* iter = nullptr;
+    ASSERT_OK(reader->new_iterator(tablet_index_sp, &iter, _opts));
+
+    // MATCH_ANY with exact tokens "hello world" should hit rows 0, 1, and 2.
+    {
+        roaring::Roaring bitmap;
+        Slice query("hello world");
+        ASSERT_OK(iter->read_from_inverted_index("c0", &query, InvertedIndexQueryType::MATCH_ANY_QUERY, &bitmap));
+        ASSERT_EQ(3, bitmap.cardinality());
+        ASSERT_TRUE(bitmap.contains(0));
+        ASSERT_TRUE(bitmap.contains(1));
+        ASSERT_TRUE(bitmap.contains(2));
+        ASSERT_FALSE(bitmap.contains(3));
+    }
+
+    // MATCH_ALL with exact tokens "hello world" should hit only row 0.
+    {
+        roaring::Roaring bitmap;
+        Slice query("hello world");
+        ASSERT_OK(iter->read_from_inverted_index("c0", &query, InvertedIndexQueryType::MATCH_ALL_QUERY, &bitmap));
+        ASSERT_EQ(1, bitmap.cardinality());
+        ASSERT_TRUE(bitmap.contains(0));
+        ASSERT_FALSE(bitmap.contains(1));
+        ASSERT_FALSE(bitmap.contains(2));
+        ASSERT_FALSE(bitmap.contains(3));
+    }
+
+    // MATCH_ANY with wildcard tokens "he% wor%" should behave the same as above.
+    {
+        roaring::Roaring bitmap;
+        std::string pattern = std::string("he% wor%");
+        Slice query(pattern);
+        ASSERT_OK(iter->read_from_inverted_index("c0", &query, InvertedIndexQueryType::MATCH_ANY_QUERY, &bitmap));
+        ASSERT_EQ(3, bitmap.cardinality());
+        ASSERT_TRUE(bitmap.contains(0));
+        ASSERT_TRUE(bitmap.contains(1));
+        ASSERT_TRUE(bitmap.contains(2));
+        ASSERT_FALSE(bitmap.contains(3));
+    }
+
+    // MATCH_ALL with wildcard tokens "he% wor%" should also hit only row 0.
+    {
+        roaring::Roaring bitmap;
+        std::string pattern = std::string("he% wor%");
+        Slice query(pattern);
+        ASSERT_OK(iter->read_from_inverted_index("c0", &query, InvertedIndexQueryType::MATCH_ALL_QUERY, &bitmap));
+        ASSERT_EQ(1, bitmap.cardinality());
+        ASSERT_TRUE(bitmap.contains(0));
+        ASSERT_FALSE(bitmap.contains(1));
+        ASSERT_FALSE(bitmap.contains(2));
+        ASSERT_FALSE(bitmap.contains(3));
+    }
+
+    delete iter;
+}
+
+TEST_F(BuiltinInvertedIndexTest, test_get_next_prefix) {
+    // Normal case
+    ASSERT_EQ("abd", get_next_prefix(Slice("abc")));
+
+    // Trailing 0xFF case: should increment and truncate
+    ASSERT_EQ("b", get_next_prefix(Slice("a\xFF")));
+    ASSERT_EQ("ac", get_next_prefix(Slice("ab\xFF")));
+    ASSERT_EQ("b", get_next_prefix(Slice("a\xFF\xFF")));
+
+    // All 0xFF case: should return empty string (overflow)
+    ASSERT_EQ("", get_next_prefix(Slice("\xFF")));
+    ASSERT_EQ("", get_next_prefix(Slice("\xFF\xFF")));
+
+    // Empty prefix
+    ASSERT_EQ("", get_next_prefix(Slice("")));
+}
+
+// Test wildcard query with various prefixes to verify range calculation and truncation
+TEST_F(BuiltinInvertedIndexTest, test_prefix_overflow_query) {
+    std::vector<std::string> values = {
+            "abc",    "abca",       "abd",                 // Case 1: abc% -> range [abc, abd)
+            "a\xFF",  "a\xFF\x01",  "b",                   // Case 2: a\xFF% -> range [a\xFF, b)
+            "ab\xFF", "ab\xFF\x01", "ac",                  // Case 3: ab\xFF% -> range [ab\xFF, ac)
+            "\xFE",   "\xFF",       "\xFF\x01", "\xFF\xFF" // Case 4 & 5: \xFF% -> [ \xFF, end]
+    };
+    std::vector<Slice> slices;
+    for (auto& v : values) {
+        slices.emplace_back(v.data(), v.size());
+    }
+
+    TabletIndex tablet_index;
+    tablet_index.add_index_properties(INVERTED_INDEX_PARSER_KEY, INVERTED_INDEX_PARSER_NONE);
+    TypeInfoPtr type_info = get_type_info(TYPE_VARCHAR);
+    std::string file_name = kTestDir + "/prefix_overflow";
+    ColumnMetaPB meta;
+    {
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+        std::unique_ptr<InvertedWriter> writer;
+        ASSERT_OK(BuiltinInvertedWriter::create(type_info, &tablet_index, &writer));
+        ASSERT_OK(writer->init());
+        writer->add_values(slices.data(), slices.size());
+        writer->add_nulls(0);
+        ASSERT_OK(writer->finish(wfile.get(), &meta));
+        ASSERT_TRUE(wfile->close().ok());
+    }
+
+    ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(file_name));
+    _opts.read_file = rfile.get();
+    auto tablet_index_sp = std::make_shared<TabletIndex>(tablet_index);
+    std::unique_ptr<InvertedReader> reader;
+    ASSERT_OK(BuiltinInvertedReader::create(tablet_index_sp, TYPE_VARCHAR, &reader));
+    BuiltinInvertedIndexPB builtin_meta_copy = meta.indexes(0).builtin_inverted_index();
+    ASSERT_OK(reader->load(_opts, &builtin_meta_copy));
+
+    InvertedIndexIterator* iter = nullptr;
+    ASSERT_OK(reader->new_iterator(tablet_index_sp, &iter, _opts));
+
+    // 1. Test "abc%"
+    {
+        roaring::Roaring bitmap;
+        Slice query("abc%");
+        ASSERT_OK(iter->read_from_inverted_index("c0", &query, InvertedIndexQueryType::MATCH_WILDCARD_QUERY, &bitmap));
+        // Should hit: "abc", "abca" (rowid 0, 1); should NOT include "abd" (rowid 2)
+        ASSERT_EQ(2, bitmap.cardinality());
+        ASSERT_TRUE(bitmap.contains(0));
+        ASSERT_TRUE(bitmap.contains(1));
+    }
+
+    // 2. Test "a\xFF%"
+    {
+        roaring::Roaring bitmap;
+        Slice query("a\xFF%");
+        ASSERT_OK(iter->read_from_inverted_index("c0", &query, InvertedIndexQueryType::MATCH_WILDCARD_QUERY, &bitmap));
+        // Should hit: "a\xFF", "a\xFF\x01" (rowid 3, 4); should NOT include "b" (rowid 5)
+        ASSERT_EQ(2, bitmap.cardinality());
+        ASSERT_TRUE(bitmap.contains(3));
+        ASSERT_TRUE(bitmap.contains(4));
+    }
+
+    // 3. Test "ab\xFF%"
+    {
+        roaring::Roaring bitmap;
+        Slice query("ab\xFF%");
+        ASSERT_OK(iter->read_from_inverted_index("c0", &query, InvertedIndexQueryType::MATCH_WILDCARD_QUERY, &bitmap));
+        // Should hit: "ab\xFF", "ab\xFF\x01" (rowid 6, 7); should NOT include "ac" (rowid 8)
+        ASSERT_EQ(2, bitmap.cardinality());
+        ASSERT_TRUE(bitmap.contains(6));
+        ASSERT_TRUE(bitmap.contains(7));
+    }
+
+    // 4. Test "\xFF%" (Overflow case)
+    {
+        roaring::Roaring bitmap;
+        Slice query("\xFF%");
+        ASSERT_OK(iter->read_from_inverted_index("c0", &query, InvertedIndexQueryType::MATCH_WILDCARD_QUERY, &bitmap));
+        // Should hit all starting with \xFF: "\xFF", "\xFF\x01", "\xFF\xFF" (rowid 10, 11, 12)
+        ASSERT_EQ(3, bitmap.cardinality());
+        ASSERT_TRUE(bitmap.contains(10));
+        ASSERT_TRUE(bitmap.contains(11));
+        ASSERT_TRUE(bitmap.contains(12));
+    }
+
+    // 5. Test "\xFE%"
+    {
+        roaring::Roaring bitmap;
+        Slice query("\xFE%");
+        ASSERT_OK(iter->read_from_inverted_index("c0", &query, InvertedIndexQueryType::MATCH_WILDCARD_QUERY, &bitmap));
+        // Should hit: "\xFE" (rowid 9)
+        ASSERT_EQ(1, bitmap.cardinality());
+        ASSERT_TRUE(bitmap.contains(9));
+    }
+
+    delete iter;
+}
+
+// Test wildcard queries with NULL rows to ensure NULLs are never matched by LIKE predicates.
+TEST_F(BuiltinInvertedIndexTest, test_wildcard_query_with_nulls) {
+    // Row layout (parser = none):
+    //  row0: "abc"
+    //  row1: NULL
+    //  row2: "abd"
+    //  row3: "zzz"
+    //  row4: NULL
+    std::vector<std::string> values = {"abc", "abd", "zzz"};
+    std::vector<Slice> slices;
+    for (auto& v : values) {
+        slices.emplace_back(v.data(), v.size());
+    }
+
+    TabletIndex tablet_index;
+    tablet_index.add_index_properties(INVERTED_INDEX_PARSER_KEY, INVERTED_INDEX_PARSER_NONE);
+    TypeInfoPtr type_info = get_type_info(TYPE_VARCHAR);
+    std::string file_name = kTestDir + "/wildcard_with_nulls";
+    ColumnMetaPB meta;
+    {
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+        std::unique_ptr<InvertedWriter> writer;
+        ASSERT_OK(BuiltinInvertedWriter::create(type_info, &tablet_index, &writer));
+        ASSERT_OK(writer->init());
+
+        // rows: 0:"abc", 1:NULL, 2:"abd", 3:"zzz", 4:NULL
+        writer->add_values(&slices[0], 1); // row 0
+        writer->add_nulls(1);              // row 1
+        writer->add_values(&slices[1], 1); // row 2
+        writer->add_values(&slices[2], 1); // row 3
+        writer->add_nulls(1);              // row 4
+
+        ASSERT_OK(writer->finish(wfile.get(), &meta));
+        ASSERT_TRUE(wfile->close().ok());
+    }
+
+    ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(file_name));
+    _opts.read_file = rfile.get();
+    auto tablet_index_sp = std::make_shared<TabletIndex>(tablet_index);
+    std::unique_ptr<InvertedReader> reader;
+    ASSERT_OK(BuiltinInvertedReader::create(tablet_index_sp, TYPE_VARCHAR, &reader));
+    BuiltinInvertedIndexPB builtin_meta_copy = meta.indexes(0).builtin_inverted_index();
+    ASSERT_OK(reader->load(_opts, &builtin_meta_copy));
+
+    InvertedIndexIterator* iter = nullptr;
+    ASSERT_OK(reader->new_iterator(tablet_index_sp, &iter, _opts));
+
+    // 1. "a%" should hit only non-NULL rows starting with "a" (rowids 0 and 2).
+    {
+        roaring::Roaring bitmap;
+        Slice query("a%");
+        ASSERT_OK(iter->read_from_inverted_index("c0", &query, InvertedIndexQueryType::MATCH_WILDCARD_QUERY, &bitmap));
+        ASSERT_EQ(2, bitmap.cardinality());
+        ASSERT_TRUE(bitmap.contains(0));
+        ASSERT_TRUE(bitmap.contains(2));
+        ASSERT_FALSE(bitmap.contains(1));
+        ASSERT_FALSE(bitmap.contains(3));
+        ASSERT_FALSE(bitmap.contains(4));
+    }
+
+    // 2. "z%" (max term prefix) should hit only row3 and never include NULLs.
+    {
+        roaring::Roaring bitmap;
+        Slice query("z%");
+        ASSERT_OK(iter->read_from_inverted_index("c0", &query, InvertedIndexQueryType::MATCH_WILDCARD_QUERY, &bitmap));
+        ASSERT_EQ(1, bitmap.cardinality());
+        ASSERT_TRUE(bitmap.contains(3));
+        ASSERT_FALSE(bitmap.contains(0));
+        ASSERT_FALSE(bitmap.contains(1));
+        ASSERT_FALSE(bitmap.contains(2));
+        ASSERT_FALSE(bitmap.contains(4));
+    }
+
+    delete iter;
+}
+
+// Test prefix overflow case (\xFF%) with NULL rows to ensure NULLs are excluded from results.
+TEST_F(BuiltinInvertedIndexTest, test_prefix_overflow_query_with_nulls) {
+    // Row layout (parser = none):
+    //  row0: "\xFE"
+    //  row1: "\xFF"
+    //  row2: NULL
+    //  row3: "\xFF\x01"
+    //  row4: "\xFF\xFF"
+    //  row5: NULL
+    std::vector<std::string> values = {"\xFE", "\xFF", "\xFF\x01", "\xFF\xFF"};
+    std::vector<Slice> slices;
+    for (auto& v : values) {
+        slices.emplace_back(v.data(), v.size());
+    }
+
+    TabletIndex tablet_index;
+    tablet_index.add_index_properties(INVERTED_INDEX_PARSER_KEY, INVERTED_INDEX_PARSER_NONE);
+    TypeInfoPtr type_info = get_type_info(TYPE_VARCHAR);
+    std::string file_name = kTestDir + "/prefix_overflow_with_nulls";
+    ColumnMetaPB meta;
+    {
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+        std::unique_ptr<InvertedWriter> writer;
+        ASSERT_OK(BuiltinInvertedWriter::create(type_info, &tablet_index, &writer));
+        ASSERT_OK(writer->init());
+
+        writer->add_values(&slices[0], 1); // row 0: "\xFE"
+        writer->add_values(&slices[1], 1); // row 1: "\xFF"
+        writer->add_nulls(1);              // row 2: NULL
+        writer->add_values(&slices[2], 1); // row 3: "\xFF\x01"
+        writer->add_values(&slices[3], 1); // row 4: "\xFF\xFF"
+        writer->add_nulls(1);              // row 5: NULL
+
+        ASSERT_OK(writer->finish(wfile.get(), &meta));
+        ASSERT_TRUE(wfile->close().ok());
+    }
+
+    ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(file_name));
+    _opts.read_file = rfile.get();
+    auto tablet_index_sp = std::make_shared<TabletIndex>(tablet_index);
+    std::unique_ptr<InvertedReader> reader;
+    ASSERT_OK(BuiltinInvertedReader::create(tablet_index_sp, TYPE_VARCHAR, &reader));
+    BuiltinInvertedIndexPB builtin_meta_copy = meta.indexes(0).builtin_inverted_index();
+    ASSERT_OK(reader->load(_opts, &builtin_meta_copy));
+
+    InvertedIndexIterator* iter = nullptr;
+    ASSERT_OK(reader->new_iterator(tablet_index_sp, &iter, _opts));
+
+    // "\xFF%" should only hit non-NULL rows whose values start with 0xFF (rowids 1, 3, 4).
+    {
+        roaring::Roaring bitmap;
+        std::string pattern = std::string("\xFF") + "%";
+        Slice query(pattern);
+        ASSERT_OK(iter->read_from_inverted_index("c0", &query, InvertedIndexQueryType::MATCH_WILDCARD_QUERY, &bitmap));
+        ASSERT_EQ(3, bitmap.cardinality());
+        ASSERT_TRUE(bitmap.contains(1));
+        ASSERT_TRUE(bitmap.contains(3));
+        ASSERT_TRUE(bitmap.contains(4));
+        ASSERT_FALSE(bitmap.contains(0));
+        ASSERT_FALSE(bitmap.contains(2));
+        ASSERT_FALSE(bitmap.contains(5));
+    }
+
+    delete iter;
+}
+
+// Test BuiltinInvertedReader's query and query_null which should return InternalError
+TEST_F(BuiltinInvertedIndexTest, test_reader_unsupported_query) {
+    auto tablet_index = std::make_shared<TabletIndex>();
+    std::unique_ptr<InvertedReader> reader;
+    ASSERT_OK(BuiltinInvertedReader::create(tablet_index, TYPE_VARCHAR, &reader));
+
+    roaring::Roaring bitmap;
+    Slice query("test");
+    ASSERT_TRUE(reader->query(nullptr, "c0", &query, InvertedIndexQueryType::EQUAL_QUERY, &bitmap).is_internal_error());
+    ASSERT_TRUE(reader->query_null(nullptr, "c0", &bitmap).is_internal_error());
+    ASSERT_EQ(InvertedIndexReaderType::TEXT, reader->get_inverted_index_reader_type());
+}
+
+// Test BuiltinInvertedIndexIterator's read_null and unsupported query types
+TEST_F(BuiltinInvertedIndexTest, test_iterator_unsupported_ops) {
+    TabletIndex tablet_index;
+    tablet_index.add_index_properties(INVERTED_INDEX_PARSER_KEY, INVERTED_INDEX_PARSER_NONE);
+    TypeInfoPtr type_info = get_type_info(TYPE_VARCHAR);
+    std::string file_name = kTestDir + "/unsupported_ops";
+    ColumnMetaPB meta;
+    {
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+        std::unique_ptr<InvertedWriter> writer;
+        ASSERT_OK(BuiltinInvertedWriter::create(type_info, &tablet_index, &writer));
+        ASSERT_OK(writer->init());
+        Slice val("test");
+        writer->add_values(&val, 1);
+        ASSERT_OK(writer->finish(wfile.get(), &meta));
+    }
+
+    ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(file_name));
+    _opts.read_file = rfile.get();
+    auto tablet_index_sp = std::make_shared<TabletIndex>(tablet_index);
+    std::unique_ptr<InvertedReader> reader;
+    ASSERT_OK(BuiltinInvertedReader::create(tablet_index_sp, TYPE_VARCHAR, &reader));
+    BuiltinInvertedIndexPB builtin_meta_copy = meta.indexes(0).builtin_inverted_index();
+    ASSERT_OK(reader->load(_opts, &builtin_meta_copy));
+
+    InvertedIndexIterator* iter = nullptr;
+    ASSERT_OK(reader->new_iterator(tablet_index_sp, &iter, _opts));
+
+    roaring::Roaring bitmap;
+    ASSERT_TRUE(iter->read_null("c0", &bitmap).is_internal_error());
+
+    Slice query("test");
+    ASSERT_TRUE(iter->read_from_inverted_index("c0", &query, static_cast<InvertedIndexQueryType>(-1), &bitmap)
+                        .is_invalid_argument());
+
+    delete iter;
+}
+
+// Test BuiltinInvertedWriter::create with unsupported types
+TEST_F(BuiltinInvertedIndexTest, test_writer_create_unsupported_type) {
+    TabletIndex tablet_index;
+    TypeInfoPtr type_info = get_type_info(TYPE_INT);
+    std::unique_ptr<InvertedWriter> writer;
+    ASSERT_FALSE(BuiltinInvertedWriter::create(type_info, &tablet_index, &writer).ok());
+}
+
+// Test BuiltinInvertedWriter with TYPE_CHAR and different parsers
+TEST_F(BuiltinInvertedIndexTest, test_writer_char_and_parsers) {
+    std::vector<InvertedIndexParserType> parsers = {InvertedIndexParserType::PARSER_STANDARD,
+                                                    InvertedIndexParserType::PARSER_CHINESE};
+
+    for (auto parser_type : parsers) {
+        TabletIndex tablet_index;
+        tablet_index.add_index_properties(INVERTED_INDEX_PARSER_KEY, inverted_index_parser_type_to_string(parser_type));
+        TypeInfoPtr type_info = get_type_info(TYPE_CHAR);
+
+        std::string file_name = kTestDir + "/writer_test_" + std::to_string(static_cast<int>(parser_type));
+        ColumnMetaPB meta;
+        {
+            ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+            std::unique_ptr<InvertedWriter> writer;
+            ASSERT_OK(BuiltinInvertedWriter::create(type_info, &tablet_index, &writer));
+            ASSERT_OK(writer->init());
+
+            std::vector<std::string> values = {"Hello World", "你好世界"};
+            std::vector<Slice> slices;
+            for (auto& v : values) slices.emplace_back(v);
+
+            writer->add_values(slices.data(), slices.size());
+            ASSERT_OK(writer->finish(wfile.get(), &meta));
+        }
+    }
+}
+
+// Test BuiltinInvertedIndexIterator with MATCH_ALL and MATCH_ANY mixed tokens
+TEST_F(BuiltinInvertedIndexTest, test_mixed_token_queries) {
+    std::vector<std::string> values = {"apple banana cherry", "apple fruit", "banana split"};
+    std::vector<Slice> slices;
+    for (auto& v : values) slices.emplace_back(v);
+
+    TabletIndex tablet_index;
+    tablet_index.add_index_properties(INVERTED_INDEX_PARSER_KEY, INVERTED_INDEX_PARSER_ENGLISH);
+    TypeInfoPtr type_info = get_type_info(TYPE_VARCHAR);
+    std::string file_name = kTestDir + "/mixed_tokens";
+    ColumnMetaPB meta;
+    {
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+        std::unique_ptr<InvertedWriter> writer;
+        ASSERT_OK(BuiltinInvertedWriter::create(type_info, &tablet_index, &writer));
+        ASSERT_OK(writer->init());
+        writer->add_values(slices.data(), slices.size());
+        ASSERT_OK(writer->finish(wfile.get(), &meta));
+    }
+
+    ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(file_name));
+    _opts.read_file = rfile.get();
+    auto tablet_index_sp = std::make_shared<TabletIndex>(tablet_index);
+    std::unique_ptr<InvertedReader> reader;
+    ASSERT_OK(BuiltinInvertedReader::create(tablet_index_sp, TYPE_VARCHAR, &reader));
+    BuiltinInvertedIndexPB builtin_meta_copy = meta.indexes(0).builtin_inverted_index();
+    ASSERT_OK(reader->load(_opts, &builtin_meta_copy));
+
+    InvertedIndexIterator* iter = nullptr;
+    ASSERT_OK(reader->new_iterator(tablet_index_sp, &iter, _opts));
+
+    // MATCH_ANY: "apple banan%" should hit all 3 rows
+    {
+        roaring::Roaring bitmap;
+        Slice query("apple banan%");
+        ASSERT_OK(iter->read_from_inverted_index("c0", &query, InvertedIndexQueryType::MATCH_ANY_QUERY, &bitmap));
+        ASSERT_EQ(3, bitmap.cardinality());
+    }
+
+    // MATCH_ALL: "apple fru%" should hit only row 1
+    {
+        roaring::Roaring bitmap;
+        Slice query("apple fru%");
+        ASSERT_OK(iter->read_from_inverted_index("c0", &query, InvertedIndexQueryType::MATCH_ALL_QUERY, &bitmap));
+        ASSERT_EQ(1, bitmap.cardinality());
+        ASSERT_TRUE(bitmap.contains(1));
+    }
+
+    delete iter;
+}
+
+// Test BuiltinInvertedIndexIterator with invalid wildcard query (no %)
+TEST_F(BuiltinInvertedIndexTest, test_invalid_wildcard) {
+    TabletIndex tablet_index;
+    tablet_index.add_index_properties(INVERTED_INDEX_PARSER_KEY, INVERTED_INDEX_PARSER_NONE);
+    TypeInfoPtr type_info = get_type_info(TYPE_VARCHAR);
+    std::string file_name = kTestDir + "/invalid_wildcard";
+    ColumnMetaPB meta;
+    {
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+        std::unique_ptr<InvertedWriter> writer;
+        ASSERT_OK(BuiltinInvertedWriter::create(type_info, &tablet_index, &writer));
+        ASSERT_OK(writer->init());
+        Slice val("test");
+        writer->add_values(&val, 1);
+        ASSERT_OK(writer->finish(wfile.get(), &meta));
+    }
+
+    ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(file_name));
+    _opts.read_file = rfile.get();
+    auto tablet_index_sp = std::make_shared<TabletIndex>(tablet_index);
+    std::unique_ptr<InvertedReader> reader;
+    ASSERT_OK(BuiltinInvertedReader::create(tablet_index_sp, TYPE_VARCHAR, &reader));
+    BuiltinInvertedIndexPB builtin_meta_copy = meta.indexes(0).builtin_inverted_index();
+    ASSERT_OK(reader->load(_opts, &builtin_meta_copy));
+
+    InvertedIndexIterator* iter = nullptr;
+    ASSERT_OK(reader->new_iterator(tablet_index_sp, &iter, _opts));
+
+    roaring::Roaring bitmap;
+    Slice query("test"); // No %
+    ASSERT_TRUE(iter->read_from_inverted_index("c0", &query, InvertedIndexQueryType::MATCH_WILDCARD_QUERY, &bitmap)
+                        .is_internal_error());
+
+    delete iter;
+}
+
+// Test complex wildcard query like "a%c" to trigger predicate seek
+TEST_F(BuiltinInvertedIndexTest, test_complex_wildcard_query) {
+    std::vector<std::string> values = {"abc", "acc", "aec", "afc", "bbc"};
+    std::vector<Slice> slices;
+    for (auto& v : values) slices.emplace_back(v);
+
+    TabletIndex tablet_index;
+    tablet_index.add_index_properties(INVERTED_INDEX_PARSER_KEY, INVERTED_INDEX_PARSER_NONE);
+    TypeInfoPtr type_info = get_type_info(TYPE_VARCHAR);
+    std::string file_name = kTestDir + "/complex_wildcard";
+    ColumnMetaPB meta;
+    {
+        ASSIGN_OR_ABORT(auto wfile, _fs->new_writable_file(file_name));
+        std::unique_ptr<InvertedWriter> writer;
+        ASSERT_OK(BuiltinInvertedWriter::create(type_info, &tablet_index, &writer));
+        ASSERT_OK(writer->init());
+        writer->add_values(slices.data(), slices.size());
+
+        // Exercise size()
+        ASSERT_GT(writer->size(), 0);
+
+        ASSERT_OK(writer->finish(wfile.get(), &meta));
+    }
+
+    ASSIGN_OR_ABORT(auto rfile, _fs->new_random_access_file(file_name));
+    _opts.read_file = rfile.get();
+    auto tablet_index_sp = std::make_shared<TabletIndex>(tablet_index);
+    std::unique_ptr<InvertedReader> reader;
+    ASSERT_OK(BuiltinInvertedReader::create(tablet_index_sp, TYPE_VARCHAR, &reader));
+    BuiltinInvertedIndexPB builtin_meta_copy = meta.indexes(0).builtin_inverted_index();
+    ASSERT_OK(reader->load(_opts, &builtin_meta_copy));
+
+    InvertedIndexIterator* iter = nullptr;
+    ASSERT_OK(reader->new_iterator(tablet_index_sp, &iter, _opts));
+
+    // "a%c" should hit abc, acc, aec, afc (rowids 0, 1, 2, 3)
+    {
+        roaring::Roaring bitmap;
+        Slice query("a%c");
+        ASSERT_OK(iter->read_from_inverted_index("c0", &query, InvertedIndexQueryType::MATCH_WILDCARD_QUERY, &bitmap));
+        ASSERT_EQ(4, bitmap.cardinality());
+        ASSERT_TRUE(bitmap.contains(0));
+        ASSERT_TRUE(bitmap.contains(1));
+        ASSERT_TRUE(bitmap.contains(2));
+        ASSERT_TRUE(bitmap.contains(3));
+        ASSERT_FALSE(bitmap.contains(4));
+    }
+
+    // Prefix not found case: "z%"
+    {
+        roaring::Roaring bitmap;
+        Slice query("z%");
+        ASSERT_OK(iter->read_from_inverted_index("c0", &query, InvertedIndexQueryType::MATCH_WILDCARD_QUERY, &bitmap));
+        ASSERT_EQ(0, bitmap.cardinality());
+    }
+
+    // Explicitly call close
+    ASSERT_OK(iter->close());
+
+    delete iter;
+}
+
+TEST_F(BuiltinInvertedIndexTest, test_simple_analyzer) {
+    SimpleAnalyzer analyzer(true);
+    char text[] = "Hello World 123";
+    std::vector<SliceToken> tokens;
+    analyzer.tokenize(text, strlen(text), tokens);
+
+    ASSERT_EQ(3, tokens.size());
+    ASSERT_EQ("hello", tokens[0].text.to_string());
+    ASSERT_EQ("world", tokens[1].text.to_string());
+    ASSERT_EQ("123", tokens[2].text.to_string());
+
+    SimpleAnalyzer analyzer2(false);
+    char text2[] = "Hello World";
+    tokens.clear();
+    analyzer2.tokenize(text2, strlen(text2), tokens);
+    ASSERT_EQ(2, tokens.size());
+    ASSERT_EQ("Hello", tokens[0].text.to_string());
+    ASSERT_EQ("World", tokens[1].text.to_string());
+
+    analyzer2.tokenize(nullptr, 0, tokens);
+    ASSERT_TRUE(tokens.empty());
+}
+
+} // namespace starrocks

--- a/be/test/storage/index/inverted_index_plugin_test.cpp
+++ b/be/test/storage/index/inverted_index_plugin_test.cpp
@@ -1,0 +1,122 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "storage/index/inverted/inverted_index_option.h"
+#include "storage/index/inverted/inverted_plugin_factory.h"
+#include "storage/tablet_index.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+TEST(InvertedIndexPluginTest, factory_test) {
+    auto builtin_res = InvertedPluginFactory::get_plugin(InvertedImplementType::BUILTIN);
+    ASSERT_TRUE(builtin_res.ok());
+    ASSERT_NE(nullptr, builtin_res.value());
+
+    auto clucene_res = InvertedPluginFactory::get_plugin(InvertedImplementType::CLUCENE);
+    ASSERT_TRUE(clucene_res.ok());
+    ASSERT_NE(nullptr, clucene_res.value());
+
+    auto invalid_res = InvertedPluginFactory::get_plugin(static_cast<InvertedImplementType>(-1));
+    ASSERT_FALSE(invalid_res.ok());
+}
+
+TEST(InvertedIndexPluginTest, option_test) {
+    TabletIndex tablet_index;
+
+    // Test get_inverted_imp_type
+    {
+        auto res = get_inverted_imp_type(tablet_index);
+        ASSERT_FALSE(res.ok());
+
+        tablet_index.set_common_properties({{INVERTED_IMP_KEY, TYPE_CLUCENE}});
+        res = get_inverted_imp_type(tablet_index);
+        ASSERT_TRUE(res.ok());
+        ASSERT_EQ(InvertedImplementType::CLUCENE, res.value());
+
+        tablet_index.set_common_properties({{INVERTED_IMP_KEY, TYPE_BUILTIN}});
+        res = get_inverted_imp_type(tablet_index);
+        ASSERT_TRUE(res.ok());
+        ASSERT_EQ(InvertedImplementType::BUILTIN, res.value());
+
+        tablet_index.set_common_properties({{INVERTED_IMP_KEY, "invalid"}});
+        res = get_inverted_imp_type(tablet_index);
+        ASSERT_FALSE(res.ok());
+    }
+
+    // Test parser string and type conversions
+    {
+        ASSERT_EQ(INVERTED_INDEX_PARSER_NONE,
+                  inverted_index_parser_type_to_string(InvertedIndexParserType::PARSER_NONE));
+        ASSERT_EQ(INVERTED_INDEX_PARSER_STANDARD,
+                  inverted_index_parser_type_to_string(InvertedIndexParserType::PARSER_STANDARD));
+        ASSERT_EQ(INVERTED_INDEX_PARSER_ENGLISH,
+                  inverted_index_parser_type_to_string(InvertedIndexParserType::PARSER_ENGLISH));
+        ASSERT_EQ(INVERTED_INDEX_PARSER_CHINESE,
+                  inverted_index_parser_type_to_string(InvertedIndexParserType::PARSER_CHINESE));
+        ASSERT_EQ(INVERTED_INDEX_PARSER_UNKNOWN,
+                  inverted_index_parser_type_to_string(static_cast<InvertedIndexParserType>(-1)));
+
+        ASSERT_EQ(InvertedIndexParserType::PARSER_NONE,
+                  get_inverted_index_parser_type_from_string(INVERTED_INDEX_PARSER_NONE));
+        ASSERT_EQ(InvertedIndexParserType::PARSER_STANDARD,
+                  get_inverted_index_parser_type_from_string(INVERTED_INDEX_PARSER_STANDARD));
+        ASSERT_EQ(InvertedIndexParserType::PARSER_ENGLISH,
+                  get_inverted_index_parser_type_from_string(INVERTED_INDEX_PARSER_ENGLISH));
+        ASSERT_EQ(InvertedIndexParserType::PARSER_CHINESE,
+                  get_inverted_index_parser_type_from_string(INVERTED_INDEX_PARSER_CHINESE));
+        ASSERT_EQ(InvertedIndexParserType::PARSER_UNKNOWN, get_inverted_index_parser_type_from_string("unknown"));
+    }
+
+    // Test get_parser_string_from_properties
+    {
+        std::map<std::string, std::string> props;
+        ASSERT_EQ(INVERTED_INDEX_PARSER_NONE, get_parser_string_from_properties(props));
+
+        props[INVERTED_INDEX_PARSER_KEY] = INVERTED_INDEX_PARSER_ENGLISH;
+        ASSERT_EQ(INVERTED_INDEX_PARSER_ENGLISH, get_parser_string_from_properties(props));
+    }
+
+    // Test is_tokenized_from_properties
+    {
+        std::map<std::string, std::string> props;
+        ASSERT_FALSE(is_tokenized_from_properties(props));
+
+        props[INVERTED_INDEX_TOKENIZED_KEY] = "true";
+        ASSERT_TRUE(is_tokenized_from_properties(props));
+
+        props[INVERTED_INDEX_TOKENIZED_KEY] = "false";
+        ASSERT_FALSE(is_tokenized_from_properties(props));
+    }
+}
+
+TEST(InvertedIndexPluginTest, builtin_plugin_test) {
+    auto* plugin = &BuiltinPlugin::get_instance();
+    ASSERT_NE(nullptr, plugin);
+
+    TypeInfoPtr typeinfo = get_type_info(TYPE_VARCHAR);
+    TabletIndex tablet_index;
+    std::unique_ptr<InvertedWriter> writer;
+    ASSERT_OK(plugin->create_inverted_index_writer(typeinfo, "c0", "path", &tablet_index, &writer));
+    ASSERT_NE(nullptr, writer);
+
+    std::unique_ptr<InvertedReader> reader;
+    auto tablet_index_sp = std::make_shared<TabletIndex>(tablet_index);
+    ASSERT_OK(plugin->create_inverted_index_reader("path", tablet_index_sp, TYPE_VARCHAR, &reader));
+    ASSERT_NE(nullptr, reader);
+}
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2874,7 +2874,8 @@ public class SchemaChangeHandler extends AlterHandler {
         IndexDef indexDef = alterClause.getIndexDef();
         Index newIndex;
         // Only assign meaningful indexId for OlapTable
-        if (olapTable.isOlapTableOrMaterializedView()) {
+        if (olapTable.isOlapTableOrMaterializedView() ||
+                (olapTable.isCloudNativeTableOrMaterializedView() && indexDef.getIndexType() != IndexDef.IndexType.VECTOR)) {
             long indexId = IndexDef.IndexType.isCompatibleIndex(indexDef.getIndexType()) ? 
                     olapTable.incAndGetMaxIndexId() : -1;
             newIndex = new Index(indexId, indexDef.getIndexName(),

--- a/fe/fe-core/src/main/java/com/starrocks/common/InvertedIndexParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/InvertedIndexParams.java
@@ -30,7 +30,8 @@ public class InvertedIndexParams {
             .collect(Collectors.toSet());
 
     public enum InvertedIndexImpType {
-        CLUCENE
+        CLUCENE,
+        BUILTIN,
     }
 
     public enum CommonIndexParamKey implements ParamsKey {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -1077,6 +1077,10 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
             if (ConnectContext.get() != null) {
                 msg.lake_scan_node.setEnable_column_expr_predicate(
                         ConnectContext.get().getSessionVariable().isEnableColumnExprPredicate());
+                msg.lake_scan_node.setEnable_prune_column_after_index_filter(
+                        ConnectContext.get().getSessionVariable().isEnablePruneColumnAfterIndexFilter());
+                msg.lake_scan_node.setEnable_gin_filter(
+                        ConnectContext.get().getSessionVariable().isEnableGinFilter());
             }
             msg.lake_scan_node.setDict_string_id_to_int_ids(dictStringIdToIntIds);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/IndexAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/IndexAnalyzer.java
@@ -55,6 +55,7 @@ import java.util.stream.Collectors;
 
 import static com.starrocks.common.InvertedIndexParams.CommonIndexParamKey.IMP_LIB;
 import static com.starrocks.common.InvertedIndexParams.IndexParamsKey.PARSER;
+import static com.starrocks.common.InvertedIndexParams.InvertedIndexImpType.BUILTIN;
 import static com.starrocks.common.InvertedIndexParams.InvertedIndexImpType.CLUCENE;
 
 /**
@@ -161,9 +162,6 @@ public class IndexAnalyzer {
         if (!validGinColumnType(column)) {
             throw new SemanticException("The inverted index can only be build on column with type of CHAR/STRING/VARCHAR type.");
         }
-        if (RunMode.isSharedDataMode()) {
-            throw new SemanticException("The inverted index does not support shared data mode");
-        }
         if (!Config.enable_experimental_gin) {
             throw new SemanticException(
                     "The inverted index is disabled, enable it by setting FE config `enable_experimental_gin` to true");
@@ -172,9 +170,15 @@ public class IndexAnalyzer {
         String impLibKey = IMP_LIB.name().toLowerCase(Locale.ROOT);
         if (properties.containsKey(impLibKey)) {
             String impValue = properties.get(impLibKey);
-            if (!CLUCENE.name().equalsIgnoreCase(impValue)) {
-                throw new SemanticException("Only support clucene implement for now. ");
+            if (!(CLUCENE.name().equalsIgnoreCase(impValue) || BUILTIN.name().equalsIgnoreCase(impValue))) {
+                throw new SemanticException("Only support clucene or builtin implement for now");
             }
+
+            if (!BUILTIN.name().equalsIgnoreCase(impValue) && RunMode.isSharedDataMode()) {
+                throw new SemanticException("Clucene inverted index does not support shared data mode");
+            }
+        } else if (RunMode.isSharedDataMode()) {
+            properties.put(impLibKey, BUILTIN.name().toLowerCase(Locale.ROOT));
         }
 
         String noMatchParamKey = properties.keySet().stream()

--- a/gensrc/proto/segment.proto
+++ b/gensrc/proto/segment.proto
@@ -250,6 +250,7 @@ enum ColumnIndexTypePB {
     ZONE_MAP_INDEX = 2;
     BITMAP_INDEX = 3;
     BLOOM_FILTER_INDEX = 4;
+    BUILTIN_INVERTED_INDEX = 5;
 }
 
 message ColumnIndexMetaPB {
@@ -258,6 +259,7 @@ message ColumnIndexMetaPB {
     optional ZoneMapIndexPB zone_map_index = 8;
     optional BitmapIndexPB bitmap_index = 9;
     optional BloomFilterIndexPB bloom_filter_index = 10;
+    optional BuiltinInvertedIndexPB builtin_inverted_index = 11;
 }
 
 message OrdinalIndexPB {
@@ -304,4 +306,8 @@ message BloomFilterIndexPB {
     optional BloomFilterAlgorithmPB algorithm = 2;
     // required: meta for bloom filters
     optional IndexedColumnMetaPB bloom_filter = 3;
+}
+
+message BuiltinInvertedIndexPB {
+    optional BitmapIndexPB bitmap_index = 1;
 }

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -689,6 +689,10 @@ struct TLakeScanNode {
   42: optional i64 back_pressure_num_rows
 
   43: optional Descriptors.TTableSchemaKey schema_key
+
+  // inverted index
+  44: optional bool enable_prune_column_after_index_filter
+  45: optional bool enable_gin_filter
 }
 
 struct TEqJoinCondition {


### PR DESCRIPTION
## What I'm doing:

This PR introduces builtin inverted index including the entire read and write logic. It builtin based on the bitmap index infrastructure.

Fixes #67167

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a built-in inverted (GIN) index backed by the bitmap index infrastructure and wires it through FE/BE, planner, and scan runtime.
> 
> - Adds builtin inverted index components: `BuiltinInvertedWriter/Reader/Iterator`, `BuiltinPlugin`, and `SimpleAnalyzer`; new `BUILTIN_INVERTED_INDEX` in `segment.proto`; `imp_lib=builtin` support and plugin factory wiring
> - Integrates index into read path: `ColumnReader` loads builtin metadata; `Segment/SegmentIterator` create/use iterators with `IndexReadOptions`; `LakeConnector` propagates `enable_gin_filter` and `prune_column_after_index_filter` and records GIN filter metrics
> - Extends bitmap index APIs for dictionary scans and unions, and optimizes writer (batched adds, ordered flush, configurable dictionary compression)
> - FE changes: enable builtin GIN in shared-data mode (default to builtin), validate `imp_lib` (clucene|builtin), adjust replicated storage behavior with GIN, planner sets new scan-node flags
> - Proto/Thrift and CMake/test updates to support the new index and behaviors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e911c3231058da78275ed17f65a083bb6a3d2476. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->