### PR TITLE
[UT] fix test_auto_refresh on cloud-native

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -308,7 +308,7 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable, 
     }
 
     public boolean isOlapTable() {
-        return type == TableType.OLAP;
+        return getType() == TableType.OLAP;
     }
 
     public boolean isOlapExternalTable() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -986,15 +986,16 @@ public class TableProperty implements Writable, GsonPostProcessable {
     }
 
     public boolean isSetPartitionRefreshNumber() {
-        return partitionRefreshNumber != INVALID;
+        return properties != null && properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER);
     }
 
     public int getPartitionRefreshNumber() {
-        return partitionRefreshNumber == INVALID ? Config.default_mv_partition_refresh_number : partitionRefreshNumber;
+        return partitionRefreshNumber;
     }
 
     public boolean isSetPartitionRefreshStrategy() {
-        return !Strings.isNullOrEmpty(partitionRefreshStrategy);
+        return properties != null && properties.containsKey(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_STRATEGY)
+                && !Strings.isNullOrEmpty(partitionRefreshStrategy);
     }
 
     public String getPartitionRefreshStrategy() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -1003,7 +1003,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
     }
 
     public String getPartitionRefreshStrategy() {
-        return isSetPartitionRefreshStrategy() ? Config.default_mv_partition_refresh_strategy
+        return !isSetPartitionRefreshStrategy() ? Config.default_mv_partition_refresh_strategy
                 : partitionRefreshStrategy;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -990,7 +990,11 @@ public class TableProperty implements Writable, GsonPostProcessable {
     }
 
     public int getPartitionRefreshNumber() {
-        return partitionRefreshNumber;
+        if (isSetPartitionRefreshNumber()) {
+            return partitionRefreshNumber;
+        } else {
+            return Config.default_mv_partition_refresh_number;
+        }
     }
 
     public boolean isSetPartitionRefreshStrategy() {
@@ -999,7 +1003,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
     }
 
     public String getPartitionRefreshStrategy() {
-        return Strings.isNullOrEmpty(partitionRefreshStrategy) ? Config.default_mv_partition_refresh_strategy
+        return isSetPartitionRefreshStrategy() ? Config.default_mv_partition_refresh_strategy
                 : partitionRefreshStrategy;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshPartitionSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/mv/MVRefreshPartitionSelector.java
@@ -150,7 +150,7 @@ public class MVRefreshPartitionSelector {
      * @return a set of actual partition names in the base table corresponding to the given logical partition name
      */
     private Set<String> resolveFinalPartitionNames(Table table, String logicalPartitionNames) {
-        if (table instanceof OlapTable) {
+        if (table.isNativeTableOrMaterializedView()) {
             return Collections.singleton(logicalPartitionNames);
         }
         PartitionNameSetMap mapping = externalPartitionMap.get(table);
@@ -175,7 +175,7 @@ public class MVRefreshPartitionSelector {
     private Map<String, Pair<Long, Long>> collectSelectedPartitionStats(Table table, Set<String> selectedPartitions) {
         Map<String, Pair<Long, Long>> result = new HashMap<>();
 
-        if (table instanceof OlapTable) {
+        if (table.isNativeTableOrMaterializedView()) {
             OlapTable olapTable = (OlapTable) table;
             for (String partitionName : selectedPartitions) {
                 Partition partition = olapTable.getPartition(partitionName);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorOlapTest.java
@@ -30,6 +30,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.io.DeepCopy;
 import com.starrocks.common.util.DebugUtil;
+import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.RuntimeProfile;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.common.util.concurrent.lock.LockTimeoutException;
@@ -1089,8 +1090,8 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
     }
 
     private void  assertPCellNameEquals(String expect, PCellSortedSet pCellWithNames) {
-        Assertions.assertTrue(pCellWithNames.size() == 1);
-        Assertions.assertEquals(expect, pCellWithNames.iterator().next().name());
+        Assertions.assertTrue(pCellWithNames.size() == 1, pCellWithNames.toString());
+        Assertions.assertEquals(expect, pCellWithNames.iterator().next().name(), pCellWithNames.toString());
     }
 
     @Test
@@ -1114,6 +1115,7 @@ public class PartitionBasedMvRefreshProcessorOlapTest extends MVTestBase {
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         initAndExecuteTaskRun(taskRun);
 
+        mv.getTableProperty().getProperties().put(PropertyAnalyzer.PROPERTIES_PARTITION_REFRESH_NUMBER, "1");
         mv.getTableProperty().setPartitionRefreshNumber(1);
 
         MVPCTBasedRefreshProcessor processor = createProcessor(taskRun, mv);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitionerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVPCTRefreshRangePartitionerTest.java
@@ -50,6 +50,7 @@ public class MVPCTRefreshRangePartitionerTest {
         when(mv.isPartitionedTable()).thenReturn(true);
 
         OlapTable refTable1 = Mockito.mock(OlapTable.class);
+        Mockito.when(refTable1.isNativeTableOrMaterializedView()).thenReturn(true);
         PCellWithName pCellWithName1 = PCellWithName.of("partition1", new PCellNone());
         PCellWithName pCellWithName2 = PCellWithName.of("partition2", new PCellNone());
         PCellSortedSet refTablePartition1 = PCellSortedSet.of(Set.of(pCellWithName1, pCellWithName2));

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVRefreshPartitionSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/mv/MVRefreshPartitionSelectorTest.java
@@ -47,6 +47,8 @@ public class MVRefreshPartitionSelectorTest {
         Mockito.when(partition.getRowCount()).thenReturn(rows);
         Mockito.when(partition.getDataSize()).thenReturn(bytes);
         Mockito.when(table.getPartition(anyString())).thenReturn(partition);
+        Mockito.when(table.getType()).thenReturn(Table.TableType.OLAP);
+        Mockito.when(table.isNativeTableOrMaterializedView()).thenReturn(true);
 
         Map<Table, PCellSortedSet> map = new HashMap<>();
         PCellSortedSet set = PCellSortedSet.of();


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

fix sql test `test_auto_refresh` on cloud-native mode.
1. `partition_refresh_numer=-1` should be respected rather than considered as INVALID
2. `instance of OlapTable` should be replaced with `isNativeTableOrMaterializedView` to support general cases

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Respect explicit MV partition refresh properties and switch OLAP checks to native-table detection, updating related tests.
> 
> - **Materialized View refresh logic**:
>   - Respect `table_property.properties['partition_refresh_number']` when determining if value is set; default only when absent.
>   - Use `isSetPartitionRefreshStrategy()` based on presence of `properties['partition_refresh_strategy']` and non-empty value; derive strategy via `isSet...`.
>   - Replace OLAP type checks with `table.isNativeTableOrMaterializedView()` in `MVRefreshPartitionSelector` for partition name resolution and stats collection.
> - **Catalog**:
>   - Minor: `Table.isOlapTable()` now uses `getType()` accessor.
> - **Tests**:
>   - Update mocks to use `isNativeTableOrMaterializedView()` and set `partition_refresh_number` via `properties`.
>   - Improve assertions (include set content on failure) and add expectations for missing partition stats in adaptive refresh.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 633c38a60a28a4a3705f7e4e2eeddc223c363cfa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->