### PR TITLE
[BugFix] Fix NPE in query planning during schema change (backport #66811)

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerTest.java
@@ -15,11 +15,13 @@
 package com.starrocks.sql;
 
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.TableFunctionTable;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.FeConstants;
 import com.starrocks.planner.OlapTableSink;
 import com.starrocks.planner.PlanFragment;
+import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.PlannerMetaLocker;
 import com.starrocks.sql.analyzer.QueryAnalyzer;
@@ -37,14 +39,19 @@ import com.starrocks.sql.ast.SubqueryRelation;
 import com.starrocks.sql.ast.ValuesRelation;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.sql.plan.PlanFragmentBuilder;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.thrift.TPartialUpdateMode;
+import com.starrocks.thrift.TResultSinkType;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -54,7 +61,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 
 class StatementPlannerTest extends PlanTestBase {
 
@@ -384,5 +399,115 @@ class StatementPlannerTest extends PlanTestBase {
         Assertions.assertTrue(exception.getMessage().contains("current query allocated"));
 
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(oldValue);
+    }
+
+    @Test
+    public void testPlanExceptionWithoutSchemaChange() throws Exception {
+        // Exception occurs in plan builder, schema is valid, exception should be re-thrown
+        FeConstants.runningUnitTest = false;
+        String sql = "select * from t1";
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        QueryStatement queryStmt = (QueryStatement) stmt;
+        Analyzer.analyze(queryStmt, connectContext);
+        PlannerMetaLocker plannerMetaLocker = new PlannerMetaLocker(connectContext, queryStmt);
+        try (MockedStatic<PlanFragmentBuilder> mockedPlanFragmentBuilder = mockStatic(PlanFragmentBuilder.class);
+                MockedStatic<OptimisticVersion> mockedOptimisticVersion =
+                        mockStatic(OptimisticVersion.class)) {
+            // Mock PlanFragmentBuilder.createPhysicalPlan to throw exception
+            RuntimeException testException = new RuntimeException("Test exception during ExecPlanBuild");
+            mockedPlanFragmentBuilder.when(() -> PlanFragmentBuilder.createPhysicalPlan(
+                    any(), any(), anyList(), any(), anyList(), any(), anyBoolean(), anyBoolean()))
+                    .thenThrow(testException);
+
+            // Mock OptimisticVersion.validateTableUpdate to return true (schema is valid)
+            mockedOptimisticVersion.when(() -> com.starrocks.sql.OptimisticVersion.validateTableUpdate(
+                    any(OlapTable.class), anyLong())).thenReturn(true);
+
+            // Call createQueryPlanWithReTry and verify exception is re-thrown
+            long planStartTime = OptimisticVersion.generate();
+            RuntimeException thrownException = assertThrows(RuntimeException.class, () ->
+                    StatementPlanner.createQueryPlanWithReTry(
+                            queryStmt, connectContext, TResultSinkType.MYSQL_PROTOCAL,
+                            plannerMetaLocker, planStartTime));
+
+            assertEquals("Test exception during ExecPlanBuild", thrownException.getMessage());
+
+            // Verify that OptimisticVersion.validateTableUpdate was called in the catch block
+            Set<OlapTable> olapTables = StatementPlanner.collectOriginalOlapTables(connectContext, queryStmt);
+            if (!olapTables.isEmpty()) {
+                mockedOptimisticVersion.verify(() -> OptimisticVersion.validateTableUpdate(
+                        any(OlapTable.class), eq(planStartTime)), times(olapTables.size()));
+            }
+        }
+    }
+
+    @Test
+    public void testPlanExceptionWithSchemaChange() throws Exception {
+        // Exception occurs, schema is invalid, should retry instead of re-throwing
+        FeConstants.runningUnitTest = false;
+        String sql = "select * from t1";
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        QueryStatement queryStmt = (QueryStatement) stmt;
+        Analyzer.analyze(queryStmt, connectContext);
+        PlannerMetaLocker plannerMetaLocker = new PlannerMetaLocker(connectContext, queryStmt);
+
+        // Collect olap tables before mocking
+        Set<OlapTable> olapTables = StatementPlanner.collectOriginalOlapTables(connectContext, queryStmt);
+        int tableCount = olapTables.size();
+        try (MockedStatic<PlanFragmentBuilder> mockedPlanFragmentBuilder = mockStatic(PlanFragmentBuilder.class);
+                MockedStatic<com.starrocks.sql.OptimisticVersion> mockedOptimisticVersion =
+                        mockStatic(com.starrocks.sql.OptimisticVersion.class)) {
+
+            // Mock PlanFragmentBuilder.createPhysicalPlan
+            // First call throws exception, second call returns a plan
+            RuntimeException testException = new RuntimeException("Test exception during ExecPlanBuild");
+            ExecPlan mockPlan = Mockito.mock(ExecPlan.class);
+            AtomicInteger callCount = new AtomicInteger(0);
+            mockedPlanFragmentBuilder.when(() -> PlanFragmentBuilder.createPhysicalPlan(
+                    any(), any(), anyList(), any(), anyList(), any(), anyBoolean(), anyBoolean()))
+                    .thenAnswer(invocation -> {
+                        int count = callCount.incrementAndGet();
+                        if (count == 1) {
+                            throw testException;
+                        } else {
+                            return mockPlan;
+                        }
+                    });
+
+            // Mock OptimisticVersion.validateTableUpdate
+            // First call (in catch block) returns false (schema invalid), triggering retry
+            // Second call (in normal flow) returns true (schema valid after retry)
+            AtomicInteger validateCallCount = new AtomicInteger(0);
+            mockedOptimisticVersion.when(() -> OptimisticVersion.validateTableUpdate(
+                    any(OlapTable.class), anyLong())).thenAnswer(invocation -> {
+                        int count = validateCallCount.incrementAndGet();
+                        // First validation (in catch block) returns false, subsequent returns true
+                        // For each table, we expect: first call (in catch) returns false, second call (in normal flow) returns true
+                        return count > tableCount;
+                    });
+
+            // Call createQueryPlanWithReTry
+            // Since schema is invalid on first exception, it should retry and succeed
+            long planStartTime = OptimisticVersion.generate();
+            ExecPlan result = StatementPlanner.createQueryPlanWithReTry(
+                    queryStmt, connectContext, TResultSinkType.MYSQL_PROTOCAL,
+                    plannerMetaLocker, planStartTime);
+
+            // Verify that a plan was returned (retry succeeded)
+            assertNotNull(result);
+
+            // Verify that PlanFragmentBuilder.createPhysicalPlan was called twice
+            // (once throwing exception, once succeeding)
+            mockedPlanFragmentBuilder.verify(() -> PlanFragmentBuilder.createPhysicalPlan(
+                    any(), any(), anyList(), any(), anyList(), any(), anyBoolean(), anyBoolean()),
+                    times(2));
+
+            // Verify that OptimisticVersion.validateTableUpdate was called
+            // (at least once in catch block, and once in normal flow)
+            if (!olapTables.isEmpty()) {
+                mockedOptimisticVersion.verify(() -> OptimisticVersion.validateTableUpdate(
+                        any(OlapTable.class), anyLong()), Mockito.atLeast(tableCount * 2));
+            }
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:
backport #66811

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [X] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds schema-validation guarded retry and exception handling in query planning, plus tests to ensure rethrow on stable schema and retry on schema changes.
> 
> - **Planner (StatementPlanner)**:
>   - `createQueryPlanWithReTry`: wrap transform/optimize/plan-build in a try-catch; validate OLAP table schema before returning; on exception, rethrow only if schema unchanged, otherwise retry; set optimizer context (`queryTables`, short-circuit options, MV context, statement, sourceTablesCount) within the guarded block.
>   - Add helper `checkOlapTableSchemaValid(...)` and use it in both normal and exceptional paths.
> - **Tests**:
>   - Add `testPlanExceptionWithoutSchemaChange` and `testPlanExceptionWithSchemaChange` to verify rethrow vs retry behavior; mock `PlanFragmentBuilder` and `OptimisticVersion` accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a718568f00265593c3052ce2adb46638f80c68d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->