### PR TITLE
[BugFix] Forget to remove hash column before flush chunk of partitionwise spillable agg when skew elimination option is off

### DIFF
--- a/be/src/serde/encode_context.h
+++ b/be/src/serde/encode_context.h
@@ -43,7 +43,10 @@ public:
     // update encode_level for each column
     void update(const int col_id, uint64_t mem_bytes, uint64_t encode_byte);
 
-    int get_encode_level(const int col_id) { return _column_encode_level[col_id]; }
+    int get_encode_level(const int col_id) {
+        DCHECK(col_id < _column_encode_level.size()) << "Mismatch the number of columns and encode levels.";
+        return _column_encode_level[col_id];
+    }
 
     const std::vector<uint32_t>& get_encode_levels() const { return _column_encode_level; }
 


### PR DESCRIPTION
## Why I'm doing:
## What I'm doing:

Fixes #https://github.com/StarRocks/StarRocksTest/issues/10744

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure non-splittable skew partitions drop the spill hash column when skew elimination is disabled; add a bounds DCHECK in encode level accessor.
> 
> - **Spill/Partitioned writer** (`be/src/exec/spill/spill_components.cpp`):
>   - Handle empty `partitions` early in `_pick_and_compact_skew_partitions`.
>   - When skew elimination is disabled (`opt_aggregator_params` not set), for non-splittable partitions remove `Chunk::HASH_AGG_SPILL_HASH_SLOT_ID` from mem-table chunks before flush to reduce serde/flush cost.
> - **Serde** (`be/src/serde/encode_context.h`):
>   - Add bounds `DCHECK` in `EncodeContext::get_encode_level` to validate `col_id`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9dad7ac8ef2e042e98761da1d0e2b7444f9df7f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->