### PR TITLE
[Enhancement] Optimize large tablet lake compaction by support parallel compaction

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1253,6 +1253,20 @@ CONF_mBool(lake_print_delete_log, "false");
 CONF_mInt64(lake_compaction_stream_buffer_size_bytes, "1048576"); // 1MB
 // The interval to check whether lake compaction is valid. Set to <= 0 to disable the check.
 CONF_mInt32(lake_compaction_check_valid_interval_minutes, "10"); // 10 minutes
+
+// Maximum data volume (bytes) per parallel compaction subtask.
+// If total picked rowsets data size is less than this threshold, parallel compaction
+// will be skipped and fallback to normal compaction flow.
+// Default: 5GB
+CONF_mInt64(lake_compaction_max_bytes_per_subtask, "5368709120");
+
+// Maximum rowset size (bytes) for compaction consideration.
+// Non-overlapped rowsets larger than this threshold are considered "well-compacted"
+// and will be skipped in compaction score calculation (treated as score 0).
+// This is also used in split_rowsets_into_groups to skip large non-overlapped rowsets.
+// Default: 4GB
+CONF_mInt64(lake_compaction_max_rowset_size, "4294967296");
+
 // Used to ensure service availability in extreme situations by sacrificing a certain degree of correctness
 CONF_mBool(experimental_lake_ignore_lost_segment, "false");
 CONF_mInt64(experimental_lake_wait_per_put_ms, "0");

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -188,6 +188,7 @@ set(STORAGE_FILES
     lake/compaction_scheduler.cpp
     lake/compaction_task.cpp
     lake/compaction_task_context.cpp
+    lake/tablet_parallel_compaction_manager.cpp
     lake/horizontal_compaction_task.cpp
     lake/delta_writer.cpp
     lake/vacuum.cpp

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -34,6 +34,7 @@
 #include "service/service_be/lake_service.h"
 #include "storage/lake/compaction_task.h"
 #include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_parallel_compaction_manager.h"
 #include "storage/memtable_flush_executor.h"
 #include "storage/storage_engine.h"
 #include "testutil/sync_point.h"
@@ -134,6 +135,13 @@ void CompactionTaskCallback::finish_task(std::unique_ptr<CompactionTaskContext>&
     DCHECK(_request != nullptr);
     _status.update(context->status);
 
+    // For parallel merged context, register it to the scheduler's _contexts list
+    // so that it's visible in list_tasks() until RPC response is sent.
+    if (context->is_parallel_merged && _scheduler != nullptr) {
+        std::lock_guard ctx_lock(_scheduler->_contexts_lock);
+        _scheduler->_contexts.Append(context.get());
+    }
+
     // Keep the context for a while until the RPC request is finished processing so that we can see the detailed
     // and complete progress of the RPC request by calling `CompactionScheduler::list_tasks()`.
     _contexts.emplace_back(std::move(context));
@@ -153,7 +161,9 @@ void CompactionTaskCallback::finish_task(std::unique_ptr<CompactionTaskContext>&
         tmp.swap(_contexts);
 
         l.unlock();
-        _scheduler->remove_states(tmp);
+        if (_scheduler != nullptr) {
+            _scheduler->remove_states(tmp);
+        }
         tmp.clear();
         TEST_SYNC_POINT("lake::CompactionTaskCallback::finish_task:finish_task");
     }
@@ -227,6 +237,9 @@ CompactionScheduler::CompactionScheduler(TabletManager* tablet_mgr)
     for (int i = 0; i < _task_queues.task_queue_size(); i++) {
         CHECK(_threads->submit_func([this, id = i]() { this->thread_task(id); }).ok());
     }
+
+    // Initialize per-tablet parallel compaction manager
+    _parallel_mgr = std::make_unique<TabletParallelCompactionManager>(tablet_mgr);
 }
 
 CompactionScheduler::~CompactionScheduler() {
@@ -258,10 +271,16 @@ void CompactionScheduler::compact(::google::protobuf::RpcController* controller,
                                         st.detailed_message());
         }
     }
+
+    // Check if parallel compaction is enabled
+    bool has_parallel_config = request->has_parallel_config();
+    bool enable_parallel = has_parallel_config && request->parallel_config().enable_parallel();
+
     // By default, all the tablet compaction tasks with the same txn id will be executed in the same
     // thread to avoid blocking other transactions, but if there are idle threads, they will steal
     // tasks from busy threads to execute.
     auto cb = std::make_shared<CompactionTaskCallback>(this, request, response, done);
+
     std::vector<std::unique_ptr<CompactionTaskContext>> contexts_vec;
     for (auto tablet_id : request->tablet_ids()) {
         auto context = std::make_unique<CompactionTaskContext>(request->txn_id(), tablet_id, request->version(),
@@ -270,6 +289,7 @@ void CompactionScheduler::compact(::google::protobuf::RpcController* controller,
         contexts_vec.push_back(std::move(context));
         // DO NOT touch `context` from here!
     }
+
     // initialize last check time, compact request is received right after FE sends it, so consider it valid now
     cb->set_last_check_time(time(nullptr));
 
@@ -280,6 +300,16 @@ void CompactionScheduler::compact(::google::protobuf::RpcController* controller,
         reject_request(controller, request, response);
         return;
     }
+
+    // Handle parallel compaction mode
+    if (enable_parallel && _parallel_mgr != nullptr) {
+        lock.unlock();
+        guard.release();
+        process_parallel_compaction(request, response, cb);
+        return;
+    }
+
+    // Original non-parallel mode
     {
         std::lock_guard l(_contexts_lock);
         for (auto& ctx : contexts_vec) {
@@ -294,28 +324,96 @@ void CompactionScheduler::compact(::google::protobuf::RpcController* controller,
     TEST_SYNC_POINT("CompactionScheduler::compact:return");
 }
 
+void CompactionScheduler::process_parallel_compaction(const CompactRequest* request, CompactResponse* response,
+                                                      const std::shared_ptr<CompactionTaskCallback>& callback) {
+    VLOG(1) << "Processing parallel compaction request. txn_id: " << request->txn_id()
+            << ", tablet_ids size: " << request->tablet_ids_size()
+            << ", max_parallel: " << request->parallel_config().max_parallel_per_tablet()
+            << ", max_bytes: " << request->parallel_config().max_bytes_per_subtask();
+
+    int total_subtasks = 0;
+    int successful_tablets = 0;
+
+    // Create limiter callbacks for parallel compaction
+    AcquireTokenFunc acquire_token = [this]() { return _limiter.acquire(); };
+    ReleaseTokenFunc release_token = [this](bool mem_limit_exceeded) {
+        if (mem_limit_exceeded) {
+            _limiter.memory_limit_exceeded();
+        } else {
+            _limiter.no_memory_limit_exceeded();
+        }
+    };
+
+    for (auto tablet_id : request->tablet_ids()) {
+        auto result = _parallel_mgr->create_parallel_tasks(
+                tablet_id, request->txn_id(), request->version(), request->parallel_config(), callback,
+                request->force_base_compaction(), _threads.get(), acquire_token, release_token);
+
+        if (result.ok() && result.value() > 0) {
+            // Parallel compaction tasks created successfully
+            total_subtasks += result.value();
+            successful_tablets++;
+            VLOG(1) << "Created " << result.value() << " parallel subtasks for tablet " << tablet_id;
+        } else {
+            // Fall back to non-parallel mode for this tablet if:
+            // 1. create_parallel_tasks failed (result.status() is not OK)
+            // 2. create_parallel_tasks returned 0 (indicates fallback, e.g., data size too small)
+            if (!result.ok()) {
+                LOG(WARNING) << "Failed to create parallel tasks for tablet " << tablet_id << ": " << result.status()
+                             << ", falling back to normal compaction";
+            } else {
+                VLOG(1) << "Parallel compaction not applicable for tablet " << tablet_id
+                        << ", falling back to normal compaction";
+            }
+            auto context = std::make_unique<CompactionTaskContext>(request->txn_id(), tablet_id, request->version(),
+                                                                   request->force_base_compaction(),
+                                                                   request->skip_write_txnlog(), callback);
+            context->enqueue_time_sec = ::time(nullptr);
+
+            {
+                std::lock_guard l(_contexts_lock);
+                _contexts.Append(context.get());
+            }
+
+            std::unique_lock lock(_mutex);
+            _task_queues.put_by_txn_id(request->txn_id(), context);
+        }
+    }
+
+    VLOG(1) << "Parallel compaction request processed. txn_id: " << request->txn_id()
+            << ", total_subtasks: " << total_subtasks << ", successful_tablets: " << successful_tablets;
+}
+
 void CompactionScheduler::list_tasks(std::vector<CompactionTaskInfo>* infos) {
-    std::lock_guard l(_contexts_lock);
-    for (butil::LinkNode<CompactionTaskContext>* node = _contexts.head(); node != _contexts.end();
-         node = node->next()) {
-        CompactionTaskContext* context = node->value();
-        auto& info = infos->emplace_back();
-        info.txn_id = context->txn_id;
-        info.tablet_id = context->tablet_id;
-        info.version = context->version;
-        info.skipped = context->skipped.load(std::memory_order_relaxed);
-        info.runs = context->runs.load(std::memory_order_relaxed);
-        info.start_time = context->start_time.load(std::memory_order_relaxed);
-        info.progress = context->progress.value();
-        // Load "finish_time" with memory_order_acquire and check its value before reading the "status" to avoid
-        // the race condition between this thread and the `CompactionScheduler::thread_task` threads.
-        info.finish_time = context->finish_time.load(std::memory_order_acquire);
-        if (info.runs > 0) {
-            info.profile = context->stats->to_json_stats();
+    // List regular (non-parallel) compaction tasks
+    {
+        std::lock_guard l(_contexts_lock);
+        for (butil::LinkNode<CompactionTaskContext>* node = _contexts.head(); node != _contexts.end();
+             node = node->next()) {
+            CompactionTaskContext* context = node->value();
+            auto& info = infos->emplace_back();
+            info.txn_id = context->txn_id;
+            info.tablet_id = context->tablet_id;
+            info.version = context->version;
+            info.skipped = context->skipped.load(std::memory_order_relaxed);
+            info.runs = context->runs.load(std::memory_order_relaxed);
+            info.start_time = context->start_time.load(std::memory_order_relaxed);
+            info.progress = context->progress.value();
+            // Load "finish_time" with memory_order_acquire and check its value before reading the "status" to avoid
+            // the race condition between this thread and the `CompactionScheduler::thread_task` threads.
+            info.finish_time = context->finish_time.load(std::memory_order_acquire);
+            if (info.runs > 0) {
+                info.profile = context->stats->to_json_stats();
+            }
+            if (info.finish_time > 0) {
+                info.status = context->status;
+            }
         }
-        if (info.finish_time > 0) {
-            info.status = context->status;
-        }
+    }
+
+    // List parallel compaction tasks
+    if (_parallel_mgr != nullptr) {
+        _parallel_mgr->list_tasks(infos);
     }
 }
 
@@ -361,6 +459,17 @@ void CompactionScheduler::remove_states(const std::vector<std::unique_ptr<Compac
     std::lock_guard l(_contexts_lock);
     for (auto& context : states) {
         context->RemoveFromList();
+    }
+
+    // Cleanup parallel compaction states for merged contexts.
+    // This is deferred from on_subtask_complete to ensure parallel compaction tasks
+    // remain visible in list_tasks until RPC response is sent.
+    if (_parallel_mgr != nullptr) {
+        for (auto& context : states) {
+            if (context->is_parallel_merged) {
+                _parallel_mgr->cleanup_tablet(context->tablet_id, context->txn_id);
+            }
+        }
     }
 }
 

--- a/be/src/storage/lake/compaction_scheduler.h
+++ b/be/src/storage/lake/compaction_scheduler.h
@@ -41,6 +41,7 @@ namespace starrocks::lake {
 class CompactionScheduler;
 class CompactionTask;
 class TabletManager;
+class TabletParallelCompactionManager;
 
 // For every `CompactRequest` a new `CompactionTaskCallback` instance will be created.
 // A single `CompactRequest` may have multiple tablets to be compacted, each time a tablet compaction
@@ -254,6 +255,13 @@ private:
     std::atomic<bool> _stopped{false};
     std::mutex _mutex;
     WrapTaskQueues _task_queues;
+
+    // Per-tablet parallel compaction manager
+    std::unique_ptr<TabletParallelCompactionManager> _parallel_mgr;
+
+    // Process compaction request with parallel mode
+    void process_parallel_compaction(const CompactRequest* request, CompactResponse* response,
+                                     const std::shared_ptr<CompactionTaskCallback>& callback);
 };
 
 inline bool CompactionScheduler::Limiter::acquire() {

--- a/be/src/storage/lake/compaction_task_context.cpp
+++ b/be/src/storage/lake/compaction_task_context.cpp
@@ -34,8 +34,8 @@ void CompactionTaskStats::collect(const OlapReaderStatistics& reader_stats) {
     column_iterator_init_ns = reader_stats.column_iterator_init_ns;
     io_count_local_disk = reader_stats.io_count_local_disk;
     io_count_remote = reader_stats.io_count_remote;
-    // read segment count is managed else where
-    // read_segment_count = reader_stats.segments_read_count;
+    // Note: read_segment_count is managed explicitly in compaction task code
+    // by summing rowset->num_segments(), not from reader_stats.
 }
 
 void CompactionTaskStats::collect(const OlapWriterStatistics& writer_stats) {
@@ -54,8 +54,7 @@ CompactionTaskStats CompactionTaskStats::operator+(const CompactionTaskStats& th
     diff.column_iterator_init_ns += that.column_iterator_init_ns;
     diff.io_count_local_disk += that.io_count_local_disk;
     diff.io_count_remote += that.io_count_remote;
-    // read segment count is managed else where
-    // diff.read_segment_count += that.read_segment_count;
+    diff.read_segment_count += that.read_segment_count;
     diff.write_segment_count += that.write_segment_count;
     diff.write_segment_bytes += that.write_segment_bytes;
     diff.io_ns_write_remote += that.io_ns_write_remote;
@@ -75,8 +74,7 @@ CompactionTaskStats CompactionTaskStats::operator-(const CompactionTaskStats& th
     diff.column_iterator_init_ns -= that.column_iterator_init_ns;
     diff.io_count_local_disk -= that.io_count_local_disk;
     diff.io_count_remote -= that.io_count_remote;
-    // read segment count is managed else where
-    // diff.read_segment_count -= that.read_segment_count;
+    diff.read_segment_count -= that.read_segment_count;
     diff.write_segment_count -= that.write_segment_count;
     diff.write_segment_bytes -= that.write_segment_bytes;
     diff.io_ns_write_remote -= that.io_ns_write_remote;

--- a/be/src/storage/lake/compaction_task_context.h
+++ b/be/src/storage/lake/compaction_task_context.h
@@ -67,6 +67,7 @@ struct CompactionTaskStats {
 
 // Context of a single tablet compaction task.
 struct CompactionTaskContext : public butil::LinkNode<CompactionTaskContext> {
+    // Constructor for normal compaction
     explicit CompactionTaskContext(int64_t txn_id_, int64_t tablet_id_, int64_t version_, bool force_base_compaction_,
                                    bool skip_write_txnlog_, std::shared_ptr<CompactionTaskCallback> cb_,
                                    int64_t table_id_ = 0, int64_t partition_id_ = 0)
@@ -78,6 +79,18 @@ struct CompactionTaskContext : public butil::LinkNode<CompactionTaskContext> {
               callback(std::move(cb_)),
               table_id(table_id_),
               partition_id(partition_id_) {}
+
+    // Factory method for parallel compaction subtasks (with subtask_id)
+    static std::unique_ptr<CompactionTaskContext> create_for_subtask(int64_t txn_id_, int64_t tablet_id_,
+                                                                     int64_t version_, bool force_base_compaction_,
+                                                                     bool skip_write_txnlog_,
+                                                                     std::shared_ptr<CompactionTaskCallback> cb_,
+                                                                     int32_t subtask_id_) {
+        auto ctx = std::make_unique<CompactionTaskContext>(txn_id_, tablet_id_, version_, force_base_compaction_,
+                                                           skip_write_txnlog_, std::move(cb_));
+        ctx->subtask_id = subtask_id_;
+        return ctx;
+    }
 
 #ifndef NDEBUG
     ~CompactionTaskContext() {
@@ -96,12 +109,16 @@ struct CompactionTaskContext : public butil::LinkNode<CompactionTaskContext> {
     std::atomic<int> runs{0};
     Status status;
     Progress progress;
-    int64_t enqueue_time_sec; // time point when put into queue
+    int64_t enqueue_time_sec{0}; // time point when put into queue
     std::shared_ptr<CompactionTaskCallback> callback;
     std::unique_ptr<CompactionTaskStats> stats = std::make_unique<CompactionTaskStats>();
     std::shared_ptr<TxnLogPB> txn_log;
     int64_t table_id;
     int64_t partition_id;
+    int32_t subtask_id = -1; // -1 means not a parallel compaction subtask
+    // Flag to indicate this is a merged context from parallel compaction.
+    // When true, cleanup_tablet should be called in remove_states after RPC response is sent.
+    bool is_parallel_merged = false;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -1139,10 +1139,36 @@ StatusOr<CompactionTaskPtr> TabletManager::compact(CompactionTaskContext* contex
 #endif
 
     ASSIGN_OR_RETURN(auto tablet, get_tablet(context->tablet_id, context->version));
-    auto tablet_metadata = tablet.metadata();
+    const auto& tablet_metadata = tablet.metadata();
     ASSIGN_OR_RETURN(auto compaction_policy,
                      CompactionPolicy::create(this, tablet_metadata, context->force_base_compaction));
     ASSIGN_OR_RETURN(auto input_rowsets, compaction_policy->pick_rowsets());
+    return compact(context, std::move(input_rowsets));
+}
+
+StatusOr<CompactionTaskPtr> TabletManager::compact(CompactionTaskContext* context,
+                                                   std::vector<RowsetPtr> input_rowsets) {
+#if defined(USE_STAROS) && !defined(BUILD_FORMAT_LIB)
+    // Retrieve table_id and partition_id from shard info if not already set.
+    // This is needed for parallel compaction which may call this overload directly.
+    if (g_worker != nullptr && (context->table_id == 0 || context->partition_id == 0)) {
+        auto shard_info_or = g_worker->retrieve_shard_info(context->tablet_id);
+        if (shard_info_or.ok()) {
+            auto id_pair = get_table_partition_id(shard_info_or.value());
+            if (context->table_id == 0) {
+                context->table_id = id_pair.first;
+            }
+            if (context->partition_id == 0) {
+                context->partition_id = id_pair.second;
+            }
+        }
+    }
+#endif
+
+    ASSIGN_OR_RETURN(auto tablet, get_tablet(context->tablet_id, context->version));
+    auto tablet_metadata = tablet.metadata();
+    ASSIGN_OR_RETURN(auto compaction_policy,
+                     CompactionPolicy::create(this, tablet_metadata, context->force_base_compaction));
     ASSIGN_OR_RETURN(auto algorithm, compaction_policy->choose_compaction_algorithm(input_rowsets));
     std::vector<uint32_t> input_rowsets_id;
     size_t total_input_rowsets_file_size = 0;

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -82,6 +82,9 @@ public:
 
     StatusOr<CompactionTaskPtr> compact(CompactionTaskContext* context);
 
+    // Compact with pre-selected rowsets (for parallel compaction)
+    StatusOr<CompactionTaskPtr> compact(CompactionTaskContext* context, std::vector<RowsetPtr> input_rowsets);
+
     Status put_tablet_metadata(const TabletMetadata& metadata);
 
     Status put_tablet_metadata(const TabletMetadataPtr& metadata);

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.cpp
@@ -1,0 +1,1264 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/tablet_parallel_compaction_manager.h"
+
+#include <algorithm>
+#include <set>
+
+#include "common/config.h"
+#include "common/logging.h"
+#include "gen_cpp/lake_types.pb.h"
+#include "gutil/strings/join.h"
+#include "gutil/strings/substitute.h"
+#include "storage/lake/compaction_policy.h"
+#include "storage/lake/compaction_scheduler.h"
+#include "storage/lake/compaction_task.h"
+#include "storage/lake/rowset.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/lake/update_manager.h"
+#include "storage/lake/versioned_tablet.h"
+#include "storage/memtable_flush_executor.h"
+#include "storage/storage_engine.h"
+#include "util/defer_op.h"
+#include "util/threadpool.h"
+
+namespace starrocks::lake {
+
+namespace {
+
+// Collect successful subtask IDs (unified logic for both PK and non-PK tables)
+// All successful subtasks are included regardless of whether they are consecutive.
+// Each successful subtask's output rowset will replace its corresponding input rowsets.
+std::vector<int32_t> collect_success_subtask_ids(
+        const std::vector<std::unique_ptr<CompactionTaskContext>>& completed_subtasks, int64_t tablet_id,
+        int64_t txn_id) {
+    std::vector<int32_t> success_subtask_ids;
+    for (const auto& ctx : completed_subtasks) {
+        if (!ctx->status.ok()) {
+            LOG(WARNING) << "Parallel compaction: skipping failed subtask " << ctx->subtask_id << " for tablet "
+                         << tablet_id << ", txn_id=" << txn_id << ", status=" << ctx->status;
+            continue;
+        }
+        success_subtask_ids.push_back(ctx->subtask_id);
+    }
+    return success_subtask_ids;
+}
+
+} // namespace
+
+// ================================================================================
+// Helper functions for split_rowsets_into_groups
+// ================================================================================
+
+// Check if a group is valid for compaction.
+// A group is valid if:
+// - It has >= 2 rowsets (can merge multiple rowsets), OR
+// - It has 1 overlapped rowset with >= 2 segments (can merge internal segments)
+bool TabletParallelCompactionManager::_is_group_valid_for_compaction(const std::vector<RowsetPtr>& group) {
+    if (group.size() >= 2) {
+        return true;
+    }
+    if (group.size() == 1) {
+        const auto& meta = group[0]->metadata();
+        return meta.overlapped() && meta.segments_size() >= 2;
+    }
+    return false;
+}
+
+// Filter out large non-overlapped rowsets that don't need compaction.
+// Returns the compactable rowsets and logs the skipped ones.
+// Uses lake_compaction_max_rowset_size for filtering large rowsets.
+std::vector<RowsetPtr> TabletParallelCompactionManager::_filter_compactable_rowsets(
+        int64_t tablet_id, std::vector<RowsetPtr> all_rowsets) {
+    std::vector<RowsetPtr> compactable_rowsets;
+    std::vector<RowsetPtr> skipped_large_rowsets;
+    int64_t max_rowset_size = config::lake_compaction_max_rowset_size;
+
+    for (auto& r : all_rowsets) {
+        const auto& meta = r->metadata();
+        // A rowset is considered "already well-compacted" if:
+        // 1. It's non-overlapped (segments don't overlap with each other)
+        // 2. Its size >= lake_compaction_max_rowset_size (already large enough)
+        // 3. It has no delete predicate (if it has delete, it needs to be processed)
+        bool is_large_non_overlapped =
+                !meta.overlapped() && r->data_size() >= max_rowset_size && !meta.has_delete_predicate();
+        if (is_large_non_overlapped) {
+            skipped_large_rowsets.push_back(std::move(r));
+        } else {
+            compactable_rowsets.push_back(std::move(r));
+        }
+    }
+
+    if (!skipped_large_rowsets.empty()) {
+        std::vector<uint32_t> skipped_ids;
+        int64_t skipped_bytes = 0;
+        for (const auto& r : skipped_large_rowsets) {
+            skipped_ids.push_back(r->id());
+            skipped_bytes += r->data_size();
+        }
+        VLOG(1) << "Parallel compaction: tablet=" << tablet_id << " skipped " << skipped_large_rowsets.size()
+                << " large non-overlapped rowsets (" << skipped_bytes << " bytes) that don't need compaction, ids=["
+                << JoinInts(skipped_ids, ",") << "]";
+    }
+
+    return compactable_rowsets;
+}
+
+// Calculate statistics about rowsets
+TabletParallelCompactionManager::RowsetStats TabletParallelCompactionManager::_calculate_rowset_stats(
+        const std::vector<RowsetPtr>& rowsets) {
+    RowsetStats stats;
+    for (const auto& r : rowsets) {
+        const auto& meta = r->metadata();
+        stats.total_bytes += r->data_size();
+        if (meta.has_delete_predicate()) {
+            stats.has_delete_predicate = true;
+        }
+        // Count effective segments
+        if (meta.overlapped()) {
+            stats.total_segments += std::max(1, meta.segments_size());
+        } else {
+            stats.total_segments += 1;
+        }
+    }
+    return stats;
+}
+
+// Calculate optimal number of subtasks
+TabletParallelCompactionManager::GroupingConfig TabletParallelCompactionManager::_calculate_grouping_config(
+        int64_t tablet_id, const std::vector<RowsetPtr>& rowsets, const RowsetStats& stats, int32_t max_parallel,
+        int64_t max_bytes) {
+    GroupingConfig config;
+
+    // Key constraint: each subtask should have at least 2 segments to be meaningful.
+    // So max possible subtasks = total_segments / 2
+    int32_t max_subtasks_by_segments = static_cast<int32_t>(stats.total_segments / 2);
+    int32_t num_subtasks_by_bytes = static_cast<int32_t>((stats.total_bytes + max_bytes - 1) / max_bytes);
+
+    // Take the minimum of: bytes-based count, max_parallel, and segments-based count
+    config.num_subtasks = std::min({num_subtasks_by_bytes, max_parallel, max_subtasks_by_segments});
+    config.num_subtasks = std::max(config.num_subtasks, 1);
+
+    // Check if we need to skip some data due to limits
+    config.skip_excess_data = num_subtasks_by_bytes > config.num_subtasks;
+    if (config.skip_excess_data) {
+        VLOG(1) << "Parallel compaction: tablet=" << tablet_id
+                << " data exceeds capacity, will skip excess data for later compaction"
+                << ", num_subtasks=" << config.num_subtasks << ", would need by bytes=" << num_subtasks_by_bytes
+                << ", max_parallel=" << max_parallel << ", max_by_segments=" << max_subtasks_by_segments;
+    }
+
+    // Calculate target bytes per subtask for even distribution
+    int64_t processable_bytes =
+            config.skip_excess_data ? (static_cast<int64_t>(config.num_subtasks) * max_bytes) : stats.total_bytes;
+    config.target_bytes_per_subtask = processable_bytes / config.num_subtasks;
+
+    // Calculate target rowsets per subtask for balanced distribution
+    config.target_rowsets_per_subtask = std::max(static_cast<size_t>(2), rowsets.size() / config.num_subtasks);
+
+    // For non-PK tables, if partial segments compaction is enabled, limit segments per subtask
+    // to avoid triggering partial compaction within each subtask.
+    // This ensures each subtask can be applied atomically without segment-level splitting.
+    if (config::enable_lake_compaction_use_partial_segments) {
+        config.max_segments_per_subtask = config::max_cumulative_compaction_num_singleton_deltas;
+    }
+
+    VLOG(1) << "Parallel compaction: tablet=" << tablet_id << " planning " << config.num_subtasks
+            << " subtasks with target_bytes_per_subtask=" << config.target_bytes_per_subtask
+            << " target_rowsets_per_subtask=" << config.target_rowsets_per_subtask
+            << " max_segments_per_subtask=" << config.max_segments_per_subtask
+            << " (processable_bytes=" << processable_bytes << ")";
+
+    return config;
+}
+
+// Group rowsets into subtasks based on the configuration.
+// Returns groups of rowsets, where each group will become a subtask.
+std::vector<std::vector<RowsetPtr>> TabletParallelCompactionManager::_group_rowsets_into_subtasks(
+        int64_t tablet_id, std::vector<RowsetPtr> all_rowsets, const GroupingConfig& config, int64_t max_bytes,
+        bool is_pk_table) {
+    std::vector<std::vector<RowsetPtr>> valid_groups;
+    std::vector<RowsetPtr> current_group;
+    int64_t current_bytes = 0;
+    int64_t current_segments = 0; // Track segments count for non-PK tables
+    size_t skipped_rowsets = 0;
+    int64_t skipped_bytes = 0;
+    int32_t last_rowset_index = -1;
+
+    // Helper lambda to get segment count for a rowset
+    auto get_rowset_segments = [](const RowsetPtr& rowset) -> int64_t {
+        const auto& meta = rowset->metadata();
+        return std::max(1, meta.segments_size());
+    };
+
+    for (size_t rowset_idx = 0; rowset_idx < all_rowsets.size(); rowset_idx++) {
+        auto& rowset = all_rowsets[rowset_idx];
+        int64_t rowset_bytes = rowset->data_size();
+        int64_t rowset_segments = get_rowset_segments(rowset);
+        int32_t current_rowset_index = rowset->index();
+
+        // Check if we should skip this rowset due to capacity limits
+        if (config.skip_excess_data) {
+            // Case 1: We've already finalized all planned groups, skip remaining
+            if (static_cast<int32_t>(valid_groups.size()) >= config.num_subtasks) {
+                skipped_rowsets++;
+                skipped_bytes += rowset_bytes;
+                continue;
+            }
+            // Case 2: We're building the last group and adding would exceed max_bytes
+            if (static_cast<int32_t>(valid_groups.size()) == config.num_subtasks - 1 && current_group.size() >= 2 &&
+                current_bytes + rowset_bytes > max_bytes) {
+                skipped_rowsets++;
+                skipped_bytes += rowset_bytes;
+                continue;
+            }
+        }
+
+        // Check for adjacency gap (only for non-PK tables)
+        bool has_adjacency_gap = false;
+        if (!is_pk_table) {
+            has_adjacency_gap =
+                    !current_group.empty() && last_rowset_index >= 0 && (current_rowset_index - last_rowset_index) > 1;
+        }
+
+        // Determine if we should start a new group
+        size_t remaining_rowsets = all_rowsets.size() - rowset_idx;
+        bool has_enough_remaining = remaining_rowsets >= 1;
+        bool current_group_valid = _is_group_valid_for_compaction(current_group);
+        // For PK tables: use greedy strategy - fill up current group to max_bytes before starting new one
+        // For non-PK tables: use balanced strategy - distribute evenly using target_bytes_per_subtask
+        int64_t bytes_threshold = is_pk_table ? max_bytes : config.target_bytes_per_subtask;
+        bool would_exceed_target = current_bytes + rowset_bytes > bytes_threshold;
+        bool can_create_more_groups = static_cast<int32_t>(valid_groups.size()) < config.num_subtasks - 1;
+
+        bool should_start_new_group = !current_group.empty() && current_group_valid && would_exceed_target &&
+                                      can_create_more_groups && has_enough_remaining;
+
+        // Force new group on adjacency gap
+        if (has_adjacency_gap && !current_group.empty()) {
+            should_start_new_group = true;
+        }
+
+        // For non-PK tables: check if adding this rowset would exceed segment limit.
+        // This avoids triggering partial compaction within each subtask.
+        // Note: Only force new group if current group already has content and is valid.
+        bool would_exceed_segments = false;
+        if (!is_pk_table && config.max_segments_per_subtask > 0 && !current_group.empty()) {
+            would_exceed_segments = (current_segments + rowset_segments > config.max_segments_per_subtask);
+            if (would_exceed_segments && current_group_valid && can_create_more_groups && has_enough_remaining) {
+                should_start_new_group = true;
+            }
+        }
+
+        if (should_start_new_group) {
+            std::vector<uint32_t> group_ids;
+            for (const auto& r : current_group) {
+                group_ids.push_back(r->id());
+            }
+            std::string reason =
+                    has_adjacency_gap ? " (adjacency gap)" : would_exceed_segments ? " (segment limit)" : "";
+            VLOG(1) << "Parallel compaction: tablet=" << tablet_id << " group " << valid_groups.size() << ": "
+                    << current_group.size() << " rowsets, " << current_bytes << " bytes, " << current_segments
+                    << " segments, ids=[" << JoinInts(group_ids, ",") << "]" << reason;
+
+            valid_groups.push_back(std::move(current_group));
+            current_group.clear();
+            current_bytes = 0;
+            current_segments = 0;
+        }
+
+        current_group.push_back(std::move(rowset));
+        current_bytes += rowset_bytes;
+        current_segments += rowset_segments;
+        last_rowset_index = current_rowset_index;
+    }
+
+    // Add the last group if not empty
+    if (!current_group.empty()) {
+        std::vector<uint32_t> group_ids;
+        for (const auto& r : current_group) {
+            group_ids.push_back(r->id());
+        }
+        VLOG(1) << "Parallel compaction: tablet=" << tablet_id << " group " << valid_groups.size() << ": "
+                << current_group.size() << " rowsets, " << current_bytes << " bytes, " << current_segments
+                << " segments, ids=[" << JoinInts(group_ids, ",") << "]";
+        valid_groups.push_back(std::move(current_group));
+    }
+
+    if (skipped_rowsets > 0) {
+        VLOG(1) << "Parallel compaction: tablet=" << tablet_id << " skipped " << skipped_rowsets << " rowsets ("
+                << skipped_bytes << " bytes) for later compaction due to capacity limit";
+    }
+
+    return valid_groups;
+}
+
+// Filter out invalid groups that cannot be compacted.
+// Single-rowset groups are only valid if they are overlapped with multiple segments.
+std::vector<std::vector<RowsetPtr>> TabletParallelCompactionManager::_filter_invalid_groups(
+        int64_t tablet_id, std::vector<std::vector<RowsetPtr>> groups) {
+    std::vector<std::vector<RowsetPtr>> filtered_groups;
+    std::vector<uint32_t> discarded_rowset_ids;
+
+    for (auto& group : groups) {
+        if (group.size() >= 2) {
+            filtered_groups.push_back(std::move(group));
+        } else if (group.size() == 1) {
+            const auto& rowset = group[0];
+            const auto& meta = rowset->metadata();
+            // An overlapped rowset with multiple segments can be compacted to merge its segments
+            bool can_compact_alone = meta.overlapped() && meta.segments_size() >= 2;
+            if (can_compact_alone) {
+                filtered_groups.push_back(std::move(group));
+                VLOG(1) << "Parallel compaction: tablet=" << tablet_id
+                        << " keeping single overlapped rowset (id=" << rowset->id()
+                        << ", segments=" << meta.segments_size() << ") as valid group";
+            } else {
+                discarded_rowset_ids.push_back(rowset->id());
+            }
+        }
+    }
+
+    if (!discarded_rowset_ids.empty()) {
+        VLOG(1) << "Parallel compaction: tablet=" << tablet_id << " discarded " << discarded_rowset_ids.size()
+                << " single non-overlapped rowset groups (ids=[" << JoinInts(discarded_rowset_ids, ",")
+                << "]) due to adjacency gaps, will be processed in next compaction cycle";
+    }
+
+    return filtered_groups;
+}
+
+TabletParallelCompactionManager::TabletParallelCompactionManager(TabletManager* tablet_mgr) : _tablet_mgr(tablet_mgr) {}
+
+TabletParallelCompactionManager::~TabletParallelCompactionManager() = default;
+
+StatusOr<std::vector<RowsetPtr>> TabletParallelCompactionManager::pick_rowsets_for_compaction(
+        int64_t tablet_id, int64_t txn_id, int64_t version, bool force_base_compaction) {
+    // Get tablet metadata
+    ASSIGN_OR_RETURN(auto tablet, _tablet_mgr->get_tablet(tablet_id, version));
+    const auto& metadata = tablet.metadata();
+    if (!metadata) {
+        return Status::NotFound(strings::Substitute("Tablet metadata not found: tablet_id=$0, txn_id=$1, version=$2",
+                                                    tablet_id, txn_id, version));
+    }
+
+    // Log metadata details for debugging duplicate compaction issues
+    std::vector<uint32_t> first_rowset_ids;
+    int count = std::min(10, metadata->rowsets_size());
+    for (int i = 0; i < count; i++) {
+        first_rowset_ids.push_back(metadata->rowsets(i).id());
+    }
+    VLOG(1) << "Parallel compaction pick_rowsets: tablet=" << tablet_id << " version=" << version
+            << " metadata_rowsets_size=" << metadata->rowsets_size() << " next_rowset_id=" << metadata->next_rowset_id()
+            << " first_10_rowset_ids=[" << JoinInts(first_rowset_ids, ",") << "]";
+
+    // Get all rowsets to compact using standard pick_rowsets()
+    ASSIGN_OR_RETURN(auto policy, CompactionPolicy::create(_tablet_mgr, metadata, force_base_compaction));
+    auto all_rowsets_or = policy->pick_rowsets();
+    if (!all_rowsets_or.ok() || all_rowsets_or.value().empty()) {
+        return Status::NotFound(strings::Substitute(
+                "No rowsets to compact: tablet_id=$0, txn_id=$1, version=$2, force_base_compaction=$3, "
+                "pick_rowsets_status=$4",
+                tablet_id, txn_id, version, force_base_compaction,
+                all_rowsets_or.ok() ? "OK(empty)" : all_rowsets_or.status().to_string()));
+    }
+
+    return std::move(all_rowsets_or.value());
+}
+
+std::vector<std::vector<RowsetPtr>> TabletParallelCompactionManager::split_rowsets_into_groups(
+        int64_t tablet_id, std::vector<RowsetPtr> all_rowsets, int32_t max_parallel, int64_t max_bytes,
+        bool is_pk_table) {
+    // Step 1: Sort rowsets by their index in metadata to ensure adjacency when grouped.
+    // This is critical because pick_rowsets() may return rowsets sorted by compaction score,
+    // not by their position in metadata.
+    std::sort(all_rowsets.begin(), all_rowsets.end(),
+              [](const RowsetPtr& a, const RowsetPtr& b) { return a->index() < b->index(); });
+
+    // Step 2: Filter out large non-overlapped rowsets that don't need compaction.
+    all_rowsets = _filter_compactable_rowsets(tablet_id, std::move(all_rowsets));
+    if (all_rowsets.empty()) {
+        VLOG(1) << "Parallel compaction: tablet=" << tablet_id
+                << " all rowsets are large non-overlapped, no compaction needed";
+        return {};
+    }
+
+    // Step 3: Calculate statistics about the rowsets.
+    RowsetStats stats = _calculate_rowset_stats(all_rowsets);
+
+    VLOG(1) << "Parallel compaction: tablet=" << tablet_id << " total_rowsets=" << all_rowsets.size()
+            << " total_segments=" << stats.total_segments << " total_bytes=" << stats.total_bytes
+            << " max_bytes_per_subtask=" << max_bytes << " has_delete_predicate=" << stats.has_delete_predicate;
+
+    // Step 4: Check early return conditions for falling back to normal compaction.
+    // Conditions:
+    // 1. Data size is small enough to fit in one subtask - no benefit from parallelism
+    // 2. max_parallel is 1 (parallelism disabled)
+    // 3. Has delete predicate (must be applied atomically)
+    // 4. Not enough segments for meaningful parallel compaction (need at least 4 segments)
+    constexpr int64_t kMinSegmentsForParallel = 4; // 2 subtasks * 2 segments each
+    bool not_enough_segments = stats.total_segments < kMinSegmentsForParallel;
+
+    if (stats.total_bytes <= max_bytes || max_parallel <= 1 || stats.has_delete_predicate || not_enough_segments) {
+        std::vector<uint32_t> group_ids;
+        for (const auto& r : all_rowsets) {
+            group_ids.push_back(r->id());
+        }
+        std::string reason = stats.has_delete_predicate
+                                     ? "has_delete_predicate"
+                                     : (max_parallel <= 1)
+                                               ? "max_parallel<=1"
+                                               : not_enough_segments ? "not_enough_segments" : "data_size_small";
+        VLOG(1) << "Parallel compaction: tablet=" << tablet_id << " fallback to normal compaction (" << reason
+                << "): " << all_rowsets.size() << " rowsets, " << stats.total_segments << " segments, "
+                << stats.total_bytes << " bytes, ids=[" << JoinInts(group_ids, ",") << "]";
+        return {};
+    }
+
+    // Step 5: Calculate grouping configuration (number of subtasks, target bytes, etc.)
+    GroupingConfig config = _calculate_grouping_config(tablet_id, all_rowsets, stats, max_parallel, max_bytes);
+
+    // Step 6: Group rowsets into subtasks.
+    std::vector<std::vector<RowsetPtr>> groups =
+            _group_rowsets_into_subtasks(tablet_id, std::move(all_rowsets), config, max_bytes, is_pk_table);
+
+    // Step 7: Filter out invalid groups (single non-overlapped rowsets).
+    std::vector<std::vector<RowsetPtr>> filtered_groups = _filter_invalid_groups(tablet_id, std::move(groups));
+
+    // Log if only 1 valid group remains.
+    if (filtered_groups.size() == 1) {
+        VLOG(1) << "Parallel compaction: tablet=" << tablet_id
+                << " only 1 valid group after filtering, using single group mode";
+    }
+
+    return filtered_groups;
+}
+
+StatusOr<std::shared_ptr<TabletParallelCompactionState>>
+TabletParallelCompactionManager::create_and_register_tablet_state(int64_t tablet_id, int64_t txn_id, int64_t version,
+                                                                  int32_t max_parallel, int64_t max_bytes,
+                                                                  std::shared_ptr<CompactionTaskCallback> callback,
+                                                                  const ReleaseTokenFunc& release_token) {
+    std::string state_key = make_state_key(tablet_id, txn_id);
+    std::lock_guard<std::mutex> lock(_states_mutex);
+
+    auto it = _tablet_states.find(state_key);
+    if (it != _tablet_states.end()) {
+        return Status::AlreadyExist(
+                strings::Substitute("Parallel compaction already exists: tablet_id=$0, txn_id=$1, version=$2, "
+                                    "existing_version=$3, existing_running_subtasks=$4, existing_completed_subtasks=$5",
+                                    tablet_id, txn_id, version, it->second->version,
+                                    it->second->running_subtasks.size(), it->second->completed_subtasks.size()));
+    }
+
+    auto state = std::make_shared<TabletParallelCompactionState>();
+    state->tablet_id = tablet_id;
+    state->txn_id = txn_id;
+    state->version = version;
+    state->max_parallel = max_parallel;
+    state->max_bytes_per_subtask = max_bytes;
+    state->callback = std::move(callback);
+    state->release_token = release_token;
+    _tablet_states[state_key] = state;
+
+    return state;
+}
+
+StatusOr<int> TabletParallelCompactionManager::submit_subtasks(
+        const std::shared_ptr<TabletParallelCompactionState>& state_ptr, std::vector<std::vector<RowsetPtr>> groups,
+        bool force_base_compaction, ThreadPool* thread_pool, const AcquireTokenFunc& acquire_token,
+        const ReleaseTokenFunc& release_token) {
+    int64_t tablet_id = state_ptr->tablet_id;
+    int64_t txn_id = state_ptr->txn_id;
+    int64_t version = state_ptr->version;
+    int32_t max_parallel = state_ptr->max_parallel;
+
+    int subtasks_created = 0;
+    int submitted_rowsets_count = 0;
+    int64_t submitted_bytes = 0;
+
+    for (size_t group_idx = 0; group_idx < groups.size(); group_idx++) {
+        auto& rowsets = groups[group_idx];
+
+        // Collect rowset IDs and calculate input bytes
+        std::vector<uint32_t> rowset_ids;
+        int64_t input_bytes = 0;
+        for (const auto& rowset : rowsets) {
+            rowset_ids.push_back(rowset->id());
+            input_bytes += rowset->data_size();
+        }
+        submitted_rowsets_count += rowset_ids.size();
+        submitted_bytes += input_bytes;
+
+        int32_t subtask_id = static_cast<int32_t>(group_idx);
+
+        // Mark rowsets as compacting and create subtask info
+        {
+            std::lock_guard<std::mutex> lock(state_ptr->mutex);
+            mark_rowsets_compacting(state_ptr.get(), rowset_ids);
+
+            SubtaskInfo info;
+            info.subtask_id = subtask_id;
+            info.input_rowset_ids = rowset_ids;
+            info.input_bytes = input_bytes;
+            info.start_time = ::time(nullptr);
+            state_ptr->running_subtasks[subtask_id] = std::move(info);
+            state_ptr->total_subtasks_created++;
+        }
+
+        _running_subtasks++;
+
+        // Acquire limiter token before submitting
+        if (!acquire_token()) {
+            LOG(WARNING) << "Parallel compaction: failed to acquire limiter token for subtask " << subtask_id
+                         << " tablet " << tablet_id << ", will skip remaining groups";
+            // Failed to acquire token, revert state changes
+            {
+                std::lock_guard<std::mutex> lock(state_ptr->mutex);
+                unmark_rowsets_compacting(state_ptr.get(), rowset_ids);
+                state_ptr->running_subtasks.erase(subtask_id);
+                state_ptr->total_subtasks_created--;
+            }
+            _running_subtasks--;
+
+            if (subtasks_created == 0) {
+                cleanup_tablet(tablet_id, txn_id);
+                return Status::ResourceBusy(strings::Substitute(
+                        "Failed to acquire limiter token for parallel compaction: tablet_id=$0, txn_id=$1, "
+                        "version=$2, subtask_id=$3, total_groups=$4, max_parallel=$5",
+                        tablet_id, txn_id, version, subtask_id, groups.size(), max_parallel));
+            }
+            break;
+        }
+
+        // Submit task to thread pool
+        auto submit_st = thread_pool->submit_func([this, tablet_id, txn_id, subtask_id, rowsets = std::move(rowsets),
+                                                   version, force_base_compaction, release_token]() mutable {
+            execute_subtask(tablet_id, txn_id, subtask_id, std::move(rowsets), version, force_base_compaction,
+                            release_token);
+        });
+
+        if (!submit_st.ok()) {
+            LOG(WARNING) << "Parallel compaction: failed to submit subtask " << subtask_id << " for tablet "
+                         << tablet_id << ": " << submit_st;
+            // Failed to submit, revert state changes and release token
+            {
+                std::lock_guard<std::mutex> lock(state_ptr->mutex);
+                unmark_rowsets_compacting(state_ptr.get(), rowset_ids);
+                state_ptr->running_subtasks.erase(subtask_id);
+                state_ptr->total_subtasks_created--;
+            }
+            _running_subtasks--;
+            release_token(false);
+
+            if (subtasks_created == 0) {
+                cleanup_tablet(tablet_id, txn_id);
+                return submit_st;
+            }
+            break;
+        }
+
+        subtasks_created++;
+
+        VLOG(1) << "Parallel compaction: created subtask " << subtask_id << " for tablet " << tablet_id
+                << ", txn_id=" << txn_id << ", rowsets=" << rowset_ids.size() << " (ids: " << JoinInts(rowset_ids, ",")
+                << "), input_bytes=" << input_bytes;
+    }
+
+    if (subtasks_created == 0) {
+        cleanup_tablet(tablet_id, txn_id);
+        // Note: Cannot calculate total_rowsets/total_bytes here because groups elements may have been
+        // moved into lambdas during the loop. This edge case should rarely happen since we return
+        // immediately when subtask creation fails on the first group.
+        return Status::NotFound(strings::Substitute(
+                "Failed to create any subtask for parallel compaction: tablet_id=$0, txn_id=$1, version=$2, "
+                "total_groups=$3, max_parallel=$4",
+                tablet_id, txn_id, version, groups.size(), max_parallel));
+    }
+
+    VLOG(1) << "Parallel compaction: successfully created " << subtasks_created << " subtasks for tablet " << tablet_id
+            << ", txn_id=" << txn_id << ", total_rowsets=" << submitted_rowsets_count
+            << ", total_bytes=" << submitted_bytes;
+
+    return subtasks_created;
+}
+
+// ================================================================================
+// create_parallel_tasks - Create parallel compaction subtasks
+// ================================================================================
+//
+// Purpose:
+// --------
+// Split a single tablet's compaction work into multiple subtasks that execute in parallel,
+// accelerating the compaction process for large data volumes. Each subtask processes an
+// independent group of rowsets, and results are merged at the end.
+//
+// Strategy:
+// ---------
+// 1. Rowset Selection: Use standard CompactionPolicy to select rowsets for compaction.
+//
+// 2. Grouping Strategy: Divide rowsets into groups based on max_bytes_per_subtask.
+//    - Maximum number of groups is limited by max_parallel.
+//    - If data volume exceeds max_parallel * max_bytes_per_subtask, excess rowsets are
+//      skipped and left for the next compaction cycle.
+//    - For small data volumes, falls back to single-task mode.
+//    - Load Balancing: Calculates target_bytes_per_subtask = total_bytes / num_subtasks
+//      to distribute data evenly across subtasks.
+//      (Note: Rowsets are assigned in order and cannot be split, so balancing is best-effort)
+//
+// 3. Concurrent Execution: Each subtask executes compaction independently, generating
+//    its own segments and rows_mapper files.
+//
+// 4. Result Merging: After all subtasks complete, merge TxnLogs (segments, statistics, etc.)
+//    and execute SST compaction once.
+//
+// Partial Failure Handling:
+// -------------------------
+// - Subtasks execute independently; one failure does not interrupt others.
+// - The tablet is marked as failed ONLY if ALL subtasks fail.
+// - As long as at least one subtask succeeds, the tablet is considered (partially) successful
+//   and can be published.
+// - Merging strategy for successful subtasks:
+//     * PK tables: Merge results from all successful subtasks (non-consecutive allowed)
+//     * Non-PK tables: Merge only the longest consecutive sequence of successful subtasks
+//       Example: [✓, ✗, ✓, ✓, ✓] → only use subtasks 2,3,4 (longest consecutive run of 3)
+// - Rowsets from failed subtasks are not included in the merged TxnLog and will be
+//   reprocessed in the next compaction cycle.
+//
+// ================================================================================
+StatusOr<int> TabletParallelCompactionManager::create_parallel_tasks(
+        int64_t tablet_id, int64_t txn_id, int64_t version, const TabletParallelConfig& config,
+        std::shared_ptr<CompactionTaskCallback> callback, bool force_base_compaction, ThreadPool* thread_pool,
+        const AcquireTokenFunc& acquire_token, const ReleaseTokenFunc& release_token) {
+    // Validate configuration
+    // max_parallel comes from table property (via FE)
+    // max_bytes comes from BE config if FE passes 0
+    int32_t max_parallel = config.max_parallel_per_tablet();
+    int64_t max_bytes = config.max_bytes_per_subtask();
+
+    // If FE doesn't specify max_bytes (passes 0), use BE config
+    if (max_bytes <= 0) {
+        max_bytes = starrocks::config::lake_compaction_max_bytes_per_subtask;
+    }
+
+    if (max_parallel <= 0 || max_bytes <= 0) {
+        return Status::InvalidArgument(
+                strings::Substitute("Invalid parallel compaction configuration: tablet_id=$0, txn_id=$1, version=$2, "
+                                    "max_parallel=$3, max_bytes=$4, force_base_compaction=$5",
+                                    tablet_id, txn_id, version, max_parallel, max_bytes, force_base_compaction));
+    }
+
+    VLOG(1) << "Parallel compaction: tablet=" << tablet_id << " txn=" << txn_id << " version=" << version
+            << " max_parallel=" << max_parallel << " max_bytes=" << max_bytes;
+
+    // Get tablet metadata to check if it's a PK table
+    ASSIGN_OR_RETURN(auto tablet, _tablet_mgr->get_tablet(tablet_id, version));
+    const auto& metadata = tablet.metadata();
+    bool is_pk_table = metadata->schema().keys_type() == PRIMARY_KEYS;
+
+    // Parallel compaction only supports:
+    // 1. PK tables with enable_pk_index_parallel_execution enabled
+    // 2. Non-PK tables with size-tiered compaction strategy (no cumulative_point)
+    // For PK tables, parallel compaction requires enable_pk_index_parallel_execution because
+    // mapper files need to be stored on remote storage for multi-node access.
+    // For non-PK tables with default (base+cumulative) strategy, the cumulative_point
+    // calculation in parallel compaction is complex and error-prone, so we fallback
+    // to normal compaction.
+    if (is_pk_table && !config::enable_pk_index_parallel_execution) {
+        VLOG(1) << "Parallel compaction: tablet=" << tablet_id << " txn=" << txn_id
+                << " fallback to normal compaction because enable_pk_index_parallel_execution is disabled";
+        return 0;
+    }
+    if (!is_pk_table && !config::enable_size_tiered_compaction_strategy) {
+        VLOG(1) << "Parallel compaction: tablet=" << tablet_id << " txn=" << txn_id
+                << " fallback to normal compaction because non-PK table with default compaction strategy";
+        return 0;
+    }
+
+    // Step 1: Pick rowsets for compaction
+    ASSIGN_OR_RETURN(auto all_rowsets, pick_rowsets_for_compaction(tablet_id, txn_id, version, force_base_compaction));
+    size_t total_rowsets_count = all_rowsets.size();
+
+    // Step 2: Split rowsets into groups
+    auto valid_groups =
+            split_rowsets_into_groups(tablet_id, std::move(all_rowsets), max_parallel, max_bytes, is_pk_table);
+
+    if (valid_groups.empty()) {
+        // Empty groups means we should fallback to normal compaction flow.
+        // This happens when:
+        // 1. Total data size is less than max_bytes_per_subtask (no parallelism benefit)
+        // 2. Not enough rowsets for parallel compaction
+        // 3. Has delete predicate
+        // 4. max_parallel <= 1
+        // Return 0 to indicate fallback to normal compaction (not an error).
+        VLOG(1) << "Parallel compaction: tablet=" << tablet_id << " txn=" << txn_id
+                << " fallback to normal compaction, total_rowsets=" << total_rowsets_count;
+        return 0;
+    }
+
+    VLOG(1) << "Parallel compaction: tablet=" << tablet_id << " created " << valid_groups.size() << " groups from "
+            << total_rowsets_count << " rowsets";
+
+    // Step 3: Create and register tablet state
+    ASSIGN_OR_RETURN(auto state_ptr, create_and_register_tablet_state(tablet_id, txn_id, version, max_parallel,
+                                                                      max_bytes, std::move(callback), release_token));
+
+    // Step 4: Submit subtasks
+    return submit_subtasks(std::move(state_ptr), std::move(valid_groups), force_base_compaction, thread_pool,
+                           acquire_token, release_token);
+}
+
+std::shared_ptr<TabletParallelCompactionState> TabletParallelCompactionManager::get_tablet_state(int64_t tablet_id,
+                                                                                                 int64_t txn_id) {
+    std::string state_key = make_state_key(tablet_id, txn_id);
+    std::lock_guard<std::mutex> lock(_states_mutex);
+    auto it = _tablet_states.find(state_key);
+    if (it == _tablet_states.end()) {
+        return nullptr;
+    }
+    return it->second; // Return shared_ptr copy to keep state alive
+}
+
+void TabletParallelCompactionManager::on_subtask_complete(int64_t tablet_id, int64_t txn_id, int32_t subtask_id,
+                                                          std::unique_ptr<CompactionTaskContext> context) {
+    std::string state_key = make_state_key(tablet_id, txn_id);
+
+    // Get a shared_ptr copy to prevent use-after-free if cleanup_tablet is called concurrently.
+    // The shared_ptr keeps the state alive even if it's removed from _tablet_states map.
+    std::shared_ptr<TabletParallelCompactionState> state;
+    {
+        std::lock_guard<std::mutex> lock(_states_mutex);
+        auto it = _tablet_states.find(state_key);
+        if (it == _tablet_states.end()) {
+            // State was cleaned up (e.g., due to timeout or cancellation from FE).
+            // We must still decrement the counter since it was incremented in create_parallel_tasks.
+            _running_subtasks--;
+            LOG(WARNING) << "Tablet state not found for subtask completion, tablet=" << tablet_id
+                         << ", txn_id=" << txn_id << ", subtask_id=" << subtask_id
+                         << ". Decremented running_subtasks counter.";
+            return;
+        }
+        state = it->second; // Copy shared_ptr to extend lifetime
+    }
+
+    std::shared_ptr<CompactionTaskCallback> callback;
+    bool all_complete = false;
+
+    {
+        std::lock_guard<std::mutex> lock(state->mutex);
+
+        auto it = state->running_subtasks.find(subtask_id);
+        if (it == state->running_subtasks.end()) {
+            // Subtask was already removed (should not happen in normal flow, but handle defensively).
+            // We must still decrement the counter to prevent counter leakage.
+            _running_subtasks--;
+            LOG(WARNING) << "Subtask not found, tablet=" << tablet_id << ", txn_id=" << txn_id
+                         << ", subtask_id=" << subtask_id << ". Decremented running_subtasks counter.";
+            return;
+        }
+
+        // Unmark rowsets
+        unmark_rowsets_compacting(state.get(), it->second.input_rowset_ids);
+
+        // Move to completed
+        state->completed_subtasks.push_back(std::move(context));
+        state->running_subtasks.erase(it);
+
+        _running_subtasks--;
+        _completed_subtasks++;
+
+        all_complete = state->is_complete();
+        callback = state->callback;
+
+        VLOG(1) << "Parallel compaction subtask completed, tablet=" << tablet_id << ", txn_id=" << txn_id
+                << ", subtask_id=" << subtask_id << ", remaining=" << state->running_subtasks.size()
+                << ", completed=" << state->completed_subtasks.size();
+    }
+
+    // If all subtasks are complete, notify the callback
+    if (all_complete && callback) {
+        // Build merged context
+        // Note: skip_write_txnlog must be true so that merged txn_log is added to response
+        auto merged_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, state->version,
+                                                                      false /* force_base_compaction */,
+                                                                      true /* skip_write_txnlog */, callback);
+
+        // Copy table_id and partition_id from one of the completed subtask contexts.
+        // These values are populated in TabletManager::compact() from shard info,
+        // and are needed for downstream processes (e.g., metrics, catalog operations).
+        {
+            std::lock_guard<std::mutex> lock(state->mutex);
+            for (const auto& subtask_ctx : state->completed_subtasks) {
+                if (subtask_ctx->table_id != 0) {
+                    merged_context->table_id = subtask_ctx->table_id;
+                }
+                if (subtask_ctx->partition_id != 0) {
+                    merged_context->partition_id = subtask_ctx->partition_id;
+                }
+                // All subtasks belong to the same tablet, so table_id and partition_id
+                // should be the same. Break once we've found valid values.
+                if (merged_context->table_id != 0 && merged_context->partition_id != 0) {
+                    break;
+                }
+            }
+        }
+
+        // Merge TxnLogs
+        auto merged_txn_log_or = get_merged_txn_log(tablet_id, txn_id);
+        if (merged_txn_log_or.ok()) {
+            merged_context->txn_log = std::make_unique<TxnLogPB>(std::move(merged_txn_log_or.value()));
+        } else {
+            merged_context->status = merged_txn_log_or.status();
+        }
+
+        // Set status based on subtask statuses
+        // Support partial success: only fail if ALL subtasks failed
+        {
+            std::lock_guard<std::mutex> lock(state->mutex);
+            int successful_count = 0;
+            int failed_count = 0;
+            Status first_failure;
+
+            for (const auto& subtask_ctx : state->completed_subtasks) {
+                if (subtask_ctx->status.ok()) {
+                    successful_count++;
+                } else {
+                    failed_count++;
+                    if (first_failure.ok()) {
+                        first_failure = subtask_ctx->status;
+                    }
+                }
+                // Merge stats from all subtasks (including failed ones for diagnostic purposes)
+                if (subtask_ctx->stats) {
+                    *(merged_context->stats) = *(merged_context->stats) + *(subtask_ctx->stats);
+                }
+            }
+
+            // Only mark as failed if ALL subtasks failed
+            // If at least one subtask succeeded, the compaction is considered (partially) successful
+            if (successful_count == 0 && failed_count > 0) {
+                merged_context->status = first_failure;
+                LOG(WARNING) << "Parallel compaction failed: all " << failed_count
+                             << " subtasks failed for tablet=" << tablet_id << ", txn_id=" << txn_id
+                             << ", first_error=" << first_failure;
+            } else if (failed_count > 0) {
+                // Partial success: some subtasks failed but at least one succeeded
+                VLOG(1) << "Parallel compaction partial success: tablet=" << tablet_id << ", txn_id=" << txn_id
+                        << ", successful=" << successful_count << ", failed=" << failed_count;
+            }
+        }
+
+        // Mark as parallel merged context so that cleanup_tablet will be called
+        // by CompactionScheduler::remove_states after RPC response is sent.
+        // This ensures parallel compaction tasks remain visible in list_tasks
+        // until all tablets complete, consistent with normal compaction behavior.
+        merged_context->is_parallel_merged = true;
+
+        callback->finish_task(std::move(merged_context));
+        // Note: Do NOT call cleanup_tablet here. The cleanup will be done by
+        // CompactionScheduler::remove_states when RPC response is sent.
+    }
+}
+
+bool TabletParallelCompactionManager::is_tablet_complete(int64_t tablet_id, int64_t txn_id) {
+    auto state = get_tablet_state(tablet_id, txn_id);
+    if (state == nullptr) {
+        return true;
+    }
+    std::lock_guard<std::mutex> lock(state->mutex);
+    return state->is_complete();
+}
+
+void TabletParallelCompactionManager::cleanup_tablet(int64_t tablet_id, int64_t txn_id) {
+    std::string state_key = make_state_key(tablet_id, txn_id);
+
+    {
+        std::lock_guard<std::mutex> lock(_states_mutex);
+        auto it = _tablet_states.find(state_key);
+        if (it != _tablet_states.end()) {
+            // Use nested scope to ensure state_lock is released before erase.
+            // Otherwise, erase() destroys the mutex while state_lock still holds it,
+            // causing use-after-free when state_lock's destructor tries to unlock.
+            {
+                std::lock_guard<std::mutex> state_lock(it->second->mutex);
+                // Just access to synchronize, no need to get subtask_count anymore
+            }
+            _tablet_states.erase(it);
+        }
+    }
+
+    // NOTE: Do NOT delete rows mapper files here!
+    // These files are needed by light_publish_primary_compaction which happens in a
+    // separate publish RPC after compaction completes. Each subtask's rows mapper file
+    // is cleaned up by RowsMapperIterator in its destructor during _light_publish_subtask().
+
+    VLOG(1) << "Cleaned up parallel compaction state for tablet " << tablet_id << ", txn_id=" << txn_id;
+}
+
+StatusOr<TxnLogPB> TabletParallelCompactionManager::get_merged_txn_log(int64_t tablet_id, int64_t txn_id) {
+    auto state = get_tablet_state(tablet_id, txn_id);
+    if (state == nullptr) {
+        return Status::NotFound(strings::Substitute(
+                "Tablet state not found for get_merged_txn_log: tablet_id=$0, txn_id=$1", tablet_id, txn_id));
+    }
+
+    TxnLogPB merged_log;
+    merged_log.set_tablet_id(tablet_id);
+    merged_log.set_txn_id(txn_id);
+
+    // Use the new OpParallelCompaction format
+    auto* op_parallel = merged_log.mutable_op_parallel_compaction();
+
+    // Variables to be used outside the lock
+    int64_t version = 0;
+    std::vector<int32_t> success_subtask_ids;
+
+    {
+        std::lock_guard<std::mutex> lock(state->mutex);
+
+        // Cache version for use outside the lock
+        version = state->version;
+
+        // Sort completed_subtasks by subtask_id to ensure consistent ordering
+        // This is critical because rows_mapper files are merged by subtask_id order,
+        // so segments must also be merged in the same order.
+        std::sort(state->completed_subtasks.begin(), state->completed_subtasks.end(),
+                  [](const std::unique_ptr<CompactionTaskContext>& a, const std::unique_ptr<CompactionTaskContext>& b) {
+                      return a->subtask_id < b->subtask_id;
+                  });
+
+        // Collect successful subtask IDs (unified logic for both PK and non-PK tables)
+        // All successful subtasks are included regardless of whether they are consecutive.
+        success_subtask_ids = collect_success_subtask_ids(state->completed_subtasks, tablet_id, txn_id);
+
+        // If no successful subtasks, return error
+        if (success_subtask_ids.empty()) {
+            return Status::InternalError(strings::Substitute(
+                    "All subtasks failed for parallel compaction: tablet_id=$0, txn_id=$1, total_subtasks=$2",
+                    tablet_id, txn_id, state->completed_subtasks.size()));
+        }
+
+        std::unordered_set<int32_t> success_subtask_id_set(success_subtask_ids.begin(), success_subtask_ids.end());
+
+        // Fill subtask_compactions: each successful subtask's OpCompaction is copied directly
+        // This allows reusing publish_primary_compaction for each subtask during apply
+        for (const auto& ctx : state->completed_subtasks) {
+            if (success_subtask_id_set.count(ctx->subtask_id) == 0) {
+                continue;
+            }
+            if (ctx->txn_log == nullptr || !ctx->txn_log->has_op_compaction()) {
+                continue;
+            }
+
+            // Copy the entire OpCompaction from this subtask
+            // Note: SST compaction fields (input_sstables/output_sstable) should be empty in subtask
+            auto* subtask_compaction = op_parallel->add_subtask_compactions();
+            subtask_compaction->CopyFrom(ctx->txn_log->op_compaction());
+            subtask_compaction->set_subtask_id(ctx->subtask_id);
+        }
+
+        // Record success_subtask_ids for tracking
+        for (int32_t id : success_subtask_ids) {
+            op_parallel->add_success_subtask_ids(id);
+        }
+
+        size_t failed_count = state->completed_subtasks.size() - success_subtask_ids.size();
+        if (failed_count > 0) {
+            VLOG(1) << "Parallel compaction partial success: tablet=" << tablet_id << ", txn_id=" << txn_id
+                    << ", successful=" << success_subtask_ids.size() << ", failed=" << failed_count
+                    << ", success_subtask_ids=[" << JoinInts(success_subtask_ids, ",") << "]";
+        }
+
+        VLOG(1) << "Merged TxnLog for tablet " << tablet_id << ", txn_id=" << txn_id
+                << ", total_subtasks=" << state->completed_subtasks.size()
+                << ", successful_subtasks=" << success_subtask_ids.size()
+                << ", subtask_compactions=" << op_parallel->subtask_compactions_size();
+    }
+    // Lock released here
+
+    // Execute SST compaction once after all subtasks complete.
+    // Store results in OpParallelCompaction (not in individual subtask OpCompactions).
+    RETURN_IF_ERROR(execute_sst_compaction_for_parallel(tablet_id, version, op_parallel));
+
+    return merged_log;
+}
+
+void TabletParallelCompactionManager::mark_rowsets_compacting(TabletParallelCompactionState* state,
+                                                              const std::vector<uint32_t>& rowset_ids) {
+    // Assumes state->mutex is already held
+    for (uint32_t rid : rowset_ids) {
+        state->compacting_rowsets.insert(rid);
+    }
+}
+
+void TabletParallelCompactionManager::unmark_rowsets_compacting(TabletParallelCompactionState* state,
+                                                                const std::vector<uint32_t>& rowset_ids) {
+    // Assumes state->mutex is already held
+    for (uint32_t rid : rowset_ids) {
+        state->compacting_rowsets.erase(rid);
+    }
+}
+
+void TabletParallelCompactionManager::execute_subtask(int64_t tablet_id, int64_t txn_id, int32_t subtask_id,
+                                                      std::vector<RowsetPtr> input_rowsets, int64_t version,
+                                                      bool force_base_compaction,
+                                                      const ReleaseTokenFunc& release_token) {
+    VLOG(1) << "Executing parallel compaction subtask " << subtask_id << " for tablet " << tablet_id
+            << ", txn_id=" << txn_id << ", rowsets=" << input_rowsets.size();
+
+    // Get tablet state and callback
+    auto state = get_tablet_state(tablet_id, txn_id);
+    if (state == nullptr) {
+        // State has been cleaned up (possibly due to timeout or cancellation).
+        // We must still decrement the global counter to prevent counter leakage.
+        // Note: Since state is gone, we cannot call on_subtask_complete or notify the callback.
+        // This is acceptable because state cleanup implies the compaction request has been
+        // abandoned (e.g., timeout from FE side).
+        _running_subtasks--;
+        // Release limiter token
+        if (release_token) {
+            release_token(false);
+        }
+        LOG(WARNING) << "Tablet state not found during subtask execution, tablet=" << tablet_id << ", txn_id=" << txn_id
+                     << ", subtask_id=" << subtask_id << ". Decremented running_subtasks counter.";
+        return;
+    }
+
+    // Create compaction context for this subtask
+    // Note: skip_write_txnlog must be true for parallel compaction, so that txn_log is saved to context
+    // and can be merged later in on_subtask_complete
+    // Pass subtask_id so that rows_mapper files use subtask-specific filenames
+    auto context = CompactionTaskContext::create_for_subtask(txn_id, tablet_id, version, force_base_compaction,
+                                                             true /* skip_write_txnlog */, state->callback, subtask_id);
+
+    auto start_time = ::time(nullptr);
+    context->start_time.store(start_time, std::memory_order_relaxed);
+
+    // Calculate in_queue_time_sec using the enqueue time from SubtaskInfo
+    // Also store context pointer in SubtaskInfo for progress/status tracking in list_tasks()
+    {
+        std::lock_guard<std::mutex> lock(state->mutex);
+        auto it = state->running_subtasks.find(subtask_id);
+        if (it != state->running_subtasks.end()) {
+            int64_t enqueue_time = it->second.start_time;
+            int64_t in_queue_time_sec = start_time > enqueue_time ? (start_time - enqueue_time) : 0;
+            context->stats->in_queue_time_sec += in_queue_time_sec;
+            // Store context pointer for real-time progress/status tracking
+            it->second.context = context.get();
+        }
+    }
+
+    // Create compaction task using pre-selected rowsets
+    auto compaction_task_or = _tablet_mgr->compact(context.get(), std::move(input_rowsets));
+    if (!compaction_task_or.ok()) {
+        LOG(WARNING) << "Failed to create compaction task for tablet " << tablet_id << " subtask " << subtask_id << ": "
+                     << compaction_task_or.status();
+        context->status = compaction_task_or.status();
+        on_subtask_complete(tablet_id, txn_id, subtask_id, std::move(context));
+        // Release limiter token on early return
+        if (release_token) {
+            release_token(compaction_task_or.status().is_mem_limit_exceeded());
+        }
+        return;
+    }
+
+    auto compaction_task = compaction_task_or.value();
+
+    // Increment runs counter to track that this subtask has actually started execution.
+    // This is important for list_tasks() to correctly display the profile for completed subtasks,
+    // as it checks "if (info.runs > 0 && ctx->stats)" before displaying the profile.
+    context->runs.fetch_add(1, std::memory_order_relaxed);
+
+    // Execute compaction
+    // Note: We capture 'this', tablet_id, and txn_id instead of the raw 'state' pointer
+    // because the state could be cleaned up by another thread calling cleanup_tablet()
+    // while this subtask is executing. By capturing stable values and using get_tablet_state()
+    // inside the lambda, we safely check if the state still exists before accessing it.
+    auto cancel_func = [this, tablet_id, txn_id, subtask_id, version]() {
+        // Check if tablet state still exists - if not, the compaction has been cancelled/timed out
+        if (get_tablet_state(tablet_id, txn_id) == nullptr) {
+            return Status::Cancelled(strings::Substitute(
+                    "Tablet parallel compaction state has been cleaned up: tablet_id=$0, txn_id=$1, "
+                    "version=$2, subtask_id=$3",
+                    tablet_id, txn_id, version, subtask_id));
+        }
+        return Status::OK();
+    };
+
+    ThreadPool* flush_pool = nullptr;
+    if (config::lake_enable_compaction_async_write) {
+        flush_pool = StorageEngine::instance()->lake_memtable_flush_executor()->get_thread_pool();
+    }
+
+    auto exec_st = compaction_task->execute(cancel_func, flush_pool);
+
+    auto finish_time = std::max<int64_t>(::time(nullptr), start_time);
+    auto cost = finish_time - start_time;
+
+    if (!exec_st.ok()) {
+        LOG(WARNING) << "Compaction subtask " << subtask_id << " failed for tablet " << tablet_id << ": " << exec_st
+                     << ", cost=" << cost << "s";
+        context->status = exec_st;
+    } else {
+        VLOG(1) << "Compaction subtask " << subtask_id << " completed for tablet " << tablet_id << ", cost=" << cost
+                << "s";
+    }
+
+    context->finish_time.store(finish_time, std::memory_order_release);
+
+    // Check if memory limit was exceeded before moving context
+    bool mem_limit_exceeded = exec_st.is_mem_limit_exceeded();
+
+    // Notify completion
+    on_subtask_complete(tablet_id, txn_id, subtask_id, std::move(context));
+
+    // Release limiter token after subtask completes
+    if (release_token) {
+        release_token(mem_limit_exceeded);
+    }
+}
+
+Status TabletParallelCompactionManager::execute_sst_compaction_for_parallel(
+        int64_t tablet_id, int64_t version, TxnLogPB_OpParallelCompaction* op_parallel) {
+    // Get tablet metadata to check if SST compaction is applicable
+    auto tablet_or = _tablet_mgr->get_tablet(tablet_id, version);
+    if (!tablet_or.ok()) {
+        LOG(WARNING) << "Failed to get tablet for SST compaction, tablet=" << tablet_id << ", version=" << version
+                     << ": " << tablet_or.status();
+        return Status::OK(); // Don't fail the entire compaction for SST compaction failure
+    }
+
+    auto tablet = tablet_or.value();
+    const auto& metadata = tablet.metadata();
+
+    // Check if this is a primary key table with cloud native persistent index
+    if (!metadata || metadata->schema().keys_type() != KeysType::PRIMARY_KEYS) {
+        return Status::OK();
+    }
+
+    if (!metadata->enable_persistent_index() ||
+        metadata->persistent_index_type() != PersistentIndexTypePB::CLOUD_NATIVE) {
+        return Status::OK();
+    }
+
+    // Execute SST compaction
+    VLOG(1) << "Executing unified SST compaction for parallel compaction, tablet=" << tablet_id
+            << ", version=" << version;
+
+    auto* update_mgr = _tablet_mgr->update_mgr();
+    if (update_mgr == nullptr) {
+        LOG(WARNING) << "UpdateManager is null, skip SST compaction for tablet " << tablet_id;
+        return Status::OK();
+    }
+
+    // Use a temporary TxnLogPB to capture SST compaction results
+    TxnLogPB temp_log;
+    auto st = update_mgr->execute_index_major_compaction(metadata, &temp_log);
+    if (!st.ok()) {
+        LOG(WARNING) << "SST compaction failed for tablet " << tablet_id << ": " << st
+                     << ". This will not fail the parallel compaction.";
+        // Don't fail the entire parallel compaction for SST compaction failure
+        // SST compaction can be retried in the next compaction cycle
+        return Status::OK();
+    }
+
+    // Copy SST compaction results from temp_log.op_compaction() to op_parallel
+    if (temp_log.has_op_compaction()) {
+        const auto& temp_op = temp_log.op_compaction();
+
+        // Copy input sstables
+        for (const auto& input_sst : temp_op.input_sstables()) {
+            op_parallel->add_input_sstables()->CopyFrom(input_sst);
+        }
+
+        // Copy output sstable (single output)
+        if (temp_op.has_output_sstable()) {
+            op_parallel->mutable_output_sstable()->CopyFrom(temp_op.output_sstable());
+        }
+
+        // Copy output sstables (multiple outputs from parallel SST compaction)
+        for (const auto& output_sst : temp_op.output_sstables()) {
+            op_parallel->add_output_sstables()->CopyFrom(output_sst);
+        }
+
+        // Log SST compaction results
+        if (!temp_op.input_sstables().empty()) {
+            size_t total_input_sst_size = 0;
+            for (const auto& input_sst : temp_op.input_sstables()) {
+                total_input_sst_size += input_sst.filesize();
+            }
+            VLOG(1) << "SST compaction completed for tablet " << tablet_id
+                    << ", input_ssts=" << temp_op.input_sstables_size() << ", input_size=" << total_input_sst_size;
+        }
+    }
+
+    return Status::OK();
+}
+
+void TabletParallelCompactionManager::list_tasks(std::vector<CompactionTaskInfo>* infos) {
+    std::lock_guard<std::mutex> lock(_states_mutex);
+    for (const auto& [state_key, state_ptr] : _tablet_states) {
+        std::lock_guard<std::mutex> state_lock(state_ptr->mutex);
+
+        // Add running subtasks
+        for (const auto& [subtask_id, subtask_info] : state_ptr->running_subtasks) {
+            auto& info = infos->emplace_back();
+            info.txn_id = state_ptr->txn_id;
+            info.tablet_id = state_ptr->tablet_id;
+            info.version = state_ptr->version;
+            info.skipped = false;
+            info.runs = 1; // Parallel subtasks run once
+            info.start_time = subtask_info.start_time;
+            info.finish_time = 0; // Still running
+            // Get real-time progress from context if available.
+            // Note: We only read progress (which uses atomic operations) for running tasks.
+            // We don't read status here because context->status may be modified concurrently
+            // in execute_subtask() without lock protection, which would cause a data race.
+            // For running tasks, status is always shown as OK (in-progress).
+            // Final status is only available after task completion (in completed_subtasks).
+            if (subtask_info.context != nullptr) {
+                info.progress = subtask_info.context->progress.value();
+            } else {
+                info.progress = 0;
+            }
+            info.status = Status::OK();
+            // Build profile with subtask-specific info
+            info.profile =
+                    fmt::format(R"({{"subtask_id":{},"input_rowsets":{},"input_bytes":{},"is_parallel_subtask":true}})",
+                                subtask_id, subtask_info.input_rowset_ids.size(), subtask_info.input_bytes);
+        }
+
+        // Add completed subtasks that haven't been cleaned up yet
+        for (const auto& ctx : state_ptr->completed_subtasks) {
+            auto& info = infos->emplace_back();
+            info.txn_id = ctx->txn_id;
+            info.tablet_id = ctx->tablet_id;
+            info.version = ctx->version;
+            info.skipped = ctx->skipped.load(std::memory_order_relaxed);
+            info.runs = ctx->runs.load(std::memory_order_relaxed);
+            info.start_time = ctx->start_time.load(std::memory_order_relaxed);
+            info.finish_time = ctx->finish_time.load(std::memory_order_acquire);
+            info.progress = ctx->progress.value();
+            if (info.runs > 0 && ctx->stats) {
+                info.profile = ctx->stats->to_json_stats();
+            }
+            if (info.finish_time > 0) {
+                info.status = ctx->status;
+            }
+        }
+    }
+}
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_parallel_compaction_manager.h
+++ b/be/src/storage/lake/tablet_parallel_compaction_manager.h
@@ -1,0 +1,256 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "common/status.h"
+#include "gen_cpp/lake_service.pb.h"
+#include "storage/lake/compaction_task_context.h"
+#include "storage/lake/rowset.h"
+
+namespace starrocks {
+class ThreadPool;
+}
+
+// Token callbacks for Limiter integration
+// AcquireTokenFunc: Returns true if a token was acquired, false otherwise
+using AcquireTokenFunc = std::function<bool()>;
+// ReleaseTokenFunc: Releases a token, parameter indicates if memory limit was exceeded
+using ReleaseTokenFunc = std::function<void(bool mem_limit_exceeded)>;
+
+namespace starrocks::lake {
+
+class TabletManager;
+class CompactionTaskCallback;
+struct CompactionTaskInfo;
+
+// Subtask info for tracking parallel compaction progress
+struct SubtaskInfo {
+    int32_t subtask_id = 0;
+    std::vector<uint32_t> input_rowset_ids;
+    int64_t input_bytes = 0;
+    int64_t start_time = 0;
+    // Pointer to the running context (valid only during execution)
+    // Used to get real-time progress and status in list_tasks()
+    CompactionTaskContext* context = nullptr;
+};
+
+// Single tablet's parallel compaction state
+struct TabletParallelCompactionState {
+    int64_t tablet_id = 0;
+    int64_t txn_id = 0;
+    int64_t version = 0;
+
+    // Rowsets currently being compacted (to avoid conflicts)
+    std::unordered_set<uint32_t> compacting_rowsets;
+
+    // Running subtasks
+    std::unordered_map<int32_t, SubtaskInfo> running_subtasks;
+
+    // Completed subtask contexts
+    std::vector<std::unique_ptr<CompactionTaskContext>> completed_subtasks;
+
+    // Configuration
+    int32_t max_parallel = 0;
+    int64_t max_bytes_per_subtask = 0;
+
+    // Next subtask ID
+    int32_t next_subtask_id = 0;
+
+    // Total number of subtasks created
+    int32_t total_subtasks_created = 0;
+
+    // Callback for the original compaction request
+    std::shared_ptr<CompactionTaskCallback> callback;
+
+    // Callback to release limiter token when subtask completes
+    ReleaseTokenFunc release_token;
+
+    // Mutex for thread-safe access
+    mutable std::mutex mutex;
+
+    // Check if we can create a new subtask
+    bool can_create_subtask() const { return running_subtasks.size() < static_cast<size_t>(max_parallel); }
+
+    // Check if a rowset is being compacted
+    bool is_rowset_compacting(uint32_t rowset_id) const { return compacting_rowsets.count(rowset_id) > 0; }
+
+    // Check if all subtasks are completed
+    bool is_complete() const { return running_subtasks.empty() && total_subtasks_created > 0; }
+};
+
+// Manager for per-tablet parallel compaction
+// This enables running multiple compaction tasks concurrently within a single tablet
+// by selecting non-overlapping rowset groups for each subtask.
+class TabletParallelCompactionManager {
+public:
+    explicit TabletParallelCompactionManager(TabletManager* tablet_mgr);
+    ~TabletParallelCompactionManager();
+
+    // Create parallel compaction tasks for a tablet
+    // Returns the number of subtasks created
+    StatusOr<int> create_parallel_tasks(int64_t tablet_id, int64_t txn_id, int64_t version,
+                                        const TabletParallelConfig& config,
+                                        std::shared_ptr<CompactionTaskCallback> callback, bool force_base_compaction,
+                                        ThreadPool* thread_pool, const AcquireTokenFunc& acquire_token,
+                                        const ReleaseTokenFunc& release_token);
+
+    // Get tablet's parallel state (for testing/monitoring)
+    // Returns shared_ptr to ensure the state remains valid while being used.
+    std::shared_ptr<TabletParallelCompactionState> get_tablet_state(int64_t tablet_id, int64_t txn_id);
+
+    // Subtask completion callback
+    void on_subtask_complete(int64_t tablet_id, int64_t txn_id, int32_t subtask_id,
+                             std::unique_ptr<CompactionTaskContext> context);
+
+    // Check if all subtasks for a tablet are complete
+    bool is_tablet_complete(int64_t tablet_id, int64_t txn_id);
+
+    // Cleanup tablet state after all subtasks complete
+    void cleanup_tablet(int64_t tablet_id, int64_t txn_id);
+
+    // Get merged TxnLog from all completed subtasks
+    StatusOr<TxnLogPB> get_merged_txn_log(int64_t tablet_id, int64_t txn_id);
+
+    // Metrics
+    int64_t running_subtasks() const { return _running_subtasks.load(); }
+    int64_t completed_subtasks() const { return _completed_subtasks.load(); }
+
+    // List all running parallel compaction tasks for monitoring
+    // Forward declaration of CompactionTaskInfo is in compaction_scheduler.h
+    void list_tasks(std::vector<CompactionTaskInfo>* infos);
+
+    // Test-only: Register a pre-created tablet state for unit testing
+    // This allows tests to bypass the normal create_parallel_tasks flow
+    void register_tablet_state_for_test(int64_t tablet_id, int64_t txn_id,
+                                        std::shared_ptr<TabletParallelCompactionState> state) {
+        std::lock_guard<std::mutex> lock(_states_mutex);
+        std::string key = make_state_key(tablet_id, txn_id);
+        _tablet_states[key] = std::move(state);
+    }
+
+private:
+    // Mark rowsets as being compacted
+    void mark_rowsets_compacting(TabletParallelCompactionState* state, const std::vector<uint32_t>& rowset_ids);
+
+    // Unmark rowsets after compaction completes
+    void unmark_rowsets_compacting(TabletParallelCompactionState* state, const std::vector<uint32_t>& rowset_ids);
+
+    // Execute a single subtask
+    void execute_subtask(int64_t tablet_id, int64_t txn_id, int32_t subtask_id, std::vector<RowsetPtr> input_rowsets,
+                         int64_t version, bool force_base_compaction, const ReleaseTokenFunc& release_token);
+
+    // Execute SST compaction once after all subtasks complete
+    // This is called from get_merged_txn_log to perform unified SST compaction
+    // Results are stored in OpParallelCompaction instead of OpCompaction
+    Status execute_sst_compaction_for_parallel(int64_t tablet_id, int64_t version,
+                                               TxnLogPB_OpParallelCompaction* op_parallel);
+
+    // Pick rowsets for compaction using CompactionPolicy
+    StatusOr<std::vector<RowsetPtr>> pick_rowsets_for_compaction(int64_t tablet_id, int64_t txn_id, int64_t version,
+                                                                 bool force_base_compaction);
+
+    // Split rowsets into groups for parallel compaction
+    // Returns empty vector if no valid groups can be formed
+    // is_pk_table: if true, skip adjacency gap detection (PK tables don't require adjacent rowsets)
+    std::vector<std::vector<RowsetPtr>> split_rowsets_into_groups(int64_t tablet_id, std::vector<RowsetPtr> all_rowsets,
+                                                                  int32_t max_parallel, int64_t max_bytes,
+                                                                  bool is_pk_table);
+
+    // Create and register tablet state for parallel compaction
+    // Returns nullptr if state already exists
+    StatusOr<std::shared_ptr<TabletParallelCompactionState>> create_and_register_tablet_state(
+            int64_t tablet_id, int64_t txn_id, int64_t version, int32_t max_parallel, int64_t max_bytes,
+            std::shared_ptr<CompactionTaskCallback> callback, const ReleaseTokenFunc& release_token);
+
+    // Submit subtasks to thread pool
+    // Returns the number of subtasks successfully submitted
+    StatusOr<int> submit_subtasks(const std::shared_ptr<TabletParallelCompactionState>& state_ptr,
+                                  std::vector<std::vector<RowsetPtr>> groups, bool force_base_compaction,
+                                  ThreadPool* thread_pool, const AcquireTokenFunc& acquire_token,
+                                  const ReleaseTokenFunc& release_token);
+
+    // Generate state key from tablet_id and txn_id
+    static std::string make_state_key(int64_t tablet_id, int64_t txn_id) {
+        return std::to_string(tablet_id) + "_" + std::to_string(txn_id);
+    }
+
+    // ================================================================================
+    // Helper structures and functions for split_rowsets_into_groups
+    // ================================================================================
+
+    // Statistics about rowsets for planning parallel compaction
+    struct RowsetStats {
+        int64_t total_bytes = 0;
+        int64_t total_segments = 0;
+        bool has_delete_predicate = false;
+    };
+
+    // Configuration for grouping algorithm
+    struct GroupingConfig {
+        int32_t num_subtasks = 1;
+        int64_t target_bytes_per_subtask = 0;
+        size_t target_rowsets_per_subtask = 2;
+        bool skip_excess_data = false;
+        // Maximum segments per subtask for non-PK tables to avoid partial compaction.
+        // Only applies when enable_lake_compaction_use_partial_segments is true.
+        // 0 means no limit.
+        int64_t max_segments_per_subtask = 0;
+    };
+
+    // Check if a group is valid for compaction
+    static bool _is_group_valid_for_compaction(const std::vector<RowsetPtr>& group);
+
+    // Filter out large non-overlapped rowsets that don't need compaction
+    static std::vector<RowsetPtr> _filter_compactable_rowsets(int64_t tablet_id, std::vector<RowsetPtr> all_rowsets);
+
+    // Calculate statistics about rowsets
+    static RowsetStats _calculate_rowset_stats(const std::vector<RowsetPtr>& rowsets);
+
+    // Calculate optimal grouping configuration
+    static GroupingConfig _calculate_grouping_config(int64_t tablet_id, const std::vector<RowsetPtr>& rowsets,
+                                                     const RowsetStats& stats, int32_t max_parallel, int64_t max_bytes);
+
+    // Group rowsets into subtasks based on the configuration
+    static std::vector<std::vector<RowsetPtr>> _group_rowsets_into_subtasks(int64_t tablet_id,
+                                                                            std::vector<RowsetPtr> all_rowsets,
+                                                                            const GroupingConfig& config,
+                                                                            int64_t max_bytes, bool is_pk_table);
+
+    // Filter out invalid groups that cannot be compacted
+    static std::vector<std::vector<RowsetPtr>> _filter_invalid_groups(int64_t tablet_id,
+                                                                      std::vector<std::vector<RowsetPtr>> groups);
+
+    TabletManager* _tablet_mgr;
+
+    // State map: key = tablet_id_txn_id
+    // Using shared_ptr to allow safe access from on_subtask_complete even if cleanup_tablet
+    // concurrently removes the state from the map.
+    std::unordered_map<std::string, std::shared_ptr<TabletParallelCompactionState>> _tablet_states;
+    mutable std::mutex _states_mutex;
+
+    // Metrics
+    std::atomic<int64_t> _running_subtasks{0};
+    std::atomic<int64_t> _completed_subtasks{0};
+};
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -16,6 +16,8 @@
 
 #include <fmt/format.h>
 
+#include <climits>
+
 #include "gutil/strings/join.h"
 #include "runtime/current_thread.h"
 #include "storage/lake/lake_primary_index.h"
@@ -228,6 +230,10 @@ public:
             RETURN_IF_ERROR(
                     check_and_recover([&]() { return apply_compaction_log(log.op_compaction(), log.txn_id()); }));
         }
+        if (log.has_op_parallel_compaction()) {
+            RETURN_IF_ERROR(check_and_recover(
+                    [&]() { return apply_parallel_compaction_log(log.op_parallel_compaction(), log.txn_id()); }));
+        }
         if (log.has_op_schema_change()) {
             RETURN_IF_ERROR(apply_schema_change_log(log.op_schema_change()));
         }
@@ -401,8 +407,84 @@ private:
             return Status::OK();
         }
         RETURN_IF_ERROR(prepare_primary_index());
+
+        // Single output compaction
         return _tablet.update_mgr()->publish_primary_compaction(op_compaction, txn_id, *_metadata, _tablet,
                                                                 _index_entry, &_builder, _base_version);
+    }
+
+    // Apply parallel compaction log: process multiple subtask compactions
+    // Each subtask has its own OpCompaction with independent input/output rowsets and lcrm file.
+    // Reuses publish_primary_compaction for each subtask, with pre-check to skip failed subtasks.
+    Status apply_parallel_compaction_log(const TxnLogPB_OpParallelCompaction& op_parallel, int64_t txn_id) {
+        // get lock to avoid gc
+        _tablet.update_mgr()->lock_shard_pk_index_shard(_tablet.id());
+        DeferOp defer([&]() { _tablet.update_mgr()->unlock_shard_pk_index_shard(_tablet.id()); });
+
+        RETURN_IF_ERROR(prepare_primary_index());
+
+        // Process each subtask's OpCompaction
+        for (int i = 0; i < op_parallel.subtask_compactions_size(); i++) {
+            const auto& subtask_op = op_parallel.subtask_compactions(i);
+
+            // Pre-check: verify all input rowsets exist in current metadata
+            // Skip this subtask if any input rowset is missing (partial success handling)
+            if (!_check_input_rowsets_exist(subtask_op)) {
+                std::vector<uint32_t> input_ids(subtask_op.input_rowsets().begin(), subtask_op.input_rowsets().end());
+                LOG(WARNING) << "Parallel compaction subtask " << i << " skipped due to missing input rowsets"
+                             << ", tablet=" << _tablet.id() << ", first_input_ids=["
+                             << JoinInts(std::vector<uint32_t>(input_ids.begin(),
+                                                               input_ids.begin() + std::min(5, (int)input_ids.size())),
+                                         ",")
+                             << "]";
+                continue;
+            }
+
+            // Reuse publish_primary_compaction for each subtask
+            // - Internal conflict check is performed per subtask
+            // - Light publish uses subtask's lcrm_file
+            // - Primary index and metadata are updated
+            RETURN_IF_ERROR(_tablet.update_mgr()->publish_primary_compaction(subtask_op, txn_id, *_metadata, _tablet,
+                                                                             _index_entry, &_builder, _base_version));
+        }
+
+        // Apply unified SST compaction results (if any)
+        // SST compaction is tablet-level, executed once after all subtasks complete
+        // Reuse apply_opcompaction by constructing a temporary OpCompaction from OpParallelCompaction
+        if (!op_parallel.input_sstables().empty() || op_parallel.has_output_sstable() ||
+            !op_parallel.output_sstables().empty()) {
+            TxnLogPB_OpCompaction sst_op;
+            for (const auto& input_sst : op_parallel.input_sstables()) {
+                sst_op.add_input_sstables()->CopyFrom(input_sst);
+            }
+            if (op_parallel.has_output_sstable()) {
+                sst_op.mutable_output_sstable()->CopyFrom(op_parallel.output_sstable());
+            }
+            for (const auto& output_sst : op_parallel.output_sstables()) {
+                sst_op.add_output_sstables()->CopyFrom(output_sst);
+            }
+            RETURN_IF_ERROR(_index_entry->value().apply_opcompaction(*_metadata, sst_op));
+            _builder.remove_compacted_sst(sst_op);
+        }
+
+        return Status::OK();
+    }
+
+    // Helper function: check if all input rowsets exist in current metadata
+    bool _check_input_rowsets_exist(const TxnLogPB_OpCompaction& op) const {
+        for (uint32_t input_id : op.input_rowsets()) {
+            bool found = false;
+            for (const auto& rowset : _metadata->rowsets()) {
+                if (rowset.id() == input_id) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                return false;
+            }
+        }
+        return true;
     }
 
     Status apply_schema_change_log(const TxnLogPB_OpSchemaChange& op_schema_change) {
@@ -565,6 +647,9 @@ public:
         }
         if (log.has_op_compaction()) {
             RETURN_IF_ERROR(apply_compaction_log(log.op_compaction()));
+        }
+        if (log.has_op_parallel_compaction()) {
+            RETURN_IF_ERROR(apply_parallel_compaction_log(log.op_parallel_compaction()));
         }
         if (log.has_op_schema_change()) {
             RETURN_IF_ERROR(apply_schema_change_log(log.op_schema_change()));
@@ -732,6 +817,39 @@ private:
     }
 
     Status apply_compaction_log(const TxnLogPB_OpCompaction& op_compaction) {
+        // Single output compaction (standard format)
+        return apply_compaction_log_single_output(op_compaction);
+    }
+
+    // Apply parallel compaction log: process multiple subtask compactions
+    // Each subtask has its own OpCompaction in subtask_compactions.
+    // Reuses apply_compaction_log_single_output for each subtask.
+    //
+    // NOTE: Parallel compaction only supports:
+    // 1. PK tables (cumulative_point is always 0)
+    // 2. Non-PK tables with size-tiered compaction strategy (cumulative_point is always 0)
+    // Non-PK tables with default (base+cumulative) strategy are NOT supported and will
+    // fallback to normal compaction in TabletParallelCompactionManager.
+    // Therefore, we don't need complex cumulative_point calculation here.
+    Status apply_parallel_compaction_log(const TxnLogPB_OpParallelCompaction& op_parallel) {
+        // Process each subtask's OpCompaction by reusing apply_compaction_log_single_output
+        // All errors (including missing rowsets) are propagated immediately.
+        for (int subtask_idx = 0; subtask_idx < op_parallel.subtask_compactions_size(); subtask_idx++) {
+            const auto& subtask_op = op_parallel.subtask_compactions(subtask_idx);
+            RETURN_IF_ERROR(apply_compaction_log_single_output(subtask_op));
+            VLOG(1) << "Applied parallel compaction subtask " << subtask_idx << ", tablet=" << _metadata->id();
+        }
+
+        // Set cumulative point to 0.
+        // Parallel compaction only supports PK tables and size-tiered non-PK tables,
+        // both of which don't use cumulative_point (always 0).
+        _metadata->set_cumulative_point(0);
+
+        return Status::OK();
+    }
+
+    // Apply compaction with single merged output (standard format)
+    Status apply_compaction_log_single_output(const TxnLogPB_OpCompaction& op_compaction) {
         // It's ok to have a compaction log without input rowset and output rowset.
         if (op_compaction.input_rowsets().empty()) {
             DCHECK(!op_compaction.has_output_rowset() || op_compaction.output_rowset().num_rows() == 0);

--- a/be/src/storage/rows_mapper.cpp
+++ b/be/src/storage/rows_mapper.cpp
@@ -16,6 +16,7 @@
 
 #include <fmt/format.h>
 
+#include "common/config.h"
 #include "fs/fs.h"
 #include "lake/filenames.h"
 #include "storage/data_dir.h"

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -538,6 +538,7 @@ SET(DW_TEST_FILES
     ./storage/lake/tablet_manager_test.cpp
     ./storage/lake/tablet_range_helper_test.cpp
     ./storage/lake/sst_seek_range_test.cpp
+    ./storage/lake/tablet_parallel_compaction_manager_test.cpp
     ./storage/lake/tablet_reader_test.cpp
     ./storage/lake/tablet_retain_info_test.cpp
     ./storage/lake/tablet_test.cpp

--- a/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
+++ b/be/test/storage/lake/tablet_parallel_compaction_manager_test.cpp
@@ -1,0 +1,2500 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/tablet_parallel_compaction_manager.h"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <future>
+
+#include "storage/lake/compaction_scheduler.h"
+#include "storage/lake/compaction_task_context.h"
+#include "storage/lake/test_util.h"
+#include "testutil/assert.h"
+#include "testutil/id_generator.h"
+#include "util/threadpool.h"
+
+namespace starrocks::lake {
+
+class TestClosure : public google::protobuf::Closure {
+public:
+    void Run() override {
+        std::lock_guard<std::mutex> lock(_mutex);
+        _finished = true;
+        _cv.notify_all();
+    }
+
+    bool wait_finish(int64_t timeout_ms = 5000) {
+        std::unique_lock<std::mutex> lock(_mutex);
+        return _cv.wait_for(lock, std::chrono::milliseconds(timeout_ms), [this] { return _finished; });
+    }
+
+    bool is_finished() {
+        std::lock_guard<std::mutex> lock(_mutex);
+        return _finished;
+    }
+
+private:
+    std::mutex _mutex;
+    std::condition_variable _cv;
+    bool _finished = false;
+};
+
+class TabletParallelCompactionStateTest : public ::testing::Test {
+protected:
+    void SetUp() override { _state = std::make_unique<TabletParallelCompactionState>(); }
+
+    std::unique_ptr<TabletParallelCompactionState> _state;
+};
+
+TEST_F(TabletParallelCompactionStateTest, test_can_create_subtask) {
+    _state->max_parallel = 3;
+
+    // Initially no running subtasks, should be able to create
+    EXPECT_TRUE(_state->can_create_subtask());
+
+    // Add running subtasks up to max
+    for (int i = 0; i < 3; i++) {
+        SubtaskInfo info;
+        info.subtask_id = i;
+        _state->running_subtasks[i] = std::move(info);
+    }
+    EXPECT_FALSE(_state->can_create_subtask());
+
+    // Remove one, should be able to create again
+    _state->running_subtasks.erase(0);
+    EXPECT_TRUE(_state->can_create_subtask());
+}
+
+TEST_F(TabletParallelCompactionStateTest, test_is_rowset_compacting) {
+    EXPECT_FALSE(_state->is_rowset_compacting(1));
+    EXPECT_FALSE(_state->is_rowset_compacting(2));
+
+    _state->compacting_rowsets.insert(1);
+    _state->compacting_rowsets.insert(3);
+
+    EXPECT_TRUE(_state->is_rowset_compacting(1));
+    EXPECT_FALSE(_state->is_rowset_compacting(2));
+    EXPECT_TRUE(_state->is_rowset_compacting(3));
+}
+
+TEST_F(TabletParallelCompactionStateTest, test_is_complete) {
+    // No subtasks created yet
+    EXPECT_FALSE(_state->is_complete());
+
+    // Create subtasks
+    _state->total_subtasks_created = 2;
+    SubtaskInfo info1, info2;
+    info1.subtask_id = 0;
+    info2.subtask_id = 1;
+    _state->running_subtasks[0] = std::move(info1);
+    _state->running_subtasks[1] = std::move(info2);
+
+    // Still running
+    EXPECT_FALSE(_state->is_complete());
+
+    // Complete one
+    _state->running_subtasks.erase(0);
+    EXPECT_FALSE(_state->is_complete());
+
+    // Complete all
+    _state->running_subtasks.erase(1);
+    EXPECT_TRUE(_state->is_complete());
+}
+
+class TabletParallelCompactionManagerTest : public TestBase {
+public:
+    TabletParallelCompactionManagerTest() : TestBase(kTestDirectory) { clear_and_init_test_dir(); }
+
+protected:
+    constexpr static const char* kTestDirectory = "test_tablet_parallel_compaction_manager";
+
+    void SetUp() override {
+        _tablet_metadata = generate_simple_tablet_metadata(DUP_KEYS);
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+        _manager = std::make_unique<TabletParallelCompactionManager>(_tablet_mgr.get());
+
+        ThreadPoolBuilder("test_pool")
+                .set_min_threads(0)
+                .set_max_threads(1) // Use 1 thread to allow execution if needed, or 0 to block
+                .build(&_thread_pool);
+    }
+
+    void TearDown() override {
+        _manager.reset();
+        if (_thread_pool) {
+            _thread_pool->shutdown();
+        }
+        remove_test_dir_ignore_error();
+    }
+
+    void create_tablet_with_rowsets(int64_t tablet_id, int num_rowsets, int64_t rowset_size) {
+        create_tablet_with_rowsets_internal(tablet_id, num_rowsets, rowset_size, DUP_KEYS);
+    }
+
+    void create_pk_tablet_with_rowsets(int64_t tablet_id, int num_rowsets, int64_t rowset_size) {
+        create_tablet_with_rowsets_internal(tablet_id, num_rowsets, rowset_size, PRIMARY_KEYS);
+    }
+
+    void create_tablet_with_rowsets_internal(int64_t tablet_id, int num_rowsets, int64_t rowset_size,
+                                             KeysType keys_type) {
+        auto metadata = generate_simple_tablet_metadata(keys_type);
+        metadata->set_id(tablet_id);
+        metadata->set_version(num_rowsets + 1);
+
+        for (int i = 0; i < num_rowsets; i++) {
+            auto* rowset = metadata->add_rowsets();
+            rowset->set_id(i);
+            rowset->set_overlapped(true);
+            rowset->set_num_rows(100);
+            rowset->set_data_size(rowset_size);
+
+            std::string segment_name = fmt::format("segment_{}.dat", i);
+            rowset->add_segments(segment_name);
+            rowset->add_segment_size(rowset_size);
+
+            // Create dummy segment file
+            std::string path = _lp->segment_location(tablet_id, segment_name);
+            std::string dir = std::filesystem::path(path).parent_path().string();
+            CHECK_OK(fs::create_directories(dir));
+            auto fs = FileSystem::CreateSharedFromString(path);
+            auto st = fs.value()->new_writable_file(path);
+            CHECK_OK(st.status());
+            CHECK_OK(st.value()->append("dummy_segment_data"));
+            CHECK_OK(st.value()->close());
+            CHECK_OK(st.status());
+        }
+
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*metadata));
+    }
+
+    std::shared_ptr<TabletMetadata> _tablet_metadata;
+    std::unique_ptr<TabletParallelCompactionManager> _manager;
+    std::unique_ptr<ThreadPool> _thread_pool;
+};
+
+TEST_F(TabletParallelCompactionManagerTest, test_get_tablet_state_not_exist) {
+    int64_t tablet_id = 12345;
+    int64_t txn_id = 67890;
+
+    auto state = _manager->get_tablet_state(tablet_id, txn_id);
+    EXPECT_EQ(nullptr, state);
+}
+
+TEST_F(TabletParallelCompactionManagerTest, test_is_tablet_complete_not_exist) {
+    int64_t tablet_id = 12345;
+    int64_t txn_id = 67890;
+
+    // Non-existent tablet should return true (considered complete)
+    EXPECT_TRUE(_manager->is_tablet_complete(tablet_id, txn_id));
+}
+
+TEST_F(TabletParallelCompactionManagerTest, test_cleanup_tablet) {
+    int64_t tablet_id = 12345;
+    int64_t txn_id = 67890;
+
+    // Cleanup non-existent tablet should not crash
+    _manager->cleanup_tablet(tablet_id, txn_id);
+}
+
+TEST_F(TabletParallelCompactionManagerTest, test_get_merged_txn_log_not_exist) {
+    int64_t tablet_id = 12345;
+    int64_t txn_id = 67890;
+
+    auto result = _manager->get_merged_txn_log(tablet_id, txn_id);
+    EXPECT_FALSE(result.ok());
+    EXPECT_TRUE(result.status().is_not_found());
+}
+
+TEST_F(TabletParallelCompactionManagerTest, test_metrics_initial_value) {
+    EXPECT_EQ(0, _manager->running_subtasks());
+    EXPECT_EQ(0, _manager->completed_subtasks());
+}
+
+TEST_F(TabletParallelCompactionManagerTest, test_on_subtask_complete_not_exist) {
+    int64_t tablet_id = 12345;
+    int64_t txn_id = 67890;
+    int32_t subtask_id = 0;
+
+    auto context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, 1, false, true, nullptr);
+
+    // Should not crash when state not exist
+    _manager->on_subtask_complete(tablet_id, txn_id, subtask_id, std::move(context));
+}
+
+TEST_F(TabletParallelCompactionManagerTest, test_create_parallel_tasks_two_groups) {
+    int64_t tablet_id = 10001;
+    int64_t txn_id = 20001;
+    int64_t version = 11;
+
+    // Create 10 rowsets, each 1MB (total 10MB)
+    create_tablet_with_rowsets(tablet_id, 10, 1024 * 1024);
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(2);
+    config.set_max_bytes_per_subtask(5 * 1024 * 1024); // 5MB per subtask, will create 2 groups
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    // Use a thread pool with 1 thread
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("test_pool").set_max_threads(1).build(&pool);
+
+    // Submit a blocking task to occupy the thread
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+    std::promise<void> start_promise;
+
+    pool->submit_func([&]() {
+        start_promise.set_value();
+        block_future.wait();
+    });
+
+    // Wait for the blocking task to start
+    start_promise.get_future().wait();
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; }, [](bool) {});
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(2, st.value()); // Should be 2 groups (10MB / 5MB per group)
+
+    auto state = _manager->get_tablet_state(tablet_id, txn_id);
+    ASSERT_NE(nullptr, state);
+    ASSERT_EQ(2, state->running_subtasks.size());
+    // Each group should have approximately 5 rowsets (5MB each)
+    ASSERT_EQ(5, state->running_subtasks[0].input_rowset_ids.size());
+    ASSERT_EQ(5, state->running_subtasks[1].input_rowset_ids.size());
+
+    // Unblock the thread
+    block_promise.set_value();
+    pool->wait();
+
+    _manager->cleanup_tablet(tablet_id, txn_id);
+}
+
+TEST_F(TabletParallelCompactionManagerTest, test_create_parallel_tasks_multiple_groups) {
+    int64_t tablet_id = 10002;
+    int64_t txn_id = 20002;
+    int64_t version = 11;
+
+    // Create 10 rowsets, each 10MB
+    create_tablet_with_rowsets(tablet_id, 10, 10 * 1024 * 1024);
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(3);
+    config.set_max_bytes_per_subtask(25 * 1024 * 1024); // 25MB limit
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    // Use a thread pool with 1 thread
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("test_pool").set_max_threads(1).build(&pool);
+
+    // Submit a blocking task to occupy the thread
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+    std::promise<void> start_promise;
+
+    pool->submit_func([&]() {
+        start_promise.set_value();
+        block_future.wait();
+    });
+
+    // Wait for the blocking task to start
+    start_promise.get_future().wait();
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; }, [](bool) {});
+    ASSERT_TRUE(st.ok());
+
+    // Total 100MB. Max 25MB per task.
+    // Group 1: 10+10 = 20MB (next is 30 > 25) -> 2 rowsets
+    // Group 2: 10+10 = 20MB -> 2 rowsets
+    // Group 3: 10+10 = 20MB -> 2 rowsets.
+    // Remaining 4 rowsets are skipped because they exceed max_parallel * max_bytes capacity.
+
+    // Expected:
+    // Group 0: 2 rowsets (20MB)
+    // Group 1: 2 rowsets (20MB)
+    // Group 2: 2 rowsets (20MB)
+
+    ASSERT_EQ(3, st.value());
+
+    auto state = _manager->get_tablet_state(tablet_id, txn_id);
+    ASSERT_NE(nullptr, state);
+    ASSERT_EQ(3, state->running_subtasks.size());
+
+    ASSERT_EQ(2, state->running_subtasks[0].input_rowset_ids.size());
+    ASSERT_EQ(2, state->running_subtasks[1].input_rowset_ids.size());
+    ASSERT_EQ(2, state->running_subtasks[2].input_rowset_ids.size());
+
+    // Unblock the thread
+    block_promise.set_value();
+    pool->wait();
+
+    _manager->cleanup_tablet(tablet_id, txn_id);
+}
+
+// Test manual completion flow by directly creating and manipulating TabletParallelCompactionState.
+// This test does NOT use create_parallel_tasks because that function starts real compaction
+// tasks which would fail with mock segment files. Instead, we test the on_subtask_complete
+// and result merging logic directly.
+TEST_F(TabletParallelCompactionManagerTest, test_manual_completion_flow) {
+    int64_t tablet_id = 10003;
+    int64_t txn_id = 20003;
+    int64_t version = 11;
+
+    create_tablet_with_rowsets(tablet_id, 10, 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    // Manually create and register tablet state
+    auto state = std::make_shared<TabletParallelCompactionState>();
+    state->tablet_id = tablet_id;
+    state->txn_id = txn_id;
+    state->version = version;
+    state->max_parallel = 2;
+    state->callback = callback;
+
+    // Create subtask info for 2 subtasks
+    {
+        SubtaskInfo info0;
+        info0.subtask_id = 0;
+        info0.input_rowset_ids = {0, 1, 2, 3, 4};
+        info0.input_bytes = 5 * 1024 * 1024;
+        info0.start_time = ::time(nullptr);
+        state->running_subtasks[0] = std::move(info0);
+        state->total_subtasks_created = 1;
+
+        SubtaskInfo info1;
+        info1.subtask_id = 1;
+        info1.input_rowset_ids = {5, 6, 7, 8, 9};
+        info1.input_bytes = 5 * 1024 * 1024;
+        info1.start_time = ::time(nullptr);
+        state->running_subtasks[1] = std::move(info1);
+        state->total_subtasks_created = 2;
+    }
+
+    // Mark rowsets as compacting
+    for (int i = 0; i < 10; i++) {
+        state->compacting_rowsets.insert(i);
+    }
+
+    // Register the state with manager using the test helper method
+    _manager->register_tablet_state_for_test(tablet_id, txn_id, state);
+
+    // Simulate completion of subtask 0
+    auto ctx0 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx0->subtask_id = 0;
+    ctx0->txn_log = std::make_unique<TxnLogPB>();
+    ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(0);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(50);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_data_size(500);
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 0, std::move(ctx0));
+
+    ASSERT_FALSE(closure.is_finished());
+    ASSERT_FALSE(_manager->is_tablet_complete(tablet_id, txn_id));
+
+    // Simulate completion of subtask 1
+    auto ctx1 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx1->subtask_id = 1;
+    ctx1->txn_log = std::make_unique<TxnLogPB>();
+    ctx1->txn_log->mutable_op_compaction()->add_input_rowsets(5);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(50);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_data_size(500);
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 1, std::move(ctx1));
+
+    ASSERT_TRUE(closure.is_finished());
+
+    // Verify result
+    ASSERT_EQ(1, response.txn_logs_size());
+    const auto& op_parallel = response.txn_logs(0).op_parallel_compaction();
+
+    // Verify subtask_compactions - each subtask has independent output
+    ASSERT_EQ(2, op_parallel.subtask_compactions_size());
+
+    const auto& subtask0 = op_parallel.subtask_compactions(0);
+    EXPECT_EQ(0, subtask0.subtask_id());
+    EXPECT_EQ(1, subtask0.input_rowsets_size());
+    EXPECT_EQ(0, subtask0.input_rowsets(0));
+    EXPECT_TRUE(subtask0.has_output_rowset());
+    EXPECT_EQ(50, subtask0.output_rowset().num_rows());
+    EXPECT_EQ(500, subtask0.output_rowset().data_size());
+
+    const auto& subtask1 = op_parallel.subtask_compactions(1);
+    EXPECT_EQ(1, subtask1.subtask_id());
+    EXPECT_EQ(1, subtask1.input_rowsets_size());
+    EXPECT_EQ(5, subtask1.input_rowsets(0));
+    EXPECT_TRUE(subtask1.has_output_rowset());
+    EXPECT_EQ(50, subtask1.output_rowset().num_rows());
+    EXPECT_EQ(500, subtask1.output_rowset().data_size());
+
+    // In real scenario, cleanup_tablet is called by CompactionScheduler::remove_states.
+    // Since we don't have CompactionScheduler in this test, manually clean up.
+    _manager->cleanup_tablet(tablet_id, txn_id);
+    ASSERT_EQ(nullptr, _manager->get_tablet_state(tablet_id, txn_id));
+}
+
+class SubtaskInfoTest : public ::testing::Test {};
+
+TEST_F(SubtaskInfoTest, test_subtask_info_default_values) {
+    SubtaskInfo info;
+    EXPECT_EQ(0, info.subtask_id);
+    EXPECT_TRUE(info.input_rowset_ids.empty());
+    EXPECT_EQ(0, info.input_bytes);
+    EXPECT_EQ(0, info.start_time);
+}
+
+TEST_F(SubtaskInfoTest, test_subtask_info_set_values) {
+    SubtaskInfo info;
+    info.subtask_id = 5;
+    info.input_rowset_ids = {1, 2, 3};
+    info.input_bytes = 1024 * 1024;
+    info.start_time = 1234567890;
+
+    EXPECT_EQ(5, info.subtask_id);
+    EXPECT_EQ(3, info.input_rowset_ids.size());
+    EXPECT_EQ(1024 * 1024, info.input_bytes);
+    EXPECT_EQ(1234567890, info.start_time);
+}
+
+class TabletParallelCompactionStateFieldsTest : public ::testing::Test {
+protected:
+    void SetUp() override { _state = std::make_unique<TabletParallelCompactionState>(); }
+
+    std::unique_ptr<TabletParallelCompactionState> _state;
+};
+
+TEST_F(TabletParallelCompactionStateFieldsTest, test_default_values) {
+    EXPECT_EQ(0, _state->tablet_id);
+    EXPECT_EQ(0, _state->txn_id);
+    EXPECT_EQ(0, _state->version);
+    EXPECT_EQ(0, _state->max_parallel);
+    EXPECT_EQ(0, _state->max_bytes_per_subtask);
+    EXPECT_EQ(0, _state->next_subtask_id);
+    EXPECT_EQ(0, _state->total_subtasks_created);
+    EXPECT_TRUE(_state->compacting_rowsets.empty());
+    EXPECT_TRUE(_state->running_subtasks.empty());
+    EXPECT_TRUE(_state->completed_subtasks.empty());
+    EXPECT_EQ(nullptr, _state->callback);
+}
+
+TEST_F(TabletParallelCompactionStateFieldsTest, test_set_fields) {
+    _state->tablet_id = 100;
+    _state->txn_id = 200;
+    _state->version = 5;
+    _state->max_parallel = 10;
+    _state->max_bytes_per_subtask = 5368709120L; // 5GB
+    _state->next_subtask_id = 3;
+    _state->total_subtasks_created = 5;
+
+    EXPECT_EQ(100, _state->tablet_id);
+    EXPECT_EQ(200, _state->txn_id);
+    EXPECT_EQ(5, _state->version);
+    EXPECT_EQ(10, _state->max_parallel);
+    EXPECT_EQ(5368709120L, _state->max_bytes_per_subtask);
+    EXPECT_EQ(3, _state->next_subtask_id);
+    EXPECT_EQ(5, _state->total_subtasks_created);
+}
+
+TEST_F(TabletParallelCompactionStateFieldsTest, test_compacting_rowsets_operations) {
+    _state->compacting_rowsets.insert(1);
+    _state->compacting_rowsets.insert(2);
+    _state->compacting_rowsets.insert(3);
+
+    EXPECT_EQ(3, _state->compacting_rowsets.size());
+    EXPECT_TRUE(_state->compacting_rowsets.count(1) > 0);
+    EXPECT_TRUE(_state->compacting_rowsets.count(2) > 0);
+    EXPECT_TRUE(_state->compacting_rowsets.count(3) > 0);
+    EXPECT_FALSE(_state->compacting_rowsets.count(4) > 0);
+
+    _state->compacting_rowsets.erase(2);
+    EXPECT_EQ(2, _state->compacting_rowsets.size());
+    EXPECT_FALSE(_state->compacting_rowsets.count(2) > 0);
+}
+
+TEST_F(TabletParallelCompactionStateFieldsTest, test_running_subtasks_operations) {
+    SubtaskInfo info1;
+    info1.subtask_id = 0;
+    info1.input_bytes = 100;
+
+    SubtaskInfo info2;
+    info2.subtask_id = 1;
+    info2.input_bytes = 200;
+
+    _state->running_subtasks[0] = std::move(info1);
+    _state->running_subtasks[1] = std::move(info2);
+
+    EXPECT_EQ(2, _state->running_subtasks.size());
+    EXPECT_EQ(100, _state->running_subtasks[0].input_bytes);
+    EXPECT_EQ(200, _state->running_subtasks[1].input_bytes);
+
+    _state->running_subtasks.erase(0);
+    EXPECT_EQ(1, _state->running_subtasks.size());
+    EXPECT_TRUE(_state->running_subtasks.find(0) == _state->running_subtasks.end());
+}
+
+TEST_F(TabletParallelCompactionStateFieldsTest, test_completed_subtasks_operations) {
+    auto ctx1 = std::make_unique<CompactionTaskContext>(100, 101, 1, false, true, nullptr);
+    auto ctx2 = std::make_unique<CompactionTaskContext>(100, 102, 1, false, true, nullptr);
+
+    _state->completed_subtasks.push_back(std::move(ctx1));
+    _state->completed_subtasks.push_back(std::move(ctx2));
+
+    EXPECT_EQ(2, _state->completed_subtasks.size());
+    EXPECT_EQ(101, _state->completed_subtasks[0]->tablet_id);
+    EXPECT_EQ(102, _state->completed_subtasks[1]->tablet_id);
+}
+
+// Test for max_bytes <= 0: should use BE config default value and fallback to normal compaction
+// if data size is small
+TEST_F(TabletParallelCompactionManagerTest, test_create_parallel_tasks_default_max_bytes) {
+    int64_t tablet_id = 10010;
+    int64_t txn_id = 20010;
+    int64_t version = 11;
+
+    // Create 10 rowsets, each 1MB (total 10MB, much smaller than default max_bytes ~5GB)
+    create_tablet_with_rowsets(tablet_id, 10, 1024 * 1024);
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(2);
+    config.set_max_bytes_per_subtask(-1); // Invalid, will use BE config default
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("test_pool").set_max_threads(1).build(&pool);
+
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+    std::promise<void> start_promise;
+
+    pool->submit_func([&]() {
+        start_promise.set_value();
+        block_future.wait();
+    });
+
+    start_promise.get_future().wait();
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; }, [](bool) {});
+
+    // When max_bytes <= 0, code uses BE config default value (lake_compaction_max_bytes_per_subtask).
+    // With small data (10MB) and large default max_bytes (~5GB), it falls back to normal compaction.
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(0, st.value()); // Returns 0 indicating fallback to normal compaction
+
+    block_promise.set_value();
+    pool->wait();
+    _manager->cleanup_tablet(tablet_id, txn_id);
+}
+
+// Test for max_parallel <= 0 (line 54-56)
+TEST_F(TabletParallelCompactionManagerTest, test_create_parallel_tasks_invalid_max_parallel) {
+    int64_t tablet_id = 10011;
+    int64_t txn_id = 20011;
+    int64_t version = 11;
+
+    create_tablet_with_rowsets(tablet_id, 10, 1024 * 1024);
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(0); // Invalid, should use 1
+    config.set_max_bytes_per_subtask(100 * 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("test_pool").set_max_threads(1).build(&pool);
+
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+    std::promise<void> start_promise;
+
+    pool->submit_func([&]() {
+        start_promise.set_value();
+        block_future.wait();
+    });
+
+    start_promise.get_future().wait();
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; }, [](bool) {});
+
+    // Should fail with invalid max_parallel
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.status().is_invalid_argument());
+
+    block_promise.set_value();
+    pool->wait();
+    _manager->cleanup_tablet(tablet_id, txn_id);
+}
+
+// Test for tablet not found (line 68)
+TEST_F(TabletParallelCompactionManagerTest, test_create_parallel_tasks_tablet_not_found) {
+    int64_t tablet_id = 99999; // Non-existent tablet
+    int64_t txn_id = 20012;
+    int64_t version = 1;
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(2);
+    config.set_max_bytes_per_subtask(10 * 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, _thread_pool.get(), []() { return true; },
+            [](bool) {});
+
+    ASSERT_FALSE(st.ok());
+}
+
+// Test for already existing parallel compaction (lines 216-217)
+TEST_F(TabletParallelCompactionManagerTest, test_create_parallel_tasks_already_exists) {
+    int64_t tablet_id = 10013;
+    int64_t txn_id = 20013;
+    int64_t version = 11;
+
+    // Create 10 rowsets, each 1MB (total 10MB)
+    create_tablet_with_rowsets(tablet_id, 10, 1024 * 1024);
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(2);
+    // Use 5MB to ensure total_bytes (10MB) > max_bytes, avoiding data_size_small fallback
+    config.set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("test_pool").set_max_threads(1).build(&pool);
+
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+    std::promise<void> start_promise;
+
+    pool->submit_func([&]() {
+        start_promise.set_value();
+        block_future.wait();
+    });
+
+    start_promise.get_future().wait();
+
+    // First creation should succeed and create parallel tasks
+    auto st1 = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; }, [](bool) {});
+    ASSERT_TRUE(st1.ok());
+    ASSERT_GT(st1.value(), 0); // Should create at least 1 group
+
+    // Second creation with same tablet_id and txn_id should fail
+    auto st2 = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; }, [](bool) {});
+    ASSERT_FALSE(st2.ok());
+    ASSERT_TRUE(st2.status().is_already_exist());
+
+    block_promise.set_value();
+    pool->wait();
+    _manager->cleanup_tablet(tablet_id, txn_id);
+}
+
+// Test for acquire_token failure (lines 274-288)
+TEST_F(TabletParallelCompactionManagerTest, test_create_parallel_tasks_acquire_token_failure) {
+    int64_t tablet_id = 10014;
+    int64_t txn_id = 20014;
+    int64_t version = 11;
+
+    // Create 10 rowsets, each 1MB (total 10MB)
+    create_tablet_with_rowsets(tablet_id, 10, 1024 * 1024);
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(2);
+    // Use 5MB to ensure total_bytes (10MB) > max_bytes, avoiding data_size_small fallback
+    config.set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("test_pool").set_max_threads(1).build(&pool);
+
+    // acquire_token always returns false to simulate failure
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return false; }, [](bool) {});
+
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.status().is_resource_busy());
+}
+
+// Test for on_subtask_complete with subtask not found (lines 374-381)
+TEST_F(TabletParallelCompactionManagerTest, test_on_subtask_complete_subtask_not_found) {
+    int64_t tablet_id = 10015;
+    int64_t txn_id = 20015;
+    int64_t version = 11;
+
+    // Create 10 rowsets, each 1MB (total 10MB)
+    create_tablet_with_rowsets(tablet_id, 10, 1024 * 1024);
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(2);
+    // Use 5MB to ensure total_bytes (10MB) > max_bytes, avoiding data_size_small fallback
+    config.set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("test_pool").set_max_threads(1).build(&pool);
+
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+    std::promise<void> start_promise;
+
+    pool->submit_func([&]() {
+        start_promise.set_value();
+        block_future.wait();
+    });
+
+    start_promise.get_future().wait();
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; }, [](bool) {});
+    ASSERT_TRUE(st.ok());
+
+    // Try to complete a non-existent subtask (id 999)
+    auto ctx = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx->subtask_id = 999; // Non-existent subtask
+    _manager->on_subtask_complete(tablet_id, txn_id, 999, std::move(ctx));
+
+    block_promise.set_value();
+    pool->wait();
+    _manager->cleanup_tablet(tablet_id, txn_id);
+}
+
+// Test for list_tasks with running and completed subtasks (lines 786-827)
+TEST_F(TabletParallelCompactionManagerTest, test_list_tasks) {
+    int64_t tablet_id = 10016;
+    int64_t txn_id = 20016;
+    int64_t version = 11;
+
+    create_tablet_with_rowsets(tablet_id, 10, 1024 * 1024);
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(2);
+    config.set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("test_pool").set_max_threads(1).build(&pool);
+
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+    std::promise<void> start_promise;
+
+    pool->submit_func([&]() {
+        start_promise.set_value();
+        block_future.wait();
+    });
+
+    start_promise.get_future().wait();
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; }, [](bool) {});
+    ASSERT_TRUE(st.ok());
+
+    // List tasks while some are running
+    std::vector<CompactionTaskInfo> infos;
+    _manager->list_tasks(&infos);
+
+    // Should have at least one task
+    EXPECT_GE(infos.size(), 1);
+
+    // Check task info
+    for (const auto& info : infos) {
+        EXPECT_EQ(txn_id, info.txn_id);
+        EXPECT_EQ(tablet_id, info.tablet_id);
+        EXPECT_EQ(version, info.version);
+    }
+
+    block_promise.set_value();
+    pool->wait();
+    _manager->cleanup_tablet(tablet_id, txn_id);
+}
+
+// Test for merged TxnLog with overlapped output (lines 520-565)
+TEST_F(TabletParallelCompactionManagerTest, test_merged_txn_log_overlapped) {
+    int64_t tablet_id = 10017;
+    int64_t txn_id = 20017;
+    int64_t version = 11;
+
+    create_tablet_with_rowsets(tablet_id, 10, 1024 * 1024);
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(2);
+    config.set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("blocked_pool").set_max_threads(1).build(&pool);
+
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; },
+            [&](bool) { block_future.wait(); });
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(2, st.value());
+
+    // Simulate completion of subtask 0 with overlapped output
+    auto ctx0 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx0->subtask_id = 0;
+    ctx0->txn_log = std::make_unique<TxnLogPB>();
+    ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(0);
+    ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(1);
+    auto* output0 = ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset();
+    output0->set_num_rows(100);
+    output0->set_data_size(1024);
+    output0->set_overlapped(true);
+    output0->add_segments("segment_0.dat");
+    output0->add_segment_size(512);
+    output0->add_segment_encryption_metas("meta0");
+    ctx0->txn_log->mutable_op_compaction()->set_compact_version(10);
+    ctx0->table_id = 1001;
+    ctx0->partition_id = 2001;
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 0, std::move(ctx0));
+
+    // Simulate completion of subtask 1
+    auto ctx1 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx1->subtask_id = 1;
+    ctx1->txn_log = std::make_unique<TxnLogPB>();
+    ctx1->txn_log->mutable_op_compaction()->add_input_rowsets(5);
+    ctx1->txn_log->mutable_op_compaction()->add_input_rowsets(6);
+    auto* output1 = ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset();
+    output1->set_num_rows(200);
+    output1->set_data_size(2048);
+    output1->set_overlapped(false);
+    output1->add_segments("segment_1.dat");
+    output1->add_segment_size(1024);
+    output1->add_segment_encryption_metas("meta1");
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 1, std::move(ctx1));
+
+    ASSERT_TRUE(closure.is_finished());
+
+    // Verify result
+    ASSERT_EQ(1, response.txn_logs_size());
+    const auto& op_parallel = response.txn_logs(0).op_parallel_compaction();
+
+    // compact_version should be set in subtask_compactions
+    ASSERT_GT(op_parallel.subtask_compactions_size(), 0);
+    const auto& first_subtask = op_parallel.subtask_compactions(0);
+    EXPECT_TRUE(first_subtask.has_compact_version());
+    EXPECT_EQ(10, first_subtask.compact_version());
+
+    // Verify subtask_compactions structure - each subtask has independent output
+    ASSERT_EQ(2, op_parallel.subtask_compactions_size());
+
+    // Subtask 0 output
+    const auto& subtask0 = op_parallel.subtask_compactions(0);
+    EXPECT_EQ(0, subtask0.subtask_id());
+    EXPECT_EQ(2, subtask0.input_rowsets_size());
+    EXPECT_EQ(0, subtask0.input_rowsets(0));
+    EXPECT_EQ(1, subtask0.input_rowsets(1));
+    EXPECT_TRUE(subtask0.has_output_rowset());
+    EXPECT_EQ(100, subtask0.output_rowset().num_rows());
+    EXPECT_TRUE(subtask0.output_rowset().overlapped());
+
+    // Subtask 1 output
+    const auto& subtask1 = op_parallel.subtask_compactions(1);
+    EXPECT_EQ(1, subtask1.subtask_id());
+    EXPECT_EQ(2, subtask1.input_rowsets_size());
+    EXPECT_EQ(5, subtask1.input_rowsets(0));
+    EXPECT_EQ(6, subtask1.input_rowsets(1));
+    EXPECT_TRUE(subtask1.has_output_rowset());
+    EXPECT_EQ(200, subtask1.output_rowset().num_rows());
+
+    block_promise.set_value();
+    pool->wait();
+}
+
+// Test for partial success: one subtask succeeds, one fails
+TEST_F(TabletParallelCompactionManagerTest, test_partial_success_one_succeeded_one_failed) {
+    int64_t tablet_id = 10018;
+    int64_t txn_id = 20018;
+    int64_t version = 11;
+
+    create_tablet_with_rowsets(tablet_id, 10, 1024 * 1024);
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(2);
+    config.set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("blocked_pool").set_max_threads(1).build(&pool);
+
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; },
+            [&](bool) { block_future.wait(); });
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(2, st.value());
+
+    // Simulate completion of subtask 0
+    auto ctx0 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx0->subtask_id = 0;
+    ctx0->txn_log = std::make_unique<TxnLogPB>();
+    ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(0);
+    ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(1);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(50);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_data_size(500);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->add_segments("segment_0.dat");
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 0, std::move(ctx0));
+
+    ASSERT_FALSE(closure.is_finished());
+    ASSERT_FALSE(_manager->is_tablet_complete(tablet_id, txn_id));
+
+    // Simulate completion of subtask 1 with failure
+    auto ctx1 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx1->subtask_id = 1;
+    ctx1->status = Status::InternalError("simulated failure");
+    ctx1->txn_log = std::make_unique<TxnLogPB>();
+    ctx1->txn_log->mutable_op_compaction()->add_input_rowsets(5);
+    ctx1->txn_log->mutable_op_compaction()->add_input_rowsets(6);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(50);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_data_size(500);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->add_segments("segment_1.dat");
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 1, std::move(ctx1));
+
+    ASSERT_TRUE(closure.is_finished());
+
+    // With partial success, the overall status should be OK (one subtask succeeded)
+    EXPECT_EQ(0, response.status().status_code());
+
+    // Verify TxnLog only contains successful subtask's data
+    ASSERT_EQ(1, response.txn_logs_size());
+    const auto& op_parallel = response.txn_logs(0).op_parallel_compaction();
+
+    // success_subtask_ids should only contain subtask 0
+    EXPECT_EQ(1, op_parallel.success_subtask_ids_size());
+    EXPECT_EQ(0, op_parallel.success_subtask_ids(0));
+
+    // Verify subtask_compactions only contains successful subtask
+    ASSERT_EQ(1, op_parallel.subtask_compactions_size());
+    const auto& subtask0 = op_parallel.subtask_compactions(0);
+    EXPECT_EQ(0, subtask0.subtask_id());
+    EXPECT_EQ(2, subtask0.input_rowsets_size());
+    EXPECT_EQ(0, subtask0.input_rowsets(0));
+    EXPECT_EQ(1, subtask0.input_rowsets(1));
+    EXPECT_TRUE(subtask0.has_output_rowset());
+    EXPECT_EQ(50, subtask0.output_rowset().num_rows());
+    EXPECT_EQ(500, subtask0.output_rowset().data_size());
+    EXPECT_EQ(1, subtask0.output_rowset().segments_size());
+    EXPECT_EQ("segment_0.dat", subtask0.output_rowset().segments(0));
+
+    block_promise.set_value();
+    pool->wait();
+}
+
+// Test for data exceeding max_parallel capacity (lines 141-156)
+TEST_F(TabletParallelCompactionManagerTest, test_create_parallel_tasks_exceeds_capacity) {
+    int64_t tablet_id = 10019;
+    int64_t txn_id = 20019;
+    int64_t version = 11;
+
+    // Create 10 rowsets, each 10MB = 100MB total
+    create_tablet_with_rowsets(tablet_id, 10, 10 * 1024 * 1024);
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(2);              // Only allow 2 subtasks
+    config.set_max_bytes_per_subtask(20 * 1024 * 1024); // 20MB per subtask, so 40MB total capacity
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("test_pool").set_max_threads(1).build(&pool);
+
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+    std::promise<void> start_promise;
+
+    pool->submit_func([&]() {
+        start_promise.set_value();
+        block_future.wait();
+    });
+
+    start_promise.get_future().wait();
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; }, [](bool) {});
+    ASSERT_TRUE(st.ok());
+    // Should create max_parallel subtasks (2), skipping excess data
+    ASSERT_EQ(2, st.value());
+
+    auto state = _manager->get_tablet_state(tablet_id, txn_id);
+    ASSERT_NE(nullptr, state);
+    // Each subtask should have limited rowsets
+    ASSERT_EQ(2, state->running_subtasks.size());
+
+    block_promise.set_value();
+    pool->wait();
+    _manager->cleanup_tablet(tablet_id, txn_id);
+}
+
+// Test for stats merging in on_subtask_complete (line 446)
+TEST_F(TabletParallelCompactionManagerTest, test_stats_merging) {
+    int64_t tablet_id = 10020;
+    int64_t txn_id = 20020;
+    int64_t version = 11;
+
+    create_tablet_with_rowsets(tablet_id, 10, 1024 * 1024);
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(2);
+    config.set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("blocked_pool").set_max_threads(1).build(&pool);
+
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; },
+            [&](bool) { block_future.wait(); });
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(2, st.value());
+
+    // Complete subtask 0 with stats
+    auto ctx0 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx0->subtask_id = 0;
+    ctx0->txn_log = std::make_unique<TxnLogPB>();
+    ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(0);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(50);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_data_size(500);
+    ctx0->stats->io_ns_read_remote = 1000;
+    ctx0->stats->io_bytes_read_remote = 2000;
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 0, std::move(ctx0));
+
+    // Complete subtask 1 with stats
+    auto ctx1 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx1->subtask_id = 1;
+    ctx1->txn_log = std::make_unique<TxnLogPB>();
+    ctx1->txn_log->mutable_op_compaction()->add_input_rowsets(5);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(50);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_data_size(500);
+    ctx1->stats->io_ns_read_remote = 3000;
+    ctx1->stats->io_bytes_read_remote = 4000;
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 1, std::move(ctx1));
+
+    ASSERT_TRUE(closure.is_finished());
+
+    block_promise.set_value();
+    pool->wait();
+}
+
+// Test for no rowsets to compact (line 75)
+TEST_F(TabletParallelCompactionManagerTest, test_create_parallel_tasks_no_rowsets) {
+    int64_t tablet_id = 10022;
+    int64_t txn_id = 20022;
+    int64_t version = 1;
+
+    // Create tablet without any rowsets
+    auto metadata = generate_simple_tablet_metadata(DUP_KEYS);
+    metadata->set_id(tablet_id);
+    metadata->set_version(version);
+    // Don't add any rowsets
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*metadata));
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(2);
+    config.set_max_bytes_per_subtask(10 * 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, _thread_pool.get(), []() { return true; },
+            [](bool) {});
+
+    // Should fail because no rowsets to compact
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(st.status().is_not_found());
+}
+
+// Test for valid_groups empty case (line 203)
+TEST_F(TabletParallelCompactionManagerTest, test_create_parallel_tasks_single_small_rowset) {
+    int64_t tablet_id = 10023;
+    int64_t txn_id = 20023;
+    int64_t version = 2;
+
+    // Create tablet with a single non-overlapped rowset (won't be selected for compaction)
+    auto metadata = generate_simple_tablet_metadata(DUP_KEYS);
+    metadata->set_id(tablet_id);
+    metadata->set_version(version);
+
+    // Add a single rowset that's not overlapped
+    auto* rowset = metadata->add_rowsets();
+    rowset->set_id(0);
+    rowset->set_overlapped(false); // Not overlapped, may not be selected
+    rowset->set_num_rows(10);
+    rowset->set_data_size(100);
+    rowset->add_segments("segment_0.dat");
+    rowset->add_segment_size(100);
+
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*metadata));
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(2);
+    config.set_max_bytes_per_subtask(10 * 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, _thread_pool.get(), []() { return true; },
+            [](bool) {});
+
+    // May fail if no rowsets selected, or succeed with single group
+    // This tests the pick_rowsets path
+}
+
+// Test for execute_subtask when state is cleaned up (lines 631-644)
+TEST_F(TabletParallelCompactionManagerTest, test_execute_subtask_state_cleaned_up) {
+    int64_t tablet_id = 10024;
+    int64_t txn_id = 20024;
+    int64_t version = 11;
+
+    // Create 10 rowsets, each 1MB (total 10MB)
+    create_tablet_with_rowsets(tablet_id, 10, 1024 * 1024);
+
+    TabletParallelConfig config;
+    // Use max_parallel=2 and max_bytes=5MB to ensure parallel tasks are created
+    config.set_max_parallel_per_tablet(2);
+    config.set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("test_pool").set_max_threads(4).build(&pool);
+
+    std::atomic<bool> subtask_started{false};
+    std::promise<void> cleanup_done_promise;
+    std::future<void> cleanup_done_future = cleanup_done_promise.get_future();
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; },
+            [&](bool) { subtask_started.store(true); });
+
+    // Wait briefly for subtask to start, then cleanup
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    // Cleanup tablet state while subtask might be running
+    // This tests the path where state is gone during execute_subtask
+    _manager->cleanup_tablet(tablet_id, txn_id);
+
+    pool->wait();
+}
+
+// Test for partial subtask creation when some fail (lines 310-314)
+TEST_F(TabletParallelCompactionManagerTest, test_partial_subtask_creation) {
+    int64_t tablet_id = 10025;
+    int64_t txn_id = 20025;
+    int64_t version = 11;
+
+    // Create 10 rowsets, each 5MB
+    create_tablet_with_rowsets(tablet_id, 10, 5 * 1024 * 1024);
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(3);
+    config.set_max_bytes_per_subtask(15 * 1024 * 1024); // ~15MB per subtask
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("test_pool").set_max_threads(1).build(&pool);
+
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+    std::promise<void> start_promise;
+
+    pool->submit_func([&]() {
+        start_promise.set_value();
+        block_future.wait();
+    });
+
+    start_promise.get_future().wait();
+
+    int acquire_count = 0;
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(),
+            [&]() {
+                acquire_count++;
+                // First acquisition succeeds, subsequent ones fail
+                return acquire_count <= 1;
+            },
+            [](bool) {});
+
+    // Should succeed with at least one subtask
+    ASSERT_TRUE(st.ok());
+    ASSERT_GE(st.value(), 1);
+
+    block_promise.set_value();
+    pool->wait();
+    _manager->cleanup_tablet(tablet_id, txn_id);
+}
+
+// Test for listing completed subtasks (lines 810-826)
+TEST_F(TabletParallelCompactionManagerTest, test_list_tasks_with_completed) {
+    int64_t tablet_id = 10026;
+    int64_t txn_id = 20026;
+    int64_t version = 11;
+
+    create_tablet_with_rowsets(tablet_id, 10, 1024 * 1024);
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(2);
+    config.set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("blocked_pool").set_max_threads(1).build(&pool);
+
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; },
+            [&](bool) { block_future.wait(); });
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(2, st.value());
+
+    // Complete subtask 0
+    auto ctx0 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx0->subtask_id = 0;
+    ctx0->runs.store(1, std::memory_order_relaxed);
+    ctx0->start_time.store(::time(nullptr) - 10, std::memory_order_relaxed);
+    ctx0->finish_time.store(::time(nullptr), std::memory_order_release);
+    ctx0->skipped.store(false, std::memory_order_relaxed);
+    ctx0->txn_log = std::make_unique<TxnLogPB>();
+    ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(0);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(50);
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 0, std::move(ctx0));
+
+    // List tasks - should include completed subtask
+    std::vector<CompactionTaskInfo> infos;
+    _manager->list_tasks(&infos);
+
+    // Should have tasks listed
+    EXPECT_GE(infos.size(), 1);
+
+    // Complete subtask 1 to finish
+    auto ctx1 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx1->subtask_id = 1;
+    ctx1->txn_log = std::make_unique<TxnLogPB>();
+    ctx1->txn_log->mutable_op_compaction()->add_input_rowsets(5);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(50);
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 1, std::move(ctx1));
+
+    ASSERT_TRUE(closure.is_finished());
+
+    block_promise.set_value();
+    pool->wait();
+}
+
+// Test for copying table_id and partition_id from subtask contexts (lines 413-428)
+TEST_F(TabletParallelCompactionManagerTest, test_table_partition_id_copy) {
+    int64_t tablet_id = 10021;
+    int64_t txn_id = 20021;
+    int64_t version = 11;
+
+    create_tablet_with_rowsets(tablet_id, 10, 1024 * 1024);
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(2);
+    config.set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("blocked_pool").set_max_threads(1).build(&pool);
+
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; },
+            [&](bool) { block_future.wait(); });
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(2, st.value());
+
+    // Complete subtask 0 without table_id and partition_id
+    auto ctx0 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx0->subtask_id = 0;
+    ctx0->txn_log = std::make_unique<TxnLogPB>();
+    ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(0);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(50);
+    ctx0->table_id = 0;     // Not set
+    ctx0->partition_id = 0; // Not set
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 0, std::move(ctx0));
+
+    // Complete subtask 1 with table_id and partition_id
+    auto ctx1 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx1->subtask_id = 1;
+    ctx1->txn_log = std::make_unique<TxnLogPB>();
+    ctx1->txn_log->mutable_op_compaction()->add_input_rowsets(5);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(50);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_data_size(500);
+    ctx1->table_id = 12345;
+    ctx1->partition_id = 67890;
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 1, std::move(ctx1));
+
+    ASSERT_TRUE(closure.is_finished());
+
+    block_promise.set_value();
+    pool->wait();
+}
+
+// Test for TxnLog merge without output (lines 520-527, 560-565)
+TEST_F(TabletParallelCompactionManagerTest, test_merged_txn_log_no_output) {
+    int64_t tablet_id = 10027;
+    int64_t txn_id = 20027;
+    int64_t version = 11;
+
+    create_tablet_with_rowsets(tablet_id, 10, 1024 * 1024);
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(2);
+    config.set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("blocked_pool").set_max_threads(1).build(&pool);
+
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; },
+            [&](bool) { block_future.wait(); });
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(2, st.value());
+
+    // Complete subtask 0 with TxnLog but no output_rowset
+    auto ctx0 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx0->subtask_id = 0;
+    ctx0->txn_log = std::make_unique<TxnLogPB>();
+    ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(0);
+    // No output_rowset set
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 0, std::move(ctx0));
+
+    // Complete subtask 1 with TxnLog but no output_rowset
+    auto ctx1 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx1->subtask_id = 1;
+    ctx1->txn_log = std::make_unique<TxnLogPB>();
+    ctx1->txn_log->mutable_op_compaction()->add_input_rowsets(5);
+    // No output_rowset set
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 1, std::move(ctx1));
+
+    ASSERT_TRUE(closure.is_finished());
+
+    // Verify subtask_compactions - each subtask has no output (or empty output)
+    ASSERT_EQ(1, response.txn_logs_size());
+    const auto& op_parallel = response.txn_logs(0).op_parallel_compaction();
+    ASSERT_EQ(2, op_parallel.subtask_compactions_size());
+
+    // Subtasks have input but no output_rowset with data
+    const auto& subtask0 = op_parallel.subtask_compactions(0);
+    EXPECT_EQ(0, subtask0.subtask_id());
+    EXPECT_EQ(1, subtask0.input_rowsets_size());
+    // output_rowset exists but has 0 rows (default value)
+
+    const auto& subtask1 = op_parallel.subtask_compactions(1);
+    EXPECT_EQ(1, subtask1.subtask_id());
+    EXPECT_EQ(1, subtask1.input_rowsets_size());
+
+    block_promise.set_value();
+    pool->wait();
+}
+
+// Test for TxnLog merge without compact_version (lines 567-574)
+TEST_F(TabletParallelCompactionManagerTest, test_merged_txn_log_no_compact_version) {
+    int64_t tablet_id = 10028;
+    int64_t txn_id = 20028;
+    int64_t version = 11;
+
+    create_tablet_with_rowsets(tablet_id, 10, 1024 * 1024);
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(2);
+    config.set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("blocked_pool").set_max_threads(1).build(&pool);
+
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; },
+            [&](bool) { block_future.wait(); });
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(2, st.value());
+
+    // Complete subtask 0 without compact_version
+    auto ctx0 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx0->subtask_id = 0;
+    ctx0->txn_log = std::make_unique<TxnLogPB>();
+    ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(0);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(50);
+    // No compact_version set
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 0, std::move(ctx0));
+
+    // Complete subtask 1
+    auto ctx1 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx1->subtask_id = 1;
+    ctx1->txn_log = std::make_unique<TxnLogPB>();
+    ctx1->txn_log->mutable_op_compaction()->add_input_rowsets(5);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(50);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_data_size(500);
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 1, std::move(ctx1));
+
+    ASSERT_TRUE(closure.is_finished());
+
+    block_promise.set_value();
+    pool->wait();
+}
+
+// Test for subtask with null TxnLog (lines 501-507)
+TEST_F(TabletParallelCompactionManagerTest, test_merged_txn_log_null_txn_log) {
+    int64_t tablet_id = 10029;
+    int64_t txn_id = 20029;
+    int64_t version = 11;
+
+    create_tablet_with_rowsets(tablet_id, 10, 1024 * 1024);
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(2);
+    config.set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("blocked_pool").set_max_threads(1).build(&pool);
+
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; },
+            [&](bool) { block_future.wait(); });
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(2, st.value());
+
+    // Complete subtask 0 with valid TxnLog
+    auto ctx0 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx0->subtask_id = 0;
+    ctx0->txn_log = std::make_unique<TxnLogPB>();
+    ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(0);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(50);
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 0, std::move(ctx0));
+
+    // Complete subtask 1 with null TxnLog
+    auto ctx1 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx1->subtask_id = 1;
+    ctx1->txn_log = nullptr; // Null TxnLog
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 1, std::move(ctx1));
+
+    ASSERT_TRUE(closure.is_finished());
+
+    block_promise.set_value();
+    pool->wait();
+}
+
+// Test for subtask with TxnLog but no op_compaction (lines 501-507, 522-523)
+TEST_F(TabletParallelCompactionManagerTest, test_merged_txn_log_no_op_compaction) {
+    int64_t tablet_id = 10030;
+    int64_t txn_id = 20030;
+    int64_t version = 11;
+
+    create_tablet_with_rowsets(tablet_id, 10, 1024 * 1024);
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(2);
+    config.set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("blocked_pool").set_max_threads(1).build(&pool);
+
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; },
+            [&](bool) { block_future.wait(); });
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(2, st.value());
+
+    // Complete subtask 0 with TxnLog but no op_compaction
+    auto ctx0 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx0->subtask_id = 0;
+    ctx0->txn_log = std::make_unique<TxnLogPB>();
+    // Don't set op_compaction
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 0, std::move(ctx0));
+
+    // Complete subtask 1 with TxnLog but no op_compaction
+    auto ctx1 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx1->subtask_id = 1;
+    ctx1->txn_log = std::make_unique<TxnLogPB>();
+    // Don't set op_compaction
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 1, std::move(ctx1));
+
+    ASSERT_TRUE(closure.is_finished());
+
+    block_promise.set_value();
+    pool->wait();
+}
+
+// Test for two subtasks output with non-overlapped results
+TEST_F(TabletParallelCompactionManagerTest, test_merged_txn_log_two_subtasks) {
+    int64_t tablet_id = 10031;
+    int64_t txn_id = 20031;
+    int64_t version = 11;
+
+    // Create 10 rowsets, each 1MB (total 10MB)
+    create_tablet_with_rowsets(tablet_id, 10, 1024 * 1024);
+
+    TabletParallelConfig config;
+    // Use max_parallel=2 and max_bytes=5MB to create 2 groups
+    config.set_max_parallel_per_tablet(2);
+    config.set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("blocked_pool").set_max_threads(1).build(&pool);
+
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; },
+            [&](bool) { block_future.wait(); });
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(2, st.value()); // Two subtasks
+
+    // Complete subtask 0 with non-overlapped output
+    auto ctx0 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx0->subtask_id = 0;
+    ctx0->txn_log = std::make_unique<TxnLogPB>();
+    ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(0);
+    ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(1);
+    auto* output0 = ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset();
+    output0->set_num_rows(100);
+    output0->set_data_size(1000);
+    output0->set_overlapped(false);
+    output0->add_segments("merged_segment_0.dat");
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 0, std::move(ctx0));
+
+    ASSERT_FALSE(closure.is_finished()); // Not finished yet
+
+    // Complete subtask 1 with non-overlapped output
+    auto ctx1 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx1->subtask_id = 1;
+    ctx1->txn_log = std::make_unique<TxnLogPB>();
+    ctx1->txn_log->mutable_op_compaction()->add_input_rowsets(5);
+    ctx1->txn_log->mutable_op_compaction()->add_input_rowsets(6);
+    auto* output1 = ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset();
+    output1->set_num_rows(200);
+    output1->set_data_size(2000);
+    output1->set_overlapped(false);
+    output1->add_segments("merged_segment_1.dat");
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 1, std::move(ctx1));
+
+    ASSERT_TRUE(closure.is_finished());
+
+    // Verify subtask_compactions for two subtasks
+    ASSERT_EQ(1, response.txn_logs_size());
+    const auto& op_parallel = response.txn_logs(0).op_parallel_compaction();
+    ASSERT_EQ(2, op_parallel.subtask_compactions_size());
+
+    const auto& subtask0 = op_parallel.subtask_compactions(0);
+    EXPECT_EQ(0, subtask0.subtask_id());
+    EXPECT_EQ(2, subtask0.input_rowsets_size());
+    EXPECT_EQ(0, subtask0.input_rowsets(0));
+    EXPECT_EQ(1, subtask0.input_rowsets(1));
+    EXPECT_TRUE(subtask0.has_output_rowset());
+    EXPECT_EQ(100, subtask0.output_rowset().num_rows());
+    EXPECT_EQ(1000, subtask0.output_rowset().data_size());
+    EXPECT_EQ("merged_segment_0.dat", subtask0.output_rowset().segments(0));
+
+    const auto& subtask1 = op_parallel.subtask_compactions(1);
+    EXPECT_EQ(1, subtask1.subtask_id());
+    EXPECT_EQ(2, subtask1.input_rowsets_size());
+    EXPECT_EQ(5, subtask1.input_rowsets(0));
+    EXPECT_EQ(6, subtask1.input_rowsets(1));
+    EXPECT_TRUE(subtask1.has_output_rowset());
+    EXPECT_EQ(200, subtask1.output_rowset().num_rows());
+    EXPECT_EQ(2000, subtask1.output_rowset().data_size());
+    EXPECT_EQ("merged_segment_1.dat", subtask1.output_rowset().segments(0));
+
+    block_promise.set_value();
+    pool->wait();
+}
+
+// Test for metrics after subtask completion
+TEST_F(TabletParallelCompactionManagerTest, test_metrics_after_completion) {
+    int64_t tablet_id = 10032;
+    int64_t txn_id = 20032;
+    int64_t version = 11;
+
+    create_tablet_with_rowsets(tablet_id, 10, 1024 * 1024);
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(2);
+    config.set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("blocked_pool").set_max_threads(1).build(&pool);
+
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+    std::promise<void> start_promise;
+
+    // Submit a blocking task first to occupy the single thread in the pool.
+    // This prevents execute_subtask from running until we unblock it,
+    // avoiding race condition with manual on_subtask_complete calls.
+    pool->submit_func([&]() {
+        start_promise.set_value();
+        block_future.wait();
+    });
+
+    // Wait for blocking task to start
+    start_promise.get_future().wait();
+
+    int64_t initial_running = _manager->running_subtasks();
+    int64_t initial_completed = _manager->completed_subtasks();
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; }, [](bool) {});
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(2, st.value());
+
+    // After creation, running subtasks should increase
+    EXPECT_EQ(initial_running + 2, _manager->running_subtasks());
+
+    // Complete both subtasks manually (execute_subtask is blocked in thread pool queue)
+    auto ctx0 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx0->subtask_id = 0;
+    ctx0->txn_log = std::make_unique<TxnLogPB>();
+    ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(0);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(50);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_data_size(500);
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 0, std::move(ctx0));
+
+    // After first completion
+    EXPECT_EQ(initial_running + 1, _manager->running_subtasks());
+    EXPECT_EQ(initial_completed + 1, _manager->completed_subtasks());
+
+    auto ctx1 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx1->subtask_id = 1;
+    ctx1->txn_log = std::make_unique<TxnLogPB>();
+    ctx1->txn_log->mutable_op_compaction()->add_input_rowsets(5);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(50);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_data_size(500);
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 1, std::move(ctx1));
+
+    ASSERT_TRUE(closure.is_finished());
+
+    // Unblock the pool. The queued execute_subtask tasks will run but find state cleaned up,
+    // which will decrement running_subtasks (expected behavior for orphaned tasks).
+    block_promise.set_value();
+    pool->wait();
+
+    // After pool completes, running_subtasks will be decremented by the orphaned execute_subtask calls.
+    // This is expected: 2 execute_subtask calls each decrement counter when they find state missing.
+    EXPECT_EQ(initial_running - 2, _manager->running_subtasks());
+}
+
+// Test for rowsets marking and unmarking (lines 606-620)
+TEST_F(TabletParallelCompactionManagerTest, test_rowsets_marking) {
+    int64_t tablet_id = 10033;
+    int64_t txn_id = 20033;
+    int64_t version = 11;
+
+    create_tablet_with_rowsets(tablet_id, 10, 1024 * 1024);
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(2);
+    config.set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("test_pool").set_max_threads(1).build(&pool);
+
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+    std::promise<void> start_promise;
+
+    pool->submit_func([&]() {
+        start_promise.set_value();
+        block_future.wait();
+    });
+
+    start_promise.get_future().wait();
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; }, [](bool) {});
+    ASSERT_TRUE(st.ok());
+
+    auto state = _manager->get_tablet_state(tablet_id, txn_id);
+    ASSERT_NE(nullptr, state);
+
+    // Check that rowsets are marked as compacting
+    {
+        std::lock_guard<std::mutex> lock(state->mutex);
+        EXPECT_FALSE(state->compacting_rowsets.empty());
+
+        // All rowsets from all subtasks should be marked
+        for (const auto& [subtask_id, info] : state->running_subtasks) {
+            for (uint32_t rid : info.input_rowset_ids) {
+                EXPECT_TRUE(state->is_rowset_compacting(rid));
+            }
+        }
+    }
+
+    block_promise.set_value();
+    pool->wait();
+    _manager->cleanup_tablet(tablet_id, txn_id);
+}
+
+// Test for callback not set scenario
+TEST_F(TabletParallelCompactionManagerTest, test_on_subtask_complete_with_callback) {
+    int64_t tablet_id = 10034;
+    int64_t txn_id = 20034;
+    int64_t version = 11;
+
+    // Create 10 rowsets, each 1MB (total 10MB)
+    create_tablet_with_rowsets(tablet_id, 10, 1024 * 1024);
+
+    TabletParallelConfig config;
+    // Use max_parallel=2 and max_bytes=5MB to create 2 groups
+    config.set_max_parallel_per_tablet(2);
+    config.set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("blocked_pool").set_max_threads(1).build(&pool);
+
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; },
+            [&](bool) { block_future.wait(); });
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(2, st.value()); // Expect 2 subtasks
+
+    // Get state to verify
+    auto state = _manager->get_tablet_state(tablet_id, txn_id);
+    ASSERT_NE(nullptr, state);
+
+    // Complete subtask 0
+    auto ctx0 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx0->subtask_id = 0;
+    ctx0->txn_log = std::make_unique<TxnLogPB>();
+    ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(0);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(100);
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 0, std::move(ctx0));
+
+    // Complete subtask 1
+    auto ctx1 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx1->subtask_id = 1;
+    ctx1->txn_log = std::make_unique<TxnLogPB>();
+    ctx1->txn_log->mutable_op_compaction()->add_input_rowsets(5);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(100);
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 1, std::move(ctx1));
+
+    ASSERT_TRUE(closure.wait_finish(5000));
+
+    block_promise.set_value();
+    pool->wait();
+}
+
+// Test for all subtasks failed (should fail overall)
+TEST_F(TabletParallelCompactionManagerTest, test_all_subtasks_failed) {
+    int64_t tablet_id = 10035;
+    int64_t txn_id = 20035;
+    int64_t version = 11;
+
+    create_tablet_with_rowsets(tablet_id, 10, 1024 * 1024);
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(2);
+    config.set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("blocked_pool").set_max_threads(1).build(&pool);
+
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; },
+            [&](bool) { block_future.wait(); });
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(2, st.value());
+
+    // Simulate completion of subtask 0 with failure
+    auto ctx0 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx0->subtask_id = 0;
+    ctx0->status = Status::InternalError("subtask 0 failed");
+    ctx0->txn_log = std::make_unique<TxnLogPB>();
+    ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(0);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(50);
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 0, std::move(ctx0));
+
+    // Simulate completion of subtask 1 with failure
+    auto ctx1 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx1->subtask_id = 1;
+    ctx1->status = Status::InternalError("subtask 1 failed");
+    ctx1->txn_log = std::make_unique<TxnLogPB>();
+    ctx1->txn_log->mutable_op_compaction()->add_input_rowsets(5);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(50);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_data_size(500);
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 1, std::move(ctx1));
+
+    ASSERT_TRUE(closure.is_finished());
+
+    // When all subtasks fail, the overall status should indicate failure
+    EXPECT_NE(0, response.status().status_code());
+
+    block_promise.set_value();
+    pool->wait();
+}
+
+// Test for partial success with multiple subtasks (2 succeed, 1 fails) - PK table
+// PK tables allow non-consecutive successful subtasks to be applied
+TEST_F(TabletParallelCompactionManagerTest, test_partial_success_multiple_subtasks_pk) {
+    int64_t tablet_id = 10036;
+    int64_t txn_id = 20036;
+    int64_t version = 16; // 15 rowsets + 1
+
+    // Create 15 rowsets, each 1MB - PK table
+    create_pk_tablet_with_rowsets(tablet_id, 15, 1024 * 1024);
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(3);
+    config.set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("blocked_pool").set_max_threads(1).build(&pool);
+
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; },
+            [&](bool) { block_future.wait(); });
+    ASSERT_TRUE(st.ok()) << st.status();
+    ASSERT_EQ(3, st.value());
+
+    // Subtask 0: failure
+    auto ctx0 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx0->subtask_id = 0;
+    ctx0->status = Status::MemoryLimitExceeded("OOM");
+    ctx0->txn_log = std::make_unique<TxnLogPB>();
+    ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(0);
+    ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(1);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(100);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_data_size(1000);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->add_segments("segment_0.dat");
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 0, std::move(ctx0));
+
+    // Subtask 1: success
+    auto ctx1 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx1->subtask_id = 1;
+    ctx1->txn_log = std::make_unique<TxnLogPB>();
+    ctx1->txn_log->mutable_op_compaction()->add_input_rowsets(5);
+    ctx1->txn_log->mutable_op_compaction()->add_input_rowsets(6);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(100);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_data_size(1000);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->add_segments("segment_1.dat");
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 1, std::move(ctx1));
+
+    // Subtask 2: success
+    auto ctx2 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx2->subtask_id = 2;
+    ctx2->txn_log = std::make_unique<TxnLogPB>();
+    ctx2->txn_log->mutable_op_compaction()->add_input_rowsets(10);
+    ctx2->txn_log->mutable_op_compaction()->add_input_rowsets(11);
+    ctx2->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(200);
+    ctx2->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_data_size(2000);
+    ctx2->txn_log->mutable_op_compaction()->mutable_output_rowset()->add_segments("segment_2.dat");
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 2, std::move(ctx2));
+
+    ASSERT_TRUE(closure.is_finished());
+
+    // With partial success (2 out of 3 succeeded), the overall status should be OK
+    EXPECT_EQ(0, response.status().status_code());
+
+    // Verify the merged TxnLog
+    ASSERT_EQ(1, response.txn_logs_size());
+    const auto& op_parallel = response.txn_logs(0).op_parallel_compaction();
+
+    // success_subtask_ids should contain 1 and 2
+    EXPECT_EQ(2, op_parallel.success_subtask_ids_size());
+    EXPECT_EQ(1, op_parallel.success_subtask_ids(0));
+    EXPECT_EQ(2, op_parallel.success_subtask_ids(1));
+
+    // Verify subtask_compactions structure - each subtask has independent output
+    ASSERT_EQ(2, op_parallel.subtask_compactions_size());
+    const auto& subtask1 = op_parallel.subtask_compactions(0);
+    EXPECT_EQ(1, subtask1.subtask_id());
+    EXPECT_EQ(2, subtask1.input_rowsets_size());
+    EXPECT_EQ(5, subtask1.input_rowsets(0));
+    EXPECT_EQ(6, subtask1.input_rowsets(1));
+    EXPECT_TRUE(subtask1.has_output_rowset());
+    EXPECT_EQ(100, subtask1.output_rowset().num_rows());
+    EXPECT_EQ(1000, subtask1.output_rowset().data_size());
+    EXPECT_EQ("segment_1.dat", subtask1.output_rowset().segments(0));
+
+    const auto& subtask2 = op_parallel.subtask_compactions(1);
+    EXPECT_EQ(2, subtask2.subtask_id());
+    EXPECT_EQ(2, subtask2.input_rowsets_size());
+    EXPECT_EQ(10, subtask2.input_rowsets(0));
+    EXPECT_EQ(11, subtask2.input_rowsets(1));
+    EXPECT_TRUE(subtask2.has_output_rowset());
+    EXPECT_EQ(200, subtask2.output_rowset().num_rows());
+    EXPECT_EQ(2000, subtask2.output_rowset().data_size());
+    EXPECT_EQ("segment_2.dat", subtask2.output_rowset().segments(0));
+
+    block_promise.set_value();
+    pool->wait();
+}
+
+// Test for partial success with non-consecutive successful subtasks
+// With unified logic, all successful subtasks are applied regardless of consecutiveness.
+TEST_F(TabletParallelCompactionManagerTest, test_non_pk_table_all_successful_subtasks) {
+    int64_t tablet_id = 10038;
+    int64_t txn_id = 20038;
+    int64_t version = 21; // 20 rowsets + 1
+
+    create_tablet_with_rowsets(tablet_id, 20, 1024 * 1024);
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(4);
+    config.set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("blocked_pool").set_max_threads(1).build(&pool);
+
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; },
+            [&](bool) { block_future.wait(); });
+    ASSERT_TRUE(st.ok()) << st.status();
+    ASSERT_EQ(4, st.value());
+
+    // Subtask 0: failure
+    auto ctx0 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx0->subtask_id = 0;
+    ctx0->status = Status::IOError("disk error");
+    ctx0->txn_log = std::make_unique<TxnLogPB>();
+    ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(0);
+    ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(1);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(100);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_data_size(1000);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->add_segments("segment_0.dat");
+    _manager->on_subtask_complete(tablet_id, txn_id, 0, std::move(ctx0));
+
+    // Subtask 1: success
+    auto ctx1 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx1->subtask_id = 1;
+    ctx1->status = Status::OK();
+    ctx1->txn_log = std::make_unique<TxnLogPB>();
+    ctx1->txn_log->mutable_op_compaction()->add_input_rowsets(5);
+    ctx1->txn_log->mutable_op_compaction()->add_input_rowsets(6);
+    ctx1->txn_log->mutable_op_compaction()->add_input_rowsets(7);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(150);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_data_size(1500);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->add_segments("segment_1.dat");
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->add_segment_size(750);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->add_segment_encryption_metas("meta1");
+    ctx1->txn_log->mutable_op_compaction()->set_compact_version(10);
+    _manager->on_subtask_complete(tablet_id, txn_id, 1, std::move(ctx1));
+
+    // Subtask 2: success (should also be applied)
+    auto ctx2 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx2->subtask_id = 2;
+    ctx2->status = Status::OK();
+    ctx2->txn_log = std::make_unique<TxnLogPB>();
+    ctx2->txn_log->mutable_op_compaction()->add_input_rowsets(10);
+    ctx2->txn_log->mutable_op_compaction()->add_input_rowsets(11);
+    ctx2->txn_log->mutable_op_compaction()->add_input_rowsets(12);
+    ctx2->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(200);
+    ctx2->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_data_size(2000);
+    ctx2->txn_log->mutable_op_compaction()->mutable_output_rowset()->add_segments("segment_2.dat");
+    ctx2->txn_log->mutable_op_compaction()->mutable_output_rowset()->add_segment_size(1000);
+    ctx2->txn_log->mutable_op_compaction()->mutable_output_rowset()->add_segment_encryption_metas("meta2");
+    ctx2->txn_log->mutable_op_compaction()->set_compact_version(10);
+    _manager->on_subtask_complete(tablet_id, txn_id, 2, std::move(ctx2));
+
+    // Subtask 3: failure
+    auto ctx3 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx3->subtask_id = 3;
+    ctx3->status = Status::MemoryLimitExceeded("OOM");
+    ctx3->txn_log = std::make_unique<TxnLogPB>();
+    ctx3->txn_log->mutable_op_compaction()->add_input_rowsets(15);
+    ctx3->txn_log->mutable_op_compaction()->add_input_rowsets(16);
+    ctx3->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(250);
+    ctx3->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_data_size(2500);
+    ctx3->txn_log->mutable_op_compaction()->mutable_output_rowset()->add_segments("segment_3.dat");
+    _manager->on_subtask_complete(tablet_id, txn_id, 3, std::move(ctx3));
+
+    ASSERT_TRUE(closure.is_finished());
+
+    // Verify result - all successful subtasks (1 and 2) should be applied
+    ASSERT_EQ(1, response.txn_logs_size());
+    const auto& op_parallel = response.txn_logs(0).op_parallel_compaction();
+
+    // compact_version should be set in subtask_compactions
+    ASSERT_GT(op_parallel.subtask_compactions_size(), 0);
+    const auto& first_subtask = op_parallel.subtask_compactions(0);
+    EXPECT_TRUE(first_subtask.has_compact_version());
+    EXPECT_EQ(10, first_subtask.compact_version());
+
+    // success_subtask_ids should contain 1 and 2
+    EXPECT_EQ(2, op_parallel.success_subtask_ids_size());
+    EXPECT_EQ(1, op_parallel.success_subtask_ids(0));
+    EXPECT_EQ(2, op_parallel.success_subtask_ids(1));
+
+    // Verify subtask_compactions structure - 2 successful subtasks with independent outputs
+    ASSERT_EQ(2, op_parallel.subtask_compactions_size());
+
+    // Subtask 1 output
+    const auto& subtask1 = op_parallel.subtask_compactions(0);
+    EXPECT_EQ(1, subtask1.subtask_id());
+    EXPECT_EQ(3, subtask1.input_rowsets_size());
+    EXPECT_EQ(5, subtask1.input_rowsets(0));
+    EXPECT_EQ(6, subtask1.input_rowsets(1));
+    EXPECT_EQ(7, subtask1.input_rowsets(2));
+    EXPECT_TRUE(subtask1.has_output_rowset());
+    EXPECT_EQ(150, subtask1.output_rowset().num_rows());
+    EXPECT_EQ(1500, subtask1.output_rowset().data_size());
+
+    // Subtask 2 output
+    const auto& subtask2 = op_parallel.subtask_compactions(1);
+    EXPECT_EQ(2, subtask2.subtask_id());
+    EXPECT_EQ(3, subtask2.input_rowsets_size());
+    EXPECT_EQ(10, subtask2.input_rowsets(0));
+    EXPECT_EQ(11, subtask2.input_rowsets(1));
+    EXPECT_EQ(12, subtask2.input_rowsets(2));
+    EXPECT_TRUE(subtask2.has_output_rowset());
+    EXPECT_EQ(200, subtask2.output_rowset().num_rows());
+    EXPECT_EQ(2000, subtask2.output_rowset().data_size());
+
+    block_promise.set_value();
+    pool->wait();
+}
+
+// Test where first subtask fails but second succeeds
+// With unified logic, all successful subtasks are applied
+TEST_F(TabletParallelCompactionManagerTest, test_first_subtask_fails_second_succeeds) {
+    int64_t tablet_id = 10039;
+    int64_t txn_id = 20039;
+    int64_t version = 11;
+
+    create_tablet_with_rowsets(tablet_id, 10, 1024 * 1024);
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(4);
+    config.set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("blocked_pool").set_max_threads(1).build(&pool);
+
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; },
+            [&](bool) { block_future.wait(); });
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ(2, st.value());
+
+    // Subtask 0: failure
+    auto ctx0 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx0->subtask_id = 0;
+    ctx0->status = Status::IOError("disk error");
+    ctx0->txn_log = std::make_unique<TxnLogPB>();
+    ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(0);
+    ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(1);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(100);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_data_size(1000);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->add_segments("segment_0.dat");
+    _manager->on_subtask_complete(tablet_id, txn_id, 0, std::move(ctx0));
+
+    // Subtask 1: success (should be applied)
+    auto ctx1 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx1->subtask_id = 1;
+    ctx1->status = Status::OK();
+    ctx1->txn_log = std::make_unique<TxnLogPB>();
+    ctx1->txn_log->mutable_op_compaction()->add_input_rowsets(5);
+    ctx1->txn_log->mutable_op_compaction()->add_input_rowsets(6);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(100);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_data_size(1000);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->add_segments("segment_1.dat");
+
+    _manager->on_subtask_complete(tablet_id, txn_id, 1, std::move(ctx1));
+
+    ASSERT_TRUE(closure.is_finished());
+
+    // With unified logic, subtask 1 should be applied as it succeeded
+    EXPECT_EQ(0, response.status().status_code());
+
+    ASSERT_EQ(1, response.txn_logs_size());
+    const auto& op_parallel = response.txn_logs(0).op_parallel_compaction();
+
+    // Only subtask 1 in success_subtask_ids
+    EXPECT_EQ(1, op_parallel.success_subtask_ids_size());
+    EXPECT_EQ(1, op_parallel.success_subtask_ids(0));
+
+    // Verify subtask_compactions structure - only subtask 1 has output
+    ASSERT_EQ(1, op_parallel.subtask_compactions_size());
+    const auto& subtask1 = op_parallel.subtask_compactions(0);
+    EXPECT_EQ(1, subtask1.subtask_id());
+    EXPECT_EQ(2, subtask1.input_rowsets_size());
+    EXPECT_EQ(5, subtask1.input_rowsets(0));
+    EXPECT_EQ(6, subtask1.input_rowsets(1));
+    EXPECT_TRUE(subtask1.has_output_rowset());
+    EXPECT_EQ(100, subtask1.output_rowset().num_rows());
+    EXPECT_EQ(1000, subtask1.output_rowset().data_size());
+    EXPECT_EQ(1, subtask1.output_rowset().segments_size());
+    EXPECT_EQ("segment_1.dat", subtask1.output_rowset().segments(0));
+
+    block_promise.set_value();
+    pool->wait();
+}
+
+// Test partial success pattern: [fail, success, success, fail]
+// With unified logic, all successful subtasks (1 and 2) should be applied
+TEST_F(TabletParallelCompactionManagerTest, test_partial_success_middle_subtasks) {
+    int64_t tablet_id = 10040;
+    int64_t txn_id = 20040;
+    int64_t version = 21; // 20 rowsets + 1
+
+    create_tablet_with_rowsets(tablet_id, 20, 1024 * 1024);
+
+    TabletParallelConfig config;
+    config.set_max_parallel_per_tablet(4);
+    config.set_max_bytes_per_subtask(5 * 1024 * 1024);
+
+    CompactRequest request;
+    request.add_tablet_ids(tablet_id);
+    CompactResponse response;
+    TestClosure closure;
+    auto callback = std::make_shared<CompactionTaskCallback>(nullptr, &request, &response, &closure);
+
+    std::unique_ptr<ThreadPool> pool;
+    ThreadPoolBuilder("blocked_pool").set_max_threads(1).build(&pool);
+
+    std::promise<void> block_promise;
+    std::future<void> block_future = block_promise.get_future();
+
+    auto st = _manager->create_parallel_tasks(
+            tablet_id, txn_id, version, config, callback, false, pool.get(), []() { return true; },
+            [&](bool) { block_future.wait(); });
+    ASSERT_TRUE(st.ok()) << st.status();
+    ASSERT_EQ(4, st.value());
+
+    // Subtask 0: failure
+    auto ctx0 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx0->subtask_id = 0;
+    ctx0->status = Status::IOError("disk error");
+    ctx0->txn_log = std::make_unique<TxnLogPB>();
+    ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(0);
+    ctx0->txn_log->mutable_op_compaction()->add_input_rowsets(1);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(100);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_data_size(1000);
+    ctx0->txn_log->mutable_op_compaction()->mutable_output_rowset()->add_segments("segment_0.dat");
+    _manager->on_subtask_complete(tablet_id, txn_id, 0, std::move(ctx0));
+
+    // Subtask 1: success
+    auto ctx1 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx1->subtask_id = 1;
+    ctx1->status = Status::OK();
+    ctx1->txn_log = std::make_unique<TxnLogPB>();
+    ctx1->txn_log->mutable_op_compaction()->add_input_rowsets(5);
+    ctx1->txn_log->mutable_op_compaction()->add_input_rowsets(6);
+    ctx1->txn_log->mutable_op_compaction()->add_input_rowsets(7);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(150);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_data_size(1500);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->add_segments("segment_1.dat");
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->add_segment_size(750);
+    ctx1->txn_log->mutable_op_compaction()->mutable_output_rowset()->add_segment_encryption_metas("meta1");
+    ctx1->txn_log->mutable_op_compaction()->set_compact_version(10);
+    _manager->on_subtask_complete(tablet_id, txn_id, 1, std::move(ctx1));
+
+    // Subtask 2: success (should be applied)
+    auto ctx2 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx2->subtask_id = 2;
+    ctx2->status = Status::OK();
+    ctx2->txn_log = std::make_unique<TxnLogPB>();
+    ctx2->txn_log->mutable_op_compaction()->add_input_rowsets(10);
+    ctx2->txn_log->mutable_op_compaction()->add_input_rowsets(11);
+    ctx2->txn_log->mutable_op_compaction()->add_input_rowsets(12);
+    ctx2->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(200);
+    ctx2->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_data_size(2000);
+    ctx2->txn_log->mutable_op_compaction()->mutable_output_rowset()->add_segments("segment_2.dat");
+    ctx2->txn_log->mutable_op_compaction()->mutable_output_rowset()->add_segment_size(1000);
+    ctx2->txn_log->mutable_op_compaction()->mutable_output_rowset()->add_segment_encryption_metas("meta2");
+    ctx2->txn_log->mutable_op_compaction()->set_compact_version(10);
+    _manager->on_subtask_complete(tablet_id, txn_id, 2, std::move(ctx2));
+
+    // Subtask 3: failure
+    auto ctx3 = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, false, true, nullptr);
+    ctx3->subtask_id = 3;
+    ctx3->status = Status::MemoryLimitExceeded("OOM");
+    ctx3->txn_log = std::make_unique<TxnLogPB>();
+    ctx3->txn_log->mutable_op_compaction()->add_input_rowsets(15);
+    ctx3->txn_log->mutable_op_compaction()->add_input_rowsets(16);
+    ctx3->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_num_rows(250);
+    ctx3->txn_log->mutable_op_compaction()->mutable_output_rowset()->set_data_size(2500);
+    ctx3->txn_log->mutable_op_compaction()->mutable_output_rowset()->add_segments("segment_3.dat");
+    _manager->on_subtask_complete(tablet_id, txn_id, 3, std::move(ctx3));
+
+    ASSERT_TRUE(closure.is_finished());
+
+    // With unified logic: all successful subtasks are applied
+    // Pattern: [fail, success, success, fail]
+    // Subtasks 1 and 2 should be applied
+    EXPECT_EQ(0, response.status().status_code());
+
+    ASSERT_EQ(1, response.txn_logs_size());
+    const auto& op_parallel = response.txn_logs(0).op_parallel_compaction();
+
+    // compact_version should be set in subtask_compactions
+    ASSERT_GT(op_parallel.subtask_compactions_size(), 0);
+    const auto& first_subtask = op_parallel.subtask_compactions(0);
+    EXPECT_TRUE(first_subtask.has_compact_version());
+    EXPECT_EQ(10, first_subtask.compact_version());
+
+    // Verify subtask_compactions structure - each subtask has independent output
+    ASSERT_EQ(2, op_parallel.subtask_compactions_size());
+    const auto& subtask1 = op_parallel.subtask_compactions(0);
+    EXPECT_EQ(1, subtask1.subtask_id());
+    EXPECT_EQ(3, subtask1.input_rowsets_size());
+    EXPECT_EQ(5, subtask1.input_rowsets(0));
+    EXPECT_EQ(6, subtask1.input_rowsets(1));
+    EXPECT_EQ(7, subtask1.input_rowsets(2));
+    EXPECT_TRUE(subtask1.has_output_rowset());
+    EXPECT_EQ(150, subtask1.output_rowset().num_rows());
+    EXPECT_EQ(1500, subtask1.output_rowset().data_size());
+
+    const auto& subtask2 = op_parallel.subtask_compactions(1);
+    EXPECT_EQ(2, subtask2.subtask_id());
+    EXPECT_EQ(3, subtask2.input_rowsets_size());
+    EXPECT_EQ(10, subtask2.input_rowsets(0));
+    EXPECT_EQ(11, subtask2.input_rowsets(1));
+    EXPECT_EQ(12, subtask2.input_rowsets(2));
+    EXPECT_TRUE(subtask2.has_output_rowset());
+    EXPECT_EQ(200, subtask2.output_rowset().num_rows());
+    EXPECT_EQ(2000, subtask2.output_rowset().data_size());
+
+    block_promise.set_value();
+    pool->wait();
+}
+
+} // namespace starrocks::lake

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobExecutor.java
@@ -464,6 +464,7 @@ public class AlterJobExecutor implements AstVisitorExtendInterface<Void, Connect
                     || properties.containsKey(PropertyAnalyzer.PROPERTIES_PERSISTENT_INDEX_TYPE)
                     || properties.containsKey(PropertyAnalyzer.PROPERTIES_FILE_BUNDLING)
                     || properties.containsKey(PropertyAnalyzer.PROPERTIES_COMPACTION_STRATEGY)
+                    || properties.containsKey(PropertyAnalyzer.PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL)
                     || properties.containsKey(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2)) {
                 if (table.isCloudNativeTable()) {
                     Locker locker = new Locker();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2136,6 +2136,16 @@ public class OlapTable extends Table {
         tableProperty.buildCompactionStrategy();
     }
 
+    public int getLakeCompactionMaxParallel() {
+        return tableProperty.getLakeCompactionMaxParallel();
+    }
+
+    public void setLakeCompactionMaxParallel(int maxParallel) {
+        tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL,
+                String.valueOf(maxParallel));
+        tableProperty.buildLakeCompactionMaxParallel();
+    }
+
     public Multimap<String, String> getLocation() {
         return tableProperty.getLocation();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -328,6 +328,12 @@ public class TableProperty implements Writable, GsonPostProcessable {
 
     private TCompactionStrategy compactionStrategy = TCompactionStrategy.DEFAULT;
 
+    // Maximum number of parallel compaction subtasks per tablet
+    // 0 means disable parallel compaction, positive value enables it
+    // Default: 3
+    @SerializedName(value = "lakeCompactionMaxParallel")
+    private int lakeCompactionMaxParallel = 3;
+
     @SerializedName(value = "enableStatisticCollectOnFirstLoad")
     private boolean enableStatisticCollectOnFirstLoad = true;
 
@@ -426,6 +432,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
                 buildStorageCoolDownTTL();
                 buildEnableStatisticCollectOnFirstLoad();
                 buildCloudNativeFastSchemaEvolutionV2();
+                buildLakeCompactionMaxParallel();
                 break;
             case OperationType.OP_MODIFY_TABLE_CONSTRAINT_PROPERTY:
                 buildConstraint();
@@ -923,6 +930,19 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return this;
     }
 
+    public TableProperty buildLakeCompactionMaxParallel() {
+        String value = properties.get(PropertyAnalyzer.PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL);
+        if (value != null) {
+            try {
+                lakeCompactionMaxParallel = Integer.parseInt(value);
+            } catch (NumberFormatException e) {
+                LOG.warn("Invalid lake_compaction_max_parallel value: {}", value);
+                lakeCompactionMaxParallel = 0;
+            }
+        }
+        return this;
+    }
+
     public static String compactionStrategyToString(TCompactionStrategy strategy) {
         switch (strategy) {
             case DEFAULT:
@@ -1129,6 +1149,10 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return compactionStrategy;
     }
 
+    public int getLakeCompactionMaxParallel() {
+        return lakeCompactionMaxParallel;
+    }
+
     public Multimap<String, String> getLocation() {
         return location;
     }
@@ -1310,6 +1334,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
         buildFileBundling();
         buildMutableBucketNum();
         buildCompactionStrategy();
+        buildLakeCompactionMaxParallel();
         buildEnableStatisticCollectOnFirstLoad();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -272,6 +272,10 @@ public class PropertyAnalyzer {
 
     public static final String PROPERTIES_COMPACTION_STRATEGY = "compaction_strategy";
 
+    // Maximum number of parallel compaction subtasks per tablet
+    // 0 means disable parallel compaction, positive value enables it
+    public static final String PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL = "lake_compaction_max_parallel";
+
     public static final String PROPERTIES_TABLET_RESHARD_TARGET_SIZE = "tablet_reshard_target_size";
 
     public static final String PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD = "enable_statistic_collect_on_first_load";
@@ -1616,6 +1620,28 @@ public class PropertyAnalyzer {
             }
         }
         return TCompactionStrategy.DEFAULT;
+    }
+
+    // Analyze lake_compaction_max_parallel property
+    // Returns the max parallel value (default 3, 0 means disabled)
+    public static int analyzeLakeCompactionMaxParallel(Map<String, String> properties) throws AnalysisException {
+        int defaultValue = 3;
+        if (properties != null && properties.containsKey(PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL)) {
+            String value = properties.get(PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL);
+            properties.remove(PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL);
+            try {
+                int maxParallel = Integer.parseInt(value);
+                if (maxParallel < 0) {
+                    throw new AnalysisException("Invalid lake_compaction_max_parallel value: " + value +
+                            ". Value must be non-negative.");
+                }
+                return maxParallel;
+            } catch (NumberFormatException e) {
+                throw new AnalysisException("Invalid lake_compaction_max_parallel value: " + value +
+                        ". Value must be an integer.");
+            }
+        }
+        return defaultValue;
     }
 
     public static long analyzeTabletReshardTargetSize(Map<String, String> properties, boolean removeProperties)

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3872,6 +3872,29 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         });
     }
 
+    private void alterLakeCompactionMaxParallel(OlapTable table,
+                                                Map<String, String> properties,
+                                                List<Runnable> appliers) throws DdlException {
+        if (!table.isCloudNativeTableOrMaterializedView()) {
+            throw new DdlException("Property " + PropertyAnalyzer.PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL +
+                    " can only be set for cloud native tables");
+        }
+        String value = properties.remove(PropertyAnalyzer.PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL);
+        try {
+            int maxParallel = Integer.parseInt(value);
+            if (maxParallel < 0) {
+                throw new DdlException("Invalid lake_compaction_max_parallel value: " + value +
+                        ". Value must be non-negative.");
+            }
+            appliers.add(() -> {
+                table.setLakeCompactionMaxParallel(maxParallel);
+            });
+        } catch (NumberFormatException e) {
+            throw new DdlException("Invalid lake_compaction_max_parallel value: " + value +
+                    ". Value must be an integer.");
+        }
+    }
+
     public void alterTableProperties(Database db, OlapTable table, Map<String, String> properties)
             throws DdlException {
         Map<String, String> propertiesToPersist = new HashMap<>(properties);
@@ -3905,6 +3928,9 @@ public class LocalMetastore implements ConnectorMetadata, MVRepairHandler, Memor
         }
         if (propertiesToPersist.containsKey(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2)) {
             alterCloudNativeFastSchemaEvolutionV2(table, properties, appliers);
+        }
+        if (propertiesToPersist.containsKey(PropertyAnalyzer.PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL)) {
+            alterLakeCompactionMaxParallel(table, properties, appliers);
         }
         if (!properties.isEmpty()) {
             throw new DdlException("Modify failed because unknown properties: " + properties);

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -410,6 +410,14 @@ public class OlapTableFactory implements AbstractTableFactory {
                     throw new DdlException("Only default compaction strategy is allowed for non-pk table.");
                 }
                 table.setCompactionStrategy(compactionStrategy);
+
+                // analyze lake_compaction_max_parallel property
+                try {
+                    int lakeCompactionMaxParallel = PropertyAnalyzer.analyzeLakeCompactionMaxParallel(properties);
+                    table.setLakeCompactionMaxParallel(lakeCompactionMaxParallel);
+                } catch (AnalysisException e) {
+                    throw new DdlException(e.getMessage());
+                }
             }
 
             try {

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -477,10 +477,11 @@ public class InformationSchemaDataSource {
             PartitionStatistics statistics = GlobalStateMgr.getCurrentState().getCompactionMgr().getStatistics(identifier);
             Quantiles compactionScore = statistics != null ? statistics.getCompactionScore() : null;
             // COMPACT_VERSION
-            partitionMetaInfo.setCompact_version(statistics != null ? statistics.getCompactionVersion().getVersion() : 0);
+            partitionMetaInfo.setCompact_version(statistics != null && statistics.getCompactionVersion() != null ?
+                    statistics.getCompactionVersion().getVersion() : 0);
             DataCacheInfo cacheInfo = partitionInfo.getDataCacheInfo(partition.getId());
             // ENABLE_DATACACHE
-            partitionMetaInfo.setEnable_datacache(cacheInfo.isEnabled());
+            partitionMetaInfo.setEnable_datacache(cacheInfo != null && cacheInfo.isEnabled());
             // AVG_CS
             partitionMetaInfo.setAvg_cs(compactionScore != null ? compactionScore.getAvg() : 0.0);
             // P50_CS

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseAnalyzer.java
@@ -462,6 +462,23 @@ public class AlterTableClauseAnalyzer implements AstVisitorExtendInterface<Void,
             }
         } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_CLOUD_NATIVE_FAST_SCHEMA_EVOLUTION_V2)) {
             PropertyAnalyzer.analyzeCloudNativeFastSchemaEvolutionV2(table.getType(), properties, false);
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL)) {
+            if (!table.isCloudNativeTableOrMaterializedView()) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                        "Property " + PropertyAnalyzer.PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL +
+                                " can only be set for cloud native tables");
+            }
+            String value = properties.get(PropertyAnalyzer.PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL);
+            try {
+                int maxParallel = Integer.parseInt(value);
+                if (maxParallel < 0) {
+                    ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                            "Invalid lake_compaction_max_parallel value: " + value + ". Value must be non-negative.");
+                }
+            } catch (NumberFormatException e) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                        "Invalid lake_compaction_max_parallel value: " + value + ". Value must be an integer.");
+            }
         } else {
             ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "Unknown properties: " + properties);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeCompactionMaxParallelTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeCompactionMaxParallelTest.java
@@ -1,0 +1,479 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.TableProperty;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.lake.LakeTable;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.sql.ast.AlterTableStmt;
+import com.starrocks.sql.ast.CreateDbStmt;
+import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.utframe.StarRocksTestBase;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test cases for lake_compaction_max_parallel property.
+ * This test covers:
+ * - PropertyAnalyzer.analyzeLakeCompactionMaxParallel
+ * - TableProperty.buildLakeCompactionMaxParallel
+ * - AlterTableClauseAnalyzer for lake_compaction_max_parallel
+ * - LocalMetastore.alterLakeCompactionMaxParallel
+ * - SchemaChangeHandler for lake_compaction_max_parallel
+ * - OlapTableFactory for lake_compaction_max_parallel
+ */
+public class LakeCompactionMaxParallelTest extends StarRocksTestBase {
+    private static final String DB_NAME = "test_lake_compaction_max_parallel";
+    private static ConnectContext connectContext;
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        connectContext = UtFrameUtils.createDefaultCtx();
+        String createDbStmtStr = "create database " + DB_NAME;
+        CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseStmtWithNewParser(createDbStmtStr, connectContext);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().createDb(createDbStmt.getFullDbName());
+        connectContext.setDatabase(DB_NAME);
+    }
+
+    private static LakeTable createTable(String sql) throws Exception {
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(createTableStmt);
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(createTableStmt.getDbName());
+        return (LakeTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
+                .getTable(db.getFullName(), createTableStmt.getTableName());
+    }
+
+    private static void alterTable(String sql) throws Exception {
+        AlterTableStmt stmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTable(connectContext, stmt);
+    }
+
+    // ===========================================
+    // Tests for PropertyAnalyzer.analyzeLakeCompactionMaxParallel
+    // Covers: PropertyAnalyzer.java lines 1630-1640
+    // ===========================================
+
+    @Test
+    public void testAnalyzeLakeCompactionMaxParallelDefault() throws AnalysisException {
+        // Test default value when property is not set
+        Map<String, String> properties = new HashMap<>();
+        int result = PropertyAnalyzer.analyzeLakeCompactionMaxParallel(properties);
+        Assertions.assertEquals(3, result);
+    }
+
+    @Test
+    public void testAnalyzeLakeCompactionMaxParallelValidValue() throws AnalysisException {
+        // Test valid integer value
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL, "5");
+        int result = PropertyAnalyzer.analyzeLakeCompactionMaxParallel(properties);
+        Assertions.assertEquals(5, result);
+        // Property should be removed after analysis
+        Assertions.assertFalse(properties.containsKey(PropertyAnalyzer.PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL));
+    }
+
+    @Test
+    public void testAnalyzeLakeCompactionMaxParallelZero() throws AnalysisException {
+        // Test zero value (disabled)
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL, "0");
+        int result = PropertyAnalyzer.analyzeLakeCompactionMaxParallel(properties);
+        Assertions.assertEquals(0, result);
+    }
+
+    @Test
+    public void testAnalyzeLakeCompactionMaxParallelNegative() {
+        // Test negative value should throw exception
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL, "-1");
+        Assertions.assertThrows(AnalysisException.class, () -> {
+            PropertyAnalyzer.analyzeLakeCompactionMaxParallel(properties);
+        });
+    }
+
+    @Test
+    public void testAnalyzeLakeCompactionMaxParallelInvalidFormat() {
+        // Test invalid format should throw exception
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL, "abc");
+        Assertions.assertThrows(AnalysisException.class, () -> {
+            PropertyAnalyzer.analyzeLakeCompactionMaxParallel(properties);
+        });
+    }
+
+    @Test
+    public void testAnalyzeLakeCompactionMaxParallelNullProperties() throws AnalysisException {
+        // Test null properties should return default
+        int result = PropertyAnalyzer.analyzeLakeCompactionMaxParallel(null);
+        Assertions.assertEquals(3, result);
+    }
+
+    // ===========================================
+    // Tests for TableProperty.buildLakeCompactionMaxParallel
+    // Covers: TableProperty.java lines 938-940
+    // ===========================================
+
+    @Test
+    public void testTablePropertyBuildLakeCompactionMaxParallelValid() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL, "8");
+        TableProperty tableProperty = new TableProperty(properties);
+        tableProperty.buildLakeCompactionMaxParallel();
+        Assertions.assertEquals(8, tableProperty.getLakeCompactionMaxParallel());
+    }
+
+    @Test
+    public void testTablePropertyBuildLakeCompactionMaxParallelInvalid() {
+        // Test invalid value should fallback to 0
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL, "invalid");
+        TableProperty tableProperty = new TableProperty(properties);
+        tableProperty.buildLakeCompactionMaxParallel();
+        Assertions.assertEquals(0, tableProperty.getLakeCompactionMaxParallel());
+    }
+
+    @Test
+    public void testTablePropertyBuildLakeCompactionMaxParallelNotSet() {
+        // Test property not set - getLakeCompactionMaxParallel returns default value 3
+        // because OlapTable.getLakeCompactionMaxParallel will use PropertyAnalyzer default
+        Map<String, String> properties = new HashMap<>();
+        TableProperty tableProperty = new TableProperty(properties);
+        tableProperty.buildLakeCompactionMaxParallel();
+        // When property is not set, lakeCompactionMaxParallel field in TableProperty is 0
+        // but PropertyAnalyzer.analyzeLakeCompactionMaxParallel returns 3 as default
+        // The buildLakeCompactionMaxParallel only sets from properties, so it stays at field default
+        Assertions.assertEquals(3, tableProperty.getLakeCompactionMaxParallel());
+    }
+
+    // ===========================================
+    // Tests for OlapTableFactory - create table with lake_compaction_max_parallel
+    // Covers: OlapTableFactory.java lines 416-420
+    // ===========================================
+
+    @Test
+    public void testCreateTableWithLakeCompactionMaxParallel() throws Exception {
+        String tableName = "t_create_with_parallel";
+        String createSql = String.format(
+                "CREATE TABLE %s.%s (c0 INT) " +
+                "PRIMARY KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 1 " +
+                "PROPERTIES('lake_compaction_max_parallel' = '10')", DB_NAME, tableName);
+        LakeTable table = createTable(createSql);
+        Assertions.assertEquals(10, table.getLakeCompactionMaxParallel());
+    }
+
+    @Test
+    public void testCreateTableWithDefaultLakeCompactionMaxParallel() throws Exception {
+        String tableName = "t_create_default_parallel";
+        String createSql = String.format(
+                "CREATE TABLE %s.%s (c0 INT) " +
+                "PRIMARY KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 1", DB_NAME, tableName);
+        LakeTable table = createTable(createSql);
+        // Default value is 3
+        Assertions.assertEquals(3, table.getLakeCompactionMaxParallel());
+    }
+
+    @Test
+    public void testCreateTableWithInvalidLakeCompactionMaxParallel() {
+        String tableName = "t_create_invalid_parallel";
+        String createSql = String.format(
+                "CREATE TABLE %s.%s (c0 INT) " +
+                "PRIMARY KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 1 " +
+                "PROPERTIES('lake_compaction_max_parallel' = 'invalid')", DB_NAME, tableName);
+        Assertions.assertThrows(Exception.class, () -> createTable(createSql));
+    }
+
+    @Test
+    public void testCreateTableWithNegativeLakeCompactionMaxParallel() {
+        String tableName = "t_create_negative_parallel";
+        String createSql = String.format(
+                "CREATE TABLE %s.%s (c0 INT) " +
+                "PRIMARY KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 1 " +
+                "PROPERTIES('lake_compaction_max_parallel' = '-5')", DB_NAME, tableName);
+        Assertions.assertThrows(Exception.class, () -> createTable(createSql));
+    }
+
+    // ===========================================
+    // Tests for AlterTableClauseAnalyzer - alter lake_compaction_max_parallel
+    // Covers: AlterTableClauseAnalyzer.java lines 465-481
+    // ===========================================
+
+    @Test
+    public void testAlterLakeCompactionMaxParallelValid() throws Exception {
+        String tableName = "t_alter_parallel_valid";
+        String createSql = String.format(
+                "CREATE TABLE %s.%s (c0 INT) " +
+                "PRIMARY KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 1", DB_NAME, tableName);
+        LakeTable table = createTable(createSql);
+        Assertions.assertEquals(3, table.getLakeCompactionMaxParallel());
+
+        String alterSql = String.format(
+                "ALTER TABLE %s.%s SET ('lake_compaction_max_parallel' = '15')", DB_NAME, tableName);
+        alterTable(alterSql);
+        Assertions.assertEquals(15, table.getLakeCompactionMaxParallel());
+    }
+
+    @Test
+    public void testAlterLakeCompactionMaxParallelToZero() throws Exception {
+        String tableName = "t_alter_parallel_zero";
+        String createSql = String.format(
+                "CREATE TABLE %s.%s (c0 INT) " +
+                "PRIMARY KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 1 " +
+                "PROPERTIES('lake_compaction_max_parallel' = '10')", DB_NAME, tableName);
+        LakeTable table = createTable(createSql);
+        Assertions.assertEquals(10, table.getLakeCompactionMaxParallel());
+
+        String alterSql = String.format(
+                "ALTER TABLE %s.%s SET ('lake_compaction_max_parallel' = '0')", DB_NAME, tableName);
+        alterTable(alterSql);
+        Assertions.assertEquals(0, table.getLakeCompactionMaxParallel());
+    }
+
+    @Test
+    public void testAlterLakeCompactionMaxParallelNegative() throws Exception {
+        String tableName = "t_alter_parallel_negative";
+        String createSql = String.format(
+                "CREATE TABLE %s.%s (c0 INT) " +
+                "PRIMARY KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 1", DB_NAME, tableName);
+        createTable(createSql);
+
+        String alterSql = String.format(
+                "ALTER TABLE %s.%s SET ('lake_compaction_max_parallel' = '-1')", DB_NAME, tableName);
+        // UtFrameUtils.parseStmtWithNewParser wraps SemanticException as AnalysisException
+        Assertions.assertThrows(AnalysisException.class, () -> {
+            UtFrameUtils.parseStmtWithNewParser(alterSql, connectContext);
+        });
+    }
+
+    @Test
+    public void testAlterLakeCompactionMaxParallelInvalidFormat() throws Exception {
+        String tableName = "t_alter_parallel_invalid";
+        String createSql = String.format(
+                "CREATE TABLE %s.%s (c0 INT) " +
+                "PRIMARY KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 1", DB_NAME, tableName);
+        createTable(createSql);
+
+        String alterSql = String.format(
+                "ALTER TABLE %s.%s SET ('lake_compaction_max_parallel' = 'abc')", DB_NAME, tableName);
+        // UtFrameUtils.parseStmtWithNewParser wraps SemanticException as AnalysisException
+        Assertions.assertThrows(AnalysisException.class, () -> {
+            UtFrameUtils.parseStmtWithNewParser(alterSql, connectContext);
+        });
+    }
+
+    // ===========================================
+    // Tests for SchemaChangeHandler - alter lake_compaction_max_parallel
+    // Covers: SchemaChangeHandler.java lines 2240-2251
+    // ===========================================
+
+    @Test
+    public void testAlterLakeCompactionMaxParallelNoChange() throws Exception {
+        String tableName = "t_alter_parallel_no_change";
+        String createSql = String.format(
+                "CREATE TABLE %s.%s (c0 INT) " +
+                "PRIMARY KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 1 " +
+                "PROPERTIES('lake_compaction_max_parallel' = '5')", DB_NAME, tableName);
+        LakeTable table = createTable(createSql);
+        Assertions.assertEquals(5, table.getLakeCompactionMaxParallel());
+
+        // Alter to the same value should be a no-op
+        String alterSql = String.format(
+                "ALTER TABLE %s.%s SET ('lake_compaction_max_parallel' = '5')", DB_NAME, tableName);
+        alterTable(alterSql);
+        Assertions.assertEquals(5, table.getLakeCompactionMaxParallel());
+    }
+
+    @Test
+    public void testAlterLakeCompactionMaxParallelChange() throws Exception {
+        String tableName = "t_alter_parallel_change";
+        String createSql = String.format(
+                "CREATE TABLE %s.%s (c0 INT) " +
+                "PRIMARY KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 1 " +
+                "PROPERTIES('lake_compaction_max_parallel' = '5')", DB_NAME, tableName);
+        LakeTable table = createTable(createSql);
+        Assertions.assertEquals(5, table.getLakeCompactionMaxParallel());
+
+        String alterSql = String.format(
+                "ALTER TABLE %s.%s SET ('lake_compaction_max_parallel' = '20')", DB_NAME, tableName);
+        alterTable(alterSql);
+        Assertions.assertEquals(20, table.getLakeCompactionMaxParallel());
+    }
+
+    // ===========================================
+    // Tests for OlapTable.setLakeCompactionMaxParallel
+    // ===========================================
+
+    @Test
+    public void testOlapTableSetLakeCompactionMaxParallel() throws Exception {
+        String tableName = "t_set_parallel";
+        String createSql = String.format(
+                "CREATE TABLE %s.%s (c0 INT) " +
+                "PRIMARY KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 1", DB_NAME, tableName);
+        LakeTable table = createTable(createSql);
+
+        table.setLakeCompactionMaxParallel(100);
+        Assertions.assertEquals(100, table.getLakeCompactionMaxParallel());
+        Assertions.assertEquals("100",
+                table.getTableProperty().getProperties().get(PropertyAnalyzer.PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL));
+    }
+
+    // ===========================================
+    // Tests for LocalMetastore.alterLakeCompactionMaxParallel
+    // Covers: LocalMetastore.java lines 3882-3900, 3937
+    // ===========================================
+
+    @Test
+    public void testLocalMetastoreAlterLakeCompactionMaxParallelDirect() throws Exception {
+        String tableName = "t_localmetastore_alter";
+        String createSql = String.format(
+                "CREATE TABLE %s.%s (c0 INT) " +
+                "PRIMARY KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 1 " +
+                "PROPERTIES('lake_compaction_max_parallel' = '3')", DB_NAME, tableName);
+        LakeTable table = createTable(createSql);
+        Assertions.assertEquals(3, table.getLakeCompactionMaxParallel());
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL, "25");
+
+        // Call alterTableProperties directly to cover LocalMetastore.alterLakeCompactionMaxParallel
+        GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, table, properties);
+
+        Assertions.assertEquals(25, table.getLakeCompactionMaxParallel());
+    }
+
+    @Test
+    public void testLocalMetastoreAlterLakeCompactionMaxParallelNonCloudNative() throws Exception {
+        // This test verifies that alterLakeCompactionMaxParallel throws exception for non-cloud-native tables
+        String tableName = "t_localmetastore_non_cloud_native";
+        String createSql = String.format(
+                "CREATE TABLE %s.%s (c0 INT) " +
+                "PRIMARY KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 1", DB_NAME, tableName);
+        LakeTable table = createTable(createSql);
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+
+        // Use MockUp to mock the table as non-cloud-native
+        new MockUp<OlapTable>() {
+            @Mock
+            public boolean isCloudNativeTableOrMaterializedView() {
+                return false;
+            }
+        };
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL, "10");
+
+        // Should throw DdlException because the table is mocked as non-cloud-native
+        Assertions.assertThrows(DdlException.class, () -> {
+            GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, table, properties);
+        });
+    }
+
+    @Test
+    public void testLocalMetastoreAlterLakeCompactionMaxParallelInvalidValue() throws Exception {
+        String tableName = "t_localmetastore_invalid";
+        String createSql = String.format(
+                "CREATE TABLE %s.%s (c0 INT) " +
+                "PRIMARY KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 1", DB_NAME, tableName);
+        LakeTable table = createTable(createSql);
+
+        Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(DB_NAME);
+
+        // Test with invalid integer format
+        Map<String, String> invalidProperties = new HashMap<>();
+        invalidProperties.put(PropertyAnalyzer.PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL, "invalid");
+        Assertions.assertThrows(DdlException.class, () -> {
+            GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, table, invalidProperties);
+        });
+
+        // Test with negative value
+        Map<String, String> negativeProperties = new HashMap<>();
+        negativeProperties.put(PropertyAnalyzer.PROPERTIES_LAKE_COMPACTION_MAX_PARALLEL, "-5");
+        Assertions.assertThrows(DdlException.class, () -> {
+            GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, table, negativeProperties);
+        });
+    }
+
+    // ===========================================
+    // Tests for OlapTableFactory - duplicate key table
+    // Covers: OlapTableFactory.java lines 416-420
+    // ===========================================
+
+    @Test
+    public void testCreateDuplicateKeyTableWithLakeCompactionMaxParallel() throws Exception {
+        String tableName = "t_create_dup_parallel";
+        String createSql = String.format(
+                "CREATE TABLE %s.%s (c0 INT, c1 INT) " +
+                "DUPLICATE KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 1 " +
+                "PROPERTIES('lake_compaction_max_parallel' = '7')", DB_NAME, tableName);
+        LakeTable table = createTable(createSql);
+        Assertions.assertEquals(7, table.getLakeCompactionMaxParallel());
+    }
+
+    @Test
+    public void testCreateAggregateKeyTableWithLakeCompactionMaxParallel() throws Exception {
+        String tableName = "t_create_agg_parallel";
+        String createSql = String.format(
+                "CREATE TABLE %s.%s (c0 INT, c1 INT SUM DEFAULT '0') " +
+                "AGGREGATE KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 1 " +
+                "PROPERTIES('lake_compaction_max_parallel' = '12')", DB_NAME, tableName);
+        LakeTable table = createTable(createSql);
+        Assertions.assertEquals(12, table.getLakeCompactionMaxParallel());
+    }
+
+    @Test
+    public void testCreateUniqueKeyTableWithLakeCompactionMaxParallel() throws Exception {
+        String tableName = "t_create_unique_parallel";
+        String createSql = String.format(
+                "CREATE TABLE %s.%s (c0 INT, c1 INT) " +
+                "UNIQUE KEY(c0) " +
+                "DISTRIBUTED BY HASH(c0) BUCKETS 1 " +
+                "PROPERTIES('lake_compaction_max_parallel' = '9')", DB_NAME, tableName);
+        LakeTable table = createTable(createSql);
+        Assertions.assertEquals(9, table.getLakeCompactionMaxParallel());
+    }
+}
+

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -102,6 +102,16 @@ message DeleteTxnLogResponse {
     optional StatusPB status = 1;
 }
 
+// Configuration for per-tablet parallel compaction
+message TabletParallelConfig {
+    // Enable parallel compaction within a single tablet
+    optional bool enable_parallel = 1 [default = false];
+    // Maximum number of parallel compaction tasks per tablet
+    optional int32 max_parallel_per_tablet = 2 [default = 3];
+    // Maximum data volume (bytes) per subtask
+    optional int64 max_bytes_per_subtask = 3 [default = 1073741824]; // 1GB
+}
+
 message CompactRequest {
     repeated int64 tablet_ids = 1;
     optional int64 txn_id = 2;
@@ -111,6 +121,9 @@ message CompactRequest {
     optional bytes encryption_meta = 6;
     optional bool force_base_compaction = 7;
     optional bool skip_write_txnlog = 8;
+    
+    // Configuration for per-tablet parallel compaction
+    optional TabletParallelConfig parallel_config = 13;
 }
 
 message AggregateCompactRequest {
@@ -141,6 +154,16 @@ message CompactStat {
     optional int32 in_queue_time_sec = 52;
 }
 
+// Subtask status for parallel compaction
+message TabletSubtaskStatus {
+    optional int64 tablet_id = 1;
+    optional int32 subtask_id = 2;
+    repeated uint32 input_rowset_ids = 3;
+    optional int64 input_bytes = 4;
+    optional int64 output_bytes = 5;
+    optional StatusPB status = 6;
+}
+
 message CompactResponse {
     repeated int64 failed_tablets = 1;
     // optional int64 execution_time = 2; // ms
@@ -152,6 +175,9 @@ message CompactResponse {
     repeated CompactStat compact_stats = 8;
     optional int64 success_compaction_input_file_size = 9;
     repeated TxnLogPB txn_logs = 10;
+    
+    // Subtask statuses for parallel compaction
+    repeated TabletSubtaskStatus subtask_statuses = 11;
 }
 
 message DropTableRequest {

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -281,6 +281,26 @@ message TxnLogPB {
         // DESIGN: FileMetaPB includes both name and size to avoid expensive get_size()
         // calls to S3/HDFS during publish phase (~10-50ms saved per file access).
         optional FileMetaPB lcrm_file = 11;
+        // Subtask ID for parallel compaction. Only set when this OpCompaction is part of
+        // OpParallelCompaction. For normal compaction, this field is not set.
+        optional int32 subtask_id = 12;
+    }
+
+    // Parallel compaction operation: contains multiple subtask compaction results.
+    // Each subtask generates an independent OpCompaction that can be processed using
+    // the standard publish_primary_compaction logic.
+    message OpParallelCompaction {
+        // Each successful subtask's standard OpCompaction.
+        // Contains input_rowsets, output_rowset, and lcrm_file for each subtask.
+        // SST compaction fields (input_sstables/output_sstable) should be empty in subtask OpCompactions.
+        repeated OpCompaction subtask_compactions = 1;
+        // List of successful subtask IDs for tracking.
+        repeated int32 success_subtask_ids = 2;
+        // Unified SST compaction results (executed once after all subtasks complete).
+        repeated PersistentIndexSstablePB input_sstables = 3;
+        optional PersistentIndexSstablePB output_sstable = 4;
+        // Pk index compaction may generate multi sstables in latest impl.
+        repeated PersistentIndexSstablePB output_sstables = 5;
     }
 
     message OpSchemaChange {
@@ -321,6 +341,7 @@ message TxnLogPB {
     optional OpReplication op_replication = 7;
     optional int64 partition_id = 8;
     optional PUniqueId load_id = 9;
+    optional OpParallelCompaction op_parallel_compaction = 10;
 }
 
 message CombinedTxnLogPB {

--- a/test/sql/test_parallel_compaction/R/test_parallel_compaction
+++ b/test/sql/test_parallel_compaction/R/test_parallel_compaction
@@ -1,0 +1,1032 @@
+-- name: test_parallel_compaction_pk_table @cloud @sequential
+create database test_parallel_compaction_pk_${uuid0};
+-- result:
+-- !result
+use test_parallel_compaction_pk_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `pk_parallel_2` (
+    `k1` BIGINT NOT NULL,
+    `k2` INT NOT NULL,
+    `v1` VARCHAR(100),
+    `v2` BIGINT
+)
+PRIMARY KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "lake_compaction_max_parallel" = "2"
+);
+-- result:
+-- !result
+[UC]tid=select TABLE_ID from information_schema.tables_config where TABLE_NAME='pk_parallel_2' and TABLE_SCHEMA='test_parallel_compaction_pk_${uuid0}';
+-- result:
+11495
+-- !result
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "${tid}");
+-- result:
+-- !result
+INSERT INTO pk_parallel_2 VALUES (1, 1, 'a', 100), (2, 2, 'b', 200);
+-- result:
+-- !result
+INSERT INTO pk_parallel_2 VALUES (3, 3, 'c', 300), (4, 4, 'd', 400);
+-- result:
+-- !result
+INSERT INTO pk_parallel_2 VALUES (5, 5, 'e', 500), (6, 6, 'f', 600);
+-- result:
+-- !result
+INSERT INTO pk_parallel_2 VALUES (7, 7, 'g', 700), (8, 8, 'h', 800);
+-- result:
+-- !result
+INSERT INTO pk_parallel_2 VALUES (9, 9, 'i', 900), (10, 10, 'j', 1000);
+-- result:
+-- !result
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_parallel_2' AND c.TABLE_SCHEMA = 'test_parallel_compaction_pk_${uuid0}';
+-- result:
+5
+-- !result
+SELECT COUNT(*) FROM pk_parallel_2;
+-- result:
+10
+-- !result
+SELECT * FROM pk_parallel_2 ORDER BY k1, k2;
+-- result:
+1	1	a	100
+2	2	b	200
+3	3	c	300
+4	4	d	400
+5	5	e	500
+6	6	f	600
+7	7	g	700
+8	8	h	800
+9	9	i	900
+10	10	j	1000
+-- !result
+UPDATE information_schema.be_configs SET VALUE = '1' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "");
+-- result:
+-- !result
+[UC]ALTER TABLE pk_parallel_2 COMPACT;
+-- result:
+-- !result
+SELECT sleep(30);
+-- result:
+1
+-- !result
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_parallel_2' AND c.TABLE_SCHEMA = 'test_parallel_compaction_pk_${uuid0}';
+-- result:
+3
+-- !result
+SELECT COUNT(*) FROM pk_parallel_2;
+-- result:
+10
+-- !result
+SELECT * FROM pk_parallel_2 ORDER BY k1, k2;
+-- result:
+1	1	a	100
+2	2	b	200
+3	3	c	300
+4	4	d	400
+5	5	e	500
+6	6	f	600
+7	7	g	700
+8	8	h	800
+9	9	i	900
+10	10	j	1000
+-- !result
+UPDATE information_schema.be_configs SET VALUE = '5368709120' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+-- result:
+-- !result
+DROP DATABASE test_parallel_compaction_pk_${uuid0} FORCE;
+-- result:
+-- !result
+-- name: test_parallel_compaction_pk_high_parallel @cloud @sequential
+create database test_parallel_compaction_pk_high_${uuid0};
+-- result:
+-- !result
+use test_parallel_compaction_pk_high_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `pk_parallel_5` (
+    `k1` BIGINT NOT NULL,
+    `k2` INT NOT NULL,
+    `v1` VARCHAR(100),
+    `v2` BIGINT
+)
+PRIMARY KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "lake_compaction_max_parallel" = "5"
+);
+-- result:
+-- !result
+[UC]tid=select TABLE_ID from information_schema.tables_config where TABLE_NAME='pk_parallel_5' and TABLE_SCHEMA='test_parallel_compaction_pk_high_${uuid0}';
+-- result:
+11453
+-- !result
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "${tid}");
+-- result:
+-- !result
+INSERT INTO pk_parallel_5 VALUES (1, 1, 'a', 100), (2, 2, 'b', 200);
+-- result:
+-- !result
+INSERT INTO pk_parallel_5 VALUES (3, 3, 'c', 300), (4, 4, 'd', 400);
+-- result:
+-- !result
+INSERT INTO pk_parallel_5 VALUES (5, 5, 'e', 500), (6, 6, 'f', 600);
+-- result:
+-- !result
+INSERT INTO pk_parallel_5 VALUES (7, 7, 'g', 700), (8, 8, 'h', 800);
+-- result:
+-- !result
+INSERT INTO pk_parallel_5 VALUES (9, 9, 'i', 900), (10, 10, 'j', 1000);
+-- result:
+-- !result
+INSERT INTO pk_parallel_5 VALUES (11, 11, 'k', 1100), (12, 12, 'l', 1200);
+-- result:
+-- !result
+INSERT INTO pk_parallel_5 VALUES (13, 13, 'm', 1300), (14, 14, 'n', 1400);
+-- result:
+-- !result
+INSERT INTO pk_parallel_5 VALUES (15, 15, 'o', 1500), (16, 16, 'p', 1600);
+-- result:
+-- !result
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_parallel_5' AND c.TABLE_SCHEMA = 'test_parallel_compaction_pk_high_${uuid0}';
+-- result:
+8
+-- !result
+SELECT COUNT(*) FROM pk_parallel_5;
+-- result:
+16
+-- !result
+SELECT * FROM pk_parallel_5 ORDER BY k1, k2;
+-- result:
+1	1	a	100
+2	2	b	200
+3	3	c	300
+4	4	d	400
+5	5	e	500
+6	6	f	600
+7	7	g	700
+8	8	h	800
+9	9	i	900
+10	10	j	1000
+11	11	k	1100
+12	12	l	1200
+13	13	m	1300
+14	14	n	1400
+15	15	o	1500
+16	16	p	1600
+-- !result
+UPDATE information_schema.be_configs SET VALUE = '1' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "");
+-- result:
+-- !result
+[UC]ALTER TABLE pk_parallel_5 COMPACT;
+-- result:
+-- !result
+SELECT sleep(30);
+-- result:
+1
+-- !result
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_parallel_5' AND c.TABLE_SCHEMA = 'test_parallel_compaction_pk_high_${uuid0}';
+-- result:
+4
+-- !result
+SELECT COUNT(*) FROM pk_parallel_5;
+-- result:
+16
+-- !result
+SELECT * FROM pk_parallel_5 ORDER BY k1, k2;
+-- result:
+1	1	a	100
+2	2	b	200
+3	3	c	300
+4	4	d	400
+5	5	e	500
+6	6	f	600
+7	7	g	700
+8	8	h	800
+9	9	i	900
+10	10	j	1000
+11	11	k	1100
+12	12	l	1200
+13	13	m	1300
+14	14	n	1400
+15	15	o	1500
+16	16	p	1600
+-- !result
+UPDATE information_schema.be_configs SET VALUE = '5368709120' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+-- result:
+-- !result
+DROP DATABASE test_parallel_compaction_pk_high_${uuid0} FORCE;
+-- result:
+-- !result
+-- name: test_parallel_compaction_dup_table @cloud @sequential
+create database test_parallel_compaction_dup_${uuid0};
+-- result:
+-- !result
+use test_parallel_compaction_dup_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `dup_parallel` (
+    `k1` BIGINT NOT NULL,
+    `k2` INT NOT NULL,
+    `v1` VARCHAR(100),
+    `v2` BIGINT
+)
+DUPLICATE KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "lake_compaction_max_parallel" = "3"
+);
+-- result:
+-- !result
+[UC]tid=select TABLE_ID from information_schema.tables_config where TABLE_NAME='dup_parallel' and TABLE_SCHEMA='test_parallel_compaction_dup_${uuid0}';
+-- result:
+11406
+-- !result
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "${tid}");
+-- result:
+-- !result
+INSERT INTO dup_parallel VALUES (1, 1, 'a', 100), (2, 2, 'b', 200);
+-- result:
+-- !result
+INSERT INTO dup_parallel VALUES (3, 3, 'c', 300), (4, 4, 'd', 400);
+-- result:
+-- !result
+INSERT INTO dup_parallel VALUES (5, 5, 'e', 500), (6, 6, 'f', 600);
+-- result:
+-- !result
+INSERT INTO dup_parallel VALUES (7, 7, 'g', 700), (8, 8, 'h', 800);
+-- result:
+-- !result
+INSERT INTO dup_parallel VALUES (9, 9, 'i', 900), (10, 10, 'j', 1000);
+-- result:
+-- !result
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'dup_parallel' AND c.TABLE_SCHEMA = 'test_parallel_compaction_dup_${uuid0}';
+-- result:
+5
+-- !result
+SELECT COUNT(*) FROM dup_parallel;
+-- result:
+10
+-- !result
+SELECT * FROM dup_parallel ORDER BY k1, k2;
+-- result:
+1	1	a	100
+2	2	b	200
+3	3	c	300
+4	4	d	400
+5	5	e	500
+6	6	f	600
+7	7	g	700
+8	8	h	800
+9	9	i	900
+10	10	j	1000
+-- !result
+UPDATE information_schema.be_configs SET VALUE = '1' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "");
+-- result:
+-- !result
+[UC]ALTER TABLE dup_parallel COMPACT;
+-- result:
+-- !result
+SELECT sleep(30);
+-- result:
+1
+-- !result
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'dup_parallel' AND c.TABLE_SCHEMA = 'test_parallel_compaction_dup_${uuid0}';
+-- result:
+3
+-- !result
+SELECT COUNT(*) FROM dup_parallel;
+-- result:
+10
+-- !result
+SELECT * FROM dup_parallel ORDER BY k1, k2;
+-- result:
+1	1	a	100
+2	2	b	200
+3	3	c	300
+4	4	d	400
+5	5	e	500
+6	6	f	600
+7	7	g	700
+8	8	h	800
+9	9	i	900
+10	10	j	1000
+-- !result
+UPDATE information_schema.be_configs SET VALUE = '5368709120' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+-- result:
+-- !result
+DROP DATABASE test_parallel_compaction_dup_${uuid0} FORCE;
+-- result:
+-- !result
+-- name: test_parallel_compaction_agg_table @cloud @sequential
+create database test_parallel_compaction_agg_${uuid0};
+-- result:
+-- !result
+use test_parallel_compaction_agg_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `agg_parallel` (
+    `k1` BIGINT NOT NULL,
+    `k2` INT NOT NULL,
+    `v1` BIGINT SUM,
+    `v2` BIGINT MAX
+)
+AGGREGATE KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "lake_compaction_max_parallel" = "3"
+);
+-- result:
+-- !result
+[UC]tid=select TABLE_ID from information_schema.tables_config where TABLE_NAME='agg_parallel' and TABLE_SCHEMA='test_parallel_compaction_agg_${uuid0}';
+-- result:
+11354
+-- !result
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "${tid}");
+-- result:
+-- !result
+INSERT INTO agg_parallel VALUES (1, 1, 100, 100), (2, 2, 200, 200);
+-- result:
+-- !result
+INSERT INTO agg_parallel VALUES (3, 3, 300, 300), (4, 4, 400, 400);
+-- result:
+-- !result
+INSERT INTO agg_parallel VALUES (1, 1, 50, 150), (2, 2, 100, 250);
+-- result:
+-- !result
+INSERT INTO agg_parallel VALUES (5, 5, 500, 500), (6, 6, 600, 600);
+-- result:
+-- !result
+INSERT INTO agg_parallel VALUES (3, 3, 200, 400), (4, 4, 300, 500);
+-- result:
+-- !result
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'agg_parallel' AND c.TABLE_SCHEMA = 'test_parallel_compaction_agg_${uuid0}';
+-- result:
+5
+-- !result
+SELECT COUNT(*) FROM agg_parallel;
+-- result:
+6
+-- !result
+SELECT * FROM agg_parallel ORDER BY k1, k2;
+-- result:
+1	1	150	150
+2	2	300	250
+3	3	500	400
+4	4	700	500
+5	5	500	500
+6	6	600	600
+-- !result
+UPDATE information_schema.be_configs SET VALUE = '1' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "");
+-- result:
+-- !result
+[UC]ALTER TABLE agg_parallel COMPACT;
+-- result:
+-- !result
+SELECT sleep(30);
+-- result:
+1
+-- !result
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'agg_parallel' AND c.TABLE_SCHEMA = 'test_parallel_compaction_agg_${uuid0}';
+-- result:
+3
+-- !result
+SELECT COUNT(*) FROM agg_parallel;
+-- result:
+6
+-- !result
+SELECT * FROM agg_parallel ORDER BY k1, k2;
+-- result:
+1	1	150	150
+2	2	300	250
+3	3	500	400
+4	4	700	500
+5	5	500	500
+6	6	600	600
+-- !result
+UPDATE information_schema.be_configs SET VALUE = '5368709120' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+-- result:
+-- !result
+DROP DATABASE test_parallel_compaction_agg_${uuid0} FORCE;
+-- result:
+-- !result
+-- name: test_parallel_compaction_unique_table @cloud @sequential
+create database test_parallel_compaction_uniq_${uuid0};
+-- result:
+-- !result
+use test_parallel_compaction_uniq_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `uniq_parallel` (
+    `k1` BIGINT NOT NULL,
+    `k2` INT NOT NULL,
+    `v1` VARCHAR(100),
+    `v2` BIGINT
+)
+UNIQUE KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "lake_compaction_max_parallel" = "4"
+);
+-- result:
+-- !result
+[UC]tid=select TABLE_ID from information_schema.tables_config where TABLE_NAME='uniq_parallel' and TABLE_SCHEMA='test_parallel_compaction_uniq_${uuid0}';
+-- result:
+11547
+-- !result
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "${tid}");
+-- result:
+-- !result
+INSERT INTO uniq_parallel VALUES (1, 1, 'a', 100), (2, 2, 'b', 200);
+-- result:
+-- !result
+INSERT INTO uniq_parallel VALUES (3, 3, 'c', 300), (4, 4, 'd', 400);
+-- result:
+-- !result
+INSERT INTO uniq_parallel VALUES (1, 1, 'a_updated', 150), (2, 2, 'b_updated', 250);
+-- result:
+-- !result
+INSERT INTO uniq_parallel VALUES (5, 5, 'e', 500), (6, 6, 'f', 600);
+-- result:
+-- !result
+INSERT INTO uniq_parallel VALUES (3, 3, 'c_updated', 350), (7, 7, 'g', 700);
+-- result:
+-- !result
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'uniq_parallel' AND c.TABLE_SCHEMA = 'test_parallel_compaction_uniq_${uuid0}';
+-- result:
+5
+-- !result
+SELECT COUNT(*) FROM uniq_parallel;
+-- result:
+7
+-- !result
+SELECT * FROM uniq_parallel ORDER BY k1, k2;
+-- result:
+1	1	a_updated	150
+2	2	b_updated	250
+3	3	c_updated	350
+4	4	d	400
+5	5	e	500
+6	6	f	600
+7	7	g	700
+-- !result
+UPDATE information_schema.be_configs SET VALUE = '1' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "");
+-- result:
+-- !result
+[UC]ALTER TABLE uniq_parallel COMPACT;
+-- result:
+-- !result
+SELECT sleep(30);
+-- result:
+1
+-- !result
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'uniq_parallel' AND c.TABLE_SCHEMA = 'test_parallel_compaction_uniq_${uuid0}';
+-- result:
+3
+-- !result
+SELECT COUNT(*) FROM uniq_parallel;
+-- result:
+7
+-- !result
+SELECT * FROM uniq_parallel ORDER BY k1, k2;
+-- result:
+1	1	a_updated	150
+2	2	b_updated	250
+3	3	c_updated	350
+4	4	d	400
+5	5	e	500
+6	6	f	600
+7	7	g	700
+-- !result
+UPDATE information_schema.be_configs SET VALUE = '5368709120' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+-- result:
+-- !result
+DROP DATABASE test_parallel_compaction_uniq_${uuid0} FORCE;
+-- result:
+-- !result
+-- name: test_parallel_compaction_disabled @cloud @sequential
+create database test_parallel_compaction_disabled_${uuid0};
+-- result:
+-- !result
+use test_parallel_compaction_disabled_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `pk_no_parallel` (
+    `k1` BIGINT NOT NULL,
+    `k2` INT NOT NULL,
+    `v1` VARCHAR(100),
+    `v2` BIGINT
+)
+PRIMARY KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "lake_compaction_max_parallel" = "0"
+);
+-- result:
+-- !result
+[UC]tid=select TABLE_ID from information_schema.tables_config where TABLE_NAME='pk_no_parallel' and TABLE_SCHEMA='test_parallel_compaction_disabled_${uuid0}';
+-- result:
+11388
+-- !result
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "${tid}");
+-- result:
+-- !result
+INSERT INTO pk_no_parallel VALUES (1, 1, 'a', 100), (2, 2, 'b', 200);
+-- result:
+-- !result
+INSERT INTO pk_no_parallel VALUES (3, 3, 'c', 300), (4, 4, 'd', 400);
+-- result:
+-- !result
+INSERT INTO pk_no_parallel VALUES (5, 5, 'e', 500), (6, 6, 'f', 600);
+-- result:
+-- !result
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_no_parallel' AND c.TABLE_SCHEMA = 'test_parallel_compaction_disabled_${uuid0}';
+-- result:
+3
+-- !result
+SELECT COUNT(*) FROM pk_no_parallel;
+-- result:
+6
+-- !result
+SELECT * FROM pk_no_parallel ORDER BY k1, k2;
+-- result:
+1	1	a	100
+2	2	b	200
+3	3	c	300
+4	4	d	400
+5	5	e	500
+6	6	f	600
+-- !result
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "");
+-- result:
+-- !result
+[UC]ALTER TABLE pk_no_parallel COMPACT;
+-- result:
+-- !result
+SELECT sleep(30);
+-- result:
+1
+-- !result
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_no_parallel' AND c.TABLE_SCHEMA = 'test_parallel_compaction_disabled_${uuid0}';
+-- result:
+3
+-- !result
+SELECT COUNT(*) FROM pk_no_parallel;
+-- result:
+6
+-- !result
+SELECT * FROM pk_no_parallel ORDER BY k1, k2;
+-- result:
+1	1	a	100
+2	2	b	200
+3	3	c	300
+4	4	d	400
+5	5	e	500
+6	6	f	600
+-- !result
+DROP DATABASE test_parallel_compaction_disabled_${uuid0} FORCE;
+-- result:
+-- !result
+-- name: test_parallel_compaction_alter_property @cloud @sequential
+create database test_parallel_compaction_alter_${uuid0};
+-- result:
+-- !result
+use test_parallel_compaction_alter_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `pk_alter_parallel` (
+    `k1` BIGINT NOT NULL,
+    `k2` INT NOT NULL,
+    `v1` VARCHAR(100),
+    `v2` BIGINT
+)
+PRIMARY KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "lake_compaction_max_parallel" = "2"
+);
+-- result:
+-- !result
+SHOW CREATE TABLE pk_alter_parallel;
+-- result:
+pk_alter_parallel	CREATE TABLE `pk_alter_parallel` (
+  `k1` bigint(20) NOT NULL COMMENT "",
+  `k2` int(11) NOT NULL COMMENT "",
+  `v1` varchar(100) NULL COMMENT "",
+  `v2` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP 
+PRIMARY KEY(`k1`, `k2`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
+PROPERTIES (
+"cloud_native_fast_schema_evolution_v2" = "true",
+"compression" = "LZ4",
+"datacache.enable" = "true",
+"enable_async_write_back" = "false",
+"enable_persistent_index" = "true",
+"file_bundling" = "true",
+"persistent_index_type" = "CLOUD_NATIVE",
+"replication_num" = "1",
+"storage_volume" = "builtin_storage_volume"
+);
+-- !result
+ALTER TABLE pk_alter_parallel SET ("lake_compaction_max_parallel" = "5");
+-- result:
+-- !result
+SHOW CREATE TABLE pk_alter_parallel;
+-- result:
+pk_alter_parallel	CREATE TABLE `pk_alter_parallel` (
+  `k1` bigint(20) NOT NULL COMMENT "",
+  `k2` int(11) NOT NULL COMMENT "",
+  `v1` varchar(100) NULL COMMENT "",
+  `v2` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP 
+PRIMARY KEY(`k1`, `k2`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
+PROPERTIES (
+"cloud_native_fast_schema_evolution_v2" = "true",
+"compression" = "LZ4",
+"datacache.enable" = "true",
+"enable_async_write_back" = "false",
+"enable_persistent_index" = "true",
+"file_bundling" = "true",
+"persistent_index_type" = "CLOUD_NATIVE",
+"replication_num" = "1",
+"storage_volume" = "builtin_storage_volume"
+);
+-- !result
+ALTER TABLE pk_alter_parallel SET ("lake_compaction_max_parallel" = "0");
+-- result:
+-- !result
+SHOW CREATE TABLE pk_alter_parallel;
+-- result:
+pk_alter_parallel	CREATE TABLE `pk_alter_parallel` (
+  `k1` bigint(20) NOT NULL COMMENT "",
+  `k2` int(11) NOT NULL COMMENT "",
+  `v1` varchar(100) NULL COMMENT "",
+  `v2` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP 
+PRIMARY KEY(`k1`, `k2`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
+PROPERTIES (
+"cloud_native_fast_schema_evolution_v2" = "true",
+"compression" = "LZ4",
+"datacache.enable" = "true",
+"enable_async_write_back" = "false",
+"enable_persistent_index" = "true",
+"file_bundling" = "true",
+"persistent_index_type" = "CLOUD_NATIVE",
+"replication_num" = "1",
+"storage_volume" = "builtin_storage_volume"
+);
+-- !result
+ALTER TABLE pk_alter_parallel SET ("lake_compaction_max_parallel" = "3");
+-- result:
+-- !result
+SHOW CREATE TABLE pk_alter_parallel;
+-- result:
+pk_alter_parallel	CREATE TABLE `pk_alter_parallel` (
+  `k1` bigint(20) NOT NULL COMMENT "",
+  `k2` int(11) NOT NULL COMMENT "",
+  `v1` varchar(100) NULL COMMENT "",
+  `v2` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP 
+PRIMARY KEY(`k1`, `k2`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
+PROPERTIES (
+"cloud_native_fast_schema_evolution_v2" = "true",
+"compression" = "LZ4",
+"datacache.enable" = "true",
+"enable_async_write_back" = "false",
+"enable_persistent_index" = "true",
+"file_bundling" = "true",
+"persistent_index_type" = "CLOUD_NATIVE",
+"replication_num" = "1",
+"storage_volume" = "builtin_storage_volume"
+);
+-- !result
+DROP DATABASE test_parallel_compaction_alter_${uuid0} FORCE;
+-- result:
+-- !result
+-- name: test_parallel_compaction_pk_with_updates @cloud @sequential
+create database test_parallel_compaction_pk_upd_${uuid0};
+-- result:
+-- !result
+use test_parallel_compaction_pk_upd_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `pk_with_updates` (
+    `k1` BIGINT NOT NULL,
+    `k2` INT NOT NULL,
+    `v1` VARCHAR(100),
+    `v2` BIGINT
+)
+PRIMARY KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "lake_compaction_max_parallel" = "3"
+);
+-- result:
+-- !result
+[UC]tid=select TABLE_ID from information_schema.tables_config where TABLE_NAME='pk_with_updates' and TABLE_SCHEMA='test_parallel_compaction_pk_upd_${uuid0}';
+-- result:
+11523
+-- !result
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "${tid}");
+-- result:
+-- !result
+INSERT INTO pk_with_updates VALUES (1, 1, 'a', 100), (2, 2, 'b', 200), (3, 3, 'c', 300);
+-- result:
+-- !result
+INSERT INTO pk_with_updates VALUES (4, 4, 'd', 400), (5, 5, 'e', 500), (6, 6, 'f', 600);
+-- result:
+-- !result
+UPDATE pk_with_updates SET v1 = 'a_v2', v2 = 110 WHERE k1 = 1;
+-- result:
+-- !result
+UPDATE pk_with_updates SET v1 = 'b_v2', v2 = 220 WHERE k1 = 2;
+-- result:
+-- !result
+DELETE FROM pk_with_updates WHERE k1 = 3;
+-- result:
+-- !result
+INSERT INTO pk_with_updates VALUES (7, 7, 'g', 700), (8, 8, 'h', 800);
+-- result:
+-- !result
+UPDATE pk_with_updates SET v1 = 'd_v2', v2 = 440 WHERE k1 = 4;
+-- result:
+-- !result
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_with_updates' AND c.TABLE_SCHEMA = 'test_parallel_compaction_pk_upd_${uuid0}';
+-- result:
+7
+-- !result
+SELECT COUNT(*) FROM pk_with_updates;
+-- result:
+7
+-- !result
+SELECT * FROM pk_with_updates ORDER BY k1, k2;
+-- result:
+1	1	a_v2	110
+2	2	b_v2	220
+4	4	d_v2	440
+5	5	e	500
+6	6	f	600
+7	7	g	700
+8	8	h	800
+-- !result
+UPDATE information_schema.be_configs SET VALUE = '1' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "");
+-- result:
+-- !result
+[UC]ALTER TABLE pk_with_updates COMPACT;
+-- result:
+-- !result
+SELECT sleep(30);
+-- result:
+1
+-- !result
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_with_updates' AND c.TABLE_SCHEMA = 'test_parallel_compaction_pk_upd_${uuid0}';
+-- result:
+4
+-- !result
+SELECT COUNT(*) FROM pk_with_updates;
+-- result:
+7
+-- !result
+SELECT * FROM pk_with_updates ORDER BY k1, k2;
+-- result:
+1	1	a_v2	110
+2	2	b_v2	220
+4	4	d_v2	440
+5	5	e	500
+6	6	f	600
+7	7	g	700
+8	8	h	800
+-- !result
+UPDATE information_schema.be_configs SET VALUE = '5368709120' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+-- result:
+-- !result
+DROP DATABASE test_parallel_compaction_pk_upd_${uuid0} FORCE;
+-- result:
+-- !result
+-- name: test_parallel_compaction_pk_large_data @cloud @sequential
+create database test_parallel_compaction_pk_large_${uuid0};
+-- result:
+-- !result
+use test_parallel_compaction_pk_large_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `pk_large_data` (
+    `k1` BIGINT NOT NULL,
+    `v1` VARCHAR(1000),
+    `v2` BIGINT
+)
+PRIMARY KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "lake_compaction_max_parallel" = "4"
+);
+-- result:
+-- !result
+[UC]tid=select TABLE_ID from information_schema.tables_config where TABLE_NAME='pk_large_data' and TABLE_SCHEMA='test_parallel_compaction_pk_large_${uuid0}';
+-- result:
+11473
+-- !result
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "${tid}");
+-- result:
+-- !result
+INSERT INTO pk_large_data SELECT generate_series, REPEAT('x', 100), generate_series * 10 FROM TABLE(generate_series(1, 1000));
+-- result:
+-- !result
+INSERT INTO pk_large_data SELECT generate_series, REPEAT('y', 100), generate_series * 10 FROM TABLE(generate_series(1001, 2000));
+-- result:
+-- !result
+INSERT INTO pk_large_data SELECT generate_series, REPEAT('z', 100), generate_series * 10 FROM TABLE(generate_series(2001, 3000));
+-- result:
+-- !result
+INSERT INTO pk_large_data SELECT generate_series, REPEAT('w', 100), generate_series * 10 FROM TABLE(generate_series(3001, 4000));
+-- result:
+-- !result
+INSERT INTO pk_large_data SELECT generate_series, REPEAT('v', 100), generate_series * 10 FROM TABLE(generate_series(4001, 5000));
+-- result:
+-- !result
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_large_data' AND c.TABLE_SCHEMA = 'test_parallel_compaction_pk_large_${uuid0}';
+-- result:
+5
+-- !result
+SELECT COUNT(*) FROM pk_large_data;
+-- result:
+5000
+-- !result
+SELECT MIN(k1), MAX(k1) FROM pk_large_data;
+-- result:
+1	5000
+-- !result
+UPDATE information_schema.be_configs SET VALUE = '1' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "");
+-- result:
+-- !result
+[UC]ALTER TABLE pk_large_data COMPACT;
+-- result:
+-- !result
+SELECT sleep(60);
+-- result:
+1
+-- !result
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_large_data' AND c.TABLE_SCHEMA = 'test_parallel_compaction_pk_large_${uuid0}';
+-- result:
+3
+-- !result
+SELECT COUNT(*) FROM pk_large_data;
+-- result:
+5000
+-- !result
+SELECT MIN(k1), MAX(k1) FROM pk_large_data;
+-- result:
+1	5000
+-- !result
+UPDATE information_schema.be_configs SET VALUE = '5368709120' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+-- result:
+-- !result
+DROP DATABASE test_parallel_compaction_pk_large_${uuid0} FORCE;
+-- result:
+-- !result
+-- name: test_parallel_compaction_multiple_buckets @cloud @sequential
+create database test_parallel_compaction_buckets_${uuid0};
+-- result:
+-- !result
+use test_parallel_compaction_buckets_${uuid0};
+-- result:
+-- !result
+CREATE TABLE `pk_multi_buckets` (
+    `k1` BIGINT NOT NULL,
+    `k2` INT NOT NULL,
+    `v1` VARCHAR(100),
+    `v2` BIGINT
+)
+PRIMARY KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+PROPERTIES (
+    "lake_compaction_max_parallel" = "2"
+);
+-- result:
+-- !result
+[UC]tid=select TABLE_ID from information_schema.tables_config where TABLE_NAME='pk_multi_buckets' and TABLE_SCHEMA='test_parallel_compaction_buckets_${uuid0}';
+-- result:
+11423
+-- !result
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "${tid}");
+-- result:
+-- !result
+INSERT INTO pk_multi_buckets VALUES (1, 1, 'a', 100), (2, 2, 'b', 200), (3, 3, 'c', 300);
+-- result:
+-- !result
+INSERT INTO pk_multi_buckets VALUES (4, 4, 'd', 400), (5, 5, 'e', 500), (6, 6, 'f', 600);
+-- result:
+-- !result
+INSERT INTO pk_multi_buckets VALUES (7, 7, 'g', 700), (8, 8, 'h', 800), (9, 9, 'i', 900);
+-- result:
+-- !result
+INSERT INTO pk_multi_buckets VALUES (10, 10, 'j', 1000), (11, 11, 'k', 1100), (12, 12, 'l', 1200);
+-- result:
+-- !result
+INSERT INTO pk_multi_buckets VALUES (13, 13, 'm', 1300), (14, 14, 'n', 1400), (15, 15, 'o', 1500);
+-- result:
+-- !result
+SELECT SUM(NUM_ROWSET) FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_multi_buckets' AND c.TABLE_SCHEMA = 'test_parallel_compaction_buckets_${uuid0}';
+-- result:
+10
+-- !result
+SELECT COUNT(*) FROM pk_multi_buckets;
+-- result:
+15
+-- !result
+SELECT * FROM pk_multi_buckets ORDER BY k1, k2;
+-- result:
+1	1	a	100
+2	2	b	200
+3	3	c	300
+4	4	d	400
+5	5	e	500
+6	6	f	600
+7	7	g	700
+8	8	h	800
+9	9	i	900
+10	10	j	1000
+11	11	k	1100
+12	12	l	1200
+13	13	m	1300
+14	14	n	1400
+15	15	o	1500
+-- !result
+UPDATE information_schema.be_configs SET VALUE = '1' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "");
+-- result:
+-- !result
+[UC]ALTER TABLE pk_multi_buckets COMPACT;
+-- result:
+-- !result
+SELECT sleep(30);
+-- result:
+1
+-- !result
+SELECT SUM(NUM_ROWSET) FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_multi_buckets' AND c.TABLE_SCHEMA = 'test_parallel_compaction_buckets_${uuid0}';
+-- result:
+8
+-- !result
+SELECT COUNT(*) FROM pk_multi_buckets;
+-- result:
+15
+-- !result
+SELECT * FROM pk_multi_buckets ORDER BY k1, k2;
+-- result:
+1	1	a	100
+2	2	b	200
+3	3	c	300
+4	4	d	400
+5	5	e	500
+6	6	f	600
+7	7	g	700
+8	8	h	800
+9	9	i	900
+10	10	j	1000
+11	11	k	1100
+12	12	l	1200
+13	13	m	1300
+14	14	n	1400
+15	15	o	1500
+-- !result
+UPDATE information_schema.be_configs SET VALUE = '5368709120' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+-- result:
+-- !result
+DROP DATABASE test_parallel_compaction_buckets_${uuid0} FORCE;
+-- result:
+-- !result
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "");
+-- result:
+-- !result

--- a/test/sql/test_parallel_compaction/T/test_parallel_compaction
+++ b/test/sql/test_parallel_compaction/T/test_parallel_compaction
@@ -1,0 +1,587 @@
+-- name: test_parallel_compaction_pk_table @cloud @sequential
+-- Test parallel compaction for primary key table with different parallelism settings
+create database test_parallel_compaction_pk_${uuid0};
+use test_parallel_compaction_pk_${uuid0};
+
+-- Create PK table with parallel compaction enabled (max_parallel = 2)
+CREATE TABLE `pk_parallel_2` (
+    `k1` BIGINT NOT NULL,
+    `k2` INT NOT NULL,
+    `v1` VARCHAR(100),
+    `v2` BIGINT
+)
+PRIMARY KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "lake_compaction_max_parallel" = "2"
+);
+
+-- Get table_id and disable compaction for this table
+[UC]tid=select TABLE_ID from information_schema.tables_config where TABLE_NAME='pk_parallel_2' and TABLE_SCHEMA='test_parallel_compaction_pk_${uuid0}';
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "${tid}");
+
+-- Insert multiple batches to generate multiple rowsets
+INSERT INTO pk_parallel_2 VALUES (1, 1, 'a', 100), (2, 2, 'b', 200);
+INSERT INTO pk_parallel_2 VALUES (3, 3, 'c', 300), (4, 4, 'd', 400);
+INSERT INTO pk_parallel_2 VALUES (5, 5, 'e', 500), (6, 6, 'f', 600);
+INSERT INTO pk_parallel_2 VALUES (7, 7, 'g', 700), (8, 8, 'h', 800);
+INSERT INTO pk_parallel_2 VALUES (9, 9, 'i', 900), (10, 10, 'j', 1000);
+
+-- Check rowset count before compaction (should be 5 rowsets from 5 inserts)
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_parallel_2' AND c.TABLE_SCHEMA = 'test_parallel_compaction_pk_${uuid0}';
+
+-- Verify data before compaction
+SELECT COUNT(*) FROM pk_parallel_2;
+SELECT * FROM pk_parallel_2 ORDER BY k1, k2;
+
+-- Set very small compaction bytes per subtask to trigger parallel compaction
+UPDATE information_schema.be_configs SET VALUE = '1' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+
+-- Re-enable compaction for this table
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "");
+
+-- Manually trigger compaction
+[UC]ALTER TABLE pk_parallel_2 COMPACT;
+
+-- Wait for compaction to complete
+SELECT sleep(30);
+
+-- Check rowset count after compaction (should be reduced, typically to 1)
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_parallel_2' AND c.TABLE_SCHEMA = 'test_parallel_compaction_pk_${uuid0}';
+
+-- Verify data correctness after compaction
+SELECT COUNT(*) FROM pk_parallel_2;
+SELECT * FROM pk_parallel_2 ORDER BY k1, k2;
+
+-- Reset BE config
+UPDATE information_schema.be_configs SET VALUE = '5368709120' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+
+DROP DATABASE test_parallel_compaction_pk_${uuid0} FORCE;
+
+-- name: test_parallel_compaction_pk_high_parallel @cloud @sequential
+-- Test parallel compaction for primary key table with higher parallelism
+create database test_parallel_compaction_pk_high_${uuid0};
+use test_parallel_compaction_pk_high_${uuid0};
+
+-- Create PK table with higher parallel compaction (max_parallel = 5)
+CREATE TABLE `pk_parallel_5` (
+    `k1` BIGINT NOT NULL,
+    `k2` INT NOT NULL,
+    `v1` VARCHAR(100),
+    `v2` BIGINT
+)
+PRIMARY KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "lake_compaction_max_parallel" = "5"
+);
+
+-- Get table_id and disable compaction for this table
+[UC]tid=select TABLE_ID from information_schema.tables_config where TABLE_NAME='pk_parallel_5' and TABLE_SCHEMA='test_parallel_compaction_pk_high_${uuid0}';
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "${tid}");
+
+-- Insert multiple batches to generate multiple rowsets
+INSERT INTO pk_parallel_5 VALUES (1, 1, 'a', 100), (2, 2, 'b', 200);
+INSERT INTO pk_parallel_5 VALUES (3, 3, 'c', 300), (4, 4, 'd', 400);
+INSERT INTO pk_parallel_5 VALUES (5, 5, 'e', 500), (6, 6, 'f', 600);
+INSERT INTO pk_parallel_5 VALUES (7, 7, 'g', 700), (8, 8, 'h', 800);
+INSERT INTO pk_parallel_5 VALUES (9, 9, 'i', 900), (10, 10, 'j', 1000);
+INSERT INTO pk_parallel_5 VALUES (11, 11, 'k', 1100), (12, 12, 'l', 1200);
+INSERT INTO pk_parallel_5 VALUES (13, 13, 'm', 1300), (14, 14, 'n', 1400);
+INSERT INTO pk_parallel_5 VALUES (15, 15, 'o', 1500), (16, 16, 'p', 1600);
+
+-- Check rowset count before compaction (should be 8 rowsets from 8 inserts)
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_parallel_5' AND c.TABLE_SCHEMA = 'test_parallel_compaction_pk_high_${uuid0}';
+
+-- Verify data before compaction
+SELECT COUNT(*) FROM pk_parallel_5;
+SELECT * FROM pk_parallel_5 ORDER BY k1, k2;
+
+-- Set very small compaction bytes per subtask
+UPDATE information_schema.be_configs SET VALUE = '1' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+
+-- Re-enable compaction for this table
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "");
+
+-- Manually trigger compaction
+[UC]ALTER TABLE pk_parallel_5 COMPACT;
+
+-- Wait for compaction to complete
+SELECT sleep(30);
+
+-- Check rowset count after compaction (should be reduced)
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_parallel_5' AND c.TABLE_SCHEMA = 'test_parallel_compaction_pk_high_${uuid0}';
+
+-- Verify data correctness after compaction
+SELECT COUNT(*) FROM pk_parallel_5;
+SELECT * FROM pk_parallel_5 ORDER BY k1, k2;
+
+-- Reset BE config
+UPDATE information_schema.be_configs SET VALUE = '5368709120' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+
+DROP DATABASE test_parallel_compaction_pk_high_${uuid0} FORCE;
+
+-- name: test_parallel_compaction_dup_table @cloud @sequential
+-- Test parallel compaction for duplicate key table
+create database test_parallel_compaction_dup_${uuid0};
+use test_parallel_compaction_dup_${uuid0};
+
+-- Create DUP table with parallel compaction enabled
+CREATE TABLE `dup_parallel` (
+    `k1` BIGINT NOT NULL,
+    `k2` INT NOT NULL,
+    `v1` VARCHAR(100),
+    `v2` BIGINT
+)
+DUPLICATE KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "lake_compaction_max_parallel" = "3"
+);
+
+-- Get table_id and disable compaction for this table
+[UC]tid=select TABLE_ID from information_schema.tables_config where TABLE_NAME='dup_parallel' and TABLE_SCHEMA='test_parallel_compaction_dup_${uuid0}';
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "${tid}");
+
+-- Insert multiple batches to generate multiple rowsets
+INSERT INTO dup_parallel VALUES (1, 1, 'a', 100), (2, 2, 'b', 200);
+INSERT INTO dup_parallel VALUES (3, 3, 'c', 300), (4, 4, 'd', 400);
+INSERT INTO dup_parallel VALUES (5, 5, 'e', 500), (6, 6, 'f', 600);
+INSERT INTO dup_parallel VALUES (7, 7, 'g', 700), (8, 8, 'h', 800);
+INSERT INTO dup_parallel VALUES (9, 9, 'i', 900), (10, 10, 'j', 1000);
+
+-- Check rowset count before compaction
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'dup_parallel' AND c.TABLE_SCHEMA = 'test_parallel_compaction_dup_${uuid0}';
+
+-- Verify data before compaction
+SELECT COUNT(*) FROM dup_parallel;
+SELECT * FROM dup_parallel ORDER BY k1, k2;
+
+-- Set very small compaction bytes per subtask
+UPDATE information_schema.be_configs SET VALUE = '1' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+
+-- Re-enable compaction for this table
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "");
+
+-- Manually trigger compaction
+[UC]ALTER TABLE dup_parallel COMPACT;
+
+-- Wait for compaction to complete
+SELECT sleep(30);
+
+-- Check rowset count after compaction
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'dup_parallel' AND c.TABLE_SCHEMA = 'test_parallel_compaction_dup_${uuid0}';
+
+-- Verify data correctness after compaction
+SELECT COUNT(*) FROM dup_parallel;
+SELECT * FROM dup_parallel ORDER BY k1, k2;
+
+-- Reset BE config
+UPDATE information_schema.be_configs SET VALUE = '5368709120' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+
+DROP DATABASE test_parallel_compaction_dup_${uuid0} FORCE;
+
+-- name: test_parallel_compaction_agg_table @cloud @sequential
+-- Test parallel compaction for aggregate key table
+create database test_parallel_compaction_agg_${uuid0};
+use test_parallel_compaction_agg_${uuid0};
+
+-- Create AGG table with parallel compaction enabled
+CREATE TABLE `agg_parallel` (
+    `k1` BIGINT NOT NULL,
+    `k2` INT NOT NULL,
+    `v1` BIGINT SUM,
+    `v2` BIGINT MAX
+)
+AGGREGATE KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "lake_compaction_max_parallel" = "3"
+);
+
+-- Get table_id and disable compaction for this table
+[UC]tid=select TABLE_ID from information_schema.tables_config where TABLE_NAME='agg_parallel' and TABLE_SCHEMA='test_parallel_compaction_agg_${uuid0}';
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "${tid}");
+
+-- Insert multiple batches to generate multiple rowsets
+INSERT INTO agg_parallel VALUES (1, 1, 100, 100), (2, 2, 200, 200);
+INSERT INTO agg_parallel VALUES (3, 3, 300, 300), (4, 4, 400, 400);
+INSERT INTO agg_parallel VALUES (1, 1, 50, 150), (2, 2, 100, 250);
+INSERT INTO agg_parallel VALUES (5, 5, 500, 500), (6, 6, 600, 600);
+INSERT INTO agg_parallel VALUES (3, 3, 200, 400), (4, 4, 300, 500);
+
+-- Check rowset count before compaction
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'agg_parallel' AND c.TABLE_SCHEMA = 'test_parallel_compaction_agg_${uuid0}';
+
+-- Verify data before compaction (aggregated)
+SELECT COUNT(*) FROM agg_parallel;
+SELECT * FROM agg_parallel ORDER BY k1, k2;
+
+-- Set very small compaction bytes per subtask
+UPDATE information_schema.be_configs SET VALUE = '1' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+
+-- Re-enable compaction for this table
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "");
+
+-- Manually trigger compaction
+[UC]ALTER TABLE agg_parallel COMPACT;
+
+-- Wait for compaction to complete
+SELECT sleep(30);
+
+-- Check rowset count after compaction
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'agg_parallel' AND c.TABLE_SCHEMA = 'test_parallel_compaction_agg_${uuid0}';
+
+-- Verify data correctness after compaction (aggregated results should be same)
+SELECT COUNT(*) FROM agg_parallel;
+SELECT * FROM agg_parallel ORDER BY k1, k2;
+
+-- Reset BE config
+UPDATE information_schema.be_configs SET VALUE = '5368709120' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+
+DROP DATABASE test_parallel_compaction_agg_${uuid0} FORCE;
+
+-- name: test_parallel_compaction_unique_table @cloud @sequential
+-- Test parallel compaction for unique key table
+create database test_parallel_compaction_uniq_${uuid0};
+use test_parallel_compaction_uniq_${uuid0};
+
+-- Create UNIQUE table with parallel compaction enabled
+CREATE TABLE `uniq_parallel` (
+    `k1` BIGINT NOT NULL,
+    `k2` INT NOT NULL,
+    `v1` VARCHAR(100),
+    `v2` BIGINT
+)
+UNIQUE KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "lake_compaction_max_parallel" = "4"
+);
+
+-- Get table_id and disable compaction for this table
+[UC]tid=select TABLE_ID from information_schema.tables_config where TABLE_NAME='uniq_parallel' and TABLE_SCHEMA='test_parallel_compaction_uniq_${uuid0}';
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "${tid}");
+
+-- Insert multiple batches to generate multiple rowsets
+INSERT INTO uniq_parallel VALUES (1, 1, 'a', 100), (2, 2, 'b', 200);
+INSERT INTO uniq_parallel VALUES (3, 3, 'c', 300), (4, 4, 'd', 400);
+INSERT INTO uniq_parallel VALUES (1, 1, 'a_updated', 150), (2, 2, 'b_updated', 250);
+INSERT INTO uniq_parallel VALUES (5, 5, 'e', 500), (6, 6, 'f', 600);
+INSERT INTO uniq_parallel VALUES (3, 3, 'c_updated', 350), (7, 7, 'g', 700);
+
+-- Check rowset count before compaction
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'uniq_parallel' AND c.TABLE_SCHEMA = 'test_parallel_compaction_uniq_${uuid0}';
+
+-- Verify data before compaction (should show latest values for duplicate keys)
+SELECT COUNT(*) FROM uniq_parallel;
+SELECT * FROM uniq_parallel ORDER BY k1, k2;
+
+-- Set very small compaction bytes per subtask
+UPDATE information_schema.be_configs SET VALUE = '1' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+
+-- Re-enable compaction for this table
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "");
+
+-- Manually trigger compaction
+[UC]ALTER TABLE uniq_parallel COMPACT;
+
+-- Wait for compaction to complete
+SELECT sleep(30);
+
+-- Check rowset count after compaction
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'uniq_parallel' AND c.TABLE_SCHEMA = 'test_parallel_compaction_uniq_${uuid0}';
+
+-- Verify data correctness after compaction (unique results should be same)
+SELECT COUNT(*) FROM uniq_parallel;
+SELECT * FROM uniq_parallel ORDER BY k1, k2;
+
+-- Reset BE config
+UPDATE information_schema.be_configs SET VALUE = '5368709120' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+
+DROP DATABASE test_parallel_compaction_uniq_${uuid0} FORCE;
+
+-- name: test_parallel_compaction_disabled @cloud @sequential
+-- Test when parallel compaction is disabled (max_parallel = 0)
+create database test_parallel_compaction_disabled_${uuid0};
+use test_parallel_compaction_disabled_${uuid0};
+
+-- Create PK table with parallel compaction disabled
+CREATE TABLE `pk_no_parallel` (
+    `k1` BIGINT NOT NULL,
+    `k2` INT NOT NULL,
+    `v1` VARCHAR(100),
+    `v2` BIGINT
+)
+PRIMARY KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "lake_compaction_max_parallel" = "0"
+);
+
+-- Get table_id and disable compaction for this table
+[UC]tid=select TABLE_ID from information_schema.tables_config where TABLE_NAME='pk_no_parallel' and TABLE_SCHEMA='test_parallel_compaction_disabled_${uuid0}';
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "${tid}");
+
+-- Insert multiple batches
+INSERT INTO pk_no_parallel VALUES (1, 1, 'a', 100), (2, 2, 'b', 200);
+INSERT INTO pk_no_parallel VALUES (3, 3, 'c', 300), (4, 4, 'd', 400);
+INSERT INTO pk_no_parallel VALUES (5, 5, 'e', 500), (6, 6, 'f', 600);
+
+-- Check rowset count before compaction
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_no_parallel' AND c.TABLE_SCHEMA = 'test_parallel_compaction_disabled_${uuid0}';
+
+-- Verify data before compaction
+SELECT COUNT(*) FROM pk_no_parallel;
+SELECT * FROM pk_no_parallel ORDER BY k1, k2;
+
+-- Re-enable compaction for this table
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "");
+
+-- Manually trigger compaction (will use normal compaction, not parallel)
+[UC]ALTER TABLE pk_no_parallel COMPACT;
+
+-- Wait for compaction to complete
+SELECT sleep(30);
+
+-- Check rowset count after compaction
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_no_parallel' AND c.TABLE_SCHEMA = 'test_parallel_compaction_disabled_${uuid0}';
+
+-- Verify data correctness after compaction
+SELECT COUNT(*) FROM pk_no_parallel;
+SELECT * FROM pk_no_parallel ORDER BY k1, k2;
+
+DROP DATABASE test_parallel_compaction_disabled_${uuid0} FORCE;
+
+-- name: test_parallel_compaction_alter_property @cloud @sequential
+-- Test altering lake_compaction_max_parallel property
+create database test_parallel_compaction_alter_${uuid0};
+use test_parallel_compaction_alter_${uuid0};
+
+-- Create PK table with default parallel compaction setting
+CREATE TABLE `pk_alter_parallel` (
+    `k1` BIGINT NOT NULL,
+    `k2` INT NOT NULL,
+    `v1` VARCHAR(100),
+    `v2` BIGINT
+)
+PRIMARY KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "lake_compaction_max_parallel" = "2"
+);
+
+-- Show table properties
+SHOW CREATE TABLE pk_alter_parallel;
+
+-- Alter property to higher parallelism
+ALTER TABLE pk_alter_parallel SET ("lake_compaction_max_parallel" = "5");
+
+-- Verify property change
+SHOW CREATE TABLE pk_alter_parallel;
+
+-- Alter property to disable parallel compaction
+ALTER TABLE pk_alter_parallel SET ("lake_compaction_max_parallel" = "0");
+
+-- Verify property change
+SHOW CREATE TABLE pk_alter_parallel;
+
+-- Alter property back to enable
+ALTER TABLE pk_alter_parallel SET ("lake_compaction_max_parallel" = "3");
+
+-- Verify property change
+SHOW CREATE TABLE pk_alter_parallel;
+
+DROP DATABASE test_parallel_compaction_alter_${uuid0} FORCE;
+
+-- name: test_parallel_compaction_pk_with_updates @cloud @sequential
+-- Test parallel compaction for primary key table with updates
+create database test_parallel_compaction_pk_upd_${uuid0};
+use test_parallel_compaction_pk_upd_${uuid0};
+
+-- Create PK table with parallel compaction enabled
+CREATE TABLE `pk_with_updates` (
+    `k1` BIGINT NOT NULL,
+    `k2` INT NOT NULL,
+    `v1` VARCHAR(100),
+    `v2` BIGINT
+)
+PRIMARY KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "lake_compaction_max_parallel" = "3"
+);
+
+-- Get table_id and disable compaction for this table
+[UC]tid=select TABLE_ID from information_schema.tables_config where TABLE_NAME='pk_with_updates' and TABLE_SCHEMA='test_parallel_compaction_pk_upd_${uuid0}';
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "${tid}");
+
+-- Insert initial data
+INSERT INTO pk_with_updates VALUES (1, 1, 'a', 100), (2, 2, 'b', 200), (3, 3, 'c', 300);
+INSERT INTO pk_with_updates VALUES (4, 4, 'd', 400), (5, 5, 'e', 500), (6, 6, 'f', 600);
+
+-- Update some records
+UPDATE pk_with_updates SET v1 = 'a_v2', v2 = 110 WHERE k1 = 1;
+UPDATE pk_with_updates SET v1 = 'b_v2', v2 = 220 WHERE k1 = 2;
+
+-- Delete some records
+DELETE FROM pk_with_updates WHERE k1 = 3;
+
+-- Insert more data
+INSERT INTO pk_with_updates VALUES (7, 7, 'g', 700), (8, 8, 'h', 800);
+
+-- Update more records
+UPDATE pk_with_updates SET v1 = 'd_v2', v2 = 440 WHERE k1 = 4;
+
+-- Check rowset count before compaction
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_with_updates' AND c.TABLE_SCHEMA = 'test_parallel_compaction_pk_upd_${uuid0}';
+
+-- Verify data before compaction
+SELECT COUNT(*) FROM pk_with_updates;
+SELECT * FROM pk_with_updates ORDER BY k1, k2;
+
+-- Set very small compaction bytes per subtask
+UPDATE information_schema.be_configs SET VALUE = '1' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+
+-- Re-enable compaction for this table
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "");
+
+-- Manually trigger compaction
+[UC]ALTER TABLE pk_with_updates COMPACT;
+
+-- Wait for compaction to complete
+SELECT sleep(30);
+
+-- Check rowset count after compaction
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_with_updates' AND c.TABLE_SCHEMA = 'test_parallel_compaction_pk_upd_${uuid0}';
+
+-- Verify data correctness after compaction
+SELECT COUNT(*) FROM pk_with_updates;
+SELECT * FROM pk_with_updates ORDER BY k1, k2;
+
+-- Reset BE config
+UPDATE information_schema.be_configs SET VALUE = '5368709120' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+
+DROP DATABASE test_parallel_compaction_pk_upd_${uuid0} FORCE;
+
+-- name: test_parallel_compaction_pk_large_data @cloud @sequential
+-- Test parallel compaction for primary key table with larger data volume
+create database test_parallel_compaction_pk_large_${uuid0};
+use test_parallel_compaction_pk_large_${uuid0};
+
+-- Create PK table with parallel compaction enabled
+CREATE TABLE `pk_large_data` (
+    `k1` BIGINT NOT NULL,
+    `v1` VARCHAR(1000),
+    `v2` BIGINT
+)
+PRIMARY KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "lake_compaction_max_parallel" = "4"
+);
+
+-- Get table_id and disable compaction for this table
+[UC]tid=select TABLE_ID from information_schema.tables_config where TABLE_NAME='pk_large_data' and TABLE_SCHEMA='test_parallel_compaction_pk_large_${uuid0}';
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "${tid}");
+
+-- Insert larger batches using generate_series to generate more data
+INSERT INTO pk_large_data SELECT generate_series, REPEAT('x', 100), generate_series * 10 FROM TABLE(generate_series(1, 1000));
+INSERT INTO pk_large_data SELECT generate_series, REPEAT('y', 100), generate_series * 10 FROM TABLE(generate_series(1001, 2000));
+INSERT INTO pk_large_data SELECT generate_series, REPEAT('z', 100), generate_series * 10 FROM TABLE(generate_series(2001, 3000));
+INSERT INTO pk_large_data SELECT generate_series, REPEAT('w', 100), generate_series * 10 FROM TABLE(generate_series(3001, 4000));
+INSERT INTO pk_large_data SELECT generate_series, REPEAT('v', 100), generate_series * 10 FROM TABLE(generate_series(4001, 5000));
+
+-- Check rowset count before compaction
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_large_data' AND c.TABLE_SCHEMA = 'test_parallel_compaction_pk_large_${uuid0}';
+
+-- Verify data count before compaction
+SELECT COUNT(*) FROM pk_large_data;
+SELECT MIN(k1), MAX(k1) FROM pk_large_data;
+
+-- Set very small compaction bytes per subtask to trigger parallel compaction
+UPDATE information_schema.be_configs SET VALUE = '1' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+
+-- Re-enable compaction for this table
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "");
+
+-- Manually trigger compaction
+[UC]ALTER TABLE pk_large_data COMPACT;
+
+-- Wait for compaction to complete
+SELECT sleep(60);
+
+-- Check rowset count after compaction
+SELECT NUM_ROWSET FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_large_data' AND c.TABLE_SCHEMA = 'test_parallel_compaction_pk_large_${uuid0}';
+
+-- Verify data correctness after compaction
+SELECT COUNT(*) FROM pk_large_data;
+SELECT MIN(k1), MAX(k1) FROM pk_large_data;
+
+-- Reset BE config
+UPDATE information_schema.be_configs SET VALUE = '5368709120' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+
+DROP DATABASE test_parallel_compaction_pk_large_${uuid0} FORCE;
+
+-- name: test_parallel_compaction_multiple_buckets @cloud @sequential
+-- Test parallel compaction with multiple buckets
+create database test_parallel_compaction_buckets_${uuid0};
+use test_parallel_compaction_buckets_${uuid0};
+
+-- Create PK table with multiple buckets
+CREATE TABLE `pk_multi_buckets` (
+    `k1` BIGINT NOT NULL,
+    `k2` INT NOT NULL,
+    `v1` VARCHAR(100),
+    `v2` BIGINT
+)
+PRIMARY KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+PROPERTIES (
+    "lake_compaction_max_parallel" = "2"
+);
+
+-- Get table_id and disable compaction for this table
+[UC]tid=select TABLE_ID from information_schema.tables_config where TABLE_NAME='pk_multi_buckets' and TABLE_SCHEMA='test_parallel_compaction_buckets_${uuid0}';
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "${tid}");
+
+-- Insert data across multiple buckets
+INSERT INTO pk_multi_buckets VALUES (1, 1, 'a', 100), (2, 2, 'b', 200), (3, 3, 'c', 300);
+INSERT INTO pk_multi_buckets VALUES (4, 4, 'd', 400), (5, 5, 'e', 500), (6, 6, 'f', 600);
+INSERT INTO pk_multi_buckets VALUES (7, 7, 'g', 700), (8, 8, 'h', 800), (9, 9, 'i', 900);
+INSERT INTO pk_multi_buckets VALUES (10, 10, 'j', 1000), (11, 11, 'k', 1100), (12, 12, 'l', 1200);
+INSERT INTO pk_multi_buckets VALUES (13, 13, 'm', 1300), (14, 14, 'n', 1400), (15, 15, 'o', 1500);
+
+-- Check rowset count before compaction (should have multiple rowsets per bucket)
+SELECT SUM(NUM_ROWSET) FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_multi_buckets' AND c.TABLE_SCHEMA = 'test_parallel_compaction_buckets_${uuid0}';
+
+-- Verify data before compaction
+SELECT COUNT(*) FROM pk_multi_buckets;
+SELECT * FROM pk_multi_buckets ORDER BY k1, k2;
+
+-- Set very small compaction bytes per subtask
+UPDATE information_schema.be_configs SET VALUE = '1' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+
+-- Re-enable compaction for this table
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "");
+
+-- Manually trigger compaction
+[UC]ALTER TABLE pk_multi_buckets COMPACT;
+
+-- Wait for compaction to complete
+SELECT sleep(30);
+
+-- Check rowset count after compaction (should be reduced for each bucket)
+SELECT SUM(NUM_ROWSET) FROM information_schema.be_tablets t, information_schema.tables_config c WHERE t.TABLE_ID = c.TABLE_ID AND c.TABLE_NAME = 'pk_multi_buckets' AND c.TABLE_SCHEMA = 'test_parallel_compaction_buckets_${uuid0}';
+
+-- Verify data correctness after compaction
+SELECT COUNT(*) FROM pk_multi_buckets;
+SELECT * FROM pk_multi_buckets ORDER BY k1, k2;
+
+-- Reset BE config
+UPDATE information_schema.be_configs SET VALUE = '5368709120' WHERE name = 'lake_compaction_max_bytes_per_subtask';
+
+DROP DATABASE test_parallel_compaction_buckets_${uuid0} FORCE;
+
+-- Restore default settings at the end
+ADMIN SET FRONTEND CONFIG ("lake_compaction_disable_ids" = "");


### PR DESCRIPTION
## Why I'm doing:

- Lake table compaction currently executes in a single thread per tablet, which
  becomes a bottleneck for large tablets with significant data volume or many
  rowsets, causing data accumulation and query performance degradation.
- To improve compaction throughput and reduce compaction lag, we need the ability
  to run multiple compaction subtasks concurrently within a single tablet.

## What I'm doing:

- Introduce TabletParallelCompactionManager to orchestrate parallel compaction
  subtasks within a single tablet by selecting non-overlapping rowset groups.
- Modify CompactionScheduler to process parallel compaction requests from FE,
  creating multiple subtasks that can run concurrently on the thread pool.
- Add rows mapper functionality to track row mappings across parallel subtasks,
  enabling proper conflict resolution for primary key tables.
- Optimize compaction score calculation by skipping large segments that are
  close to max_segment_file_size (configurable via lake_compaction_skip_large_
  segment_ratio), avoiding unnecessary compaction of already optimized segments.
- Defer SST compaction to execute once after all subtasks complete, preventing
  multiple subtasks from competing to compact the same SST files.
- Add FE configurations: lake_compaction_enable_parallel_per_tablet,
  lake_compaction_max_parallel_per_tablet, lake_compaction_max_bytes_per_subtask.
- Add BE configurations: lake_compaction_max_parallel_per_tablet,
  lake_compaction_max_bytes_per_subtask, enable_lake_compaction_skip_large_segment.
- Extend protobuf messages (TabletParallelConfig, CompactionResultPB) to support
  parallel compaction coordination between FE and BE.
- Add comprehensive unit tests for parallel compaction manager and scheduler.

Fixes #66457

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces concurrent compaction within a single Lake tablet and merges outputs safely, improving throughput on large tablets.
> 
> - Add `TabletParallelCompactionManager` to split rowsets into groups, submit subtasks, track state, and merge results (`op_parallel_compaction`)
> - Extend `CompactionScheduler` to handle parallel requests, create subtasks, integrate with limiter/threadpool, list/cleanup parallel tasks
> - Support parallel context end-to-end: set `subtask_id` in writers, per-subtask rows-mapper files, skip per-subtask SST compaction and run once after all subtasks
> - Update txn log applier to apply `op_parallel_compaction` (merge successful subtasks, apply unified SST compaction)
> - Improve compaction scoring: skip large non-overlapped rowsets/segments via `calc_effective_segment_count` and correct partial-segment accounting
> - Add `TabletManager::compact(context, input_rowsets)` overload for pre-selected rowsets
> - New configs: `lake_compaction_max_bytes_per_subtask`, `lake_compaction_max_rowset_size`
> - Add tests for scheduler/manager and wire into build
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6726a5c44d40826ab09ef4d9f4e4b7ec6e365cab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->