### PR TITLE
[BugFix] Optimize metacache lock contention and reduce critical section

### DIFF
--- a/be/src/storage/lake/metacache.cpp
+++ b/be/src/storage/lake/metacache.cpp
@@ -16,6 +16,8 @@
 
 #include <bvar/bvar.h>
 
+#include <mutex>
+
 #include "gen_cpp/lake_types.pb.h"
 #include "runtime/exec_env.h"
 #include "storage/del_vector.h"
@@ -179,7 +181,7 @@ std::shared_ptr<const TabletSchema> Metacache::lookup_tablet_schema(std::string_
 }
 
 std::shared_ptr<Segment> Metacache::lookup_segment(std::string_view key) {
-    std::lock_guard<std::mutex> lock(_mutex);
+    std::shared_lock lock(_mutex);
     return _lookup_segment_no_lock(key);
 }
 
@@ -238,26 +240,40 @@ bool Metacache::lookup_aggregation_partition(std::string_view key) {
 }
 
 void Metacache::cache_segment(std::string_view key, std::shared_ptr<Segment> segment) {
-    std::lock_guard<std::mutex> lock(_mutex);
-    _cache_segment_no_lock(key, std::move(segment));
+    auto mem_cost = segment->mem_usage();
+    std::unique_lock lock(_mutex);
+    _cache_segment_no_lock(key, mem_cost, std::move(segment));
 }
 
-void Metacache::_cache_segment_no_lock(std::string_view key, std::shared_ptr<Segment> segment) {
-    auto mem_cost = segment->mem_usage();
+void Metacache::_cache_segment_no_lock(std::string_view key, size_t mem_cost, std::shared_ptr<Segment> segment) {
     auto value = std::make_unique<CacheValue>(std::move(segment));
     insert(key, value.release(), mem_cost);
 }
 
-std::shared_ptr<Segment> Metacache::cache_segment_if_absent(std::string_view key, std::shared_ptr<Segment> segment) {
-    std::lock_guard<std::mutex> lock(_mutex);
+std::shared_ptr<Segment> Metacache::cache_segment_if_absent(std::string_view key,
+                                                            const std::shared_ptr<Segment>& segment) {
+    auto mem_cost = segment->mem_usage();
+    std::unique_lock lock(_mutex);
     auto seg = _lookup_segment_no_lock(key);
     if (seg != nullptr) {
         // already exists, return the one in cache
         return seg;
     }
-    _cache_segment_no_lock(key, std::move(segment));
-    // it is possible that the `cache_segment` fails
+    _cache_segment_no_lock(key, mem_cost, segment);
     return _lookup_segment_no_lock(key);
+}
+
+intptr_t Metacache::cache_segment_if_present(std::string_view key, size_t mem_cost, intptr_t segment_addr_hint) {
+    std::unique_lock lock(_mutex);
+    auto seg = _lookup_segment_no_lock(key);
+    if (seg == nullptr) {
+        return 0;
+    }
+    if (segment_addr_hint != 0 && reinterpret_cast<intptr_t>(seg.get()) != segment_addr_hint) {
+        return 0;
+    }
+    _cache_segment_no_lock(key, mem_cost, std::move(seg));
+    return segment_addr_hint;
 }
 
 void Metacache::cache_delvec(std::string_view key, std::shared_ptr<const DelVector> delvec) {

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -164,18 +164,8 @@ Status TabletManager::drop_local_cache(const std::string& path) {
 }
 
 // current lru cache does not support updating value size, so use refill to update.
-void TabletManager::update_segment_cache_size(std::string_view key, intptr_t segment_addr_hint) {
-    // use write lock to protect parallel segment size update
-    std::unique_lock wrlock(_meta_lock);
-    auto segment = _metacache->lookup_segment(key);
-    if (segment == nullptr) {
-        return;
-    }
-    if (segment_addr_hint != 0 && segment_addr_hint != reinterpret_cast<intptr_t>(segment.get())) {
-        // the segment in cache is not the one as expected, skip the cache update
-        return;
-    }
-    _metacache->cache_segment(key, std::move(segment));
+void TabletManager::update_segment_cache_size(std::string_view key, size_t mem_cost, intptr_t segment_addr_hint) {
+    _metacache->cache_segment_if_present(key, mem_cost, segment_addr_hint);
 }
 
 void TabletManager::prune_metacache() {
@@ -1243,7 +1233,7 @@ StatusOr<SegmentPtr> TabletManager::load_segment(const FileInfo& segment_info, i
         if (fill_meta_cache) {
             // NOTE: the returned segment may be not the same as the parameter passed in
             // Use the one in cache if the same key already exists
-            if (auto cached_segment = metacache()->cache_segment_if_absent(segment_info.path, segment);
+            if (auto cached_segment = _metacache->cache_segment_if_absent(segment_info.path, segment);
                 cached_segment != nullptr) {
                 segment = cached_segment;
             }

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -235,7 +235,7 @@ public:
     // If segment_addr_hint is provided and it's non-zero, the cache size will be only updated when the
     // instance address matches the address provided by the segment_addr_hint. This is used to prevent
     // updating the cache size where the cached object is not the one as expected.
-    void update_segment_cache_size(std::string_view key, intptr_t segment_addr_hint = 0);
+    void update_segment_cache_size(std::string_view key, size_t mem_cost, intptr_t segment_addr_hint = 0);
 
     StatusOr<SegmentPtr> load_segment(const FileInfo& segment_info, int segment_id, size_t* footer_size_hint,
                                       const LakeIOOptions& lake_io_opts, bool fill_meta_cache,

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -651,7 +651,8 @@ size_t Segment::_column_index_mem_usage() const {
 
 void Segment::update_cache_size() {
     if (_tablet_manager != nullptr) {
-        _tablet_manager->update_segment_cache_size(file_name(), reinterpret_cast<intptr_t>(this));
+        auto mem_cost = mem_usage();
+        _tablet_manager->update_segment_cache_size(file_name(), mem_cost, reinterpret_cast<intptr_t>(this));
     }
 }
 


### PR DESCRIPTION
* Change Metacache lock to `std::shared_mutex` to allow concurrent segment lookups.
* Move `Segment::mem_usage()` calculation out of the Metacache lock critical section
  to reduce lock holding time.
* Introduce `Metacache::cache_segment_if_present` to atomically update cache
  entry memory usage only if the segment exists and matches the expected instance.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use shared locking for metacache lookups, compute segment mem cost outside locks, and add an API to atomically update cached segment size wired through TabletManager/Segment.
> 
> - **Concurrency & Locking**:
>   - Replace `std::mutex` with `std::shared_mutex` in `storage/lake/metacache.{h,cpp}`; use `std::shared_lock` for `lookup_segment` and `std::unique_lock` for writes.
> - **Cache update semantics & performance**:
>   - Move `Segment::mem_usage()` calculation outside metacache lock; pass `mem_cost` into `_cache_segment_no_lock` to reduce critical sections.
>   - Add `Metacache::cache_segment_if_present(key, mem_cost, segment_addr_hint)` to atomically refresh entry size only if present and matching.
> - **API changes & call sites**:
>   - Change `TabletManager::update_segment_cache_size` to `update_segment_cache_size(key, mem_cost, segment_addr_hint)` and delegate to `Metacache::cache_segment_if_present`.
>   - Update `Segment::update_cache_size()` to compute `mem_cost` and call the new `TabletManager` API.
>   - Precompute `mem_cost` and pass by value in `cache_segment`/`cache_segment_if_absent`; use `_metacache->cache_segment_if_absent` in `TabletManager::load_segment`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb574335a68b71cf8f96482bbe43d571328d23aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->