### PR TITLE
[BugFix] Fix NPE in query planning during schema change (backport #66811)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -363,52 +363,59 @@ public class StatementPlanner {
                 isSchemaValid = true;
             }
 
-            LogicalPlan logicalPlan;
-            MVTransformerContext mvTransformerContext = MVTransformerContext.of(session, true);
-            try (Timer ignored = Tracers.watchScope("Transformer")) {
-                // get a logicalPlan without inlining views
-                TransformerContext transformerContext = new TransformerContext(columnRefFactory, session, mvTransformerContext);
-                logicalPlan = new RelationTransformer(transformerContext).transformWithSelectLimit(query);
-            }
-
-            boolean isShortCircuit = ShortCircuitPlanner.checkSupportShortCircuitRead(logicalPlan.getRoot(), session);
-            OptExpression optimizedPlan;
-            try (Timer ignored = Tracers.watchScope("Optimizer")) {
-                OptimizerContext optimizerContext = OptimizerFactory.initContext(session, columnRefFactory);
-                // 2. Optimize logical plan and build physical plan
-                // FIXME: refactor this into Optimizer.optimize() method.
-                // set query tables into OptimizeContext so can be added for mv rewrite
-                if (Config.skip_whole_phase_lock_mv_limit >= 0) {
-                    optimizerContext.setQueryTables(olapTables);
+            try {
+                LogicalPlan logicalPlan;
+                MVTransformerContext mvTransformerContext = MVTransformerContext.of(session, true);
+                try (Timer ignored = Tracers.watchScope("Transformer")) {
+                    // get a logicalPlan without inlining views
+                    TransformerContext transformerContext =
+                            new TransformerContext(columnRefFactory, session, mvTransformerContext);
+                    logicalPlan = new RelationTransformer(transformerContext).transformWithSelectLimit(query);
                 }
 
-                if (isShortCircuit) {
-                    optimizerContext.setOptimizerOptions(OptimizerOptions.newShortCircuitOpt());
+                boolean isShortCircuit =
+                        ShortCircuitPlanner.checkSupportShortCircuitRead(logicalPlan.getRoot(), session);
+                OptExpression optimizedPlan;
+                try (Timer ignored = Tracers.watchScope("Optimizer")) {
+                    OptimizerContext optimizerContext = OptimizerFactory.initContext(session, columnRefFactory);
+                    // 2. Optimize logical plan and build physical plan
+                    // FIXME: refactor this into Optimizer.optimize() method.
+                    // set query tables into OptimizeContext so can be added for mv rewrite
+                    if (Config.skip_whole_phase_lock_mv_limit >= 0) {
+                        optimizerContext.setQueryTables(olapTables);
+                    }
+
+                    if (isShortCircuit) {
+                        optimizerContext.setOptimizerOptions(OptimizerOptions.newShortCircuitOpt());
+                    }
+                    optimizerContext.setMvTransformerContext(mvTransformerContext);
+                    optimizerContext.setStatement(queryStmt);
+
+                    Optimizer optimizer = OptimizerFactory.create(optimizerContext);
+                    optimizedPlan = optimizer.optimize(logicalPlan.getRoot(), new PhysicalPropertySet(),
+                            new ColumnRefSet(logicalPlan.getOutputColumn()));
                 }
-                optimizerContext.setMvTransformerContext(mvTransformerContext);
-                optimizerContext.setStatement(queryStmt);
 
-                Optimizer optimizer = OptimizerFactory.create(optimizerContext);
-                optimizedPlan = optimizer.optimize(logicalPlan.getRoot(), new PhysicalPropertySet(),
-                        new ColumnRefSet(logicalPlan.getOutputColumn()));
-            }
-
-            try (Timer ignored = Tracers.watchScope("ExecPlanBuild")) {
-                // 3. Build fragment exec plan
-                // SingleNodeExecPlan is set in TableQueryPlanAction to generate a single-node Plan,
-                // currently only used in Spark/Flink Connector
-                // Because the connector sends only simple queries, it only needs to remove the output fragment
-                ExecPlan plan = PlanFragmentBuilder.createPhysicalPlan(
-                        optimizedPlan, session, logicalPlan.getOutputColumn(), columnRefFactory, colNames,
-                        resultSinkType,
-                        !session.getSessionVariable().isSingleNodeExecPlan(), isShortCircuit);
-                final long finalPlanStartTime = planStartTime;
-                isSchemaValid = olapTables.stream().allMatch(t -> OptimisticVersion.validateTableUpdate(t,
-                        finalPlanStartTime));
+                try (Timer ignored = Tracers.watchScope("ExecPlanBuild")) {
+                    // 3. Build fragment exec plan
+                    // SingleNodeExecPlan is set in TableQueryPlanAction to generate a single-node Plan,
+                    // currently only used in Spark/Flink Connector
+                    // Because the connector sends only simple queries, it only needs to remove the output fragment
+                    ExecPlan plan = PlanFragmentBuilder.createPhysicalPlan(
+                            optimizedPlan, session, logicalPlan.getOutputColumn(), columnRefFactory, colNames,
+                            resultSinkType,
+                            !session.getSessionVariable().isSingleNodeExecPlan(), isShortCircuit);
+                    isSchemaValid = checkOlapTableSchemaValid(olapTables, planStartTime);
+                    if (isSchemaValid) {
+                        plan.setLogicalPlan(logicalPlan);
+                        plan.setColumnRefFactory(columnRefFactory);
+                        return plan;
+                    }
+                }
+            } catch (RuntimeException exception) {
+                isSchemaValid = checkOlapTableSchemaValid(olapTables, planStartTime);
                 if (isSchemaValid) {
-                    plan.setLogicalPlan(logicalPlan);
-                    plan.setColumnRefFactory(columnRefFactory);
-                    return plan;
+                    throw exception;
                 }
             }
         }
@@ -421,6 +428,10 @@ public class StatementPlanner {
 
         throw new StarRocksPlannerException(ErrorType.INTERNAL_ERROR,
                 "schema of %s had been updated frequently during the plan generation", updatedTables);
+    }
+
+    private static boolean checkOlapTableSchemaValid(Set<OlapTable> olapTables, long planStartTime) {
+        return olapTables.stream().allMatch(t -> OptimisticVersion.validateTableUpdate(t, planStartTime));
     }
 
     public static Set<OlapTable> collectOriginalOlapTables(ConnectContext session, StatementBase queryStmt) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/StatementPlannerTest.java
@@ -15,11 +15,13 @@
 package com.starrocks.sql;
 
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.TableFunctionTable;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.FeConstants;
 import com.starrocks.planner.OlapTableSink;
 import com.starrocks.planner.PlanFragment;
+import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.PlannerMetaLocker;
 import com.starrocks.sql.analyzer.QueryAnalyzer;
@@ -36,12 +38,17 @@ import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.SubqueryRelation;
 import com.starrocks.sql.ast.ValuesRelation;
 import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.sql.plan.PlanFragmentBuilder;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.thrift.TPartialUpdateMode;
+import com.starrocks.thrift.TResultSinkType;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -51,7 +58,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 
 class StatementPlannerTest extends PlanTestBase {
 
@@ -368,5 +383,115 @@ class StatementPlannerTest extends PlanTestBase {
         PlanFragment fragment = plan.getFragments().get(0);
         OlapTableSink sink = (OlapTableSink) fragment.getSink();
         return sink.getPartialUpdateMode();
+    }
+
+    @Test
+    public void testPlanExceptionWithoutSchemaChange() throws Exception {
+        // Exception occurs in plan builder, schema is valid, exception should be re-thrown
+        FeConstants.runningUnitTest = false;
+        String sql = "select * from t1";
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        QueryStatement queryStmt = (QueryStatement) stmt;
+        Analyzer.analyze(queryStmt, connectContext);
+        PlannerMetaLocker plannerMetaLocker = new PlannerMetaLocker(connectContext, queryStmt);
+        try (MockedStatic<PlanFragmentBuilder> mockedPlanFragmentBuilder = mockStatic(PlanFragmentBuilder.class);
+                MockedStatic<OptimisticVersion> mockedOptimisticVersion =
+                        mockStatic(OptimisticVersion.class)) {
+            // Mock PlanFragmentBuilder.createPhysicalPlan to throw exception
+            RuntimeException testException = new RuntimeException("Test exception during ExecPlanBuild");
+            mockedPlanFragmentBuilder.when(() -> PlanFragmentBuilder.createPhysicalPlan(
+                    any(), any(), anyList(), any(), anyList(), any(), anyBoolean(), anyBoolean()))
+                    .thenThrow(testException);
+
+            // Mock OptimisticVersion.validateTableUpdate to return true (schema is valid)
+            mockedOptimisticVersion.when(() -> com.starrocks.sql.OptimisticVersion.validateTableUpdate(
+                    any(OlapTable.class), anyLong())).thenReturn(true);
+
+            // Call createQueryPlanWithReTry and verify exception is re-thrown
+            long planStartTime = OptimisticVersion.generate();
+            RuntimeException thrownException = assertThrows(RuntimeException.class, () ->
+                    StatementPlanner.createQueryPlanWithReTry(
+                            queryStmt, connectContext, TResultSinkType.MYSQL_PROTOCAL,
+                            plannerMetaLocker, planStartTime));
+
+            assertEquals("Test exception during ExecPlanBuild", thrownException.getMessage());
+
+            // Verify that OptimisticVersion.validateTableUpdate was called in the catch block
+            Set<OlapTable> olapTables = StatementPlanner.collectOriginalOlapTables(connectContext, queryStmt);
+            if (!olapTables.isEmpty()) {
+                mockedOptimisticVersion.verify(() -> OptimisticVersion.validateTableUpdate(
+                        any(OlapTable.class), eq(planStartTime)), times(olapTables.size()));
+            }
+        }
+    }
+
+    @Test
+    public void testPlanExceptionWithSchemaChange() throws Exception {
+        // Exception occurs, schema is invalid, should retry instead of re-throwing
+        FeConstants.runningUnitTest = false;
+        String sql = "select * from t1";
+        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        QueryStatement queryStmt = (QueryStatement) stmt;
+        Analyzer.analyze(queryStmt, connectContext);
+        PlannerMetaLocker plannerMetaLocker = new PlannerMetaLocker(connectContext, queryStmt);
+
+        // Collect olap tables before mocking
+        Set<OlapTable> olapTables = StatementPlanner.collectOriginalOlapTables(connectContext, queryStmt);
+        int tableCount = olapTables.size();
+        try (MockedStatic<PlanFragmentBuilder> mockedPlanFragmentBuilder = mockStatic(PlanFragmentBuilder.class);
+                MockedStatic<com.starrocks.sql.OptimisticVersion> mockedOptimisticVersion =
+                        mockStatic(com.starrocks.sql.OptimisticVersion.class)) {
+
+            // Mock PlanFragmentBuilder.createPhysicalPlan
+            // First call throws exception, second call returns a plan
+            RuntimeException testException = new RuntimeException("Test exception during ExecPlanBuild");
+            ExecPlan mockPlan = Mockito.mock(ExecPlan.class);
+            AtomicInteger callCount = new AtomicInteger(0);
+            mockedPlanFragmentBuilder.when(() -> PlanFragmentBuilder.createPhysicalPlan(
+                    any(), any(), anyList(), any(), anyList(), any(), anyBoolean(), anyBoolean()))
+                    .thenAnswer(invocation -> {
+                        int count = callCount.incrementAndGet();
+                        if (count == 1) {
+                            throw testException;
+                        } else {
+                            return mockPlan;
+                        }
+                    });
+
+            // Mock OptimisticVersion.validateTableUpdate
+            // First call (in catch block) returns false (schema invalid), triggering retry
+            // Second call (in normal flow) returns true (schema valid after retry)
+            AtomicInteger validateCallCount = new AtomicInteger(0);
+            mockedOptimisticVersion.when(() -> OptimisticVersion.validateTableUpdate(
+                    any(OlapTable.class), anyLong())).thenAnswer(invocation -> {
+                        int count = validateCallCount.incrementAndGet();
+                        // First validation (in catch block) returns false, subsequent returns true
+                        // For each table, we expect: first call (in catch) returns false, second call (in normal flow) returns true
+                        return count > tableCount;
+                    });
+
+            // Call createQueryPlanWithReTry
+            // Since schema is invalid on first exception, it should retry and succeed
+            long planStartTime = OptimisticVersion.generate();
+            ExecPlan result = StatementPlanner.createQueryPlanWithReTry(
+                    queryStmt, connectContext, TResultSinkType.MYSQL_PROTOCAL,
+                    plannerMetaLocker, planStartTime);
+
+            // Verify that a plan was returned (retry succeeded)
+            assertNotNull(result);
+
+            // Verify that PlanFragmentBuilder.createPhysicalPlan was called twice
+            // (once throwing exception, once succeeding)
+            mockedPlanFragmentBuilder.verify(() -> PlanFragmentBuilder.createPhysicalPlan(
+                    any(), any(), anyList(), any(), anyList(), any(), anyBoolean(), anyBoolean()),
+                    times(2));
+
+            // Verify that OptimisticVersion.validateTableUpdate was called
+            // (at least once in catch block, and once in normal flow)
+            if (!olapTables.isEmpty()) {
+                mockedOptimisticVersion.verify(() -> OptimisticVersion.validateTableUpdate(
+                        any(OlapTable.class), anyLong()), Mockito.atLeast(tableCount * 2));
+            }
+        }
     }
 }


### PR DESCRIPTION
## Why I'm doing:
backport #66811

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [X] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optimistic retry around ExecPlan build: rethrows planning exceptions if schema unchanged, retries if schema changed, with unit tests.
> 
> - **Planner**:
>   - Update `createQueryPlanWithReTry` to wrap transform/optimize/plan-build in try/catch and validate OLAP table versions via `checkOlapTableSchemaValid`.
>     - Retry planning when schema changed; rethrow the exception when schema unchanged.
>     - Set `logicalPlan` and `columnRefFactory` on the plan only when schema is validated.
>   - Add helper `checkOlapTableSchemaValid(Set<OlapTable>, long)`.
> - **Tests**:
>   - Add `testPlanExceptionWithoutSchemaChange` and `testPlanExceptionWithSchemaChange` to verify rethrow vs retry behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efa1b0bf0034840c1183b8a11f875baabb5c6a36. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->