### PR TITLE
[Enhancement] Support repairing tablet metadata in frontend

### DIFF
--- a/be/src/service/service_be/lake_service.h
+++ b/be/src/service/service_be/lake_service.h
@@ -16,6 +16,7 @@
 #include <span>
 
 #ifndef __APPLE__
+#include "common/status.h"
 #include "gen_cpp/lake_service.pb.h"
 
 namespace starrocks {
@@ -118,6 +119,8 @@ private:
     void _submit_publish_log_version_task(const int64_t* tablet_ids, size_t tablet_size,
                                           std::span<const TxnInfoPB> txn_infos, const int64_t* log_versions,
                                           ::starrocks::PublishLogVersionResponse* response);
+
+    Status _cleanup_before_repair(std::map<int64_t, TabletMetadataPB>& tablet_metadatas);
 
 private:
     static constexpr int64_t kDefaultTimeoutForGetTabletStat = 5 * 60 * 1000L;  // 5 minutes

--- a/be/src/service/service_be/lake_service.h
+++ b/be/src/service/service_be/lake_service.h
@@ -120,7 +120,7 @@ private:
                                           std::span<const TxnInfoPB> txn_infos, const int64_t* log_versions,
                                           ::starrocks::PublishLogVersionResponse* response);
 
-    Status _cleanup_before_repair(std::map<int64_t, TabletMetadataPB>& tablet_metadatas);
+    Status _cleanup_before_repair(const ::starrocks::RepairTabletMetadataRequest* request);
 
 private:
     static constexpr int64_t kDefaultTimeoutForGetTabletStat = 5 * 60 * 1000L;  // 5 minutes

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -168,6 +168,7 @@ public:
 #endif
 #endif // USE_STAROS
 
+    Status drop_local_cache(const std::string& path);
     void prune_metacache();
 
     // TODO: remove this method
@@ -260,7 +261,6 @@ private:
     static std::string global_schema_cache_key(int64_t index_id);
     static std::string tablet_schema_cache_key(int64_t tablet_id);
     static std::string tablet_latest_metadata_cache_key(int64_t tablet_id);
-    static Status drop_local_cache(const std::string& path);
 
     StatusOr<TabletSchemaPtr> load_and_parse_schema_file(const std::string& path);
     StatusOr<TabletSchemaPtr> get_tablet_schema_by_id(int64_t tablet_id, int64_t schema_id);

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -3215,6 +3215,7 @@ TEST_F(LakeServiceTest, test_repair_tablet_metadata) {
         request.add_tablet_metadatas()->CopyFrom(metadata_to_repair_1);
         request.add_tablet_metadatas()->CopyFrom(metadata_to_repair_2);
         request.set_enable_file_bundling(true);
+        request.set_write_bundling_file(true);
 
         _lake_service.repair_tablet_metadata(&cntl, &request, &response, nullptr);
         ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
@@ -3292,6 +3293,7 @@ TEST_F(LakeServiceTest, test_repair_tablet_metadata) {
         metadata_to_repair.set_version(100);
         request.add_tablet_metadatas()->CopyFrom(metadata_to_repair);
         request.set_enable_file_bundling(true);
+        request.set_write_bundling_file(true);
 
         _lake_service.repair_tablet_metadata(&cntl, &request, &response, nullptr);
         ASSERT_FALSE(cntl.Failed());
@@ -3335,6 +3337,7 @@ TEST_F(LakeServiceTest, test_repair_tablet_metadata) {
             metadata_to_repair.set_version(100);
             request.add_tablet_metadatas()->CopyFrom(metadata_to_repair);
             request.set_enable_file_bundling(true);
+            request.set_write_bundling_file(true);
 
             _lake_service.repair_tablet_metadata(&cntl, &request, &response, nullptr);
             ASSERT_FALSE(cntl.Failed());

--- a/fe/fe-core/src/main/java/com/starrocks/lake/TabletRepairHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/TabletRepairHelper.java
@@ -158,6 +158,7 @@ public class TabletRepairHelper {
             // if enable file bundling, we only need to send the write bundling metadata request to one node.
             // other node requests are used for some cleanup work.
             Set<Long> tabletIds = request.writeBundlingFile ? Sets.newHashSet(info.allTablets) : entry.getValue();
+            Preconditions.checkState(!tabletIds.isEmpty());
             if (request.writeBundlingFile) {
                 writeBundlingFile = false;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
@@ -41,6 +41,8 @@ import com.starrocks.proto.PublishLogVersionRequest;
 import com.starrocks.proto.PublishLogVersionResponse;
 import com.starrocks.proto.PublishVersionRequest;
 import com.starrocks.proto.PublishVersionResponse;
+import com.starrocks.proto.RepairTabletMetadataRequest;
+import com.starrocks.proto.RepairTabletMetadataResponse;
 import com.starrocks.proto.RestoreSnapshotsRequest;
 import com.starrocks.proto.RestoreSnapshotsResponse;
 import com.starrocks.proto.TabletStatRequest;
@@ -74,6 +76,7 @@ public interface LakeService {
     long TIMEOUT_ABORT_COMPACTION = 5 * MILLIS_PER_SECOND;
     long TIMEOUT_VACUUM = MILLIS_PER_HOUR;
     long TIMEOUT_VACUUM_FULL = MILLIS_PER_HOUR * 24;
+    long TIMEOUT_REPAIR_METADATA = MILLIS_PER_HOUR;
 
     @ProtobufRPC(serviceName = "LakeService", methodName = "publish_version", onceTalkTimeout = TIMEOUT_PUBLISH_VERSION)
     Future<PublishVersionResponse> publishVersion(PublishVersionRequest request);
@@ -135,5 +138,8 @@ public interface LakeService {
 
     @ProtobufRPC(serviceName = "LakeService", methodName = "get_tablet_metadatas", onceTalkTimeout = TIMEOUT_GET_TABLET_STATS)
     Future<GetTabletMetadatasResponse> getTabletMetadatas(GetTabletMetadatasRequest request);
+
+    @ProtobufRPC(serviceName = "LakeService", methodName = "repair_tablet_metadata", onceTalkTimeout = TIMEOUT_REPAIR_METADATA)
+    Future<RepairTabletMetadataResponse> repairTabletMetadata(RepairTabletMetadataRequest request);
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/LakeServiceWithMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/LakeServiceWithMetrics.java
@@ -39,6 +39,8 @@ import com.starrocks.proto.PublishLogVersionRequest;
 import com.starrocks.proto.PublishLogVersionResponse;
 import com.starrocks.proto.PublishVersionRequest;
 import com.starrocks.proto.PublishVersionResponse;
+import com.starrocks.proto.RepairTabletMetadataRequest;
+import com.starrocks.proto.RepairTabletMetadataResponse;
 import com.starrocks.proto.RestoreSnapshotsRequest;
 import com.starrocks.proto.RestoreSnapshotsResponse;
 import com.starrocks.proto.TabletStatRequest;
@@ -184,5 +186,11 @@ public class LakeServiceWithMetrics implements LakeService {
     public Future<GetTabletMetadatasResponse> getTabletMetadatas(GetTabletMetadatasRequest request) {
         increaseMetrics();
         return lakeService.getTabletMetadatas(request);
+    }
+
+    @Override
+    public Future<RepairTabletMetadataResponse> repairTabletMetadata(RepairTabletMetadataRequest request) {
+        increaseMetrics();
+        return lakeService.repairTabletMetadata(request);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
@@ -85,6 +85,8 @@ import com.starrocks.proto.PublishLogVersionRequest;
 import com.starrocks.proto.PublishLogVersionResponse;
 import com.starrocks.proto.PublishVersionRequest;
 import com.starrocks.proto.PublishVersionResponse;
+import com.starrocks.proto.RepairTabletMetadataRequest;
+import com.starrocks.proto.RepairTabletMetadataResponse;
 import com.starrocks.proto.RestoreSnapshotsRequest;
 import com.starrocks.proto.RestoreSnapshotsResponse;
 import com.starrocks.proto.StatusPB;
@@ -1218,6 +1220,11 @@ public class PseudoBackend {
 
         @Override
         public Future<GetTabletMetadatasResponse> getTabletMetadatas(GetTabletMetadatasRequest request) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public Future<RepairTabletMetadataResponse> repairTabletMetadata(RepairTabletMetadataRequest request) {
             return CompletableFuture.completedFuture(null);
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/rpc/LakeServiceWithMetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/rpc/LakeServiceWithMetricsTest.java
@@ -38,6 +38,8 @@ import com.starrocks.proto.PublishLogVersionRequest;
 import com.starrocks.proto.PublishLogVersionResponse;
 import com.starrocks.proto.PublishVersionRequest;
 import com.starrocks.proto.PublishVersionResponse;
+import com.starrocks.proto.RepairTabletMetadataRequest;
+import com.starrocks.proto.RepairTabletMetadataResponse;
 import com.starrocks.proto.RestoreSnapshotsRequest;
 import com.starrocks.proto.RestoreSnapshotsResponse;
 import com.starrocks.proto.TabletStatRequest;
@@ -305,6 +307,20 @@ public class LakeServiceWithMetricsTest {
         };
 
         Future<GetTabletMetadatasResponse> result = lakeServiceWithMetrics.getTabletMetadatas(new GetTabletMetadatasRequest());
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testRepairTabletMetadata() throws Exception {
+        new Expectations() {
+            {
+                lakeService.repairTabletMetadata((RepairTabletMetadataRequest) any);
+                result = CompletableFuture.completedFuture(new RepairTabletMetadataResponse());
+            }
+        };
+
+        Future<RepairTabletMetadataResponse> result =
+                lakeServiceWithMetrics.repairTabletMetadata(new RepairTabletMetadataRequest());
         assertNotNull(result);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
@@ -71,6 +71,8 @@ import com.starrocks.proto.PublishLogVersionRequest;
 import com.starrocks.proto.PublishLogVersionResponse;
 import com.starrocks.proto.PublishVersionRequest;
 import com.starrocks.proto.PublishVersionResponse;
+import com.starrocks.proto.RepairTabletMetadataRequest;
+import com.starrocks.proto.RepairTabletMetadataResponse;
 import com.starrocks.proto.RestoreSnapshotsRequest;
 import com.starrocks.proto.RestoreSnapshotsResponse;
 import com.starrocks.proto.StatusPB;
@@ -722,6 +724,11 @@ public class MockedBackend {
 
         @Override
         public Future<GetTabletMetadatasResponse> getTabletMetadatas(GetTabletMetadatasRequest request) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public Future<RepairTabletMetadataResponse> repairTabletMetadata(RepairTabletMetadataRequest request) {
             return CompletableFuture.completedFuture(null);
         }
     }

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -407,6 +407,9 @@ message RepairTabletMetadataRequest {
     repeated TabletMetadataPB tablet_metadatas = 1;
     // whether enable file bundling
     optional bool enable_file_bundling = 2;
+    // whether write bundling file
+    // only one node needs to write bundling tablet metadata file for all tablets in one physical partition
+    optional bool write_bundling_file = 3;
 }
 
 message TabletMetadataRepairStatus {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This PR adds `repairTabletMetadata` method in `TabletRepairHelper` class of frontend to repair valid tablet metadata through the backends, also add some cleanup before repairing tablet metadata in backend.

https://github.com/StarRocks/starrocks/issues/66015

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds FE/BE support to repair tablet metadata with pre-repair cache/index cleanup, bundling write control, and corresponding RPC/proto updates and tests.
> 
> - **Backend (BE)**:
>   - Implement `LakeServiceImpl::repair_tablet_metadata` with validation, optional bundling, and per-tablet puts.
>   - Add `_cleanup_before_repair()` to drop local data/meta cache, bundle cache, and clear PK index (including local persistent index files).
>   - Expose `TabletManager::drop_local_cache` publicly; minor warning log formatting changes.
> - **Frontend (FE)**:
>   - Add `TabletRepairHelper.repairTabletMetadata(...)` to orchestrate repair across nodes, including bundling write coordination and version alignment.
>   - Extend `LakeService` and `LakeServiceWithMetrics` with `repairTabletMetadata` RPC and `TIMEOUT_REPAIR_METADATA`.
> - **Protocol**:
>   - Update `RepairTabletMetadataRequest` to include `write_bundling_file` flag.
> - **Tests**:
>   - Add/extend BE and FE unit tests covering repair flows (bundling/non-bundling), errors, cancellations, and metrics wrappers; update pseudocluster stubs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f47b5ac4486eeba3acd1f707367cda24e4bb6a46. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->