### PR TITLE
[BugFix] Fix race condition in load spill when close

### DIFF
--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -328,6 +328,7 @@ inline void AsyncDeltaWriterImpl::close() {
 
         // Wait for block merge finished.
         if (_block_merge_token != nullptr) {
+            _block_merge_token->wait();
             _block_merge_token->shutdown();
             _block_merge_token.reset();
         }


### PR DESCRIPTION
## Why I'm doing:
```
branch-4.0.3 RELEASE (build 1c854e9 distro centos arch x86_64)
query_id:00000000-0000-0000-0000-000000000000, fragment_instance:00000000-0000-0000-0000-000000000000, plan_node_id:-1
*** Aborted at 1765771544 (unix time) try "date -d @1765771544" if you are using GNU date ***
PC: @          0x8c75ec7 starrocks::Chunk::clone_empty_with_schema(unsigned long) const
*** SIGSEGV (@0x0) received by PID 3146 (TID 0x2b7f8cc09700) LWP(42376) from PID 0; stack trace: ***
    @     0x2b66fe24420b __pthread_once_slow
    @          0xdd436d4 google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x2b66fe24d630 (/usr/lib64/[libpthread-2.17.so](http://libpthread-2.17.so/)+0xf62f)
    @          0x8c75ec7 starrocks::Chunk::clone_empty_with_schema(unsigned long) const
    @          0x764d4aa starrocks::MemTable::_sort(bool, bool)
    @          0x764ecd1 starrocks::MemTable::finalize()
    @          0xa71da03 starrocks::lake::DeltaWriterImpl::flush_async()
    @          0xa71dd01 starrocks::lake::DeltaWriterImpl::flush()
    @          0xa7192dc starrocks::lake::DeltaWriterImpl::finish()
    @          0xa71a7ba starrocks::lake::DeltaWriterImpl::finish_with_txnlog(starrocks::lake::DeltaWriterFinishMode)
    @          0xa71c634 starrocks::lake::DeltaWriter::finish_with_txnlog(starrocks::lake::DeltaWriterFinishMode)
    @          0xa71303d starrocks::lake::MergeBlockTask::run()
    @          0x848ef17 starrocks::ThreadPool::dispatch_thread()
    @          0x8485cf0 starrocks::Thread::supervise_thread(void*)
    @     0x2b66fe245ea5 start_thread
    @     0x2b6700716b0d __clone
```

```
Thread A (Submitter)              Thread B (Worker)              Thread C (Closer)
  ====================              =================              =================
  submit(MergeBlockTask)
    token->_entries.push(task)
    token->state = RUNNING
    _active_threads = 0  ←←←
    (return)
                                    (busy with other tasks)
                                                                   close()
                                                                     _block_merge_token->shutdown()
                                                                     // Lock acquired
                                                                     // state == RUNNING
                                                                     // _active_threads == 0 !!!
                                                                     to_release = move(_entries)
                                                                     transition(QUIESCED)
                                                                     // Return immediately!
                                                                     _block_merge_token.reset()
                                                                     execution_queue_join()
                                                                       → DeltaWriterImpl::close()
                                                                         → _mem_table.reset()  ← Free
                                    pick up task (too late!)
                                    MergeBlockTask::run()
                                      flush_async()
                                        _mem_table->finalize()  ← Use-After-Free!
```


## What I'm doing:
Fix race condition in load spill when close

Fixes https://github.com/StarRocks/StarRocksTest/issues/10734

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `AsyncDeltaWriterImpl::close()` waits for ongoing block-merge tasks (`_block_merge_token->wait()`) before shutdown to prevent race conditions.
> 
> - **Lake storage**
>   - In `be/src/storage/lake/async_delta_writer.cpp`:
>     - `AsyncDeltaWriterImpl::close()` now calls `_block_merge_token->wait()` before `shutdown()`/reset, ensuring all merge tasks finish before stopping/joining the execution queue.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08cb9f83ac657c53dd054fca8587097f4c9b1309. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->