### PR TITLE
[Enhancement] Support _META_ scan with tablet() and partition() hints

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalMetaScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalMetaScanOperator.java
@@ -32,6 +32,7 @@ public class LogicalMetaScanOperator extends LogicalScanOperator {
     // agg column id -> (agg_function_name, column)
     private Map<Integer, Pair<String, Column>> aggColumnIdToColumns = ImmutableMap.of();
     private List<String> selectPartitionNames = Collections.emptyList();
+    private List<Long> hintsTabletIds = Collections.emptyList();
 
     private LogicalMetaScanOperator() {
         super(OperatorType.LOGICAL_META_SCAN);
@@ -47,6 +48,10 @@ public class LogicalMetaScanOperator extends LogicalScanOperator {
 
     public long getSelectedIndexId() {
         return selectedIndexId;
+    }
+
+    public List<Long> getHintsTabletIds() {
+        return hintsTabletIds;
     }
 
     @Override
@@ -68,12 +73,13 @@ public class LogicalMetaScanOperator extends LogicalScanOperator {
         LogicalMetaScanOperator that = (LogicalMetaScanOperator) o;
         return Objects.equals(aggColumnIdToColumns, that.aggColumnIdToColumns) &&
                 Objects.equals(selectPartitionNames, that.selectPartitionNames) &&
+                Objects.equals(hintsTabletIds, that.hintsTabletIds) &&
                 selectedIndexId == that.selectedIndexId;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), aggColumnIdToColumns);
+        return Objects.hash(super.hashCode(), aggColumnIdToColumns, selectPartitionNames, hintsTabletIds, selectedIndexId);
     }
 
     public static LogicalMetaScanOperator.Builder builder() {
@@ -93,6 +99,7 @@ public class LogicalMetaScanOperator extends LogicalScanOperator {
             super.withOperator(operator);
             builder.aggColumnIdToColumns = ImmutableMap.copyOf(operator.aggColumnIdToColumns);
             builder.selectPartitionNames = operator.selectPartitionNames;
+            builder.hintsTabletIds = operator.hintsTabletIds;
             builder.columnAccessPaths = ImmutableList.copyOf(operator.columnAccessPaths);
             return this;
         }
@@ -110,6 +117,11 @@ public class LogicalMetaScanOperator extends LogicalScanOperator {
 
         public LogicalMetaScanOperator.Builder setSelectedIndexId(long selectedIndexId) {
             builder.selectedIndexId = selectedIndexId;
+            return this;
+        }
+
+        public LogicalMetaScanOperator.Builder setHintsTabletIds(List<Long> hintsTabletIds) {
+            builder.hintsTabletIds = hintsTabletIds != null ? hintsTabletIds : Collections.emptyList();
             return this;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalMetaScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalMetaScanOperator.java
@@ -31,18 +31,21 @@ import java.util.Objects;
 public class PhysicalMetaScanOperator extends PhysicalScanOperator {
     private Map<Integer, Pair<String, Column>> aggColumnIdToColumns;
     private List<String> selectPartitionNames;
+    private List<Long> hintsTabletIds;
     private long selectedIndexId = -1;
 
     public PhysicalMetaScanOperator() {
         super(OperatorType.PHYSICAL_META_SCAN);
         this.aggColumnIdToColumns = ImmutableMap.of();
         this.selectPartitionNames = ImmutableList.of();
+        this.hintsTabletIds = ImmutableList.of();
     }
 
     public PhysicalMetaScanOperator(LogicalMetaScanOperator scanOperator) {
         super(OperatorType.PHYSICAL_META_SCAN, scanOperator);
         this.aggColumnIdToColumns = scanOperator.getAggColumnIdToColumns();
         this.selectPartitionNames = scanOperator.getSelectPartitionNames();
+        this.hintsTabletIds = scanOperator.getHintsTabletIds();
         this.selectedIndexId = scanOperator.getSelectedIndexId();
     }
 
@@ -56,6 +59,10 @@ public class PhysicalMetaScanOperator extends PhysicalScanOperator {
 
     public long getSelectedIndexId() {
         return selectedIndexId;
+    }
+
+    public List<Long> getHintsTabletIds() {
+        return hintsTabletIds;
     }
 
     @Override
@@ -81,12 +88,13 @@ public class PhysicalMetaScanOperator extends PhysicalScanOperator {
         PhysicalMetaScanOperator that = (PhysicalMetaScanOperator) o;
         return Objects.equals(aggColumnIdToColumns, that.aggColumnIdToColumns) &&
                 Objects.equals(selectPartitionNames, that.selectPartitionNames) &&
+                Objects.equals(hintsTabletIds, that.hintsTabletIds) &&
                 selectedIndexId == that.selectedIndexId;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), aggColumnIdToColumns, selectPartitionNames, selectedIndexId);
+        return Objects.hash(super.hashCode(), aggColumnIdToColumns, selectPartitionNames, hintsTabletIds, selectedIndexId);
     }
 
     public static Builder builder() {
@@ -106,6 +114,7 @@ public class PhysicalMetaScanOperator extends PhysicalScanOperator {
             super.withOperator(operator);
             builder.aggColumnIdToColumns = ImmutableMap.copyOf(operator.aggColumnIdToColumns);
             builder.selectPartitionNames = ImmutableList.copyOf(operator.selectPartitionNames);
+            builder.hintsTabletIds = ImmutableList.copyOf(operator.hintsTabletIds);
             builder.selectedIndexId = operator.selectedIndexId;
             return this;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToMetaScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToMetaScanRule.java
@@ -175,6 +175,7 @@ public class RewriteSimpleAggToMetaScanRule extends TransformationRule {
                 .setTable(scanOperator.getTable())
                 .setSelectPartitionNames(selectedPartitionNames)
                 .setSelectedIndexId(scanOperator.getSelectedIndexId())
+                .setHintsTabletIds(scanOperator.getHintsTabletIds())
                 .setColRefToColumnMetaMap(newScanColumnRefs)
                 .setAggColumnIdToColumns(aggColumnIdToColumns).build();
         LogicalAggregationOperator newAggOperator = new LogicalAggregationOperator(aggregationOperator.getType(),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -647,6 +647,7 @@ public class RelationTransformer implements AstVisitorExtendInterface<LogicalPla
                         .setSelectPartitionNames(node.getPartitionNames() == null ? Collections.emptyList() :
                                 node.getPartitionNames().getPartitionNames())
                         .setSelectedIndexId(((OlapTable) node.getTable()).getBaseIndexMetaId())
+                        .setHintsTabletIds(node.getTabletIds())
                         .build();
             } else if (!isMVPlanner) {
                 scanOperator = LogicalOlapScanOperator.builder()

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1099,7 +1099,7 @@ public class PlanFragmentBuilder {
 
             MetaScanNode scanNode = new MetaScanNode(context.getNextNodeId(),
                     tupleDescriptor, (OlapTable) scan.getTable(), scan.getAggColumnIdToColumns(),
-                    scan.getSelectPartitionNames(), scan.getSelectedIndexId(),
+                    scan.getSelectPartitionNames(), scan.getHintsTabletIds(), scan.getSelectedIndexId(),
                     context.getConnectContext().getCurrentComputeResource());
 
             scanNode.setColumnAccessPaths(scan.getColumnAccessPaths());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -1599,6 +1599,26 @@ public class LowCardinalityTest extends PlanTestBase {
     }
 
     @Test
+    public void testMetaScanWithTabletHint() throws Exception {
+        // Test that tablet hint is properly passed to MetaScan operator
+        String sql = "select max(t1c), min(t1d) from test_all_type tablet(12345) [_META_]";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "0:MetaScan");
+        assertContains(plan, "Table: test_all_type");
+        assertContains(plan, "TabletIds: [12345]");
+    }
+
+    @Test
+    public void testMetaScanWithMultipleTabletHints() throws Exception {
+        // Test multiple tablet hints
+        String sql = "select max(t1c), min(t1d) from test_all_type tablet(12345, 67890) [_META_]";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "0:MetaScan");
+        assertContains(plan, "Table: test_all_type");
+        assertContains(plan, "TabletIds: [12345, 67890]");
+    }
+
+    @Test
     public void testHasGlobalDictButNotFound() throws Exception {
         IDictManager dictManager = IDictManager.getInstance();
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -22,7 +22,6 @@ import com.starrocks.catalog.Tablet;
 import com.starrocks.common.FeConstants;
 import com.starrocks.planner.OlapScanNode;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.utframe.StarRocksAssert;
@@ -1649,10 +1648,13 @@ public class LowCardinalityTest extends PlanTestBase {
     }
 
     @Test
-    public void testMetaScanWithInvalidTabletHint() {
-        // Test that invalid tablet ID throws error
+    public void testMetaScanWithInvalidTabletHint() throws Exception {
+        // Test that invalid tablet ID returns empty result (no tablets scanned)
         String sql = "select max(t1c), min(t1d) from test_all_type tablet(99999) [_META_]";
-        Assertions.assertThrows(StarRocksPlannerException.class, () -> getFragmentPlan(sql));
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "MetaScan");
+        // TabletIds should show empty list when hint provided but no match
+        assertContains(plan, "TabletIds: []");
     }
 
     @Test

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -3582,3 +3582,19 @@ out.append("${{dictMgr.NO_DICT_STRING_COLUMNS.contains(cid)}}")
         return {
             "success": True
         }
+
+    def set_first_tablet_id(self, table_name, partition_name=None):
+        """
+        Get the first tablet ID for a table (optionally from a specific partition)
+        and store it as self.tablet_id for use in subsequent SQL with ${tablet_id}
+        """
+        if partition_name:
+            sql = f"SHOW TABLETS FROM {table_name} PARTITION ({partition_name}) LIMIT 1"
+        else:
+            sql = f"SHOW TABLETS FROM {table_name} LIMIT 1"
+        result = self.execute_sql(sql, True)
+        if result and result.get("result") and len(result["result"]) > 0:
+            self.tablet_id = str(result["result"][0][0])  # First column is TabletId
+            log.info(f"Set tablet_id = {self.tablet_id}")
+        else:
+            raise Exception(f"Failed to get tablet ID for table {table_name}")

--- a/test/sql/test_meta_scan/R/test_meta_scan
+++ b/test/sql/test_meta_scan/R/test_meta_scan
@@ -586,20 +586,20 @@ PROPERTIES ("replication_num" = "1");
 INSERT INTO t_tablet_hint VALUES ("2019-12-01", 10), ("2020-01-15", 20), ("2020-02-15", 30);
 -- result:
 -- !result
--- Test: Invalid tablet hint should throw error (similar to OlapScanNode behavior)
+-- Test: Invalid tablet hint should return empty result (no matching tablets)
 SELECT min(k2), max(k2) FROM t_tablet_hint TABLET(99999) [_META_];
 -- result:
-E: (1064, "Invalid tablet id: '99999'")
+None	None
 -- !result
--- Test: Multiple invalid tablet hints should throw error
+-- Test: Multiple invalid tablet hints should return empty result
 SELECT min(k2), max(k2) FROM t_tablet_hint TABLET(11111, 22222) [_META_];
 -- result:
-E: (1064, "Invalid tablet id: '11111'")
+None	None
 -- !result
--- Test: Invalid tablet hint with partition should throw error (partition name is auto-generated like p201912)
+-- Test: Invalid tablet hint with partition should return empty result (partition name is auto-generated like p201912)
 SELECT min(k2), max(k2) FROM t_tablet_hint PARTITION(p201912) TABLET(99999) [_META_];
 -- result:
-E: (1064, "Invalid tablet id: '99999'")
+None	None
 -- !result
 -- Test: Valid tablet hint should work correctly with EXPLAIN verification
 function: set_first_tablet_id("t_tablet_hint")

--- a/test/sql/test_meta_scan/R/test_meta_scan
+++ b/test/sql/test_meta_scan/R/test_meta_scan
@@ -578,11 +578,7 @@ CREATE TABLE t_tablet_hint (
     k2 int
 )
 DUPLICATE KEY(k1)
-PARTITION BY RANGE(k1) (
-    PARTITION p1 VALUES LESS THAN ("2020-01-01"),
-    PARTITION p2 VALUES LESS THAN ("2020-02-01"),
-    PARTITION p3 VALUES LESS THAN ("2020-03-01")
-)
+PARTITION BY date_trunc('month', k1)
 DISTRIBUTED BY HASH(k1) BUCKETS 3
 PROPERTIES ("replication_num" = "1");
 -- result:
@@ -590,18 +586,34 @@ PROPERTIES ("replication_num" = "1");
 INSERT INTO t_tablet_hint VALUES ("2019-12-01", 10), ("2020-01-15", 20), ("2020-02-15", 30);
 -- result:
 -- !result
--- Test: Single tablet hint - EXPLAIN should show TabletIds
-EXPLAIN SELECT min(k2), max(k2) FROM t_tablet_hint TABLET(99999) [_META_];
+-- Test: Invalid tablet hint should throw error (similar to OlapScanNode behavior)
+SELECT min(k2), max(k2) FROM t_tablet_hint TABLET(99999) [_META_];
 -- result:
-[REGEX].*TabletIds: \[99999\].*
+E: (1064, "Invalid tablet id: '99999'")
 -- !result
--- Test: Multiple tablet hints
-EXPLAIN SELECT min(k2), max(k2) FROM t_tablet_hint TABLET(11111, 22222) [_META_];
+-- Test: Multiple invalid tablet hints should throw error
+SELECT min(k2), max(k2) FROM t_tablet_hint TABLET(11111, 22222) [_META_];
 -- result:
-[REGEX].*TabletIds: \[11111, 22222\].*
+E: (1064, "Invalid tablet id: '11111'")
 -- !result
--- Test: Partition + Tablet hint combination
-EXPLAIN SELECT min(k2), max(k2) FROM t_tablet_hint PARTITION(p1) TABLET(99999) [_META_];
+-- Test: Invalid tablet hint with partition should throw error (partition name is auto-generated like p201912)
+SELECT min(k2), max(k2) FROM t_tablet_hint PARTITION(p201912) TABLET(99999) [_META_];
 -- result:
-[REGEX].*Partitions: \[p1\][\s\S]*TabletIds: \[99999\].*
+E: (1064, "Invalid tablet id: '99999'")
+-- !result
+-- Test: Valid tablet hint should work correctly with EXPLAIN verification
+function: set_first_tablet_id("t_tablet_hint")
+-- result:
+-- !result
+EXPLAIN SELECT count(*) FROM t_tablet_hint TABLET(${tablet_id}) [_META_];
+-- result:
+[REGEX][\s\S]*MetaScan[\s\S]*TabletIds: \[\d+\][\s\S]*
+-- !result
+-- Test: Valid partition and tablet hint together
+function: set_first_tablet_id("t_tablet_hint", "p201912")
+-- result:
+-- !result
+EXPLAIN SELECT min(k2), max(k2) FROM t_tablet_hint PARTITION(p201912) TABLET(${tablet_id}) [_META_];
+-- result:
+[REGEX][\s\S]*MetaScan[\s\S]*Partitions: \[p201912\][\s\S]*TabletIds: \[\d+\][\s\S]*
 -- !result

--- a/test/sql/test_meta_scan/R/test_meta_scan
+++ b/test/sql/test_meta_scan/R/test_meta_scan
@@ -571,3 +571,37 @@ SELECT count(*), max(k13), min(k13), count(k13) FROM update_table_with_null_part
 -- result:
 12	51.000000000	40.000000000	11
 -- !result
+
+-- name: test_meta_scan_with_tablet_hint
+CREATE TABLE t_tablet_hint (
+    k1 date,
+    k2 int
+)
+DUPLICATE KEY(k1)
+PARTITION BY RANGE(k1) (
+    PARTITION p1 VALUES LESS THAN ("2020-01-01"),
+    PARTITION p2 VALUES LESS THAN ("2020-02-01"),
+    PARTITION p3 VALUES LESS THAN ("2020-03-01")
+)
+DISTRIBUTED BY HASH(k1) BUCKETS 3
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO t_tablet_hint VALUES ("2019-12-01", 10), ("2020-01-15", 20), ("2020-02-15", 30);
+-- result:
+-- !result
+-- Test: Single tablet hint - EXPLAIN should show TabletIds
+EXPLAIN SELECT min(k2), max(k2) FROM t_tablet_hint TABLET(99999) [_META_];
+-- result:
+[REGEX].*TabletIds: \[99999\].*
+-- !result
+-- Test: Multiple tablet hints
+EXPLAIN SELECT min(k2), max(k2) FROM t_tablet_hint TABLET(11111, 22222) [_META_];
+-- result:
+[REGEX].*TabletIds: \[11111, 22222\].*
+-- !result
+-- Test: Partition + Tablet hint combination
+EXPLAIN SELECT min(k2), max(k2) FROM t_tablet_hint PARTITION(p1) TABLET(99999) [_META_];
+-- result:
+[REGEX].*Partitions: \[p1\][\s\S]*TabletIds: \[99999\].*
+-- !result

--- a/test/sql/test_meta_scan/T/test_meta_scan
+++ b/test/sql/test_meta_scan/T/test_meta_scan
@@ -259,13 +259,13 @@ PROPERTIES ("replication_num" = "1");
 
 INSERT INTO t_tablet_hint VALUES ("2019-12-01", 10), ("2020-01-15", 20), ("2020-02-15", 30);
 
--- Test: Invalid tablet hint should throw error (similar to OlapScanNode behavior)
+-- Test: Invalid tablet hint should return empty result (no matching tablets)
 SELECT min(k2), max(k2) FROM t_tablet_hint TABLET(99999) [_META_];
 
--- Test: Multiple invalid tablet hints should throw error
+-- Test: Multiple invalid tablet hints should return empty result
 SELECT min(k2), max(k2) FROM t_tablet_hint TABLET(11111, 22222) [_META_];
 
--- Test: Invalid tablet hint with partition should throw error (partition name is auto-generated like p201912)
+-- Test: Invalid tablet hint with partition should return empty result (partition name is auto-generated like p201912)
 SELECT min(k2), max(k2) FROM t_tablet_hint PARTITION(p201912) TABLET(99999) [_META_];
 
 -- Test: Valid tablet hint should work correctly with EXPLAIN verification

--- a/test/sql/test_meta_scan/T/test_meta_scan
+++ b/test/sql/test_meta_scan/T/test_meta_scan
@@ -246,3 +246,28 @@ SELECT count(*), max(k10), min(k10), count(k10) FROM update_table_with_null_part
 SELECT count(*), max(k11), min(k11), count(k11) FROM update_table_with_null_partition PARTITION (p202009);
 SELECT count(*), max(k12), min(k12), count(k12) FROM update_table_with_null_partition PARTITION (p202009);
 SELECT count(*), max(k13), min(k13), count(k13) FROM update_table_with_null_partition PARTITION (p202009);
+
+-- name: test_meta_scan_with_tablet_hint
+CREATE TABLE t_tablet_hint (
+    k1 date,
+    k2 int
+)
+DUPLICATE KEY(k1)
+PARTITION BY RANGE(k1) (
+    PARTITION p1 VALUES LESS THAN ("2020-01-01"),
+    PARTITION p2 VALUES LESS THAN ("2020-02-01"),
+    PARTITION p3 VALUES LESS THAN ("2020-03-01")
+)
+DISTRIBUTED BY HASH(k1) BUCKETS 3
+PROPERTIES ("replication_num" = "1");
+
+INSERT INTO t_tablet_hint VALUES ("2019-12-01", 10), ("2020-01-15", 20), ("2020-02-15", 30);
+
+-- Test: Single tablet hint - EXPLAIN should show TabletIds
+EXPLAIN SELECT min(k2), max(k2) FROM t_tablet_hint TABLET(99999) [_META_];
+
+-- Test: Multiple tablet hints
+EXPLAIN SELECT min(k2), max(k2) FROM t_tablet_hint TABLET(11111, 22222) [_META_];
+
+-- Test: Partition + Tablet hint combination
+EXPLAIN SELECT min(k2), max(k2) FROM t_tablet_hint PARTITION(p1) TABLET(99999) [_META_];

--- a/test/sql/test_meta_scan/T/test_meta_scan
+++ b/test/sql/test_meta_scan/T/test_meta_scan
@@ -253,21 +253,25 @@ CREATE TABLE t_tablet_hint (
     k2 int
 )
 DUPLICATE KEY(k1)
-PARTITION BY RANGE(k1) (
-    PARTITION p1 VALUES LESS THAN ("2020-01-01"),
-    PARTITION p2 VALUES LESS THAN ("2020-02-01"),
-    PARTITION p3 VALUES LESS THAN ("2020-03-01")
-)
+PARTITION BY date_trunc('month', k1)
 DISTRIBUTED BY HASH(k1) BUCKETS 3
 PROPERTIES ("replication_num" = "1");
 
 INSERT INTO t_tablet_hint VALUES ("2019-12-01", 10), ("2020-01-15", 20), ("2020-02-15", 30);
 
--- Test: Single tablet hint - EXPLAIN should show TabletIds
-EXPLAIN SELECT min(k2), max(k2) FROM t_tablet_hint TABLET(99999) [_META_];
+-- Test: Invalid tablet hint should throw error (similar to OlapScanNode behavior)
+SELECT min(k2), max(k2) FROM t_tablet_hint TABLET(99999) [_META_];
 
--- Test: Multiple tablet hints
-EXPLAIN SELECT min(k2), max(k2) FROM t_tablet_hint TABLET(11111, 22222) [_META_];
+-- Test: Multiple invalid tablet hints should throw error
+SELECT min(k2), max(k2) FROM t_tablet_hint TABLET(11111, 22222) [_META_];
 
--- Test: Partition + Tablet hint combination
-EXPLAIN SELECT min(k2), max(k2) FROM t_tablet_hint PARTITION(p1) TABLET(99999) [_META_];
+-- Test: Invalid tablet hint with partition should throw error (partition name is auto-generated like p201912)
+SELECT min(k2), max(k2) FROM t_tablet_hint PARTITION(p201912) TABLET(99999) [_META_];
+
+-- Test: Valid tablet hint should work correctly with EXPLAIN verification
+function: set_first_tablet_id("t_tablet_hint")
+EXPLAIN SELECT count(*) FROM t_tablet_hint TABLET(${tablet_id}) [_META_];
+
+-- Test: Valid partition and tablet hint together
+function: set_first_tablet_id("t_tablet_hint", "p201912")
+EXPLAIN SELECT min(k2), max(k2) FROM t_tablet_hint PARTITION(p201912) TABLET(${tablet_id}) [_META_];


### PR DESCRIPTION
## Why I'm doing:

META scan currently ignores tablet hints, making it impossible to target specific tablets for metadata queries.

## What I'm doing:

Propagate hintsTabletIds from LogicalOlapScanOperator to MetaScanNode through the optimizer pipeline, enabling tablet-level filtering in META scans.

The outcome of this PR is as follows.
<img width="865" height="1234" alt="image" src="https://github.com/user-attachments/assets/4a025477-2f39-458a-beba-02b3a2657936" />


Fixes #62673

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> _META_ scans now respect TABLET(...) hints (and partitions), filtering to specified tablets and showing TabletIds in EXPLAIN; optimizer/planner propagation added with tests and a test helper.
> 
> - **Planner/Execution**:
>   - `MetaScanNode`: accept `hintsTabletIds`, filter tablets by hint set, and append `TabletIds` to EXPLAIN when hints present.
>   - `PlanFragmentBuilder`: pass `hintsTabletIds` from physical operator to `MetaScanNode`.
> - **Optimizer**:
>   - `LogicalMetaScanOperator`/`PhysicalMetaScanOperator`: add `hintsTabletIds`, getters, equals/hash, and builder wiring.
>   - `RelationTransformer`: propagate `node.getTabletIds()` into `LogicalMetaScanOperator` for meta queries.
>   - `RewriteSimpleAggToMetaScanRule`: preserve `hintsTabletIds` when rewriting to `MetaScan`.
> - **Tests/Utils**:
>   - Add META scan tablet-hint tests (`LowCardinalityTest`, SQL R/T cases) validating empty results for invalid hints and EXPLAIN `TabletIds` output.
>   - Test lib: add `set_first_tablet_id()` helper to fetch a tablet id for tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d9eede2f62a25fff28a7d8306dba86a57d7edf6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->