### PR TITLE
[BugFix] fix json v2 rewrite with lambda

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JsonPathRewriteRule.java
@@ -428,8 +428,16 @@ public class JsonPathRewriteRule extends TransformationRule {
             ScalarOperator jsonColumn = call.getArguments().get(0);
             ScalarOperator pathArg = call.getArguments().get(1);
 
-            if (!(pathArg instanceof ConstantOperator) || !(jsonColumn instanceof ColumnRefOperator)) {
+            if (!(pathArg instanceof ConstantOperator) || !(jsonColumn instanceof ColumnRefOperator jsonColumnRef)) {
                 return call;
+            }
+
+            // Check if the JSON column is attached to a table
+            // Lambda arguments are ColumnRefOperators but not attached to tables,
+            // so we should not attempt to rewrite them
+            Pair<Table, Column> tableAndColumn = context.getColumnRefFactory().getTableAndColumn(jsonColumnRef);
+            if (tableAndColumn == null) {
+                return call; // Cannot rewrite if not attached to a table (e.g., lambda arguments)
             }
 
             String path = ((ConstantOperator) pathArg).getVarchar();
@@ -449,10 +457,12 @@ public class JsonPathRewriteRule extends TransformationRule {
         private ScalarOperator createColumnAccessExpression(ColumnRefOperator jsonColumn,
                                                             List<String> fields,
                                                             Type resultType) {
+            // Note: tableAndColumn should not be null here because we check it in rewriteJsonFunction
+            // before calling this method. This check is kept for safety.
             Pair<Table, Column> tableAndColumn = context.getColumnRefFactory().getTableAndColumn(jsonColumn);
-            if (tableAndColumn == null) {
-                return jsonColumn; // Cannot rewrite if not attached to a table
-            }
+            Preconditions.checkState(tableAndColumn != null,
+                    "ColumnRefOperator %s must be attached to a table when creating column access expression",
+                    jsonColumn);
 
             // Build full path: columnName.field1.field2
             List<String> fullPath = Lists.newArrayList();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonPathRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JsonPathRewriteTest.java
@@ -221,6 +221,12 @@ public class JsonPathRewriteTest extends PlanTestBase {
                         "select get_json_string(c2, 'f1') from extend_predicate3",
                         "get_json_string(2: c2, 'f1')",
                         ""
+                ),
+                // [22] With lambda function
+                Arguments.of(
+                        "SELECT * FROM extend_predicate " +
+                                "WHERE any_match(x -> get_json_double(x, '$.longitude') > 0, CAST(c2 AS ARRAY<JSON>)) ",
+                        "get_json_double", "any_match"
                 )
         );
     }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

```
SELECT * FROM extend_predicate 
WHERE any_match(x -> get_json_double(x, '$.longitude') > 0, CAST(c2 AS ARRAY<JSON>))
```

The lambda function was rewritten into a wrong expresison.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skip rewriting JSON functions when the JSON argument is a lambda variable not attached to a table; add a test for any_match scenario and tighten precondition checks.
> 
> - **Optimizer (JSON path rewrite)**
>   - Avoid rewriting supported JSON functions when the JSON argument is a `ColumnRefOperator` not attached to a table (e.g., lambda variables), by checking `columnRefFactory.getTableAndColumn(...)`.
>   - Strengthen safety with `Preconditions.checkState` in `createColumnAccessExpression` instead of silently returning the original column.
> - **Tests**
>   - Add lambda case to ensure `get_json_double` inside `any_match` is not rewritten (`JsonPathRewriteTest` case [22]).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3887d72d9478cad01d84e474e59bec0ae1346674. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->