### PR TITLE
[BugFix] fix be crash when [offset + count] number out of bounds

### DIFF
--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -59,8 +59,15 @@ void BinaryColumnBase<T>::append(const Column& src, size_t offset, size_t count)
     DCHECK(offset + count <= src.size());
     const auto& b = down_cast<const BinaryColumnBase<T>&>(src);
 
-    const unsigned char* p = &b._bytes[b._offsets[offset]];
-    const unsigned char* e = &b._bytes[b._offsets[offset + count]];
+    size_t start_off = b._offsets[offset];
+    size_t end_off = b._offsets[offset + count];
+
+    if (end_off < start_off) {
+        return;
+    }
+
+    const unsigned char* p = &b._bytes[start_off];
+    const unsigned char* e = &b._bytes[end_off];
     _bytes.insert(_bytes.end(), p, e);
 
     // `new_offsets[i] = offsets[(num_prev_offsets + i - 1) + 1]` is the end offset of the new i-th string.


### PR DESCRIPTION
## Why I'm doing:
crash

*** Aborted at 1762764813 (unix time) try "date -d @1762764813" if you are using GNU date ***
PC: @     0x7f36fe6551f7 __GI_raise
*** SIGABRT (@0xba3c) received by PID 47676 (TID 0x7f35a7d9f700) from PID 47676; stack trace: ***
    @          0x6236322 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f36fe9f25e0 (unknown)
    @     0x7f36fe6551f7 __GI_raise
    @     0x7f36fe6568e8 __GI_abort
    @          0x276c896 _ZN9__gnu_cxx27__verbose_terminate_handlerEv.cold
    @          0x8287516 __cxxabiv1::__terminate()
    @          0x8287581 std::terminate()
    @          0x82876d4 __cxa_throw
    @          0x276e447 std::__throw_length_error()
    @          0x29975a1 std::vector<>::_M_range_insert<>()
    @          0x299aa64 starrocks::BinaryColumnBase<>::append()
    @          0x31b151e starrocks::NullableColumn::append()
    @          0x3196472 starrocks::Chunk::append()
    @          0x4f21a2c starrocks::ChunkAccumulator::push()
    @          0x4c61017 starrocks::ArrayMapExpr::evaluate_checked()
    @          0x432ea93 starrocks::ExprContext::evaluate()
    @          0x4ba0b94 starrocks::VectorizedFunctionCallExpr::evaluate_checked()
    @          0x432f353 starrocks::Expr::evaluate_with_filter()
    @          0x432e9e6 starrocks::ExprContext::evaluate()
    @          0x432eddf starrocks::ExprContext::evaluate()
    @          0x31de87e starrocks::ExecNode::eval_conjuncts_into_filter()
    @          0x58b7e5b starrocks::HdfsOrcScanner::_do_get_next()
    @          0x58b8ac9 starrocks::HdfsOrcScanner::do_get_next()
    @          0x58afb45 starrocks::HdfsScanner::get_next()
    @          0x584beaf starrocks::connector::HiveDataSource::get_next()
    @          0x356502a starrocks::pipeline::ConnectorChunkSource::_read_chunk()
    @          0x387e55f starrocks::pipeline::ChunkSource::buffer_next_batch_chunks_blocking()
    @          0x3556369 _ZZN9starrocks8pipeline12ScanOperator18_trigger_next_scanEPNS_12RuntimeStateEiENKUlvE_clEv
    @          0x3661841 starrocks::workgroup::ScanExecutor::worker_thread()
    @          0x2bd769c starrocks::ThreadPool::dispatch_thread()
    @          0x2bd131a starrocks::Thread::supervise_thread()
    @     0x7f36fe9eae25 start_thread
## What I'm doing:
If  end_offset [offset] is less than start_offset [offset+count] return directly, to avoid be crash.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Validate and use computed start/end offsets in `BinaryColumnBase::append` and early-return when `end_off < start_off` to avoid out-of-bounds byte insertion.
> 
> - **Bug fix** in `be/src/column/binary_column.cpp`:
>   - In `BinaryColumnBase::append(const Column&, size_t, size_t)`, compute `start_off`/`end_off`, return early if `end_off < start_off`, and use these offsets for the byte copy range.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a1af82567016e7a855158f3ac03969803d0c610. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->