### PR TITLE
[BugFix] Update JUnit version to use property in pom.xml and build.gradle.kts

### DIFF
--- a/fe/build.gradle.kts
+++ b/fe/build.gradle.kts
@@ -63,6 +63,7 @@ subprojects {
         set("jackson.version", "2.15.2")
         set("jetty.version", "9.4.57.v20241219")
         set("jprotobuf-starrocks.version", "1.0.0")
+        set("junit.version", "5.8.2")
         set("kafka-clients.version", "3.4.0")
         set("kudu.version", "1.17.1")
         set("log4j.version", "2.19.0")
@@ -83,6 +84,8 @@ subprojects {
         implementation(platform("com.azure:azure-sdk-bom:${project.ext["azure.version"]}"))
         implementation(platform("io.opentelemetry:opentelemetry-bom:1.14.0"))
         implementation(platform("software.amazon.awssdk:bom:${project.ext["aws-v2-sdk.version"]}"))
+        // Enforce the same JUnit 5 versions as Maven (via `junit.version`) across all FE subprojects.
+        testImplementation(enforcedPlatform("org.junit:junit-bom:${project.ext["junit.version"]}"))
 
         constraints {
             // dependency sync start
@@ -223,7 +226,7 @@ subprojects {
             implementation("org.jboss.xnio:xnio-nio:3.8.16.Final")
             implementation("org.jdom:jdom2:2.0.6.1")
             implementation("org.json:json:20231013")
-            implementation("org.junit.jupiter:junit-jupiter:5.8.2")
+            implementation("org.junit.jupiter:junit-jupiter:${project.ext["junit.version"]}")
             implementation("org.mariadb.jdbc:mariadb-java-client:3.3.2")
             implementation("org.owasp.encoder:encoder:1.3.1")
             implementation("org.postgresql:postgresql:42.4.4")

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -46,6 +46,7 @@ under the License.
     <properties>
         <starrocks.home>${basedir}/../</starrocks.home>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <junit.version>5.8.2</junit.version>
         <jprotobuf-starrocks.version>1.0.0</jprotobuf-starrocks.version>
         <log4j.version>2.19.0</log4j.version>
         <jackson.version>2.15.2</jackson.version>
@@ -485,7 +486,7 @@ under the License.
             <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter</artifactId>
-                <version>5.8.2</version>
+                <version>${junit.version}</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This pull request standardizes the JUnit 5 version across both Gradle and Maven build configurations for the FE subprojects, ensuring consistency and easier maintenance. The changes introduce a shared `junit.version` property and update all relevant dependencies to reference this property.

Dependency management improvements:

* Added a `junit.version` property (`5.8.2`) to both `fe/build.gradle.kts` and `fe/pom.xml` for centralized version management. [[1]](diffhunk://#diff-711c8906780096a2b018ddab40f5bb1cffefa75869524a80859b3ea46f3c7616R66) [[2]](diffhunk://#diff-ac3be7b9da003e43f78a9a5782e8a2967b476b2a63deb57faab013b2de12810cR49)
* Updated all JUnit 5 dependencies in `fe/build.gradle.kts` and `fe/pom.xml` to use the shared `junit.version` property instead of hardcoding the version. [[1]](diffhunk://#diff-711c8906780096a2b018ddab40f5bb1cffefa75869524a80859b3ea46f3c7616L226-R229) [[2]](diffhunk://#diff-ac3be7b9da003e43f78a9a5782e8a2967b476b2a63deb57faab013b2de12810cL488-R489)
* Enforced the use of the JUnit 5 BOM in Gradle to ensure all test dependencies use the specified version across all FE subprojects.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
