### PR TITLE
[BugFix] Change timezone cache miss log level from WARNING to VLOG

### DIFF
--- a/be/src/util/timezone_utils.cpp
+++ b/be/src/util/timezone_utils.cpp
@@ -67,7 +67,7 @@ void TimezoneUtils::init_time_zones() {
         if (cctz::load_time_zone(timezone, &ctz)) {
             _s_cached_timezone.emplace(timezone, ctz);
         } else {
-            LOG(WARNING) << "not found timezone:" << timezone;
+            VLOG(1) << "not found timezone:" << timezone;
         }
     }
     auto civil = cctz::civil_second(2021, 12, 1, 8, 30, 1);
@@ -90,7 +90,7 @@ void TimezoneUtils::init_time_zones() {
         if (cctz::load_time_zone(timezone, &ctz)) {
             _s_cached_timezone.emplace(timezone, ctz);
         } else {
-            LOG(WARNING) << "not found timezone:" << timezone;
+            VLOG(1) << "not found timezone:" << timezone;
         }
     }
 }


### PR DESCRIPTION
## Why I'm doing:

During BE initialization, if some timezones listed in `timezone.dat` or `othertimezone.dat` are not available on the system (e.g., in minimal Docker images without complete tzdata), the current code logs WARNING messages like:

```text
W20251125 19:01:08.521512 +0800 timezone_utils.cpp:93] not found timezone:Africa/Casablanca
W20251125 19:01:08.536134 +0800 timezone_utils.cpp:93] not found timezone:Africa/El_Aaiun
```

These warnings are misleading because the system continues to work normally - timezone lookup has a fallback mechanism that dynamically loads timezones when needed.

## What I'm doing:

Change the log level from `LOG(WARNING)` to `VLOG(1)` for timezone pre-caching failures.

Fixes #65942

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

**Does this PR entail a change in behavior?**

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Downgrades "not found timezone" pre-caching logs in `be/src/util/timezone_utils.cpp` from `WARNING` to `VLOG(1)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3772899ed1c23a89229c5c929fbeafaee020563b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->