### PR TITLE
[BugFix] fix max(not null string) from empty table throw exception: std::length_error

### DIFF
--- a/be/src/exprs/agg/maxmin.h
+++ b/be/src/exprs/agg/maxmin.h
@@ -49,7 +49,7 @@ struct MaxAggregateData<LT, StringLTGuard<LT>> {
 
     bool has_value() const { return _size > -1; }
 
-    Slice slice() const { return {_buffer.data(), (size_t)_size}; }
+    Slice slice() const { return {_buffer.data(), _size > -1 ? (size_t)_size : 0}; }
 
     void reset() {
         _buffer.clear();
@@ -83,7 +83,7 @@ struct MinAggregateData<LT, StringLTGuard<LT>> {
 
     bool has_value() const { return _size > -1; }
 
-    Slice slice() const { return {_buffer.data(), (size_t)_size}; }
+    Slice slice() const { return {_buffer.data(), _size > -1 ? (size_t)_size : 0}; }
 
     void reset() {
         _buffer.clear();

--- a/test/sql/test_agg/R/test_empty_input
+++ b/test/sql/test_agg/R/test_empty_input
@@ -47,3 +47,32 @@ select count(distinct v1) from t0;
 -- result:
 0
 -- !result
+-- name: test_empty_input_not_null_string
+CREATE TABLE `tt0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) not NULL COMMENT "",
+  `c2` varchar(200) not NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 4
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into tt0 values (1,"test","test",1);
+-- result:
+-- !result
+select max(c2) from tt0 where 1=0;
+-- result:
+None
+-- !result
+select min(c2) from tt0 where 1=0;
+-- result:
+None
+-- !result

--- a/test/sql/test_agg/T/test_empty_input
+++ b/test/sql/test_agg/T/test_empty_input
@@ -23,3 +23,24 @@ select max(v1),count(*) from t0;
 select count(v1) from t0;
 select count(*) from t0;
 select count(distinct v1) from t0;
+
+-- name: test_empty_input_not_null_string
+CREATE TABLE `tt0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) not NULL COMMENT "",
+  `c2` varchar(200) not NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 4
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+insert into tt0 values (1,"test","test",1);
+select max(c2) from tt0 where 1=0;
+select min(c2) from tt0 where 1=0;
+


### PR DESCRIPTION
## Why I'm doing:
default _size of MaxAggregateData is -1, if cast it into size_t, then it will become super huge

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fix string max/min aggregation over empty input by returning zero-length slice and add tests for NOT NULL varchar cases.
> 
> - **Backend (Aggregation)**
>   - Guard `slice()` length for string states in `be/src/exprs/agg/maxmin.h` (`MaxAggregateData`/`MinAggregateData`) to return length `0` when `_size == -1`, avoiding invalid cast on empty input.
> - **Tests**
>   - Add SQL tests `test/sql/test_agg/T/R/test_empty_input` for NOT NULL varchar columns verifying `max(c2)`/`min(c2)` with empty filter return `None`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eefabbbafe86f501bcbe59b52738c523e2c2bb74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->