### PR TITLE
[Enhancement] support hll/bitmap/varbinary default value

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ColumnDefAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ColumnDefAnalyzer.java
@@ -161,16 +161,7 @@ public class ColumnDefAnalyzer {
             }
             // not set default value
         }
-        if (type.isHllType()) {
-            if (defaultValueDef.isSet) {
-                throw new AnalysisException(String.format("Invalid default value for '%s'", name));
-            }
-        }
-        if (type.isBitmapType()) {
-            if (defaultValueDef.isSet) {
-                throw new AnalysisException(String.format("Invalid default value for '%s'", name));
-            }
-        }
+
         if (aggregateType == AggregateType.REPLACE_IF_NOT_NULL) {
             // If aggregate type is REPLACE_IF_NOT_NULL, we set it nullable.
             // If default value is not set, we set it NULL
@@ -260,12 +251,17 @@ public class ColumnDefAnalyzer {
                     break;
                 case CHAR:
                 case VARCHAR:
-                case HLL:
                     if (defaultValue.length() > scalarType.getLength()) {
                         throw new AnalysisException("Default value is too long: " + defaultValue);
                     }
                     break;
+                case HLL:
                 case BITMAP:
+                    // HLL and BITMAP only support empty string "" as default value (creates empty object)
+                    if (!defaultValue.isEmpty()) {
+                        throw new AnalysisException(
+                                String.format("Type '%s' only supports empty string \"\" as default value", type));
+                    }
                     break;
                 default:
                     throw new AnalysisException(String.format("Cannot add default value for type '%s'", type));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ColumnDefAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ColumnDefAnalyzer.java
@@ -257,7 +257,9 @@ public class ColumnDefAnalyzer {
                     break;
                 case HLL:
                 case BITMAP:
-                    // HLL and BITMAP only support empty string "" as default value (creates empty object)
+                case VARBINARY:
+                    // HLL, BITMAP and VARBINARY only support empty string "" as default value
+                    // Empty string creates: empty HLL object, empty BITMAP object, or 0-byte binary data
                     if (!defaultValue.isEmpty()) {
                         throw new AnalysisException(
                                 String.format("Type '%s' only supports empty string \"\" as default value", type));

--- a/test/sql/test_default_value/R/test_hll_bitmap_default.sql
+++ b/test/sql/test_default_value/R/test_hll_bitmap_default.sql
@@ -1,0 +1,146 @@
+-- name: test_hll_bitmap_default
+DROP DATABASE IF EXISTS test_hll_bitmap_default;
+-- result:
+-- !result
+CREATE DATABASE test_hll_bitmap_default;
+-- result:
+-- !result
+USE test_hll_bitmap_default;
+-- result:
+-- !result
+CREATE TABLE test_bitmap_create (
+    id INT,
+    bm BITMAP BITMAP_UNION DEFAULT ""
+) AGGREGATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO test_bitmap_create (id) VALUES (1);
+-- result:
+-- !result
+INSERT INTO test_bitmap_create (id) VALUES (2);
+-- result:
+-- !result
+INSERT INTO test_bitmap_create VALUES (3, to_bitmap(100));
+-- result:
+-- !result
+SELECT id, bitmap_to_string(bm), bitmap_count(bm) FROM test_bitmap_create ORDER BY id;
+-- result:
+1		0
+2		0
+3	100	1
+-- !result
+CREATE TABLE test_hll_create (
+    id INT,
+    h HLL HLL_UNION DEFAULT ""
+) AGGREGATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO test_hll_create (id) VALUES (1);
+-- result:
+-- !result
+INSERT INTO test_hll_create (id) VALUES (2);
+-- result:
+-- !result
+INSERT INTO test_hll_create VALUES (3, hll_hash(100));
+-- result:
+-- !result
+SELECT id, hll_cardinality(h) FROM test_hll_create ORDER BY id;
+-- result:
+1	0
+2	0
+3	1
+-- !result
+CREATE TABLE test_bitmap_alter (
+    id INT,
+    name VARCHAR(50)
+) AGGREGATE KEY(id, name)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO test_bitmap_alter VALUES (1, 'alice'), (2, 'bob'), (3, 'charlie');
+-- result:
+-- !result
+ALTER TABLE test_bitmap_alter ADD COLUMN bm BITMAP BITMAP_UNION DEFAULT "";
+-- result:
+-- !result
+SELECT id, name, bitmap_to_string(bm), bitmap_count(bm) FROM test_bitmap_alter ORDER BY id;
+-- result:
+1	alice		0
+2	bob		0
+3	charlie		0
+-- !result
+CREATE TABLE test_hll_alter (
+    id INT,
+    name VARCHAR(50)
+) AGGREGATE KEY(id, name)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO test_hll_alter VALUES (1, 'alice'), (2, 'bob'), (3, 'charlie');
+-- result:
+-- !result
+ALTER TABLE test_hll_alter ADD COLUMN h HLL HLL_UNION DEFAULT "";
+-- result:
+-- !result
+SELECT id, name, hll_cardinality(h) FROM test_hll_alter ORDER BY id;
+-- result:
+1	alice	0
+2	bob	0
+3	charlie	0
+-- !result
+CREATE TABLE test_bitmap_nonempty (
+    id INT,
+    bm BITMAP BITMAP_UNION DEFAULT "test"
+) AGGREGATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Invalid default value for \'bm\': Type \'BITMAP\' only supports empty string "" as default value.')
+-- !result
+CREATE TABLE test_hll_nonempty (
+    id INT,
+    h HLL HLL_UNION DEFAULT "test"
+) AGGREGATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Invalid default value for \'h\': Type \'HLL\' only supports empty string "" as default value.')
+-- !result
+CREATE TABLE test_bitmap_with_default (
+    id INT,
+    name VARCHAR(50),
+    bm BITMAP BITMAP_UNION DEFAULT ""
+) AGGREGATE KEY(id, name)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE test_bitmap_without_default (
+    id INT,
+    name VARCHAR(50),
+    bm BITMAP BITMAP_UNION
+) AGGREGATE KEY(id, name)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO test_bitmap_with_default (id, name) VALUES (1, 'alice');
+-- result:
+-- !result
+INSERT INTO test_bitmap_without_default (id, name) VALUES (1, 'alice');
+-- result:
+-- !result
+SELECT 'with_default' as type, id, name, bitmap_count(bm) FROM test_bitmap_with_default
+UNION ALL
+SELECT 'without_default', id, name, bitmap_count(bm) FROM test_bitmap_without_default
+ORDER BY type, id;
+-- result:
+with_default	1	alice	0
+without_default	1	alice	0
+-- !result

--- a/test/sql/test_default_value/R/test_varbinary_default.sql
+++ b/test/sql/test_default_value/R/test_varbinary_default.sql
@@ -1,0 +1,259 @@
+-- name: test_varbinary_default
+DROP DATABASE if exists test_varbinary_default_db;
+-- result:
+-- !result
+CREATE DATABASE test_varbinary_default_db;
+-- result:
+-- !result
+USE test_varbinary_default_db;
+-- result:
+-- !result
+CREATE TABLE test_varbinary_create (
+    id INT NOT NULL,
+    name VARCHAR(50),
+    binary_col VARBINARY DEFAULT "",
+    binary_no_default VARBINARY
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO test_varbinary_create (id, name) VALUES (1, 'user1');
+-- result:
+-- !result
+INSERT INTO test_varbinary_create (id, name, binary_no_default) VALUES (2, 'user2', 'custom');
+-- result:
+-- !result
+INSERT INTO test_varbinary_create VALUES (3, 'user3', 'explicit', 'data');
+-- result:
+-- !result
+INSERT INTO test_varbinary_create VALUES (4, 'user4', '', NULL);
+-- result:
+-- !result
+SELECT 
+    id,
+    name,
+    binary_col,
+    binary_col IS NULL AS col_is_null,
+    HEX(binary_col),
+    LENGTH(binary_col) AS col_len,
+    binary_no_default,
+    binary_no_default IS NULL AS no_default_is_null,
+    LENGTH(binary_no_default) AS no_default_len,
+    HEX(binary_col) AS col_hex
+FROM test_varbinary_create
+ORDER BY id;
+-- result:
+1	user1		0		0	None	1	None	
+2	user2		0		0	custom	0	6	
+3	user3	explicit	0	6578706C69636974	8	data	0	4	6578706C69636974
+4	user4		0		0	None	1	None	
+-- !result
+CREATE TABLE test_varbinary_alter (
+    id INT NOT NULL,
+    name VARCHAR(50)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO test_varbinary_alter VALUES (1, 'alice'), (2, 'bob'), (3, 'charlie');
+-- result:
+-- !result
+ALTER TABLE test_varbinary_alter ADD COLUMN binary_col VARBINARY DEFAULT "";
+-- result:
+-- !result
+SELECT 
+    id,
+    name,
+    binary_col,
+    binary_col IS NULL AS is_null,
+    LENGTH(binary_col) AS len
+FROM test_varbinary_alter
+ORDER BY id;
+-- result:
+1	alice		0	0
+2	bob		0	0
+3	charlie		0	0
+-- !result
+INSERT INTO test_varbinary_alter VALUES (4, 'david', 'new_data');
+-- result:
+-- !result
+SELECT 
+    id,
+    name,
+    CAST(binary_col AS VARCHAR) AS binary_str,
+    LENGTH(binary_col) AS len
+FROM test_varbinary_alter
+ORDER BY id;
+-- result:
+1	alice		0
+2	bob		0
+3	charlie		0
+4	david	new_data	8
+-- !result
+CREATE TABLE test_varbinary_traditional (
+    id INT NOT NULL,
+    name VARCHAR(50)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "false");
+-- result:
+-- !result
+INSERT INTO test_varbinary_traditional VALUES (1, 'eve'), (2, 'frank');
+-- result:
+-- !result
+ALTER TABLE test_varbinary_traditional ADD COLUMN binary_col VARBINARY DEFAULT "";
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select count(*) from test_varbinary_traditional;
+-- result:
+2
+-- !result
+CREATE TABLE test_varbinary_primary (
+    order_id INT NOT NULL,
+    customer VARCHAR(50),
+    signature VARBINARY DEFAULT ""
+) PRIMARY KEY(order_id)
+DISTRIBUTED BY HASH(order_id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO test_varbinary_primary (order_id, customer) VALUES (1, 'customer1');
+-- result:
+-- !result
+INSERT INTO test_varbinary_primary VALUES (2, 'customer2', 'sign123');
+-- result:
+-- !result
+INSERT INTO test_varbinary_primary VALUES (3, 'customer3', '');
+-- result:
+-- !result
+SELECT 
+    order_id,
+    customer,
+    CAST(signature AS VARCHAR) AS sign_str,
+    LENGTH(signature) AS sign_len,
+    signature IS NULL AS is_null
+FROM test_varbinary_primary
+ORDER BY order_id;
+-- result:
+1	customer1		0	0
+2	customer2	sign123	7	0
+3	customer3		0	0
+-- !result
+CREATE TABLE test_varbinary_edge (
+    id INT NOT NULL,
+    binary_col VARBINARY DEFAULT ""
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO test_varbinary_edge (id) VALUES (1);
+-- result:
+-- !result
+INSERT INTO test_varbinary_edge VALUES (2, NULL);
+-- result:
+-- !result
+INSERT INTO test_varbinary_edge VALUES (3, '');
+-- result:
+-- !result
+SELECT 
+    id,
+    binary_col IS NULL AS is_null,
+    LENGTH(binary_col) AS len,
+    HEX(binary_col) AS hex,
+    CAST(binary_col AS VARCHAR) AS str
+FROM test_varbinary_edge
+ORDER BY id;
+-- result:
+1	0	0		
+2	1	None	None	None
+3	0	0		
+-- !result
+CREATE TABLE test_varbinary_invalid1 (
+    id INT,
+    binary_col VARBINARY DEFAULT "test"
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Invalid default value for \'binary_col\': Type \'VARBINARY\' only supports empty string "" as default value.')
+-- !result
+CREATE TABLE test_varbinary_invalid2 (
+    id INT,
+    binary_col VARBINARY DEFAULT x'CAFE'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+E: (1064, "Getting syntax error at line 3, column 33. Detail message: Unexpected input 'x'CAFE'', the most similar input is {'NULL', 'CURRENT_TIMESTAMP', SINGLE_QUOTED_TEXT, DOUBLE_QUOTED_TEXT, '('}.")
+-- !result
+CREATE TABLE test_varbinary_sized (
+    id INT NOT NULL,
+    small_binary VARBINARY(10) DEFAULT "",
+    large_binary VARBINARY(100) DEFAULT ""
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO test_varbinary_sized (id) VALUES (1);
+-- result:
+-- !result
+INSERT INTO test_varbinary_sized VALUES (2, 'short', 'this_is_longer');
+-- result:
+-- !result
+SELECT 
+    id,
+    CAST(small_binary AS VARCHAR) AS small_val,
+    LENGTH(small_binary) AS small_len,
+    CAST(large_binary AS VARCHAR) AS large_val,
+    LENGTH(large_binary) AS large_len
+FROM test_varbinary_sized
+ORDER BY id;
+-- result:
+1		0		0
+2	short	5	this_is_longer	14
+-- !result
+CREATE TABLE with_default (
+    id INT,
+    binary_col VARBINARY DEFAULT ""
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE without_default (
+    id INT,
+    binary_col VARBINARY
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO with_default (id) VALUES (1);
+-- result:
+-- !result
+INSERT INTO without_default (id) VALUES (1);
+-- result:
+-- !result
+SELECT 
+    'with_default' AS type,
+    binary_col IS NULL AS is_null,
+    LENGTH(binary_col) AS len
+FROM with_default
+UNION ALL
+SELECT 
+    'without_default',
+    binary_col IS NULL,
+    LENGTH(binary_col)
+FROM without_default;
+-- result:
+without_default	1	None
+with_default	0	0
+-- !result

--- a/test/sql/test_default_value/T/test_hll_bitmap_default.sql
+++ b/test/sql/test_default_value/T/test_hll_bitmap_default.sql
@@ -1,0 +1,133 @@
+-- name: test_hll_bitmap_default
+
+-- Test HLL and BITMAP default values after code change
+-- Default value "" creates empty object (same behavior as not specifying default)
+
+DROP DATABASE IF EXISTS test_hll_bitmap_default;
+CREATE DATABASE test_hll_bitmap_default;
+USE test_hll_bitmap_default;
+
+-- =====================================================
+-- Test 1: BITMAP with DEFAULT "" in CREATE TABLE
+-- =====================================================
+CREATE TABLE test_bitmap_create (
+    id INT,
+    bm BITMAP BITMAP_UNION DEFAULT ""
+) AGGREGATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- Insert only id (should use default)
+INSERT INTO test_bitmap_create (id) VALUES (1);
+INSERT INTO test_bitmap_create (id) VALUES (2);
+
+-- Insert with explicit bitmap
+INSERT INTO test_bitmap_create VALUES (3, to_bitmap(100));
+
+SELECT id, bitmap_to_string(bm), bitmap_count(bm) FROM test_bitmap_create ORDER BY id;
+
+
+-- =====================================================
+-- Test 2: HLL with DEFAULT "" in CREATE TABLE  
+-- =====================================================
+CREATE TABLE test_hll_create (
+    id INT,
+    h HLL HLL_UNION DEFAULT ""
+) AGGREGATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- Insert only id (should use default)
+INSERT INTO test_hll_create (id) VALUES (1);
+INSERT INTO test_hll_create (id) VALUES (2);
+
+-- Insert with explicit hll
+INSERT INTO test_hll_create VALUES (3, hll_hash(100));
+
+SELECT id, hll_cardinality(h) FROM test_hll_create ORDER BY id;
+
+
+-- =====================================================
+-- Test 3: ALTER TABLE ADD COLUMN with BITMAP DEFAULT
+-- =====================================================
+CREATE TABLE test_bitmap_alter (
+    id INT,
+    name VARCHAR(50)
+) AGGREGATE KEY(id, name)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO test_bitmap_alter VALUES (1, 'alice'), (2, 'bob'), (3, 'charlie');
+
+-- Add BITMAP column with default (Fast Schema Evolution)
+ALTER TABLE test_bitmap_alter ADD COLUMN bm BITMAP BITMAP_UNION DEFAULT "";
+
+-- Read old data with new column
+SELECT id, name, bitmap_to_string(bm), bitmap_count(bm) FROM test_bitmap_alter ORDER BY id;
+
+
+-- =====================================================
+-- Test 4: ALTER TABLE ADD COLUMN with HLL DEFAULT
+-- =====================================================
+CREATE TABLE test_hll_alter (
+    id INT,
+    name VARCHAR(50)
+) AGGREGATE KEY(id, name)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO test_hll_alter VALUES (1, 'alice'), (2, 'bob'), (3, 'charlie');
+
+-- Add HLL column with default (Fast Schema Evolution)
+ALTER TABLE test_hll_alter ADD COLUMN h HLL HLL_UNION DEFAULT "";
+
+-- Read old data with new column
+SELECT id, name, hll_cardinality(h) FROM test_hll_alter ORDER BY id;
+
+
+-- =====================================================
+-- Test 5: Verify non-empty default value is rejected
+-- =====================================================
+-- This should fail (only empty string "" is allowed)
+CREATE TABLE test_bitmap_nonempty (
+    id INT,
+    bm BITMAP BITMAP_UNION DEFAULT "test"
+) AGGREGATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- This should also fail
+CREATE TABLE test_hll_nonempty (
+    id INT,
+    h HLL HLL_UNION DEFAULT "test"
+) AGGREGATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- =====================================================
+-- Test 6: Compare behavior with and without DEFAULT
+-- =====================================================
+CREATE TABLE test_bitmap_with_default (
+    id INT,
+    name VARCHAR(50),
+    bm BITMAP BITMAP_UNION DEFAULT ""
+) AGGREGATE KEY(id, name)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+CREATE TABLE test_bitmap_without_default (
+    id INT,
+    name VARCHAR(50),
+    bm BITMAP BITMAP_UNION
+) AGGREGATE KEY(id, name)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- Both should behave the same when inserting partial columns
+INSERT INTO test_bitmap_with_default (id, name) VALUES (1, 'alice');
+INSERT INTO test_bitmap_without_default (id, name) VALUES (1, 'alice');
+
+SELECT 'with_default' as type, id, name, bitmap_count(bm) FROM test_bitmap_with_default
+UNION ALL
+SELECT 'without_default', id, name, bitmap_count(bm) FROM test_bitmap_without_default
+ORDER BY type, id;

--- a/test/sql/test_default_value/T/test_varbinary_default.sql
+++ b/test/sql/test_default_value/T/test_varbinary_default.sql
@@ -1,0 +1,234 @@
+-- name: test_varbinary_default
+-- Test VARBINARY type default value support (only empty string "" is allowed)
+-- Similar to HLL and BITMAP, VARBINARY only supports DEFAULT ""
+
+DROP DATABASE if exists test_varbinary_default_db;
+CREATE DATABASE test_varbinary_default_db;
+USE test_varbinary_default_db;
+
+-- =====================================================
+-- Test 1: CREATE TABLE with VARBINARY DEFAULT "" (DUPLICATE KEY)
+-- =====================================================
+CREATE TABLE test_varbinary_create (
+    id INT NOT NULL,
+    name VARCHAR(50),
+    binary_col VARBINARY DEFAULT "",
+    binary_no_default VARBINARY
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- Insert only id and name (binary_col uses default, binary_no_default is NULL)
+INSERT INTO test_varbinary_create (id, name) VALUES (1, 'user1');
+
+-- Insert id, name, and binary_no_default (binary_col uses default)
+INSERT INTO test_varbinary_create (id, name, binary_no_default) VALUES (2, 'user2', 'custom');
+
+-- Insert all columns explicitly
+INSERT INTO test_varbinary_create VALUES (3, 'user3', 'explicit', 'data');
+
+-- Insert with empty string and NULL
+INSERT INTO test_varbinary_create VALUES (4, 'user4', '', NULL);
+
+SELECT 
+    id,
+    name,
+    binary_col,
+    binary_col IS NULL AS col_is_null,
+    HEX(binary_col),
+    LENGTH(binary_col) AS col_len,
+    binary_no_default,
+    binary_no_default IS NULL AS no_default_is_null,
+    LENGTH(binary_no_default) AS no_default_len,
+    HEX(binary_col) AS col_hex
+FROM test_varbinary_create
+ORDER BY id;
+
+-- =====================================================
+-- Test 2: Fast Schema Evolution (ALTER TABLE ADD COLUMN)
+-- =====================================================
+CREATE TABLE test_varbinary_alter (
+    id INT NOT NULL,
+    name VARCHAR(50)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+-- Insert initial data
+INSERT INTO test_varbinary_alter VALUES (1, 'alice'), (2, 'bob'), (3, 'charlie');
+
+-- Add VARBINARY column with empty default (Fast Schema Evolution)
+ALTER TABLE test_varbinary_alter ADD COLUMN binary_col VARBINARY DEFAULT "";
+
+-- Read old data with new column (should use default)
+SELECT 
+    id,
+    name,
+    binary_col,
+    binary_col IS NULL AS is_null,
+    LENGTH(binary_col) AS len
+FROM test_varbinary_alter
+ORDER BY id;
+
+-- Insert new data
+INSERT INTO test_varbinary_alter VALUES (4, 'david', 'new_data');
+
+SELECT 
+    id,
+    name,
+    CAST(binary_col AS VARCHAR) AS binary_str,
+    LENGTH(binary_col) AS len
+FROM test_varbinary_alter
+ORDER BY id;
+
+-- =====================================================
+-- Test 3: Traditional Schema Change (fast_schema_evolution = false)
+-- =====================================================
+CREATE TABLE test_varbinary_traditional (
+    id INT NOT NULL,
+    name VARCHAR(50)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "false");
+
+INSERT INTO test_varbinary_traditional VALUES (1, 'eve'), (2, 'frank');
+
+-- Add VARBINARY column (traditional schema change)
+ALTER TABLE test_varbinary_traditional ADD COLUMN binary_col VARBINARY DEFAULT "";
+
+function: wait_alter_table_finish()
+
+select count(*) from test_varbinary_traditional;
+
+-- =====================================================
+-- Test 4: PRIMARY KEY table with VARBINARY DEFAULT
+-- =====================================================
+CREATE TABLE test_varbinary_primary (
+    order_id INT NOT NULL,
+    customer VARCHAR(50),
+    signature VARBINARY DEFAULT ""
+) PRIMARY KEY(order_id)
+DISTRIBUTED BY HASH(order_id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- Partial column insert (testing default value usage)
+INSERT INTO test_varbinary_primary (order_id, customer) VALUES (1, 'customer1');
+
+-- Full insert
+INSERT INTO test_varbinary_primary VALUES (2, 'customer2', 'sign123');
+INSERT INTO test_varbinary_primary VALUES (3, 'customer3', '');
+
+SELECT 
+    order_id,
+    customer,
+    CAST(signature AS VARCHAR) AS sign_str,
+    LENGTH(signature) AS sign_len,
+    signature IS NULL AS is_null
+FROM test_varbinary_primary
+ORDER BY order_id;
+
+-- =====================================================
+-- Test 5: Edge Cases
+-- =====================================================
+CREATE TABLE test_varbinary_edge (
+    id INT NOT NULL,
+    binary_col VARBINARY DEFAULT ""
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- Case 1: Omit column (use default)
+INSERT INTO test_varbinary_edge (id) VALUES (1);
+
+-- Case 2: Explicit NULL
+INSERT INTO test_varbinary_edge VALUES (2, NULL);
+
+-- Case 3: Empty string
+INSERT INTO test_varbinary_edge VALUES (3, '');
+
+
+SELECT 
+    id,
+    binary_col IS NULL AS is_null,
+    LENGTH(binary_col) AS len,
+    HEX(binary_col) AS hex,
+    CAST(binary_col AS VARCHAR) AS str
+FROM test_varbinary_edge
+ORDER BY id;
+
+-- =====================================================
+-- Test 6: Verify non-empty default is rejected
+-- =====================================================
+-- This should fail: non-empty string
+CREATE TABLE test_varbinary_invalid1 (
+    id INT,
+    binary_col VARBINARY DEFAULT "test"
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- This should fail: hex literal
+CREATE TABLE test_varbinary_invalid2 (
+    id INT,
+    binary_col VARBINARY DEFAULT x'CAFE'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- =====================================================
+-- Test 7: VARBINARY with size constraints
+-- =====================================================
+CREATE TABLE test_varbinary_sized (
+    id INT NOT NULL,
+    small_binary VARBINARY(10) DEFAULT "",
+    large_binary VARBINARY(100) DEFAULT ""
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO test_varbinary_sized (id) VALUES (1);
+
+INSERT INTO test_varbinary_sized VALUES (2, 'short', 'this_is_longer');
+
+SELECT 
+    id,
+    CAST(small_binary AS VARCHAR) AS small_val,
+    LENGTH(small_binary) AS small_len,
+    CAST(large_binary AS VARCHAR) AS large_val,
+    LENGTH(large_binary) AS large_len
+FROM test_varbinary_sized
+ORDER BY id;
+
+-- =====================================================
+-- Test 8: Compare with and without DEFAULT
+-- =====================================================
+CREATE TABLE with_default (
+    id INT,
+    binary_col VARBINARY DEFAULT ""
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+CREATE TABLE without_default (
+    id INT,
+    binary_col VARBINARY
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- Both omit binary_col
+INSERT INTO with_default (id) VALUES (1);
+INSERT INTO without_default (id) VALUES (1);
+
+SELECT 
+    'with_default' AS type,
+    binary_col IS NULL AS is_null,
+    LENGTH(binary_col) AS len
+FROM with_default
+UNION ALL
+SELECT 
+    'without_default',
+    binary_col IS NULL,
+    LENGTH(binary_col)
+FROM without_default;
+


### PR DESCRIPTION
## Why I'm doing:

Previously, HLL, BITMAP, and VARBINARY types did not support default values at all. When creating or altering tables, specifying `DEFAULT` for these columns would result in an error: "Invalid default value for 'column_name'". 

However, when inserting partial columns (omitting these columns), the system automatically fills them with empty objects (bitmap_count=0, hll_cardinality=0) or NULL (for VARBINARY). This limitation prevented users from explicitly defining this natural behavior in the schema, making it inconsistent with other data types like VARCHAR.

## What I'm doing:

1. **Enable HLL, BITMAP, and VARBINARY default value support**: Allow these types to specify default values using empty string `""`, which creates empty objects/data consistent with the system's natural behavior.



Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables `DEFAULT ""` for `HLL`, `BITMAP`, and `VARBINARY` types with strict validation and adds comprehensive SQL tests for create/alter and error cases.
> 
> - **Analyzer (backend)**:
>   - Update `ColumnDefAnalyzer.validateDefaultValue` to permit only empty string `""` as default for `HLL`, `BITMAP`, and `VARBINARY` (creates empty objects/0-byte data).
>   - Remove previous blanket rejection of defaults for `HLL`/`BITMAP` and centralize checks in the type switch.
> - **Tests**:
>   - Add `test_sql/test_default_value/T|R/test_hll_bitmap_default.sql` covering create/alter with `DEFAULT ""`, behavior parity without defaults, and rejection of non-empty defaults.
>   - Add `test_sql/test_default_value/T|R/test_varbinary_default.sql` covering `VARBINARY` with `DEFAULT ""`, schema evolution (fast/traditional), primary key tables, edge cases (NULL/empty), size variants, and rejection of invalid defaults.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dcc2d56bfa249d9c431cfafb364f9b6e2d3dbf54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->