### PR TITLE
[Enhancement] add trino function map_agg

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/ComplexFunctionCallTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/ComplexFunctionCallTransformer.java
@@ -123,6 +123,14 @@ public class ComplexFunctionCallTransformer {
             // "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" -> "yyyy-MM-ddTHH:mm:ss.SSS"
             formatString = formatString.replace("'", "").replace("Z", "");
             return new FunctionCallExpr("str_to_jodatime", java.util.List.of(args[0], new StringLiteral(formatString)));
+        } else if (functionName.equalsIgnoreCase("map_agg")) {
+            // map_agg(key, value) -> map_from_arrays(array_agg(key), array_agg(value))
+            if (args.length != 2) {
+                throw new SemanticException("map_agg function must have 2 argument");
+            }
+            FunctionCallExpr key = new FunctionCallExpr("array_agg", ImmutableList.of(args[0]));
+            FunctionCallExpr value = new FunctionCallExpr("array_agg", ImmutableList.of(args[1]));
+            return new FunctionCallExpr("map_from_arrays", ImmutableList.of(key, value));
         }
         return null;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -507,4 +507,10 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
         sql = "select merge(approx_set(\"tc\")) from tall";
         assertPlanContains(sql, "hll_raw_agg(hll_hash(CAST(3: tc AS VARCHAR)))");
     }
+
+    @Test
+    public void testMapFunction() throws Exception {
+        String sql = "select map_agg('key', 'value')";
+        assertPlanContains(sql, "array_agg('key'), array_agg('value')", "map_from_arrays(2: array_agg, 3: array_agg)");
+    }
 }


### PR DESCRIPTION
## Why I'm doing:
When using the Trino dialect, the map_agg function is not supported.

https://trino.io/docs/385/functions/aggregate.html?highlight=map_agg#map_agg

## What I'm doing:
map_agg(key, value) -> map_from_arrays(array_agg(key), array_agg(value))

support the map_agg function.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Trino `map_agg(key, value)` support by rewriting to `map_from_arrays(array_agg(key), array_agg(value))` and includes a unit test.
> 
> - **Trino function transformation**:
>   - In `fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/ComplexFunctionCallTransformer.java`:
>     - Add support for `map_agg(key, value)` -> `map_from_arrays(array_agg(key), array_agg(value))` with arg count validation.
> - **Tests**:
>   - In `fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java`:
>     - Add `testMapFunction` asserting transformation to `array_agg('key'), array_agg('value')` and `map_from_arrays(...)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit db8dedd496541d8cf1799443b3c5771955c27ada. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->