### PR TITLE
[Enhancement] Support CSV header row for EXPORT and INSERT INTO FILES

### DIFF
--- a/be/src/exec/pipeline/sink/export_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/export_sink_operator.cpp
@@ -24,6 +24,7 @@
 #include "formats/csv/output_stream.h"
 #include "fs/fs_broker.h"
 #include "runtime/runtime_state.h"
+#include "util/uid_util.h"
 
 namespace starrocks::pipeline {
 
@@ -115,8 +116,12 @@ Status ExportSinkIOBuffer::_open_file_writer() {
     // Set header options if configured
     if (_t_export_sink.__isset.with_header && _t_export_sink.with_header) {
         builder_options.with_header = true;
-        if (_t_export_sink.__isset.column_names) {
+        if (_t_export_sink.__isset.column_names && !_t_export_sink.column_names.empty()) {
             builder_options.column_names = _t_export_sink.column_names;
+        } else {
+            LOG(WARNING) << "with_header is enabled but column_names is empty, header row will be skipped"
+                         << ", query_id=" << print_id(_fragment_ctx->query_id())
+                         << ", fragment_instance_id=" << print_id(_fragment_ctx->fragment_instance_id());
         }
     }
 

--- a/be/src/exec/plain_text_builder.cpp
+++ b/be/src/exec/plain_text_builder.cpp
@@ -6,6 +6,7 @@
 #include "exprs/column_ref.h"
 #include "exprs/expr.h"
 #include "formats/csv/converter.h"
+#include "formats/csv/csv_escape.h"
 #include "formats/csv/output_stream.h"
 #include "formats/csv/output_stream_file.h"
 #include "gutil/strings/substitute.h"
@@ -23,6 +24,8 @@ PlainTextBuilder::PlainTextBuilder(PlainTextBuilderOptions options, std::unique_
           _output_stream(
                   std::make_unique<csv::OutputStreamFile>(std::move(writable_file), OUTSTREAM_BUFFER_SIZE_BYTES)),
           _init(false) {}
+
+PlainTextBuilder::~PlainTextBuilder() = default;
 
 Status PlainTextBuilder::init() {
     if (_init) {
@@ -43,6 +46,20 @@ Status PlainTextBuilder::init() {
         }
         _converters.emplace_back(std::move(conv));
     }
+
+    // Write header row if enabled
+    if (_options.with_header && !_options.column_names.empty()) {
+        auto* os = _output_stream.get();
+        const size_t num_cols = _options.column_names.size();
+        for (size_t i = 0; i < num_cols; i++) {
+            // Escape column names that contain special characters (delimiter, quotes, newlines)
+            std::string escaped_name = csv::escape_csv_field(_options.column_names[i], _options.column_terminated_by);
+            RETURN_IF_ERROR(os->write(escaped_name));
+            RETURN_IF_ERROR(
+                    os->write((i == num_cols - 1) ? _options.line_terminated_by : _options.column_terminated_by));
+        }
+    }
+
     _init = true;
 
     return Status::OK();
@@ -95,6 +112,8 @@ std::size_t PlainTextBuilder::file_size() {
 
 Status PlainTextBuilder::finish() {
     DCHECK(_output_stream != nullptr);
+    // Ensure header is written even if no data was added
+    RETURN_IF_ERROR(init());
     return _output_stream->finalize();
 }
 

--- a/be/src/exec/plain_text_builder.cpp
+++ b/be/src/exec/plain_text_builder.cpp
@@ -48,15 +48,20 @@ Status PlainTextBuilder::init() {
     }
 
     // Write header row if enabled
-    if (_options.with_header && !_options.column_names.empty()) {
-        auto* os = _output_stream.get();
-        const size_t num_cols = _options.column_names.size();
-        for (size_t i = 0; i < num_cols; i++) {
-            // Escape column names that contain special characters (delimiter, quotes, newlines)
-            std::string escaped_name = csv::escape_csv_field(_options.column_names[i], _options.column_terminated_by);
-            RETURN_IF_ERROR(os->write(escaped_name));
-            RETURN_IF_ERROR(
-                    os->write((i == num_cols - 1) ? _options.line_terminated_by : _options.column_terminated_by));
+    if (_options.with_header) {
+        if (_options.column_names.empty()) {
+            LOG(WARNING)
+                    << "with_header is enabled but column_names is empty, this may indicate an upstream logic issue";
+        } else {
+            const size_t num_cols = _options.column_names.size();
+            for (size_t i = 0; i < num_cols; i++) {
+                // Escape column names that contain special characters (delimiter, quotes, newlines)
+                std::string escaped_name =
+                        csv::escape_csv_field(_options.column_names[i], _options.column_terminated_by);
+                RETURN_IF_ERROR(_output_stream->write(escaped_name));
+                RETURN_IF_ERROR(_output_stream->write((i == num_cols - 1) ? _options.line_terminated_by
+                                                                          : _options.column_terminated_by));
+            }
         }
     }
 

--- a/be/src/exec/plain_text_builder.h
+++ b/be/src/exec/plain_text_builder.h
@@ -18,6 +18,7 @@
 #include <map>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "exec/file_builder.h"
 
@@ -34,13 +35,15 @@ class FileWriter;
 struct PlainTextBuilderOptions {
     std::string column_terminated_by;
     std::string line_terminated_by;
+    bool with_header = false;
+    std::vector<std::string> column_names;
 };
 
 class PlainTextBuilder final : public FileBuilder {
 public:
     PlainTextBuilder(PlainTextBuilderOptions options, std::unique_ptr<WritableFile> writable_file,
                      const std::vector<ExprContext*>& output_expr_ctxs);
-    ~PlainTextBuilder() override = default;
+    ~PlainTextBuilder() override;
 
     Status add_chunk(Chunk* chunk) override;
 

--- a/be/src/formats/csv/csv_escape.h
+++ b/be/src/formats/csv/csv_escape.h
@@ -1,0 +1,66 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+namespace starrocks::csv {
+
+// Escape a CSV field according to RFC 4180 rules:
+// - If the field contains the column delimiter, double quotes, or newlines (CR/LF),
+//   the field must be enclosed in double quotes
+// - Any double quotes within the field must be escaped by doubling them
+// - Returns the original string if no escaping is needed
+inline std::string escape_csv_field(const std::string& field, const std::string& column_delimiter) {
+    // Check if the field needs quoting
+    bool needs_quoting = false;
+
+    // Check for double quotes, newlines, or column delimiter
+    for (char c : field) {
+        if (c == '"' || c == '\n' || c == '\r') {
+            needs_quoting = true;
+            break;
+        }
+    }
+
+    // Check if field contains the column delimiter
+    if (!needs_quoting && field.find(column_delimiter) != std::string::npos) {
+        needs_quoting = true;
+    }
+
+    if (!needs_quoting) {
+        return field;
+    }
+
+    // Build the escaped field
+    std::string escaped;
+    escaped.reserve(field.size() + 2); // At minimum, we add two quotes
+    escaped.push_back('"');
+
+    for (char c : field) {
+        if (c == '"') {
+            // Escape double quotes by doubling them
+            escaped.push_back('"');
+            escaped.push_back('"');
+        } else {
+            escaped.push_back(c);
+        }
+    }
+
+    escaped.push_back('"');
+    return escaped;
+}
+
+} // namespace starrocks::csv

--- a/be/src/formats/csv/csv_file_writer.cpp
+++ b/be/src/formats/csv/csv_file_writer.cpp
@@ -71,19 +71,35 @@ Status CSVFileWriter::init() {
                                                                   : _writer_options->mapkey_delim.front();
     }
 
-    // Write header row if include_header is enabled
-    if (_writer_options->include_header && !_column_names.empty()) {
-        for (size_t i = 0; i < _column_names.size(); i++) {
-            // Escape column names that contain special characters (delimiter, quotes, newlines)
-            std::string escaped_name = csv::escape_csv_field(_column_names[i], _writer_options->column_terminated_by);
-            RETURN_IF_ERROR(_output_stream->write(escaped_name));
-            if (i + 1 != _column_names.size()) {
-                RETURN_IF_ERROR(_output_stream->write(_writer_options->column_terminated_by));
-            }
-        }
-        RETURN_IF_ERROR(_output_stream->write(_writer_options->line_terminated_by));
+    return Status::OK();
+}
+
+Status CSVFileWriter::_write_header() {
+    if (_header_written) {
+        return Status::OK();
     }
 
+    // Write header row if include_header is enabled
+    if (_writer_options->include_header) {
+        if (_column_names.empty()) {
+            LOG(WARNING)
+                    << "include_header is enabled but column_names is empty, this may indicate an upstream logic issue";
+        } else {
+            for (size_t i = 0; i < _column_names.size(); i++) {
+                // Escape column names that contain special characters (delimiter, quotes, newlines)
+                std::string escaped_name =
+                        csv::escape_csv_field(_column_names[i], _writer_options->column_terminated_by);
+                RETURN_IF_ERROR(_output_stream->write(escaped_name));
+                if (i + 1 != _column_names.size()) {
+                    RETURN_IF_ERROR(_output_stream->write(_writer_options->column_terminated_by));
+                }
+            }
+            RETURN_IF_ERROR(_output_stream->write(_writer_options->line_terminated_by));
+        }
+    }
+
+    // Mark header as written only after all operations succeed
+    _header_written = true;
     return Status::OK();
 }
 
@@ -100,6 +116,9 @@ int64_t CSVFileWriter::get_flush_batch_size() {
 }
 
 Status CSVFileWriter::write(Chunk* chunk) {
+    // Write header on first write
+    RETURN_IF_ERROR(_write_header());
+
     _num_rows += chunk->num_rows();
 
     auto columns = Columns();
@@ -130,6 +149,11 @@ Status CSVFileWriter::write(Chunk* chunk) {
 FileWriter::CommitResult CSVFileWriter::commit() {
     FileWriter::CommitResult result{
             .io_status = Status::OK(), .format = CSV, .location = _location, .rollback_action = _rollback_action};
+
+    // Ensure header is written even if no data was written
+    if (auto st = _write_header(); !st.ok()) {
+        result.io_status.update(st);
+    }
 
     if (auto st = _output_stream->finalize(); !st.ok()) {
         result.io_status.update(st);

--- a/be/src/formats/csv/csv_file_writer.h
+++ b/be/src/formats/csv/csv_file_writer.h
@@ -26,12 +26,14 @@ struct CSVWriterOptions : FileWriterOptions {
     std::string collection_delim = ",";
     std::string mapkey_delim = ",";
     bool is_hive = false;
+    bool include_header = false;
 
     inline static std::string COLUMN_TERMINATED_BY = "column_terminated_by";
     inline static std::string LINE_TERMINATED_BY = "line_terminated_by";
     inline static std::string COLLECTION_DELIM = "collection_delim";
     inline static std::string MAPKEY_DELIM = "mapkey_delim";
     inline static std::string IS_HIVE = "is_hive";
+    inline static std::string INCLUDE_HEADER = "include_header";
 };
 
 // The primary purpose of this class is to support hive + csv. Use with caution in other cases.

--- a/be/src/formats/csv/csv_file_writer.h
+++ b/be/src/formats/csv/csv_file_writer.h
@@ -72,8 +72,11 @@ private:
     std::shared_ptr<csv::Converter::Options> _converter_options;
 
     int64_t _num_rows = 0;
+    bool _header_written = false;
     // (nullable converter, not-null converter)
     std::vector<std::pair<std::unique_ptr<csv::Converter>, std::unique_ptr<csv::Converter>>> _column_converters;
+
+    Status _write_header();
 };
 
 class CSVFileWriterFactory : public FileWriterFactory {

--- a/be/src/runtime/table_function_table_sink.cpp
+++ b/be/src/runtime/table_function_table_sink.cpp
@@ -108,6 +108,9 @@ Status TableFunctionTableSink::decompose_to_pipeline(pipeline::OpFactories prev_
     if (target_table.__isset.csv_row_delimiter) {
         sink_ctx->options[formats::CSVWriterOptions::LINE_TERMINATED_BY] = target_table.csv_row_delimiter;
     }
+    if (target_table.__isset.csv_include_header && target_table.csv_include_header) {
+        sink_ctx->options[formats::CSVWriterOptions::INCLUDE_HEADER] = "true";
+    }
     if (target_table.__isset.parquet_use_legacy_encoding && target_table.parquet_use_legacy_encoding) {
         sink_ctx->options[formats::ParquetWriterOptions::USE_LEGACY_DECIMAL_ENCODING] = "true";
         sink_ctx->options[formats::ParquetWriterOptions::USE_INT96_TIMESTAMP_ENCODING] = "true";

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -57,6 +57,7 @@ set(EXEC_FILES
         ./fs/bundle_file_test.cpp
         ./exec/column_value_range_test.cpp
         ./exec/range_router_test.cpp
+        ./exec/plain_text_builder_test.cpp
         ./exec/es/es_query_builder_test.cpp
         ./exec/es/es_scan_reader_test.cpp
         ./exec/es/es_scroll_parser_test.cpp

--- a/be/test/exec/plain_text_builder_test.cpp
+++ b/be/test/exec/plain_text_builder_test.cpp
@@ -1,0 +1,414 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/plain_text_builder.h"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+#include <fstream>
+
+#include "column/chunk.h"
+#include "column/column_helper.h"
+#include "column/fixed_length_column.h"
+#include "column/nullable_column.h"
+#include "exprs/column_ref.h"
+#include "exprs/mock_vectorized_expr.h"
+#include "fs/fs.h"
+#include "runtime/descriptor_helper.h"
+#include "runtime/descriptors.h"
+#include "runtime/exec_env.h"
+#include "runtime/runtime_state.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+class PlainTextBuilderTest : public testing::Test {
+protected:
+    void SetUp() override {
+        _test_dir = "./plain_text_builder_test_" + std::to_string(::getpid());
+        std::filesystem::create_directories(_test_dir);
+    }
+
+    void TearDown() override {
+        if (std::filesystem::exists(_test_dir)) {
+            std::filesystem::remove_all(_test_dir);
+        }
+    }
+
+    std::string read_file(const std::string& path) {
+        std::ifstream file(path);
+        std::stringstream buffer;
+        buffer << file.rdbuf();
+        return buffer.str();
+    }
+
+    std::string _test_dir;
+};
+
+// Test PlainTextBuilder without header
+TEST_F(PlainTextBuilderTest, TestNoHeader) {
+    std::string file_path = _test_dir + "/no_header.csv";
+
+    PlainTextBuilderOptions options{.column_terminated_by = ",",
+                                    .line_terminated_by = "\n",
+                                    .with_header = false,
+                                    .column_names = {"col1", "col2", "col3"}};
+
+    ASSIGN_OR_ABORT(auto writable_file, FileSystem::Default()->new_writable_file(file_path));
+
+    // Create empty expr contexts vector (for simplicity, we test init() directly)
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    PlainTextBuilder builder(std::move(options), std::move(writable_file), output_expr_ctxs);
+
+    // Call finish to flush and close file
+    ASSERT_OK(builder.finish());
+
+    // Read the file content
+    std::string content = read_file(file_path);
+
+    // Without header, file should be empty when no data is added
+    EXPECT_EQ(content, "");
+}
+
+// Test PlainTextBuilder with header but empty column names
+TEST_F(PlainTextBuilderTest, TestHeaderWithEmptyColumnNames) {
+    std::string file_path = _test_dir + "/empty_column_names.csv";
+
+    PlainTextBuilderOptions options{
+            .column_terminated_by = ",", .line_terminated_by = "\n", .with_header = true, .column_names = {}};
+
+    ASSIGN_OR_ABORT(auto writable_file, FileSystem::Default()->new_writable_file(file_path));
+
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    PlainTextBuilder builder(std::move(options), std::move(writable_file), output_expr_ctxs);
+
+    ASSERT_OK(builder.finish());
+
+    std::string content = read_file(file_path);
+
+    // With empty column names, no header row should be written
+    EXPECT_EQ(content, "");
+}
+
+// Test PlainTextBuilder with header and column names
+TEST_F(PlainTextBuilderTest, TestHeaderWithColumnNames) {
+    std::string file_path = _test_dir + "/with_header.csv";
+
+    PlainTextBuilderOptions options{.column_terminated_by = ",",
+                                    .line_terminated_by = "\n",
+                                    .with_header = true,
+                                    .column_names = {"id", "name", "score"}};
+
+    ASSIGN_OR_ABORT(auto writable_file, FileSystem::Default()->new_writable_file(file_path));
+
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    PlainTextBuilder builder(std::move(options), std::move(writable_file), output_expr_ctxs);
+
+    ASSERT_OK(builder.finish());
+
+    std::string content = read_file(file_path);
+
+    // Header row should be written with column names
+    EXPECT_EQ(content, "id,name,score\n");
+}
+
+// Test PlainTextBuilder with custom delimiters
+TEST_F(PlainTextBuilderTest, TestHeaderWithCustomDelimiters) {
+    std::string file_path = _test_dir + "/custom_delimiters.csv";
+
+    PlainTextBuilderOptions options{.column_terminated_by = "\t",
+                                    .line_terminated_by = "\r\n",
+                                    .with_header = true,
+                                    .column_names = {"col_a", "col_b"}};
+
+    ASSIGN_OR_ABORT(auto writable_file, FileSystem::Default()->new_writable_file(file_path));
+
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    PlainTextBuilder builder(std::move(options), std::move(writable_file), output_expr_ctxs);
+
+    ASSERT_OK(builder.finish());
+
+    std::string content = read_file(file_path);
+
+    // Header row should use custom delimiters
+    EXPECT_EQ(content, "col_a\tcol_b\r\n");
+}
+
+// Test PlainTextBuilder with single column header
+TEST_F(PlainTextBuilderTest, TestHeaderWithSingleColumn) {
+    std::string file_path = _test_dir + "/single_column.csv";
+
+    PlainTextBuilderOptions options{.column_terminated_by = ",",
+                                    .line_terminated_by = "\n",
+                                    .with_header = true,
+                                    .column_names = {"only_column"}};
+
+    ASSIGN_OR_ABORT(auto writable_file, FileSystem::Default()->new_writable_file(file_path));
+
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    PlainTextBuilder builder(std::move(options), std::move(writable_file), output_expr_ctxs);
+
+    ASSERT_OK(builder.finish());
+
+    std::string content = read_file(file_path);
+
+    EXPECT_EQ(content, "only_column\n");
+}
+
+// Test PlainTextBuilder with many columns
+TEST_F(PlainTextBuilderTest, TestHeaderWithManyColumns) {
+    std::string file_path = _test_dir + "/many_columns.csv";
+
+    std::vector<std::string> column_names;
+    for (int i = 0; i < 100; i++) {
+        column_names.push_back("col_" + std::to_string(i));
+    }
+
+    PlainTextBuilderOptions options{
+            .column_terminated_by = ",", .line_terminated_by = "\n", .with_header = true, .column_names = column_names};
+
+    ASSIGN_OR_ABORT(auto writable_file, FileSystem::Default()->new_writable_file(file_path));
+
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    PlainTextBuilder builder(std::move(options), std::move(writable_file), output_expr_ctxs);
+
+    ASSERT_OK(builder.finish());
+
+    std::string content = read_file(file_path);
+
+    // Build expected header
+    std::string expected_header;
+    for (int i = 0; i < 100; i++) {
+        if (i > 0) expected_header += ",";
+        expected_header += "col_" + std::to_string(i);
+    }
+    expected_header += "\n";
+
+    EXPECT_EQ(content, expected_header);
+}
+
+// Test PlainTextBuilder with special characters in column names (space and @)
+TEST_F(PlainTextBuilderTest, TestHeaderWithSpecialChars) {
+    std::string file_path = _test_dir + "/special_chars.csv";
+
+    PlainTextBuilderOptions options{.column_terminated_by = ",",
+                                    .line_terminated_by = "\n",
+                                    .with_header = true,
+                                    .column_names = {"user_id", "user name", "user@email"}};
+
+    ASSIGN_OR_ABORT(auto writable_file, FileSystem::Default()->new_writable_file(file_path));
+
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    PlainTextBuilder builder(std::move(options), std::move(writable_file), output_expr_ctxs);
+
+    ASSERT_OK(builder.finish());
+
+    std::string content = read_file(file_path);
+
+    EXPECT_EQ(content, "user_id,user name,user@email\n");
+}
+
+// Test PlainTextBuilder with column names containing comma (delimiter)
+TEST_F(PlainTextBuilderTest, TestHeaderWithComma) {
+    std::string file_path = _test_dir + "/comma_in_name.csv";
+
+    PlainTextBuilderOptions options{.column_terminated_by = ",",
+                                    .line_terminated_by = "\n",
+                                    .with_header = true,
+                                    .column_names = {"user,id", "name"}};
+
+    ASSIGN_OR_ABORT(auto writable_file, FileSystem::Default()->new_writable_file(file_path));
+
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    PlainTextBuilder builder(std::move(options), std::move(writable_file), output_expr_ctxs);
+
+    ASSERT_OK(builder.finish());
+
+    std::string content = read_file(file_path);
+
+    // Column name with comma should be quoted
+    EXPECT_EQ(content, "\"user,id\",name\n");
+}
+
+// Test PlainTextBuilder with column names containing double quotes
+TEST_F(PlainTextBuilderTest, TestHeaderWithQuotes) {
+    std::string file_path = _test_dir + "/quotes_in_name.csv";
+
+    PlainTextBuilderOptions options{.column_terminated_by = ",",
+                                    .line_terminated_by = "\n",
+                                    .with_header = true,
+                                    .column_names = {"user\"name", "id"}};
+
+    ASSIGN_OR_ABORT(auto writable_file, FileSystem::Default()->new_writable_file(file_path));
+
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    PlainTextBuilder builder(std::move(options), std::move(writable_file), output_expr_ctxs);
+
+    ASSERT_OK(builder.finish());
+
+    std::string content = read_file(file_path);
+
+    // Column name with quotes should be quoted and internal quotes doubled
+    EXPECT_EQ(content, "\"user\"\"name\",id\n");
+}
+
+// Test PlainTextBuilder with column names containing newline
+TEST_F(PlainTextBuilderTest, TestHeaderWithNewline) {
+    std::string file_path = _test_dir + "/newline_in_name.csv";
+
+    PlainTextBuilderOptions options{.column_terminated_by = ",",
+                                    .line_terminated_by = "\n",
+                                    .with_header = true,
+                                    .column_names = {"user\ninfo", "id"}};
+
+    ASSIGN_OR_ABORT(auto writable_file, FileSystem::Default()->new_writable_file(file_path));
+
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    PlainTextBuilder builder(std::move(options), std::move(writable_file), output_expr_ctxs);
+
+    ASSERT_OK(builder.finish());
+
+    std::string content = read_file(file_path);
+
+    // Column name with newline should be quoted
+    EXPECT_EQ(content, "\"user\ninfo\",id\n");
+}
+
+// Test PlainTextBuilder with column names containing carriage return
+TEST_F(PlainTextBuilderTest, TestHeaderWithCarriageReturn) {
+    std::string file_path = _test_dir + "/cr_in_name.csv";
+
+    PlainTextBuilderOptions options{.column_terminated_by = ",",
+                                    .line_terminated_by = "\n",
+                                    .with_header = true,
+                                    .column_names = {"user\rinfo", "id"}};
+
+    ASSIGN_OR_ABORT(auto writable_file, FileSystem::Default()->new_writable_file(file_path));
+
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    PlainTextBuilder builder(std::move(options), std::move(writable_file), output_expr_ctxs);
+
+    ASSERT_OK(builder.finish());
+
+    std::string content = read_file(file_path);
+
+    // Column name with carriage return should be quoted
+    EXPECT_EQ(content, "\"user\rinfo\",id\n");
+}
+
+// Test PlainTextBuilder with column names containing multiple special characters
+TEST_F(PlainTextBuilderTest, TestHeaderWithMultipleSpecialChars) {
+    std::string file_path = _test_dir + "/multiple_special.csv";
+
+    PlainTextBuilderOptions options{.column_terminated_by = ",",
+                                    .line_terminated_by = "\n",
+                                    .with_header = true,
+                                    .column_names = {"user,\"name\"\ninfo", "id"}};
+
+    ASSIGN_OR_ABORT(auto writable_file, FileSystem::Default()->new_writable_file(file_path));
+
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    PlainTextBuilder builder(std::move(options), std::move(writable_file), output_expr_ctxs);
+
+    ASSERT_OK(builder.finish());
+
+    std::string content = read_file(file_path);
+
+    // Column name with comma, quotes, and newline should be properly escaped
+    EXPECT_EQ(content, "\"user,\"\"name\"\"\ninfo\",id\n");
+}
+
+// Test PlainTextBuilder with custom delimiter in column name
+TEST_F(PlainTextBuilderTest, TestHeaderWithCustomDelimiterInName) {
+    std::string file_path = _test_dir + "/custom_delim.csv";
+
+    PlainTextBuilderOptions options{.column_terminated_by = "\t",
+                                    .line_terminated_by = "\n",
+                                    .with_header = true,
+                                    .column_names = {"user\tid", "name"}};
+
+    ASSIGN_OR_ABORT(auto writable_file, FileSystem::Default()->new_writable_file(file_path));
+
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    PlainTextBuilder builder(std::move(options), std::move(writable_file), output_expr_ctxs);
+
+    ASSERT_OK(builder.finish());
+
+    std::string content = read_file(file_path);
+
+    // Column name with tab (delimiter) should be quoted
+    EXPECT_EQ(content, "\"user\tid\"\tname\n");
+}
+
+// Test PlainTextBuilder header written only once
+TEST_F(PlainTextBuilderTest, TestHeaderWrittenOnce) {
+    std::string file_path = _test_dir + "/header_once.csv";
+
+    PlainTextBuilderOptions options{.column_terminated_by = ",",
+                                    .line_terminated_by = "\n",
+                                    .with_header = true,
+                                    .column_names = {"a", "b", "c"}};
+
+    ASSIGN_OR_ABORT(auto writable_file, FileSystem::Default()->new_writable_file(file_path));
+
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    PlainTextBuilder builder(std::move(options), std::move(writable_file), output_expr_ctxs);
+
+    // Multiple calls to finish() should not write header multiple times
+    // The init() is called lazily in add_chunk(), but we're calling finish() directly
+    ASSERT_OK(builder.finish());
+
+    std::string content = read_file(file_path);
+
+    // Header should appear only once
+    EXPECT_EQ(content, "a,b,c\n");
+}
+
+// Test file size includes header
+TEST_F(PlainTextBuilderTest, TestFileSizeIncludesHeader) {
+    std::string file_path = _test_dir + "/size_test.csv";
+
+    PlainTextBuilderOptions options{
+            .column_terminated_by = ",", .line_terminated_by = "\n", .with_header = true, .column_names = {"x", "y"}};
+
+    ASSIGN_OR_ABORT(auto writable_file, FileSystem::Default()->new_writable_file(file_path));
+
+    std::vector<ExprContext*> output_expr_ctxs;
+
+    PlainTextBuilder builder(std::move(options), std::move(writable_file), output_expr_ctxs);
+
+    ASSERT_OK(builder.finish());
+
+    // After finish(), file_size() should reflect the header
+    // Note: file_size() returns the size tracked by output stream
+    std::string content = read_file(file_path);
+    EXPECT_EQ(content.size(), 4); // "x,y\n" = 4 bytes
+}
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -136,6 +136,7 @@ public class TableFunctionTable extends Table {
     private static final String PROPERTY_CSV_ENCLOSE = "csv.enclose";
     private static final String PROPERTY_CSV_ESCAPE = "csv.escape";
     private static final String PROPERTY_CSV_TRIM_SPACE = "csv.trim_space";
+    private static final String PROPERTY_CSV_INCLUDE_HEADER = "csv.include_header";
 
     private static final String PROPERTY_PARQUET_USE_LEGACY_ENCODING = "parquet.use_legacy_encoding";
     private static final Set<String> SUPPORTED_PARQUET_VERSIONS = Sets.newHashSet("1.0", "2.4", "2.6");
@@ -199,6 +200,7 @@ public class TableFunctionTable extends Table {
     private byte csvEscape;
     private long csvSkipHeader;
     private boolean csvTrimSpace;
+    private boolean csvIncludeHeader = false;
 
     // PARQUET format options
     private boolean parquetUseLegacyEncoding = false;
@@ -393,6 +395,7 @@ public class TableFunctionTable extends Table {
         if (CSV.equalsIgnoreCase(format)) {
             tTableFunctionTable.setCsv_column_seperator(csvColumnSeparator);
             tTableFunctionTable.setCsv_row_delimiter(csvRowDelimiter);
+            tTableFunctionTable.setCsv_include_header(csvIncludeHeader);
         }
         tTableFunctionTable.setParquet_use_legacy_encoding(parquetUseLegacyEncoding);
         TParquetOptions parquetOptions = new TParquetOptions();
@@ -895,6 +898,15 @@ public class TableFunctionTable extends Table {
                 throw new SemanticException("The valid bytes length for '%s' is [%d, %d]", PROPERTY_CSV_ROW_DELIMITER,
                         1, CsvFormat.MAX_ROW_DELIMITER_LENGTH);
             }
+        }
+
+        if (properties.containsKey(PROPERTY_CSV_INCLUDE_HEADER)) {
+            String includeHeader = properties.get(PROPERTY_CSV_INCLUDE_HEADER);
+            if (!includeHeader.equalsIgnoreCase("true") && !includeHeader.equalsIgnoreCase("false")) {
+                throw new SemanticException("got invalid parameter \"csv.include_header\" = \"%s\", " +
+                        "expect a boolean value (true or false).", includeHeader);
+            }
+            this.csvIncludeHeader = includeHeader.equalsIgnoreCase("true");
         }
 
         // parquet options

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
@@ -169,7 +169,7 @@ public class ExportJob implements Writable, GsonPostProcessable {
     @SerializedName("rd")
     private String rowDelimiter;
     private boolean includeQueryId;
-    @SerializedName("wh")
+    @SerializedName("withHdr")
     private boolean withHeader;
     @SerializedName("pt")
     private Map<String, String> properties = Maps.newHashMap();

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
@@ -169,6 +169,8 @@ public class ExportJob implements Writable, GsonPostProcessable {
     @SerializedName("rd")
     private String rowDelimiter;
     private boolean includeQueryId;
+    @SerializedName("wh")
+    private boolean withHeader;
     @SerializedName("pt")
     private Map<String, String> properties = Maps.newHashMap();
     @SerializedName("ps")
@@ -257,6 +259,7 @@ public class ExportJob implements Writable, GsonPostProcessable {
         this.columnSeparator = stmt.getColumnSeparator();
         this.rowDelimiter = stmt.getRowDelimiter();
         this.includeQueryId = stmt.isIncludeQueryId();
+        this.withHeader = stmt.isWithHeader();
         this.properties = stmt.getProperties();
 
         exportPath = stmt.getPath();
@@ -465,8 +468,15 @@ public class ExportJob implements Writable, GsonPostProcessable {
             HdfsUtil.getTProperties(exportTempPath, brokerPersistInfo.getProperties(), hdfsProperties);
         }
         BrokerDesc runtimeBrokerDesc = new BrokerDesc(brokerPersistInfo.getName(), brokerPersistInfo.getProperties());
+
+        // Extract column names from slot descriptors for CSV header row
+        List<String> exportColumnNames = Lists.newArrayList();
+        for (SlotDescriptor slot : exportTupleDesc.getSlots()) {
+            exportColumnNames.add(slot.getColumn().getName());
+        }
+
         fragment.setSink(new ExportSink(exportTempPath, fileNamePrefix + taskIdx + "_", columnSeparator,
-                rowDelimiter, runtimeBrokerDesc, hdfsProperties));
+                rowDelimiter, runtimeBrokerDesc, hdfsProperties, exportColumnNames, withHeader));
         try {
             fragment.createDataSink(TResultSinkType.MYSQL_PROTOCAL);
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ExportSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ExportSink.java
@@ -48,6 +48,8 @@ import com.starrocks.thrift.THdfsProperties;
 import com.starrocks.thrift.TNetworkAddress;
 import org.apache.commons.lang.StringEscapeUtils;
 
+import java.util.List;
+
 public class ExportSink extends DataSink {
     private final String exportPath;
     private String fileNamePrefix;
@@ -55,6 +57,8 @@ public class ExportSink extends DataSink {
     private final String rowDelimiter;
     private final BrokerDesc brokerDesc;
     private final THdfsProperties hdfsProperties;
+    private List<String> columnNames;
+    private boolean withHeader = false;
 
     public ExportSink(String exportPath, String fileNamePrefix, String columnSeparator,
                       String rowDelimiter, BrokerDesc brokerDesc, THdfsProperties hdfsProperties) {
@@ -64,6 +68,14 @@ public class ExportSink extends DataSink {
         this.rowDelimiter = rowDelimiter;
         this.brokerDesc = brokerDesc;
         this.hdfsProperties = hdfsProperties;
+    }
+
+    public ExportSink(String exportPath, String fileNamePrefix, String columnSeparator,
+                      String rowDelimiter, BrokerDesc brokerDesc, THdfsProperties hdfsProperties,
+                      List<String> columnNames, boolean withHeader) {
+        this(exportPath, fileNamePrefix, columnSeparator, rowDelimiter, brokerDesc, hdfsProperties);
+        this.columnNames = columnNames;
+        this.withHeader = withHeader;
     }
 
     // for insert broker table
@@ -116,6 +128,12 @@ public class ExportSink extends DataSink {
         if (fileNamePrefix != null) {
             tExportSink.setFile_name_prefix(fileNamePrefix);
         }
+
+        // Set column names and with_header for CSV header row support
+        if (columnNames != null && !columnNames.isEmpty()) {
+            tExportSink.setColumn_names(columnNames);
+        }
+        tExportSink.setWith_header(withHeader);
 
         result.setExport_sink(tExportSink);
         return result;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ExportStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ExportStmt.java
@@ -55,6 +55,7 @@ import java.util.Set;
 public class ExportStmt extends StatementBase {
 
     private static final String INCLUDE_QUERY_ID_PROP = "include_query_id";
+    private static final String WITH_HEADER_PROP = "with_header";
 
     private static final String DEFAULT_COLUMN_SEPARATOR = "\t";
     private static final String DEFAULT_LINE_DELIMITER = "\n";
@@ -74,6 +75,7 @@ public class ExportStmt extends StatementBase {
     private String columnSeparator;
     private String rowDelimiter;
     private boolean includeQueryId = true;
+    private boolean withHeader = false;
 
     private long exportStartTime;
     private boolean sync;
@@ -178,6 +180,10 @@ public class ExportStmt extends StatementBase {
 
     public boolean isIncludeQueryId() {
         return includeQueryId;
+    }
+
+    public boolean isWithHeader() {
+        return withHeader;
     }
 
     public void checkTable(GlobalStateMgr globalStateMgr) {
@@ -302,6 +308,16 @@ public class ExportStmt extends StatementBase {
                 throw new AnalysisException("Invalid include query id value: " + includeQueryIdStr);
             }
             includeQueryId = Boolean.parseBoolean(properties.get(INCLUDE_QUERY_ID_PROP));
+        }
+
+        // with header
+        if (properties.containsKey(WITH_HEADER_PROP)) {
+            String withHeaderStr = properties.get(WITH_HEADER_PROP);
+            if (!withHeaderStr.equalsIgnoreCase("true")
+                    && !withHeaderStr.equalsIgnoreCase("false")) {
+                throw new AnalysisException("Invalid with_header value: " + withHeaderStr);
+            }
+            withHeader = Boolean.parseBoolean(properties.get(WITH_HEADER_PROP));
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ExportRelativeStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ExportRelativeStmtTest.java
@@ -149,6 +149,22 @@ public class ExportRelativeStmtTest {
                 "(\"load_mem_limit\"=\"2147483648\", \"timeout\" = \"7200\", \"include_query_id\" = \"false\") WITH " +
                 "BROKER \"broker\" (\"username\"=\"test\", \"password\"=\"test\");";
         analyzeFail(originStmt);
+
+        // test with_header property
+        originStmt = "EXPORT TABLE tp TO \"hdfs://hdfs_host:port/a/b/c/\" PROPERTIES " +
+                "(\"with_header\" = \"true\") WITH BROKER \"broker\" (\"username\"=\"test\", \"password\"=\"test\");";
+        stmt = (ExportStmt) analyzeSuccess(originStmt);
+        Assertions.assertTrue(stmt.isWithHeader());
+
+        originStmt = "EXPORT TABLE tp TO \"hdfs://hdfs_host:port/a/b/c/\" PROPERTIES " +
+                "(\"with_header\" = \"false\") WITH BROKER \"broker\" (\"username\"=\"test\", \"password\"=\"test\");";
+        stmt = (ExportStmt) analyzeSuccess(originStmt);
+        Assertions.assertFalse(stmt.isWithHeader());
+
+        // bad with_header value
+        originStmt = "EXPORT TABLE tp TO \"hdfs://hdfs_host:port/a/b/c/\" PROPERTIES " +
+                "(\"with_header\" = \"invalid\") WITH BROKER \"broker\" (\"username\"=\"test\", \"password\"=\"test\");";
+        analyzeFail(originStmt);
         originStmt = "EXPORT TABLE tp (,) TO \"hdfs://hdfs_host:port/a/b/c/\" PROPERTIES " +
                 "(\"load_mem_limit\"=\"2147483648\", \"timeout\" = \"7200\", \"include_query_id\" = \"false\") WITH " +
                 "BROKER \"broker\" (\"username\"=\"test\", \"password\"=\"test\");";

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
@@ -299,7 +299,7 @@ public class TableFunctionTableTest {
     @Test
     public void testCSVDelimiterConverterForUnload() {
         Map<String, String> properties = new HashMap<>();
-        properties.put("path", "file://test_dir");
+        properties.put("path", "file:///test_dir");
         properties.put("format", "csv");
 
         {
@@ -366,7 +366,7 @@ public class TableFunctionTableTest {
     @Test
     public void testCSVIncludeHeaderForUnload() {
         Map<String, String> properties = new HashMap<>();
-        properties.put("path", "file://test_dir");
+        properties.put("path", "file:///test_dir");
         properties.put("format", "csv");
 
         // default: csv.include_header is false

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
@@ -362,4 +362,57 @@ public class TableFunctionTableTest {
                 "Invalid parquet.version: '2.0'. Expected values should be 2.4, 2.6, 1.0",
                 () -> new TableFunctionTable(new ArrayList<>(), properties, new SessionVariable()));
     }
+
+    @Test
+    public void testCSVIncludeHeaderForUnload() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("path", "file://test_dir");
+        properties.put("format", "csv");
+
+        // default: csv.include_header is false
+        {
+            TableFunctionTable table = new TableFunctionTable(new ArrayList<>(), properties, new SessionVariable());
+            Assertions.assertFalse((Boolean) Deencapsulation.getField(table, "csvIncludeHeader"));
+            // verify toTTableFunctionTable also sets this field
+            Assertions.assertFalse(table.toTTableFunctionTable().isCsv_include_header());
+        }
+
+        // csv.include_header = true
+        {
+            properties.put("csv.include_header", "true");
+            TableFunctionTable table = new TableFunctionTable(new ArrayList<>(), properties, new SessionVariable());
+            Assertions.assertTrue((Boolean) Deencapsulation.getField(table, "csvIncludeHeader"));
+            Assertions.assertTrue(table.toTTableFunctionTable().isCsv_include_header());
+        }
+
+        // csv.include_header = false (explicit)
+        {
+            properties.put("csv.include_header", "false");
+            TableFunctionTable table = new TableFunctionTable(new ArrayList<>(), properties, new SessionVariable());
+            Assertions.assertFalse((Boolean) Deencapsulation.getField(table, "csvIncludeHeader"));
+            Assertions.assertFalse(table.toTTableFunctionTable().isCsv_include_header());
+        }
+
+        // csv.include_header = TRUE (case insensitive)
+        {
+            properties.put("csv.include_header", "TRUE");
+            TableFunctionTable table = new TableFunctionTable(new ArrayList<>(), properties, new SessionVariable());
+            Assertions.assertTrue((Boolean) Deencapsulation.getField(table, "csvIncludeHeader"));
+        }
+
+        // csv.include_header = FALSE (case insensitive)
+        {
+            properties.put("csv.include_header", "FALSE");
+            TableFunctionTable table = new TableFunctionTable(new ArrayList<>(), properties, new SessionVariable());
+            Assertions.assertFalse((Boolean) Deencapsulation.getField(table, "csvIncludeHeader"));
+        }
+
+        // abnormal: invalid value
+        {
+            properties.put("csv.include_header", "invalid");
+            ExceptionChecker.expectThrowsWithMsg(SemanticException.class,
+                    "got invalid parameter \"csv.include_header\" = \"invalid\", expect a boolean value (true or false).",
+                    () -> new TableFunctionTable(new ArrayList<>(), properties, new SessionVariable()));
+        }
+    }
 }

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -191,6 +191,10 @@ struct TExportSink {
 
     // export file name prefix
     30: optional string file_name_prefix
+    // column names for CSV header row
+    31: optional list<string> column_names
+    // whether to include header row in CSV output
+    32: optional bool with_header = false
 }
 
 struct TDictionaryCacheSink {

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -534,6 +534,8 @@ struct TTableFunctionTable {
 
     10: optional bool parquet_use_legacy_encoding
     11: optional Types.TParquetOptions parquet_options
+
+    12: optional bool csv_include_header
 }
 
 struct TIcebergSchemaField {


### PR DESCRIPTION
This PR adds support for including a header row in CSV file exports:

1. EXPORT statement: Add `with_header` property to include column names as the first row in exported CSV files. Example: EXPORT TABLE t TO "path" PROPERTIES ("with_header" = "true")

2. INSERT INTO FILES: Add `csv.include_header` property for the same functionality when using INSERT INTO FILES with CSV format. Example: INSERT INTO FILES ("format"="csv", "csv.include_header"="true", ...)

Changes:
- FE: Add property parsing in ExportStmt, ExportJob, ExportSink
- FE: Add csv.include_header support in TableFunctionTable
- BE: Add header writing logic in PlainTextBuilder for EXPORT
- BE: Add header writing logic in CSVFileWriter for INSERT INTO FILES
- Thrift: Add with_header field to TExportSink
- Thrift: Add csv_include_header field to TTableFunctionTable

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables writing a header row (column names) in CSV outputs for both EXPORT and INSERT INTO FILES.
> 
> - FE: Parse `with_header` in `ExportStmt`; propagate via `ExportJob` and `ExportSink` (sets `column_names`/`with_header` in `TExportSink`).
> - FE: Parse `csv.include_header` in `TableFunctionTable`; include in `TTableFunctionTable`.
> - BE (EXPORT): `PlainTextBuilder` gains header support (escapes via `csv::escape_csv_field`) and is configured from `ExportSinkOperator`.
> - BE (INSERT INTO FILES): `CSVFileWriter`/Factory support `include_header` option, write header on first write/commit, escape special chars, and parse option.
> - Thrift: `TExportSink` adds `column_names` and `with_header`; `TTableFunctionTable` adds `csv_include_header`.
> - Tests: New/updated UTs for `PlainTextBuilder`, `CSVFileWriter`, and `ExportSinkOperator`; test list updated.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20507ce67aa7d56ee9113b2729ace72a7489ea26. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->