### PR TITLE
[Tool] skip build if format fails

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -848,7 +848,7 @@ jobs:
 
   build:
     runs-on: [self-hosted, normal]
-    needs: [basic-checker, test-checker, thirdparty-info, fe-codestyle-check]
+    needs: [basic-checker, test-checker, thirdparty-info, fe-codestyle-check, clang-format]
     name: BUILD
     env:
       PR_NUMBER: ${{ github.event.number }}
@@ -873,6 +873,7 @@ jobs:
       always() && 
       needs.thirdparty-info.result != 'failure' && 
       needs.fe-codestyle-check.result != 'failure' && 
+      needs.clang-format.result != 'failure' &&
       (needs.thirdparty-info.result == 'success' || needs.fe-codestyle-check.result == 'success' || needs.test-checker.outputs.test_change == 'true')
     steps:
       - name: CLEAN


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a Clang-Format check job and makes downstream build/update steps depend on its success.
> 
> - **CI workflow (`.github/workflows/ci-pipeline.yml`)**:
>   - **New job**: `clang-format` runs `build-support/check-format.sh` after `be-checker`.
>   - **Pre-commit propagation**: `be-checker` now extracts `"Clang-Format"` status; pass-through of `pre_format_conclusion` to consumers.
>   - **Dependencies/guards**:
>     - `build` now needs `clang-format` and checks `needs.clang-format.result != 'failure'` in its `if`.
>     - `thirdparty-update` depends on `clang-format` and uses its outputs for gating.
>   - Ensures formatting failures block subsequent build-related steps.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab1d6d9299cbb0f46e811ea8c48cd4c50473dee9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->