### PR TITLE
[Enhancement] Add catalog config credential fallback for Iceberg REST Catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -385,4 +385,9 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     public CloudConfiguration getCloudConfiguration() {
         return normal.getCloudConfiguration();
     }
+
+    @Override
+    public Map<String, String> getCatalogProperties() {
+        return normal.getCatalogProperties();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -360,6 +360,10 @@ public interface ConnectorMetadata {
         throw new StarRocksConnectorException("This connector doesn't support getting cloud configuration");
     }
 
+    default Map<String, String> getCatalogProperties() {
+        return Map.of();
+    }
+
     default Set<DeleteFile> getDeleteFiles(IcebergTable icebergTable, Long snapshotId,
                                            ScalarOperator predicate, FileContent fileContent) {
         throw new StarRocksConnectorException("This connector doesn't support getting delete files");

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -176,6 +176,11 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     }
 
     @Override
+    public Map<String, String> getCatalogProperties() {
+        return delegate.getCatalogProperties();
+    }
+
+    @Override
     public List<String> listAllDatabases(ConnectContext connectContext) {
         return delegate.listAllDatabases(connectContext);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -241,6 +241,10 @@ public interface IcebergCatalog extends MemoryTrackable {
                 srScanContext);
     }
 
+    default Map<String, String> getCatalogProperties() {
+        return new HashMap<>();
+    }
+
     default String defaultTableLocation(ConnectContext context, Namespace ns, String tableName) {
         Map<String, String> properties = loadNamespaceMetadata(context, ns);
         String databaseLocation = properties.get(LOCATION_PROPERTY);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -1576,6 +1576,11 @@ public class IcebergMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public Map<String, String> getCatalogProperties() {
+        return icebergCatalog.getCatalogProperties();
+    }
+
+    @Override
     public Procedure getProcedure(DatabaseTableName procedureName) {
         Procedure procedure = procedureRegistry.find(procedureName);
         if (procedure == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -146,6 +146,11 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     }
 
     @Override
+    public Map<String, String> getCatalogProperties() {
+        return delegate.properties();
+    }
+
+    @Override
     public Table getTable(ConnectContext context, String dbName, String tableName) throws StarRocksConnectorException {
         try {
             return delegate.loadTable(buildContext(context), TableIdentifier.of(convertDbNameToNamespace(dbName), tableName));

--- a/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -239,5 +240,30 @@ public class CatalogConnectorMetadataTest {
         catalogConnectorMetadata.getPartitions(null, null);
         catalogConnectorMetadata.getTableStatistics(null, null, null, null, null, -1,
                 TvrTableSnapshot.empty());
+    }
+
+    @Test
+    void testGetCatalogPropertiesDelegatesToNormal(@Mocked ConnectorMetadata connectorMetadata) {
+        Map<String, String> expectedProperties = Map.of(
+                "uri", "http://rest-catalog:8181",
+                "credential", "test-credential"
+        );
+
+        new Expectations() {
+            {
+                connectorMetadata.getCatalogProperties();
+                result = expectedProperties;
+                times = 1;
+            }
+        };
+
+        CatalogConnectorMetadata catalogConnectorMetadata = new CatalogConnectorMetadata(
+                connectorMetadata,
+                informationSchemaMetadata,
+                metaMetadata
+        );
+
+        Map<String, String> actualProperties = catalogConnectorMetadata.getCatalogProperties();
+        assertEquals(expectedProperties, actualProperties);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -2184,4 +2184,57 @@ public class IcebergMetadataTest extends TableTestBase {
                 HDFS_ENVIRONMENT);
         executor.execute();
     }
+
+    @Test
+    public void testGetCatalogProperties(@Mocked IcebergCatalog icebergCatalog) {
+        Map<String, String> expectedProps = ImmutableMap.of(
+                "s3.access-key-id", "AKIA_TEST_KEY",
+                "s3.secret-access-key", "test_secret_key",
+                "client.region", "ap-northeast-2"
+        );
+
+        new Expectations() {{
+            icebergCatalog.getCatalogProperties();
+            result = expectedProps;
+            times = 1;
+        }};
+
+        IcebergMetadata metadata = new IcebergMetadata(
+                CATALOG_NAME,
+                HDFS_ENVIRONMENT,
+                icebergCatalog,
+                Executors.newSingleThreadExecutor(),
+                Executors.newSingleThreadExecutor(),
+                DEFAULT_CATALOG_PROPERTIES
+        );
+
+        Map<String, String> result = metadata.getCatalogProperties();
+
+        Assertions.assertEquals(expectedProps, result);
+        Assertions.assertEquals("AKIA_TEST_KEY", result.get("s3.access-key-id"));
+        Assertions.assertEquals("test_secret_key", result.get("s3.secret-access-key"));
+        Assertions.assertEquals("ap-northeast-2", result.get("client.region"));
+    }
+
+    @Test
+    public void testGetCatalogPropertiesEmpty(@Mocked IcebergCatalog icebergCatalog) {
+        new Expectations() {{
+            icebergCatalog.getCatalogProperties();
+            result = ImmutableMap.of();
+            times = 1;
+        }};
+
+        IcebergMetadata metadata = new IcebergMetadata(
+                CATALOG_NAME,
+                HDFS_ENVIRONMENT,
+                icebergCatalog,
+                Executors.newSingleThreadExecutor(),
+                Executors.newSingleThreadExecutor(),
+                DEFAULT_CATALOG_PROPERTIES
+        );
+
+        Map<String, String> result = metadata.getCatalogProperties();
+
+        Assertions.assertTrue(result.isEmpty());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -2193,11 +2193,13 @@ public class IcebergMetadataTest extends TableTestBase {
                 "client.region", "ap-northeast-2"
         );
 
-        new Expectations() {{
-            icebergCatalog.getCatalogProperties();
-            result = expectedProps;
-            times = 1;
-        }};
+        new Expectations() {
+            {
+                icebergCatalog.getCatalogProperties();
+                result = expectedProps;
+                times = 1;
+            }
+        };
 
         IcebergMetadata metadata = new IcebergMetadata(
                 CATALOG_NAME,
@@ -2218,11 +2220,13 @@ public class IcebergMetadataTest extends TableTestBase {
 
     @Test
     public void testGetCatalogPropertiesEmpty(@Mocked IcebergCatalog icebergCatalog) {
-        new Expectations() {{
-            icebergCatalog.getCatalogProperties();
-            result = ImmutableMap.of();
-            times = 1;
-        }};
+        new Expectations() {
+            {
+                icebergCatalog.getCatalogProperties();
+                result = ImmutableMap.of();
+                times = 1;
+            }
+        };
 
         IcebergMetadata metadata = new IcebergMetadata(
                 CATALOG_NAME,

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
@@ -481,4 +481,46 @@ public class IcebergRESTCatalogTest {
 
         Assertions.assertTrue(exception.getMessage().contains("View operations are disabled for this catalog"));
     }
+
+    @Test
+    public void testGetCatalogProperties(@Mocked RESTSessionCatalog restCatalog) {
+        Map<String, String> catalogProperties = ImmutableMap.of(
+                "s3.access-key-id", "AKIA_TEST_KEY",
+                "s3.secret-access-key", "test_secret_key",
+                "s3.session-token", "test_session_token",
+                "client.region", "us-east-1"
+        );
+
+        new Expectations() {
+            {
+                restCatalog.properties();
+                result = catalogProperties;
+                times = 1;
+            }
+        };
+
+        IcebergRESTCatalog icebergRESTCatalog = new IcebergRESTCatalog(restCatalog, new Configuration());
+        Map<String, String> result = icebergRESTCatalog.getCatalogProperties();
+
+        Assertions.assertEquals("AKIA_TEST_KEY", result.get("s3.access-key-id"));
+        Assertions.assertEquals("test_secret_key", result.get("s3.secret-access-key"));
+        Assertions.assertEquals("test_session_token", result.get("s3.session-token"));
+        Assertions.assertEquals("us-east-1", result.get("client.region"));
+    }
+
+    @Test
+    public void testGetCatalogPropertiesEmpty(@Mocked RESTSessionCatalog restCatalog) {
+        new Expectations() {
+            {
+                restCatalog.properties();
+                result = ImmutableMap.of();
+                times = 1;
+            }
+        };
+
+        IcebergRESTCatalog icebergRESTCatalog = new IcebergRESTCatalog(restCatalog, new Configuration());
+        Map<String, String> result = icebergRESTCatalog.getCatalogProperties();
+
+        Assertions.assertTrue(result.isEmpty());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/IcebergScanNodeTest.java
@@ -28,6 +28,9 @@ import com.starrocks.connector.iceberg.IcebergTableMORParams;
 import com.starrocks.connector.iceberg.IcebergTableOperation;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationFactory;
+import com.starrocks.credential.CloudType;
+import com.starrocks.credential.aws.AwsCloudConfiguration;
+import com.starrocks.credential.aws.AwsCloudCredential;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.StmtExecutor;
@@ -1093,6 +1096,12 @@ public class IcebergScanNodeTest {
 
         CloudConfiguration cloudConfig = Deencapsulation.getField(scanNode, "cloudConfiguration");
         Assertions.assertNotNull(cloudConfig);
+        // Verify that credentials came from catalog config (lines 215-220)
+        Assertions.assertEquals(CloudType.AWS, cloudConfig.getCloudType());
+        AwsCloudConfiguration awsConfig = (AwsCloudConfiguration) cloudConfig;
+        AwsCloudCredential credential = awsConfig.getAwsCloudCredential();
+        Assertions.assertEquals("AKIA_FROM_CONFIG", credential.getAccessKey());
+        Assertions.assertEquals("secret_from_config", credential.getSecretKey());
     }
 
     @Test


### PR DESCRIPTION
Support credential fallback to /v1/config when vended credentials unavailable,
matching Other Iceberg client behavior for REST Catalogs without STS (e.g., Polaris).

## Why I'm doing:
  When using Iceberg REST Catalog (e.g., Apache Polaris) with STS unavailable, the `loadTable` API doesn't return vended credentials for S3. Other Iceberg clients like Spark and PyIceberg handle this by falling back to credentials from the `/v1/config` endpoint, but StarRocks didn't have this fallback logic, causing query failures in such environments.

## What I'm doing:

Add a 3-level credential fallback mechanism in `IcebergScanNode.setupCloudCredential()`:

1. **Vended credentials** - from `loadTable` response (highest priority)
2. **Catalog config credentials** - from `/v1/config` response (new fallback)
3. **User-provided credentials** - from catalog properties (existing fallback)

Changes:
  - Added `getCatalogProperties()` method to `IcebergCatalog` interface and `IcebergRESTCatalog` implementation
  - Added `getCatalogProperties()` method to `ConnectorMetadata` interface and `IcebergMetadata` implementation
  - Modified `IcebergScanNode.setupCloudCredential()` to try catalog config credentials before falling back to user-provided credentials

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expose getCatalogProperties across connectors and update Iceberg scan/sink to resolve credentials as vended -> catalog config (/v1/config) -> user-provided.
> 
> - **API/Connectors**:
>   - Add `getCatalogProperties()` to `ConnectorMetadata` and `IcebergCatalog`.
>   - Implement/delegate in `IcebergRESTCatalog` (returns `delegate.properties()`), `CachingIcebergCatalog` (delegates), `IcebergMetadata` (delegates), and `CatalogConnectorMetadata` (delegates).
> - **Planner/Execution**:
>   - Update `IcebergScanNode` and `IcebergTableSink` to use 3-tier credentials: `loadTable` vended credentials → catalog config (`getCatalogProperties()`) → user-provided `getCloudConfiguration()`.
> - **Tests**:
>   - Add/extend UTs covering delegation of `getCatalogProperties()` and credential fallback priority in scan/sink paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01a2a9342fcc256d0f23fe69aad9cbb3988e201b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->