### PR TITLE
[Enhancement] Support repairing a single physical partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/TabletRepairHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/TabletRepairHelper.java
@@ -29,6 +29,7 @@ import com.starrocks.proto.TabletMetadatas;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
 import com.starrocks.rpc.RpcException;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.TStatusCode;
 import org.apache.logging.log4j.LogManager;
@@ -39,9 +40,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 public class TabletRepairHelper {
     private static final Logger LOG = LogManager.getLogger(TabletRepairHelper.class);
+
+    private static final long BATCH_VERSION_NUM = 5L;
 
     record PhysicalPartitionInfo(
             long physicalPartitionId,
@@ -142,6 +146,137 @@ public class TabletRepairHelper {
         return tabletVersionMetadatas;
     }
 
+    /**
+     * Finds valid tablet metadata for a physical partition based on version consistency requirements.
+     * If `enforceConsistentVersion` is true, it attempts to find a single version for which all tablets in the
+     * physical partition have metadata. This ensures all tablets are repaired to a consistent state.
+     * If `enforceConsistentVersion` is false, it finds the latest available valid metadata for each individual tablet
+     * within the specified version range.
+     * The identified valid metadata entries are stored in the `validMetadatas` map.
+     */
+    private static void findValidTabletMetadata(PhysicalPartitionInfo info,
+                                                Map<Long, Map<Long, TabletMetadataPB>> tabletVersionMetadatas, long maxVersion,
+                                                long minVersion, boolean enforceConsistentVersion,
+                                                Map<Long, TabletMetadataPB> validMetadatas) {
+        List<Long> allTablets = info.allTablets;
+
+        // try to find the valid tablet metadata
+        if (enforceConsistentVersion) {
+            // find consistent valid metadata version
+            Preconditions.checkState(validMetadatas.isEmpty());
+
+            long validVersion = 0;
+            for (long version = maxVersion; version >= minVersion; --version) {
+                boolean allTabletsMetadataExist = true;
+                for (long tabletId : allTablets) {
+                    Map<Long, TabletMetadataPB> versionMetadatas = tabletVersionMetadatas.get(tabletId);
+                    if (versionMetadatas == null || !versionMetadatas.containsKey(version)) {
+                        allTabletsMetadataExist = false;
+                        break;
+                    }
+                }
+
+                if (allTabletsMetadataExist) {
+                    validVersion = version;
+                    break;
+                }
+            }
+
+            if (validVersion != 0) {
+                for (long tabletId : allTablets) {
+                    validMetadatas.put(tabletId, tabletVersionMetadatas.get(tabletId).get(validVersion));
+                }
+            }
+        } else {
+            // find the latest valid metadata for each tablet
+            Preconditions.checkState(!validMetadatas.keySet().containsAll(allTablets));
+
+            for (long tabletId : allTablets) {
+                if (validMetadatas.containsKey(tabletId)) {
+                    continue;
+                }
+
+                Map<Long, TabletMetadataPB> versionMetadatas = tabletVersionMetadatas.get(tabletId);
+                if (versionMetadatas == null) {
+                    continue;
+                }
+
+                for (long version = maxVersion; version >= minVersion; --version) {
+                    TabletMetadataPB metadata = versionMetadatas.get(version);
+                    if (metadata != null) {
+                        validMetadatas.put(tabletId, metadata);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    private static TabletMetadataPB createEmptyTabletMetadata(long tabletId, TabletMetadataPB otherValidMetadata) {
+        TabletMetadataPB metadata = new TabletMetadataPB();
+        metadata.id = tabletId;
+        // version will be overwritten to visible version later
+        metadata.version = 0L;
+        metadata.schema = otherValidMetadata.schema;
+        metadata.rowsets = Lists.newArrayList();
+        metadata.nextRowsetId = 1;
+        metadata.cumulativePoint = 0;
+        metadata.enablePersistentIndex = otherValidMetadata.enablePersistentIndex;
+        metadata.persistentIndexType = otherValidMetadata.persistentIndexType;
+        metadata.gtid = GlobalStateMgr.getCurrentState().getGtidGenerator().nextGtid();
+        metadata.compactionStrategy = otherValidMetadata.compactionStrategy;
+        metadata.flatJsonConfig = otherValidMetadata.flatJsonConfig;
+        return metadata;
+    }
+
+    private static void checkOrCreateEmptyTabletMetadata(PhysicalPartitionInfo info, Map<Long, TabletMetadataPB> validMetadatas,
+                                                         boolean enforceConsistentVersion, boolean allowEmptyTabletRecovery)
+            throws StarRocksException {
+        long maxVersion = info.maxVersion;
+        List<Long> allTablets = info.allTablets;
+        if (validMetadatas.keySet().containsAll(allTablets)) {
+            // check all tablets have consistent valid metadata, and the version is visible version
+            boolean allHaveVisibleVersionMetadata = true;
+            for (TabletMetadataPB metadata : validMetadatas.values()) {
+                if (metadata.version != maxVersion) {
+                    allHaveVisibleVersionMetadata = false;
+                    break;
+                }
+            }
+            if (allHaveVisibleVersionMetadata) {
+                throw new StarRocksException(
+                        String.format("all tablets have valid metadata with version %d, no need for repair", maxVersion));
+            } else {
+                return;
+            }
+        }
+
+        if (enforceConsistentVersion) {
+            throw new StarRocksException("no consistent valid tablet metadata version was found, " +
+                    "you can set enforce_consistent_version=false");
+        } else {
+            if (validMetadatas.isEmpty()) {
+                throw new StarRocksException(
+                        "no latest valid tablet metadatas were found for all allTablets, you should recreate the partition");
+            }
+
+            Set<Long> missingTablets = Sets.newHashSet(allTablets);
+            missingTablets.removeAll(validMetadatas.keySet());
+            Preconditions.checkState(!missingTablets.isEmpty());
+            if (!allowEmptyTabletRecovery) {
+                throw new StarRocksException(String.format(
+                        "tablet %d has no valid tablet metadatas, " +
+                                "you can set enforce_consistent_version=false and allow_empty_tablet_recovery=true",
+                        missingTablets.iterator().next()));
+            }
+
+            TabletMetadataPB validMetadata = validMetadatas.values().iterator().next();
+            for (long tabletId : missingTablets) {
+                validMetadatas.put(tabletId, createEmptyTabletMetadata(tabletId, validMetadata));
+            }
+        }
+    }
+
     private static Map<Long, String> repairTabletMetadata(PhysicalPartitionInfo info, Map<Long, TabletMetadataPB> validMetadatas,
                                                           boolean isFileBundling) throws Exception {
         long physicalPartitionId = info.physicalPartitionId;
@@ -228,5 +363,55 @@ public class TabletRepairHelper {
         }
 
         return tabletErrors;
+    }
+
+    /**
+     * Repairs the tablet metadata for a single physical partition.
+     * This function attempts to find valid tablet metadata for all tablets within the given physical partition.
+     * It iterates through versions to retrieve tablet metadatas from compute nodes by batches.
+     * If valid metadata is found for all tablets, or
+     * if `allowEmptyTabletRecovery` is true and empty metadata can be created for missing tablets,
+     * it then sends these valid metadatas to the compute nodes to perform the repair operation.
+     *
+     * @param info                     Information about the physical partition.
+     * @param enforceConsistentVersion Whether to enforce consistent metadata version across all tablets.
+     * @param allowEmptyTabletRecovery Whether to allow creating empty metadata for tablets without valid metadata.
+     * @param isFileBundling           Whether file bundling is enabled for the table.
+     * @return A map of tablet IDs to error messages for any tablets that failed to repair.
+     * @throws Exception If an error occurs during the repair process.
+     */
+    private static Map<Long, String> repairPhysicalPartition(PhysicalPartitionInfo info, boolean enforceConsistentVersion,
+                                                             boolean allowEmptyTabletRecovery, boolean isFileBundling)
+            throws Exception {
+        List<Long> allTablets = info.allTablets;
+        Set<Long> leftTablets = info.leftTablets;
+        long partitionMaxVersion = info.maxVersion;
+        long partitionMinVersion = info.minVersion;
+        Map<Long, TabletMetadataPB> validMetadatas = Maps.newHashMap();
+
+        for (long maxVersion = partitionMaxVersion; maxVersion >= partitionMinVersion; maxVersion -= BATCH_VERSION_NUM) {
+            long minVersion = Math.max(maxVersion - BATCH_VERSION_NUM + 1, partitionMinVersion);
+
+            // get tablet metadatas from backends
+            Map<Long, Map<Long, TabletMetadataPB>> tabletVersionMetadatas = getTabletMetadatas(info, maxVersion, minVersion);
+
+            // find the valid tablet metadata
+            findValidTabletMetadata(info, tabletVersionMetadatas, maxVersion, minVersion, enforceConsistentVersion,
+                    validMetadatas);
+
+            if (validMetadatas.keySet().containsAll(allTablets)) {
+                break;
+            } else {
+                leftTablets.removeAll(validMetadatas.keySet());
+            }
+        }
+
+        // check the valid tablet metadata, and create empty tablet metadata if no valid metadata is found
+        checkOrCreateEmptyTabletMetadata(info, validMetadatas, enforceConsistentVersion, allowEmptyTabletRecovery);
+        LOG.info("Found valid tablet metadatas for partition {}, tablet versions: {}", info.physicalPartitionId,
+                validMetadatas.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().version)));
+
+        // repair the valid tablet metadata through backends
+        return repairTabletMetadata(info, validMetadatas, isFileBundling);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/TabletRepairHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/TabletRepairHelperTest.java
@@ -302,7 +302,7 @@ public class TabletRepairHelperTest {
             Assertions.assertFalse(validMetadatas.containsKey(tabletId2));
 
             ExceptionChecker.expectThrowsWithMsg(StarRocksException.class,
-                    "tablet 10002 has no valid tablet metadatas",
+                    "no tablet metadatas were found for tablets [10002]",
                     () -> Deencapsulation.invoke(TabletRepairHelper.class, "checkOrCreateEmptyTabletMetadata",
                             info, validMetadatas, false, false));
 
@@ -571,12 +571,12 @@ public class TabletRepairHelperTest {
             }
         };
 
-        // consistent version
+        // case 1: enforceConsistentVersion = true
         Map<Long, String> tabletErrors =
                 Deencapsulation.invoke(TabletRepairHelper.class, "repairPhysicalPartition", info, true, false, false);
         Assertions.assertTrue(tabletErrors.isEmpty());
 
-        // inconsistent version
+        // case 2: enforceConsistentVersion = false
         info = new PhysicalPartitionInfo(physicalPartitionId, Lists.newArrayList(tabletId1, tabletId2),
                 Sets.newHashSet(tabletId1, tabletId2), nodeToTablets, maxVersion, minVersion);
         tabletErrors = Deencapsulation.invoke(TabletRepairHelper.class, "repairPhysicalPartition", info, false, false, false);

--- a/fe/fe-core/src/test/java/com/starrocks/lake/TabletRepairHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/TabletRepairHelperTest.java
@@ -577,6 +577,8 @@ public class TabletRepairHelperTest {
         Assertions.assertTrue(tabletErrors.isEmpty());
 
         // inconsistent version
+        info = new PhysicalPartitionInfo(physicalPartitionId, Lists.newArrayList(tabletId1, tabletId2),
+                Sets.newHashSet(tabletId1, tabletId2), nodeToTablets, maxVersion, minVersion);
         tabletErrors = Deencapsulation.invoke(TabletRepairHelper.class, "repairPhysicalPartition", info, false, false, false);
         Assertions.assertTrue(tabletErrors.isEmpty());
     }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Repairs the tablet metadata for a single physical partition.
The function attempts to find valid tablet metadata for all tablets within the given physical partition.
It iterates through versions to retrieve tablet metadatas from compute nodes by batches.
If valid metadata is found for all tablets, or if `allowEmptyTabletRecovery` is true and empty metadata can be created for missing tablets,
it then sends these valid metadatas to the compute nodes to perform the repair operation.

https://github.com/StarRocks/starrocks/issues/66015

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a repair flow for a single physical partition that scans versions in batches, selects consistent/latest valid tablet metadata, optionally creates empty metadata, and executes repair; includes comprehensive unit tests.
> 
> - **Backend (`fe/fe-core/src/main/java/com/starrocks/lake/TabletRepairHelper.java`)**:
>   - Introduces `repairPhysicalPartition(...)` to repair a single physical partition by scanning versions in batches (`BATCH_VERSION_NUM`).
>   - Adds validation/selection of valid metadata via `findValidTabletMetadata(...)` with two strategies:
>     - Consistent version across all tablets.
>     - Latest available per tablet.
>   - Supports optional empty-tablet recovery (`checkOrCreateEmptyTabletMetadata(...)`, `createEmptyTabletMetadata(...)`) and verifies visible version before repair.
>   - Enhances metadata retrieval `getTabletMetadatas(...)`, executes repair via `repairTabletMetadata(...)`, supports file bundling, and renames `leftTablets` to `unverifiedTablets`.
> - **Tests (`fe/fe-core/src/test/java/com/starrocks/lake/TabletRepairHelperTest.java`)**:
>   - Adds unit tests covering metadata fetch paths, selection strategies, empty recovery, repair execution (with/without file bundling), and error handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b328eb59c0b44ea7cbf1ad066dbcae1d2ec522b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->