### PR TITLE
[Enhancement] Optimize mv rewrite performance

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvRefreshArbiter.java
@@ -40,8 +40,8 @@ public class MvRefreshArbiter {
     private static final Logger LOG = LogManager.getLogger(MvRefreshArbiter.class);
 
     public static boolean needsToRefreshTable(MaterializedView mv, BaseTableInfo baseTableInfo, Table table,
-                                              boolean isQueryRewrite) {
-        Optional<Boolean> needsToRefresh = needsToRefreshTable(mv, baseTableInfo, table, true, isQueryRewrite);
+                                              MVTimelinessArbiter.QueryRewriteParams queryRewriteParams) {
+        Optional<Boolean> needsToRefresh = needsToRefreshTable(mv, baseTableInfo, table, true, queryRewriteParams);
         if (needsToRefresh.isPresent()) {
             return needsToRefresh.get();
         }
@@ -52,11 +52,12 @@ public class MvRefreshArbiter {
      * Once materialized view's base tables have updated, we need to check correspond materialized views' partitions
      * to be refreshed.
      * @param mv The materialized view to check
-     * @param isQueryRewrite Mark whether this caller is query rewrite or not, when it's true we can use staleness to shortcut
+     * @param queryRewriteParams Mark whether this caller is query rewrite or not, when it's true we can use staleness to shortcut
      * @return mv timeliness update info which contains all need refreshed partitions of materialized view and partition name
      * to partition values.
      */
-    public static MvUpdateInfo getMVTimelinessUpdateInfo(MaterializedView mv, boolean isQueryRewrite) {
+    public static MvUpdateInfo getMVTimelinessUpdateInfo(MaterializedView mv,
+                                                         MVTimelinessArbiter.QueryRewriteParams queryRewriteParams) {
         // Skip check for sync materialized view.
         if (mv.getRefreshScheme().isSync()) {
             return MvUpdateInfo.noRefresh(mv);
@@ -65,7 +66,7 @@ public class MvRefreshArbiter {
         // check mv's query rewrite consistency mode property only in query rewrite.
         TableProperty tableProperty = mv.getTableProperty();
         TableProperty.QueryRewriteConsistencyMode mvConsistencyRewriteMode = tableProperty.getQueryRewriteConsistencyMode();
-        if (isQueryRewrite) {
+        if (queryRewriteParams.isQueryRewrite()) {
             switch (mvConsistencyRewriteMode) {
                 case DISABLE:
                     return MvUpdateInfo.fullRefresh(mv);
@@ -80,7 +81,7 @@ public class MvRefreshArbiter {
 
         logMVPrepare(mv, "MV refresh arbiter start to get partition names to refresh, query rewrite mode: {}",
                 mvConsistencyRewriteMode);
-        MVTimelinessArbiter timelinessArbiter = buildMVTimelinessArbiter(mv, isQueryRewrite);
+        MVTimelinessArbiter timelinessArbiter = buildMVTimelinessArbiter(mv, queryRewriteParams);
         try (Timer ignored = Tracers.watchScope("MVTimelinessUpdateInfo")) {
             return timelinessArbiter.getMVTimelinessUpdateInfo(mvConsistencyRewriteMode);
         } catch (AnalysisException e) {
@@ -92,18 +93,18 @@ public class MvRefreshArbiter {
     /**
      * Create the MVTimelinessArbiter instance according to the partition info of the materialized view.
      * @param mv the materialized view to get the timeliness arbiter
-     * @param isQueryRewrite whether this caller is query rewrite or mv refresh
+     * @param queryRewriteParams whether this caller is query rewrite or mv refresh
      * @return MVTimelinessArbiter instance according to the partition info of the materialized view
      */
     public static MVTimelinessArbiter buildMVTimelinessArbiter(MaterializedView mv,
-                                                               boolean isQueryRewrite) {
+                                                               MVTimelinessArbiter.QueryRewriteParams queryRewriteParams) {
         PartitionInfo partitionInfo = mv.getPartitionInfo();
         if (partitionInfo.isUnPartitioned()) {
-            return new MVTimelinessNonPartitionArbiter(mv, isQueryRewrite);
+            return new MVTimelinessNonPartitionArbiter(mv, queryRewriteParams);
         } else if (partitionInfo.isRangePartition()) {
-            return new MVTimelinessRangePartitionArbiter(mv, isQueryRewrite);
+            return new MVTimelinessRangePartitionArbiter(mv, queryRewriteParams);
         } else if (partitionInfo.isListPartition()) {
-            return new MVTimelinessListPartitionArbiter(mv, isQueryRewrite);
+            return new MVTimelinessListPartitionArbiter(mv, queryRewriteParams);
         } else {
             throw UnsupportedException.unsupportedException("unsupported partition info type:" +
                     partitionInfo.getClass().getName());
@@ -118,7 +119,7 @@ public class MvRefreshArbiter {
                                                          BaseTableInfo baseTableInfo,
                                                          Table baseTable,
                                                          boolean withMv,
-                                                         boolean isQueryRewrite) {
+                                                         MVTimelinessArbiter.QueryRewriteParams queryRewriteParams) {
         if (baseTable.isView()) {
             // do nothing
             return Optional.of(false);
@@ -129,14 +130,15 @@ public class MvRefreshArbiter {
                 return Optional.of(false);
             }
 
-            Set<String> baseUpdatedPartitionNames = mv.getUpdatedPartitionNamesOfOlapTable(olapBaseTable, isQueryRewrite);
+            Set<String> baseUpdatedPartitionNames = mv.getUpdatedPartitionNamesOfOlapTable(olapBaseTable,
+                    queryRewriteParams.isQueryRewrite());
             if (!baseUpdatedPartitionNames.isEmpty()) {
                 return Optional.of(true);
             }
 
             // recursive check its children
             if (withMv && baseTable.isMaterializedView()) {
-                MvUpdateInfo mvUpdateInfo = getMVTimelinessUpdateInfo((MaterializedView) baseTable, isQueryRewrite);
+                MvUpdateInfo mvUpdateInfo = getMVTimelinessUpdateInfo((MaterializedView) baseTable, queryRewriteParams);
                 if (mvUpdateInfo == null || !mvUpdateInfo.isValidRewrite()) {
                     return Optional.empty();
                 }
@@ -145,7 +147,8 @@ public class MvRefreshArbiter {
             }
             return Optional.of(false);
         } else {
-            Set<String> baseUpdatedPartitionNames = mv.getUpdatedPartitionNamesOfExternalTable(baseTable, isQueryRewrite);
+            Set<String> baseUpdatedPartitionNames = mv.getUpdatedPartitionNamesOfExternalTable(baseTable,
+                    queryRewriteParams.isQueryRewrite());
             if (baseUpdatedPartitionNames == null) {
                 return Optional.empty();
             }
@@ -157,27 +160,28 @@ public class MvRefreshArbiter {
      * Get to refresh partition info of the specific table.
      * @param baseTable: the table to check
      * @param withMv: whether to check the materialized view if it's a materialized view
-     * @param isQueryRewrite: whether this caller is query rewrite or not
+     * @param queryRewriteParams: whether this caller is query rewrite or not
      * @return MvBaseTableUpdateInfo: the update info of the base table
      */
     public static MvBaseTableUpdateInfo getMvBaseTableUpdateInfo(MaterializedView mv,
                                                                  Table baseTable,
                                                                  boolean withMv,
-                                                                 boolean isQueryRewrite) {
+                                                                 MVTimelinessArbiter.QueryRewriteParams queryRewriteParams) {
         MvBaseTableUpdateInfo baseTableUpdateInfo = new MvBaseTableUpdateInfo();
         if (baseTable.isView()) {
             // do nothing
             return baseTableUpdateInfo;
         } else if (baseTable.isNativeTableOrMaterializedView()) {
             OlapTable olapBaseTable = (OlapTable) baseTable;
-            Set<String> baseUpdatedPartitionNames = mv.getUpdatedPartitionNamesOfOlapTable(olapBaseTable, isQueryRewrite);
+            Set<String> baseUpdatedPartitionNames = mv.getUpdatedPartitionNamesOfOlapTable(olapBaseTable,
+                    queryRewriteParams.isQueryRewrite());
             if (baseUpdatedPartitionNames == null) {
                 return null;
             }
             PCellSortedSet updatedPCellSet = PCellUtils.ofOlapTable(olapBaseTable, baseUpdatedPartitionNames);
             // recursive check its children
             if (withMv && baseTable.isMaterializedView()) {
-                MvUpdateInfo mvUpdateInfo = getMVTimelinessUpdateInfo((MaterializedView) baseTable, isQueryRewrite);
+                MvUpdateInfo mvUpdateInfo = getMVTimelinessUpdateInfo((MaterializedView) baseTable, queryRewriteParams);
                 if (mvUpdateInfo == null || !mvUpdateInfo.isValidRewrite()) {
                     return null;
                 }
@@ -188,7 +192,8 @@ public class MvRefreshArbiter {
             // update base table's partition info
             baseTableUpdateInfo.addToRefreshPartitionNames(updatedPCellSet);
         } else {
-            Set<String> baseUpdatedPartitionNames = mv.getUpdatedPartitionNamesOfExternalTable(baseTable, isQueryRewrite);
+            Set<String> baseUpdatedPartitionNames = mv.getUpdatedPartitionNamesOfExternalTable(baseTable,
+                    queryRewriteParams.isQueryRewrite());
             if (baseUpdatedPartitionNames == null) {
                 return null;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
@@ -15,6 +15,7 @@
 package com.starrocks.catalog.mv;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Stopwatch;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import com.starrocks.catalog.BaseTableInfo;
@@ -30,6 +31,7 @@ import com.starrocks.catalog.TableProperty;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.common.PCellSetMapping;
 import com.starrocks.sql.common.PCellSortedSet;
 import com.starrocks.sql.common.PCellUtils;
@@ -37,6 +39,7 @@ import com.starrocks.sql.common.PCellWithName;
 import com.starrocks.sql.common.PartitionDiff;
 import com.starrocks.sql.common.PartitionDiffResult;
 import com.starrocks.sql.common.PartitionDiffer;
+import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
@@ -46,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static com.starrocks.catalog.MvRefreshArbiter.getMvBaseTableUpdateInfo;
@@ -68,9 +72,59 @@ public abstract class MVTimelinessArbiter {
     // whether is query rewrite or mv refresh
     protected final boolean isQueryRewrite;
 
-    public MVTimelinessArbiter(MaterializedView mv, boolean isQueryRewrite) {
+    // parameters for query rewrite
+    public static class QueryRewriteParams {
+        private final boolean isQueryRewrite;
+        private final OptimizerContext optimizerContext;
+        private final long timeLimit;
+        private long loopCounter = 0;
+
+        public QueryRewriteParams(boolean isQueryRewrite, OptimizerContext optimizerContext) {
+            this.isQueryRewrite = isQueryRewrite;
+            this.optimizerContext = optimizerContext;
+            if (optimizerContext != null) {
+                SessionVariable sessionVariable = optimizerContext.getSessionVariable();
+                this.timeLimit = Math.max(sessionVariable.getOptimizerExecuteTimeout() / 2, 1000);
+            } else {
+                this.timeLimit = -1;
+            }
+        }
+
+        public static QueryRewriteParams ofRefresh() {
+            return new QueryRewriteParams(false, null);
+        }
+
+        public static QueryRewriteParams ofQueryRewrite(OptimizerContext optimizerContext) {
+            return new QueryRewriteParams(true, optimizerContext);
+        }
+
+        public void checkQueryRewriteExhausted() {
+            if (!isQueryRewrite || timeLimit <= 0) {
+                return;
+            }
+            // to avoid too frequent check, check every 100 loops
+            if (++loopCounter % 100 != 0) {
+                return;
+            }
+            Stopwatch stopwatch = optimizerContext.getOptimizerTimer();
+            long elapsed = stopwatch.elapsed(TimeUnit.MILLISECONDS);
+            if (elapsed > timeLimit) {
+                throw new RuntimeException(String.format("Materialized view query rewrite time limit exceeded, " +
+                        ",time limit: %d ms, elapsed: %d ms", timeLimit, elapsed));
+            }
+        }
+
+        public boolean isQueryRewrite() {
+            return isQueryRewrite;
+        }
+    }
+    protected final QueryRewriteParams queryRewriteParams;
+
+    public MVTimelinessArbiter(MaterializedView mv,
+                               QueryRewriteParams queryRewriteParams) {
         this.mv = mv;
-        this.isQueryRewrite = isQueryRewrite;
+        this.isQueryRewrite = queryRewriteParams.isQueryRewrite;
+        this.queryRewriteParams = queryRewriteParams;
     }
 
     /**
@@ -132,7 +186,7 @@ public abstract class MVTimelinessArbiter {
                 return true;
             }
             // If the non-ref table has already changed, need refresh all materialized views' partitions.
-            if (needsToRefreshTable(mv, tableInfo, baseTable, isQueryRewrite)) {
+            if (needsToRefreshTable(mv, tableInfo, baseTable, queryRewriteParams)) {
                 return true;
             }
         }
@@ -181,7 +235,7 @@ public abstract class MVTimelinessArbiter {
         Map<Table, PCellSortedSet> baseChangedPartitionNames = Maps.newHashMap();
         for (Table baseTable : refBaseTableAndColumns.keySet()) {
             MvBaseTableUpdateInfo mvBaseTableUpdateInfo = getMvBaseTableUpdateInfo(mv, baseTable,
-                    true, isQueryRewrite);
+                    true, queryRewriteParams);
             mvUpdateInfo.getBaseTableUpdateInfos().put(baseTable, mvBaseTableUpdateInfo);
             // If base table is a mv, its to-update partitions may not be created yet, skip it
             baseChangedPartitionNames.put(baseTable, mvBaseTableUpdateInfo.getToRefreshPCells());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessArbiter.java
@@ -69,8 +69,6 @@ public abstract class MVTimelinessArbiter {
     protected final MaterializedView mv;
     // differ
     protected PartitionDiffer differ;
-    // whether is query rewrite or mv refresh
-    protected final boolean isQueryRewrite;
 
     // parameters for query rewrite
     public static class QueryRewriteParams {
@@ -117,13 +115,16 @@ public abstract class MVTimelinessArbiter {
         public boolean isQueryRewrite() {
             return isQueryRewrite;
         }
+
+        public OptimizerContext getOptimizerContext() {
+            return optimizerContext;
+        }
     }
     protected final QueryRewriteParams queryRewriteParams;
 
     public MVTimelinessArbiter(MaterializedView mv,
                                QueryRewriteParams queryRewriteParams) {
         this.mv = mv;
-        this.isQueryRewrite = queryRewriteParams.isQueryRewrite;
         this.queryRewriteParams = queryRewriteParams;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessListPartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessListPartitionArbiter.java
@@ -41,9 +41,9 @@ import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVPrepare;
 public final class MVTimelinessListPartitionArbiter extends MVTimelinessArbiter {
     private static final Logger LOG = LogManager.getLogger(MVTimelinessListPartitionArbiter.class);
 
-    public MVTimelinessListPartitionArbiter(MaterializedView mv, boolean isQueryRewrite) {
-        super(mv, isQueryRewrite);
-        differ = new ListPartitionDiffer(mv, isQueryRewrite);
+    public MVTimelinessListPartitionArbiter(MaterializedView mv, QueryRewriteParams queryRewriteParams) {
+        super(mv, queryRewriteParams);
+        differ = new ListPartitionDiffer(mv, queryRewriteParams);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessNonPartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessNonPartitionArbiter.java
@@ -36,8 +36,8 @@ import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVPrepare;
 public final class MVTimelinessNonPartitionArbiter extends MVTimelinessArbiter {
     private static final Logger LOG = LogManager.getLogger(MVTimelinessNonPartitionArbiter.class);
 
-    public MVTimelinessNonPartitionArbiter(MaterializedView mv, boolean isQueryRewrite) {
-        super(mv, isQueryRewrite);
+    public MVTimelinessNonPartitionArbiter(MaterializedView mv, QueryRewriteParams queryRewriteParams) {
+        super(mv, queryRewriteParams);
     }
 
     /**
@@ -67,7 +67,7 @@ public final class MVTimelinessNonPartitionArbiter extends MVTimelinessArbiter {
             }
 
             // once mv's base table has updated, refresh the materialized view totally.
-            MvBaseTableUpdateInfo mvBaseTableUpdateInfo = getMvBaseTableUpdateInfo(mv, table, true, isQueryRewrite);
+            MvBaseTableUpdateInfo mvBaseTableUpdateInfo = getMvBaseTableUpdateInfo(mv, table, true, queryRewriteParams);
             // TODO: fixme if mvBaseTableUpdateInfo is null, should return full refresh?
             if (mvBaseTableUpdateInfo != null &&
                     mvBaseTableUpdateInfo.getToRefreshPCells() != null &&

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessRangePartitionArbiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/mv/MVTimelinessRangePartitionArbiter.java
@@ -47,9 +47,9 @@ import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVPrepare;
 public final class MVTimelinessRangePartitionArbiter extends MVTimelinessArbiter {
     private static final Logger LOG = LogManager.getLogger(MVTimelinessRangePartitionArbiter.class);
 
-    public MVTimelinessRangePartitionArbiter(MaterializedView mv, boolean isQueryRewrite) {
-        super(mv, isQueryRewrite);
-        this.differ = new RangePartitionDiffer(mv, isQueryRewrite, null);
+    public MVTimelinessRangePartitionArbiter(MaterializedView mv, QueryRewriteParams queryRewriteParams) {
+        super(mv, queryRewriteParams);
+        this.differ = new RangePartitionDiffer(mv, queryRewriteParams, null);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -3578,6 +3578,13 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "Whether enable to cache mv query context or not")
     public static boolean enable_mv_query_context_cache = true;
 
+    @ConfField(mutable = true, comment = "Whether enable to cache mv global context or not which its lifecycle is " +
+            "as the same with the mv")
+    public static boolean enable_mv_global_context_cache = true;
+
+    @ConfField(mutable = true, comment = "Max materialized view global context cache size during one mv's lifecycle.")
+    public static long mv_global_context_cache_max_size = 5000;
+
     @ConfField(mutable = true, comment = "Mv refresh fails if there is filtered data, true by default")
     public static boolean mv_refresh_fail_on_filter_data = true;
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVTimelinessMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVTimelinessMgr.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvRefreshArbiter;
 import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.catalog.TableProperty;
+import com.starrocks.catalog.mv.MVTimelinessArbiter;
 import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.memory.MemoryTrackable;
@@ -50,12 +51,13 @@ public class MVTimelinessMgr implements MemoryTrackable {
         MV_PARTITION_DROPPED,
     }
 
-    public MvUpdateInfo getMVTimelinessInfo(MaterializedView mv) {
+    public MvUpdateInfo getMVTimelinessInfo(MaterializedView mv,
+                                            MVTimelinessArbiter.QueryRewriteParams queryRewriteParams) {
         if (!isEnableMVTimelinessGlobalCache(mv)) {
-            return MvRefreshArbiter.getMVTimelinessUpdateInfo(mv, true);
+            return MvRefreshArbiter.getMVTimelinessUpdateInfo(mv, queryRewriteParams);
         } else {
             return mvTimelinessMap.computeIfAbsent(mv,
-                    (ignored) -> MvRefreshArbiter.getMVTimelinessUpdateInfo(mv, true));
+                    (ignored) -> MvRefreshArbiter.getMVTimelinessUpdateInfo(mv, queryRewriteParams));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshListPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshListPartitioner.java
@@ -87,7 +87,7 @@ public final class MVPCTRefreshListPartitioner extends MVPCTRefreshPartitioner {
                                        MaterializedView mv,
                                        MVRefreshParams mvRefreshParams) {
         super(mvContext, context, db, mv, mvRefreshParams);
-        this.differ = new ListPartitionDiffer(mv, false);
+        this.differ = new ListPartitionDiffer(mv, queryRewriteParams);
         this.logger = MVTraceUtils.getLogger(mv, MVPCTRefreshListPartitioner.class);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshNonPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshNonPartitioner.java
@@ -82,7 +82,7 @@ public final class MVPCTRefreshNonPartitioner extends MVPCTRefreshPartitioner {
     @Override
     public PCellSortedSet getMVPartitionsToRefreshWithCheck(Map<Long, BaseTableSnapshotInfo> snapshotBaseTables) {
         // non-partitioned materialized view
-        if (mvRefreshParams.isForce() || isNonPartitionedMVNeedToRefresh(snapshotBaseTables, mv)) {
+        if (mvRefreshParams.isForce() || isNonPartitionedMVNeedToRefresh(snapshotBaseTables, mv, queryRewriteParams)) {
             return getNonPartitionedMVPartitionsToRefresh();
         }
         return PCellSortedSet.of();

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshPartitioner.java
@@ -89,13 +89,13 @@ public abstract class MVPCTRefreshPartitioner {
             Table.TableType.HUDI,
             Table.TableType.DELTALAKE
     );
+    private final Logger logger;
 
     protected final MvTaskRunContext mvContext;
     protected final TaskRunContext context;
     protected final Database db;
     protected final MaterializedView mv;
     protected final MVRefreshParams mvRefreshParams;
-    protected final Logger logger;
     protected final MVTimelinessArbiter.QueryRewriteParams queryRewriteParams;
 
     // The partitions to refresh for mv which is filtered before various filter actions.

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshRangePartitioner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/pct/MVPCTRefreshRangePartitioner.java
@@ -89,7 +89,7 @@ public final class MVPCTRefreshRangePartitioner extends MVPCTRefreshPartitioner 
                                         MaterializedView mv,
                                         MVRefreshParams mvRefreshParams) {
         super(mvContext, context, db, mv, mvRefreshParams);
-        this.differ = new RangePartitionDiffer(mv, false, null);
+        this.differ = new RangePartitionDiffer(mv, queryRewriteParams, null);
         this.logger = MVTraceUtils.getLogger(mv, MVPCTRefreshRangePartitioner.class);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/ListPartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/ListPartitionDiffer.java
@@ -380,7 +380,7 @@ public final class ListPartitionDiffer extends PartitionDiffer {
 
         // collect external partition column mapping
         Map<Table, PartitionNameSetMap> externalPartitionMaps = Maps.newHashMap();
-        if (!isQueryRewrite) {
+        if (!queryRewriteParams.isQueryRewrite()) {
             try {
                 collectExternalPartitionNameMapping(mv.getRefBaseTablePartitionColumns(), externalPartitionMaps);
             } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PCellWithName.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PCellWithName.java
@@ -14,7 +14,19 @@
 
 package com.starrocks.sql.common;
 
+import com.google.common.collect.Range;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.SlotRef;
+import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
+
+import java.util.Comparator;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * PCellWithName is a record that associates a partition name with a PCell.
@@ -56,5 +68,101 @@ public record PCellWithName(String name, PCell cell) implements Comparable<PCell
         }
         // if pcell is equal, compare by partition name
         return this.name.compareTo(o.name);
+    }
+
+    /**
+     * For base table's partition name & partition range cell, its associated pcell cache key should only remapped to one
+     * pRangeCellPlus.
+     */
+    public static class PCellCacheKey {
+        private final Table refBaseTable;
+        private final PCellWithName pCellWithName;
+
+        public PCellCacheKey(Table refBaseTable,
+                             PCellWithName pCellWithName) {
+            this.refBaseTable = refBaseTable;
+            this.pCellWithName = pCellWithName;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            PCellCacheKey that = (PCellCacheKey) o;
+            return Objects.equals(refBaseTable, that.refBaseTable) &&
+                    Objects.equals(pCellWithName, that.pCellWithName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(refBaseTable, pCellWithName);
+        }
+    }
+
+    /**
+     * This is a help class to keep the original base cell and normalized cell at the same time.
+     * @param basePCell original base cell
+     * @param normalized normalized cell
+     */
+    public record PCellWithNorm(PCellWithName basePCell, PCellWithName normalized) {
+        public static PCellWithNorm of(PCellWithName basePCell, PCellWithName normalized) {
+            return  new PCellWithNorm(basePCell, normalized);
+        }
+    }
+
+    /**
+     * Convert a range map to list of partition range cell plus which is sorted by range cell.
+     */
+    public static List<PCellWithNorm> normalizePCellWithNames(MaterializedView mv, Table refBaseTable,
+                                                              PCellSortedSet rangeMap, Expr expr) {
+        if (expr == null || expr instanceof SlotRef) {
+            return rangeMap.getPartitions().stream()
+                    .map(p -> PCellWithNorm.of(p, p))
+                    .collect(Collectors.toList());
+        }
+        return rangeMap.getPartitions()
+                .stream()
+                .map(pCell -> PCellWithNorm.of(pCell, toNormalizedCell(mv, refBaseTable, pCell, expr)))
+                // sort by normalized pcell
+                .sorted(new Comparator<PCellWithNorm>() {
+                    @Override
+                    public int compare(PCellWithNorm o1, PCellWithNorm o2) {
+                        return o1.normalized.compareTo(o2.normalized);
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+
+    private static PCellWithName toNormalizedCell(MaterializedView mv, Table refBaseTable,
+                                                  PCellWithName pCellWithName, Expr expr) {
+        // for simple expr, no need to do conversion
+        if (expr == null || expr instanceof SlotRef) {
+            return pCellWithName;
+        }
+        if (Config.enable_mv_global_context_cache) {
+            CachingMvPlanContextBuilder.MVCacheEntity mvCacheEntity = CachingMvPlanContextBuilder.getMVCache(mv);
+            PCellCacheKey cacheKey = new PCellCacheKey(refBaseTable, pCellWithName);
+            Object cacheValue = mvCacheEntity.get(cacheKey, () -> toNormalizedCell(pCellWithName, expr));
+            if (cacheValue != null && cacheValue instanceof PCellWithName) {
+                return (PCellWithName) cacheValue;
+            } else {
+                return toNormalizedCell(pCellWithName, expr);
+            }
+        } else {
+            return toNormalizedCell(pCellWithName, expr);
+        }
+    }
+
+    public static PCellWithName toNormalizedCell(PCellWithName pCellWithName, Expr expr) {
+        if (expr == null || expr instanceof SlotRef) {
+            return pCellWithName;
+        }
+        Range<PartitionKey> partitionKeyRanges = ((PRangeCell) pCellWithName.cell()).getRange();
+        Range<PartitionKey> convertRanges = SyncPartitionUtils.convertToDatePartitionRange(partitionKeyRanges);
+        return new PCellWithName(pCellWithName.name(), new PRangeCell(SyncPartitionUtils.transferRange(convertRanges, expr)));
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
@@ -34,13 +34,11 @@ public abstract class PartitionDiffer {
     protected final MaterializedView mv;
     // whether it's used for query rewrite or refresh, the difference is that query rewrite will not
     // consider partition_ttl_number and mv refresh will consider it to avoid creating too much partitions
-    protected final boolean isQueryRewrite;
     protected final MVTimelinessArbiter.QueryRewriteParams queryRewriteParams;
 
     public PartitionDiffer(MaterializedView mv, MVTimelinessArbiter.QueryRewriteParams queryRewriteParams) {
         this.mv = mv;
         this.queryRewriteParams = queryRewriteParams;
-        this.isQueryRewrite = queryRewriteParams.isQueryRewrite();
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
@@ -19,6 +19,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.mv.MVTimelinessArbiter;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.connector.PartitionUtil;
 
@@ -34,10 +35,12 @@ public abstract class PartitionDiffer {
     // whether it's used for query rewrite or refresh, the difference is that query rewrite will not
     // consider partition_ttl_number and mv refresh will consider it to avoid creating too much partitions
     protected final boolean isQueryRewrite;
+    protected final MVTimelinessArbiter.QueryRewriteParams queryRewriteParams;
 
-    public PartitionDiffer(MaterializedView mv, boolean isQueryRewrite) {
+    public PartitionDiffer(MaterializedView mv, MVTimelinessArbiter.QueryRewriteParams queryRewriteParams) {
         this.mv = mv;
-        this.isQueryRewrite = isQueryRewrite;
+        this.queryRewriteParams = queryRewriteParams;
+        this.isQueryRewrite = queryRewriteParams.isQueryRewrite();
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/RangePartitionDiffer.java
@@ -379,7 +379,7 @@ public final class RangePartitionDiffer extends PartitionDiffer {
             //
             // Diff_{deletes} = P_{MV} \setminus P_{\bigcup_{baseTables}^{}} \\
             //                = \bigcap_{baseTables} P_{MV}\setminus P_{baseTable}
-            RangePartitionDiffer differ = isQueryRewrite ? null
+            RangePartitionDiffer differ = queryRewriteParams.isQueryRewrite() ? null
                     : new RangePartitionDiffer(mv, queryRewriteParams, rangeToInclude);
             PartitionDiff rangePartitionDiff = PartitionUtil.getPartitionDiff(mvPartitionExpr, mergedRBTPartitionKeyMap,
                     mvPartitionCells, differ);
@@ -388,7 +388,7 @@ public final class RangePartitionDiffer extends PartitionDiffer {
                 return null;
             }
             Map<Table, PartitionNameSetMap> extRBTMVPartitionNameMap = Maps.newHashMap();
-            if (!isQueryRewrite) {
+            if (!queryRewriteParams.isQueryRewrite()) {
                 // To solve multi partition columns' problem of external table, record the mv partition name to all the same
                 // partition names map here.
                 collectExternalPartitionNameMapping(refBaseTablePartitionColumns, extRBTMVPartitionNameMap);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
@@ -443,4 +443,16 @@ public class CachingMvPlanContextBuilder {
             }
         });
     }
+
+    public static String getMVPlanCacheStats() {
+        return MV_PLAN_CONTEXT_CACHE.synchronous().stats().toString();
+    }
+
+    public static String getMVGlobalContextCacheStats(MaterializedView mv) {
+        MVCacheEntity mvCacheEntity = MV_GLOBAL_CONTEXT_CACHE_MAP.get(mv);
+        if (mvCacheEntity != null) {
+            return mvCacheEntity.cache.stats().toString();
+        }
+        return "";
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -44,6 +44,7 @@ import com.starrocks.catalog.RandomDistributionInfo;
 import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.mv.MVPlanValidationResult;
+import com.starrocks.catalog.mv.MVTimelinessArbiter;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
@@ -731,11 +732,13 @@ public class MvRewritePreprocessor {
 
         List<Pair<MaterializedViewWrapper, MvUpdateInfo>> mvInfos =
                 Lists.newArrayListWithExpectedSize(mvWithPlanContexts.size());
+        MVTimelinessArbiter.QueryRewriteParams queryRewriteParams =
+                MVTimelinessArbiter.QueryRewriteParams.ofQueryRewrite(context);
         for (MaterializedViewWrapper wrapper : mvWithPlanContexts) {
             MaterializedView mv = wrapper.getMV();
             try {
                 // mv's partitions to refresh
-                MvUpdateInfo mvUpdateInfo = queryMaterializationContext.getOrInitMVTimelinessInfos(mv);
+                MvUpdateInfo mvUpdateInfo = queryMaterializationContext.getOrInitMVTimelinessInfos(mv, queryRewriteParams);
                 if (mvUpdateInfo == null || !mvUpdateInfo.isValidRewrite()) {
                     OptimizerTraceUtil.logMVRewriteFailReason(mv.getName(), "stale partitions {}", mvUpdateInfo);
                     continue;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -195,6 +195,9 @@ public class MvRewritePreprocessor {
                 if (queryMaterializationContext.getValidCandidateMVs().size() > 1) {
                     queryMaterializationContext.setEnableQueryContextCache(true);
                 }
+
+                // record the current MV plan cache stats
+                Tracers.record("MVPlanCacheStats", CachingMvPlanContextBuilder.getMVPlanCacheStats());
             } catch (Exception e) {
                 List<String> tableNames = queryTables.stream().map(Table::getName).collect(Collectors.toList());
                 logMVPrepare(connectContext, "Prepare query tables {} for mv failed:{}",
@@ -858,7 +861,8 @@ public class MvRewritePreprocessor {
             
             try {
                 future.get(individualTimeoutMs, TimeUnit.MILLISECONDS);
-                // Success - no action needed
+                // record MV global cache stats after successful preparation
+                Tracers.record("MVGlobalCacheStats", CachingMvPlanContextBuilder.getMVGlobalContextCacheStats(mv));
             } catch (TimeoutException e) {
                 LOG.warn("MV {} preparation timeout after {} ms", mvName, individualTimeoutMs);
                 timeoutMvNames.add(mvName);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -199,10 +199,16 @@ public class MvRewritePreprocessor {
                 // record the current MV plan cache stats
                 Tracers.record("MVPlanCacheStats", CachingMvPlanContextBuilder.getMVPlanCacheStats());
             } catch (Exception e) {
-                List<String> tableNames = queryTables.stream().map(Table::getName).collect(Collectors.toList());
-                logMVPrepare(connectContext, "Prepare query tables {} for mv failed:{}",
-                        tableNames, DebugUtil.getStackTrace(e));
-                LOG.warn("Prepare query tables {} for mv failed", tableNames, e);
+                try {
+                    List<String> tableNames = queryTables.stream().map(Table::getName).collect(Collectors.toList());
+                    logMVPrepare(connectContext, "Prepare query tables {} for mv failed:{}",
+                            tableNames, DebugUtil.getStackTrace(e));
+                    LOG.warn("Prepare query tables {} for mv failed", tableNames, e);
+                } catch (Throwable traceLogException) {
+                    // ignore all exception in mv rewrite prepare
+                    LOG.warn("Failed to log mv rewrite prepare exception: {}",
+                            DebugUtil.getStackTrace(traceLogException));
+                }
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
@@ -301,6 +301,10 @@ public class OptimizerContext {
         return uniquePartitionIdGenerator++;
     }
 
+    public Stopwatch getOptimizerTimer() {
+        return optimizerTimer;
+    }
+
     /**
      * Throw exception if reach optimizer timeout
      */

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryMaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryMaterializationContext.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Maps;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvUpdateInfo;
+import com.starrocks.catalog.mv.MVTimelinessArbiter;
 import com.starrocks.common.Config;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.persist.gson.GsonUtils;
@@ -232,13 +233,14 @@ public class QueryMaterializationContext {
      * @param mv intput mv
      * @return MvUpdateInfo of the mv, null if mv is null or initialize fail
      */
-    public MvUpdateInfo getOrInitMVTimelinessInfos(MaterializedView mv) {
+    public MvUpdateInfo getOrInitMVTimelinessInfos(MaterializedView mv,
+                                                   MVTimelinessArbiter.QueryRewriteParams queryRewriteParams) {
         if (mv == null) {
             return null;
         }
         if (!mvTimelinessInfos.containsKey(mv)) {
             MVTimelinessMgr mvTimelinessMgr = GlobalStateMgr.getCurrentState().getMaterializedViewMgr().getMvTimelinessMgr();
-            MvUpdateInfo result = mvTimelinessMgr.getMVTimelinessInfo(mv);
+            MvUpdateInfo result = mvTimelinessMgr.getMVTimelinessInfo(mv, queryRewriteParams);
             mvTimelinessInfos.put(mv, result);
             return result;
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MaterializedViewTransparentRewriteRule.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
+import com.starrocks.catalog.mv.MVTimelinessArbiter;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.optimizer.MaterializationContext;
@@ -173,7 +174,9 @@ public class MaterializedViewTransparentRewriteRule extends TransformationRule {
 
         // mv's to refresh partition info
         QueryMaterializationContext queryMaterializationContext = context.getQueryMaterializationContext();
-        MvUpdateInfo mvUpdateInfo = queryMaterializationContext.getOrInitMVTimelinessInfos(mv);
+        MVTimelinessArbiter.QueryRewriteParams queryRewriteParams =
+                MVTimelinessArbiter.QueryRewriteParams.ofQueryRewrite(context);
+        MvUpdateInfo mvUpdateInfo = queryMaterializationContext.getOrInitMVTimelinessInfos(mv, queryRewriteParams);
         if (mvUpdateInfo == null || !mvUpdateInfo.isValidRewrite()) {
             logMVRewrite(context, this, "Get mv to refresh partition info failed, and redirect to mv's defined query");
             return getOptExpressionByDefault(context, mv, mvPlanContext, olapScanOperator, queryTables);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/TextMatchBasedRewriteRule.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
+import com.starrocks.catalog.mv.MVTimelinessArbiter;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.PropertyAnalyzer;
@@ -220,6 +221,8 @@ public class TextMatchBasedRewriteRule extends Rule {
                 return null;
             }
             int mvRelatedCount = 0;
+            MVTimelinessArbiter.QueryRewriteParams queryRewriteParams =
+                    MVTimelinessArbiter.QueryRewriteParams.ofQueryRewrite(context);
             for (MaterializedView mv : candidateMvs) {
                 Pair<Boolean, String> status = isValidForTextBasedRewrite(context, mv);
                 if (!status.first) {
@@ -232,7 +235,7 @@ public class TextMatchBasedRewriteRule extends Rule {
                 if (mvRelatedCount++ > mvRewriteRelatedMVsLimit) {
                     return null;
                 }
-                MvUpdateInfo mvUpdateInfo = queryMaterializationContext.getOrInitMVTimelinessInfos(mv);
+                MvUpdateInfo mvUpdateInfo = queryMaterializationContext.getOrInitMVTimelinessInfos(mv, queryRewriteParams);
                 if (mvUpdateInfo == null || !mvUpdateInfo.isValidRewrite()) {
                     logMVRewrite(context, this, "MV {} cannot be used for rewrite, " +
                             "stale partitions {}", mv.getName(), mvUpdateInfo);

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -32,6 +32,7 @@ import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.statistic.StatisticsMetaManager;
 import com.starrocks.thrift.TExplainLevel;
+import com.starrocks.utframe.StarRocksTestExtension;
 import com.starrocks.utframe.UtFrameUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -40,6 +41,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 
@@ -50,6 +52,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @State(Scope.Thread) // Add State annotation with appropriate scope
+@ExtendWith(StarRocksTestExtension.class)
 public class MaterializedViewTestBase extends PlanTestBase {
     protected static final Logger LOG = LogManager.getLogger(MaterializedViewTestBase.class);
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/PCellWithNameTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/PCellWithNameTest.java
@@ -17,10 +17,16 @@ package com.starrocks.sql.common;
 import com.google.common.collect.Range;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.planner.SlotId;
+import com.starrocks.sql.ast.expression.Expr;
+import com.starrocks.sql.ast.expression.SlotRef;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.NavigableSet;
+import java.util.TreeSet;
 
 public class PCellWithNameTest {
     @Test
@@ -54,5 +60,118 @@ public class PCellWithNameTest {
         Assertions.assertEquals(-1, cell4.compareTo(cell5));
         Assertions.assertEquals(1, cell4.compareTo(cell6));
         Assertions.assertEquals(1, cell5.compareTo(cell6));
+    }
+
+    @Test
+    public void pCellCacheKeyEqualsAndHashCode_whenSamePCellAndNullTable() throws Exception {
+        final String partitionName = "p1";
+        final PartitionKey key1 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 10, 0, 0));
+        final PartitionKey key2 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 11, 0, 0));
+
+        Range<PartitionKey> r1 = Range.closed(key1, key2);
+        PCellWithName pcell = new PCellWithName(partitionName, new PRangeCell(r1));
+        PCellWithName samePCell = new PCellWithName(partitionName, new PRangeCell(r1));
+        PCellWithName differentPCell = new PCellWithName("p2", new PRangeCell(r1));
+
+        PCellWithName.PCellCacheKey keyA = new PCellWithName.PCellCacheKey(null, pcell);
+        PCellWithName.PCellCacheKey keyB = new PCellWithName.PCellCacheKey(null, samePCell);
+        PCellWithName.PCellCacheKey keyC = new PCellWithName.PCellCacheKey(null, differentPCell);
+
+        Assertions.assertEquals(keyA, keyA);
+        Assertions.assertEquals(keyA, keyB);
+        Assertions.assertEquals(keyA.hashCode(), keyB.hashCode());
+        Assertions.assertNotEquals(keyA, keyC);
+    }
+
+    @Test
+    public void pCellCacheKeyNotEqual_whenDifferentTableOrPCell() throws Exception {
+        final String partitionName = "p1";
+        final PartitionKey key1 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 10, 0, 0));
+        final PartitionKey key2 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 11, 0, 0));
+
+        Range<PartitionKey> r1 = Range.closed(key1, key2);
+        PCellWithName pcell1 = new PCellWithName(partitionName, new PRangeCell(r1));
+        PCellWithName pcell2 = new PCellWithName("p2", new PRangeCell(r1));
+
+        PCellWithName.PCellCacheKey keyNull = new PCellWithName.PCellCacheKey(null, pcell1);
+        PCellWithName.PCellCacheKey keyOtherPCell = new PCellWithName.PCellCacheKey(null, pcell2);
+
+        Assertions.assertNotEquals(keyNull, keyOtherPCell);
+    }
+
+    @Test
+    public void pCellWithNormOf_returnsProvidedBaseAndNormalized() throws Exception {
+        final String partitionName = "p1";
+        final PartitionKey key1 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 10, 0, 0));
+        final PartitionKey key2 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 11, 0, 0));
+
+        Range<PartitionKey> r1 = Range.closed(key1, key2);
+        PCellWithName base = new PCellWithName(partitionName, new PRangeCell(r1));
+        PCellWithName normalized = new PCellWithName("p_norm", new PRangeCell(r1));
+
+        PCellWithName.PCellWithNorm norm = PCellWithName.PCellWithNorm.of(base, normalized);
+        Assertions.assertEquals(base, norm.basePCell());
+        Assertions.assertEquals(normalized, norm.normalized());
+    }
+
+    @Test
+    public void normalizePCellWithNames_returnsIdentityList_whenExprIsNull() throws Exception {
+        final String partitionName1 = "p1";
+        final String partitionName2 = "p2";
+        final PartitionKey k1 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 10, 0, 0));
+        final PartitionKey k2 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 11, 0, 0));
+        final PartitionKey k3 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 12, 0, 0));
+        final PartitionKey k4 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 13, 0, 0));
+
+        Range<PartitionKey> r1 = Range.closed(k1, k2);
+        Range<PartitionKey> r2 = Range.closed(k3, k4);
+        PCellWithName p1 = new PCellWithName(partitionName1, new PRangeCell(r1));
+        PCellWithName p2 = new PCellWithName(partitionName2, new PRangeCell(r2));
+
+        // Provide a minimal PCellSortedSet by overriding getPartitions()
+        PCellSortedSet rangeMap = new PCellSortedSet(new TreeSet<>()) {
+            @Override
+            public NavigableSet<PCellWithName> getPartitions() {
+                return new TreeSet<>(List.of(p1, p2));
+            }
+        };
+
+        List<PCellWithName.PCellWithNorm> result = PCellWithName.normalizePCellWithNames(null, null, rangeMap, null);
+        Assertions.assertEquals(2, result.size());
+        Assertions.assertSame(result.get(0).basePCell(), result.get(0).normalized());
+        Assertions.assertSame(result.get(1).basePCell(), result.get(1).normalized());
+    }
+
+    @Test
+    public void normalizePCellWithNames_returnsIdentityList_whenExprIsSlotRef() throws Exception {
+        final String partitionName1 = "p1";
+        final PartitionKey k1 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 10, 0, 0));
+        final PartitionKey k2 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 11, 0, 0));
+        Range<PartitionKey> r1 = Range.closed(k1, k2);
+        PCellWithName p1 = new PCellWithName(partitionName1, new PRangeCell(r1));
+
+        PCellSortedSet rangeMap = new PCellSortedSet(new TreeSet<>()) {
+            @Override
+            public NavigableSet<PCellWithName> getPartitions() {
+                return new TreeSet(List.of(p1));
+            }
+        };
+
+        Expr slotRef = new SlotRef(new SlotId(9));
+        List<PCellWithName.PCellWithNorm> result = PCellWithName.normalizePCellWithNames(null, null, rangeMap, slotRef);
+        Assertions.assertEquals(1, result.size());
+        Assertions.assertSame(result.get(0).basePCell(), result.get(0).normalized());
+    }
+
+    @Test
+    public void toNormalizedCell_returnsSameInstance_whenExprIsNullOrSlotRef() throws Exception {
+        final String partitionName = "p1";
+        final PartitionKey k1 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 10, 0, 0));
+        final PartitionKey k2 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 11, 0, 0));
+        Range<PartitionKey> r1 = Range.closed(k1, k2);
+        PCellWithName pcell = new PCellWithName(partitionName, new PRangeCell(r1));
+
+        Assertions.assertSame(pcell, PCellWithName.toNormalizedCell(pcell, null));
+        Assertions.assertSame(pcell, PCellWithName.toNormalizedCell(pcell, new SlotRef(new SlotId(1))));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/PCellWithNameTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/PCellWithNameTest.java
@@ -63,7 +63,7 @@ public class PCellWithNameTest {
     }
 
     @Test
-    public void pCellCacheKeyEqualsAndHashCode_whenSamePCellAndNullTable() throws Exception {
+    public void testPCellCacheKeyEqualsAndHashCode() throws Exception {
         final String partitionName = "p1";
         final PartitionKey key1 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 10, 0, 0));
         final PartitionKey key2 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 11, 0, 0));
@@ -84,7 +84,7 @@ public class PCellWithNameTest {
     }
 
     @Test
-    public void pCellCacheKeyNotEqual_whenDifferentTableOrPCell() throws Exception {
+    public void testPCellCacheKeyNotEqual() throws Exception {
         final String partitionName = "p1";
         final PartitionKey key1 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 10, 0, 0));
         final PartitionKey key2 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 11, 0, 0));
@@ -100,7 +100,7 @@ public class PCellWithNameTest {
     }
 
     @Test
-    public void pCellWithNormOf_returnsProvidedBaseAndNormalized() throws Exception {
+    public void testPCellWithNormOf() throws Exception {
         final String partitionName = "p1";
         final PartitionKey key1 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 10, 0, 0));
         final PartitionKey key2 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 11, 0, 0));
@@ -115,7 +115,7 @@ public class PCellWithNameTest {
     }
 
     @Test
-    public void normalizePCellWithNames_returnsIdentityList_whenExprIsNull() throws Exception {
+    public void testNormalizePCellWithNames1() throws Exception {
         final String partitionName1 = "p1";
         final String partitionName2 = "p2";
         final PartitionKey k1 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 10, 0, 0));
@@ -143,7 +143,7 @@ public class PCellWithNameTest {
     }
 
     @Test
-    public void normalizePCellWithNames_returnsIdentityList_whenExprIsSlotRef() throws Exception {
+    public void testNormalizePCellWithNames2() throws Exception {
         final String partitionName1 = "p1";
         final PartitionKey k1 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 10, 0, 0));
         final PartitionKey k2 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 11, 0, 0));
@@ -164,7 +164,7 @@ public class PCellWithNameTest {
     }
 
     @Test
-    public void toNormalizedCell_returnsSameInstance_whenExprIsNullOrSlotRef() throws Exception {
+    public void testtoNormalizedCell() throws Exception {
         final String partitionName = "p1";
         final PartitionKey k1 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 10, 0, 0));
         final PartitionKey k2 = PartitionKey.ofDateTime(LocalDateTime.of(2025, 5, 27, 11, 0, 0));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
@@ -318,7 +318,7 @@ public abstract class MVTestBase extends StarRocksTestBase {
         OptimizerContext optimizerContext = OptimizerFactory.initContext(connectContext,
                 new ColumnRefFactory());
         MVTimelinessArbiter.QueryRewriteParams queryRewriteParams =
-                MVTimelinessArbiter.QueryRewriteParams.ofRefresh();
+                MVTimelinessArbiter.QueryRewriteParams.ofQueryRewrite(optimizerContext);
         return MvRefreshArbiter.getMVTimelinessUpdateInfo(mv, queryRewriteParams);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVTestBase.java
@@ -28,6 +28,7 @@ import com.starrocks.catalog.MvUpdateInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
 import com.starrocks.catalog.View;
+import com.starrocks.catalog.mv.MVTimelinessArbiter;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
@@ -314,11 +315,15 @@ public abstract class MVTestBase extends StarRocksTestBase {
     }
 
     public static MvUpdateInfo getMvUpdateInfo(MaterializedView mv) {
-        return MvRefreshArbiter.getMVTimelinessUpdateInfo(mv, true);
+        OptimizerContext optimizerContext = OptimizerFactory.initContext(connectContext,
+                new ColumnRefFactory());
+        MVTimelinessArbiter.QueryRewriteParams queryRewriteParams =
+                MVTimelinessArbiter.QueryRewriteParams.ofRefresh();
+        return MvRefreshArbiter.getMVTimelinessUpdateInfo(mv, queryRewriteParams);
     }
 
     public static Set<String> getPartitionNamesToRefreshForMv(MaterializedView mv) {
-        MvUpdateInfo mvUpdateInfo = MvRefreshArbiter.getMVTimelinessUpdateInfo(mv, true);
+        MvUpdateInfo mvUpdateInfo = getMvUpdateInfo(mv);
         Preconditions.checkState(mvUpdateInfo != null);
         return mvUpdateInfo.getMVToRefreshPCells().getPartitionNames();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -59,6 +59,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableName;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.UserIdentity;
+import com.starrocks.catalog.mv.MVTimelinessArbiter;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
@@ -1286,11 +1287,12 @@ public class UtFrameUtils {
     public static void mockTimelinessForAsyncMVTest(ConnectContext connectContext) {
         new MockUp<MvRefreshArbiter>() {
             /**
-             * {@link MvRefreshArbiter#getMVTimelinessUpdateInfo(MaterializedView, boolean)}
+             * {@link MvRefreshArbiter#getMVTimelinessUpdateInfo(MaterializedView,
+             * com.starrocks.catalog.mv.MVTimelinessArbiter.QueryRewriteParams)}
              */
             @Mock
             public MvUpdateInfo getMVTimelinessUpdateInfo(MaterializedView mv,
-                                                          boolean isQueryRewrite) {
+                                                          MVTimelinessArbiter.QueryRewriteParams queryRewriteParams) {
                 return MvUpdateInfo.noRefresh(mv);
             }
         };


### PR DESCRIPTION
## Why I'm doing:

Fix some hotspots in mv rewrite path:

<img width="2506" height="1139" alt="image" src="https://github.com/user-attachments/assets/4cb171f2-b604-4403-aaf5-2f524015a7b2" />



<img width="2493" height="1090" alt="image" src="https://github.com/user-attachments/assets/9112ece5-a18c-4339-8eca-a4ea04f60af6" />



## What I'm doing:
Do optimizations as below:
- Add an MV global cache whose lifecycle is alongside MV's lifecycle to store some objects to avoid recomputing for each MV rewrite/refresh. 
- Align query rewrite's optimizer timeout into `RangeDiffer` to avoid mv preprocessor's timeout causing query's timeout.

Fixes #issue


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces query-aware MV timeliness parameters with timeout checks, adds a per-MV global context cache, and propagates these across rewrite/refresh paths to improve MV rewrite performance.
> 
> - **Core API/Refactor**:
>   - Replace boolean `isQueryRewrite` with `MVTimelinessArbiter.QueryRewriteParams` across `MvRefreshArbiter`, `MVTimeliness*Arbiter`, `PartitionDiffer`, `ListPartitionDiffer`, `RangePartitionDiffer`, PCT refresh partitioners, and rewrite rules.
>   - `QueryRewriteParams` carries optimizer context and enforces time-limited checks via `checkQueryRewriteExhausted`.
> - **Caching**:
>   - Add per-MV global context cache `CachingMvPlanContextBuilder.MVCacheEntity` with stats; invalidate on MV evict.
>   - Cache normalized partition cells in `PCellWithName` using MV global cache.
>   - Config: `enable_mv_global_context_cache`, `mv_global_context_cache_max_size`.
> - **Timeouts & Tracing**:
>   - Enforce per-loop timeout during partition mapping/diff in list/range differ via `QueryRewriteParams`.
>   - `MvRewritePreprocessor`: per-MV preparation with individual timeouts; record `MVPlanCacheStats` and `MVGlobalCacheStats`; improved exception-safe logging.
> - **Timeliness/Refresh**:
>   - `MVTimelinessMgr.getMVTimelinessInfo` accepts `QueryRewriteParams`.
>   - Propagate params through non/partitioned refresh partitioners and non-ref table checks.
> - **Tests/Config**:
>   - New/updated UTs for cache, timeout, and API changes; annotate test base with `StarRocksTestExtension`.
>   - Minor configs and utility updates supporting new cache and timeouts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e3455b773a4c292f0bc3c5a2c95fc0e3a4f0699. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->