### PR TITLE
[Enhancement][Draft]change update_tablet_meta_info thread pool max thread to 2

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -251,8 +251,9 @@ Status AgentServer::Impl::init() {
         BUILD_DYNAMIC_TASK_THREAD_POOL(move_dir, 0, calc_real_num_threads(config::download_worker_count),
                                        std::numeric_limits<int>::max(), _thread_pool_move_dir);
 
-        BUILD_DYNAMIC_TASK_THREAD_POOL(update_tablet_meta_info, 0, 1, std::numeric_limits<int>::max(),
-                                       _thread_pool_update_tablet_meta_info);
+        BUILD_DYNAMIC_TASK_THREAD_POOL(update_tablet_meta_info, 0,
+                                       calc_real_num_threads(config::update_tablet_meta_info_worker_count),
+                                       std::numeric_limits<int>::max(), _thread_pool_update_tablet_meta_info);
 
         BUILD_DYNAMIC_TASK_THREAD_POOL(drop_auto_increment_map_dir, 0, 1, std::numeric_limits<int>::max(),
                                        _thread_pool_drop_auto_increment_map);

--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -899,7 +899,7 @@ void run_update_meta_info_task(const std::shared_ptr<UpdateTabletMetaInfoAgentTa
                                ExecEnv* exec_env) {
     const TUpdateTabletMetaInfoReq& update_tablet_meta_req = agent_task_req->task_req;
 
-    VLOG(1) << "get update tablet meta task, signature:" << agent_task_req->signature;
+    LOG(INFO) << "get update tablet meta task, signature:" << agent_task_req->signature;
 
     auto update_manager = StorageEngine::instance()->update_manager();
     TStatusCode::type status_code = TStatusCode::OK;

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -156,6 +156,8 @@ CONF_Int32(storage_medium_migrate_count, "3");
 CONF_mInt32(check_consistency_worker_count, "1");
 // The count of thread to update scheam
 CONF_Int32(update_schema_worker_count, "3");
+// The max count of thread to update tablet meta info (lake/get_tablet_stats), 0 means same as cpu cores.
+CONF_mInt32(update_tablet_meta_info_worker_count, "2");
 // The count of thread to upload.
 CONF_mInt32(upload_worker_count, "0");
 // The count of thread to download.


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes the `UPDATE_TABLET_META_INFO` thread pool size configurable via `update_tablet_meta_info_worker_count` and adds start/end timing logs to `LakeServiceImpl::get_tablet_stats`, plus elevates update-meta task log level to INFO.
> 
> - **Agent Server**:
>   - Configure `update_tablet_meta_info` thread pool using `calc_real_num_threads(config::update_tablet_meta_info_worker_count)` instead of a fixed size.
> - **Config**:
>   - Add `config::update_tablet_meta_info_worker_count` (default `2`, `0` = CPU cores) to control `UPDATE_TABLET_META_INFO` pool.
> - **Lake Service**:
>   - `get_tablet_stats` adds start/end INFO logs and elapsed timing; minor refactor to cache `tablet_count`.
> - **Logging**:
>   - Promote update tablet meta task start log from verbose to `INFO`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1451c6fa5e4d81a49fb67167149f588115448702. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->