### PR TITLE
[Refactor] Add TypeParser and related utility methods for SQL type handling

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilderUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilderUtils.java
@@ -1,0 +1,51 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.parser;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.sql.ast.Identifier;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.Token;
+
+public class AstBuilderUtils {
+    public static Identifier getIdentifier(
+            com.starrocks.sql.parser.StarRocksParser.IdentifierContext identifierContext) {
+        if (identifierContext instanceof com.starrocks.sql.parser.StarRocksParser.BackQuotedIdentifierContext) {
+            Identifier backQuotedIdentifier = new Identifier(identifierContext.getText().replace("`", ""),
+                    createPos(identifierContext));
+            backQuotedIdentifier.setBackQuoted(true);
+            return backQuotedIdentifier;
+        } else {
+            return new Identifier(identifierContext.getText(), createPos(identifierContext));
+        }
+    }
+
+    protected static NodePosition createPos(ParserRuleContext context) {
+        Preconditions.checkState(context != null);
+        return createPos(context.start, context.stop);
+    }
+
+    static NodePosition createPos(Token start, Token stop) {
+        if (start == null) {
+            return NodePosition.ZERO;
+        }
+
+        if (stop == null) {
+            return new NodePosition(start.getLine(), start.getCharPositionInLine());
+        }
+
+        return new NodePosition(start, stop);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/TypeParser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/TypeParser.java
@@ -1,0 +1,219 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.parser;
+
+import com.starrocks.common.Config;
+import com.starrocks.sql.ast.Identifier;
+import com.starrocks.type.ArrayType;
+import com.starrocks.type.BitmapType;
+import com.starrocks.type.BooleanType;
+import com.starrocks.type.CharType;
+import com.starrocks.type.DateType;
+import com.starrocks.type.DecimalType;
+import com.starrocks.type.FloatType;
+import com.starrocks.type.FunctionType;
+import com.starrocks.type.HLLType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.JsonType;
+import com.starrocks.type.MapType;
+import com.starrocks.type.NullType;
+import com.starrocks.type.PercentileType;
+import com.starrocks.type.PrimitiveType;
+import com.starrocks.type.ScalarType;
+import com.starrocks.type.StringType;
+import com.starrocks.type.StructField;
+import com.starrocks.type.StructType;
+import com.starrocks.type.Type;
+import com.starrocks.type.TypeFactory;
+import com.starrocks.type.UnknownType;
+import com.starrocks.type.VarbinaryType;
+import com.starrocks.type.VarcharType;
+import com.starrocks.type.VariantType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.starrocks.sql.parser.AstBuilderUtils.createPos;
+import static com.starrocks.sql.parser.AstBuilderUtils.getIdentifier;
+import static com.starrocks.sql.parser.ErrorMsgProxy.PARSER_ERROR_MSG;
+
+public class TypeParser {
+    public static Type getType(com.starrocks.sql.parser.StarRocksParser.TypeContext context) {
+        if (context.baseType() != null) {
+            return getBaseType(context.baseType());
+        } else if (context.decimalType() != null) {
+            return getDecimalType(context.decimalType());
+        } else if (context.arrayType() != null) {
+            return getArrayType(context.arrayType());
+        } else if (context.structType() != null) {
+            return getStructType(context.structType());
+        } else {
+            return getMapType(context.mapType());
+        }
+    }
+
+    private static Type getBaseType(com.starrocks.sql.parser.StarRocksParser.BaseTypeContext context) {
+        int length = -1;
+        if (context.typeParameter() != null) {
+            length = Integer.parseInt(context.typeParameter().INTEGER_VALUE().toString());
+        }
+        if (context.STRING() != null || context.TEXT() != null) {
+            return TypeFactory.createVarcharType(StringType.DEFAULT_STRING_LENGTH);
+        } else if (context.VARCHAR() != null) {
+            return TypeFactory.createVarcharType(length);
+        } else if (context.CHAR() != null) {
+            return TypeFactory.createCharType(length);
+        } else if (context.SIGNED() != null) {
+            return IntegerType.INT;
+        } else if (context.HLL() != null) {
+            return HLLType.HLL;
+        } else if (context.BINARY() != null || context.VARBINARY() != null) {
+            return TypeFactory.createVarbinary(length);
+        } else {
+            String typeStr = context.getChild(0).getText();
+            return getTypeByName(typeStr);
+        }
+    }
+
+    public static ScalarType getDecimalType(com.starrocks.sql.parser.StarRocksParser.DecimalTypeContext context) {
+        Integer precision = null;
+        Integer scale = null;
+        if (context.precision != null) {
+            precision = Integer.parseInt(context.precision.getText());
+            if (context.scale != null) {
+                scale = Integer.parseInt(context.scale.getText());
+            }
+        }
+        if (context.DECIMAL() != null || context.NUMBER() != null || context.NUMERIC() != null) {
+            if (precision != null) {
+                if (scale != null) {
+                    return TypeFactory.createUnifiedDecimalType(precision, scale);
+                }
+                return TypeFactory.createUnifiedDecimalType(precision);
+            }
+            return TypeFactory.createUnifiedDecimalType(10, 0);
+        } else if (context.DECIMAL32() != null || context.DECIMAL64() != null ||
+                context.DECIMAL128() != null || context.DECIMAL256() != null) {
+            if (!Config.enable_decimal_v3) {
+                throw new ParsingException("Config field enable_decimal_v3 is false now, " +
+                        "turn it on before decimal32/64/128/256 are used, " +
+                        "execute cmd 'admin set frontend config (\"enable_decimal_v3\" = \"true\")' " +
+                        "on every FE server");
+            }
+            final PrimitiveType primitiveType = PrimitiveType.valueOf(context.children.get(0).getText().toUpperCase());
+            if (precision != null) {
+                if (scale != null) {
+                    return TypeFactory.createDecimalV3Type(primitiveType, precision, scale);
+                }
+                return TypeFactory.createDecimalV3Type(primitiveType, precision);
+            }
+            return TypeFactory.createDecimalV3Type(primitiveType);
+        } else if (context.DECIMALV2() != null) {
+            if (precision != null) {
+                if (scale != null) {
+                    return TypeFactory.createDecimalV2Type(precision, scale);
+                }
+                return TypeFactory.createDecimalV2Type(precision);
+            }
+            return DecimalType.DEFAULT_DECIMALV2;
+        } else {
+            throw new IllegalArgumentException("Unsupported type " + context.getText());
+        }
+    }
+
+    public static ArrayType getArrayType(com.starrocks.sql.parser.StarRocksParser.ArrayTypeContext context) {
+        return new ArrayType(getType(context.type()));
+    }
+
+    public static StructType getStructType(com.starrocks.sql.parser.StarRocksParser.StructTypeContext context) {
+        ArrayList<StructField> fields = new ArrayList<>();
+        List<com.starrocks.sql.parser.StarRocksParser.SubfieldDescContext> subfields =
+                context.subfieldDescs().subfieldDesc();
+        for (com.starrocks.sql.parser.StarRocksParser.SubfieldDescContext type : subfields) {
+            Identifier fieldIdentifier = getIdentifier(type.identifier());
+            String fieldName = fieldIdentifier.getValue();
+            fields.add(new StructField(fieldName, getType(type.type()), null));
+        }
+
+        return new StructType(fields);
+    }
+
+    public static MapType getMapType(com.starrocks.sql.parser.StarRocksParser.MapTypeContext context) {
+        Type keyType = getType(context.type(0));
+        if (!keyType.isValidMapKeyType()) {
+            throw new ParsingException(PARSER_ERROR_MSG.unsupportedType(keyType.toString(),
+                    "for map's key, which should be base types"),
+                    createPos(context.type(0)));
+        }
+        Type valueType = getType(context.type(1));
+        return new MapType(keyType, valueType);
+    }
+
+    private static ScalarType getTypeByName(String typeName) {
+        if (typeName == null) {
+            return null;
+        }
+
+        String upperTypeName = typeName.toUpperCase();
+        return switch (upperTypeName) {
+            // Null type
+            case "NULL_TYPE" -> NullType.NULL;
+
+            // Boolean type
+            case "BOOLEAN" -> BooleanType.BOOLEAN;
+
+            // Integer types
+            case "TINYINT" -> IntegerType.TINYINT;
+            case "SMALLINT" -> IntegerType.SMALLINT;
+            case "INTEGER", "UNSIGNED", "INT" -> IntegerType.INT;
+            case "BIGINT" -> IntegerType.BIGINT;
+            case "LARGEINT" -> IntegerType.LARGEINT;
+
+            // Float types
+            case "FLOAT" -> FloatType.FLOAT;
+            case "DOUBLE" -> FloatType.DOUBLE;
+
+            // Decimal types
+            case "DECIMAL", "DECIMALV2" -> DecimalType.DEFAULT_DECIMALV2;
+            case "DECIMAL32" -> DecimalType.DECIMAL32;
+            case "DECIMAL64" -> DecimalType.DECIMAL64;
+            case "DECIMAL128" -> DecimalType.DECIMAL128;
+            case "DECIMAL256" -> DecimalType.DECIMAL256;
+
+            // String types
+            case "STRING" -> StringType.DEFAULT_STRING;
+            case "CHAR" -> CharType.CHAR;
+            case "VARCHAR" -> VarcharType.VARCHAR;
+
+            // Date/Time types
+            case "DATE" -> DateType.DATE;
+            case "DATETIME" -> DateType.DATETIME;
+            case "TIME" -> DateType.TIME;
+
+            // Binary types
+            case "VARBINARY" -> VarbinaryType.VARBINARY;
+
+            // Special types
+            case "HLL" -> HLLType.HLL;
+            case "BITMAP" -> BitmapType.BITMAP;
+            case "PERCENTILE" -> PercentileType.PERCENTILE;
+            case "JSON" -> JsonType.JSON;
+            case "VARIANT" -> VariantType.VARIANT;
+            case "FUNCTION" -> FunctionType.FUNCTION;
+            case "UNKNOWN_TYPE" -> UnknownType.UNKNOWN_TYPE;
+            default -> null;
+        };
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This pull request refactors the type parsing logic in the `AstBuilder` class by moving type-related methods into a new `TypeParser` class (not shown here) and utility methods for node position and identifier handling into a new `AstBuilderUtils` class. This change simplifies `AstBuilder`, improves code organization, and makes utility functions reusable across the codebase.

Key changes:

**Type parsing refactor:**
- Replaced direct calls to type parsing helper methods (such as `getType`, `getArrayType`, `getMapType`, etc.) in `AstBuilder` with calls to static methods in a new `TypeParser` class, consolidating all type parsing logic outside of `AstBuilder`. This includes changes in column definitions, function arguments, cast/conversion expressions, array/map constructors, and aggregate state parsing. [[1]](diffhunk://#diff-fca6dd6005d7a22328f3c0f3d6e51544e6bb76f58c3faa2a8e77bb9eeaf6535aL1145-R1125) [[2]](diffhunk://#diff-fca6dd6005d7a22328f3c0f3d6e51544e6bb76f58c3faa2a8e77bb9eeaf6535aL5049-R5029) [[3]](diffhunk://#diff-fca6dd6005d7a22328f3c0f3d6e51544e6bb76f58c3faa2a8e77bb9eeaf6535aL6510-R6490) [[4]](diffhunk://#diff-fca6dd6005d7a22328f3c0f3d6e51544e6bb76f58c3faa2a8e77bb9eeaf6535aL7940-R7926) [[5]](diffhunk://#diff-fca6dd6005d7a22328f3c0f3d6e51544e6bb76f58c3faa2a8e77bb9eeaf6535aL8194-R8174) [[6]](diffhunk://#diff-fca6dd6005d7a22328f3c0f3d6e51544e6bb76f58c3faa2a8e77bb9eeaf6535aL8221-R8201) [[7]](diffhunk://#diff-fca6dd6005d7a22328f3c0f3d6e51544e6bb76f58c3faa2a8e77bb9eeaf6535aL9074-R9054) [[8]](diffhunk://#diff-fca6dd6005d7a22328f3c0f3d6e51544e6bb76f58c3faa2a8e77bb9eeaf6535aL9210-R9176)
- Removed all type parsing helper methods (`getType`, `getBaseType`, `getTypeByName`, `getDecimalType`, `getArrayType`, `getStructType`, `getMapType`) from `AstBuilder`, further simplifying the class. [[1]](diffhunk://#diff-fca6dd6005d7a22328f3c0f3d6e51544e6bb76f58c3faa2a8e77bb9eeaf6535aL9156-L9169) [[2]](diffhunk://#diff-fca6dd6005d7a22328f3c0f3d6e51544e6bb76f58c3faa2a8e77bb9eeaf6535aL9250-L9441)

**Utility extraction:**
- Moved the `createPos` utility (for generating `NodePosition` from parser contexts or tokens) and identifier handling logic out of `AstBuilder` into a new `AstBuilderUtils` class, making these utilities more broadly accessible and reducing code duplication. [[1]](diffhunk://#diff-fca6dd6005d7a22328f3c0f3d6e51544e6bb76f58c3faa2a8e77bb9eeaf6535aR578) [[2]](diffhunk://#diff-fca6dd6005d7a22328f3c0f3d6e51544e6bb76f58c3faa2a8e77bb9eeaf6535aL9587-L9603) [[3]](diffhunk://#diff-8de321c8cf8345fc444f57cd6b69ef8a3384bfbc22367d74de0db0598ae5b716R1-R51)

**Imports cleanup:**
- Cleaned up unused imports in `AstBuilder` as a result of moving type parsing logic to `TypeParser`.

These changes make the parser codebase cleaner, more modular, and easier to maintain.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
