### PR TITLE
[BugFix] Fix missing set `USE_STAROS` macro while using location provider

### DIFF
--- a/be/src/storage/lake/lake_replication_txn_manager.cpp
+++ b/be/src/storage/lake/lake_replication_txn_manager.cpp
@@ -64,7 +64,7 @@ Status LakeReplicationTxnManager::replicate_lake_remote_storage(const TReplicate
         return Status::Corruption("No missing version");
     }
 
-#ifndef BE_TEST
+#if !defined(BE_TEST) && defined(USE_STAROS)
     auto src_meta_dir =
             _remote_location_provider->metadata_root_location(src_tablet_id, src_db_id, src_table_id, src_partition_id);
     auto src_data_dir =

--- a/be/src/storage/lake/lake_replication_txn_manager.h
+++ b/be/src/storage/lake/lake_replication_txn_manager.h
@@ -35,8 +35,13 @@ class TabletManager;
 class LakeReplicationTxnManager {
 public:
     explicit LakeReplicationTxnManager(lake::TabletManager* tablet_manager)
-            : _tablet_manager(tablet_manager),
-              _remote_location_provider(std::make_unique<lake::RemoteStarletLocationProvider>()) {}
+            : _tablet_manager(tablet_manager)
+#ifdef USE_STAROS
+              ,
+              _remote_location_provider(std::make_unique<RemoteStarletLocationProvider>())
+#endif
+    {
+    }
 
     Status replicate_lake_remote_storage(const TReplicateSnapshotRequest& request);
 
@@ -76,7 +81,9 @@ public:
 
 private:
     TabletManager* _tablet_manager;
-    std::unique_ptr<lake::RemoteStarletLocationProvider> _remote_location_provider;
+#ifdef USE_STAROS
+    std::unique_ptr<RemoteStarletLocationProvider> _remote_location_provider;
+#endif
 };
 
 } // namespace starrocks::lake

--- a/fe/fe-core/src/test/java/com/starrocks/replication/LakeReplicationJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/replication/LakeReplicationJobTest.java
@@ -51,14 +51,14 @@ public class LakeReplicationJobTest extends ReplicationJobTest {
 
         db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb("test");
 
-        String sql = "create table single_partition_duplicate_key (key1 int, key2 varchar(10))\n" +
+        String sql = "create table lake_single_partition_duplicate_key (key1 int, key2 varchar(10))\n" +
                 "distributed by hash(key1) buckets 1\n" +
                 "properties('replication_num' = '1'); ";
         CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql,
                 AnalyzeTestUtil.getConnectContext());
         StarRocksAssert.utCreateTableWithRetry(createTableStmt);
         table = (OlapTable) GlobalStateMgr.getCurrentState().getLocalMetastore()
-                .getTable(db.getFullName(), "single_partition_duplicate_key");
+                .getTable(db.getFullName(), "lake_single_partition_duplicate_key");
         srcTable = DeepCopy.copyWithGson(table, OlapTable.class);
 
         partition = table.getPartitions().iterator().next();


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes be building errors while not set `USE_STAROS`, related to pr #60587 

Fixes #66682

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wrap StarOS location provider usage in USE_STAROS to fix non-StarOS builds; update FE test table name.
> 
> - **BE (Lake replication)**:
>   - Gate StarOS-specific code with `#if !defined(BE_TEST) && defined(USE_STAROS)` in `be/src/storage/lake/lake_replication_txn_manager.cpp`.
>   - Make `_remote_location_provider` member and constructor init conditional on `USE_STAROS` in `be/src/storage/lake/lake_replication_txn_manager.h`.
> - **FE Tests**:
>   - Rename test table to `lake_single_partition_duplicate_key` in `fe/fe-core/src/test/java/com/starrocks/replication/LakeReplicationJobTest.java`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8bd36592ccb97eaddb069abd58625f38dc0eede8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->