### PR TITLE
[BugFix] Revert '[Enhancement] Enable low cardinality optimization on PRIMARY KEY tables. (backport #59487) (#59840)'

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeCollector.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.ArrayType;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ColumnAccessPath;
 import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Type;
@@ -602,6 +603,9 @@ public class DecodeCollector extends OptExpressionVisitor<DecodeInfo, DecodeInfo
         long version = table.getPartitions().stream().flatMap(p -> p.getSubPartitions().stream()).map(
                 PhysicalPartition::getVisibleVersionTime).max(Long::compareTo).orElse(0L);
 
+        if ((table.getKeysType().equals(KeysType.PRIMARY_KEYS))) {
+            return DecodeInfo.EMPTY;
+        }
         if (table.hasForbiddenGlobalDict()) {
             return DecodeInfo.EMPTY;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityArrayTest.java
@@ -108,12 +108,12 @@ public class LowCardinalityArrayTest extends PlanTestBase {
                 ");");
 
         starRocksAssert.withTable("CREATE TABLE `s4` (    \n" +
-                "  `v1` bigint(20) NOT NULL COMMENT \"\",    \n" +
+                "  `v1` bigint(20) NULL COMMENT \"\",    \n" +
                 "  `v2` int NULL,    \n" +
                 "  `a1` array<string> NULL COMMENT \"\",    \n" +
                 "  `a2` array<string> NULL COMMENT \"\"    \n" +
                 ") ENGINE=OLAP    \n" +
-                "PRIMARY KEY(`v1`)    \n" +
+                "UNIQUE KEY(`v1`)    \n" +
                 "COMMENT \"OLAP\"    \n" +
                 "DISTRIBUTED BY HASH(`v1`) BUCKETS 10    \n" +
                 "PROPERTIES (    \n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -2194,14 +2194,6 @@ public class LowCardinalityTest2 extends PlanTestBase {
     }
 
     @Test
-    public void testShortCircuitQuery() throws Exception {
-        connectContext.getSessionVariable().setEnableShortCircuit(true);
-        String sql = "select * from low_card_t2 where d_date='20160404' and c_mr = '12'";
-        final String plan = getFragmentPlan(sql);
-        assertContains(plan, "Short Circuit Scan: true");
-    }
-
-    @Test
     public void testAggregateWithUnion() throws Exception {
         try {
             connectContext.getSessionVariable().setNewPlanerAggStage(2);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -151,7 +151,7 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "  `c_new` int(11) ,\n" +
                 "  `cpc` int(11)\n" +
                 ") ENGINE=OLAP \n" +
-                "PRIMARY KEY(`d_date`, `c_mr`)\n" +
+                "DUPLICATE KEY(`d_date`, `c_mr`)\n" +
                 "COMMENT \"OLAP\"\n" +
                 "DISTRIBUTED BY HASH(`d_date`, `c_mr`) BUCKETS 16 \n" +
                 "PROPERTIES (\n" +


### PR DESCRIPTION

This reverts commit a8766bb1805a06af1d2bcfd4cdef76e6d53528b1.

## Why I'm doing:

now global have not support collect global dicts from partial update segments. 

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skips low-cardinality dict optimization on PRIMARY KEY tables and updates tests/schemas accordingly.
> 
> - **Optimizer**:
>   - In `DecodeCollector.visitPhysicalOlapScan`, skip low-cardinality processing for `OlapTable` with `KeysType.PRIMARY_KEYS`.
> - **Tests**:
>   - Update test table schemas to avoid PRIMARY KEY usage (e.g., `s4` to `UNIQUE KEY`, `low_card_t2` to `DUPLICATE KEY`; adjust `v1` nullability).
>   - Remove `testShortCircuitQuery` from `LowCardinalityTest2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6d0f3606cc0004de59e9125a9d325ef8102acf0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->