### PR TITLE
[BugFix] Revert 63265 and add another config

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2808,8 +2808,11 @@ public class Config extends ConfigBase {
             comment = "Enable the sql digest feature, building a parameterized digest for each sql in the query detail")
     public static boolean enable_sql_digest = false;
 
-    @ConfField(mutable = true, comment = "explain level of query plan in this detail")
+    @ConfField(mutable = true, comment = "explain level of query plan in query_detail API")
     public static String query_detail_explain_level = "COSTS";
+
+    @ConfField(mutable = true, comment = "explain level of query plan")
+    public static String query_explain_level = "NORMAL";
 
     /**
      * StarRocks-manager pull queries every 1 second

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -8516,7 +8516,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
 
     private static StatementBase.ExplainLevel getExplainType(
             com.starrocks.sql.parser.StarRocksParser.ExplainDescContext context) {
-        StatementBase.ExplainLevel explainLevel = StatementBase.ExplainLevel.NORMAL;
+        StatementBase.ExplainLevel explainLevel = StatementBase.ExplainLevel.parse(Config.query_explain_level);
         if (context.LOGICAL() != null) {
             explainLevel = StatementBase.ExplainLevel.LOGICAL;
         } else if (context.ANALYZE() != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -8516,7 +8516,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
 
     private static StatementBase.ExplainLevel getExplainType(
             com.starrocks.sql.parser.StarRocksParser.ExplainDescContext context) {
-        StatementBase.ExplainLevel explainLevel = StatementBase.ExplainLevel.parse(Config.query_detail_explain_level);
+        StatementBase.ExplainLevel explainLevel = StatementBase.ExplainLevel.NORMAL;
         if (context.LOGICAL() != null) {
             explainLevel = StatementBase.ExplainLevel.LOGICAL;
         } else if (context.ANALYZE() != null) {

--- a/fe/fe-core/src/test/java/com/starrocks/http/ExecuteSqlActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/ExecuteSqlActionTest.java
@@ -13,7 +13,6 @@
 // limitations under the License.
 package com.starrocks.http;
 
-import com.starrocks.common.Config;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -48,7 +47,6 @@ public class ExecuteSqlActionTest extends StarRocksHttpTestCase {
 
     @Override
     protected void doSetUp() throws Exception {
-        Config.query_detail_explain_level = "NORMAL";
         MetricRepo.init();
         ExecuteEnv.setup();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshListPartitionOlapTest.java
@@ -22,7 +22,6 @@ import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
-import com.starrocks.common.Config;
 import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
 import com.starrocks.scheduler.persist.MVTaskRunExtraMessage;
 import com.starrocks.server.GlobalStateMgr;
@@ -61,7 +60,6 @@ public class PCTRefreshListPartitionOlapTest extends MVTestBase {
 
     @BeforeAll
     public static void beforeClass() throws Exception {
-        Config.query_detail_explain_level = "NORMAL";
         MVTestBase.beforeClass();
         // table whose partitions have multiple values
         T1 = "CREATE TABLE t1 (\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshNonPartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshNonPartitionOlapTest.java
@@ -15,7 +15,6 @@
 package com.starrocks.scheduler;
 
 import com.starrocks.catalog.MaterializedView;
-import com.starrocks.common.Config;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanTestBase;
@@ -33,7 +32,6 @@ public class PCTRefreshNonPartitionOlapTest extends MVTestBase {
 
     @BeforeAll
     public static void beforeClass() throws Exception {
-        Config.query_detail_explain_level = "NORMAL";
         MVTestBase.beforeClass();
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshRangePartitionOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PCTRefreshRangePartitionOlapTest.java
@@ -15,7 +15,6 @@
 package com.starrocks.scheduler;
 
 import com.starrocks.catalog.MaterializedView;
-import com.starrocks.common.Config;
 import com.starrocks.scheduler.mv.pct.MVPCTBasedRefreshProcessor;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MVTestBase;
 import com.starrocks.sql.plan.ExecPlan;
@@ -34,7 +33,6 @@ public class PCTRefreshRangePartitionOlapTest extends MVTestBase {
 
     @BeforeAll
     public static void beforeClass() throws Exception {
-        Config.query_detail_explain_level = "NORMAL";
         MVTestBase.beforeClass();
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExplainTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExplainTest.java
@@ -14,12 +14,7 @@
 
 package com.starrocks.sql.plan;
 
-import com.starrocks.common.Config;
 import com.starrocks.sql.Explain;
-import com.starrocks.sql.ast.QueryStatement;
-import com.starrocks.sql.ast.StatementBase;
-import com.starrocks.utframe.UtFrameUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class ExplainTest extends PlanTestBase {
@@ -65,24 +60,6 @@ public class ExplainTest extends PlanTestBase {
         sql = "SELECT MIN(pow(t0.v1, 2)) FROM t0";
         plan = getFragmentPlan(sql);
         assertContains(plan, "min(pow(CAST(1: v1 AS DOUBLE), ?))");
-
-    }
-
-
-    @Test
-    public void testExplainUsesConfiguredDefaultLevel() throws Exception {
-        String originalLevel = Config.query_detail_explain_level;
-        Config.query_detail_explain_level = "LOGICAL";
-        try {
-            StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(
-                    "EXPLAIN SELECT * FROM t0", connectContext);
-            Assertions.assertTrue(statementBase instanceof QueryStatement);
-            QueryStatement queryStatement = (QueryStatement) statementBase;
-            Assertions.assertTrue(queryStatement.isExplain());
-            Assertions.assertEquals(StatementBase.ExplainLevel.LOGICAL, queryStatement.getExplainLevel());
-        } finally {
-            Config.query_detail_explain_level = originalLevel;
-        }
 
     }
 }

--- a/test/sql/test_automatic_partition/R/test_multi_expr
+++ b/test/sql/test_automatic_partition/R/test_multi_expr
@@ -42,9 +42,6 @@ select * from t;
 
 
 -- name: test_multi_list_function
-ADMIN SET FRONTEND CONFIG ("query_detail_explain_level" = "NORMAL");
--- result:
--- !result
 create table t(k1 int, k2 datetime, v int) partition by k1,date_trunc('day', k2);
 -- result:
 -- !result

--- a/test/sql/test_automatic_partition/R/test_partition_prune
+++ b/test/sql/test_automatic_partition/R/test_partition_prune
@@ -1,7 +1,4 @@
 -- name: test_create_table_exp
-ADMIN SET FRONTEND CONFIG ("query_detail_explain_level" = "NORMAL");
--- result:
--- !result
 CREATE TABLE orders_new (     ts INT NOT NULL,     id BIGINT NOT NULL,     city STRING NOT NULL ) PARTITION BY date_trunc('month', str_to_date(CAST(ts as STRING),'%Y%m%d'));
 -- result:
 -- !result

--- a/test/sql/test_automatic_partition/T/test_multi_expr
+++ b/test/sql/test_automatic_partition/T/test_multi_expr
@@ -5,7 +5,6 @@ show partitions from t;
 select * from t;
 
 -- name: test_multi_list_function
-ADMIN SET FRONTEND CONFIG ("query_detail_explain_level" = "NORMAL");
 create table t(k1 int, k2 datetime, v int) partition by k1,date_trunc('day', k2);
 insert into t values(1,'2020-01-01',1);
 insert into t values(1,'2020-01-02',1);

--- a/test/sql/test_automatic_partition/T/test_partition_prune
+++ b/test/sql/test_automatic_partition/T/test_partition_prune
@@ -1,5 +1,4 @@
 -- name: test_create_table_exp
-ADMIN SET FRONTEND CONFIG ("query_detail_explain_level" = "NORMAL");
 CREATE TABLE orders_new (     ts INT NOT NULL,     id BIGINT NOT NULL,     city STRING NOT NULL ) PARTITION BY date_trunc('month', str_to_date(CAST(ts as STRING),'%Y%m%d'));
 insert into orders_new values('20200201',1,'cd');
 insert into orders_new values('20200101',1,'cd');

--- a/test/sql/test_materialized_column/R/test_generated_column_rewrite
+++ b/test/sql/test_materialized_column/R/test_generated_column_rewrite
@@ -382,9 +382,6 @@ DROP TABLE t_generated_column_complex_rewrite_5;
 -- result:
 -- !result
 -- name: test_bug_join_with_same_column_name
-ADMIN SET FRONTEND CONFIG ("query_detail_explain_level" = "NORMAL");
--- result:
--- !result
 CREATE TABLE `t_bug_join_with_same_column_name_1` (
   `id` bigint(20) NOT NULL COMMENT "",
   `col` STRING AS CONCAT(CAST(id AS STRING), "_abc")

--- a/test/sql/test_materialized_column/T/test_generated_column_rewrite
+++ b/test/sql/test_materialized_column/T/test_generated_column_rewrite
@@ -185,7 +185,6 @@ DROP TABLE t_generated_column_complex_rewrite_4;
 DROP TABLE t_generated_column_complex_rewrite_5;
 
 -- name: test_bug_join_with_same_column_name
-ADMIN SET FRONTEND CONFIG ("query_detail_explain_level" = "NORMAL");
 CREATE TABLE `t_bug_join_with_same_column_name_1` (
   `id` bigint(20) NOT NULL COMMENT "",
   `col` STRING AS CONCAT(CAST(id AS STRING), "_abc")

--- a/test/sql/test_query_history/R/test_spm_plan_rewrite_enable_disable
+++ b/test/sql/test_query_history/R/test_spm_plan_rewrite_enable_disable
@@ -1,7 +1,4 @@
 -- name: test_spm_plan_rewrite_enable_disable @sequential
-ADMIN SET FRONTEND CONFIG ("query_detail_explain_level" = "NORMAL");
--- result:
--- !result
 create table t1 (
     k1 int,
     k2 int,

--- a/test/sql/test_query_history/T/test_spm_plan_rewrite_enable_disable
+++ b/test/sql/test_query_history/T/test_spm_plan_rewrite_enable_disable
@@ -1,5 +1,5 @@
 -- name: test_spm_plan_rewrite_enable_disable @sequential
-ADMIN SET FRONTEND CONFIG ("query_detail_explain_level" = "NORMAL");
+
 create table t1 (
     k1 int,
     k2 int,


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

#63265 unintentionally altered the behavior of `EXPLAIN <query>` because `query_detail_explain_level` is only applied to the query_detail API and not to `EXPLAIN`.

This PR reverts #63265, and use a separate config `query_explain_level` to control the level of `EXPLAIN <query>.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
