### PR TITLE
[BugFix] Prevent reopening of aborted load channels

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -509,6 +509,17 @@ CONF_mBool(enable_load_channel_rpc_async, "true");
 CONF_mInt32(load_channel_rpc_thread_pool_num, "-1");
 // The queue size for Load channel rpc thread pool
 CONF_Int32(load_channel_rpc_thread_pool_queue_size, "1024000");
+// Time(seconds) for load channel to wait for clean up load id after aborted.
+//
+// When a load job is cancelled or failed, load channel will be aborted.
+// In order to reject any late-arrival request, load channel will keep
+// the aborted load id for this duration before cleaning up.
+// * Setting it too small may cause late-arrival requests being accepted incorrectly.
+// * Setting it too large may cause resources to be held for a long time.
+// NOTE: The background thread will clean up periodically.
+// In production, the minimum interval is 60 seconds.
+// Default is 600 seconds.
+CONF_mInt32(load_channel_abort_clean_up_delay_seconds, "600");
 // Number of thread for async delta writer.
 // Default value is max(cpucores/2, 16)
 CONF_mInt32(number_tablet_writer_threads, "0");

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -626,15 +626,16 @@ void LakeServiceImpl::abort_txn(::google::protobuf::RpcController* controller,
     brpc::ClosureGuard guard(done);
     (void)controller;
 
+    const std::string reason("transaction aborted via LakeService rpc");
     LOG(INFO) << "Aborting transactions. request=" << request->DebugString();
 
     // Cancel active tasks.
     if (LoadChannelMgr* load_mgr = _env->load_channel_mgr(); load_mgr != nullptr) {
         for (auto& txn_id : request->txn_ids()) { // For request sent by and older version FE
-            load_mgr->abort_txn(txn_id);
+            load_mgr->abort_txn(txn_id, reason);
         }
         for (auto& txn_info : request->txn_infos()) { // For request sent by a new version FE
-            load_mgr->abort_txn(txn_info.txn_id());
+            load_mgr->abort_txn(txn_info.txn_id(), reason);
         }
     }
 

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -2230,8 +2230,9 @@ TEST_F(LakeServiceTest, test_abort_txn2) {
 
             load_mgr->add_chunk(add_chunk_request, &add_chunk_response);
             if (add_chunk_response.status().status_code() != TStatusCode::OK) {
-                std::cerr << add_chunk_response.status().error_msgs(0) << '\n';
-                cancelled = MatchPattern(add_chunk_response.status().error_msgs(0), "*has been closed*");
+                cancelled = MatchPattern(add_chunk_response.status().error_msgs(0),
+                                         "*was aborted at *, reason: transaction aborted via LakeService rpc");
+                ASSERT_TRUE(cancelled) << add_chunk_response.status();
                 break;
             } else {
                 std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -1389,6 +1389,15 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Description: Sets the maximum pending-task queue size for the Load channel RPC thread pool created by LoadChannelMgr. This thread pool executes asynchronous `open` requests when `enable_load_channel_rpc_async` is enabled; the pool size is paired with `load_channel_rpc_thread_pool_num`. The large default (1024000) aligns with brpc workers' defaults to preserve behavior after switching from synchronous to asynchronous handling. If the queue is full, ThreadPool::submit() will fail and the incoming open RPC is cancelled with an error, causing the caller to receive a rejection. Increase this value to buffer larger bursts of concurrent `open` requests; reducing it tightens backpressure but may cause more rejections under load.
 - Introduced in: v3.5.0
 
+##### load_channel_abort_clean_up_delay_seconds
+
+- Default: 600
+- Type: Int
+- Unit: Seconds
+- Is mutable: Yes
+- Description: Controls how long (in seconds) LoadChannelMgr keeps the load IDs of aborted load channels before removing them from `_aborted_load_channels`. When a load job is cancelled or fails, the load ID stays recorded so any late-arriving load RPCs can be rejected immediately; once the delay expires, the entry is cleaned during the periodic background sweep (minimum sweep interval is 60 seconds). Setting the delay too low risks accepting stray RPCs after an abort, while setting it too high may retain state and consume resources longer than necessary. Tune this to balance correctness of late-request rejection and resource retention for aborted loads.
+- Introduced in: v3.5.11, v4.0.4
+
 ##### load_diagnose_rpc_timeout_profile_threshold_ms
 
 - Default: 60000
@@ -3275,4 +3284,3 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Is mutable: No
 - Description: Maximum number of bytes to read from the INFO logfile and show on the BE debug webserver's log page. The handler uses this value to compute a seek offset (showing the last N bytes) to avoid reading or serving very large log files. If the logfile is smaller than this value the whole file is shown. Note: in the current implementation the code that reads and serves the INFO log is commented out and the handler reports that the INFO log file couldn't be opened, so this parameter may have no effect unless the log-serving code is enabled.
 - Introduced in: v3.2.0
-


### PR DESCRIPTION
When a load channel is aborted (e.g., due to cancellation or error), late-arriving requests (like `open` or `add_chunk`) could previously trigger the creation of a new, invalid load channel or return misleading internal errors.

This change introduces a mechanism to track aborted load channels for a configurable duration (`load_channel_abort_clean_up_delay_seconds`, default 600s).

Key changes:
1.  Maintain an `_aborted_load_channels` map to store IDs of recently aborted channels.
2.  Reject `open` requests for known aborted channels with `TStatusCode::ABORTED`.
3.  Return `TStatusCode::ABORTED` instead of `INTERNAL_ERROR` for `add_chunk`/`add_segment` requests targeting aborted channels.
4.  Periodically clean up expired aborted channel records to prevent memory leaks.

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Track aborted load channels to return ABORTED for late open/add requests, add a configurable cleanup delay, propagate abort reasons via LakeService, and add tests/docs.
> 
> - **Backend (LoadChannelMgr)**:
>   - Track aborted channels in `_aborted_load_channels` and reject `open` for aborted `load_id` with `TStatusCode::ABORTED`.
>   - Route missing-channel `add_chunk`/`add_chunks`/`add_segment` through `_fail_rpc_request` to return `ABORTED` if previously aborted, else `INTERNAL_ERROR`.
>   - Introduce helpers: `_remove_load_channel`/`_abort_load_channel`/`_is_load_channel_aborted`/`_fail_rpc_request`; update `remove_load_channel` path for normal completion.
>   - Background cleaner now:
>     - Prunes expired aborted records (per `load_channel_abort_clean_up_delay_seconds`).
>     - Moves timed-out channels to aborted map with detailed reason.
>   - Update `cancel` and `abort_txn(int64_t, const std::string&)` to record abort reason and prevent recreation.
>   - Minor: lock now protects both active and aborted maps.
> - **Service (LakeService)**:
>   - `abort_txn` supplies a reason to `LoadChannelMgr::abort_txn`, enabling clear ABORTED messages.
> - **Config & Docs**:
>   - Add `config::load_channel_abort_clean_up_delay_seconds` (default 600s) and document it.
> - **Tests/Utils**:
>   - Add `LoadChannelMgrTest` for aborted and timeout behaviors; add `MockCountDownClosure`.
>   - Update lake service tests to expect ABORTED with reason string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4903975316592f85b5195a02f5b04b1f568c78ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->