### PR TITLE
[Enhancement]Display the index of the blacklist rule matched for a forbidden SQL

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/meta/SqlBlackList.java
+++ b/fe/fe-core/src/main/java/com/starrocks/meta/SqlBlackList.java
@@ -64,7 +64,7 @@ public class SqlBlackList {
                 Matcher m = patternAndId.pattern.matcher(formatSql);
                 if (m.find()) {
                     MetricRepo.COUNTER_SQL_BLOCK_HIT_COUNT.increase(1L);
-                    ErrorReport.reportAnalysisException(ErrorCode.ERR_SQL_IN_BLACKLIST_ERROR);
+                    ErrorReport.reportAnalysisException(ErrorCode.ERR_SQL_IN_BLACKLIST_ERROR, patternAndId.id);
                 }
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SqlBlacklistAndWhitelistTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SqlBlacklistAndWhitelistTest.java
@@ -13,6 +13,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.regex.Pattern;
+
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeFail;
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeSuccess;
 
@@ -27,6 +29,18 @@ public class SqlBlacklistAndWhitelistTest {
     @BeforeAll
     public static void beforeClass() throws Exception {
         AnalyzeTestUtil.init();
+    }
+
+
+
+    @Test
+    public void testVerifyingSQL() throws Exception {
+        AddSqlBlackListStmt stmt =
+                (AddSqlBlackListStmt) analyzeSuccess("ADD SQLBLACKLIST \"select count\\(distinct .+\\) from .+\";");
+        Assertions.assertEquals("select count(distinct .+) from .+", stmt.getSql());
+        StmtExecutor stmtExecutor = new StmtExecutor(AnalyzeTestUtil.getConnectContext(), stmt);
+        stmtExecutor.execute();
+        Assertions.assertTrue(AnalyzeTestUtil.getConnectContext().getState().isError());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SqlBlacklistAndWhitelistTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SqlBlacklistAndWhitelistTest.java
@@ -31,18 +31,6 @@ public class SqlBlacklistAndWhitelistTest {
         AnalyzeTestUtil.init();
     }
 
-
-
-    @Test
-    public void testVerifyingSQL() throws Exception {
-        AddSqlBlackListStmt stmt =
-                (AddSqlBlackListStmt) analyzeSuccess("ADD SQLBLACKLIST \"select count\\(distinct .+\\) from .+\";");
-        Assertions.assertEquals("select count(distinct .+) from .+", stmt.getSql());
-        StmtExecutor stmtExecutor = new StmtExecutor(AnalyzeTestUtil.getConnectContext(), stmt);
-        stmtExecutor.execute();
-        Assertions.assertTrue(AnalyzeTestUtil.getConnectContext().getState().isError());
-    }
-
     @Test
     public void testAddSqlBlacklist() throws Exception {
         AddSqlBlackListStmt stmt =

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SqlBlacklistAndWhitelistTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SqlBlacklistAndWhitelistTest.java
@@ -13,8 +13,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import java.util.regex.Pattern;
-
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeFail;
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeSuccess;
 

--- a/fe/fe-core/src/test/java/com/starrocks/meta/SqlBlacklistTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/meta/SqlBlacklistTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.meta;
 
+import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.persist.DeleteSqlBlackLists;
 import com.starrocks.persist.SqlBlackListPersistInfo;
@@ -37,6 +38,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.parseSql;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class SqlBlacklistTest {
     SqlBlackList sqlBlackList;
@@ -169,5 +171,13 @@ public class SqlBlacklistTest {
                         .noneMatch(x -> x.id == 123L || x.id == 1234L)
         );
 
+    }
+
+    @Test
+    public void testVerifyingSQLExistsInBlackList() {
+        Pattern p = Pattern.compile("qwert");
+        sqlBlackList.put(p);
+        assertThrows(AnalysisException.class,
+                () -> sqlBlackList.verifying("qwert"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/meta/SqlBlacklistTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/meta/SqlBlacklistTest.java
@@ -177,7 +177,8 @@ public class SqlBlacklistTest {
     public void testVerifyingSQLExistsInBlackList() {
         Pattern p = Pattern.compile("qwert");
         sqlBlackList.put(p);
-        assertThrows(AnalysisException.class,
-                () -> sqlBlackList.verifying("qwert"));
+        AnalysisException exception = assertThrows(AnalysisException.class, () -> sqlBlackList.verifying("qwert"));
+        Assertions.assertEquals("Access denied; This sql is in blacklist (id: 0), please contact your admin",
+                exception.getMessage());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlannerTest.java
@@ -171,7 +171,7 @@ public class QueryPlannerTest {
                 connectContext.getSessionVariable().getSqlMode());
         StmtExecutor stmtExecutor2 = new StmtExecutor(connectContext, statement);
         stmtExecutor2.execute();
-        Assertions.assertEquals("Access denied; This sql is in blacklist, please contact your admin",
+        Assertions.assertEquals("Access denied; This sql is in blacklist[Index 0], please contact your admin",
                 connectContext.getState().getErrorMessage());
         connectContext.getState().setError("");
 
@@ -182,7 +182,7 @@ public class QueryPlannerTest {
                 SqlParser.parse(sqlWithLineSeparators, connectContext.getSessionVariable().getSqlMode()).get(0);
         StmtExecutor stmtExecutor4 = new StmtExecutor(connectContext, statement1);
         stmtExecutor4.execute();
-        Assertions.assertEquals("Access denied; This sql is in blacklist, please contact your admin",
+        Assertions.assertEquals("Access denied; This sql is in blacklist[Index 0], please contact your admin",
                 connectContext.getState().getErrorMessage());
         connectContext.getState().setError("");
 
@@ -192,7 +192,7 @@ public class QueryPlannerTest {
                 connectContext.getSessionVariable().getSqlMode());
         StmtExecutor stmtExecutor5 = new StmtExecutor(connectContext, statement);
         stmtExecutor5.execute();
-        Assertions.assertEquals("Access denied; This sql is in blacklist, please contact your admin",
+        Assertions.assertEquals("Access denied; This sql is in blacklist[Index 0], please contact your admin",
                 connectContext.getState().getErrorMessage());
         connectContext.getState().setError("");
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlannerTest.java
@@ -171,8 +171,10 @@ public class QueryPlannerTest {
                 connectContext.getSessionVariable().getSqlMode());
         StmtExecutor stmtExecutor2 = new StmtExecutor(connectContext, statement);
         stmtExecutor2.execute();
-        Assertions.assertEquals("Access denied; This sql is in blacklist[Index 0], please contact your admin",
-                connectContext.getState().getErrorMessage());
+        Assertions.assertTrue(
+                connectContext.getState().getErrorMessage()
+                        .contains("Access denied; This sql is in blacklist")
+        );
         connectContext.getState().setError("");
 
         String sqlWithLineSeparators = "select k1 \n" +
@@ -182,8 +184,10 @@ public class QueryPlannerTest {
                 SqlParser.parse(sqlWithLineSeparators, connectContext.getSessionVariable().getSqlMode()).get(0);
         StmtExecutor stmtExecutor4 = new StmtExecutor(connectContext, statement1);
         stmtExecutor4.execute();
-        Assertions.assertEquals("Access denied; This sql is in blacklist[Index 0], please contact your admin",
-                connectContext.getState().getErrorMessage());
+        Assertions.assertTrue(
+                connectContext.getState().getErrorMessage()
+                        .contains("Access denied; This sql is in blacklist")
+        );
         connectContext.getState().setError("");
 
         // for ctas
@@ -192,8 +196,10 @@ public class QueryPlannerTest {
                 connectContext.getSessionVariable().getSqlMode());
         StmtExecutor stmtExecutor5 = new StmtExecutor(connectContext, statement);
         stmtExecutor5.execute();
-        Assertions.assertEquals("Access denied; This sql is in blacklist[Index 0], please contact your admin",
-                connectContext.getState().getErrorMessage());
+        Assertions.assertTrue(
+                connectContext.getState().getErrorMessage()
+                        .contains("Access denied; This sql is in blacklist")
+        );
         connectContext.getState().setError("");
 
         String deleteBlackListSql = "delete sqlblacklist " + String.valueOf(id);
@@ -229,8 +235,10 @@ public class QueryPlannerTest {
         statement = SqlParser.parse(sql, connectContext.getSessionVariable().getSqlMode()).get(0);
         StmtExecutor stmtExecutor2 = new StmtExecutor(connectContext, statement);
         stmtExecutor2.execute();
-        Assertions.assertEquals("Access denied; This sql is in blacklist, please contact your admin",
-                connectContext.getState().getErrorMessage());
+        Assertions.assertTrue(
+                connectContext.getState().getErrorMessage()
+                        .contains("Access denied; This sql is in blacklist")
+        );
         connectContext.getState().setError("");
 
         String sqlWithLineSeparators = "select k1 \n" +
@@ -240,8 +248,10 @@ public class QueryPlannerTest {
                 SqlParser.parse(sqlWithLineSeparators, connectContext.getSessionVariable().getSqlMode()).get(0);
         StmtExecutor stmtExecutor4 = new StmtExecutor(connectContext, statement1);
         stmtExecutor4.execute();
-        Assertions.assertEquals("Access denied; This sql is in blacklist, please contact your admin",
-                connectContext.getState().getErrorMessage());
+        Assertions.assertTrue(
+                connectContext.getState().getErrorMessage()
+                        .contains("Access denied; This sql is in blacklist")
+        );
         connectContext.getState().setError("");
 
         String deleteBlackListSql = "delete sqlblacklist " + String.valueOf(id);
@@ -283,8 +293,10 @@ public class QueryPlannerTest {
         StatementBase statementBase = SqlParser.parse(sql, connectContext.getSessionVariable().getSqlMode()).get(0);
         StmtExecutor stmtExecutor2 = new StmtExecutor(connectContext, statementBase);
         stmtExecutor2.execute();
-        Assertions.assertEquals("Access denied; This sql is in blacklist, please contact your admin",
-                connectContext.getState().getErrorMessage());
+        Assertions.assertTrue(
+                connectContext.getState().getErrorMessage()
+                        .contains("Access denied; This sql is in blacklist")
+        );
 
         String deleteBlackListSql = "delete sqlblacklist " + String.valueOf(id);
         statement = SqlParser.parseSingleStatement(deleteBlackListSql,
@@ -323,8 +335,10 @@ public class QueryPlannerTest {
         } catch (AnalysisException e) {
 
         }
-        Assertions.assertEquals("Access denied; This sql is in blacklist, please contact your admin",
-                connectContext.getState().getErrorMessage());
+        Assertions.assertTrue(
+                connectContext.getState().getErrorMessage()
+                        .contains("Access denied; This sql is in blacklist")
+        );
 
         String deleteBlackListSql = "delete sqlblacklist " + String.valueOf(id);
         statement = SqlParser.parseSingleStatement(deleteBlackListSql,

--- a/fe/fe-spi/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-spi/src/main/java/com/starrocks/common/ErrorCode.java
@@ -248,7 +248,7 @@ public enum ErrorCode {
     ERR_PASSWD_LENGTH(5201, new byte[] {'H', 'Y', '0', '0', '0'},
             "Password hash should be a %d-digit hexadecimal number"),
     ERR_SQL_IN_BLACKLIST_ERROR(5202, new byte[] {'4', '2', '0', '0', '0'},
-            "Access denied; This sql is in blacklist[Index %s], please contact your admin"),
+            "Access denied; This sql is in blacklist (id: %d), please contact your admin"),
     ERR_ACCESS_DENIED(5203, new byte[] {'4', '2', '0', '0', '0'},
             "Access denied; you need (at least one of) the %s privilege(s) on %s%s for this operation. " +
                     ErrorCode.ERR_ACCESS_DENIED_HINT_MSG_FORMAT),

--- a/fe/fe-spi/src/main/java/com/starrocks/common/ErrorCode.java
+++ b/fe/fe-spi/src/main/java/com/starrocks/common/ErrorCode.java
@@ -248,7 +248,7 @@ public enum ErrorCode {
     ERR_PASSWD_LENGTH(5201, new byte[] {'H', 'Y', '0', '0', '0'},
             "Password hash should be a %d-digit hexadecimal number"),
     ERR_SQL_IN_BLACKLIST_ERROR(5202, new byte[] {'4', '2', '0', '0', '0'},
-            "Access denied; This sql is in blacklist, please contact your admin"),
+            "Access denied; This sql is in blacklist[Index %s], please contact your admin"),
     ERR_ACCESS_DENIED(5203, new byte[] {'4', '2', '0', '0', '0'},
             "Access denied; you need (at least one of) the %s privilege(s) on %s%s for this operation. " +
                     ErrorCode.ERR_ACCESS_DENIED_HINT_MSG_FORMAT),


### PR DESCRIPTION
## Why I'm doing:
It’s a bit easy for the admin to track which blacklist rule matches a given SQL

## What I'm doing:
as title

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Include the matched blacklist rule index in the blocked SQL error message and adjust unit tests accordingly.
> 
> - **Backend**:
>   - Pass blacklist rule `id` to `ErrorReport.reportAnalysisException` in `SqlBlackList.verifying`.
>   - Update `ErrorCode.ERR_SQL_IN_BLACKLIST_ERROR` message to include rule index: `Access denied; This sql is in blacklist[Index %s]...`.
> - **Tests**:
>   - Relax assertions in `QueryPlannerTest` to check error message contains "Access denied; This sql is in blacklist".
>   - Add `SqlBlacklistTest.testVerifyingSQLExistsInBlackList` to assert `verifying` throws `AnalysisException`.
>   - Minor imports added for new assertions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f3b554743011394cf719390243352649448db16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->