### PR TITLE
[BugFix] [Enhancement] Optimize mv rewrite performance(backport  #66623)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/DateLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/DateLiteral.java
@@ -207,9 +207,12 @@ public class DateLiteral extends LiteralExpr {
     public boolean isMinValue() {
         switch (type.getPrimitiveType()) {
             case DATE:
-                return this.getStringValue().compareTo(MIN_DATE.getStringValue()) == 0;
+                return this.year == MIN_DATE.year && this.month == MIN_DATE.month && this.day == MIN_DATE.day;
             case DATETIME:
-                return this.getStringValue().compareTo(MIN_DATETIME.getStringValue()) == 0;
+                return this.year == MIN_DATETIME.year && this.month == MIN_DATETIME.month
+                        && this.day == MIN_DATETIME.day && this.hour == MIN_DATETIME.hour
+                        && this.minute == MIN_DATETIME.minute && this.second == MIN_DATETIME.second
+                        && this.microsecond == MIN_DATETIME.microsecond;
             default:
                 return false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
@@ -47,8 +47,8 @@ public class MvRefreshArbiter {
     private static final Logger LOG = LogManager.getLogger(MvRefreshArbiter.class);
 
     public static boolean needsToRefreshTable(MaterializedView mv, BaseTableInfo baseTableInfo, Table table,
-                                              boolean isQueryRewrite) {
-        Optional<Boolean> needsToRefresh = needsToRefreshTable(mv, baseTableInfo, table, true, isQueryRewrite);
+                                              MVTimelinessArbiter.QueryRewriteParams queryRewriteParams) {
+        Optional<Boolean> needsToRefresh = needsToRefreshTable(mv, baseTableInfo, table, true, queryRewriteParams);
         if (needsToRefresh.isPresent()) {
             return needsToRefresh.get();
         }
@@ -59,11 +59,12 @@ public class MvRefreshArbiter {
      * Once materialized view's base tables have updated, we need to check correspond materialized views' partitions
      * to be refreshed.
      * @param mv The materialized view to check
-     * @param isQueryRewrite Mark whether this caller is query rewrite or not, when it's true we can use staleness to shortcut
+     * @param queryRewriteParams Mark whether this caller is query rewrite or not, when it's true we can use staleness to shortcut
      * @return mv timeliness update info which contains all need refreshed partitions of materialized view and partition name
      * to partition values.
      */
-    public static MvUpdateInfo getMVTimelinessUpdateInfo(MaterializedView mv, boolean isQueryRewrite) {
+    public static MvUpdateInfo getMVTimelinessUpdateInfo(MaterializedView mv,
+                                                         MVTimelinessArbiter.QueryRewriteParams queryRewriteParams) {
         // Skip check for sync materialized view.
         if (mv.getRefreshScheme().isSync()) {
             return MvUpdateInfo.noRefresh(mv);
@@ -72,7 +73,7 @@ public class MvRefreshArbiter {
         // check mv's query rewrite consistency mode property only in query rewrite.
         TableProperty tableProperty = mv.getTableProperty();
         TableProperty.QueryRewriteConsistencyMode mvConsistencyRewriteMode = tableProperty.getQueryRewriteConsistencyMode();
-        if (isQueryRewrite) {
+        if (queryRewriteParams.isQueryRewrite()) {
             switch (mvConsistencyRewriteMode) {
                 case DISABLE:
                     return MvUpdateInfo.fullRefresh(mv);
@@ -87,7 +88,7 @@ public class MvRefreshArbiter {
 
         logMVPrepare(mv, "MV refresh arbiter start to get partition names to refresh, query rewrite mode: {}",
                 mvConsistencyRewriteMode);
-        MVTimelinessArbiter timelinessArbiter = buildMVTimelinessArbiter(mv, isQueryRewrite);
+        MVTimelinessArbiter timelinessArbiter = buildMVTimelinessArbiter(mv, queryRewriteParams);
         try (Timer ignored = Tracers.watchScope("MVTimelinessUpdateInfo")) {
             return timelinessArbiter.getMVTimelinessUpdateInfo(mvConsistencyRewriteMode);
         } catch (AnalysisException e) {
@@ -99,18 +100,18 @@ public class MvRefreshArbiter {
     /**
      * Create the MVTimelinessArbiter instance according to the partition info of the materialized view.
      * @param mv the materialized view to get the timeliness arbiter
-     * @param isQueryRewrite whether this caller is query rewrite or mv refresh
+     * @param queryRewriteParams whether this caller is query rewrite or mv refresh
      * @return MVTimelinessArbiter instance according to the partition info of the materialized view
      */
     public static MVTimelinessArbiter buildMVTimelinessArbiter(MaterializedView mv,
-                                                               boolean isQueryRewrite) {
+                                                               MVTimelinessArbiter.QueryRewriteParams queryRewriteParams) {
         PartitionInfo partitionInfo = mv.getPartitionInfo();
         if (partitionInfo.isUnPartitioned()) {
-            return new MVTimelinessNonPartitionArbiter(mv, isQueryRewrite);
+            return new MVTimelinessNonPartitionArbiter(mv, queryRewriteParams);
         } else if (partitionInfo.isRangePartition()) {
-            return new MVTimelinessRangePartitionArbiter(mv, isQueryRewrite);
+            return new MVTimelinessRangePartitionArbiter(mv, queryRewriteParams);
         } else if (partitionInfo.isListPartition()) {
-            return new MVTimelinessListPartitionArbiter(mv, isQueryRewrite);
+            return new MVTimelinessListPartitionArbiter(mv, queryRewriteParams);
         } else {
             throw UnsupportedException.unsupportedException("unsupported partition info type:" +
                     partitionInfo.getClass().getName());
@@ -125,7 +126,7 @@ public class MvRefreshArbiter {
                                                          BaseTableInfo baseTableInfo,
                                                          Table baseTable,
                                                          boolean withMv,
-                                                         boolean isQueryRewrite) {
+                                                         MVTimelinessArbiter.QueryRewriteParams queryRewriteParams) {
         if (baseTable.isView()) {
             // do nothing
             return Optional.of(false);
@@ -136,14 +137,15 @@ public class MvRefreshArbiter {
                 return Optional.of(false);
             }
 
-            Set<String> baseUpdatedPartitionNames = mv.getUpdatedPartitionNamesOfOlapTable(olapBaseTable, isQueryRewrite);
+            Set<String> baseUpdatedPartitionNames = mv.getUpdatedPartitionNamesOfOlapTable(olapBaseTable,
+                    queryRewriteParams.isQueryRewrite());
             if (!baseUpdatedPartitionNames.isEmpty()) {
                 return Optional.of(true);
             }
 
             // recursive check its children
             if (withMv && baseTable.isMaterializedView()) {
-                MvUpdateInfo mvUpdateInfo = getMVTimelinessUpdateInfo((MaterializedView) baseTable, isQueryRewrite);
+                MvUpdateInfo mvUpdateInfo = getMVTimelinessUpdateInfo((MaterializedView) baseTable, queryRewriteParams);
                 if (mvUpdateInfo == null || !mvUpdateInfo.isValidRewrite()) {
                     return Optional.empty();
                 }
@@ -152,7 +154,8 @@ public class MvRefreshArbiter {
             }
             return Optional.of(false);
         } else {
-            Set<String> baseUpdatedPartitionNames = mv.getUpdatedPartitionNamesOfExternalTable(baseTable, isQueryRewrite);
+            Set<String> baseUpdatedPartitionNames = mv.getUpdatedPartitionNamesOfExternalTable(baseTable,
+                    queryRewriteParams.isQueryRewrite());
             if (baseUpdatedPartitionNames == null) {
                 return Optional.empty();
             }
@@ -164,24 +167,24 @@ public class MvRefreshArbiter {
      * Get to refresh partition info of the specific table.
      * @param baseTable: the table to check
      * @param withMv: whether to check the materialized view if it's a materialized view
-     * @param isQueryRewrite: whether this caller is query rewrite or not
+     * @param queryRewriteParams: whether this caller is query rewrite or not
      * @return MvBaseTableUpdateInfo: the update info of the base table
      */
     public static MvBaseTableUpdateInfo getMvBaseTableUpdateInfo(MaterializedView mv,
                                                                  Table baseTable,
                                                                  boolean withMv,
-                                                                 boolean isQueryRewrite) {
+                                                                 MVTimelinessArbiter.QueryRewriteParams queryRewriteParams) {
         MvBaseTableUpdateInfo baseTableUpdateInfo = new MvBaseTableUpdateInfo();
         if (baseTable.isView()) {
             // do nothing
             return baseTableUpdateInfo;
         } else if (baseTable.isNativeTableOrMaterializedView()) {
             OlapTable olapBaseTable = (OlapTable) baseTable;
-            Set<String> baseUpdatedPartitionNames = mv.getUpdatedPartitionNamesOfOlapTable(olapBaseTable, isQueryRewrite);
-
+            Set<String> baseUpdatedPartitionNames = mv.getUpdatedPartitionNamesOfOlapTable(olapBaseTable, 
+                    queryRewriteParams.isQueryRewrite());
             // recursive check its children
             if (withMv && baseTable.isMaterializedView()) {
-                MvUpdateInfo mvUpdateInfo = getMVTimelinessUpdateInfo((MaterializedView) baseTable, isQueryRewrite);
+                MvUpdateInfo mvUpdateInfo = getMVTimelinessUpdateInfo((MaterializedView) baseTable, queryRewriteParams);
                 if (mvUpdateInfo == null || !mvUpdateInfo.isValidRewrite()) {
                     return null;
                 }
@@ -192,7 +195,8 @@ public class MvRefreshArbiter {
             // update base table's partition info
             baseTableUpdateInfo.addToRefreshPartitionNames(baseUpdatedPartitionNames);
         } else {
-            Set<String> baseUpdatedPartitionNames = mv.getUpdatedPartitionNamesOfExternalTable(baseTable, isQueryRewrite);
+            Set<String> baseUpdatedPartitionNames = mv.getUpdatedPartitionNamesOfExternalTable(baseTable,
+                    queryRewriteParams.isQueryRewrite());
             if (baseUpdatedPartitionNames == null) {
                 return null;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
@@ -15,6 +15,7 @@
 package com.starrocks.catalog.mv;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Stopwatch;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -30,10 +31,12 @@ import com.starrocks.catalog.TableProperty;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.common.PCell;
 import com.starrocks.sql.common.PartitionDiff;
 import com.starrocks.sql.common.PartitionDiffResult;
 import com.starrocks.sql.common.PartitionDiffer;
+import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
@@ -43,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static com.starrocks.catalog.MvRefreshArbiter.getMvBaseTableUpdateInfo;
@@ -62,12 +66,63 @@ public abstract class MVTimelinessArbiter {
     protected final MaterializedView mv;
     // differ
     protected PartitionDiffer differ;
-    // whether is query rewrite or mv refresh
-    protected final boolean isQueryRewrite;
 
-    public MVTimelinessArbiter(MaterializedView mv, boolean isQueryRewrite) {
+    // parameters for query rewrite
+    public static class QueryRewriteParams {
+        private final boolean isQueryRewrite;
+        private final OptimizerContext optimizerContext;
+        private final long timeLimit;
+        private long loopCounter = 0;
+
+        public QueryRewriteParams(boolean isQueryRewrite, OptimizerContext optimizerContext) {
+            this.isQueryRewrite = isQueryRewrite;
+            this.optimizerContext = optimizerContext;
+            if (optimizerContext != null) {
+                SessionVariable sessionVariable = optimizerContext.getSessionVariable();
+                this.timeLimit = Math.max(sessionVariable.getOptimizerExecuteTimeout() / 2, 1000);
+            } else {
+                this.timeLimit = -1;
+            }
+        }
+
+        public static QueryRewriteParams ofRefresh() {
+            return new QueryRewriteParams(false, null);
+        }
+
+        public static QueryRewriteParams ofQueryRewrite(OptimizerContext optimizerContext) {
+            return new QueryRewriteParams(true, optimizerContext);
+        }
+
+        public void checkQueryRewriteExhausted() {
+            if (!isQueryRewrite || timeLimit <= 0) {
+                return;
+            }
+            // to avoid too frequent check, check every 100 loops
+            if (++loopCounter % 100 != 0) {
+                return;
+            }
+            Stopwatch stopwatch = optimizerContext.getOptimizerTimer();
+            long elapsed = stopwatch.elapsed(TimeUnit.MILLISECONDS);
+            if (elapsed > timeLimit) {
+                throw new RuntimeException(String.format("Materialized view query rewrite time limit exceeded, " +
+                        ",time limit: %d ms, elapsed: %d ms", timeLimit, elapsed));
+            }
+        }
+
+        public boolean isQueryRewrite() {
+            return isQueryRewrite;
+        }
+
+        public OptimizerContext getOptimizerContext() {
+            return optimizerContext;
+        }
+    }
+    protected final QueryRewriteParams queryRewriteParams;
+
+    public MVTimelinessArbiter(MaterializedView mv,
+                               QueryRewriteParams queryRewriteParams) {
         this.mv = mv;
-        this.isQueryRewrite = isQueryRewrite;
+        this.queryRewriteParams = queryRewriteParams;
     }
 
     /**
@@ -129,7 +184,7 @@ public abstract class MVTimelinessArbiter {
                 return true;
             }
             // If the non-ref table has already changed, need refresh all materialized views' partitions.
-            if (needsToRefreshTable(mv, tableInfo, baseTable, isQueryRewrite)) {
+            if (needsToRefreshTable(mv, tableInfo, baseTable, queryRewriteParams)) {
                 return true;
             }
         }
@@ -176,7 +231,7 @@ public abstract class MVTimelinessArbiter {
         Map<Table, Set<String>> baseChangedPartitionNames = Maps.newHashMap();
         for (Table baseTable : refBaseTableAndColumns.keySet()) {
             MvBaseTableUpdateInfo mvBaseTableUpdateInfo = getMvBaseTableUpdateInfo(mv, baseTable,
-                    true, isQueryRewrite);
+                    true, queryRewriteParams);
             mvUpdateInfo.getBaseTableUpdateInfos().put(baseTable, mvBaseTableUpdateInfo);
             // If base table is a mv, its to-update partitions may not be created yet, skip it
             baseChangedPartitionNames.put(baseTable, mvBaseTableUpdateInfo.getToRefreshPartitionNames());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessListPartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessListPartitionArbiter.java
@@ -42,9 +42,9 @@ import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVPrepare;
 public final class MVTimelinessListPartitionArbiter extends MVTimelinessArbiter {
     private static final Logger LOG = LogManager.getLogger(MVTimelinessListPartitionArbiter.class);
 
-    public MVTimelinessListPartitionArbiter(MaterializedView mv, boolean isQueryRewrite) {
-        super(mv, isQueryRewrite);
-        differ = new ListPartitionDiffer(mv, isQueryRewrite);
+    public MVTimelinessListPartitionArbiter(MaterializedView mv, QueryRewriteParams queryRewriteParams) {
+        super(mv, queryRewriteParams);
+        differ = new ListPartitionDiffer(mv, queryRewriteParams);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessNonPartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessNonPartitionArbiter.java
@@ -37,8 +37,8 @@ import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVPrepare;
 public final class MVTimelinessNonPartitionArbiter extends MVTimelinessArbiter {
     private static final Logger LOG = LogManager.getLogger(MVTimelinessNonPartitionArbiter.class);
 
-    public MVTimelinessNonPartitionArbiter(MaterializedView mv, boolean isQueryRewrite) {
-        super(mv, isQueryRewrite);
+    public MVTimelinessNonPartitionArbiter(MaterializedView mv, QueryRewriteParams queryRewriteParams) {
+        super(mv, queryRewriteParams);
     }
 
     /**
@@ -68,7 +68,7 @@ public final class MVTimelinessNonPartitionArbiter extends MVTimelinessArbiter {
             }
 
             // once mv's base table has updated, refresh the materialized view totally.
-            MvBaseTableUpdateInfo mvBaseTableUpdateInfo = getMvBaseTableUpdateInfo(mv, table, true, isQueryRewrite);
+            MvBaseTableUpdateInfo mvBaseTableUpdateInfo = getMvBaseTableUpdateInfo(mv, table, true, queryRewriteParams);
             // TODO: fixme if mvBaseTableUpdateInfo is null, should return full refresh?
             if (mvBaseTableUpdateInfo != null &&
                     CollectionUtils.isNotEmpty(mvBaseTableUpdateInfo.getToRefreshPartitionNames())) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessRangePartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessRangePartitionArbiter.java
@@ -50,9 +50,9 @@ import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVPrepare;
 public final class MVTimelinessRangePartitionArbiter extends MVTimelinessArbiter {
     private static final Logger LOG = LogManager.getLogger(MVTimelinessRangePartitionArbiter.class);
 
-    public MVTimelinessRangePartitionArbiter(MaterializedView mv, boolean isQueryRewrite) {
-        super(mv, isQueryRewrite);
-        this.differ = new RangePartitionDiffer(mv, isQueryRewrite, null);
+    public MVTimelinessRangePartitionArbiter(MaterializedView mv, QueryRewriteParams queryRewriteParams) {
+        super(mv, queryRewriteParams);
+        this.differ = new RangePartitionDiffer(mv, queryRewriteParams, null);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3441,6 +3441,13 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "Whether enable to cache mv query context or not")
     public static boolean enable_mv_query_context_cache = true;
 
+    @ConfField(mutable = true, comment = "Whether enable to cache mv global context or not which its lifecycle is " +
+            "as the same with the mv")
+    public static boolean enable_mv_global_context_cache = true;
+
+    @ConfField(mutable = true, comment = "Max materialized view global context cache size during one mv's lifecycle.")
+    public static long mv_global_context_cache_max_size = 5000;
+
     @ConfField(mutable = true, comment = "Mv refresh fails if there is filtered data, true by default")
     public static boolean mv_refresh_fail_on_filter_data = true;
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshListPartitioner.java
@@ -83,7 +83,7 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
                                        Database db,
                                        MaterializedView mv) {
         super(mvContext, context, db, mv);
-        this.differ = new ListPartitionDiffer(mv, false);
+        this.differ = new ListPartitionDiffer(mv, queryRewriteParams);
         this.logger = MVTraceUtils.getLogger(mv, MVPCTRefreshListPartitioner.class);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshPartitioner.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.MvBaseTableUpdateInfo;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.mv.MVTimelinessArbiter;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
@@ -68,7 +69,9 @@ public abstract class MVPCTRefreshPartitioner {
     protected final TaskRunContext context;
     protected final Database db;
     protected final MaterializedView mv;
-    private final Logger logger;
+    protected final Logger logger;
+    protected final MVTimelinessArbiter.QueryRewriteParams queryRewriteParams =
+            MVTimelinessArbiter.QueryRewriteParams.ofRefresh();
 
     public MVPCTRefreshPartitioner(MvTaskRunContext mvContext,
                                    TaskRunContext context,
@@ -221,7 +224,7 @@ public abstract class MVPCTRefreshPartitioner {
 
             // check the updated partition names in the ref base table
             MvBaseTableUpdateInfo mvBaseTableUpdateInfo = getMvBaseTableUpdateInfo(mv, baseTable,
-                    false, false);
+                    false, queryRewriteParams);
             if (mvBaseTableUpdateInfo == null) {
                 throw new DmlException(String.format("Find the updated partition info of ref base table %s of mv " +
                         "%s failed, current mv partitions:%s", baseTable.getName(), mv.getName(), mvPartitionNames));
@@ -262,7 +265,7 @@ public abstract class MVPCTRefreshPartitioner {
             if (tableColumnMap.containsKey(snapshotTable)) {
                 continue;
             }
-            if (needsToRefreshTable(mv, snapshotInfo.getBaseTableInfo(), snapshotTable, false)) {
+            if (needsToRefreshTable(mv, snapshotInfo.getBaseTableInfo(), snapshotTable, queryRewriteParams)) {
                 return true;
             }
         }
@@ -281,7 +284,8 @@ public abstract class MVPCTRefreshPartitioner {
             if (!isPartitionRefreshSupported(snapshotTable)) {
                 return true;
             }
-            if (needsToRefreshTable(mv, snapshotInfo.getBaseTableInfo(), snapshotTable, false)) {
+            if (needsToRefreshTable(mv, snapshotInfo.getBaseTableInfo(), snapshotTable,
+                    MVTimelinessArbiter.QueryRewriteParams.ofRefresh())) {
                 return true;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitioner.java
@@ -88,7 +88,7 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
                                         Database db,
                                         MaterializedView mv) {
         super(mvContext, context, db, mv);
-        this.differ = new RangePartitionDiffer(mv, false, null);
+        this.differ = new RangePartitionDiffer(mv, queryRewriteParams, null);
         this.logger = MVTraceUtils.getLogger(mv, MVPCTRefreshRangePartitioner.class);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVTimelinessMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVTimelinessMgr.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvRefreshArbiter;
 import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.catalog.TableProperty;
+import com.starrocks.catalog.mv.MVTimelinessArbiter;
 import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.memory.MemoryTrackable;
@@ -50,12 +51,13 @@ public class MVTimelinessMgr implements MemoryTrackable {
         MV_PARTITION_DROPPED,
     }
 
-    public MvUpdateInfo getMVTimelinessInfo(MaterializedView mv) {
+    public MvUpdateInfo getMVTimelinessInfo(MaterializedView mv,
+                                            MVTimelinessArbiter.QueryRewriteParams queryRewriteParams) {
         if (!isEnableMVTimelinessGlobalCache(mv)) {
-            return MvRefreshArbiter.getMVTimelinessUpdateInfo(mv, true);
+            return MvRefreshArbiter.getMVTimelinessUpdateInfo(mv, queryRewriteParams);
         } else {
             return mvTimelinessMap.computeIfAbsent(mv,
-                    (ignored) -> MvRefreshArbiter.getMVTimelinessUpdateInfo(mv, true));
+                    (ignored) -> MvRefreshArbiter.getMVTimelinessUpdateInfo(mv, queryRewriteParams));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PRangeCellPlus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PRangeCellPlus.java
@@ -16,7 +16,12 @@ package com.starrocks.sql.common;
 
 import com.google.common.collect.Range;
 import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.SlotRef;
+import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
+import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -61,24 +66,22 @@ public class PRangeCellPlus implements Comparable<PRangeCellPlus> {
      * @param ranges need to be sorted.
      * @return intersected cells
      */
-    public static List<PRangeCellPlus> getIntersectedCells(PRangeCellPlus cell, List<PRangeCellPlus> ranges) {
+    public static List<PRangeCellPlus> getIntersectedCells(PRangeCellPlus cell,
+                                                           List<PRangeCellPlus> ranges,
+                                                           List<PartitionKey> mvLowerPoints,
+                                                           List<PartitionKey> mvUpperPoints) {
         if (ranges.isEmpty()) {
             return List.of();
         }
-        List<PartitionKey> lowerPoints = ranges.stream().map(
-                dstRange -> dstRange.getCell().getRange().lowerEndpoint()).toList();
-        List<PartitionKey> upperPoints = ranges.stream().map(
-                dstRange -> dstRange.getCell().getRange().upperEndpoint()).toList();
 
         PartitionKey lower = cell.getCell().getRange().lowerEndpoint();
         PartitionKey upper = cell.getCell().getRange().upperEndpoint();
-
         // For an interval [l, r], if there exists another interval [li, ri] that intersects with it, this interval
         // must satisfy l ≤ ri and r ≥ li. Therefore, if there exists a pos_a such that for all k < pos_a,
         // ri[k] < l, and there exists a pos_b such that for all k > pos_b, li[k] > r, then all intervals between
         // pos_a and pos_b might potentially intersect with the interval [l, r].
-        int posA = PartitionKey.findLastLessEqualInOrderedList(lower, upperPoints);
-        int posB = PartitionKey.findLastLessEqualInOrderedList(upper, lowerPoints);
+        int posA = PartitionKey.findLastLessEqualInOrderedList(lower, mvUpperPoints);
+        int posB = PartitionKey.findLastLessEqualInOrderedList(upper, mvLowerPoints);
 
         List<PRangeCellPlus> results = new LinkedList<>();
         for (int i = posA; i <= posB; ++i) {
@@ -112,16 +115,82 @@ public class PRangeCellPlus implements Comparable<PRangeCellPlus> {
     }
 
     /**
+     * For base table's partition name & partition range cell, its associated pcell cache key should only remapped to one
+     * pRangeCellPlus.
+     */
+    public static class PCellCacheKey {
+        private final Table refBaseTable;
+        private final String partitionName;
+        private final PRangeCell rangeCell;
+
+        public PCellCacheKey(Table refBaseTable,
+                             String partitionName, PRangeCell rangeCell) {
+            this.refBaseTable = refBaseTable;
+            this.partitionName = partitionName;
+            this.rangeCell = rangeCell;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            PCellCacheKey that = (PCellCacheKey) o;
+            return Objects.equals(refBaseTable, that.refBaseTable) &&
+                    Objects.equals(partitionName, that.partitionName) &&
+                    Objects.equals(rangeCell, that.rangeCell);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(refBaseTable, partitionName, rangeCell);
+        }
+    }
+
+    /**
      * Convert a range map to list of partition range cell plus which is sorted by range cell.
      */
-    public static List<PRangeCellPlus> toPRangeCellPlus(Map<String, PCell> rangeMap,
+    private static PRangeCellPlus toPRangeCellPlus(MaterializedView mv, Table refBaseTable,
+                                                   String partitionName, PRangeCell rangeCell,
+                                                   Expr expr) {
+        // for simple expr, no need to do conversion
+        if (expr == null || expr instanceof SlotRef) {
+            return new PRangeCellPlus(partitionName, rangeCell);
+        }
+
+        if (Config.enable_mv_global_context_cache) {
+            CachingMvPlanContextBuilder.MVCacheEntity mvCacheEntity = CachingMvPlanContextBuilder.getMVCache(mv);
+            PCellCacheKey cacheKey = new PCellCacheKey(refBaseTable, partitionName, rangeCell);
+            Object cacheValue = mvCacheEntity.get(cacheKey, () -> toPRangeCellPlus(partitionName, rangeCell, expr));
+            if (cacheValue != null && cacheValue instanceof PRangeCellPlus) {
+                return (PRangeCellPlus) cacheValue;
+            } else {
+                return toPRangeCellPlus(partitionName, rangeCell, expr);
+            }
+        } else {
+            return toPRangeCellPlus(partitionName, rangeCell, expr);
+        }
+    }
+
+    private static PRangeCellPlus toPRangeCellPlus(String partitionName, PRangeCell rangeCell,
+                                                   Expr expr) {
+        if (expr == null || expr instanceof SlotRef) {
+            return new PRangeCellPlus(partitionName, rangeCell);
+        } else {
+            Range<PartitionKey> partitionKeyRanges = rangeCell.getRange();
+            Range<PartitionKey> convertRanges = SyncPartitionUtils.convertToDatePartitionRange(partitionKeyRanges);
+            return new PRangeCellPlus(partitionName, SyncPartitionUtils.transferRange(convertRanges, expr));
+        }
+    }
+
+    public static List<PRangeCellPlus> toPRangeCellPlus(MaterializedView mv, Table refBaseTable,
+                                                        Map<String, PCell> rangeMap,
                                                         Expr expr) {
         return rangeMap.entrySet().stream()
-                .map(e -> {
-                    Range<PartitionKey> partitionKeyRanges = ((PRangeCell) e.getValue()).getRange();
-                    Range<PartitionKey> convertRanges = SyncPartitionUtils.convertToDatePartitionRange(partitionKeyRanges);
-                    return new PRangeCellPlus(e.getKey(), SyncPartitionUtils.transferRange(convertRanges, expr));
-                })
+                .map(e -> toPRangeCellPlus(mv, refBaseTable, e.getKey(), (PRangeCell) e.getValue(), expr))
                 .sorted(PRangeCellPlus::compareTo)
                 .collect(Collectors.toList());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PRangeCellPlus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PRangeCellPlus.java
@@ -123,6 +123,10 @@ public class PRangeCellPlus implements Comparable<PRangeCellPlus> {
         private final String partitionName;
         private final PRangeCell rangeCell;
 
+        public PCellCacheKey(Table refBaseTable, PRangeCellPlus plus) {
+            this(refBaseTable, plus.getPartitionName(), plus.getCell());
+        }
+
         public PCellCacheKey(Table refBaseTable,
                              String partitionName, PRangeCell rangeCell) {
             this.refBaseTable = refBaseTable;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
@@ -19,6 +19,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.mv.MVTimelinessArbiter;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.connector.PartitionUtil;
 
@@ -34,11 +35,11 @@ public abstract class PartitionDiffer {
     protected final MaterializedView mv;
     // whether it's used for query rewrite or refresh, the difference is that query rewrite will not
     // consider partition_ttl_number and mv refresh will consider it to avoid creating too much partitions
-    protected final boolean isQueryRewrite;
+    protected final MVTimelinessArbiter.QueryRewriteParams queryRewriteParams;
 
-    public PartitionDiffer(MaterializedView mv, boolean isQueryRewrite) {
+    public PartitionDiffer(MaterializedView mv, MVTimelinessArbiter.QueryRewriteParams queryRewriteParams) {
         this.mv = mv;
-        this.isQueryRewrite = isQueryRewrite;
+        this.queryRewriteParams = queryRewriteParams;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.optimizer;
 
 import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
 import com.github.benmanes.caffeine.cache.AsyncLoadingCache;
+import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
@@ -91,6 +92,28 @@ public class CachingMvPlanContextBuilder {
     // store the ast of mv's define query to mvs
     private static final Map<AstKey, Set<MaterializedView>> AST_TO_MV_MAP = Maps.newConcurrentMap();
 
+    public static class MVCacheEntity {
+        private final Cache<Object, Object> cache = Caffeine.newBuilder()
+                .maximumSize(Config.mv_global_context_cache_max_size)
+                .recordStats()
+                .build();
+
+        public void invalidateAll() {
+            cache.invalidateAll();
+        }
+
+        public Object get(Object key, Supplier<Object> valueSupplier) {
+            return cache.get(key, k -> valueSupplier.get());
+        }
+
+        public Object getIfPresent(Object key) {
+            return cache.getIfPresent(key);
+        }
+    }
+    // Cache mv context entity for each materialized view, this cache's lifetime is same as materialized view.
+    // We can cache some mv level context info in MVCacheEntity to avoid recomputing them frequently.
+    private static final Map<MaterializedView, MVCacheEntity> MV_GLOBAL_CONTEXT_CACHE_MAP = Maps.newConcurrentMap();
+
     public static class AstKey {
         private final String sql;
 
@@ -128,7 +151,6 @@ public class CachingMvPlanContextBuilder {
         }
     }
 
-
     private CachingMvPlanContextBuilder() {
     }
 
@@ -138,6 +160,10 @@ public class CachingMvPlanContextBuilder {
 
     private CompletableFuture<List<MvPlanContext>> getPlanContextFuture(MaterializedView mv) {
         return MV_PLAN_CONTEXT_CACHE.get(mv);
+    }
+
+    public static MVCacheEntity getMVCache(MaterializedView mv) {
+        return MV_GLOBAL_CONTEXT_CACHE_MAP.computeIfAbsent(mv, k -> new MVCacheEntity());
     }
 
     /**
@@ -251,6 +277,9 @@ public class CachingMvPlanContextBuilder {
         try {
             // invalidate mv from plan cache
             MV_PLAN_CONTEXT_CACHE.synchronous().invalidate(mv);
+
+            // invalidate mv from mv level cache
+            MV_GLOBAL_CONTEXT_CACHE_MAP.remove(mv);
 
             // invalidate mv from timeline cache
             MVTimelinessMgr mvTimelinessMgr = GlobalStateMgr.getCurrentState().getMaterializedViewMgr().getMvTimelinessMgr();
@@ -412,5 +441,17 @@ public class CachingMvPlanContextBuilder {
                 LOG.warn("async task {} failed: {}, cost: {}ms", taskName, e.getMessage(), duration, e);
             }
         });
+    }
+
+    public static String getMVPlanCacheStats() {
+        return MV_PLAN_CONTEXT_CACHE.synchronous().stats().toString();
+    }
+
+    public static String getMVGlobalContextCacheStats(MaterializedView mv) {
+        MVCacheEntity mvCacheEntity = MV_GLOBAL_CONTEXT_CACHE_MAP.get(mv);
+        if (mvCacheEntity != null) {
+            return mvCacheEntity.cache.stats().toString();
+        }
+        return "";
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -42,6 +42,7 @@ import com.starrocks.catalog.RandomDistributionInfo;
 import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.mv.MVPlanValidationResult;
+import com.starrocks.catalog.mv.MVTimelinessArbiter;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
@@ -189,11 +190,20 @@ public class MvRewritePreprocessor {
                 if (queryMaterializationContext.getValidCandidateMVs().size() > 1) {
                     queryMaterializationContext.setEnableQueryContextCache(true);
                 }
+
+                // record the current MV plan cache stats
+                Tracers.record("MVPlanCacheStats", CachingMvPlanContextBuilder.getMVPlanCacheStats());
             } catch (Exception e) {
-                List<String> tableNames = queryTables.stream().map(Table::getName).collect(Collectors.toList());
-                logMVPrepare(connectContext, "Prepare query tables {} for mv failed:{}",
-                        tableNames, DebugUtil.getStackTrace(e));
-                LOG.warn("Prepare query tables {} for mv failed", tableNames, e);
+                try {
+                    List<String> tableNames = queryTables.stream().map(Table::getName).collect(Collectors.toList());
+                    logMVPrepare(connectContext, "Prepare query tables {} for mv failed:{}",
+                            tableNames, DebugUtil.getStackTrace(e));
+                    LOG.warn("Prepare query tables {} for mv failed", tableNames, e);
+                } catch (Throwable traceLogException) {
+                    // ignore all exception in mv rewrite prepare
+                    LOG.warn("Failed to log mv rewrite prepare exception: {}",
+                            DebugUtil.getStackTrace(traceLogException));
+                }
             }
         }
     }
@@ -721,11 +731,13 @@ public class MvRewritePreprocessor {
 
         List<Pair<MaterializedViewWrapper, MvUpdateInfo>> mvInfos =
                 Lists.newArrayListWithExpectedSize(mvWithPlanContexts.size());
+        MVTimelinessArbiter.QueryRewriteParams queryRewriteParams =
+                MVTimelinessArbiter.QueryRewriteParams.ofQueryRewrite(context);
         for (MaterializedViewWrapper wrapper : mvWithPlanContexts) {
             MaterializedView mv = wrapper.getMV();
             try {
                 // mv's partitions to refresh
-                MvUpdateInfo mvUpdateInfo = queryMaterializationContext.getOrInitMVTimelinessInfos(mv);
+                MvUpdateInfo mvUpdateInfo = queryMaterializationContext.getOrInitMVTimelinessInfos(mv, queryRewriteParams);
                 if (mvUpdateInfo == null || !mvUpdateInfo.isValidRewrite()) {
                     OptimizerTraceUtil.logMVRewriteFailReason(mv.getName(), "stale partitions {}", mvUpdateInfo);
                     continue;
@@ -845,7 +857,8 @@ public class MvRewritePreprocessor {
             
             try {
                 future.get(individualTimeoutMs, TimeUnit.MILLISECONDS);
-                // Success - no action needed
+                // record MV global cache stats after successful preparation
+                Tracers.record("MVGlobalCacheStats", CachingMvPlanContextBuilder.getMVGlobalContextCacheStats(mv));
             } catch (TimeoutException e) {
                 LOG.warn("MV {} preparation timeout after {} ms", mvName, individualTimeoutMs);
                 timeoutMvNames.add(mvName);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
@@ -268,6 +268,10 @@ public class OptimizerContext {
         return uniquePartitionIdGenerator++;
     }
 
+    public Stopwatch getOptimizerTimer() {
+        return optimizerTimer;
+    }
+
     /**
      * Throw exception if reach optimizer timeout
      */

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryMaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryMaterializationContext.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvUpdateInfo;
+import com.starrocks.catalog.mv.MVTimelinessArbiter;
 import com.starrocks.common.Config;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.persist.gson.GsonUtils;
@@ -216,13 +217,14 @@ public class QueryMaterializationContext {
      * @param mv intput mv
      * @return MvUpdateInfo of the mv, null if mv is null or initialize fail
      */
-    public MvUpdateInfo getOrInitMVTimelinessInfos(MaterializedView mv) {
+    public MvUpdateInfo getOrInitMVTimelinessInfos(MaterializedView mv,
+                                                   MVTimelinessArbiter.QueryRewriteParams queryRewriteParams) {
         if (mv == null) {
             return null;
         }
         if (!mvTimelinessInfos.containsKey(mv)) {
             MVTimelinessMgr mvTimelinessMgr = GlobalStateMgr.getCurrentState().getMaterializedViewMgr().getMvTimelinessMgr();
-            MvUpdateInfo result = mvTimelinessMgr.getMVTimelinessInfo(mv);
+            MvUpdateInfo result = mvTimelinessMgr.getMVTimelinessInfo(mv, queryRewriteParams);
             mvTimelinessInfos.put(mv, result);
             return result;
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
+import com.starrocks.catalog.mv.MVTimelinessArbiter;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.MaterializationContext;
@@ -172,7 +173,9 @@ public class MaterializedViewTransparentRewriteRule extends TransformationRule {
 
         // mv's to refresh partition info
         QueryMaterializationContext queryMaterializationContext = context.getQueryMaterializationContext();
-        MvUpdateInfo mvUpdateInfo = queryMaterializationContext.getOrInitMVTimelinessInfos(mv);
+        MVTimelinessArbiter.QueryRewriteParams queryRewriteParams =
+                MVTimelinessArbiter.QueryRewriteParams.ofQueryRewrite(context);
+        MvUpdateInfo mvUpdateInfo = queryMaterializationContext.getOrInitMVTimelinessInfos(mv, queryRewriteParams);
         if (mvUpdateInfo == null || !mvUpdateInfo.isValidRewrite()) {
             logMVRewrite(context, this, "Get mv to refresh partition info failed, and redirect to mv's defined query");
             return getOptExpressionByDefault(context, mv, mvPlanContext, olapScanOperator, queryTables);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
@@ -26,6 +26,7 @@ import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
+import com.starrocks.catalog.mv.MVTimelinessArbiter;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.PropertyAnalyzer;
@@ -218,6 +219,8 @@ public class TextMatchBasedRewriteRule extends Rule {
                 return null;
             }
             int mvRelatedCount = 0;
+            MVTimelinessArbiter.QueryRewriteParams queryRewriteParams =
+                    MVTimelinessArbiter.QueryRewriteParams.ofQueryRewrite(context);
             for (MaterializedView mv : candidateMvs) {
                 Pair<Boolean, String> status = isValidForTextBasedRewrite(context, mv);
                 if (!status.first) {
@@ -230,7 +233,7 @@ public class TextMatchBasedRewriteRule extends Rule {
                 if (mvRelatedCount++ > mvRewriteRelatedMVsLimit) {
                     return null;
                 }
-                MvUpdateInfo mvUpdateInfo = queryMaterializationContext.getOrInitMVTimelinessInfos(mv);
+                MvUpdateInfo mvUpdateInfo = queryMaterializationContext.getOrInitMVTimelinessInfos(mv, queryRewriteParams);
                 if (mvUpdateInfo == null || !mvUpdateInfo.isValidRewrite()) {
                     logMVRewrite(context, this, "MV {} cannot be used for rewrite, " +
                             "stale partitions {}", mv.getName(), mvUpdateInfo);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/PRangeCellPlusTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/PRangeCellPlusTest.java
@@ -15,12 +15,18 @@
 package com.starrocks.sql.common;
 
 import com.google.common.collect.Range;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.SlotId;
+import com.starrocks.analysis.SlotRef;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.common.AnalysisException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.NavigableSet;
+import java.util.TreeSet;
 
 public class PRangeCellPlusTest {
     @Test
@@ -54,5 +60,118 @@ public class PRangeCellPlusTest {
         Assertions.assertEquals(-1, cell4.compareTo(cell5));
         Assertions.assertEquals(1, cell4.compareTo(cell6));
         Assertions.assertEquals(1, cell5.compareTo(cell6));
+    }
+
+    @Test
+    public void testPCellCacheKeyEqualsAndHashCode() throws Exception {
+        final String partitionName = "p1";
+        final PartitionKey key1 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 10, 0, 0));
+        final PartitionKey key2 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 11, 0, 0));
+
+        Range<PartitionKey> r1 = Range.closed(key1, key2);
+        PRangeCellPlus pcell = new PRangeCellPlus(partitionName, new PRangeCell(r1));
+        PRangeCellPlus samePCell = new PRangeCellPlus(partitionName, new PRangeCell(r1));
+        PRangeCellPlus differentPCell = new PRangeCellPlus("p2", new PRangeCell(r1));
+
+        PRangeCellPlus.PCellCacheKey keyA = new PRangeCellPlus.PCellCacheKey(null, pcell);
+        PRangeCellPlus.PCellCacheKey keyB = new PRangeCellPlus.PCellCacheKey(null, samePCell);
+        PRangeCellPlus.PCellCacheKey keyC = new PRangeCellPlus.PCellCacheKey(null, differentPCell);
+
+        Assertions.assertEquals(keyA, keyA);
+        Assertions.assertEquals(keyA, keyB);
+        Assertions.assertEquals(keyA.hashCode(), keyB.hashCode());
+        Assertions.assertNotEquals(keyA, keyC);
+    }
+
+    @Test
+    public void testPCellCacheKeyNotEqual() throws Exception {
+        final String partitionName = "p1";
+        final PartitionKey key1 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 10, 0, 0));
+        final PartitionKey key2 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 11, 0, 0));
+
+        Range<PartitionKey> r1 = Range.closed(key1, key2);
+        PRangeCellPlus pcell1 = new PRangeCellPlus(partitionName, new PRangeCell(r1));
+        PRangeCellPlus pcell2 = new PRangeCellPlus("p2", new PRangeCell(r1));
+
+        PRangeCellPlus.PCellCacheKey keyNull = new PRangeCellPlus.PCellCacheKey(null, pcell1);
+        PRangeCellPlus.PCellCacheKey keyOtherPCell = new PRangeCellPlus.PCellCacheKey(null, pcell2);
+
+        Assertions.assertNotEquals(keyNull, keyOtherPCell);
+    }
+
+    @Test
+    public void testPCellWithNormOf() throws Exception {
+        final String partitionName = "p1";
+        final PartitionKey key1 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 10, 0, 0));
+        final PartitionKey key2 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 11, 0, 0));
+
+        Range<PartitionKey> r1 = Range.closed(key1, key2);
+        PRangeCellPlus base = new PRangeCellPlus(partitionName, new PRangeCell(r1));
+        PRangeCellPlus normalized = new PRangeCellPlus("p_norm", new PRangeCell(r1));
+
+        PRangeCellPlus.PCellWithNorm norm = PRangeCellPlus.PCellWithNorm.of(base, normalized);
+        Assertions.assertEquals(base, norm.basePCell());
+        Assertions.assertEquals(normalized, norm.normalized());
+    }
+
+    @Test
+    public void testNormalizePRangeCellPluss1() throws Exception {
+        final String partitionName1 = "p1";
+        final String partitionName2 = "p2";
+        final PartitionKey k1 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 10, 0, 0));
+        final PartitionKey k2 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 11, 0, 0));
+        final PartitionKey k3 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 12, 0, 0));
+        final PartitionKey k4 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 13, 0, 0));
+
+        Range<PartitionKey> r1 = Range.closed(k1, k2);
+        Range<PartitionKey> r2 = Range.closed(k3, k4);
+        PRangeCellPlus p1 = new PRangeCellPlus(partitionName1, new PRangeCell(r1));
+        PRangeCellPlus p2 = new PRangeCellPlus(partitionName2, new PRangeCell(r2));
+
+        // Provide a minimal PCellSortedSet by overriding getPartitions()
+        PCellSortedSet rangeMap = new PCellSortedSet(new TreeSet<>()) {
+            @Override
+            public NavigableSet<PRangeCellPlus> getPartitions() {
+                return new TreeSet<>(List.of(p1, p2));
+            }
+        };
+
+        List<PRangeCellPlus.PCellWithNorm> result = PRangeCellPlus.normalizePRangeCellPluss(null, null, rangeMap, null);
+        Assertions.assertEquals(2, result.size());
+        Assertions.assertSame(result.get(0).basePCell(), result.get(0).normalized());
+        Assertions.assertSame(result.get(1).basePCell(), result.get(1).normalized());
+    }
+
+    @Test
+    public void testNormalizePRangeCellPluss2() throws Exception {
+        final String partitionName1 = "p1";
+        final PartitionKey k1 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 10, 0, 0));
+        final PartitionKey k2 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 11, 0, 0));
+        Range<PartitionKey> r1 = Range.closed(k1, k2);
+        PRangeCellPlus p1 = new PRangeCellPlus(partitionName1, new PRangeCell(r1));
+
+        PCellSortedSet rangeMap = new PCellSortedSet(new TreeSet<>()) {
+            @Override
+            public NavigableSet<PRangeCellPlus> getPartitions() {
+                return new TreeSet(List.of(p1));
+            }
+        };
+
+        Expr slotRef = new SlotRef(new SlotId(9));
+        List<PRangeCellPlus.PCellWithNorm> result = PRangeCellPlus.normalizePRangeCellPluss(null, null, rangeMap, slotRef);
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertSame(result.get(0).basePCell(), result.get(0).normalized());
+    }
+
+    @Test
+    public void testtoNormalizedCell() throws Exception {
+        final String partitionName = "p1";
+        final PartitionKey k1 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 10, 0, 0));
+        final PartitionKey k2 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 11, 0, 0));
+        Range<PartitionKey> r1 = Range.closed(k1, k2);
+        PRangeCellPlus pcell = new PRangeCellPlus(partitionName, new PRangeCell(r1));
+
+        Assertions.assertSame(pcell, PRangeCellPlus.toNormalizedCell(pcell, null));
+        Assertions.assertSame(pcell, PRangeCellPlus.toNormalizedCell(pcell, new SlotRef(new SlotId(1))));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/PRangeCellPlusTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/PRangeCellPlusTest.java
@@ -15,18 +15,12 @@
 package com.starrocks.sql.common;
 
 import com.google.common.collect.Range;
-import com.starrocks.analysis.Expr;
-import com.starrocks.analysis.SlotId;
-import com.starrocks.analysis.SlotRef;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.common.AnalysisException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.NavigableSet;
-import java.util.TreeSet;
 
 public class PRangeCellPlusTest {
     @Test
@@ -97,81 +91,5 @@ public class PRangeCellPlusTest {
         PRangeCellPlus.PCellCacheKey keyOtherPCell = new PRangeCellPlus.PCellCacheKey(null, pcell2);
 
         Assertions.assertNotEquals(keyNull, keyOtherPCell);
-    }
-
-    @Test
-    public void testPCellWithNormOf() throws Exception {
-        final String partitionName = "p1";
-        final PartitionKey key1 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 10, 0, 0));
-        final PartitionKey key2 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 11, 0, 0));
-
-        Range<PartitionKey> r1 = Range.closed(key1, key2);
-        PRangeCellPlus base = new PRangeCellPlus(partitionName, new PRangeCell(r1));
-        PRangeCellPlus normalized = new PRangeCellPlus("p_norm", new PRangeCell(r1));
-
-        PRangeCellPlus.PCellWithNorm norm = PRangeCellPlus.PCellWithNorm.of(base, normalized);
-        Assertions.assertEquals(base, norm.basePCell());
-        Assertions.assertEquals(normalized, norm.normalized());
-    }
-
-    @Test
-    public void testNormalizePRangeCellPluss1() throws Exception {
-        final String partitionName1 = "p1";
-        final String partitionName2 = "p2";
-        final PartitionKey k1 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 10, 0, 0));
-        final PartitionKey k2 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 11, 0, 0));
-        final PartitionKey k3 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 12, 0, 0));
-        final PartitionKey k4 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 13, 0, 0));
-
-        Range<PartitionKey> r1 = Range.closed(k1, k2);
-        Range<PartitionKey> r2 = Range.closed(k3, k4);
-        PRangeCellPlus p1 = new PRangeCellPlus(partitionName1, new PRangeCell(r1));
-        PRangeCellPlus p2 = new PRangeCellPlus(partitionName2, new PRangeCell(r2));
-
-        // Provide a minimal PCellSortedSet by overriding getPartitions()
-        PCellSortedSet rangeMap = new PCellSortedSet(new TreeSet<>()) {
-            @Override
-            public NavigableSet<PRangeCellPlus> getPartitions() {
-                return new TreeSet<>(List.of(p1, p2));
-            }
-        };
-
-        List<PRangeCellPlus.PCellWithNorm> result = PRangeCellPlus.normalizePRangeCellPluss(null, null, rangeMap, null);
-        Assertions.assertEquals(2, result.size());
-        Assertions.assertSame(result.get(0).basePCell(), result.get(0).normalized());
-        Assertions.assertSame(result.get(1).basePCell(), result.get(1).normalized());
-    }
-
-    @Test
-    public void testNormalizePRangeCellPluss2() throws Exception {
-        final String partitionName1 = "p1";
-        final PartitionKey k1 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 10, 0, 0));
-        final PartitionKey k2 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 11, 0, 0));
-        Range<PartitionKey> r1 = Range.closed(k1, k2);
-        PRangeCellPlus p1 = new PRangeCellPlus(partitionName1, new PRangeCell(r1));
-
-        PCellSortedSet rangeMap = new PCellSortedSet(new TreeSet<>()) {
-            @Override
-            public NavigableSet<PRangeCellPlus> getPartitions() {
-                return new TreeSet(List.of(p1));
-            }
-        };
-
-        Expr slotRef = new SlotRef(new SlotId(9));
-        List<PRangeCellPlus.PCellWithNorm> result = PRangeCellPlus.normalizePRangeCellPluss(null, null, rangeMap, slotRef);
-        Assertions.assertEquals(1, result.size());
-        Assertions.assertSame(result.get(0).basePCell(), result.get(0).normalized());
-    }
-
-    @Test
-    public void testtoNormalizedCell() throws Exception {
-        final String partitionName = "p1";
-        final PartitionKey k1 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 10, 0, 0));
-        final PartitionKey k2 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 11, 0, 0));
-        Range<PartitionKey> r1 = Range.closed(k1, k2);
-        PRangeCellPlus pcell = new PRangeCellPlus(partitionName, new PRangeCell(r1));
-
-        Assertions.assertSame(pcell, PRangeCellPlus.toNormalizedCell(pcell, null));
-        Assertions.assertSame(pcell, PRangeCellPlus.toNormalizedCell(pcell, new SlotRef(new SlotId(1))));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
@@ -303,7 +303,7 @@ public abstract class MVTestBase extends StarRocksTestBase {
     }
 
     public static Set<String> getPartitionNamesToRefreshForMv(MaterializedView mv) {
-        MvUpdateInfo mvUpdateInfo = MvRefreshArbiter.getMVTimelinessUpdateInfo(mv, true);
+        MvUpdateInfo mvUpdateInfo = getMvUpdateInfo(mv);
         Preconditions.checkState(mvUpdateInfo != null);
         return mvUpdateInfo.getMvToRefreshPartitionNames();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
@@ -31,6 +31,7 @@ import com.starrocks.catalog.MvRefreshArbiter;
 import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.View;
+import com.starrocks.catalog.mv.MVTimelinessArbiter;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
@@ -299,7 +300,10 @@ public abstract class MVTestBase extends StarRocksTestBase {
     }
 
     public static MvUpdateInfo getMvUpdateInfo(MaterializedView mv) {
-        return MvRefreshArbiter.getMVTimelinessUpdateInfo(mv, true);
+        OptimizerContext optimizerContext = OptimizerFactory.mockContext(connectContext, new ColumnRefFactory());
+        MVTimelinessArbiter.QueryRewriteParams queryRewriteParams =
+                MVTimelinessArbiter.QueryRewriteParams.ofQueryRewrite(optimizerContext);
+        return MvRefreshArbiter.getMVTimelinessUpdateInfo(mv, queryRewriteParams);
     }
 
     public static Set<String> getPartitionNamesToRefreshForMv(MaterializedView mv) {

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -61,6 +61,7 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.mv.MVTimelinessArbiter;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
@@ -1276,11 +1277,12 @@ public class UtFrameUtils {
     public static void mockTimelinessForAsyncMVTest(ConnectContext connectContext) {
         new MockUp<MvRefreshArbiter>() {
             /**
-             * {@link MvRefreshArbiter#getMVTimelinessUpdateInfo(MaterializedView, boolean)}
+             * {@link MvRefreshArbiter#getMVTimelinessUpdateInfo(MaterializedView,
+             * com.starrocks.catalog.mv.MVTimelinessArbiter.QueryRewriteParams)}
              */
             @Mock
             public MvUpdateInfo getMVTimelinessUpdateInfo(MaterializedView mv,
-                                                          boolean isQueryRewrite) {
+                                                          MVTimelinessArbiter.QueryRewriteParams queryRewriteParams) {
                 return MvUpdateInfo.noRefresh(mv);
             }
         };


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Backport from https://github.com/StarRocks/starrocks/pull/66623

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds time-limited MV timeliness checks and a per‑MV global context cache, refactors APIs to pass QueryRewriteParams, and optimizes partition diff/intersection for faster MV rewrite and refresh.
> 
> - **MV Timeliness & Rewrite Pipeline**:
>   - Introduce `MVTimelinessArbiter.QueryRewriteParams` (time-limited, optimizer-aware) and propagate across `MvRefreshArbiter`, `MVTimeliness*Arbiter`, `MVPCTRefresh*Partitioner`, rewrite rules, and tests (replacing `isQueryRewrite`).
>   - `MVTimelinessMgr`/`MvRefreshArbiter` now fetch timeliness with `QueryRewriteParams`.
> - **Performance Optimizations**:
>   - Range/list partition diff: precompute endpoints for intersection, add periodic exhaustion checks, and avoid repeated computation.
>   - Cache per-MV global context via `CachingMvPlanContextBuilder.MVCacheEntity`; cache `PRangeCellPlus` conversions.
>   - Expose `OptimizerContext.getOptimizerTimer()` and use for rewrite time budgeting.
> - **Config**:
>   - Add `enable_mv_global_context_cache` and `mv_global_context_cache_max_size`.
> - **API Refactors**:
>   - Update constructors/methods in `RangePartitionDiffer`, `ListPartitionDiffer`, `MVTimeliness*Arbiter`, `MVPCTRefresh*Partitioner`, and callers to accept `QueryRewriteParams`.
> - **Misc**:
>   - Optimize `DateLiteral.isMinValue()` by direct field comparison.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ce0fcb56e0bd62b2f1df0e42cf59fb0052a1134. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->