### PR TITLE
[BugFix] Fix publish_version log showing empty txn_ids with new FE

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -140,6 +140,21 @@ std::string txn_info_string(const TxnInfoPB& info) {
 
 } // namespace
 
+// Get txn_ids string from request (compatible with both new and old FE versions)
+// New FE uses txn_infos field, old FE uses deprecated txn_ids field
+std::string get_txn_ids_string(const PublishVersionRequest* request) {
+    if (request->txn_infos_size() > 0) {
+        std::vector<int64_t> ids;
+        ids.reserve(request->txn_infos_size());
+        for (const auto& info : request->txn_infos()) {
+            ids.push_back(info.txn_id());
+        }
+        return JoinInts(ids, ",");
+    } else {
+        return JoinInts(request->txn_ids(), ",");
+    }
+}
+
 using BThreadCountDownLatch = GenericCountDownLatch<bthread::Mutex, bthread::ConditionVariable>;
 
 LakeServiceImpl::LakeServiceImpl(ExecEnv* env, lake::TabletManager* tablet_mgr) : _env(env), _tablet_mgr(tablet_mgr) {}
@@ -180,9 +195,8 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
     bthread::Mutex response_mtx;
     scoped_refptr<Trace> trace_gurad = scoped_refptr<Trace>(new Trace());
     Trace* trace = trace_gurad.get();
-    TRACE_TO(trace, "got request. txn_ids=$0 base_version=$1 new_version=$2 #tablets=$3",
-             JoinInts(request->txn_ids(), ","), request->base_version(), request->new_version(),
-             request->tablet_ids_size());
+    TRACE_TO(trace, "got request. txn_ids=$0 base_version=$1 new_version=$2 #tablets=$3", get_txn_ids_string(request),
+             request->base_version(), request->new_version(), request->tablet_ids_size());
 
     Status::OK().to_protobuf(response->mutable_status());
     std::unordered_set<int64> rebuild_pindex_tablets;
@@ -300,7 +314,7 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
         if (!st.ok()) {
             g_publish_version_failed_tasks << 1;
             LOG(WARNING) << "Fail to submit publish version task: " << st << ". tablet_id=" << tablet_id
-                         << " txn_ids=" << JoinInts(request->txn_ids(), ",");
+                         << " txn_ids=" << get_txn_ids_string(request);
             std::lock_guard l(response_mtx);
             response->add_failed_tablets(tablet_id);
             st.to_protobuf(response->mutable_status());
@@ -312,10 +326,10 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
     auto cost = butil::gettimeofday_us() - start_ts;
     auto is_slow = cost >= config::lake_publish_version_slow_log_ms * 1000;
     if (config::lake_enable_publish_version_trace_log && is_slow) {
-        LOG(INFO) << "Published txns=" << JoinInts(request->txn_ids(), ",") << ". cost=" << cost << "us\n"
+        LOG(INFO) << "Published txns=" << get_txn_ids_string(request) << ". cost=" << cost << "us\n"
                   << trace->DumpToString();
     } else if (is_slow) {
-        LOG(INFO) << "Published txns=" << JoinInts(request->txn_ids(), ",")
+        LOG(INFO) << "Published txns=" << get_txn_ids_string(request)
                   << ". tablets=" << JoinInts(request->tablet_ids(), ",") << " cost=" << cost
                   << "us, trace: " << trace->MetricsAsJSON();
     }

--- a/be/src/service/service_be/lake_service.h
+++ b/be/src/service/service_be/lake_service.h
@@ -127,5 +127,10 @@ private:
     lake::TabletManager* _tablet_mgr;
 };
 
+// Get txn_ids string from PublishVersionRequest (compatible with both new and old FE versions)
+// New FE uses txn_infos field, old FE uses deprecated txn_ids field
+// This function is exposed for unit testing
+std::string get_txn_ids_string(const PublishVersionRequest* request);
+
 } // namespace starrocks
 #endif // __APPLE__

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -3370,4 +3370,79 @@ TEST_F(LakeServiceTest, test_repair_tablet_metadata) {
     }
 }
 
+// Test cases for get_txn_ids_string function
+// This function extracts txn_ids from PublishVersionRequest, supporting both new and old FE versions
+TEST_F(LakeServiceTest, test_get_txn_ids_string_with_txn_infos) {
+    // Test case 1: txn_infos has data (new FE version)
+    {
+        PublishVersionRequest request;
+        auto* txn_info1 = request.add_txn_infos();
+        txn_info1->set_txn_id(12345);
+        auto* txn_info2 = request.add_txn_infos();
+        txn_info2->set_txn_id(67890);
+
+        std::string result = get_txn_ids_string(&request);
+        EXPECT_EQ("12345,67890", result);
+    }
+
+    // Test case 2: single txn_info
+    {
+        PublishVersionRequest request;
+        auto* txn_info = request.add_txn_infos();
+        txn_info->set_txn_id(99999);
+
+        std::string result = get_txn_ids_string(&request);
+        EXPECT_EQ("99999", result);
+    }
+}
+
+TEST_F(LakeServiceTest, test_get_txn_ids_string_with_txn_ids) {
+    // Test case 3: txn_ids has data (old FE version, txn_infos is empty)
+    {
+        PublishVersionRequest request;
+        request.add_txn_ids(11111);
+        request.add_txn_ids(22222);
+        request.add_txn_ids(33333);
+
+        std::string result = get_txn_ids_string(&request);
+        EXPECT_EQ("11111,22222,33333", result);
+    }
+
+    // Test case 4: single txn_id
+    {
+        PublishVersionRequest request;
+        request.add_txn_ids(44444);
+
+        std::string result = get_txn_ids_string(&request);
+        EXPECT_EQ("44444", result);
+    }
+}
+
+TEST_F(LakeServiceTest, test_get_txn_ids_string_empty) {
+    // Test case 5: both txn_infos and txn_ids are empty
+    {
+        PublishVersionRequest request;
+
+        std::string result = get_txn_ids_string(&request);
+        EXPECT_EQ("", result);
+    }
+}
+
+TEST_F(LakeServiceTest, test_get_txn_ids_string_priority) {
+    // Test case 6: both txn_infos and txn_ids have data, txn_infos takes priority
+    {
+        PublishVersionRequest request;
+        // Add txn_ids (old way)
+        request.add_txn_ids(11111);
+        request.add_txn_ids(22222);
+        // Add txn_infos (new way) - should take priority
+        auto* txn_info = request.add_txn_infos();
+        txn_info->set_txn_id(99999);
+
+        std::string result = get_txn_ids_string(&request);
+        // Should use txn_infos since it has data
+        EXPECT_EQ("99999", result);
+    }
+}
+
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

When FE uses the new txn_infos field instead of the deprecated txn_ids field, the publish_version logs in CN would show "txns=." (empty).

## What I'm doing:

This fix adds a helper function get_txn_ids_string() that extracts txn_ids from either txn_infos (new FE) or txn_ids (old FE) field, ensuring backward compatibility.

Changes:
- Add get_txn_ids_string() helper function in lake_service.cpp
- Expose function declaration in lake_service.h for unit testing
- Update 4 log output locations to use the new helper function
- Add 4 unit tests for complete branch coverage

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `get_txn_ids_string` and switch publish_version logs to it for compatibility with `txn_infos` and deprecated `txn_ids`, plus unit tests.
> 
> - **Backend (logging)**:
>   - Use `get_txn_ids_string` in `LakeServiceImpl::publish_version` to log txn IDs from either `txn_infos` or deprecated `txn_ids`.
>   - Add helper `get_txn_ids_string` in `service_be/lake_service.cpp`; declare in `lake_service.h` (for tests).
> - **Tests**:
>   - Add unit tests covering `get_txn_ids_string` for `txn_infos`, `txn_ids`, empty, and priority cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2c0a6025bf25e79286ef5dbe257e1405be960722. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->