### PR TITLE
[BugFix] fixed `ALTER STORAGE VOLUME [IF EXISTS]`

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -1145,16 +1145,8 @@ public class DDLStmtExecutor {
         @Override
         public ShowResultSet visitAlterStorageVolumeStatement(AlterStorageVolumeStmt stmt, ConnectContext context) {
             ErrorReport.wrapWithRuntimeException(() -> {
-                try {
-                    context.getGlobalStateMgr().getStorageVolumeMgr().updateStorageVolume(stmt);
-                } catch (MetaNotFoundException e) {
-                    if (stmt.isSetIfExists()) {
-                        LOG.info("alter storage volume[{}] which does not exist", stmt.getName());
-                    } else {
-                        throw e;
-                    }
-                }
-            });
+                context.getGlobalStateMgr().getStorageVolumeMgr().updateStorageVolume(stmt)
+        });
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -1144,9 +1144,17 @@ public class DDLStmtExecutor {
 
         @Override
         public ShowResultSet visitAlterStorageVolumeStatement(AlterStorageVolumeStmt stmt, ConnectContext context) {
-            ErrorReport.wrapWithRuntimeException(() ->
-                    context.getGlobalStateMgr().getStorageVolumeMgr().updateStorageVolume(stmt)
-            );
+            ErrorReport.wrapWithRuntimeException(() -> {
+                try {
+                    context.getGlobalStateMgr().getStorageVolumeMgr().updateStorageVolume(stmt);
+                } catch (MetaNotFoundException e) {
+                    if (stmt.isSetIfExists()) {
+                        LOG.info("alter storage volume[{}] which does not exist", stmt.getName());
+                    } else {
+                        throw e;
+                    }
+                }
+            });
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -1146,7 +1146,7 @@ public class DDLStmtExecutor {
         public ShowResultSet visitAlterStorageVolumeStatement(AlterStorageVolumeStmt stmt, ConnectContext context) {
             ErrorReport.wrapWithRuntimeException(() -> {
                 context.getGlobalStateMgr().getStorageVolumeMgr().updateStorageVolume(stmt)
-        });
+            });
             return null;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -1145,7 +1145,7 @@ public class DDLStmtExecutor {
         @Override
         public ShowResultSet visitAlterStorageVolumeStatement(AlterStorageVolumeStmt stmt, ConnectContext context) {
             ErrorReport.wrapWithRuntimeException(() -> {
-                context.getGlobalStateMgr().getStorageVolumeMgr().updateStorageVolume(stmt)
+                context.getGlobalStateMgr().getStorageVolumeMgr().updateStorageVolume(stmt);
             });
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -1145,7 +1145,13 @@ public class DDLStmtExecutor {
         @Override
         public ShowResultSet visitAlterStorageVolumeStatement(AlterStorageVolumeStmt stmt, ConnectContext context) {
             ErrorReport.wrapWithRuntimeException(() -> {
-                context.getGlobalStateMgr().getStorageVolumeMgr().updateStorageVolume(stmt);
+                try {
+                    context.getGlobalStateMgr().getStorageVolumeMgr().updateStorageVolume(stmt);
+                } catch (MetaNotFoundException e) {
+                    if (!stmt.isSetIfExists()) {
+                        throw e;
+                    }
+                }
             });
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -4515,7 +4515,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
             }
         }
 
-        return new AlterStorageVolumeStmt(svName, properties, comment, pos);
+        return new AlterStorageVolumeStmt(context.IF() != null, svName, properties, comment, pos);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/qe/RedirectStatusTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/RedirectStatusTest.java
@@ -1787,7 +1787,7 @@ public class RedirectStatusTest {
 
     @Test
     public void testAlterStorageVolumeStmtCoverage() {
-        AlterStorageVolumeStmt stmt = new AlterStorageVolumeStmt("test_volume", java.util.Collections.emptyMap(), null,
+        AlterStorageVolumeStmt stmt = new AlterStorageVolumeStmt(false, "test_volume", java.util.Collections.emptyMap(), null,
                 NodePosition.ZERO);
         Assertions.assertEquals(RedirectStatus.FORWARD_WITH_SYNC, RedirectStatus.getRedirectStatus(stmt));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
@@ -878,7 +878,7 @@ public class SharedDataStorageVolumeMgrTest {
     }
 
     @Test
-    public void testCreateHDFS() throws DdlException, AlreadyExistsException {
+    public void testCreateHDFS() throws DdlException, AlreadyExistsException, MetaNotFoundException {
         String svName = "test";
         // create
         StorageVolumeMgr svm = new SharedDataStorageVolumeMgr();
@@ -891,10 +891,14 @@ public class SharedDataStorageVolumeMgrTest {
         String svKey = svm.createStorageVolume(svName, "hdfs", locations, storageParams, Optional.empty(), "");
         Assertions.assertEquals(true, svm.exists(svName));
 
+        // print storage volumes
+        StorageVolume sv = svm.getStorageVolumeByName(svName);
+        Assertions.assertEquals(svKey, sv.getId());
+        
         storageParams.put("dfs.client.failover.proxy.provider",
                 "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider");
-        Assertions.assertThrows(MetaNotFoundException.class,
-                () -> svm.updateStorageVolume("test", null, null, storageParams, Optional.of(false), ""));
+        svm.updateStorageVolume(svName, null, null, storageParams, Optional.of(false), "");
+        Assertions.assertEquals(false, svm.getStorageVolumeByName(svName).getEnabled());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
@@ -893,8 +893,8 @@ public class SharedDataStorageVolumeMgrTest {
 
         storageParams.put("dfs.client.failover.proxy.provider",
                 "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider");
-        svm.updateStorageVolume("test", null, null, storageParams, Optional.of(false), "");
-        Assertions.assertEquals(false, svm.getStorageVolumeByName(svName).getEnabled());
+        Assertions.assertThrows(MetaNotFoundException.class,
+                () -> svm.updateStorageVolume("test", null, null, storageParams, Optional.of(false), ""));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
@@ -209,12 +209,8 @@ public class SharedDataStorageVolumeMgrTest {
         storageParams.put(AWS_S3_ENDPOINT, "endpoint1");
         storageParams.put(AWS_S3_ACCESS_KEY, "ak");
         storageParams.put(AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR, "true");
-        try {
-            svm.updateStorageVolume(svName1, null, null, storageParams, Optional.of(false), "test update");
-            Assertions.fail();
-        } catch (IllegalStateException e) {
-            Assertions.assertTrue(e.getMessage().contains("Storage volume 'test1' does not exist"));
-        }
+        Assertions.assertThrows(MetaNotFoundException.class, () ->
+                svm.updateStorageVolume(svName1, null, null, storageParams, Optional.of(true), "test update"));
         storageParams.put("aaa", "bbb");
         Assertions.assertThrows(DdlException.class, () ->
                 svm.updateStorageVolume(svName, null, null, storageParams, Optional.of(true), "test update"));

--- a/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/SharedDataStorageVolumeMgrTest.java
@@ -891,10 +891,6 @@ public class SharedDataStorageVolumeMgrTest {
         String svKey = svm.createStorageVolume(svName, "hdfs", locations, storageParams, Optional.empty(), "");
         Assertions.assertEquals(true, svm.exists(svName));
 
-        // print storage volumes
-        StorageVolume sv = svm.getStorageVolumeByName(svName);
-        Assertions.assertEquals(svKey, sv.getId());
-        
         storageParams.put("dfs.client.failover.proxy.provider",
                 "org.apache.hadoop.hdfs.server.namenode.ha.ConfiguredFailoverProxyProvider");
         svm.updateStorageVolume(svName, null, null, storageParams, Optional.of(false), "");

--- a/fe/fe-core/src/test/java/com/starrocks/server/SharedNothingStorageVolumeMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/SharedNothingStorageVolumeMgrTest.java
@@ -86,12 +86,8 @@ public class SharedNothingStorageVolumeMgrTest {
         storageParams.put(AWS_S3_ENDPOINT, "endpoint1");
         storageParams.put(AWS_S3_ACCESS_KEY, "ak");
         storageParams.put(AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR, "true");
-        try {
-            svm.updateStorageVolume(svName1, null, null, storageParams, Optional.of(false), "test update");
-            Assertions.fail();
-        } catch (IllegalStateException e) {
-            Assertions.assertTrue(e.getMessage().contains("Storage volume 'test1' does not exist"));
-        }
+        Assertions.assertThrows(MetaNotFoundException.class, () ->
+                svm.updateStorageVolume(svName1, null, null, storageParams, Optional.of(true), "test update"));
         storageParams.put("aaa", "bbb");
         Assertions.assertThrows(DdlException.class, () ->
                 svm.updateStorageVolume(svName, null, null, storageParams, Optional.of(true), "test update"));

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -856,7 +856,7 @@ dropStorageVolumeStatement
     ;
 
 alterStorageVolumeStatement
-    : ALTER STORAGE VOLUME identifierOrString alterStorageVolumeClause (',' alterStorageVolumeClause)*
+    : ALTER STORAGE VOLUME (IF EXISTS)? identifierOrString alterStorageVolumeClause (',' alterStorageVolumeClause)*
     ;
 
 alterStorageVolumeClause

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AlterStorageVolumeStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AlterStorageVolumeStmt.java
@@ -20,13 +20,19 @@ import com.starrocks.sql.parser.NodePosition;
 import java.util.Map;
 
 public class AlterStorageVolumeStmt extends DdlStmt {
+    private final boolean ifExists;
     private final String storageVolumeName;
     private final Map<String, String> properties;
     private final String comment;
 
-    public AlterStorageVolumeStmt(String storageVolumeName, Map<String, String> properties,
-                                  String comment, NodePosition pos) {
+    public AlterStorageVolumeStmt(boolean ifExists,
+                                  String storageVolumeName,
+                                  Map<String, String> properties,
+                                  String comment,
+                                  NodePosition pos) {
         super(pos);
+
+        this.ifExists = ifExists;
         this.storageVolumeName = storageVolumeName;
         this.properties = properties;
         this.comment = Strings.nullToEmpty(comment);
@@ -42,6 +48,10 @@ public class AlterStorageVolumeStmt extends DdlStmt {
 
     public String getComment() {
         return comment;
+    }
+
+    public boolean isSetIfExists() {
+        return ifExists;
     }
 
     @Override

--- a/test/sql/test_storage_volume/R/alter_storage_volume
+++ b/test/sql/test_storage_volume/R/alter_storage_volume
@@ -38,3 +38,7 @@ E: (1064, "Storage volume property 'aws.s3.num_partitioned_prefix' is immutable!
 DROP STORAGE VOLUME IF EXISTS storage_volume_immutable;
 -- result:
 -- !result
+-- name: test_alter_storage_volume_if_not_exists
+ALTER STORAGE VOLUME IF EXISTS storage_volume_not_exists SET ("aws.s3.region"="us-west-1", "aws.s3.endpoint"="endpoint1", "enabled"="true");
+-- result:
+-- !result

--- a/test/sql/test_storage_volume/R/alter_storage_volume
+++ b/test/sql/test_storage_volume/R/alter_storage_volume
@@ -38,7 +38,7 @@ E: (1064, "Storage volume property 'aws.s3.num_partitioned_prefix' is immutable!
 DROP STORAGE VOLUME IF EXISTS storage_volume_immutable;
 -- result:
 -- !result
--- name: test_alter_storage_volume_if_not_exists
+-- name: test_alter_storage_volume_if_not_exists @cloud
 ALTER STORAGE VOLUME IF EXISTS storage_volume_not_exists SET ("aws.s3.region"="us-west-1", "aws.s3.endpoint"="endpoint1", "enabled"="true");
 -- result:
 -- !result

--- a/test/sql/test_storage_volume/T/alter_storage_volume
+++ b/test/sql/test_storage_volume/T/alter_storage_volume
@@ -11,3 +11,5 @@ CREATE STORAGE VOLUME IF NOT EXISTS storage_volume_immutable type = s3 LOCATIONS
 ALTER STORAGE VOLUME storage_volume_immutable SET ("aws.s3.enable_partitioned_prefix" = "true");
 ALTER STORAGE VOLUME storage_volume_immutable SET ("aws.s3.num_partitioned_prefix" = "32");
 DROP STORAGE VOLUME IF EXISTS storage_volume_immutable;
+-- name: test_alter_storage_volume_if_not_exists
+ALTER STORAGE VOLUME IF EXISTS storage_volume_not_exists SET ("aws.s3.region"="us-west-1", "aws.s3.endpoint"="endpoint1", "enabled"="true");

--- a/test/sql/test_storage_volume/T/alter_storage_volume
+++ b/test/sql/test_storage_volume/T/alter_storage_volume
@@ -11,5 +11,5 @@ CREATE STORAGE VOLUME IF NOT EXISTS storage_volume_immutable type = s3 LOCATIONS
 ALTER STORAGE VOLUME storage_volume_immutable SET ("aws.s3.enable_partitioned_prefix" = "true");
 ALTER STORAGE VOLUME storage_volume_immutable SET ("aws.s3.num_partitioned_prefix" = "32");
 DROP STORAGE VOLUME IF EXISTS storage_volume_immutable;
--- name: test_alter_storage_volume_if_not_exists
+-- name: test_alter_storage_volume_if_not_exists @cloud
 ALTER STORAGE VOLUME IF EXISTS storage_volume_not_exists SET ("aws.s3.region"="us-west-1", "aws.s3.endpoint"="endpoint1", "enabled"="true");


### PR DESCRIPTION
## Why I'm doing:
According to [this](https://docs.starrocks.io/docs/sql-reference/sql-statements/cluster-management/storage_volume/ALTER_STORAGE_VOLUME/), the syntax is
```sql
ALTER STORAGE VOLUME [ IF EXISTS ] <storage_volume_name>
{ COMMENT = '<comment_string>'
| SET ("key" = "value"[,...]) }
```

But doesn't support `IF EXISTS`.

## What I'm doing:

Fixes syntax to add `IF EXISTS`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements `IF EXISTS` for `ALTER STORAGE VOLUME` and aligns not-found behavior across layers.
> 
> - Grammar: allow `ALTER STORAGE VOLUME (IF EXISTS)? ...`; `AstBuilder` passes the flag; `AlterStorageVolumeStmt` stores `ifExists`.
> - Executor: `visitAlterStorageVolumeStatement` ignores `MetaNotFoundException` when `IF EXISTS` is set.
> - Manager: `StorageVolumeMgr.updateStorageVolume(...)` now throws `MetaNotFoundException` if the volume is missing; signature updated and immutable-property checks preserved.
> - Tests: updated unit tests to expect `MetaNotFoundException`; added SQL tests for `ALTER STORAGE VOLUME IF EXISTS` behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 487193fcb59dbcc69b91133d247029f9d591e409. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->