### PR TITLE
[UT] Fix be test compile error

### DIFF
--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -81,11 +81,13 @@ protected:
     }
 
     void TearDown() override {
+#ifdef USE_STAROS
         if (config::starlet_cache_dir.compare(0, 5, std::string("/tmp/")) == 0) {
             // Clean cache directory
             std::string cmd = fmt::format("rm -rf {}", config::starlet_cache_dir);
             ::system(cmd.c_str());
         }
+#endif
 
         config::enable_transparent_data_encryption = false;
 


### PR DESCRIPTION
## Why I'm doing:

```
./run-be-ut.sh -j 64   --without-java-ext    --without-debug-symbol-split

/root/work/dev2/be/test/storage/lake/lake_replication_txn_manager_test.cpp: In member function ‘virtual void starrocks::lake::SharedDataReplicationTxnManagerTest::TearDown()’:
/root/work/dev2/be/test/storage/lake/lake_replication_txn_manager_test.cpp:84:21: error: ‘starlet_cache_dir’ is not a member of ‘starrocks::config’
   84 |         if (config::starlet_cache_dir.compare(0, 5, std::string("/tmp/")) == 0) {
      |                     ^~~~~~~~~~~~~~~~~
/root/work/dev2/be/test/storage/lake/lake_replication_txn_manager_test.cpp:86:64: error: ‘starlet_cache_dir’ is not a member of ‘starrocks::config’
   86 |             std::string cmd = fmt::format("rm -rf {}", config::starlet_cache_dir);
      |                                                                ^~~~~~~~~~~~~~~~~
make[2]: *** [test/CMakeFiles/starrocks_dw_objs.dir/build.make:1072: test/CMakeFiles/starrocks_dw_objs.dir/storage/lake/lake_replication_txn_manager_test.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....


```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
