### PR TITLE
[BugFix] Fix the issue where versions are incorrectly skipped during batch publish

### DIFF
--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -121,6 +121,8 @@ public:
     static StatusOr<TabletMetadataPtrs> get_metas_from_bundle_tablet_metadata(const std::string& location,
                                                                               FileSystem* input_fs = nullptr);
 
+    // NOTICE : latest_cached_tablet_metadata may contain a tablet meta that
+    // is either older or newer than the FE visible version.
     TabletMetadataPtr get_latest_cached_tablet_metadata(int64_t tablet_id);
 
     StatusOr<TabletMetadataIter> list_tablet_metadata(int64_t tablet_id);

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -80,10 +80,6 @@ static void clear_remote_snapshot_async(TabletManager* tablet_mgr, int64_t table
 int64_t cal_new_base_version(int64_t tablet_id, TabletManager* tablet_mgr, int64_t base_version, int64_t new_version,
                              const std::span<const TxnInfoPB>& txns) {
     int64_t version = base_version;
-    auto metadata = tablet_mgr->get_latest_cached_tablet_metadata(tablet_id);
-    if (metadata != nullptr && metadata->version() <= new_version) {
-        version = std::max(version, metadata->version());
-    }
 
     auto index_version = tablet_mgr->update_mgr()->get_primary_index_data_version(tablet_id);
     if (index_version > new_version) {


### PR DESCRIPTION
## Why I'm doing:
latest_cached_tablet_metadata may contain a tablet meta that is either older or newer than the FE visible version. So we can't skip version during batch publish using this meta.

## What I'm doing:
This pull request makes a minor documentation update to the `TabletManager` class and removes a logic block from the version calculation in `transactions.cpp`. The main change is the removal of the use of cached tablet metadata in the version calculation, which may affect how versions are determined in transaction processing.

Version calculation logic update:

* Removed the use of `get_latest_cached_tablet_metadata` in `cal_new_base_version`, so the version is no longer updated based on the latest cached tablet metadata. This may impact how the base version is computed during transaction processing.

Documentation improvement:

* Added a comment to `TabletManager::get_latest_cached_tablet_metadata` clarifying that the returned metadata may be older or newer than the version visible to the Frontend (FE), helping to prevent misunderstandings about the method's guarantees.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
