### PR TITLE
[BugFix] Fix usage and record for changing warehouse in inline comment

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -34,7 +34,6 @@
 
 package com.starrocks.qe;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -1020,19 +1019,46 @@ public class StmtExecutor {
         }
     }
 
+    public void processQueryScopeSetVarHint() throws DdlException {
+        if (!parsedStmt.isExistQueryScopeHint()) {
+            return;
+        }
+
+        SessionVariable clonedSessionVariable = null;
+        for (HintNode hint : parsedStmt.getAllQueryScopeHints()) {
+            if (!(hint instanceof SetVarHint)) {
+                continue;
+            }
+
+            if (clonedSessionVariable == null) {
+                clonedSessionVariable = (SessionVariable) context.sessionVariable.clone();
+            }
+            for (Map.Entry<String, String> entry : hint.getValue().entrySet()) {
+                GlobalStateMgr.getCurrentState().getVariableMgr().setSystemVariable(clonedSessionVariable,
+                        new SystemVariable(entry.getKey(), new StringLiteral(entry.getValue())), true, context);
+            }
+        }
+
+        if (clonedSessionVariable == null) {
+            return;
+        }
+
+        context.setSessionVariable(clonedSessionVariable);
+    }
+
     // support select hint e.g. select /*+ SET_VAR(query_timeout=1) */ sleep(3);
-    @VisibleForTesting
     public void processQueryScopeHint() throws DdlException {
         SessionVariable clonedSessionVariable = null;
         UUID queryId = context.getQueryId();
         final TUniqueId executionId = context.getExecutionId();
-        Map<String, UserVariable> clonedUserVars = new ConcurrentHashMap<>();
-        clonedUserVars.putAll(context.getUserVariables());
+
+        Map<String, UserVariable> clonedUserVars = new ConcurrentHashMap<>(context.getUserVariables());
         boolean hasUserVariableHint = parsedStmt.getAllQueryScopeHints()
                 .stream().anyMatch(hint -> hint instanceof UserVariableHint);
         if (hasUserVariableHint) {
             context.modifyUserVariablesCopyInWrite(clonedUserVars);
         }
+
         boolean executeSuccess = true;
         try {
             for (HintNode hint : parsedStmt.getAllQueryScopeHints()) {
@@ -1042,7 +1068,7 @@ public class StmtExecutor {
                     }
                     for (Map.Entry<String, String> entry : hint.getValue().entrySet()) {
                         GlobalStateMgr.getCurrentState().getVariableMgr().setSystemVariable(clonedSessionVariable,
-                                new SystemVariable(entry.getKey(), new StringLiteral(entry.getValue())), true);
+                                new SystemVariable(entry.getKey(), new StringLiteral(entry.getValue())), true, context);
                     }
                 }
 
@@ -3173,38 +3199,50 @@ public class StmtExecutor {
         if (!Config.enable_collect_query_detail_info) {
             return;
         }
-        String sql = parsedStmt.getOrigStmt().originStmt;
-        boolean needEncrypt = AuditEncryptionChecker.needEncrypt(parsedStmt);
-        if (needEncrypt || Config.enable_sql_desensitize_in_log) {
-            sql = AstToSQLBuilder.toSQL(parsedStmt, FormatOptions.allEnable()
-                            .setColumnSimplifyTableName(false)
-                            .setHideCredential(needEncrypt)
-                            .setEnableDigest(Config.enable_sql_desensitize_in_log))
-                    .orElse("this is a desensitized sql");
+
+        SessionVariable sessionVariableBackup = context.getSessionVariable();
+        try {
+            processQueryScopeSetVarHint();
+        } catch (DdlException e) {
+            LOG.warn("Failed to process query scope set variable.", e);
         }
 
-        boolean isQuery = context.isQueryStmt(parsedStmt);
+        try {
+            String sql = parsedStmt.getOrigStmt().originStmt;
+            boolean needEncrypt = AuditEncryptionChecker.needEncrypt(parsedStmt);
+            if (needEncrypt || Config.enable_sql_desensitize_in_log) {
+                sql = AstToSQLBuilder.toSQL(parsedStmt, FormatOptions.allEnable()
+                                .setColumnSimplifyTableName(false)
+                                .setHideCredential(needEncrypt)
+                                .setEnableDigest(Config.enable_sql_desensitize_in_log))
+                        .orElse("this is a desensitized sql");
+            }
 
-        QueryDetail queryDetail = new QueryDetail(
-                DebugUtil.printId(context.getQueryId()),
-                isQuery,
-                context.connectionId,
-                context.getMysqlChannel() != null ? context.getMysqlChannel().getRemoteIp() : "System",
-                context.getStartTime(), -1, -1,
-                QueryDetail.QueryMemState.RUNNING,
-                context.getDatabase(),
-                sql,
-                context.getQualifiedUser(),
-                Optional.ofNullable(context.getResourceGroup()).map(TWorkGroup::getName).orElse(""),
-                context.getCurrentWarehouseName(),
-                context.getCurrentCatalog(),
-                context.getCommandStr(),
-                getPreparedStmtId());
-        // Set query source from context
-        queryDetail.setQuerySource(context.getQuerySource());
-        context.setQueryDetail(queryDetail);
-        // copy queryDetail, cause some properties can be changed in future
-        QueryDetailQueue.addQueryDetail(queryDetail.copy());
+            boolean isQuery = context.isQueryStmt(parsedStmt);
+
+            QueryDetail queryDetail = new QueryDetail(
+                    DebugUtil.printId(context.getQueryId()),
+                    isQuery,
+                    context.connectionId,
+                    context.getMysqlChannel() != null ? context.getMysqlChannel().getRemoteIp() : "System",
+                    context.getStartTime(), -1, -1,
+                    QueryDetail.QueryMemState.RUNNING,
+                    context.getDatabase(),
+                    sql,
+                    context.getQualifiedUser(),
+                    Optional.ofNullable(context.getResourceGroup()).map(TWorkGroup::getName).orElse(""),
+                    context.getCurrentWarehouseName(),
+                    context.getCurrentCatalog(),
+                    context.getCommandStr(),
+                    getPreparedStmtId());
+            // Set query source from context
+            queryDetail.setQuerySource(context.getQuerySource());
+            context.setQueryDetail(queryDetail);
+            // copy queryDetail, cause some properties can be changed in future
+            QueryDetailQueue.addQueryDetail(queryDetail.copy());
+        } finally {
+            context.setSessionVariable(sessionVariableBackup);
+        }
     }
 
     /*


### PR DESCRIPTION
## Why I'm doing:

For the inline comment `/*+SET_VAR(warehouse=wh2)*/`, both the *warehouse recorded in Query Detail* and the *warehouse actually used at runtime* are incorrect.

1. **Warehouse recorded in Query Detail**
    - Problem: `addRunningQueryDetail` is called first, and only later does `processQueryScopeHint` parse the warehouse hint.
    - Fix: In `addRunningQueryDetail`, call `processQueryScopeSetVarHint` to update the session variables, and restore the original session variables at the end of `addRunningQueryDetail`.

2. **Warehouse actually used by the query**
    - Problem: The resource group for a query is determined by `ConnectContext.computeResource`. This is a cache that is only reset when a query finishes. At query start, `computeResource` has already cached the current session variable’s warehouse, so a later inline `SET_VAR` hint won’t refresh the cached `computeResource`.
    - Fix: When `SET_VAR` updates session variables via `setSystemVariable`, also update `computeResource`, similar to how `SetExecutor` handles `set warehouse = 'wh2'`.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure changing `warehouse` via inline `SET_VAR` or session variable resets compute resource and updates query detail, coordinator, and audit log.
> 
> - **QE execution flow**:
>   - After `processQueryScopeHint`, if the current warehouse changed, update `QueryDetail.warehouse` and re-add running query detail.
>   - Audit builder continues to record current warehouse and CN group.
> - **Session variable management**:
>   - `VariableMgr.setSystemVariable(...)` now accepts `ConnectContext`; when setting `warehouse`, invoke `handleSetWarehouse` to reset/ensure compute resource accordingly.
>   - New `handleSetWarehouse` resets compute resource when warehouse changes; otherwise re-acquires for availability.
>   - Kept backward-compatible overload of `setSystemVariable` without context.
> - **Tests**:
>   - Add end-to-end tests validating warehouse selection via inline hint and via session `set warehouse`, asserting `QueryDetail.warehouse`, coordinator's compute resource, and audit event warehouse.
>   - Add test ensuring compute resource reflects warehouse changes via `SET warehouse` in shared-data mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b0ee90877e38b07ac2586f192543064a07806c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->