### PR TITLE
[BugFix] Batch update segment cache size to improve wide table column init performance

### DIFF
--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -189,6 +189,7 @@ Status TabletManager::drop_local_cache(const std::string& path) {
 
 // current lru cache does not support updating value size, so use refill to update.
 void TabletManager::update_segment_cache_size(std::string_view key, size_t mem_cost, intptr_t segment_addr_hint) {
+    TEST_SYNC_POINT_CALLBACK("lake::TabletManager::update_segment_cache_size", nullptr);
     _metacache->cache_segment_if_present(key, mem_cost, segment_addr_hint);
 }
 

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -222,10 +222,23 @@ public:
 
     const FileEncryptionInfo* encryption_info() const { return _encryption_info.get(); };
 
+    inline void turn_on_batch_update_cache_size() {
+#ifdef BE_TEST
+        if (!_s_allow_batch_update_mode) return;
+#endif
+        _batch_on_flags_counter.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    void turn_off_batch_update_cache_size();
+
     DISALLOW_COPY_AND_MOVE(Segment);
 
     // for ut test
     void set_num_rows(uint32_t num_rows) { _num_rows = num_rows; }
+
+#ifdef BE_TEST
+    static void toggle_batch_update_cache_mode(bool enabled) { _s_allow_batch_update_mode = enabled; }
+#endif
 
 private:
     friend struct SegmentZoneMapPruner;
@@ -312,10 +325,16 @@ private:
 
     std::unique_ptr<FileEncryptionInfo> _encryption_info;
 
+    std::atomic_int _batch_on_flags_counter{0};
+    std::atomic_int _dirty_cache_counter{0};
+
     // for cloud native tablet
     lake::TabletManager* _tablet_manager = nullptr;
     // used to guarantee that segment will be opened at most once in a thread-safe way
     OnceFlag _open_once;
+#ifdef BE_TEST
+    static bool _s_allow_batch_update_mode;
+#endif
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -611,6 +611,8 @@ Status SegmentIterator::_init() {
 
     /// the calling order matters, do not change unless you know why.
 
+    _segment->turn_on_batch_update_cache_size();
+    DeferOp op([&] { _segment->turn_off_batch_update_cache_size(); });
     // init stage
     // The main task is to do some initialization,
     // initialize the iterator and check if certain optimizations can be applied

--- a/be/test/storage/lake/tablet_reader_test.cpp
+++ b/be/test/storage/lake/tablet_reader_test.cpp
@@ -16,6 +16,9 @@
 
 #include <gtest/gtest.h>
 
+#include <iomanip>
+#include <utility>
+
 #include "column/chunk.h"
 #include "column/datum_tuple.h"
 #include "column/fixed_length_column.h"
@@ -32,6 +35,8 @@
 #include "test_util.h"
 #include "testutil/assert.h"
 #include "testutil/id_generator.h"
+#include "testutil/sync_point.h"
+#include "util/defer_op.h"
 
 namespace starrocks::lake {
 
@@ -50,7 +55,10 @@ public:
         CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
     }
 
-    void TearDown() override { remove_test_dir_ignore_error(); }
+    void TearDown() override {
+        remove_test_dir_ignore_error();
+        Segment::toggle_batch_update_cache_mode(true);
+    }
 
 protected:
     constexpr static const char* const kTestDirectory = "test_duplicate_lake_tablet_reader";
@@ -119,6 +127,16 @@ TEST_F(LakeDuplicateTabletReaderTest, test_read_success) {
     // write tablet metadata
     _tablet_metadata->set_version(2);
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    int invocation_counter = 0;
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("lake::TabletManager::update_segment_cache_size",
+                                          [&](void* arg) { ++invocation_counter; });
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("lake::TabletManager::update_segment_cache_size");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    ASSERT_EQ(0, invocation_counter);
 
     // test reader
     auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), _tablet_metadata, *_schema);
@@ -140,6 +158,11 @@ TEST_F(LakeDuplicateTabletReaderTest, test_read_success) {
             EXPECT_EQ(v1[i], read_chunk_ptr->get(k0.size() + i)[1].get_int32());
         }
     }
+    // With the fix: 2 segments, 2 calls per segment: 1 for _open, 1 for initializing column iterators
+    // total = 2 segments × (1 segment open + 1 column init) = 4 calls
+    // Without the fix: there would be 6 invocations: 2 segment opens and 2 column inits per segment.
+    // total = 2 segments × (1 segment open + 2 column inits) = 6 calls
+    ASSERT_EQ(4, invocation_counter);
 
     read_chunk_ptr->reset();
     ASSERT_TRUE(reader->get_next(read_chunk_ptr.get()).is_end_of_file());
@@ -876,4 +899,234 @@ TEST_F(DISABLED_LakeLoadSegmentParallelTest, test_normal) {
     reader->close();
 }
 
+class LakeDuplicateTablet10kColumnReaderTest : public TestBase {
+public:
+    LakeDuplicateTablet10kColumnReaderTest() : TestBase(kTestDirectory) {
+        _tablet_metadata = generate_simple_tablet_metadata(DUP_KEYS, kColumnSize);
+        _tablet_schema = TabletSchema::create(_tablet_metadata->schema());
+        _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
+    }
+
+    void SetUp() override {
+        clear_and_init_test_dir();
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    }
+
+    void TearDown() override {
+        remove_test_dir_ignore_error();
+        Segment::toggle_batch_update_cache_mode(true);
+    }
+
+    void test_10k_column_read_perf_body(bool enable_batch_update, size_t* time_costs);
+
+    StatusOr<std::pair<size_t, size_t>> testOneRoundGetColumnInit(const Chunk& chunk, size_t num_rows,
+                                                                  size_t num_columns);
+
+protected:
+    constexpr static const char* const kTestDirectory = "test_duplicate_lake_tablet_reader_10k";
+    constexpr static const size_t kColumnSize = 10000;
+
+    std::shared_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::shared_ptr<Schema> _schema;
+};
+
+static Chunk generate_chunk(SchemaPtr schema, size_t num_rows, size_t num_columns) {
+    Columns columns;
+    columns.reserve(num_columns);
+    for (int i = 0; i < num_columns; ++i) {
+        auto col = Int32Column::create();
+        std::vector<int> col_v;
+        col_v.reserve(num_rows);
+        for (int j = 0; j < num_rows; ++j) {
+            col_v.emplace_back(i * 1000 + j);
+        }
+        col->append_numbers(col_v.data(), col_v.size() * sizeof(int));
+        columns.push_back(std::move(col));
+    }
+    return Chunk(columns, schema);
+}
+
+void LakeDuplicateTablet10kColumnReaderTest::test_10k_column_read_perf_body(bool enable_batch_update,
+                                                                            size_t* time_costs) {
+    Segment::toggle_batch_update_cache_mode(enable_batch_update);
+
+    auto chunk = generate_chunk(_schema, 100, kColumnSize);
+    const int segment_rows = chunk.num_rows();
+
+    VersionedTablet tablet(_tablet_mgr.get(), _tablet_metadata);
+    // clear historic rowsets
+    _tablet_metadata->clear_rowsets();
+    {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+        ASSERT_OK(writer->open());
+        ASSERT_OK(writer->write(chunk));
+        ASSERT_OK(writer->finish());
+
+        auto files = writer->files();
+        ASSERT_EQ(1, files.size());
+        auto* rowset = _tablet_metadata->add_rowsets();
+        rowset->set_overlapped(true);
+        rowset->set_id(1);
+        auto* segs = rowset->mutable_segments();
+        auto* segs_size = rowset->mutable_segment_size();
+        for (auto& file : writer->files()) {
+            segs->Add(std::move(file.path));
+            segs_size->Add(std::move(file.size.value()));
+        }
+        writer->close();
+    }
+
+    // write tablet metadata
+    _tablet_metadata->set_version(2);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    int invocation_counter = 0;
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("lake::TabletManager::update_segment_cache_size",
+                                          [&](void* arg) { ++invocation_counter; });
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("lake::TabletManager::update_segment_cache_size");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    ASSERT_EQ(0, invocation_counter);
+
+    auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), _tablet_metadata, *_schema);
+    ASSERT_OK(reader->prepare());
+    TabletReaderParams params;
+    ASSERT_OK(reader->open(params));
+
+    auto read_chunk_ptr = ChunkHelper::new_chunk(*_schema, 1024);
+    read_chunk_ptr->reset();
+    ASSERT_OK(reader->get_next(read_chunk_ptr.get()));
+    ASSERT_EQ(segment_rows, read_chunk_ptr->num_rows());
+    LOG(INFO) << "[BatchUpdateMode=" << enable_batch_update
+              << "] Segment init time cost: " << reader->stats().segment_init_ns << "ns";
+    if (time_costs != nullptr) {
+        *time_costs = reader->stats().segment_init_ns;
+    }
+    if (enable_batch_update) {
+        ASSERT_EQ(2, invocation_counter); // 1 segment open + 1 batch update
+    } else {
+        ASSERT_EQ(1 + kColumnSize, invocation_counter);
+    }
+
+    read_chunk_ptr->reset();
+    ASSERT_TRUE(reader->get_next(read_chunk_ptr.get()).is_end_of_file());
+    reader->close();
+}
+
+// Perf comparison details (columns=10000): batch=false, time_costs=1334756936ns; batch=true, time_costs=32745137ns. Perf diff times: 40.8x
+TEST_F(LakeDuplicateTablet10kColumnReaderTest, test_10k_column_read_perf) {
+    size_t time_costs_false = 0;
+    size_t time_costs_true = 0;
+    test_10k_column_read_perf_body(false, &time_costs_false);
+    test_10k_column_read_perf_body(true, &time_costs_true);
+    LOG(WARNING) << "Perf comparison details (columns=" << kColumnSize
+                 << "): batch=false, time_costs=" << time_costs_false
+                 << "ns; batch=true, time_costs=" << time_costs_true << "ns. Perf diff times: " << std::setprecision(3)
+                 << (double)time_costs_false / time_costs_true << "x";
+}
+
+StatusOr<std::pair<size_t, size_t>> LakeDuplicateTablet10kColumnReaderTest::testOneRoundGetColumnInit(
+        const Chunk& chunk, size_t num_rows, size_t num_columns) {
+    const int segment_rows = chunk.num_rows();
+    VersionedTablet tablet(_tablet_mgr.get(), _tablet_metadata);
+    // clear all historic rowsets
+    _tablet_metadata->clear_rowsets();
+    {
+        int64_t txn_id = next_id();
+        ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+        RETURN_IF_ERROR(writer->open());
+        RETURN_IF_ERROR(writer->write(chunk));
+        RETURN_IF_ERROR(writer->finish());
+        auto files = writer->files();
+        EXPECT_EQ(1, files.size());
+        auto* rowset = _tablet_metadata->add_rowsets();
+        rowset->set_overlapped(true);
+        rowset->set_id(1);
+        auto* segs = rowset->mutable_segments();
+        auto* segs_size = rowset->mutable_segment_size();
+        for (auto& file : writer->files()) {
+            segs->Add(std::move(file.path));
+            segs_size->Add(std::move(file.size.value()));
+        }
+        writer->close();
+    }
+
+    _tablet_metadata->set_version(next_id());
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    int invocation_counter = 0;
+    SyncPoint::GetInstance()->EnableProcessing();
+    SyncPoint::GetInstance()->SetCallBack("lake::TabletManager::update_segment_cache_size",
+                                          [&](void* arg) { ++invocation_counter; });
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("lake::TabletManager::update_segment_cache_size");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    EXPECT_EQ(0, invocation_counter);
+    auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), _tablet_metadata, *_schema);
+    RETURN_IF_ERROR(reader->prepare());
+    TabletReaderParams params;
+    RETURN_IF_ERROR(reader->open(params));
+
+    auto read_chunk_ptr = ChunkHelper::new_chunk(*_schema, 1024);
+    read_chunk_ptr->reset();
+    RETURN_IF_ERROR(reader->get_next(read_chunk_ptr.get()));
+    EXPECT_EQ(segment_rows, read_chunk_ptr->num_rows());
+    read_chunk_ptr->reset();
+    EXPECT_TRUE(reader->get_next(read_chunk_ptr.get()).is_end_of_file());
+    reader->close();
+    return std::make_pair(reader->stats().segment_init_ns, invocation_counter);
+}
+
+// Perf comparison details(Columns=5000): batch=false, time_costs=268474431ns; batch=true, time_costs=13515903ns. Perf diff times: 19.9x
+// This case takes time, disable it by default.
+TEST_F(LakeDuplicateTablet10kColumnReaderTest, DISABLED_test_bench_5kcolumn_init) {
+    constexpr size_t num_columns = 5000;
+    constexpr size_t num_rows = 100;
+    constexpr size_t round = 10;
+    _tablet_metadata = generate_simple_tablet_metadata(DUP_KEYS, num_columns);
+    _tablet_schema = TabletSchema::create(_tablet_metadata->schema());
+    _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
+    auto chunk = generate_chunk(_schema, num_rows, num_columns);
+
+    size_t total_time_ns_false = 0;
+    Segment::toggle_batch_update_cache_mode(false);
+    {
+        size_t total_invocations = 0;
+        for (int i = 0; i < round; ++i) {
+            auto result = testOneRoundGetColumnInit(chunk, num_rows, num_columns);
+            ASSERT_OK(result.status());
+            auto [time_cost, invocation_counter] = result.value();
+            total_time_ns_false += time_cost;
+            total_invocations += invocation_counter;
+        }
+        LOG(INFO) << "[BatchUpdateMode=false] Done running " << round
+                  << " round, average time cost: " << total_time_ns_false / round
+                  << "ns, average update cache invocation: " << total_invocations / round;
+    }
+    size_t total_time_ns_true = 0;
+    Segment::toggle_batch_update_cache_mode(true);
+    {
+        size_t total_invocations = 0;
+        for (int i = 0; i < round; ++i) {
+            auto result = testOneRoundGetColumnInit(chunk, num_rows, num_columns);
+            ASSERT_OK(result.status());
+            auto [time_cost, invocation_counter] = result.value();
+            total_time_ns_true += time_cost;
+            total_invocations += invocation_counter;
+        }
+        LOG(INFO) << "[BatchUpdateMode=true] Done running " << round
+                  << " round, average time cost: " << total_time_ns_true / round
+                  << "ns, average update cache invocation: " << total_invocations / round;
+    }
+    LOG(WARNING) << "Perf comparison details(Columns=" << num_columns
+                 << "): batch=false, time_costs=" << total_time_ns_false / round
+                 << "ns; batch=true, time_costs=" << total_time_ns_true / round
+                 << "ns. Perf diff times: " << std::setprecision(3) << (double)total_time_ns_false / total_time_ns_true
+                 << "x";
+}
 } // namespace starrocks::lake

--- a/be/test/storage/lake/test_util.h
+++ b/be/test/storage/lake/test_util.h
@@ -278,7 +278,7 @@ inline StatusOr<TabletMetadataPtr> TestBase::batch_publish(int64_t tablet_id, in
     return TEST_batch_publish(_tablet_mgr.get(), tablet_id, base_version, new_version, txn_ids);
 }
 
-inline std::shared_ptr<TabletMetadataPB> generate_simple_tablet_metadata(KeysType keys_type) {
+inline std::shared_ptr<TabletMetadataPB> generate_simple_tablet_metadata(KeysType keys_type, size_t num_of_columns) {
     auto metadata = std::make_shared<TabletMetadata>();
     metadata->set_id(next_id());
     metadata->set_version(1);
@@ -289,29 +289,29 @@ inline std::shared_ptr<TabletMetadataPB> generate_simple_tablet_metadata(KeysTyp
     //  +--------+------+-----+------+
     //  |   c0   |  INT | YES |  NO  |
     //  |   c1   |  INT | NO  |  NO  |
+    //  |   ..   |  INT | ... |  ... |
+    //  |   ci   |  INT | Y,N |  NO  |
     auto schema = metadata->mutable_schema();
     schema->set_keys_type(keys_type);
     schema->set_id(next_id());
     schema->set_num_short_key_columns(1);
     schema->set_num_rows_per_row_block(65535);
-    auto c0 = schema->add_column();
-    {
-        c0->set_unique_id(next_id());
-        c0->set_name("c0");
-        c0->set_type("INT");
-        c0->set_is_key(true);
-        c0->set_is_nullable(false);
-    }
-    auto c1 = schema->add_column();
-    {
-        c1->set_unique_id(next_id());
-        c1->set_name("c1");
-        c1->set_type("INT");
-        c1->set_is_key(false);
-        c1->set_is_nullable(false);
-        c1->set_aggregation(keys_type == DUP_KEYS ? "NONE" : "REPLACE");
+    for (size_t i = 0; i < num_of_columns; ++i) {
+        auto c = schema->add_column();
+        c->set_unique_id(next_id());
+        c->set_name("c" + std::to_string(i));
+        c->set_type("INT");
+        c->set_is_nullable(false);
+        c->set_is_key(i % 2 == 0);
+        if (i % 2 == 1) {
+            c->set_aggregation(keys_type == DUP_KEYS ? "NONE" : "REPLACE");
+        }
     }
     return metadata;
+}
+
+inline std::shared_ptr<TabletMetadataPB> generate_simple_tablet_metadata(KeysType keys_type) {
+    return generate_simple_tablet_metadata(keys_type, 2);
 }
 
 inline std::shared_ptr<RuntimeState> create_runtime_state() {


### PR DESCRIPTION
## Why I'm doing:

**Problem:**
When querying a table with a large number of columns (e.g., 10,000 columns),
`update_segment_cache_size` is invoked for every column initialization during
`SegmentIterator` init. This causes significant CPU overhead and lock contention
in the cache manager, degrading query performance.

**Solution:**
Introduce a batch update mode for `Segment` cache size updates.
1. Added `turn_on_batch_update_cache_size()` and `turn_off_batch_update_cache_size()` to `Segment`.
2. When batch mode is enabled, `update_cache_size()` only increments a dirty counter
   instead of calling the tablet manager immediately.
3. When batch mode is turned off, if there are dirty updates, the cache size is updated once.
4. Applied this batch mode in `SegmentIterator::_init()` to cover the column initialization phase.

**Result:**
Performance tests show a ~40x improvement in segment initialization time for a table with 10,000 columns.


## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves segment init performance for wide tables by batching metadata cache size updates instead of updating per column.
> 
> - Adds `Segment::turn_on_batch_update_cache_size()`/`turn_off_batch_update_cache_size()` with atomic flags and a dirty counter; `update_cache_size()` now defers updates when batch mode is on
> - Wraps `SegmentIterator::_init()` with batch mode (RAII via `DeferOp`) to coalesce cache updates
> - Inserts a test sync point in `TabletManager::update_segment_cache_size` for invocation counting
> - Adds unit tests validating reduced update invocations and performance with 10k columns; extends test util to generate schemas with N columns
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94f2b3e2d7db25dc27f507f62e5d846e5a2e5170. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->