### PR TITLE
[Enhancement] Enable additional optimizations in ETL execution mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -2331,7 +2331,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             setEnableSpill(true);
             setEnableQueryQueue(Config.enable_query_queue_v2);
         } else {
-            setEnableWaitDependentEvent(sv.enablePhasedScheduler);
+            setEnableWaitDependentEvent(sv.enableWaitDependentEvent);
             setEnablePhasedScheduler(sv.enablePhasedScheduler);
             setEnableSpill(sv.enableSpill);
             setEnableQueryQueue(sv.enableQueryQueue);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -45,6 +45,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.ToNumberPolicy;
 import com.starrocks.catalog.InternalCatalog;
+import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeConstants;
@@ -2323,12 +2324,17 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     }
 
     public void setExecMode(String execMode) {
+        final SessionVariable sv = DEFAULT_SESSION_VARIABLE;
         if (execMode.equalsIgnoreCase(SessionVariableConstants.ETL)) {
+            setEnableWaitDependentEvent(true);
             setEnablePhasedScheduler(true);
             setEnableSpill(true);
+            setEnableQueryQueue(Config.enable_query_queue_v2);
         } else {
-            setEnablePhasedScheduler(false);
-            setEnableSpill(false);
+            setEnableWaitDependentEvent(sv.enablePhasedScheduler);
+            setEnablePhasedScheduler(sv.enablePhasedScheduler);
+            setEnableSpill(sv.enableSpill);
+            setEnableQueryQueue(sv.enableQueryQueue);
         }
         this.execMode = execMode;
     }
@@ -2347,6 +2353,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableParallelMerge(boolean enableParallelMerge) {
         this.enableParallelMerge = enableParallelMerge;
+    }
+
+    public void setEnableQueryQueue(boolean enableQueryQueue) {
+        this.enableQueryQueue = enableQueryQueue;
     }
 
     public boolean isEnableQueryQueue() {
@@ -3078,6 +3088,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setPhasedSchedulerMaxConcurrency(int phasedSchedulerMaxConcurrency) {
         this.phasedSchedulerMaxConcurrency = phasedSchedulerMaxConcurrency;
+    }
+
+    public boolean enableWaitDependentEvent() {
+        return enableWaitDependentEvent;
+    }
+
+    public void setEnableWaitDependentEvent(boolean enableWaitDependentEvent) {
+        this.enableWaitDependentEvent = enableWaitDependentEvent;
     }
 
     public boolean enablePhasedScheduler() {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> ETL `exec_mode` now also enables wait-dependent events and query queue (via config) and non-ETL resets related flags to session defaults; adds accessors for `enable_wait_dependent_event` and a setter for `enable_query_queue`.
> 
> - **Session execution mode (`SessionVariable#setExecMode`)**:
>   - ETL mode additionally enables `enable_wait_dependent_event` and `enable_query_queue` (using `Config.enable_query_queue_v2`).
>   - Non-ETL mode resets `enable_wait_dependent_event`, `enable_phased_scheduler`, `enable_spill`, and `enable_query_queue` to `DEFAULT_SESSION_VARIABLE` values instead of hardcoded disables.
> - **APIs**:
>   - Add `setEnableQueryQueue(boolean)`.
>   - Add getters/setters for `enable_wait_dependent_event`.
> - **Misc**:
>   - Import `com.starrocks.common.Config`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b30c22ee21f752d92e0c78349e6ea00e29693efa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->