### PR TITLE
[Feature] Add tablet range pruning for range-distribution Lake tables for shared segments and sstables.

### DIFF
--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -204,6 +204,8 @@ set(STORAGE_FILES
     lake/tablet.cpp
     lake/tablet_manager.cpp
     lake/tablet_reader.cpp
+    lake/tablet_range_helper.cpp
+    lake/sst_seek_range.cpp
     lake/transactions.cpp
     lake/metadata_iterator.cpp
     lake/spark_load.cpp

--- a/be/src/storage/lake/lake_persistent_index.h
+++ b/be/src/storage/lake/lake_persistent_index.h
@@ -176,12 +176,12 @@ private:
     static Status prepare_merging_iterator(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata,
                                            TxnLogPB* txn_log,
                                            std::vector<std::shared_ptr<PersistentIndexSstable>>* merging_sstables,
-                                           std::unique_ptr<sstable::Iterator>* merging_iter_ptr,
-                                           bool* merge_base_level);
+                                           std::unique_ptr<sstable::Iterator>* merging_iter_ptr, bool* merge_base_level,
+                                           bool* contain_shared_sstables);
 
     static StatusOr<std::vector<KeyValueMerger::KeyValueMergerOutput>> merge_sstables(
             std::unique_ptr<sstable::Iterator> iter_ptr, bool base_level_merge, TabletManager* tablet_mgr,
-            int64_t tablet_id);
+            const TabletMetadataPtr& metadata, bool contain_shared_sstables);
 
     Status merge_sstable_into_fileset(std::unique_ptr<PersistentIndexSstable>& sstable);
 

--- a/be/src/storage/lake/lake_persistent_index_parallel_compact_mgr.h
+++ b/be/src/storage/lake/lake_persistent_index_parallel_compact_mgr.h
@@ -20,8 +20,8 @@
 #include <vector>
 
 #include "common/status.h"
-#include "gen_cpp/lake_types.pb.h"
 #include "gutil/ref_counted.h"
+#include "storage/lake/sst_seek_range.h"
 #include "storage/lake/tablet_metadata.h"
 #include "util/threadpool.h"
 #include "util/trace.h"
@@ -66,21 +66,12 @@ private:
 
 using AsyncCompactCBPtr = std::unique_ptr<AsyncCompactCB>;
 
-// SeekRange represents a basic key range unit for compaction tasks split.
-struct SeekRange {
-    // scan range is [seek_key, stop_key). stop_key is exclusive.
-    std::string seek_key;
-    std::string stop_key; // could be empty meaning infinity
-    bool has_overlap(const PersistentIndexSstableRangePB& range) const;
-    bool full_contains(const PersistentIndexSstableRangePB& range) const;
-};
-
 class LakePersistentIndexParallelCompactTask : public Runnable {
 public:
     LakePersistentIndexParallelCompactTask(const std::vector<std::vector<PersistentIndexSstablePB>>& input_sstables,
                                            TabletManager* tablet_mgr, const TabletMetadataPtr& metadata,
                                            bool merge_base_level, const UniqueId& fileset_id,
-                                           const SeekRange& seek_range)
+                                           const SstSeekRange& seek_range)
             : _input_sstables(input_sstables),
               _tablet_mgr(tablet_mgr),
               _metadata(metadata),
@@ -112,7 +103,7 @@ private:
     TabletMetadataPtr _metadata;
     bool _merge_base_level = false;
     UniqueId _output_fileset_id;
-    SeekRange _seek_range;
+    SstSeekRange _seek_range;
     AsyncCompactCB* _cb = nullptr;
     // output sstable pb
     std::vector<PersistentIndexSstablePB> _output_sstables;

--- a/be/src/storage/lake/sst_seek_range.cpp
+++ b/be/src/storage/lake/sst_seek_range.cpp
@@ -1,0 +1,60 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/sst_seek_range.h"
+
+namespace starrocks::lake {
+
+bool SstSeekRange::has_overlap(const PersistentIndexSstableRangePB& range) const {
+    const auto* cmp = sstable::BytewiseComparator();
+    // range is on the right side of [seek_key, stop_key)
+    if (!stop_key.empty() && cmp->Compare(Slice(stop_key), Slice(range.start_key())) <= 0) {
+        return false;
+    }
+    // range is on the left side of [seek_key, stop_key)
+    if (cmp->Compare(Slice(range.end_key()), Slice(seek_key)) < 0) {
+        return false;
+    }
+    return true;
+}
+
+bool SstSeekRange::full_contains(const PersistentIndexSstableRangePB& range) const {
+    const auto* cmp = sstable::BytewiseComparator();
+    if (cmp->Compare(Slice(seek_key), Slice(range.start_key())) > 0) {
+        return false;
+    }
+    if (!stop_key.empty() && cmp->Compare(Slice(stop_key), Slice(range.end_key())) <= 0) {
+        return false;
+    }
+    return true;
+}
+
+SstSeekRange& SstSeekRange::operator&=(const SstSeekRange& rhs) {
+    const auto* cmp = sstable::BytewiseComparator();
+
+    if (seek_key.empty()) {
+        seek_key = rhs.seek_key;
+    } else if (!rhs.seek_key.empty() && cmp->Compare(Slice(seek_key), Slice(rhs.seek_key)) < 0) {
+        seek_key = rhs.seek_key;
+    }
+
+    if (stop_key.empty()) {
+        stop_key = rhs.stop_key;
+    } else if (!rhs.stop_key.empty() && cmp->Compare(Slice(stop_key), Slice(rhs.stop_key)) > 0) {
+        stop_key = rhs.stop_key;
+    }
+    return *this;
+}
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/sst_seek_range.h
+++ b/be/src/storage/lake/sst_seek_range.h
@@ -1,0 +1,46 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+#include "gen_cpp/lake_types.pb.h"
+#include "storage/sstable/comparator.h"
+#include "util/slice.h"
+
+namespace starrocks::lake {
+
+// SstSeekRange represents a basic key range unit for compaction tasks split.
+// The scan range is [seek_key, stop_key). stop_key is exclusive.
+class SstSeekRange {
+public:
+    // could be empty meaning infinity
+    std::string seek_key;
+    std::string stop_key;
+
+    SstSeekRange() = default;
+    SstSeekRange(std::string seek, std::string stop) : seek_key(std::move(seek)), stop_key(std::move(stop)) {}
+
+    // Return true when [seek_key, stop_key) and [range.start_key(), range.end_key()] overlap.
+    bool has_overlap(const PersistentIndexSstableRangePB& range) const;
+
+    // Return true when [seek_key, stop_key) fully contains [range.start_key(), range.end_key()].
+    bool full_contains(const PersistentIndexSstableRangePB& range) const;
+
+    // Intersect this range with rhs.
+    SstSeekRange& operator&=(const SstSeekRange& rhs);
+};
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_range_helper.cpp
+++ b/be/src/storage/lake/tablet_range_helper.cpp
@@ -1,0 +1,200 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/tablet_range_helper.h"
+
+#include <memory>
+
+#include "column/binary_column.h"
+#include "column/column_helper.h"
+#include "column/datum_convert.h"
+#include "column/schema.h"
+#include "common/logging.h"
+#include "fmt/format.h"
+#include "storage/chunk_helper.h"
+#include "storage/primary_key_encoder.h"
+#include "storage/types.h"
+
+namespace starrocks::lake {
+
+Status TabletRangeHelper::_parse_string_to_datum(const TypeDescriptor& type_desc, const std::string& value_str,
+                                                 Datum* datum, MemPool* mem_pool) {
+    auto type_info = get_type_info(type_desc);
+    if (type_info == nullptr) {
+        return Status::InternalError(fmt::format("Unsupported type: {}", type_desc.type));
+    }
+    return datum_from_string(type_info.get(), datum, value_str, mem_pool);
+}
+
+Status TabletRangeHelper::_validate_tablet_range(const TabletRangePB& tablet_range_pb) {
+    if (!tablet_range_pb.has_lower_bound() && !tablet_range_pb.has_upper_bound()) {
+        return Status::OK();
+    }
+
+    if (tablet_range_pb.has_upper_bound()) {
+        if (!tablet_range_pb.has_upper_bound_included()) {
+            return Status::Corruption("upper_bound_included is required");
+        }
+        if (tablet_range_pb.upper_bound_included()) {
+            return Status::Corruption("Upper bound is inclusive");
+        }
+    }
+
+    if (tablet_range_pb.has_lower_bound()) {
+        if (!tablet_range_pb.has_lower_bound_included()) {
+            return Status::Corruption("lower_bound_included is required");
+        }
+        if (!tablet_range_pb.lower_bound_included()) {
+            return Status::Corruption("Lower bound is exclusive");
+        }
+    }
+
+    return Status::OK();
+}
+
+StatusOr<SeekRange> TabletRangeHelper::create_seek_range_from(const TabletRangePB& tablet_range_pb,
+                                                              const TabletSchemaCSPtr& tablet_schema,
+                                                              MemPool* mem_pool) {
+    SeekRange tablet_range;
+    RETURN_IF_ERROR(_validate_tablet_range(tablet_range_pb));
+    if (!tablet_range_pb.has_lower_bound() && !tablet_range_pb.has_upper_bound()) {
+        // (-inf, +inf)
+        return tablet_range;
+    }
+    const auto& sort_key_idxes = tablet_schema->sort_key_idxes();
+    DCHECK(!sort_key_idxes.empty());
+    auto parse_bound_to_seek_tuple = [&](const TuplePB& tuple) -> StatusOr<SeekTuple> {
+        const int n = tuple.values_size();
+        if (n != sort_key_idxes.size()) {
+            return Status::Corruption(
+                    fmt::format("Unexpected number of values in TabletRangePB bound value, expected: {}, actual: {}",
+                                sort_key_idxes.size(), n));
+        }
+
+        Schema schema;
+        std::vector<Datum> values;
+        values.reserve(n);
+        for (int i = 0; i < n; i++) {
+            const int idx = sort_key_idxes[i];
+            schema.append_sort_key_idx(idx);
+            auto f = std::make_shared<Field>(ChunkHelper::convert_field(idx, tablet_schema->column(idx)));
+            schema.append(std::move(f));
+
+            const auto& v = tuple.values(i);
+            if (!v.has_type()) {
+                return Status::Corruption("Missing type in TabletRangePB bound value");
+            }
+            if (!v.has_value()) {
+                return Status::Corruption("Missing value in TabletRangePB_VariantPB bound value");
+            }
+
+            Datum datum;
+            auto type_desc = TypeDescriptor::from_protobuf(v.type());
+            RETURN_IF_ERROR(_parse_string_to_datum(type_desc, v.value(), &datum, mem_pool));
+            values.emplace_back(std::move(datum));
+        }
+        return SeekTuple(std::move(schema), std::move(values));
+    };
+
+    SeekTuple lower;
+    SeekTuple upper;
+    if (tablet_range_pb.has_lower_bound()) {
+        ASSIGN_OR_RETURN(lower, parse_bound_to_seek_tuple(tablet_range_pb.lower_bound()));
+    }
+    if (tablet_range_pb.has_upper_bound()) {
+        ASSIGN_OR_RETURN(upper, parse_bound_to_seek_tuple(tablet_range_pb.upper_bound()));
+    }
+
+    tablet_range = SeekRange(std::move(lower), std::move(upper));
+    tablet_range.set_inclusive_lower(tablet_range_pb.lower_bound_included());
+    tablet_range.set_inclusive_upper(tablet_range_pb.upper_bound_included());
+    return tablet_range;
+}
+
+// TabletRangePB should always be [lower_bound, upper_bound) which is consistent with the SstSeekRange.
+StatusOr<SstSeekRange> TabletRangeHelper::create_sst_seek_range_from(const TabletRangePB& tablet_range_pb,
+                                                                     const TabletSchemaCSPtr& tablet_schema) {
+    SstSeekRange sst_seek_range;
+    RETURN_IF_ERROR(_validate_tablet_range(tablet_range_pb));
+    if (!tablet_range_pb.has_lower_bound() && !tablet_range_pb.has_upper_bound()) {
+        // (-inf, +inf)
+        return sst_seek_range;
+    }
+
+    const auto& sort_key_idxes = tablet_schema->sort_key_idxes();
+    DCHECK(!sort_key_idxes.empty());
+    // sort key must the same as pk key
+    RETURN_IF(sort_key_idxes.size() != tablet_schema->num_key_columns(),
+              Status::InternalError(fmt::format("Sort key index size {} must be the same as pk key size {}",
+                                                sort_key_idxes.size(), tablet_schema->num_key_columns())));
+    for (int i = 0; i < tablet_schema->num_key_columns(); i++) {
+        if (sort_key_idxes[i] != i) {
+            return Status::InternalError(
+                    fmt::format("Sort key index {} must be {}, but is {}", i, i, sort_key_idxes[i]));
+        }
+    }
+
+    auto parse_bound_to_seek_string = [&](const TuplePB& tuple) -> StatusOr<std::string> {
+        DCHECK_EQ(tuple.values_size(), static_cast<int>(sort_key_idxes.size()));
+        if (tuple.values_size() != sort_key_idxes.size()) {
+            return Status::Corruption(
+                    fmt::format("Unexpected number of values in TabletRangePB bound value, expected: {}, actual: {}",
+                                sort_key_idxes.size(), tuple.values_size()));
+        }
+
+        auto chunk = std::make_unique<Chunk>();
+        for (int i = 0; i < tuple.values_size(); i++) {
+            const int idx = sort_key_idxes[i];
+            const auto& v = tuple.values(i);
+            if (!v.has_type()) {
+                return Status::Corruption("Missing type in TabletRangePB bound value");
+            }
+            if (!v.has_value()) {
+                return Status::Corruption("Missing value in TabletRangePB_VariantPB bound value");
+            }
+
+            Datum datum;
+            auto type_desc = TypeDescriptor::from_protobuf(v.type());
+            RETURN_IF_ERROR(_parse_string_to_datum(type_desc, v.value(), &datum, nullptr));
+            auto column = ColumnHelper::create_column(type_desc, false);
+            column->append_datum(datum);
+            chunk->append_column(std::move(column), (SlotId)idx);
+        }
+
+        std::vector<ColumnId> pk_columns(tablet_schema->num_key_columns());
+        for (int i = 0; i < tablet_schema->num_key_columns(); i++) {
+            pk_columns[i] = (ColumnId)i;
+        }
+        auto pkey_schema = ChunkHelper::convert_schema(tablet_schema, pk_columns);
+        MutableColumnPtr pk_column;
+        RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));
+        PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, 1, pk_column.get());
+        if (pk_column->is_binary()) {
+            return down_cast<BinaryColumn*>(pk_column.get())->get_slice(0).to_string();
+        } else {
+            return std::string(reinterpret_cast<const char*>(pk_column->raw_data()), pk_column->type_size());
+        }
+    };
+
+    if (tablet_range_pb.has_lower_bound()) {
+        ASSIGN_OR_RETURN(sst_seek_range.seek_key, parse_bound_to_seek_string(tablet_range_pb.lower_bound()));
+    }
+    if (tablet_range_pb.has_upper_bound()) {
+        ASSIGN_OR_RETURN(sst_seek_range.stop_key, parse_bound_to_seek_string(tablet_range_pb.upper_bound()));
+    }
+
+    return sst_seek_range;
+}
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_range_helper.h
+++ b/be/src/storage/lake/tablet_range_helper.h
@@ -1,0 +1,61 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <vector>
+
+#include "column/chunk.h"
+#include "common/statusor.h"
+#include "gen_cpp/Types_types.h"
+#include "gen_cpp/types.pb.h"
+#include "storage/lake/sst_seek_range.h"
+#include "storage/seek_range.h"
+#include "storage/tablet_schema.h"
+
+namespace starrocks::lake {
+class TabletRangeHelper {
+public:
+    /**
+     * @brief Create a SeekRange from TabletRangePB.
+     *
+     * @note IMPORTANT:
+     *  - If `mem_pool` is nullptr, the returned SeekRange may contain Slices that point
+     *    directly to the string data within `tablet_range_pb` for string-like columns.
+     *    The caller MUST ensure that `tablet_range_pb` outlives the returned SeekRange
+     *    to avoid dangling pointers.
+     *  - If `mem_pool` is non-null, the string data will be copied into `mem_pool`, and
+     *    the caller MUST ensure that `mem_pool` outlives the returned SeekRange.
+     *
+     * @param tablet_range_pb The protobuf source of the range.
+     * @param tablet_schema The schema used to parse types.
+     * @param mem_pool Optional memory pool used to allocate string data for Slices.
+     * @return StatusOr<SeekRange> A SeekRange referencing data owned either by
+     *         `tablet_range_pb` or `mem_pool`, depending on `mem_pool`.
+     */
+    static StatusOr<SeekRange> create_seek_range_from(const TabletRangePB& tablet_range_pb,
+                                                      const TabletSchemaCSPtr& tablet_schema, MemPool* mem_pool);
+
+    static StatusOr<SstSeekRange> create_sst_seek_range_from(const TabletRangePB& tablet_range_pb,
+                                                             const TabletSchemaCSPtr& tablet_schema);
+
+private:
+    static Status _parse_string_to_datum(const TypeDescriptor& type_desc, const std::string& value_str, Datum* datum,
+                                         MemPool* mem_pool);
+
+    // check if the tablet range is closedOpen
+    static Status _validate_tablet_range(const TabletRangePB& tablet_range_pb);
+};
+
+} // namespace starrocks::lake

--- a/be/src/storage/rowset/segment_options.cpp
+++ b/be/src/storage/rowset/segment_options.cpp
@@ -69,6 +69,12 @@ Status SegmentReadOptions::convert_to(SegmentReadOptions* dst, const std::vector
     dst->rowid_range_option = rowid_range_option;
     dst->short_key_ranges = short_key_ranges;
     dst->is_first_split_of_segment = is_first_split_of_segment;
+    if (tablet_range.has_value()) {
+        dst->tablet_range = SeekRange();
+        tablet_range->convert_to(&dst->tablet_range.value(), new_types);
+    } else {
+        dst->tablet_range.reset();
+    }
 
     return Status::OK();
 }

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <optional>
 #include <unordered_map>
 #include <vector>
 
@@ -56,6 +57,9 @@ public:
 
     // Specified ranges outside the segment, is used to support parallel-reading within a tablet
     std::vector<SeekRange> ranges;
+
+    // Use to filter the data by range distribution key
+    std::optional<SeekRange> tablet_range;
 
     PredicateTree pred_tree;
     PredicateTree pred_tree_for_zone_map;

--- a/be/src/storage/seek_range.h
+++ b/be/src/storage/seek_range.h
@@ -39,6 +39,8 @@ public:
     const SeekTuple& lower() const { return _lower; }
     const SeekTuple& upper() const { return _upper; }
 
+    bool all_range() const { return _lower.empty() && _upper.empty(); }
+
     void convert_to(SeekRange* dst, const std::vector<LogicalType>& new_types) const {
         dst->_inc_lower = _inc_lower;
         dst->_inc_upper = _inc_upper;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -533,6 +533,8 @@ SET(DW_TEST_FILES
     ./storage/lake/spill_mem_table_sink_test.cpp
     ./storage/lake/starlet_location_provider_test.cpp
     ./storage/lake/tablet_manager_test.cpp
+    ./storage/lake/tablet_range_helper_test.cpp
+    ./storage/lake/sst_seek_range_test.cpp
     ./storage/lake/tablet_reader_test.cpp
     ./storage/lake/tablet_retain_info_test.cpp
     ./storage/lake/tablet_test.cpp

--- a/be/test/exec/range_router_test.cpp
+++ b/be/test/exec/range_router_test.cpp
@@ -28,6 +28,7 @@
 #include "runtime/descriptors.h"
 #include "runtime/types.h"
 #include "storage/type_utils.h"
+#include "testutil/assert.h"
 
 namespace starrocks {
 
@@ -506,6 +507,141 @@ TEST_F(RangeRouterTest, VarcharThreeRangesFullCoverage) {
     // "banana","cherry" -> R1 (20)
     // "date", "fig"     -> R2 (30)
     std::vector<int64_t> expected = {10, 20, 20, 30, 30};
+    ASSERT_EQ(expected.size(), routed_ids.size());
+    for (int i = 0; i < static_cast<int>(expected.size()); ++i) {
+        ASSERT_EQ(expected[i], routed_ids[i]) << "row " << i << " value " << values[i] << " mismatch";
+    }
+}
+
+// ----------------------------------------------------------------------
+// Tests that explicitly exercise RangeRouter::_validate_range() error
+// branches.
+// ----------------------------------------------------------------------
+
+// NOLINTNEXTLINE
+TEST_F(RangeRouterTest, ValidateRangeRejectsOverlappingInclusiveBounds) {
+    // Two ranges that both include the shared boundary value at 10.
+    // R0: (-inf, 10]
+    // R1: [10, +inf)
+    std::vector<TTabletRange> ranges;
+    ranges.emplace_back(make_single_long_range(std::nullopt, false, 10, true));
+    ranges.emplace_back(make_single_long_range(10, true, std::nullopt, false));
+
+    RangeRouter router;
+    Status st = router.init(ranges, 1);
+    ASSERT_FALSE(st.ok());
+    assert_status_message_contains(
+            st, "adjacent ranges are overlapping / not complementary for the inclusive/exclusive bound");
+}
+
+// NOLINTNEXTLINE
+TEST_F(RangeRouterTest, ValidateRangeRejectsTypeMismatchOnBoundary) {
+    // Two ranges whose boundary values are equal in string form but use
+    // different TVariant.type descriptors, which should be rejected.
+    //
+    // To simulate this, construct the TTabletRanges manually instead of using
+    // the helpers above.
+    std::vector<TTabletRange> ranges(2);
+
+    // R0: (-inf, 10) with INT type
+    {
+        TVariant v;
+        v.__set_type(TYPE_INT_DESC.to_thrift());
+        v.__set_value("10");
+        TTuple upper;
+        upper.__set_values(std::vector<TVariant>{v});
+        ranges[0].__set_upper_bound(upper);
+        ranges[0].__set_upper_bound_included(false);
+    }
+
+    // R1: [10, +inf) with VARCHAR type
+    {
+        TVariant v;
+        v.__set_type(TYPE_VARCHAR_DESC.to_thrift());
+        v.__set_value("10");
+        TTuple lower;
+        lower.__set_values(std::vector<TVariant>{v});
+        ranges[1].__set_lower_bound(lower);
+        ranges[1].__set_lower_bound_included(true);
+    }
+
+    RangeRouter router;
+    Status st = router.init(ranges, 1);
+    ASSERT_FALSE(st.ok());
+    assert_status_message_contains(st, "Type mismatch at column 0 between range[0] and range[1]");
+}
+
+// NOLINTNEXTLINE
+TEST_F(RangeRouterTest, ValidateRangeRejectsUpperLowerValueMismatch) {
+    // Two ranges whose boundary types are the same but the encoded values
+    // differ, which should be rejected.
+    //
+    // R0: (-inf, 10)
+    // R1: [20, +inf)
+    std::vector<TTabletRange> ranges(2);
+
+    {
+        TVariant v;
+        v.__set_type(TYPE_INT_DESC.to_thrift());
+        v.__set_value("10");
+        TTuple upper;
+        upper.__set_values(std::vector<TVariant>{v});
+        ranges[0].__set_upper_bound(upper);
+        ranges[0].__set_upper_bound_included(false);
+    }
+
+    {
+        TVariant v;
+        v.__set_type(TYPE_INT_DESC.to_thrift());
+        v.__set_value("20");
+        TTuple lower;
+        lower.__set_values(std::vector<TVariant>{v});
+        ranges[1].__set_lower_bound(lower);
+        ranges[1].__set_lower_bound_included(true);
+    }
+
+    RangeRouter router;
+    Status st = router.init(ranges, 1);
+    ASSERT_FALSE(st.ok());
+    assert_status_message_contains(st, "Range[0] != range[1] at column 0");
+}
+
+// NOLINTNEXTLINE
+TEST_F(RangeRouterTest, RangeRouterSingleIntRangesRouting) {
+    // Build four ranges on a single INT column:
+    //   R0: (-inf, 10)
+    //   R1: [10, 20)
+    //   R2: [20, 30)
+    //   R3: [30, +inf)
+    //
+    // Verify that RangeRouter correctly routes values into these ranges.
+    std::vector<TTabletRange> ranges;
+    ranges.emplace_back(make_single_long_range(std::nullopt, false, 10, false));
+    ranges.emplace_back(make_single_long_range(10, true, 20, false));
+    ranges.emplace_back(make_single_long_range(20, true, 30, false));
+    ranges.emplace_back(make_single_long_range(30, true, std::nullopt, false));
+
+    // The RangeRouter should be able to initialize and route correctly.
+    std::vector<int64_t> tablet_ids{100, 200, 300, 400};
+    RangeRouter router;
+    ASSERT_TRUE(router.init(ranges, 1).ok());
+
+    std::vector<int32_t> values{5, 10, 15, 20, 25, 30, 35};
+    Chunk chunk = make_int_chunk("c1", values);
+
+    SlotDescriptor slot_desc(0, "c1", TypeDescriptor::from_logical_type(TYPE_INT));
+    std::vector<SlotDescriptor*> slot_descs{&slot_desc};
+    chunk.set_slot_id_to_index(slot_desc.id(), 0);
+
+    std::vector<uint16_t> row_indices;
+    for (int i = 0; i < chunk.num_rows(); ++i) {
+        row_indices.emplace_back(i);
+    }
+    std::vector<int64_t> routed_ids;
+
+    ASSERT_TRUE(router.route_chunk_rows(&chunk, slot_descs, row_indices, tablet_ids, &routed_ids).ok());
+
+    std::vector<int64_t> expected = {100, 200, 200, 300, 300, 400, 400};
     ASSERT_EQ(expected.size(), routed_ids.size());
     for (int i = 0; i < static_cast<int>(expected.size()); ++i) {
         ASSERT_EQ(expected[i], routed_ids[i]) << "row " << i << " value " << values[i] << " mismatch";

--- a/be/test/storage/lake/lake_persistent_index_parallel_compact_mgr_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_parallel_compact_mgr_test.cpp
@@ -18,14 +18,17 @@
 
 #include <memory>
 
+#include "column/column_helper.h"
 #include "common/config.h"
 #include "fs/fs_util.h"
 #include "storage/lake/join_path.h"
 #include "storage/lake/persistent_index_sstable.h"
 #include "storage/persistent_index.h"
+#include "storage/primary_key_encoder.h"
 #include "storage/sstable/comparator.h"
 #include "storage/sstable/options.h"
 #include "storage/sstable/table_builder.h"
+#include "storage/tablet_schema.h"
 #include "test_util.h"
 #include "testutil/assert.h"
 
@@ -110,6 +113,59 @@ protected:
         }
         auto fileset_id = UniqueId::gen_uid();
         sst_pb->mutable_fileset_id()->CopyFrom(fileset_id.to_proto());
+
+        return Status::OK();
+    }
+
+    // Helper function to create a test sstable file using PrimaryKeyEncoder
+    Status create_test_sstable_with_pk(const std::string& filename, int start_key, int count,
+                                       PersistentIndexSstablePB* sst_pb, bool shared = false) {
+        sstable::Options options;
+        std::string filepath = _tablet_mgr->sst_location(_tablet_metadata->id(), filename);
+        ASSIGN_OR_RETURN(auto wf, fs::new_writable_file(filepath));
+        sstable::TableBuilder builder(options, wf.get());
+
+        std::vector<ColumnId> pk_columns = {0};
+        auto pkey_schema = ChunkHelper::convert_schema(TabletSchema::create(_tablet_metadata->schema()), pk_columns);
+
+        for (int i = 0; i < count; i++) {
+            auto chunk = std::make_unique<Chunk>();
+            auto col = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false);
+            col->append_datum(Datum((int32_t)(start_key + i)));
+            chunk->append_column(std::move(col), (SlotId)0);
+
+            MutableColumnPtr pk_column;
+            RETURN_IF_ERROR(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));
+            PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, 1, pk_column.get());
+            std::string key;
+            if (pk_column->is_binary()) {
+                key = ColumnHelper::get_binary_column(pk_column.get())->get_slice(0).to_string();
+            } else {
+                key = std::string(reinterpret_cast<const char*>(pk_column->raw_data()), pk_column->type_size());
+            }
+
+            IndexValue val(start_key + i);
+            IndexValuesWithVerPB val_pb;
+            auto* v = val_pb.add_values();
+            v->set_version(1);
+            v->set_rssid(val.get_rssid());
+            v->set_rowid(val.get_rowid());
+            builder.Add(Slice(key), val_pb.SerializeAsString());
+        }
+        RETURN_IF_ERROR(builder.Finish());
+        uint64_t filesize = builder.FileSize();
+        RETURN_IF_ERROR(wf->close());
+
+        // Fill the sstable pb
+        sst_pb->set_filename(filename);
+        sst_pb->set_filesize(filesize);
+        if (count > 0) {
+            sst_pb->mutable_range()->set_start_key(builder.KeyRange().first.to_string());
+            sst_pb->mutable_range()->set_end_key(builder.KeyRange().second.to_string());
+        }
+        auto fileset_id = UniqueId::gen_uid();
+        sst_pb->mutable_fileset_id()->CopyFrom(fileset_id.to_proto());
+        sst_pb->set_shared(shared);
 
         return Status::OK();
     }
@@ -539,7 +595,7 @@ TEST_F(LakePersistentIndexParallelCompactMgrTest, test_task_run_with_empty_input
     ASSERT_OK(mgr->init());
     std::vector<std::vector<PersistentIndexSstablePB>> input_sstables;
     auto fileset_id = UniqueId::gen_uid();
-    SeekRange seek_range{"", ""}; // Empty range means full range
+    SstSeekRange seek_range{"", ""}; // Empty range means full range
 
     auto task = std::make_shared<LakePersistentIndexParallelCompactTask>(
             input_sstables, _tablet_mgr.get(), _tablet_metadata, false, fileset_id, seek_range);
@@ -564,7 +620,7 @@ TEST_F(LakePersistentIndexParallelCompactMgrTest, test_task_run_with_null_tablet
     std::vector<std::vector<PersistentIndexSstablePB>> input_sstables;
     input_sstables.push_back({sst1});
     auto fileset_id = UniqueId::gen_uid();
-    SeekRange seek_range{"", ""}; // Empty range means full range
+    SstSeekRange seek_range{"", ""}; // Empty range means full range
 
     auto task = std::make_shared<LakePersistentIndexParallelCompactTask>(input_sstables, nullptr, _tablet_metadata,
                                                                          false, fileset_id, seek_range);
@@ -589,7 +645,7 @@ TEST_F(LakePersistentIndexParallelCompactMgrTest, test_task_run_single_sstable_o
     std::vector<std::vector<PersistentIndexSstablePB>> input_sstables;
     input_sstables.push_back({sst1});
     auto fileset_id = UniqueId::gen_uid();
-    SeekRange seek_range{"", ""}; // Empty range means full range
+    SstSeekRange seek_range{"", ""}; // Empty range means full range
 
     auto task = std::make_shared<LakePersistentIndexParallelCompactTask>(
             input_sstables, _tablet_mgr.get(), _tablet_metadata, false, fileset_id, seek_range);
@@ -620,7 +676,7 @@ TEST_F(LakePersistentIndexParallelCompactMgrTest, test_task_run_multiple_sstable
     std::vector<std::vector<PersistentIndexSstablePB>> input_sstables;
     input_sstables.push_back({sst1, sst2});
     auto fileset_id = UniqueId::gen_uid();
-    SeekRange seek_range{"", ""}; // Empty range means full range
+    SstSeekRange seek_range{"", ""}; // Empty range means full range
 
     std::vector<PersistentIndexSstablePB> output;
     auto task = std::make_shared<LakePersistentIndexParallelCompactTask>(
@@ -654,7 +710,7 @@ TEST_F(LakePersistentIndexParallelCompactMgrTest, test_task_run_with_overlapping
     std::vector<std::vector<PersistentIndexSstablePB>> input_sstables;
     input_sstables.push_back({sst1, sst2});
     auto fileset_id = UniqueId::gen_uid();
-    SeekRange seek_range{"", ""}; // Empty range means full range
+    SstSeekRange seek_range{"", ""}; // Empty range means full range
 
     std::vector<PersistentIndexSstablePB> output;
     auto task = std::make_shared<LakePersistentIndexParallelCompactTask>(
@@ -681,7 +737,7 @@ TEST_F(LakePersistentIndexParallelCompactMgrTest, test_task_run_with_merge_base_
     std::vector<std::vector<PersistentIndexSstablePB>> input_sstables;
     input_sstables.push_back({sst1, sst2});
     auto fileset_id = UniqueId::gen_uid();
-    SeekRange seek_range{"", ""}; // Empty range means full range
+    SstSeekRange seek_range{"", ""}; // Empty range means full range
 
     // Test with merge_base_level = true
     std::vector<PersistentIndexSstablePB> output;
@@ -712,7 +768,7 @@ TEST_F(LakePersistentIndexParallelCompactMgrTest, test_task_run_multiple_fileset
     input_sstables.push_back({sst1, sst2}); // Fileset 1
     input_sstables.push_back({sst3, sst4}); // Fileset 2
     auto fileset_id = UniqueId::gen_uid();
-    SeekRange seek_range{"", ""}; // Empty range means full range
+    SstSeekRange seek_range{"", ""}; // Empty range means full range
 
     std::vector<PersistentIndexSstablePB> output;
     auto task = std::make_shared<LakePersistentIndexParallelCompactTask>(
@@ -740,7 +796,7 @@ TEST_F(LakePersistentIndexParallelCompactMgrTest, test_task_run_with_zero_size_s
     std::vector<std::vector<PersistentIndexSstablePB>> input_sstables;
     input_sstables.push_back({sst1, sst2});
     auto fileset_id = UniqueId::gen_uid();
-    SeekRange seek_range{"", ""}; // Empty range means full range
+    SstSeekRange seek_range{"", ""}; // Empty range means full range
 
     std::vector<PersistentIndexSstablePB> output;
     auto task = std::make_shared<LakePersistentIndexParallelCompactTask>(
@@ -977,6 +1033,183 @@ TEST_F(LakePersistentIndexParallelCompactMgrTest, test_sample_keys_with_differen
 
     // Restore original config
     config::pk_index_sstable_sample_interval_bytes = old_interval;
+}
+
+TEST_F(LakePersistentIndexParallelCompactMgrTest, test_compact_with_tablet_range_filtering) {
+    auto mgr = std::make_unique<LakePersistentIndexParallelCompactMgr>(_tablet_mgr.get());
+    ASSERT_OK(mgr->init());
+
+    // 1. Setup Tablet Metadata with a specific range [100, 200)
+    auto* range = _tablet_metadata->mutable_range();
+    auto* lower = range->mutable_lower_bound();
+    auto* v_lower = lower->add_values();
+    v_lower->mutable_type()->CopyFrom(TypeDescriptor(TYPE_INT).to_protobuf());
+    v_lower->set_value("100");
+    range->set_lower_bound_included(true);
+
+    auto* upper = range->mutable_upper_bound();
+    auto* v_upper = upper->add_values();
+    v_upper->mutable_type()->CopyFrom(TypeDescriptor(TYPE_INT).to_protobuf());
+    v_upper->set_value("200");
+    range->set_upper_bound_included(false);
+
+    // 2. Create an SST with rows [50, 250)
+    PersistentIndexSstablePB sst1;
+    ASSERT_OK(create_test_sstable_with_pk("test_sst_1.sst", 50, 200, &sst1, true /* shared */));
+
+    std::vector<std::vector<PersistentIndexSstablePB>> candidates;
+    candidates.push_back({sst1});
+
+    std::vector<PersistentIndexSstablePB> output_sstables;
+    ASSERT_OK(mgr->compact(candidates, _tablet_metadata, false, &output_sstables));
+
+    // 3. Verify output
+    // The output should only contain rows in [100, 200).
+    // Since the original SST was [50, 250), it must be rewritten (not moved).
+    ASSERT_EQ(output_sstables.size(), 1);
+    ASSERT_NE(output_sstables[0].filename(), sst1.filename());
+
+    // Check range of output SST
+    // The keys are encoded INTs. We can't directly compare with "100" string.
+    // But we can check if they match the encoded values of 100 and 199.
+    auto encode_key = [&](int32_t v) {
+        auto pk_columns = std::vector<ColumnId>{0};
+        auto pkey_schema = ChunkHelper::convert_schema(TabletSchema::create(_tablet_metadata->schema()), pk_columns);
+        auto chunk = std::make_unique<Chunk>();
+        auto col = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false);
+        col->append_datum(Datum(v));
+        chunk->append_column(std::move(col), (SlotId)0);
+        MutableColumnPtr pk_column;
+        EXPECT_OK(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));
+        PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, 1, pk_column.get());
+        if (pk_column->is_binary()) {
+            return ColumnHelper::get_binary_column(pk_column.get())->get_slice(0).to_string();
+        } else {
+            return std::string(reinterpret_cast<const char*>(pk_column->raw_data()), pk_column->type_size());
+        }
+    };
+
+    ASSERT_EQ(output_sstables[0].range().start_key(), encode_key(100));
+    ASSERT_EQ(output_sstables[0].range().end_key(), encode_key(199));
+}
+
+TEST_F(LakePersistentIndexParallelCompactMgrTest, test_compact_with_multi_column_tablet_range_filtering) {
+    // Setup tablet metadata with 2 key columns
+    _tablet_metadata = std::make_shared<TabletMetadata>();
+    _tablet_metadata->set_id(next_id());
+    _tablet_metadata->set_version(1);
+    _tablet_metadata->set_enable_persistent_index(true);
+    _tablet_metadata->set_persistent_index_type(PersistentIndexTypePB::CLOUD_NATIVE);
+
+    auto schema = _tablet_metadata->mutable_schema();
+    schema->set_id(next_id());
+    schema->set_num_short_key_columns(2);
+    schema->set_keys_type(PRIMARY_KEYS);
+    auto c0 = schema->add_column();
+    c0->set_unique_id(next_id());
+    c0->set_name("c0");
+    c0->set_type("INT");
+    c0->set_is_key(true);
+    c0->set_is_nullable(false);
+    auto c1 = schema->add_column();
+    c1->set_unique_id(next_id());
+    c1->set_name("c1");
+    c1->set_type("VARCHAR");
+    c1->set_is_key(true);
+    c1->set_is_nullable(false);
+    auto c2 = schema->add_column();
+    c2->set_unique_id(next_id());
+    c2->set_name("c2");
+    c2->set_type("INT");
+    c2->set_is_key(false);
+    c2->set_is_nullable(false);
+
+    auto mgr = std::make_unique<LakePersistentIndexParallelCompactMgr>(_tablet_mgr.get());
+    ASSERT_OK(mgr->init());
+
+    // 1. Setup Tablet Metadata with range [ (100, "abc"), (200, "def") )
+    auto* range = _tablet_metadata->mutable_range();
+    auto* lower = range->mutable_lower_bound();
+    auto* v_lower1 = lower->add_values();
+    v_lower1->mutable_type()->CopyFrom(TypeDescriptor(TYPE_INT).to_protobuf());
+    v_lower1->set_value("100");
+    auto* v_lower2 = lower->add_values();
+    v_lower2->mutable_type()->CopyFrom(TypeDescriptor(TYPE_VARCHAR).to_protobuf());
+    v_lower2->set_value("abc");
+    range->set_lower_bound_included(true);
+
+    auto* upper = range->mutable_upper_bound();
+    auto* v_upper1 = upper->add_values();
+    v_upper1->mutable_type()->CopyFrom(TypeDescriptor(TYPE_INT).to_protobuf());
+    v_upper1->set_value("200");
+    auto* v_upper2 = upper->add_values();
+    v_upper2->mutable_type()->CopyFrom(TypeDescriptor(TYPE_VARCHAR).to_protobuf());
+    v_upper2->set_value("def");
+    range->set_upper_bound_included(false);
+
+    // 2. Create an SST with data that spans across the range
+    sstable::Options options;
+    std::string filename = "test_multi_col.sst";
+    std::string filepath = _tablet_mgr->sst_location(_tablet_metadata->id(), filename);
+    ASSIGN_OR_ABORT(auto wf, fs::new_writable_file(filepath));
+    sstable::TableBuilder builder(options, wf.get());
+
+    std::vector<ColumnId> pk_columns = {0, 1};
+    auto pkey_schema = ChunkHelper::convert_schema(TabletSchema::create(_tablet_metadata->schema()), pk_columns);
+
+    auto encode_key = [&](int32_t v1, const std::string& v2) {
+        auto chunk = std::make_unique<Chunk>();
+        auto col1 = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false);
+        col1->append_datum(Datum(v1));
+        chunk->append_column(std::move(col1), (SlotId)0);
+        auto col2 = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false);
+        col2->append_datum(Datum(Slice(v2)));
+        chunk->append_column(std::move(col2), (SlotId)1);
+
+        MutableColumnPtr pk_column;
+        EXPECT_OK(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));
+        PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, 1, pk_column.get());
+        return ColumnHelper::get_binary_column(pk_column.get())->get_slice(0).to_string();
+    };
+
+    // Add keys: (50, "xxx"), (100, "abc"), (150, "mmm"), (200, "def"), (250, "yyy")
+    std::vector<std::pair<int32_t, std::string>> test_keys = {
+            {50, "xxx"}, {100, "abc"}, {150, "mmm"}, {200, "def"}, {250, "yyy"}};
+    for (const auto& k : test_keys) {
+        std::string encoded_key = encode_key(k.first, k.second);
+        IndexValuesWithVerPB val_pb;
+        auto* v = val_pb.add_values();
+        v->set_version(1);
+        v->set_rssid(1);
+        v->set_rowid(1);
+        builder.Add(Slice(encoded_key), val_pb.SerializeAsString());
+    }
+    ASSERT_OK(builder.Finish());
+    ASSERT_OK(wf->close());
+
+    PersistentIndexSstablePB sst1;
+    sst1.set_filename(filename);
+    sst1.set_filesize(builder.FileSize());
+    sst1.mutable_range()->set_start_key(builder.KeyRange().first.to_string());
+    sst1.mutable_range()->set_end_key(builder.KeyRange().second.to_string());
+    sst1.set_shared(true);
+    auto fileset_id = UniqueId::gen_uid();
+    sst1.mutable_fileset_id()->CopyFrom(fileset_id.to_proto());
+
+    std::vector<std::vector<PersistentIndexSstablePB>> candidates;
+    candidates.push_back({sst1});
+
+    std::vector<PersistentIndexSstablePB> output_sstables;
+    ASSERT_OK(mgr->compact(candidates, _tablet_metadata, false, &output_sstables));
+
+    // 3. Verify output
+    // Should only contain (100, "abc") and (150, "mmm").
+    // (50, "xxx") is before lower bound.
+    // (200, "def") is the upper bound (exclusive).
+    // (250, "yyy") is after upper bound.
+    ASSERT_EQ(output_sstables.size(), 1);
+    ASSERT_EQ(output_sstables[0].range().start_key(), encode_key(100, "abc"));
+    ASSERT_EQ(output_sstables[0].range().end_key(), encode_key(150, "mmm"));
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/lake_persistent_index_test.cpp
+++ b/be/test/storage/lake/lake_persistent_index_test.cpp
@@ -16,7 +16,14 @@
 
 #include <gtest/gtest.h>
 
+#include "column/binary_column.h"
+#include "column/column_helper.h"
+#include "column/datum.h"
+#include "column/type_traits.h"
+#include "storage/chunk_helper.h"
 #include "storage/lake/meta_file.h"
+#include "storage/lake/tablet_range_helper.h"
+#include "storage/primary_key_encoder.h"
 #include "storage/record_predicate/column_hash_is_congruent.h"
 #include "test_util.h"
 #include "testutil/assert.h"
@@ -71,6 +78,37 @@ protected:
     constexpr static const char* const kTestDirectory = "test_lake_persistent_index";
 
     std::shared_ptr<TabletMetadata> _tablet_metadata;
+
+    TabletSchemaPB create_tablet_schema_pb(const std::vector<std::pair<std::string, std::string>>& columns,
+                                           int num_key_columns) {
+        TabletSchemaPB schema_pb;
+        schema_pb.set_keys_type(PRIMARY_KEYS);
+        schema_pb.set_num_short_key_columns(num_key_columns);
+        for (int i = 0; i < (int)columns.size(); ++i) {
+            auto* c = schema_pb.add_column();
+            c->set_name(columns[i].first);
+            c->set_type(columns[i].second);
+            c->set_is_key(i < num_key_columns);
+            c->set_is_nullable(false);
+        }
+        return schema_pb;
+    }
+
+    VariantPB make_int_variant_pb(int32_t v) {
+        VariantPB var;
+        TypeDescriptor type_desc(TYPE_INT);
+        var.mutable_type()->CopyFrom(type_desc.to_protobuf());
+        var.set_value(std::to_string(v));
+        return var;
+    }
+
+    VariantPB make_string_variant_pb(const std::string& v) {
+        VariantPB var;
+        TypeDescriptor type_desc(TYPE_VARCHAR);
+        var.mutable_type()->CopyFrom(type_desc.to_protobuf());
+        var.set_value(v);
+        return var;
+    }
 };
 
 TEST_F(LakePersistentIndexTest, test_basic_api) {
@@ -249,6 +287,112 @@ TEST_F(LakePersistentIndexTest, test_major_compaction) {
     for (int i = 0; i < M * N; i++) {
         ASSERT_EQ(total_values[i], get_values[i]);
     }
+    config::l0_max_mem_usage = l0_max_mem_usage;
+}
+
+TEST_F(LakePersistentIndexTest, test_major_compaction_with_tablet_range) {
+    auto l0_max_mem_usage = config::l0_max_mem_usage;
+    config::l0_max_mem_usage = 10;
+    const int N = 100;
+
+    // Use single column VARCHAR primary key
+    _tablet_metadata->mutable_schema()->mutable_column(0)->set_type("VARCHAR");
+    _tablet_metadata->mutable_schema()->mutable_column(0)->set_length(65535);
+
+    auto tablet_schema = TabletSchema::create(_tablet_metadata->schema());
+    std::vector<ColumnId> pk_columns = {0};
+    auto pkey_schema = ChunkHelper::convert_schema(tablet_schema, pk_columns);
+    auto encode_key = [&](const std::string& v) {
+        auto chunk = std::make_unique<Chunk>();
+        auto col = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false);
+        col->append_datum(Datum(Slice(v)));
+        chunk->append_column(std::move(col), (SlotId)0);
+
+        MutableColumnPtr pk_column;
+        EXPECT_OK(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));
+        PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, 1, pk_column.get());
+        if (pk_column->is_binary()) {
+            return down_cast<BinaryColumn*>(pk_column.get())->get_slice(0).to_string();
+        } else {
+            return std::string(reinterpret_cast<const char*>(pk_column->raw_data()), pk_column->type_size());
+        }
+    };
+
+    auto tablet_id = _tablet_metadata->id();
+    auto index = std::make_unique<LakePersistentIndex>(_tablet_mgr.get(), tablet_id);
+    ASSERT_OK(index->init(_tablet_metadata));
+
+    // Build multiple levels of sstables to trigger merge.
+    std::vector<std::string> keys;
+    std::vector<Slice> key_slices;
+    std::vector<IndexValue> values;
+    std::vector<IndexValue> upsert_old_values(N);
+    for (int i = 0; i < 3; ++i) {
+        keys.clear();
+        key_slices.clear();
+        values.clear();
+        keys.reserve(N);
+        key_slices.reserve(N);
+        values.reserve(N);
+        for (int j = 0; j < N; ++j) {
+            // Use keys like "key_00", "key_01", ..., "key_99"
+            char buf[16];
+            snprintf(buf, sizeof(buf), "key_%02d", j);
+            keys.emplace_back(encode_key(buf));
+            key_slices.emplace_back(keys.back());
+            values.emplace_back(j * 2 + i);
+        }
+        index->prepare(EditVersion(i, 0), 0);
+        ASSERT_OK(index->upsert(N, key_slices.data(), values.data(), upsert_old_values.data()));
+        ASSERT_OK(index->flush_memtable(true));
+    }
+    ASSERT_TRUE(index->memory_usage() > 0);
+
+    // Build tablet metadata with a tablet range so that major_compact will honor it.
+    Tablet tablet(_tablet_mgr.get(), tablet_id);
+    auto tablet_metadata_ptr = std::make_shared<TabletMetadata>();
+    tablet_metadata_ptr->CopyFrom(*_tablet_metadata);
+
+    // Ensure sort key is the primary key column so that TabletRangeHelper can build SstSeekRange.
+    auto* schema_pb = tablet_metadata_ptr->mutable_schema();
+    schema_pb->clear_sort_key_idxes();
+    schema_pb->add_sort_key_idxes(0);
+
+    // Configure a tablet range ["key_10", "key_30").
+    TabletRangePB* range_pb = tablet_metadata_ptr->mutable_range();
+    range_pb->Clear();
+    auto* lower = range_pb->mutable_lower_bound();
+    auto* lower_v = lower->add_values();
+    TypeDescriptor type_varchar(TYPE_VARCHAR);
+    lower_v->mutable_type()->CopyFrom(type_varchar.to_protobuf());
+    lower_v->set_value("key_10");
+    range_pb->set_lower_bound_included(true);
+    auto* upper = range_pb->mutable_upper_bound();
+    auto* upper_v = upper->add_values();
+    upper_v->mutable_type()->CopyFrom(type_varchar.to_protobuf());
+    upper_v->set_value("key_30");
+    range_pb->set_upper_bound_included(false);
+
+    MetaFileBuilder builder(tablet, tablet_metadata_ptr);
+    ASSERT_OK(index->commit(&builder));
+
+    // Mark all sstables as shared so that range pruning path is exercised.
+    auto* sstable_meta = tablet_metadata_ptr->mutable_sstable_meta();
+    for (auto& sst_pb : *sstable_meta->mutable_sstables()) {
+        sst_pb.set_shared(true);
+    }
+
+    auto txn_log = std::make_shared<TxnLogPB>();
+    ASSERT_OK(LakePersistentIndex::major_compact(_tablet_mgr.get(), tablet_metadata_ptr, txn_log.get()));
+    ASSERT_TRUE(txn_log->op_compaction().has_output_sstable());
+
+    const auto& out_sst = txn_log->op_compaction().output_sstable();
+
+    // The compacted output sstable should only cover keys in ["key_10", "key_30").
+    ASSERT_EQ(encode_key("key_10"), out_sst.range().start_key());
+    // end_key is inclusive, so for ["key_10", "key_30") we expect the last key to be "key_29".
+    ASSERT_EQ(encode_key("key_29"), out_sst.range().end_key());
+
     config::l0_max_mem_usage = l0_max_mem_usage;
 }
 
@@ -557,6 +701,100 @@ TEST_F(LakePersistentIndexTest, test_major_compaction_with_predicate) {
             ASSERT_EQ(IndexValue(NullIndexValue), get_values[i]);
         }
     }
+}
+
+TEST_F(LakePersistentIndexTest, test_tablet_range_single_column_pk) {
+    auto schema_pb = create_tablet_schema_pb({{"pk", "INT"}, {"v1", "INT"}}, 1);
+    auto schema = std::make_shared<const TabletSchema>(schema_pb);
+
+    TabletRangePB range_pb;
+    range_pb.mutable_lower_bound()->add_values()->CopyFrom(make_int_variant_pb(100));
+    range_pb.set_lower_bound_included(true);
+    range_pb.mutable_upper_bound()->add_values()->CopyFrom(make_int_variant_pb(200));
+    range_pb.set_upper_bound_included(false);
+
+    ASSIGN_OR_ABORT(auto sst_seek_range, TabletRangeHelper::create_sst_seek_range_from(range_pb, schema));
+
+    // Encode expected keys
+    std::vector<ColumnId> pk_columns = {0};
+    auto pkey_schema = ChunkHelper::convert_schema(schema, pk_columns);
+
+    auto encode_key = [&](int32_t v) {
+        auto chunk = std::make_unique<Chunk>();
+        auto col = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false);
+        col->append_datum(Datum(v));
+        chunk->append_column(std::move(col), (SlotId)0);
+
+        MutableColumnPtr pk_column;
+        EXPECT_OK(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));
+        PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, 1, pk_column.get());
+        if (pk_column->is_binary()) {
+            return down_cast<BinaryColumn*>(pk_column.get())->get_slice(0).to_string();
+        } else {
+            return std::string(reinterpret_cast<const char*>(pk_column->raw_data()), pk_column->type_size());
+        }
+    };
+
+    ASSERT_EQ(sst_seek_range.seek_key, encode_key(100));
+    ASSERT_EQ(sst_seek_range.stop_key, encode_key(200));
+}
+
+TEST_F(LakePersistentIndexTest, test_tablet_range_multi_column_pk) {
+    auto schema_pb = create_tablet_schema_pb({{"pk1", "INT"}, {"pk2", "VARCHAR"}, {"v1", "INT"}}, 2);
+    auto schema = std::make_shared<const TabletSchema>(schema_pb);
+
+    TabletRangePB range_pb;
+    auto* lower = range_pb.mutable_lower_bound();
+    lower->add_values()->CopyFrom(make_int_variant_pb(100));
+    lower->add_values()->CopyFrom(make_string_variant_pb("abc"));
+    range_pb.set_lower_bound_included(true);
+
+    auto* upper = range_pb.mutable_upper_bound();
+    upper->add_values()->CopyFrom(make_int_variant_pb(200));
+    upper->add_values()->CopyFrom(make_string_variant_pb("def"));
+    range_pb.set_upper_bound_included(false);
+
+    ASSIGN_OR_ABORT(auto sst_seek_range, TabletRangeHelper::create_sst_seek_range_from(range_pb, schema));
+
+    // Encode expected keys
+    std::vector<ColumnId> pk_columns = {0, 1};
+    auto pkey_schema = ChunkHelper::convert_schema(schema, pk_columns);
+
+    auto encode_key = [&](int32_t v1, const std::string& v2) {
+        auto chunk = std::make_unique<Chunk>();
+        auto col1 = ColumnHelper::create_column(TypeDescriptor(TYPE_INT), false);
+        col1->append_datum(Datum(v1));
+        chunk->append_column(std::move(col1), (SlotId)0);
+
+        auto col2 = ColumnHelper::create_column(TypeDescriptor(TYPE_VARCHAR), false);
+        col2->append_datum(Datum(Slice(v2)));
+        chunk->append_column(std::move(col2), (SlotId)1);
+
+        MutableColumnPtr pk_column;
+        EXPECT_OK(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column));
+        PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, 1, pk_column.get());
+        if (pk_column->is_binary()) {
+            return down_cast<BinaryColumn*>(pk_column.get())->get_slice(0).to_string();
+        } else {
+            return std::string(reinterpret_cast<const char*>(pk_column->raw_data()), pk_column->type_size());
+        }
+    };
+
+    ASSERT_EQ(sst_seek_range.seek_key, encode_key(100, "abc"));
+    ASSERT_EQ(sst_seek_range.stop_key, encode_key(200, "def"));
+}
+
+TEST_F(LakePersistentIndexTest, test_tablet_range_infinite_bounds) {
+    auto schema_pb = create_tablet_schema_pb({{"pk", "INT"}}, 1);
+    auto schema = std::make_shared<const TabletSchema>(schema_pb);
+
+    TabletRangePB range_pb;
+    // No lower or upper bound
+
+    ASSIGN_OR_ABORT(auto sst_seek_range, TabletRangeHelper::create_sst_seek_range_from(range_pb, schema));
+
+    ASSERT_TRUE(sst_seek_range.seek_key.empty());
+    ASSERT_TRUE(sst_seek_range.stop_key.empty());
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/sst_seek_range_test.cpp
+++ b/be/test/storage/lake/sst_seek_range_test.cpp
@@ -1,0 +1,151 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/sst_seek_range.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace starrocks::lake {
+
+TEST(SstSeekRangeTest, test_has_overlap) {
+    {
+        // [10, 30) and [20, 40] -> overlap
+        SstSeekRange range{"10", "30"};
+        PersistentIndexSstableRangePB sst_range;
+        sst_range.set_start_key("20");
+        sst_range.set_end_key("40");
+        ASSERT_TRUE(range.has_overlap(sst_range));
+    }
+    {
+        // [10, 30) and [05, 20] -> overlap
+        SstSeekRange range{"10", "30"};
+        PersistentIndexSstableRangePB sst_range;
+        sst_range.set_start_key("05");
+        sst_range.set_end_key("20");
+        ASSERT_TRUE(range.has_overlap(sst_range));
+    }
+    {
+        // [10, 30) and [30, 40] -> no overlap (stop_key is exclusive)
+        SstSeekRange range{"10", "30"};
+        PersistentIndexSstableRangePB sst_range;
+        sst_range.set_start_key("30");
+        sst_range.set_end_key("40");
+        ASSERT_FALSE(range.has_overlap(sst_range));
+    }
+    {
+        // [10, 30) and [00, 05] -> no overlap
+        SstSeekRange range{"10", "30"};
+        PersistentIndexSstableRangePB sst_range;
+        sst_range.set_start_key("00");
+        sst_range.set_end_key("05");
+        ASSERT_FALSE(range.has_overlap(sst_range));
+    }
+    {
+        // [10, "") and [20, 40] -> overlap
+        SstSeekRange range{"10", ""};
+        PersistentIndexSstableRangePB sst_range;
+        sst_range.set_start_key("20");
+        sst_range.set_end_key("40");
+        ASSERT_TRUE(range.has_overlap(sst_range));
+    }
+    {
+        // ["", "") and [20, 40] -> overlap
+        SstSeekRange range{"", ""};
+        PersistentIndexSstableRangePB sst_range;
+        sst_range.set_start_key("20");
+        sst_range.set_end_key("40");
+        ASSERT_TRUE(range.has_overlap(sst_range));
+    }
+}
+
+TEST(SstSeekRangeTest, test_full_contains) {
+    {
+        // [10, 40) contains [20, 30] -> true
+        SstSeekRange range{"10", "40"};
+        PersistentIndexSstableRangePB sst_range;
+        sst_range.set_start_key("20");
+        sst_range.set_end_key("30");
+        ASSERT_TRUE(range.full_contains(sst_range));
+    }
+    {
+        // [10, 40) contains [10, 30] -> true
+        SstSeekRange range{"10", "40"};
+        PersistentIndexSstableRangePB sst_range;
+        sst_range.set_start_key("10");
+        sst_range.set_end_key("30");
+        ASSERT_TRUE(range.full_contains(sst_range));
+    }
+    {
+        // [10, 40) contains [20, 40] -> false (stop_key is exclusive)
+        SstSeekRange range{"10", "40"};
+        PersistentIndexSstableRangePB sst_range;
+        sst_range.set_start_key("20");
+        sst_range.set_end_key("40");
+        ASSERT_FALSE(range.full_contains(sst_range));
+    }
+    {
+        // [10, 40) contains [05, 30] -> false
+        SstSeekRange range{"10", "40"};
+        PersistentIndexSstableRangePB sst_range;
+        sst_range.set_start_key("05");
+        sst_range.set_end_key("30");
+        ASSERT_FALSE(range.full_contains(sst_range));
+    }
+    {
+        // [10, "") contains [20, 99] -> true
+        SstSeekRange range{"10", ""};
+        PersistentIndexSstableRangePB sst_range;
+        sst_range.set_start_key("20");
+        sst_range.set_end_key("99");
+        ASSERT_TRUE(range.full_contains(sst_range));
+    }
+    {
+        // ["", "") contains [00, 99] -> true
+        SstSeekRange range{"", ""};
+        PersistentIndexSstableRangePB sst_range;
+        sst_range.set_start_key("00");
+        sst_range.set_end_key("99");
+        ASSERT_TRUE(range.full_contains(sst_range));
+    }
+}
+
+TEST(SstSeekRangeTest, test_intersect) {
+    {
+        // [10, 40) & [20, 30) -> [20, 30)
+        SstSeekRange r1{"10", "40"};
+        SstSeekRange r2{"20", "30"};
+        r1 &= r2;
+        ASSERT_EQ("20", r1.seek_key);
+        ASSERT_EQ("30", r1.stop_key);
+    }
+    {
+        // [10, 40) & [05, 50) -> [10, 40)
+        SstSeekRange r1{"10", "40"};
+        SstSeekRange r2{"05", "50"};
+        r1 &= r2;
+        ASSERT_EQ("10", r1.seek_key);
+        ASSERT_EQ("40", r1.stop_key);
+    }
+    {
+        // [10, "") & ["", 30) -> [10, 30)
+        SstSeekRange r1{"10", ""};
+        SstSeekRange r2{"", "30"};
+        r1 &= r2;
+        ASSERT_EQ("10", r1.seek_key);
+        ASSERT_EQ("30", r1.stop_key);
+    }
+}
+
+} // namespace starrocks::lake

--- a/be/test/storage/lake/tablet_range_helper_test.cpp
+++ b/be/test/storage/lake/tablet_range_helper_test.cpp
@@ -1,0 +1,82 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/tablet_range_helper.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "runtime/types.h"
+#include "storage/tablet_schema.h"
+#include "testutil/assert.h"
+
+namespace starrocks::lake {
+
+TEST(TabletRangeHelperTest, test_create_sst_seek_range_from) {
+    TabletSchemaPB schema_pb;
+    schema_pb.set_keys_type(PRIMARY_KEYS);
+
+    // c0, c1 are keys
+    auto c0 = schema_pb.add_column();
+    c0->set_name("c0");
+    c0->set_type("INT");
+    c0->set_is_key(true);
+    c0->set_is_nullable(false);
+
+    auto c1 = schema_pb.add_column();
+    c1->set_name("c1");
+    c1->set_type("INT");
+    c1->set_is_key(true);
+    c1->set_is_nullable(false);
+
+    auto c2 = schema_pb.add_column();
+    c2->set_name("c2");
+    c2->set_type("INT");
+    c2->set_is_key(false);
+    c2->set_is_nullable(true);
+
+    // Case 1: sort keys are the same as pk keys (c0, c1) -> index (0, 1)
+    schema_pb.clear_sort_key_idxes();
+    schema_pb.add_sort_key_idxes(0);
+    schema_pb.add_sort_key_idxes(1);
+
+    auto tablet_schema = TabletSchema::create(schema_pb);
+
+    TabletRangePB range_pb;
+    auto lower = range_pb.mutable_lower_bound();
+    auto v0 = lower->add_values();
+    TypeDescriptor type_int(TYPE_INT);
+    v0->mutable_type()->CopyFrom(type_int.to_protobuf());
+    v0->set_value("1");
+    auto v1 = lower->add_values();
+    v1->mutable_type()->CopyFrom(type_int.to_protobuf());
+    v1->set_value("2");
+    range_pb.set_lower_bound_included(true);
+
+    auto res = TabletRangeHelper::create_sst_seek_range_from(range_pb, tablet_schema);
+    ASSERT_OK(res.status());
+    ASSERT_FALSE(res.value().seek_key.empty());
+
+    // Case 2: different order -> Should return InternalError
+    schema_pb.clear_sort_key_idxes();
+    schema_pb.add_sort_key_idxes(1);
+    schema_pb.add_sort_key_idxes(0);
+    auto tablet_schema_wrong = TabletSchema::create(schema_pb);
+    auto res2 = TabletRangeHelper::create_sst_seek_range_from(range_pb, tablet_schema_wrong);
+    ASSERT_FALSE(res2.ok());
+    ASSERT_TRUE(res2.status().is_internal_error());
+    ASSERT_THAT(res2.status().to_string(), testing::HasSubstr("Sort key index 0 must be 0, but is 1"));
+}
+
+} // namespace starrocks::lake

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -493,8 +493,11 @@ public class CreateTableAnalyzer {
                     keyColIdxes.add(idx);
                 }
 
-                boolean res = new HashSet<>(keyColIdxes).equals(new HashSet<>(sortKeyIdxes));
-                if (!res) {
+                if (keysType == KeysType.PRIMARY_KEYS && !keyColIdxes.equals(sortKeyIdxes)) {
+                    throw new SemanticException("The sort columns must be same with primary key columns " +
+                                                "and the order must be consistent");
+                } else if (keysType != KeysType.PRIMARY_KEYS &&
+                                !new HashSet<>(keyColIdxes).equals(new HashSet<>(sortKeyIdxes))) {
                     throw new SemanticException("The sort columns must be same with key columns");
                 }
             }

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -219,6 +219,8 @@ message TabletMetadataPB {
     optional CompactionStrategyPB compaction_strategy = 20;
     // flat json
     optional FlatJsonConfigPB flat_json_config = 21;
+    // Indicates sort key range for range distribution table only
+    optional TabletRangePB range = 22;
 }
 
 message MetadataUpdateInfoPB {


### PR DESCRIPTION
## Summary

Adds tablet-range based pruning for Lake range-distribution tablets across:
Query path (Rowset → SegmentReadOptions.tablet_range → SegmentIterator::_apply_tablet_range), only for shared segments.

PK index compaction path (both serial LakePersistentIndex::major_compact and parallel LakePersistentIndexParallelCompactMgr) via TabletRangeHelper::create_sst_seek_range_from.

Centralizes TabletRangePB parsing in TabletRangeHelper and introduces a standalone SstSeekRange type under lake/, cleaning up includes and ownership between helpers and the compaction manager.

UTs cover single/multi-column PK, inclusive/exclusive bounds, invalid metadata, CHAR/VARCHAR, and both serial/parallel compaction with tablet range filtering.

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces tablet-range pruning across query and compaction paths for Lake range-distribution tablets.
> 
> - Query path: propagate `SegmentReadOptions.tablet_range` from `Rowset` and apply in `SegmentIterator::_apply_tablet_range()` to filter shared segments only
> - PK index compaction: honor tablet range in both `LakePersistentIndex::major_compact` and `LakePersistentIndexParallelCompactMgr`, seeking/limiting via `SstSeekRange`; detect shared sstables
> - New helpers/types: `TabletRangeHelper` centralizes `TabletRangePB` parsing; `SstSeekRange` encapsulates [seek, stop) logic and intersection
> - API/struct changes: add optional `tablet_range` into `SegmentReadOptions`; adjust `merge_sstables`/`prepare_merging_iterator` signatures to pass metadata and shared flags; add `TabletRangePB range` to `TabletMetadataPB`
> - FE: enforce sort key equals primary key (including order) for PK tables (range distribution context); add analyzer tests
> - Build/tests: add `tablet_range_helper.cpp`, `sst_seek_range.*`; extensive UTs for single/multi-column keys, inclusive/exclusive bounds, CHAR/VARCHAR, invalid metadata, and serial/parallel compaction behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1909b9c0030324d706e8cdfff33a91614c256ce9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->