### PR TITLE
[BugFix] fix issues when querying renamed column with meta scan

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalMetaScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalMetaScanOperator.java
@@ -16,6 +16,8 @@ package com.starrocks.sql.optimizer.operator.logical;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.starrocks.catalog.Column;
+import com.starrocks.common.Pair;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 
@@ -24,17 +26,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+// @TODO getName maynot be the base column name
 public class LogicalMetaScanOperator extends LogicalScanOperator {
     private long selectedIndexId = -1;
-    private Map<Integer, String> aggColumnIdToNames = ImmutableMap.of();
+    // agg column id -> (agg_function_name, column)
+    private Map<Integer, Pair<String, Column>> aggColumnIdToColumns = ImmutableMap.of();
     private List<String> selectPartitionNames = Collections.emptyList();
 
     private LogicalMetaScanOperator() {
         super(OperatorType.LOGICAL_META_SCAN);
     }
 
-    public Map<Integer, String> getAggColumnIdToNames() {
-        return aggColumnIdToNames;
+    public Map<Integer, Pair<String, Column>> getAggColumnIdToColumns() {
+        return aggColumnIdToColumns;
     }
 
     public List<String> getSelectPartitionNames() {
@@ -62,14 +66,14 @@ public class LogicalMetaScanOperator extends LogicalScanOperator {
             return false;
         }
         LogicalMetaScanOperator that = (LogicalMetaScanOperator) o;
-        return Objects.equals(aggColumnIdToNames, that.aggColumnIdToNames) &&
+        return Objects.equals(aggColumnIdToColumns, that.aggColumnIdToColumns) &&
                 Objects.equals(selectPartitionNames, that.selectPartitionNames) &&
                 selectedIndexId == that.selectedIndexId;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), aggColumnIdToNames);
+        return Objects.hash(super.hashCode(), aggColumnIdToColumns);
     }
 
     public static LogicalMetaScanOperator.Builder builder() {
@@ -87,14 +91,15 @@ public class LogicalMetaScanOperator extends LogicalScanOperator {
         @Override
         public LogicalMetaScanOperator.Builder withOperator(LogicalMetaScanOperator operator) {
             super.withOperator(operator);
-            builder.aggColumnIdToNames = ImmutableMap.copyOf(operator.aggColumnIdToNames);
+            builder.aggColumnIdToColumns = ImmutableMap.copyOf(operator.aggColumnIdToColumns);
             builder.selectPartitionNames = operator.selectPartitionNames;
             builder.columnAccessPaths = ImmutableList.copyOf(operator.columnAccessPaths);
             return this;
         }
 
-        public LogicalMetaScanOperator.Builder setAggColumnIdToNames(Map<Integer, String> aggColumnIdToNames) {
-            builder.aggColumnIdToNames = aggColumnIdToNames;
+        public LogicalMetaScanOperator.Builder setAggColumnIdToColumns(
+                Map<Integer, Pair<String, Column>> aggColumnIdToColumns) {
+            builder.aggColumnIdToColumns = aggColumnIdToColumns;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalMetaScanOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalMetaScanOperator.java
@@ -16,6 +16,8 @@ package com.starrocks.sql.optimizer.operator.physical;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.starrocks.catalog.Column;
+import com.starrocks.common.Pair;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.operator.OperatorType;
@@ -27,25 +29,25 @@ import java.util.Map;
 import java.util.Objects;
 
 public class PhysicalMetaScanOperator extends PhysicalScanOperator {
-    private Map<Integer, String> aggColumnIdToNames;
+    private Map<Integer, Pair<String, Column>> aggColumnIdToColumns;
     private List<String> selectPartitionNames;
     private long selectedIndexId = -1;
 
     public PhysicalMetaScanOperator() {
         super(OperatorType.PHYSICAL_META_SCAN);
-        this.aggColumnIdToNames = ImmutableMap.of();
+        this.aggColumnIdToColumns = ImmutableMap.of();
         this.selectPartitionNames = ImmutableList.of();
     }
 
     public PhysicalMetaScanOperator(LogicalMetaScanOperator scanOperator) {
         super(OperatorType.PHYSICAL_META_SCAN, scanOperator);
-        this.aggColumnIdToNames = scanOperator.getAggColumnIdToNames();
+        this.aggColumnIdToColumns = scanOperator.getAggColumnIdToColumns();
         this.selectPartitionNames = scanOperator.getSelectPartitionNames();
         this.selectedIndexId = scanOperator.getSelectedIndexId();
     }
 
-    public Map<Integer, String> getAggColumnIdToNames() {
-        return aggColumnIdToNames;
+    public Map<Integer, Pair<String, Column>> getAggColumnIdToColumns() {
+        return aggColumnIdToColumns;
     }
 
     public List<String> getSelectPartitionNames() {
@@ -77,14 +79,14 @@ public class PhysicalMetaScanOperator extends PhysicalScanOperator {
         }
 
         PhysicalMetaScanOperator that = (PhysicalMetaScanOperator) o;
-        return Objects.equals(aggColumnIdToNames, that.aggColumnIdToNames) &&
+        return Objects.equals(aggColumnIdToColumns, that.aggColumnIdToColumns) &&
                 Objects.equals(selectPartitionNames, that.selectPartitionNames) &&
                 selectedIndexId == that.selectedIndexId;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), aggColumnIdToNames, selectPartitionNames, selectedIndexId);
+        return Objects.hash(super.hashCode(), aggColumnIdToColumns, selectPartitionNames, selectedIndexId);
     }
 
     public static Builder builder() {
@@ -102,7 +104,7 @@ public class PhysicalMetaScanOperator extends PhysicalScanOperator {
         @Override
         public PhysicalMetaScanOperator.Builder withOperator(PhysicalMetaScanOperator operator) {
             super.withOperator(operator);
-            builder.aggColumnIdToNames = ImmutableMap.copyOf(operator.aggColumnIdToNames);
+            builder.aggColumnIdToColumns = ImmutableMap.copyOf(operator.aggColumnIdToColumns);
             builder.selectPartitionNames = ImmutableList.copyOf(operator.selectPartitionNames);
             builder.selectedIndexId = operator.selectedIndexId;
             return this;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalculator.java
@@ -837,7 +837,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
     public Void visitLogicalMetaScan(LogicalMetaScanOperator node, ExpressionContext context) {
         Statistics.Builder builder = StatisticsCalcUtils.estimateScanColumns(node.getTable(),
                 node.getColRefToColumnMetaMap(), optimizerContext);
-        builder.setOutputRowCount(node.getAggColumnIdToNames().size());
+        builder.setOutputRowCount(node.getAggColumnIdToColumns().size());
 
         context.setStatistics(builder.build());
         return visitOperator(node, context);
@@ -847,7 +847,7 @@ public class StatisticsCalculator extends OperatorVisitor<Void, ExpressionContex
     public Void visitPhysicalMetaScan(PhysicalMetaScanOperator node, ExpressionContext context) {
         Statistics.Builder builder = StatisticsCalcUtils.estimateScanColumns(node.getTable(),
                 node.getColRefToColumnMetaMap(), optimizerContext);
-        builder.setOutputRowCount(node.getAggColumnIdToNames().size());
+        builder.setOutputRowCount(node.getAggColumnIdToColumns().size());
 
         context.setStatistics(builder.build());
         return visitOperator(node, context);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1096,7 +1096,7 @@ public class PlanFragmentBuilder {
                     ConnectContext.get().getCurrentComputeResource() : WarehouseManager.DEFAULT_RESOURCE;
 
             MetaScanNode scanNode = new MetaScanNode(context.getNextNodeId(),
-                    tupleDescriptor, (OlapTable) scan.getTable(), scan.getAggColumnIdToNames(),
+                    tupleDescriptor, (OlapTable) scan.getTable(), scan.getAggColumnIdToColumns(),
                     scan.getSelectPartitionNames(), scan.getSelectedIndexId(),
                     context.getConnectContext().getCurrentComputeResource());
 

--- a/test/sql/test_agg/R/test_meta_scan_agg
+++ b/test/sql/test_agg/R/test_meta_scan_agg
@@ -112,3 +112,42 @@ select min(c0), max(c0), min(c1), max(c1) from t1 TEMPORARY PARTITION(tp202403);
 -- result:
 2024-03-10	2024-03-20	50	70
 -- !result
+-- name: test_meta_scan_with_renamed_column
+create table t2 (
+    c0 INT
+) DUPLICATE key (c0) DISTRIBUTED BY HASH(c0) BUCKETS 3 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t2 values (1), (2), (3);
+-- result:
+-- !result
+select count(*) from t2[_META_];
+-- result:
+3
+-- !result
+select count(*) from t2;
+-- result:
+3
+-- !result
+alter table t2 rename column c0 to c1;
+-- result:
+-- !result
+select count(*) from t2[_META_];
+-- result:
+3
+-- !result
+select count(*) from t2;
+-- result:
+3
+-- !result
+alter table t2 rename column c1 to c2;
+-- result:
+-- !result
+select count(*) from t2[_META_];
+-- result:
+3
+-- !result
+select count(*) from t2;
+-- result:
+3
+-- !result

--- a/test/sql/test_agg/T/test_meta_scan_agg
+++ b/test/sql/test_agg/T/test_meta_scan_agg
@@ -51,3 +51,25 @@ select min(c0), max(c0) from t1 TEMPORARY PARTITION(tp202403);
 select min(c1), max(c1) from t1 TEMPORARY PARTITION(tp202403);
 select min(c0), max(c0), min(c1), max(c1) from t1 TEMPORARY PARTITION(tp202403);
 
+-- name: test_meta_scan_with_renamed_column
+create table t2 (
+    c0 INT
+) DUPLICATE key (c0) DISTRIBUTED BY HASH(c0) BUCKETS 3 PROPERTIES('replication_num' = '1');
+
+insert into t2 values (1), (2), (3);
+
+select count(*) from t2[_META_];
+select count(*) from t2;
+
+alter table t2 rename column c0 to c1;
+
+select count(*) from t2[_META_];
+select count(*) from t2;
+
+alter table t2 rename column c1 to c2;
+
+select count(*) from t2[_META_];
+select count(*) from t2;
+
+
+


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/10738


MetaScan reports errors when querying renamed columns. The reason is that the query plan directly uses the new column names without correctly handling the column name mapping, causing the BE to be unable to find the corresponding columns in the tablet schema. This PR aims to fix this issue.

Main changes:
Change `aggColumnIdToNames` to `aggColumnToColumns` in meta scan operator. During query optimization, only the agg function name and the `Column` used are recorded. When the final plan is deployed, `MetaScanNode` handles the column name mapping.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch meta scan to build/display meta-agg columns from (agg_func, Column) using column IDs, fixing queries after column renames and updating planner/optimizer/stats; add tests.
> 
> - **MetaScan refactor/fix**:
>   - Replace `Map<Integer, String>` with `Map<Integer, Pair<String, Column>>` for meta-agg mapping in `MetaScanNode`, `LogicalMetaScanOperator`, and `PhysicalMetaScanOperator`.
>   - Build Thrift `id_to_names` from `(agg_func, Column)` using column ID; set `TColumn.column_name` to the column ID.
>   - Update explain output to derive names from `(agg_func, Column)`.
> - **Optimizer rules updated**:
>   - `RewriteSimpleAggToMetaScanRule`, `PushDownAggToMetaScanRule`, and `PushDownFlatJsonMetaToMetaScanRule` now produce and consume the new mapping.
> - **Plan/Stats**:
>   - `PlanFragmentBuilder` passes the new mapping to `MetaScanNode`.
>   - `StatisticsCalculator` derives output row count from the new map size.
> - **Tests**:
>   - Add `test_meta_scan_with_renamed_column` to verify `count(*)` works after column renames.
>   - Extend existing meta-scan agg tests accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a20179a51432f55eef73f7cab022d051887d7125. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->