### PR TITLE
[Enhancement] be support call gcore when query unexpected timeout

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -936,6 +936,9 @@ CONF_Int64(pipeline_sink_brpc_dop, "64");
 CONF_Int64(pipeline_max_num_drivers_per_exec_thread, "10240");
 CONF_mBool(pipeline_print_profile, "false");
 CONF_mBool(pipeline_timeout_diagnostic, "false");
+// If this value is greater than 0 and the query time exceeds the timeout, then execute gcore on the process.
+CONF_Int64(pipeline_gcore_timeout_threshold_sec, "-1");
+CONF_String(pipeline_gcore_output_dir, "${STARROCKS_HOME}/");
 
 // The arguments of multilevel feedback pipeline_driver_queue. It prioritizes small queries over larger ones,
 // when the value of level_time_slice_base_ns is smaller and queue_ratio_of_adjacent_queue is larger.

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -938,7 +938,7 @@ CONF_mBool(pipeline_print_profile, "false");
 CONF_mBool(pipeline_timeout_diagnostic, "false");
 // If this value is greater than 0 and the query time exceeds the timeout, then execute gcore on the process.
 CONF_Int64(pipeline_gcore_timeout_threshold_sec, "-1");
-CONF_String(pipeline_gcore_output_dir, "${STARROCKS_HOME}/");
+CONF_String(pipeline_gcore_output_dir, "${STARROCKS_HOME}/log");
 
 // The arguments of multilevel feedback pipeline_driver_queue. It prioritizes small queries over larger ones,
 // when the value of level_time_slice_base_ns is smaller and queue_ratio_of_adjacent_queue is larger.

--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -239,7 +239,7 @@ void hook_on_query_timeout(TUniqueId& query_id, size_t timeout_seconds) {
             jemalloc_dontdump();
         }
 
-        std::string core_file = config::pipeline_gcore_output_dir + "core-" + print_id(query_id);
+        std::string core_file = config::pipeline_gcore_output_dir + "/core-" + print_id(query_id);
         LOG(WARNING) << "dump gcore via query timeout:" << timeout_seconds;
         pid_t pid = getpid();
         // gcore have too many verbose output. skip them

--- a/be/src/common/logging.h
+++ b/be/src/common/logging.h
@@ -90,7 +90,8 @@
 
 namespace starrocks {
 class TUniqueId;
-}
+void hook_on_query_timeout(TUniqueId& query_id, size_t timeout_seconds);
+} // namespace starrocks
 
 // Print log with query id.
 #define QUERY_LOG(level) LOG(level) << "[" << tls_thread_status.query_id() << "] "

--- a/be/src/exec/pipeline/fragment_context.cpp
+++ b/be/src/exec/pipeline/fragment_context.cpp
@@ -21,6 +21,7 @@
 #include <mutex>
 #include <thread>
 
+#include "common/logging.h"
 #include "exec/data_sink.h"
 #include "exec/pipeline/group_execution/execution_group.h"
 #include "exec/pipeline/pipeline_driver_executor.h"
@@ -209,6 +210,10 @@ void FragmentContext::set_final_status(const Status& status) {
 
         auto detailed_message = _s_status.detailed_message();
         bool is_timeout = detailed_message == "TimeOut";
+        if (is_timeout) {
+            hook_on_query_timeout(_query_id, _runtime_state->query_ctx()->get_query_expire_seconds());
+        }
+
         if (_s_status.is_cancelled()) {
             std::string cancel_msg =
                     fmt::format("[Driver] Canceled, query_id={}, instance_id={}, reason={}", print_id(_query_id),

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -96,9 +96,11 @@ void PipelineDriverPoller::run_internal() {
                         LOG(WARNING) << "[Driver] Timeout " << driver->to_readable_string();
                         driver->fragment_ctx()->set_expired_log_count(++expired_log_count);
                     }
+                    auto query_id = driver->query_ctx()->query_id();
+                    size_t timeout = driver->query_ctx()->get_query_expire_seconds();
+                    hook_on_query_timeout(query_id, timeout);
                     driver->fragment_ctx()->cancel(
-                            Status::TimedOut(fmt::format("Query reached its timeout of {} seconds",
-                                                         driver->query_ctx()->get_query_expire_seconds())));
+                            Status::TimedOut(fmt::format("Query reached its timeout of {} seconds", timeout)));
                     on_cancel(driver, ready_drivers, _local_blocked_drivers, driver_it);
                 } else if (driver->fragment_ctx()->is_canceled()) {
                     // If the fragment is cancelled when the source operator is already pending i/o task,

--- a/be/src/exec/pipeline/schedule/timeout_tasks.cpp
+++ b/be/src/exec/pipeline/schedule/timeout_tasks.cpp
@@ -24,6 +24,8 @@ void CheckFragmentTimeout::Run() {
     auto query_ctx = _fragment_ctx->runtime_state()->query_ctx();
     size_t expire_seconds = query_ctx->get_query_expire_seconds();
     TRACE_SCHEDULE_LOG << "fragment_instance_id:" << print_id(_fragment_ctx->fragment_instance_id());
+    auto query_id = query_ctx->query_id();
+    hook_on_query_timeout(query_id, expire_seconds);
     _fragment_ctx->cancel(Status::TimedOut(fmt::format("Query reached its timeout of {} seconds", expire_seconds)));
 
     _fragment_ctx->iterate_drivers([](const DriverPtr& driver) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional gcore dump on query timeout, controlled by new configs, and invokes it from all timeout paths with jemalloc optimizations.
> 
> - **Config**:
>   - Add `config::pipeline_gcore_timeout_threshold_sec` (default `-1`) and `config::pipeline_gcore_output_dir` to control gcore-on-timeout behavior.
> - **Logging/Core dump**:
>   - Implement `hook_on_query_timeout(TUniqueId&, size_t)` in `be/src/common/logconfig.cpp`; runs `gcore` once per process when timeout exceeds threshold, outputs to `core-<query_id>` in `pipeline_gcore_output_dir`.
>   - Optimize core size via jemalloc: add `jemalloc_purge()` and `jemalloc_dontdump()` helpers; refactor dontdump logic.
> - **Pipeline timeout integration**:
>   - Invoke `hook_on_query_timeout` on timeout in:
>     - `be/src/exec/pipeline/fragment_context.cpp` (`set_final_status`).
>     - `be/src/exec/pipeline/pipeline_driver_poller.cpp` (expired driver handling).
>     - `be/src/exec/pipeline/schedule/timeout_tasks.cpp` (`CheckFragmentTimeout::Run`).
> - **Headers/Includes**:
>   - Declare `hook_on_query_timeout` in `be/src/common/logging.h`; minor include additions and macros for jemalloc control.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cdcc3407f7ccebedb79300b76c2d63c525238566. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->