### PR TITLE
[BugFix] Fix a potential connection leak in MysqlProto

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/ssl/SSLDecoder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/ssl/SSLDecoder.java
@@ -80,7 +80,9 @@ public class SSLDecoder {
                     appBuffer.flip();
                     return appBuffer;
                 case CLOSED:
-                    throw new IOException("SSL engine closed");
+                    netBuffer.compact();
+                    appBuffer.flip();
+                    return appBuffer;
                 default:
                     throw new IllegalStateException("Unexpected SSL status: " + result.getStatus());
             }


### PR DESCRIPTION
## Why I'm doing:

If tasks are still running when exiting, the connection will not be released promptly.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents connection leaks by deferring cleanup until pending requests finish and handling SSL CLOSED status gracefully.
> 
> - **MySQL protocol I/O**:
>   - Add `terminated` flag and `pendingTasks` tracking in `MySQLReadListener` to defer `ctx.cleanup()` until all scheduled request handlers finish.
>   - On client disconnect (`bytesRead == -1`), conditionally kill running query via `Config.mysql_service_kill_after_disconnect`; otherwise attempt deferred cleanup.
>   - Increment/decrement task counters around request execution; stop accepting queries and cleanup when context is killed or connection terminated.
> - **SSL decoding**:
>   - In `SSLDecoder.decode()`, treat `CLOSED` status by compacting/returning remaining plaintext instead of throwing, avoiding premature exceptions during shutdown.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4899cd5e60f9fbaa6ea86597f469d8aafabae251. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->