### PR TITLE
[Enhancement] - Python Client - Support Python 3.14 & Enable Select from FilesSource

### DIFF
--- a/contrib/starrocks-python-client/README.md
+++ b/contrib/starrocks-python-client/README.md
@@ -14,7 +14,7 @@ pip install starrocks
 
 #### Supported Python Versions
 
-Python >= 3.10, <= 3.13
+Python >= 3.10, <= 3.14
 
 #### Using a Virtual Environment (Recommended)
 

--- a/contrib/starrocks-python-client/pyproject.toml
+++ b/contrib/starrocks-python-client/pyproject.toml
@@ -46,7 +46,6 @@ classifiers = [
 ]
 dependencies = [
     "sqlalchemy>=1.4",
-    "sqlalchemy-utils>=0.41.2",
     "pymysql>=1.1.0",
     "lark>=1.3.1",
     "alembic>=1.14.0",

--- a/contrib/starrocks-python-client/pyproject.toml
+++ b/contrib/starrocks-python-client/pyproject.toml
@@ -26,7 +26,7 @@ maintainers = [
     {name = "StarRocks Team", email = "no-reply@starrocks.com"},
 ]
 description = "Python SQLAlchemy Dialect for StarRocks with optional Alembic integration"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10,<3.15"
 keywords = ["starrocks", "sqlalchemy", "dialect"]
 license = "Apache-2.0"
 license-files = ["LICENSE"]
@@ -40,6 +40,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Database :: Front-Ends",
@@ -96,7 +97,7 @@ force-sort-within-sections = true
 lines-after-imports = 2
 
 [tool.black]
-target-version = ["py310", "py311", "py312", "py313"]
+target-version = ["py310", "py311", "py312", "py313", "py314"]
 line-length = 120
 skip-string-normalization = false
 include = '\.pyi?$'

--- a/contrib/starrocks-python-client/requirements-dev.txt
+++ b/contrib/starrocks-python-client/requirements-dev.txt
@@ -1,5 +1,4 @@
 sqlalchemy==2.0.25
-sqlalchemy-utils==0.41.2
 alembic==1.14.1
 pymysql==1.1.1
 lark>=1.3.1

--- a/contrib/starrocks-python-client/starrocks/__init__.py
+++ b/contrib/starrocks-python-client/starrocks/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "1.3.2"
+__version__ = "1.3.3"
 
 # import it to import some internal alembic packages implicitly
 # but, it's not needed if users only want to use SQLAlchemy rather than Alembic

--- a/contrib/starrocks-python-client/starrocks/sql/dml.py
+++ b/contrib/starrocks-python-client/starrocks/sql/dml.py
@@ -32,6 +32,7 @@ class FilesClause(ClauseElement):
     __visit_name__ = 'files'
 
     def __init__(self, format: "FilesFormat", options: "_FilesOptions" = None):
+        super().__init__()
         self.format = format
         self.options = options
 

--- a/contrib/starrocks-python-client/starrocks/sql/dml.py
+++ b/contrib/starrocks-python-client/starrocks/sql/dml.py
@@ -18,10 +18,10 @@ from urllib.parse import urlparse
 from sqlalchemy.schema import Table
 from sqlalchemy.sql import TableClause, ClauseElement
 from sqlalchemy.sql.dml import UpdateBase
-from sqlalchemy.sql.roles import FromClauseRole
+from sqlalchemy.sql.functions import FunctionElement
 
 
-class FilesClause(ClauseElement, FromClauseRole):
+class FilesClause(ClauseElement):
     """FILES Base Class
 
     This class represents the base class for a FILES <https://docs.starrocks.io/docs/sql-reference/sql-functions/table-functions/files/> table function in Starrocks
@@ -190,10 +190,10 @@ class FilesTargetOptions(_FilesOptions):
             self.options["partitioned_by"] = partitioned_by
 
 
-class FilesSource(FilesClause):
+class FilesSource(FilesClause, FunctionElement):
     """Represents a FILES table function in Starrocks when used for loading data
 
-    Example Usage, used with InsertFromFiles class:
+    Example Usage, used with InsertFromFiles class::
 
         m = MetaData()
         tbl = Table(
@@ -217,8 +217,28 @@ class FilesSource(FilesClause):
             ),
         )
 
+    Example Usage, selecting with table_valued method::
+
+        m = MetaData()
+        tbl_files = FilesSource(
+            storage=GoogleCloudStorage(
+                uri='gs://starrocks/atable.parquet',
+                service_account_email='x@y.z',
+                service_account_private_key_id='mykey',
+                service_account_private_key='some_private_key',
+            ),
+            format=ParquetFormat(
+                compression=Compression.SNAPPY
+            ),
+        ).table_valued(*[literal_column(f"${i}") for i in range(10)])
+        sel_cols = sqlalchemy.select(
+            cast(tbl_files.c['$1'], String).label('Col1'),
+            func.IF(tbl_files.c['$2'] == "xyz", "NULL", t_files.c['$2']).label('Col2'),
+        )
+
     """
     __visit_name__ = 'files_source'
+    inherit_cache = False
 
     def __init__(
         self,


### PR DESCRIPTION
## Why I'm doing:
Support is required for Python 3.14 as this is the latest version currently available for use.
With previous code relating to `FILES` table function, it was not possible to select directly from this. This PR introduces support for selecting from a `FILES` object by use of `table_valued` SQLAlchemy method for a function element.

## What I'm doing:
Added support for Python 3.14 by extending the classifiers and checking the test suite.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Python 3.14 support and makes `FilesSource` a selectable table-valued function with tests; removes `sqlalchemy-utils`; bumps version to 1.3.3.
> 
> - **Core (SQLAlchemy dialect)**:
>   - Make `FilesSource` a `FunctionElement` and enable `table_valued(...)` for selecting from `FILES`; adjust `FilesClause` and disable cache (`inherit_cache=False`).
> - **Tests**:
>   - Add/select tests for `FILES` table function; update imports and compilation assertions in `test/test_files_clause.py`.
> - **Packaging/Metadata**:
>   - Add Python 3.14 support: update `README.md`, `requires-python` to `<3.15`, classifiers, and Black target versions.
>   - Remove `sqlalchemy-utils` from dependencies and dev requirements.
>   - Bump version to `1.3.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c48326e5011a30d1a8627e363a04050bdad783b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->