### PR TITLE
[BugFix] decimal2decimal cast returns input column directly as result unexpectedly

### DIFF
--- a/be/src/exprs/decimal_cast_expr.h
+++ b/be/src/exprs/decimal_cast_expr.h
@@ -39,7 +39,7 @@ struct DecimalDecimalCast {
 
         // source type and target type has the same logical type and scale
         if (to_scale == from_scale && Type == ResultType) {
-            auto result = (std::move(*column)).mutate();
+            auto result = column->clone();
             ColumnHelper::cast_to_raw<Type>(result.get())->set_precision(to_precision);
             return result;
         }


### PR DESCRIPTION
## Why I'm doing:

when casting decimal type into another decimal type with the same scale and width but different precision,  input column is returned directly, which would cause two column pointers reference the same column object in a chunk, in project/select operator,  invoking Chunk::append or Chunk::filter would mutate the same column object twice unexpectedly.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> On decimal-to-decimal casts with identical type and scale, return a cloned column and set precision instead of returning/mutating the input column.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44bdfe6598873e64e74424153f3b4279d7d0dfa8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->