### PR TITLE
[BugFix] FinalizeTabletCtx if tablet expired

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -142,7 +142,8 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         FINISHED, // task is finished
         CANCELLED, // task is failed
         TIMEOUT, // task is timeout
-        UNEXPECTED // other unexpected errors
+        UNEXPECTED, // other unexpected errors
+        EXPIRED // tablet will erase soon
     }
 
     private Type type;

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -143,7 +143,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         CANCELLED, // task is failed
         TIMEOUT, // task is timeout
         UNEXPECTED, // other unexpected errors
-        EXPIRED // tablet will erase soon
+        EXPIRED // tablet will be erased soon
     }
 
     private Type type;

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -1826,6 +1826,7 @@ public class TabletScheduler extends FrontendDaemon {
             try {
                 // ignore tablets that will expire and erase soon
                 if (checkIfTabletExpired(tablet)) {
+                    finalizeTabletCtx(tablet, TabletSchedCtx.State.EXPIRED, "will erase soon");
                     continue;
                 }
                 list.add(tablet);

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -378,7 +378,7 @@ public class GlobalStateMgr {
     private final TabletInvertedIndex tabletInvertedIndex;
     private ColocateTableIndex colocateTableIndex;
 
-    private CatalogRecycleBin recycleBin;
+    private final CatalogRecycleBin recycleBin;
     private final FunctionSet functionSet;
 
     private final MetaReplayState metaReplayState;
@@ -587,11 +587,6 @@ public class GlobalStateMgr {
 
     public CatalogRecycleBin getRecycleBin() {
         return this.recycleBin;
-    }
-
-    @VisibleForTesting
-    public void setRecycleBin(CatalogRecycleBin catalogRecycleBin) {
-        this.recycleBin = catalogRecycleBin;
     }
 
     public MetaReplayState getMetaReplayState() {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -378,7 +378,7 @@ public class GlobalStateMgr {
     private final TabletInvertedIndex tabletInvertedIndex;
     private ColocateTableIndex colocateTableIndex;
 
-    private final CatalogRecycleBin recycleBin;
+    private CatalogRecycleBin recycleBin;
     private final FunctionSet functionSet;
 
     private final MetaReplayState metaReplayState;
@@ -587,6 +587,11 @@ public class GlobalStateMgr {
 
     public CatalogRecycleBin getRecycleBin() {
         return this.recycleBin;
+    }
+
+    @VisibleForTesting
+    public void setRecycleBin(CatalogRecycleBin catalogRecycleBin) {
+        this.recycleBin = catalogRecycleBin;
     }
 
     public MetaReplayState getMetaReplayState() {

--- a/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/TabletSchedulerTest.java
@@ -201,13 +201,13 @@ public class TabletSchedulerTest {
             allCtxs.add(tabletSchedCtx);
         }
 
+        Deencapsulation.setField(GlobalStateMgr.getCurrentState(), "recycleBin", recycleBin);
         TabletScheduler tabletScheduler = new TabletScheduler(tabletSchedulerStat);
 
         Config.catalog_trash_expire_second = 1;
         allCtxs.forEach(e -> tabletScheduler.addTablet(e, false));
         Assertions.assertEquals(tabletScheduler.getTotalNum(), 4);
-        GlobalStateMgr.getCurrentState().setRecycleBin(recycleBin);
-        Thread.sleep(1000);
+        Thread.sleep(1100);
         List<TabletSchedCtx> nextBatch = Deencapsulation.invoke(tabletScheduler, "getNextTabletCtxBatch");
         Assertions.assertEquals(nextBatch.size(), 0);
         Assertions.assertEquals(tabletScheduler.getTotalNum(), 0);


### PR DESCRIPTION
## Why I'm doing:
<img width="2026" height="620" alt="1a1fbe6c-2d8d-4047-b8ff-d95f6d7693be" src="https://github.com/user-attachments/assets/e741ae3c-6235-4b85-8e7a-0f60b18d30dc" />

The growth of all_tablets continues unabated and pendingTablets + runningTablets != allTabletIds

<img width="2858" height="360" alt="f2831034-84fe-47a3-866b-c419ef54e832" src="https://github.com/user-attachments/assets/7eab5589-9c21-468c-8c3f-cbdbb36d042c" />
At the same time, I found some expired partitions in the logs
So I guess it could be because the partition has expired and the tablet is not scheduled, but it has not been removed from all_tables

## What I'm doing:
finalizeTabletCtx if tablet expired

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents stale tablet entries from lingering in scheduler queues by finalizing expired contexts.
> 
> - Adds `EXPIRED` to `TabletSchedCtx.State` and uses it when `checkIfTabletExpired()` is true in `TabletScheduler.getNextTabletCtxBatch()` via `finalizeTabletCtx(..., EXPIRED, ...)`
> - Ensures expired tablets are removed from `allTabletIds`, recorded in `schedHistory`, and not scheduled
> - Adds UTs: `testRemoveAllTabletIdsIfExpired` (verifies expired tablets are finalized and counted) and `testSubmitBatchTaskIfNotExpired` (verifies non-expired tablets proceed)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ac27b2d45334bd77e4d047c047f8f73f22779830. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->