### PR TITLE
[BugFix] Fix DISTINCT and GROUP BY returning incorrect results due to missing withLocalShuffle in DecodeRewriter

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -237,6 +237,7 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
                 new PhysicalHashAggregateOperator(aggregate.getType(), groupBys, partitions, aggregations,
                         aggregate.isSplit(), aggregate.getLimit(), predicate,
                         projection);
+        op.setWithLocalShuffle(aggregate.isWithLocalShuffle());
         op.setMergedLocalAgg(aggregate.isMergedLocalAgg());
         op.setUseSortAgg(aggregate.isUseSortAgg());
         op.setUsePerBucketOptmize(aggregate.isUsePerBucketOptmize());


### PR DESCRIPTION
## Why I'm doing:

Fixes #65570

When using low cardinality optimization, DISTINCT and GROUP BY queries return incorrect results (duplicates or wrong aggregation values). The bug is more likely to reproduce with specific `pipeline_dop` settings (e.g., `pipeline_dop=4`).

**Reproduction:**
```
CREATE TABLE `sales2` (
  `v1` int(11) NOT NULL COMMENT "",
  `v2` varchar(255) NOT NULL COMMENT "",
  `v3` datetime NOT NULL COMMENT "",
  `v4` varchar(255) NOT NULL COMMENT ""
) ENGINE=OLAP 
PRIMARY KEY(`v1`, `v2`, `v3`)
PARTITION BY date_trunc('month', v3)
DISTRIBUTED BY HASH(`v1`)
ORDER BY(`created_at`)
PROPERTIES (
"compression" = "LZ4",
"enable_persistent_index" = "true",
"fast_schema_evolution" = "true",
"replicated_storage" = "true",
"replication_num" = "1"
); 

INSERT INTO sales2 VALUES
(1, '07-1', '2025-11-15 12:37:44', 'C1'),
(1, '98-1', '2025-12-01 12:37:11', 'C1');

SET pipeline_dop = 4;

SELECT DISTINCT v4 FROM sales2;
```

-- Expected: 1 row (C1)
-- Actual: 2 rows (C1, C1)  ← Duplicates!

**Root cause:**
In PR #64450, there are some refactor but **misses the `withLocalShuffle` property**.

Without `withLocalShuffle`, under certain `pipeline_dop` settings (e.g., DOP matches bucket count), BE selects per-bucket optimization without proper LOCAL_EXCHANGE, causing each driver to output results independently without final merge, leading to duplicates or incorrect aggregation.

## What I'm doing:

Add the missing `withLocalShuffle` property copy in `DecodeRewriter.visitPhysicalHashAggregate()` (line 242).


Fixes #65570

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures `withLocalShuffle` is preserved when rewriting `PhysicalHashAggregate` under low-cardinality optimization and adds a test validating `SELECT DISTINCT` keeps local shuffle in single-phase agg.
> 
> - **Optimizer (low-cardinality rewrite)**:
>   - Preserve `withLocalShuffle` by forwarding `aggregate.isWithLocalShuffle()` to new `PhysicalHashAggregateOperator` in `DecodeRewriter.visitPhysicalHashAggregate()`.
> - **Tests**:
>   - Add case asserting `SELECT DISTINCT v2 FROM colocate_t0` keeps `withLocalShuffle: true` in single-phase aggregate (`PlanFragmentWithCostTest`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9292ee6eaf96b098dd0614b7cf82a9f13d92587a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->