### PR TITLE
[BugFix] handle memory allocation failure in HyperLogLog

### DIFF
--- a/be/src/runtime/memory/mem_chunk_allocator.cpp
+++ b/be/src/runtime/memory/mem_chunk_allocator.cpp
@@ -61,8 +61,11 @@ void MemChunkAllocator::init_metrics() {
     REGISTER_METIRC(system_free_cost_ns);
 }
 
+DEFINE_FAIL_POINT(mem_chunk_allocator_allocate_fail);
+
 bool MemChunkAllocator::allocate(size_t size, MemChunk* chunk) {
     FAIL_POINT_TRIGGER_RETURN(random_error, false);
+    FAIL_POINT_TRIGGER_RETURN(mem_chunk_allocator_allocate_fail, false);
 
     chunk->size = size;
 

--- a/be/src/runtime/memory/mem_chunk_allocator.h
+++ b/be/src/runtime/memory/mem_chunk_allocator.h
@@ -55,7 +55,7 @@ public:
     // Allocate a MemChunk with a power-of-two length "size".
     // Return true if success and allocated chunk is saved in "chunk".
     // Otherwise return false.
-    static bool allocate(size_t size, MemChunk* chunk);
+    [[nodiscard]] static bool allocate(size_t size, MemChunk* chunk);
 
     // Free chunk allocated from this allocator
     static void free(const MemChunk& chunk);

--- a/be/test/serde/column_array_serde_test.cpp
+++ b/be/test/serde/column_array_serde_test.cpp
@@ -19,9 +19,7 @@
 #include "column/array_column.h"
 #include "column/binary_column.h"
 #include "column/column_helper.h"
-#include "column/column_visitor.h"
 #include "column/const_column.h"
-#include "column/decimalv3_column.h"
 #include "column/fixed_length_column.h"
 #include "column/json_column.h"
 #include "column/nullable_column.h"
@@ -30,6 +28,9 @@
 #include "gutil/strings/substitute.h"
 #include "testutil/assert.h"
 #include "testutil/parallel_test.h"
+#include "types/hll.h"
+#include "util/failpoint/fail_point.h"
+#include "util/hash_util.hpp"
 #include "util/json.h"
 #include "util/variant_util.h"
 
@@ -168,6 +169,46 @@ PARALLEL_TEST(ColumnArraySerdeTest, variant_column_failed_deserialize) {
     auto c2 = VariantColumn::create();
     ASSERT_ERROR(ColumnArraySerde::deserialize(buffer.data(), c2.get()));
     ASSERT_EQ(0, c2->size()); // Deserialization should fail, resulting in an empty column
+}
+
+// NOLINTNEXTLINE
+PARALLEL_TEST(ColumnArraySerdeTest, hll_column_failed_deserialize) {
+    auto c1 = HyperLogLogColumn::create();
+    // prepare a sparse-encoded HLL (few non-zero registers)
+    HyperLogLog sparse_hll;
+    for (int i = 0; i < 200; ++i) {
+        sparse_hll.update(HashUtil::murmur_hash64A(&i, sizeof(i), HashUtil::MURMUR_SEED));
+    }
+    // prepare a full-encoded HLL (many non-zero registers)
+    HyperLogLog full_hll;
+    for (int i = 0; i < 5000; ++i) {
+        full_hll.update(HashUtil::murmur_hash64A(&i, sizeof(i), HashUtil::MURMUR_SEED));
+    }
+    c1->append(&sparse_hll);
+    c1->append(&full_hll);
+    ASSERT_EQ(2, c1->size());
+
+    std::vector<uint8_t> buffer;
+    buffer.resize(ColumnArraySerde::max_serialized_size(*c1));
+    ASSERT_OK(ColumnArraySerde::serialize(*c1, buffer.data()));
+
+    auto* fp = failpoint::FailPointRegistry::GetInstance()->get("mem_chunk_allocator_allocate_fail");
+    ASSERT_NE(fp, nullptr);
+    PFailPointTriggerMode mode;
+    mode.set_mode(FailPointTriggerModeType::ENABLE);
+    fp->setMode(mode);
+
+    auto c2 = HyperLogLogColumn::create();
+    ASSERT_OK(ColumnArraySerde::deserialize(buffer.data(), c2.get()));
+    ASSERT_EQ(2, c2->size());
+    for (int i = 0; i < c2->size(); ++i) {
+        const HyperLogLog* h = c2->get(i).get_hyperloglog();
+        ASSERT_NE(h, nullptr);
+        EXPECT_EQ(0, h->estimate_cardinality()); // should be empty after failed deserialize
+    }
+
+    mode.set_mode(FailPointTriggerModeType::DISABLE);
+    fp->setMode(mode);
 }
 
 // NOLINTNEXTLINE


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/10733

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Guard HyperLogLog allocations to throw on failure (deserialize fails to empty), add allocator failpoint, and add tests covering failure paths.
> 
> - **Memory**:
>   - Add failpoint `mem_chunk_allocator_allocate_fail` and trigger it in `MemChunkAllocator::allocate`.
>   - Mark `MemChunkAllocator::allocate` as `[[nodiscard]]`.
> - **HLL**:
>   - Check all `MemChunkAllocator::allocate` calls; on failure: throw `std::bad_alloc` (copy ctor/assign, `update`, `merge`), or return `false` in `deserialize` to keep HLL empty.
> - **Tests**:
>   - Add `hll_column_failed_deserialize` in `serde/column_array_serde_test.cpp` validating empty HLLs when allocation fails during deserialize.
>   - Add `AllocateFail` in `storage/hll_test.cpp` covering copy, update, merge throwing on allocation failure and graceful deserialize.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf0447202b27d366f6f8778a9278dfdc74466372. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->