### PR TITLE
[Feature] support autonomous lake compaction compaction framework

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1193,6 +1193,35 @@ CONF_mBool(lake_print_delete_log, "false");
 CONF_mInt64(lake_compaction_stream_buffer_size_bytes, "1048576"); // 1MB
 // The interval to check whether lake compaction is valid. Set to <= 0 to disable the check.
 CONF_mInt32(lake_compaction_check_valid_interval_minutes, "10"); // 10 minutes
+
+// Autonomous compaction configurations
+// Enable autonomous compaction for lake tablets
+CONF_mBool(enable_lake_autonomous_compaction, "false");
+// Compaction score threshold to trigger autonomous compaction
+CONF_mDouble(lake_compaction_score_threshold, "10.0");
+// Maximum number of concurrent autonomous compaction tasks globally
+CONF_mInt32(lake_compaction_max_concurrent_tasks, "32");
+// Maximum number of concurrent compaction tasks per tablet
+CONF_mInt32(lake_compaction_max_tasks_per_tablet, "3");
+// Maximum data volume (bytes) to compact in a single task (10GB default)
+CONF_mInt64(lake_compaction_max_bytes_per_task, "10737418240");
+
+// Per-tablet parallel compaction configurations (FE-scheduled mode)
+// Maximum number of parallel compaction subtasks per tablet
+CONF_mInt32(lake_compaction_max_parallel_per_tablet, "3");
+// Maximum data volume (bytes) per parallel subtask (10GB default)
+CONF_mInt64(lake_compaction_max_bytes_per_subtask, "10737418240");
+
+// ============== Autonomous Compaction Recovery Configurations (Section 6.1) ==============
+// Enable recovery of local compaction results on BE startup
+CONF_mBool(enable_lake_compaction_recovery_on_startup, "true");
+// Maximum age (in seconds) of compaction results to consider valid during recovery
+// Results older than this will be cleaned up (default: 24 hours)
+CONF_mInt64(lake_compaction_result_max_age_seconds, "86400");
+// Minimum number of tablets with results to trigger partial publish
+CONF_mInt32(lake_compaction_partial_publish_min_tablets, "1");
+// Enable partial compaction state detection and publish
+CONF_mBool(enable_lake_compaction_partial_publish, "true");
 // Used to ensure service availability in extreme situations by sacrificing a certain degree of correctness
 CONF_mBool(experimental_lake_ignore_lost_segment, "false");
 CONF_mInt64(experimental_lake_wait_per_put_ms, "0");

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -184,10 +184,13 @@ set(STORAGE_FILES
     primary_key_recover.cpp
     local_primary_key_recover.cpp
     lake/async_delta_writer.cpp
+    lake/autonomous_compaction_handler.cpp
     lake/compaction_policy.cpp
+    lake/compaction_result_manager.cpp
     lake/compaction_scheduler.cpp
     lake/compaction_task.cpp
     lake/compaction_task_context.cpp
+    lake/tablet_parallel_compaction_manager.cpp
     lake/horizontal_compaction_task.cpp
     lake/delta_writer.cpp
     lake/vacuum.cpp

--- a/be/src/storage/lake/autonomous_compaction_handler.cpp
+++ b/be/src/storage/lake/autonomous_compaction_handler.cpp
@@ -1,0 +1,261 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/autonomous_compaction_handler.h"
+
+#include <unordered_map>
+#include <unordered_set>
+
+#include "common/config.h"
+#include "common/logging.h"
+#include "gutil/strings/substitute.h"
+#include "storage/lake/compaction_policy.h"
+#include "storage/lake/compaction_result_manager.h"
+#include "storage/lake/lake_compaction_manager.h"
+#include "storage/lake/tablet_manager.h"
+
+namespace starrocks::lake {
+
+AutonomousCompactionHandler::AutonomousCompactionHandler(TabletManager* tablet_mgr)
+        : _tablet_mgr(tablet_mgr), _result_mgr(std::make_unique<CompactionResultManager>()) {}
+
+AutonomousCompactionHandler::~AutonomousCompactionHandler() = default;
+
+Status AutonomousCompactionHandler::process_request(const CompactRequest* request, CompactResponse* response) {
+    if (!request->autonomous_compaction()) {
+        return Status::InvalidArgument("Not an autonomous compaction request");
+    }
+
+    // Reset statistics
+    _last_stats = AutonomousCompactionStats{};
+    _last_stats.tablets_processed = request->tablet_ids_size();
+
+    LOG(INFO) << "Processing autonomous compaction request for " << request->tablet_ids_size()
+              << " tablets, txn_id=" << request->txn_id() << ", version=" << request->version()
+              << ", visible_version=" << request->visible_version();
+
+    int64_t visible_version = request->has_visible_version() ? request->visible_version() : request->version();
+    std::vector<int64_t> tablet_ids(request->tablet_ids().begin(), request->tablet_ids().end());
+
+    // Step 1: Trigger async compaction for tablets that need it
+    trigger_compaction_scheduling(tablet_ids);
+
+    // Step 2: Collect completed compaction results
+    std::unordered_map<int64_t, std::vector<CompactionResultPB>> tablet_results;
+    std::unordered_map<int64_t, std::vector<std::string>> tablet_result_files;
+
+    for (int64_t tablet_id : tablet_ids) {
+        auto results_or = load_tablet_results(tablet_id, visible_version);
+        if (!results_or.ok()) {
+            LOG(WARNING) << "Failed to load results for tablet " << tablet_id << ": " << results_or.status();
+            continue;
+        }
+
+        auto results = results_or.value();
+        if (!results.empty()) {
+            tablet_results[tablet_id] = std::move(results);
+
+            auto files_or = _result_mgr->list_result_files(tablet_id);
+            if (files_or.ok()) {
+                tablet_result_files[tablet_id] = std::move(files_or.value());
+            }
+        }
+    }
+
+    _last_stats.tablets_with_compaction = tablet_results.size();
+    LOG(INFO) << "Loaded compaction results for " << tablet_results.size() << " tablets out of "
+              << request->tablet_ids_size() << " total tablets";
+
+    // Step 3: Build TxnLogs and add to response
+    int success_count = 0;
+    for (const auto& [tablet_id, results] : tablet_results) {
+        auto txn_log_or = build_txn_log(tablet_id, results);
+        if (!txn_log_or.ok()) {
+            LOG(WARNING) << "Failed to build TxnLog for tablet " << tablet_id << ": " << txn_log_or.status();
+            response->add_failed_tablets(tablet_id);
+            continue;
+        }
+
+        auto* txn_log = response->add_txn_logs();
+        *txn_log = std::move(txn_log_or.value());
+        success_count++;
+
+        // Clean up result files
+        if (tablet_result_files.count(tablet_id) > 0) {
+            cleanup_tablet_results(tablet_id, tablet_result_files[tablet_id]);
+            _last_stats.result_files_cleaned += tablet_result_files[tablet_id].size();
+        }
+    }
+
+    _last_stats.tablets_succeeded = success_count;
+
+    LOG(INFO) << "Autonomous compaction completed: scheduled=" << _last_stats.tablets_scheduled
+              << ", collected=" << tablet_results.size() << ", succeeded=" << success_count
+              << ", result_files_cleaned=" << _last_stats.result_files_cleaned;
+
+    Status::OK().to_protobuf(response->mutable_status());
+    return Status::OK();
+}
+
+void AutonomousCompactionHandler::trigger_compaction_scheduling(const std::vector<int64_t>& tablet_ids) {
+    if (!config::enable_lake_autonomous_compaction) {
+        VLOG(2) << "Autonomous compaction disabled, skipping scheduling trigger";
+        return;
+    }
+
+    auto* compaction_mgr = LakeCompactionManager::instance();
+    if (compaction_mgr == nullptr) {
+        LOG(WARNING) << "LakeCompactionManager not initialized, cannot trigger scheduling";
+        return;
+    }
+
+    auto tablets_needing_compaction = identify_tablets_needing_compaction(tablet_ids);
+
+    int scheduled_count = 0;
+    for (int64_t tablet_id : tablets_needing_compaction) {
+        compaction_mgr->update_tablet_async(tablet_id);
+        scheduled_count++;
+    }
+
+    _last_stats.tablets_scheduled = scheduled_count;
+    LOG(INFO) << "Triggered compaction scheduling for " << scheduled_count << " tablets out of " << tablet_ids.size();
+}
+
+std::unordered_set<int64_t> AutonomousCompactionHandler::identify_tablets_needing_compaction(
+        const std::vector<int64_t>& tablet_ids) {
+    std::unordered_set<int64_t> result;
+
+    for (int64_t tablet_id : tablet_ids) {
+        bool needs_compaction = false;
+
+        // Check 1: Has pending results from previous compaction
+        if (_result_mgr->has_pending_results(tablet_id)) {
+            needs_compaction = true;
+            VLOG(2) << "Tablet " << tablet_id << " has pending compaction results";
+        }
+
+        // Check 2: High compaction score
+        if (!needs_compaction) {
+            auto metadata_iter_or = _tablet_mgr->list_tablet_metadata(tablet_id);
+            if (metadata_iter_or.ok()) {
+                TabletMetadataPtr metadata = nullptr;
+                int64_t max_version = 0;
+                auto& metadata_iter = metadata_iter_or.value();
+                while (metadata_iter.has_next()) {
+                    auto meta_or = metadata_iter.next();
+                    if (meta_or.ok() && meta_or.value()->version() > max_version) {
+                        max_version = meta_or.value()->version();
+                        metadata = meta_or.value();
+                    }
+                }
+                if (metadata) {
+                    double score = compaction_score(_tablet_mgr, metadata);
+                    if (score >= config::lake_compaction_score_threshold) {
+                        needs_compaction = true;
+                        VLOG(2) << "Tablet " << tablet_id << " has high compaction score: " << score;
+                    }
+                }
+            }
+        }
+
+        if (needs_compaction) {
+            result.insert(tablet_id);
+        }
+    }
+
+    return result;
+}
+
+StatusOr<std::vector<CompactionResultPB>> AutonomousCompactionHandler::load_tablet_results(int64_t tablet_id,
+                                                                                           int64_t max_version) {
+    ASSIGN_OR_RETURN(auto results, _result_mgr->load_and_validate_results(_tablet_mgr, tablet_id, max_version, true));
+
+    if (results.empty()) {
+        VLOG(2) << "No valid compaction results found for tablet " << tablet_id;
+    } else {
+        LOG(INFO) << "Loaded " << results.size() << " valid compaction results for tablet " << tablet_id
+                  << ", max_version=" << max_version;
+    }
+
+    return results;
+}
+
+StatusOr<TxnLogPB> AutonomousCompactionHandler::build_txn_log(int64_t tablet_id,
+                                                              const std::vector<CompactionResultPB>& results) {
+    if (results.empty()) {
+        return Status::InvalidArgument("No results to build TxnLog");
+    }
+
+    TxnLogPB txn_log;
+    txn_log.set_tablet_id(tablet_id);
+
+    auto* op_compaction = txn_log.mutable_op_compaction();
+
+    // Collect all input rowsets (deduplicate)
+    std::unordered_set<uint32_t> input_rowset_set;
+    for (const auto& result : results) {
+        for (uint32_t rid : result.input_rowset_ids()) {
+            input_rowset_set.insert(rid);
+        }
+    }
+
+    for (uint32_t rid : input_rowset_set) {
+        op_compaction->add_input_rowsets(rid);
+    }
+
+    // Set output rowset (OpCompaction only supports single output)
+    // Use the first result's output_rowset
+    for (const auto& result : results) {
+        if (result.has_output_rowset()) {
+            *op_compaction->mutable_output_rowset() = result.output_rowset();
+            break; // Only one output rowset is supported
+        }
+    }
+
+    // Handle SSTable metadata for primary key tables
+    for (const auto& result : results) {
+        for (const auto& input_sst : result.input_sstables()) {
+            op_compaction->add_input_sstables()->CopyFrom(input_sst);
+        }
+        // output_sstable is singular in OpCompaction
+        if (result.output_sstables_size() > 0) {
+            *op_compaction->mutable_output_sstable() = result.output_sstables(0);
+        }
+    }
+
+    // Set base version for conflict checking
+    if (results[0].has_base_version()) {
+        op_compaction->set_compact_version(results[0].base_version());
+    }
+
+    LOG(INFO) << "Built TxnLog for tablet " << tablet_id << ": " << input_rowset_set.size() << " input rowsets, "
+              << results.size() << " output rowsets";
+
+    return txn_log;
+}
+
+void AutonomousCompactionHandler::cleanup_tablet_results(int64_t tablet_id,
+                                                         const std::vector<std::string>& file_paths) {
+    int deleted_count = 0;
+    for (const auto& file_path : file_paths) {
+        auto st = _result_mgr->delete_result(file_path);
+        if (st.ok()) {
+            deleted_count++;
+        }
+    }
+
+    LOG(INFO) << "Cleaned up " << deleted_count << " result files for tablet " << tablet_id;
+}
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/autonomous_compaction_handler.h
+++ b/be/src/storage/lake/autonomous_compaction_handler.h
@@ -1,0 +1,85 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <unordered_set>
+
+#include "common/status.h"
+#include "gen_cpp/lake_service.pb.h"
+
+namespace starrocks::lake {
+
+class TabletManager;
+class CompactionResultManager;
+class LakeCompactionManager;
+
+// Statistics for autonomous compaction processing
+struct AutonomousCompactionStats {
+    int64_t tablets_processed = 0;
+    int64_t tablets_with_compaction = 0;
+    int64_t tablets_succeeded = 0;
+    int64_t tablets_scheduled = 0; // Tablets added to compaction queue
+    int64_t result_files_cleaned = 0;
+};
+
+// Handles autonomous compaction requests
+//
+// Autonomous compaction workflow:
+// 1. Trigger async compaction for tablets that need it (add to scheduling queue)
+// 2. Collect completed compaction results from BE local storage
+// 3. Build TxnLogs and return to FE via response
+//
+// Key difference from original compaction:
+// - Original: FE sends request -> BE synchronously executes compaction -> returns result
+// - Autonomous: FE sends request -> BE triggers async compaction + collects completed results -> returns
+//
+// Commit and Publish are still handled by FE (commitCompaction + PublishVersionDaemon)
+class AutonomousCompactionHandler {
+public:
+    explicit AutonomousCompactionHandler(TabletManager* tablet_mgr);
+    ~AutonomousCompactionHandler();
+
+    // Process autonomous compaction request:
+    // 1. Trigger async compaction for tablets that need it
+    // 2. Collect completed compaction results and build TxnLogs
+    // 3. Return TxnLogs to FE for commit
+    // Note: FE is responsible for commit (commitCompaction) and PublishVersionDaemon handles publish
+    Status process_request(const CompactRequest* request, CompactResponse* response);
+
+    // Get statistics from the last process_request call
+    const AutonomousCompactionStats& last_stats() const { return _last_stats; }
+
+private:
+    // Trigger compaction scheduling for tablets that need it
+    void trigger_compaction_scheduling(const std::vector<int64_t>& tablet_ids);
+
+    // Check which tablets need compaction (have high score or pending results)
+    std::unordered_set<int64_t> identify_tablets_needing_compaction(const std::vector<int64_t>& tablet_ids);
+
+    // Load and filter compaction results for a tablet
+    StatusOr<std::vector<CompactionResultPB>> load_tablet_results(int64_t tablet_id, int64_t max_version);
+
+    // Build TxnLog from compaction results
+    StatusOr<TxnLogPB> build_txn_log(int64_t tablet_id, const std::vector<CompactionResultPB>& results);
+
+    // Clean up result files for a tablet
+    void cleanup_tablet_results(int64_t tablet_id, const std::vector<std::string>& file_paths);
+
+    TabletManager* _tablet_mgr;
+    std::unique_ptr<CompactionResultManager> _result_mgr;
+    AutonomousCompactionStats _last_stats;
+};
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/compaction_policy.h
+++ b/be/src/storage/lake/compaction_policy.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <unordered_set>
 #include <vector>
 
 #include "common/statusor.h"
@@ -31,12 +32,46 @@ class CompactionPolicy;
 using CompactionPolicyPtr = std::shared_ptr<CompactionPolicy>;
 class TabletManager;
 
+// Partial compaction state for a tablet (Design Doc Section 6.3.3)
+// Used to support the Selector Strategy Extension for autonomous compaction
+struct PartialCompactionState {
+    int64_t tablet_id = 0;
+    bool has_pending_results = false;      // Some tablets have finished compaction
+    bool has_running_tasks = false;        // Some tablets still running compaction
+    int pending_result_count = 0;          // Number of pending results
+    int running_task_count = 0;            // Number of running tasks
+    
+    // Check if this tablet is in partial completion state
+    // A tablet is in partial state if it has pending results but also running tasks
+    bool is_partial() const {
+        return has_pending_results && has_running_tasks;
+    }
+    
+    // Check if tablet should trigger publish
+    // Returns true if there are pending results that can be published
+    bool should_trigger_publish() const {
+        return has_pending_results;
+    }
+};
+
 // Compaction policy for lake tablet
+//
+// Enhanced with Partial Compaction Support (Design Doc Section 6.3.3):
+// - Detects partial completion states
+// - Supports publish even when only some tablets have results
+// - Maintains version consistency using force_publish
 class CompactionPolicy {
 public:
     virtual ~CompactionPolicy();
 
     virtual StatusOr<std::vector<RowsetPtr>> pick_rowsets() = 0;
+
+    // Pick rowsets with data volume limit and rowset exclusion support for autonomous compaction
+    // @param max_bytes: maximum total data size to compact in one task
+    // @param exclude_rowsets: rowset IDs currently being compacted (should be excluded)
+    // @return: selected rowsets for compaction
+    virtual StatusOr<std::vector<RowsetPtr>> pick_rowsets_with_limit(int64_t max_bytes,
+                                                                      const std::unordered_set<uint32_t>& exclude_rowsets);
 
     virtual StatusOr<CompactionAlgorithm> choose_compaction_algorithm(const std::vector<RowsetPtr>& rowsets);
 
@@ -62,5 +97,49 @@ protected:
 };
 
 double compaction_score(TabletManager* tablet_mgr, const std::shared_ptr<const TabletMetadataPB>& metadata);
+
+// ============== Partial Compaction Support (Section 6.3.3) ==============
+
+// Selector that supports partial compaction states for autonomous compaction
+// 
+// Design Doc Section 6.3.3: Necessity of Selector Extension
+// Why must Selector support "partial compaction"?
+// Scenario: In autonomous compaction mode:
+// - Some tablets finish early (local results exist)
+// - Others are still running
+// Selector must:
+// - Detect partial completion states
+// - Trigger publish when some results exist
+// - Use force_publish to maintain version consistency
+class PartialCompactionSelector {
+public:
+    // Check if tablets in a partition have partial compaction state
+    // @param tablet_ids: list of tablet IDs to check
+    // @param compacting_rowsets_map: map of tablet_id -> currently compacting rowset IDs
+    // @param pending_results_tablets: set of tablet IDs with pending results
+    // @return: partial compaction state for the partition
+    static PartialCompactionState check_partition_state(
+            const std::vector<int64_t>& tablet_ids,
+            const std::unordered_map<int64_t, std::unordered_set<uint32_t>>& compacting_rowsets_map,
+            const std::unordered_set<int64_t>& pending_results_tablets);
+
+    // Determine if a partition should trigger publish based on partial compaction state
+    // Returns true if:
+    // 1. Some tablets have pending results
+    // 2. The number of tablets with results exceeds threshold (configurable)
+    // 3. Or force_publish is requested
+    static bool should_publish_partial(const PartialCompactionState& state, 
+                                       int min_tablets_with_results = 1,
+                                       bool force_publish = false);
+
+    // Build publish request for partial compaction
+    // - Includes all tablets in the partition
+    // - Sets force_publish flag to maintain version consistency
+    // - Only tablets with results will have actual compaction applied
+    static void prepare_partial_publish(const std::vector<int64_t>& tablet_ids,
+                                        const std::unordered_set<int64_t>& tablets_with_results,
+                                        bool* force_publish_out,
+                                        std::vector<int64_t>* tablets_to_publish_out);
+};
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/compaction_result_manager.cpp
+++ b/be/src/storage/lake/compaction_result_manager.cpp
@@ -1,0 +1,519 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/compaction_result_manager.h"
+
+#include <fmt/format.h>
+
+#include <chrono>
+#include <random>
+#include <regex>
+#include <set>
+
+#include "common/config.h"
+#include "common/logging.h"
+#include "fs/fs_util.h"
+#include "gutil/strings/substitute.h"
+#include "storage/data_dir.h"
+#include "storage/lake/tablet.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/storage_engine.h"
+#include "util/raw_container.h"
+
+namespace starrocks::lake {
+
+// Helper function to read file content as string
+static StatusOr<std::string> read_file_to_string(const std::string& path) {
+    ASSIGN_OR_RETURN(auto rf, fs::new_sequential_file(path));
+    std::string content;
+    raw::stl_string_resize_uninitialized(&content, 10 * 1024 * 1024); // 10MB max
+    ASSIGN_OR_RETURN(auto nread, rf->read(content.data(), content.size()));
+    content.resize(nread);
+    return content;
+}
+
+// Helper function to write string to file
+static Status write_string_to_file(const std::string& path, const std::string& content) {
+    ASSIGN_OR_RETURN(auto wf, fs::new_writable_file(path));
+    RETURN_IF_ERROR(wf->append(content));
+    RETURN_IF_ERROR(wf->close());
+    return Status::OK();
+}
+
+// P7 fix: Use thread-local static generator for better performance
+thread_local std::mt19937 g_random_gen(std::random_device{}());
+
+std::string CompactionResultManager::get_results_dir(const std::string& storage_root) {
+    return fmt::format("{}/lake/compaction_results", storage_root);
+}
+
+std::string CompactionResultManager::generate_result_filename(int64_t tablet_id) {
+    auto now = std::chrono::system_clock::now();
+    auto timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()).count();
+
+    // Use static thread-local generator instead of creating new one each time
+    std::uniform_int_distribution<> dis(0, 999999);
+    int random_suffix = dis(g_random_gen);
+
+    return fmt::format("tablet_{}_result_{}_{}.pb", tablet_id, timestamp, random_suffix);
+}
+
+std::vector<std::string> CompactionResultManager::get_storage_roots() {
+    std::vector<std::string> roots;
+    auto* engine = StorageEngine::instance();
+    if (engine == nullptr) {
+        return roots;
+    }
+
+    for (const auto& data_dir : engine->get_stores()) {
+        roots.push_back(data_dir->path());
+    }
+    return roots;
+}
+
+StatusOr<int64_t> CompactionResultManager::extract_tablet_id_from_filename(const std::string& filename) {
+    // Filename format: tablet_{tablet_id}_result_{timestamp}_{random}.pb
+    std::regex pattern("tablet_(\\d+)_result_\\d+_\\d+\\.pb");
+    std::smatch match;
+    if (std::regex_match(filename, match, pattern) && match.size() == 2) {
+        try {
+            return std::stoll(match[1].str());
+        } catch (const std::exception& e) {
+            return Status::InvalidArgument(fmt::format("Invalid tablet_id in filename: {}", filename));
+        }
+    }
+    return Status::InvalidArgument(fmt::format("Cannot extract tablet_id from filename: {}", filename));
+}
+
+StatusOr<std::vector<std::pair<std::string, int64_t>>> CompactionResultManager::scan_all_result_files() {
+    std::vector<std::pair<std::string, int64_t>> result_files;  // (file_path, tablet_id)
+
+    auto roots = get_storage_roots();
+    for (const auto& root : roots) {
+        std::string results_dir = get_results_dir(root);
+
+        // Check if directory exists
+        if (!fs::path_exist(results_dir)) {
+            continue;
+        }
+
+        // List all files in the directory
+        std::set<std::string> dirs, files;
+        auto list_st = fs::list_dirs_files(results_dir, &dirs, &files);
+        if (!list_st.ok()) {
+            LOG(WARNING) << "Failed to list files in " << results_dir << ": " << list_st;
+            continue;
+        }
+
+        for (const auto& file : files) {
+            if (file.ends_with(".pb") && file.find("tablet_") == 0) {
+                std::string file_path = fmt::format("{}/{}", results_dir, file);
+                auto tablet_id_or = extract_tablet_id_from_filename(file);
+                if (tablet_id_or.ok()) {
+                    result_files.emplace_back(file_path, tablet_id_or.value());
+                }
+            }
+        }
+    }
+
+    return result_files;
+}
+
+// ============== Startup Recovery (Mechanism 1 from Design Doc 6.1.1) ==============
+
+StatusOr<RecoveryStats> CompactionResultManager::recover_on_startup(TabletManager* tablet_mgr) {
+    RecoveryStats stats;
+
+    if (tablet_mgr == nullptr) {
+        return Status::InvalidArgument("tablet_mgr cannot be null");
+    }
+
+    LOG(INFO) << "Starting compaction result recovery on BE startup...";
+
+    // Step 1: Scan all result files
+    ASSIGN_OR_RETURN(auto all_files, scan_all_result_files());
+    stats.total_files_scanned = all_files.size();
+
+    LOG(INFO) << "Found " << all_files.size() << " compaction result files to validate";
+
+    // Step 2: Group files by tablet_id
+    std::unordered_map<int64_t, std::vector<std::string>> tablet_files;
+    for (const auto& [file_path, tablet_id] : all_files) {
+        tablet_files[tablet_id].push_back(file_path);
+    }
+
+    // Step 3: Validate each result file
+    std::unordered_set<int64_t> tablets_with_valid_results;
+
+    for (const auto& [tablet_id, files] : tablet_files) {
+        for (const auto& file_path : files) {
+            // Read and parse the result file
+            auto content_or = read_file_to_string(file_path);
+            if (!content_or.ok()) {
+                LOG(WARNING) << "Failed to read result file " << file_path << ": " << content_or.status();
+                stats.parse_errors++;
+                // Delete unreadable files
+                (void)fs::delete_file(file_path);
+                stats.invalid_results_cleaned++;
+                continue;
+            }
+
+            CompactionResultPB result;
+            if (!result.ParseFromString(content_or.value())) {
+                LOG(WARNING) << "Failed to parse result file " << file_path;
+                stats.parse_errors++;
+                // Delete unparseable files
+                (void)fs::delete_file(file_path);
+                stats.invalid_results_cleaned++;
+                continue;
+            }
+
+            // Validate the result
+            std::string invalid_reason;
+            auto valid_or = validate_result(tablet_mgr, result, &invalid_reason);
+            if (!valid_or.ok()) {
+                LOG(WARNING) << "Failed to validate result file " << file_path << ": " << valid_or.status();
+                stats.validation_errors++;
+                continue;
+            }
+
+            if (valid_or.value()) {
+                // Valid result - retain it
+                stats.valid_results++;
+                tablets_with_valid_results.insert(tablet_id);
+                LOG(INFO) << "Valid compaction result retained: tablet=" << tablet_id 
+                          << ", base_version=" << result.base_version()
+                          << ", input_rowsets=" << result.input_rowset_ids_size();
+            } else {
+                // Invalid result - clean up
+                LOG(INFO) << "Invalid compaction result cleaned up: tablet=" << tablet_id
+                          << ", reason=" << invalid_reason;
+                (void)fs::delete_file(file_path);
+                stats.invalid_results_cleaned++;
+            }
+        }
+    }
+
+    // Update the cache of tablets with pending results
+    {
+        std::lock_guard<std::mutex> lock(_pending_results_mutex);
+        _tablets_with_pending_results = tablets_with_valid_results;
+    }
+    stats.recovered_tablet_ids = tablets_with_valid_results;
+
+    LOG(INFO) << "Compaction result recovery completed: "
+              << "total_files=" << stats.total_files_scanned
+              << ", valid=" << stats.valid_results
+              << ", cleaned=" << stats.invalid_results_cleaned
+              << ", parse_errors=" << stats.parse_errors
+              << ", validation_errors=" << stats.validation_errors
+              << ", tablets_with_results=" << stats.recovered_tablet_ids.size();
+
+    return stats;
+}
+
+StatusOr<bool> CompactionResultManager::validate_result(TabletManager* tablet_mgr, const CompactionResultPB& result,
+                                                         std::string* invalid_reason) {
+    if (tablet_mgr == nullptr) {
+        return Status::InvalidArgument("tablet_mgr cannot be null");
+    }
+
+    if (!result.has_tablet_id()) {
+        if (invalid_reason) *invalid_reason = "missing tablet_id";
+        return false;
+    }
+
+    int64_t tablet_id = result.tablet_id();
+
+    // Get latest tablet metadata by listing all versions and finding the max
+    auto metadata_iter_or = tablet_mgr->list_tablet_metadata(tablet_id);
+    if (!metadata_iter_or.ok()) {
+        if (invalid_reason) *invalid_reason = fmt::format("tablet not found: {}", metadata_iter_or.status().message());
+        return false;
+    }
+
+    TabletMetadataPtr metadata = nullptr;
+    int64_t max_version = 0;
+    auto& metadata_iter = metadata_iter_or.value();
+    while (metadata_iter.has_next()) {
+        auto meta_or = metadata_iter.next();
+        if (meta_or.ok() && meta_or.value()->version() > max_version) {
+            max_version = meta_or.value()->version();
+            metadata = meta_or.value();
+        }
+    }
+
+    if (!metadata) {
+        if (invalid_reason) *invalid_reason = "tablet metadata not found";
+        return false;
+    }
+
+    int64_t visible_version = metadata->version();
+
+    // Validation 1: Check base_version <= visible_version
+    if (result.has_base_version() && result.base_version() > visible_version) {
+        if (invalid_reason) {
+            *invalid_reason = fmt::format("base_version ({}) > visible_version ({})", 
+                                          result.base_version(), visible_version);
+        }
+        return false;
+    }
+
+    // Validation 2: Check input rowsets still exist
+    std::unordered_set<uint32_t> existing_rowsets;
+    for (const auto& rowset : metadata->rowsets()) {
+        existing_rowsets.insert(rowset.id());
+    }
+
+    bool all_rowsets_exist = true;
+    std::vector<uint32_t> missing_rowsets;
+    for (uint32_t input_rid : result.input_rowset_ids()) {
+        if (existing_rowsets.find(input_rid) == existing_rowsets.end()) {
+            all_rowsets_exist = false;
+            missing_rowsets.push_back(input_rid);
+        }
+    }
+
+    if (!all_rowsets_exist) {
+        if (invalid_reason) {
+            std::string missing_str;
+            for (uint32_t rid : missing_rowsets) {
+                if (!missing_str.empty()) missing_str += ",";
+                missing_str += std::to_string(rid);
+            }
+            *invalid_reason = fmt::format("input rowsets no longer exist: [{}]", missing_str);
+        }
+        return false;
+    }
+
+    return true;
+}
+
+StatusOr<std::vector<CompactionResultPB>> CompactionResultManager::load_and_validate_results(
+        TabletManager* tablet_mgr, int64_t tablet_id, int64_t max_version, bool cleanup_invalid) {
+    std::vector<CompactionResultPB> valid_results;
+
+    // Get all result files for this tablet
+    ASSIGN_OR_RETURN(auto files, list_result_files(tablet_id));
+
+    for (const auto& file_path : files) {
+        // Read and parse
+        auto content_or = read_file_to_string(file_path);
+        if (!content_or.ok()) {
+            LOG(WARNING) << "Failed to read result file " << file_path;
+            if (cleanup_invalid) {
+                (void)fs::delete_file(file_path);
+            }
+            continue;
+        }
+
+        CompactionResultPB result;
+        if (!result.ParseFromString(content_or.value())) {
+            LOG(WARNING) << "Failed to parse result file " << file_path;
+            if (cleanup_invalid) {
+                (void)fs::delete_file(file_path);
+            }
+            continue;
+        }
+
+        // Filter by max_version
+        if (max_version >= 0 && result.has_base_version() && result.base_version() > max_version) {
+            LOG(INFO) << "Skipping result with base_version=" << result.base_version() 
+                      << " > max_version=" << max_version;
+            continue;
+        }
+
+        // Validate
+        std::string invalid_reason;
+        auto valid_or = validate_result(tablet_mgr, result, &invalid_reason);
+        if (valid_or.ok() && valid_or.value()) {
+            valid_results.push_back(std::move(result));
+        } else {
+            LOG(INFO) << "Invalid result file " << file_path << ": " << invalid_reason;
+            if (cleanup_invalid) {
+                (void)fs::delete_file(file_path);
+            }
+        }
+    }
+
+    return valid_results;
+}
+
+bool CompactionResultManager::has_pending_results(int64_t tablet_id) {
+    std::lock_guard<std::mutex> lock(_pending_results_mutex);
+    return _tablets_with_pending_results.count(tablet_id) > 0;
+}
+
+std::unordered_set<int64_t> CompactionResultManager::get_tablets_with_pending_results() {
+    std::lock_guard<std::mutex> lock(_pending_results_mutex);
+    return _tablets_with_pending_results;
+}
+
+// ============== Basic Operations ==============
+
+StatusOr<std::string> CompactionResultManager::save_result(const CompactionResultPB& result) {
+    if (!result.has_tablet_id()) {
+        return Status::InvalidArgument("tablet_id is required");
+    }
+
+    // Use the first storage root (typically the primary data directory)
+    auto roots = get_storage_roots();
+    if (roots.empty()) {
+        return Status::InternalError("No storage root found");
+    }
+
+    std::string results_dir = get_results_dir(roots[0]);
+
+    // Ensure the results directory exists
+    RETURN_IF_ERROR(fs::create_directories(results_dir));
+
+    // Generate unique filename
+    std::string filename = generate_result_filename(result.tablet_id());
+    std::string file_path = fmt::format("{}/{}", results_dir, filename);
+
+    // Serialize and write to file
+    std::string serialized;
+    if (!result.SerializeToString(&serialized)) {
+        return Status::InternalError("Failed to serialize CompactionResultPB");
+    }
+
+    RETURN_IF_ERROR(write_string_to_file(file_path, serialized));
+
+    // Update pending results cache
+    {
+        std::lock_guard<std::mutex> lock(_pending_results_mutex);
+        _tablets_with_pending_results.insert(result.tablet_id());
+    }
+
+    LOG(INFO) << "Saved compaction result for tablet " << result.tablet_id() << " to " << file_path
+              << ", base_version=" << result.base_version();
+
+    return file_path;
+}
+
+StatusOr<std::vector<CompactionResultPB>> CompactionResultManager::load_results(int64_t tablet_id,
+                                                                                 int64_t max_version) {
+    std::vector<CompactionResultPB> results;
+
+    auto roots = get_storage_roots();
+    for (const auto& root : roots) {
+        std::string results_dir = get_results_dir(root);
+
+        // Check if directory exists
+        if (!fs::path_exist(results_dir)) {
+            continue;
+        }
+
+        // List all files in the directory
+        std::set<std::string> dirs, files;
+        RETURN_IF_ERROR(fs::list_dirs_files(results_dir, &dirs, &files));
+
+        // Filter files for this tablet
+        std::string tablet_prefix = fmt::format("tablet_{}_result_", tablet_id);
+        for (const auto& file : files) {
+            if (file.find(tablet_prefix) == 0 && file.ends_with(".pb")) {
+                std::string file_path = fmt::format("{}/{}", results_dir, file);
+
+                // Read and deserialize
+                std::string content;
+                ASSIGN_OR_RETURN(content, read_file_to_string(file_path));
+
+                CompactionResultPB result;
+                if (!result.ParseFromString(content)) {
+                    LOG(WARNING) << "Failed to parse compaction result from " << file_path << ", skipping";
+                    continue;
+                }
+
+                // Filter by version if specified
+                if (max_version >= 0 && result.base_version() > max_version) {
+                    LOG(INFO) << "Skipping result from " << file_path << " with base_version=" << result.base_version()
+                              << " > max_version=" << max_version;
+                    continue;
+                }
+
+                results.push_back(std::move(result));
+            }
+        }
+    }
+
+    LOG(INFO) << "Loaded " << results.size() << " compaction results for tablet " << tablet_id;
+    return results;
+}
+
+Status CompactionResultManager::delete_result(const std::string& file_path) {
+    auto st = fs::delete_file(file_path);
+    if (st.ok()) {
+        LOG(INFO) << "Deleted compaction result file: " << file_path;
+    } else {
+        LOG(WARNING) << "Failed to delete compaction result file " << file_path << ": " << st;
+    }
+    return st;
+}
+
+Status CompactionResultManager::delete_tablet_results(int64_t tablet_id) {
+    auto files_or = list_result_files(tablet_id);
+    if (!files_or.ok()) {
+        return files_or.status();
+    }
+
+    int deleted_count = 0;
+    for (const auto& file_path : files_or.value()) {
+        auto st = fs::delete_file(file_path);
+        if (st.ok()) {
+            deleted_count++;
+        } else {
+            LOG(WARNING) << "Failed to delete result file " << file_path << ": " << st;
+        }
+    }
+
+    // Update pending results cache
+    {
+        std::lock_guard<std::mutex> lock(_pending_results_mutex);
+        _tablets_with_pending_results.erase(tablet_id);
+    }
+
+    LOG(INFO) << "Deleted " << deleted_count << " compaction result files for tablet " << tablet_id;
+    return Status::OK();
+}
+
+StatusOr<std::vector<std::string>> CompactionResultManager::list_result_files(int64_t tablet_id) {
+    std::vector<std::string> result_files;
+
+    auto roots = get_storage_roots();
+    for (const auto& root : roots) {
+        std::string results_dir = get_results_dir(root);
+
+        // Check if directory exists
+        if (!fs::path_exist(results_dir)) {
+            continue;
+        }
+
+        // List all files for this tablet
+        std::set<std::string> dirs, files;
+        RETURN_IF_ERROR(fs::list_dirs_files(results_dir, &dirs, &files));
+
+        std::string tablet_prefix = fmt::format("tablet_{}_result_", tablet_id);
+        for (const auto& file : files) {
+            if (file.find(tablet_prefix) == 0 && file.ends_with(".pb")) {
+                result_files.push_back(fmt::format("{}/{}", results_dir, file));
+            }
+        }
+    }
+
+    return result_files;
+}
+
+} // namespace starrocks::lake
+
+

--- a/be/src/storage/lake/compaction_result_manager.h
+++ b/be/src/storage/lake/compaction_result_manager.h
@@ -1,0 +1,139 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "common/status.h"
+#include "common/statusor.h"
+#include "gen_cpp/lake_types.pb.h"
+
+namespace starrocks::lake {
+
+class TabletManager;
+
+// Information about a recovered compaction result
+struct RecoveredResultInfo {
+    std::string file_path;
+    CompactionResultPB result;
+    bool is_valid = false;
+    std::string invalid_reason;
+};
+
+// Recovery statistics
+struct RecoveryStats {
+    int64_t total_files_scanned = 0;
+    int64_t valid_results = 0;
+    int64_t invalid_results_cleaned = 0;
+    int64_t parse_errors = 0;
+    int64_t validation_errors = 0;
+    std::unordered_set<int64_t> recovered_tablet_ids;
+};
+
+// Manages local persistence of autonomous compaction results.
+// Results are stored in: {storage_root}/lake/compaction_results/tablet_{id}_result_{timestamp}_{random}.pb
+//
+// Key features for exception recovery (Section 6.1.1 of design doc):
+// - recover_on_startup(): Scans local result directory after BE restart
+// - Validates effectiveness: base_version <= visible_version and input rowsets still exist
+// - Invalid results are cleaned up, valid ones are retained
+class CompactionResultManager {
+public:
+    CompactionResultManager() = default;
+    ~CompactionResultManager() = default;
+
+    // ============== Startup Recovery (Mechanism 1) ==============
+    
+    // Recover compaction results after BE restart
+    // This implements Mechanism 1: Local Result Recovery
+    // - Scans the local result directory
+    // - Loads all CompactionResultPB files
+    // - Validates effectiveness (base_version <= visible_version, input rowsets exist)
+    // - Valid results are retained, invalid ones are cleaned up
+    // Returns recovery statistics
+    StatusOr<RecoveryStats> recover_on_startup(TabletManager* tablet_mgr);
+
+    // ============== Basic Operations ==============
+
+    // Save a compaction result to local disk
+    // Returns the file path where the result was saved
+    StatusOr<std::string> save_result(const CompactionResultPB& result);
+
+    // Load all compaction results for a specific tablet
+    // Filters out results with base_version > max_version if max_version >= 0
+    StatusOr<std::vector<CompactionResultPB>> load_results(int64_t tablet_id, int64_t max_version = -1);
+
+    // Delete result file by path
+    Status delete_result(const std::string& file_path);
+
+    // Delete all result files for a tablet
+    Status delete_tablet_results(int64_t tablet_id);
+
+    // List all result file paths for a tablet
+    StatusOr<std::vector<std::string>> list_result_files(int64_t tablet_id);
+
+    // ============== Validation ==============
+
+    // Validate a single compaction result
+    // Checks:
+    // 1. base_version <= visible_version
+    // 2. input rowsets still exist in the tablet
+    // Returns true if valid, false otherwise with reason
+    StatusOr<bool> validate_result(TabletManager* tablet_mgr, const CompactionResultPB& result, 
+                                    std::string* invalid_reason = nullptr);
+
+    // Load and validate results for a tablet, filtering out invalid ones
+    // Also cleans up invalid result files if cleanup_invalid is true
+    StatusOr<std::vector<CompactionResultPB>> load_and_validate_results(
+            TabletManager* tablet_mgr, int64_t tablet_id, int64_t max_version = -1,
+            bool cleanup_invalid = true);
+
+    // ============== Query Methods ==============
+
+    // Check if there are any pending results for a tablet
+    bool has_pending_results(int64_t tablet_id);
+
+    // Get the set of tablet IDs that have pending results (after recovery)
+    std::unordered_set<int64_t> get_tablets_with_pending_results();
+
+    // Get the compaction results directory for a specific storage root
+    static std::string get_results_dir(const std::string& storage_root);
+
+private:
+    // Generate a unique filename for a compaction result
+    static std::string generate_result_filename(int64_t tablet_id);
+
+    // Get all storage roots configured in the system
+    static std::vector<std::string> get_storage_roots();
+
+    // Scan all result files in all storage roots
+    StatusOr<std::vector<std::pair<std::string, int64_t>>> scan_all_result_files();
+
+    // Extract tablet ID from result filename
+    static StatusOr<int64_t> extract_tablet_id_from_filename(const std::string& filename);
+
+    // Cache of tablet IDs with pending results (populated during recovery)
+    std::unordered_set<int64_t> _tablets_with_pending_results;
+    mutable std::mutex _pending_results_mutex;
+};
+
+} // namespace starrocks::lake
+
+

--- a/be/src/storage/lake/compaction_scheduler.h
+++ b/be/src/storage/lake/compaction_scheduler.h
@@ -41,6 +41,7 @@ namespace starrocks::lake {
 class CompactionScheduler;
 class CompactionTask;
 class TabletManager;
+class TabletParallelCompactionManager;
 
 // For every `CompactRequest` a new `CompactionTaskCallback` instance will be created.
 // A single `CompactRequest` may have multiple tablets to be compacted, each time a tablet compaction
@@ -254,6 +255,13 @@ private:
     std::atomic<bool> _stopped{false};
     std::mutex _mutex;
     WrapTaskQueues _task_queues;
+
+    // Per-tablet parallel compaction manager
+    std::unique_ptr<TabletParallelCompactionManager> _parallel_mgr;
+
+    // Process compaction request with parallel mode
+    void process_parallel_compaction(const CompactRequest* request, CompactResponse* response,
+                                     std::shared_ptr<CompactionTaskCallback> callback);
 };
 
 inline bool CompactionScheduler::Limiter::acquire() {

--- a/be/src/storage/lake/lake_compaction_manager.cpp
+++ b/be/src/storage/lake/lake_compaction_manager.cpp
@@ -1,0 +1,523 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/lake_compaction_manager.h"
+
+#include "common/config.h"
+#include "common/logging.h"
+#include "gutil/strings/substitute.h"
+#include "storage/lake/compaction_policy.h"
+#include "storage/lake/compaction_result_manager.h"
+#include "storage/lake/tablet_manager.h"
+#include "util/defer_op.h"
+
+namespace starrocks::lake {
+
+// Singleton instance
+static LakeCompactionManager* g_lake_compaction_manager = nullptr;
+static std::once_flag g_init_once;
+static std::mutex g_mgr_mutex;
+
+Status LakeCompactionManager::create_instance(TabletManager* tablet_mgr) {
+    std::lock_guard<std::mutex> lock(g_mgr_mutex);
+    if (g_lake_compaction_manager != nullptr) {
+        return Status::OK();
+    }
+
+    if (tablet_mgr == nullptr) {
+        return Status::InvalidArgument("tablet_mgr cannot be null");
+    }
+
+    g_lake_compaction_manager = new LakeCompactionManager(tablet_mgr);
+    return g_lake_compaction_manager->init();
+}
+
+LakeCompactionManager* LakeCompactionManager::instance() {
+    if (g_lake_compaction_manager == nullptr) {
+        LOG(FATAL) << "LakeCompactionManager not initialized. "
+                   << "Call create_instance() first during system startup.";
+    }
+    return g_lake_compaction_manager;
+}
+
+LakeCompactionManager::LakeCompactionManager(TabletManager* tablet_mgr)
+        : _tablet_mgr(tablet_mgr), _result_mgr(std::make_unique<CompactionResultManager>()) {}
+
+LakeCompactionManager::~LakeCompactionManager() {
+    stop();
+}
+
+Status LakeCompactionManager::init() {
+    if (_stopped.load()) {
+        return Status::InternalError("LakeCompactionManager already stopped");
+    }
+
+    if (_tablet_mgr == nullptr) {
+        return Status::InvalidArgument("_tablet_mgr cannot be null");
+    }
+
+    // Validate configuration parameters (P8 fix)
+    if (config::lake_compaction_max_concurrent_tasks <= 0) {
+        return Status::InvalidArgument(
+            fmt::format("Invalid lake_compaction_max_concurrent_tasks: {}",
+                       config::lake_compaction_max_concurrent_tasks));
+    }
+
+    if (config::lake_compaction_max_tasks_per_tablet <= 0) {
+        return Status::InvalidArgument(
+            fmt::format("Invalid lake_compaction_max_tasks_per_tablet: {}",
+                       config::lake_compaction_max_tasks_per_tablet));
+    }
+
+    if (config::lake_compaction_max_bytes_per_task <= 0) {
+        return Status::InvalidArgument(
+            fmt::format("Invalid lake_compaction_max_bytes_per_task: {}",
+                       config::lake_compaction_max_bytes_per_task));
+    }
+
+    if (config::lake_compaction_score_threshold < 0) {
+        return Status::InvalidArgument(
+            fmt::format("Invalid lake_compaction_score_threshold: {}",
+                       config::lake_compaction_score_threshold));
+    }
+
+    // Create thread pool for executing compaction tasks
+    RETURN_IF_ERROR(ThreadPoolBuilder("lake_auto_compact")
+                            .set_min_threads(0)
+                            .set_max_threads(config::lake_compaction_max_concurrent_tasks)
+                            .set_max_queue_size(1000)
+                            .build(&_thread_pool));
+
+    // Start background scheduler thread (P2 fix - correct method name)
+    _schedule_thread = std::make_unique<std::thread>(
+        [this]() { this->_schedule_thread_func(); }
+    );
+
+    LOG(INFO) << "LakeCompactionManager initialized with max_concurrent_tasks="
+              << config::lake_compaction_max_concurrent_tasks;
+
+    return Status::OK();
+}
+
+void LakeCompactionManager::stop() {
+    if (_stopped.exchange(true)) {
+        return;
+    }
+
+    LOG(INFO) << "Stopping LakeCompactionManager";
+
+    // Wake up scheduler thread
+    _queue_cv.notify_all();
+
+    // Wait for scheduler thread to exit
+    if (_schedule_thread && _schedule_thread->joinable()) {
+        _schedule_thread->join();
+    }
+
+    // Shutdown thread pool
+    if (_thread_pool) {
+        _thread_pool->shutdown();
+    }
+
+    LOG(INFO) << "LakeCompactionManager stopped";
+}
+
+void LakeCompactionManager::update_tablet_async(int64_t tablet_id) {
+    if (_stopped.load()) {
+        return;
+    }
+
+    // Calculate compaction score
+    auto score_or = _calculate_score(tablet_id);
+    if (!score_or.ok()) {
+        VLOG(2) << "Failed to calculate score for tablet " << tablet_id << ": " << score_or.status();
+        return;
+    }
+
+    double score = score_or.value();
+    
+    // Only add to queue if score exceeds threshold
+    if (score < config::lake_compaction_score_threshold) {
+        VLOG(2) << "Tablet " << tablet_id << " score " << score << " below threshold "
+                << config::lake_compaction_score_threshold;
+        return;
+    }
+
+    _update_tablet_state(tablet_id, score);
+}
+
+StatusOr<double> LakeCompactionManager::_calculate_score(int64_t tablet_id) {
+    // Get tablet metadata
+    ASSIGN_OR_RETURN(auto tablet, _tablet_mgr->get_tablet(tablet_id));
+    auto metadata = tablet.metadata();
+    
+    if (!metadata) {
+        return Status::NotFound(strings::Substitute("Tablet $0 metadata not found", tablet_id));
+    }
+
+    // Calculate compaction score
+    double score = compaction_score(_tablet_mgr, metadata);
+    
+    return score;
+}
+
+void LakeCompactionManager::_update_tablet_state(int64_t tablet_id, double score) {
+    // P6 fix: Separate lock operations to avoid potential deadlock
+    // Step 1: Update state
+    TabletCompactionInfo info;
+    bool should_add_to_queue = false;
+    {
+        std::lock_guard<std::mutex> state_lock(_state_mutex);
+
+        auto& state = _tablet_states[tablet_id];
+        state.tablet_id = tablet_id;
+        state.last_score = score;
+        state.last_update_time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                             std::chrono::system_clock::now().time_since_epoch())
+                                             .count();
+
+        if (!state.in_queue) {
+            info.tablet_id = tablet_id;
+            info.score = score;
+            info.last_update_time_ms = state.last_update_time_ms;
+            should_add_to_queue = true;
+        }
+    }
+
+    // Step 2: Add to queue if needed (outside state lock)
+    if (should_add_to_queue) {
+        std::lock_guard<std::mutex> queue_lock(_queue_mutex);
+        _tablet_queue.push(info);
+
+        // Update in_queue flag
+        {
+            std::lock_guard<std::mutex> state_lock(_state_mutex);
+            auto it = _tablet_states.find(tablet_id);
+            if (it != _tablet_states.end()) {
+                it->second.in_queue = true;
+            }
+        }
+
+        VLOG(2) << "Added tablet " << tablet_id << " to compaction queue with score " << info.score;
+
+        // Wake up scheduler thread
+        _queue_cv.notify_one();
+    }
+}
+
+int64_t LakeCompactionManager::queue_size() const {
+    std::lock_guard<std::mutex> lock(_queue_mutex);
+    return _tablet_queue.size();
+}
+
+bool LakeCompactionManager::_can_schedule_tablet(const TabletCompactionState& state) {
+    // Check global concurrent task limit
+    if (_running_tasks.load() >= config::lake_compaction_max_concurrent_tasks) {
+        return false;
+    }
+
+    // Check per-tablet task limit
+    if (state.running_tasks >= config::lake_compaction_max_tasks_per_tablet) {
+        return false;
+    }
+
+    return true;
+}
+
+void LakeCompactionManager::_schedule_thread_func() {
+    LOG(INFO) << "LakeCompactionManager scheduler thread started";
+
+    while (!_stopped.load()) {
+        std::unique_lock<std::mutex> lock(_queue_mutex);
+
+        // Wait for tablets in queue or stop signal
+        _queue_cv.wait_for(lock, std::chrono::seconds(1), [this]() { return !_tablet_queue.empty() || _stopped.load(); });
+
+        if (_stopped.load()) {
+            break;
+        }
+
+        if (_tablet_queue.empty()) {
+            continue;
+        }
+
+        // Get highest priority tablet
+        auto info = _tablet_queue.top();
+        _tablet_queue.pop();
+        lock.unlock();
+
+        // Mark as not in queue
+        {
+            std::lock_guard<std::mutex> state_lock(_state_mutex);
+            auto it = _tablet_states.find(info.tablet_id);
+            if (it != _tablet_states.end()) {
+                it->second.in_queue = false;
+            }
+        }
+
+        // Try to schedule compaction for this tablet
+        auto st = _schedule_tablet(info.tablet_id);
+        if (!st.ok()) {
+            VLOG(2) << "Failed to schedule tablet " << info.tablet_id << ": " << st;
+            
+            // Re-add to queue if it's a temporary failure
+            if (st.is_resource_busy()) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                update_tablet_async(info.tablet_id);
+            }
+        }
+    }
+
+    LOG(INFO) << "LakeCompactionManager scheduler thread exited";
+}
+
+Status LakeCompactionManager::_schedule_tablet(int64_t tablet_id) {
+    // Get tablet state
+    std::unique_lock<std::mutex> state_lock(_state_mutex);
+    auto it = _tablet_states.find(tablet_id);
+    if (it == _tablet_states.end()) {
+        return Status::NotFound(strings::Substitute("Tablet $0 state not found", tablet_id));
+    }
+
+    auto& state = it->second;
+
+    // Check if we can schedule more tasks for this tablet
+    if (!_can_schedule_tablet(state)) {
+        return Status::ResourceBusy(strings::Substitute("Tablet $0 already at max concurrent tasks", tablet_id));
+    }
+
+    // Get tablet and metadata
+    ASSIGN_OR_RETURN(auto tablet, _tablet_mgr->get_tablet(tablet_id));
+    auto metadata = tablet.metadata();
+
+    if (!metadata) {
+        return Status::NotFound(strings::Substitute("Tablet $0 metadata not found", tablet_id));
+    }
+
+    // Create compaction policy
+    ASSIGN_OR_RETURN(auto policy, CompactionPolicy::create(_tablet_mgr, metadata, false));
+
+    // Pick rowsets with limit and exclusion
+    ASSIGN_OR_RETURN(auto input_rowsets,
+                     policy->pick_rowsets_with_limit(config::lake_compaction_max_bytes_per_task, state.compacting_rowsets));
+
+    if (input_rowsets.empty()) {
+        VLOG(2) << "No rowsets to compact for tablet " << tablet_id;
+        return Status::OK();
+    }
+
+    // Collect rowset IDs
+    std::vector<uint32_t> input_rowset_ids;
+    for (const auto& rowset : input_rowsets) {
+        input_rowset_ids.push_back(rowset->id());
+    }
+
+    // Mark rowsets as being compacted
+    _mark_rowsets_compacting(tablet_id, input_rowset_ids);
+
+    // Update running tasks count
+    state.running_tasks++;
+    _running_tasks++;
+
+    state_lock.unlock();
+
+    // Create compaction context
+    // Set skip_write_txnlog=true so the txn_log is saved in context->txn_log
+    // instead of being written to storage. This allows us to extract output_rowset
+    // for CompactionResultPB.
+    auto context = std::make_unique<CompactionTaskContext>(0 /* txn_id */, tablet_id, metadata->version(),
+                                                           false /* force_base_compaction */,
+                                                           true /* skip_write_txnlog */, nullptr /* callback */);
+
+    // Submit to thread pool
+    auto submit_st = _thread_pool->submit_func([this, ctx = std::move(context)]() mutable { _execute_compaction(std::move(ctx)); });
+
+    if (!submit_st.ok()) {
+        // Failed to submit, revert state changes
+        std::lock_guard<std::mutex> lock(_state_mutex);
+        auto it = _tablet_states.find(tablet_id);
+        if (it != _tablet_states.end()) {
+            _unmark_rowsets_compacting(tablet_id, input_rowset_ids);
+            it->second.running_tasks--;
+            _running_tasks--;
+        }
+        return submit_st;
+    }
+
+    LOG(INFO) << "Scheduled autonomous compaction for tablet " << tablet_id << ", rowsets: " << input_rowset_ids.size();
+
+    return Status::OK();
+}
+
+void LakeCompactionManager::_mark_rowsets_compacting(int64_t tablet_id, const std::vector<uint32_t>& rowset_ids) {
+    // Assumes _state_mutex is already held
+    auto& state = _tablet_states[tablet_id];
+    for (uint32_t rid : rowset_ids) {
+        state.compacting_rowsets.insert(rid);
+    }
+}
+
+void LakeCompactionManager::_unmark_rowsets_compacting(int64_t tablet_id, const std::vector<uint32_t>& rowset_ids) {
+    std::lock_guard<std::mutex> lock(_state_mutex);
+    auto it = _tablet_states.find(tablet_id);
+    if (it != _tablet_states.end()) {
+        for (uint32_t rid : rowset_ids) {
+            it->second.compacting_rowsets.erase(rid);
+        }
+    }
+}
+
+void LakeCompactionManager::_execute_compaction(std::unique_ptr<CompactionTaskContext> context) {
+    int64_t tablet_id = context->tablet_id;
+    DeferOp defer([this, tablet_id]() {
+        // Decrement running tasks count
+        _running_tasks--;
+
+        std::lock_guard<std::mutex> lock(_state_mutex);
+        auto it = _tablet_states.find(tablet_id);
+        if (it != _tablet_states.end()) {
+            it->second.running_tasks--;
+        }
+    });
+
+    VLOG(1) << "Executing autonomous compaction for tablet " << tablet_id;
+
+    // Get tablet
+    auto tablet_or = _tablet_mgr->get_tablet(tablet_id);
+    if (!tablet_or.ok()) {
+        LOG(WARNING) << "Failed to get tablet " << tablet_id << ": " << tablet_or.status();
+        _failed_tasks++;
+        return;
+    }
+
+    auto tablet = tablet_or.value();
+    auto metadata = tablet.metadata();
+
+    if (!metadata) {
+        LOG(WARNING) << "Tablet " << tablet_id << " metadata not found";
+        _failed_tasks++;
+        return;
+    }
+
+    // Create compaction policy and pick rowsets
+    auto policy_or = CompactionPolicy::create(_tablet_mgr, metadata, false);
+    if (!policy_or.ok()) {
+        LOG(WARNING) << "Failed to create compaction policy for tablet " << tablet_id << ": " << policy_or.status();
+        _failed_tasks++;
+        return;
+    }
+
+    std::unordered_set<uint32_t> exclude_rowsets;
+    {
+        std::lock_guard<std::mutex> lock(_state_mutex);
+        auto it = _tablet_states.find(tablet_id);
+        if (it != _tablet_states.end()) {
+            exclude_rowsets = it->second.compacting_rowsets;
+        }
+    }
+
+    auto rowsets_or = policy_or.value()->pick_rowsets_with_limit(config::lake_compaction_max_bytes_per_task, exclude_rowsets);
+    if (!rowsets_or.ok() || rowsets_or.value().empty()) {
+        VLOG(2) << "No rowsets to compact for tablet " << tablet_id;
+        _completed_tasks++;
+        return;
+    }
+
+    auto input_rowsets = rowsets_or.value();
+    std::vector<uint32_t> input_rowset_ids;
+    for (const auto& rowset : input_rowsets) {
+        input_rowset_ids.push_back(rowset->id());
+    }
+
+    // Perform compaction using tablet_mgr->compact()
+    // Note: context->version is already set during context creation in _schedule_tablet
+    auto compaction_task_or = _tablet_mgr->compact(context.get());
+    
+    if (!compaction_task_or.ok()) {
+        LOG(WARNING) << "Failed to create compaction task for tablet " << tablet_id << ": " << compaction_task_or.status();
+        _unmark_rowsets_compacting(tablet_id, input_rowset_ids);
+        _failed_tasks++;
+        return;
+    }
+
+    auto compaction_task = compaction_task_or.value();
+    
+    // Execute compaction
+    auto cancel_func = []() { return Status::OK(); };
+    auto exec_st = compaction_task->execute(cancel_func, nullptr);
+
+    _unmark_rowsets_compacting(tablet_id, input_rowset_ids);
+
+    if (!exec_st.ok()) {
+        LOG(WARNING) << "Compaction failed for tablet " << tablet_id << ": " << exec_st;
+        _failed_tasks++;
+        return;
+    }
+
+    // Save compaction result locally
+    CompactionResultPB result;
+    result.set_tablet_id(tablet_id);
+    result.set_base_version(metadata->version());
+    result.set_finish_time_ms(std::chrono::duration_cast<std::chrono::milliseconds>(
+                                      std::chrono::system_clock::now().time_since_epoch())
+                                      .count());
+    
+    for (uint32_t rid : input_rowset_ids) {
+        result.add_input_rowset_ids(rid);
+    }
+
+    // Extract output rowset and SSTable info from txn_log
+    // This is critical: without output_rowset, the publish will only delete input rowsets
+    // without adding the compacted output, causing data loss.
+    if (context->txn_log != nullptr && context->txn_log->has_op_compaction()) {
+        const auto& op_compaction = context->txn_log->op_compaction();
+        if (op_compaction.has_output_rowset()) {
+            *result.mutable_output_rowset() = op_compaction.output_rowset();
+        }
+        // Copy SSTable metadata for primary key tables
+        for (const auto& input_sst : op_compaction.input_sstables()) {
+            result.add_input_sstables()->CopyFrom(input_sst);
+        }
+        for (const auto& output_sst : op_compaction.output_sstables()) {
+            result.add_output_sstables()->CopyFrom(output_sst);
+        }
+    }
+
+    auto save_st = _result_mgr->save_result(result);
+    if (!save_st.ok()) {
+        LOG(WARNING) << "Failed to save compaction result for tablet " << tablet_id << ": " << save_st.status();
+        _failed_tasks++;
+        return;
+    }
+
+    _completed_tasks++;
+
+    LOG(INFO) << "Autonomous compaction completed for tablet " << tablet_id 
+              << ", result saved to " << save_st.value();
+
+    // Check if we should trigger next round
+    int64_t total_bytes = 0;
+    for (const auto& rowset : input_rowsets) {
+        total_bytes += rowset->data_size();
+    }
+
+    // If processed close to limit, trigger next task
+    if (total_bytes >= config::lake_compaction_max_bytes_per_task * 0.8) {
+        update_tablet_async(tablet_id);
+    }
+}
+
+} // namespace starrocks::lake
+
+

--- a/be/src/storage/lake/lake_compaction_manager.h
+++ b/be/src/storage/lake/lake_compaction_manager.h
@@ -1,0 +1,194 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "common/status.h"
+#include "storage/lake/compaction_result_manager.h"
+#include "storage/lake/compaction_task.h"
+#include "util/threadpool.h"
+
+namespace starrocks::lake {
+
+class TabletManager;
+class CompactionResultManager;
+
+// Tablet compaction info for priority queue
+struct TabletCompactionInfo {
+    int64_t tablet_id;
+    double score;
+    int64_t last_update_time_ms;
+
+    // For priority queue ordering (higher score = higher priority)
+    bool operator<(const TabletCompactionInfo& other) const {
+        if (score != other.score) {
+            return score < other.score; // max heap
+        }
+        return last_update_time_ms > other.last_update_time_ms; // older first
+    }
+};
+
+// Tracks compaction state for a single tablet
+struct TabletCompactionState {
+    int64_t tablet_id;
+    // Rowsets currently being compacted
+    std::unordered_set<uint32_t> compacting_rowsets;
+    // Number of running compaction tasks for this tablet
+    int running_tasks = 0;
+    // Last calculated compaction score
+    double last_score = 0.0;
+    // Last update time
+    int64_t last_update_time_ms = 0;
+    // Whether this tablet is in the priority queue
+    bool in_queue = false;
+    // Has pending results from previous compaction (recovered from crash)
+    bool has_pending_results = false;
+};
+
+// Autonomous compaction manager for lake tablets
+// Implements event-driven, tablet-level compaction scheduling with:
+// - Priority queue based on compaction score
+// - Per-tablet parallel task support
+// - Rowset-level conflict avoidance
+// - Data volume limits per task
+//
+// Exception Recovery (Design Doc Section 6.3.1):
+// This manager leverages existing mechanisms instead of BE startup self-check:
+// - Score-Driven Scheduling: Partition score remains high → FE schedules it again
+// - Request-Triggered Scheduling: PUBLISH_AUTONOMOUS brings tablet_ids → BE queues them on demand
+// - On-Demand Execution: BE only processes partitions FE determines require compaction
+class LakeCompactionManager {
+public:
+    explicit LakeCompactionManager(TabletManager* tablet_mgr);
+    ~LakeCompactionManager();
+
+    // Create and initialize the singleton instance
+    // Must be called once during system startup
+    static Status create_instance(TabletManager* tablet_mgr);
+
+    // Get singleton instance (returns nullptr if not initialized)
+    static LakeCompactionManager* instance();
+
+    // Initialize and start the manager (called automatically by create_instance)
+    Status init();
+
+    // Stop the manager
+    void stop();
+
+    // ============== Event-Driven Scheduling ==============
+
+    // Update a tablet's compaction state (event-driven trigger)
+    // This is called when:
+    // - Version is published
+    // - Manual compaction is triggered
+    // - A compaction task completes
+    // - PUBLISH_AUTONOMOUS triggers scheduling (Mechanism 3)
+    void update_tablet_async(int64_t tablet_id);
+
+    // Batch update for multiple tablets
+    // Used by PUBLISH_AUTONOMOUS to trigger scheduling for all tablets in a partition
+    void update_tablets_async(const std::vector<int64_t>& tablet_ids);
+
+    // ============== Startup Recovery ==============
+
+    // Recover state from local compaction results after BE restart
+    // This implements Mechanism 1: Local Result Recovery
+    // Called during BE startup after init()
+    Status recover_from_local_results();
+
+    // ============== Query Methods ==============
+
+    // Get current metrics
+    int64_t running_tasks() const { return _running_tasks.load(); }
+    int64_t queue_size() const;
+    int64_t completed_tasks() const { return _completed_tasks.load(); }
+    int64_t failed_tasks() const { return _failed_tasks.load(); }
+    int64_t recovered_tablets() const { return _recovered_tablets.load(); }
+
+    // Check if a tablet has pending compaction results
+    bool has_pending_results(int64_t tablet_id) const;
+
+    // Get the set of rowsets currently being compacted for a tablet
+    std::unordered_set<uint32_t> get_compacting_rowsets(int64_t tablet_id) const;
+
+    // ============== Partial Compaction Support (Mechanism 4) ==============
+    
+    // Check if a tablet has partial compaction state (some results exist, others running)
+    bool has_partial_compaction_state(int64_t tablet_id) const;
+
+private:
+    // Background thread function that processes the priority queue
+    void _schedule_thread_func();
+
+    // Try to schedule a compaction task for a tablet
+    Status _schedule_tablet(int64_t tablet_id);
+
+    // Execute a compaction task
+    void _execute_compaction(std::unique_ptr<CompactionTaskContext> context,
+                             std::vector<uint32_t> input_rowset_ids);
+
+    // Calculate compaction score for a tablet
+    StatusOr<double> _calculate_score(int64_t tablet_id);
+
+    // Update tablet state after score calculation
+    void _update_tablet_state(int64_t tablet_id, double score);
+
+    // Check if we can schedule more tasks for a tablet
+    bool _can_schedule_tablet(const TabletCompactionState& state);
+
+    // Mark rowsets as being compacted. Caller must hold _state_mutex.
+    void _mark_rowsets_compacting(int64_t tablet_id, const std::vector<uint32_t>& rowset_ids);
+
+    // Unmark rowsets after compaction completes. Caller must hold _state_mutex.
+    void _unmark_rowsets_compacting(int64_t tablet_id, const std::vector<uint32_t>& rowset_ids);
+
+    TabletManager* _tablet_mgr;
+    std::unique_ptr<CompactionResultManager> _result_mgr;
+
+    // Priority queue for tablets pending compaction
+    std::priority_queue<TabletCompactionInfo> _tablet_queue;
+    mutable std::mutex _queue_mutex;
+    std::condition_variable _queue_cv;
+
+    // Per-tablet compaction state
+    std::unordered_map<int64_t, TabletCompactionState> _tablet_states;
+    mutable std::mutex _state_mutex;
+
+    // Thread pool for executing compaction tasks
+    std::unique_ptr<ThreadPool> _thread_pool;
+
+    // Background scheduler thread
+    std::unique_ptr<std::thread> _schedule_thread;
+
+    // Metrics
+    std::atomic<int64_t> _running_tasks{0};
+    std::atomic<int64_t> _completed_tasks{0};
+    std::atomic<int64_t> _failed_tasks{0};
+    std::atomic<int64_t> _recovered_tablets{0};
+
+    // Control flags
+    std::atomic<bool> _stopped{false};
+    std::atomic<bool> _recovered{false};
+};
+
+} // namespace starrocks::lake
+
+

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -1108,6 +1108,15 @@ StatusOr<CompactionTaskPtr> TabletManager::compact(CompactionTaskContext* contex
     ASSIGN_OR_RETURN(auto compaction_policy,
                      CompactionPolicy::create(this, tablet_metadata, context->force_base_compaction));
     ASSIGN_OR_RETURN(auto input_rowsets, compaction_policy->pick_rowsets());
+    return compact(context, std::move(input_rowsets));
+}
+
+StatusOr<CompactionTaskPtr> TabletManager::compact(CompactionTaskContext* context,
+                                                   std::vector<RowsetPtr> input_rowsets) {
+    ASSIGN_OR_RETURN(auto tablet, get_tablet(context->tablet_id, context->version));
+    auto tablet_metadata = tablet.metadata();
+    ASSIGN_OR_RETURN(auto compaction_policy,
+                     CompactionPolicy::create(this, tablet_metadata, context->force_base_compaction));
     ASSIGN_OR_RETURN(auto algorithm, compaction_policy->choose_compaction_algorithm(input_rowsets));
     std::vector<uint32_t> input_rowsets_id;
     size_t total_input_rowsets_file_size = 0;

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -80,6 +80,9 @@ public:
 
     StatusOr<CompactionTaskPtr> compact(CompactionTaskContext* context);
 
+    // Compact with pre-selected rowsets (for parallel compaction)
+    StatusOr<CompactionTaskPtr> compact(CompactionTaskContext* context, std::vector<RowsetPtr> input_rowsets);
+
     Status put_tablet_metadata(const TabletMetadata& metadata);
 
     Status put_tablet_metadata(const TabletMetadataPtr& metadata);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -494,7 +494,9 @@ SET(DW_TEST_FILES
     ./storage/lake/alter_tablet_meta_test.cpp
     ./storage/lake/async_delta_writer_test.cpp
     ./storage/lake/auto_increment_partial_update_test.cpp
+    ./storage/lake/autonomous_compaction_handler_test.cpp
     ./storage/lake/compaction_policy_test.cpp
+    ./storage/lake/compaction_result_manager_test.cpp
     ./storage/lake/compaction_scheduler_test.cpp
     ./storage/lake/compaction_task_context_test.cpp
     ./storage/lake/condition_update_test.cpp

--- a/be/test/storage/lake/autonomous_compaction_handler_test.cpp
+++ b/be/test/storage/lake/autonomous_compaction_handler_test.cpp
@@ -1,0 +1,326 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/autonomous_compaction_handler.h"
+
+#include <gtest/gtest.h>
+
+#include "common/config.h"
+#include "fs/fs.h"
+#include "fs/fs_util.h"
+#include "storage/lake/join_path.h"
+#include "storage/lake/test_util.h"
+#include "testutil/assert.h"
+#include "testutil/id_generator.h"
+
+namespace starrocks::lake {
+
+class AutonomousCompactionHandlerTest : public TestBase {
+public:
+    AutonomousCompactionHandlerTest() : TestBase(kTestDir), _handler(_tablet_mgr.get()) { clear_and_init_test_dir(); }
+
+    ~AutonomousCompactionHandlerTest() override = default;
+
+    void SetUp() override {
+        // Create a tablet with metadata
+        _tablet_metadata = generate_simple_tablet_metadata(DUP_KEYS);
+        _tablet_id = _tablet_metadata->id();
+        _tablet_metadata->set_version(1);
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(_tablet_metadata));
+    }
+
+    void TearDown() override { (void)fs::remove_all(_test_dir); }
+
+protected:
+    constexpr static const char* kTestDir = "test_autonomous_compaction_handler";
+    AutonomousCompactionHandler _handler;
+    std::shared_ptr<TabletMetadata> _tablet_metadata;
+    int64_t _tablet_id = 0;
+};
+
+// ============== Test AutonomousCompactionStats default values ==============
+TEST_F(AutonomousCompactionHandlerTest, test_stats_default_values) {
+    AutonomousCompactionStats stats;
+    EXPECT_EQ(0, stats.tablets_processed);
+    EXPECT_EQ(0, stats.tablets_with_compaction);
+    EXPECT_EQ(0, stats.tablets_succeeded);
+    EXPECT_EQ(0, stats.tablets_scheduled);
+    EXPECT_EQ(0, stats.result_files_cleaned);
+}
+
+// ============== Test last_stats initially empty ==============
+TEST_F(AutonomousCompactionHandlerTest, test_last_stats_initially_empty) {
+    const auto& stats = _handler.last_stats();
+    EXPECT_EQ(0, stats.tablets_processed);
+    EXPECT_EQ(0, stats.tablets_with_compaction);
+    EXPECT_EQ(0, stats.tablets_succeeded);
+    EXPECT_EQ(0, stats.tablets_scheduled);
+    EXPECT_EQ(0, stats.result_files_cleaned);
+}
+
+// ============== Test process_request with non-autonomous request ==============
+TEST_F(AutonomousCompactionHandlerTest, test_process_request_not_autonomous) {
+    CompactRequest request;
+    CompactResponse response;
+
+    // Not set autonomous_compaction flag
+    request.set_txn_id(next_id());
+    request.add_tablet_ids(_tablet_id);
+    request.set_version(1);
+
+    auto status = _handler.process_request(&request, &response);
+    EXPECT_FALSE(status.ok());
+    EXPECT_TRUE(status.is_invalid_argument());
+}
+
+// ============== Test process_request with autonomous request ==============
+TEST_F(AutonomousCompactionHandlerTest, test_process_request_autonomous_empty_results) {
+    CompactRequest request;
+    CompactResponse response;
+
+    request.set_autonomous_compaction(true);
+    request.set_txn_id(next_id());
+    request.add_tablet_ids(_tablet_id);
+    request.set_version(1);
+    request.set_visible_version(1);
+
+    auto status = _handler.process_request(&request, &response);
+    EXPECT_TRUE(status.ok());
+
+    // Check stats
+    const auto& stats = _handler.last_stats();
+    EXPECT_EQ(1, stats.tablets_processed);
+    // No compaction results, so tablets_with_compaction should be 0
+    EXPECT_EQ(0, stats.tablets_with_compaction);
+    EXPECT_EQ(0, stats.tablets_succeeded);
+}
+
+// ============== Test process_request with multiple tablets ==============
+TEST_F(AutonomousCompactionHandlerTest, test_process_request_multiple_tablets) {
+    // Create another tablet
+    auto tablet_metadata2 = generate_simple_tablet_metadata(DUP_KEYS);
+    int64_t tablet_id2 = tablet_metadata2->id();
+    tablet_metadata2->set_version(1);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(tablet_metadata2));
+
+    CompactRequest request;
+    CompactResponse response;
+
+    request.set_autonomous_compaction(true);
+    request.set_txn_id(next_id());
+    request.add_tablet_ids(_tablet_id);
+    request.add_tablet_ids(tablet_id2);
+    request.set_version(1);
+    request.set_visible_version(1);
+
+    auto status = _handler.process_request(&request, &response);
+    EXPECT_TRUE(status.ok());
+
+    // Check stats
+    const auto& stats = _handler.last_stats();
+    EXPECT_EQ(2, stats.tablets_processed);
+}
+
+// ============== Test process_request with non-existent tablet ==============
+TEST_F(AutonomousCompactionHandlerTest, test_process_request_nonexistent_tablet) {
+    CompactRequest request;
+    CompactResponse response;
+
+    request.set_autonomous_compaction(true);
+    request.set_txn_id(next_id());
+    request.add_tablet_ids(99999); // Non-existent tablet
+    request.set_version(1);
+    request.set_visible_version(1);
+
+    auto status = _handler.process_request(&request, &response);
+    EXPECT_TRUE(status.ok()); // Should not fail, just skip the tablet
+
+    // Check stats
+    const auto& stats = _handler.last_stats();
+    EXPECT_EQ(1, stats.tablets_processed);
+    EXPECT_EQ(0, stats.tablets_with_compaction);
+}
+
+// ============== Test process_request without visible_version ==============
+TEST_F(AutonomousCompactionHandlerTest, test_process_request_without_visible_version) {
+    CompactRequest request;
+    CompactResponse response;
+
+    request.set_autonomous_compaction(true);
+    request.set_txn_id(next_id());
+    request.add_tablet_ids(_tablet_id);
+    request.set_version(5); // visible_version should default to version
+
+    auto status = _handler.process_request(&request, &response);
+    EXPECT_TRUE(status.ok());
+
+    const auto& stats = _handler.last_stats();
+    EXPECT_EQ(1, stats.tablets_processed);
+}
+
+// ============== Test process_request with config disabled ==============
+TEST_F(AutonomousCompactionHandlerTest, test_process_request_config_disabled) {
+    // Disable autonomous compaction
+    bool old_value = config::enable_lake_autonomous_compaction;
+    config::enable_lake_autonomous_compaction = false;
+
+    CompactRequest request;
+    CompactResponse response;
+
+    request.set_autonomous_compaction(true);
+    request.set_txn_id(next_id());
+    request.add_tablet_ids(_tablet_id);
+    request.set_version(1);
+    request.set_visible_version(1);
+
+    auto status = _handler.process_request(&request, &response);
+    EXPECT_TRUE(status.ok());
+
+    // Restore config
+    config::enable_lake_autonomous_compaction = old_value;
+
+    // With config disabled, tablets_scheduled should be 0
+    const auto& stats = _handler.last_stats();
+    EXPECT_EQ(0, stats.tablets_scheduled);
+}
+
+// ============== Test multiple process_request calls reset stats ==============
+TEST_F(AutonomousCompactionHandlerTest, test_process_request_resets_stats) {
+    // First request with 2 tablets
+    auto tablet_metadata2 = generate_simple_tablet_metadata(DUP_KEYS);
+    int64_t tablet_id2 = tablet_metadata2->id();
+    tablet_metadata2->set_version(1);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(tablet_metadata2));
+
+    {
+        CompactRequest request;
+        CompactResponse response;
+        request.set_autonomous_compaction(true);
+        request.set_txn_id(next_id());
+        request.add_tablet_ids(_tablet_id);
+        request.add_tablet_ids(tablet_id2);
+        request.set_version(1);
+        ASSERT_OK(_handler.process_request(&request, &response));
+        EXPECT_EQ(2, _handler.last_stats().tablets_processed);
+    }
+
+    // Second request with 1 tablet - stats should be reset
+    {
+        CompactRequest request;
+        CompactResponse response;
+        request.set_autonomous_compaction(true);
+        request.set_txn_id(next_id());
+        request.add_tablet_ids(_tablet_id);
+        request.set_version(1);
+        ASSERT_OK(_handler.process_request(&request, &response));
+        EXPECT_EQ(1, _handler.last_stats().tablets_processed);
+    }
+}
+
+// ============== Test response status ==============
+TEST_F(AutonomousCompactionHandlerTest, test_process_request_sets_response_status) {
+    CompactRequest request;
+    CompactResponse response;
+
+    request.set_autonomous_compaction(true);
+    request.set_txn_id(next_id());
+    request.add_tablet_ids(_tablet_id);
+    request.set_version(1);
+    request.set_visible_version(1);
+
+    auto status = _handler.process_request(&request, &response);
+    EXPECT_TRUE(status.ok());
+
+    // Response should have OK status
+    EXPECT_TRUE(response.has_status());
+    EXPECT_EQ(TStatusCode::OK, response.status().status_code());
+}
+
+// ============== Test empty tablet list ==============
+TEST_F(AutonomousCompactionHandlerTest, test_process_request_empty_tablets) {
+    CompactRequest request;
+    CompactResponse response;
+
+    request.set_autonomous_compaction(true);
+    request.set_txn_id(next_id());
+    // No tablet_ids added
+    request.set_version(1);
+    request.set_visible_version(1);
+
+    auto status = _handler.process_request(&request, &response);
+    EXPECT_TRUE(status.ok());
+
+    const auto& stats = _handler.last_stats();
+    EXPECT_EQ(0, stats.tablets_processed);
+    EXPECT_EQ(0, stats.tablets_with_compaction);
+}
+
+// ============== Test with tablet having rowsets ==============
+TEST_F(AutonomousCompactionHandlerTest, test_process_request_tablet_with_rowsets) {
+    // Create a tablet with some rowsets
+    auto metadata = generate_simple_tablet_metadata(DUP_KEYS);
+    int64_t tablet_id = metadata->id();
+    metadata->set_version(5);
+
+    // Add several rowsets to create compaction opportunity
+    for (int i = 0; i < 5; i++) {
+        auto* rowset = metadata->add_rowsets();
+        rowset->set_id(i + 1);
+        rowset->set_overlapped(true);
+        rowset->set_num_rows(100);
+        rowset->set_data_size(1000);
+    }
+
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(metadata));
+
+    CompactRequest request;
+    CompactResponse response;
+
+    request.set_autonomous_compaction(true);
+    request.set_txn_id(next_id());
+    request.add_tablet_ids(tablet_id);
+    request.set_version(5);
+    request.set_visible_version(5);
+
+    auto status = _handler.process_request(&request, &response);
+    EXPECT_TRUE(status.ok());
+
+    const auto& stats = _handler.last_stats();
+    EXPECT_EQ(1, stats.tablets_processed);
+}
+
+// ============== Test constructor and destructor ==============
+TEST_F(AutonomousCompactionHandlerTest, test_constructor_destructor) {
+    // Test that we can create and destroy handler without issues
+    {
+        AutonomousCompactionHandler handler(_tablet_mgr.get());
+        EXPECT_EQ(0, handler.last_stats().tablets_processed);
+    }
+    // Handler should be destroyed without any issues
+}
+
+// ============== Test with null tablet manager ==============
+// Note: This is just to document behavior, not necessarily recommended
+TEST_F(AutonomousCompactionHandlerTest, test_with_nullptr_tablet_mgr) {
+    // Creating handler with nullptr tablet_mgr
+    // The handler should be created but process_request would fail
+    AutonomousCompactionHandler handler(nullptr);
+    EXPECT_EQ(0, handler.last_stats().tablets_processed);
+
+    // Don't call process_request as it would likely crash or fail badly
+}
+
+} // namespace starrocks::lake
+
+

--- a/be/test/storage/lake/compaction_result_manager_test.cpp
+++ b/be/test/storage/lake/compaction_result_manager_test.cpp
@@ -1,0 +1,561 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/compaction_result_manager.h"
+
+#include <gtest/gtest.h>
+
+#include <regex>
+#include <set>
+
+#include "fs/fs.h"
+#include "fs/fs_util.h"
+#include "storage/lake/join_path.h"
+#include "storage/lake/test_util.h"
+#include "testutil/assert.h"
+#include "testutil/id_generator.h"
+#include "util/raw_container.h"
+
+namespace starrocks::lake {
+
+class CompactionResultManagerTest : public TestBase {
+public:
+    CompactionResultManagerTest() : TestBase(kTestDir) { clear_and_init_test_dir(); }
+
+    ~CompactionResultManagerTest() override = default;
+
+    void SetUp() override {
+        // Create compaction_results directory
+        _results_dir = CompactionResultManager::get_results_dir(_test_dir);
+        CHECK_OK(fs::create_directories(_results_dir));
+    }
+
+    void TearDown() override { (void)fs::remove_all(_test_dir); }
+
+protected:
+    constexpr static const char* kTestDir = "test_compaction_result_manager";
+    std::string _results_dir;
+    CompactionResultManager _manager;
+};
+
+// ============== Test get_results_dir ==============
+TEST_F(CompactionResultManagerTest, test_get_results_dir) {
+    std::string storage_root = "/path/to/storage";
+    std::string expected = "/path/to/storage/lake/compaction_results";
+    EXPECT_EQ(expected, CompactionResultManager::get_results_dir(storage_root));
+
+    // Test with trailing slash
+    std::string storage_root2 = "/path/to/storage/";
+    std::string expected2 = "/path/to/storage//lake/compaction_results";
+    EXPECT_EQ(expected2, CompactionResultManager::get_results_dir(storage_root2));
+
+    // Test with empty string
+    std::string expected_empty = "/lake/compaction_results";
+    EXPECT_EQ(expected_empty, CompactionResultManager::get_results_dir(""));
+}
+
+// ============== Test extract_tablet_id_from_filename ==============
+class ExtractTabletIdTest : public testing::Test {};
+
+TEST_F(ExtractTabletIdTest, test_valid_filename) {
+    // Valid filename format: tablet_{tablet_id}_result_{timestamp}_{random}.pb
+    auto result = CompactionResultManager::extract_tablet_id_from_filename("tablet_12345_result_1234567890_123456.pb");
+    ASSERT_TRUE(result.ok());
+    EXPECT_EQ(12345, result.value());
+}
+
+TEST_F(ExtractTabletIdTest, test_large_tablet_id) {
+    auto result =
+            CompactionResultManager::extract_tablet_id_from_filename("tablet_9223372036854775807_result_1_1.pb");
+    ASSERT_TRUE(result.ok());
+    EXPECT_EQ(9223372036854775807LL, result.value());
+}
+
+TEST_F(ExtractTabletIdTest, test_invalid_filename_no_tablet_prefix) {
+    auto result = CompactionResultManager::extract_tablet_id_from_filename("12345_result_1234567890_123456.pb");
+    ASSERT_FALSE(result.ok());
+}
+
+TEST_F(ExtractTabletIdTest, test_invalid_filename_wrong_extension) {
+    auto result = CompactionResultManager::extract_tablet_id_from_filename("tablet_12345_result_1234567890_123456.txt");
+    ASSERT_FALSE(result.ok());
+}
+
+TEST_F(ExtractTabletIdTest, test_invalid_filename_missing_parts) {
+    auto result = CompactionResultManager::extract_tablet_id_from_filename("tablet_12345.pb");
+    ASSERT_FALSE(result.ok());
+
+    auto result2 = CompactionResultManager::extract_tablet_id_from_filename("tablet_12345_result.pb");
+    ASSERT_FALSE(result2.ok());
+}
+
+TEST_F(ExtractTabletIdTest, test_invalid_filename_non_numeric_tablet_id) {
+    auto result = CompactionResultManager::extract_tablet_id_from_filename("tablet_abc_result_1234567890_123456.pb");
+    ASSERT_FALSE(result.ok());
+}
+
+TEST_F(ExtractTabletIdTest, test_empty_filename) {
+    auto result = CompactionResultManager::extract_tablet_id_from_filename("");
+    ASSERT_FALSE(result.ok());
+}
+
+// ============== Test has_pending_results and get_tablets_with_pending_results ==============
+TEST_F(CompactionResultManagerTest, test_pending_results_initially_empty) {
+    // Initially, no pending results
+    EXPECT_FALSE(_manager.has_pending_results(12345));
+    EXPECT_TRUE(_manager.get_tablets_with_pending_results().empty());
+}
+
+// ============== Test validate_result ==============
+TEST_F(CompactionResultManagerTest, test_validate_result_null_tablet_mgr) {
+    CompactionResultPB result;
+    result.set_tablet_id(12345);
+    result.set_base_version(1);
+
+    std::string reason;
+    auto valid_or = _manager.validate_result(nullptr, result, &reason);
+    ASSERT_FALSE(valid_or.ok());
+}
+
+TEST_F(CompactionResultManagerTest, test_validate_result_missing_tablet_id) {
+    CompactionResultPB result;
+    // Don't set tablet_id
+
+    std::string reason;
+    auto valid_or = _manager.validate_result(_tablet_mgr.get(), result, &reason);
+    ASSERT_TRUE(valid_or.ok());
+    EXPECT_FALSE(valid_or.value());
+    EXPECT_EQ("missing tablet_id", reason);
+}
+
+TEST_F(CompactionResultManagerTest, test_validate_result_tablet_not_found) {
+    CompactionResultPB result;
+    result.set_tablet_id(99999); // Non-existent tablet
+
+    std::string reason;
+    auto valid_or = _manager.validate_result(_tablet_mgr.get(), result, &reason);
+    ASSERT_TRUE(valid_or.ok());
+    EXPECT_FALSE(valid_or.value());
+    // The error message may contain "tablet not found" or "tablet metadata not found"
+    EXPECT_TRUE(reason.find("not found") != std::string::npos || reason.find("metadata") != std::string::npos);
+}
+
+TEST_F(CompactionResultManagerTest, test_validate_result_with_valid_tablet) {
+    // Create a tablet with metadata
+    auto metadata = generate_simple_tablet_metadata(DUP_KEYS);
+    int64_t tablet_id = metadata->id();
+    metadata->set_version(10);
+
+    // Add a rowset
+    auto* rowset = metadata->add_rowsets();
+    rowset->set_id(1);
+    rowset->set_overlapped(false);
+    rowset->set_num_rows(100);
+    rowset->set_data_size(1000);
+
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(metadata));
+
+    // Test with valid result
+    CompactionResultPB result;
+    result.set_tablet_id(tablet_id);
+    result.set_base_version(5); // base_version < visible_version
+    result.add_input_rowset_ids(1); // Existing rowset
+
+    std::string reason;
+    auto valid_or = _manager.validate_result(_tablet_mgr.get(), result, &reason);
+    ASSERT_TRUE(valid_or.ok());
+    EXPECT_TRUE(valid_or.value());
+}
+
+TEST_F(CompactionResultManagerTest, test_validate_result_base_version_too_high) {
+    // Create a tablet with metadata
+    auto metadata = generate_simple_tablet_metadata(DUP_KEYS);
+    int64_t tablet_id = metadata->id();
+    metadata->set_version(5);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(metadata));
+
+    // Test with base_version > visible_version
+    CompactionResultPB result;
+    result.set_tablet_id(tablet_id);
+    result.set_base_version(10); // base_version > visible_version (5)
+
+    std::string reason;
+    auto valid_or = _manager.validate_result(_tablet_mgr.get(), result, &reason);
+    ASSERT_TRUE(valid_or.ok());
+    EXPECT_FALSE(valid_or.value());
+    EXPECT_TRUE(reason.find("base_version") != std::string::npos);
+}
+
+TEST_F(CompactionResultManagerTest, test_validate_result_missing_rowsets) {
+    // Create a tablet with metadata
+    auto metadata = generate_simple_tablet_metadata(DUP_KEYS);
+    int64_t tablet_id = metadata->id();
+    metadata->set_version(10);
+
+    // Add a rowset with id 1
+    auto* rowset = metadata->add_rowsets();
+    rowset->set_id(1);
+    rowset->set_overlapped(false);
+    rowset->set_num_rows(100);
+    rowset->set_data_size(1000);
+
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(metadata));
+
+    // Test with non-existent input rowset
+    CompactionResultPB result;
+    result.set_tablet_id(tablet_id);
+    result.set_base_version(5);
+    result.add_input_rowset_ids(999); // Non-existent rowset
+
+    std::string reason;
+    auto valid_or = _manager.validate_result(_tablet_mgr.get(), result, &reason);
+    ASSERT_TRUE(valid_or.ok());
+    EXPECT_FALSE(valid_or.value());
+    EXPECT_TRUE(reason.find("input rowsets no longer exist") != std::string::npos);
+}
+
+// Helper function to write string to file
+static Status write_string_to_file(const std::string& path, const std::string& content) {
+    ASSIGN_OR_RETURN(auto wf, fs::new_writable_file(path));
+    RETURN_IF_ERROR(wf->append(content));
+    RETURN_IF_ERROR(wf->close());
+    return Status::OK();
+}
+
+// Helper function to read string from file
+static StatusOr<std::string> read_string_from_file(const std::string& path) {
+    std::string content;
+    ASSIGN_OR_RETURN(auto rf, fs::new_sequential_file(path));
+    raw::stl_string_resize_uninitialized(&content, 1024 * 1024); // 1MB max
+    ASSIGN_OR_RETURN(auto nread, rf->read(content.data(), content.size()));
+    content.resize(nread);
+    return content;
+}
+
+// ============== Test delete_result ==============
+TEST_F(CompactionResultManagerTest, test_delete_result_file_exists) {
+    // Create a test file
+    std::string file_path = _results_dir + "/test_result.pb";
+    ASSERT_OK(write_string_to_file(file_path, "test content"));
+
+    // Verify file exists
+    ASSERT_TRUE(fs::path_exist(file_path));
+
+    // Delete the file
+    ASSERT_OK(_manager.delete_result(file_path));
+
+    // Verify file is deleted
+    EXPECT_FALSE(fs::path_exist(file_path));
+}
+
+TEST_F(CompactionResultManagerTest, test_delete_result_file_not_exists) {
+    std::string file_path = _results_dir + "/non_existent.pb";
+    // Should not fail even if file doesn't exist (graceful handling)
+    auto status = _manager.delete_result(file_path);
+    // The actual behavior depends on fs::delete_file implementation
+}
+
+// ============== Test file operations with direct file system access ==============
+TEST_F(CompactionResultManagerTest, test_result_file_read_write) {
+    // Create a CompactionResultPB
+    CompactionResultPB result;
+    result.set_tablet_id(12345);
+    result.set_base_version(10);
+    result.add_input_rowset_ids(1);
+    result.add_input_rowset_ids(2);
+    result.add_input_rowset_ids(3);
+
+    // Manually write to file (simulating save_result without StorageEngine)
+    std::string filename = "tablet_12345_result_1234567890_123456.pb";
+    std::string file_path = _results_dir + "/" + filename;
+
+    std::string serialized;
+    ASSERT_TRUE(result.SerializeToString(&serialized));
+    ASSERT_OK(write_string_to_file(file_path, serialized));
+
+    // Read and parse
+    auto content_or = read_string_from_file(file_path);
+    ASSERT_TRUE(content_or.ok());
+
+    CompactionResultPB loaded_result;
+    ASSERT_TRUE(loaded_result.ParseFromString(content_or.value()));
+
+    // Verify
+    EXPECT_EQ(12345, loaded_result.tablet_id());
+    EXPECT_EQ(10, loaded_result.base_version());
+    EXPECT_EQ(3, loaded_result.input_rowset_ids_size());
+    EXPECT_EQ(1, loaded_result.input_rowset_ids(0));
+    EXPECT_EQ(2, loaded_result.input_rowset_ids(1));
+    EXPECT_EQ(3, loaded_result.input_rowset_ids(2));
+}
+
+TEST_F(CompactionResultManagerTest, test_result_file_parse_invalid_content) {
+    // Write invalid content to file
+    std::string filename = "tablet_12345_result_1234567890_123456.pb";
+    std::string file_path = _results_dir + "/" + filename;
+    ASSERT_OK(write_string_to_file(file_path, "invalid protobuf content"));
+
+    // Read and try to parse
+    auto content_or = read_string_from_file(file_path);
+    ASSERT_TRUE(content_or.ok());
+
+    CompactionResultPB result;
+    EXPECT_FALSE(result.ParseFromString(content_or.value()));
+}
+
+// ============== Test filename pattern matching ==============
+TEST_F(CompactionResultManagerTest, test_filename_pattern_matching) {
+    // Test the pattern used in scan_all_result_files
+    std::vector<std::string> test_files = {"tablet_100_result_1234_5678.pb",
+                                           "tablet_200_result_9999_1111.pb",
+                                           "other_file.pb",
+                                           "tablet_invalid.pb",
+                                           "tablet_300_result_abc_def.pb"};
+
+    for (const auto& file : test_files) {
+        std::string file_path = _results_dir + "/" + file;
+        ASSERT_OK(write_string_to_file(file_path, "test"));
+    }
+
+    // List files
+    std::set<std::string> dirs, files;
+    ASSERT_OK(fs::list_dirs_files(_results_dir, &dirs, &files));
+
+    // Filter matching files
+    std::vector<std::string> matching_files;
+    for (const auto& file : files) {
+        if (file.ends_with(".pb") && file.find("tablet_") == 0) {
+            auto tablet_id_or = CompactionResultManager::extract_tablet_id_from_filename(file);
+            if (tablet_id_or.ok()) {
+                matching_files.push_back(file);
+            }
+        }
+    }
+
+    // Should match tablet_100 and tablet_200 (tablet_300 has invalid format)
+    EXPECT_EQ(2, matching_files.size());
+}
+
+// ============== Test load_and_validate_results ==============
+TEST_F(CompactionResultManagerTest, test_load_and_validate_results_empty) {
+    // Create a tablet
+    auto metadata = generate_simple_tablet_metadata(DUP_KEYS);
+    int64_t tablet_id = metadata->id();
+    metadata->set_version(10);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(metadata));
+
+    // No result files exist for this tablet
+    auto results = _manager.load_and_validate_results(_tablet_mgr.get(), tablet_id);
+    ASSERT_TRUE(results.ok());
+    EXPECT_TRUE(results.value().empty());
+}
+
+TEST_F(CompactionResultManagerTest, test_load_and_validate_results_with_valid_file) {
+    // Create a tablet with metadata
+    auto metadata = generate_simple_tablet_metadata(DUP_KEYS);
+    int64_t tablet_id = metadata->id();
+    metadata->set_version(10);
+
+    // Add a rowset
+    auto* rowset = metadata->add_rowsets();
+    rowset->set_id(1);
+    rowset->set_overlapped(false);
+    rowset->set_num_rows(100);
+    rowset->set_data_size(1000);
+
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(metadata));
+
+    // Create a valid result file
+    CompactionResultPB result;
+    result.set_tablet_id(tablet_id);
+    result.set_base_version(5);
+    result.add_input_rowset_ids(1);
+
+    std::string filename = fmt::format("tablet_{}_result_1234567890_123456.pb", tablet_id);
+    std::string file_path = _results_dir + "/" + filename;
+
+    std::string serialized;
+    ASSERT_TRUE(result.SerializeToString(&serialized));
+    ASSERT_OK(write_string_to_file(file_path, serialized));
+
+    // Load and validate - this requires the storage root to match
+    // Since we can't easily mock get_storage_roots, we'll test the validation logic directly
+    std::string invalid_reason;
+    auto valid_or = _manager.validate_result(_tablet_mgr.get(), result, &invalid_reason);
+    ASSERT_TRUE(valid_or.ok());
+    EXPECT_TRUE(valid_or.value());
+}
+
+// ============== Test recover_on_startup with null tablet_mgr ==============
+TEST_F(CompactionResultManagerTest, test_recover_on_startup_null_tablet_mgr) {
+    auto result = _manager.recover_on_startup(nullptr);
+    ASSERT_FALSE(result.ok());
+}
+
+// ============== Test RecoveryStats structure ==============
+TEST_F(CompactionResultManagerTest, test_recovery_stats_default_values) {
+    RecoveryStats stats;
+    EXPECT_EQ(0, stats.total_files_scanned);
+    EXPECT_EQ(0, stats.valid_results);
+    EXPECT_EQ(0, stats.invalid_results_cleaned);
+    EXPECT_EQ(0, stats.parse_errors);
+    EXPECT_EQ(0, stats.validation_errors);
+    EXPECT_TRUE(stats.recovered_tablet_ids.empty());
+}
+
+// ============== Test RecoveredResultInfo structure ==============
+TEST_F(CompactionResultManagerTest, test_recovered_result_info_default_values) {
+    RecoveredResultInfo info;
+    EXPECT_TRUE(info.file_path.empty());
+    EXPECT_FALSE(info.is_valid);
+    EXPECT_TRUE(info.invalid_reason.empty());
+}
+
+// ============== Test multiple rowsets validation ==============
+TEST_F(CompactionResultManagerTest, test_validate_result_partial_missing_rowsets) {
+    // Create a tablet with metadata
+    auto metadata = generate_simple_tablet_metadata(DUP_KEYS);
+    int64_t tablet_id = metadata->id();
+    metadata->set_version(10);
+
+    // Add rowsets 1 and 2
+    auto* rowset1 = metadata->add_rowsets();
+    rowset1->set_id(1);
+    rowset1->set_overlapped(false);
+    rowset1->set_num_rows(100);
+    rowset1->set_data_size(1000);
+
+    auto* rowset2 = metadata->add_rowsets();
+    rowset2->set_id(2);
+    rowset2->set_overlapped(false);
+    rowset2->set_num_rows(100);
+    rowset2->set_data_size(1000);
+
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(metadata));
+
+    // Test with some existing and some non-existent rowsets
+    CompactionResultPB result;
+    result.set_tablet_id(tablet_id);
+    result.set_base_version(5);
+    result.add_input_rowset_ids(1); // Exists
+    result.add_input_rowset_ids(2); // Exists
+    result.add_input_rowset_ids(3); // Does not exist
+
+    std::string reason;
+    auto valid_or = _manager.validate_result(_tablet_mgr.get(), result, &reason);
+    ASSERT_TRUE(valid_or.ok());
+    EXPECT_FALSE(valid_or.value());
+    EXPECT_TRUE(reason.find("3") != std::string::npos);
+}
+
+// ============== Test validate_result with all rowsets present ==============
+TEST_F(CompactionResultManagerTest, test_validate_result_all_rowsets_present) {
+    // Create a tablet with metadata
+    auto metadata = generate_simple_tablet_metadata(DUP_KEYS);
+    int64_t tablet_id = metadata->id();
+    metadata->set_version(10);
+
+    // Add multiple rowsets
+    for (uint32_t i = 1; i <= 5; i++) {
+        auto* rowset = metadata->add_rowsets();
+        rowset->set_id(i);
+        rowset->set_overlapped(false);
+        rowset->set_num_rows(100);
+        rowset->set_data_size(1000);
+    }
+
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(metadata));
+
+    // Test with all existing rowsets
+    CompactionResultPB result;
+    result.set_tablet_id(tablet_id);
+    result.set_base_version(5);
+    for (uint32_t i = 1; i <= 5; i++) {
+        result.add_input_rowset_ids(i);
+    }
+
+    std::string reason;
+    auto valid_or = _manager.validate_result(_tablet_mgr.get(), result, &reason);
+    ASSERT_TRUE(valid_or.ok());
+    EXPECT_TRUE(valid_or.value());
+    EXPECT_TRUE(reason.empty());
+}
+
+// ============== Test validate_result without invalid_reason parameter ==============
+TEST_F(CompactionResultManagerTest, test_validate_result_without_reason_output) {
+    CompactionResultPB result;
+    // Missing tablet_id
+
+    // Should work without providing invalid_reason
+    auto valid_or = _manager.validate_result(_tablet_mgr.get(), result, nullptr);
+    ASSERT_TRUE(valid_or.ok());
+    EXPECT_FALSE(valid_or.value());
+}
+
+// ============== Test edge case: base_version equals visible_version ==============
+TEST_F(CompactionResultManagerTest, test_validate_result_base_version_equals_visible) {
+    // Create a tablet with metadata
+    auto metadata = generate_simple_tablet_metadata(DUP_KEYS);
+    int64_t tablet_id = metadata->id();
+    metadata->set_version(10);
+
+    auto* rowset = metadata->add_rowsets();
+    rowset->set_id(1);
+    rowset->set_overlapped(false);
+    rowset->set_num_rows(100);
+    rowset->set_data_size(1000);
+
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(metadata));
+
+    // base_version == visible_version should be valid
+    CompactionResultPB result;
+    result.set_tablet_id(tablet_id);
+    result.set_base_version(10); // Equal to visible_version
+    result.add_input_rowset_ids(1);
+
+    std::string reason;
+    auto valid_or = _manager.validate_result(_tablet_mgr.get(), result, &reason);
+    ASSERT_TRUE(valid_or.ok());
+    EXPECT_TRUE(valid_or.value());
+}
+
+// ============== Test thread safety of pending results ==============
+TEST_F(CompactionResultManagerTest, test_pending_results_thread_safety) {
+    // This test verifies that the has_pending_results and get_tablets_with_pending_results
+    // methods are thread-safe (they use mutex internally)
+
+    // Since we can't easily populate _tablets_with_pending_results directly,
+    // we just verify the methods don't crash when called concurrently
+    std::vector<std::thread> threads;
+    std::atomic<int> counter{0};
+
+    for (int i = 0; i < 10; i++) {
+        threads.emplace_back([&, i]() {
+            for (int j = 0; j < 100; j++) {
+                _manager.has_pending_results(i * 1000 + j);
+                _manager.get_tablets_with_pending_results();
+                counter++;
+            }
+        });
+    }
+
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    EXPECT_EQ(1000, counter.load());
+}
+
+} // namespace starrocks::lake
+

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/SystemId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/SystemId.java
@@ -110,6 +110,8 @@ public class SystemId {
 
     public static final long FE_THREADS_ID = 46L;
 
+    public static final long BE_TABLET_WRITE_LOG_ID = 47L;
+
     public static final long SYS_DB_ID = 100L;
 
     public static final long ROLE_EDGES_ID = 101L;

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3175,6 +3175,27 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static boolean lake_compaction_allow_partial_success = true;
 
+    // Autonomous compaction: BE triggers async compaction + collects completed results
+    // When enabled, CompactRequest.autonomousCompaction will be set to true
+    @ConfField(mutable = true, comment = "Enable autonomous compaction mode for lake tablets")
+    public static boolean enable_lake_autonomous_compaction = false;
+
+    // Per-tablet parallel compaction configurations (FE-scheduled mode)
+    @ConfField(mutable = true, comment = "Enable per-tablet parallel compaction in FE-scheduled mode")
+    public static boolean lake_compaction_enable_parallel_per_tablet = false;
+
+    @ConfField(mutable = true, comment = "Maximum number of parallel compaction subtasks per tablet")
+    public static int lake_compaction_max_parallel_per_tablet = 3;
+
+    @ConfField(mutable = true, comment = "Maximum data volume (bytes) per parallel subtask (10GB default)")
+    public static long lake_compaction_max_bytes_per_subtask = 10737418240L;
+
+    @ConfField(mutable = true, comment = "Enable partial compaction publish (when some tablets have results)")
+    public static boolean enable_lake_compaction_partial_publish = true;
+
+    @ConfField(mutable = true, comment = "Minimum number of tablets with results to trigger partial publish")
+    public static int lake_compaction_partial_publish_min_tablets = 1;
+
     @ConfField(mutable = true, comment = "the max number of previous version files to keep")
     public static int lake_autovacuum_max_previous_versions = 0;
 

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -102,6 +102,16 @@ message DeleteTxnLogResponse {
     optional StatusPB status = 1;
 }
 
+// Configuration for per-tablet parallel compaction
+message TabletParallelConfig {
+    // Enable parallel compaction within a single tablet
+    optional bool enable_parallel = 1 [default = false];
+    // Maximum number of parallel compaction tasks per tablet
+    optional int32 max_parallel_per_tablet = 2 [default = 3];
+    // Maximum data volume (bytes) per subtask
+    optional int64 max_bytes_per_subtask = 3 [default = 10737418240]; // 10GB
+}
+
 message CompactRequest {
     repeated int64 tablet_ids = 1;
     optional int64 txn_id = 2;
@@ -111,6 +121,15 @@ message CompactRequest {
     optional bytes encryption_meta = 6;
     optional bool force_base_compaction = 7;
     optional bool skip_write_txnlog = 8;
+
+    optional int64 table_id = 9;
+    optional int64 partition_id = 10;
+    // For autonomous compaction: trigger async compaction and collect completed results
+    optional bool autonomous_compaction = 11;
+    optional int64 visible_version = 12; // Current visible version for filtering results
+    
+    // Configuration for per-tablet parallel compaction
+    optional TabletParallelConfig parallel_config = 13;
 }
 
 message AggregateCompactRequest {
@@ -141,6 +160,16 @@ message CompactStat {
     optional int32 in_queue_time_sec = 52;
 }
 
+// Subtask status for parallel compaction
+message TabletSubtaskStatus {
+    optional int64 tablet_id = 1;
+    optional int32 subtask_id = 2;
+    repeated uint32 input_rowset_ids = 3;
+    optional int64 input_bytes = 4;
+    optional int64 output_bytes = 5;
+    optional StatusPB status = 6;
+}
+
 message CompactResponse {
     repeated int64 failed_tablets = 1;
     // optional int64 execution_time = 2; // ms
@@ -152,6 +181,9 @@ message CompactResponse {
     repeated CompactStat compact_stats = 8;
     optional int64 success_compaction_input_file_size = 9;
     repeated TxnLogPB txn_logs = 10;
+    
+    // Subtask statuses for parallel compaction
+    repeated TabletSubtaskStatus subtask_statuses = 11;
 }
 
 message DropTableRequest {

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -327,3 +327,15 @@ message ReshardingTabletsInfoPB {
     repeated MergingTabletInfoPB merging_tablet_infos = 2;
     repeated IdenticalTabletInfoPB identical_tablet_infos = 3;
 }
+
+// Autonomous compaction result, stored locally on BE
+message CompactionResultPB {
+    optional int64 tablet_id = 1;
+    optional int64 base_version = 2;           // Which version compaction was based on
+    repeated uint32 input_rowset_ids = 3;
+    optional RowsetMetadataPB output_rowset = 4;
+    optional int64 finish_time_ms = 5;
+    // SSTable info for primary key tables
+    repeated PersistentIndexSstablePB input_sstables = 6;
+    repeated PersistentIndexSstablePB output_sstables = 7;
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce autonomous lake compaction (async BE-scheduled, recoverable via local results) with FE/BE wiring, proto/config updates, partial publish support, and per-tablet parallel compaction hooks.
> 
> - **Backend (BE)**:
>   - Add `lake/AutonomousCompactionHandler`, `lake/CompactionResultManager` (local result scan/validate/save/cleanup), and `lake/LakeCompactionManager` (score-based queue, per-tablet concurrent tasks, rowset exclusion, size limits).
>   - Extend `lake/CompactionPolicy` with `pick_rowsets_with_limit` and partial-compaction selector helpers.
>   - Enhance `lake/CompactionScheduler` to accept autonomous mode and per-tablet parallel compaction; integrate `TabletParallelCompactionManager` and propagate table/partition/visible_version.
>   - Add `TabletManager::compact(context, input_rowsets)` overload for preselected rowsets.
>   - Wire-ups and builds (`CMakeLists.txt`).
> - **Frontend (FE)**:
>   - `CompactionScheduler`: populate new fields (`tableId`, `partitionId`, `visibleVersion`), enable autonomous mode and optional per-tablet parallel config in requests.
>   - Add system table id constant `BE_TABLET_WRITE_LOG_ID`.
> - **Proto**:
>   - `CompactRequest`: add `table_id`, `partition_id`, `autonomous_compaction`, `visible_version`, `parallel_config`.
>   - New `TabletParallelConfig`; `CompactResponse` adds `subtask_statuses`.
>   - New `CompactionResultPB` in `lake_types.proto`.
> - **Config**:
>   - Introduce multiple BE/FE configs for autonomous compaction, recovery, thresholds, and per-tablet parallel compaction.
> - **Tests**:
>   - Add UTs for `AutonomousCompactionHandler` and `CompactionResultManager`; update test build lists.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c448701f75a870962ebbb2cb00dc5e90e7a8d62f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->