### PR TITLE
[BugFix] fix json length check

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -538,7 +538,7 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
             }
         }
         if (getPrimitiveType().isJsonType() && other.getPrimitiveType().isCharFamily()) {
-            if (other.getStrLen() <= getPrimitiveType().getTypeSize()) {
+            if (other.getStrLen() < getPrimitiveType().getTypeSize()) {
                 throw new DdlException("JSON needs minimum length of " + getPrimitiveType().getTypeSize());
             }
         }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Minimal length is 1024, which should be allowed.

Fixes #https://github.com/StarRocks/StarRocksTest/issues/10673

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Permits schema change from JSON to CHAR/VARCHAR when target length equals the JSON minimum (e.g., 1024).
> 
> - **Catalog**
>   - In `Column.checkSchemaChangeAllowed`, relax JSON length check: change `<=` to `<` so converting JSON to `CHAR`/`VARCHAR` is allowed when target `strLen` equals `PrimitiveType.JSON.getTypeSize()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b81f3cd8a17459f13180465dde20dd4f2ea6c380. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->