### PR TITLE
[Feature] Add json_pretty function

### DIFF
--- a/be/src/exprs/json_functions.h
+++ b/be/src/exprs/json_functions.h
@@ -101,6 +101,13 @@ public:
      * @paramType: [JsonColumn]
      * @return: BinaryColumn
      */
+    DEFINE_VECTORIZED_FN(json_pretty);
+
+    /**
+     * @param: [json_column]
+     * @paramType: [JsonColumn]
+     * @return: BinaryColumn
+     */
     DEFINE_VECTORIZED_FN(json_string);
 
     /**

--- a/docs/en/sql-reference/sql-functions/json-functions/json-query-and-processing-functions/json_pretty.md
+++ b/docs/en/sql-reference/sql-functions/json-functions/json-query-and-processing-functions/json_pretty.md
@@ -1,0 +1,85 @@
+---
+displayed_sidebar: docs
+---
+
+# json_pretty
+
+Formats a JSON document into an easy-to-read, indented string format. This function is useful for debugging or displaying JSON data in a human-readable structure.
+
+:::tip
+All of the JSON functions and operators are listed in the navigation and on the overview page.
+:::
+
+## Syntax
+
+```SQL
+json_pretty(json_object_expr)
+```
+
+## Parameters
+- `json_object_expr`: The expression that represents the JSON object. The object can be a JSON column, a string containing valid JSON, or a JSON object produced by a JSON constructor function such as PARSE_JSON.
+
+## Return value
+Returns the formatted JSON document as a string.
+
+> - Returns NULL if the argument is NULL.
+> - The returned string includes newlines and spaces for indentation.
+> - Object keys are sorted alphabetically in the output.
+
+## Examples
+
+Example 1: Format a simple JSON object.
+
+```Plaintext
+mysql> SELECT json_pretty('{"b": 2, "a": 1}');
+       -> {
+            "a": 1,
+            "b": 2
+          }
+```
+
+Example 2: Format a JSON array.
+
+```Plaintext
+mysql> SELECT json_pretty('[1, 2, 3]');
+       -> [
+            1,
+            2,
+            3
+          ]
+```
+
+Example 3: Format a nested JSON structure.
+
+```Plaintext
+mysql> SELECT json_pretty('{"level1": {"level2": {"level3": "value"}}}');
+       -> {
+            "level1": {
+              "level2": {
+                "level3": "value"
+              }
+            }
+          }
+```
+
+Example 4: Use with a table column containing JSON data.
+
+```Plaintext
+
+mysql> CREATE TABLE json_test (id INT, data JSON);
+mysql> INSERT INTO json_test VALUES (1, parse_json('{"name": "Alice", "details": {"age": 25, "city": "NYC"}}'));
+mysql> SELECT json_pretty(data) FROM json_test;
+       -> {
+            "details": {
+              "age": 25,
+              "city": "NYC"
+            },
+            "name": "Alice"
+          }
+```
+
+## Usage notes
+- **Indentation:** The function adds standard indentation (spaces) and newlines to make the JSON structure visual.
+- **Key Sorting:** JSON object keys are sorted alphabetically in the output string. This is standard behavior for the underlying JSON processing library (VelocyPack).
+- **Null Handling:** If the input is SQL NULL, the function returns NULL.
+- **Data Types:** It supports formatting of standard JSON types including Objects, Arrays, Strings, Numbers, Booleans, and Nulls.

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -273,6 +273,7 @@ public class FunctionSet {
     public static final String JSON_LENGTH = "json_length";
     public static final String JSON_REMOVE = "json_remove";
     public static final String JSON_SET = "json_set";
+    public static final String JSON_PRETTY = "json_pretty";
 
     // Variant functions:
     public static final String VARIANT_QUERY = "variant_query";

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -882,6 +882,7 @@ vectorized_functions = [
     [110024, "json_remove", False, False, "JSON", ["JSON", "VARCHAR", "..."], "JsonFunctions::json_remove",
      "JsonFunctions::native_json_path_prepare", "JsonFunctions::native_json_path_close"],
     [110025, "json_set", False, False, "JSON", ["JSON", "JSON", "..."], "JsonFunctions::json_set"],
+    [110026, "json_pretty", False, True, "VARCHAR", ["JSON"], "JsonFunctions::json_pretty"],
     [110100, "to_json", False, False, "JSON", ["ANY_MAP"], "JsonFunctions::to_json"],
     [110101, "to_json", False, False, "JSON", ["ANY_STRUCT"], "JsonFunctions::to_json"],
     [110112, "json_contains", False, False, "BOOLEAN", ["JSON", "JSON"], "JsonFunctions::json_contains"],

--- a/test/sql/test_json/R/test_json_pretty
+++ b/test/sql/test_json/R/test_json_pretty
@@ -1,0 +1,127 @@
+-- name: test_json_pretty
+CREATE DATABASE IF NOT EXISTS test_json_pretty_db;
+-- result:
+-- !result
+
+USE test_json_pretty_db;
+-- result:
+-- !result
+
+SELECT json_pretty('{"a": 1, "b": 2}');
+-- result:
+{
+  "a" : 1,
+  "b" : 2
+}
+-- !result
+
+SELECT json_pretty('[1, 2, 3]');
+-- result:
+[
+  1,
+  2,
+  3
+]
+-- !result
+
+SELECT json_pretty('{"a": true, "b": null, "c": "string"}');
+-- result:
+{
+  "a" : true,
+  "b" : null,
+  "c" : "string"
+}
+-- !result
+
+SELECT json_pretty('{"level1": {"level2": {"level3": "value"}}}');
+-- result:
+{
+  "level1" : {
+    "level2" : {
+      "level3" : "value"
+    }
+  }
+}
+-- !result
+
+SELECT json_pretty('[{"id": 1, "val": [10, 20]}, {"id": 2}]');
+-- result:
+[
+  {
+    "id" : 1,
+    "val" : [
+      10,
+      20
+    ]
+  },
+  {
+    "id" : 2
+  }
+]
+-- !result
+
+SELECT json_pretty('{"message": "Hello { world }", "tags": "[tag1, tag2]"}');
+-- result:
+{
+  "message" : "Hello { world }",
+  "tags" : "[tag1, tag2]"
+}
+-- !result
+
+SELECT json_pretty('{}');
+-- result:
+{
+}
+-- !result
+
+SELECT json_pretty('[]');
+-- result:
+[
+]
+-- !result
+
+SELECT json_pretty('{"int": 123, "float": 12.34}');
+-- result:
+{
+  "float" : 12.34,
+  "int" : 123
+}
+-- !result
+
+CREATE TABLE json_pretty_test_table (
+    id INT,
+    data JSON
+) DUPLICATE KEY(id)
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+
+INSERT INTO json_pretty_test_table VALUES
+(1, parse_json('{"name": "Alice", "details": {"age": 25}}')),
+(2, parse_json('[10, 20]')),
+(3, NULL);
+-- result:
+-- !result
+
+SELECT id, json_pretty(data) FROM json_pretty_test_table ORDER BY id;
+-- result:
+1	{
+  "details" : {
+    "age" : 25
+  },
+  "name" : "Alice"
+}
+2	[
+  10,
+  20
+]
+3	None
+-- !result
+
+DROP TABLE json_pretty_test_table;
+-- result:
+-- !result
+
+DROP DATABASE test_json_pretty_db;
+-- result:
+-- !result

--- a/test/sql/test_json/T/test_json_pretty
+++ b/test/sql/test_json/T/test_json_pretty
@@ -1,0 +1,49 @@
+-- name: test_json_pretty
+-- description: Comprehensive test cases for JSON_PRETTY function
+
+-- Preamble
+CREATE DATABASE IF NOT EXISTS test_json_pretty_db;
+USE test_json_pretty_db;
+
+-- 1. Simple Object
+SELECT json_pretty('{"a": 1, "b": 2}');
+
+-- 2. Simple Array
+SELECT json_pretty('[1, 2, 3]');
+
+-- 3. Mixed Types
+SELECT json_pretty('{"a": true, "b": null, "c": "string"}');
+
+-- 4. Nested Structure
+SELECT json_pretty('{"level1": {"level2": {"level3": "value"}}}');
+
+-- 5. Array of Objects
+SELECT json_pretty('[{"id": 1, "val": [10, 20]}, {"id": 2}]');
+
+-- 6. Special Characters
+SELECT json_pretty('{"message": "Hello { world }", "tags": "[tag1, tag2]"}');
+
+-- 7. Empty Structures
+SELECT json_pretty('{}');
+SELECT json_pretty('[]');
+
+-- 8. Numbers Formatting
+SELECT json_pretty('{"int": 123, "float": 12.34}');
+
+-- 9. Table Test
+CREATE TABLE json_pretty_test_table (
+    id INT,
+    data JSON
+) DUPLICATE KEY(id)
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO json_pretty_test_table VALUES
+(1, parse_json('{"name": "Alice", "details": {"age": 25}}')),
+(2, parse_json('[10, 20]')),
+(3, NULL);
+
+SELECT id, json_pretty(data) FROM json_pretty_test_table ORDER BY id;
+
+-- Cleanup
+DROP TABLE json_pretty_test_table;
+DROP DATABASE test_json_pretty_db;


### PR DESCRIPTION
## Why I'm doing:

StarRocks currently displays JSON data in a compact, single-line format, which makes it difficult for users to read and debug complex or nested JSON structures. Users need a standard way to format JSON output with indentation and newlines for better readability, similar to the `JSON_PRETTY` function available in MySQL and other databases.

## What I'm doing:

This PR implements the `JSON_PRETTY` function to format JSON documents into a human-readable string.

### Function Signature
`JSON_PRETTY(json_doc)`

### Implementation Details
1.  **Frontend:** Registered the function in `FunctionSet.java` and `functions.py` (ID: 110026).
2.  **Backend (C++):** Implemented logic in `JsonFunctions::json_pretty` using the `arangodb::velocypack` library.
    - Used `arangodb::velocypack::Options` with `prettyPrint = true` to handle the formatting.
    - Handles **Key Sorting**: Keys are automatically sorted alphabetically (standard VelocyPack behavior).
    - Handles **Nulls**: Returns NULL if input is NULL.
3.  **Documentation:** Added user documentation in `json_pretty.md`.
4.  **Testing:** Added SQL regression tests and C++ Unit tests covering:
    - Basic Objects and Arrays.
    - Nested structures.
    - Sorting of keys.
    - Handling of empty objects/arrays and special characters.

### Verification
Verified locally with manual queries.
**Example: Formatting a nested object**
Query: `SELECT json_pretty('{"b": 2, "a": [1, 2]}');`
Result:
```json
{
  "a": [
    1,
    2
  ],
  "b": 2
}
```

<img width="891" height="575" alt="image" src="https://github.com/user-attachments/assets/ad945f68-1699-48dd-8bf5-87f6d89f380d" />

Fixes #62535 

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
- [x] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `json_pretty(JSON)` that returns an indented, human-readable JSON string, with FE/BE wiring, tests, and docs.
> 
> - **Backend (BE)**:
>   - Implement `JsonFunctions::json_pretty` in `be/src/exprs/json_functions.cpp` and declare in `json_functions.h` to pretty-print JSON (using VelocyPack `prettyPrint`).
> - **Frontend/Registration**:
>   - Register function name `JSON_PRETTY` in `fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java`.
>   - Add vectorized entry `[110026, "json_pretty", ...]` in `gensrc/script/functions.py` returning `VARCHAR` from `JSON`.
> - **Tests**:
>   - Add C++ unit tests in `be/test/exprs/json_functions_test.cpp` covering objects, arrays, nesting, empty structures, special characters, and NULL.
>   - Add SQL regression tests `test/sql/test_json/T|R/test_json_pretty`.
> - **Docs**:
>   - New user guide `docs/en/sql-reference/sql-functions/json-functions/json-query-and-processing-functions/json_pretty.md` with syntax, behavior (indentation, key sorting, NULL handling), and examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4700214178e7d5d699e5afe20664b74eaf805d90. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->