### PR TITLE
[BugFix]Fixed the AsyncTaskQueue deadlock issue.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/AsyncTaskQueue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/AsyncTaskQueue.java
@@ -258,9 +258,10 @@ public class AsyncTaskQueue<T> {
             executor.execute(new RunnableTask(task));
             success = true;
             return true;
-        } catch (Exception e) {
-            LOG.error("Failed to execute task in AsyncTaskQueue", e);
-            updateTaskException(e);
+        } catch (Throwable t) {
+            LOG.error("Throwable occurred while triggering task in AsyncTaskQueue", t);
+            Exception exception = (t instanceof Exception) ? (Exception) t : new RuntimeException(t);
+            updateTaskException(exception);
         } finally {
             if (!success) {
                 runningTaskCount.decrementAndGet();
@@ -309,9 +310,10 @@ public class AsyncTaskQueue<T> {
                         taskQueueSize.addAndGet(1);
                         taskQueue.addLast(task);
                     }
-                } catch (Exception e) {
-                    LOG.error("Exception occurred while executing task in AsyncTaskQueue", e);
-                    updateTaskException(e);
+                } catch (Throwable t) {
+                    LOG.error("Throwable occurred while executing task in AsyncTaskQueue", t);
+                    Exception exception = (t instanceof Exception) ? (Exception) t : new RuntimeException(t);
+                    updateTaskException(exception);
                 }
             }
             runningTaskCount.decrementAndGet();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/AsyncTaskQueueTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/AsyncTaskQueueTest.java
@@ -126,4 +126,115 @@ public class AsyncTaskQueueTest {
             testGenerateString();
         }
     }
+
+    @Test
+    public void testInterruptedExceptionHandling() throws InterruptedException {
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        
+        class SlowTask implements AsyncTaskQueue.Task<String> {
+            @Override
+            public List<String> run() throws InterruptedException {
+                Thread.sleep(1000);
+                return List.of("result");
+            }
+        }
+
+        AsyncTaskQueue<String> asyncTaskQueue = new AsyncTaskQueue<>(executorService);
+        asyncTaskQueue.setMaxRunningTaskCount(1);
+        asyncTaskQueue.start(List.of(new SlowTask()));
+
+        Thread consumerThread = new Thread(() -> {
+            try {
+                asyncTaskQueue.getOutputs(1);
+            } catch (Exception e) {
+                Assertions.fail("Should not throw exception when interrupted");
+            }
+            Assertions.assertTrue(Thread.currentThread().isInterrupted(),
+                    "Thread interrupt status should be restored");
+        });
+
+        consumerThread.start();
+        Thread.sleep(100);
+        consumerThread.interrupt();
+        consumerThread.join(2000);
+
+        executorService.shutdown();
+    }
+
+    @Test
+    public void testTriggerTaskExceptionHandling() throws InterruptedException {
+        class SimpleTask implements AsyncTaskQueue.Task<String> {
+            private final boolean shouldFail;
+            
+            SimpleTask(boolean shouldFail) {
+                this.shouldFail = shouldFail;
+            }
+            
+            @Override
+            public List<String> run() {
+                if (shouldFail) {
+                    throw new RuntimeException("Task execution failed");
+                }
+                return List.of("result");
+            }
+        }
+
+        Executor executor = Executors.newFixedThreadPool(2);
+        AsyncTaskQueue<String> asyncTaskQueue = new AsyncTaskQueue<>(executor);
+
+        List<SimpleTask> tasks = new ArrayList<>();
+        tasks.add(new SimpleTask(true));
+        tasks.add(new SimpleTask(false));
+        tasks.add(new SimpleTask(false));
+        asyncTaskQueue.start(tasks);
+
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            asyncTaskQueue.getOutputs(3);
+        }, "Should throw exception when task fails");
+
+        Assertions.assertNotNull(exception.getCause(), "Should have cause exception");
+        Assertions.assertTrue(exception.getCause().getMessage().contains("Task execution failed"),
+                            "Should propagate original task exception as cause");
+    }
+
+    @Test
+    public void testTriggerTaskFinallyBlockWithEmptyQueue() throws Exception {
+        Executor faultyExecutor = command -> {
+            throw new RuntimeException("Executor rejected task");
+        };
+        
+        class SimpleTask implements AsyncTaskQueue.Task<String> {
+            @Override
+            public List<String> run() {
+                return List.of("result");
+            }
+        }
+
+        AsyncTaskQueue<String> asyncTaskQueue = new AsyncTaskQueue<>(faultyExecutor);
+        
+        asyncTaskQueue.start(List.of(new SimpleTask()));
+        
+        RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> {
+            asyncTaskQueue.getOutputs(1);
+        }, "Should throw exception when executor fails");
+        
+        Assertions.assertNotNull(exception.getCause(), "Should have cause exception");
+        Assertions.assertTrue(exception.getCause().getMessage().contains("Executor rejected task"),
+                            "Should propagate executor exception as cause");
+        
+        java.lang.reflect.Field taskQueueSizeField = AsyncTaskQueue.class.getDeclaredField("taskQueueSize");
+        taskQueueSizeField.setAccessible(true);
+        java.util.concurrent.atomic.AtomicInteger taskQueueSize =
+                (java.util.concurrent.atomic.AtomicInteger) taskQueueSizeField.get(asyncTaskQueue);
+        Assertions.assertEquals(0, taskQueueSize.get(), 
+                              "taskQueueSize should be 0 after exception (decremented in finally block)");
+        
+        java.lang.reflect.Field taskExceptionField = AsyncTaskQueue.class.getDeclaredField("taskException");
+        taskExceptionField.setAccessible(true);
+        java.util.concurrent.atomic.AtomicReference<Exception> taskException =
+                (java.util.concurrent.atomic.AtomicReference<Exception>) taskExceptionField.get(asyncTaskQueue);
+        Assertions.assertNotNull(taskException.get(), "taskException should be set when task fails");
+        Assertions.assertTrue(taskException.get().getCause().getMessage().contains("Executor rejected task"),
+                            "taskException should contain the original executor exception");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/AsyncTaskQueueTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/AsyncTaskQueueTest.java
@@ -179,7 +179,7 @@ public class AsyncTaskQueueTest {
             }
         }
 
-        Executor executor = Executors.newFixedThreadPool(2);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
         AsyncTaskQueue<String> asyncTaskQueue = new AsyncTaskQueue<>(executor);
 
         List<SimpleTask> tasks = new ArrayList<>();
@@ -195,6 +195,7 @@ public class AsyncTaskQueueTest {
         Assertions.assertNotNull(exception.getCause(), "Should have cause exception");
         Assertions.assertTrue(exception.getCause().getMessage().contains("Task execution failed"),
                             "Should propagate original task exception as cause");
+        executor.shutdown();
     }
 
     @Test


### PR DESCRIPTION
## Why I'm doing:
```
"starrocks-mysql-nio-pool-366" #4931401 daemon prio=5 os_prio=0 cpu=1367.57ms elapsed=1199556.35s tid=0x00007f257c5af0a0 nid=0x67e96 waiting on condition  [0x00007f24fefb6000]
   java.lang.Thread.State: WAITING (parking)
	at jdk.internal.misc.Unsafe.park(java.base@17.0.6/Native Method)
	- parking to wait for  <0x00007f28755089e0> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
	at java.util.concurrent.locks.LockSupport.park(java.base@17.0.6/LockSupport.java:341)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(java.base@17.0.6/AbstractQueuedSynchronizer.java:506)
	at java.util.concurrent.ForkJoinPool.unmanagedBlock(java.base@17.0.6/ForkJoinPool.java:3463)
	at java.util.concurrent.ForkJoinPool.managedBlock(java.base@17.0.6/ForkJoinPool.java:3434)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@17.0.6/AbstractQueuedSynchronizer.java:1623)
	at com.starrocks.connector.AsyncTaskQueue.tryGetOutputs(AsyncTaskQueue.java:167)
	at com.starrocks.connector.AsyncTaskQueue.hasMoreOutput(AsyncTaskQueue.java:199)
	at com.starrocks.connector.HMSPartitionBasedRemoteInfoSource.hasMoreOutput(HMSPartitionBasedRemoteInfoSource.java:58)
	at com.starrocks.connector.hive.HiveConnectorScanRangeSource.updateIterator(HiveConnectorScanRangeSource.java:374)
	at com.starrocks.connector.hive.HiveConnectorScanRangeSource.getSourceOutputs(HiveConnectorScanRangeSource.java:397)
	at com.starrocks.connector.ConnectorScanRangeSource.getOutputs(ConnectorScanRangeSource.java:27)
	at com.starrocks.connector.ConnectorScanRangeSource.getAllOutputs(ConnectorScanRangeSource.java:31)
	at com.starrocks.planner.HudiScanNode.getScanRangeLocations(HudiScanNode.java:89)
	at com.starrocks.qe.scheduler.assignment.BackendSelectorFactory.create(BackendSelectorFactory.java:56)
	at com.starrocks.qe.scheduler.assignment.LocalFragmentAssignmentStrategy.assignScanRangesToWorker(LocalFragmentAssignmentStrategy.java:90)
	at com.starrocks.qe.scheduler.assignment.LocalFragmentAssignmentStrategy.assignFragmentToWorker(LocalFragmentAssignmentStrategy.java:74)
	at com.starrocks.qe.CoordinatorPreprocessor.computeFragmentInstances(CoordinatorPreprocessor.java:249)
	at com.starrocks.qe.CoordinatorPreprocessor.prepareExec(CoordinatorPreprocessor.java:205)
	at com.starrocks.qe.DefaultCoordinator.prepareExec(DefaultCoordinator.java:517)
	at com.starrocks.qe.DefaultCoordinator.startScheduling(DefaultCoordinator.java:569)
	at com.starrocks.qe.scheduler.Coordinator.execWithQueryDeployExecutor(Coordinator.java:112)
	at com.starrocks.qe.StmtExecutor.handleQueryStmt(StmtExecutor.java:1386)
	at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:703)
	at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:424)
	at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:635)
	at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:988)
	at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:71)
	at com.starrocks.mysql.nio.ReadListener$$Lambda$947/0x000000080198ea70.run(Unknown Source)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@17.0.6/ThreadPoolExecutor.java:1136)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@17.0.6/ThreadPoolExecutor.java:635)
	at java.lang.Thread.run(java.base@17.0.6/Thread.java:833)

   Locked ownable synchronizers:
	- <0x00007f286bf97bc8> (a java.util.concurrent.ThreadPoolExecutor$Worker)
```
java.lang.NoClassDefFoundError:
```
Exception in thread "pull-hudi-remote-files-269" java.lang.NoClassDefFoundError: org/apache/hadoop/fs/cosn/ranger/client/RangerQcloudObjectStorageClient
	at java.base/java.lang.Class.getDeclaredFields0(Native Method)
	at java.base/java.lang.Class.privateGetDeclaredFields(Class.java:3297)
	at java.base/java.lang.Class.getDeclaredFields(Class.java:2371)
	at org.apache.spark.util.SizeEstimator$.getClassInfo(SizeEstimator.scala:330)
	at org.apache.spark.util.SizeEstimator$.visitSingleObject(SizeEstimator.scala:222)
	at org.apache.spark.util.SizeEstimator$.estimate(SizeEstimator.scala:201)
	at org.apache.spark.util.SizeEstimator$.estimate(SizeEstimator.scala:68)
	at org.apache.spark.util.SizeEstimator.estimate(SizeEstimator.scala)
	at com.starrocks.connector.CachingRemoteFileIO.lambda$new$0(CachingRemoteFileIO.java:58)
	at com.github.benmanes.caffeine.cache.BoundedWeigher.weigh(Weigher.java:93)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.lambda$doComputeIfAbsent$14(BoundedLocalCache.java:2411)
	at java.base/java.util.concurrent.ConcurrentHashMap.compute(ConcurrentHashMap.java:1916)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.doComputeIfAbsent(BoundedLocalCache.java:2404)
	at com.github.benmanes.caffeine.cache.BoundedLocalCache.computeIfAbsent(BoundedLocalCache.java:2387)
	at com.github.benmanes.caffeine.cache.LocalCache.computeIfAbsent(LocalCache.java:108)
	at com.github.benmanes.caffeine.cache.LocalLoadingCache.get(LocalLoadingCache.java:56)
	at com.starrocks.connector.CachingRemoteFileIO.getRemoteFiles(CachingRemoteFileIO.java:100)
	at com.starrocks.connector.RemoteFileOperations.lambda$getRemoteFilesAsync$1(RemoteFileOperations.java:148)
	at com.starrocks.connector.HMSPartitionBasedRemoteInfoSource$ListPartitionFilesTask.run(HMSPartitionBasedRemoteInfoSource.java:85)
	at com.starrocks.connector.AsyncTaskQueue$RunnableTask.run(AsyncTaskQueue.java:286)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.ClassNotFoundException: org.apache.hadoop.fs.cosn.ranger.client.RangerQcloudObjectStorageClient
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)
	... 23 more
```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves `AsyncTaskQueue` to preserve interrupts, catch/log `Throwable`, propagate task failures, and adds tests to verify these behaviors.
> 
> - **AsyncTaskQueue**:
>   - Preserve interrupt status in `tryGetOutputs` and log when interrupted.
>   - Broaden error handling to catch `Throwable` in `triggerTask` and `RunnableTask.run`, log errors, wrap as `RuntimeException`, and propagate via `taskException`.
>   - Ensure `taskQueueSize` is decremented in `triggerTask` failure path when a task was polled but not executed.
> - **Tests**:
>   - Add `testInterruptedExceptionHandling` to verify interrupt preservation without throwing.
>   - Add `testTriggerTaskExceptionHandling` to ensure task failures propagate as causes.
>   - Add `testTriggerTaskFinallyBlockWithEmptyQueue` to validate cleanup and exception propagation when executor fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89c1f7695cdbc827b9f0a81f2a31088486cce512. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->