### PR TITLE
[Enhancement] Array agg over window support

### DIFF
--- a/be/src/exprs/agg/array_agg.h
+++ b/be/src/exprs/agg/array_agg.h
@@ -28,12 +28,12 @@
 #include "util/defer_op.h"
 
 namespace starrocks {
-
 template <LogicalType PT, bool is_distinct, typename MyHashSet = std::set<int>>
 struct ArrayAggAggregateState {
     using ColumnType = RunTimeColumnType<PT>;
     using CppType = RunTimeCppType<PT>;
     using KeyType = typename SliceHashSet::key_type;
+
     void update(MemPool* mem_pool, const ColumnType& column, size_t offset, size_t count) {
         if constexpr (is_distinct) {
             if constexpr (lt_is_string<PT>) {
@@ -69,6 +69,7 @@ struct ArrayAggAggregateState {
             null_count++;
         }
     }
+
     void append_null(size_t count) {
         if constexpr (is_distinct) {
             if (count > 0) {
@@ -110,15 +111,56 @@ struct ArrayAggAggregateState {
         return false;
     }
 
+    void reset() {
+        data_column.resize(0);
+        null_count = 0;
+        set.clear();
+    }
+
     ColumnType data_column; // Aggregated elements for array_agg
     size_t null_count = 0;
     MyHashSet set;
 };
 
-template <LogicalType LT, bool is_distinct, typename MyHashSet = std::set<int>>
-class ArrayAggAggregateFunction final
-        : public AggregateFunctionBatchHelper<ArrayAggAggregateState<LT, is_distinct, MyHashSet>,
-                                              ArrayAggAggregateFunction<LT, is_distinct, MyHashSet>> {
+template <LogicalType PT, typename = guard::Guard>
+struct WithMemPool {};
+
+template <LogicalType PT>
+struct WithMemPool<PT, StringLTGuard<PT>> {
+    MemPool mem_pool{};
+};
+
+template <LogicalType PT, bool is_distinct, typename MyHashSet = std::set<int>>
+struct ArrayAggWindowState : public ArrayAggAggregateState<PT, is_distinct, MyHashSet>, WithMemPool<PT> {
+    using Base = ArrayAggAggregateState<PT, is_distinct, MyHashSet>;
+    using Self = ArrayAggWindowState<PT, is_distinct, MyHashSet>;
+    using CppType = typename Base::CppType;
+    using ColumnType = typename Base::ColumnType;
+    using Base::update;
+    using Base::append_null;
+    using Base::reset;
+
+    void update(MemPool* mem_pool, const ColumnType& column, size_t offset, size_t count) {
+        if constexpr (lt_is_string<PT>) {
+            this->Base::update(&this->mem_pool, column, offset, count);
+        } else {
+            this->Base::update(nullptr, column, offset, count);
+        }
+    }
+
+    void reset() {
+        this->Base::reset();
+        if constexpr (lt_is_string<PT>) {
+            this->mem_pool.clear();
+        }
+    }
+};
+
+template <LogicalType LT, bool is_distinct, template <LogicalType, bool, typename> typename State,
+          typename MyHashSet = std::set<int>>
+class ArrayAggAggregateFunctionBase final
+        : public AggregateFunctionBatchHelper<State<LT, is_distinct, MyHashSet>,
+                                              ArrayAggAggregateFunctionBase<LT, is_distinct, State, MyHashSet>> {
 public:
     using InputColumnType = RunTimeColumnType<LT>;
 
@@ -179,15 +221,65 @@ public:
         }
     }
 
+    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
+        this->data(state).reset();
+    }
+
+    void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
+                    size_t end) const override {
+        auto& state_impl = this->data(const_cast<AggDataPtr>(state));
+        const auto& data_column = state_impl.get_data_column();
+        auto* array_column = down_cast<ArrayColumn*>(dst);
+        for (auto i = start; i < end; i++) {
+            array_column->append_array_element(*data_column, state_impl.null_count);
+            if (UNLIKELY(state_impl.check_overflow(*array_column, ctx))) {
+                return;
+            }
+        }
+    }
+
+    void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
+                                              int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
+                                              int64_t frame_end) const override {
+        // For distinct mode, data_column used as a result cache for get_values method, any updates to
+        // this state should invalidate the cache.
+        this->data(state).data_column.resize(0);
+        const auto* column = down_cast<const InputColumnType*>(columns[0]);
+        this->data(state).update(ctx->mem_pool(), *column, frame_start, frame_end - frame_start);
+        this->data(state).check_overflow(ctx);
+    }
+
+    void update_single_state_null(FunctionContext* ctx, AggDataPtr __restrict state, int64_t peer_group_start,
+                                  int64_t peer_group_end) const override {
+        // For distinct mode, data_column used as a result cache for get_values method, any updates to
+        // this state should invalidate the cache.
+        this->data(state).data_column.resize(0);
+        this->data(state).append_null(peer_group_end - peer_group_start);
+    }
+
     std::string get_name() const override { return is_distinct ? "array_agg_distinct" : "array_agg"; }
 };
+
+template <LogicalType LT, bool is_distinct, typename MyHashSet = std::set<int>>
+using ArrayAggAggregateFunction = ArrayAggAggregateFunctionBase<LT, is_distinct, ArrayAggAggregateState, MyHashSet>;
+
+template <LogicalType LT, bool is_distinct, typename MyHashSet = std::set<int>>
+using ArrayAggAggregateWindowFunction = ArrayAggAggregateFunctionBase<LT, is_distinct, ArrayAggWindowState, MyHashSet>;
 
 // input columns result in intermediate result: struct{array[col0], array[col1], array[col2]... array[coln]}
 // return ordered array[col0']
 struct ArrayAggAggregateStateV2 {
+    void initialize(FunctionContext* ctx) const {
+        for (auto i = 0; i < ctx->get_arg_types().size(); ++i) {
+            data_columns.emplace_back(ctx->create_column(*ctx->get_arg_type(i), true));
+        }
+        DCHECK(data_columns.size() == ctx->get_is_asc_order().size() + 1);
+    }
+
     void update(const Column& column, size_t index, size_t offset, size_t count) {
         data_columns[index]->append(column, offset, count);
     }
+
     void update_nulls(size_t index, size_t count) { data_columns[index]->append_nulls(count); }
 
     bool check_overflow(FunctionContext* ctx) const {
@@ -222,30 +314,39 @@ struct ArrayAggAggregateStateV2 {
         data_columns.resize(1);
     }
 
+    void reset(FunctionContext* ctx) { data_columns.clear(); }
+
     // using pointer rather than vector to avoid variadic size
     // array_agg(a order by b, c, d), the a,b,c,d are put into data_columns in order.
-    MutableColumns data_columns;
+    mutable MutableColumns data_columns;
 };
 
+struct ArrayAggWindowStateV2 : public ArrayAggAggregateStateV2 {
+    using Base = ArrayAggAggregateStateV2;
+    using Base::Base;
+    using Base::initialize;
+    using Base::reset;
+
+    void initialize(FunctionContext* ctx) const {
+        Base::initialize(ctx);
+        result_column = ctx->create_column(ctx->get_return_type(), true);
+    }
+    void reset(FunctionContext* ctx) {
+        Base::reset(ctx);
+        result_column.reset();
+        DCHECK(data_columns.empty() && result_column == nullptr);
+        initialize(ctx);
+    }
+    mutable MutableColumnPtr result_column;
+};
+
+template <typename AggState>
 class ArrayAggAggregateFunctionV2 final
-        : public AggregateFunctionBatchHelper<ArrayAggAggregateStateV2, ArrayAggAggregateFunctionV2> {
+        : public AggregateFunctionBatchHelper<AggState, ArrayAggAggregateFunctionV2<AggState>> {
 public:
     void create(FunctionContext* ctx, AggDataPtr __restrict ptr) const override {
-        auto num = ctx->get_num_args();
-        auto* state = new (ptr) ArrayAggAggregateStateV2;
-        for (auto i = 0; i < num; ++i) {
-            state->data_columns.emplace_back(ctx->create_column(*ctx->get_arg_type(i), true));
-        }
-        DCHECK(state->data_columns.size() == ctx->get_is_asc_order().size() + 1);
-    }
-
-    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
-        auto& state_impl = this->data(state);
-        if (!state_impl.data_columns.empty()) {
-            for (auto& col : state_impl.data_columns) {
-                col->resize(0);
-            }
-        }
+        auto* state = new (ptr) AggState;
+        state->initialize(ctx);
     }
 
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
@@ -356,7 +457,11 @@ public:
             Status st = sort_and_tie_columns(ctx->state()->cancelled_ref(), order_by_columns, sort_desc, &perm);
             // release order-by columns early
             order_by_columns.clear();
-            state_impl.release_order_by_columns();
+            // for window function, we can not clear State::data_columns, since its data are used to produce
+            // result,for an example: array_agg(c) over(partition by a order by b)
+            if constexpr (!std::is_same_v<AggState, ArrayAggWindowStateV2>) {
+                state_impl.release_order_by_columns();
+            }
             if (UNLIKELY(ctx->state()->cancelled_ref())) {
                 ctx->set_error("array_agg detects cancelled.", false);
                 return;
@@ -418,7 +523,11 @@ public:
         } else {
             elements_col->append_selective(*res, index);
         }
-        state_impl.data_columns.clear(); // early release memory
+        // for window function, we can not clear State::data_columns, since its data are used to produce
+        // result,for an example: array_agg(c) over(partition by a order by b)
+        if constexpr (!std::is_same_v<AggState, ArrayAggWindowStateV2>) {
+            state_impl.data_columns.clear(); // early release memory
+        }
         auto* offsets_col = array_col->offsets_column_raw_ptr();
         offsets_col->append(offsets_col->immutable_data().back() + elem_size);
         // should check overflow after append, otherwise the result column with multi row will be overflow.
@@ -452,8 +561,37 @@ public:
             }
         }
     }
+
+    void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
+        this->data(state).reset(ctx);
+    }
+
+    void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
+                    size_t end) const override {
+        if constexpr (std::is_same_v<AggState, ArrayAggWindowStateV2>) {
+            auto& state_impl = this->data(const_cast<AggDataPtr>(state));
+            auto* result_column = state_impl.result_column.get();
+            if (result_column->size() == 0) {
+                finalize_to_column(ctx, state, result_column);
+            }
+            DCHECK(result_column->size() == 1);
+            dst->append_value_multiple_times(*result_column, 0, end - start);
+        }
+    }
+
+    void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
+                                              int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
+                                              int64_t frame_end) const override {
+        if constexpr (std::is_same_v<AggState, ArrayAggWindowStateV2>) {
+            this->data(state).result_column->resize(0);
+        }
+
+        for (auto i = frame_start; i < frame_end; ++i) {
+            update(ctx, columns, state, i);
+        }
+    }
+
     // V2 support order by
     std::string get_name() const override { return "array_agg2"; }
 };
-
 } // namespace starrocks

--- a/be/src/exprs/agg/factory/aggregate_factory.hpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.hpp
@@ -114,8 +114,9 @@ public:
         return std::make_shared<ExchangePerfAggregateFunction<PerfType>>();
     }
 
+    template <typename ArrayAggState>
     static AggregateFunctionPtr MakeArrayAggAggregateFunctionV2() {
-        return std::make_shared<ArrayAggAggregateFunctionV2>();
+        return std::make_shared<ArrayAggAggregateFunctionV2<ArrayAggState>>();
     }
 
     static AggregateFunctionPtr MakeGroupConcatAggregateFunctionV2() {

--- a/be/src/exprs/agg/factory/aggregate_resolver.hpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver.hpp
@@ -108,6 +108,12 @@ public:
         }
     }
 
+    template <typename SpecificAggFunctionPtr = AggregateFunctionPtr>
+    void add_general_window_mapping_notnull(const std::string& name, SpecificAggFunctionPtr fun) {
+        _general_mapping.emplace(std::make_tuple(name, true, false), fun);
+        _general_mapping.emplace(std::make_tuple(name, true, true), fun);
+    }
+
     template <class StateType, typename SpecificAggFunctionPtr = AggregateFunctionPtr, bool IgnoreNull = true>
     void add_general_mapping(const std::string& name, bool is_window, SpecificAggFunctionPtr fun) {
         _general_mapping.emplace(std::make_tuple(name, false, false), fun);

--- a/be/src/exprs/agg/factory/aggregate_resolver_others.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_others.cpp
@@ -111,7 +111,10 @@ void AggregateFuncResolver::register_others() {
     add_array_mapping<TYPE_DATE, TYPE_INT>("window_funnel");
 
     add_general_mapping<AnyValueSemiState>("any_value", false, AggregateFactory::MakeAnyValueSemiAggregateFunction());
-    add_general_mapping_notnull("array_agg2", false, AggregateFactory::MakeArrayAggAggregateFunctionV2());
+    add_general_mapping_notnull("array_agg2", false,
+                                AggregateFactory::MakeArrayAggAggregateFunctionV2<ArrayAggAggregateStateV2>());
+    add_general_window_mapping_notnull("array_agg2",
+                                       AggregateFactory::MakeArrayAggAggregateFunctionV2<ArrayAggWindowStateV2>());
     add_general_mapping_notnull("group_concat2", false, AggregateFactory::MakeGroupConcatAggregateFunctionV2());
 
     add_general_mapping_notnull("dict_merge", false, AggregateFactory::MakeDictMergeAggregateFunction());

--- a/be/src/exprs/agg/nullable_aggregate.h
+++ b/be/src/exprs/agg/nullable_aggregate.h
@@ -47,11 +47,22 @@ inline constexpr bool IsUnresizableWindowFunctionState<MinAggregateData<TYPE_VAR
 template <LogicalType LT>
 inline constexpr bool IsUnresizableWindowFunctionState<ApproxTopKState<LT>> = true;
 
+template <LogicalType LT, bool is_distinct, typename MyHashSet>
+inline constexpr bool IsUnresizableWindowFunctionState<ArrayAggWindowState<LT, is_distinct, MyHashSet>> = true;
+
+template <>
+inline constexpr bool IsUnresizableWindowFunctionState<ArrayAggWindowStateV2> = true;
+
 template <typename T>
 constexpr bool IsNeverNullFunctionState = false;
 
 template <LogicalType LT>
 inline constexpr bool IsNeverNullFunctionState<ApproxTopKState<LT>> = true;
+
+template <LogicalType LT, bool is_distinct, typename MyHashSet>
+inline constexpr bool IsNeverNullFunctionState<ArrayAggWindowState<LT, is_distinct, MyHashSet>> = true;
+template <>
+inline constexpr bool IsNeverNullFunctionState<ArrayAggWindowStateV2> = true;
 
 struct NullableAggregateWindowFunctionState {
     // The following two fields are only used in "update_state_removable_cumulatively"

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -1268,7 +1268,7 @@ public class FunctionSet {
 
         addBuiltin(AggregateFunction.createBuiltin(ARRAY_AGG,
                 Lists.newArrayList(AnyElementType.ANY_ELEMENT), AnyArrayType.ANY_ARRAY, AnyStructType.ANY_STRUCT, true,
-                true, false, false));
+                true, true, false));
 
         addBuiltin(AggregateFunction.createBuiltin(GROUP_CONCAT,
                 Lists.newArrayList(AnyElementType.ANY_ELEMENT), VarcharType.VARCHAR, AnyStructType.ANY_STRUCT, true,
@@ -1709,24 +1709,24 @@ public class FunctionSet {
             Type arrayType = new ArrayType(type);
             addBuiltin(AggregateFunction.createBuiltin(FunctionSet.ARRAY_AGG_DISTINCT,
                     Lists.newArrayList(type), arrayType, arrayType,
-                    false, false, false));
+                    false, true, false));
         }
         for (ScalarType type : STRING_TYPES) {
             Type arrayType = new ArrayType(type);
             addBuiltin(AggregateFunction.createBuiltin(FunctionSet.ARRAY_AGG_DISTINCT,
                     Lists.newArrayList(type), arrayType, arrayType,
-                    false, false, false));
+                    false, true, false));
         }
 
         for (ScalarType type : DateType.DATE_TYPES) {
             Type arrayType = new ArrayType(type);
             addBuiltin(AggregateFunction.createBuiltin(FunctionSet.ARRAY_AGG_DISTINCT,
                     Lists.newArrayList(type), arrayType, arrayType,
-                    false, false, false));
+                    false, true, false));
         }
         addBuiltin(AggregateFunction.createBuiltin(FunctionSet.ARRAY_AGG_DISTINCT,
                 Lists.newArrayList(DateType.TIME), ArrayType.ARRAY_DATETIME, ArrayType.ARRAY_DATETIME,
-                false, false, false));
+                false, true, false));
     }
 
     private void registerBuiltinMapAggFunction() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyticAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyticAnalyzer.java
@@ -402,7 +402,9 @@ public class AnalyticAnalyzer {
         final Set<String> supportFunctions = ImmutableSet.of(
                 FunctionSet.SUM,
                 FunctionSet.AVG,
-                FunctionSet.COUNT);
+                FunctionSet.COUNT,
+                FunctionSet.ARRAY_AGG,
+                FunctionSet.ARRAY_AGG_DISTINCT);
 
         return supportFunctions.contains(fnCall.getFunctionName());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayAggOverWindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayAggOverWindowTest.java
@@ -1,0 +1,526 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.common.FeConstants;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.utframe.StarRocksAssert;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class ArrayAggOverWindowTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        FeConstants.unitTestView = false;
+        PlanTestBase.beforeClass();
+        StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withTable("CREATE TABLE `s1` (    \n" +
+                "  `v1` bigint(20) NULL COMMENT \"\",    \n" +
+                "  `v2` int(11) NULL COMMENT \"\",    \n" +
+                "  `s1` struct<count bigint, sum double, avg double> NULL COMMENT \"\",    \n" +
+                "  `a1` array<varchar(65533)> NULL COMMENT \"\",    \n" +
+                "  `a2` array<varchar(65533)> NULL COMMENT \"\",    \n" +
+                "  `map_v1` map<int,varchar(65533)>,\n" +
+                "  `map_v2` map<int, map<int,double>>,\n" +
+                "   nested_array array<array<int>>,\n" +
+                "   nested_struct struct<a int, b array<varchar(65533)>>,\n" +
+                "   complex_map map<int, struct<x int, y varchar(65533)>>\n" +
+                ") ENGINE=OLAP    \n" +
+                "DUPLICATE KEY(`v1`)    \n" +
+                "COMMENT \"OLAP\"    \n" +
+                "DISTRIBUTED BY HASH(`v1`) BUCKETS 10    \n" +
+                "PROPERTIES (    \n" +
+                "\"replication_num\" = \"1\",       \n" +
+                "\"in_memory\" = \"false\",    \n" +
+                "\"enable_persistent_index\" = \"true\",    \n" +
+                "\"replicated_storage\" = \"false\",    \n" +
+                "\"light_schema_change\" = \"true\",    \n" +
+                "\"compression\" = \"LZ4\"    \n" +
+                ");");
+    }
+
+    @Test
+    public void testArrayAgg() throws Exception {
+        String sql = "select v1,v2,v3,\n" +
+                "      array_agg(v3) \n" +
+                "      over(partition by v1, v2)\n" +
+                "from t0;";
+        assertPlanContains(sql, "array_agg", "PARTITION", "ANALYTIC");
+    }
+
+    // Test basic array_agg with different window definitions
+    @Test
+    public void testArrayAggBasicWindows() throws Exception {
+        // Test 1: over() - no partition, no order by
+        String sql1 = "select v1, array_agg(v3) over() from t0;";
+        assertPlanContains(sql1, "array_agg", "ANALYTIC");
+
+        // Test 2: over(partition by...) - partition only
+        String sql2 = "select v1, array_agg(v3) over(partition by v1) from t0;";
+        assertPlanContains(sql2, "array_agg", "PARTITION", "ANALYTIC");
+
+        // Test 3: over(partition by... order by...) - partition and order by
+        String sql3 = "select v1, array_agg(v3) over(partition by v1 order by v2) from t0;";
+        assertPlanContains(sql3, "array_agg", "PARTITION", "ORDER BY", "ANALYTIC");
+
+        // Test 4: over(order by...) - order by only
+        String sql4 = "select v1, array_agg(v3) over(order by v1) from t0;";
+        assertPlanContains(sql4, "array_agg", "ORDER BY", "ANALYTIC");
+    }
+
+    // Test array_agg with different column types
+    @Test
+    public void testArrayAggDifferentTypes() throws Exception {
+        // Test with bigint columns
+        String sql1 = "select v1, array_agg(v2) over(partition by v1 order by v3) from t0;";
+        assertPlanContains(sql1, "array_agg", "PARTITION", "ANALYTIC");
+
+        // Test with string columns
+        String sql2 = "select k1, array_agg(k2) over(partition by k1 order by k3) from t7;";
+        assertPlanContains(sql2, "array_agg", "PARTITION", "ANALYTIC");
+
+        // Test with decimal columns
+        String sql3 =
+                "select id_decimal, array_agg(id_decimal) over(partition by id_decimal order by id_decimal) " +
+                        "from test_all_type;";
+        assertPlanContains(sql3, "array_agg", "PARTITION", "ANALYTIC");
+
+        // Test with float columns
+        String sql4 = "select t1e, array_agg(t1e) over(partition by t1e order by t1f) from test_all_type;";
+        assertPlanContains(sql4, "array_agg", "PARTITION", "ANALYTIC");
+
+        // Test with double columns
+        String sql5 = "select t1f, array_agg(t1f) over(partition by t1f order by t1e) from test_all_type;";
+        assertPlanContains(sql5, "array_agg", "PARTITION", "ANALYTIC");
+    }
+
+    // Test array_agg with ORDER BY clause in function
+    @Test
+    public void testArrayAggWithOrderBy() throws Exception {
+        // Test array_agg(column order by column)
+        String sql1 = "select v1, array_agg(v3 order by v2) over(partition by v1) from t0;";
+        assertPlanContains(sql1, "array_agg", "ORDER BY", "ANALYTIC");
+
+        // Test array_agg(column order by different_column)
+        String sql2 = "select v1, array_agg(v3 order by v2) over(partition by v1 order by v3) from t0;";
+        assertPlanContains(sql2, "array_agg", "ORDER BY", "ANALYTIC");
+
+        // Test with string order by
+        String sql3 = "select k1, array_agg(k2 order by k3 desc) over(partition by k1) from t7;";
+        assertPlanContains(sql3, "array_agg", "ORDER BY", "ANALYTIC");
+    }
+
+    // Test array_agg with DISTINCT
+    @Test
+    public void testArrayAggDistinct() throws Exception {
+        // Test array_agg(distinct column)
+        String sql1 = "select v1, array_agg(distinct v3) over(partition by v1) from t0;";
+        assertPlanContains(sql1, "array_agg", "DISTINCT", "ANALYTIC");
+
+        // Test array_agg(distinct column order by column)
+        String sql2 = "select v1, array_agg(distinct v3 order by v2) over(partition by v1) from t0;";
+        assertPlanContains(sql2, "array_agg", "DISTINCT", "ORDER BY", "ANALYTIC");
+
+        // Test with string distinct
+        String sql3 = "select k1, array_agg(distinct k2) over(partition by k1 order by k3) from t7;";
+        assertPlanContains(sql3, "array_agg", "DISTINCT", "ANALYTIC");
+    }
+
+    // Test array_agg with complex types (struct, array)
+    @Test
+    public void testArrayAggComplexTypes() throws Exception {
+        // Test with struct column
+        String sql1 = "select v1, array_agg(s1) over(partition by v1) from s1;";
+        assertPlanContains(sql1, "array_agg", "ANALYTIC");
+
+        // Test with array column
+        String sql2 = "select v1, array_agg(a1) over(partition by v1) from s1;";
+        assertPlanContains(sql2, "array_agg", "ANALYTIC");
+
+        // Test with multiple complex columns
+        String sql3 = "select v1, array_agg(a2) over(partition by v1 order by v2) from s1;";
+        assertPlanContains(sql3, "array_agg", "ORDER BY", "ANALYTIC");
+    }
+
+    // Test array_agg with complex window scenarios
+    @Test
+    public void testArrayAggComplexWindows() throws Exception {
+        // Test with multiple partition columns
+        String sql1 = "select v1, v2, array_agg(v3) over(partition by v1, v2 order by v3) from t0;";
+        assertPlanContains(sql1, "array_agg", "PARTITION", "ANALYTIC");
+
+        // Test with no partition, with order by
+        String sql2 = "select v1, array_agg(v3) over(order by v1, v2) from t0;";
+        assertPlanContains(sql2, "array_agg", "ORDER BY", "ANALYTIC");
+
+        // Test with partition and multiple order by columns
+        String sql3 = "select v1, array_agg(v3) over(partition by v1 order by v2, v3 desc) from t0;";
+        assertPlanContains(sql3, "array_agg", "PARTITION", "ORDER BY", "ANALYTIC");
+    }
+
+    // Test array_agg with decimal precision
+    @Test
+    public void testArrayAggDecimalTypes() throws Exception {
+        // Test with cast decimal
+        String sql1 = "select v1, array_agg(cast(v3 as decimal(19,2))) over(partition by v1) from t0;";
+        assertPlanContains(sql1, "array_agg", "ANALYTIC");
+        
+        // Test with decimal distinct
+        String sql2 =
+                "select v1, array_agg(distinct cast(v3 as decimal(10,5))) over(partition by v1 order by v2) from t0;";
+        assertPlanContains(sql2, "array_agg", "DISTINCT", "ORDER BY", "ANALYTIC");
+
+        // Test with existing decimal column
+        String sql3 =
+                "select id_decimal, array_agg(distinct id_decimal) over(partition by id_decimal) from test_all_type;";
+        assertPlanContains(sql3, "array_agg", "DISTINCT", "ANALYTIC");
+    }
+
+    // Test array_agg with float/double precision
+    @Test
+    public void testArrayAggFloatTypes() throws Exception {
+        // Test with float
+        String sql1 = "select t1e, array_agg(t1e) over(partition by t1e order by t1f) from test_all_type;";
+        assertPlanContains(sql1, "array_agg", "PARTITION", "ANALYTIC");
+
+        // Test with double
+        String sql2 = "select t1f, array_agg(distinct t1f) over(partition by t1f) from test_all_type;";
+        assertPlanContains(sql2, "array_agg", "DISTINCT", "ANALYTIC");
+
+        // Test with cast float
+        String sql3 = "select v1, array_agg(cast(v3 as float)) over(partition by v1 order by v2) from t0;";
+        assertPlanContains(sql3, "array_agg", "ORDER BY", "ANALYTIC");
+    }
+
+    // Test array_agg with mixed data types in same query
+    @Test
+    public void testArrayAggMixedTypes() throws Exception {
+        String sql = "select v1,\n" +
+                "       array_agg(v2) over(partition by v1),\n" +
+                "       array_agg(distinct v3) over(partition by v1 order by v2),\n" +
+                "       array_agg(v3 order by v2 desc) over(partition by v1)\n" +
+                "from t0;";
+        assertPlanContains(sql, "array_agg", "DISTINCT", "ORDER BY", "ANALYTIC");
+    }
+
+    // Test array_agg with complex expressions
+    @Test
+    public void testArrayAggComplexExpressions() throws Exception {
+        // Test with arithmetic expression
+        String sql1 = "select v1, array_agg(v2 + v3) over(partition by v1) from t0;";
+        assertPlanContains(sql1, "array_agg", "ANALYTIC");
+
+        // Test with string concatenation
+        String sql2 = "select k1, array_agg(k2 || k3) over(partition by k1) from t7;";
+        assertPlanContains(sql2, "array_agg", "ANALYTIC");
+
+        // Test with case expression
+        String sql3 = "select v1, array_agg(case when v2 > 5 then v3 else null end) over(partition by v1) from t0;";
+        assertPlanContains(sql3, "array_agg", "ANALYTIC");
+    }
+
+    // Test array_agg with limit in window (if supported)
+    @Test
+    public void testArrayAggWithWindowFrame() throws Exception {
+        // Test range frame
+        String sql1 =
+                "select v1, array_agg(v3) " +
+                        "over(partition by v1 order by v2 rows between unbounded preceding and current row) from t0;";
+        assertPlanContains(sql1, "array_agg", "PARTITION", "ROWS", "ANALYTIC");
+
+        // Test range frame with values
+        String sql2 =
+                "select v1, array_agg(v3) " +
+                        "over(partition by v1 order by v2 range between 2 preceding and 2 following) from t0;";
+        Assertions.assertThrows(SemanticException.class, () -> getCostExplain(sql2));
+    }
+
+    // Test array_agg with NULL value handling
+    @Test
+    public void testArrayAggWithNullValues() throws Exception {
+        // Test array_agg with NULL values
+        String sql1 = "select v1, array_agg(v3) over(partition by v1) from t0 where v3 is null;";
+        assertPlanContains(sql1, "array_agg", "ANALYTIC");
+
+        // Test array_agg(distinct) with NULL values
+        String sql2 = "select v1, array_agg(distinct v3) over(partition by v1) from t0;";
+        assertPlanContains(sql2, "array_agg", "DISTINCT", "ANALYTIC");
+
+        // Test array_agg with ORDER BY and NULL values
+        String sql3 = "select v1, array_agg(v3 order by v2 nulls first) over(partition by v1) from t0;";
+        assertPlanContains(sql3, "array_agg", "ORDER BY", "ANALYTIC");
+    }
+
+    // Test array_agg with map types and complex scenarios
+    @Test
+    public void testArrayAggWithMapTypes() throws Exception {
+        // Test with simple map
+        String sql1 = "select v1, array_agg(map_v1) over(partition by v1) from s1;";
+        assertPlanContains(sql1, "array_agg", "ANALYTIC");
+
+        // Test with nested map
+        String sql2 = "select v1, array_agg(map_v1) over(partition by v1 order by v2) from s1;";
+        assertPlanContains(sql2, "array_agg", "ORDER BY", "ANALYTIC");
+
+        // Test array_agg(distinct) with map
+        String sql3 = "select v1, array_agg(distinct map_v2) over(partition by v1) from s1;";
+        assertPlanContains(sql3, "array_agg", "DISTINCT", "ANALYTIC");
+    }
+
+    // Test array_agg with various decimal precision and scale combinations
+    @Test
+    public void testArrayAggWithVariousDecimalPrecisions() throws Exception {
+        // Test with different decimal precisions
+        String sql1 = "select v1, array_agg(cast(v3 as decimal(10,2))) over(partition by v1 order by v2) from t0;";
+        assertPlanContains(sql1, "array_agg", "ORDER BY", "ANALYTIC");
+
+        // Test with decimal(38,10)
+        String sql2 = "select v1, array_agg(cast(v3 as decimal(38,10))) over(partition by v1) from t0;";
+        assertPlanContains(sql2, "array_agg", "ANALYTIC");
+
+        // Test with decimal(5,0) - integer-like decimal
+        String sql3 = "select v1, array_agg(cast(v3 as decimal(5,0))) over(partition by v1 order by v2) from t0;";
+        assertPlanContains(sql3, "array_agg", "ORDER BY", "ANALYTIC");
+
+        // Test with high precision decimal
+        String sql4 = "select v1, array_agg(distinct cast(v3 as decimal(27,9))) over(partition by v1) from t0;";
+        assertPlanContains(sql4, "array_agg", "DISTINCT", "ANALYTIC");
+    }
+
+    // Test array_agg with nested complex types
+    @Test
+    public void testArrayAggWithNestedComplexTypes() throws Exception {
+        // Test with nested array
+        String sql1 = "select v1, array_agg(nested_array) over(partition by v1) from s1;";
+        assertPlanContains(sql1, "array_agg", "ANALYTIC");
+
+        // Test with nested struct
+        String sql2 = "select v1, array_agg(nested_struct) over(partition by v1 order by v2) from s1;";
+        assertPlanContains(sql2, "array_agg", "ORDER BY", "ANALYTIC");
+
+        // Test with complex map
+        String sql3 = "select v1, array_agg(distinct complex_map order by v1) over(partition by v1) from s1;";
+        assertPlanContains(sql3, "array_agg", "DISTINCT", "ANALYTIC");
+    }
+
+    // Test array_agg with window frame boundaries
+    @Test
+    public void testArrayAggWithWindowFrameBoundaries() throws Exception {
+        // Test with rows between unbounded preceding and current row
+        String sql1 =
+                "select v1, array_agg(v3) " +
+                        "over(partition by v1 order by v2 rows between unbounded preceding and current row) from t0;";
+        assertPlanContains(sql1, "array_agg", "PARTITION", "ROWS", "ANALYTIC");
+
+        // Test with range between unbounded preceding and unbounded following
+        String sql2 =
+                "select v1, array_agg(v3) " +
+                        "over(partition by v1 order by v2 range between unbounded preceding and unbounded following)" +
+                        " from t0;";
+        assertPlanContains(sql2, "array_agg", "PARTITION", "RANGE", "ANALYTIC");
+
+        // Test with rows between current row and unbounded following
+        String sql3 =
+                "select v1, array_agg(distinct v3) " +
+                        "over(partition by v1 order by v2 rows between current row and unbounded following) from t0;";
+        Assertions.assertThrows(SemanticException.class, () -> getCostExplain(sql3));
+
+        // Test with range between value preceding and value following
+        String sql4 =
+                "select v1, array_agg(v3 order by v2) " +
+                        "over(partition by v1 order by v2 range between 2 preceding and 2 following) from t0;";
+        Assertions.assertThrows(SemanticException.class, () -> getCostExplain(sql4));
+    }
+
+    // Test array_agg with different numeric type conversions
+    @Test
+    public void testArrayAggWithNumericConversions() throws Exception {
+        // Test with bigint to int conversion
+        String sql1 = "select v1, array_agg(cast(v2 as int)) over(partition by v1) from t0;";
+        assertPlanContains(sql1, "array_agg", "ANALYTIC");
+
+        // Test with double to decimal conversion
+        String sql2 =
+                "select t1f, array_agg(cast(t1f as decimal(10,2))) " +
+                        "over(partition by t1f order by t1e) from test_all_type;";
+        assertPlanContains(sql2, "array_agg", "ORDER BY", "ANALYTIC");
+
+        // Test with float to decimal conversion
+        String sql3 =
+                "select t1e, array_agg(distinct cast(t1e as decimal(15,5))) over(partition by t1e) from test_all_type;";
+        assertPlanContains(sql3, "array_agg", "DISTINCT", "ANALYTIC");
+    }
+
+    // Test array_agg with string operations and functions
+    @Test
+    public void testArrayAggWithStringOperations() throws Exception {
+        // Test with string concatenation
+        String sql1 = "select k1, array_agg(concat(k2, k3)) over(partition by k1 order by k2) from t7;";
+        assertPlanContains(sql1, "array_agg", "ORDER BY", "ANALYTIC");
+
+        // Test with substring function
+        String sql2 = "select k1, array_agg(substring(k2, 1, 5)) over(partition by k1) from t7;";
+        assertPlanContains(sql2, "array_agg", "ANALYTIC");
+
+        // Test with upper function
+        String sql3 = "select k1, array_agg(distinct upper(k2)) over(partition by k1 order by k3) from t7;";
+        assertPlanContains(sql3, "array_agg", "DISTINCT", "ORDER BY", "ANALYTIC");
+
+        // Test with length function
+        String sql4 = "select k1, array_agg(length(k2)) over(partition by k1 order by k2, k3) from t7;";
+        assertPlanContains(sql4, "array_agg", "ORDER BY", "ANALYTIC");
+    }
+
+    // Test array_agg with conditional logic and case statements
+    @Test
+    public void testArrayAggWithConditionalLogic() throws Exception {
+        // Test with case statement
+        String sql1 = "select v1, array_agg(case when v2 > 5 then v3 else 0 end) over(partition by v1) from t0;";
+        assertPlanContains(sql1, "array_agg", "ANALYTIC");
+
+        // Test with if function
+        String sql2 = "select v1, array_agg(if(v2 > 5, v3, null)) over(partition by v1 order by v2) from t0;";
+        assertPlanContains(sql2, "array_agg", "ORDER BY", "ANALYTIC");
+
+        // Test with coalesce function
+        String sql3 = "select v1, array_agg(distinct coalesce(v3, -1)) over(partition by v1) from t0;";
+        assertPlanContains(sql3, "array_agg", "DISTINCT", "ANALYTIC");
+
+        // Test with nullif function
+        String sql4 = "select v1, array_agg(nullif(v3, 0)) over(partition by v1 order by v2) from t0;";
+        assertPlanContains(sql4, "array_agg", "ORDER BY", "ANALYTIC");
+    }
+
+    // Test array_agg with date/time functions and types
+    @Test
+    public void testArrayAggWithDateTimeTypes() throws Exception {
+        // Test with date type
+        String sql1 =
+                "select id_date, array_agg(id_date) over(partition by id_date order by id_decimal) from test_all_type;";
+        assertPlanContains(sql1, "array_agg", "PARTITION", "ANALYTIC");
+
+        // Test with datetime type
+        String sql2 =
+                "select id_datetime, array_agg(distinct id_datetime) over(partition by id_datetime) from test_all_type;";
+        assertPlanContains(sql2, "array_agg", "DISTINCT", "ANALYTIC");
+
+        // Test with date functions
+        String sql3 =
+                "select id_date, array_agg(year(id_date)) " +
+                        "over(partition by id_date order by id_decimal) from test_all_type;";
+        assertPlanContains(sql3, "array_agg", "PARTITION", "ANALYTIC");
+
+        // Test with datetime functions
+        String sql4 =
+                "select id_datetime, array_agg(month(id_datetime)) " +
+                        "over(partition by id_datetime order by id_date) from test_all_type;";
+        assertPlanContains(sql4, "array_agg", "PARTITION", "ANALYTIC");
+    }
+
+    // Test array_agg with mathematical functions and operations
+    @Test
+    public void testArrayAggWithMathFunctions() throws Exception {
+        // Test with absolute value
+        String sql1 = "select v1, array_agg(abs(v3)) over(partition by v1 order by v2) from t0;";
+        assertPlanContains(sql1, "array_agg", "ORDER BY", "ANALYTIC");
+
+        // Test with square root
+        String sql2 = "select v1, array_agg(sqrt(abs(v3))) over(partition by v1) from t0;";
+        assertPlanContains(sql2, "array_agg", "ANALYTIC");
+
+        // Test with power function
+        String sql3 = "select v1, array_agg(distinct pow(v2, 2)) over(partition by v1 order by v3) from t0;";
+        assertPlanContains(sql3, "array_agg", "DISTINCT", "ORDER BY", "ANALYTIC");
+
+        // Test with rounding
+        String sql4 = "select t1e, array_agg(round(t1f, 2)) over(partition by t1e order by t1f) from test_all_type;";
+        assertPlanContains(sql4, "array_agg", "ORDER BY", "ANALYTIC");
+    }
+
+    // Test array_agg with very large datasets and performance scenarios
+    @Test
+    public void testArrayAggWithLargeDatasets() throws Exception {
+        // Test with multiple array_agg calls in same query
+        String sql1 = "select v1,\n" +
+                "       array_agg(v2) over(partition by v1 order by v3),\n" +
+                "       array_agg(distinct v3) over(partition by v1),\n" +
+                "       array_agg(v2 order by v3 desc) over(partition by v1)\n" +
+                "from t0;";
+        assertPlanContains(sql1, "array_agg", "DISTINCT", "ORDER BY", "ANALYTIC");
+
+        // Test with many partition columns
+        String sql2 = "select v1, v2, v3,\n" +
+                "       array_agg(v1 + v2 + v3) over(partition by v1, v2, v3 order by v1)\n" +
+                "from t0;";
+        assertPlanContains(sql2, "array_agg", "PARTITION", "ORDER BY", "ANALYTIC");
+
+        // Test with complex expressions and functions
+        String sql3 = "select k1,\n" +
+                "       array_agg(length(k2) + length(k3)) over(partition by k1 order by k2),\n" +
+                "       array_agg(distinct concat(k2, k3)) over(partition by k1)\n" +
+                "from t7;";
+        assertPlanContains(sql3, "array_agg", "DISTINCT", "ORDER BY", "ANALYTIC");
+    }
+
+    // Test array_agg edge cases and error conditions
+    @Test
+    public void testArrayAggEdgeCases() throws Exception {
+        // Test with constant values
+        String sql1 = "select v1, array_agg(1) over(partition by v1) from t0;";
+        assertPlanContains(sql1, "array_agg", "ANALYTIC");
+
+        // Test with expression resulting in same value
+        String sql2 = "select v1, array_agg(v2 - v2) over(partition by v1) from t0;";
+        assertPlanContains(sql2, "array_agg", "ANALYTIC");
+
+        // Test with very small decimal values
+        String sql3 = "select v1, array_agg(cast(0.00001 as decimal(10,8))) over(partition by v1 order by v2) from t0;";
+        assertPlanContains(sql3, "array_agg", "ORDER BY", "ANALYTIC");
+
+        // Test with very large decimal values
+        String sql4 = "select v1, array_agg(cast(999999.99 as decimal(10,2))) over(partition by v1) from t0;";
+        assertPlanContains(sql4, "array_agg", "ANALYTIC");
+    }
+
+    // Test array_agg compatibility with other window functions
+    @Test
+    public void testArrayAggWithOtherWindowFunctions() throws Exception {
+        // Test array_agg with row_number
+        String sql1 =
+                "select v1, " +
+                        "array_agg(v2) over(partition by v1), row_number() over(partition by v1 order by v2) from t0;";
+        assertPlanContains(sql1, "array_agg", "ROW_NUMBER", "ANALYTIC");
+
+        // Test array_agg with rank
+        String sql2 =
+                "select v1, array_agg(distinct v2) " +
+                        "over(partition by v1 order by v3), rank() over(partition by v1 order by v2) from t0;";
+        assertPlanContains(sql2, "array_agg", "DISTINCT", "RANK", "ANALYTIC");
+
+        // Test array_agg with dense_rank
+        String sql3 =
+                "select v1, array_agg(v2 order by v3) " +
+                        "over(partition by v1), dense_rank() over(partition by v1 order by v2) from t0;";
+        assertPlanContains(sql3, "array_agg", "ORDER BY", "DENSE_RANK", "ANALYTIC");
+
+        // Test array_agg with lag
+        String sql4 =
+                "select v1, array_agg(v2) " +
+                        "over(partition by v1 order by v2), lag(v2, 1) over(partition by v1 order by v2) from t0;";
+        assertPlanContains(sql4, "array_agg", "LAG", "ANALYTIC");
+    }
+}

--- a/test/sql/test_array_agg_over_window/R/test_array_agg_over_window
+++ b/test/sql/test_array_agg_over_window/R/test_array_agg_over_window
@@ -1,0 +1,813 @@
+-- name: test_array_agg_over_window
+CREATE TABLE `t0` (
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `v3` bigint(20) NULL COMMENT "",
+  `v4` varchar(50) NULL COMMENT "",
+  `v5` decimal(10,2) NULL COMMENT "",
+  `v6` float NULL COMMENT ""
+) ENGINE=OLAP
+PROPERTIES("replication_num"="1");
+-- result:
+-- !result
+insert into t0 select i/19 as v1, i/11 as v2, i/5 as v3, concat('item_', cast(i as varchar)) as v4, i/3.14 as v5, i/2.71 as v6 from table(generate_series(1,100)) t(i);
+-- result:
+-- !result
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over() as arr_basic,
+  array_agg(distinct v2) over() as arr_distinct,
+  array_agg(v3 order by v2) over() as arr_order_by
+  from t0
+) as t;
+-- result:
+1082312479600
+-- !result
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over(partition by v1) as arr_basic,
+  array_agg(distinct v2) over(partition by v1) as arr_distinct,
+  array_agg(v3 order by v2) over(partition by v1) as arr_order_by
+  from t0
+) as t;
+-- result:
+254113522645
+-- !result
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over(partition by v1 order by v2) as arr_basic,
+  array_agg(distinct v2) over(partition by v1 order by v2) as arr_distinct,
+  array_agg(v3 order by v2) over(partition by v1 order by v2) as arr_order_by
+  from t0
+) as t;
+-- result:
+91628652953
+-- !result
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over(order by v2) as arr_basic,
+  array_agg(distinct v2) over(order by v2) as arr_distinct,
+  array_agg(v3 order by v2) over(order by v2) as arr_order_by
+  from t0
+) as t;
+-- result:
+-1825582172939
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over() as arr_basic
+  from t0
+) as t;
+-- result:
+1241908580600
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(distinct v2) over() as arr_distinct
+  from t0
+) as t;
+-- result:
+-1049684500
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3 order by v2) over() as arr_order_by
+  from t0
+) as t;
+-- result:
+-158546416500
+-- !result
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0)
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over(partition by v1) as arr_basic,
+  array_agg(distinct v2) over(partition by v1) as arr_distinct
+  from t0
+) as t;
+-- result:
+362862152094
+-- !result
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over(partition by v1 order by v2) as arr_basic,
+  array_agg(v3 order by v2) over(partition by v1 order by v2) as arr_order_by
+  from t0
+) as t;
+-- result:
+109562789390
+-- !result
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(distinct v2) over(partition by v1 order by v2) as arr_distinct,
+  array_agg(v3 order by v2) over(partition by v1 order by v2) as arr_order_by
+  from t0
+) as t;
+-- result:
+-191899060298
+-- !result
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over(partition by v1 order by v2) as arr_basic,
+  array_agg(distinct v2) over(partition by v1 order by v2) as arr_distinct,
+  array_agg(v3 order by v2) over(partition by v1 order by v2) as arr_order_by
+  from t0
+) as t;
+-- result:
+91628652953
+-- !result
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over(order by v2) as arr_basic,
+  array_agg(distinct v2) over(order by v2) as arr_distinct,
+  array_agg(v3 order by v2) over(order by v2) as arr_order_by
+  from t0
+) as t;
+-- result:
+-1825582172939
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_int)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over(partition by v1 order by v2) as arr_int
+  from t0
+) as t;
+-- result:
+283527713251
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, '')), arr_string)), 0)) as fingerprint from (
+  select v1, v2, v4,
+  array_agg(v4) over(partition by v1 order by v2) as arr_string
+  from t0
+) as t;
+-- result:
+-208819384442
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_decimal)), 0)) as fingerprint from (
+  select v1, v2, v5,
+  array_agg(v5) over(partition by v1 order by v2) as arr_decimal
+  from t0
+) as t;
+-- result:
+-75372882575
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_float)), 0)) as fingerprint from (
+  select v1, v2, v6,
+  array_agg(v6) over(partition by v1 order by v2) as arr_float
+  from t0
+) as t;
+-- result:
+39683042522
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct_int)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(distinct v1) over(partition by v1 order by v2) as arr_distinct_int
+  from t0
+) as t;
+-- result:
+12419085806
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, '')), arr_distinct_string)), 0)) as fingerprint from (
+  select v1, v2, v4,
+  array_agg(distinct v4) over(partition by v1 order by v2) as arr_distinct_string
+  from t0
+) as t;
+-- result:
+-208819384442
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct_decimal)), 0)) as fingerprint from (
+  select v1, v2, v5,
+  array_agg(distinct v5) over(partition by v1 order by v2) as arr_distinct_decimal
+  from t0
+) as t;
+-- result:
+-75372882575
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct_float)), 0)) as fingerprint from (
+  select v1, v2, v6,
+  array_agg(distinct v6) over(partition by v1 order by v2) as arr_distinct_float
+  from t0
+) as t;
+-- result:
+39683042522
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by_int)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1 order by v2) over(partition by v1 order by v2) as arr_order_by_int
+  from t0
+) as t;
+-- result:
+283527713251
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, '')), arr_order_by_string)), 0)) as fingerprint from (
+  select v1, v2, v4,
+  array_agg(v4 order by v2) over(partition by v1 order by v2) as arr_order_by_string
+  from t0
+) as t;
+-- result:
+-208819384442
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by_decimal)), 0)) as fingerprint from (
+  select v1, v2, v5,
+  array_agg(v5 order by v2) over(partition by v1 order by v2) as arr_order_by_decimal
+  from t0
+) as t;
+-- result:
+-75372882575
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by_float)), 0)) as fingerprint from (
+  select v1, v2, v6,
+  array_agg(v6 order by v2) over(partition by v1 order by v2) as arr_order_by_float
+  from t0
+) as t;
+-- result:
+39683042522
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1 + v2) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+-- result:
+271933640598
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1 * v2) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+-- result:
+-99563701502
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(cast(v3 as decimal(10,2))) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+-- result:
+385384766157
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, '')), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(upper(v4)) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+-- result:
+7330928859
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(length(v4)) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+-- result:
+-1538148009290
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(abs(v6)) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+-- result:
+39683042522
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(round(v6, 2)) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+-- result:
+-14298832528
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, '')), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(concat('prefix_', v4)) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+-- result:
+253578633734
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, '')), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(case when v1 > 2 then 'high' else 'low' end) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+-- result:
+-1550176920387
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(coalesce(v5, 0.0)) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+-- result:
+-75372882575
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(sqrt(abs(v6))) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+-- result:
+-75913267945
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(pow(v6, 2)) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+-- result:
+-143410186525
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(year(days_add('2025-01-01', v3))) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+-- result:
+1883573623296
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(month(days_add('2025-01-01', v3))) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+-- result:
+-2455033040224
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(nullif(v1, 1)) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+-- result:
+408107586817
+-- !result
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_complex)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_with_null)), 0)
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(distinct v2) over(partition by v1 order by v2) as arr_basic,
+  array_agg(v1) over(partition by v1 order by v2 range between unbounded preceding and unbounded following) as arr_complex,
+  array_agg(distinct nullif(v2, 2)) over(partition by v1 order by v2) as arr_with_null
+  from t0
+) as t;
+-- result:
+297784138304
+-- !result
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_complex)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_with_null)), 0)
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3 order by v2) over(partition by v1 order by v2) as arr_basic,
+  array_agg(v1) over(partition by v1 order by v2 range between current row and unbounded following) as arr_complex,
+  array_agg(v3 order by v2) over(partition by v1 order by v2) as arr_with_null
+  from t0
+) as t;
+-- result:
+-64402134471
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_large)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over(partition by v1 order by v2) as arr_large,
+  array_agg(distinct v2) over(partition by v1 order by v2) as arr_large2,
+  array_agg(v3 order by v2) over(partition by v1 order by v2) as arr_large3
+  from t0
+) as t;
+-- result:
+283527713251
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_large)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1 + v2) over(partition by v1 order by v2) as arr_large,
+  array_agg(cast(v3 as decimal(19,2))) over(partition by v1 order by v2) as arr_large2,
+  array_agg(length(v4)) over(partition by v1 order by v2) as arr_large3
+  from t0
+) as t;
+-- result:
+271933640598
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(0) over(partition by v1 order by v2) as arr_basic,
+  array_agg('constant') over(partition by v1 order by v2) as arr_basic2,
+  array_agg(3.14159) over(partition by v1 order by v2) as arr_basic3
+  from t0
+) as t;
+-- result:
+-1813784698768
+-- !result
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  murmur_hash3_32(coalesce(rn, 0)) +
+  murmur_hash3_32(coalesce(rank, 0))
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over(partition by v1 order by v2) as arr_basic,
+  row_number() over(partition by v1 order by v2) as rn,
+  rank() over(partition by v1 order by v2) as rank
+  from t0
+) as t;
+-- result:
+257137190310
+-- !result
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  murmur_hash3_32(coalesce(d_rank, 0)) +
+  murmur_hash3_32(coalesce(lag, 0))
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(distinct v2) over(partition by v1 order by v2) as arr_basic,
+  dense_rank() over(partition by v1 order by v2) as d_rank,
+  lag(v1, 1) over(partition by v1 order by v2) as lag
+  from t0
+) as t;
+-- result:
+E: (1064, "Getting syntax error at line 4, column 30. Detail message: No viable statement for input 'sum(\n  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +\n  murmur_hash3_32(coalesce(d_rank, 0)) +\n  murmur_hash3_32(coalesce(lag,'.")
+-- !result
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  murmur_hash3_32(coalesce(lead, 0)) +
+  murmur_hash3_32(coalesce(sum_window, 0))
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3 order by v2) over(partition by v1 order by v2) as arr_basic,
+  lead(v1, 1) over(partition by v1 order by v2) as lead,
+  sum(v1) over(partition by v1 order by v2) as sum_window
+  from t0
+) as t;
+-- result:
+E: (1064, "Getting syntax error at line 3, column 31. Detail message: No viable statement for input 'sum(\n  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +\n  murmur_hash3_32(coalesce(lead,'.")
+-- !result
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  murmur_hash3_32(coalesce(cast(avg_window as bigint), 0)) +
+  murmur_hash3_32(coalesce(count_window, 0))
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over(partition by v1 order by v2) as arr_basic,
+  avg(v1) over(partition by v1 order by v2) as avg_window,
+  count(v1) over(partition by v1 order by v2) as count_window
+  from t0
+) as t;
+-- result:
+316516447996
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(123456789012345678901234567890.123456789) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+-- result:
+1243055542400
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(-9876543210.987654321) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+-- result:
+-2823745306736
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, '')), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg('this_is_a_very_long_string_with_many_characters_for_testing') over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+-- result:
+-1394098186768
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over(partition by v1, v2 order by v3) as arr_basic
+  from t0
+) as t;
+-- result:
+131529312206
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(distinct v1) over(partition by v1, v2 order by v3) as arr_basic
+  from t0
+) as t;
+-- result:
+12419085806
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1 order by v2, v3) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+-- result:
+283527713251
+-- !result
+CREATE TABLE `t1` (
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `v3` bigint(20) NULL COMMENT "",
+  `v4` varchar(50) NULL COMMENT "",
+  `v5` decimal(10,2) NULL COMMENT "",
+  `v6` float NULL COMMENT ""
+) ENGINE=OLAP
+PROPERTIES("replication_num"="1");
+-- result:
+-- !result
+insert into t1 values
+  (1, 1, 100, 'a', 1.1, 1.1),
+  (1, 2, NULL, 'b', 2.2, NULL),
+  (1, NULL, 300, NULL, 3.3, 3.3),
+  (NULL, 4, 400, 'd', NULL, 4.4),
+  (2, 1, 500, 'e', 5.5, 5.5),
+  (2, NULL, NULL, NULL, NULL, NULL),
+  (2, 3, 700, 'g', 7.7, 7.7),
+  (NULL, NULL, NULL, NULL, NULL, NULL),
+  (3, 1, 900, 'i', 9.9, 9.9),
+  (3, 2, 1000, 'j', 10.1, 10.1);
+-- result:
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over() as arr_basic
+  from t1
+) as t;
+-- result:
+-12880919090
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(distinct v1) over() as arr_distinct
+  from t1
+) as t;
+-- result:
+-5610049520
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3 order by v2) over() as arr_order_by
+  from t1
+) as t;
+-- result:
+-33055826870
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, '')), arr_string)), 0)) as fingerprint from (
+  select v1, v2, v4,
+  array_agg(v4) over() as arr_string
+  from t1
+) as t;
+-- result:
+-61112594500
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_decimal)), 0)) as fingerprint from (
+  select v1, v2, v5,
+  array_agg(v5) over() as arr_decimal
+  from t1
+) as t;
+-- result:
+30886453330
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_float)), 0)) as fingerprint from (
+  select v1, v2, v6,
+  array_agg(v6) over() as arr_float
+  from t1
+) as t;
+-- result:
+-15703911810
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v2) over(partition by v1) as arr_basic
+  from t1
+) as t;
+-- result:
+-11117803241
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(distinct v2) over(partition by v1) as arr_distinct
+  from t1
+) as t;
+-- result:
+-11117803241
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3 order by v2) over(partition by v1) as arr_order_by
+  from t1
+) as t;
+-- result:
+-9084927487
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3) over(partition by v1 order by v2) as arr_basic
+  from t1
+) as t;
+-- result:
+-5103979314
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(distinct v3) over(partition by v1 order by v2) as arr_distinct
+  from t1
+) as t;
+-- result:
+-5103979314
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3 order by v2) over(partition by v1 order by v2) as arr_order_by
+  from t1
+) as t;
+-- result:
+-5103979314
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_frame)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3) over(partition by v1 order by v2 range between unbounded preceding and unbounded following) as arr_frame
+  from t1
+) as t;
+-- result:
+-9084927487
+-- !result
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_int)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, '')), arr_str)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_dec)), 0)
+) as fingerprint from (
+  select v1, v2, v3, v4, v5,
+  array_agg(v2) over(partition by v1 order by v2) as arr_int,
+  array_agg(v4) over(partition by v1 order by v2) as arr_str,
+  array_agg(v5) over(partition by v1 order by v2) as arr_dec
+  from t1
+) as t;
+-- result:
+-20981508916
+-- !result
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  murmur_hash3_32(coalesce(rn, 0)) +
+  murmur_hash3_32(coalesce(sum_val, 0))
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3) over(partition by v1 order by v2) as arr_basic,
+  row_number() over(partition by v1 order by v2) as rn,
+  sum(v3) over(partition by v1 order by v2) as sum_val
+  from t1
+) as t;
+-- result:
+-2466082725
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_expr)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1 + v2 + v3) over(partition by v1 order by v2) as arr_expr
+  from t1
+) as t;
+-- result:
+-8480150293
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3) over(partition by v1, v2 order by v3) as arr_basic
+  from t1
+) as t;
+-- result:
+-3305582687
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, '')), arr_distinct_str)), 0)) as fingerprint from (
+  select v1, v2, v4,
+  array_agg(distinct v4) over(partition by v1 order by v2) as arr_distinct_str
+  from t1
+) as t;
+-- result:
+-12013265094
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v6) over(partition by v1 order by v2) as arr_basic
+  from t1
+  where v1 = 2
+) as t;
+-- result:
+-3071775271
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3) over() as arr_basic
+  from t1
+  where v1 = 1 and v2 = 2
+) as t;
+-- result:
+-1365801731
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_coalesce)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(coalesce(v3, -1)) over(partition by v1 order by v2) as arr_coalesce
+  from t1
+) as t;
+-- result:
+-8022645636
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v2) over(order by v1, v2) as arr_basic
+  from t1
+) as t;
+-- result:
+-26029627301
+-- !result
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_int)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_bigint)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, '')), arr_str)), 0)
+) as fingerprint from (
+  select v1, v2, v3, v4,
+  array_agg(distinct v1) over() as arr_int,
+  array_agg(distinct v3) over() as arr_bigint,
+  array_agg(distinct v4) over() as arr_str
+  from t1
+) as t;
+-- result:
+-53154861670
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3 order by v3) over(partition by v1) as arr_order_by
+  from t1
+) as t;
+-- result:
+-9084927487
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3 order by v2, v3) over(partition by v1) as arr_order_by
+  from t1
+) as t;
+-- result:
+-9084927487
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3) over(partition by v1 order by v2) as arr_basic
+  from t1
+  where v1 is null
+) as t;
+-- result:
+-1150863345
+-- !result
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(distinct v5) over(partition by v1) as arr_distinct
+  from t1
+  where v1 = 2
+) as t;
+-- result:
+2623805304
+-- !result
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3) over(partition by v1 order by v2) as arr_basic,
+  array_agg(distinct v2) over(partition by v1 order by v2) as arr_distinct,
+  array_agg(v3 order by v2) over(partition by v1 order by v2) as arr_order_by
+  from t1
+) as t;
+-- result:
+-26254139207
+-- !result

--- a/test/sql/test_array_agg_over_window/T/test_array_agg_over_window
+++ b/test/sql/test_array_agg_over_window/T/test_array_agg_over_window
@@ -1,0 +1,687 @@
+-- name: test_array_agg_over_window
+CREATE TABLE `t0` (
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `v3` bigint(20) NULL COMMENT "",
+  `v4` varchar(50) NULL COMMENT "",
+  `v5` decimal(10,2) NULL COMMENT "",
+  `v6` float NULL COMMENT ""
+) ENGINE=OLAP
+PROPERTIES("replication_num"="1");
+insert into t0 select i/19 as v1, i/11 as v2, i/5 as v3, concat('item_', cast(i as varchar)) as v4, i/3.14 as v5, i/2.71 as v6 from table(generate_series(1,100)) t(i);
+
+-- Basic array_agg tests with different window types
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over() as arr_basic,
+  array_agg(distinct v2) over() as arr_distinct,
+  array_agg(v3 order by v2) over() as arr_order_by
+  from t0
+) as t;
+
+-- Window with partition by
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over(partition by v1) as arr_basic,
+  array_agg(distinct v2) over(partition by v1) as arr_distinct,
+  array_agg(v3 order by v2) over(partition by v1) as arr_order_by
+  from t0
+) as t;
+
+-- Window with partition by and order by
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over(partition by v1 order by v2) as arr_basic,
+  array_agg(distinct v2) over(partition by v1 order by v2) as arr_distinct,
+  array_agg(v3 order by v2) over(partition by v1 order by v2) as arr_order_by
+  from t0
+) as t;
+
+-- Window with order by only
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over(order by v2) as arr_basic,
+  array_agg(distinct v2) over(order by v2) as arr_distinct,
+  array_agg(v3 order by v2) over(order by v2) as arr_order_by
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over() as arr_basic
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(distinct v2) over() as arr_distinct
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3 order by v2) over() as arr_order_by
+  from t0
+) as t;
+
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0)
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over(partition by v1) as arr_basic,
+  array_agg(distinct v2) over(partition by v1) as arr_distinct
+  from t0
+) as t;
+
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over(partition by v1 order by v2) as arr_basic,
+  array_agg(v3 order by v2) over(partition by v1 order by v2) as arr_order_by
+  from t0
+) as t;
+
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(distinct v2) over(partition by v1 order by v2) as arr_distinct,
+  array_agg(v3 order by v2) over(partition by v1 order by v2) as arr_order_by
+  from t0
+) as t;
+
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over(partition by v1 order by v2) as arr_basic,
+  array_agg(distinct v2) over(partition by v1 order by v2) as arr_distinct,
+  array_agg(v3 order by v2) over(partition by v1 order by v2) as arr_order_by
+  from t0
+) as t;
+
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over(order by v2) as arr_basic,
+  array_agg(distinct v2) over(order by v2) as arr_distinct,
+  array_agg(v3 order by v2) over(order by v2) as arr_order_by
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_int)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over(partition by v1 order by v2) as arr_int
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, '')), arr_string)), 0)) as fingerprint from (
+  select v1, v2, v4,
+  array_agg(v4) over(partition by v1 order by v2) as arr_string
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_decimal)), 0)) as fingerprint from (
+  select v1, v2, v5,
+  array_agg(v5) over(partition by v1 order by v2) as arr_decimal
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_float)), 0)) as fingerprint from (
+  select v1, v2, v6,
+  array_agg(v6) over(partition by v1 order by v2) as arr_float
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct_int)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(distinct v1) over(partition by v1 order by v2) as arr_distinct_int
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, '')), arr_distinct_string)), 0)) as fingerprint from (
+  select v1, v2, v4,
+  array_agg(distinct v4) over(partition by v1 order by v2) as arr_distinct_string
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct_decimal)), 0)) as fingerprint from (
+  select v1, v2, v5,
+  array_agg(distinct v5) over(partition by v1 order by v2) as arr_distinct_decimal
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct_float)), 0)) as fingerprint from (
+  select v1, v2, v6,
+  array_agg(distinct v6) over(partition by v1 order by v2) as arr_distinct_float
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by_int)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1 order by v2) over(partition by v1 order by v2) as arr_order_by_int
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, '')), arr_order_by_string)), 0)) as fingerprint from (
+  select v1, v2, v4,
+  array_agg(v4 order by v2) over(partition by v1 order by v2) as arr_order_by_string
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by_decimal)), 0)) as fingerprint from (
+  select v1, v2, v5,
+  array_agg(v5 order by v2) over(partition by v1 order by v2) as arr_order_by_decimal
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by_float)), 0)) as fingerprint from (
+  select v1, v2, v6,
+  array_agg(v6 order by v2) over(partition by v1 order by v2) as arr_order_by_float
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1 + v2) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1 * v2) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(cast(v3 as decimal(10,2))) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, '')), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(upper(v4)) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(length(v4)) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(abs(v6)) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(round(v6, 2)) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, '')), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(concat('prefix_', v4)) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, '')), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(case when v1 > 2 then 'high' else 'low' end) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(coalesce(v5, 0.0)) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(sqrt(abs(v6))) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(pow(v6, 2)) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(year(days_add('2025-01-01', v3))) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(month(days_add('2025-01-01', v3))) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(nullif(v1, 1)) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_complex)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_with_null)), 0)
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(distinct v2) over(partition by v1 order by v2) as arr_basic,
+  array_agg(v1) over(partition by v1 order by v2 range between unbounded preceding and unbounded following) as arr_complex,
+  array_agg(distinct nullif(v2, 2)) over(partition by v1 order by v2) as arr_with_null
+  from t0
+) as t;
+
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_complex)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_with_null)), 0)
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3 order by v2) over(partition by v1 order by v2) as arr_basic,
+  array_agg(v1) over(partition by v1 order by v2 range between current row and unbounded following) as arr_complex,
+  array_agg(v3 order by v2) over(partition by v1 order by v2) as arr_with_null
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_large)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over(partition by v1 order by v2) as arr_large,
+  array_agg(distinct v2) over(partition by v1 order by v2) as arr_large2,
+  array_agg(v3 order by v2) over(partition by v1 order by v2) as arr_large3
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_large)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1 + v2) over(partition by v1 order by v2) as arr_large,
+  array_agg(cast(v3 as decimal(19,2))) over(partition by v1 order by v2) as arr_large2,
+  array_agg(length(v4)) over(partition by v1 order by v2) as arr_large3
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(0) over(partition by v1 order by v2) as arr_basic,
+  array_agg('constant') over(partition by v1 order by v2) as arr_basic2,
+  array_agg(3.14159) over(partition by v1 order by v2) as arr_basic3
+  from t0
+) as t;
+
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  murmur_hash3_32(coalesce(rn, 0)) +
+  murmur_hash3_32(coalesce(rank, 0))
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over(partition by v1 order by v2) as arr_basic,
+  row_number() over(partition by v1 order by v2) as rn,
+  rank() over(partition by v1 order by v2) as rank
+  from t0
+) as t;
+
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  murmur_hash3_32(coalesce(d_rank, 0)) +
+  murmur_hash3_32(coalesce(lag, 0))
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(distinct v2) over(partition by v1 order by v2) as arr_basic,
+  dense_rank() over(partition by v1 order by v2) as d_rank,
+  lag(v1, 1) over(partition by v1 order by v2) as lag
+  from t0
+) as t;
+
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  murmur_hash3_32(coalesce(lead, 0)) +
+  murmur_hash3_32(coalesce(sum_window, 0))
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3 order by v2) over(partition by v1 order by v2) as arr_basic,
+  lead(v1, 1) over(partition by v1 order by v2) as lead,
+  sum(v1) over(partition by v1 order by v2) as sum_window
+  from t0
+) as t;
+
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  murmur_hash3_32(coalesce(cast(avg_window as bigint), 0)) +
+  murmur_hash3_32(coalesce(count_window, 0))
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over(partition by v1 order by v2) as arr_basic,
+  avg(v1) over(partition by v1 order by v2) as avg_window,
+  count(v1) over(partition by v1 order by v2) as count_window
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(123456789012345678901234567890.123456789) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(-9876543210.987654321) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, '')), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg('this_is_a_very_long_string_with_many_characters_for_testing') over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over(partition by v1, v2 order by v3) as arr_basic
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(distinct v1) over(partition by v1, v2 order by v3) as arr_basic
+  from t0
+) as t;
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1 order by v2, v3) over(partition by v1 order by v2) as arr_basic
+  from t0
+) as t;
+
+-- ============================================================
+-- NULLABLE COLUMN TESTS WITH NULL VALUES
+-- ============================================================
+
+-- Create table with explicit NULL values for testing null handling
+CREATE TABLE `t1` (
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `v3` bigint(20) NULL COMMENT "",
+  `v4` varchar(50) NULL COMMENT "",
+  `v5` decimal(10,2) NULL COMMENT "",
+  `v6` float NULL COMMENT ""
+) ENGINE=OLAP
+PROPERTIES("replication_num"="1");
+
+-- Insert data with intentional NULLs in various positions
+insert into t1 values
+  (1, 1, 100, 'a', 1.1, 1.1),
+  (1, 2, NULL, 'b', 2.2, NULL),
+  (1, NULL, 300, NULL, 3.3, 3.3),
+  (NULL, 4, 400, 'd', NULL, 4.4),
+  (2, 1, 500, 'e', 5.5, 5.5),
+  (2, NULL, NULL, NULL, NULL, NULL),
+  (2, 3, 700, 'g', 7.7, 7.7),
+  (NULL, NULL, NULL, NULL, NULL, NULL),
+  (3, 1, 900, 'i', 9.9, 9.9),
+  (3, 2, 1000, 'j', 10.1, 10.1);
+
+-- Basic NULL handling tests
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1) over() as arr_basic
+  from t1
+) as t;
+
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(distinct v1) over() as arr_distinct
+  from t1
+) as t;
+
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3 order by v2) over() as arr_order_by
+  from t1
+) as t;
+
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, '')), arr_string)), 0)) as fingerprint from (
+  select v1, v2, v4,
+  array_agg(v4) over() as arr_string
+  from t1
+) as t;
+
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_decimal)), 0)) as fingerprint from (
+  select v1, v2, v5,
+  array_agg(v5) over() as arr_decimal
+  from t1
+) as t;
+
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_float)), 0)) as fingerprint from (
+  select v1, v2, v6,
+  array_agg(v6) over() as arr_float
+  from t1
+) as t;
+
+-- Partitioned window with NULLs
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v2) over(partition by v1) as arr_basic
+  from t1
+) as t;
+
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(distinct v2) over(partition by v1) as arr_distinct
+  from t1
+) as t;
+
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3 order by v2) over(partition by v1) as arr_order_by
+  from t1
+) as t;
+
+-- Window with partition by and order by on nullable columns
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3) over(partition by v1 order by v2) as arr_basic
+  from t1
+) as t;
+
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(distinct v3) over(partition by v1 order by v2) as arr_distinct
+  from t1
+) as t;
+
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3 order by v2) over(partition by v1 order by v2) as arr_order_by
+  from t1
+) as t;
+
+-- Window frames with NULLs
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_frame)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3) over(partition by v1 order by v2 range between unbounded preceding and unbounded following) as arr_frame
+  from t1
+) as t;
+
+-- Mixed scenarios with multiple array_agg on nullable columns
+
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_int)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, '')), arr_str)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_dec)), 0)
+) as fingerprint from (
+  select v1, v2, v3, v4, v5,
+  array_agg(v2) over(partition by v1 order by v2) as arr_int,
+  array_agg(v4) over(partition by v1 order by v2) as arr_str,
+  array_agg(v5) over(partition by v1 order by v2) as arr_dec
+  from t1
+) as t;
+
+
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  murmur_hash3_32(coalesce(rn, 0)) +
+  murmur_hash3_32(coalesce(sum_val, 0))
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3) over(partition by v1 order by v2) as arr_basic,
+  row_number() over(partition by v1 order by v2) as rn,
+  sum(v3) over(partition by v1 order by v2) as sum_val
+  from t1
+) as t;
+
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_expr)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v1 + v2 + v3) over(partition by v1 order by v2) as arr_expr
+  from t1
+) as t;
+
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3) over(partition by v1, v2 order by v3) as arr_basic
+  from t1
+) as t;
+
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, '')), arr_distinct_str)), 0)) as fingerprint from (
+  select v1, v2, v4,
+  array_agg(distinct v4) over(partition by v1 order by v2) as arr_distinct_str
+  from t1
+) as t;
+
+-- Edge cases with NULLs
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v6) over(partition by v1 order by v2) as arr_basic
+  from t1
+  where v1 = 2
+) as t;
+
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3) over() as arr_basic
+  from t1
+  where v1 = 1 and v2 = 2
+) as t;
+
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_coalesce)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(coalesce(v3, -1)) over(partition by v1 order by v2) as arr_coalesce
+  from t1
+) as t;
+
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v2) over(order by v1, v2) as arr_basic
+  from t1
+) as t;
+
+
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_int)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_bigint)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, '')), arr_str)), 0)
+) as fingerprint from (
+  select v1, v2, v3, v4,
+  array_agg(distinct v1) over() as arr_int,
+  array_agg(distinct v3) over() as arr_bigint,
+  array_agg(distinct v4) over() as arr_str
+  from t1
+) as t;
+
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3 order by v3) over(partition by v1) as arr_order_by
+  from t1
+) as t;
+
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3 order by v2, v3) over(partition by v1) as arr_order_by
+  from t1
+) as t;
+
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3) over(partition by v1 order by v2) as arr_basic
+  from t1
+  where v1 is null
+) as t;
+
+
+select sum(coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0)) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(distinct v5) over(partition by v1) as arr_distinct
+  from t1
+  where v1 = 2
+) as t;
+
+
+select sum(
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_basic)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_distinct)), 0) +
+  coalesce(array_sum(array_map(x -> murmur_hash3_32(coalesce(x, 0)), arr_order_by)), 0)
+) as fingerprint from (
+  select v1, v2, v3,
+  array_agg(v3) over(partition by v1 order by v2) as arr_basic,
+  array_agg(distinct v2) over(partition by v1 order by v2) as arr_distinct,
+  array_agg(v3 order by v2) over(partition by v1 order by v2) as arr_order_by
+  from t1
+) as t;


### PR DESCRIPTION
## Why I'm doing:
Array agg over window support
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add ARRAY_AGG as a window function (RANGE-only) with DISTINCT/ORDER BY support, plus planner/runtime, docs, and tests.
> 
> - **SQL/Planner/Analyzer**:
>   - Enable `ARRAY_AGG` as a window function; restrict window frames to `RANGE`; allow `DISTINCT`/`ORDER BY`.
>   - Map single `ARRAY_AGG(DISTINCT ...)` to `ARRAY_AGG_DISTINCT` in planning; add DISTINCT whitelist for windows.
> - **Backend Runtime**:
>   - Extend analytor to pass `is_distinct` and `ORDER BY` info to `FunctionContext` for `array_agg`.
>   - Implement window-capable states for `array_agg` (`ArrayAggWindowState`, V2 variants), add reset/get_values/frame update paths, mem-pool handling for strings.
>   - Register array_agg(window) functions; mark window states as non-resizable/never-null where applicable.
> - **Factory/Registration**:
>   - Generalize `ArrayAgg` V2 factory to accept window/non-window states; add window mappings for `array_agg2` and `array_agg_distinct`.
> - **Docs**:
>   - Add ARRAY_AGG window section and note limitation (RANGE-only) in EN/JA/ZH window-function docs.
> - **Tests**:
>   - Add extensive FE unit tests and SQL golden tests covering ARRAY_AGG over windows, DISTINCT/ORDER BY, types, and frame validations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dabf5482fe24c0497e6aa0d6ba34913c1065203b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->