### PR TITLE
[Enhancement] Add column statistic labels to explain statement (backport #65899)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1021,6 +1021,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_PRE_AGG_TOP_N_PUSH_DOWN = "enable_pre_agg_top_n_push_down";
 
+    public static final String ENABLE_LABELED_COLUMN_STATISTIC_OUTPUT = "enable_labeled_column_statistic_output";
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(MAX_EXECUTION_TIME)
@@ -2110,6 +2112,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_PRE_AGG_TOP_N_PUSH_DOWN, flag = VariableMgr.INVISIBLE)
     private boolean enablePreAggTopNPushDown = true;
+
+    @VarAttr(name = ENABLE_LABELED_COLUMN_STATISTIC_OUTPUT)
+    private boolean enableLabeledColumnStatisticOutput = false;
 
     public int getCboPruneJsonSubfieldDepth() {
         return cboPruneJsonSubfieldDepth;
@@ -5570,6 +5575,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnablePreAggTopNPushDown() {
         return enablePreAggTopNPushDown;
+    }
+
+    public void setEnableLabeledColumnStatisticOutput(boolean flag) {
+        this.enableLabeledColumnStatisticOutput = flag;
+    }
+
+    public boolean isEnableLabeledColumnStatisticOutput() {
+        return this.enableLabeledColumnStatisticOutput;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnStatistic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/ColumnStatistic.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.optimizer.statistics;
 
 import com.google.common.base.Preconditions;
+import com.starrocks.qe.ConnectContext;
 
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.NaN;
@@ -173,14 +174,28 @@ public class ColumnStatistic {
     @Override
     public String toString() {
         String separator = ", ";
-        return "[" + minValue + separator
-                + maxValue + separator
-                + nullsFraction + separator
-                + averageRowSize + separator
-                + distinctValuesCount + "] "
-                + (collectionSize == DEFAULT_COLLECTION_SIZE ? "" : "COS: " + collectionSize + " ")
-                + (histogram == null ? "" : histogram.getMcvString() + " ")
-                + type;
+        boolean enableLabeledColumnStatisticOutput =
+                ConnectContext.get() != null && ConnectContext.get().getSessionVariable() != null &&
+                        ConnectContext.get().getSessionVariable().isEnableLabeledColumnStatisticOutput();
+        if (enableLabeledColumnStatisticOutput) {
+            return "[MIN: " + minValue + separator
+                    + "MAX: " + maxValue + separator
+                    + "NULLS: " + nullsFraction + separator
+                    + "ROS: " + averageRowSize + separator
+                    + "NDV: " + distinctValuesCount + "] "
+                    + (collectionSize == DEFAULT_COLLECTION_SIZE ? "" : "COS: " + collectionSize + " ")
+                    + (histogram == null ? "" : histogram.getMcvString() + " ")
+                    + type;
+        } else {
+            return "[" + minValue + separator
+                    + maxValue + separator
+                    + nullsFraction + separator
+                    + averageRowSize + separator
+                    + distinctValuesCount + "] "
+                    + (collectionSize == DEFAULT_COLLECTION_SIZE ? "" : "COS: " + collectionSize + " ")
+                    + (histogram == null ? "" : histogram.getMcvString() + " ")
+                    + type;
+        }
     }
 
     public static Builder buildFrom(ColumnStatistic other) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExplainTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExplainTest.java
@@ -67,4 +67,68 @@ public class ExplainTest extends PlanTestBase {
         }
 
     }
+
+    @Test
+    public void testExplainCosts() throws Exception {
+        String sql = "SELECT DISTINCT t0.v1 FROM t0 LEFT JOIN t1 ON t0.v1 = t1.v4";
+        String plan = getCostExplain(sql);
+        Assertions.assertTrue(plan.contains("3:AGGREGATE (merge finalize)\n" +
+                "  |  group by: [1: v1, BIGINT, true]\n" +
+                "  |  cardinality: 1\n" +
+                "  |  column statistics: \n" +
+                "  |  * v1-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN\n" +
+                "  |  \n" +
+                "  2:EXCHANGE\n" +
+                "     distribution type: SHUFFLE\n" +
+                "     partition exprs: [1: v1, BIGINT, true]\n" +
+                "     cardinality: 1"), plan);
+        Assertions.assertTrue(plan.contains("1:AGGREGATE (update serialize)\n" +
+                "  |  STREAMING\n" +
+                "  |  group by: [1: v1, BIGINT, true]\n" +
+                "  |  cardinality: 1\n" +
+                "  |  column statistics: \n" +
+                "  |  * v1-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN\n" +
+                "  |  \n" +
+                "  0:OlapScanNode\n" +
+                "     table: t0, rollup: t0\n" +
+                "     preAggregation: on\n" +
+                "     partitionsRatio=0/1, tabletsRatio=0/0\n" +
+                "     tabletList=\n" +
+                "     actualRows=0, avgRowSize=1.0\n" +
+                "     cardinality: 1\n" +
+                "     column statistics: \n" +
+                "     * v1-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN"), plan);
+    }
+
+    @Test
+    public void testExplainCostsWithLabels() throws Exception {
+        String sql = "SELECT DISTINCT t0.v1 FROM t0 LEFT JOIN t1 ON t0.v1 = t1.v4";
+        String plan = getCostExplainWithLabels(sql);
+        Assertions.assertTrue(plan.contains("3:AGGREGATE (merge finalize)\n" +
+                "  |  group by: [1: v1, BIGINT, true]\n" +
+                "  |  cardinality: 1\n" +
+                "  |  column statistics: \n" +
+                "  |  * v1-->[MIN: -Infinity, MAX: Infinity, NULLS: 0.0, ROS: 1.0, NDV: 1.0] UNKNOWN\n" +
+                "  |  \n" +
+                "  2:EXCHANGE\n" +
+                "     distribution type: SHUFFLE\n" +
+                "     partition exprs: [1: v1, BIGINT, true]\n" +
+                "     cardinality: 1"), plan);
+        Assertions.assertTrue(plan.contains("1:AGGREGATE (update serialize)\n" +
+                "  |  STREAMING\n" +
+                "  |  group by: [1: v1, BIGINT, true]\n" +
+                "  |  cardinality: 1\n" +
+                "  |  column statistics: \n" +
+                "  |  * v1-->[MIN: -Infinity, MAX: Infinity, NULLS: 0.0, ROS: 1.0, NDV: 1.0] UNKNOWN\n" +
+                "  |  \n" +
+                "  0:OlapScanNode\n" +
+                "     table: t0, rollup: t0\n" +
+                "     preAggregation: on\n" +
+                "     partitionsRatio=0/1, tabletsRatio=0/0\n" +
+                "     tabletList=\n" +
+                "     actualRows=0, avgRowSize=1.0\n" +
+                "     cardinality: 1\n" +
+                "     column statistics: \n" +
+                "     * v1-->[MIN: -Infinity, MAX: Infinity, NULLS: 0.0, ROS: 1.0, NDV: 1.0] UNKNOWN"), plan);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -313,6 +313,14 @@ public class PlanTestNoneDBBase extends StarRocksTestBase {
                 getExplainString(TExplainLevel.COSTS);
     }
 
+    public String getCostExplainWithLabels(String sql) throws Exception {
+        connectContext.getSessionVariable().setEnableLabeledColumnStatisticOutput(true);
+        String plan = UtFrameUtils.getPlanAndFragment(connectContext, sql).second.
+                getExplainString(TExplainLevel.COSTS);
+        connectContext.getSessionVariable().setEnableLabeledColumnStatisticOutput(false);
+        return plan;
+    }
+
     public String getDumpString(String sql) throws Exception {
         UtFrameUtils.getPlanAndFragment(connectContext, sql);
         return GsonUtils.GSON.toJson(connectContext.getDumpInfo());


### PR DESCRIPTION
## Why I'm doing:

this is a backport of https://github.com/StarRocks/starrocks/pull/65899

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `enable_labeled_column_statistic_output` session variable to toggle labeled column statistics in COSTS explain output and updates tests accordingly.
> 
> - **Explain/Statistics**
>   - `ColumnStatistic.toString()` now conditionally outputs labeled fields (`MIN`, `MAX`, `NULLS`, `ROS`, `NDV`) based on session context.
> - **Session Variables**
>   - Introduces `enable_labeled_column_statistic_output` with getter/setter (default `false`).
> - **Tests**
>   - Extends `ExplainTest` with labeled/unlabeled COSTS explain assertions.
>   - Adds helper `getCostExplainWithLabels` in `PlanTestNoneDBBase` to toggle the new session variable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34a67d79f7d248dec699058c192d179b7879cc0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->