### PR TITLE
[Doc] Refine syntax formatting in iceberg_timetravel.md

### DIFF
--- a/docs/en/data_source/catalog/iceberg/iceberg_timetravel.md
+++ b/docs/en/data_source/catalog/iceberg/iceberg_timetravel.md
@@ -20,7 +20,7 @@ By integrating Iceberg's snapshot branching and tagging feature, StarRocks suppo
 
 ### Create a branch
 
-**Syntax**
+**`CREATE BRANCH` Syntax**
 
 ```SQL
 ALTER TABLE [catalog.][database.]table_name
@@ -73,7 +73,7 @@ WITH SNAPSHOT RETENTION 2 SNAPSHOTS 2 DAYS;
 
 ### Load data into a specific branch of a table
 
-**Syntax**
+**`VERSION AS OF` Syntax**
 
 ```SQL
 INSERT INTO [catalog.][database.]table_name
@@ -98,7 +98,7 @@ SELECT c1, k1 FROM tbl;
 
 ### Create a tag
 
-**Syntax**
+**`CREATE TAG` Syntax**
 
 ```SQL
 ALTER TABLE [catalog.][database.]table_name
@@ -125,7 +125,7 @@ RETAIN 7 DAYS;
 
 ### Fast forward a branch to another
 
-**Syntax**
+**`fast_forward` Syntax**
 
 ```SQL
 ALTER TABLE [catalog.][database.]table_name
@@ -150,7 +150,7 @@ EXECUTE fast_forward('main', 'test-branch');
 
 You can cherry pick a specific snapshot and apply it to the current status of the table. This operation will create a new snapshot based on an existing snapshot, and the original snapshot will not be affected.
 
-**Syntax**
+**`cherrypick_snapshot` Syntax**
 
 ```SQL
 ALTER TABLE [catalog.][database.]table_name
@@ -172,7 +172,7 @@ EXECUTE cherrypick_snapshot(54321);
 
 You can expire snapshots earlier than a specific point of time. This operation will delete the data files of the expired snapshots.
 
-**Syntax**
+**`expire_snapshot` Syntax**
 
 ```SQL
 ALTER TABLE [catalog.][database.]table_name
@@ -188,14 +188,14 @@ EXECUTE expire_snapshot('2023-12-17 00:14:38')
 
 ### Drop a branch or a tag
 
-**Syntax**
+**`DROP BRANCH`, `DROP TAG` Syntax**
 
 ```SQL
 ALTER TABLE [catalog.][database.]table_name
 DROP { BRANCH <branch_name> | TAG <tag_name> }
 ```
 
-**Exmaple**
+**Example**
 
 ```SQL
 ALTER TABLE iceberg.sales.order
@@ -209,7 +209,7 @@ DROP TAG `test-tag`;
 
 ### Time Travel to a specific branch or tag
 
-**Syntax**
+**`VERSION AS OF` Syntax**
 
 ```SQL
 [FOR] VERSION AS OF '<branch_or_tag>'
@@ -230,7 +230,7 @@ SELECT * FROM iceberg.sales.order VERSION AS OF 'test-tag';
 
 ### Time Travel to a specific snapshot
 
-**Syntax**
+**`VERSION AS OF` Syntax**
 
 ```SQL
 [FOR] VERSION AS OF '<snapshot_id>'
@@ -248,7 +248,7 @@ SELECT * FROM iceberg.sales.order VERSION AS OF 12345;
 
 ### Time Travel to a specific datetime or date
 
-**Syntax**
+**`TIMESTAMP AS OF` Syntax**
 
 ```SQL
 [FOR] TIMESTAMP AS OF { '<datetime>' | '<date>' | date_and_time_function }

--- a/docs/ja/data_source/catalog/iceberg/iceberg_timetravel.md
+++ b/docs/ja/data_source/catalog/iceberg/iceberg_timetravel.md
@@ -8,19 +8,19 @@ import Beta from '../../../_assets/commonMarkdown/_beta.mdx'
 
 <Beta />
 
-このトピックでは、Iceberg catalog に対する StarRocks のタイムトラベル機能を紹介します。この機能は v3.4.0 以降でサポートされています。
+このトピックでは、Iceberg カタログにおける StarRocks のタイムトラベル機能を紹介します。この機能は v3.4.0 以降でサポートされています。
 
 ## 概要
 
-各 Iceberg テーブルはメタデータスナップショットログを保持しており、それに対する変更を表します。データベースはこれらの履歴スナップショットにアクセスすることで Iceberg テーブルに対してタイムトラベルクエリを実行できます。Iceberg はスナップショットのライフサイクル管理を高度に行うために、スナップショットのブランチングとタグ付けをサポートしており、各ブランチやタグはカスタマイズされた保持ポリシーに基づいて独自のライフサイクルを維持できます。Iceberg のブランチングとタグ付け機能の詳細については、[公式ドキュメント](https://iceberg.apache.org/docs/latest/branching/) を参照してください。
+各 Iceberg テーブルはメタデータのスナップショットログを保持しており、それに対する変更を表します。データベースは、これらの履歴スナップショットにアクセスすることで Iceberg テーブルに対してタイムトラベルクエリを実行できます。Iceberg はスナップショットの分岐とタグ付けをサポートしており、カスタマイズされた保持ポリシーに基づいて各ブランチやタグが独自のライフサイクルを維持できるようにしています。Iceberg の分岐とタグ付け機能の詳細については、[公式ドキュメント](https://iceberg.apache.org/docs/latest/branching/) を参照してください。
 
-Iceberg のスナップショットブランチングとタグ付け機能を統合することで、StarRocks は Iceberg catalog 内でのブランチとタグの作成および管理、そしてテーブルに対するタイムトラベルクエリをサポートしています。
+Iceberg のスナップショット分岐とタグ付け機能を統合することで、StarRocks は Iceberg カタログ内でのブランチとタグの作成および管理、そしてテーブルに対するタイムトラベルクエリをサポートしています。
 
 ## ブランチ、タグ、スナップショットの管理
 
-### ブランチの作成
+### ブランチを作成する
 
-**構文**
+**`CREATE BRANCH` 構文**
 
 ```SQL
 ALTER TABLE [catalog.][database.]table_name
@@ -39,12 +39,12 @@ maxSnapshotAge ::= <int> { DAYS | HOURS | MINUTES }
 
 - `branch_name`: 作成するブランチの名前。
 - `AS OF VERSION`: ブランチを作成するスナップショット（バージョン）の ID。
-- `RETAIN`: ブランチを保持する期間。形式: `<int> <unit>`。サポートされる単位: `DAYS`, `HOURS`, `MINUTES`。例: `7 DAYS`, `12 HOURS`, `30 MINUTES`。
-- `WITH SNAPSHOT RETENTION`: 保持するスナップショットの最小数および/またはスナップショットを保持する最大時間。
+- `RETAIN`: ブランチを保持する期間。フォーマット: `<int> <unit>`。サポートされている単位: `DAYS`、`HOURS`、`MINUTES`。例: `7 DAYS`、`12 HOURS`、`30 MINUTES`。
+- `WITH SNAPSHOT RETENTION`: 保持するスナップショットの最小数または最大保持期間。
 
 **例**
 
-テーブル `iceberg.sales.order` のバージョン（スナップショット ID）`12345` に基づいてブランチ `test-branch` を作成し、ブランチを `7` 日間保持し、ブランチ上で少なくとも `2` つのスナップショットを保持します。
+テーブル `iceberg.sales.order` のバージョン（スナップショット ID）`12345` に基づいてブランチ `test-branch` を作成し、ブランチを `7` 日間保持し、少なくとも `2` つのスナップショットをブランチに保持します。
 
 ```SQL
 ALTER TABLE iceberg.sales.order CREATE BRANCH `test-branch` 
@@ -53,7 +53,7 @@ RETAIN 7 DAYS
 WITH SNAPSHOT RETENTION 2 SNAPSHOTS;
 ```
 
-テーブル `iceberg.sales.order` のバージョン（スナップショット ID）`12345` に基づいてブランチ `test-branch2` を作成し、ブランチを `7` 日間保持し、ブランチ上のスナップショットを最大 `2` 日間保持する。
+テーブル `iceberg.sales.order` のバージョン（スナップショット ID）`12345` に基づいてブランチ `test-branch2` を作成し、ブランチを `7` 日間保持し、スナップショットをブランチに最大 `2` 日間保持します。
 
 ```SQL
 ALTER TABLE iceberg.sales.order CREATE BRANCH `test-branch2` 
@@ -62,7 +62,7 @@ RETAIN 7 DAYS
 WITH SNAPSHOT RETENTION 2 DAYS;
 ```
 
-テーブル `iceberg.sales.order` のバージョン（スナップショット ID）`12345` に基づいてブランチ `test-branch3` を作成し、ブランチを `7` 日間保持し、ブランチ上に少なくとも `2` 個のスナップショットを、それぞれ最大 `2` 日間保持する。
+テーブル `iceberg.sales.order` のバージョン（スナップショット ID）`12345` に基づいてブランチ `test-branch3` を作成し、ブランチを `7` 日間保持し、少なくとも `2` つのスナップショットをブランチに保持し、それぞれを最大 `2` 日間保持します。
 
 ```SQL
 ALTER TABLE iceberg.sales.order CREATE BRANCH `test-branch3` 
@@ -71,9 +71,9 @@ RETAIN 7 DAYS
 WITH SNAPSHOT RETENTION 2 SNAPSHOTS 2 DAYS;
 ```
 
-### テーブルの特定のブランチにデータをロード
+### 特定のブランチにデータをロードする
 
-**構文**
+**`VERSION AS OF` 構文**
 
 ```SQL
 INSERT INTO [catalog.][database.]table_name
@@ -84,7 +84,7 @@ INSERT INTO [catalog.][database.]table_name
 **パラメータ**
 
 - `branch_name`: データをロードするテーブルブランチの名前。
-- `query_statement`: 結果が宛先テーブルにロードされるクエリステートメント。StarRocks がサポートする任意の SQL ステートメントを使用できます。
+- `query_statement`: 結果が宛先テーブルにロードされるクエリ文。StarRocks がサポートする任意の SQL 文を使用できます。
 
 **例**
 
@@ -96,9 +96,9 @@ FOR VERSION AS OF `test-branch`
 SELECT c1, k1 FROM tbl;
 ```
 
-### タグの作成
+### タグを作成する
 
-**構文**
+**`CREATE TAG` 構文**
 
 ```SQL
 ALTER TABLE [catalog.][database.]table_name
@@ -111,7 +111,7 @@ CREATE [OR REPLACE] TAG [IF NOT EXISTS] <tag_name>
 
 - `tag_name`: 作成するタグの名前。
 - `AS OF VERSION`: タグを作成するスナップショット（バージョン）の ID。
-- `RETAIN`: タグを保持する期間。形式: `<int> <unit>`。サポートされる単位: `DAYS`, `HOURS`, `MINUTES`。例: `7 DAYS`, `12 HOURS`, `30 MINUTES`。
+- `RETAIN`: タグを保持する期間。フォーマット: `<int> <unit>`。サポートされている単位: `DAYS`、`HOURS`、`MINUTES`。例: `7 DAYS`、`12 HOURS`、`30 MINUTES`。
 
 **例**
 
@@ -123,9 +123,9 @@ AS OF VERSION 12345
 RETAIN 7 DAYS;
 ```
 
-### ブランチを別のブランチにファストフォワード
+### ブランチを別のブランチにファストフォワードする
 
-**構文**
+**`fast_forward` 構文**
 
 ```SQL
 ALTER TABLE [catalog.][database.]table_name
@@ -134,8 +134,8 @@ EXECUTE fast_forward('<from_branch>', '<to_branch>')
 
 **パラメータ**
 
-- `from_branch`: ファストフォワードしたいブランチ。ブランチ名をクォートで囲みます。
-- `to_branch`: `from_branch` をファストフォワードしたいブランチ。ブランチ名をクォートで囲みます。
+- `from_branch`: ファストフォワードしたいブランチ。ブランチ名を引用符で囲みます。
+- `to_branch`: `from_branch` をファストフォワードしたいブランチ。ブランチ名を引用符で囲みます。
 
 **例**
 
@@ -146,11 +146,11 @@ ALTER TABLE iceberg.sales.order
 EXECUTE fast_forward('main', 'test-branch');
 ```
 
-### スナップショットを選択的に適用
+### スナップショットを選択する
 
-特定のスナップショットを選択してテーブルの現在の状態に適用できます。この操作により、既存のスナップショットに基づいて新しいスナップショットが作成され、元のスナップショットは影響を受けません。
+特定のスナップショットを選択して、テーブルの現在の状態に適用できます。この操作は既存のスナップショットに基づいて新しいスナップショットを作成し、元のスナップショットには影響を与えません。
 
-**構文**
+**`cherrypick_snapshot` 構文**
 
 ```SQL
 ALTER TABLE [catalog.][database.]table_name
@@ -159,7 +159,7 @@ EXECUTE cherrypick_snapshot(<snapshot_id>)
 
 **パラメータ**
 
-`snapshot_id`: 選択的に適用したいスナップショットの ID。
+`snapshot_id`: 選択したいスナップショットの ID。
 
 **例**
 
@@ -168,11 +168,11 @@ ALTER TABLE iceberg.sales.order
 EXECUTE cherrypick_snapshot(54321);
 ```
 
-### スナップショットの期限切れ
+### スナップショットを期限切れにする
 
-特定の時点よりも前のスナップショットを期限切れにできます。この操作により、期限切れのスナップショットのデータファイルが削除されます。
+特定の時点より前のスナップショットを期限切れにすることができます。この操作は期限切れのスナップショットのデータファイルを削除します。
 
-**構文**
+**`expire_snapshot` 構文**
 
 ```SQL
 ALTER TABLE [catalog.][database.]table_name
@@ -186,9 +186,9 @@ ALTER TABLE iceberg.sales.order
 EXECUTE expire_snapshot('2023-12-17 00:14:38')
 ```
 
-### ブランチまたはタグの削除
+### ブランチまたはタグを削除する
 
-**構文**
+**`DROP BRANCH`, `DROP TAG` 構文**
 
 ```SQL
 ALTER TABLE [catalog.][database.]table_name
@@ -209,7 +209,7 @@ DROP TAG `test-tag`;
 
 ### 特定のブランチまたはタグへのタイムトラベル
 
-**構文**
+**`VERSION AS OF` 構文**
 
 ```SQL
 [FOR] VERSION AS OF '<branch_or_tag>'
@@ -217,20 +217,20 @@ DROP TAG `test-tag`;
 
 **パラメータ**
 
-`tag_or_branch`: タイムトラベルしたいブランチまたはタグの名前。ブランチ名が指定された場合、クエリはブランチのヘッドスナップショットにタイムトラベルします。タグ名が指定された場合、クエリはタグが参照するスナップショットにタイムトラベルします。
+`tag_or_branch`: タイムトラベルしたいブランチまたはタグの名前。ブランチ名が指定された場合、クエリはブランチの最新スナップショットにタイムトラベルします。タグ名が指定された場合、クエリはタグが参照するスナップショットにタイムトラベルします。
 
 **例**
 
 ```SQL
--- ブランチのヘッドスナップショットにタイムトラベル。
+-- ブランチの最新スナップショットにタイムトラベルします。
 SELECT * FROM iceberg.sales.order VERSION AS OF 'test-branch';
--- タグが参照するスナップショットにタイムトラベル。
+-- タグが参照するスナップショットにタイムトラベルします。
 SELECT * FROM iceberg.sales.order VERSION AS OF 'test-tag';
 ```
 
 ### 特定のスナップショットへのタイムトラベル
 
-**構文**
+**`VERSION AS OF` 構文**
 
 ```SQL
 [FOR] VERSION AS OF '<snapshot_id>'
@@ -248,7 +248,7 @@ SELECT * FROM iceberg.sales.order VERSION AS OF 12345;
 
 ### 特定の日時または日付へのタイムトラベル
 
-**構文**
+**`TIMESTAMP AS OF` 構文**
 
 ```SQL
 [FOR] TIMESTAMP AS OF { '<datetime>' | '<date>' | date_and_time_function }

--- a/docs/ja/data_source/catalog/iceberg/iceberg_timetravel.md
+++ b/docs/ja/data_source/catalog/iceberg/iceberg_timetravel.md
@@ -8,17 +8,17 @@ import Beta from '../../../_assets/commonMarkdown/_beta.mdx'
 
 <Beta />
 
-このトピックでは、Iceberg カタログにおける StarRocks のタイムトラベル機能を紹介します。この機能は v3.4.0 以降でサポートされています。
+このトピックでは、Iceberg catalog に対する StarRocks のタイムトラベル機能を紹介します。この機能は v3.4.0 以降でサポートされています。
 
 ## 概要
 
-各 Iceberg テーブルはメタデータのスナップショットログを保持しており、それに対する変更を表します。データベースは、これらの履歴スナップショットにアクセスすることで Iceberg テーブルに対してタイムトラベルクエリを実行できます。Iceberg はスナップショットの分岐とタグ付けをサポートしており、カスタマイズされた保持ポリシーに基づいて各ブランチやタグが独自のライフサイクルを維持できるようにしています。Iceberg の分岐とタグ付け機能の詳細については、[公式ドキュメント](https://iceberg.apache.org/docs/latest/branching/) を参照してください。
+各 Iceberg テーブルはメタデータスナップショットログを保持しており、それに対する変更を表します。データベースはこれらの履歴スナップショットにアクセスすることで Iceberg テーブルに対してタイムトラベルクエリを実行できます。Iceberg はスナップショットのライフサイクル管理を高度に行うために、スナップショットのブランチングとタグ付けをサポートしており、各ブランチやタグはカスタマイズされた保持ポリシーに基づいて独自のライフサイクルを維持できます。Iceberg のブランチングとタグ付け機能の詳細については、[公式ドキュメント](https://iceberg.apache.org/docs/latest/branching/) を参照してください。
 
-Iceberg のスナップショット分岐とタグ付け機能を統合することで、StarRocks は Iceberg カタログ内でのブランチとタグの作成および管理、そしてテーブルに対するタイムトラベルクエリをサポートしています。
+Iceberg のスナップショットブランチングとタグ付け機能を統合することで、StarRocks は Iceberg catalog 内でのブランチとタグの作成および管理、そしてテーブルに対するタイムトラベルクエリをサポートしています。
 
 ## ブランチ、タグ、スナップショットの管理
 
-### ブランチを作成する
+### ブランチの作成
 
 **`CREATE BRANCH` 構文**
 
@@ -39,12 +39,12 @@ maxSnapshotAge ::= <int> { DAYS | HOURS | MINUTES }
 
 - `branch_name`: 作成するブランチの名前。
 - `AS OF VERSION`: ブランチを作成するスナップショット（バージョン）の ID。
-- `RETAIN`: ブランチを保持する期間。フォーマット: `<int> <unit>`。サポートされている単位: `DAYS`、`HOURS`、`MINUTES`。例: `7 DAYS`、`12 HOURS`、`30 MINUTES`。
-- `WITH SNAPSHOT RETENTION`: 保持するスナップショットの最小数または最大保持期間。
+- `RETAIN`: ブランチを保持する期間。形式: `<int> <unit>`。サポートされる単位: `DAYS`, `HOURS`, `MINUTES`。例: `7 DAYS`, `12 HOURS`, `30 MINUTES`。
+- `WITH SNAPSHOT RETENTION`: 保持するスナップショットの最小数および/またはスナップショットを保持する最大時間。
 
 **例**
 
-テーブル `iceberg.sales.order` のバージョン（スナップショット ID）`12345` に基づいてブランチ `test-branch` を作成し、ブランチを `7` 日間保持し、少なくとも `2` つのスナップショットをブランチに保持します。
+テーブル `iceberg.sales.order` のバージョン（スナップショット ID）`12345` に基づいてブランチ `test-branch` を作成し、ブランチを `7` 日間保持し、ブランチ上で少なくとも `2` つのスナップショットを保持します。
 
 ```SQL
 ALTER TABLE iceberg.sales.order CREATE BRANCH `test-branch` 
@@ -53,7 +53,7 @@ RETAIN 7 DAYS
 WITH SNAPSHOT RETENTION 2 SNAPSHOTS;
 ```
 
-テーブル `iceberg.sales.order` のバージョン（スナップショット ID）`12345` に基づいてブランチ `test-branch2` を作成し、ブランチを `7` 日間保持し、スナップショットをブランチに最大 `2` 日間保持します。
+テーブル `iceberg.sales.order` のバージョン（スナップショット ID）`12345` に基づいてブランチ `test-branch2` を作成し、ブランチを `7` 日間保持し、ブランチ上のスナップショットを最大 `2` 日間保持する。
 
 ```SQL
 ALTER TABLE iceberg.sales.order CREATE BRANCH `test-branch2` 
@@ -62,7 +62,7 @@ RETAIN 7 DAYS
 WITH SNAPSHOT RETENTION 2 DAYS;
 ```
 
-テーブル `iceberg.sales.order` のバージョン（スナップショット ID）`12345` に基づいてブランチ `test-branch3` を作成し、ブランチを `7` 日間保持し、少なくとも `2` つのスナップショットをブランチに保持し、それぞれを最大 `2` 日間保持します。
+テーブル `iceberg.sales.order` のバージョン（スナップショット ID）`12345` に基づいてブランチ `test-branch3` を作成し、ブランチを `7` 日間保持し、ブランチ上に少なくとも `2` 個のスナップショットを、それぞれ最大 `2` 日間保持する。
 
 ```SQL
 ALTER TABLE iceberg.sales.order CREATE BRANCH `test-branch3` 
@@ -71,7 +71,7 @@ RETAIN 7 DAYS
 WITH SNAPSHOT RETENTION 2 SNAPSHOTS 2 DAYS;
 ```
 
-### 特定のブランチにデータをロードする
+### テーブルの特定のブランチにデータをロード
 
 **`VERSION AS OF` 構文**
 
@@ -84,7 +84,7 @@ INSERT INTO [catalog.][database.]table_name
 **パラメータ**
 
 - `branch_name`: データをロードするテーブルブランチの名前。
-- `query_statement`: 結果が宛先テーブルにロードされるクエリ文。StarRocks がサポートする任意の SQL 文を使用できます。
+- `query_statement`: 結果が宛先テーブルにロードされるクエリステートメント。StarRocks がサポートする任意の SQL ステートメントを使用できます。
 
 **例**
 
@@ -96,7 +96,7 @@ FOR VERSION AS OF `test-branch`
 SELECT c1, k1 FROM tbl;
 ```
 
-### タグを作成する
+### タグの作成
 
 **`CREATE TAG` 構文**
 
@@ -111,7 +111,7 @@ CREATE [OR REPLACE] TAG [IF NOT EXISTS] <tag_name>
 
 - `tag_name`: 作成するタグの名前。
 - `AS OF VERSION`: タグを作成するスナップショット（バージョン）の ID。
-- `RETAIN`: タグを保持する期間。フォーマット: `<int> <unit>`。サポートされている単位: `DAYS`、`HOURS`、`MINUTES`。例: `7 DAYS`、`12 HOURS`、`30 MINUTES`。
+- `RETAIN`: タグを保持する期間。形式: `<int> <unit>`。サポートされる単位: `DAYS`, `HOURS`, `MINUTES`。例: `7 DAYS`, `12 HOURS`, `30 MINUTES`。
 
 **例**
 
@@ -123,7 +123,7 @@ AS OF VERSION 12345
 RETAIN 7 DAYS;
 ```
 
-### ブランチを別のブランチにファストフォワードする
+### ブランチを別のブランチにファストフォワード
 
 **`fast_forward` 構文**
 
@@ -134,8 +134,8 @@ EXECUTE fast_forward('<from_branch>', '<to_branch>')
 
 **パラメータ**
 
-- `from_branch`: ファストフォワードしたいブランチ。ブランチ名を引用符で囲みます。
-- `to_branch`: `from_branch` をファストフォワードしたいブランチ。ブランチ名を引用符で囲みます。
+- `from_branch`: ファストフォワードしたいブランチ。ブランチ名をクォートで囲みます。
+- `to_branch`: `from_branch` をファストフォワードしたいブランチ。ブランチ名をクォートで囲みます。
 
 **例**
 
@@ -146,9 +146,9 @@ ALTER TABLE iceberg.sales.order
 EXECUTE fast_forward('main', 'test-branch');
 ```
 
-### スナップショットを選択する
+### スナップショットを選択的に適用
 
-特定のスナップショットを選択して、テーブルの現在の状態に適用できます。この操作は既存のスナップショットに基づいて新しいスナップショットを作成し、元のスナップショットには影響を与えません。
+特定のスナップショットを選択してテーブルの現在の状態に適用できます。この操作により、既存のスナップショットに基づいて新しいスナップショットが作成され、元のスナップショットは影響を受けません。
 
 **`cherrypick_snapshot` 構文**
 
@@ -159,7 +159,7 @@ EXECUTE cherrypick_snapshot(<snapshot_id>)
 
 **パラメータ**
 
-`snapshot_id`: 選択したいスナップショットの ID。
+`snapshot_id`: 選択的に適用したいスナップショットの ID。
 
 **例**
 
@@ -168,9 +168,9 @@ ALTER TABLE iceberg.sales.order
 EXECUTE cherrypick_snapshot(54321);
 ```
 
-### スナップショットを期限切れにする
+### スナップショットの期限切れ
 
-特定の時点より前のスナップショットを期限切れにすることができます。この操作は期限切れのスナップショットのデータファイルを削除します。
+特定の時点よりも前のスナップショットを期限切れにできます。この操作により、期限切れのスナップショットのデータファイルが削除されます。
 
 **`expire_snapshot` 構文**
 
@@ -186,9 +186,9 @@ ALTER TABLE iceberg.sales.order
 EXECUTE expire_snapshot('2023-12-17 00:14:38')
 ```
 
-### ブランチまたはタグを削除する
+### ブランチまたはタグの削除
 
-**`DROP BRANCH`, `DROP TAG` 構文**
+**`DROP BRANCH`、`DROP TAG` 構文**
 
 ```SQL
 ALTER TABLE [catalog.][database.]table_name
@@ -217,14 +217,14 @@ DROP TAG `test-tag`;
 
 **パラメータ**
 
-`tag_or_branch`: タイムトラベルしたいブランチまたはタグの名前。ブランチ名が指定された場合、クエリはブランチの最新スナップショットにタイムトラベルします。タグ名が指定された場合、クエリはタグが参照するスナップショットにタイムトラベルします。
+`tag_or_branch`: タイムトラベルしたいブランチまたはタグの名前。ブランチ名が指定された場合、クエリはブランチのヘッドスナップショットにタイムトラベルします。タグ名が指定された場合、クエリはタグが参照するスナップショットにタイムトラベルします。
 
 **例**
 
 ```SQL
--- ブランチの最新スナップショットにタイムトラベルします。
+-- ブランチのヘッドスナップショットにタイムトラベル。
 SELECT * FROM iceberg.sales.order VERSION AS OF 'test-branch';
--- タグが参照するスナップショットにタイムトラベルします。
+-- タグが参照するスナップショットにタイムトラベル。
 SELECT * FROM iceberg.sales.order VERSION AS OF 'test-tag';
 ```
 

--- a/docs/zh/data_source/catalog/iceberg/iceberg_timetravel.md
+++ b/docs/zh/data_source/catalog/iceberg/iceberg_timetravel.md
@@ -4,7 +4,7 @@ displayed_sidebar: docs
 
 import Beta from '../../../_assets/commonMarkdown/_beta.mdx'
 
-# 使用 Iceberg Catalog 进行时间旅行
+# 使用 Iceberg Catalog 的时间旅行
 
 <Beta />
 
@@ -12,7 +12,7 @@ import Beta from '../../../_assets/commonMarkdown/_beta.mdx'
 
 ## 概述
 
-每个 Iceberg 表都会维护一个元数据快照日志，记录对其进行的更改。数据库可以通过访问这些历史快照对 Iceberg 表执行时间旅行查询。Iceberg 支持分支和标记快照，以实现复杂的快照生命周期管理，允许每个分支或标记根据自定义保留策略维护其自身的生命周期。有关 Iceberg 分支和标记功能的更多信息，请参见[官方文档](https://iceberg.apache.org/docs/latest/branching/)。
+每个 Iceberg 表都会维护一个元数据快照日志，记录其所做的更改。数据库可以通过访问这些历史快照对 Iceberg 表执行时间旅行查询。Iceberg 支持分支和标记快照，以实现复杂的快照生命周期管理，允许每个分支或标记根据自定义保留策略维护其自身的生命周期。有关 Iceberg 分支和标记功能的更多信息，请参见[官方文档](https://iceberg.apache.org/docs/latest/branching/)。
 
 通过集成 Iceberg 的快照分支和标记功能，StarRocks 支持在 Iceberg catalogs 中创建和管理分支和标记，并对表进行时间旅行查询。
 
@@ -39,12 +39,12 @@ maxSnapshotAge ::= <int> { DAYS | HOURS | MINUTES }
 
 - `branch_name`: 要创建的分支名称。
 - `AS OF VERSION`: 用于创建分支的快照（版本）ID。
-- `RETAIN`: 分支的保留时间。格式：`<int> <unit>`。支持的单位：`DAYS`、`HOURS` 和 `MINUTES`。例如：`7 DAYS`、`12 HOURS` 或 `30 MINUTES`。
-- `WITH SNAPSHOT RETENTION`: 要保留的最小快照数量和/或保留快照的最长时间。
+- `RETAIN`: 分支的保留时间。格式：`<int> <unit>`。支持的单位：`DAYS`，`HOURS` 和 `MINUTES`。例如：`7 DAYS`，`12 HOURS` 或 `30 MINUTES`。
+- `WITH SNAPSHOT RETENTION`: 要保留的最小快照数量和/或快照的最大保留时间。
 
 **示例**
 
-基于表 `iceberg.sales.order` 的版本（快照 ID）`12345` 创建分支 `test-branch`，保留该分支 `7` 天，并在该分支上至少保留 `2` 个快照。
+基于表 `iceberg.sales.order` 的版本（快照 ID）`12345` 创建一个分支 `test-branch`，保留该分支 `7` 天，并在该分支上至少保留 `2` 个快照。
 
 ```SQL
 ALTER TABLE iceberg.sales.order CREATE BRANCH `test-branch` 
@@ -53,7 +53,7 @@ RETAIN 7 DAYS
 WITH SNAPSHOT RETENTION 2 SNAPSHOTS;
 ```
 
-基于表 `iceberg.sales.order` 的版本（快照 ID）`12345` 创建分支 `test-branch2`，保留该分支 `7` 天，并在该分支上最多保留快照 `2` 天。
+基于表 `iceberg.sales.order` 的版本（快照 ID）`12345` 创建一个分支 `test-branch2`，保留该分支 `7` 天，该分支上的快照至多保留 `2` 天。
 
 ```SQL
 ALTER TABLE iceberg.sales.order CREATE BRANCH `test-branch2` 
@@ -62,7 +62,7 @@ RETAIN 7 DAYS
 WITH SNAPSHOT RETENTION 2 DAYS;
 ```
 
-基于表 `iceberg.sales.order` 的版本（快照 ID）`12345` 创建分支 `test-branch3`，保留该分支 `7` 天，并在该分支上至少保留 `2` 个快照，每个快照最多保留 `2` 天。
+基于表 `iceberg.sales.order` 的版本（快照 ID）`12345` 创建一个分支 `test-branch3`，保留该分支 `7` 天，并在该分支上至少保留 `2` 个快照，每个快照至多保留 `2` 天。
 
 ```SQL
 ALTER TABLE iceberg.sales.order CREATE BRANCH `test-branch3` 
@@ -84,11 +84,11 @@ INSERT INTO [catalog.][database.]table_name
 **参数**
 
 - `branch_name`: 要导入数据的表分支名称。
-- `query_statement`: 其结果将被导入目标表的查询语句。可以是 StarRocks 支持的任何 SQL 语句。
+- `query_statement`: 查询语句，其结果将被导入到目标表中。可以是 StarRocks 支持的任何 SQL 语句。
 
 **示例**
 
-将查询结果导入表 `iceberg.sales.order` 的分支 `test-branch`。
+将查询结果导入到表 `iceberg.sales.order` 的分支 `test-branch` 中。
 
 ```SQL
 INSERT INTO iceberg.sales.order
@@ -111,11 +111,11 @@ CREATE [OR REPLACE] TAG [IF NOT EXISTS] <tag_name>
 
 - `tag_name`: 要创建的标记名称。
 - `AS OF VERSION`: 用于创建标记的快照（版本）ID。
-- `RETAIN`: 标记的保留时间。格式：`<int> <unit>`。支持的单位：`DAYS`、`HOURS` 和 `MINUTES`。例如：`7 DAYS`、`12 HOURS` 或 `30 MINUTES`。
+- `RETAIN`: 标记的保留时间。格式：`<int> <unit>`。支持的单位：`DAYS`，`HOURS` 和 `MINUTES`。例如：`7 DAYS`，`12 HOURS` 或 `30 MINUTES`。
 
 **示例**
 
-基于表 `iceberg.sales.order` 的版本（快照 ID）`12345` 创建标记 `test-tag`，并保留该标记 `7` 天。
+基于表 `iceberg.sales.order` 的版本（快照 ID）`12345` 创建一个标记 `test-tag`，并保留该标记 `7` 天。
 
 ```SQL
 ALTER TABLE iceberg.sales.order CREATE TAG `test-tag` 
@@ -134,8 +134,8 @@ EXECUTE fast_forward('<from_branch>', '<to_branch>')
 
 **参数**
 
-- `from_branch`: 要快进的分支。用引号括起分支名称。
-- `to_branch`: 要将 `from_branch` 快进到的分支。用引号括起分支名称。
+- `from_branch`: 要快进的分支。用引号括住分支名称。
+- `to_branch`: 要快进到的分支。用引号括住分支名称。
 
 **示例**
 
@@ -146,9 +146,9 @@ ALTER TABLE iceberg.sales.order
 EXECUTE fast_forward('main', 'test-branch');
 ```
 
-### 挑选一个快照
+### 拣选一个快照
 
-您可以挑选一个特定的快照并将其应用于表的当前状态。此操作将基于现有快照创建一个新快照，原始快照不会受到影响。
+您可以拣选一个特定的快照并将其应用到表的当前状态。此操作将基于现有快照创建一个新快照，原始快照不会受到影响。
 
 **`cherrypick_snapshot` 语法**
 
@@ -159,7 +159,7 @@ EXECUTE cherrypick_snapshot(<snapshot_id>)
 
 **参数**
 
-`snapshot_id`: 您想要挑选的快照的 ID。
+`snapshot_id`: 您要拣选的快照 ID。
 
 **示例**
 
@@ -170,7 +170,7 @@ EXECUTE cherrypick_snapshot(54321);
 
 ### 过期快照
 
-您可以使早于特定时间点的快照过期。此操作将删除过期快照的数据文件。
+您可以使快照在特定时间点之前过期。此操作将删除过期快照的数据文件。
 
 **`expire_snapshot` 语法**
 
@@ -188,7 +188,7 @@ EXECUTE expire_snapshot('2023-12-17 00:14:38')
 
 ### 删除分支或标记
 
-**`DROP BRANCH`, `DROP TAG` 语法**
+**`DROP BRANCH`、`DROP TAG` 语法**
 
 ```SQL
 ALTER TABLE [catalog.][database.]table_name
@@ -238,7 +238,7 @@ SELECT * FROM iceberg.sales.order VERSION AS OF 'test-tag';
 
 **参数**
 
-`snapshot_id`: 您想要时间旅行到的快照的 ID。
+`snapshot_id`: 您想要时间旅行到的快照 ID。
 
 **示例**
 

--- a/docs/zh/data_source/catalog/iceberg/iceberg_timetravel.md
+++ b/docs/zh/data_source/catalog/iceberg/iceberg_timetravel.md
@@ -4,7 +4,7 @@ displayed_sidebar: docs
 
 import Beta from '../../../_assets/commonMarkdown/_beta.mdx'
 
-# 使用 Iceberg Catalog 的时间旅行
+# 使用 Iceberg Catalog 进行时间旅行
 
 <Beta />
 
@@ -12,7 +12,7 @@ import Beta from '../../../_assets/commonMarkdown/_beta.mdx'
 
 ## 概述
 
-每个 Iceberg 表都会维护一个元数据快照日志，记录其所做的更改。数据库可以通过访问这些历史快照对 Iceberg 表执行时间旅行查询。Iceberg 支持分支和标记快照，以实现复杂的快照生命周期管理，允许每个分支或标记根据自定义保留策略维护其自身的生命周期。有关 Iceberg 分支和标记功能的更多信息，请参见[官方文档](https://iceberg.apache.org/docs/latest/branching/)。
+每个 Iceberg 表都会维护一个元数据快照日志，记录对其进行的更改。数据库可以通过访问这些历史快照对 Iceberg 表执行时间旅行查询。Iceberg 支持分支和标记快照，以实现复杂的快照生命周期管理，允许每个分支或标记根据自定义保留策略维护其自身的生命周期。有关 Iceberg 分支和标记功能的更多信息，请参见[官方文档](https://iceberg.apache.org/docs/latest/branching/)。
 
 通过集成 Iceberg 的快照分支和标记功能，StarRocks 支持在 Iceberg catalogs 中创建和管理分支和标记，并对表进行时间旅行查询。
 
@@ -20,7 +20,7 @@ import Beta from '../../../_assets/commonMarkdown/_beta.mdx'
 
 ### 创建分支
 
-**语法**
+**`CREATE BRANCH` 语法**
 
 ```SQL
 ALTER TABLE [catalog.][database.]table_name
@@ -39,12 +39,12 @@ maxSnapshotAge ::= <int> { DAYS | HOURS | MINUTES }
 
 - `branch_name`: 要创建的分支名称。
 - `AS OF VERSION`: 用于创建分支的快照（版本）ID。
-- `RETAIN`: 分支的保留时间。格式：`<int> <unit>`。支持的单位：`DAYS`，`HOURS` 和 `MINUTES`。例如：`7 DAYS`，`12 HOURS` 或 `30 MINUTES`。
-- `WITH SNAPSHOT RETENTION`: 要保留的最小快照数量和/或快照的最大保留时间。
+- `RETAIN`: 分支的保留时间。格式：`<int> <unit>`。支持的单位：`DAYS`、`HOURS` 和 `MINUTES`。例如：`7 DAYS`、`12 HOURS` 或 `30 MINUTES`。
+- `WITH SNAPSHOT RETENTION`: 要保留的最小快照数量和/或保留快照的最长时间。
 
 **示例**
 
-基于表 `iceberg.sales.order` 的版本（快照 ID）`12345` 创建一个分支 `test-branch`，保留该分支 `7` 天，并在该分支上至少保留 `2` 个快照。
+基于表 `iceberg.sales.order` 的版本（快照 ID）`12345` 创建分支 `test-branch`，保留该分支 `7` 天，并在该分支上至少保留 `2` 个快照。
 
 ```SQL
 ALTER TABLE iceberg.sales.order CREATE BRANCH `test-branch` 
@@ -53,7 +53,7 @@ RETAIN 7 DAYS
 WITH SNAPSHOT RETENTION 2 SNAPSHOTS;
 ```
 
-基于表 `iceberg.sales.order` 的版本（快照 ID）`12345` 创建一个分支 `test-branch2`，保留该分支 `7` 天，该分支上的快照至多保留 `2` 天。
+基于表 `iceberg.sales.order` 的版本（快照 ID）`12345` 创建分支 `test-branch2`，保留该分支 `7` 天，并在该分支上最多保留快照 `2` 天。
 
 ```SQL
 ALTER TABLE iceberg.sales.order CREATE BRANCH `test-branch2` 
@@ -62,7 +62,7 @@ RETAIN 7 DAYS
 WITH SNAPSHOT RETENTION 2 DAYS;
 ```
 
-基于表 `iceberg.sales.order` 的版本（快照 ID）`12345` 创建一个分支 `test-branch3`，保留该分支 `7` 天，并在该分支上至少保留 `2` 个快照，每个快照至多保留 `2` 天。
+基于表 `iceberg.sales.order` 的版本（快照 ID）`12345` 创建分支 `test-branch3`，保留该分支 `7` 天，并在该分支上至少保留 `2` 个快照，每个快照最多保留 `2` 天。
 
 ```SQL
 ALTER TABLE iceberg.sales.order CREATE BRANCH `test-branch3` 
@@ -73,7 +73,7 @@ WITH SNAPSHOT RETENTION 2 SNAPSHOTS 2 DAYS;
 
 ### 将数据导入到表的特定分支
 
-**语法**
+**`VERSION AS OF` 语法**
 
 ```SQL
 INSERT INTO [catalog.][database.]table_name
@@ -84,11 +84,11 @@ INSERT INTO [catalog.][database.]table_name
 **参数**
 
 - `branch_name`: 要导入数据的表分支名称。
-- `query_statement`: 查询语句，其结果将被导入到目标表中。可以是 StarRocks 支持的任何 SQL 语句。
+- `query_statement`: 其结果将被导入目标表的查询语句。可以是 StarRocks 支持的任何 SQL 语句。
 
 **示例**
 
-将查询结果导入到表 `iceberg.sales.order` 的分支 `test-branch` 中。
+将查询结果导入表 `iceberg.sales.order` 的分支 `test-branch`。
 
 ```SQL
 INSERT INTO iceberg.sales.order
@@ -98,7 +98,7 @@ SELECT c1, k1 FROM tbl;
 
 ### 创建标记
 
-**语法**
+**`CREATE TAG` 语法**
 
 ```SQL
 ALTER TABLE [catalog.][database.]table_name
@@ -111,11 +111,11 @@ CREATE [OR REPLACE] TAG [IF NOT EXISTS] <tag_name>
 
 - `tag_name`: 要创建的标记名称。
 - `AS OF VERSION`: 用于创建标记的快照（版本）ID。
-- `RETAIN`: 标记的保留时间。格式：`<int> <unit>`。支持的单位：`DAYS`，`HOURS` 和 `MINUTES`。例如：`7 DAYS`，`12 HOURS` 或 `30 MINUTES`。
+- `RETAIN`: 标记的保留时间。格式：`<int> <unit>`。支持的单位：`DAYS`、`HOURS` 和 `MINUTES`。例如：`7 DAYS`、`12 HOURS` 或 `30 MINUTES`。
 
 **示例**
 
-基于表 `iceberg.sales.order` 的版本（快照 ID）`12345` 创建一个标记 `test-tag`，并保留该标记 `7` 天。
+基于表 `iceberg.sales.order` 的版本（快照 ID）`12345` 创建标记 `test-tag`，并保留该标记 `7` 天。
 
 ```SQL
 ALTER TABLE iceberg.sales.order CREATE TAG `test-tag` 
@@ -125,7 +125,7 @@ RETAIN 7 DAYS;
 
 ### 快进一个分支到另一个分支
 
-**语法**
+**`fast_forward` 语法**
 
 ```SQL
 ALTER TABLE [catalog.][database.]table_name
@@ -134,8 +134,8 @@ EXECUTE fast_forward('<from_branch>', '<to_branch>')
 
 **参数**
 
-- `from_branch`: 要快进的分支。用引号括住分支名称。
-- `to_branch`: 要快进到的分支。用引号括住分支名称。
+- `from_branch`: 要快进的分支。用引号括起分支名称。
+- `to_branch`: 要将 `from_branch` 快进到的分支。用引号括起分支名称。
 
 **示例**
 
@@ -146,11 +146,11 @@ ALTER TABLE iceberg.sales.order
 EXECUTE fast_forward('main', 'test-branch');
 ```
 
-### 拣选一个快照
+### 挑选一个快照
 
-您可以拣选一个特定的快照并将其应用到表的当前状态。此操作将基于现有快照创建一个新快照，原始快照不会受到影响。
+您可以挑选一个特定的快照并将其应用于表的当前状态。此操作将基于现有快照创建一个新快照，原始快照不会受到影响。
 
-**语法**
+**`cherrypick_snapshot` 语法**
 
 ```SQL
 ALTER TABLE [catalog.][database.]table_name
@@ -159,7 +159,7 @@ EXECUTE cherrypick_snapshot(<snapshot_id>)
 
 **参数**
 
-`snapshot_id`: 您要拣选的快照 ID。
+`snapshot_id`: 您想要挑选的快照的 ID。
 
 **示例**
 
@@ -170,9 +170,9 @@ EXECUTE cherrypick_snapshot(54321);
 
 ### 过期快照
 
-您可以使快照在特定时间点之前过期。此操作将删除过期快照的数据文件。
+您可以使早于特定时间点的快照过期。此操作将删除过期快照的数据文件。
 
-**语法**
+**`expire_snapshot` 语法**
 
 ```SQL
 ALTER TABLE [catalog.][database.]table_name
@@ -188,7 +188,7 @@ EXECUTE expire_snapshot('2023-12-17 00:14:38')
 
 ### 删除分支或标记
 
-**语法**
+**`DROP BRANCH`, `DROP TAG` 语法**
 
 ```SQL
 ALTER TABLE [catalog.][database.]table_name
@@ -209,7 +209,7 @@ DROP TAG `test-tag`;
 
 ### 时间旅行到特定分支或标记
 
-**语法**
+**`VERSION AS OF` 语法**
 
 ```SQL
 [FOR] VERSION AS OF '<branch_or_tag>'
@@ -230,7 +230,7 @@ SELECT * FROM iceberg.sales.order VERSION AS OF 'test-tag';
 
 ### 时间旅行到特定快照
 
-**语法**
+**`VERSION AS OF` 语法**
 
 ```SQL
 [FOR] VERSION AS OF '<snapshot_id>'
@@ -238,7 +238,7 @@ SELECT * FROM iceberg.sales.order VERSION AS OF 'test-tag';
 
 **参数**
 
-`snapshot_id`: 您想要时间旅行到的快照 ID。
+`snapshot_id`: 您想要时间旅行到的快照的 ID。
 
 **示例**
 
@@ -248,7 +248,7 @@ SELECT * FROM iceberg.sales.order VERSION AS OF 12345;
 
 ### 时间旅行到特定日期时间或日期
 
-**语法**
+**`TIMESTAMP AS OF` 语法**
 
 ```SQL
 [FOR] TIMESTAMP AS OF { '<datetime>' | '<date>' | date_and_time_function }


### PR DESCRIPTION
Updated syntax headings for various clauses related to branches, tags, and snapshots in the Iceberg time travel documentation.

## Why I'm doing:

Code samples do not get indexed by Algolia. By adding the clauses to the heading for the syntax blocks they should get indexed.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3
