### PR TITLE
[BugFix] BugFix append_string_char_if_absent

### DIFF
--- a/be/src/exprs/string_functions.cpp
+++ b/be/src/exprs/string_functions.cpp
@@ -1839,8 +1839,8 @@ StatusOr<ColumnPtr> StringFunctions::append_trailing_char_if_absent(FunctionCont
             src = ColumnHelper::as_raw_column<BinaryColumn>(src_null->data_column());
 
             MutableColumnPtr data = RunTimeColumnType<TYPE_VARCHAR>::create();
+            binary_dst = ColumnHelper::as_raw_column<BinaryColumn>(data.get());
             dst = NullableColumn::create(std::move(data), Column::mutate(src_null->null_column()));
-            binary_dst = ColumnHelper::as_raw_column<BinaryColumn>(dst);
         } else {
             src = ColumnHelper::as_raw_column<BinaryColumn>(columns[0]);
             MutableColumnPtr data = RunTimeColumnType<TYPE_VARCHAR>::create();


### PR DESCRIPTION
## Why I'm doing:
fix typo
## What I'm doing:

Fixes #https://github.com/StarRocks/StarRocksTest/issues/10739

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes a bug in `append_trailing_char_if_absent` by obtaining the underlying `BinaryColumn` from the inner data column instead of the outer nullable column.
> 
> - **String functions** (`be/src/exprs/string_functions.cpp`):
>   - Fix `append_trailing_char_if_absent` for nullable inputs by taking `BinaryColumn` from the created inner data column (`data.get()`) rather than the outer `NullableColumn`, ensuring correct byte/offset writes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6648df28cf67361fd7321c4d5dbd5331271111f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->