### PR TITLE
[BugFix] Fix missing column statistics error during join reorder

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/ReorderJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/ReorderJoinRule.java
@@ -390,8 +390,30 @@ public class ReorderJoinRule extends Rule {
                     .setTableRowCountMayInaccurate(oldStats.isTableRowCountMayInaccurate())
                     .setShadowColumns(oldStats.getShadowColumns())
                     .addMultiColumnStatistics(oldStats.getMultiColumnCombinedStats());
+
+            // Calculate columns that must be preserved in statistics:
+            // 1. Columns used in projection expressions (e.g., columns inside CAST)
+            // 2. Columns used in predicates (WHERE conditions, JOIN conditions)
+            // These columns must be preserved even if not in output columns,
+            // because they're needed when computing statistics for expressions/predicates
+            ColumnRefSet usedColumns = new ColumnRefSet();
+            for (ScalarOperator expr : newOutputProjections.values()) {
+                usedColumns.union(expr.getUsedColumns());
+            }
+            // Preserve columns used in filter predicates
+            if (operator.getPredicate() != null) {
+                usedColumns.union(operator.getPredicate().getUsedColumns());
+            }
+            // Preserve columns used in join ON predicates
+            if (operator instanceof LogicalJoinOperator) {
+                LogicalJoinOperator joinOp = (LogicalJoinOperator) operator;
+                if (joinOp.getOnPredicate() != null) {
+                    usedColumns.union(joinOp.getOnPredicate().getUsedColumns());
+                }
+            }
+
             oldStats.getColumnStatistics().forEach((col, stat) -> {
-                if (newCols.contains(col)) {
+                if (newCols.contains(col) || usedColumns.contains(col)) {
                     newStatsBuilder.addColumnStatistic(col, stat);
                 }
             });


### PR DESCRIPTION
  Summary

  Fixes StarRocksPlannerException: only found column statistics: {...}, but missing statistic of col: X errors that occur on queries with multiple INNER JOINs when column statistics are present.

  Root Cause

  During join reorder optimization, ReorderJoinRule.OutputColumnsPrune.deriveNewOptExpression filters statistics to only keep columns that appear in the output. This incorrectly removes statistics for columns that
  are:

  1. Used inside projection expressions - e.g., the source column inside CAST(col AS BIGINT) for implicit type conversion in JOIN conditions
  2. Used in filter predicates - columns referenced in WHERE conditions
  3. Used in JOIN ON predicates - columns referenced in JOIN conditions

  Later optimization stages fail when computing statistics for expressions or predicates that reference these removed columns.

  Fix

  Preserve statistics for all columns used in:
  - Projection expression values (columns inside CAST, functions, etc.)
  - Operator filter predicates (getPredicate())
  - Join ON predicates (getOnPredicate())

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Preserves column statistics for columns referenced in projection expressions and predicates when pruning join outputs to prevent missing-stat errors.
> 
> - **Optimizer - Join Reorder (`ReorderJoinRule`)**:
>   - In `OutputColumnsPrune.deriveNewOptExpression`, retain statistics for columns used by:
>     - Projection expression values (e.g., `CAST`, functions)
>     - Operator filter predicates (`getPredicate()`)
>     - Join `ON` predicates (`getOnPredicate()`)
>   - Prunes column stats only if a column is neither in new output columns nor in the computed used set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7af1a68d5bd9ad4df546f4218e18fc711e2c746. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->