### PR TITLE
[Enhancement] release spill operator memory in advance

### DIFF
--- a/be/src/connector/partition_chunk_writer.h
+++ b/be/src/connector/partition_chunk_writer.h
@@ -17,6 +17,7 @@
 #include "column/chunk.h"
 #include "common/status.h"
 #include "connector/utils.h"
+#include "exec/sorting/sorting.h"
 #include "formats/file_writer.h"
 #include "fs/fs.h"
 #include "runtime/exec_env.h"

--- a/be/src/exec/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/aggregate/distinct_blocking_node.cpp
@@ -253,7 +253,7 @@ pipeline::OpFactories DistinctBlockingNode::decompose_to_pipeline(pipeline::Pipe
                 ops_with_source = _decompose_to_pipeline<AggregatorFactory,
                                                          SpillableAggregateDistinctBlockingSourceOperatorFactory,
                                                          SpillableAggregateDistinctBlockingSinkOperatorFactory>(
-                        ops_with_sink, context, use_per_bucket_optimize);
+                        ops_with_sink, context, false);
             }
         } else {
             ops_with_source = _decompose_to_pipeline<AggregatorFactory, AggregateDistinctBlockingSourceOperatorFactory,

--- a/be/src/exec/aggregator.cpp
+++ b/be/src/exec/aggregator.cpp
@@ -774,6 +774,7 @@ void Aggregator::close(RuntimeState* state) {
         (void)agg_close();
     }
 #endif
+    _spiller.reset();
 }
 
 bool Aggregator::is_chunk_buffer_empty() {

--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -326,6 +326,7 @@ StatusOr<ChunkPtr> HashJoiner::_pull_probe_output_chunk(RuntimeState* state) {
 }
 
 void HashJoiner::close(RuntimeState* state) {
+    _spiller.reset();
     _hash_join_builder->close();
 }
 

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
@@ -97,6 +97,8 @@ Status SpillableAggregateBlockingSinkOperator::set_finishing(RuntimeState* state
 
 void SpillableAggregateBlockingSinkOperator::close(RuntimeState* state) {
     AggregateBlockingSinkOperator::close(state);
+    DCHECK(is_finished());
+    DCHECK(!need_input());
 }
 
 Status SpillableAggregateBlockingSinkOperator::prepare(RuntimeState* state) {

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
@@ -110,8 +110,7 @@ Status SpillableAggregateBlockingSinkOperator::prepare(RuntimeState* state) {
     if (state->spill_mode() == TSpillMode::FORCE) {
         _spill_strategy = spill::SpillStrategy::SPILL_ALL;
     }
-    _peak_revocable_mem_bytes = _unique_metrics->AddHighWaterMarkCounter(
-            "PeakRevocableMemoryBytes", TUnit::BYTES, RuntimeProfile::Counter::create_strategy(TUnit::BYTES));
+    _peak_revocable_mem_bytes = ADD_PEAK_COUNTER(_unique_metrics, "PeakRevocableMemoryBytes", TUnit::BYTES);
     _hash_table_spill_times = ADD_COUNTER(_unique_metrics.get(), "HashTableSpillTimes", TUnit::UNIT);
     _agg_group_by_with_limit = false;
     _aggregator->params()->enable_pipeline_share_limit = false;

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
@@ -51,7 +51,7 @@ Status SpillableAggregateBlockingSinkOperator::set_finishing(RuntimeState* state
     }
     ONCE_DETECT(_set_finishing_once);
     auto defer_set_finishing = DeferOp([this]() {
-        _aggregator->spill_channel()->set_finishing_if_not_reuseable();
+        _aggregator->spill_channel()->set_finishing();
         _is_finished = true;
     });
 

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
@@ -34,6 +34,9 @@ void SpillableAggregateBlockingSourceOperator::close(RuntimeState* state) {
 }
 
 bool SpillableAggregateBlockingSourceOperator::has_output() const {
+    if (_is_finished) {
+        return false;
+    }
     bool has_spilled = _aggregator->spiller()->spilled();
 
     if (!has_spilled && AggregateBlockingSourceOperator::has_output()) {

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
@@ -31,6 +31,8 @@ Status SpillableAggregateBlockingSourceOperator::prepare(RuntimeState* state) {
 void SpillableAggregateBlockingSourceOperator::close(RuntimeState* state) {
     AggregateBlockingSourceOperator::close(state);
     _stream_aggregator->close(state);
+    DCHECK(is_finished());
+    DCHECK(!has_output());
 }
 
 bool SpillableAggregateBlockingSourceOperator::has_output() const {

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
@@ -33,7 +33,7 @@ Status SpillableAggregateDistinctBlockingSinkOperator::set_finishing(RuntimeStat
     if (_is_finished) return Status::OK();
     ONCE_DETECT(_set_finishing_once);
     auto defer_set_finishing = DeferOp([this]() {
-        _aggregator->spill_channel()->set_finishing_if_not_reuseable();
+        _aggregator->spill_channel()->set_finishing();
         _is_finished = true;
     });
 

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
@@ -191,6 +191,9 @@ bool SpillableAggregateDistinctBlockingSourceOperator::has_output() const {
     if (AggregateDistinctBlockingSourceOperator::has_output()) {
         return true;
     }
+    if (_is_finished) {
+        return false;
+    }
     if (!_aggregator->spiller()->spilled()) {
         return false;
     }

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
@@ -188,11 +188,11 @@ Status SpillableAggregateDistinctBlockingSourceOperator::prepare(RuntimeState* s
 }
 
 bool SpillableAggregateDistinctBlockingSourceOperator::has_output() const {
-    if (AggregateDistinctBlockingSourceOperator::has_output()) {
-        return true;
-    }
     if (_is_finished) {
         return false;
+    }
+    if (AggregateDistinctBlockingSourceOperator::has_output()) {
+        return true;
     }
     if (!_aggregator->spiller()->spilled()) {
         return false;

--- a/be/src/exec/pipeline/aggregate/spillable_partitionwise_aggregate_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_partitionwise_aggregate_operator.cpp
@@ -34,7 +34,7 @@ Status SpillablePartitionWiseAggregateSinkOperator::set_finishing(RuntimeState* 
     }
     ONCE_DETECT(_set_finishing_once);
     auto defer_set_finishing = DeferOp([this]() {
-        _agg_op->aggregator()->spill_channel()->set_finishing_if_not_reuseable();
+        _agg_op->aggregator()->spill_channel()->set_finishing();
         _is_finished = true;
     });
 

--- a/be/src/exec/pipeline/aggregate/spillable_partitionwise_distinct_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_partitionwise_distinct_operator.cpp
@@ -37,7 +37,7 @@ Status SpillablePartitionWiseDistinctSinkOperator::set_finishing(RuntimeState* s
     }
     ONCE_DETECT(_set_finishing_once);
     auto defer_set_finishing = DeferOp([this]() {
-        _distinct_op->aggregator()->spill_channel()->set_finishing_if_not_reuseable();
+        _distinct_op->aggregator()->spill_channel()->set_finishing();
         _is_finished = true;
     });
 

--- a/be/src/exec/pipeline/bucket_process_operator.cpp
+++ b/be/src/exec/pipeline/bucket_process_operator.cpp
@@ -72,11 +72,6 @@ bool BucketProcessSinkOperator::is_finished() const {
 Status BucketProcessSinkOperator::set_finishing(RuntimeState* state) {
     auto notify = _ctx->defer_notify_source();
     ONCE_DETECT(_set_finishing_once);
-    auto defer = DeferOp([&]() {
-        if (_ctx->spill_channel != nullptr) {
-            _ctx->spill_channel->set_finishing();
-        }
-    });
     _ctx->all_input_finishing = true;
     DCHECK(_ctx->reset_version <= _ctx->sink_complete_version);
     // acquire finish token and never release

--- a/be/src/exec/pipeline/bucket_process_operator.h
+++ b/be/src/exec/pipeline/bucket_process_operator.h
@@ -44,7 +44,6 @@ struct BucketProcessContext {
 
     OperatorPtr source;
     OperatorPtr sink;
-    SpillProcessChannelPtr spill_channel;
 
     Status reset_operator_state(RuntimeState* state);
 

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -54,6 +54,8 @@ Status SpillableHashJoinBuildOperator::prepare(RuntimeState* state) {
 
 void SpillableHashJoinBuildOperator::close(RuntimeState* state) {
     HashJoinBuildOperator::close(state);
+    DCHECK(is_finished());
+    DCHECK(!need_input());
 }
 
 size_t SpillableHashJoinBuildOperator::estimated_memory_reserved(const ChunkPtr& chunk) {

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -58,6 +58,8 @@ void SpillableHashJoinProbeOperator::close(RuntimeState* state) {
     _probe_spiller.reset();
     _reset_load_partitions();
     HashJoinProbeOperator::close(state);
+    DCHECK(!has_output());
+    DCHECK(is_finished());
 }
 
 bool SpillableHashJoinProbeOperator::has_output() const {

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -55,6 +55,8 @@ Status SpillableHashJoinProbeOperator::prepare(RuntimeState* state) {
 }
 
 void SpillableHashJoinProbeOperator::close(RuntimeState* state) {
+    _probe_spiller.reset();
+    _reset_load_partitions();
     HashJoinProbeOperator::close(state);
 }
 
@@ -74,6 +76,9 @@ bool SpillableHashJoinProbeOperator::has_output() const {
 
     if (!_status().ok()) {
         return true;
+    }
+    if (_is_finished) {
+        return false;
     }
 
     if (_processing_partitions.empty()) {
@@ -111,8 +116,8 @@ bool SpillableHashJoinProbeOperator::has_output() const {
             } else if (!_current_reader[i]->has_restore_task()) {
                 // if trigger_restore returns error, should record this status and return it in pull_chunk
                 _update_status(_current_reader[i]->trigger_restore(
-                        runtime_state(),
-                        RESOURCE_TLS_MEMTRACER_GUARD(runtime_state(), std::weak_ptr(_current_reader[i]))));
+                        runtime_state(), TRACKER_WITH_SPILLER_RES_GUARD(runtime_state(), _probe_spiller,
+                                                                        std::weak_ptr(_current_reader[i]))));
                 if (!_status().ok()) {
                     return true;
                 }
@@ -136,6 +141,10 @@ bool SpillableHashJoinProbeOperator::need_input() const {
         return false;
     }
 
+    if (_is_finished) {
+        return false;
+    }
+
     if (_processing_partitions.empty()) {
         as_mutable()->_acquire_next_partitions();
         _update_status(as_mutable()->_load_all_partition_build_side(runtime_state()));
@@ -156,12 +165,11 @@ bool SpillableHashJoinProbeOperator::need_input() const {
 }
 
 bool SpillableHashJoinProbeOperator::is_finished() const {
-    if (!spilled()) {
-        return HashJoinProbeOperator::is_finished();
-    }
-
     if (_is_finished) {
         return true;
+    }
+    if (!spilled()) {
+        return HashJoinProbeOperator::is_finished();
     }
 
     if (_is_finishing && _all_partition_finished()) {
@@ -270,8 +278,8 @@ Status SpillableHashJoinProbeOperator::_load_partition_build_side(workgroup::Yie
                 return Status::Cancelled("cancelled");
             }
 
-            RETURN_IF_ERROR(reader->trigger_restore<spill::SyncTaskExecutor>(state, MemTrackerGuard(tls_mem_tracker)));
-            auto chunk_st = reader->restore<spill::SyncTaskExecutor>(state, MemTrackerGuard(tls_mem_tracker));
+            RETURN_IF_ERROR(reader->trigger_restore<SyncTaskExecutor>(state, MemTrackerGuard(tls_mem_tracker)));
+            auto chunk_st = reader->restore<SyncTaskExecutor>(state, MemTrackerGuard(tls_mem_tracker));
 
             FAIL_POINT_TRIGGER_EXECUTE(spill_hash_join_throw_bad_alloc, { throw std::bad_alloc(); });
 
@@ -371,17 +379,25 @@ void SpillableHashJoinProbeOperator::_check_partitions() {
     }
 }
 
+void SpillableHashJoinProbeOperator::_reset_load_partitions() {
+    // release memory
+    _processing_partitions.clear();
+    _current_reader.clear();
+    _builders.clear();
+    _probers.clear();
+    _component_pool.clear();
+}
+
 Status SpillableHashJoinProbeOperator::_restore_probe_partition(RuntimeState* state) {
     for (size_t i = 0; i < _probers.size(); ++i) {
+        auto guard = TRACKER_WITH_SPILLER_RES_GUARD(state, _probe_spiller, std::weak_ptr(_current_reader[i]));
         // probe partition has been processed
         if (_probe_read_eofs[i]) continue;
         if (!_current_reader[i]->has_restore_task()) {
-            RETURN_IF_ERROR(_current_reader[i]->trigger_restore(
-                    state, RESOURCE_TLS_MEMTRACER_GUARD(state, std::weak_ptr(_current_reader[i]))));
+            RETURN_IF_ERROR(_current_reader[i]->trigger_restore(state, guard));
         }
         if (_current_reader[i]->has_output_data()) {
-            auto chunk_st = _current_reader[i]->restore(
-                    state, RESOURCE_TLS_MEMTRACER_GUARD(state, std::weak_ptr(_current_reader[i])));
+            auto chunk_st = _current_reader[i]->restore(state, guard);
             if (chunk_st.ok() && chunk_st.value() && !chunk_st.value()->is_empty()) {
                 RETURN_IF_ERROR(_probers[i]->push_probe_chunk(state, std::move(chunk_st.value())));
             } else if (chunk_st.status().is_end_of_file()) {
@@ -462,19 +478,17 @@ StatusOr<ChunkPtr> SpillableHashJoinProbeOperator::pull_chunk(RuntimeState* stat
         for (auto* partition : _processing_partitions) {
             _processed_partitions.emplace(partition->partition_id);
         }
-        _processing_partitions.clear();
-        _current_reader.clear();
         _has_probe_remain = false;
-        _builders.clear();
         COUNTER_SET(metrics.build_partition_peak_memory_usage, 0);
         COUNTER_SET(metrics.peak_processing_partition_count, 0);
+        _reset_load_partitions();
     }
 
     return nullptr;
 }
 
 bool SpillableHashJoinProbeOperator::spilled() const {
-    return _join_builder->spiller()->spilled();
+    return _join_builder->spiller() && _join_builder->spiller()->spilled();
 }
 
 void SpillableHashJoinProbeOperator::_acquire_next_partitions() {

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.h
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.h
@@ -113,6 +113,8 @@ private:
     // some DCHECK for hash table/partition num_rows
     void _check_partitions();
 
+    void _reset_load_partitions();
+
 private:
     SpillableHashJoinProbeMetrics metrics;
 

--- a/be/src/exec/pipeline/spill_process_channel.cpp
+++ b/be/src/exec/pipeline/spill_process_channel.cpp
@@ -33,7 +33,7 @@ SpillProcessChannelPtr SpillProcessChannelFactory::get_or_create(int32_t sequenc
 Status SpillProcessChannel::execute(SpillProcessTasksBuilder& task_builder) {
     std::lock_guard guard(_mutex);
     Status res;
-    if (is_working() || _is_closed) {
+    if (is_working() && !_is_closed) {
         for (auto&& task : task_builder.tasks()) {
             add_spill_task(std::move(task));
         }
@@ -67,7 +67,9 @@ void SpillProcessChannel::close() {
     DCHECK(task);
 
     // run the last task
-    (void)task();
+    if (task) {
+        (void)task();
+    }
 
     _spiller.reset();
     _is_closed = true;

--- a/be/src/exec/pipeline/spill_process_channel.cpp
+++ b/be/src/exec/pipeline/spill_process_channel.cpp
@@ -33,7 +33,12 @@ SpillProcessChannelPtr SpillProcessChannelFactory::get_or_create(int32_t sequenc
 Status SpillProcessChannel::execute(SpillProcessTasksBuilder& task_builder) {
     std::lock_guard guard(_mutex);
     Status res;
-    if (is_working() && !_is_closed) {
+    if (_is_closed) {
+        auto st = task_builder.final_task()();
+        if (!st.status().is_ok_or_eof()) {
+            res = st.status();
+        }
+    } else if (is_working()) {
         for (auto&& task : task_builder.tasks()) {
             add_spill_task(std::move(task));
         }

--- a/be/src/exec/pipeline/spill_process_channel.cpp
+++ b/be/src/exec/pipeline/spill_process_channel.cpp
@@ -69,7 +69,6 @@ void SpillProcessChannel::close() {
     while (!_spill_tasks.empty()) {
         _spill_tasks.try_get(&task);
     }
-    DCHECK(task);
 
     // run the last task
     if (task) {

--- a/be/src/exec/pipeline/spill_process_channel.h
+++ b/be/src/exec/pipeline/spill_process_channel.h
@@ -89,7 +89,7 @@ public:
     bool add_last_task(SpillProcessTask&& task) {
         DCHECK(!_is_finishing);
         _is_working = true;
-        auto defer = DeferOp([this]() { set_finishing_if_not_reuseable(); });
+        auto defer = DeferOp([this]() { set_finishing(); });
         return _spill_tasks.put(std::move(task));
     }
 
@@ -101,17 +101,14 @@ public:
     bool is_finishing() { return _is_finishing; }
     bool is_working() { return _is_working; }
 
-    void set_finishing_if_not_reuseable() {
-        if (!_is_reuseable) {
-            set_finishing();
-        }
-    }
-
-    void set_reuseable(bool reuseable) { _is_reuseable = reuseable; }
-
     SpillProcessTask& current_task() { return _current_task; }
 
-    bool has_output() { return (has_spill_task() || _current_task) && !_spiller->is_full(); }
+    bool has_output() {
+        if (is_finished()) {
+            return false;
+        }
+        return (has_spill_task() || _current_task) && !_spiller->is_full();
+    }
 
     bool has_task() { return has_spill_task() || _current_task; }
 
@@ -122,15 +119,16 @@ public:
 
     Status execute(SpillProcessTasksBuilder& task_builder);
 
-    void close() { _spiller.reset(); }
+    void close();
 
 private:
-    bool _is_reuseable = false;
     bool _is_finishing = false;
     bool _is_working = false;
+    bool _is_closed = false;
     std::shared_ptr<spill::Spiller> _spiller;
     UnboundedBlockingQueue<SpillProcessTask> _spill_tasks;
     SpillProcessTask _current_task;
+    std::mutex _mutex;
 };
 
 class SpillProcessTasksBuilder {

--- a/be/src/exec/pipeline/spill_process_channel.h
+++ b/be/src/exec/pipeline/spill_process_channel.h
@@ -122,6 +122,8 @@ public:
 
     Status execute(SpillProcessTasksBuilder& task_builder);
 
+    void close() { _spiller.reset(); }
+
 private:
     bool _is_reuseable = false;
     bool _is_finishing = false;

--- a/be/src/exec/pipeline/spill_process_operator.cpp
+++ b/be/src/exec/pipeline/spill_process_operator.cpp
@@ -23,11 +23,16 @@
 namespace starrocks::pipeline {
 
 bool SpillProcessOperator::has_output() const {
-    return _channel->has_output();
+    return _is_finished && _channel->has_output();
 }
 
 bool SpillProcessOperator::is_finished() const {
-    return _channel->is_finished();
+    return _is_finished || _channel->is_finished();
+}
+
+Status SpillProcessOperator::set_finished(RuntimeState* state) {
+    _is_finished = true;
+    return Status::OK();
 }
 
 void SpillProcessOperator::close(RuntimeState* state) {

--- a/be/src/exec/pipeline/spill_process_operator.cpp
+++ b/be/src/exec/pipeline/spill_process_operator.cpp
@@ -31,6 +31,7 @@ bool SpillProcessOperator::is_finished() const {
 }
 
 void SpillProcessOperator::close(RuntimeState* state) {
+    _channel->close();
     SourceOperator::close(state);
 }
 

--- a/be/src/exec/pipeline/spill_process_operator.cpp
+++ b/be/src/exec/pipeline/spill_process_operator.cpp
@@ -23,7 +23,7 @@
 namespace starrocks::pipeline {
 
 bool SpillProcessOperator::has_output() const {
-    return _is_finished && _channel->has_output();
+    return !_is_finished && _channel->has_output();
 }
 
 bool SpillProcessOperator::is_finished() const {

--- a/be/src/exec/pipeline/spill_process_operator.h
+++ b/be/src/exec/pipeline/spill_process_operator.h
@@ -43,9 +43,12 @@ public:
 
     bool is_finished() const override;
 
+    Status set_finished(RuntimeState* state) override;
+
     StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
 
 private:
+    bool _is_finished = false;
     SpillProcessChannelPtr _channel;
 };
 

--- a/be/src/exec/spill/executor.h
+++ b/be/src/exec/spill/executor.h
@@ -176,6 +176,9 @@ struct SyncTaskExecutor {
 
 #define TRACKER_WITH_SPILLER_GUARD(state, spiller) RESOURCE_TLS_MEMTRACER_GUARD(state, spiller->weak_from_this())
 
+#define TRACKER_WITH_SPILLER_RES_GUARD(state, spiller, ...) \
+    RESOURCE_TLS_MEMTRACER_GUARD(state, spiller->weak_from_this(), ##__VA_ARGS__)
+
 #define TRACKER_WITH_SPILLER_READER_GUARD(state, spiller) \
     RESOURCE_TLS_MEMTRACER_GUARD(state, spiller->weak_from_this(), std::weak_ptr((spiller)->reader()))
 

--- a/be/src/exec/spill/spiller.cpp
+++ b/be/src/exec/spill/spiller.cpp
@@ -38,8 +38,10 @@
 #include "gutil/port.h"
 #include "runtime/runtime_state.h"
 #include "serde/column_array_serde.h"
+#include "util/failpoint/fail_point.h"
 
 namespace starrocks::spill {
+DEFINE_FAIL_POINT(spill_restore_sleep);
 
 SpillProcessMetrics::SpillProcessMetrics(RuntimeProfile* profile, std::atomic_int64_t* total_spill_bytes_) {
     DCHECK(profile != nullptr);

--- a/be/src/exec/spill/spiller.h
+++ b/be/src/exec/spill/spiller.h
@@ -248,6 +248,11 @@ public:
 
     size_t max_sorted_block_cnt() const { return _max_sorted_block_cnt; }
 
+    void release() {
+        _writer.reset();
+        _reader.reset();
+    }
+
 private:
     Status _acquire_input_stream(RuntimeState* state);
 

--- a/be/src/exec/spill/spiller_factory.cpp
+++ b/be/src/exec/spill/spiller_factory.cpp
@@ -22,9 +22,7 @@
 
 namespace starrocks::spill {
 std::shared_ptr<Spiller> SpillerFactory::create(const SpilledOptions& options) {
-    std::lock_guard guard(_mutex);
     auto spiller = std::make_shared<Spiller>(options, shared_from_this());
-    _spillers.emplace_back(spiller);
     return spiller;
 }
 

--- a/be/src/exec/spill/spiller_factory.h
+++ b/be/src/exec/spill/spiller_factory.h
@@ -14,15 +14,9 @@
 
 #pragma once
 
-#include <atomic>
 #include <memory>
-#include <mutex>
 
-#include "exec/sort_exec_exprs.h"
-#include "exec/sorting/sorting.h"
 #include "exec/spill/spill_fwd.h"
-#include "exprs/expr_context.h"
-#include "runtime/runtime_state.h"
 
 namespace starrocks::spill {
 
@@ -33,13 +27,6 @@ public:
 
     // create a spiller
     std::shared_ptr<Spiller> create(const SpilledOptions& options);
-
-    // release some resource in advance
-    void close();
-
-private:
-    std::mutex _mutex;
-    std::vector<std::shared_ptr<Spiller>> _spillers;
 };
 
 using SpillerFactoryPtr = std::shared_ptr<SpillerFactory>;

--- a/be/src/util/failpoint/fail_point.cpp
+++ b/be/src/util/failpoint/fail_point.cpp
@@ -1,3 +1,18 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef FIU_ENABLE
 
 #include "util/failpoint/fail_point.h"
 
@@ -194,3 +209,5 @@ DEFINE_FAIL_POINT(random_error);
 DEFINE_FAIL_POINT(output_stream_io_error);
 
 } // namespace starrocks::failpoint
+
+#endif

--- a/be/src/util/failpoint/fail_point.h
+++ b/be/src/util/failpoint/fail_point.h
@@ -1,4 +1,20 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
+
+#ifdef FIU_ENABLE
 
 #include <condition_variable>
 #include <memory>
@@ -121,6 +137,11 @@ private:
     bool a_triggered_{};
 };
 
+bool init_failpoint_from_conf(const std::string& conf_file);
+
+} // namespace starrocks::failpoint
+#endif
+
 #ifdef FIU_ENABLE
 // Use this macro to define failpoint
 // NOTE: it can only be used in cpp files, the name of failpoint must be globally unique
@@ -172,7 +193,3 @@ private:
 #define FAIL_POINT_TRIGGER_RETURN_ERROR(NAME)
 #define FAIL_POINT_TRIGGER_ASSIGN_STATUS_OR_DEFAULT(NAME, status, stmt, default_stmt) status = default_stmt
 #endif
-
-bool init_failpoint_from_conf(const std::string& conf_file);
-
-} // namespace starrocks::failpoint

--- a/be/test/io/spill_test.cpp
+++ b/be/test/io/spill_test.cpp
@@ -696,9 +696,10 @@ TEST_F(SpillTest, partition_yield_with_failed) {
             ASSERT_OK(spiller->_spilled_task_status);
             holder.push_back(chunk);
         }
-
-        PredoSyncExecutor::predo = [&]() { spiller.reset(); };
-        ASSERT_OK(spiller->flush<PredoSyncExecutor>(&dummy_rt_st, EmptyMemGuard{}));
+        auto dummy = std::make_shared<int>();
+        PredoSyncExecutor::predo = [&]() { dummy.reset(); };
+        ASSERT_OK(spiller->flush<PredoSyncExecutor>(&dummy_rt_st,
+                                                    spill::ResourceMemTrackerGuard(nullptr, std::weak_ptr(dummy))));
     }
 }
 

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -2498,7 +2498,7 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
             if not res["status"]:
                 tools.assert_true(False, "acquire task state error")
             state = res["result"][0][0]
-            if state != "RUNNING" and state != "PENDING":
+            if state != "RUNNING" and state != "PENDING" and state != "SUBMITTED":
                 return ""
             time.sleep(1)
 

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -2498,7 +2498,17 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
             if not res["status"]:
                 tools.assert_true(False, "acquire task state error")
             state = res["result"][0][0]
-            if status != "RUNNING":
+            if state != "RUNNING" and state != "PENDING":
+                return ""
+            time.sleep(1)
+
+    def wait_util_no_queries(self):
+        while True:
+            sql = "show proc '/current_queries'"
+            res = self.execute_sql(sql, True)
+            if not res["status"]:
+                tools.assert_true(False, "run current_queries error")
+            if len(res["result"]) == 0:
                 return ""
             time.sleep(1)
 

--- a/test/sql/test_spill/R/test_spill_hash_join_restore_cancelled
+++ b/test/sql/test_spill/R/test_spill_hash_join_restore_cancelled
@@ -1,0 +1,48 @@
+-- name: test_spill_hash_join_restore_cancelled @sequential
+CREATE TABLE `t0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  4096000));
+-- result:
+-- !result
+admin enable failpoint 'spill_restore_sleep';
+-- result:
+-- !result
+[UC]submit task etl_${uuid0} 
+PROPERTIES (
+    "session.pipeline_dop"= "1",
+    "session.enable_spill"="true",
+    "session.spill_mode"="force",
+    "session.spill_operator_min_bytes"="1024",
+    "session.spill_mem_table_size"="1024"
+)
+as CREATE table tmp as select sum(l.c0), sum(l.c1), sum(l.c2), sum(l.c3), sum(r.c0), sum(r.c1), sum(r.c2), sum(r.c3) from t0 l join t0 r on l.c0=r.c0 and l.c1 = r.c1;
+-- result:
+etl_1e34dc9dff5f48549e22d40cb2922cf3	SUBMITTED
+-- !result
+shell: sleep 1
+-- result:
+0
+
+-- !result
+drop task etl_${uuid0};
+-- result:
+-- !result
+function: wait_util_no_queries()
+-- result:
+
+-- !result
+admin disable failpoint 'spill_restore_sleep';
+-- result:
+-- !result

--- a/test/sql/test_spill/T/test_spill_hash_join_restore_cancelled
+++ b/test/sql/test_spill/T/test_spill_hash_join_restore_cancelled
@@ -1,0 +1,36 @@
+-- name: test_spill_hash_join_restore_cancelled
+
+CREATE TABLE `t0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `c1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  4096000));
+
+admin enable failpoint 'spill_restore_sleep';
+[UC]submit task etl_${uuid0} 
+PROPERTIES (
+    "session.pipeline_dop"= "1",
+    "session.enable_spill"="true",
+    "session.spill_mode"="force",
+    "session.spill_operator_min_bytes"="1024",
+    "session.spill_mem_table_size"="1024"
+)
+as CREATE table tmp as select sum(l.c0), sum(l.c1), sum(l.c2), sum(l.c3), sum(r.c0), sum(r.c1), sum(r.c2), sum(r.c3) from t0 l join t0 r on l.c0=r.c0 and l.c1 = r.c1;
+
+shell: sleep 1
+
+drop task etl_${uuid0};
+
+function: wait_util_no_queries()
+
+admin disable failpoint 'spill_restore_sleep';
+


### PR DESCRIPTION
## Why I'm doing:

I observed significantly higher-than-expected memory usage when testing group execution with spill joins. I ultimately pinpointed the issue to the spiller failing to release memory promptly.
This PR introduces early release behavior.

reproduce case:
ssb 100g

```
set enable_spill=true;
set pipeline_dop=1;
set spill_mode="force";
select      count(l.lo_orderkey),     count(l.lo_linenumber),     count(l.lo_custkey),     count(l.lo_partkey),     count(l.lo_suppkey),     count(l.lo_orderdate),     count(l.lo_orderpriority),     count(l.lo_shippriority),     count(l.lo_quantity),     count(l.lo_extendedprice),     count(l.lo_ordtotalprice),     count(l.lo_discount),     count(l.lo_revenue),     count(l.lo_supplycost),     count(l.lo_tax),     count(l.lo_commitdate),     count(l.lo_shipmode),     count(r.lo_orderkey),     count(l.lo_shipmode) from lineorder l left join lineorder r on l.lo_orderkey=r.lo_orderkey ;
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Proactively releases spiller resources and tightens spill pipeline and hash-join lifecycles (channel closing, finished-state checks), adds failpoints and tests, and minor metrics/API tweaks.
> 
> - **Spill resource lifecycle**:
>   - Release/reset spiller resources earlier: `_spiller.reset()` in `Aggregator`/`HashJoiner` and probe operator; new `Spiller::release()`.
>   - Spill process operator/channel: add `set_finished()`, `close()` and finished guards; `has_output()` respects finished state.
> - **Spill process channel**:
>   - Serialize access with mutex; handle closed/finishing states in `execute()`/`close()`; remove reusable-channel paths; add `_is_closed` flag.
> - **Aggregate/Distinct/Partition-wise operators**:
>   - Use `spill_channel()->set_finishing()` consistently; assert finished state in `close()`; gate `has_output`/`is_finished` by `_is_finished`.
>   - Metrics: replace peak counter construction with `ADD_PEAK_COUNTER`.
>   - DistinctBlocking pipeline: disable per-bucket optimize for spill path.
> - **Hash Join**:
>   - Probe: reset spiller and loaded partition structures on `close()`; add early finished checks in `has_output`/`need_input`; guard restore with `TRACKER_WITH_SPILLER_RES_GUARD`; executor type simplifications; robust `spilled()` null check; add `_reset_load_partitions()`.
>   - Build: add defensive `DCHECK`s in `close()`.
> - **Failpoints**:
>   - Introduce `spill_restore_sleep` and wrap failpoint impl with `FIU_ENABLE` guards.
> - **Tests/Utils**:
>   - Add SQL test `test_spill_hash_join_restore_cancelled` and helper `wait_util_no_queries()`; update spill unit tests to use resource guards.
> - **Misc**:
>   - Minor include addition (`exec/sorting/sorting.h`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f65c65b293816739584d4be324168455dd1f77c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->