### PR TITLE
[BugFix] fix LocalTabletsChannel and LakeTabletsChannel dead lock

### DIFF
--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -60,8 +60,8 @@ class LakeTabletsChannel : public TabletsChannel {
     using TxnLogPtr = AsyncDeltaWriter::TxnLogPtr;
 
 public:
-    LakeTabletsChannel(LoadChannel* load_channel, lake::TabletManager* tablet_manager, const TabletsChannelKey& key,
-                       MemTracker* mem_tracker, RuntimeProfile* parent_profile);
+    LakeTabletsChannel(lake::TabletManager* tablet_manager, const TabletsChannelKey& key, MemTracker* mem_tracker,
+                       RuntimeProfile* parent_profile);
 
     ~LakeTabletsChannel() override;
 
@@ -246,7 +246,6 @@ private:
         }
     };
 
-    LoadChannel* _load_channel;
     lake::TabletManager* _tablet_manager;
 
     TabletsChannelKey _key;
@@ -315,11 +314,9 @@ private:
     std::unique_ptr<RuntimeProfile> _tablets_profile;
 };
 
-LakeTabletsChannel::LakeTabletsChannel(LoadChannel* load_channel, lake::TabletManager* tablet_manager,
-                                       const TabletsChannelKey& key, MemTracker* mem_tracker,
-                                       RuntimeProfile* parent_profile)
+LakeTabletsChannel::LakeTabletsChannel(lake::TabletManager* tablet_manager, const TabletsChannelKey& key,
+                                       MemTracker* mem_tracker, RuntimeProfile* parent_profile)
         : TabletsChannel(),
-          _load_channel(load_channel),
           _tablet_manager(tablet_manager),
           _key(key),
           _mem_tracker(mem_tracker),
@@ -646,7 +643,6 @@ void LakeTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequ
     COUNTER_UPDATE(_wait_writer_timer, wait_writer_ns);
 
     if (close_channel) {
-        _load_channel->remove_tablets_channel(_key);
         if (_finish_mode == lake::DeltaWriterFinishMode::kDontWriteTxnLog) {
             _txn_log_collector.notify();
         }
@@ -1024,7 +1020,9 @@ void LakeTabletsChannel::_update_tablet_profile(const DeltaWriter* writer, Runti
 std::shared_ptr<TabletsChannel> new_lake_tablets_channel(LoadChannel* load_channel, lake::TabletManager* tablet_manager,
                                                          const TabletsChannelKey& key, MemTracker* mem_tracker,
                                                          RuntimeProfile* parent_profile) {
-    return std::make_shared<LakeTabletsChannel>(load_channel, tablet_manager, key, mem_tracker, parent_profile);
+    // NOTE: `load_channel` is not used for now, just keep it for now so that it could be used later and
+    // be consistent with LocalTabletsChannel.
+    return std::make_shared<LakeTabletsChannel>(tablet_manager, key, mem_tracker, parent_profile);
 }
 
 } // namespace starrocks

--- a/be/src/runtime/load_channel.cpp
+++ b/be/src/runtime/load_channel.cpp
@@ -187,14 +187,17 @@ void LoadChannel::_add_chunk(Chunk* chunk, const MonotonicStopWatch* watch, cons
                 fmt::format("cannot find the tablets channel associated with the key {}", key.to_string()));
         return;
     }
-    bool close_channel;
+    bool close_channel = false;
     channel->add_chunk(chunk, request, response, &close_channel);
-    if (close_channel &&
-        (_should_enable_profile() || (watch != nullptr && watch->elapsed_time() > request.timeout_ms() * 1000000))) {
-        // If close_channel is true, the channel has been removed from _tablets_channels
-        // in TabletsChannel::add_chunk, so there will be no chance to get the channel to
-        // update the profile later. So update the profile here
-        channel->update_profile();
+    if (close_channel) {
+        _remove_tablets_channel(key);
+        if ((_should_enable_profile() ||
+             (watch != nullptr && watch->elapsed_time() > request.timeout_ms() * 1000000))) {
+            // If close_channel is true, the channel is removed from _tablets_channels,
+            // there will be no chance to get the channel to update the profile later.
+            // So update the profile here.
+            channel->update_profile();
+        }
     }
 }
 
@@ -321,14 +324,13 @@ void LoadChannel::abort(const TabletsChannelKey& key, const std::vector<int64_t>
     }
 }
 
-void LoadChannel::remove_tablets_channel(const TabletsChannelKey& key) {
+void LoadChannel::_remove_tablets_channel(const TabletsChannelKey& key) {
     std::unique_lock l(_lock);
     _tablets_channels.erase(key);
     if (_tablets_channels.empty()) {
         l.unlock();
         _closed.store(true);
         _load_mgr->remove_load_channel(_load_id);
-        // Do NOT touch |this| since here, it could have been deleted.
     }
 }
 

--- a/be/src/runtime/load_channel.h
+++ b/be/src/runtime/load_channel.h
@@ -121,8 +121,6 @@ public:
 
     std::shared_ptr<TabletsChannel> get_tablets_channel(const TabletsChannelKey& key);
 
-    void remove_tablets_channel(const TabletsChannelKey& key);
-
     MemTracker* mem_tracker() { return _mem_tracker.get(); }
 
     Span get_span() { return _span; }
@@ -134,6 +132,7 @@ public:
                                  PLoadReplicaStatusResult* response);
 
 private:
+    void _remove_tablets_channel(const TabletsChannelKey& key);
     void _add_chunk(Chunk* chunk, const MonotonicStopWatch* watch, const PTabletWriterAddChunkRequest& request,
                     PTabletWriterAddBatchResult* response);
     Status _build_chunk_meta(const ChunkPB& pb_chunk);

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -525,11 +525,6 @@ void LocalTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkReq
     COUNTER_UPDATE(_submit_commit_task_timer, finish_submit_commit_task_ts - finish_submit_write_task_ts);
     COUNTER_UPDATE(_wait_write_timer, wait_writer_ns);
     COUNTER_UPDATE(_wait_replica_timer, wait_replica_ns);
-
-    // remove tablets channel and load channel after all things done
-    if (close_channel) {
-        _load_channel->remove_tablets_channel(_key);
-    }
 }
 
 Status LocalTabletsChannel::log_and_error_tablet_not_found(int64_t tablet_id, const PUniqueId& id,


### PR DESCRIPTION
* fix the circular lock wait by moving `remove_tablets_channel()` to LoadChannel, TabletsChannel will not deregister itself from LoadChannel any more.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Move tablets channel deregistration to LoadChannel on close; update Lake/Local tablets channels and constructors accordingly.
> 
> - **LoadChannel**
>   - Handles channel removal via private `_remove_tablets_channel()` when `add_chunk()` signals `close_channel` and updates profile if needed.
>   - Initializes `close_channel` explicitly and removes public `remove_tablets_channel()` API.
> - **LakeTabletsChannel**
>   - Drops `LoadChannel*` dependency: constructor now `LakeTabletsChannel(tablet_manager, key, mem_tracker, parent_profile)`; member `_load_channel` removed.
>   - Factory `new_lake_tablets_channel(...)` keeps `load_channel` param (unused) and constructs with new signature.
>   - Stops self-deregistering on close (no call to `remove_tablets_channel`).
> - **LocalTabletsChannel**
>   - Removes self-deregistration on close; channel lifecycle now managed by `LoadChannel`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 642c88d65993f9d8aa27ecdc9136af12fe27ee65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->