### PR TITLE
[Enhancement] Introduce MutableChunk class

### DIFF
--- a/be/src/column/chunk.cpp
+++ b/be/src/column/chunk.cpp
@@ -94,6 +94,29 @@ Chunk::Chunk(Columns&& columns, SlotHashMap slot_map, ChunkExtraDataPtr extra_da
     }
 }
 
+Chunk::Chunk(MutableChunk&& other)
+        : _columns(ColumnHelper::to_columns(std::move(other._columns))),
+          _schema(std::move(other._schema)),
+          _extra_data(std::move(other._extra_data)) {
+    _slot_id_to_index = std::move(other._slot_id_to_index);
+    _cid_to_index = std::move(other._cid_to_index);
+    _delete_state = other._delete_state;
+    _owner_info = other._owner_info;
+    check_or_die();
+}
+
+Chunk& Chunk::operator=(MutableChunk&& other) {
+    _columns = ColumnHelper::to_columns(std::move(other._columns));
+    _schema = std::move(other._schema);
+    _extra_data = std::move(other._extra_data);
+    _slot_id_to_index = std::move(other._slot_id_to_index);
+    _cid_to_index = std::move(other._cid_to_index);
+    _delete_state = other._delete_state;
+    _owner_info = other._owner_info;
+    check_or_die();
+    return *this;
+}
+
 void Chunk::reset() {
     for (auto& c : _columns) {
         c->as_mutable_raw_ptr()->reset_column();
@@ -586,4 +609,490 @@ void Chunk::_append_column_checked(size_t idx, ColumnPtr&& ptr) {
     auto& new_column = _columns.back();
     _column_ptr_set.emplace(new_column.get(), idx);
 }
+
+MutableChunk::MutableChunk() {
+    _slot_id_to_index.reserve(4);
+}
+
+Status MutableChunk::upgrade_if_overflow() {
+    for (auto& column : _columns) {
+        auto ret = column->upgrade_if_overflow();
+        if (!ret.ok()) {
+            return ret.status();
+        } else if (ret.value() != nullptr) {
+            column = std::move(ret.value());
+        }
+    }
+    return Status::OK();
+}
+
+Status MutableChunk::downgrade() {
+    for (auto& column : _columns) {
+        auto ret = column->downgrade();
+        if (!ret.ok()) {
+            return ret.status();
+        } else if (ret.value() != nullptr) {
+            column = std::move(ret.value());
+        }
+    }
+    return Status::OK();
+}
+
+bool MutableChunk::has_large_column() const {
+    for (const auto& column : _columns) {
+        if (column != nullptr && column->has_large_column()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+MutableChunk::MutableChunk(MutableColumns columns, SchemaPtr schema)
+        : MutableChunk(std::move(columns), std::move(schema), nullptr) {}
+
+MutableChunk::MutableChunk(MutableColumns columns, SlotHashMap slot_map)
+        : MutableChunk(std::move(columns), std::move(slot_map), nullptr) {}
+
+MutableChunk::MutableChunk(MutableColumns columns, SchemaPtr schema, ChunkExtraDataPtr extra_data)
+        : _columns(std::move(columns)), _schema(std::move(schema)), _extra_data(std::move(extra_data)) {
+    _cid_to_index.reserve(std::max<size_t>(1, _columns.size() * 2));
+    _slot_id_to_index.reserve(std::max<size_t>(1, _columns.size() * 2));
+    rebuild_cid_index();
+    check_or_die();
+}
+
+MutableChunk::MutableChunk(MutableColumns columns, SlotHashMap slot_map, ChunkExtraDataPtr extra_data)
+        : _columns(std::move(columns)), _slot_id_to_index(std::move(slot_map)), _extra_data(std::move(extra_data)) {
+    // when use _slot_id_to_index, we don't need to rebuild_cid_index
+}
+
+void MutableChunk::reset() {
+    for (auto& c : _columns) {
+        c->reset_column();
+    }
+    _delete_state = DEL_NOT_SATISFIED;
+    _extra_data.reset();
+}
+
+void MutableChunk::swap_chunk(MutableChunk& other) {
+    _columns.swap(other._columns);
+    _schema.swap(other._schema);
+    _cid_to_index.swap(other._cid_to_index);
+    _slot_id_to_index.swap(other._slot_id_to_index);
+    std::swap(_delete_state, other._delete_state);
+    _extra_data.swap(other._extra_data);
+}
+
+void MutableChunk::set_num_rows(size_t count) {
+    for (auto& c : _columns) {
+        c->resize(count);
+    }
+}
+
+void MutableChunk::update_rows(const Chunk& src, const uint32_t* indexes) {
+    DCHECK(_columns.size() == src.num_columns());
+    for (int i = 0; i < _columns.size(); i++) {
+        _columns[i]->update_rows(*src.columns()[i], indexes);
+    }
+}
+
+std::string_view MutableChunk::get_column_name(size_t idx) const {
+    DCHECK_LT(idx, _columns.size());
+    return _schema->field(idx)->name();
+}
+
+void MutableChunk::append_column(MutableColumnPtr&& column, const FieldPtr& field) {
+    DCHECK(!_cid_to_index.contains(field->id()));
+    _cid_to_index[field->id()] = _columns.size();
+    _columns.emplace_back(std::move(column));
+    _schema->append(field);
+    check_or_die();
+}
+
+void MutableChunk::append_vector_column(MutableColumnPtr&& column, const FieldPtr& field, SlotId slot_id) {
+    DCHECK(!_cid_to_index.contains(field->id()));
+    _cid_to_index[field->id()] = _columns.size();
+    _slot_id_to_index[slot_id] = _columns.size();
+    _columns.emplace_back(std::move(column));
+    _schema->append(field);
+    check_or_die();
+}
+
+void MutableChunk::append_column(MutableColumnPtr&& column, SlotId slot_id) {
+    DCHECK(!_slot_id_to_index.contains(slot_id)) << "slot_id:" + std::to_string(slot_id) << std::endl;
+    if (UNLIKELY(_slot_id_to_index.contains(slot_id))) {
+        throw std::runtime_error(fmt::format("slot_id {} already exists", slot_id));
+    }
+    _slot_id_to_index[slot_id] = _columns.size();
+    _columns.emplace_back(std::move(column));
+    check_or_die();
+}
+
+void MutableChunk::update_column(MutableColumnPtr&& column, SlotId slot_id) {
+    _columns[_slot_id_to_index[slot_id]] = std::move(column);
+    check_or_die();
+}
+
+void MutableChunk::update_column_by_index(MutableColumnPtr&& column, size_t idx) {
+    _columns[idx] = std::move(column);
+    check_or_die();
+}
+
+void MutableChunk::append_or_update_column(MutableColumnPtr&& column, SlotId slot_id) {
+    if (_slot_id_to_index.contains(slot_id)) {
+        _columns[_slot_id_to_index[slot_id]] = std::move(column);
+    } else {
+        _slot_id_to_index[slot_id] = _columns.size();
+        _columns.emplace_back(std::move(column));
+        // only check it when append a new column
+        check_or_die();
+    }
+}
+
+void MutableChunk::insert_column(size_t idx, MutableColumnPtr&& column, const FieldPtr& field) {
+    DCHECK_LT(idx, _columns.size());
+    _columns.emplace(_columns.begin() + idx, std::move(column));
+    _schema->insert(idx, field);
+    rebuild_cid_index();
+    check_or_die();
+}
+
+void MutableChunk::append_default() {
+    for (auto& column : _columns) {
+        column->append_default();
+    }
+}
+
+void MutableChunk::remove_column_by_index(size_t idx) {
+    DCHECK_LT(idx, _columns.size());
+    _columns.erase(_columns.begin() + idx);
+    if (_schema != nullptr) {
+        _schema->remove(idx);
+        rebuild_cid_index();
+    }
+}
+
+void MutableChunk::remove_column_by_slot_id(SlotId slot_id) {
+    auto iter = _slot_id_to_index.find(slot_id);
+    if (iter != _slot_id_to_index.end()) {
+        auto idx = iter->second;
+        _columns.erase(_columns.begin() + idx);
+        if (_schema != nullptr) {
+            _schema->remove(idx);
+            rebuild_cid_index();
+        }
+        _slot_id_to_index.erase(iter);
+        for (auto& tmp_iter : _slot_id_to_index) {
+            if (tmp_iter.second > idx) {
+                tmp_iter.second--;
+            }
+        }
+    }
+}
+
+void MutableChunk::remove_columns_by_index(const std::vector<size_t>& indexes) {
+    DCHECK(std::is_sorted(indexes.begin(), indexes.end()));
+    for (size_t i = indexes.size(); i > 0; i--) {
+        _columns.erase(_columns.begin() + indexes[i - 1]);
+    }
+    if (_schema != nullptr && !indexes.empty()) {
+        for (size_t i = indexes.size(); i > 0; i--) {
+            _schema->remove(indexes[i - 1]);
+        }
+        rebuild_cid_index();
+    }
+}
+
+void MutableChunk::rebuild_cid_index() {
+    _cid_to_index.clear();
+    for (size_t i = 0; i < _schema->num_fields(); i++) {
+        _cid_to_index[_schema->field(i)->id()] = i;
+    }
+}
+
+MutableChunkPtr MutableChunk::clone_empty() const {
+    return clone_empty(num_rows());
+}
+
+MutableChunkPtr MutableChunk::clone_empty(size_t size) const {
+    if (_columns.size() == _slot_id_to_index.size()) {
+        return clone_empty_with_slot(size);
+    } else {
+        return clone_empty_with_schema(size);
+    }
+}
+
+MutableChunkPtr MutableChunk::clone_empty_with_slot() const {
+    return clone_empty_with_slot(num_rows());
+}
+
+MutableChunkPtr MutableChunk::clone_empty_with_slot(size_t size) const {
+    DCHECK_EQ(_columns.size(), _slot_id_to_index.size());
+    MutableColumns columns(_slot_id_to_index.size());
+    for (size_t i = 0; i < _slot_id_to_index.size(); i++) {
+        auto mutable_col = _columns[i]->clone_empty();
+        mutable_col->reserve(size);
+        columns[i] = std::move(mutable_col);
+    }
+    return std::make_shared<MutableChunk>(std::move(columns), _slot_id_to_index);
+}
+
+MutableChunkPtr MutableChunk::clone_empty_with_schema() const {
+    return clone_empty_with_schema(num_rows());
+}
+
+MutableChunkPtr MutableChunk::clone_empty_with_schema(size_t size) const {
+    MutableColumns columns(_columns.size());
+    for (size_t i = 0; i < _columns.size(); ++i) {
+        auto mutable_col = _columns[i]->clone_empty();
+        mutable_col->reserve(size);
+        columns[i] = std::move(mutable_col);
+    }
+    return std::make_shared<MutableChunk>(std::move(columns), _schema);
+}
+
+MutableChunkPtr MutableChunk::clone_unique() const {
+    MutableChunkPtr chunk = clone_empty(0);
+    for (size_t idx = 0; idx < _columns.size(); idx++) {
+        chunk->_columns[idx] = _columns[idx]->clone();
+    }
+    chunk->_delete_state = _delete_state;
+    chunk->_owner_info = _owner_info;
+    if (_extra_data != nullptr) {
+        chunk->_extra_data = _extra_data->clone();
+    }
+    chunk->check_or_die();
+    return chunk;
+}
+
+void MutableChunk::append_selective(const Chunk& src, const uint32_t* indexes, uint32_t from, uint32_t size) {
+    DCHECK_EQ(_columns.size(), src.columns().size());
+    for (size_t i = 0; i < _columns.size(); ++i) {
+        _columns[i]->append_selective(*src.columns()[i].get(), indexes, from, size);
+    }
+}
+
+void MutableChunk::rolling_append_selective(Chunk& src, const uint32_t* indexes, uint32_t from, uint32_t size) {
+    size_t num_columns = _columns.size();
+    DCHECK_EQ(num_columns, src.columns().size());
+    for (size_t i = 0; i < num_columns; ++i) {
+        _columns[i]->append_selective(*src.columns()[i].get(), indexes, from, size);
+        src.columns()[i].reset();
+    }
+}
+
+size_t MutableChunk::filter(const Buffer<uint8_t>& selection, bool force) {
+    if (!force && SIMD::count_zero(selection) == 0) {
+        return num_rows();
+    }
+    for (auto& column : _columns) {
+        column->filter(selection);
+    }
+    return num_rows();
+}
+
+size_t MutableChunk::filter_range(const Buffer<uint8_t>& selection, size_t from, size_t to) {
+    for (auto& column : _columns) {
+        column->filter_range(selection, from, to);
+    }
+    return num_rows();
+}
+
+DatumTuple MutableChunk::get(size_t n) const {
+    DatumTuple res;
+    res.reserve(_columns.size());
+    for (const auto& column : _columns) {
+        res.append(column->get(n));
+    }
+    return res;
+}
+
+size_t MutableChunk::memory_usage() const {
+    size_t memory_usage = 0;
+    for (const auto& column : _columns) {
+        memory_usage += column->memory_usage();
+    }
+    return memory_usage;
+}
+
+size_t MutableChunk::container_memory_usage() const {
+    size_t container_memory_usage = 0;
+    for (const auto& column : _columns) {
+        container_memory_usage += column->container_memory_usage();
+    }
+    return container_memory_usage;
+}
+
+size_t MutableChunk::reference_memory_usage(size_t from, size_t size) const {
+    DCHECK_LE(from + size, num_rows()) << "Range error";
+    size_t reference_memory_usage = 0;
+    for (const auto& column : _columns) {
+        reference_memory_usage += column->reference_memory_usage(from, size);
+    }
+    return reference_memory_usage;
+}
+
+size_t MutableChunk::bytes_usage() const {
+    return bytes_usage(0, num_rows());
+}
+
+size_t MutableChunk::bytes_usage(size_t from, size_t size) const {
+    DCHECK_LE(from + size, num_rows()) << "Range error";
+    size_t bytes_usage = 0;
+    for (const auto& column : _columns) {
+        bytes_usage += column->byte_size(from, size);
+    }
+    return bytes_usage;
+}
+
+#ifndef NDEBUG
+void MutableChunk::check_or_die() {
+    if (_columns.empty()) {
+        CHECK(_schema == nullptr || _schema->fields().empty());
+        CHECK(_cid_to_index.empty());
+        CHECK(_slot_id_to_index.empty());
+    } else {
+        for (const MutableColumnPtr& c : _columns) {
+            if (!c->is_constant()) {
+                CHECK_EQ(num_rows(), c->size());
+            }
+            c->check_or_die();
+        }
+    }
+
+    if (_schema != nullptr) {
+        for (const auto& kv : _cid_to_index) {
+            ColumnId cid = kv.first;
+            size_t idx = kv.second;
+            CHECK_LT(idx, _columns.size());
+            CHECK_LT(idx, _schema->num_fields());
+            CHECK_EQ(cid, _schema->field(idx)->id());
+        }
+    }
+}
+#endif
+
+std::string MutableChunk::debug_row(size_t index) const {
+    std::stringstream os;
+    os << "[";
+    for (size_t col = 0; col < _columns.size() - 1; ++col) {
+        os << _columns[col]->debug_item(index);
+        os << ", ";
+    }
+    os << _columns[_columns.size() - 1]->debug_item(index) << "]";
+    return os.str();
+}
+
+std::string MutableChunk::rebuild_csv_row(size_t index, const std::string& delimiter) const {
+    std::stringstream os;
+    for (size_t col = 0; col < _columns.size() - 1; ++col) {
+        os << _columns[col]->debug_item(index);
+        os << delimiter;
+    }
+    if (_columns.size() > 0) {
+        os << _columns[_columns.size() - 1]->debug_item(index);
+    }
+    return os.str();
+}
+
+std::string MutableChunk::debug_columns() const {
+    std::stringstream os;
+    os << "nullable[";
+    for (size_t col = 0; col < _columns.size() - 1; ++col) {
+        os << _columns[col]->is_nullable();
+        os << ", ";
+    }
+    os << _columns[_columns.size() - 1]->is_nullable() << "]";
+    os << " const[";
+    for (size_t col = 0; col < _columns.size() - 1; ++col) {
+        os << _columns[col]->is_constant();
+        os << ", ";
+    }
+    os << _columns[_columns.size() - 1]->is_constant() << "]";
+    return os.str();
+}
+
+void MutableChunk::merge(MutableChunk&& src) {
+    DCHECK_EQ(src.num_rows(), num_rows());
+    for (auto& it : src._slot_id_to_index) {
+        SlotId slot_id = it.first;
+        size_t index = it.second;
+        MutableColumnPtr& c = src._columns[index];
+        append_column(std::move(c), slot_id);
+    }
+}
+
+void MutableChunk::append(const Chunk& src, size_t offset, size_t count) {
+    DCHECK_EQ(num_columns(), src.num_columns());
+    const size_t n = src.num_columns();
+    for (size_t i = 0; i < n; i++) {
+        _columns[i]->append(*src.get_column_by_index(i), offset, count);
+    }
+}
+
+void MutableChunk::append_safe(const Chunk& src, size_t offset, size_t count) {
+    DCHECK_EQ(num_columns(), src.num_columns());
+    const size_t n = src.num_columns();
+    size_t cur_rows = num_rows();
+    for (size_t i = 0; i < n; i++) {
+        auto& column = _columns[i];
+        if (column->size() == cur_rows) {
+            column->append(*src.get_column_by_index(i), offset, count);
+        }
+    }
+}
+
+void MutableChunk::reserve(size_t cap) {
+    for (auto& c : _columns) {
+        c->reserve(cap);
+    }
+}
+
+bool MutableChunk::has_const_column() const {
+    for (const auto& c : _columns) {
+        if (c->is_constant()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void MutableChunk::unpack_and_duplicate_const_columns() {
+    size_t num_rows = this->num_rows();
+    for (size_t i = 0; i < _columns.size(); i++) {
+        auto& column = _columns[i];
+        if (column->is_constant()) {
+            auto unpack_column = ColumnHelper::unpack_and_duplicate_const_column(num_rows, std::move(column));
+            _columns[i] = std::move(unpack_column);
+        }
+    }
+}
+
+Chunk MutableChunk::to_chunk() {
+    return Chunk(std::move(*this));
+}
+
+MutableChunk::MutableChunk(Chunk&& other)
+        : _columns(ColumnHelper::to_mutable_columns(std::move((other._columns)))),
+          _schema(std::move(other._schema)),
+          _extra_data(std::move(other._extra_data)) {
+    _slot_id_to_index = std::move(other._slot_id_to_index);
+    _cid_to_index = std::move(other._cid_to_index);
+    _delete_state = other._delete_state;
+    _owner_info = other._owner_info;
+    check_or_die();
+}
+
+MutableChunk& MutableChunk::operator=(Chunk&& other) {
+    _columns = ColumnHelper::to_mutable_columns(std::move((other._columns)));
+    _schema = std::move(other._schema);
+    _extra_data = std::move(other._extra_data);
+    _slot_id_to_index = std::move(other._slot_id_to_index);
+    _cid_to_index = std::move(other._cid_to_index);
+    _delete_state = other._delete_state;
+    _owner_info = other._owner_info;
+    check_or_die();
+    return *this;
+}
+
 } // namespace starrocks

--- a/be/src/column/chunk.h
+++ b/be/src/column/chunk.h
@@ -32,6 +32,10 @@ class ChunkPB;
 class DatumTuple;
 class ChunkExtraData;
 using ChunkExtraDataPtr = std::shared_ptr<ChunkExtraData>;
+class MutableChunk;
+using MutableChunkPtr = std::shared_ptr<MutableChunk>;
+
+/**
 /**
  * ChunkExtraData is an extra data which can be used to extend Chunk and 
  * attach extra infos beside the schema. eg, In Stream MV scenes, 
@@ -73,6 +77,11 @@ public:
 
     Chunk(Chunk&& other) = default;
     Chunk& operator=(Chunk&& other) = default;
+
+    // Build a Chunk from the MutableChunk and transfer the ownership to the Chunk.
+    friend class MutableChunk;
+    Chunk(MutableChunk&& other);
+    Chunk& operator=(MutableChunk&& other);
 
     ~Chunk() = default;
 
@@ -455,4 +464,235 @@ inline const Column* Chunk::get_column_raw_ptr_by_slot_id(SlotId slot_id) const 
     return _columns[idx].get();
 }
 
+// MutableChunk: a variant of Chunk where all columns are MutableColumns.
+// Its API closely follows Chunk so it can substitute Chunk in many contexts.
+class MutableChunk {
+public:
+    using MutableChunkPtr = std::shared_ptr<MutableChunk>;
+    using SlotHashMap = Chunk::SlotHashMap;
+    using ColumnIdHashMap = Chunk::ColumnIdHashMap;
+
+    MutableChunk();
+    MutableChunk(MutableColumns columns, SchemaPtr schema);
+    MutableChunk(MutableColumns columns, SlotHashMap slot_map);
+    MutableChunk(MutableColumns columns, SchemaPtr schema, ChunkExtraDataPtr extra_data);
+    MutableChunk(MutableColumns columns, SlotHashMap slot_map, ChunkExtraDataPtr extra_data);
+
+    MutableChunk(MutableChunk&& other) = default;
+    MutableChunk& operator=(MutableChunk&& other) = default;
+
+    ~MutableChunk() = default;
+
+    // Disallow copy and assignment.
+    MutableChunk(const MutableChunk& other) = delete;
+    MutableChunk& operator=(const MutableChunk& other) = delete;
+
+    friend class Chunk;
+    MutableChunk(Chunk&& other);
+    MutableChunk& operator=(Chunk&& other);
+    // Build a Chunk from the MutableChunk and transfer the ownership to the Chunk.
+    // NOTE: After build, the MutableChunk will be in an invalid state and should not be used anymore.
+    Chunk to_chunk();
+
+    Status upgrade_if_overflow();
+    Status downgrade();
+    void reset();
+
+    bool has_large_column() const;
+
+    bool has_rows() const { return num_rows() > 0; }
+    bool is_empty() const { return num_rows() == 0; }
+    bool has_columns() const { return !_columns.empty(); }
+    size_t num_columns() const { return _columns.size(); }
+    size_t num_rows() const { return _columns.empty() ? 0 : _columns[0]->size(); }
+
+    // Resize the chunk to contain |count| rows elements.
+    //  - If the current size is less than count, additional default values are appended.
+    //  - If the current size is greater than count, the chunk is reduced to its first count elements.
+    void set_num_rows(size_t count);
+
+    void swap_chunk(MutableChunk& other);
+
+    const SchemaPtr& schema() const { return _schema; }
+    SchemaPtr& schema() { return _schema; }
+    void reset_schema() { _schema.reset(); }
+    const MutableColumns& columns() const { return _columns; }
+    MutableColumns& columns() { return _columns; }
+    // schema must exists.
+    std::string_view get_column_name(size_t idx) const;
+
+    // schema must exist and will be updated.
+    void append_column(MutableColumnPtr&& column, const FieldPtr& field);
+    void append_vector_column(MutableColumnPtr&& column, const FieldPtr& field, SlotId slot_id);
+    void append_column(MutableColumnPtr&& column, SlotId slot_id);
+    void insert_column(size_t idx, MutableColumnPtr&& column, const FieldPtr& field);
+    void update_column(MutableColumnPtr&& column, SlotId slot_id);
+    void update_column_by_index(MutableColumnPtr&& column, size_t idx);
+    void append_or_update_column(MutableColumnPtr&& column, SlotId slot_id);
+
+    void update_rows(const Chunk& src, const uint32_t* indexes);
+    void append_default();
+
+    void remove_column_by_index(size_t idx);
+    void remove_column_by_slot_id(SlotId slot_id);
+    void remove_columns_by_index(const std::vector<size_t>& indexes);
+
+    // schema must exists.
+    const MutableColumnPtr& get_column_by_name(const std::string& column_name) const {
+        size_t idx = _schema->get_field_index_by_name(column_name);
+        DCHECK_LT(idx, _columns.size());
+        return _columns[idx];
+    }
+    MutableColumnPtr& get_column_by_name(const std::string& column_name) {
+        size_t idx = _schema->get_field_index_by_name(column_name);
+        DCHECK_LT(idx, _columns.size());
+        return _columns[idx];
+    }
+
+    const MutableColumnPtr& get_column_by_index(size_t idx) const {
+        DCHECK_LT(idx, _columns.size());
+        return _columns[idx];
+    }
+    MutableColumnPtr& get_column_by_index(size_t idx) {
+        DCHECK_LT(idx, _columns.size());
+        return _columns[idx];
+    }
+
+    const MutableColumnPtr& get_column_by_id(ColumnId cid) const {
+        DCHECK(!_cid_to_index.empty());
+        DCHECK(_cid_to_index.contains(cid));
+        size_t idx = _cid_to_index.at(cid);
+        return _columns[idx];
+    }
+    MutableColumnPtr& get_column_by_id(ColumnId cid) {
+        DCHECK(!_cid_to_index.empty());
+        DCHECK(_cid_to_index.contains(cid));
+        size_t idx = _cid_to_index.at(cid);
+        return _columns[idx];
+    }
+
+    // Must ensure the slot_id exist
+    const MutableColumnPtr& get_column_by_slot_id(SlotId slot_id) const {
+        DCHECK(is_slot_exist(slot_id)) << slot_id;
+        if (UNLIKELY(!_slot_id_to_index.contains(slot_id))) {
+            throw std::runtime_error(fmt::format("slot_id {} not found", slot_id));
+        }
+        size_t idx = _slot_id_to_index.at(slot_id);
+        return _columns[idx];
+    }
+    MutableColumnPtr& get_column_by_slot_id(SlotId slot_id) {
+        DCHECK(is_slot_exist(slot_id)) << slot_id;
+        if (UNLIKELY(!_slot_id_to_index.contains(slot_id))) {
+            throw std::runtime_error(fmt::format("slot_id {} not found", slot_id));
+        }
+        size_t idx = _slot_id_to_index.at(slot_id);
+        return _columns[idx];
+    }
+
+    bool is_column_nullable(SlotId slot_id) const { return get_column_by_slot_id(slot_id)->is_nullable(); }
+    void set_slot_id_to_index(SlotId slot_id, size_t idx) { _slot_id_to_index[slot_id] = idx; }
+    bool is_slot_exist(SlotId id) const { return _slot_id_to_index.contains(id); }
+    bool is_cid_exist(ColumnId cid) const { return _cid_to_index.contains(cid); }
+    void reset_slot_id_to_index() { _slot_id_to_index.clear(); }
+    size_t get_index_by_slot_id(SlotId slot_id) const {
+        DCHECK(is_slot_exist(slot_id)) << slot_id;
+        return _slot_id_to_index.at(slot_id);
+    }
+
+    // Create an empty chunk with the same meta and reserve it of size chunk _num_rows
+    MutableChunkPtr clone_empty() const;
+    MutableChunkPtr clone_empty_with_slot() const;
+    MutableChunkPtr clone_empty_with_schema() const;
+    // Create an empty chunk with the same meta and reserve it of specified size.
+    MutableChunkPtr clone_empty(size_t size) const;
+    MutableChunkPtr clone_empty_with_slot(size_t size) const;
+    MutableChunkPtr clone_empty_with_schema(size_t size) const;
+    MutableChunkPtr clone_unique() const;
+
+    void append(const Chunk& src) { append(src, 0, src.num_rows()); }
+    void merge(MutableChunk&& src);
+    void append(const Chunk& src, size_t offset, size_t count);
+    void append_safe(const Chunk& src) { append_safe(src, 0, src.num_rows()); }
+    void append_safe(const Chunk& src, size_t offset, size_t count);
+    void append_selective(const Chunk& src, const uint32_t* indexes, uint32_t from, uint32_t size);
+    void rolling_append_selective(Chunk& src, const uint32_t* indexes, uint32_t from, uint32_t size);
+    size_t filter(const Buffer<uint8_t>& selection, bool force = false);
+    size_t filter_range(const Buffer<uint8_t>& selection, size_t from, size_t to);
+    DatumTuple get(size_t n) const;
+
+    void set_delete_state(DelCondSatisfied state) { _delete_state = state; }
+    DelCondSatisfied delete_state() const { return _delete_state; }
+
+    const SlotHashMap& get_slot_id_to_index_map() const { return _slot_id_to_index; }
+    const ColumnIdHashMap& get_column_id_to_index_map() const { return _cid_to_index; }
+
+    void reserve(size_t cap);
+
+    size_t memory_usage() const;
+
+    size_t container_memory_usage() const;
+    size_t reference_memory_usage() const { return reference_memory_usage(0, num_rows()); }
+    size_t reference_memory_usage(size_t from, size_t size) const;
+
+    size_t bytes_usage() const;
+    size_t bytes_usage(size_t from, size_t size) const;
+
+    bool has_const_column() const;
+
+    void materialized_nullable() {
+        for (auto& c : _columns) {
+            c->materialized_nullable();
+        }
+    }
+
+    void unpack_and_duplicate_const_columns();
+
+#ifndef NDEBUG
+    // check whether the internal state is consistent, abort the program if check failed.
+    void check_or_die();
+#else
+    void check_or_die() {}
+#endif
+
+#ifndef NDEBUG
+#define DCHECK_CHUNK(chunk_ptr)          \
+    do {                                 \
+        if ((chunk_ptr) != nullptr) {    \
+            (chunk_ptr)->check_or_die(); \
+        }                                \
+    } while (false)
+#else
+#define DCHECK_CHUNK(chunk_ptr)
+#endif
+
+    std::string debug_row(size_t index) const;
+    std::string debug_columns() const;
+
+    std::string rebuild_csv_row(size_t index, const std::string& delimiter) const;
+
+    Status capacity_limit_reached() const {
+        for (const auto& column : _columns) {
+            RETURN_IF_ERROR(column->capacity_limit_reached());
+        }
+        return Status::OK();
+    }
+    bool has_capacity_limit_reached() const { return !capacity_limit_reached().ok(); }
+
+    query_cache::owner_info& owner_info() { return _owner_info; }
+    const ChunkExtraDataPtr& get_extra_data() const { return _extra_data; }
+    ChunkExtraDataPtr& get_extra_data() { return _extra_data; }
+    void set_extra_data(ChunkExtraDataPtr data) { this->_extra_data = std::move(data); }
+    bool has_extra_data() const { return this->_extra_data != nullptr; }
+
+private:
+    void rebuild_cid_index();
+
+    MutableColumns _columns;
+    std::shared_ptr<Schema> _schema;
+    ColumnIdHashMap _cid_to_index;
+    SlotHashMap _slot_id_to_index;
+    DelCondSatisfied _delete_state = DEL_NOT_SATISFIED;
+    query_cache::owner_info _owner_info;
+    ChunkExtraDataPtr _extra_data;
+};
 } // namespace starrocks

--- a/be/src/storage/chunk_helper.h
+++ b/be/src/storage/chunk_helper.h
@@ -75,6 +75,15 @@ public:
     static StatusOr<ChunkUniquePtr> new_chunk_checked(const std::vector<SlotDescriptor*>& slots, size_t n);
     static StatusOr<ChunkUniquePtr> new_chunk_checked(const TupleDescriptor& tuple_desc, size_t n);
 
+    // Create an empty mutable chunk according to the |slots| and reserve it of size |n|.
+    static MutableChunkPtr new_mutable_chunk(const std::vector<SlotDescriptor*>& slots, size_t n);
+    static MutableChunkPtr new_mutable_chunk(const Schema& schema, size_t n);
+    static MutableChunkPtr new_mutable_chunk(const TupleDescriptor& tuple_desc, size_t n);
+    // a wrapper of new_mutable_chunk with memory check
+    static StatusOr<MutableChunkPtr> new_mutable_chunk_checked(const Schema& schema, size_t n);
+    static StatusOr<MutableChunkPtr> new_mutable_chunk_checked(const std::vector<SlotDescriptor*>& slots, size_t n);
+    static StatusOr<MutableChunkPtr> new_mutable_chunk_checked(const TupleDescriptor& tuple_desc, size_t n);
+
     // Create a vectorized column from field .
     // REQUIRE: |type| must be scalar type.
     static MutableColumnPtr column_from_field_type(LogicalType type, bool nullable);

--- a/be/test/column/chunk_test.cpp
+++ b/be/test/column/chunk_test.cpp
@@ -20,6 +20,7 @@
 #include "column/chunk_extra_data.h"
 #include "column/column_helper.h"
 #include "column/const_column.h"
+#include "column/datum_tuple.h"
 #include "column/field.h"
 #include "column/fixed_length_column.h"
 #include "column/vectorized_fwd.h"
@@ -58,10 +59,10 @@ public:
         return column;
     }
 
-    Columns make_columns(size_t num_cols, size_t size = 100) {
+    Columns make_columns(size_t num_cols, size_t size = 100, size_t start = -1) {
         Columns columns;
         for (size_t i = 0; i < num_cols; i++) {
-            columns.emplace_back(make_column(i, size));
+            columns.emplace_back(make_column(start == -1 ? i : start, size));
         }
         return columns;
     }
@@ -87,6 +88,22 @@ public:
         }
         auto extra_data_cols = make_columns(num_cols, size);
         return std::make_shared<ChunkExtraColumnsData>(std::move(extra_data_metas), std::move(extra_data_cols));
+    }
+
+    MutableColumnPtr make_mutable_column(size_t start, size_t size = 100) {
+        auto column = FixedLengthColumn<int32_t>::create();
+        for (int i = 0; i < size; i++) {
+            column->append(start + i);
+        }
+        return column;
+    }
+
+    MutableColumns make_mutable_columns(size_t num_cols, size_t size = 100, size_t start = -1) {
+        MutableColumns columns;
+        for (size_t i = 0; i < num_cols; i++) {
+            columns.emplace_back(make_mutable_column(start == -1 ? i : start, size));
+        }
+        return columns;
     }
 };
 
@@ -597,6 +614,743 @@ TEST_F(ChunkTest, test_check_or_die_after_swap) {
     ASSERT_NO_FATAL_FAILURE(chunk2->check_or_die());
     ASSERT_EQ(3, chunk1->num_columns());
     ASSERT_EQ(2, chunk2->num_columns());
+}
+
+// ==================== MutableChunk Tests ====================
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_construct_default) {
+    auto mutable_chunk = std::make_shared<MutableChunk>();
+    ASSERT_FALSE(mutable_chunk->has_rows());
+    ASSERT_FALSE(mutable_chunk->has_columns());
+    ASSERT_EQ(0, mutable_chunk->num_columns());
+    ASSERT_EQ(0, mutable_chunk->num_rows());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_construct_with_schema) {
+    auto mutable_columns = make_mutable_columns(2);
+    auto schema = make_schema(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    ASSERT_TRUE(mutable_chunk->has_rows());
+    ASSERT_TRUE(mutable_chunk->has_columns());
+    ASSERT_EQ(2, mutable_chunk->num_columns());
+    ASSERT_EQ(100, mutable_chunk->num_rows());
+    ASSERT_NE(nullptr, mutable_chunk->schema());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_construct_with_slot_map) {
+    auto mutable_columns = make_mutable_columns(2);
+    MutableChunk::SlotHashMap slot_map;
+    slot_map[1] = 0;
+    slot_map[2] = 1;
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), std::move(slot_map));
+
+    ASSERT_TRUE(mutable_chunk->has_rows());
+    ASSERT_EQ(2, mutable_chunk->num_columns());
+    ASSERT_TRUE(mutable_chunk->is_slot_exist(1));
+    ASSERT_TRUE(mutable_chunk->is_slot_exist(2));
+    ASSERT_EQ(0, mutable_chunk->get_index_by_slot_id(1));
+    ASSERT_EQ(1, mutable_chunk->get_index_by_slot_id(2));
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_construct_with_extra_data) {
+    auto mutable_columns = make_mutable_columns(2);
+    auto schema = make_schema(2);
+    auto extra_data = make_extra_data(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema, extra_data);
+
+    ASSERT_TRUE(mutable_chunk->has_extra_data());
+    ASSERT_EQ(2, mutable_chunk->num_columns());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_from_chunk) {
+    auto chunk = std::make_unique<Chunk>(make_columns(2), make_schema(2));
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(*chunk));
+
+    ASSERT_EQ(2, mutable_chunk->num_columns());
+    ASSERT_EQ(100, mutable_chunk->num_rows());
+    ASSERT_NE(nullptr, mutable_chunk->schema());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_to_chunk) {
+    auto mutable_columns = make_mutable_columns(2);
+    auto schema = make_schema(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    auto chunk = std::move(*mutable_chunk).to_chunk();
+    ASSERT_EQ(2, chunk.num_columns());
+    ASSERT_EQ(100, chunk.num_rows());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_basic_operations) {
+    auto mutable_columns = make_mutable_columns(2);
+    auto schema = make_schema(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    ASSERT_TRUE(mutable_chunk->has_rows());
+    ASSERT_FALSE(mutable_chunk->is_empty());
+    ASSERT_TRUE(mutable_chunk->has_columns());
+    ASSERT_EQ(2, mutable_chunk->num_columns());
+    ASSERT_EQ(100, mutable_chunk->num_rows());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_set_num_rows) {
+    auto mutable_columns = make_mutable_columns(2);
+    auto schema = make_schema(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    mutable_chunk->set_num_rows(50);
+    ASSERT_EQ(50, mutable_chunk->num_rows());
+
+    mutable_chunk->set_num_rows(150);
+    ASSERT_EQ(150, mutable_chunk->num_rows());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_get_column_by_index) {
+    auto mutable_columns = make_mutable_columns(2);
+    auto schema = make_schema(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    const auto& col0 = mutable_chunk->get_column_by_index(0);
+    auto* fixed_col = ColumnHelper::as_raw_column<FixedLengthColumn<int32_t>>(col0.get());
+    ASSERT_EQ(100, fixed_col->size());
+    ASSERT_EQ(0, fixed_col->get(0).get_int32());
+
+    auto& col1 = mutable_chunk->get_column_by_index(1);
+    auto* fixed_col1 = ColumnHelper::as_raw_column<FixedLengthColumn<int32_t>>(col1.get());
+    ASSERT_EQ(1, fixed_col1->get(0).get_int32());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_get_column_by_slot_id) {
+    auto mutable_columns = make_mutable_columns(2);
+    MutableChunk::SlotHashMap slot_map;
+    slot_map[1] = 0;
+    slot_map[2] = 1;
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), std::move(slot_map));
+
+    const auto& col1 = mutable_chunk->get_column_by_slot_id(1);
+    auto* fixed_col = ColumnHelper::as_raw_column<FixedLengthColumn<int32_t>>(col1.get());
+    ASSERT_EQ(0, fixed_col->get(0).get_int32());
+
+    auto& col2 = mutable_chunk->get_column_by_slot_id(2);
+    auto* fixed_col2 = ColumnHelper::as_raw_column<FixedLengthColumn<int32_t>>(col2.get());
+    ASSERT_EQ(1, fixed_col2->get(0).get_int32());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_get_column_by_name) {
+    auto mutable_columns = make_mutable_columns(2);
+    auto schema = make_schema(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    const auto& col = mutable_chunk->get_column_by_name("c1");
+    auto* fixed_col = ColumnHelper::as_raw_column<FixedLengthColumn<int32_t>>(col.get());
+    check_column(fixed_col, 1);
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_get_column_by_id) {
+    auto mutable_columns = make_mutable_columns(2);
+    auto schema = make_schema(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    const auto& col = mutable_chunk->get_column_by_id(1);
+    auto* fixed_col = ColumnHelper::as_raw_column<FixedLengthColumn<int32_t>>(col.get());
+    check_column(fixed_col, 1);
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_append_column_with_field) {
+    auto mutable_columns = make_mutable_columns(2);
+    auto schema = make_schema(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    auto new_col = make_mutable_column(2);
+    mutable_chunk->append_column(std::move(new_col), make_field(2));
+
+    ASSERT_EQ(3, mutable_chunk->num_columns());
+    const auto& col = mutable_chunk->get_column_by_index(2);
+    auto* fixed_col = ColumnHelper::as_raw_column<FixedLengthColumn<int32_t>>(col.get());
+    check_column(fixed_col, 2);
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_append_column_with_slot_id) {
+    auto mutable_chunk = std::make_shared<MutableChunk>();
+    auto col1 = make_mutable_column(0);
+    auto col2 = make_mutable_column(1);
+
+    mutable_chunk->append_column(std::move(col1), 1);
+    mutable_chunk->append_column(std::move(col2), 2);
+
+    ASSERT_EQ(2, mutable_chunk->num_columns());
+    ASSERT_TRUE(mutable_chunk->is_slot_exist(1));
+    ASSERT_TRUE(mutable_chunk->is_slot_exist(2));
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_insert_column) {
+    auto mutable_columns = make_mutable_columns(2);
+    auto schema = make_schema(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    auto new_col = make_mutable_column(2);
+    mutable_chunk->insert_column(1, std::move(new_col), make_field(2));
+
+    ASSERT_EQ(3, mutable_chunk->num_columns());
+    const auto& col0 = mutable_chunk->get_column_by_index(0);
+    const auto& col1 = mutable_chunk->get_column_by_index(1);
+    const auto& col2 = mutable_chunk->get_column_by_index(2);
+    auto* fixed_col0 = ColumnHelper::as_raw_column<FixedLengthColumn<int32_t>>(col0.get());
+    auto* fixed_col1 = ColumnHelper::as_raw_column<FixedLengthColumn<int32_t>>(col1.get());
+    auto* fixed_col2 = ColumnHelper::as_raw_column<FixedLengthColumn<int32_t>>(col2.get());
+    check_column(fixed_col0, 0);
+    check_column(fixed_col1, 2);
+    check_column(fixed_col2, 1);
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_update_column) {
+    auto mutable_columns = make_mutable_columns(2);
+    MutableChunk::SlotHashMap slot_map;
+    slot_map[1] = 0;
+    slot_map[2] = 1;
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), std::move(slot_map));
+
+    auto new_col = make_mutable_column(100);
+    mutable_chunk->update_column(std::move(new_col), 1);
+
+    const auto& col = mutable_chunk->get_column_by_slot_id(1);
+    auto* fixed_col = ColumnHelper::as_raw_column<FixedLengthColumn<int32_t>>(col.get());
+    check_column(fixed_col, 100);
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_update_column_by_index) {
+    auto mutable_columns = make_mutable_columns(2);
+    auto schema = make_schema(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    auto new_col = make_mutable_column(100);
+    mutable_chunk->update_column_by_index(std::move(new_col), 0);
+
+    const auto& col = mutable_chunk->get_column_by_index(0);
+    auto* fixed_col = ColumnHelper::as_raw_column<FixedLengthColumn<int32_t>>(col.get());
+    check_column(fixed_col, 100);
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_append_or_update_column) {
+    auto mutable_chunk = std::make_shared<MutableChunk>();
+    auto col1 = make_mutable_column(0);
+    mutable_chunk->append_or_update_column(std::move(col1), 1);
+
+    ASSERT_EQ(1, mutable_chunk->num_columns());
+    ASSERT_TRUE(mutable_chunk->is_slot_exist(1));
+
+    auto col2 = make_mutable_column(100);
+    mutable_chunk->append_or_update_column(std::move(col2), 1);
+
+    ASSERT_EQ(1, mutable_chunk->num_columns());
+    const auto& col = mutable_chunk->get_column_by_slot_id(1);
+    auto* fixed_col = ColumnHelper::as_raw_column<FixedLengthColumn<int32_t>>(col.get());
+    check_column(fixed_col, 100);
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_remove_column_by_index) {
+    auto mutable_columns = make_mutable_columns(3);
+    auto schema = make_schema(3);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    mutable_chunk->remove_column_by_index(1);
+    ASSERT_EQ(2, mutable_chunk->num_columns());
+
+    const auto& col0 = mutable_chunk->get_column_by_index(0);
+    const auto& col1 = mutable_chunk->get_column_by_index(1);
+    auto* fixed_col0 = ColumnHelper::as_raw_column<FixedLengthColumn<int32_t>>(col0.get());
+    auto* fixed_col1 = ColumnHelper::as_raw_column<FixedLengthColumn<int32_t>>(col1.get());
+    check_column(fixed_col0, 0);
+    check_column(fixed_col1, 2);
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_remove_column_by_slot_id) {
+    auto mutable_columns = make_mutable_columns(3);
+    MutableChunk::SlotHashMap slot_map;
+    slot_map[1] = 0;
+    slot_map[2] = 1;
+    slot_map[3] = 2;
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), std::move(slot_map));
+
+    mutable_chunk->remove_column_by_slot_id(2);
+    ASSERT_EQ(2, mutable_chunk->num_columns());
+    ASSERT_FALSE(mutable_chunk->is_slot_exist(2));
+    ASSERT_TRUE(mutable_chunk->is_slot_exist(1));
+    ASSERT_TRUE(mutable_chunk->is_slot_exist(3));
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_remove_columns_by_index) {
+    auto mutable_columns = make_mutable_columns(4);
+    auto schema = make_schema(4);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    std::vector<size_t> indexes{1, 3};
+    mutable_chunk->remove_columns_by_index(indexes);
+    ASSERT_EQ(2, mutable_chunk->num_columns());
+
+    const auto& col0 = mutable_chunk->get_column_by_index(0);
+    const auto& col1 = mutable_chunk->get_column_by_index(1);
+    auto* fixed_col0 = ColumnHelper::as_raw_column<FixedLengthColumn<int32_t>>(col0.get());
+    auto* fixed_col1 = ColumnHelper::as_raw_column<FixedLengthColumn<int32_t>>(col1.get());
+    check_column(fixed_col0, 0);
+    check_column(fixed_col1, 2);
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_append_default) {
+    auto mutable_columns = make_mutable_columns(2);
+    auto schema = make_schema(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    size_t old_size = mutable_chunk->num_rows();
+    mutable_chunk->append_default();
+    ASSERT_EQ(old_size + 1, mutable_chunk->num_rows());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_clone_empty) {
+    auto mutable_columns = make_mutable_columns(2);
+    auto schema = make_schema(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    auto cloned = mutable_chunk->clone_empty();
+    ASSERT_EQ(2, cloned->num_columns());
+    ASSERT_EQ(0, cloned->num_rows());
+    ASSERT_NE(nullptr, cloned->schema());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_clone_empty_with_size) {
+    auto mutable_columns = make_mutable_columns(2);
+    auto schema = make_schema(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    auto cloned = mutable_chunk->clone_empty(200);
+    ASSERT_EQ(2, cloned->num_columns());
+    ASSERT_EQ(0, cloned->num_rows());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_clone_empty_with_slot) {
+    auto mutable_columns = make_mutable_columns(2);
+    MutableChunk::SlotHashMap slot_map;
+    slot_map[1] = 0;
+    slot_map[2] = 1;
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), std::move(slot_map));
+
+    auto cloned = mutable_chunk->clone_empty_with_slot();
+    ASSERT_EQ(2, cloned->num_columns());
+    ASSERT_EQ(0, cloned->num_rows());
+    ASSERT_TRUE(cloned->is_slot_exist(1));
+    ASSERT_TRUE(cloned->is_slot_exist(2));
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_clone_empty_with_schema) {
+    auto mutable_columns = make_mutable_columns(2);
+    auto schema = make_schema(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    auto cloned = mutable_chunk->clone_empty_with_schema();
+    ASSERT_EQ(2, cloned->num_columns());
+    ASSERT_EQ(0, cloned->num_rows());
+    ASSERT_NE(nullptr, cloned->schema());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_clone_unique) {
+    auto mutable_columns = make_mutable_columns(2);
+    auto schema = make_schema(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    auto cloned = mutable_chunk->clone_unique();
+    ASSERT_EQ(2, cloned->num_columns());
+    ASSERT_EQ(100, cloned->num_rows());
+    cloned->check_or_die();
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_append) {
+    auto mutable_columns1 = make_mutable_columns(2, 50);
+    auto schema = make_schema(2);
+    auto mutable_chunk1 = std::make_shared<MutableChunk>(std::move(mutable_columns1), schema);
+
+    auto chunk2 = std::make_unique<Chunk>(make_columns(2, 30), make_schema(2));
+    mutable_chunk1->append(*chunk2);
+
+    ASSERT_EQ(80, mutable_chunk1->num_rows());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_append_with_offset) {
+    auto mutable_columns1 = make_mutable_columns(2, 50);
+    auto schema = make_schema(2);
+    auto mutable_chunk1 = std::make_shared<MutableChunk>(std::move(mutable_columns1), schema);
+
+    auto chunk2 = std::make_unique<Chunk>(make_columns(2, 30), make_schema(2));
+    mutable_chunk1->append(*chunk2, 10, 20);
+
+    ASSERT_EQ(70, mutable_chunk1->num_rows());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_append_safe) {
+    auto mutable_columns1 = make_mutable_columns(2, 50);
+    auto schema = make_schema(2);
+    auto mutable_chunk1 = std::make_shared<MutableChunk>(std::move(mutable_columns1), schema);
+
+    auto chunk2 = std::make_unique<Chunk>(make_columns(2, 30), make_schema(2));
+    mutable_chunk1->append_safe(*chunk2);
+
+    ASSERT_EQ(80, mutable_chunk1->num_rows());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_append_selective) {
+    auto mutable_columns1 = make_mutable_columns(2, 10);
+    auto schema = make_schema(2);
+    auto mutable_chunk1 = std::make_shared<MutableChunk>(std::move(mutable_columns1), schema);
+
+    auto chunk2 = std::make_unique<Chunk>(make_columns(2, 10), make_schema(2));
+    uint32_t indexes[] = {0, 2, 4, 6, 8};
+    mutable_chunk1->append_selective(*chunk2, indexes, 0, 5);
+
+    ASSERT_EQ(15, mutable_chunk1->num_rows());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_filter) {
+    auto mutable_columns = make_mutable_columns(2, 4);
+    auto schema = make_schema(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    Buffer<uint8_t> selection{0, 1, 0, 1};
+    size_t filtered = mutable_chunk->filter(selection);
+    ASSERT_EQ(2, filtered);
+    ASSERT_EQ(2, mutable_chunk->num_rows());
+    mutable_chunk->check_or_die();
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_filter_range) {
+    auto mutable_columns = make_mutable_columns(2, 6);
+    auto schema = make_schema(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    Buffer<uint8_t> selection{0, 1, 0, 1, 0, 1};
+    size_t filtered = mutable_chunk->filter_range(selection, 1, 4);
+    ASSERT_EQ(3, filtered);
+    ASSERT_EQ(3, mutable_chunk->num_rows());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_get) {
+    auto mutable_columns = make_mutable_columns(2);
+    auto schema = make_schema(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    auto tuple = mutable_chunk->get(0);
+    ASSERT_EQ(2, tuple.size());
+    ASSERT_EQ(0, tuple[0].get_int32());
+    ASSERT_EQ(1, tuple[1].get_int32());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_swap_chunk) {
+    auto mutable_columns1 = make_mutable_columns(2);
+    auto schema1 = make_schema(2);
+    auto mutable_chunk1 = std::make_shared<MutableChunk>(std::move(mutable_columns1), schema1);
+    mutable_chunk1->set_delete_state(DEL_PARTIAL_SATISFIED);
+    mutable_chunk1->set_slot_id_to_index(1001, 0);
+
+    auto mutable_columns2 = make_mutable_columns(3);
+    auto schema2 = make_schema(3);
+    auto mutable_chunk2 = std::make_shared<MutableChunk>(std::move(mutable_columns2), schema2);
+    mutable_chunk2->set_delete_state(DEL_NOT_SATISFIED);
+
+    mutable_chunk1->swap_chunk(*mutable_chunk2);
+
+    ASSERT_EQ(3, mutable_chunk1->num_columns());
+    ASSERT_EQ(DEL_NOT_SATISFIED, mutable_chunk1->delete_state());
+    ASSERT_EQ(0, mutable_chunk1->get_slot_id_to_index_map().size());
+
+    ASSERT_EQ(2, mutable_chunk2->num_columns());
+    ASSERT_EQ(DEL_PARTIAL_SATISFIED, mutable_chunk2->delete_state());
+    ASSERT_EQ(1, mutable_chunk2->get_slot_id_to_index_map().size());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_reset) {
+    auto mutable_columns = make_mutable_columns(2);
+    auto schema = make_schema(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+    mutable_chunk->set_delete_state(DEL_PARTIAL_SATISFIED);
+    mutable_chunk->set_slot_id_to_index(1, 0);
+
+    mutable_chunk->reset();
+    ASSERT_EQ(2, mutable_chunk->num_columns());
+    ASSERT_EQ(0, mutable_chunk->num_rows());
+    ASSERT_EQ(DEL_NOT_SATISFIED, mutable_chunk->delete_state());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_reserve) {
+    auto mutable_columns = make_mutable_columns(2);
+    auto schema = make_schema(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    mutable_chunk->reserve(200);
+    // Reserve doesn't change the number of rows, just capacity
+    ASSERT_EQ(100, mutable_chunk->num_rows());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_memory_usage) {
+    auto mutable_columns = make_mutable_columns(2);
+    auto schema = make_schema(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    size_t mem_usage = mutable_chunk->memory_usage();
+    ASSERT_GT(mem_usage, 0);
+
+    size_t container_mem = mutable_chunk->container_memory_usage();
+    ASSERT_GT(container_mem, 0);
+
+    size_t ref_mem = mutable_chunk->reference_memory_usage();
+    ASSERT_GE(ref_mem, 0);
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_bytes_usage) {
+    auto mutable_columns = make_mutable_columns(2);
+    auto schema = make_schema(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    size_t bytes = mutable_chunk->bytes_usage();
+    ASSERT_GT(bytes, 0);
+
+    size_t bytes_range = mutable_chunk->bytes_usage(0, 50);
+    ASSERT_GT(bytes_range, 0);
+    ASSERT_LE(bytes_range, bytes);
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_has_const_column) {
+    auto mutable_columns = make_mutable_columns(2);
+    auto schema = make_schema(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    ASSERT_FALSE(mutable_chunk->has_const_column());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_materialized_nullable) {
+    auto col1 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_INT), true);
+    col1->append_default();
+    auto col2 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_INT), true);
+    col2->append_default();
+
+    MutableColumns mutable_columns;
+    mutable_columns.push_back(Column::mutate(std::move(col1)));
+    mutable_columns.push_back(Column::mutate(std::move(col2)));
+
+    auto schema = make_schema(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    mutable_chunk->materialized_nullable();
+    mutable_chunk->check_or_die();
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_upgrade_if_overflow) {
+    size_t row_count = 1 << 20;
+    auto c1 = BinaryColumn::create();
+    c1->resize(row_count);
+    auto c2 = BinaryColumn::create();
+    for (size_t i = 0; i < row_count; i++) {
+        c2->append(std::to_string(i));
+    }
+
+    MutableColumns mutable_columns;
+    mutable_columns.push_back(Column::mutate(std::move(c1)));
+    mutable_columns.push_back(Column::mutate(std::move(c2)));
+
+    MutableChunk::SlotHashMap slot_map;
+    slot_map[1] = 0;
+    slot_map[2] = 1;
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), std::move(slot_map));
+
+    Status st = mutable_chunk->upgrade_if_overflow();
+    ASSERT_TRUE(st.ok());
+    ASSERT_TRUE(mutable_chunk->get_column_by_slot_id(1)->is_binary());
+    ASSERT_FALSE(mutable_chunk->get_column_by_slot_id(2)->is_large_binary());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_downgrade) {
+    auto c1 = LargeBinaryColumn::create();
+    c1->append_string("1");
+    auto c2 = LargeBinaryColumn::create();
+    c2->append_string("2");
+
+    MutableColumns mutable_columns;
+    mutable_columns.push_back(Column::mutate(std::move(c1)));
+    mutable_columns.push_back(Column::mutate(std::move(c2)));
+
+    MutableChunk::SlotHashMap slot_map;
+    slot_map[1] = 0;
+    slot_map[2] = 1;
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), std::move(slot_map));
+
+    ASSERT_TRUE(mutable_chunk->has_large_column());
+    auto ret = mutable_chunk->downgrade();
+    ASSERT_TRUE(ret.ok());
+    ASSERT_FALSE(mutable_chunk->has_large_column());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_has_large_column) {
+    auto c1 = BinaryColumn::create();
+    c1->append_string("1");
+    auto c2 = LargeBinaryColumn::create();
+    c2->append_string("2");
+
+    MutableColumns mutable_columns;
+    mutable_columns.push_back(Column::mutate(std::move(c1)));
+    mutable_columns.push_back(Column::mutate(std::move(c2)));
+
+    MutableChunk::SlotHashMap slot_map;
+    slot_map[1] = 0;
+    slot_map[2] = 1;
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), std::move(slot_map));
+
+    ASSERT_TRUE(mutable_chunk->has_large_column());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_is_column_nullable) {
+    auto col1 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_INT), false);
+    auto col2 = ColumnHelper::create_column(TypeDescriptor::from_logical_type(TYPE_INT), true);
+
+    MutableColumns mutable_columns;
+    mutable_columns.push_back(Column::mutate(std::move(col1)));
+    mutable_columns.push_back(Column::mutate(std::move(col2)));
+
+    MutableChunk::SlotHashMap slot_map;
+    slot_map[1] = 0;
+    slot_map[2] = 1;
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), std::move(slot_map));
+
+    ASSERT_FALSE(mutable_chunk->is_column_nullable(1));
+    ASSERT_TRUE(mutable_chunk->is_column_nullable(2));
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_with_extra_data) {
+    auto mutable_columns = make_mutable_columns(2);
+    auto schema = make_schema(2);
+    auto extra_data = make_extra_data(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema, extra_data);
+
+    ASSERT_TRUE(mutable_chunk->has_extra_data());
+    ASSERT_NE(nullptr, mutable_chunk->get_extra_data());
+
+    auto new_extra_data = make_extra_data(2);
+    mutable_chunk->set_extra_data(new_extra_data);
+    ASSERT_TRUE(mutable_chunk->has_extra_data());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_get_column_name) {
+    auto mutable_columns = make_mutable_columns(2);
+    auto schema = make_schema(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    std::string_view name0 = mutable_chunk->get_column_name(0);
+    ASSERT_EQ("c0", name0);
+
+    std::string_view name1 = mutable_chunk->get_column_name(1);
+    ASSERT_EQ("c1", name1);
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_merge) {
+    auto mutable_columns1 = make_mutable_columns(2, 40, 0);
+    auto schema = make_schema(2);
+    auto mutable_chunk1 = std::make_shared<MutableChunk>(std::move(mutable_columns1), schema);
+
+    auto mutable_columns2 = make_mutable_columns(2, 40, 0);
+    auto mutable_chunk2 = std::make_shared<MutableChunk>(std::move(mutable_columns2), schema);
+
+    mutable_chunk1->merge(std::move(*mutable_chunk2));
+    ASSERT_EQ(40, mutable_chunk1->num_rows());
+    ASSERT_EQ(2, mutable_chunk1->num_columns());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_rolling_append_selective) {
+    auto mutable_columns1 = make_mutable_columns(2, 10);
+    auto schema = make_schema(2);
+    auto mutable_chunk1 = std::make_shared<MutableChunk>(std::move(mutable_columns1), schema);
+
+    auto chunk2 = std::make_unique<Chunk>(make_columns(2, 10), make_schema(2));
+    uint32_t indexes[] = {0, 2, 4, 6, 8};
+    mutable_chunk1->rolling_append_selective(*chunk2, indexes, 0, 5);
+
+    ASSERT_EQ(15, mutable_chunk1->num_rows());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_update_rows) {
+    auto mutable_columns = make_mutable_columns(2, 5, 0);
+    auto schema = make_schema(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    auto src_chunk = std::make_unique<Chunk>(make_columns(2, 3, 0), make_schema(2));
+    uint32_t indexes[] = {0, 1, 2};
+    mutable_chunk->update_rows(*src_chunk, indexes);
+
+    mutable_chunk->check_or_die();
+    ASSERT_EQ(5, mutable_chunk->num_rows());
+}
+
+// NOLINTNEXTLINE
+TEST_F(ChunkTest, test_mutable_chunk_unpack_and_duplicate_const_columns) {
+    auto const_col = ConstColumn::create(make_column(0, 1), 100);
+    auto normal_col = make_mutable_column(1);
+
+    MutableColumns mutable_columns;
+    mutable_columns.push_back(Column::mutate(std::move(const_col)));
+    mutable_columns.push_back(std::move(normal_col));
+
+    auto schema = make_schema(2);
+    auto mutable_chunk = std::make_shared<MutableChunk>(std::move(mutable_columns), schema);
+
+    mutable_chunk->unpack_and_duplicate_const_columns();
+    mutable_chunk->check_or_die();
+    ASSERT_FALSE(mutable_chunk->has_const_column());
 }
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a mutable variant of `Chunk` and related utilities, enabling efficient in-place column operations with clear interop.
> 
> - Adds `MutableChunk` class mirroring `Chunk` API using `MutableColumns` (constructors, append/update/remove, clone/filter/append_selective, memory stats, delete state, extra data)
> - Enables interop: `Chunk(MutableChunk&&)` and assignment from `MutableChunk`, plus `MutableChunk(Chunk&&)`, assignment from `Chunk`, and `MutableChunk::to_chunk()`
> - Extends `ChunkHelper` with `new_mutable_chunk(...)` and `new_mutable_chunk_checked(...)` for `Schema`, `TupleDescriptor`, and slots
> - Tweaks `padding_char_column` null handling to move/mutate the null column safely
> - Enhances `Chunk::debug_columns` and internal uniqueness tracking; adds extensive unit tests covering `MutableChunk` behaviors
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae3816f00e9a86e982afbb3ea4d9355e67126cfd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->