### PR TITLE
[Enhancement] [BugFix] Ensure columns in a Chunk are not shared with each other

### DIFF
--- a/be/src/bench/shuffle_chunk_bench.cpp
+++ b/be/src/bench/shuffle_chunk_bench.cpp
@@ -109,10 +109,10 @@ ColumnPtr ShuffleChunkPerf::init_dest_column(const TypeDescriptor& type) {
 ChunkPtr ShuffleChunkPerf::init_src_chunk() {
     auto chunk = std::make_unique<Chunk>();
     auto col = init_src_key_column(_types[0]);
-    chunk->append_column(col, 0);
+    chunk->append_column(std::move(col), 0);
     for (int i = 1; i < _column_count; i++) {
         col = init_src_column(_types[i]);
-        chunk->append_column(col, i);
+        chunk->append_column(std::move(col), i);
     }
     return chunk;
 }
@@ -137,7 +137,7 @@ ChunkPtr ShuffleChunkPerf::init_dest_chunk() {
     auto chunk = std::make_unique<Chunk>();
     for (int i = 0; i < _column_count; i++) {
         auto col = init_dest_column(_types[i]);
-        chunk->append_column(col, i);
+        chunk->append_column(std::move(col), i);
     }
     return chunk;
 }
@@ -311,7 +311,7 @@ public:
         auto chunk = std::make_unique<Chunk>();
         for (int i = 0; i < _column_count; i++) {
             auto col = init_dest_column(_types[i], chunk_size);
-            chunk->append_column(col, i);
+            chunk->append_column(std::move(col), i);
         }
         return chunk;
     }

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -304,7 +304,7 @@ Status HiveDataSource::_init_partition_values() {
         int partition_col_idx = _partition_index_in_hdfs_partition_columns[i];
         ASSIGN_OR_RETURN(auto partition_value_col, partition_values[partition_col_idx]->evaluate(nullptr));
         DCHECK(partition_value_col->is_constant());
-        partition_chunk->append_column(partition_value_col, slot_id);
+        partition_chunk->append_column(std::move(partition_value_col), slot_id);
     }
 
     // eval conjuncts and skip if no rows.

--- a/be/src/exec/chunks_sorter.cpp
+++ b/be/src/exec/chunks_sorter.cpp
@@ -102,10 +102,10 @@ StatusOr<ChunkPtr> ChunksSorter::materialize_chunk_before_sort(Chunk* chunk, Tup
                 new_col->assign(row_num, 0);
                 if (order_by_types[i].is_nullable) {
                     ColumnPtr nullable_column =
-                            NullableColumn::create(ColumnPtr(std::move(new_col)), NullColumn::create(row_num, 0));
-                    materialize_chunk->append_column(nullable_column, slots_in_row_descriptor[i]->id());
+                            NullableColumn::create(std::move(new_col), NullColumn::create(row_num, 0));
+                    materialize_chunk->append_column(std::move(nullable_column), slots_in_row_descriptor[i]->id());
                 } else {
-                    materialize_chunk->append_column(ColumnPtr(std::move(new_col)), slots_in_row_descriptor[i]->id());
+                    materialize_chunk->append_column(std::move(new_col), slots_in_row_descriptor[i]->id());
                 }
             }
         } else {
@@ -113,7 +113,7 @@ StatusOr<ChunkPtr> ChunksSorter::materialize_chunk_before_sort(Chunk* chunk, Tup
             if (!col->is_nullable() && order_by_types[i].is_nullable) {
                 col = NullableColumn::create(col, NullColumn::create(col->size(), 0));
             }
-            materialize_chunk->append_column(col, slots_in_row_descriptor[i]->id());
+            materialize_chunk->append_column(std::move(col), slots_in_row_descriptor[i]->id());
         }
     }
 

--- a/be/src/exec/pipeline/project_operator.cpp
+++ b/be/src/exec/pipeline/project_operator.cpp
@@ -85,7 +85,7 @@ Status ProjectOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
 
     _cur_chunk = std::make_shared<Chunk>();
     for (size_t i = 0; i < result_columns.size(); ++i) {
-        _cur_chunk->append_column(result_columns[i], _column_ids[i]);
+        _cur_chunk->append_column(std::move(result_columns[i]), _column_ids[i]);
     }
     _cur_chunk->owner_info() = chunk->owner_info();
     TRY_CATCH_ALLOC_SCOPE_END()

--- a/be/src/exec/pipeline/select_operator.cpp
+++ b/be/src/exec/pipeline/select_operator.cpp
@@ -90,7 +90,7 @@ Status SelectOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
         SCOPED_TIMER(_conjuncts_timer);
         for (const auto& [slot_id, expr] : _common_exprs) {
             ASSIGN_OR_RETURN(auto col, expr->evaluate(_curr_chunk.get()));
-            _curr_chunk->append_column(col, slot_id);
+            _curr_chunk->append_column(std::move(col), slot_id);
         }
     }
     RETURN_IF_ERROR(eval_conjuncts_and_in_filters(_conjunct_ctxs, _curr_chunk.get()));

--- a/be/src/exec/sorting/merge_path.cpp
+++ b/be/src/exec/sorting/merge_path.cpp
@@ -638,7 +638,7 @@ ChunkPtr detail::LeafNode::_generate_ordinal(const size_t chunk_id, const size_t
 
     Columns columns;
     columns.push_back(std::move(ordinal_column));
-    return std::make_shared<Chunk>(columns, s_slot_map);
+    return std::make_shared<Chunk>(std::move(columns), s_slot_map);
 }
 
 MergePathCascadeMerger::MergePathCascadeMerger(const size_t chunk_size, const int32_t degree_of_parallelism,

--- a/be/src/exprs/array_map_expr.cpp
+++ b/be/src/exprs/array_map_expr.cpp
@@ -106,7 +106,7 @@ StatusOr<ColumnPtr> ArrayMapExpr::evaluate_lambda_expr(ExprContext* context, Chu
     // 1. evaluate outer common expressions
     for (const auto& [slot_id, expr] : _outer_common_exprs) {
         ASSIGN_OR_RETURN(auto col, context->evaluate(expr, tmp_chunk.get()));
-        tmp_chunk->append_column(col, slot_id);
+        tmp_chunk->append_column(std::move(col), slot_id);
     }
     auto lambda_func = dynamic_cast<LambdaFunction*>(_children[0]);
     std::vector<SlotId> capture_slot_ids;

--- a/be/src/exprs/cast_expr_array.cpp
+++ b/be/src/exprs/cast_expr_array.cpp
@@ -214,7 +214,7 @@ StatusOr<ColumnPtr> CastStringToArray::evaluate_checked(ExprContext* context, Ch
     if (element_type != TYPE_VARCHAR && element_type != TYPE_CHAR) {
         ChunkPtr chunk = std::make_shared<Chunk>();
         SlotId slot_id = down_cast<ColumnRef*>(_cast_elements_expr->get_child(0))->slot_id();
-        chunk->append_column(elements, slot_id);
+        chunk->append_column(std::move(elements), slot_id);
         ASSIGN_OR_RETURN(auto cast_res, _cast_elements_expr->evaluate_checked(context, chunk.get()));
         elements = ColumnHelper::cast_to_nullable_column(std::move(cast_res));
     }
@@ -294,7 +294,7 @@ StatusOr<ColumnPtr> CastJsonToArray::evaluate_checked(ExprContext* context, Chun
     if (element_type != TYPE_JSON) {
         ChunkPtr chunk = std::make_shared<Chunk>();
         SlotId slot_id = down_cast<ColumnRef*>(_cast_elements_expr->get_child(0))->slot_id();
-        chunk->append_column(elements, slot_id);
+        chunk->append_column(std::move(elements), slot_id);
         ASSIGN_OR_RETURN(auto cast_res, _cast_elements_expr->evaluate_checked(context, chunk.get()));
         elements = ColumnHelper::cast_to_nullable_column(std::move(cast_res));
     }

--- a/be/src/exprs/cast_expr_map.cpp
+++ b/be/src/exprs/cast_expr_map.cpp
@@ -62,14 +62,14 @@ StatusOr<ColumnPtr> CastJsonToMap::evaluate_checked(ExprContext* context, Chunk*
     if (_key_cast_expr != nullptr) {
         ChunkPtr chunk = std::make_shared<Chunk>();
         SlotId slot_id = down_cast<ColumnRef*>(_key_cast_expr->get_child(0))->slot_id();
-        chunk->append_column(keys_column, slot_id);
+        chunk->append_column(std::move(keys_column), slot_id);
         ASSIGN_OR_RETURN(auto result, _key_cast_expr->evaluate_checked(context, chunk.get()));
         keys_column = ColumnHelper::cast_to_nullable_column(std::move(result));
     }
     if (_value_cast_expr != nullptr) {
         ChunkPtr chunk = std::make_shared<Chunk>();
         SlotId slot_id = down_cast<ColumnRef*>(_value_cast_expr->get_child(0))->slot_id();
-        chunk->append_column(values_column, slot_id);
+        chunk->append_column(std::move(values_column), slot_id);
         ASSIGN_OR_RETURN(auto result, _value_cast_expr->evaluate_checked(context, chunk.get()));
         values_column = ColumnHelper::cast_to_nullable_column(std::move(result));
     }

--- a/be/src/exprs/cast_expr_struct.cpp
+++ b/be/src/exprs/cast_expr_struct.cpp
@@ -107,7 +107,7 @@ StatusOr<ColumnPtr> CastJsonToStruct::evaluate_checked(ExprContext* context, Chu
         ColumnPtr elements = json_columns[i].build_nullable_column();
         if (_field_casts[i] != nullptr) {
             Chunk field_chunk;
-            field_chunk.append_column(elements, 0);
+            field_chunk.append_column(std::move(elements), 0);
             ASSIGN_OR_RETURN(auto casted_field, _field_casts[i]->evaluate_checked(context, &field_chunk));
             casted_field = NullableColumn::wrap_if_necessary(std::move(casted_field));
             casted_fields.emplace_back(std::move(casted_field)->as_mutable_ptr());

--- a/be/src/exprs/dictionary_get_expr.cpp
+++ b/be/src/exprs/dictionary_get_expr.cpp
@@ -55,7 +55,7 @@ StatusOr<ColumnPtr> DictionaryGetExpr::evaluate_checked(ExprContext* context, Ch
     // assign the key chunk
     for (int i = 0; i < _dictionary_get_expr.key_size; ++i) {
         ColumnPtr key_column = columns[1 + i];
-        key_chunk->update_column_by_index(key_column, i);
+        key_chunk->update_column_by_index(std::move(key_column), i);
     }
     value_chunk->reserve(size);
 

--- a/be/src/exprs/lambda_function.cpp
+++ b/be/src/exprs/lambda_function.cpp
@@ -123,7 +123,7 @@ StatusOr<ColumnPtr> LambdaFunction::evaluate_constant(ExprContext* context) {
     ChunkPtr chunk = std::make_shared<Chunk>();
     for (auto i = 0; i < _common_sub_expr.size(); ++i) {
         ASSIGN_OR_RETURN(auto sub_col, context->evaluate(_common_sub_expr[i], nullptr));
-        chunk->append_column(sub_col, _common_sub_expr_ids[i]);
+        chunk->append_column(std::move(sub_col), _common_sub_expr_ids[i]);
     }
     // try to evaluate lambda expr to constant column
     return this->get_child(0)->evaluate_checked(context, nullptr);
@@ -236,7 +236,7 @@ Status LambdaFunction::prepare(starrocks::RuntimeState* state, starrocks::ExprCo
 StatusOr<ColumnPtr> LambdaFunction::evaluate_checked(ExprContext* context, Chunk* chunk) {
     for (auto i = 0; i < _common_sub_expr.size(); ++i) {
         ASSIGN_OR_RETURN(auto sub_col, context->evaluate(_common_sub_expr[i], chunk));
-        chunk->append_column(sub_col, _common_sub_expr_ids[i]);
+        chunk->append_column(std::move(sub_col), _common_sub_expr_ids[i]);
     }
     return get_child(0)->evaluate_checked(context, chunk);
 }

--- a/be/src/exprs/map_apply_expr.cpp
+++ b/be/src/exprs/map_apply_expr.cpp
@@ -125,7 +125,7 @@ StatusOr<ColumnPtr> MapApplyExpr::evaluate_checked(ExprContext* context, Chunk* 
             }
 
             ASSIGN_OR_RETURN(auto replicated_col, captured->replicate(input_map->offsets_column_raw_ptr()->get_data()));
-            cur_chunk->append_column(replicated_col, id);
+            cur_chunk->append_column(std::move(replicated_col), id);
         }
         // evaluate the lambda expression
         if (cur_chunk->num_rows() <= chunk->num_rows() * 8) {

--- a/be/test/exec/chunks_sorter_test.cpp
+++ b/be/test/exec/chunks_sorter_test.cpp
@@ -484,9 +484,9 @@ public:
             map[i] = i;
         }
 
-        _chunk_1 = std::make_shared<Chunk>(columns1, map);
-        _chunk_2 = std::make_shared<Chunk>(columns2, map);
-        _chunk_3 = std::make_shared<Chunk>(columns3, map);
+        _chunk_1 = std::make_shared<Chunk>(std::move(columns1), map);
+        _chunk_2 = std::make_shared<Chunk>(std::move(columns2), map);
+        _chunk_3 = std::make_shared<Chunk>(std::move(columns3), map);
 
         _expr_cust_key = std::make_unique<ColumnRef>(TypeDescriptor(TYPE_INT), 0);     // refer to cust_key
         _expr_nation = std::make_unique<ColumnRef>(TypeDescriptor(TYPE_VARCHAR), 1);   // refer to nation
@@ -512,8 +512,8 @@ public:
             map[i] = i;
         }
 
-        _chunk_ranking_1 = std::make_shared<Chunk>(columns1, map);
-        _chunk_ranking_2 = std::make_shared<Chunk>(columns2, map);
+        _chunk_ranking_1 = std::make_shared<Chunk>(std::move(columns1), map);
+        _chunk_ranking_2 = std::make_shared<Chunk>(std::move(columns2), map);
 
         _expr_ranking_key = std::make_unique<ColumnRef>(TYPE_INT_DESC, 0);
     }

--- a/be/test/exec/range_router_test.cpp
+++ b/be/test/exec/range_router_test.cpp
@@ -86,7 +86,7 @@ protected:
         Fields fields;
         fields.emplace_back(std::make_shared<Field>(0, name, get_type_info(TYPE_INT), false));
         auto schema = std::make_shared<Schema>(fields);
-        return Chunk(cols, schema);
+        return Chunk(std::move(cols), std::move(schema));
     }
 
     Chunk make_varchar_chunk(const std::string& name, const std::vector<std::string>& values) {
@@ -100,7 +100,7 @@ protected:
         Fields fields;
         fields.emplace_back(std::make_shared<Field>(0, name, get_type_info(TYPE_VARCHAR), false));
         auto schema = std::make_shared<Schema>(fields);
-        return Chunk(cols, schema);
+        return Chunk(std::move(cols), std::move(schema));
     }
 
     // ---- Single-column TTabletRange helpers ----

--- a/be/test/exec/tablet_sink_sender_range_test.cpp
+++ b/be/test/exec/tablet_sink_sender_range_test.cpp
@@ -304,7 +304,7 @@ protected:
         fields.emplace_back(std::make_shared<Field>(0, "c1", get_type_info(TYPE_BIGINT), false));
         auto schema = std::make_shared<Schema>(fields);
 
-        auto chunk = std::make_shared<Chunk>(cols, schema);
+        auto chunk = std::make_shared<Chunk>(std::move(cols), std::move(schema));
         // Set slot_id to column index mapping
         chunk->set_slot_id_to_index(0, 0); // slot_id 0 -> column index 0
         return chunk;
@@ -328,7 +328,7 @@ protected:
         fields.emplace_back(std::make_shared<Field>(1, "c2", get_type_info(TYPE_BIGINT), false));
         auto schema = std::make_shared<Schema>(fields);
 
-        auto chunk = std::make_shared<Chunk>(cols, schema);
+        auto chunk = std::make_shared<Chunk>(std::move(cols), std::move(schema));
         // Set slot_id to column index mapping
         chunk->set_slot_id_to_index(0, 0); // slot_id 0 -> column index 0
         chunk->set_slot_id_to_index(1, 1); // slot_id 1 -> column index 1
@@ -1212,7 +1212,7 @@ TEST_F(TabletSinkSenderRangeTest, SparseDataRouting) {
     Fields fields;
     fields.emplace_back(std::make_shared<Field>(0, "c1", get_type_info(TYPE_BIGINT), false));
     auto schema = std::make_shared<Schema>(fields);
-    auto chunk = std::make_shared<Chunk>(cols, schema);
+    auto chunk = std::make_shared<Chunk>(std::move(cols), std::move(schema));
     // Set slot_id to column index mapping
     chunk->set_slot_id_to_index(0, 0); // slot_id 0 -> column index 0
 

--- a/be/test/runtime/sorted_chunks_merger_test.cpp
+++ b/be/test/runtime/sorted_chunks_merger_test.cpp
@@ -100,9 +100,9 @@ public:
             map[i] = i;
         }
 
-        _chunk_1 = std::make_shared<Chunk>(columns_1, map);
-        _chunk_2 = std::make_shared<Chunk>(columns_2, map);
-        _chunk_3 = std::make_shared<Chunk>(columns_3, map);
+        _chunk_1 = std::make_shared<Chunk>(std::move(columns_1), map);
+        _chunk_2 = std::make_shared<Chunk>(std::move(columns_2), map);
+        _chunk_3 = std::make_shared<Chunk>(std::move(columns_3), map);
 
         auto* expr1 = new ColumnRef(TypeDescriptor(TYPE_VARCHAR), 2); // refer to region
         auto* expr2 = new ColumnRef(TypeDescriptor(TYPE_VARCHAR), 1); // refer to nation

--- a/be/test/storage/chunk_aggregator_test.cpp
+++ b/be/test/storage/chunk_aggregator_test.cpp
@@ -55,7 +55,7 @@ TEST(ChunkAggregatorTest, testNoneAggregator) {
 
     Columns cols({std::move(k_col), std::move(v_col)});
 
-    ChunkPtr chunk = std::make_shared<Chunk>(cols, schema);
+    ChunkPtr chunk = std::make_shared<Chunk>(std::move(cols), schema);
 
     aggregator.update_source(chunk);
     ASSERT_EQ(true, aggregator.is_do_aggregate());
@@ -105,7 +105,7 @@ TEST(ChunkAggregatorTest, testNonKeyColumnsByMask) {
         }
     }
     Columns cols{std::move(v_col)};
-    ChunkPtr chunk = std::make_shared<Chunk>(cols, schema);
+    ChunkPtr chunk = std::make_shared<Chunk>(std::move(cols), schema);
 
     aggregator.update_source(chunk, &source_masks);
     ASSERT_EQ(true, aggregator.is_do_aggregate());

--- a/be/test/storage/disjunctive_predicates_test.cpp
+++ b/be/test/storage/disjunctive_predicates_test.cpp
@@ -53,7 +53,7 @@ TEST(DisjunctivePredicatesTest, TwoPredicateTest) {
     Chunk::SlotHashMap hash_map;
     hash_map[0] = 0;
     hash_map[1] = 1;
-    auto chunk = std::make_shared<Chunk>(columns, hash_map);
+    auto chunk = std::make_shared<Chunk>(std::move(columns), hash_map);
     chunk->_cid_to_index[0] = 0;
     chunk->_cid_to_index[1] = 1;
 


### PR DESCRIPTION
## Background
- https://github.com/StarRocks/starrocks/issues/56147 has introduced a Cow policy and may try to Cow in some cases.
- https://github.com/StarRocks/starrocks/pull/66037 has identified ColumnPtr immutable & MutablePtr mutable.

When a ColumnPtr is triggered to MutablePtr, there are some methods:
- `Column:mutate`: try to Cow and move ownership ;
- `std::move(*col).muate`: try to Cow and not move ownership;
- deep copy;
- shadow copy;

Method 3/Method 4 needs to be controlled by hand and is not recommended.

Method 1 is safe, but there are few codes that can be used for Cow:
<img width="571" height="462" alt="image" src="https://github.com/user-attachments/assets/94b65c49-d290-453b-bd6b-0ff680889fce" />

Method 2 try the best to use `Cow` optimization, but it assumes the input column is immutable and can be transfered from input to output.

<img width="571" height="462" alt="image" src="https://github.com/user-attachments/assets/1416c35b-e6bb-4e8b-9d89-3f0ae584050d" />

But there are still dangerous (unsafe) codes that are still not obey the `ColumnPtr is immutable` rule, so it's not safe to use `Method 2` totally. 

NOTE: all `as_mutable_ptr`/`as_mutable_raw_ptr` in current code bases are not expected since they break the `Cow` rules.

For example, this case:
```
Status SelectOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
    _curr_chunk = chunk;
    if (!_common_exprs.empty()) {
        SCOPED_TIMER(_conjuncts_timer);
        for (const auto& [slot_id, expr] : _common_exprs) {
            ASSIGN_OR_RETURN(auto col, expr->evaluate(_curr_chunk.get())); // This may trigger shadow copy
            _curr_chunk->append_column(col, slot_id);
        }
    }
    RETURN_IF_ERROR(eval_conjuncts_and_in_filters(_conjunct_ctxs, _curr_chunk.get()));
    {
        // common_exprs' slots are only needed inside this operator, no need to pass it downsteam
        for (const auto& [slot_id, _] : _common_exprs) {
            _curr_chunk->remove_column_by_slot_id(slot_id);
        }
    }
    return Status::OK();
}
```

`ASSIGN_OR_RETURN(auto col, expr->evaluate(_curr_chunk.get()));`  may trigger shadow copy, but the shadow copy column may be inserted into the original chunk again, so the chunk contains two columns  which shared the same column!!!

If the chunk trigger `Chunk::filter` (this method still can change the `ColumnPtr`), the data will be wrong!

## Why I'm doing:

Chunk's inner columns cannot be changed (eg: by Cow) directly since the column may be referred to by others. But we can check the Chunk Columns in the `input gate`. 

Columns in chunk are added in those two methods:
- Constructor
- `append_column`

1. When those two methods are called with `&&`, we can check & trigger `Cow` to ensure the columns in Chunk are not shared with each other.
2. Add extra checks in `check_or_die` method (which is enabled in ASAN mode ) to avoid columns in Chunk sharing the same column.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces unique column ownership within `Chunk` by introducing move-aware constructors/append/update APIs with safety checks, adds runtime assertions, and updates operators/exprs/tests to use `std::move`.
> 
> - **Core (Chunk)**
>   - Make `Chunk` constructors take `Columns&&`; initialize via `_append_column_checked`.
>   - Add move-aware APIs: `append_column(ColumnPtr&&, ...)`, `update_column(ColumnPtr&&, ...)`, `update_column_by_index(ColumnPtr&&, ...)`, `append_or_update_column(ColumnPtr&&, ...)`, and `append_vector_column(ColumnPtr&&, ...)`; retain const-ref variants with ownership caveats.
>   - Track column pointers via `_column_ptr_set` and guard with `_append_column_checked`/`_update_column_checked` to avoid shared columns and trigger COW when needed.
>   - Strengthen `check_or_die()` to assert no shared columns and consistent sizes; adjust `clone_empty_*` and `merge()` to use moves.
>   - Remove index-based `insert_column` API (and related impl).
> - **Callers Updated**
>   - Replace `append_column(col, ...)` with `append_column(std::move(col), ...)` across scan/expr/operators/sort/bench/storage/tests (e.g., `hive_connector`, `chunks_sorter`, `project_operator`, `select_operator`, `merge_path`, cast/array/map/struct exprs).
>   - Use `std::move(columns)` when constructing `Chunk` with prebuilt `Columns`/slot maps.
>   - Update `dictionary_get_expr` to `update_column_by_index(std::move(col), ...)`.
> - **Benchmarks/Tests**
>   - Bench code updated for move-based appends.
>   - Add extensive unit tests for new `check_or_die` invariants, const columns handling, slot/index removals, cloning, filtering, and swaps; adapt existing tests to move semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97f4a4add6c57c1736e93dd9ef57f8438ad7e2dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->