### PR TITLE
[Enhancement] sort dicts directly to speed up BitmapIndexWriter.

### DIFF
--- a/be/src/storage/rowset/bitmap_index_writer.cpp
+++ b/be/src/storage/rowset/bitmap_index_writer.cpp
@@ -393,7 +393,7 @@ private:
             auto it = ordered_mem_index.find(dict);
             if (it == ordered_mem_index.end()) {
                 // should never happen
-                return Status::InternalError("");
+                return Status::InternalError(fmt::format("No bitmap found for dict {}", dict));
             }
             bitmaps.push_back(&(it->second));
         }

--- a/be/src/storage/rowset/bitmap_index_writer.cpp
+++ b/be/src/storage/rowset/bitmap_index_writer.cpp
@@ -393,7 +393,7 @@ private:
             auto it = ordered_mem_index.find(dict);
             if (it == ordered_mem_index.end()) {
                 // should never happen
-                return Status::InternalError(fmt::format("No bitmap found for dict {}", dict));
+                return Status::InternalError("No bitmap found for dict");
             }
             bitmaps.push_back(&(it->second));
         }

--- a/be/src/storage/rowset/bitmap_index_writer.cpp
+++ b/be/src/storage/rowset/bitmap_index_writer.cpp
@@ -213,14 +213,12 @@ struct BitmapIndexSliceHash {
 template <typename CppType>
 struct BitmapIndexTraits {
     using UnorderedMemoryIndexType = phmap::flat_hash_map<CppType, BitmapUpdateContextRefOrSingleValue>;
-    using OrderedMemoryIndexType = std::map<CppType, BitmapUpdateContextRefOrSingleValue>;
 };
 
 template <>
 struct BitmapIndexTraits<Slice> {
     using UnorderedMemoryIndexType = phmap::flat_hash_map<Slice, BitmapUpdateContextRefOrSingleValue,
                                                           BitmapIndexSliceHash, std::equal_to<Slice>>;
-    using OrderedMemoryIndexType = std::map<Slice, BitmapUpdateContextRefOrSingleValue, Slice::Comparator>;
 };
 
 // Builder for bitmap index. Bitmap index is comprised of two parts
@@ -241,7 +239,6 @@ class BitmapIndexWriterImpl : public BitmapIndexWriter {
 public:
     using CppType = typename CppTypeTraits<field_type>::CppType;
     using UnorderedMemoryIndexType = typename BitmapIndexTraits<CppType>::UnorderedMemoryIndexType;
-    using OrderedMemoryIndexType = typename BitmapIndexTraits<CppType>::OrderedMemoryIndexType;
 
     explicit BitmapIndexWriterImpl(TypeInfoPtr type_info, int32_t gram_num)
             : _gram_num(gram_num), _typeinfo(std::move(type_info)) {}
@@ -289,29 +286,41 @@ public:
         meta->set_bitmap_type(BitmapIndexPB::ROARING_BITMAP);
         meta->set_has_null(!_null_bitmap.isEmpty());
 
-        OrderedMemoryIndexType ordered_mem_index;
+        std::vector<CppType> sorted_dicts;
+        sorted_dicts.reserve(_mem_index.size());
         for (auto& p : _mem_index) {
             p.second.flush_pending_adds();
-            ordered_mem_index.insert(std::move(p));
+            sorted_dicts.emplace_back(p.first);
         }
+        std::sort(sorted_dicts.begin(), sorted_dicts.end());
 
         // write dictionary
-        RETURN_IF_ERROR(_write_dictionary(ordered_mem_index, wfile, meta->mutable_dict_column()));
+        RETURN_IF_ERROR(_write_dictionary(sorted_dicts, wfile, meta->mutable_dict_column()));
         // write bitmap
-        RETURN_IF_ERROR(_write_bitmap(ordered_mem_index, wfile, meta->mutable_bitmap_column()));
+        RETURN_IF_ERROR(_write_bitmap(_mem_index, sorted_dicts, wfile, meta->mutable_bitmap_column()));
 
         if (_gram_num > 0) {
             if constexpr (field_type == TYPE_VARCHAR || field_type == TYPE_CHAR) {
                 size_t offset = 0;
-                OrderedMemoryIndexType ngram_index;
-                for (const auto& it : ordered_mem_index) {
-                    RETURN_IF_ERROR(_build_ngram(ngram_index, &it.first, offset++));
+                UnorderedMemoryIndexType ngram_index;
+                for (const auto& dict : sorted_dicts) {
+                    RETURN_IF_ERROR(_build_ngram(ngram_index, &dict, offset++));
                 }
-                for (auto& it: ngram_index) {
+
+                for (auto& it : ngram_index) {
                     it.second.flush_pending_adds();
                 }
-                RETURN_IF_ERROR(_write_dictionary(ngram_index, wfile, meta->mutable_ngram_dict_column()));
-                RETURN_IF_ERROR(_write_bitmap(ngram_index, wfile, meta->mutable_ngram_bitmap_column()));
+
+                std::vector<Slice> sorted_ngram_dicts;
+                sorted_ngram_dicts.reserve(ngram_index.size());
+                for (const auto& it : ngram_index) {
+                    sorted_ngram_dicts.emplace_back(it.first);
+                }
+                std::ranges::sort(sorted_ngram_dicts);
+
+                RETURN_IF_ERROR(_write_dictionary(sorted_ngram_dicts, wfile, meta->mutable_ngram_dict_column()));
+                RETURN_IF_ERROR(
+                        _write_bitmap(ngram_index, sorted_ngram_dicts, wfile, meta->mutable_ngram_bitmap_column()));
             }
         }
         return Status::OK();
@@ -334,7 +343,7 @@ public:
     inline void incre_rowid() override { _rid++; }
 
 private:
-    Status _build_ngram(OrderedMemoryIndexType& ngram_index, const Slice* cur_slice, const size_t offset) {
+    Status _build_ngram(UnorderedMemoryIndexType& ngram_index, const Slice* cur_slice, const size_t offset) {
         if (_gram_num <= 0) {
             return Status::InvalidArgument(
                     "Invalid gram num while building ngram index for inverted index dictionary.");
@@ -362,8 +371,7 @@ private:
         return Status::OK();
     }
 
-    Status _write_dictionary(OrderedMemoryIndexType& ordered_mem_index, WritableFile* wfile,
-                             IndexedColumnMetaPB* meta) {
+    Status _write_dictionary(const std::vector<CppType>& sorted_dicts, WritableFile* wfile, IndexedColumnMetaPB* meta) {
         IndexedColumnWriterOptions options;
         options.write_ordinal_index = true;
         options.write_value_index = true;
@@ -372,16 +380,22 @@ private:
 
         IndexedColumnWriter dict_column_writer(options, _typeinfo, wfile);
         RETURN_IF_ERROR(dict_column_writer.init());
-        for (auto const& it : ordered_mem_index) {
-            RETURN_IF_ERROR(dict_column_writer.add(&(it.first)));
+        for (auto const& dict : sorted_dicts) {
+            RETURN_IF_ERROR(dict_column_writer.add(&dict));
         }
         return dict_column_writer.finish(meta);
     }
 
-    Status _write_bitmap(OrderedMemoryIndexType& ordered_mem_index, WritableFile* wfile, IndexedColumnMetaPB* meta) {
+    Status _write_bitmap(UnorderedMemoryIndexType& ordered_mem_index, const std::vector<CppType>& sorted_dicts,
+                         WritableFile* wfile, IndexedColumnMetaPB* meta) {
         std::vector<BitmapUpdateContextRefOrSingleValue*> bitmaps;
-        for (auto& it : ordered_mem_index) {
-            bitmaps.push_back(&(it.second));
+        for (const auto& dict : sorted_dicts) {
+            auto it = ordered_mem_index.find(dict);
+            if (it == ordered_mem_index.end()) {
+                // should never happen
+                return Status::InternalError("");
+            }
+            bitmaps.push_back(&(it->second));
         }
 
         uint32_t max_bitmap_size = 0;


### PR DESCRIPTION
## Why I'm doing:

Currently, we use a `std::map` at `BitmapIndexWriterImpl::finish` to get sorted dictionaries and sorted ngram dictionaries. It will waste a lots of CPU and memory according to the test that its result is shown below:

<img width="1974" height="1604" alt="image" src="https://github.com/user-attachments/assets/ee478b13-b23a-4370-a787-2b3abed53df9" />

It is obvious that using a `std::unordered_map` to deduplicate and using a `std::vector` to store all keys to get a sorted dictionaries could get the best performance.

## What I'm doing:

Use `std::unordered_map` to deduplicate dictionaries and use a `std::vector` to get sorted dictionaries.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces ordered maps with unordered maps and sorts collected keys for dictionary/ngram writes, updating write APIs accordingly.
> 
> - **BitmapIndexWriter**:
>   - Replace ordered maps with `phmap::flat_hash_map` for in-memory and ngram indices; collect keys into `std::vector` and `sort` for dictionary order.
>   - Update `_write_dictionary` to accept `std::vector<CppType>` of sorted keys.
>   - Update `_write_bitmap` to accept the unordered index plus sorted keys; add internal check for missing bitmap.
>   - Build ngram index with unordered map, collect/sort `Slice` keys, and use updated write paths.
>   - Flush pending adds before key collection; preserve null bitmap handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ec5c0adb75be01d8836bbfd015a465417bea347. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->