### PR TITLE
[Tool] fix ccache sloppy when working with pch

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -560,6 +560,10 @@ endif()
 # enable global pch compiling
 add_library(StarRocksPCH INTERFACE)
 target_precompile_headers(StarRocksPCH INTERFACE ${SRC_DIR}/pch/starrocks_pch.h)
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    target_compile_options(StarRocksPCH INTERFACE "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-Xclang -fno-pch-timestamp>")
+endif()
+
 
 # Add all external dependencies. They should come after the starrocks libs.
 

--- a/build-mac/env_macos.sh
+++ b/build-mac/env_macos.sh
@@ -134,6 +134,7 @@ export LDFLAGS="-L${HOMEBREW_PREFIX}/lib ${LDFLAGS:-}"
 export CCACHE_DIR="$HOME/.ccache"
 export CCACHE_MAXSIZE="50G"
 export USE_CCACHE=1
+export CCACHE_SLOPPINESS="pch_defines,time_macros"
 
 # Parallel builds
 export PARALLEL="$(sysctl -n hw.ncpu)"

--- a/build.sh
+++ b/build.sh
@@ -246,6 +246,7 @@ fi
 
 if [[ -z ${CCACHE} ]] && [[ -x "$(command -v ccache)" ]]; then
     CCACHE=ccache
+    export CCACHE_SLOPPINESS="pch_defines,time_macros"
 fi
 
 if [ -e /proc/cpuinfo ] ; then

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -208,11 +208,17 @@ else
     echo "Skip Building Java Extensions"
 fi
 
+if [[ -z ${CCACHE} ]] && [[ -x "$(command -v ccache)" ]]; then
+    CCACHE=ccache
+    export CCACHE_SLOPPINESS="pch_defines,time_macros"
+fi
+
+
 cd ${CMAKE_BUILD_DIR}
 ${CMAKE_CMD}  -G "${CMAKE_GENERATOR}" \
             -DSTARROCKS_THIRDPARTY=${STARROCKS_THIRDPARTY}\
             -DSTARROCKS_HOME=${STARROCKS_HOME} \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=$CCACHE \
             -DMAKE_TEST=ON -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
             -DUSE_AVX2=$USE_AVX2 -DUSE_AVX512=$USE_AVX512 -DUSE_SSE4_2=$USE_SSE4_2 -DUSE_BMI_2=$USE_BMI_2\
             -DUSE_STAROS=${USE_STAROS} \


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configure ccache and Clang PCH settings to stabilize builds: set ccache sloppiness, disable PCH timestamps, and use CCACHE launcher in UT builds.
> 
> - **Build tooling**:
>   - Set `CCACHE_SLOPPINESS="pch_defines,time_macros"` in `build-mac/env_macos.sh`, `build.sh`, and `run-be-ut.sh` when `ccache` is used.
>   - In `run-be-ut.sh`, pass `-DCMAKE_CXX_COMPILER_LAUNCHER=$CCACHE` instead of hardcoded `ccache`.
> - **CMake (BE)**:
>   - For Clang, add `-Xclang -fno-pch-timestamp` to `StarRocksPCH` to stabilize PCH behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 551009d651fabd3fead3e8ba2cf6f99c89999068. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->