### PR TITLE
[Feature] Implement publish version in BE for tablet splitting

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -37,6 +37,7 @@
 #include "storage/lake/metacache.h"
 #include "storage/lake/options.h"
 #include "storage/lake/tablet.h"
+#include "storage/lake/tablet_reshard.h"
 #include "storage/lake/transactions.h"
 #include "storage/lake/update_manager.h"
 #include "storage/lake/vacuum.h"
@@ -141,6 +142,38 @@ std::string txn_info_string(const TxnInfoPB& info) {
     return info.DebugString();
 }
 
+std::ostream& operator<<(std::ostream& os, const std::span<const lake::PublishTabletInfo>& tablet_infos) {
+    os << '[';
+    bool first = true;
+    for (const auto& tablet_info : tablet_infos) {
+        if (first) {
+            first = false;
+        } else {
+            os << ", ";
+        }
+        os << tablet_info;
+    }
+    return os << ']';
+}
+
+std::string publish_tablet_info_string(const std::span<const lake::PublishTabletInfo>& tablet_infos) {
+    std::stringstream ss;
+    ss << tablet_infos;
+    return ss.str();
+}
+
+void add_failed_tablets(PublishVersionResponse* response, const ReshardingTabletInfoPB& resharding_tablet_info) {
+    if (resharding_tablet_info.has_splitting_tablet_info()) {
+        response->add_failed_tablets(resharding_tablet_info.splitting_tablet_info().old_tablet_id());
+    } else if (resharding_tablet_info.has_merging_tablet_info()) {
+        for (auto old_tablet_id : resharding_tablet_info.merging_tablet_info().old_tablet_ids()) {
+            response->add_failed_tablets(old_tablet_id);
+        }
+    } else if (resharding_tablet_info.has_identical_tablet_info()) {
+        response->add_failed_tablets(resharding_tablet_info.identical_tablet_info().old_tablet_id());
+    }
+}
+
 } // namespace
 
 // Get txn_ids string from request (compatible with both new and old FE versions)
@@ -183,8 +216,58 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
         cntl->SetFailed("neither txn_ids nor txn_infos is set, one of them must be set");
         return;
     }
-    if (request->tablet_ids_size() == 0) {
-        cntl->SetFailed("missing tablet_ids");
+
+    int task_num = request->tablet_ids_size();
+
+    // Prepare publish tablet infos
+    std::vector<lake::PublishTabletInfo> publish_tablet_infos;
+    publish_tablet_infos.reserve(request->tablet_ids_size());
+    for (auto tablet_id : request->tablet_ids()) {
+        // Publish normal tablets
+        publish_tablet_infos.emplace_back(tablet_id);
+    }
+
+    bool is_tablet_reshard_txn = false;
+    if (request->txn_infos_size() == 1 && request->txn_infos()[0].txn_type() == TXN_TABLET_RESHARD) {
+        // Tablet reshard transaction
+        if (request->resharding_tablet_infos_size() == 0) {
+            cntl->SetFailed("missing resharding_tablet_infos when txn_type is TXN_TABLET_RESHARD");
+            return;
+        }
+        is_tablet_reshard_txn = true;
+        task_num += request->resharding_tablet_infos_size();
+    } else { // Normal transaction
+        for (const auto& resharding_tablet_info : request->resharding_tablet_infos()) {
+            // Cross publish
+            if (resharding_tablet_info.has_splitting_tablet_info()) {
+                // Splitting tablet
+                const auto& splitting_tablet_info = resharding_tablet_info.splitting_tablet_info();
+                task_num += splitting_tablet_info.new_tablet_ids_size();
+                for (auto new_tablet_id : splitting_tablet_info.new_tablet_ids()) {
+                    publish_tablet_infos.emplace_back(lake::PublishTabletInfo::SPLITTING_TABLET,
+                                                      splitting_tablet_info.old_tablet_id(), new_tablet_id);
+                }
+            } else if (resharding_tablet_info.has_merging_tablet_info()) {
+                // Merging tablets
+                task_num += 1;
+                const auto& merging_tablet_info = resharding_tablet_info.merging_tablet_info();
+                for (auto old_tablet_id : merging_tablet_info.old_tablet_ids()) {
+                    publish_tablet_infos.emplace_back(lake::PublishTabletInfo::MERGING_TABLET, old_tablet_id,
+                                                      merging_tablet_info.new_tablet_id());
+                }
+            } else if (resharding_tablet_info.has_identical_tablet_info()) {
+                // Identical tablet
+                task_num += 1;
+                const auto& identical_tablet_info = resharding_tablet_info.identical_tablet_info();
+                publish_tablet_infos.emplace_back(lake::PublishTabletInfo::IDENTICAL_TABLET,
+                                                  identical_tablet_info.old_tablet_id(),
+                                                  identical_tablet_info.new_tablet_id());
+            }
+        }
+    }
+
+    if (task_num == 0) {
+        cntl->SetFailed("neither tablet_ids nor resharding_tablet_infos is set, one of them must be set");
         return;
     }
 
@@ -194,12 +277,13 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
     auto thread_pool = publish_version_thread_pool(_env);
     CHECK(thread_pool != nullptr);
     auto thread_pool_token = ConcurrencyLimitedThreadPoolToken(thread_pool, thread_pool->max_threads() * 2);
-    auto latch = BThreadCountDownLatch(request->tablet_ids_size());
+    auto latch = BThreadCountDownLatch(task_num);
     bthread::Mutex response_mtx;
     scoped_refptr<Trace> trace_gurad = scoped_refptr<Trace>(new Trace());
     Trace* trace = trace_gurad.get();
-    TRACE_TO(trace, "got request. txn_ids=$0 base_version=$1 new_version=$2 #tablets=$3", get_txn_ids_string(request),
-             request->base_version(), request->new_version(), request->tablet_ids_size());
+    TRACE_TO(trace, "got request. txn_ids=$0 base_version=$1 new_version=$2 #tablets=$3 #task_num=$4",
+             get_txn_ids_string(request), request->base_version(), request->new_version(), request->tablet_ids_size(),
+             task_num);
 
     Status::OK().to_protobuf(response->mutable_status());
     std::unordered_set<int64> rebuild_pindex_tablets;
@@ -208,105 +292,129 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
         rebuild_pindex_tablets.insert(id);
     }
     bool skip_write_tablet_metadata = request->has_enable_aggregate_publish() && request->enable_aggregate_publish();
-    for (auto tablet_id : request->tablet_ids()) {
+
+    for (auto iter = publish_tablet_infos.begin(); iter != publish_tablet_infos.end(); ++iter) {
+        const auto begin_iter = iter;
+        auto end_iter = iter + 1;
+        // Tablets to be merged must be published in a batch task
+        if (begin_iter->get_publish_tablet_type() == lake::PublishTabletInfo::MERGING_TABLET) {
+            while (end_iter != publish_tablet_infos.end() &&
+                   end_iter->get_publish_tablet_type() == lake::PublishTabletInfo::MERGING_TABLET &&
+                   end_iter->get_tablet_id_in_metadata() == begin_iter->get_tablet_id_in_metadata()) {
+                ++end_iter;
+                ++iter;
+            }
+        }
+        std::span<lake::PublishTabletInfo> publish_tablet_batch(begin_iter, end_iter);
+
         auto task = std::make_shared<CancellableRunnable>(
-                [&, tablet_id] {
+                [&, publish_tablet_batch] {
                     DeferOp defer([&] { latch.count_down(); });
-                    scoped_refptr<Trace> child_trace(new Trace);
-                    Trace* sub_trace = child_trace.get();
-                    trace->AddChildTrace("PublishTablet", sub_trace);
 
-                    ADOPT_TRACE(sub_trace);
-                    TRACE("start publish tablet $0 at thread $1", tablet_id, Thread::current_thread()->tid());
+                    for (const auto& tablet_info : publish_tablet_batch) {
+                        scoped_refptr<Trace> child_trace(new Trace);
+                        Trace* sub_trace = child_trace.get();
+                        trace->AddChildTrace("PublishTablet", sub_trace);
 
-                    auto run_ts = butil::gettimeofday_us();
-                    auto queuing_latency = run_ts - start_ts;
-                    g_publish_tablet_version_queuing_latency << queuing_latency;
+                        ADOPT_TRACE(sub_trace);
+                        TRACE("start publish tablet $0 at thread $1", tablet_info.get_tablet_id_in_metadata(),
+                              Thread::current_thread()->tid());
 
-                    auto base_version = request->base_version();
-                    auto new_version = request->new_version();
-                    auto txns = std::vector<TxnInfoPB>();
-                    if (request->txn_infos_size() > 0) {
-                        txns.insert(txns.begin(), request->txn_infos().begin(), request->txn_infos().end());
-                        if (rebuild_pindex_tablets.count(tablet_id) > 0) {
-                            for (auto& txn : txns) {
-                                txn.set_rebuild_pindex(true);
+                        auto run_ts = butil::gettimeofday_us();
+                        auto queuing_latency = run_ts - start_ts;
+                        g_publish_tablet_version_queuing_latency << queuing_latency;
+
+                        auto base_version = request->base_version();
+                        auto new_version = request->new_version();
+                        auto txns = std::vector<TxnInfoPB>();
+                        if (request->txn_infos_size() > 0) {
+                            txns.insert(txns.begin(), request->txn_infos().begin(), request->txn_infos().end());
+                            if (rebuild_pindex_tablets.count(tablet_info.get_tablet_id_in_txn_log()) > 0) {
+                                for (auto& txn : txns) {
+                                    txn.set_rebuild_pindex(true);
+                                }
+                            }
+                        } else { // This is a request from older version FE
+                            // Construct TxnInfoPB from other fields
+                            txns.reserve(request->txn_ids_size());
+                            for (auto i = 0, sz = request->txn_ids_size(); i < sz; i++) {
+                                auto& info = txns.emplace_back();
+                                info.set_txn_id(request->txn_ids(i));
+                                info.set_txn_type(TXN_NORMAL);
+                                info.set_combined_txn_log(false);
+                                info.set_commit_time(request->commit_time());
+                                info.set_force_publish(false);
+                                if (rebuild_pindex_tablets.count(tablet_info.get_tablet_id_in_txn_log()) > 0) {
+                                    info.set_rebuild_pindex(true);
+                                }
                             }
                         }
-                    } else { // This is a request from older version FE
-                        // Construct TxnInfoPB from other fields
-                        txns.reserve(request->txn_ids_size());
-                        for (auto i = 0, sz = request->txn_ids_size(); i < sz; i++) {
-                            auto& info = txns.emplace_back();
-                            info.set_txn_id(request->txn_ids(i));
-                            info.set_txn_type(TXN_NORMAL);
-                            info.set_combined_txn_log(false);
-                            info.set_commit_time(request->commit_time());
-                            info.set_force_publish(false);
-                            if (rebuild_pindex_tablets.count(tablet_id) > 0) {
-                                info.set_rebuild_pindex(true);
-                            }
-                        }
-                    }
 
-                    TRACE_COUNTER_INCREMENT("tablet_id", tablet_id);
-                    TRACE_COUNTER_INCREMENT("queuing_latency_us", queuing_latency);
+                        TRACE_COUNTER_INCREMENT("tablet_id", tablet_info.get_tablet_id_in_metadata());
+                        TRACE_COUNTER_INCREMENT("queuing_latency_us", queuing_latency);
 
-                    StatusOr<TabletMetadataPtr> res;
-                    if (std::chrono::system_clock::now() < timeout_deadline) {
-                        res = lake::publish_version(_tablet_mgr, tablet_id, base_version, new_version, txns,
-                                                    skip_write_tablet_metadata);
-                    } else {
-                        auto t = MilliSecondsSinceEpochFromTimePoint(timeout_deadline);
-                        res = Status::TimedOut(fmt::format("reached deadline={}/timeout={}", t, timeout_ms));
-                    }
-                    if (res.ok()) {
-                        auto metadata = std::move(res).value();
-                        auto score = compaction_score(_tablet_mgr, metadata);
-                        TabletMetadataPB* prealloc_metadata = nullptr;
-                        {
-                            std::lock_guard l(response_mtx);
-                            response->mutable_compaction_scores()->insert({tablet_id, score});
-                            if (request->base_version() == 1) {
-                                int64_t row_nums = std::accumulate(
-                                        metadata->rowsets().begin(), metadata->rowsets().end(), 0,
-                                        [](int64_t sum, const auto& rowset) { return sum + rowset.num_rows(); });
-                                // Used to collect statistics when the partition is first imported
-                                response->mutable_tablet_row_nums()->insert({tablet_id, row_nums});
-                            }
-                            if (skip_write_tablet_metadata) {
-                                auto& map = *response->mutable_tablet_metas();
-                                prealloc_metadata = &map[tablet_id];
-                            }
-                        }
-                        // Move copy metadata out of the lock(response_mtx), to let it execute in parallel.
-                        if (prealloc_metadata != nullptr) {
-                            prealloc_metadata->CopyFrom(*metadata);
-                        }
-                    } else {
-                        g_publish_version_failed_tasks << 1;
-                        if (res.status().is_resource_busy()) {
-                            VLOG(2) << "Fail to publish version: " << res.status() << ". tablet_id=" << tablet_id
-                                    << " txns=" << JoinMapped(txns, txn_info_string, ",") << " version=" << new_version;
+                        StatusOr<TabletMetadataPtr> res;
+                        if (std::chrono::system_clock::now() < timeout_deadline) {
+                            res = lake::publish_version(_tablet_mgr, tablet_info, base_version, new_version, txns,
+                                                        skip_write_tablet_metadata);
                         } else {
-                            LOG(WARNING) << "Fail to publish version: " << res.status() << ". tablet_id=" << tablet_id
-                                         << " txn_ids=" << JoinMapped(txns, txn_info_string, ",")
-                                         << " version=" << new_version;
+                            auto t = MilliSecondsSinceEpochFromTimePoint(timeout_deadline);
+                            res = Status::TimedOut(fmt::format("reached deadline={}/timeout={}", t, timeout_ms));
                         }
-                        std::lock_guard l(response_mtx);
-                        response->add_failed_tablets(tablet_id);
-                        res.status().to_protobuf(response->mutable_status());
+                        if (res.ok()) {
+                            auto metadata = std::move(res).value();
+                            auto score = compaction_score(_tablet_mgr, metadata);
+                            TabletMetadataPB* prealloc_metadata = nullptr;
+                            {
+                                std::lock_guard l(response_mtx);
+                                response->mutable_compaction_scores()->insert({metadata->id(), score});
+                                if (request->base_version() == 1) {
+                                    int64_t row_nums = std::accumulate(
+                                            metadata->rowsets().begin(), metadata->rowsets().end(), 0,
+                                            [](int64_t sum, const auto& rowset) { return sum + rowset.num_rows(); });
+                                    // Used to collect statistics when the partition is first imported
+                                    response->mutable_tablet_row_nums()->insert({metadata->id(), row_nums});
+                                }
+                                if (skip_write_tablet_metadata) {
+                                    auto& map = *response->mutable_tablet_metas();
+                                    prealloc_metadata = &map[metadata->id()];
+                                }
+                            }
+                            // Move copy metadata out of the lock(response_mtx), to let it execute in parallel.
+                            if (prealloc_metadata != nullptr) {
+                                prealloc_metadata->CopyFrom(*metadata);
+                            }
+                        } else {
+                            g_publish_version_failed_tasks << 1;
+                            if (res.status().is_resource_busy()) {
+                                VLOG(2) << "Fail to publish version: " << res.status()
+                                        << ". tablet_info=" << tablet_info
+                                        << " txns=" << JoinMapped(txns, txn_info_string, ",")
+                                        << " version=" << new_version;
+                            } else {
+                                LOG(WARNING) << "Fail to publish version: " << res.status()
+                                             << ". tablet_info=" << tablet_info
+                                             << " txn_ids=" << JoinMapped(txns, txn_info_string, ",")
+                                             << " version=" << new_version;
+                            }
+
+                            std::lock_guard l(response_mtx);
+                            response->add_failed_tablets(tablet_info.get_tablet_id_in_txn_log());
+                            res.status().to_protobuf(response->mutable_status());
+                        }
+                        TRACE("finished");
+                        g_publish_tablet_version_latency << (butil::gettimeofday_us() - run_ts);
                     }
-                    TRACE("finished");
-                    g_publish_tablet_version_latency << (butil::gettimeofday_us() - run_ts);
                 },
-                [&] {
+                [&, publish_tablet_batch] {
                     g_publish_version_failed_tasks << 1;
-                    Status st = Status::Cancelled(
-                            fmt::format("publish version task has been cancelled, tablet_id={}", tablet_id));
+                    Status st = Status::Cancelled(fmt::format("publish version task has been cancelled, tablet_info={}",
+                                                              publish_tablet_info_string(publish_tablet_batch)));
                     LOG(WARNING) << st;
                     std::lock_guard l(response_mtx);
-                    response->add_failed_tablets(tablet_id);
+                    for (const auto& tablet_info : publish_tablet_batch) {
+                        response->add_failed_tablets(tablet_info.get_tablet_id_in_txn_log());
+                    }
                     if (response->status().status_code() == 0) {
                         st.to_protobuf(response->mutable_status());
                     }
@@ -316,12 +424,105 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
         auto st = thread_pool_token.submit(std::move(task), timeout_deadline);
         if (!st.ok()) {
             g_publish_version_failed_tasks << 1;
-            LOG(WARNING) << "Fail to submit publish version task: " << st << ". tablet_id=" << tablet_id
+            LOG(WARNING) << "Fail to submit publish version task: " << st << ". tablet_info=" << publish_tablet_batch
                          << " txn_ids=" << get_txn_ids_string(request);
             std::lock_guard l(response_mtx);
-            response->add_failed_tablets(tablet_id);
+            for (const auto& tablet_info : publish_tablet_batch) {
+                response->add_failed_tablets(tablet_info.get_tablet_id_in_txn_log());
+            }
             st.to_protobuf(response->mutable_status());
             latch.count_down();
+        }
+    }
+
+    if (is_tablet_reshard_txn) {
+        for (const auto& resharding_tablet_info : request->resharding_tablet_infos()) {
+            auto task = std::make_shared<CancellableRunnable>(
+                    [&, resharding_tablet_info] {
+                        DeferOp defer([&latch] { latch.count_down(); });
+
+                        auto txn_info = request->txn_infos()[0];
+                        auto base_version = request->base_version();
+                        auto new_version = request->new_version();
+
+                        Status res;
+                        std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+                        std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+
+                        if (std::chrono::system_clock::now() < timeout_deadline) {
+                            res = lake::publish_resharding_tablet(_tablet_mgr, resharding_tablet_info, base_version,
+                                                                  new_version, txn_info, skip_write_tablet_metadata,
+                                                                  tablet_metadatas, tablet_ranges);
+                        } else {
+                            auto t = MilliSecondsSinceEpochFromTimePoint(timeout_deadline);
+                            res = Status::TimedOut(fmt::format("reached deadline={}/timeout={}", t, timeout_ms));
+                        }
+
+                        if (res.ok()) {
+                            if (skip_write_tablet_metadata) {
+                                // Copy metadata out of the lock(response_mtx), to let it execute in parallel.
+                                std::unordered_map<int64_t, TabletMetadataPB> copied_tablet_metas;
+                                for (auto& pair : tablet_metadatas) {
+                                    copied_tablet_metas[pair.first].CopyFrom(*pair.second);
+                                }
+
+                                std::lock_guard l(response_mtx);
+                                auto& response_tablet_metas = *response->mutable_tablet_metas();
+                                for (auto& pair : copied_tablet_metas) {
+                                    response_tablet_metas[pair.first].Swap(&pair.second);
+                                }
+                            }
+                            if (!tablet_ranges.empty()) {
+                                std::lock_guard l(response_mtx);
+                                auto& response_tablet_ranges = *response->mutable_tablet_ranges();
+                                for (auto& pair : tablet_ranges) {
+                                    response_tablet_ranges[pair.first].Swap(&pair.second);
+                                }
+                            }
+                        } else {
+                            g_publish_version_failed_tasks << 1;
+                            if (res.is_resource_busy()) {
+                                VLOG(2) << "Failed to publish resharding tablet: " << res
+                                        << ". resharding_tablet_info=" << resharding_tablet_info.DebugString()
+                                        << " txn=" << txn_info.DebugString() << " version=" << new_version;
+                            } else {
+                                LOG(WARNING) << "Failed to publish resharding tablet: " << res
+                                             << ". resharding_tablet_info=" << resharding_tablet_info.DebugString()
+                                             << " txn=" << txn_info.DebugString() << " version=" << new_version;
+                            }
+
+                            std::lock_guard l(response_mtx);
+                            add_failed_tablets(response, resharding_tablet_info);
+                            res.to_protobuf(response->mutable_status());
+                        }
+                    },
+                    [&, resharding_tablet_info] {
+                        g_publish_version_failed_tasks << 1;
+                        Status st = Status::Cancelled(fmt::format(
+                                "publish splitting tablet task has been cancelled, resharding_tablet_info={}",
+                                resharding_tablet_info.DebugString()));
+                        LOG(WARNING) << st;
+
+                        std::lock_guard l(response_mtx);
+                        add_failed_tablets(response, resharding_tablet_info);
+                        if (response->status().status_code() == 0) {
+                            st.to_protobuf(response->mutable_status());
+                        }
+                        latch.count_down();
+                    });
+
+            auto st = thread_pool_token.submit(std::move(task), timeout_deadline);
+            if (!st.ok()) {
+                g_publish_version_failed_tasks << 1;
+                LOG(WARNING) << "Failed to submit publish splitting tablet task: " << st
+                             << ". resharding_tablet_info=" << resharding_tablet_info.DebugString()
+                             << " txn_infos=" << JoinMapped(request->txn_infos(), txn_info_string, ",")
+                             << " version=" << request->new_version();
+                std::lock_guard l(response_mtx);
+                add_failed_tablets(response, resharding_tablet_info);
+                st.to_protobuf(response->mutable_status());
+                latch.count_down();
+            }
         }
     }
 
@@ -379,6 +580,10 @@ struct AggregatePublishContext {
         for (auto& [tid, meta] : *resp->mutable_tablet_metas()) {
             // Use swap to avoid copy
             tablet_metas[tid].Swap(&meta);
+        }
+        for (auto& [tid, range] : *resp->mutable_tablet_ranges()) {
+            // Use swap to avoid copy
+            (*response->mutable_tablet_ranges())[tid].Swap(&range);
         }
     }
 

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -197,6 +197,7 @@ set(STORAGE_FILES
     lake/pk_tablet_writer.cpp
     lake/pk_tablet_sst_writer.cpp
     lake/primary_key_compaction_policy.cpp
+    lake/tablet_reshard.cpp
     lake/replication_txn_manager.cpp
     lake/lake_replication_txn_manager.cpp
     lake/rowset.cpp

--- a/be/src/storage/lake/tablet_reshard.cpp
+++ b/be/src/storage/lake/tablet_reshard.cpp
@@ -1,0 +1,369 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/tablet_reshard.h"
+
+#include <span>
+
+#include "storage/lake/metacache.h"
+#include "storage/lake/tablet_manager.h"
+
+namespace starrocks::lake {
+
+std::ostream& operator<<(std::ostream& out, const PublishTabletInfo& tablet_info) {
+    if (tablet_info.get_publish_tablet_type() == PublishTabletInfo::PUBLISH_NORMAL) {
+        return out << "{tablet_id: " << tablet_info.get_tablet_id_in_metadata() << '}';
+    }
+
+    return out << "{publish_tablet_type: " << (int)tablet_info.get_publish_tablet_type()
+               << ", tablet_id_in_metadata: " << tablet_info.get_tablet_id_in_metadata()
+               << ", tablet_id_in_txn_log: " << tablet_info.get_tablet_id_in_txn_log() << '}';
+}
+
+static void set_all_data_files_shared(RowsetMetadataPB* rowset_metadata) {
+    // Set dat files shared
+    auto* shared_segments = rowset_metadata->mutable_shared_segments();
+    shared_segments->Clear();
+    shared_segments->Resize(rowset_metadata->segments_size(), true);
+
+    // Set del files shared
+    for (auto& del : *rowset_metadata->mutable_del_files()) {
+        del.set_shared(true);
+    }
+}
+
+static void set_all_data_files_shared(TxnLogPB* txn_log) {
+    if (txn_log->has_op_write()) {
+        auto* op_write = txn_log->mutable_op_write();
+        if (op_write->has_rowset()) {
+            set_all_data_files_shared(op_write->mutable_rowset());
+        }
+    }
+
+    if (txn_log->has_op_compaction()) {
+        auto* op_compaction = txn_log->mutable_op_compaction();
+        if (op_compaction->has_output_rowset()) {
+            set_all_data_files_shared(op_compaction->mutable_output_rowset());
+        }
+        if (op_compaction->has_output_sstable()) {
+            auto* sstable = op_compaction->mutable_output_sstable();
+            sstable->set_shared(true);
+        }
+    }
+
+    if (txn_log->has_op_schema_change()) {
+        auto* op_schema_change = txn_log->mutable_op_schema_change();
+        for (auto& rowset : *op_schema_change->mutable_rowsets()) {
+            set_all_data_files_shared(&rowset);
+        }
+        if (op_schema_change->has_delvec_meta()) {
+            for (auto& pair : *op_schema_change->mutable_delvec_meta()->mutable_version_to_file()) {
+                pair.second.set_shared(true);
+            }
+        }
+    }
+
+    if (txn_log->has_op_replication()) {
+        for (auto& op_write : *txn_log->mutable_op_replication()->mutable_op_writes()) {
+            if (op_write.has_rowset()) {
+                set_all_data_files_shared(op_write.mutable_rowset());
+            }
+        }
+    }
+}
+
+static void set_all_data_files_shared(TabletMetadataPB* tablet_metadata) {
+    // rowset (dat and del)
+    for (auto& rowset_metadata : *tablet_metadata->mutable_rowsets()) {
+        set_all_data_files_shared(&rowset_metadata);
+    }
+
+    // delvec
+    if (tablet_metadata->has_delvec_meta()) {
+        for (auto& pair : *tablet_metadata->mutable_delvec_meta()->mutable_version_to_file()) {
+            pair.second.set_shared(true);
+        }
+    }
+
+    // dcg
+    if (tablet_metadata->has_dcg_meta()) {
+        for (auto& dcg : *tablet_metadata->mutable_dcg_meta()->mutable_dcgs()) {
+            auto* shared_files = dcg.second.mutable_shared_files();
+            shared_files->Clear();
+            shared_files->Resize(dcg.second.column_files_size(), true);
+        }
+    }
+
+    // sst
+    if (tablet_metadata->has_sstable_meta()) {
+        for (auto& sstable : *tablet_metadata->mutable_sstable_meta()->mutable_sstables()) {
+            sstable.set_shared(true);
+        }
+    }
+}
+
+static Status handle_splitting_tablet(TabletManager* tablet_manager, const SplittingTabletInfoPB& splitting_tablet,
+                                      int64_t base_version, int64_t new_version, const TxnInfoPB& txn_info,
+                                      std::unordered_map<int64_t, TabletMetadataPtr>& new_metadatas,
+                                      std::unordered_map<int64_t, TabletRangePB>& tablet_ranges) {
+    // Check tablet metadata cache
+    {
+        auto old_tablet_new_metadata_location =
+                tablet_manager->tablet_metadata_location(splitting_tablet.old_tablet_id(), new_version);
+        auto cached_old_tablet_new_metadata =
+                tablet_manager->metacache()->lookup_tablet_metadata(old_tablet_new_metadata_location);
+        if (cached_old_tablet_new_metadata == nullptr) {
+            goto CONTINUE_HANDLE_SPLITTING_TABLET;
+        }
+
+        new_metadatas.emplace(splitting_tablet.old_tablet_id(), std::move(cached_old_tablet_new_metadata));
+
+        for (auto new_tablet_id : splitting_tablet.new_tablet_ids()) {
+            auto new_tablet_new_metadata_location =
+                    tablet_manager->tablet_metadata_location(new_tablet_id, new_version);
+            auto cached_new_tablet_new_metadata =
+                    tablet_manager->metacache()->lookup_tablet_metadata(new_tablet_new_metadata_location);
+            if (cached_new_tablet_new_metadata == nullptr) {
+                new_metadatas.clear();
+                tablet_ranges.clear();
+                goto CONTINUE_HANDLE_SPLITTING_TABLET;
+            }
+
+            new_metadatas.emplace(new_tablet_id, std::move(cached_new_tablet_new_metadata));
+            tablet_ranges.emplace(new_tablet_id, TabletRangePB());
+        }
+
+        // All new metadatas found in cache, return ok
+        return Status::OK();
+    }
+
+CONTINUE_HANDLE_SPLITTING_TABLET:
+
+    auto old_tablet_old_metadata_or =
+            tablet_manager->get_tablet_metadata(splitting_tablet.old_tablet_id(), base_version, false);
+    if (old_tablet_old_metadata_or.status().is_not_found()) {
+        // Check new metadata
+        auto old_tablet_new_metadata_or =
+                tablet_manager->get_tablet_metadata(splitting_tablet.old_tablet_id(), new_version, txn_info.gtid());
+        if (!old_tablet_new_metadata_or.ok()) {
+            // Return old metadata not found error
+            return old_tablet_old_metadata_or.status();
+        }
+
+        new_metadatas.emplace(splitting_tablet.old_tablet_id(), std::move(old_tablet_new_metadata_or.value()));
+
+        for (auto new_tablet_id : splitting_tablet.new_tablet_ids()) {
+            auto new_tablet_new_metadata_or =
+                    tablet_manager->get_tablet_metadata(new_tablet_id, new_version, txn_info.gtid());
+            if (!new_tablet_new_metadata_or.ok()) {
+                // Return old metadata not found error
+                return old_tablet_old_metadata_or.status();
+            }
+
+            new_metadatas.emplace(new_tablet_id, std::move(new_tablet_new_metadata_or.value()));
+            tablet_ranges.emplace(new_tablet_id, TabletRangePB());
+        }
+
+        // All new metadatas found, return ok
+        return Status::OK();
+    }
+
+    if (!old_tablet_old_metadata_or.ok()) {
+        LOG(WARNING) << "Failed to get tablet: " << splitting_tablet.old_tablet_id() << ", version: " << base_version
+                     << ", status: " << old_tablet_old_metadata_or.status();
+        return old_tablet_old_metadata_or.status();
+    }
+
+    const auto& old_tablet_old_metadata = old_tablet_old_metadata_or.value();
+
+    // Old tablet
+    {
+        auto old_tablet_new_metadata = std::make_shared<TabletMetadataPB>(*old_tablet_old_metadata);
+        old_tablet_new_metadata->set_version(new_version);
+        old_tablet_new_metadata->set_commit_time(txn_info.commit_time());
+        old_tablet_new_metadata->set_gtid(txn_info.gtid());
+        set_all_data_files_shared(old_tablet_new_metadata.get());
+
+        new_metadatas.emplace(splitting_tablet.old_tablet_id(), std::move(old_tablet_new_metadata));
+    }
+
+    // New tablets
+    for (auto new_tablet_id : splitting_tablet.new_tablet_ids()) {
+        auto new_tablet_new_metadata = std::make_shared<TabletMetadataPB>(*old_tablet_old_metadata);
+        new_tablet_new_metadata->set_id(new_tablet_id);
+        new_tablet_new_metadata->set_version(new_version);
+        new_tablet_new_metadata->set_commit_time(txn_info.commit_time());
+        new_tablet_new_metadata->set_gtid(txn_info.gtid());
+        set_all_data_files_shared(new_tablet_new_metadata.get());
+
+        // Update num rows and data size for rowsets
+        for (auto& rowset_metadata : *new_tablet_new_metadata->mutable_rowsets()) {
+            rowset_metadata.set_num_rows(rowset_metadata.num_rows() / splitting_tablet.new_tablet_ids_size());
+            rowset_metadata.set_data_size(rowset_metadata.data_size() / splitting_tablet.new_tablet_ids_size());
+        }
+
+        new_metadatas.emplace(new_tablet_id, std::move(new_tablet_new_metadata));
+        // TODO: Get split point and construct new ranges
+        tablet_ranges.emplace(new_tablet_id, TabletRangePB());
+    }
+
+    return Status::OK();
+}
+
+static Status handle_merging_tablet(TabletManager* tablet_manager, const MergingTabletInfoPB& merging_tablet,
+                                    int64_t base_version, int64_t new_version, const TxnInfoPB& txn_info,
+                                    std::unordered_map<int64_t, TabletMetadataPtr>& new_metadatas) {
+    return Status::NotSupported("Tablet merging is not implemented");
+}
+
+static Status handle_identical_tablet(TabletManager* tablet_manager, const IdenticalTabletInfoPB& identical_tablet,
+                                      int64_t base_version, int64_t new_version, const TxnInfoPB& txn_info,
+                                      std::unordered_map<int64_t, TabletMetadataPtr>& new_metadatas) {
+    // Check tablet metadata cache
+    {
+        auto old_tablet_new_metadata_location =
+                tablet_manager->tablet_metadata_location(identical_tablet.old_tablet_id(), new_version);
+        auto cached_old_tablet_new_metadata =
+                tablet_manager->metacache()->lookup_tablet_metadata(old_tablet_new_metadata_location);
+        if (cached_old_tablet_new_metadata == nullptr) {
+            goto CONTINUE_HANDLE_IDENTICAL_TABLET;
+        }
+
+        new_metadatas.emplace(identical_tablet.old_tablet_id(), std::move(cached_old_tablet_new_metadata));
+
+        auto new_tablet_new_metadata_location =
+                tablet_manager->tablet_metadata_location(identical_tablet.new_tablet_id(), new_version);
+        auto cached_new_tablet_new_metadata =
+                tablet_manager->metacache()->lookup_tablet_metadata(new_tablet_new_metadata_location);
+        if (cached_new_tablet_new_metadata == nullptr) {
+            new_metadatas.clear();
+            goto CONTINUE_HANDLE_IDENTICAL_TABLET;
+        }
+
+        new_metadatas.emplace(identical_tablet.new_tablet_id(), std::move(cached_new_tablet_new_metadata));
+
+        // All new metadatas found in cache, return ok
+        return Status::OK();
+    }
+
+CONTINUE_HANDLE_IDENTICAL_TABLET:
+
+    auto old_tablet_old_metadata_or =
+            tablet_manager->get_tablet_metadata(identical_tablet.old_tablet_id(), base_version, false);
+    if (old_tablet_old_metadata_or.status().is_not_found()) {
+        // Check new metadata
+        auto old_tablet_new_metadata_or =
+                tablet_manager->get_tablet_metadata(identical_tablet.old_tablet_id(), new_version, txn_info.gtid());
+        if (!old_tablet_new_metadata_or.ok()) {
+            // Return old metadata not found error
+            return old_tablet_old_metadata_or.status();
+        }
+
+        new_metadatas.emplace(identical_tablet.old_tablet_id(), std::move(old_tablet_new_metadata_or.value()));
+
+        auto new_tablet_new_metadata_or =
+                tablet_manager->get_tablet_metadata(identical_tablet.new_tablet_id(), new_version, txn_info.gtid());
+        if (!new_tablet_new_metadata_or.ok()) {
+            // Return old metadata not found error
+            return old_tablet_old_metadata_or.status();
+        }
+
+        new_metadatas.emplace(identical_tablet.new_tablet_id(), std::move(new_tablet_new_metadata_or.value()));
+
+        // All new metadatas found, return ok
+        return Status::OK();
+    }
+
+    if (!old_tablet_old_metadata_or.ok()) {
+        LOG(WARNING) << "Failed to get tablet: " << identical_tablet.old_tablet_id() << ", version: " << base_version
+                     << ", status: " << old_tablet_old_metadata_or.status();
+        return old_tablet_old_metadata_or.status();
+    }
+
+    const auto& old_tablet_old_metadata = old_tablet_old_metadata_or.value();
+
+    // Old tablet
+    {
+        auto old_tablet_new_metadata = std::make_shared<TabletMetadataPB>(*old_tablet_old_metadata);
+        old_tablet_new_metadata->set_version(new_version);
+        old_tablet_new_metadata->set_commit_time(txn_info.commit_time());
+        old_tablet_new_metadata->set_gtid(txn_info.gtid());
+        set_all_data_files_shared(old_tablet_new_metadata.get());
+
+        new_metadatas.emplace(identical_tablet.old_tablet_id(), std::move(old_tablet_new_metadata));
+    }
+
+    // New tablet
+    {
+        auto new_tablet_new_metadata = std::make_shared<TabletMetadataPB>(*old_tablet_old_metadata);
+        new_tablet_new_metadata->set_id(identical_tablet.new_tablet_id());
+        new_tablet_new_metadata->set_version(new_version);
+        new_tablet_new_metadata->set_commit_time(txn_info.commit_time());
+        new_tablet_new_metadata->set_gtid(txn_info.gtid());
+        // New tablet in identical tablet need not to share data files
+
+        new_metadatas.emplace(identical_tablet.new_tablet_id(), std::move(new_tablet_new_metadata));
+    }
+
+    return Status::OK();
+}
+
+TxnLogPtr convert_txn_log(const TxnLogPtr& txn_log, const TabletMetadataPtr& base_tablet_metadata,
+                          const PublishTabletInfo& publish_tablet_info) {
+    if (publish_tablet_info.get_publish_tablet_type() == PublishTabletInfo::PUBLISH_NORMAL) {
+        return txn_log;
+    }
+
+    // Copy a new txn log from original txn log
+    auto new_txn_log = std::make_shared<TxnLogPB>(*txn_log);
+    new_txn_log->set_tablet_id(publish_tablet_info.get_tablet_id_in_metadata());
+
+    // For tablet splitting, set all data files shared in new txn log
+    if (publish_tablet_info.get_publish_tablet_type() == PublishTabletInfo::SPLITTING_TABLET) {
+        set_all_data_files_shared(new_txn_log.get());
+    }
+
+    return new_txn_log;
+}
+
+Status publish_resharding_tablet(TabletManager* tablet_manager, const ReshardingTabletInfoPB& resharding_tablet,
+                                 int64_t base_version, int64_t new_version, const TxnInfoPB& txn_info,
+                                 bool skip_write_tablet_metadata,
+                                 std::unordered_map<int64_t, TabletMetadataPtr>& tablet_metadatas,
+                                 std::unordered_map<int64_t, TabletRangePB>& tablet_ranges) {
+    if (resharding_tablet.has_splitting_tablet_info()) {
+        RETURN_IF_ERROR(handle_splitting_tablet(tablet_manager, resharding_tablet.splitting_tablet_info(), base_version,
+                                                new_version, txn_info, tablet_metadatas, tablet_ranges));
+    } else if (resharding_tablet.has_merging_tablet_info()) {
+        RETURN_IF_ERROR(handle_merging_tablet(tablet_manager, resharding_tablet.merging_tablet_info(), base_version,
+                                              new_version, txn_info, tablet_metadatas));
+    } else if (resharding_tablet.has_identical_tablet_info()) {
+        RETURN_IF_ERROR(handle_identical_tablet(tablet_manager, resharding_tablet.identical_tablet_info(), base_version,
+                                                new_version, txn_info, tablet_metadatas));
+    }
+
+    for (const auto& [tablet_id, new_metadata] : tablet_metadatas) {
+        if (!skip_write_tablet_metadata) {
+            RETURN_IF_ERROR(tablet_manager->put_tablet_metadata(new_metadata));
+        } else {
+            RETURN_IF_ERROR(tablet_manager->cache_tablet_metadata(new_metadata));
+            tablet_manager->metacache()->cache_aggregation_partition(
+                    tablet_manager->tablet_metadata_root_location(tablet_id), true);
+        }
+    }
+
+    return Status::OK();
+}
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_reshard.h
+++ b/be/src/storage/lake/tablet_reshard.h
@@ -1,0 +1,71 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <span>
+
+#include "common/statusor.h"
+#include "gen_cpp/lake_types.pb.h"
+#include "storage/lake/tablet_metadata.h"
+#include "storage/lake/txn_log.h"
+
+namespace starrocks::lake {
+class TabletManager;
+
+class PublishTabletInfo {
+public:
+    enum PublishTabletType {
+        PUBLISH_NORMAL,   // Publish normal tablet, a txn log will be applied to the corresponding tablet.
+        SPLITTING_TABLET, // Cross publish splitting tablet, a txn log will be applied to multiple tablets.
+        MERGING_TABLET,   // Cross publish merging tablet, multiple txn logs will be applied to a tablet.
+        IDENTICAL_TABLET, // Cross publish identical tablet, a txn log will be applied to another tablet.
+    };
+
+public:
+    // For publish normal transaction
+    PublishTabletInfo(int64_t tablet_id)
+            : publish_tablet_type(PUBLISH_NORMAL), tablet_id_in_txn_log(tablet_id), tablet_id_in_metadata(tablet_id) {}
+
+    // For cross publish
+    PublishTabletInfo(PublishTabletType publish_tablet_type, int64_t tablet_id_in_txn_log,
+                      int64_t tablet_id_in_metadata)
+            : publish_tablet_type(publish_tablet_type),
+              tablet_id_in_txn_log(tablet_id_in_txn_log),
+              tablet_id_in_metadata(tablet_id_in_metadata) {}
+
+    PublishTabletType get_publish_tablet_type() const { return publish_tablet_type; }
+    int64_t get_tablet_id_in_txn_log() const { return tablet_id_in_txn_log; }
+    int64_t get_tablet_id_in_metadata() const { return tablet_id_in_metadata; }
+    // A txn log will be applied to multiple tablets in splitting tablet, so it cannot be deleted after applied.
+    bool can_delete_txn_log() const { return publish_tablet_type != SPLITTING_TABLET; }
+
+private:
+    PublishTabletType publish_tablet_type;
+    int64_t tablet_id_in_txn_log;
+    int64_t tablet_id_in_metadata;
+};
+
+std::ostream& operator<<(std::ostream& out, const PublishTabletInfo& tablet_info);
+
+TxnLogPtr convert_txn_log(const TxnLogPtr& txn_log, const TabletMetadataPtr& base_tablet_metadata,
+                          const PublishTabletInfo& publish_tablet_info);
+
+Status publish_resharding_tablet(TabletManager* tablet_manager, const ReshardingTabletInfoPB& resharding_tablet,
+                                 int64_t base_version, int64_t new_version, const TxnInfoPB& txn_info,
+                                 bool skip_write_tablet_metadata,
+                                 std::unordered_map<int64_t, TabletMetadataPtr>& tablet_metadatas,
+                                 std::unordered_map<int64_t, TabletRangePB>& tablet_ranges);
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/transactions.h
+++ b/be/src/storage/lake/transactions.h
@@ -27,6 +27,7 @@ class TxnLogPB;
 namespace starrocks::lake {
 
 class TabletManager;
+class PublishTabletInfo;
 
 // Publish a new version of tablet metadata by applying a set of transactions.
 //
@@ -51,8 +52,8 @@ class TabletManager;
 //
 // Return:
 // - StatusOr containing the new published TabletMetadataPtr on success.
-StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, int64_t tablet_id, int64_t base_version,
-                                            int64_t new_version, std::span<const TxnInfoPB> txns,
+StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, const PublishTabletInfo& tablet_info,
+                                            int64_t base_version, int64_t new_version, std::span<const TxnInfoPB> txns,
                                             bool skip_write_tablet_metadata);
 
 // Publish a batch new versions of transaction logs.

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -218,6 +218,11 @@ public:
     }
 
     Status apply(const TxnLogPB& log) override {
+        // Tablet id check for cross publish
+        if (log.tablet_id() != _metadata->id()) {
+            return Status::InternalError("Tablet id in txn log and metadata are not the same");
+        }
+
         SCOPED_THREAD_LOCAL_CHECK_MEM_LIMIT_SETTER(true);
         SCOPED_THREAD_LOCAL_SINGLETON_CHECK_MEM_TRACKER_SETTER(
                 config::enable_pk_strict_memcheck ? _tablet.update_mgr()->mem_tracker() : nullptr);
@@ -258,6 +263,11 @@ public:
 
         // Pre-check: only accept op_write operations
         for (const auto& log : txn_logs) {
+            // Tablet id check for cross publish
+            if (log->tablet_id() != _metadata->id()) {
+                return Status::InternalError("Tablet id in txn log and metadata are not the same");
+            }
+
             _max_txn_id = std::max(_max_txn_id, log->txn_id());
 
             // Ensure this log has op_write
@@ -709,6 +719,11 @@ public:
     }
 
     Status apply(const TxnLogPB& log) override {
+        // Tablet id check for cross publish
+        if (log.tablet_id() != _metadata->id()) {
+            return Status::InternalError("Tablet id in txn log and metadata are not the same");
+        }
+
         if (log.has_op_write()) {
             RETURN_IF_ERROR(apply_write_log(log.op_write(), log.txn_id()));
         }
@@ -748,6 +763,11 @@ public:
         // Traverse all transaction logs and collect op_write information
         VLOG(2) << "Collecting op_write information from transaction logs for tablet " << _tablet.id();
         for (const auto& log : txn_logs) {
+            // Tablet id check for cross publish
+            if (log->tablet_id() != _metadata->id()) {
+                return Status::InternalError("Tablet id in txn log and metadata are not the same");
+            }
+
             if (log->has_op_write()) {
                 const auto& op_write = log->op_write();
                 RETURN_IF_ERROR(update_metadata_schema(op_write, log->txn_id(), _metadata, _tablet.tablet_mgr()));

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -531,6 +531,7 @@ SET(DW_TEST_FILES
     ./storage/lake/persistent_index_sstable_test.cpp
     ./storage/lake/primary_key_compaction_task_test.cpp
     ./storage/lake/primary_key_publish_test.cpp
+    ./storage/lake/tablet_reshard_test.cpp
     ./storage/lake/replication_txn_manager_test.cpp
     ./storage/lake/rowset_test.cpp
     ./storage/lake/schema_change_test.cpp

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -223,7 +223,7 @@ TEST_F(LakeServiceTest, test_publish_version_missing_tablet_ids) {
     request.add_txn_ids(1000);
     _lake_service.publish_version(&cntl, &request, &response, nullptr);
     ASSERT_TRUE(cntl.Failed());
-    ASSERT_EQ("missing tablet_ids", cntl.ErrorText());
+    ASSERT_EQ("neither tablet_ids nor resharding_tablet_infos is set, one of them must be set", cntl.ErrorText());
 }
 
 TEST_F(LakeServiceTest, test_publish_version_missing_txn_ids) {
@@ -754,6 +754,425 @@ TEST_F(LakeServiceTest, test_publish_version_transform_batch_to_single) {
         ASSERT_EQ(_tablet_id, metadata->id());
         ASSERT_EQ(101, metadata->rowsets(0).num_rows());
         ASSERT_EQ(4096, metadata->rowsets(0).data_size());
+    }
+}
+
+TEST_F(LakeServiceTest, test_publish_splitting_tablet) {
+    {
+        auto txn_log = generate_write_txn_log(1, 100, 100);
+        ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
+
+        PublishVersionRequest publish_request;
+        publish_request.set_base_version(1);
+        publish_request.set_new_version(2);
+        publish_request.add_tablet_ids(_tablet_id);
+        publish_request.add_txn_ids(txn_log.txn_id());
+
+        {
+            SyncPoint::GetInstance()->SetCallBack("ThreadPool::do_submit:1", [](void* arg) { *(int64_t*)arg = 0; });
+            SyncPoint::GetInstance()->EnableProcessing();
+            DeferOp defer([]() {
+                SyncPoint::GetInstance()->ClearCallBack("ThreadPool::do_submit:1");
+                SyncPoint::GetInstance()->DisableProcessing();
+            });
+
+            PublishVersionResponse response;
+            _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+            ASSERT_EQ(1, response.failed_tablets_size());
+            EXPECT_NE(0, response.status().status_code()) << response.status().error_msgs(0);
+        }
+
+        {
+            class MockRunnable : public Runnable {
+            public:
+                MockRunnable() {}
+                virtual ~MockRunnable() override {}
+                virtual void run() override {}
+                virtual void cancel() override {}
+            };
+
+            SyncPoint::GetInstance()->SetCallBack("ThreadPool::do_submit:replace_task", [](void* arg) {
+                auto ptr = (*(std::shared_ptr<Runnable>*)arg);
+                ptr->cancel();
+                (*(std::shared_ptr<Runnable>*)arg) = std::make_shared<MockRunnable>();
+            });
+            SyncPoint::GetInstance()->EnableProcessing();
+            DeferOp defer([]() {
+                SyncPoint::GetInstance()->ClearCallBack("ThreadPool::do_submit:replace_task");
+                SyncPoint::GetInstance()->DisableProcessing();
+            });
+
+            PublishVersionResponse response;
+            _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+            ASSERT_EQ(1, response.failed_tablets_size());
+            EXPECT_NE(0, response.status().status_code()) << response.status().error_msgs(0);
+        }
+
+        {
+            PublishVersionResponse response;
+            _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+            ASSERT_EQ(0, response.failed_tablets_size());
+            EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+            ASSERT_EQ(0, response.tablet_metas_size());
+            ASSERT_EQ(0, response.tablet_ranges_size());
+        }
+
+        {
+            publish_request.set_enable_aggregate_publish(true);
+            PublishVersionResponse response;
+            _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+            ASSERT_EQ(0, response.failed_tablets_size());
+            EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+            ASSERT_EQ(1, response.tablet_metas_size());
+            ASSERT_EQ(0, response.tablet_ranges_size());
+        }
+    }
+
+    ReshardingTabletInfoPB resharding_tablet_info;
+    auto* splitting_tablet_info = resharding_tablet_info.mutable_splitting_tablet_info();
+    splitting_tablet_info->set_old_tablet_id(_tablet_id);
+    splitting_tablet_info->add_new_tablet_ids(next_id());
+    splitting_tablet_info->add_new_tablet_ids(next_id());
+
+    // Test tablet reshard transaction
+    {
+        PublishVersionRequest publish_request;
+        publish_request.set_base_version(2);
+        publish_request.set_new_version(3);
+
+        auto* txn_info = publish_request.add_txn_infos();
+        txn_info->set_txn_id(next_id());
+        txn_info->set_txn_type(TXN_TABLET_RESHARD);
+        txn_info->set_combined_txn_log(false);
+        txn_info->set_commit_time(12345);
+        txn_info->set_force_publish(false);
+
+        publish_request.add_resharding_tablet_infos()->CopyFrom(resharding_tablet_info);
+
+        {
+            PublishVersionResponse response;
+            _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+            ASSERT_EQ(0, response.failed_tablets_size());
+            EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+            ASSERT_EQ(0, response.tablet_metas_size());
+            ASSERT_EQ(2, response.tablet_ranges_size());
+        }
+
+        {
+            publish_request.set_enable_aggregate_publish(true);
+            PublishVersionResponse response;
+            _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+            ASSERT_EQ(0, response.failed_tablets_size());
+            EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+            ASSERT_EQ(3, response.tablet_metas_size());
+            ASSERT_EQ(2, response.tablet_ranges_size());
+        }
+    }
+
+    // Test cross publish
+    {
+        auto txn_log = generate_write_txn_log(1, 100, 100);
+        ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
+
+        PublishVersionRequest publish_request;
+        publish_request.set_base_version(3);
+        publish_request.set_new_version(4);
+        publish_request.add_txn_ids(txn_log.txn_id());
+        publish_request.add_resharding_tablet_infos()->CopyFrom(resharding_tablet_info);
+
+        {
+            PublishVersionResponse response;
+            _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+            ASSERT_EQ(0, response.failed_tablets_size());
+            EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+            ASSERT_EQ(0, response.tablet_metas_size());
+            ASSERT_EQ(0, response.tablet_ranges_size());
+        }
+
+        {
+            publish_request.set_enable_aggregate_publish(true);
+            PublishVersionResponse response;
+            _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+            ASSERT_EQ(0, response.failed_tablets_size());
+            EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+            ASSERT_EQ(2, response.tablet_metas_size());
+            ASSERT_EQ(0, response.tablet_ranges_size());
+        }
+    }
+}
+
+TEST_F(LakeServiceTest, test_publish_merging_tablet) {
+    {
+        auto txn_log = generate_write_txn_log(1, 100, 100);
+        ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
+
+        PublishVersionRequest publish_request;
+        publish_request.set_base_version(1);
+        publish_request.set_new_version(2);
+        publish_request.add_tablet_ids(_tablet_id);
+        auto* txn_info = publish_request.add_txn_infos();
+        txn_info->set_txn_id(txn_log.txn_id());
+
+        {
+            PublishVersionResponse response;
+            _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+            ASSERT_EQ(0, response.failed_tablets_size());
+            EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+        }
+
+        {
+            publish_request.set_enable_aggregate_publish(true);
+            PublishVersionResponse response;
+            _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+            ASSERT_EQ(0, response.failed_tablets_size());
+            EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+        }
+    }
+
+    ReshardingTabletInfoPB resharding_tablet_info;
+    auto* merging_tablet_info = resharding_tablet_info.mutable_merging_tablet_info();
+    merging_tablet_info->add_old_tablet_ids(_tablet_id);
+    merging_tablet_info->add_old_tablet_ids(_tablet_id);
+    merging_tablet_info->set_new_tablet_id(next_id());
+
+    {
+        PublishVersionRequest publish_request;
+        publish_request.set_base_version(2);
+        publish_request.set_new_version(3);
+
+        auto* txn_info = publish_request.add_txn_infos();
+        txn_info->set_txn_id(next_id());
+        txn_info->set_txn_type(TXN_TABLET_RESHARD);
+        txn_info->set_combined_txn_log(false);
+        txn_info->set_commit_time(12345);
+        txn_info->set_force_publish(false);
+
+        publish_request.add_resharding_tablet_infos()->CopyFrom(resharding_tablet_info);
+
+        {
+            SyncPoint::GetInstance()->SetCallBack("ThreadPool::do_submit:1", [](void* arg) { *(int64_t*)arg = 0; });
+            SyncPoint::GetInstance()->EnableProcessing();
+            DeferOp defer([]() {
+                SyncPoint::GetInstance()->ClearCallBack("ThreadPool::do_submit:1");
+                SyncPoint::GetInstance()->DisableProcessing();
+            });
+
+            PublishVersionResponse response;
+            _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+            ASSERT_EQ(2, response.failed_tablets_size());
+            EXPECT_NE(0, response.status().status_code()) << response.status().error_msgs(0);
+        }
+
+        {
+            class MockRunnable : public Runnable {
+            public:
+                MockRunnable() {}
+                virtual ~MockRunnable() override {}
+                virtual void run() override {}
+                virtual void cancel() override {}
+            };
+
+            SyncPoint::GetInstance()->SetCallBack("ThreadPool::do_submit:replace_task", [](void* arg) {
+                auto ptr = (*(std::shared_ptr<Runnable>*)arg);
+                ptr->cancel();
+                (*(std::shared_ptr<Runnable>*)arg) = std::make_shared<MockRunnable>();
+            });
+            SyncPoint::GetInstance()->EnableProcessing();
+            DeferOp defer([]() {
+                SyncPoint::GetInstance()->ClearCallBack("ThreadPool::do_submit:replace_task");
+                SyncPoint::GetInstance()->DisableProcessing();
+            });
+
+            PublishVersionResponse response;
+            _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+            ASSERT_EQ(2, response.failed_tablets_size());
+            EXPECT_NE(0, response.status().status_code()) << response.status().error_msgs(0);
+        }
+
+        // Failed due to not implemented
+        {
+            PublishVersionResponse response;
+            _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+            ASSERT_EQ(2, response.failed_tablets_size());
+            EXPECT_NE(0, response.status().status_code());
+        }
+
+        {
+            publish_request.set_enable_aggregate_publish(true);
+            PublishVersionResponse response;
+            _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+            ASSERT_EQ(2, response.failed_tablets_size());
+            EXPECT_NE(0, response.status().status_code());
+        }
+    }
+
+    // Test cross publish
+    {
+        auto txn_log = generate_write_txn_log(1, 100, 100);
+        ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
+
+        PublishVersionRequest publish_request;
+        publish_request.set_base_version(3);
+        publish_request.set_new_version(4);
+        publish_request.add_txn_ids(txn_log.txn_id());
+        publish_request.add_resharding_tablet_infos()->CopyFrom(resharding_tablet_info);
+
+        {
+            PublishVersionResponse response;
+            _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+            ASSERT_EQ(2, response.failed_tablets_size());
+            EXPECT_NE(0, response.status().status_code()) << response.status().error_msgs(0);
+        }
+
+        {
+            publish_request.set_enable_aggregate_publish(true);
+            PublishVersionResponse response;
+            _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+            ASSERT_EQ(2, response.failed_tablets_size());
+            EXPECT_NE(0, response.status().status_code()) << response.status().error_msgs(0);
+        }
+    }
+}
+
+TEST_F(LakeServiceTest, test_publish_identical_tablet) {
+    {
+        auto txn_log = generate_write_txn_log(1, 100, 100);
+        ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
+
+        PublishVersionRequest publish_request;
+        publish_request.set_base_version(1);
+        publish_request.set_new_version(2);
+        publish_request.add_tablet_ids(_tablet_id);
+        publish_request.add_txn_ids(txn_log.txn_id());
+
+        {
+            PublishVersionResponse response;
+            _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+            ASSERT_EQ(0, response.failed_tablets_size());
+            EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+            ASSERT_EQ(0, response.tablet_metas_size());
+            ASSERT_EQ(0, response.tablet_ranges_size());
+        }
+
+        {
+            publish_request.set_enable_aggregate_publish(true);
+            PublishVersionResponse response;
+            _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+            ASSERT_EQ(0, response.failed_tablets_size());
+            EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+            ASSERT_EQ(1, response.tablet_metas_size());
+            ASSERT_EQ(0, response.tablet_ranges_size());
+        }
+    }
+
+    ReshardingTabletInfoPB resharding_tablet_info;
+    auto* identical_tablet_info = resharding_tablet_info.mutable_identical_tablet_info();
+    identical_tablet_info->set_old_tablet_id(_tablet_id);
+    identical_tablet_info->set_new_tablet_id(next_id());
+
+    {
+        PublishVersionRequest publish_request;
+        publish_request.set_base_version(2);
+        publish_request.set_new_version(3);
+
+        auto* txn_info = publish_request.add_txn_infos();
+        txn_info->set_txn_id(next_id());
+        txn_info->set_txn_type(TXN_TABLET_RESHARD);
+        txn_info->set_combined_txn_log(false);
+        txn_info->set_commit_time(12345);
+        txn_info->set_force_publish(false);
+
+        publish_request.add_resharding_tablet_infos()->CopyFrom(resharding_tablet_info);
+
+        {
+            SyncPoint::GetInstance()->SetCallBack("ThreadPool::do_submit:1", [](void* arg) { *(int64_t*)arg = 0; });
+            SyncPoint::GetInstance()->EnableProcessing();
+            DeferOp defer([]() {
+                SyncPoint::GetInstance()->ClearCallBack("ThreadPool::do_submit:1");
+                SyncPoint::GetInstance()->DisableProcessing();
+            });
+
+            PublishVersionResponse response;
+            _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+            ASSERT_EQ(1, response.failed_tablets_size());
+            EXPECT_NE(0, response.status().status_code()) << response.status().error_msgs(0);
+        }
+
+        {
+            class MockRunnable : public Runnable {
+            public:
+                MockRunnable() {}
+                virtual ~MockRunnable() override {}
+                virtual void run() override {}
+                virtual void cancel() override {}
+            };
+
+            SyncPoint::GetInstance()->SetCallBack("ThreadPool::do_submit:replace_task", [](void* arg) {
+                auto ptr = (*(std::shared_ptr<Runnable>*)arg);
+                ptr->cancel();
+                (*(std::shared_ptr<Runnable>*)arg) = std::make_shared<MockRunnable>();
+            });
+            SyncPoint::GetInstance()->EnableProcessing();
+            DeferOp defer([]() {
+                SyncPoint::GetInstance()->ClearCallBack("ThreadPool::do_submit:replace_task");
+                SyncPoint::GetInstance()->DisableProcessing();
+            });
+
+            PublishVersionResponse response;
+            _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+            ASSERT_EQ(1, response.failed_tablets_size());
+            EXPECT_NE(0, response.status().status_code()) << response.status().error_msgs(0);
+        }
+
+        {
+            PublishVersionResponse response;
+            _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+            ASSERT_EQ(0, response.failed_tablets_size());
+            EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+            ASSERT_EQ(0, response.tablet_metas_size());
+            ASSERT_EQ(0, response.tablet_ranges_size());
+        }
+
+        {
+            publish_request.set_enable_aggregate_publish(true);
+            PublishVersionResponse response;
+            _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+            ASSERT_EQ(0, response.failed_tablets_size());
+            EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+            ASSERT_EQ(2, response.tablet_metas_size());
+            ASSERT_EQ(0, response.tablet_ranges_size());
+        }
+    }
+
+    // Test cross publish
+    {
+        auto txn_log = generate_write_txn_log(1, 100, 100);
+        ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
+
+        PublishVersionRequest publish_request;
+        publish_request.set_base_version(3);
+        publish_request.set_new_version(4);
+        publish_request.add_txn_ids(txn_log.txn_id());
+        publish_request.add_resharding_tablet_infos()->CopyFrom(resharding_tablet_info);
+
+        {
+            PublishVersionResponse response;
+            _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+            ASSERT_EQ(0, response.failed_tablets_size());
+            EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+            ASSERT_EQ(0, response.tablet_metas_size());
+            ASSERT_EQ(0, response.tablet_ranges_size());
+        }
+
+        {
+            publish_request.set_enable_aggregate_publish(true);
+            PublishVersionResponse response;
+            _lake_service.publish_version(nullptr, &publish_request, &response, nullptr);
+            ASSERT_EQ(0, response.failed_tablets_size());
+            EXPECT_EQ(0, response.status().status_code()) << response.status().error_msgs(0);
+            ASSERT_EQ(1, response.tablet_metas_size());
+            ASSERT_EQ(0, response.tablet_ranges_size());
+        }
     }
 }
 

--- a/be/test/storage/lake/alter_tablet_meta_test.cpp
+++ b/be/test/storage/lake/alter_tablet_meta_test.cpp
@@ -194,6 +194,7 @@ void AlterTabletMetaTest::test_alter_update_tablet_schema(KeysType keys_type) {
     // write new rowset
     {
         TxnLogPB log;
+        log.set_tablet_id(tablet_metadata->id());
         auto op_write_meta = log.mutable_op_write();
         auto rs_meta = op_write_meta->mutable_rowset();
         rs_meta->set_id(next_id());
@@ -214,6 +215,7 @@ void AlterTabletMetaTest::test_alter_update_tablet_schema(KeysType keys_type) {
     auto schema_id1 = tablet_metadata->schema().id();
     {
         TxnLogPB log;
+        log.set_tablet_id(tablet_metadata->id());
         auto alter_metadata = log.mutable_op_alter_metadata();
         auto update_info = alter_metadata->add_metadata_update_infos();
         auto tablet_schema_pb = update_info->mutable_tablet_schema();
@@ -241,6 +243,7 @@ void AlterTabletMetaTest::test_alter_update_tablet_schema(KeysType keys_type) {
     auto schema_id2 = tablet_metadata->schema().id();
     {
         TxnLogPB log;
+        log.set_tablet_id(tablet_metadata->id());
         auto op_write_meta = log.mutable_op_write();
         auto rs_meta = op_write_meta->mutable_rowset();
         rs_meta->set_id(next_id());
@@ -269,6 +272,7 @@ void AlterTabletMetaTest::test_alter_update_tablet_schema(KeysType keys_type) {
     // update meta
     {
         TxnLogPB log;
+        log.set_tablet_id(tablet_metadata->id());
         auto alter_metadata = log.mutable_op_alter_metadata();
         auto update_info = alter_metadata->add_metadata_update_infos();
         auto tablet_schema_pb = update_info->mutable_tablet_schema();
@@ -299,6 +303,7 @@ void AlterTabletMetaTest::test_alter_update_tablet_schema(KeysType keys_type) {
     auto schema_id3 = tablet_metadata->schema().id();
     {
         TxnLogPB log;
+        log.set_tablet_id(tablet_metadata->id());
         auto op_compaction_meta = log.mutable_op_compaction();
         if (keys_type == PRIMARY_KEYS) {
             op_compaction_meta->add_input_rowsets(tablet_metadata->rowsets(2).id());
@@ -340,6 +345,7 @@ void AlterTabletMetaTest::test_alter_update_tablet_schema(KeysType keys_type) {
     // compaction one rowset
     {
         TxnLogPB log;
+        log.set_tablet_id(tablet_metadata->id());
         auto op_compaction_meta = log.mutable_op_compaction();
 
         int32_t input_rowset_idx = 0;
@@ -380,6 +386,7 @@ void AlterTabletMetaTest::test_alter_update_tablet_schema(KeysType keys_type) {
 
     {
         TxnLogPB log;
+        log.set_tablet_id(tablet_metadata->id());
         auto op_write_meta = log.mutable_op_write();
         auto rs_meta = op_write_meta->mutable_rowset();
         rs_meta->set_id(next_id());
@@ -418,6 +425,7 @@ void AlterTabletMetaTest::test_alter_update_tablet_schema(KeysType keys_type) {
 
     {
         TxnLogPB log;
+        log.set_tablet_id(tablet_metadata->id());
         auto op_compaction_meta = log.mutable_op_compaction();
         op_compaction_meta->add_input_rowsets(tablet_metadata->rowsets(1).id());
         op_compaction_meta->add_input_rowsets(tablet_metadata->rowsets(2).id());
@@ -588,6 +596,7 @@ TEST_F(AlterTabletMetaTest, test_skip_load_pindex) {
     // write empty rowset
     {
         TxnLogPB log;
+        log.set_tablet_id(tablet_metadata->id());
         auto op_write_meta = log.mutable_op_write();
         auto rs_meta = op_write_meta->mutable_rowset();
         rs_meta->set_id(next_id());
@@ -603,6 +612,7 @@ TEST_F(AlterTabletMetaTest, test_skip_load_pindex) {
 
     {
         TxnLogPB log;
+        log.set_tablet_id(tablet_metadata->id());
         auto op_compaction_meta = log.mutable_op_compaction();
         auto tablet_id = tablet_metadata->id();
         auto version = tablet_metadata->version() + 1;

--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -37,6 +37,7 @@
 #include "storage/lake/meta_file.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_reader.h"
+#include "storage/lake/tablet_reshard.h"
 #include "storage/lake/transactions.h"
 #include "storage/lake/update_manager.h"
 #include "storage/options.h"
@@ -209,8 +210,8 @@ protected:
             txn_info.set_combined_txn_log(false);
             txn_info.set_commit_time(0);
             auto txn_info_span = std::span<const TxnInfoPB>(&txn_info, 1);
-            ASSERT_OK(lake::publish_version(_tablet_mgr.get(), _src_tablet_id, version, version + 1, txn_info_span,
-                                            false));
+            ASSERT_OK(lake::publish_version(_tablet_mgr.get(), PublishTabletInfo(_src_tablet_id), version, version + 1,
+                                            txn_info_span, false));
             version++;
         }
         ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(_src_tablet_id, version));
@@ -313,8 +314,8 @@ TEST_P(SharedDataReplicationTxnManagerTest, test_replicate_normal) {
     txn_info.set_combined_txn_log(false);
     txn_info.set_commit_time(0);
     auto txn_info_span = std::span<const TxnInfoPB>(&txn_info, 1);
-    auto status_or =
-            lake::publish_version(_tablet_mgr.get(), _target_tablet_id, _version, _src_version, txn_info_span, false);
+    auto status_or = lake::publish_version(_tablet_mgr.get(), PublishTabletInfo(_target_tablet_id), _version,
+                                           _src_version, txn_info_span, false);
     EXPECT_TRUE(status_or.ok()) << status_or.status();
 
     EXPECT_EQ(_src_version, status_or.value()->version());
@@ -504,8 +505,8 @@ TEST_P(SharedDataReplicationTxnManagerTest, test_replicate_normal_encrypted) {
     txn_info.set_combined_txn_log(false);
     txn_info.set_commit_time(0);
     auto txn_info_span = std::span<const TxnInfoPB>(&txn_info, 1);
-    auto status_or =
-            lake::publish_version(_tablet_mgr.get(), _target_tablet_id, _version, _src_version, txn_info_span, false);
+    auto status_or = lake::publish_version(_tablet_mgr.get(), PublishTabletInfo(_target_tablet_id), _version,
+                                           _src_version, txn_info_span, false);
     EXPECT_TRUE(status_or.ok()) << status_or.status();
 
     EXPECT_EQ(_src_version, status_or.value()->version());

--- a/be/test/storage/lake/replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/replication_txn_manager_test.cpp
@@ -30,6 +30,7 @@
 #include "storage/lake/join_path.h"
 #include "storage/lake/location_provider.h"
 #include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_reshard.h"
 #include "storage/lake/transactions.h"
 #include "storage/lake/update_manager.h"
 #include "storage/olap_define.h"
@@ -345,8 +346,8 @@ TEST_P(LakeReplicationTxnManagerTest, test_publish_failed) {
     txn_info.set_txn_type(TXN_REPLICATION);
     txn_info.set_commit_time(0);
     auto txn_info_span = std::span<const TxnInfoPB>(&txn_info, 1);
-    auto status_or =
-            lake::publish_version(_tablet_manager.get(), _tablet_id, _version, _src_version, txn_info_span, false);
+    auto status_or = lake::publish_version(_tablet_manager.get(), lake::PublishTabletInfo(_tablet_id), _version,
+                                           _src_version, txn_info_span, false);
     EXPECT_TRUE(!status_or.ok()) << status_or.status();
 
     lake::abort_txn(_tablet_manager.get(), _tablet_id, txn_info_span);
@@ -400,8 +401,8 @@ TEST_P(LakeReplicationTxnManagerTest, test_run_normal) {
     txn_info.set_combined_txn_log(false);
     txn_info.set_commit_time(0);
     auto txn_info_span = std::span<const TxnInfoPB>(&txn_info, 1);
-    auto status_or =
-            lake::publish_version(_tablet_manager.get(), _tablet_id, _version, _src_version, txn_info_span, false);
+    auto status_or = lake::publish_version(_tablet_manager.get(), lake::PublishTabletInfo(_tablet_id), _version,
+                                           _src_version, txn_info_span, false);
     EXPECT_TRUE(status_or.ok()) << status_or.status();
 
     EXPECT_EQ(_src_version, status_or.value()->version());
@@ -469,8 +470,8 @@ TEST_P(LakeReplicationTxnManagerTest, test_run_normal_encrypted) {
     txn_info.set_combined_txn_log(false);
     txn_info.set_commit_time(0);
     auto txn_info_span = std::span<const TxnInfoPB>(&txn_info, 1);
-    auto status_or =
-            lake::publish_version(_tablet_manager.get(), _tablet_id, _version, _src_version, txn_info_span, false);
+    auto status_or = lake::publish_version(_tablet_manager.get(), lake::PublishTabletInfo(_tablet_id), _version,
+                                           _src_version, txn_info_span, false);
     EXPECT_TRUE(status_or.ok()) << status_or.status();
 
     EXPECT_EQ(_src_version, status_or.value()->version());

--- a/be/test/storage/lake/schema_change_test.cpp
+++ b/be/test/storage/lake/schema_change_test.cpp
@@ -30,6 +30,7 @@
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_reader.h"
+#include "storage/lake/tablet_reshard.h"
 #include "storage/lake/test_util.h"
 #include "storage/lake/update_manager.h"
 #include "storage/lake/versioned_tablet.h"
@@ -101,7 +102,7 @@ protected:
         txn_info.set_txn_id(txn_id);
         txn_info.set_combined_txn_log(false);
         txn_info.set_commit_time(time(nullptr));
-        return publish_version(_tablet_manager.get(), tablet_id, 1, new_version,
+        return publish_version(_tablet_manager.get(), lake::PublishTabletInfo(tablet_id), 1, new_version,
                                std::span<const TxnInfoPB>(&txn_info, 1), false)
                 .status();
     }

--- a/be/test/storage/lake/tablet_reshard_test.cpp
+++ b/be/test/storage/lake/tablet_reshard_test.cpp
@@ -1,0 +1,175 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/tablet_reshard.h"
+
+#include <fmt/format.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "common/config.h"
+#include "fs/fs.h"
+#include "fs/fs_util.h"
+#include "fs/key_cache.h"
+#include "storage/lake/fixed_location_provider.h"
+#include "storage/lake/join_path.h"
+#include "storage/lake/location_provider.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/lake/update_manager.h"
+#include "testutil/assert.h"
+#include "testutil/id_generator.h"
+#include "util/filesystem_util.h"
+
+namespace starrocks {
+
+class LakeTabletReshardTest : public testing::Test {
+public:
+    void SetUp() override {
+        std::vector<starrocks::StorePath> paths;
+        CHECK_OK(starrocks::parse_conf_store_paths(starrocks::config::storage_root_path, &paths));
+        _test_dir = paths[0].path + "/lake";
+        _location_provider = std::make_shared<lake::FixedLocationProvider>(_test_dir);
+        CHECK_OK(FileSystem::Default()->create_dir_recursive(_location_provider->metadata_root_location(1)));
+        CHECK_OK(FileSystem::Default()->create_dir_recursive(_location_provider->txn_log_root_location(1)));
+        CHECK_OK(FileSystem::Default()->create_dir_recursive(_location_provider->segment_root_location(1)));
+        _mem_tracker = std::make_unique<MemTracker>(1024 * 1024);
+        _update_manager = std::make_unique<lake::UpdateManager>(_location_provider, _mem_tracker.get());
+        _tablet_manager = std::make_unique<lake::TabletManager>(_location_provider, _update_manager.get(), 16384);
+    }
+
+    void TearDown() override {
+        auto status = fs::remove_all(config::storage_root_path);
+        EXPECT_TRUE(status.ok() || status.is_not_found()) << status;
+    }
+
+protected:
+    std::unique_ptr<starrocks::lake::TabletManager> _tablet_manager;
+    std::string _test_dir;
+    std::shared_ptr<lake::LocationProvider> _location_provider;
+    std::unique_ptr<MemTracker> _mem_tracker;
+    std::unique_ptr<lake::UpdateManager> _update_manager;
+};
+
+TEST_F(LakeTabletReshardTest, test_tablet_splitting) {
+    starrocks::TabletMetadata metadata;
+    auto tablet_id = next_id();
+    metadata.set_id(tablet_id);
+    metadata.set_version(2);
+
+    auto rowset_meta_pb = metadata.add_rowsets();
+    rowset_meta_pb->set_id(2);
+    rowset_meta_pb->add_segments("test.dat");
+    rowset_meta_pb->add_del_files()->set_name("test.del");
+    rowset_meta_pb->set_overlapped(false);
+    rowset_meta_pb->set_data_size(1024);
+    rowset_meta_pb->set_num_rows(5);
+
+    FileMetaPB file_meta;
+    file_meta.set_name("test.delvec");
+    metadata.mutable_delvec_meta()->mutable_version_to_file()->insert({2, file_meta});
+
+    DeltaColumnGroupVerPB dcg;
+    dcg.add_column_files("test.dcg");
+    metadata.mutable_dcg_meta()->mutable_dcgs()->insert({2, dcg});
+
+    metadata.mutable_sstable_meta()->add_sstables()->set_filename("test.sst");
+
+    EXPECT_OK(_tablet_manager->put_tablet_metadata(metadata));
+
+    ReshardingTabletInfoPB resharding_tablet_for_splitting;
+    auto& splitting_tablet = *resharding_tablet_for_splitting.mutable_splitting_tablet_info();
+    splitting_tablet.set_old_tablet_id(tablet_id);
+    splitting_tablet.add_new_tablet_ids(next_id());
+    splitting_tablet.add_new_tablet_ids(next_id());
+
+    TxnInfoPB txn_info;
+    txn_info.set_commit_time(1);
+    txn_info.set_gtid(1);
+
+    std::unordered_map<int64_t, TabletMetadataPtr> tablet_metadatas;
+    std::unordered_map<int64_t, TabletRangePB> tablet_ranges;
+    auto res =
+            lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet_for_splitting, metadata.version(),
+                                            metadata.version() + 1, txn_info, false, tablet_metadatas, tablet_ranges);
+    EXPECT_OK(res);
+    EXPECT_EQ(3, tablet_metadatas.size());
+    EXPECT_EQ(2, tablet_ranges.size());
+
+    ReshardingTabletInfoPB resharding_tablet_for_identical;
+    auto& identical_tablet = *resharding_tablet_for_identical.mutable_identical_tablet_info();
+    identical_tablet.set_old_tablet_id(tablet_id);
+    identical_tablet.set_new_tablet_id(next_id());
+
+    tablet_metadatas.clear();
+    tablet_ranges.clear();
+    res = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet_for_identical, metadata.version(),
+                                          metadata.version() + 1, txn_info, false, tablet_metadatas, tablet_ranges);
+    EXPECT_OK(res);
+    EXPECT_EQ(2, tablet_metadatas.size());
+    EXPECT_EQ(0, tablet_ranges.size());
+
+    tablet_metadatas.clear();
+    tablet_ranges.clear();
+    res = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet_for_splitting, metadata.version(),
+                                          metadata.version() + 1, txn_info, false, tablet_metadatas, tablet_ranges);
+    EXPECT_OK(res);
+    EXPECT_EQ(3, tablet_metadatas.size());
+    EXPECT_EQ(2, tablet_ranges.size());
+
+    tablet_metadatas.clear();
+    tablet_ranges.clear();
+    res = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet_for_identical, metadata.version(),
+                                          metadata.version() + 1, txn_info, false, tablet_metadatas, tablet_ranges);
+    EXPECT_OK(res);
+    EXPECT_EQ(2, tablet_metadatas.size());
+    EXPECT_EQ(0, tablet_ranges.size());
+
+    _tablet_manager->prune_metacache();
+
+    tablet_metadatas.clear();
+    tablet_ranges.clear();
+    res = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet_for_splitting, metadata.version(),
+                                          metadata.version() + 1, txn_info, false, tablet_metadatas, tablet_ranges);
+    EXPECT_OK(res);
+    EXPECT_EQ(3, tablet_metadatas.size());
+    EXPECT_EQ(2, tablet_ranges.size());
+
+    tablet_metadatas.clear();
+    tablet_ranges.clear();
+    res = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet_for_identical, metadata.version(),
+                                          metadata.version() + 1, txn_info, false, tablet_metadatas, tablet_ranges);
+    EXPECT_OK(res);
+    EXPECT_EQ(2, tablet_metadatas.size());
+    EXPECT_EQ(0, tablet_ranges.size());
+
+    EXPECT_OK(_tablet_manager->delete_tablet_metadata(metadata.id(), metadata.version()));
+
+    tablet_metadatas.clear();
+    tablet_ranges.clear();
+    res = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet_for_splitting, metadata.version(),
+                                          metadata.version() + 1, txn_info, false, tablet_metadatas, tablet_ranges);
+    EXPECT_OK(res);
+    EXPECT_EQ(3, tablet_metadatas.size());
+    EXPECT_EQ(2, tablet_ranges.size());
+
+    tablet_metadatas.clear();
+    tablet_ranges.clear();
+    res = lake::publish_resharding_tablet(_tablet_manager.get(), resharding_tablet_for_identical, metadata.version(),
+                                          metadata.version() + 1, txn_info, false, tablet_metadatas, tablet_ranges);
+    EXPECT_OK(res);
+    EXPECT_EQ(2, tablet_metadatas.size());
+    EXPECT_EQ(0, tablet_ranges.size());
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
This PR implements the BE-side publish version logic for tablet splitting/resharding feature.

## What I'm doing:
Key changes:
  - Add tablet_reshard.cpp/h: Core logic for handling tablet splitting, merging, and identical tablet scenarios during publish version
  - Modify transactions.cpp: Extend publish_version() to support PublishTabletInfo which carries cross-publish information
  - Modify lake_service.cpp: Handle resharding tablet info in publish_version RPC, support both tablet reshard transactions and cross-publish for normal transactions
  - Add txn_log_applier.cpp: Add tablet ID validation for cross-publish scenarios

  Main features:
  - Support TXN_TABLET_RESHARD transaction type for tablet resharding
  - Support cross-publish: apply txn logs from source tablets to target tablets
  - Handle three resharding scenarios: splitting (1->N), merging (N->1), and identical (1->1)
  - Properly set shared flags for data files when tablets share the same underlying data
  - Cache optimization to avoid redundant metadata operations on retry

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce tablet resharding (split/merge/identical) and cross-publish in BE, extending publish flow, RPC, and log applier; add tests and wiring.
> 
> - **Lake Service (`service_be/lake_service.cpp`)**:
>   - Handle `resharding_tablet_infos` in `publish_version` including tablet-reshard txns and cross-publish for normal txns; batch merging tasks; improved tracing/logging; return `tablet_ranges` for reshard txns.
> - **Storage/Lake**:
>   - **New** `lake/tablet_reshard.{h,cpp}`: `PublishTabletInfo`, `publish_resharding_tablet`, `convert_txn_log`, sharing-file flags for resharding.
>   - **Transactions (`lake/transactions.cpp/h`)**: `publish_version` now accepts `PublishTabletInfo`; support applying txn/vtxn logs across tablets and conditional txn-log deletion.
>   - **TxnLogApplier (`lake/txn_log_applier.cpp`)**: validate txn log `tablet_id` matches metadata; batch apply checks.
>   - **Build**: register `lake/tablet_reshard.cpp` in CMake.
> - **Tests**:
>   - Add `lake/tablet_reshard_test.cpp`; extend `service/lake_service_test.cpp` for split/merge/identical and aggregate publish; update tests to set `tablet_id` in logs and to use `PublishTabletInfo`; adjust error text expectation for missing tablet inputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit decb321230d9b8c2967563febd79db636ffc259b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->