### PR TITLE
[Enhancement] add config enable_statistic_collect_on_update

### DIFF
--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -1741,6 +1741,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 
 - Introduced in: v3.1
 
+##### enable_statistic_collect_on_update
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Controls whether UPDATE statements can trigger automatic statistics collection. When enabled, UPDATE operations that modify table data may schedule statistics collection through the same ingestion-based statistics framework controlled by `enable_statistic_collect_on_first_load`. Disabling this configuration skips statistics collection for UPDATE statements while keeping load-triggered statistics collection behavior unchanged.
+- Introduced in: v3.5.11, v4.0.4
+
 ##### enable_udf
 
 - Default: false

--- a/docs/ja/administration/management/FE_configuration.md
+++ b/docs/ja/administration/management/FE_configuration.md
@@ -1353,6 +1353,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 - 導入バージョン: v3.1
 
+##### enable_statistic_collect_on_update
+
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: はい
+- 説明: UPDATE ステートメントが自動統計収集をトリガーできるかどうかを制御します。有効にすると、テーブルデータを変更する UPDATE 操作は、`enable_statistic_collect_on_first_load` によって制御されるインジェスションベースの統計フレームワークを通じて統計収集をスケジュールする場合があります。この設定を無効にすると、ロードによってトリガーされる統計収集の動作はそのままに、UPDATE ステートメントの統計収集がスキップされます。
+- 導入バージョン: v3.5.11, v4.0.4
+
 ##### enable_udf
 
 - デフォルト: false

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -1346,6 +1346,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 - 引入版本：v3.1
 
+##### enable_statistic_collect_on_update
+
+- 默认值：true
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：控制 UPDATE 语句是否可以触发自动统计信息采集。启用时，修改表数据的 UPDATE 操作可以通过由 `enable_statistic_collect_on_first_load` 控制的基于导入的统计信息框架来调度统计信息采集。禁用此配置将跳过 UPDATE 语句的统计信息采集，同时保持由导入触发的统计信息采集行为不变。
+- 引入版本：v3.5.11, v4.0.4
+
 ##### enable_udf
 
 - 默认值：false

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2181,6 +2181,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static boolean enable_statistic_collect_on_first_load = true;
 
+    @ConfField(mutable = true, comment = "Whether trigger statistic collection on update statement")
+    public static boolean enable_statistic_collect_on_update = true;
+
     /**
      * Max await time for semi-sync statistics collection during data loading (DML operations).
      * This applies to INSERT and INSERT OVERWRITE statements where sync=true.


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Add config: `enable_statistic_collect_on_update` 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `enable_statistic_collect_on_update` and updates the statistics trigger to optionally collect on UPDATE, refine analyze-type decisions, and optimize INSERT OVERWRITE handling.
> 
> - **Statistics**:
>   - **Config**: Add `Config.enable_statistic_collect_on_update` (mutable, default `true`).
>   - **Trigger (`StatisticsCollectionTrigger`)**:
>     - Respect new config; skip collection for `UPDATE` when disabled.
>     - Support `UPDATE`: collect statistics on touched partitions regardless of first-load version.
>     - Refine analyze-type selection for loads using `BasicStatsMeta` total rows when available.
>     - Overwrite handling: if small delta on `INSERT_OVERWRITE`, copy stats from source to target; otherwise collect (supports SAMPLE with tablet row counts).
>     - Pass partition-tablet row counts to SAMPLE jobs and clear when not needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 66e6e3d682dbb988c7391a3e0917aff0a9e5f3fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->