### PR TITLE
[Enhancement] [FOLLOWUP] Optimize Cow related methods to ensure the semantic correctness of Copy-on-Write

### DIFF
--- a/be/src/bench/bench_util.h
+++ b/be/src/bench/bench_util.h
@@ -120,7 +120,7 @@ public:
     static MutableColumnPtr create_random_string_column(int num_rows, int min_length) {
         std::vector<string> elements = create_random_string(num_rows, min_length, 60);
         TypeDescriptor type_desc = TypeDescriptor(TYPE_VARCHAR);
-        auto column = ColumnHelper::create_column(type_desc, false)->as_mutable_ptr();
+        auto column = ColumnHelper::create_column(type_desc, false);
         for (auto& x : elements) {
             column->append_datum(Datum(Slice(x)));
         }

--- a/be/src/bench/hash_functions_bench.cpp
+++ b/be/src/bench/hash_functions_bench.cpp
@@ -242,10 +242,10 @@ public:
             auto dt_col = starrocks::ColumnHelper::cast_to<starrocks::TYPE_DATETIME>(dt_col_ptr);
             int64_t sum = 0;
             // Use const_cast for read-only benchmark access
-            auto* mutable_dt_col = dt_col->as_mutable_ptr();
             for (int i = 0; i < N; ++i) {
                 int year, month, day, hour, minute, second, usec;
-                mutable_dt_col->get_data()[i].to_timestamp(&year, &month, &day, &hour, &minute, &second, &usec);
+                dt_col->as_mutable_raw_ptr()->get_data()[i].to_timestamp(&year, &month, &day, &hour, &minute, &second,
+                                                                         &usec);
                 sum += hour;
             }
             benchmark::DoNotOptimize(sum);

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -314,7 +314,7 @@ public:
         size_t num_columns = _columns.size();
         MutableColumns mutable_columns(num_columns);
         for (size_t i = 0; i < num_columns; ++i) {
-            mutable_columns[i] = _columns[i]->as_mutable_ptr();
+            mutable_columns[i] = std::move(*(_columns[i])).mutate();
         }
         return mutable_columns;
     }

--- a/be/src/column/column.cpp
+++ b/be/src/column/column.cpp
@@ -57,27 +57,25 @@ void Column::serialize_batch_with_null_masks(uint8_t* dst, Buffer<uint32_t>& sli
     }
 }
 
-StatusOr<Column::MutablePtr> Column::downgrade_helper_func(Column::MutablePtr* col) {
-    auto ret = (*col)->downgrade();
+StatusOr<Column::MutablePtr> Column::downgrade_helper_func(Column* col) {
+    auto ret = col->downgrade();
     if (!ret.ok()) {
         return ret;
     } else if (ret.value() == nullptr) {
         return nullptr;
     } else {
-        (*col) = std::move(ret.value());
-        return nullptr;
+        return std::move(ret.value());
     }
 }
 
-StatusOr<Column::MutablePtr> Column::upgrade_helper_func(Column::MutablePtr* col) {
-    auto ret = (*col)->upgrade_if_overflow();
+StatusOr<Column::MutablePtr> Column::upgrade_helper_func(Column* col) {
+    auto ret = col->upgrade_if_overflow();
     if (!ret.ok()) {
         return ret;
     } else if (ret.value() == nullptr) {
         return nullptr;
     } else {
-        (*col) = std::move(ret.value());
-        return nullptr;
+        return std::move(ret.value());
     }
 }
 

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -22,6 +22,7 @@
 #include "column/column_visitor_mutable.h"
 #include "column/container_resource.h"
 #include "column/vectorized_fwd.h"
+#include "common/config.h"
 #include "common/cow.h"
 #include "common/statusor.h"
 #include "gutil/casts.h"
@@ -469,9 +470,13 @@ public:
 
     // mutate the column to mutable column, but doesn't reset the column
     MutablePtr mutate() const&& {
-        MutablePtr res = try_mutate();
-        res->mutate_each_subcolumn();
-        return res;
+        if (config::enable_cow_optimization) {
+            MutablePtr res = try_mutate();
+            res->mutate_each_subcolumn();
+            return res;
+        } else {
+            return clone();
+        }
     }
 
     // mutate the column to mutable column, and reset the column to nullptr
@@ -487,12 +492,12 @@ protected:
     // if downgrade failed, return the error status.
     // if upgrade success, always return nullptr.
     // if downgrade's result is not nullptr, it will replace the input col with the new column.
-    static StatusOr<MutablePtr> downgrade_helper_func(MutablePtr* col);
+    static StatusOr<MutablePtr> downgrade_helper_func(Column* col);
     // Helper functions for upgrade and downgrade,
     // if upgrade failed, return the error status.
     // if upgrade success, always return nullptr.
     // if upgrade's result is not nullptr, it will replace the input col with the new column.
-    static StatusOr<MutablePtr> upgrade_helper_func(MutablePtr* col);
+    static StatusOr<MutablePtr> upgrade_helper_func(Column* col);
 
     DelCondSatisfied _delete_state = DEL_NOT_SATISFIED;
 };

--- a/be/src/column/column_builder.h
+++ b/be/src/column/column_builder.h
@@ -102,16 +102,16 @@ public:
         }
 
         if (is_const) {
-            return ConstColumn::create(_column->as_mutable_ptr(), _column->size());
+            return ConstColumn::create(std::move(*_column).mutate(), _column->size());
         } else if (_has_null) {
-            return NullableColumn::create(_column->as_mutable_ptr(), _null_column->as_mutable_ptr());
+            return NullableColumn::create(std::move(*_column).mutate(), std::move(*_null_column).mutate());
         } else {
-            return _column->as_mutable_ptr();
+            return std::move(*_column).mutate();
         }
     }
 
     MutableColumnPtr build_nullable_column() {
-        return NullableColumn::create(_column->as_mutable_ptr(), _null_column->as_mutable_ptr());
+        return NullableColumn::create(std::move(*_column).mutate(), std::move(*_null_column).mutate());
     }
 
     void reserve(size_t size) {
@@ -124,8 +124,8 @@ public:
         _null_column->resize_uninitialized(size);
     }
 
-    DataColumnMutablePtr data_column() { return DataColumn::static_pointer_cast(_column->as_mutable_ptr()); }
-    NullColumnMutablePtr null_column() { return NullColumn::static_pointer_cast(_null_column->as_mutable_ptr()); }
+    DataColumn* data_column_raw_ptr() { return _column.get(); }
+    NullColumn* null_column_raw_ptr() { return _null_column.get(); }
     void set_has_null(bool v) { _has_null = v; }
 
 protected:
@@ -211,7 +211,7 @@ public:
         bytes.resize(bytes.size() - n);
     }
 
-    NullColumnMutablePtr get_null_column() { return NullColumn::static_pointer_cast(_null_column->as_mutable_ptr()); }
+    NullColumn* get_null_column_raw_ptr() { return _null_column.get(); }
 
     NullColumn::Container& get_null_data() { return _null_column->get_data(); }
 

--- a/be/src/column/column_helper.cpp
+++ b/be/src/column/column_helper.cpp
@@ -561,7 +561,7 @@ MutableColumns ColumnHelper::to_mutable_columns(const Columns& columns) {
     MutableColumns mutable_columns;
     mutable_columns.reserve(columns.size());
     for (auto& column : columns) {
-        mutable_columns.emplace_back(column->as_mutable_ptr());
+        mutable_columns.emplace_back(std::move(*column).mutate());
     }
     return mutable_columns;
 }

--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -147,8 +147,7 @@ public:
             return col;
         } else if (column->is_constant()) {
             // use clone is not safe, because the new cloned data may be freed after the function returns.
-            auto mut_column = column->as_mutable_ptr();
-            auto* const_column = down_cast<ConstColumn*>(mut_column.get());
+            auto* const_column = down_cast<ConstColumn*>(column->as_mutable_raw_ptr());
             const_column->assign(size, 0);
             return const_column->data_column()->as_mutable_ptr();
         } else {

--- a/be/src/column/const_column.cpp
+++ b/be/src/column/const_column.cpp
@@ -97,20 +97,17 @@ StatusOr<MutableColumnPtr> ConstColumn::upgrade_if_overflow() {
     if (_size > Column::MAX_CAPACITY_LIMIT) {
         return Status::InternalError("Size of ConstColumn exceed the limit");
     }
-
-    auto mutable_data_col = _data->as_mutable_ptr();
-    auto ret = upgrade_helper_func(&mutable_data_col);
-    if (ret.ok()) {
-        _data = std::move(mutable_data_col);
+    auto ret = upgrade_helper_func(_data->as_mutable_raw_ptr());
+    if (ret.ok() && ret.value() != nullptr) {
+        _data = std::move(ret.value());
     }
     return ret;
 }
 
 StatusOr<MutableColumnPtr> ConstColumn::downgrade() {
-    auto mutable_data_col = _data->as_mutable_ptr();
-    auto ret = downgrade_helper_func(&mutable_data_col);
-    if (ret.ok()) {
-        _data = std::move(mutable_data_col);
+    auto ret = downgrade_helper_func(_data->as_mutable_raw_ptr());
+    if (ret.ok() && ret.value() != nullptr) {
+        _data = std::move(ret.value());
     }
     return ret;
 }

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -385,19 +385,17 @@ void NullableColumn::check_or_die() const {
 
 StatusOr<MutableColumnPtr> NullableColumn::upgrade_if_overflow() {
     RETURN_IF_ERROR(_null_column->capacity_limit_reached());
-    MutableColumnPtr data_col = _data_column->as_mutable_ptr();
-    auto ret = upgrade_helper_func(&data_col);
-    if (ret.ok()) {
-        _data_column = std::move(data_col);
+    auto ret = upgrade_helper_func(_data_column->as_mutable_raw_ptr());
+    if (ret.ok() && ret.value() != nullptr) {
+        _data_column = std::move(ret.value());
     }
     return ret;
 }
 
 StatusOr<MutableColumnPtr> NullableColumn::downgrade() {
-    MutableColumnPtr data_col = _data_column->as_mutable_ptr();
-    auto ret = downgrade_helper_func(&data_col);
-    if (ret.ok()) {
-        _data_column = std::move(data_col);
+    auto ret = downgrade_helper_func(_data_column->as_mutable_raw_ptr());
+    if (ret.ok() && ret.value() != nullptr) {
+        _data_column = std::move(ret.value());
     }
     return ret;
 }

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -38,10 +38,10 @@ public:
 
     inline static MutableColumnPtr wrap_if_necessary(ColumnPtr&& column) {
         if (column->is_nullable()) {
-            return (std::move(column))->as_mutable_ptr();
+            return std::move(*column).mutate();
         }
         auto null = NullColumn::create(column->size(), 0);
-        return NullableColumn::create((std::move(column))->as_mutable_ptr(), std::move(null));
+        return NullableColumn::create(std::move(*column).mutate(), std::move(null));
     }
 
     inline static ColumnPtr wrap_if_necessary(const ColumnPtr& column) {

--- a/be/src/column/struct_column.cpp
+++ b/be/src/column/struct_column.cpp
@@ -121,24 +121,26 @@ void StructColumn::resize(size_t n) {
 
 StatusOr<MutableColumnPtr> StructColumn::upgrade_if_overflow() {
     for (auto& column : _fields) {
-        auto mutable_column = column->as_mutable_ptr();
-        auto status = upgrade_helper_func(&mutable_column);
-        if (!status.ok()) {
-            return status;
+        auto ret = upgrade_helper_func(column->as_mutable_raw_ptr());
+        if (!ret.ok()) {
+            return ret;
         }
-        column = std::move(mutable_column);
+        if (ret.value() != nullptr) {
+            column = std::move(ret.value());
+        }
     }
     return nullptr;
 }
 
 StatusOr<MutableColumnPtr> StructColumn::downgrade() {
     for (auto& column : _fields) {
-        auto mutable_column = column->as_mutable_ptr();
-        StatusOr<MutableColumnPtr> status = downgrade_helper_func(&mutable_column);
+        StatusOr<MutableColumnPtr> status = downgrade_helper_func(column->as_mutable_raw_ptr());
         if (!status.ok()) {
             return status;
         }
-        column = std::move(mutable_column);
+        if (status.value() != nullptr) {
+            column = std::move(status.value());
+        }
     }
     return nullptr;
 }
@@ -535,7 +537,7 @@ Status StructColumn::unfold_const_children(const starrocks::TypeDescriptor& type
     auto num_fields = type.children.size();
     auto num_rows = _fields[0]->size();
     for (int i = 0; i < num_fields; ++i) {
-        _fields[i] = ColumnHelper::unfold_const_column(type.children[i], num_rows, std::move(_fields[i]));
+        _fields[i] = ColumnHelper::unfold_const_column(type.children[i], num_rows, _fields[i]);
     }
     return Status::OK();
 }

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1868,7 +1868,12 @@ CONF_mInt64(max_batch_num_per_fetch_operator, "8");
 CONF_mInt64(max_chunk_num_per_fetch_batch, "8");
 CONF_mBool(enable_fetch_local_pass_through, "true");
 CONF_mInt64(max_lookup_batch_request, "8");
-
 // For table schema service: max retry attempts for fetching schema from FE.
 CONF_mInt32(table_schema_service_max_retries, "3");
+
+// Enable cow optimization for column operations, used to avoid the overhead of reference counting when accessing columns.
+CONF_mBool(enable_cow_optimization, "true");
+// The diagnose level for cow optimization, 0 means no diagnose, 1 means diagnose when use_count > 1, 2 means diagnose when use_count > 2.
+CONF_Int32(cow_optimization_diagnose_level, "0");
+
 } // namespace starrocks::config

--- a/be/src/exec/file_scanner/json_scanner.cpp
+++ b/be/src/exec/file_scanner/json_scanner.cpp
@@ -281,7 +281,7 @@ JsonReader::JsonReader(RuntimeState* state, ScannerCounter* counter, JsonScanner
           _strict_mode(strict_mode),
           _file(std::move(file)),
           _slot_descs(std::move(slot_descs)),
-          _type_descs(std::move(std::move(type_descs))),
+          _type_descs(std::move(type_descs)),
           _op_col_index(-1),
           _range_desc(range_desc) {
     int index = 0;

--- a/be/src/exec/pipeline/exchange/multi_cast_local_exchange_sink_operator.h
+++ b/be/src/exec/pipeline/exchange/multi_cast_local_exchange_sink_operator.h
@@ -26,7 +26,7 @@ public:
                                        const int32_t driver_sequence,
                                        std::shared_ptr<MultiCastLocalExchanger> exchanger)
             : Operator(factory, id, "multi_cast_local_exchange_sink", plan_node_id, true, driver_sequence),
-              _exchanger(std::move(std::move(exchanger))) {}
+              _exchanger(std::move(exchanger)) {}
 
     ~MultiCastLocalExchangeSinkOperator() override = default;
 
@@ -59,8 +59,7 @@ class MultiCastLocalExchangeSinkOperatorFactory : public OperatorFactory {
 public:
     MultiCastLocalExchangeSinkOperatorFactory(int32_t id, int32_t plan_node_id,
                                               std::shared_ptr<MultiCastLocalExchanger> exchanger)
-            : OperatorFactory(id, "multi_cast_local_exchange_sink", plan_node_id),
-              _exchanger(std::move(std::move(exchanger))) {}
+            : OperatorFactory(id, "multi_cast_local_exchange_sink", plan_node_id), _exchanger(std::move(exchanger)) {}
 
     ~MultiCastLocalExchangeSinkOperatorFactory() override = default;
 

--- a/be/src/exec/pipeline/exchange/multi_cast_local_exchange_source_operator.h
+++ b/be/src/exec/pipeline/exchange/multi_cast_local_exchange_source_operator.h
@@ -26,7 +26,7 @@ public:
                                          std::shared_ptr<MultiCastLocalExchanger> exchanger)
             : SourceOperator(factory, id, "multi_cast_local_exchange_source", plan_node_id, true, driver_sequence),
               _mcast_consumer_index(mcast_consumer_index),
-              _exchanger(std::move(std::move(exchanger))) {}
+              _exchanger(std::move(exchanger)) {}
 
     Status prepare(RuntimeState* state) override;
 
@@ -52,7 +52,7 @@ public:
                                                 std::shared_ptr<MultiCastLocalExchanger> exchanger)
             : SourceOperatorFactory(id, "multi_cast_local_exchange_source", plan_node_id),
               _mcast_consumer_index(mcast_consumer_index),
-              _exchanger(std::move(std::move(exchanger))) {}
+              _exchanger(std::move(exchanger)) {}
     ~MultiCastLocalExchangeSourceOperatorFactory() override = default;
     bool support_event_scheduler() const override { return _exchanger->support_event_scheduler(); }
 

--- a/be/src/exec/pipeline/sink/export_sink_operator.h
+++ b/be/src/exec/pipeline/sink/export_sink_operator.h
@@ -36,7 +36,7 @@ public:
     ExportSinkOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
                        std::shared_ptr<ExportSinkIOBuffer> export_sink_buffer, std::atomic<int32_t>& num_sinkers)
             : Operator(factory, id, "export_sink", plan_node_id, false, driver_sequence),
-              _export_sink_buffer(std::move(std::move(export_sink_buffer))),
+              _export_sink_buffer(std::move(export_sink_buffer)),
               _num_sinkers(num_sinkers) {}
 
     ~ExportSinkOperator() override = default;
@@ -72,7 +72,7 @@ public:
                               int32_t num_sinkers, FragmentContext* fragment_ctx)
             : OperatorFactory(id, "export_sink", Operator::s_pseudo_plan_node_id_for_final_sink),
               _t_export_sink(t_export_sink),
-              _t_output_expr(std::move(std::move(t_output_expr))),
+              _t_output_expr(std::move(t_output_expr)),
               _total_num_sinkers(num_sinkers),
               _fragment_ctx(fragment_ctx) {}
 

--- a/be/src/exec/pipeline/sink/file_sink_operator.h
+++ b/be/src/exec/pipeline/sink/file_sink_operator.h
@@ -34,7 +34,7 @@ public:
     FileSinkOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
                      std::shared_ptr<FileSinkIOBuffer> file_sink_buffer)
             : Operator(factory, id, "file_sink", plan_node_id, false, driver_sequence),
-              _file_sink_buffer(std::move(std::move(file_sink_buffer))) {}
+              _file_sink_buffer(std::move(file_sink_buffer)) {}
 
     ~FileSinkOperator() override = default;
 

--- a/be/src/exec/pipeline/sink/mysql_table_sink_operator.h
+++ b/be/src/exec/pipeline/sink/mysql_table_sink_operator.h
@@ -32,7 +32,7 @@ public:
     MysqlTableSinkOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
                            std::shared_ptr<MysqlTableSinkIOBuffer> mysql_table_sink_buffer)
             : Operator(factory, id, "mysql_table_sink", plan_node_id, false, driver_sequence),
-              _mysql_table_sink_buffer(std::move(std::move(mysql_table_sink_buffer))) {}
+              _mysql_table_sink_buffer(std::move(mysql_table_sink_buffer)) {}
 
     ~MysqlTableSinkOperator() override = default;
 

--- a/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
+++ b/be/src/exec/pipeline/sort/partition_sort_sink_operator.h
@@ -107,10 +107,10 @@ public:
             std::vector<SlotId> early_materialized_slots, SpillProcessChannelFactoryPtr spill_channel_factory,
             const char* name = "local_sort_sink")
             : OperatorFactory(id, name, plan_node_id),
-              _sort_context_factory(std::move(std::move(sort_context_factory))),
+              _sort_context_factory(std::move(sort_context_factory)),
               _sort_exec_exprs(sort_exec_exprs),
-              _is_asc_order(std::move(std::move(is_asc_order))),
-              _is_null_first(std::move(std::move(is_null_first))),
+              _is_asc_order(std::move(is_asc_order)),
+              _is_null_first(std::move(is_null_first)),
               _sort_keys(std::move(sort_keys)),
               _offset(offset),
               _limit(limit),

--- a/be/src/exprs/agg/any_value.h
+++ b/be/src/exprs/agg/any_value.h
@@ -86,7 +86,7 @@ public:
 
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
                                      MutableColumnPtr& dst) const override {
-        dst = src[0]->as_mutable_ptr();
+        dst = std::move(*(src[0])).mutate();
     }
 
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
@@ -144,7 +144,7 @@ public:
 
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
                                      MutableColumnPtr& dst) const override {
-        dst = src[0]->as_mutable_ptr();
+        dst = std::move(*(src[0])).mutate();
     }
 
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {

--- a/be/src/exprs/agg/bitmap_intersect.h
+++ b/be/src/exprs/agg/bitmap_intersect.h
@@ -62,7 +62,7 @@ public:
 
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
                                      MutableColumnPtr& dst) const override {
-        dst = src[0]->clone();
+        dst = std::move(*(src[0])).mutate();
     }
 
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {

--- a/be/src/exprs/agg/bitmap_union.h
+++ b/be/src/exprs/agg/bitmap_union.h
@@ -60,7 +60,7 @@ public:
 
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
                                      MutableColumnPtr& dst) const override {
-        dst = src[0]->as_mutable_ptr();
+        dst = std::move(*(src[0])).mutate();
     }
 
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {

--- a/be/src/exprs/agg/bitmap_union_count.h
+++ b/be/src/exprs/agg/bitmap_union_count.h
@@ -67,7 +67,7 @@ public:
 
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
                                      MutableColumnPtr& dst) const override {
-        dst = src[0]->clone();
+        dst = std::move(*(src[0])).mutate();
     }
 
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {

--- a/be/src/exprs/agg/boolor.h
+++ b/be/src/exprs/agg/boolor.h
@@ -177,7 +177,7 @@ public:
 
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
                                      MutableColumnPtr& dst) const override {
-        dst = src[0]->clone();
+        dst = std::move(*(src[0])).mutate();
     }
 
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {

--- a/be/src/exprs/agg/combinator/agg_state_merge.h
+++ b/be/src/exprs/agg/combinator/agg_state_merge.h
@@ -57,7 +57,7 @@ public:
     void convert_to_serialize_format([[maybe_unused]] FunctionContext* ctx, const Columns& srcs, size_t chunk_size,
                                      MutableColumnPtr& dst) const override {
         DCHECK_EQ(1, srcs.size());
-        dst = srcs[0]->clone();
+        dst = std::move(*(srcs[0])).mutate();
     }
 
     void finalize_to_column(FunctionContext* ctx __attribute__((unused)), ConstAggDataPtr __restrict state,

--- a/be/src/exprs/agg/combinator/agg_state_union.h
+++ b/be/src/exprs/agg/combinator/agg_state_union.h
@@ -51,7 +51,7 @@ public:
     void convert_to_serialize_format([[maybe_unused]] FunctionContext* ctx, const Columns& srcs, size_t chunk_size,
                                      MutableColumnPtr& dst) const override {
         DCHECK_EQ(1, srcs.size());
-        dst = srcs[0]->clone();
+        dst = std::move(*(srcs[0])).mutate();
     }
 
     void finalize_to_column(FunctionContext* ctx __attribute__((unused)), ConstAggDataPtr __restrict state,

--- a/be/src/exprs/agg/hll_union.h
+++ b/be/src/exprs/agg/hll_union.h
@@ -81,7 +81,7 @@ public:
 
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
                                      MutableColumnPtr& dst) const override {
-        dst = src[0]->as_mutable_ptr();
+        dst = std::move(*(src[0])).mutate();
     }
 
     void finalize_to_column(FunctionContext* ctx __attribute__((unused)), ConstAggDataPtr __restrict state,

--- a/be/src/exprs/agg/hll_union_count.h
+++ b/be/src/exprs/agg/hll_union_count.h
@@ -86,7 +86,7 @@ public:
 
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
                                      MutableColumnPtr& dst) const override {
-        dst = src[0]->as_mutable_ptr();
+        dst = std::move(*(src[0])).mutate();
     }
 
     void finalize_to_column(FunctionContext* ctx __attribute__((unused)), ConstAggDataPtr __restrict state,

--- a/be/src/exprs/agg/maxmin.h
+++ b/be/src/exprs/agg/maxmin.h
@@ -239,7 +239,7 @@ public:
 
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
                                      MutableColumnPtr& dst) const override {
-        dst = src[0]->as_mutable_ptr();
+        dst = std::move(*(src[0])).mutate();
     }
 
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
@@ -336,7 +336,7 @@ public:
 
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
                                      MutableColumnPtr& dst) const override {
-        dst = src[0]->as_mutable_ptr();
+        dst = std::move(*(src[0])).mutate();
     }
 
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {

--- a/be/src/exprs/agg/percentile_union.h
+++ b/be/src/exprs/agg/percentile_union.h
@@ -61,7 +61,7 @@ public:
 
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
                                      MutableColumnPtr& dst) const override {
-        dst = src[0]->clone();
+        dst = std::move(*(src[0])).mutate();
     }
 
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {

--- a/be/src/exprs/agg/stream/retract_maxmin.h
+++ b/be/src/exprs/agg/stream/retract_maxmin.h
@@ -152,7 +152,7 @@ public:
 
     void convert_to_serialize_format(FunctionContext* ctx, const Columns& src, size_t chunk_size,
                                      MutableColumnPtr& dst) const override {
-        dst = src[0]->as_mutable_ptr();
+        dst = std::move(*(src[0])).mutate();
     }
 
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {

--- a/be/src/exprs/array_functions.cpp
+++ b/be/src/exprs/array_functions.cpp
@@ -60,7 +60,7 @@ StatusOr<ColumnPtr> ArrayFunctions::array_length([[maybe_unused]] FunctionContex
         if (arg0->has_null()) {
             // Copy null flags.
             return NullableColumn::create(std::move(col_result),
-                                          down_cast<const NullableColumn*>(arg0)->null_column()->clone());
+                                          std::move(*(down_cast<const NullableColumn*>(arg0)->null_column())).mutate());
         } else {
             return col_result;
         }
@@ -391,14 +391,14 @@ public:
             return ConstColumn::create(std::move(arr_col_h), input->size());
         } else if (col->is_nullable()) {
             auto res = col->clone();
-            auto* input = down_cast<NullableColumn*>(res->as_mutable_raw_ptr());
+            auto* input = down_cast<NullableColumn*>(res.get());
             NullColumn* null_column = input->null_column_raw_ptr();
             auto* arr_col = down_cast<ArrayColumn*>(input->data_column_raw_ptr());
             call_cum_sum(arr_col, null_column);
             return res;
         } else {
             auto res = col->clone();
-            auto* arr_col = down_cast<ArrayColumn*>(res->as_mutable_raw_ptr());
+            auto* arr_col = down_cast<ArrayColumn*>(res.get());
             call_cum_sum(arr_col, nullptr);
             return res;
         }
@@ -437,8 +437,8 @@ private:
             element_data = data_column->get_data().data();
             element_null_data = nullable_element->null_column_data().data();
         } else {
-            auto* data_column = ColumnHelper::as_raw_column<RunTimeColumnType<TYPE>>(
-                    arr_col->elements_column()->as_mutable_raw_ptr());
+            auto* data_column =
+                    ColumnHelper::as_raw_column<RunTimeColumnType<TYPE>>(arr_col->elements_column_raw_ptr());
             element_data = data_column->get_data().data();
         }
         auto& offsets = arr_col->offsets().get_data();
@@ -1236,7 +1236,7 @@ StatusOr<ColumnPtr> ArrayFunctions::array_slice(FunctionContext* ctx, const Colu
 
     size_t chunk_size = columns[0]->size();
     ColumnPtr src_column = ColumnHelper::unpack_and_duplicate_const_column(chunk_size, columns[0]);
-    ColumnPtr dest_column = src_column->clone_empty();
+    auto dest_column = src_column->clone_empty();
 
     bool is_nullable = false;
     bool has_null = false;
@@ -1293,7 +1293,7 @@ StatusOr<ColumnPtr> ArrayFunctions::array_slice(FunctionContext* ctx, const Colu
 
     ArrayColumn* dest_data_column = nullptr;
     if (columns[0]->is_nullable()) {
-        auto* dest_nullable_column = down_cast<NullableColumn*>(dest_column->as_mutable_raw_ptr());
+        auto* dest_nullable_column = down_cast<NullableColumn*>(dest_column.get());
         dest_data_column = down_cast<ArrayColumn*>(dest_nullable_column->data_column_raw_ptr());
         dest_nullable_column->set_has_null(has_null);
         // Update the null column to match the computed null_result
@@ -1304,7 +1304,7 @@ StatusOr<ColumnPtr> ArrayFunctions::array_slice(FunctionContext* ctx, const Colu
             dest_null_col.get_data().assign(null_result->get_data().begin(), null_result->get_data().end());
         }
     } else {
-        dest_data_column = down_cast<ArrayColumn*>(dest_column->as_mutable_raw_ptr());
+        dest_data_column = down_cast<ArrayColumn*>(dest_column.get());
     }
 
     if (columns.size() > 2) {
@@ -1744,7 +1744,7 @@ StatusOr<ColumnPtr> ArrayFunctions::array_top_n(FunctionContext* ctx, const Colu
 
     bool is_nullable = false;
     bool has_null = false;
-    NullColumnPtr null_result = nullptr;
+    NullColumn::MutablePtr null_result = nullptr;
 
     // Handle array column nullability
     const ArrayColumn* array_column = nullptr;
@@ -1780,13 +1780,13 @@ StatusOr<ColumnPtr> ArrayFunctions::array_top_n(FunctionContext* ctx, const Colu
     // Setup destination column
     ArrayColumn* dest_data_column = nullptr;
     if (is_nullable) {
-        auto dest_nullable_column = down_cast<NullableColumn*>(dest_column->as_mutable_raw_ptr());
+        auto dest_nullable_column = down_cast<NullableColumn*>(dest_column.get());
         dest_data_column = down_cast<ArrayColumn*>(dest_nullable_column->data_column_raw_ptr());
         auto& dest_null_data = dest_nullable_column->null_column_data();
-        dest_null_data = static_cast<NullColumn*>(null_result->as_mutable_raw_ptr())->get_data();
+        dest_null_data = static_cast<NullColumn*>(null_result.get())->get_data();
         dest_nullable_column->set_has_null(has_null);
     } else {
-        dest_data_column = down_cast<ArrayColumn*>(dest_column->as_mutable_raw_ptr());
+        dest_data_column = down_cast<ArrayColumn*>(dest_column.get());
     }
 
     // Get the elements column for comparison
@@ -2037,7 +2037,7 @@ StatusOr<ColumnPtr> ArrayFunctions::arrays_zip(FunctionContext* ctx, const Colum
     for (const auto* nullable_col : nullable_columns) {
         if (nullable_col && nullable_col->has_null()) {
             if (result_nulls == nullptr) {
-                result_nulls = NullColumn::static_pointer_cast(nullable_col->null_column()->clone());
+                result_nulls = NullColumn::static_pointer_cast(std::move(*(nullable_col->null_column())).mutate());
             } else {
                 ColumnHelper::or_two_filters(num_rows, result_nulls->get_data().data(),
                                              nullable_col->null_column()->immutable_data().data());

--- a/be/src/exprs/array_functions.tpp
+++ b/be/src/exprs/array_functions.tpp
@@ -61,7 +61,7 @@ private:
             const auto* src_nullable_column = down_cast<const NullableColumn*>(src_column.get());
             const auto* src_data_column = down_cast<const ArrayColumn*>(src_nullable_column->data_column_raw_ptr());
             const auto null_data = src_nullable_column->immutable_null_column_data();
-            auto& dest_nullable_column = down_cast<NullableColumn&>(*dest_column->as_mutable_raw_ptr());
+            auto& dest_nullable_column = down_cast<NullableColumn&>(*dest_column.get());
             auto& dest_null_data = dest_nullable_column.null_column_data();
             auto& dest_data_column = down_cast<ArrayColumn&>(*dest_nullable_column.data_column_raw_ptr());
 
@@ -85,7 +85,7 @@ private:
             }
         } else {
             const auto* src_data_column = down_cast<const ArrayColumn*>(src_column.get());
-            auto* dest_data_column = down_cast<ArrayColumn*>(dest_column->as_mutable_raw_ptr());
+            auto* dest_data_column = down_cast<ArrayColumn*>(dest_column.get());
 
             for (size_t i = 0; i < chunk_size; i++) {
                 _array_distinct_item<HashSet>(*src_data_column, i, &hash_set, dest_data_column);
@@ -159,7 +159,7 @@ private:
 
         size_t chunk_size = columns[0]->size();
         ColumnPtr src_column = ColumnHelper::unpack_and_duplicate_const_column(chunk_size, columns[0]);
-        ColumnPtr dest_column_data = nullptr;
+        MutableColumnPtr dest_column_data = nullptr;
         ColumnPtr dest_column = nullptr;
 
         if constexpr (lt_is_decimal<LT>) {
@@ -177,12 +177,11 @@ private:
             const auto* src_nullable_column = down_cast<const NullableColumn*>(src_column.get());
             const auto* src_data_column = down_cast<const ArrayColumn*>(src_nullable_column->data_column_raw_ptr());
             auto src_null_data = src_nullable_column->immutable_null_column_data();
-            auto dest_column_imm = NullableColumn::create(
-                    ArrayColumn::create(dest_column_data, UInt32Column::create(src_data_column->offsets())),
+            auto dest_column_mut = NullableColumn::create(
+                    ArrayColumn::create(std::move(dest_column_data), UInt32Column::create(src_data_column->offsets())),
                     NullColumn::create());
-            MutableColumnPtr dest_column_mut = dest_column_imm->clone();
 
-            auto& dest_nullable_column = down_cast<NullableColumn&>(*dest_column_mut->as_mutable_raw_ptr());
+            auto& dest_nullable_column = down_cast<NullableColumn&>(*dest_column_mut.get());
             auto& dest_null_data = dest_nullable_column.null_column_data();
             auto& dest_data_column = down_cast<ArrayColumn&>(*dest_nullable_column.data_column_raw_ptr());
 
@@ -203,11 +202,10 @@ private:
             }
         } else {
             const auto* src_data_column = down_cast<const ArrayColumn*>(src_column.get());
-            auto dest_column_imm =
-                    ArrayColumn::create(dest_column_data, UInt32Column::create(src_data_column->offsets()));
-            MutableColumnPtr dest_column_mut = dest_column_imm->clone();
+            auto dest_column_mut =
+                    ArrayColumn::create(std::move(dest_column_data), UInt32Column::create(src_data_column->offsets()));
 
-            auto* dest_data_column = down_cast<ArrayColumn*>(dest_column_mut->as_mutable_raw_ptr());
+            auto* dest_data_column = down_cast<ArrayColumn*>(dest_column_mut.get());
             for (size_t i = 0; i < chunk_size; i++) {
                 _array_difference_item<ResultType>(*src_data_column, i, dest_data_column);
             }
@@ -695,7 +693,7 @@ public:
             const auto& src_null_column = src_nullable_column->null_column_ref();
             auto imm_null_data = src_null_column.immutable_data();
 
-            auto* dest_nullable_column = down_cast<NullableColumn*>(dest_column->as_mutable_raw_ptr());
+            auto* dest_nullable_column = down_cast<NullableColumn*>(dest_column.get());
             auto* dest_data_column = dest_nullable_column->data_column_raw_ptr();
             auto* dest_null_column = dest_nullable_column->null_column_raw_ptr();
 
@@ -708,7 +706,7 @@ public:
 
             _sort_array_column(dest_data_column, &sort_index, src_data_column);
         } else {
-            _sort_array_column(dest_column->as_mutable_raw_ptr(), &sort_index, *src_column);
+            _sort_array_column(dest_column.get(), &sort_index, *src_column);
         }
         return dest_column;
     }
@@ -823,13 +821,12 @@ public:
         }
 
         ColumnPtr src_column = ColumnHelper::unpack_and_duplicate_const_column(chunk_size, columns[0]);
-        ColumnPtr dest_column = src_column->clone();
+        auto dest_column = src_column->clone();
 
         if (dest_column->is_nullable()) {
-            _reverse_array_column(down_cast<NullableColumn*>(dest_column->as_mutable_raw_ptr())->data_column_raw_ptr(),
-                                  chunk_size);
+            _reverse_array_column(down_cast<NullableColumn*>(dest_column.get())->data_column_raw_ptr(), chunk_size);
         } else {
-            _reverse_array_column(dest_column->as_mutable_raw_ptr(), chunk_size);
+            _reverse_array_column(dest_column.get(), chunk_size);
         }
         return dest_column;
     }
@@ -1112,12 +1109,12 @@ private:
             } else {
                 // return a nullable column with only empty arrays, the null column shoule be same with src column.
                 MutableColumnPtr dest_column = src_column->clone_empty();
-                Column* data_column = dest_column->as_mutable_raw_ptr();
+                Column* data_column = dest_column.get();
                 if (src_column->is_nullable()) {
                     const auto src_null_column = down_cast<const NullableColumn*>(src_column.get())->null_column();
                     const auto src_null_data = src_null_column->immutable_data();
 
-                    auto dest_nullable_column = down_cast<NullableColumn*>(dest_column->as_mutable_raw_ptr());
+                    auto dest_nullable_column = down_cast<NullableColumn*>(dest_column.get());
                     auto dest_null_column = dest_nullable_column->null_column_raw_ptr();
                     dest_null_column->get_data().assign(src_null_data.begin(), src_null_data.end());
                     dest_nullable_column->set_has_null(src_column->has_null());
@@ -1138,7 +1135,7 @@ private:
             const auto& src_null_column = src_nullable_column->null_column();
             const auto src_null_data = src_null_column->immutable_data();
 
-            auto* dest_nullable_column = down_cast<NullableColumn*>(dest_column->as_mutable_raw_ptr());
+            auto* dest_nullable_column = down_cast<NullableColumn*>(dest_column.get());
             dest_null_column = dest_nullable_column->null_column_raw_ptr();
 
             dest_null_column->get_data().assign(src_null_data.begin(), src_null_data.end());
@@ -1146,7 +1143,7 @@ private:
         }
 
         ColumnPtr src_data_column = src_column;
-        Column* dest_data_column_ptr = dest_column->as_mutable_raw_ptr();
+        Column* dest_data_column_ptr = dest_column.get();
         if (is_src_const) {
             src_data_column = FunctionHelper::get_data_column_of_const(src_column);
             src_data_column = FunctionHelper::get_data_column_of_nullable(src_data_column);
@@ -1264,7 +1261,7 @@ public:
         //  which will be optimized later
 
         ColumnPtr src_column = ColumnHelper::unpack_and_duplicate_const_column(chunk_size, columns[0]);
-        ColumnPtr dest_column = src_column->clone_empty();
+        auto dest_column = src_column->clone_empty();
         ColumnPtr key_column = ColumnHelper::unpack_and_duplicate_const_column(chunk_size, columns[1]);
         if (key_column->size() != src_column->size()) {
             throw std::runtime_error("Input array size is not equal in array_sortby.");
@@ -1276,7 +1273,7 @@ public:
             const auto& src_null_column = src_nullable_column->null_column_ref();
             const auto src_null_data = src_null_column.immutable_data();
 
-            auto* dest_nullable_column = down_cast<NullableColumn*>(dest_column->as_mutable_raw_ptr());
+            auto* dest_nullable_column = down_cast<NullableColumn*>(dest_column.get());
             auto* dest_data_column = dest_nullable_column->data_column_raw_ptr();
             auto* dest_null_column = dest_nullable_column->null_column_raw_ptr();
 
@@ -1289,7 +1286,7 @@ public:
 
             _sort_array_column(dest_data_column, src_data_column, key_column, &src_null_column);
         } else {
-            _sort_array_column(dest_column->as_mutable_raw_ptr(), *src_column, key_column, nullptr);
+            _sort_array_column(dest_column.get(), *src_column, key_column, nullptr);
         }
         return dest_column;
     }
@@ -1638,11 +1635,11 @@ private:
         }
 
         if (elements->has_null()) {
-            FUNC::template process<ResultType, ElementType, true>(elements_data, elements_nulls, &offsets,
-                                                                  result->as_mutable_raw_ptr(), array_null_ptr);
+            FUNC::template process<ResultType, ElementType, true>(elements_data, elements_nulls, &offsets, result.get(),
+                                                                  array_null_ptr);
         } else {
             FUNC::template process<ResultType, ElementType, false>(elements_data, elements_nulls, &offsets,
-                                                                   result->as_mutable_raw_ptr(), array_null_ptr);
+                                                                   result.get(), array_null_ptr);
         }
 
         return NullableColumn::create(std::move(result), std::move(array_null));

--- a/be/src/exprs/array_map_expr.cpp
+++ b/be/src/exprs/array_map_expr.cpp
@@ -175,7 +175,8 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_lambda_expr(ExprContext* context, Chu
         }
     }
     DCHECK(aligned_offsets != nullptr);
-    auto& aligned_offsets_data = UInt32Column::static_pointer_cast(aligned_offsets->as_mutable_ptr())->get_data();
+    auto& aligned_offsets_data =
+            ColumnHelper::as_raw_column<UInt32Column>(aligned_offsets->as_mutable_raw_ptr())->get_data();
 
     // 4. prepare capture columns
     for (auto slot_id : capture_slot_ids) {
@@ -247,7 +248,7 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_lambda_expr(ExprContext* context, Chu
                 tmp_col = ColumnHelper::align_return_type(std::move(tmp_col), type().children[0], tmp_chunk->num_rows(),
                                                           true);
                 if (column == nullptr) {
-                    column = tmp_col->as_mutable_ptr();
+                    column = std::move(*tmp_col).mutate();
                 } else {
                     column->append(*tmp_col);
                 }
@@ -267,7 +268,7 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_lambda_expr(ExprContext* context, Chu
         new_aligned_offsets->append(0);
         new_aligned_offsets->append(data_column->size());
         aligned_offsets = std::move(new_aligned_offsets);
-        auto array_column = ArrayColumn::create(data_column->as_mutable_ptr(), aligned_offsets);
+        auto array_column = ArrayColumn::create(std::move(*data_column).mutate(), aligned_offsets);
         array_column->check_or_die();
         ColumnPtr result_column = array_column;
         if (result_null_column != nullptr) {
@@ -381,7 +382,7 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_checked(ExprContext* context, Chunk* 
         auto array_col = ArrayColumn::create(std::move(column), std::move(aligned_offsets));
         array_col->check_or_die();
         if (result_null_column) {
-            auto result_null_mut = NullColumn::static_pointer_cast(std::move(result_null_column)->as_mutable_ptr());
+            auto result_null_mut = NullColumn::static_pointer_cast(std::move(*result_null_column).mutate());
             result_null_mut->resize(1);
             auto result = ConstColumn::create(NullableColumn::create(std::move(array_col), std::move(result_null_mut)),
                                               chunk->num_rows());

--- a/be/src/exprs/binary_function.h
+++ b/be/src/exprs/binary_function.h
@@ -276,7 +276,7 @@ public:
             NullColumn::MutablePtr null_flags;
             if (data->is_nullable()) {
                 auto nullable_column = ColumnHelper::as_raw_column<NullableColumn>(data);
-                null_flags = NullColumn::static_pointer_cast(nullable_column->null_column()->as_mutable_ptr());
+                null_flags = NullColumn::static_pointer_cast(std::move(*nullable_column->null_column()).mutate());
             } else {
                 null_flags = RunTimeColumnType<TYPE_NULL>::create();
                 null_flags->resize(data->size());
@@ -366,7 +366,7 @@ public:
 
         ColumnPtr produce_null = PRODUCE_NULL_FN::template evaluate<LType, RType, TYPE_NULL>(data1, data2);
 
-        NullColumn::MutablePtr null_result = ColumnHelper::as_column<NullColumn>(produce_null->as_mutable_ptr());
+        NullColumn::MutablePtr null_result = ColumnHelper::as_column<NullColumn>(std::move(*produce_null).mutate());
         FunctionHelper::union_produce_nullable_column(v1, v2, &null_result);
 
         ColumnPtr data_result = FN::template evaluate<LType, RType, ResultType>(data1, data2);

--- a/be/src/exprs/cast_expr.h
+++ b/be/src/exprs/cast_expr.h
@@ -79,7 +79,7 @@ private:
             : Expr(rhs),
               _cast_to_type_desc(rhs._cast_to_type_desc),
               _throw_exception_if_err(rhs._throw_exception_if_err),
-              _constant_res(rhs._constant_res != nullptr ? rhs._constant_res->clone() : nullptr) {}
+              _constant_res(rhs._constant_res != nullptr ? std::move(*(rhs._constant_res)).mutate() : nullptr) {}
 
     Slice _unquote(Slice slice) const;
     Slice _trim(Slice slice) const;

--- a/be/src/exprs/cast_expr_array.cpp
+++ b/be/src/exprs/cast_expr_array.cpp
@@ -145,7 +145,7 @@ StatusOr<ColumnPtr> CastStringToArray::evaluate_checked(ExprContext* context, Ch
         if (input->only_null()) {
             return ColumnHelper::create_const_null_column(rows);
         } else {
-            return ConstColumn::create(input->data_column()->clone(), rows);
+            return ConstColumn::create(std::move(*(input->data_column())).mutate(), rows);
         }
     }
     ASSIGN_OR_RETURN(ColumnPtr column, _children[0]->evaluate_checked(context, input_chunk));

--- a/be/src/exprs/cast_expr_struct.cpp
+++ b/be/src/exprs/cast_expr_struct.cpp
@@ -110,9 +110,9 @@ StatusOr<ColumnPtr> CastJsonToStruct::evaluate_checked(ExprContext* context, Chu
             field_chunk.append_column(elements, 0);
             ASSIGN_OR_RETURN(auto casted_field, _field_casts[i]->evaluate_checked(context, &field_chunk));
             casted_field = NullableColumn::wrap_if_necessary(std::move(casted_field));
-            casted_fields.emplace_back(std::move(casted_field)->as_mutable_ptr());
+            casted_fields.emplace_back(std::move(*casted_field).mutate());
         } else {
-            casted_fields.emplace_back(NullableColumn::wrap_if_necessary(elements->clone()));
+            casted_fields.emplace_back(NullableColumn::wrap_if_necessary(std::move(*elements).mutate()));
         }
         DCHECK(casted_fields[i]->is_nullable());
     }

--- a/be/src/exprs/cast_nested.cpp
+++ b/be/src/exprs/cast_nested.cpp
@@ -32,27 +32,30 @@ StatusOr<ColumnPtr> CastMapExpr::evaluate_checked(ExprContext* context, Chunk* p
     ColumnPtr casted_key_column;
     ColumnPtr casted_value_column;
 
+    auto& src_keys_column = map_column->keys_column();
+    auto& src_values_column = map_column->values_column();
+    auto& src_offsets_column = map_column->offsets_column();
     // cast key column
     if (_key_cast != nullptr) {
         Chunk field_chunk;
-        field_chunk.append_column(map_column->keys_column(), 0);
+        field_chunk.append_column(src_keys_column, 0);
         ASSIGN_OR_RETURN(casted_key_column, _key_cast->evaluate_checked(context, &field_chunk));
     } else {
-        casted_key_column = map_column->keys_column()->clone();
+        casted_key_column = src_keys_column->clone();
     }
     casted_key_column = NullableColumn::wrap_if_necessary(std::move(casted_key_column));
 
     // cast value column
     if (_value_cast != nullptr) {
         Chunk field_chunk;
-        field_chunk.append_column(map_column->values_column(), 0);
+        field_chunk.append_column(src_values_column, 0);
         ASSIGN_OR_RETURN(casted_value_column, _value_cast->evaluate_checked(context, &field_chunk));
     } else {
-        casted_value_column = map_column->values_column()->clone();
+        casted_value_column = src_values_column->clone();
     }
     casted_value_column = NullableColumn::wrap_if_necessary(std::move(casted_value_column));
     auto casted_map = MapColumn::create(std::move(casted_key_column), std::move(casted_value_column),
-                                        ColumnHelper::as_column<UInt32Column>(map_column->offsets_column()->clone()));
+                                        ColumnHelper::as_column<UInt32Column>(std::move(*src_offsets_column).mutate()));
     RETURN_IF_ERROR(down_cast<MapColumn*>(casted_map->as_mutable_raw_ptr())->unfold_const_children(_type));
     if (!orig_column->is_nullable()) {
         return casted_map;
@@ -71,22 +74,23 @@ StatusOr<ColumnPtr> CastStructExpr::evaluate_checked(ExprContext* context, Chunk
     }
     // NOTE: const(nullable) case is handled by last if case
     const auto* struct_column = down_cast<const StructColumn*>(ColumnHelper::get_data_column(orig_column.get()));
-    Columns casted_fields;
+    MutableColumns casted_fields;
     for (int i = 0; i < _field_casts.size(); ++i) {
         if (_field_casts[i] != nullptr) {
             Chunk field_chunk;
             field_chunk.append_column(struct_column->fields()[i], 0);
             ASSIGN_OR_RETURN(auto casted_field, _field_casts[i]->evaluate_checked(context, &field_chunk));
             casted_field = NullableColumn::wrap_if_necessary(std::move(casted_field));
-            casted_fields.emplace_back(std::move(casted_field));
+            casted_fields.emplace_back(std::move(*casted_field).mutate());
         } else {
-            casted_fields.emplace_back(NullableColumn::wrap_if_necessary(struct_column->fields()[i]->clone()));
+            auto& field_column = struct_column->get_column_by_idx(i);
+            casted_fields.emplace_back(NullableColumn::wrap_if_necessary(std::move(*field_column).mutate()));
         }
         DCHECK(casted_fields[i]->is_nullable());
     }
 
     auto casted_struct = StructColumn::create(std::move(casted_fields), _type.field_names);
-    RETURN_IF_ERROR(down_cast<StructColumn*>(casted_struct->as_mutable_raw_ptr())->unfold_const_children(_type));
+    RETURN_IF_ERROR(down_cast<StructColumn*>(casted_struct.get())->unfold_const_children(_type));
     if (!orig_column->is_nullable()) {
         return std::move(casted_struct);
     }
@@ -112,13 +116,13 @@ StatusOr<ColumnPtr> CastArrayExpr::evaluate_checked(ExprContext* context, Chunk*
         field_chunk.append_column(array_column->elements_column(), 0);
         ASSIGN_OR_RETURN(casted_element_column, _element_cast->evaluate_checked(context, &field_chunk));
     } else {
-        casted_element_column = array_column->elements_column()->clone();
+        casted_element_column = std::move(*(array_column->elements_column())).mutate();
     }
     casted_element_column = NullableColumn::wrap_if_necessary(std::move(casted_element_column));
 
-    auto casted_array =
-            ArrayColumn::create(std::move(casted_element_column),
-                                ColumnHelper::as_column<UInt32Column>(array_column->offsets_column()->clone()));
+    auto casted_array = ArrayColumn::create(
+            std::move(casted_element_column),
+            ColumnHelper::as_column<UInt32Column>(std::move(*(array_column->offsets_column())).mutate()));
     RETURN_IF_ERROR(down_cast<ArrayColumn*>(casted_array->as_mutable_raw_ptr())->unfold_const_children(_type));
     if (orig_column->is_constant()) {
         return ConstColumn::create(casted_array, orig_column->size());
@@ -130,7 +134,7 @@ StatusOr<ColumnPtr> CastArrayExpr::evaluate_checked(ExprContext* context, Chunk*
     return NullableColumn::create(
             std::move(casted_array),
             ColumnHelper::as_column<NullColumn>(
-                    ColumnHelper::as_column<NullableColumn>(orig_column)->null_column()->clone()));
+                    std::move(*(ColumnHelper::as_column<NullableColumn>(orig_column)->null_column())).mutate()));
 }
 
 } // namespace starrocks

--- a/be/src/exprs/function_context.cpp
+++ b/be/src/exprs/function_context.cpp
@@ -272,7 +272,7 @@ MutableColumnPtr FunctionContext::create_column(const FunctionContext::TypeDesc&
         p = MapColumn::create(std::move(keys), std::move(values), std::move(offsets));
     } else {
         auto col = type_dispatch_column(type, ColumnBuilder(), type_desc);
-        p = col ? std::move(col)->as_mutable_ptr() : nullptr;
+        p = col ? std::move(*col).mutate() : nullptr;
     }
 
     if (nullable && p != nullptr) {

--- a/be/src/exprs/in_const_predicate.hpp
+++ b/be/src/exprs/in_const_predicate.hpp
@@ -236,9 +236,9 @@ public:
         ColumnBuilder<TYPE_BOOLEAN> builder(size);
         builder.resize_uninitialized(size);
 
-        uint8_t* null_data = builder.null_column()->get_data().data();
+        uint8_t* null_data = builder.null_column_raw_ptr()->get_data().data();
         memset(null_data, 0x0, size);
-        uint8_t* output = ColumnHelper::cast_to_raw<TYPE_BOOLEAN>(builder.data_column().get())->get_data().data();
+        uint8_t* output = ColumnHelper::cast_to_raw<TYPE_BOOLEAN>(builder.data_column_raw_ptr())->get_data().data();
 
         auto update_row = [&](int row) {
             if (viewer.is_null(row)) {

--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -335,7 +335,7 @@ StatusOr<ColumnPtr> JsonFunctions::parse_json(FunctionContext* context, const Co
         }
     }
 
-    DCHECK(num_rows == result.data_column()->size());
+    DCHECK(num_rows == result.data_column_raw_ptr()->size());
     return result.build(ColumnHelper::is_all_const(columns));
 }
 
@@ -693,7 +693,7 @@ StatusOr<ColumnPtr> JsonFunctions::_flat_json_query_impl(FunctionContext* contex
             chunk.append_column(flat_column, 0);
             ret = state->cast_expr->evaluate_checked(nullptr, &chunk);
         } else {
-            ret = std::move(flat_column->clone());
+            ret = std::move(*flat_column).mutate();
         }
         if (ret.ok()) {
             ret.value()->check_or_die();

--- a/be/src/exprs/jsonpath.h
+++ b/be/src/exprs/jsonpath.h
@@ -117,7 +117,7 @@ struct JsonPathPiece {
     std::shared_ptr<ArraySelector> array_selector;
 
     JsonPathPiece(std::string key, std::shared_ptr<ArraySelector> selector)
-            : key(std::move(key)), array_selector(std::move(std::move(selector))) {}
+            : key(std::move(key)), array_selector(std::move(selector)) {}
 
     JsonPathPiece(std::string key, ArraySelector* selector) : key(std::move(key)), array_selector(selector) {}
 

--- a/be/src/exprs/map_apply_expr.cpp
+++ b/be/src/exprs/map_apply_expr.cpp
@@ -73,7 +73,7 @@ StatusOr<ColumnPtr> MapApplyExpr::evaluate_checked(ExprContext* context, Chunk* 
             DCHECK(nullable != nullptr);
             data_column = nullable->data_column();
             // empty null map with non-empty elements
-            auto data_mut = data_column->as_mutable_ptr();
+            auto data_mut = std::move(*data_column).mutate();
             data_mut->empty_null_in_complex_column(
                     nullable->null_column()->immutable_data(),
                     down_cast<MapColumn*>(data_mut.get())->offsets_column()->immutable_data());
@@ -82,7 +82,7 @@ StatusOr<ColumnPtr> MapApplyExpr::evaluate_checked(ExprContext* context, Chunk* 
                 input_null_map = FunctionHelper::union_null_column(nullable->null_column(),
                                                                    std::move(input_null_map)); // merge null
             } else {
-                input_null_map = ColumnHelper::as_column<NullColumn>(nullable->null_column()->clone());
+                input_null_map = ColumnHelper::as_column<NullColumn>(std::move(*nullable->null_column()).mutate());
             }
         }
         DCHECK(data_column->is_map());
@@ -130,8 +130,8 @@ StatusOr<ColumnPtr> MapApplyExpr::evaluate_checked(ExprContext* context, Chunk* 
         // evaluate the lambda expression
         if (cur_chunk->num_rows() <= chunk->num_rows() * 8) {
             ASSIGN_OR_RETURN(auto tmp_column, context->evaluate(_children[0], cur_chunk.get()));
-            column = ColumnHelper::align_return_type(std::move(tmp_column), type(), cur_chunk->num_rows(), false)
-                             ->as_mutable_ptr();
+            column = ColumnHelper::align_return_type(std::move(*tmp_column).mutate(), type(), cur_chunk->num_rows(),
+                                                     false);
         } else { // split large chunks into small ones to avoid too large or various batch_size
             ChunkAccumulator accumulator(DEFAULT_CHUNK_SIZE);
             RETURN_IF_ERROR(accumulator.push(std::move(cur_chunk)));
@@ -140,7 +140,7 @@ StatusOr<ColumnPtr> MapApplyExpr::evaluate_checked(ExprContext* context, Chunk* 
                 ASSIGN_OR_RETURN(auto tmp_col, context->evaluate(_children[0], tmp_chunk.get()));
                 tmp_col = ColumnHelper::align_return_type(std::move(tmp_col), type(), tmp_chunk->num_rows(), false);
                 if (column == nullptr) {
-                    column = std::move(tmp_col)->as_mutable_ptr();
+                    column = std::move(*tmp_col).mutate();
                 } else {
                     column->append(*tmp_col);
                 }
@@ -155,9 +155,9 @@ StatusOr<ColumnPtr> MapApplyExpr::evaluate_checked(ExprContext* context, Chunk* 
                                                  map_col->keys_column()->size()));
     }
 
-    auto res_map_imm = MapColumn::create(map_col->keys_column(), map_col->values_column(),
-                                         ColumnHelper::as_column<UInt32Column>(input_map->offsets_column()->clone()));
-    MutableColumnPtr res_map = res_map_imm->clone();
+    auto res_map = MapColumn::create(
+            std::move(*map_col->keys_column()).mutate(), std::move(*map_col->values_column()).mutate(),
+            ColumnHelper::as_column<UInt32Column>(std::move(*input_map->offsets_column()).mutate()));
 
     if (_maybe_duplicated_keys && res_map->size() > 0) {
         down_cast<MapColumn*>(res_map->as_mutable_raw_ptr())->remove_duplicated_keys();

--- a/be/src/exprs/map_expr.cpp
+++ b/be/src/exprs/map_expr.cpp
@@ -74,8 +74,8 @@ StatusOr<ColumnPtr> MapExpr::evaluate_checked(ExprContext* context, Chunk* chunk
             offsets->append(curr_offset);
         }
     } else if (num_pairs > 0) { // avoid copying for only one pair
-        key_col = pairs_columns[0]->as_mutable_ptr();
-        value_col = pairs_columns[1]->as_mutable_ptr();
+        key_col = std::move(*pairs_columns[0]).mutate();
+        value_col = std::move(*pairs_columns[1]).mutate();
         for (size_t i = 0; i < num_rows; ++i) {
             curr_offset++;
             offsets->append(curr_offset);

--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -526,7 +526,7 @@ ColumnPtr string_func_const(StringConstFuncType func, const Columns& columns, Ar
             }
             if (binary->is_constant()) {
                 auto* dst_const = down_cast<ConstColumn*>(binary->as_mutable_raw_ptr());
-                auto data_mut = dst_const->data_column()->as_mutable_ptr();
+                auto data_mut = std::move(*(dst_const->data_column())).mutate();
                 data_mut->assign(dst_const->size(), 0);
                 return NullableColumn::create(std::move(data_mut), std::move(src_null));
             }
@@ -790,8 +790,8 @@ public:
         const auto len_array = len_column->immutable_data();
         const auto num_rows = len_column->size();
         NullableBinaryColumnBuilder builder;
-        auto& dst_bytes = builder.data_column()->get_bytes();
-        auto& dst_offsets = builder.data_column()->get_offset();
+        auto& dst_bytes = builder.data_column_raw_ptr()->get_bytes();
+        auto& dst_offsets = builder.data_column_raw_ptr()->get_offset();
         auto& nulls = builder.get_null_data();
 
         raw::make_room(&dst_offsets, num_rows + 1);
@@ -883,8 +883,8 @@ static inline ColumnPtr repeat_const_not_null(const Columns& columns, const Bina
 
     NullableBinaryColumnBuilder builder;
     auto& dst_nulls = builder.get_null_data();
-    auto& dst_offsets = builder.data_column()->get_offset();
-    auto& dst_bytes = builder.data_column()->get_bytes();
+    auto& dst_offsets = builder.data_column_raw_ptr()->get_offset();
+    auto& dst_bytes = builder.data_column_raw_ptr()->get_bytes();
 
     dst_nulls.resize(num_rows);
     bool has_null = false;
@@ -947,8 +947,8 @@ static inline ColumnPtr repeat_not_const(const Columns& columns) {
     const size_t num_rows = columns[0]->size();
     NullableBinaryColumnBuilder builder;
     auto& dst_nulls = builder.get_null_data();
-    auto& dst_offsets = builder.data_column()->get_offset();
-    auto& dst_bytes = builder.data_column()->get_bytes();
+    auto& dst_offsets = builder.data_column_raw_ptr()->get_offset();
+    auto& dst_bytes = builder.data_column_raw_ptr()->get_bytes();
     dst_nulls.resize(num_rows);
     raw::make_room(&dst_offsets, num_rows + 1);
     dst_offsets[0] = 0;
@@ -1242,8 +1242,8 @@ static inline ColumnPtr translate_with_utf8_const_nonnull_from_and_to(const Colu
     DCHECK(!state->is_ascii_map);
 
     NullableBinaryColumnBuilder builder;
-    auto& dst_offsets = builder.data_column()->get_offset();
-    auto& dst_bytes = builder.data_column()->get_bytes();
+    auto& dst_offsets = builder.data_column_raw_ptr()->get_offset();
+    auto& dst_bytes = builder.data_column_raw_ptr()->get_bytes();
     auto& dst_nulls = builder.get_null_data();
 
     const size_t num_rows = src->size();
@@ -1311,8 +1311,8 @@ ColumnPtr translate_with_non_const_from_or_to(const Columns& columns, const Tran
     ColumnViewer<TYPE_VARCHAR> to_viewer(columns[TranslateState::TO_STR_INDEX]);
 
     NullableBinaryColumnBuilder builder;
-    auto& dst_offsets = builder.data_column()->get_offset();
-    auto& dst_bytes = builder.data_column()->get_bytes();
+    auto& dst_offsets = builder.data_column_raw_ptr()->get_offset();
+    auto& dst_bytes = builder.data_column_raw_ptr()->get_bytes();
     auto& dst_nulls = builder.get_null_data();
 
     const size_t num_rows = columns[TranslateState::SRC_STR_INDEX]->size();
@@ -1501,7 +1501,7 @@ static inline ColumnPtr pad_utf8_const(Columns const& columns, const BinaryColum
     const auto num_rows = src->size();
     NullableBinaryColumnBuilder builder;
 
-    auto& dst_offsets = builder.data_column()->get_offset();
+    auto& dst_offsets = builder.data_column_raw_ptr()->get_offset();
     auto& dst_nulls = builder.get_null_data();
 
     raw::make_room(&dst_offsets, num_rows + 1);
@@ -1579,7 +1579,7 @@ static inline ColumnPtr pad_utf8_const(Columns const& columns, const BinaryColum
         dst_offsets[i + 1] = dst_off;
     }
     dst_bytes.resize(dst_off);
-    builder.data_column()->get_bytes().swap(reinterpret_cast<Bytes&>(dst_bytes));
+    builder.data_column_raw_ptr()->get_bytes().swap(reinterpret_cast<Bytes&>(dst_bytes));
     builder.set_has_null(has_null);
     return builder.build(ColumnHelper::is_all_const(columns));
 }
@@ -1645,7 +1645,7 @@ ColumnPtr pad_not_const(const Columns& columns, [[maybe_unused]] const PadState*
     const auto num_rows = columns[0]->size();
     NullableBinaryColumnBuilder builder;
     builder.resize(num_rows, 0);
-    auto& dst_offsets = builder.data_column()->get_offset();
+    auto& dst_offsets = builder.data_column_raw_ptr()->get_offset();
     auto& dst_nulls = builder.get_null_data();
     Bytes dst_bytes;
     dst_bytes.reserve(16ULL << 20);
@@ -1752,7 +1752,7 @@ ColumnPtr pad_not_const(const Columns& columns, [[maybe_unused]] const PadState*
         dst_offsets[i + 1] = dst_off;
     }
     DCHECK(dst_bytes.size() == dst_off);
-    builder.data_column()->get_bytes().swap(reinterpret_cast<Bytes&>(dst_bytes));
+    builder.data_column_raw_ptr()->get_bytes().swap(reinterpret_cast<Bytes&>(dst_bytes));
     builder.set_has_null(has_null);
     return builder.build(ColumnHelper::is_all_const(columns));
 }
@@ -2890,7 +2890,7 @@ StatusOr<ColumnPtr> StringFunctions::strpos_instance(FunctionContext* context, c
 static inline ColumnPtr concat_const_not_null(Columns const& columns, const BinaryColumn* src,
                                               const ConcatState* state) {
     NullableBinaryColumnBuilder builder;
-    auto* binary = down_cast<BinaryColumn*>(builder.data_column().get());
+    auto* binary = down_cast<BinaryColumn*>(builder.data_column_raw_ptr());
     auto& nulls = builder.get_null_data();
     auto& dst_offsets = binary->get_offset();
     auto& dst_bytes = binary->get_bytes();
@@ -2947,8 +2947,8 @@ static inline ColumnPtr concat_not_const_small(std::vector<ColumnViewer<TYPE_VAR
                                                const bool is_const) {
     NullableBinaryColumnBuilder builder;
     auto& dst_nulls = builder.get_null_data();
-    auto& dst_offsets = builder.data_column()->get_offset();
-    auto& dst_bytes = builder.data_column()->get_bytes();
+    auto& dst_offsets = builder.data_column_raw_ptr()->get_offset();
+    auto& dst_bytes = builder.data_column_raw_ptr()->get_bytes();
     dst_nulls.resize(num_rows);
     raw::make_room(&dst_offsets, num_rows + 1);
     dst_offsets[0] = 0;
@@ -3074,8 +3074,8 @@ ColumnPtr concat_ws_small(ColumnViewer<TYPE_VARCHAR>& sep_viewer, std::vector<Co
                           const size_t num_rows, const size_t dst_bytes_max_size, const bool is_const) {
     NullableBinaryColumnBuilder builder;
     auto& dst_nulls = builder.get_null_data();
-    auto& dst_offsets = builder.data_column()->get_offset();
-    auto& dst_bytes = builder.data_column()->get_bytes();
+    auto& dst_offsets = builder.data_column_raw_ptr()->get_offset();
+    auto& dst_bytes = builder.data_column_raw_ptr()->get_bytes();
     dst_nulls.resize(num_rows);
     raw::make_room(&dst_offsets, num_rows + 1);
     dst_offsets[0] = 0;
@@ -3660,7 +3660,7 @@ static ColumnPtr regexp_extract_all_const(re2::RE2* const_re, const Columns& col
     NullColumn::MutablePtr nl_col;
     if (columns[0]->is_nullable()) {
         auto x = down_cast<const NullableColumn*>(columns[0].get())->null_column();
-        nl_col = NullColumn::static_pointer_cast(x->clone());
+        nl_col = NullColumn::static_pointer_cast(std::move(*x).mutate());
     } else {
         nl_col = NullColumn::create(size, 0);
     }
@@ -3975,8 +3975,9 @@ StatusOr<ColumnPtr> StringFunctions::regexp_replace_use_hyperscan_vec(StringFunc
     ASSIGN_OR_RETURN(auto res, hyperscan_vec_evaluate(binary, state, rpl_value));
     if (columns[0]->is_nullable()) {
         return NullableColumn::create(
-                std::move(res), NullColumn::static_pointer_cast(
-                                        down_cast<const NullableColumn*>(columns[0].get())->null_column()->clone()));
+                std::move(res),
+                NullColumn::static_pointer_cast(
+                        std::move(*down_cast<const NullableColumn*>(columns[0].get())->null_column()).mutate()));
     } else if (columns[0]->is_constant()) {
         return ConstColumn::create(std::move(res), columns[0]->size());
     }
@@ -4100,7 +4101,7 @@ static StatusOr<ColumnPtr> regexp_split_const(re2::RE2* const_re, const Columns&
     NullColumn::MutablePtr nl_col;
     if (columns[0]->is_nullable()) {
         auto x = down_cast<const NullableColumn*>(columns[0].get())->null_column();
-        nl_col = NullColumn::static_pointer_cast(x->clone());
+        nl_col = NullColumn::static_pointer_cast((std::move(*x)).mutate());
     } else {
         nl_col = NullColumn::create(size, 0);
     }
@@ -4158,7 +4159,7 @@ static StatusOr<ColumnPtr> regexp_split_const_pattern(re2::RE2* const_re, const 
     NullColumn::MutablePtr nl_col;
     if (columns[0]->is_nullable()) {
         auto x = down_cast<const NullableColumn*>(columns[0].get())->null_column();
-        nl_col = NullColumn::static_pointer_cast(x->clone());
+        nl_col = NullColumn::static_pointer_cast(std::move(*x).mutate());
     } else {
         nl_col = NullColumn::create(size, 0);
     }

--- a/be/src/exprs/time_functions.cpp
+++ b/be/src/exprs/time_functions.cpp
@@ -2567,7 +2567,7 @@ ColumnPtr date_format_func(const Columns& cols, size_t patten_size) {
 
     size_t num_rows = viewer.size();
     ColumnBuilder<TYPE_VARCHAR> builder(num_rows);
-    builder.data_column()->reserve(num_rows, num_rows * patten_size);
+    builder.data_column_raw_ptr()->reserve(num_rows, num_rows * patten_size);
 
     for (int i = 0; i < num_rows; ++i) {
         if (viewer.is_null(i)) {

--- a/be/src/formats/avro/cpp/nullable_column_reader.cpp
+++ b/be/src/formats/avro/cpp/nullable_column_reader.cpp
@@ -30,7 +30,7 @@ Status NullableColumnReader::read_datum_for_adaptive_column(const avro::GenericD
     }
 
     auto nullable_column = down_cast<AdaptiveNullableColumn*>(column);
-    auto* data_column = nullable_column->mutable_begin_append_not_default_value();
+    auto* data_column = nullable_column->begin_append_not_default_value();
     auto st = _base_reader->read_datum(datum, data_column);
     if (st.ok()) {
         nullable_column->finish_append_one_not_default_value();

--- a/be/src/formats/avro/nullable_column.cpp
+++ b/be/src/formats/avro/nullable_column.cpp
@@ -31,8 +31,8 @@ static Status add_adaptive_nullable_numeric_column(Column* column, const TypeDes
         column->append_nulls(1);
         return Status::OK();
     }
-    auto data_column = nullable_column->begin_append_not_default_value();
-    RETURN_IF_ERROR(add_numeric_column<T>(data_column.get(), type_desc, name, value));
+    auto* data_column = nullable_column->begin_append_not_default_value();
+    RETURN_IF_ERROR(add_numeric_column<T>(data_column, type_desc, name, value));
     nullable_column->finish_append_one_not_default_value();
     return Status::OK();
 }
@@ -84,9 +84,9 @@ static Status add_adpative_nullable_binary_column(Column* column, const TypeDesc
         nullable_column->append_nulls(1);
         return Status::OK();
     }
-    auto data_column = nullable_column->begin_append_not_default_value();
+    auto* data_column = nullable_column->begin_append_not_default_value();
 
-    RETURN_IF_ERROR(add_binary_column(data_column.get(), type_desc, name, value));
+    RETURN_IF_ERROR(add_binary_column(data_column, type_desc, name, value));
 
     nullable_column->finish_append_one_not_default_value();
 
@@ -115,9 +115,9 @@ static Status add_adpative_nullable_native_json_column(Column* column, const Typ
         nullable_column->append_nulls(1);
         return Status::OK();
     }
-    auto data_column = nullable_column->begin_append_not_default_value();
+    auto* data_column = nullable_column->begin_append_not_default_value();
 
-    RETURN_IF_ERROR(add_native_json_column(data_column.get(), type_desc, name, value));
+    RETURN_IF_ERROR(add_native_json_column(data_column, type_desc, name, value));
 
     nullable_column->finish_append_one_not_default_value();
 
@@ -221,7 +221,7 @@ static Status add_adpative_nullable_column(Column* column, const TypeDescriptor&
         if (avro_value_get_type(&value) == AVRO_ARRAY) {
             auto nullable_column = down_cast<AdaptiveNullableColumn*>(column);
 
-            auto array_column = down_cast<ArrayColumn*>(nullable_column->mutable_begin_append_not_default_value());
+            auto array_column = down_cast<ArrayColumn*>(nullable_column->begin_append_not_default_value());
 
             auto* elems_column = array_column->elements_column_raw_ptr();
             size_t n = 0;

--- a/be/src/formats/csv/nullable_converter.cpp
+++ b/be/src/formats/csv/nullable_converter.cpp
@@ -58,7 +58,7 @@ bool NullableConverter::read_string_for_adaptive_null_column(Column* column, Sli
     if (s == "\\N") {
         return nullable_column->append_nulls(1);
     }
-    auto* data = nullable_column->mutable_begin_append_not_default_value();
+    auto* data = nullable_column->begin_append_not_default_value();
     if (_base_converter->read_string(data, s, options)) {
         nullable_column->finish_append_one_not_default_value();
         return true;

--- a/be/src/formats/json/nullable_column.cpp
+++ b/be/src/formats/json/nullable_column.cpp
@@ -37,8 +37,8 @@ static Status add_adaptive_nullable_numeric_column(Column* column, const TypeDes
     auto nullable_column = down_cast<AdaptiveNullableColumn*>(column);
 
     try {
-        auto data_column = nullable_column->begin_append_not_default_value();
-        RETURN_IF_ERROR(add_numeric_column<T>(data_column.get(), type_desc, name, value));
+        auto* data_column = nullable_column->begin_append_not_default_value();
+        RETURN_IF_ERROR(add_numeric_column<T>(data_column, type_desc, name, value));
         nullable_column->finish_append_one_not_default_value();
         return Status::OK();
     } catch (simdjson::simdjson_error& e) {
@@ -189,7 +189,7 @@ static Status add_adaptive_nullable_boolean_column(Column* column, const TypeDes
     auto nullable_column = down_cast<AdaptiveNullableColumn*>(column);
 
     try {
-        auto data_column = nullable_column->begin_append_not_default_value();
+        auto* data_column = nullable_column->begin_append_not_default_value();
         RETURN_IF_ERROR(add_boolean_column(data_column, type_desc, name, value));
         nullable_column->finish_append_one_not_default_value();
         return Status::OK();
@@ -224,7 +224,7 @@ static Status add_adaptive_nullable_binary_column(Column* column, const TypeDesc
     auto nullable_column = down_cast<AdaptiveNullableColumn*>(column);
 
     try {
-        auto data_column = nullable_column->begin_append_not_default_value();
+        auto* data_column = nullable_column->begin_append_not_default_value();
         RETURN_IF_ERROR(add_binary_column(data_column, type_desc, name, value));
         nullable_column->finish_append_one_not_default_value();
         return Status::OK();
@@ -258,7 +258,7 @@ static Status add_adaptive_nullable_native_json_column(Column* column, const Typ
     auto nullable_column = down_cast<AdaptiveNullableColumn*>(column);
 
     try {
-        auto data_column = nullable_column->begin_append_not_default_value();
+        auto* data_column = nullable_column->begin_append_not_default_value();
         RETURN_IF_ERROR(add_native_json_column(data_column, type_desc, name, value));
         nullable_column->finish_append_one_not_default_value();
         return Status::OK();
@@ -292,7 +292,7 @@ static Status add_adaptive_nullable_array_column(Column* column, const TypeDescr
     try {
         if (value->type() == simdjson::ondemand::json_type::array) {
             auto nullable_column = down_cast<AdaptiveNullableColumn*>(column);
-            auto array_column = down_cast<ArrayColumn*>(nullable_column->mutable_begin_append_not_default_value());
+            auto array_column = down_cast<ArrayColumn*>(nullable_column->begin_append_not_default_value());
             auto* elems_column = array_column->elements_column_raw_ptr();
 
             simdjson::ondemand::array arr = value->get_array();
@@ -358,7 +358,7 @@ static Status add_adaptive_nullable_struct_column(Column* column, const TypeDesc
                                                   const std::string& name, simdjson::ondemand::value* value) {
     DCHECK(!value->is_null());
     auto nullable_column = down_cast<AdaptiveNullableColumn*>(column);
-    auto data_column = nullable_column->begin_append_not_default_value();
+    auto* data_column = nullable_column->begin_append_not_default_value();
     RETURN_IF_ERROR(add_struct_column(data_column, type_desc, name, value));
     nullable_column->finish_append_one_not_default_value();
     return Status::OK();
@@ -379,7 +379,7 @@ static Status add_adaptive_nullable_map_column(Column* column, const TypeDescrip
                                                simdjson::ondemand::value* value) {
     DCHECK(!value->is_null());
     auto nullable_column = down_cast<AdaptiveNullableColumn*>(column);
-    auto data_column = nullable_column->begin_append_not_default_value();
+    auto* data_column = nullable_column->begin_append_not_default_value();
     RETURN_IF_ERROR(add_map_column(data_column, type_desc, name, value));
     nullable_column->finish_append_one_not_default_value();
     return Status::OK();
@@ -466,7 +466,7 @@ Status add_adaptive_nullable_column_by_json_object(Column* column, const TypeDes
     try {
         auto nullable_column = down_cast<AdaptiveNullableColumn*>(column);
 
-        auto data_column = nullable_column->begin_append_not_default_value();
+        auto* data_column = nullable_column->begin_append_not_default_value();
 
         switch (type_desc.type) {
         case TYPE_JSON: {
@@ -475,7 +475,7 @@ Status add_adaptive_nullable_column_by_json_object(Column* column, const TypeDes
         }
         case TYPE_VARCHAR:
         case TYPE_CHAR: {
-            RETURN_IF_ERROR(add_binary_column_from_json_object(data_column.get(), type_desc, name, value));
+            RETURN_IF_ERROR(add_binary_column_from_json_object(data_column, type_desc, name, value));
             break;
         }
         default:

--- a/be/src/io/compressed_input_stream.h
+++ b/be/src/io/compressed_input_stream.h
@@ -84,8 +84,7 @@ private:
 
 class CompressedSeekableInputStream final : public SeekableInputStream {
 public:
-    CompressedSeekableInputStream(std::shared_ptr<CompressedInputStream> source)
-            : _source(std::move(std::move(source))) {}
+    CompressedSeekableInputStream(std::shared_ptr<CompressedInputStream> source) : _source(std::move(source)) {}
 
     StatusOr<int64_t> read(void* data, int64_t size) override { return _source->read(data, size); }
 

--- a/be/src/runtime/data_stream_sender.cpp
+++ b/be/src/runtime/data_stream_sender.cpp
@@ -318,7 +318,7 @@ Status DataStreamSender::Channel::_send_current_chunk(bool eos) {
 
     // we only clear column data, because we need to reuse column schema
     for (ColumnPtr& column : _chunk->columns()) {
-        column->as_mutable_ptr()->resize(0);
+        column->as_mutable_raw_ptr()->resize(0);
     }
     return Status::OK();
 }

--- a/be/src/runtime/global_dict/parser.cpp
+++ b/be/src/runtime/global_dict/parser.cpp
@@ -136,7 +136,7 @@ private:
         }
 
         if (_always_const) {
-            auto res = _dict_opt_ctx->convert_column->clone();
+            auto res = std::move(*_dict_opt_ctx->convert_column).mutate();
             res->resize(num_rows);
             return res;
         }

--- a/be/src/storage/column_expr_predicate.cpp
+++ b/be/src/storage/column_expr_predicate.cpp
@@ -80,7 +80,7 @@ Status ColumnExprPredicate::evaluate(const Column* column, uint8_t* selection, u
     Chunk chunk;
     // `column` is owned by storage layer
     // we don't have ownership
-    ColumnPtr bits = const_cast<Column*>(column)->as_mutable_ptr();
+    ColumnPtr bits = column->get_ptr();
     chunk.append_column(bits, _slot_desc->id());
 
     // theoretically there will be a chain of expr contexts.

--- a/be/src/storage/lake/fixed_location_provider.h
+++ b/be/src/storage/lake/fixed_location_provider.h
@@ -23,7 +23,7 @@ namespace starrocks::lake {
 
 class FixedLocationProvider : public LocationProvider {
 public:
-    explicit FixedLocationProvider(std::string root) : _root(std::move(std::move(root))) {
+    explicit FixedLocationProvider(std::string root) : _root(std::move(root)) {
         while (!_root.empty() && _root.back() == '/') {
             _root.pop_back();
         }

--- a/be/test/storage/lake/lake_primary_key_consistency_test.cpp
+++ b/be/test/storage/lake/lake_primary_key_consistency_test.cpp
@@ -103,11 +103,11 @@ public:
         for (int i = 0; i < chunk->num_rows(); i++) {
             if (tmp_chunk.count(chunk->columns()[0]->get(i).get_slice().to_string()) > 0) {
                 // duplicate pk
-                LOG(ERROR) << "duplicate pk: " << chunk->mutable_columns()[0]->get(i).get_slice().to_string();
+                LOG(ERROR) << "duplicate pk: " << chunk->columns()[0]->get(i).get_slice().to_string();
                 return false;
             }
-            tmp_chunk[chunk->mutable_columns()[0]->get(i).get_slice().to_string()] = {
-                    chunk->mutable_columns()[1]->get(i).get_int32(), chunk->mutable_columns()[2]->get(i).get_int32()};
+            tmp_chunk[chunk->columns()[0]->get(i).get_slice().to_string()] = {
+                    chunk->columns()[1]->get(i).get_int32(), chunk->columns()[2]->get(i).get_int32()};
         }
         if (tmp_chunk.size() != _replayer_index.size()) {
             LOG(ERROR) << "inconsistency row number, actual : " << tmp_chunk.size()
@@ -146,26 +146,26 @@ public:
             if (log.op == ReplayerOP::UPSERT) {
                 // Upsert
                 for (int i = 0; i < chunk->num_rows(); i++) {
-                    _replayer_index[chunk->mutable_columns()[0]->get(i).get_slice().to_string()] = {
-                            chunk->mutable_columns()[1]->get(i).get_int32(),
-                            chunk->mutable_columns()[2]->get(i).get_int32()};
+                    _replayer_index[chunk->columns()[0]->get(i).get_slice().to_string()] = {
+                            chunk->columns()[1]->get(i).get_int32(),
+                            chunk->columns()[2]->get(i).get_int32()};
                 }
             } else if (log.op == ReplayerOP::ERASE) {
                 // Delete
                 for (int i = 0; i < chunk->num_rows(); i++) {
-                    _replayer_index.erase(chunk->mutable_columns()[0]->get(i).get_slice().to_string());
+                    _replayer_index.erase(chunk->columns()[0]->get(i).get_slice().to_string());
                 }
             } else if (log.op == ReplayerOP::PARTIAL_UPSERT || log.op == ReplayerOP::PARTIAL_UPDATE) {
                 // Partial update
                 for (int i = 0; i < chunk->num_rows(); i++) {
-                    auto iter = _replayer_index.find(chunk->mutable_columns()[0]->get(i).get_slice().to_string());
+                    auto iter = _replayer_index.find(chunk->columns()[0]->get(i).get_slice().to_string());
                     if (iter != _replayer_index.end()) {
-                        _replayer_index[chunk->mutable_columns()[0]->get(i).get_slice().to_string()] = {
-                                chunk->mutable_columns()[1]->get(i).get_int32(), iter->second.second};
+                        _replayer_index[chunk->columns()[0]->get(i).get_slice().to_string()] = {
+                                chunk->columns()[1]->get(i).get_int32(), iter->second.second};
                     } else if (log.op == ReplayerOP::PARTIAL_UPSERT) {
                         // insert new record with default val
-                        _replayer_index[chunk->mutable_columns()[0]->get(i).get_slice().to_string()] = {
-                                chunk->mutable_columns()[1]->get(i).get_int32(), 0};
+                        _replayer_index[chunk->columns()[0]->get(i).get_slice().to_string()] = {
+                                chunk->columns()[1]->get(i).get_int32(), 0};
                     } else {
                         // do nothing
                     }
@@ -174,11 +174,11 @@ public:
                 // condition update
                 auto is_condition_meet_fn = [&](const std::pair<int, int>& current, int index) {
                     if (log.condition_col == "c1") {
-                        if (chunk->mutable_columns()[1]->get(index).get_int32() >= current.first) {
+                        if (chunk->columns()[1]->get(index).get_int32() >= current.first) {
                             return true;
                         }
                     } else if (log.condition_col == "c2") {
-                        if (chunk->mutable_columns()[2]->get(index).get_int32() >= current.second) {
+                        if (chunk->columns()[2]->get(index).get_int32() >= current.second) {
                             return true;
                         }
                     } else {
@@ -187,11 +187,11 @@ public:
                     return false;
                 };
                 for (int i = 0; i < chunk->num_rows(); i++) {
-                    auto iter = _replayer_index.find(chunk->mutable_columns()[0]->get(i).get_slice().to_string());
+                    auto iter = _replayer_index.find(chunk->columns()[0]->get(i).get_slice().to_string());
                     if (iter == _replayer_index.end() || is_condition_meet_fn(iter->second, i)) {
                         // update if condition meet or not found
                         // insert new record
-                        _replayer_index[chunk->mutable_columns()[0]->get(i).get_slice().to_string()] = {
+                        _replayer_index[chunk->columns()[0]->get(i).get_slice().to_string()] = {
                                 chunk->columns()[1]->get(i).get_int32(), chunk->columns()[2]->get(i).get_int32()};
                     }
                 }

--- a/be/test/storage/lake/lake_primary_key_consistency_test.cpp
+++ b/be/test/storage/lake/lake_primary_key_consistency_test.cpp
@@ -106,8 +106,8 @@ public:
                 LOG(ERROR) << "duplicate pk: " << chunk->columns()[0]->get(i).get_slice().to_string();
                 return false;
             }
-            tmp_chunk[chunk->columns()[0]->get(i).get_slice().to_string()] = {
-                    chunk->columns()[1]->get(i).get_int32(), chunk->columns()[2]->get(i).get_int32()};
+            tmp_chunk[chunk->columns()[0]->get(i).get_slice().to_string()] = {chunk->columns()[1]->get(i).get_int32(),
+                                                                              chunk->columns()[2]->get(i).get_int32()};
         }
         if (tmp_chunk.size() != _replayer_index.size()) {
             LOG(ERROR) << "inconsistency row number, actual : " << tmp_chunk.size()
@@ -147,8 +147,7 @@ public:
                 // Upsert
                 for (int i = 0; i < chunk->num_rows(); i++) {
                     _replayer_index[chunk->columns()[0]->get(i).get_slice().to_string()] = {
-                            chunk->columns()[1]->get(i).get_int32(),
-                            chunk->columns()[2]->get(i).get_int32()};
+                            chunk->columns()[1]->get(i).get_int32(), chunk->columns()[2]->get(i).get_int32()};
                 }
             } else if (log.op == ReplayerOP::ERASE) {
                 // Delete


### PR DESCRIPTION
## Why I'm doing:

This is a followup of #66037 

Try to use `as_mutable_ptr` and `as_mutable_raw_ptr` as less as possible.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens copy-on-write (COW) semantics and reduces unsafe mutable access patterns across column, array/map/struct, and expr code paths.
> 
> - Introduces `config::enable_cow_optimization` and `config::cow_optimization_diagnose_level`; adds diagnostics/logging in `cow.h`; gates `Column::mutate()` behavior by config
> - Reworks `Column::upgrade_helper_func`/`downgrade_helper_func` to accept raw `Column*` and return optional new columns; updates callers (`NullableColumn`, `ConstColumn`, `ArrayColumn`, `MapColumn`, `StructColumn`, `AdaptiveNullableColumn`, etc.)
> - Replaces `as_mutable_ptr()` with move-based `mutate()` or `as_mutable_raw_ptr()`; updates builders (`ColumnBuilder`, `NullableBinaryColumnBuilder`), `Chunk::mutable_columns`, and `ColumnHelper::to_mutable_columns`
> - Adjusts const-unfold and clone paths to avoid unsafe sharing and redundant clones; switches many `clone()`/`clone_empty()` and unwrap/wrap flows to move/mutate
> - Changes `AdaptiveNullableColumn::begin_append_not_default_value` to return `Column*`; propagates to CSV/JSON/Avro readers and array/map processing
> - Cleans up double std::move and minor correctness fixes (bench, exchange/file/mysql sink operators, json/path, io wrapper); adds config include to `column.h`
> 
> Scope: widespread API updates in columns/exprs/functions; no behavior change intended aside from configurable COW optimization and added diagnostics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebc1084a41a11d47c9f618a976ac557d8dacd296. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->