### PR TITLE
[UT] Fix MV unstable tests caused by parallel mv prepare

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/TracerImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/TracerImpl.java
@@ -50,20 +50,20 @@ class TracerImpl extends Tracer {
         return timing.elapsed(TimeUnit.NANOSECONDS);
     }
 
-    public Timer watchScope(String name) {
+    public synchronized Timer watchScope(String name) {
         tracerCost.start();
         Timer t = watcher.scope(timePointNanoSecond(), name);
         tracerCost.stop();
         return t;
     }
 
-    public void log(String event) {
+    public synchronized void log(String event) {
         tracerCost.start();
         logTracer.log(timePoint(), event);
         tracerCost.stop();
     }
 
-    public void log(String event, Object... args) {
+    public synchronized void log(String event, Object... args) {
         tracerCost.start();
         logTracer.log(timePoint(), event, args);
         tracerCost.stop();
@@ -71,26 +71,26 @@ class TracerImpl extends Tracer {
 
     @Override
     // lazy log, use it if you want to avoid construct log string when log is disabled
-    public void log(Function<Object[], String> func, Object... args) {
+    public synchronized void log(Function<Object[], String> func, Object... args) {
         tracerCost.start();
         logTracer.log(timePoint(), func, args);
         tracerCost.stop();
     }
 
     @Override
-    public void reason(String reason, Object... args) {
+    public synchronized void reason(String reason, Object... args) {
         tracerCost.start();
         reasonTracer.log(timePoint(), reason, args);
         tracerCost.stop();
     }
 
-    public void record(String name, String value) {
+    public synchronized void record(String name, String value) {
         tracerCost.start();
         varTracer.record(timePoint(), name, value);
         tracerCost.stop();
     }
 
-    public void count(String name, long count) {
+    public synchronized void count(String name, long count) {
         tracerCost.start();
         varTracer.count(timePoint(), name, count);
         tracerCost.stop();

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -1662,6 +1662,8 @@ public class PropertyAnalyzer {
             short replicationNum = RunMode.defaultReplicationNum();
             if (properties.containsKey(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM)) {
                 if (FeConstants.isReplayFromQueryDump) {
+                    // still call analyzeReplicationNum to check the validity of replication_num
+                    PropertyAnalyzer.analyzeReplicationNum(properties, replicationNum);
                     replicationNum = 1;
                 } else {
                     replicationNum = PropertyAnalyzer.analyzeReplicationNum(properties, replicationNum);
@@ -1944,7 +1946,7 @@ public class PropertyAnalyzer {
             }
         } catch (AnalysisException e) {
             if (FeConstants.isReplayFromQueryDump) {
-                LOG.warn("Ignore MV properties analysis error during replay from query dump: ", e);
+                LOG.warn("Ignore MV properties analysis error during replay from query dump: " + e.getMessage());
             } else {
                 if (materializedView.isCloudNativeMaterializedView()) {
                     GlobalStateMgr.getCurrentState().getStorageVolumeMgr()

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -790,13 +790,11 @@ public class MvRewritePreprocessor {
             return;
         }
 
-        synchronized (queryMaterializationContext) {
-            if (partitionNamesToRefresh.isEmpty()) {
-                logMVPrepare(tracers, connectContext, mv, "MV {} has no partitions to refresh", mv.getName());
-            } else {
-                logMVPrepare(tracers, mv, "MV's partitions to refresh(size: {}): {}", partitionNamesToRefresh.size(),
-                        partitionNamesToRefresh);
-            }
+        if (partitionNamesToRefresh.isEmpty()) {
+            logMVPrepare(tracers, connectContext, mv, "MV {} has no partitions to refresh", mv.getName());
+        } else {
+            logMVPrepare(tracers, mv, "MV's partitions to refresh(size: {}): {}", partitionNamesToRefresh.size(),
+                    partitionNamesToRefresh);
         }
 
         MaterializationContext materializationContext = buildMaterializationContext(context, mv, mvPlanContext,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -778,6 +778,9 @@ public class MvRewritePreprocessor {
                 candidateMvNames);
     }
 
+    /**
+     * Since this method is executed in parallel for multiple MVs, it must be thread-safe.
+     */
     private void prepareMV(Tracers tracers, Set<Table> queryTables, MaterializedViewWrapper mvWithPlanContext,
                            MvUpdateInfo mvUpdateInfo, long timeoutMs) {
         MaterializedView mv = mvWithPlanContext.getMV();
@@ -786,11 +789,14 @@ public class MvRewritePreprocessor {
         if (!checkMvPartitionNamesToRefresh(connectContext, mv, partitionNamesToRefresh, mvPlanContext)) {
             return;
         }
-        if (partitionNamesToRefresh.isEmpty()) {
-            logMVPrepare(tracers, connectContext, mv, "MV {} has no partitions to refresh", mv.getName());
-        } else {
-            logMVPrepare(tracers, mv, "MV's partitions to refresh(size: {}): {}", partitionNamesToRefresh.size(),
-                    partitionNamesToRefresh);
+
+        synchronized (queryMaterializationContext) {
+            if (partitionNamesToRefresh.isEmpty()) {
+                logMVPrepare(tracers, connectContext, mv, "MV {} has no partitions to refresh", mv.getName());
+            } else {
+                logMVPrepare(tracers, mv, "MV's partitions to refresh(size: {}): {}", partitionNamesToRefresh.size(),
+                        partitionNamesToRefresh);
+            }
         }
 
         MaterializationContext materializationContext = buildMaterializationContext(context, mv, mvPlanContext,
@@ -803,8 +809,8 @@ public class MvRewritePreprocessor {
         // to avoid race condition when multiple threads are adding valid candidate mvs to query materialization context
         synchronized (queryMaterializationContext) {
             queryMaterializationContext.addValidCandidateMV(materializationContext);
+            logMVPrepare(tracers, connectContext, mv, "Prepare MV {} success", mv.getName());
         }
-        logMVPrepare(tracers, connectContext, mv, "Prepare MV {} success", mv.getName());
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
@@ -107,6 +107,9 @@ public class OptimizerTraceUtil {
      * Safe log for MV module, ignore any exception during logging.
      */
     private static void traceLogMVSafe(Function<Object[], String> func, Object... args) {
+        if (!Tracers.isSetTraceModule(Tracers.Module.MV)) {
+            return;
+        }
         try {
             Tracers.log(Tracers.Module.MV, func, args);
         } catch (Exception e) {
@@ -118,6 +121,9 @@ public class OptimizerTraceUtil {
      * Safe log for MV module, ignore any exception during logging.
      */
     private static void traceLogMVSafe(Tracers tracers, Function<Object[], String> func, Object... args) {
+        if (!Tracers.isSetTraceModule(Tracers.Module.MV)) {
+            return;
+        }
         try {
             Tracers.log(tracers, Tracers.Module.MV, func, args);
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
@@ -24,6 +24,7 @@ import com.starrocks.sql.optimizer.rule.Rule;
 import org.slf4j.helpers.MessageFormatter;
 
 import java.util.List;
+import java.util.function.Function;
 
 public class OptimizerTraceUtil {
     public static void logOptExpression(String format, OptExpression optExpression) {
@@ -45,7 +46,7 @@ public class OptimizerTraceUtil {
 
     public static void logMVPrepare(ConnectContext ctx, MaterializedView mv,
                                     String format, Object... object) {
-        Tracers.log(Tracers.Module.MV, input -> {
+        traceLogMVSafe(input -> {
             String str = MessageFormatter.arrayFormat(format, object).getMessage();
             Object[] args = new Object[] {mv == null ? "GLOBAL" : mv.getName(), str};
             return MessageFormatter.arrayFormat("[MV TRACE] [PREPARE {}] {}", args).getMessage();
@@ -54,7 +55,7 @@ public class OptimizerTraceUtil {
 
     public static void logMVPrepare(Tracers tracers, ConnectContext ctx, MaterializedView mv,
                                     String format, Object... object) {
-        Tracers.log(tracers, Tracers.Module.MV, input -> {
+        traceLogMVSafe(tracers, input -> {
             String str = MessageFormatter.arrayFormat(format, object).getMessage();
             Object[] args = new Object[] {mv == null ? "GLOBAL" : mv.getName(), str};
             return MessageFormatter.arrayFormat("[MV TRACE] [PREPARE {}] {}", args).getMessage();
@@ -71,7 +72,7 @@ public class OptimizerTraceUtil {
 
     public static void logMVPrepare(MaterializedView mv,
                                     String format, Object... object) {
-        Tracers.log(Tracers.Module.MV, input -> {
+        traceLogMVSafe(input -> {
             String str = MessageFormatter.arrayFormat(format, object).getMessage();
             Object[] args = new Object[] {mv == null ? "GLOBAL" : mv.getName(), str};
             return MessageFormatter.arrayFormat("[MV TRACE] [PREPARE {}] {}", args).getMessage();
@@ -80,7 +81,7 @@ public class OptimizerTraceUtil {
 
     public static void logMVPrepare(Tracers tracers, MaterializedView mv,
                                     String format, Object... object) {
-        Tracers.log(tracers, Tracers.Module.MV, input -> {
+        traceLogMVSafe(tracers, input -> {
             String str = MessageFormatter.arrayFormat(format, object).getMessage();
             Object[] args = new Object[] {mv == null ? "GLOBAL" : mv.getName(), str};
             return MessageFormatter.arrayFormat("[MV TRACE] [PREPARE {}] {}", args).getMessage();
@@ -96,10 +97,32 @@ public class OptimizerTraceUtil {
     }
 
     public static void logMVRewrite(String mvName, String format, Object... objects) {
-        Tracers.log(Tracers.Module.MV, input -> {
+        traceLogMVSafe(input -> {
             String str = MessageFormatter.arrayFormat(format, objects).getMessage();
             return MessageFormatter.format("[MV TRACE] [REWRITE {}] {}", mvName, str).getMessage();
         });
+    }
+
+    /**
+     * Safe log for MV module, ignore any exception during logging.
+     */
+    private static void traceLogMVSafe(Function<Object[], String> func, Object... args) {
+        try {
+            Tracers.log(Tracers.Module.MV, func, args);
+        } catch (Exception e) {
+            // ignore log exception
+        }
+    }
+
+    /**
+     * Safe log for MV module, ignore any exception during logging.
+     */
+    private static void traceLogMVSafe(Tracers tracers, Function<Object[], String> func, Object... args) {
+        try {
+            Tracers.log(tracers, Tracers.Module.MV, func, args);
+        } catch (Exception e) {
+            // ignore log exception
+        }
     }
 
     /**
@@ -132,7 +155,7 @@ public class OptimizerTraceUtil {
     }
 
     public static void logMVRewrite(MaterializationContext mvContext, Rule rule, String format, Object... object) {
-        Tracers.log(Tracers.Module.MV, input -> {
+        traceLogMVSafe(input -> {
             Object[] args = new Object[] {
                     rule == null ? "" : rule.type().name(),
                     mvContext.getOptimizerContext().isInMemoPhase(),
@@ -146,7 +169,7 @@ public class OptimizerTraceUtil {
 
     public static void logMVRewrite(MvRewriteContext mvRewriteContext, String format, Object... object) {
         MaterializationContext mvContext = mvRewriteContext.getMaterializationContext();
-        Tracers.log(Tracers.Module.MV, input -> {
+        traceLogMVSafe(input -> {
             Object[] args = new Object[] {
                     mvRewriteContext.getRule().type().name(),
                     mvRewriteContext.getMaterializationContext().getOptimizerContext().isInMemoPhase(),
@@ -160,7 +183,7 @@ public class OptimizerTraceUtil {
 
     public static void logMVRewrite(OptimizerContext optimizerContext, Rule rule,
                                     String format, Object... object) {
-        Tracers.log(Tracers.Module.MV, input -> {
+        traceLogMVSafe(input -> {
             Object[] args = new Object[] {
                     rule == null ? "" : rule.type().name(),
                     optimizerContext.isInMemoPhase(),
@@ -171,7 +194,7 @@ public class OptimizerTraceUtil {
     }
 
     public static void logMVRewriteRule(String ruleName, String format, Object... object) {
-        Tracers.log(Tracers.Module.MV, input -> {
+        traceLogMVSafe(input -> {
             Object[] args = new Object[] {
                     ruleName,
                     MessageFormatter.arrayFormat(format, object).getMessage()


### PR DESCRIPTION
## Why I'm doing:

```
2025-12-12T06:55:35.4046100Z 2025-12-12 14:55:34 [main] WARN  MvRewritePreprocessor:890 - MV mv_manyjoin_12 preparation failed with unexpected exception
2025-12-12T06:55:35.4046605Z java.lang.IllegalStateException: This stopwatch is already running.
2025-12-12T06:55:35.4047098Z 	at com.google.common.base.Preconditions.checkState(Preconditions.java:512) ~[spark-dpp-main.jar:?]
2025-12-12T06:55:35.4047639Z 	at com.google.common.base.Stopwatch.start(Stopwatch.java:166) ~[spark-dpp-main.jar:?]
2025-12-12T06:55:35.4048128Z 	at com.starrocks.common.profile.TracerImpl.record(TracerImpl.java:88) ~[classes/:?]
2025-12-12T06:55:35.4048612Z 	at com.starrocks.common.profile.Tracers.record(Tracers.java:238) ~[classes/:?]
2025-12-12T06:55:35.4049070Z 	at com.starrocks.common.profile.Tracers.record(Tracers.java:233) ~[classes/:?]
2025-12-12T06:55:35.4049845Z 	at com.starrocks.sql.optimizer.MvRewritePreprocessor.processMVsWithIndividualTimeouts(MvRewritePreprocessor.java:871) ~[classes/:?]
2025-12-12T06:55:35.4050719Z 	at com.starrocks.sql.optimizer.MvRewritePreprocessor.prepareRelatedMVs(MvRewritePreprocessor.java:768) ~[classes/:?]
2025-12-12T06:55:35.4051422Z 	at com.starrocks.sql.optimizer.MvRewritePreprocessor.prepare(MvRewritePreprocessor.java:176) ~[classes/:?]
2025-12-12T06:55:35.4052070Z 	at com.starrocks.sql.optimizer.QueryOptimizer.prepareMvRewrite(QueryOptimizer.java:339) ~[classes/:?]
2025-12-12T06:55:35.4052672Z 	at com.starrocks.sql.optimizer.QueryOptimizer.optimize(QueryOptimizer.java:195) ~[classes/:?]
2025-12-12T06:55:35.4053235Z 	at com.starrocks.sql.StatementPlanner.createQueryPlan(StatementPlanner.java:327) ~[classes/:?]
2025-12-12T06:55:35.4053765Z 	at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:151) ~[classes/:?]
2025-12-12T06:55:35.4054240Z 	at com.starrocks.sql.StatementPlanner.plan(StatementPlanner.java:109) ~[classes/:?]
2025-12-12T06:55:35.4054749Z 	at com.starrocks.utframe.UtFrameUtils.buildPlan(UtFrameUtils.java:558) ~[test-classes/:?]
2025-12-12T06:55:35.4055358Z 	at com.starrocks.utframe.UtFrameUtils.getPlanAndFragment(UtFrameUtils.java:616) ~[test-classes/:?]
2025-12-12T06:55:35.4055992Z 	at com.starrocks.sql.plan.PlanTestNoneDBBase.getFragmentPlan(PlanTestNoneDBBase.java:282) ~[test-classes/:?]
2025-12-12T06:55:35.4056743Z 	at com.starrocks.planner.MaterializedViewManyJoinTest.testManyJoins(MaterializedViewManyJoinTest.java:142) ~[test-classes/:?]
2025-12-12T06:55:35.4057382Z 	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]

```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
