### PR TITLE
[Enhancement] Support simple agg (count) push down for Paimon Table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -793,6 +793,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_REWRITE_SUM_BY_ASSOCIATIVE_RULE = "enable_rewrite_sum_by_associative_rule";
     public static final String ENABLE_REWRITE_SIMPLE_AGG_TO_META_SCAN = "enable_rewrite_simple_agg_to_meta_scan";
     public static final String ENABLE_REWRITE_SIMPLE_AGG_TO_HDFS_SCAN = "enable_rewrite_simple_agg_to_hdfs_scan";
+    public static final String ENABLE_REWRITE_SIMPLE_AGG_TO_PAIMON_META_SCAN = "enable_rewrite_simple_agg_to_paimon_meta_scan";
     public static final String ENABLE_REWRITE_PARTITION_COLUMN_MINMAX = "enable_rewrite_partition_column_minmax";
     public static final String ENABLE_MIN_MAX_OPTIMIZATION = "enable_min_max_optimization";
     public static final String ENABLE_PRUNE_COMPLEX_TYPES = "enable_prune_complex_types";
@@ -1954,6 +1955,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_REWRITE_SIMPLE_AGG_TO_HDFS_SCAN)
     private boolean enableRewriteSimpleAggToHdfsScan = true;
+
+    @VarAttr(name = ENABLE_REWRITE_SIMPLE_AGG_TO_PAIMON_META_SCAN)
+    private boolean enableRewriteSimpleAggToPaimonMetaScan = true;
 
     @VarAttr(name = ENABLE_EVALUATE_SCHEMA_SCAN_RULE)
     private boolean enableEvaluateSchemaScanRule = true;
@@ -4975,6 +4979,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableRewriteSimpleAggToHdfsScan() {
         return this.enableRewriteSimpleAggToHdfsScan;
+    }
+
+    public void setEnableRewriteSimpleAggToPaimonMetaScan(boolean v) {
+        this.enableRewriteSimpleAggToPaimonMetaScan = v;
+    }
+
+    public boolean isEnableRewriteSimpleAggToPaimonMetaScan() {
+        return this.enableRewriteSimpleAggToPaimonMetaScan;
     }
 
     public boolean isEnableEvaluateSchemaScanRule() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryOptimizer.java
@@ -83,6 +83,7 @@ import com.starrocks.sql.optimizer.rule.transformation.RewriteGroupingSetsByCTER
 import com.starrocks.sql.optimizer.rule.transformation.RewriteMinMaxByMonotonicFunctionRule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteMultiDistinctRule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteSimpleAggToHDFSScanRule;
+import com.starrocks.sql.optimizer.rule.transformation.RewriteSimpleAggToLogicalValuesRule;
 import com.starrocks.sql.optimizer.rule.transformation.RewriteUnnestBitmapRule;
 import com.starrocks.sql.optimizer.rule.transformation.SchemaTableEvaluateRule;
 import com.starrocks.sql.optimizer.rule.transformation.SeparateProjectRule;
@@ -703,6 +704,7 @@ public class QueryOptimizer extends Optimizer {
         scheduler.rewriteOnce(tree, rootTaskContext, RuleSet.META_SCAN_REWRITE_RULES);
         scheduler.rewriteIterative(tree, rootTaskContext, new MergeTwoProjectRule());
         scheduler.rewriteOnce(tree, rootTaskContext, new PartitionColumnValueOnlyOnScanRule());
+        scheduler.rewriteOnce(tree, rootTaskContext, RewriteSimpleAggToLogicalValuesRule.PAIMON_SCAN);
         // before MergeProjectWithChildRule, after INLINE_CTE and MergeApplyWithTableFunction
         scheduler.rewriteIterative(tree, rootTaskContext, RewriteUnnestBitmapRule.getInstance());
         // After this rule, we shouldn't generate logical project operator
@@ -725,6 +727,7 @@ public class QueryOptimizer extends Optimizer {
         scheduler.rewriteOnce(tree, rootTaskContext, JsonPathRewriteRule.createForOlapScan());
         scheduler.rewriteIterative(tree, rootTaskContext, new RewriteMinMaxByMonotonicFunctionRule());
         scheduler.rewriteOnce(tree, rootTaskContext, RewriteSimpleAggToHDFSScanRule.SCAN_NO_PROJECT);
+        scheduler.rewriteOnce(tree, rootTaskContext, RewriteSimpleAggToLogicalValuesRule.PAIMON_SCAN_NO_PROJECT);
         // NOTE: This rule should be after MV Rewrite because MV Rewrite cannot handle
         // select count(distinct c) from t group by a, b
         // if this rule has applied before MV.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToLogicalValuesRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToLogicalValuesRule.java
@@ -1,0 +1,237 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.AggregateFunction;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.tvr.TvrTableSnapshot;
+import com.starrocks.common.tvr.TvrVersionRange;
+import com.starrocks.connector.GetRemoteFilesParams;
+import com.starrocks.connector.RemoteFileDesc;
+import com.starrocks.connector.RemoteFileInfo;
+import com.starrocks.connector.paimon.PaimonRemoteFileDesc;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalValuesOperator;
+import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rule.RuleType;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.Split;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+public class RewriteSimpleAggToLogicalValuesRule extends TransformationRule {
+    private static final Logger LOG = LogManager.getLogger(RewriteSimpleAggToLogicalValuesRule.class);
+
+
+    public static final RewriteSimpleAggToLogicalValuesRule PAIMON_SCAN_NO_PROJECT =
+            new RewriteSimpleAggToLogicalValuesRule(OperatorType.LOGICAL_PAIMON_SCAN, false);
+
+    public static final RewriteSimpleAggToLogicalValuesRule PAIMON_SCAN =
+            new RewriteSimpleAggToLogicalValuesRule(OperatorType.LOGICAL_PAIMON_SCAN);
+
+    final OperatorType scanOperatorType;
+    final boolean hasProjectOperator;
+
+    private RewriteSimpleAggToLogicalValuesRule(OperatorType logicalOperatorType, boolean /* unused */ noProject) {
+        super(RuleType.TF_REWRITE_SIMPLE_AGG, Pattern.create(OperatorType.LOGICAL_AGGR)
+                .addChildren(Pattern.create(logicalOperatorType)));
+        hasProjectOperator = false;
+        scanOperatorType = logicalOperatorType;
+    }
+
+    private RewriteSimpleAggToLogicalValuesRule(OperatorType logicalOperatorType) {
+        super(RuleType.TF_REWRITE_SIMPLE_AGG, Pattern.create(OperatorType.LOGICAL_AGGR)
+                .addChildren(Pattern.create(OperatorType.LOGICAL_PROJECT, logicalOperatorType)));
+        hasProjectOperator = true;
+        scanOperatorType = logicalOperatorType;
+    }
+
+    private LogicalScanOperator getScanOperator(final OptExpression input) {
+        LogicalScanOperator scanOperator;
+        if (hasProjectOperator) {
+            scanOperator = (LogicalScanOperator) input.getInputs().get(0).getInputs().get(0).getOp();
+        } else {
+            scanOperator = (LogicalScanOperator) input.getInputs().get(0).getOp();
+        }
+        return scanOperator;
+    }
+
+    @Override
+    public boolean check(final OptExpression input, OptimizerContext context) {
+        if (!context.getSessionVariable().isEnableRewriteSimpleAggToPaimonMetaScan()) {
+            return false;
+        }
+        LogicalAggregationOperator aggregationOperator = (LogicalAggregationOperator) input.getOp();
+        LogicalScanOperator scanOperator = getScanOperator(input);
+
+        // no limit
+        if (scanOperator.getLimit() != -1) {
+            return false;
+        }
+
+        // filter only involved with partition keys.
+        if (scanOperator.getPredicate() != null) {
+            if (!new HashSet<>(scanOperator.getTable().getPartitionColumnNames())
+                    .containsAll(scanOperator.getPredicate().getColumnRefs().stream().map(ColumnRefOperator::getName).toList())) {
+                return false;
+            }
+        }
+        // no group by keys on agg operator
+        List<ColumnRefOperator> groupingKeys = aggregationOperator.getGroupingKeys();
+        if (groupingKeys != null && !groupingKeys.isEmpty()) {
+            return false;
+        }
+
+        // no predicate on agg operator
+        if (aggregationOperator.getPredicate() != null) {
+            return false;
+        }
+
+        // not applicable if there is no aggregation functions, like `distinct x`.
+        if (aggregationOperator.getAggregations().isEmpty()) {
+            return false;
+        }
+
+        return aggregationOperator.getAggregations().values().stream().allMatch(
+                aggregator -> {
+                    AggregateFunction aggregateFunction = (AggregateFunction) aggregator.getFunction();
+                    String functionName = aggregateFunction.functionName();
+                    ColumnRefSet usedColumns = aggregator.getUsedColumns();
+
+                    if (functionName.equals(FunctionSet.COUNT) && !aggregator.isDistinct() && usedColumns.isEmpty()) {
+                        List<ScalarOperator> arguments = aggregator.getArguments();
+                        // count(non-null constant)
+                        if (arguments.isEmpty()) {
+                            // count()/count(*)
+                            return true;
+                        } else {
+                            return arguments.size() == 1 && !arguments.get(0).isConstantNull();
+                        }
+                    }
+                    return false;
+                }
+        );
+
+    }
+
+    private long calculateCount(LogicalScanOperator scanOperator) {
+        long count = 0;
+        Table table = scanOperator.getTable();
+        List<String> fieldNames = scanOperator.getColRefToColumnMetaMap().keySet().stream()
+                .map(ColumnRefOperator::getName)
+                .toList();
+        TvrVersionRange tvrVersionRange = scanOperator.getTvrVersionRange();
+        if (tvrVersionRange == null) {
+            tvrVersionRange = TvrTableSnapshot.empty();
+        }
+        GetRemoteFilesParams params = GetRemoteFilesParams.newBuilder()
+                .setPredicate(scanOperator.getPredicate())
+                .setFieldNames(fieldNames)
+                .setTableVersionRange(tvrVersionRange)
+                .setLimit(-1)
+                .build();
+        List<RemoteFileInfo> fileInfos = GlobalStateMgr.getCurrentState().getMetadataMgr().getRemoteFiles(
+                table, params);
+
+        if (fileInfos.isEmpty()) {
+            return -1;
+        }
+
+        if (scanOperatorType == OperatorType.LOGICAL_PAIMON_SCAN) {
+            // Process all RemoteFileInfo entries to handle multiple files
+            boolean hasValidFileInfo = false;
+            boolean hasValidSplit = false;
+            for (RemoteFileInfo fileInfo : fileInfos) {
+                if (fileInfo.getFiles() == null || fileInfo.getFiles().isEmpty()) {
+                    continue;
+                }
+                hasValidFileInfo = true;
+                for (RemoteFileDesc file : fileInfo.getFiles()) {
+                    if (!(file instanceof PaimonRemoteFileDesc remoteFileDesc)) {
+                        LOG.warn("Unexpected file type in PaimonRemoteFileDesc: {}", file.getClass().getName());
+                        return -1;
+                    }
+                    List<Split> splits = remoteFileDesc.getPaimonSplitsInfo().getPaimonSplits();
+                    if (splits.isEmpty()) {
+                        continue;
+                    }
+                    for (Split split : splits) {
+                        if (!(split instanceof DataSplit dataSplit)) {
+                            LOG.warn("Non-DataSplit found in Paimon splits, cannot calculate count");
+                            return -1;
+                        }
+                        if (!dataSplit.mergedRowCountAvailable()) {
+                            LOG.debug("DataSplit mergedRowCount not available, cannot calculate count");
+                            return -1;
+                        }
+                        hasValidSplit = true;
+                        count += dataSplit.mergedRowCount();
+                    }
+                }
+            }
+            // If no valid fileInfo was processed or no valid split was found, return -1 to indicate count cannot be calculated
+            if (!hasValidFileInfo || !hasValidSplit) {
+                return -1;
+            }
+            return count;
+        } else {
+            throw new UnsupportedOperationException("RewriteSimpleAggToLogicalValuesRule only supports Paimon Table");
+        }
+    }
+
+    @Override
+    public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
+        LogicalAggregationOperator aggregationOperator = (LogicalAggregationOperator) input.getOp();
+        LogicalScanOperator scanOperator = getScanOperator(input);
+        long count = calculateCount(scanOperator);
+
+        if (count == -1) {
+            // Unable to calculate count through metadata, continue with scan operator
+            LOG.debug("Unable to calculate count through metadata for table {}, continue with scan operator",
+                    scanOperator.getTable().getName());
+            return Lists.newArrayList(input);
+        }
+
+        LOG.debug("Rewrite simple agg to logical values for table {}, calculated count: {}",
+                scanOperator.getTable().getName(), count);
+
+        List<ColumnRefOperator> columns = new ArrayList<>(aggregationOperator.getAggregations().keySet());
+        // Create a value for each aggregation column, all with the same count value
+        List<ScalarOperator> valueRow = new ArrayList<>();
+        for (int i = 0; i < columns.size(); i++) {
+            valueRow.add(ConstantOperator.createBigint(count));
+        }
+        LogicalValuesOperator logicalValuesOperator = new LogicalValuesOperator.Builder()
+                .setRows(List.of(valueRow))
+                .setColumnRefSet(columns)
+                .build();
+        return Lists.newArrayList(OptExpression.create(logicalValuesOperator));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Push down simple agg (count) to meta level for Paimon table

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces metadata-based optimization for simple aggregates on Paimon tables to bypass data scans.
> 
> - Adds `RewriteSimpleAggToLogicalValuesRule` to convert simple global `COUNT` over `LOGICAL_PAIMON_SCAN` to `LogicalValues` using Paimon split row counts; supports with/without `Project`
> - Wires the rule into `QueryOptimizer` in both META-SCAN phases (with and without Project)
> - New session variable `enable_rewrite_simple_agg_to_paimon_meta_scan` (default: true) with getters/setters in `SessionVariable`
> - Extends `PaimonMetadataTest` with comprehensive cases covering enable flag, predicates, grouping/HAVING, distinct, constant NULL, empty/invalid file infos, split availability, and version range handling; minor assertion cleanups
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7a6f53877fabd1a8e3fd1be8859c7e802eb63a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->