### PR TITLE
[UT] fix unstable case test_partial_update_char_padding

### DIFF
--- a/test/sql/test_partial_update_column_mode/R/test_partial_update_char_padding
+++ b/test/sql/test_partial_update_column_mode/R/test_partial_update_char_padding
@@ -17,6 +17,9 @@ PROPERTIES (
 set partial_update_mode = "column";
 -- result:
 -- !result
+set cbo_enable_low_cardinality_optimize=false;
+-- result:
+-- !result
 insert into tab1 values (1, 'aaa', 'aaa', 'aaa'), 
 (2, 'aaa', 'aaa', 'aaa'), 
 (3, 'aaa', 'aaa', 'aaa'), 

--- a/test/sql/test_partial_update_column_mode/T/test_partial_update_char_padding
+++ b/test/sql/test_partial_update_column_mode/T/test_partial_update_char_padding
@@ -13,6 +13,7 @@ PROPERTIES (
     "replication_num" = "1"
 );
 set partial_update_mode = "column";
+set cbo_enable_low_cardinality_optimize=false;
 insert into tab1 values (1, 'aaa', 'aaa', 'aaa'), 
 (2, 'aaa', 'aaa', 'aaa'), 
 (3, 'aaa', 'aaa', 'aaa'), 


### PR DESCRIPTION
## Why I'm doing:
The global index needs to collect dictionary metadata via meta scan, but meta scan is not yet supported for the delta column group of PK tables, so it is temporarily bypassed.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
