### PR TITLE
[Enhancement] Support ARRAY type export in INSERT INTO FILES with CSV format

### DIFF
--- a/be/src/formats/csv/csv_file_writer.cpp
+++ b/be/src/formats/csv/csv_file_writer.cpp
@@ -46,8 +46,8 @@ Status CSVFileWriter::init() {
     RETURN_IF_ERROR(ColumnEvaluator::init(_column_evaluators));
     _column_converters.reserve(_types.size());
     for (auto& type : _types) {
-        // TODO: support nested type of hive
-        if (type.is_complex_type()) {
+        // ARRAY type is supported, other complex types (STRUCT, MAP) are not supported yet
+        if (type.is_complex_type() && !type.is_array_type()) {
             return Status::InternalError(fmt::format("Type {} is not supported yet", type.debug_string()));
         }
         auto nullable_conv = csv::get_converter(type, true);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This PR adds support for exporting ARRAY type columns when using INSERT INTO FILES with CSV format. Previously, all complex types (ARRAY, MAP, STRUCT) were blocked, but ARRAY types already have proper CSV converter support.

Changes:
- BE: Modified csv_file_writer.cpp to allow ARRAY type through the complex type check (MAP and STRUCT still blocked)
- Test: Added unit tests for ARRAY<INT>, ARRAY<BIGINT>, ARRAY with NULL elements, and nested ARRAY<ARRAY<INT>>

Example output format: [1,2,3] for array values

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allow writing ARRAY columns (including nested arrays) in CSV export while MAP/STRUCT remain unsupported; add focused unit tests.
> 
> - **Formats/CSV**:
>   - Permit `ARRAY` types in `CSVFileWriter::init()` by relaxing complex-type check (still rejects `STRUCT` and `MAP`).
> - **Tests**:
>   - Add coverage for `ARRAY<INT>`, `ARRAY<BIGINT>`, `ARRAY<INT>` with null arrays/elements, and nested `ARRAY<ARRAY<INT>>`; update expectations to successful init/write with correct CSV outputs (e.g., `[1,2,3]`).
>   - Keep `MAP` test expecting init error to confirm it remains unsupported.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5c76719cf3185d34ae6588b6a90637984542965d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->