### PR TITLE
[Enhancement] Eliminate heartbeat error logs for backends in suspended warehouses

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/WarehouseManager.java
@@ -59,6 +59,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.stream.Collectors;
 
 public class WarehouseManager implements Writable {
     private static final Logger LOG = LogManager.getLogger(WarehouseManager.class);
@@ -112,6 +113,15 @@ public class WarehouseManager implements Writable {
     public List<Long> getAllWarehouseIds() {
         try (LockCloseable ignored = new LockCloseable(rwLock.readLock())) {
             return new ArrayList<>(idToWh.keySet());
+        }
+    }
+
+    public Set<Long> getAliveWarehouseIds() {
+        try (LockCloseable ignored = new LockCloseable(rwLock.readLock())) {
+            return nameToWh.values().stream()
+                    .filter(Warehouse::isAvailable)
+                    .map(Warehouse::getId)
+                    .collect(Collectors.toSet());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -38,6 +38,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.starrocks.catalog.FsBroker;
 import com.starrocks.common.Config;
 import com.starrocks.common.ThreadPoolManager;
@@ -72,6 +73,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -120,19 +122,30 @@ public class HeartbeatMgr extends FrontendDaemon {
             return;
         }
 
+        Set<Long> aliveWarehouseIds = GlobalStateMgr.getCurrentState().getWarehouseMgr().getAliveWarehouseIds();
+        Set<Long> backendsForSuspendedWarehouse = Sets.newHashSet();
+
         List<Future<HeartbeatResponse>> hbResponses = Lists.newArrayList();
 
         long startTime = System.currentTimeMillis();
         // send backend heartbeat
         for (Backend backend : idToBackendRef.values()) {
-            BackendHeartbeatHandler handler = new BackendHeartbeatHandler(backend);
+            boolean isWarehouseAvailable = aliveWarehouseIds.contains(backend.getWarehouseId());
+            if (!isWarehouseAvailable) {
+                backendsForSuspendedWarehouse.add(backend.getId());
+            }
+            BackendHeartbeatHandler handler = new BackendHeartbeatHandler(backend, isWarehouseAvailable);
             hbResponses.add(executor.submit(handler));
         }
 
         // send compute node heartbeat
         for (ComputeNode computeNode : GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getIdComputeNode()
                 .values()) {
-            BackendHeartbeatHandler handler = new BackendHeartbeatHandler(computeNode);
+            boolean isWarehouseAvailable = aliveWarehouseIds.contains(computeNode.getWarehouseId());
+            if (!isWarehouseAvailable) {
+                backendsForSuspendedWarehouse.add(computeNode.getId());
+            }
+            BackendHeartbeatHandler handler = new BackendHeartbeatHandler(computeNode, isWarehouseAvailable);
             hbResponses.add(executor.submit(handler));
         }
 
@@ -166,7 +179,12 @@ public class HeartbeatMgr extends FrontendDaemon {
                 // the heartbeat rpc's timeout is 5 seconds, so we will not be blocked here too long.
                 HeartbeatResponse response = future.get();
                 if (response.getStatus() != HbStatus.OK) {
-                    LOG.warn("get bad heartbeat response: {}", response);
+                    if ((response.getType() != HeartbeatResponse.Type.BACKEND ||
+                            !backendsForSuspendedWarehouse.contains(((BackendHbResponse) response).getBeId()))) {
+                        LOG.warn("get bad heartbeat response: {}", response);
+                    } else {
+                        LOG.debug("get bad heartbeat response: {}", response);
+                    }
                 }
                 isChanged = handleHbResponse(response, false);
 
@@ -255,17 +273,18 @@ public class HeartbeatMgr extends FrontendDaemon {
 
     // backend heartbeat
     public static class BackendHeartbeatHandler implements Callable<HeartbeatResponse> {
-        private ComputeNode computeNode;
+        private final ComputeNode computeNode;
+        private final boolean isWarehouseAvailable;
 
-        public BackendHeartbeatHandler(ComputeNode computeNode) {
+        public BackendHeartbeatHandler(ComputeNode computeNode, boolean isWarehouseAvailable) {
             this.computeNode = computeNode;
+            this.isWarehouseAvailable = isWarehouseAvailable;
         }
 
         @Override
         public HeartbeatResponse call() {
             long computeNodeId = computeNode.getId();
             TNetworkAddress beAddr = new TNetworkAddress(computeNode.getHost(), computeNode.getHeartbeatPort());
-            boolean ok = false;
             try {
                 TMasterInfo copiedMasterInfo = new TMasterInfo(MASTER_INFO.get());
                 copiedMasterInfo.setBackend_ip(computeNode.getHost());
@@ -288,7 +307,6 @@ public class HeartbeatMgr extends FrontendDaemon {
                         beAddr,
                         client -> client.heartbeat(copiedMasterInfo));
 
-                ok = true;
                 if (result.getStatus().getStatus_code() == TStatusCode.OK) {
                     TBackendInfo tBackendInfo = result.getBackend_info();
                     int bePort = tBackendInfo.getBe_port();
@@ -331,8 +349,13 @@ public class HeartbeatMgr extends FrontendDaemon {
                                     : result.getStatus().getError_msgs().get(0));
                 }
             } catch (Exception e) {
-                LOG.warn("backend heartbeat got exception, addr: {}:{}",
-                        computeNode.getHost(), computeNode.getHeartbeatPort(), e);
+                if (isWarehouseAvailable) {
+                    LOG.warn("backend heartbeat got exception, addr: {}:{}",
+                            computeNode.getHost(), computeNode.getHeartbeatPort(), e);
+                } else {
+                    LOG.debug("backend heartbeat got exception, addr: {}:{}",
+                            computeNode.getHost(), computeNode.getHeartbeatPort(), e);
+                }
                 return new BackendHbResponse(computeNodeId, TStatusCode.UNKNOWN,
                         Strings.isNullOrEmpty(e.getMessage()) ? "got exception" : e.getMessage());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -179,11 +179,12 @@ public class HeartbeatMgr extends FrontendDaemon {
                 // the heartbeat rpc's timeout is 5 seconds, so we will not be blocked here too long.
                 HeartbeatResponse response = future.get();
                 if (response.getStatus() != HbStatus.OK) {
-                    if ((response.getType() != HeartbeatResponse.Type.BACKEND ||
-                            !backendsForSuspendedWarehouse.contains(((BackendHbResponse) response).getBeId()))) {
-                        LOG.warn("get bad heartbeat response: {}", response);
-                    } else {
+                    boolean isBackendForSuspendedWarehouse = response.getType() == HeartbeatResponse.Type.BACKEND &&
+                            backendsForSuspendedWarehouse.contains(((BackendHbResponse) response).getBeId());
+                    if (isBackendForSuspendedWarehouse) {
                         LOG.debug("get bad heartbeat response: {}", response);
+                    } else {
+                        LOG.warn("get bad heartbeat response: {}", response);
                     }
                 }
                 isChanged = handleHbResponse(response, false);

--- a/fe/fe-core/src/main/java/com/starrocks/warehouse/DefaultWarehouse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/warehouse/DefaultWarehouse.java
@@ -135,4 +135,9 @@ public class DefaultWarehouse extends Warehouse {
     public long getResumeTime() {
         return -1L;
     }
+
+    @Override
+    public boolean isAvailable() {
+        return true;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/warehouse/Warehouse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/warehouse/Warehouse.java
@@ -79,4 +79,6 @@ public abstract class Warehouse implements Writable {
     public abstract void alterCNGroup(AlterCnGroupStmt stmt) throws DdlException;
 
     public abstract void replayInternalOpLog(String payload);
+
+    public abstract boolean isAvailable();
 }

--- a/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
@@ -51,6 +51,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class WarehouseManagerTest {
@@ -541,5 +542,38 @@ public class WarehouseManagerTest {
         AtomicInteger result = warehouseManager.getNextComputeNodeIndexFromWarehouse(computeResource);
         Assertions.assertNotNull(result);
         Assertions.assertEquals(0, result.get());
+    }
+
+    @Test
+    public void testGetAliveWarehouseIds() {
+        Warehouse wh1 = new MockedWarehouse(1L, "wh1", true);
+        Warehouse wh2 = new MockedWarehouse(2L, "wh2", false);
+        Warehouse wh3 = new MockedWarehouse(3L, "wh3", true);
+        Warehouse wh4 = new MockedWarehouse(4L, "wh4", false);
+
+        WarehouseManager warehouseManager = new WarehouseManager();
+        warehouseManager.addWarehouse(wh1);
+        warehouseManager.addWarehouse(wh2);
+        warehouseManager.addWarehouse(wh3);
+        warehouseManager.addWarehouse(wh4);
+
+        Set<Long> aliveWarehouseIds = warehouseManager.getAliveWarehouseIds();
+        Assertions.assertEquals(2, aliveWarehouseIds.size());
+        Assertions.assertTrue(aliveWarehouseIds.contains(1L));
+        Assertions.assertTrue(aliveWarehouseIds.contains(3L));
+    }
+
+    private static class MockedWarehouse extends DefaultWarehouse {
+        private final boolean isAvailable;
+
+        public MockedWarehouse(long id, String name, boolean isAvailable) {
+            super(id, name);
+            this.isAvailable = isAvailable;
+        }
+
+        @Override
+        public boolean isAvailable() {
+            return isAvailable;
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/system/HeartbeatMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/HeartbeatMgrTest.java
@@ -231,7 +231,7 @@ public class HeartbeatMgrTest {
         new HeartbeatMgr(false).setLeader(1, "123", 1);
 
         ComputeNode cn = new ComputeNode(1, "192.168.1.1", 8111);
-        HeartbeatMgr.BackendHeartbeatHandler handler = new HeartbeatMgr.BackendHeartbeatHandler(cn);
+        HeartbeatMgr.BackendHeartbeatHandler handler = new HeartbeatMgr.BackendHeartbeatHandler(cn, true);
         HeartbeatResponse response = handler.call();
         Assertions.assertTrue(response instanceof BackendHbResponse);
         BackendHbResponse hbResponse = (BackendHbResponse) response;


### PR DESCRIPTION
## Why I'm doing:

When a warehouse is suspended, the Leader FE still sends heartbeats to the backends under that warehouse every 5 seconds and logs a warning on failure. As a result, once a warehouse is suspended, `fe.warn.log` keeps getting flooded with meaningless heartbeat failure messages.

```
2025-12-15 00:07:39.606-08:00 WARN (heartbeat mgr|17) [HeartbeatMgr.runAfterCatalogReady():168] get bad heartbeat response: type: BACKEND, status: BAD, msg: java.net.NoRouteToHostException: No route to host
 2025-12-15 00:07:41.526-08:00 WARN (heartbeat-mgr-pool-2|166) [HeartbeatMgr$BackendHeartbeatHandler.call():333] backend heartbeat got exception, addr: [x.x.x.x:9050](http://x.x.x.x:9050/)
 org.apache.thrift.TException: java.net.NoRouteToHostException: No route to host
        at com.starrocks.rpc.ThriftRPCRequestExecutor.call(ThriftRPCRequestExecutor.java:60)
        at com.starrocks.rpc.ThriftRPCRequestExecutor.callNoRetry(ThriftRPCRequestExecutor.java:40)
        at com.starrocks.system.HeartbeatMgr$BackendHeartbeatHandler.call(HeartbeatMgr.java:285)
        at com.starrocks.system.HeartbeatMgr$BackendHeartbeatHandler.call(HeartbeatMgr.java:256)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:840)
```

## What I'm doing:
This PR only suppresses heartbeat failure logs for backends belonging to suspended warehouses. It does not change the behavior that the Leader FE still sends heartbeats to them.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Downgrades backend/compute node heartbeat failures to debug when their warehouse is suspended, via warehouse availability checks and handler propagation.
> 
> - **Heartbeat/logging**:
>   - Send backend/compute node heartbeats with `isWarehouseAvailable` and track nodes under suspended warehouses.
>   - Downgrade non-OK backend heartbeat responses and exceptions to debug for suspended warehouses; keep warn otherwise.
> - **Warehouse API**:
>   - Add `Warehouse.isAvailable()` and implement in `DefaultWarehouse` (always true).
>   - Add `WarehouseManager.getAliveWarehouseIds()` to expose IDs of available warehouses.
> - **Tests**:
>   - Update `HeartbeatMgrTest` to use new handler signature.
>   - Add `WarehouseManagerTest.testGetAliveWarehouseIds()` with mocked warehouses.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a89514d82d73188d486f53768f3dea0efded54aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->