### PR TITLE
[BugFix] Fix COUNT(DISTINCT) not rewritten to multi_distinct_count with single bucket and non-distinct aggregates

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -826,7 +826,7 @@ public class Utils {
             return false;
         }
         Set<ColumnRefOperator> distinctChildren = Sets.newHashSet();
-        for (CallOperator callOperator : aggCallOperators) {
+        for (CallOperator callOperator : distinctFuncs) {
             if (distinctChildren.isEmpty()) {
                 distinctChildren = Sets.newHashSet(callOperator.getColumnRefs());
             } else {


### PR DESCRIPTION
## Why I'm doing:

When a query contains multiple COUNT(DISTINCT) along with non-distinct aggregates (like SUM) on a BUCKETS=1 table, the COUNT(DISTINCT) is not rewritten to multi_distinct_count, causing BE to select a non-distinct COUNT method, resulting in incorrect results.

Reproduction case:
```
CREATE TABLE reproduce (id int, v1 int, v3 int) 
DUPLICATE KEY(id, v1, v3) 
DISTRIBUTED BY HASH(id) BUCKETS 1;

INSERT INTO reproduce 
SELECT generate_series, 4096 - generate_series % 30, generate_series 
FROM TABLE(generate_series(1, 100));

SELECT COUNT(DISTINCT (CASE WHEN 1=2 THEN v1 ELSE NULL END)) AS x0,
       COUNT(DISTINCT (CASE WHEN TRUE THEN v1 ELSE NULL END)) AS x1,
       SUM((CASE WHEN TRUE THEN v3 ELSE NULL END))
FROM reproduce;
```

Expected: x1 = 30 (distinct count)
Actual: x1 = 100 (wrong, no deduplication)

```
 OUTPUT EXPRS:5: count | 6: count | 7: sum
  PARTITION: RANDOM

  RESULT SINK

  1:AGGREGATE (update finalize)
  |  output: count(DISTINCT NULL), count(DISTINCT 2: full_cafeteria), sum(3: ATTENDANCE_BUDGET)
  |  group by: 
  |  
  0:OlapScanNode
```

Incorrect plan shows: count(DISTINCT 2: v1) instead of multi_distinct_count(2: v1)
This causes BE to use non-distinct CountAggregateFunction, which just increments counter without deduplication.

## What I'm doing:

Fix Utils.hasMultipleDistinctFuncShareSameDistinctColumns() line 829.

Changed from iterating over all aggregate functions (aggCallOperators) to only distinct functions (distinctFuncs).

The bug: when iterating all aggregates including SUM, the method incorrectly returns false because SUM has different column references, preventing RewriteMultiDistinctRule from rewriting COUNT(DISTINCT) to multi_distinct_count.

```
OUTPUT EXPRS:5: count | 6: count | 7: sum
  PARTITION: RANDOM

  RESULT SINK

  1:AGGREGATE (update finalize)
  |  output: multi_distinct_count(NULL), multi_distinct_count(2: full_cafeteria), sum(3: ATTENDANCE_BUDGET)
  |  group by: 
  |  
  0:OlapScanNode
```
After fix, the plan correctly shows: multi_distinct_count(2: v1)
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fix DISTINCT-aggregation detection to enable rewriting COUNT(DISTINCT) alongside non-distinct SUM on single-bucket tables, and add a regression test.
> 
> - **Optimizer**:
>   - Update `Utils.hasMultipleDistinctFuncShareSameDistinctColumns` to iterate only over DISTINCT agg calls (`distinctFuncs`) instead of all `aggCallOperators`, ensuring shared DISTINCT columns are correctly detected.
> - **Tests**:
>   - Add `testMultiDistinctCountWithSum` in `AggTableTest` creating `reproduce` and asserting plan rewrites to `multi_distinct_count(...)` with `SUM(...)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64837d7f96c4fc77a94e4a4b9784e571cbc5dae1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->