### PR TITLE
[Enhancement] log the cause in sigterm handler

### DIFF
--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -41,6 +41,7 @@
 #include "common/minidump.h"
 #include "common/process_exit.h"
 #include "exec/workgroup/work_group.h"
+#include "util/system_metrics.h"
 #ifdef USE_STAROS
 #include "fslib/star_cache_handler.h"
 #endif
@@ -74,6 +75,8 @@
 
 namespace starrocks {
 DEFINE_bool(cn, false, "start as compute node");
+
+std::string dump_memory_tracker();
 
 /*
  * This thread will calculate some metrics at a fix interval(15 sec)
@@ -139,20 +142,7 @@ void calculate_metrics(void* arg_this) {
                                                                                 &lst_net_receive_bytes);
         }
 
-        auto* mem_metrics = StarRocksMetrics::instance()->system_metrics()->memory_metrics();
-
-        LOG(INFO) << fmt::format(
-                "Current memory statistics: process({}), query_pool({}), load({}), "
-                "metadata({}), compaction({}), schema_change({}), "
-                "page_cache({}), update({}), passthrough({}), clone({}), consistency({}), "
-                "datacache({}), jit({}), brpc_iobuf({})",
-                mem_metrics->process_mem_bytes.value(), mem_metrics->query_mem_bytes.value(),
-                mem_metrics->load_mem_bytes.value(), mem_metrics->metadata_mem_bytes.value(),
-                mem_metrics->compaction_mem_bytes.value(), mem_metrics->schema_change_mem_bytes.value(),
-                mem_metrics->storage_page_cache_mem_bytes.value(), mem_metrics->update_mem_bytes.value(),
-                mem_metrics->passthrough_mem_bytes.value(), mem_metrics->clone_mem_bytes.value(),
-                mem_metrics->consistency_mem_bytes.value(), mem_metrics->datacache_mem_bytes.value(),
-                mem_metrics->jit_cache_mem_bytes.value(), mem_metrics->brpc_iobuf_mem_bytes.value());
+        LOG(INFO) << dump_memory_tracker();
 
         StarRocksMetrics::instance()->table_metrics_mgr()->cleanup();
         nap_sleep(15, [daemon] { return daemon->stopped(); });
@@ -221,6 +211,35 @@ void jemalloc_tracker_daemon(void* arg_this) {
 }
 #endif
 
+#define DUMP_METRIC(name, value_expr) fmt::format_to(std::back_inserter(buffer), " " #name "({})", value_expr);
+std::string dump_memory_tracker() {
+    auto* mem_metrics = StarRocksMetrics::instance()->system_metrics()->memory_metrics();
+
+    fmt::memory_buffer buffer;
+    fmt::format_to(std::back_inserter(buffer), "Current memory statistics:");
+
+    DUMP_METRIC(process, mem_metrics->process_mem_bytes.value())
+    DUMP_METRIC(query_pool, mem_metrics->query_mem_bytes.value())
+    DUMP_METRIC(load, mem_metrics->load_mem_bytes.value())
+    DUMP_METRIC(metadata, mem_metrics->metadata_mem_bytes.value())
+    DUMP_METRIC(compaction, mem_metrics->compaction_mem_bytes.value())
+    DUMP_METRIC(schema_change, mem_metrics->schema_change_mem_bytes.value())
+    DUMP_METRIC(page_cache, mem_metrics->storage_page_cache_mem_bytes.value())
+    DUMP_METRIC(update, mem_metrics->update_mem_bytes.value())
+    DUMP_METRIC(passthrough, mem_metrics->passthrough_mem_bytes.value())
+    DUMP_METRIC(clone, mem_metrics->clone_mem_bytes.value())
+    DUMP_METRIC(consistency, mem_metrics->consistency_mem_bytes.value())
+    DUMP_METRIC(datacache, mem_metrics->datacache_mem_bytes.value())
+    DUMP_METRIC(jit, mem_metrics->jit_cache_mem_bytes.value())
+    DUMP_METRIC(brpc_iobuf, mem_metrics->brpc_iobuf_mem_bytes.value())
+
+    DUMP_METRIC(jemalloc_active, mem_metrics->jemalloc_active_bytes.value())
+    DUMP_METRIC(jemalloc_allocated, mem_metrics->jemalloc_allocated_bytes.value())
+    DUMP_METRIC(jemalloc_rss, mem_metrics->jemalloc_resident_bytes.value())
+
+    return fmt::to_string(buffer);
+}
+
 static void init_starrocks_metrics(const std::vector<StorePath>& store_paths) {
     bool init_system_metrics = config::enable_system_metrics;
     bool init_jvm_metrics = config::enable_jvm_metrics;
@@ -247,11 +266,43 @@ static void init_starrocks_metrics(const std::vector<StorePath>& store_paths) {
                                              network_interfaces);
 }
 
+Slice get_process_comm(pid_t pid, char* buffer, int max_size) {
+    std::string path = fmt::format("/proc/{}/comm", static_cast<int>(pid));
+
+    int fd = open(path.c_str(), O_RDONLY);
+    if (fd < 0) {
+        return {};
+    }
+
+    ssize_t n = read(fd, buffer, max_size - 1);
+    close(fd);
+
+    if (n <= 0) {
+        buffer[0] = '\0';
+        return {};
+    }
+
+    buffer[n] = '\0';
+
+    // trim '\n'
+    if (n > 0 && buffer[n - 1] == '\n') {
+        buffer[--n] = '\0';
+    }
+
+    return Slice(buffer, static_cast<size_t>(n));
+}
+
 void sigterm_handler(int signo, siginfo_t* info, void* context) {
     if (info == nullptr) {
         LOG(ERROR) << "got signal: " << strsignal(signo) << "from unknown pid, is going to exit";
     } else {
-        LOG(ERROR) << "got signal: " << strsignal(signo) << " from pid: " << info->si_pid << ", is going to exit";
+        char buffer[1024];
+        Slice process_comm = get_process_comm(info->si_pid, buffer, sizeof(buffer));
+        LOG(ERROR) << "got signal: " << strsignal(signo) << " from pid: " << info->si_pid << "(" << process_comm << ")"
+                   << ", is going to exit";
+
+        StarRocksMetrics::instance()->system_metrics()->update_memory_metrics();
+        LOG(ERROR) << dump_memory_tracker();
     }
     set_process_exit();
 }
@@ -260,6 +311,7 @@ int install_signal(int signo, void (*handler)(int sig, siginfo_t* info, void* co
     struct sigaction sa;
     memset(&sa, 0, sizeof(struct sigaction));
     sa.sa_sigaction = handler;
+    sa.sa_flags = SA_SIGINFO;
     sigemptyset(&sa.sa_mask);
     auto ret = sigaction(signo, &sa, nullptr);
     if (ret != 0) {

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -294,6 +294,10 @@ Slice get_process_comm(pid_t pid, char* buffer, int max_size) {
     return Slice(buffer, static_cast<size_t>(n));
 }
 
+// Ideally, we should avoid calling any non-signal-safe functions within signal handler, such as malloc, open, or log.
+// This could potentially cause deadlocks or unexpected recursion.
+// Typically, the main thread receives SIGTERM, and under normal circumstances,
+// the main thread remains in a sleep state. Therefore, the current implementation is safe.
 void sigterm_handler(int signo, siginfo_t* info, void* context) {
     if (info == nullptr) {
         LOG(ERROR) << "got signal: " << strsignal(signo) << "from unknown pid, is going to exit";

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -232,9 +232,11 @@ std::string dump_memory_tracker() {
     DUMP_METRIC(datacache, mem_metrics->datacache_mem_bytes.value())
     DUMP_METRIC(jit, mem_metrics->jit_cache_mem_bytes.value())
     DUMP_METRIC(brpc_iobuf, mem_metrics->brpc_iobuf_mem_bytes.value())
+    DUMP_METRIC(replication, mem_metrics->replication_mem_bytes.value())
 
     DUMP_METRIC(jemalloc_active, mem_metrics->jemalloc_active_bytes.value())
     DUMP_METRIC(jemalloc_allocated, mem_metrics->jemalloc_allocated_bytes.value())
+    DUMP_METRIC(jemalloc_metadata, mem_metrics->jemalloc_metadata_bytes.value())
     DUMP_METRIC(jemalloc_rss, mem_metrics->jemalloc_resident_bytes.value())
 
     return fmt::to_string(buffer);

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -198,8 +198,9 @@ void SystemMetrics::install(MetricRegistry* registry, const std::set<std::string
 }
 
 void SystemMetrics::update() {
+    update_memory_metrics();
+
     _update_cpu_metrics();
-    _update_memory_metrics();
     _update_disk_metrics();
     _update_net_metrics();
     _update_fd_metrics();
@@ -323,7 +324,7 @@ void SystemMetrics::_update_pagecache_mem_tracker() {
     }
 }
 
-void SystemMetrics::_update_memory_metrics() {
+void SystemMetrics::update_memory_metrics() {
 #if defined(ADDRESS_SANITIZER) || defined(LEAK_SANITIZER) || defined(THREAD_SANITIZER)
     LOG(INFO) << "Memory tracking is not available with address sanitizer builds.";
 #else

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -391,6 +391,7 @@ void SystemMetrics::update_memory_metrics() {
     SET_MEM_METRIC_VALUE(clone_mem_tracker, clone_mem_bytes)
     SET_MEM_METRIC_VALUE(consistency_mem_tracker, consistency_mem_bytes)
     SET_MEM_METRIC_VALUE(datacache_mem_tracker, datacache_mem_bytes)
+    SET_MEM_METRIC_VALUE(replication_mem_tracker, replication_mem_bytes)
 #undef SET_MEM_METRIC_VALUE
 }
 

--- a/be/src/util/system_metrics.h
+++ b/be/src/util/system_metrics.h
@@ -103,6 +103,8 @@ public:
     const MemoryMetrics* memory_metrics() const { return _memory_metrics.get(); }
     IOMetrics* get_io_metrics_by_tag(uint32_t tag) const { return !_io_metrics.empty() ? _io_metrics[tag] : nullptr; }
 
+    void update_memory_metrics();
+
 private:
     void _install_cpu_metrics(MetricRegistry*);
     // On Intel(R) Xeon(R) CPU E5-2450 0 @ 2.10GHz;
@@ -110,7 +112,6 @@ private:
     void _update_cpu_metrics();
 
     void _install_memory_metrics(MetricRegistry* registry);
-    void _update_memory_metrics();
 
     void _install_disk_metrics(MetricRegistry* registry, const std::set<std::string>& devices);
     void _update_disk_metrics();

--- a/be/src/util/system_metrics.h
+++ b/be/src/util/system_metrics.h
@@ -79,6 +79,7 @@ public:
     METRIC_DEFINE_INT_GAUGE(clone_mem_bytes, MetricUnit::BYTES);
     METRIC_DEFINE_INT_GAUGE(consistency_mem_bytes, MetricUnit::BYTES);
     METRIC_DEFINE_INT_GAUGE(datacache_mem_bytes, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_GAUGE(replication_mem_bytes, MetricUnit::BYTES);
 };
 
 class SystemMetrics {


### PR DESCRIPTION
## Why I'm doing:

log example:
```
E20251215 16:59:21.761194 22706903104640 daemon.cpp:301] got signal: Terminated from pid: 61684(earlyoom), is going to exit
E20251215 16:59:21.761752 22706903104640 daemon.cpp:305] Current memory statistics: process(7526060504) query_pool(7187011035) load(0) metadata(835566) compaction(0) schema_change(0) page_cache(0) update(0) passthrough(5841200) clone(0) consistency(0) datacache(0) jit(0) brpc_iobuf(156794880) jemalloc_active(7746351104) jemalloc_allocated(7490139040) jemalloc_rss(8032059392)
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Logs SIGTERM sender pid/comm and current memory stats, refactors memory metrics update, and adds a new `replication_mem_bytes` metric.
> 
> - **Daemon/Signals**:
>   - `sigterm_handler` now logs sender pid and process name from `/proc/<pid>/comm`, updates memory metrics, and dumps concise memory stats; installs handler with `SA_SIGINFO`.
>   - Introduces `dump_memory_tracker()` for compact memory statistics logging and uses it in periodic metrics logging.
> - **Metrics**:
>   - Exposes `SystemMetrics::update_memory_metrics()` (renamed from private `_update_memory_metrics`) and calls it at the start of `SystemMetrics::update()`.
>   - Adds `replication_mem_bytes` to `MemoryMetrics` and sets it in `update_memory_metrics()`.
>   - Memory dump now includes jemalloc details (`active`, `allocated`, `metadata`, `resident`) and other tracked categories.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e190b0c15a05c94736095800be3c54b8b4a7424e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->