### PR TITLE
[BugFix] enable rewrite simple agg to meta scan by default (backport #64698) (#66555)

### DIFF
--- a/be/src/storage/lake_meta_reader.cpp
+++ b/be/src/storage/lake_meta_reader.cpp
@@ -82,12 +82,13 @@ Status LakeMetaReader::_build_collect_context(const lake::VersionedTablet& table
 
         // only collect the field of dict need read data page
         // others just depend on footer
-        if (collect_field == "dict_merge") {
+        if (collect_field == META_DICT_MERGE || collect_field == META_COUNT_COL) {
             _collect_context.seg_collecter_params.read_page.emplace_back(true);
         } else {
             _collect_context.seg_collecter_params.read_page.emplace_back(false);
         }
-        _has_count_agg |= (collect_field == "count");
+        _has_count_agg |= (collect_field == META_COUNT_ROWS);
+        _has_count_agg |= (collect_field == META_COUNT_COL);
     }
     _collect_context.seg_collecter_params.tablet_schema = tablet_schema;
     return Status::OK();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalMetaScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalMetaScanOperator.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Objects;
 
 public class LogicalMetaScanOperator extends LogicalScanOperator {
+    private long selectedIndexId = -1;
     private Map<Integer, String> aggColumnIdToNames = ImmutableMap.of();
     private List<String> selectPartitionNames = Collections.emptyList();
 
@@ -37,6 +38,10 @@ public class LogicalMetaScanOperator extends LogicalScanOperator {
 
     public List<String> getSelectPartitionNames() {
         return selectPartitionNames;
+    }
+
+    public long getSelectedIndexId() {
+        return selectedIndexId;
     }
 
     @Override
@@ -57,7 +62,8 @@ public class LogicalMetaScanOperator extends LogicalScanOperator {
         }
         LogicalMetaScanOperator that = (LogicalMetaScanOperator) o;
         return Objects.equals(aggColumnIdToNames, that.aggColumnIdToNames) &&
-                Objects.equals(selectPartitionNames, that.selectPartitionNames);
+                Objects.equals(selectPartitionNames, that.selectPartitionNames) &&
+                selectedIndexId == that.selectedIndexId;
     }
 
     @Override
@@ -92,6 +98,11 @@ public class LogicalMetaScanOperator extends LogicalScanOperator {
 
         public LogicalMetaScanOperator.Builder setSelectPartitionNames(List<String> selectPartitionNames) {
             builder.selectPartitionNames = selectPartitionNames;
+            return this;
+        }
+
+        public LogicalMetaScanOperator.Builder setSelectedIndexId(long selectedIndexId) {
+            builder.selectedIndexId = selectedIndexId;
             return this;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -631,6 +631,7 @@ public class RelationTransformer implements AstVisitor<LogicalPlan, ExpressionMa
                         .setColRefToColumnMetaMap(colRefToColumnMetaMapBuilder.build())
                         .setSelectPartitionNames(node.getPartitionNames() == null ? Collections.emptyList() :
                                 node.getPartitionNames().getPartitionNames())
+                        .setSelectedIndexId(((OlapTable) node.getTable()).getBaseIndexId())
                         .build();
             } else if (!isMVPlanner) {
                 scanOperator = LogicalOlapScanOperator.builder()

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1027,7 +1027,7 @@ public class PlanFragmentBuilder {
 
             MetaScanNode scanNode = new MetaScanNode(context.getNextNodeId(),
                     tupleDescriptor, (OlapTable) scan.getTable(), scan.getAggColumnIdToNames(),
-                    scan.getSelectPartitionNames(),
+                    scan.getSelectPartitionNames(), scan.getSelectedIndexId(),
                     context.getConnectContext().getCurrentWarehouseId());
             scanNode.computeRangeLocations();
             scanNode.computeStatistics(optExpression.getStatistics());

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtWithDecimalTypesNewPlannerTest.java
@@ -298,6 +298,7 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
 
     @Test
     public void testDecimal32Count() throws Exception {
+        ctx.getSessionVariable().setEnableRewriteSimpleAggToMetaScan(false);
         String sql = "select count(col_decimal32p9s2) from db1.decimal_table";
         String plan = UtFrameUtils.getVerboseFragmentPlan(ctx, sql);
         String snippet = "count[([2: col_decimal32p9s2, DECIMAL32(9,2), false]); args: DECIMAL32; result: BIGINT";
@@ -487,6 +488,7 @@ public class SelectStmtWithDecimalTypesNewPlannerTest {
 
     @Test
     public void testDecimalNullableProperties() throws Exception {
+        ctx.getSessionVariable().setEnableRewriteSimpleAggToMetaScan(false);
         String sql;
         String plan;
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -755,6 +755,7 @@ public class TrinoQueryTest extends TrinoTestBase {
 
     @Test
     public void testAggFunction() throws Exception {
+        connectContext.getSessionVariable().setEnableRewriteSimpleAggToMetaScan(false);
         String sql = "select count(v1) from t0";
         assertPlanContains(sql, "output: count(1: v1)");
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryCacheTest.java
@@ -393,6 +393,7 @@ public class QueryCacheTest {
         ctx.getSessionVariable().setEnablePipelineEngine(true);
         ctx.getSessionVariable().setEnableQueryCache(true);
         ctx.getSessionVariable().setOptimizerExecuteTimeout(30000);
+        ctx.getSessionVariable().setEnableRewriteSimpleAggToMetaScan(false);
         FeConstants.runningUnitTest = true;
         StarRocksAssert starRocksAssert = new StarRocksAssert(ctx);
         starRocksAssert.withDatabase(StatsConstants.STATISTICS_DB_NAME)

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/PhasedScheduleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/PhasedScheduleTest.java
@@ -76,6 +76,7 @@ public class PhasedScheduleTest extends SchedulerTestBase {
     public void testPhasedScheduleWithCTE() throws Exception {
         connectContext.getSessionVariable().setEnablePhasedScheduler(true);
         connectContext.getSessionVariable().setPhasedSchedulerMaxConcurrency(1);
+        connectContext.getSessionVariable().setEnableRewriteSimpleAggToMetaScan(false);
 
         String sql =
                 "with a as (select count(*) from lineitem) " +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVRewriteTest.java
@@ -100,6 +100,7 @@ public class MVRewriteTest {
                 "    \"database\" = \"test\",\n" +
                 "    \"table\" = \"ods_order\"\n" +
                 "    )");
+        starRocksAssert.getCtx().getSessionVariable().setEnableRewriteSimpleAggToMetaScan(false);
     }
 
     @BeforeEach

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
@@ -46,6 +46,7 @@ public class MvRefreshAndRewriteIcebergTest extends MVTestBase {
         ConnectorPlanTestBase.mockCatalog(connectContext, MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME);
         connectContext.getSessionVariable().setMaterializedViewUnionRewriteMode(1);
         connectContext.getSessionVariable().setEnableMaterializedViewTransparentUnionRewrite(false);
+        connectContext.getSessionVariable().setEnableRewriteSimpleAggToMetaScan(false);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -1869,6 +1869,27 @@ public class AggregateTest extends PlanTestBase {
                 "     <id 18> : min_id_datetime\n" +
                 "     <id 19> : count_t1b");
 
+        sql = "select count(*) from test_all_type_not_null";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  1:AGGREGATE (update serialize)\n" +
+                "  |  output: sum(rows_t1a)\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  0:MetaScan\n" +
+                "     Table: test_all_type_not_null\n" +
+                "     <id 12> : rows_t1a");
+
+        sql = "select count(*) from part_t1 partitions(p1)";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  1:AGGREGATE (update serialize)\n" +
+                "  |  output: sum(rows_v4)\n" +
+                "  |  group by: \n" +
+                "  |  \n" +
+                "  0:MetaScan\n" +
+                "     Table: part_t1\n" +
+                "     <id 5> : rows_v4\n" +
+                "     Partitions: [p1]");
+
         // The following cases will not use MetaScan because some conditions are not met
         // with group by key
         sql = "select t1b,max(id_datetime) from test_all_type_not_null group by t1b";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecimalTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecimalTypeTest.java
@@ -60,6 +60,7 @@ public class DecimalTypeTest extends PlanTestBase {
                 "AGGREGATE KEY (c_2_0) " +
                 "DISTRIBUTED BY HASH (c_2_0) " +
                 "properties(\"replication_num\"=\"1\") ;");
+        starRocksAssert.getCtx().getSessionVariable().setEnableRewriteSimpleAggToMetaScan(false);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -45,6 +45,7 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
         DistributedEnvPlanTestBase.beforeClass();
         FeConstants.runningUnitTest = true;
         Config.tablet_sched_disable_colocate_overall_balance = true;
+        connectContext.getSessionVariable().setEnableRewriteSimpleAggToMetaScan(false);
     }
 
     @AfterEach

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/FilterUnusedColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/FilterUnusedColumnTest.java
@@ -69,6 +69,7 @@ public class FilterUnusedColumnTest extends PlanTestBase {
         FeConstants.USE_MOCK_DICT_MANAGER = true;
         connectContext.getSessionVariable().setSqlMode(2);
         connectContext.getSessionVariable().enableTrimOnlyFilteredColumnsInScanStage();
+        connectContext.getSessionVariable().setEnableRewriteSimpleAggToMetaScan(false);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -167,6 +167,7 @@ public class LowCardinalityTest extends PlanTestBase {
         connectContext.getSessionVariable().setEnableLowCardinalityOptimize(true);
         connectContext.getSessionVariable().setCboCteReuse(false);
         connectContext.getSessionVariable().setEnableEliminateAgg(false);
+        connectContext.getSessionVariable().setEnableRewriteSimpleAggToMetaScan(false);
         FeConstants.runningUnitTest = true;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -171,6 +171,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
         connectContext.getSessionVariable().setCboCteReuse(false);
         connectContext.getSessionVariable().setUseLowCardinalityOptimizeV2(true);
         connectContext.getSessionVariable().setEnableEliminateAgg(false);
+        connectContext.getSessionVariable().setEnableRewriteSimpleAggToMetaScan(false);
     }
 
     @AfterAll

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
@@ -34,6 +34,7 @@ class OrderByTest extends PlanTestBase {
     @BeforeAll
     public static void beforeClass() throws Exception {
         PlanTestBase.beforeClass();
+        connectContext.getSessionVariable().setEnableRewriteSimpleAggToMetaScan(false);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
@@ -109,6 +109,7 @@ public class PartitionPruneTest extends PlanTestBase {
                 " PARTITION BY (c2, c3) " +
                 " PROPERTIES('replication_num'='1')");
         starRocksAssert.ddl("ALTER TABLE t_gen_col_1 ADD PARTITION p1_01 VALUES IN (('1', '1'))");
+        starRocksAssert.getCtx().getSessionVariable().setEnableRewriteSimpleAggToMetaScan(false);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ScanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ScanTest.java
@@ -346,6 +346,7 @@ public class ScanTest extends PlanTestBase {
 
     @Test
     public void testProjectFilterRewrite() throws Exception {
+        connectContext.getSessionVariable().setEnableRewriteSimpleAggToMetaScan(false);
         String queryStr = "select 1 as b, MIN(v1) from t0 having (b + 1) != b;";
         String explainString = getFragmentPlan(queryStr);
         Assertions.assertTrue(explainString.contains("  1:AGGREGATE (update finalize)\n"
@@ -491,6 +492,7 @@ public class ScanTest extends PlanTestBase {
     @Test
     public void testPruneColumnTest() throws Exception {
         connectContext.getSessionVariable().setEnableCountStarOptimization(true);
+        connectContext.getSessionVariable().setEnableRewriteSimpleAggToMetaScan(false);
         String[] sqlString = {
                 "select count(*) from lineitem_partition",
                 // for olap, partition key is not partition column.

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SelectConstTest.java
@@ -113,6 +113,7 @@ public class SelectConstTest extends PlanTestBase {
 
     @Test
     public void testSubquery() throws Exception {
+        connectContext.getSessionVariable().setEnableRewriteSimpleAggToMetaScan(false);
         assertPlanContains("select * from t0 where v3 in (select 2)", "LEFT SEMI JOIN", "<slot 7> : 2");
         assertPlanContains("select * from t0 where v3 not in (select 2)", "NULL AWARE LEFT ANTI JOIN",
                 "<slot 7> : 2");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -820,6 +820,7 @@ public class SubqueryTest extends PlanTestBase {
 
     @Test
     public void testOnClauseNonCorrelatedScalarAggSubquery() throws Exception {
+        connectContext.getSessionVariable().setEnableRewriteSimpleAggToMetaScan(false);
         {
             String sql = "select * from t0 " +
                     "join t1 on t0.v1 = (select count(*) from t3 join t4)";
@@ -1349,6 +1350,7 @@ public class SubqueryTest extends PlanTestBase {
 
     @Test
     public void testSubqueryTypeRewrite() throws Exception {
+        connectContext.getSessionVariable().setEnableRewriteSimpleAggToMetaScan(false);
         {
             String sql =
                     "select nullif((select max(v4) from t1), (select min(v6) from t1))";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCHPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCHPlanTest.java
@@ -38,6 +38,7 @@ public class TPCHPlanTest extends PlanTestBase {
         connectContext.getSessionVariable().setNewPlanerAggStage(2);
         connectContext.getSessionVariable().setEnableViewBasedMvRewrite(false);
         connectContext.getSessionVariable().setCboEqBaseType(SessionVariableConstants.DOUBLE);
+        connectContext.getSessionVariable().setEnableRewriteSimpleAggToMetaScan(false);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
@@ -92,6 +92,7 @@ public class WindowTest extends PlanTestBase {
 
     @Test
     public void testPruneEmptyWindow() throws Exception {
+        connectContext.getSessionVariable().setEnableRewriteSimpleAggToMetaScan(false);
         String sql = "select count(*) from( select avg(t1g) over(partition by t1a) from test_all_type ) r";
         assertLogicalPlanContains(sql,
                 "AGGREGATE ([GLOBAL] aggregate [{12: count=count()}] group by [[]] having [null]\n" +

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -1258,7 +1258,8 @@ struct TMetaScanNode {
     // column id to column name
     1: optional map<i32, string> id_to_names
     2: optional list<Descriptors.TColumn> columns
-    3: optional i32 low_cardinality_threshold;
+    3: optional i32 low_cardinality_threshold
+    5: optional i64 schema_id
 }
 
 struct TDecodeNode {

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -2792,7 +2792,7 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
     def wait_compaction_finish(self, table_name: str, expected_num_segments: int):
         timeout = 300
         scan_table_sql = (
-            f"SELECT /*+SET_VAR(enable_profile=true,enable_async_profile=false)*/ COUNT(1) FROM {table_name}"
+            f"SELECT /*+SET_VAR(enable_profile=true,enable_async_profile=false,enable_rewrite_simple_agg_to_meta_scan=false)*/ COUNT(1) FROM {table_name}"
         )
         fetch_segments_sql = r"""
             with profile as (

--- a/test/sql/test_materialized_view/R/test_sync_materialized_view1
+++ b/test/sql/test_materialized_view/R/test_sync_materialized_view1
@@ -2,6 +2,9 @@
 admin set frontend config('alter_scheduler_interval_millisecond' = '100');
 -- result:
 -- !result
+set enable_rewrite_simple_agg_to_meta_scan = false;
+-- result:
+-- !result
 create table user_tags (time date, user_id int, user_name varchar(20), tag_id int) partition by range (time)  (partition p1 values less than MAXVALUE) distributed by hash(time) buckets 3 properties('replication_num' = '1');
 -- result:
 -- !result

--- a/test/sql/test_materialized_view/T/test_sync_materialized_view1
+++ b/test/sql/test_materialized_view/T/test_sync_materialized_view1
@@ -2,6 +2,7 @@
 
 admin set frontend config('alter_scheduler_interval_millisecond' = '100');
 
+set enable_rewrite_simple_agg_to_meta_scan = false;
 create table user_tags (time date, user_id int, user_name varchar(20), tag_id int) partition by range (time)  (partition p1 values less than MAXVALUE) distributed by hash(time) buckets 3 properties('replication_num' = '1');
 insert into user_tags values('2023-04-13', 1, 'a', 1), ('2023-04-13', 1, 'b', 2), ('2023-04-13', 1, 'c', 3), ('2023-04-13', 1, 'd', 4), ('2023-04-13', 1, 'e', 5), ('2023-04-13', 2, 'e', 5), ('2023-04-13', 3, 'e', 6);
 

--- a/test/sql/test_resource_group/R/test_resource_group_big_query
+++ b/test/sql/test_resource_group/R/test_resource_group_big_query
@@ -63,6 +63,9 @@ select /*+SET_VAR(resource_group='rg_${uuid0}')*/ count(1) from w1;
 alter resource group rg_${uuid0} with ('big_query_cpu_second_limit'='0','big_query_scan_rows_limit'='1');
 -- result:
 -- !result
+set enable_rewrite_simple_agg_to_meta_scan = false;
+-- result:
+-- !result
 select /*+SET_VAR(resource_group='rg_${uuid0}')*/ count(1) from t1;
 -- result:
 [REGEX].*exceed big query scan_rows limit: current is \d+ but limit is 1.*

--- a/test/sql/test_resource_group/T/test_resource_group_big_query
+++ b/test/sql/test_resource_group/T/test_resource_group_big_query
@@ -40,6 +40,7 @@ select /*+SET_VAR(resource_group='rg_${uuid0}')*/ count(1) from w1;
 
 
 alter resource group rg_${uuid0} with ('big_query_cpu_second_limit'='0','big_query_scan_rows_limit'='1');
+set enable_rewrite_simple_agg_to_meta_scan = false;
 select /*+SET_VAR(resource_group='rg_${uuid0}')*/ count(1) from t1;
 
 

--- a/test/sql/test_transparent_mv/R/test_mv_with_multi_partition_columns_iceberg1_nulls
+++ b/test/sql/test_transparent_mv/R/test_mv_with_multi_partition_columns_iceberg1_nulls
@@ -32,6 +32,9 @@ INSERT INTO t1 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '20
                       (1, 'beijing2', 20, '2024-01-01'), (2, 'guangdong2', 20, '2024-01-01'), (3, 'guangdong2', 20, '2024-01-02'), (4, 'nanjing', NULL, NULL);
 -- result:
 -- !result
+set enable_rewrite_simple_agg_to_meta_scan=false;
+-- result:
+-- !result
 CREATE MATERIALIZED VIEW test_mv1
 PARTITION BY (province, date_trunc('day', dt))
 REFRESH DEFERRED MANUAL

--- a/test/sql/test_transparent_mv/T/test_mv_with_multi_partition_columns_iceberg1_nulls
+++ b/test/sql/test_transparent_mv/T/test_mv_with_multi_partition_columns_iceberg1_nulls
@@ -27,6 +27,7 @@ INSERT INTO t1 VALUES (1, 'beijing', 20, '2024-01-01'), (2, 'guangdong', 20, '20
                       (1, 'beijing1', 20, '2024-01-01'), (2, 'guangdong1', 20, '2024-01-01'), (3, 'guangdong1', 20, '2024-01-02'), (4, 'beijing', NULL, NULL),
                       (1, 'beijing2', 20, '2024-01-01'), (2, 'guangdong2', 20, '2024-01-01'), (3, 'guangdong2', 20, '2024-01-02'), (4, 'nanjing', NULL, NULL);
 
+set enable_rewrite_simple_agg_to_meta_scan=false;
 CREATE MATERIALIZED VIEW test_mv1
 PARTITION BY (province, date_trunc('day', dt))
 REFRESH DEFERRED MANUAL


### PR DESCRIPTION
[BugFix] enable rewrite simple agg to meta scan by default (backport #64698)
[BugFix] fix meta scan rewrite bugs on temporay partition and random buckets (backport #65617)

## Why I'm doing:

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/10726

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines MetaScan rewrite with schema/index awareness, partition handling, and count(*) support, plumbing schema_id/selectedIndexId through FE/BE and updating tests.
> 
> - **Planner/Rewrite**:
>   - Meta-scan rewrite enhanced: distinguishes `count(*)` vs `count(col)` (uses `rows_`/`count_` meta columns) and computes selected partition names; carries `selectedIndexId` from logical to physical.
>   - `MetaScanNode` now accepts `selectedIndexId`; selects partitions by subpartitions when names provided.
> - **Frontend (FE)**:
>   - `LogicalMetaScanOperator`/`PhysicalMetaScanOperator`: add `selectedIndexId` field, builders, equals/hash updates.
>   - `RelationTransformer`: sets `selectedIndexId` for meta scans; `PlanFragmentBuilder` passes it to `MetaScanNode`.
>   - `MetaScanNode`: optionally sets `schema_id` in `TMetaScanNode` from selected index meta.
> - **Backend (BE)**:
>   - `OlapMetaScanner`: selects `tablet_schema` by matching `schema_id`; falls back to copied schema when columns specified; otherwise uses tablet schema.
>   - `LakeMetaReader`: use constants (`META_DICT_MERGE`, `META_COUNT_ROWS`, `META_COUNT_COL`); set `read_page` for dict/col-count; track count aggs.
> - **Thrift**:
>   - `TMetaScanNode`: add optional `schema_id`.
> - **Tests/Utils**:
>   - Widespread test updates to disable simple-agg-to-meta-scan via session var where needed; add plans asserting `count(*)` meta-scan and partition cases.
>   - `sr_sql_lib.wait_compaction_finish`: disables meta-scan rewrite in COUNT query.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0a1819b02423edf274bb63557e21b0fa3eb739a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->