### PR TITLE
[BugFix] Add configurable option for HDFS FileSystem cache to fix excessive FileSystem instance creation

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1076,6 +1076,15 @@ CONF_Int32(hdfs_client_hedged_read_threadpool_size, "128");
 // dfs.client.hedged.read.threshold.millis
 CONF_Int32(hdfs_client_hedged_read_threshold_millis, "2500");
 CONF_Int32(hdfs_client_max_cache_size, "64");
+// If true, force create new Hadoop FileSystem instance for each connection,
+// bypassing Hadoop internal FileSystem cache. This prevents "FileSystem closed" errors
+// but may cause performance issues for heavy clients (e.g., Curvine) that create
+// many threads per FileSystem instance.
+// If false, Hadoop's internal FileSystem cache will be used, which is more efficient
+// but may cause "FileSystem closed" errors if the cache entry is evicted while in use.
+// Note: When set to false, FileSystem instances are managed by Hadoop's cache and
+// will not be disconnected when HdfsFsClient is destroyed.
+CONF_Bool(hdfs_client_force_new_instance, "true");
 CONF_Int32(hdfs_client_io_read_retry, "0");
 
 // Enable output trace logs in aws-sdk-cpp for diagnosis purpose.

--- a/be/test/fs/hdfs_fs_cache_test.cpp
+++ b/be/test/fs/hdfs_fs_cache_test.cpp
@@ -1,0 +1,138 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "fs/hdfs/hdfs_fs_cache.h"
+
+#include <gtest/gtest.h>
+
+#include "common/config.h"
+#include "gen_cpp/Types_types.h"
+
+namespace starrocks {
+
+class HdfsFsCacheTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        // Save original config value
+        _original_force_new_instance = config::hdfs_client_force_new_instance;
+    }
+
+    void TearDown() override {
+        // Restore original config value
+        config::hdfs_client_force_new_instance = _original_force_new_instance;
+    }
+
+    bool _original_force_new_instance;
+};
+
+// Test should_force_new_hdfs_instance with nullptr properties
+TEST_F(HdfsFsCacheTest, ShouldForceNewInstanceWithNullProperties) {
+    // When properties is nullptr, should use global config
+    config::hdfs_client_force_new_instance = true;
+    EXPECT_TRUE(should_force_new_hdfs_instance(nullptr));
+
+    config::hdfs_client_force_new_instance = false;
+    EXPECT_FALSE(should_force_new_hdfs_instance(nullptr));
+}
+
+// Test should_force_new_hdfs_instance with properties but disable_cache not set
+TEST_F(HdfsFsCacheTest, ShouldForceNewInstanceWithPropertiesNoDisableCache) {
+    THdfsProperties properties;
+    // disable_cache is not set (__isset.disable_cache = false)
+
+    config::hdfs_client_force_new_instance = true;
+    EXPECT_TRUE(should_force_new_hdfs_instance(&properties));
+
+    config::hdfs_client_force_new_instance = false;
+    EXPECT_FALSE(should_force_new_hdfs_instance(&properties));
+}
+
+// Test should_force_new_hdfs_instance with disable_cache=true overriding global config
+TEST_F(HdfsFsCacheTest, ShouldForceNewInstanceDisableCacheTrueOverride) {
+    THdfsProperties properties;
+    properties.__isset.disable_cache = true;
+    properties.disable_cache = true;
+
+    // disable_cache=true should override global config=false
+    config::hdfs_client_force_new_instance = false;
+    EXPECT_TRUE(should_force_new_hdfs_instance(&properties));
+
+    // disable_cache=true should be consistent with global config=true
+    config::hdfs_client_force_new_instance = true;
+    EXPECT_TRUE(should_force_new_hdfs_instance(&properties));
+}
+
+// Test should_force_new_hdfs_instance with disable_cache=false overriding global config
+TEST_F(HdfsFsCacheTest, ShouldForceNewInstanceDisableCacheFalseOverride) {
+    THdfsProperties properties;
+    properties.__isset.disable_cache = true;
+    properties.disable_cache = false;
+
+    // disable_cache=false should override global config=true
+    config::hdfs_client_force_new_instance = true;
+    EXPECT_FALSE(should_force_new_hdfs_instance(&properties));
+
+    // disable_cache=false should be consistent with global config=false
+    config::hdfs_client_force_new_instance = false;
+    EXPECT_FALSE(should_force_new_hdfs_instance(&properties));
+}
+
+// Test HdfsFsClient ownership flag default value
+TEST_F(HdfsFsCacheTest, HdfsFsClientOwnershipDefault) {
+    HdfsFsClient client;
+    // Default should be true (owns the hdfs_fs)
+    EXPECT_TRUE(client._owns_hdfs_fs);
+}
+
+// Test HdfsFsClient ownership flag can be set
+TEST_F(HdfsFsCacheTest, HdfsFsClientOwnershipCanBeSet) {
+    HdfsFsClient client;
+    client._owns_hdfs_fs = false;
+    EXPECT_FALSE(client._owns_hdfs_fs);
+
+    client._owns_hdfs_fs = true;
+    EXPECT_TRUE(client._owns_hdfs_fs);
+}
+
+// Test HdfsFsClient destructor behavior with _owns_hdfs_fs=false
+// When _owns_hdfs_fs is false, hdfsDisconnect should NOT be called
+TEST_F(HdfsFsCacheTest, HdfsFsClientDestructorNotOwned) {
+    // This test verifies that when _owns_hdfs_fs=false and hdfs_fs=nullptr,
+    // the destructor does not crash (no-op)
+    {
+        HdfsFsClient client;
+        client.hdfs_fs = nullptr;
+        client._owns_hdfs_fs = false;
+        // Destructor will be called at end of scope
+    }
+    // If we get here without crash, test passes
+    SUCCEED();
+}
+
+// Test HdfsFsClient destructor behavior with _owns_hdfs_fs=true and nullptr
+TEST_F(HdfsFsCacheTest, HdfsFsClientDestructorOwnedButNull) {
+    // This test verifies that when _owns_hdfs_fs=true but hdfs_fs=nullptr,
+    // the destructor does not crash (condition checks nullptr first)
+    {
+        HdfsFsClient client;
+        client.hdfs_fs = nullptr;
+        client._owns_hdfs_fs = true;
+        // Destructor will be called at end of scope
+    }
+    // If we get here without crash, test passes
+    SUCCEED();
+}
+
+} // namespace starrocks
+

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -789,6 +789,24 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - Description: Specifies the number of milliseconds to wait before starting up a hedged read. For example, you have set this parameter to `30`. In this situation, if a read from a block has not returned within 30 milliseconds, your HDFS client immediately starts up a new read against a different block replica. It is equivalent to the `dfs.client.hedged.read.threshold.millis` parameter in the **hdfs-site.xml** file of your HDFS cluster.
 - Introduced in: v3.0
 
+##### hdfs_client_max_cache_size
+
+- Default: 64
+- Type: Int
+- Unit: -
+- Is mutable: No
+- Description: Maximum number of HDFS client connections cached at StarRocks level. Default caches up to 64 connections, with random replacement when full.
+- Introduced in: v3.0
+
+##### hdfs_client_force_new_instance
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: No
+- Description: Whether to force create a new Hadoop FileSystem instance each time. `true` (default): Creates independent instance each time, safe but may cause thread exhaustion for heavy clients (e.g., Curvine). `false`: Reuses Hadoop's cached FileSystem, more efficient, recommended for Curvine scenarios. Note: Request-level parameter `disable_cache` takes precedence over this global config.
+- Introduced in: -
+
 ##### io_coalesce_adaptive_lazy_active
 
 - Default: true

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -583,6 +583,24 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：发起 Hedged Read 请求前需要等待多少毫秒。例如，假设该参数设置为 `30`，那么如果一个 Read 任务未能在 30 毫秒内返回结果，则 HDFS 客户端会立即发起一个 Hedged Read，从目标数据块的副本上读取数据。该参数对应 HDFS 集群配置文件 **hdfs-site.xml** 中的 `dfs.client.hedged.read.threshold.millis` 参数。
 - 引入版本：v3.0
 
+##### hdfs_client_max_cache_size
+
+- 默认值：64
+- 类型：Int
+- 单位：-
+- 是否动态：否
+- 描述：StarRocks 层面缓存的 HDFS 客户端连接最大数量。默认最多缓存 64 个连接，缓存满时随机替换旧连接。
+- 引入版本：v3.0
+
+##### hdfs_client_force_new_instance
+
+- 默认值：true
+- 类型：Boolean
+- 单位：-
+- 是否动态：否
+- 描述：是否强制每次都创建新的 Hadoop FileSystem 实例。`true`（默认）：每次创建独立实例，安全但对重量级客户端（如 Curvine）可能导致线程耗尽。`false`：复用 Hadoop 缓存的 FileSystem，更高效，推荐 Curvine 等场景使用。注意：请求级参数 `disable_cache` 优先级高于此全局配置。
+- 引入版本：-
+
 ##### io_coalesce_adaptive_lazy_active
 
 - 默认值：true


### PR DESCRIPTION
## Why I'm doing:

### Background

In data lake query and Broker Load scenarios, we identified severe performance issues on BE/CN nodes:

1. **Excessive FileSystem instance creation**: Thousands of Hadoop FileSystem instances created in a short time
2. **Heavy resource consumption**: Each FileSystem instance consumes connections, memory, threads and other system resources
3. **System crash in extreme cases**: For certain HDFS-compatible clients (like curvine) that create additional thread pools per instance, massive instances can exhaust threads:

```
Thread pool failed to create thread: Runtime error: Could not create thread: Resource temporarily unavailable
```

**Core problem**: Hadoop FileSystem has a built-in cache mechanism — FileSystem instances with the same configuration should be reused instead of creating new ones each time. However, the current code completely bypasses this cache.

### Root Cause

The problem is at line 54 in `be/src/fs/hdfs/hdfs_fs_cache.cpp`:

```cpp
hdfsBuilderSetForceNewInstance(hdfs_builder);  // unconditional call
```

This line **unconditionally** calls `hdfsBuilderSetForceNewInstance()`, forcing a new Hadoop FileSystem instance to be created every time, completely bypassing Hadoop's built-in FileSystem cache.

### History

| Date | Commit | Behavior | Reason |
|------|--------|----------|--------|
| 2023-03 | b9b15d07d7 | **Conditional call**: only when `disable_cache=true` | Original design, respects Hadoop cache |
| 2023-12 | d26618ef8b | **Unconditional call**: always | Fix "FileSystem closed" error (#36864) |

The December 2023 change was to fix a "FileSystem closed" error. To understand this issue, we need to understand the two-layer cache mechanism:

**Two-Layer Cache Architecture:**

```
┌─────────────────────────────────────────────────────────────────┐
│  Layer 1: StarRocks HdfsFsCache                                 │
│  - Caches HdfsFsClient objects                                  │
│  - Capacity: hdfs_client_max_cache_size (default 64)            │
│  - Eviction: LRU, evicts least recently used when full          │
│  - On eviction: calls HdfsFsClient destructor → hdfsDisconnect()│
└─────────────────────────────────────────────────────────────────┘
                              │
                              ▼
┌─────────────────────────────────────────────────────────────────┐
│  Layer 2: Hadoop FileSystem Cache                               │
│  - Caches FileSystem instances (e.g., CurvineFileSystem)        │
│  - Key: (scheme, authority, username)                           │
│  - Requests with same config share the same FileSystem instance │
└─────────────────────────────────────────────────────────────────┘
```

**How "FileSystem closed" error occurs:**

1. Request A gets HdfsFsClient from HdfsFsCache, underlying reuses Hadoop cached FileSystem instance X
2. Request B also gets another HdfsFsClient from HdfsFsCache, also reuses the same FileSystem instance X
3. HdfsFsCache becomes full, evicts Request A's HdfsFsClient
4. Eviction calls `hdfsDisconnect()`, **closes FileSystem instance X**
5. Request B continues using instance X → Error "FileSystem closed"

**Root cause**: StarRocks closed a FileSystem it doesn't own (this instance is a shared resource managed by Hadoop cache).

**This fix was too aggressive** — it completely disabled Hadoop's FileSystem cache. While it solved the "FileSystem closed" error, it introduced more severe performance issues:

- Every HDFS operation creates a new FileSystem instance
- Connections cannot be reused, causing frequent connect/disconnect
- Memory and thread resources keep accumulating
- High concurrency scenarios may exhaust system resources

---

## What I'm doing:

### Core Fix Strategy

Introduce a new configuration parameter `hdfs_client_force_new_instance` that allows users to control whether to bypass Hadoop FileSystem cache. Also, introduce an `_owns_hdfs_fs` flag to properly manage FileSystem lifecycle and avoid "FileSystem closed" errors.

### Specific Changes

#### 1. New BE configuration parameter (`be/src/common/config.h`)

```cpp
// Default true for backward compatibility
CONF_Bool(hdfs_client_force_new_instance, "true");
```

#### 2. Modify HdfsFsClient class (`be/src/fs/hdfs/hdfs_fs_cache.h`)

Add `_owns_hdfs_fs` member variable to mark whether this instance "owns" the underlying `hdfsFS`:

```cpp
class HdfsFsClient {
public:
    ~HdfsFsClient() {
        if (hdfs_fs != nullptr && _owns_hdfs_fs) {
            // Only close if we "own" this instance
            hdfsDisconnect(hdfs_fs);
        }
    }
    
    hdfsFS hdfs_fs{nullptr};
    bool _owns_hdfs_fs{true};  // new
};
```

#### 3. Modify FileSystem creation logic (`be/src/fs/hdfs/hdfs_fs_cache.cpp`)

```cpp
// Decide whether to force new instance based on config
bool force_new_instance = config::hdfs_client_force_new_instance;
if (properties != nullptr && properties->__isset.disable_cache) {
    force_new_instance = properties->disable_cache;  // request-level override
}

if (force_new_instance) {
    hdfsBuilderSetForceNewInstance(hdfs_builder);
    hdfs_client->_owns_hdfs_fs = true;   // exclusive instance, need to close
} else {
    hdfs_client->_owns_hdfs_fs = false;  // shared instance, must not close
}
```

### How It Works

The key is understanding FileSystem "ownership":

- **`force_new_instance=true`**: Creates independent FileSystem instance each time. StarRocks owns it and must call `hdfsDisconnect()` on destruction.
- **`force_new_instance=false`**: Uses shared instance from Hadoop cache. Hadoop owns it. StarRocks **must not** call `hdfsDisconnect()`.

This solves both problems:
1. Setting `force_new_instance=false` enables Hadoop cache, prevents excessive FileSystem instance creation, and significantly reduces resource consumption
2. When using shared instances, `hdfsDisconnect()` is not called, avoiding "FileSystem closed" errors
---

Fixes #issue

## What type of PR is this:

- [x] BugFix

- [ ] Feature

- [ ] Enhancement

- [ ] Refactor

- [ ] UT

- [ ] Doc

- [ ] Tool

## Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.

- [x] No, this PR will not result in a change in behavior.

**If yes, please specify the type of change:**

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information

- [x] Parameter changes: default values, similar parameters but with different default values

- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled

- [ ] Feature removed

- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

**Behavior Change Details:**

New BE configuration parameter `hdfs_client_force_new_instance` with default value `true`, maintaining full backward compatibility. Behavior only changes when user explicitly sets it to `false`.

| Value | Behavior | Use Case |
|-------|----------|----------|
| `true` (default) | Create new FileSystem each time, same as current behavior | Scenarios requiring full isolation |
| `false` | Use Hadoop FileSystem cache, reuse instances | High concurrency queries, scenarios needing reduced resource consumption |

---

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature

- [x] This pr needs user documentation (for new or modified features or behaviors)

  - [x] I have added documentation for my new feature or new function

- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1

  - [ ] 4.0

  - [ ] 3.5

  - [ ] 3.4

  - [ ] 3.3

---

## Documentation Updates

Updated the following documentation:
- `docs/en/administration/management/BE_configuration.md`
- `docs/zh/administration/management/BE_configuration.md`

New parameter description:

```
hdfs_client_force_new_instance
- Default: true
- Description: Whether to force creating a new Hadoop FileSystem instance each time. 
  Set to false to enable Hadoop's built-in cache, reuse FileSystem instances, 
  reduce connection overhead and resource consumption. Suitable for high concurrency 
  data lake query scenarios.
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `hdfs_client_force_new_instance` to control Hadoop FileSystem caching, updates HDFS client creation/destruction to respect cache via an ownership flag, and documents/tests the behavior.
> 
> - **HDFS client lifecycle & caching**:
>   - Introduce `config` flag `hdfs_client_force_new_instance` (default `true`) in `be/src/common/config.h` to control forcing new Hadoop `FileSystem` instances.
>   - Add `should_force_new_hdfs_instance(...)` to prioritize request-level `THdfsProperties.disable_cache` over global config.
>   - Update `create_hdfs_fs_handle` in `be/src/fs/hdfs/hdfs_fs_cache.cpp`:
>     - Conditionally call `hdfsBuilderSetForceNewInstance` based on `should_force_new_hdfs_instance`.
>     - Track ownership via `HdfsFsClient::_owns_hdfs_fs` to decide whether to `hdfsDisconnect` on destruction.
>   - Modify `HdfsFsClient` in `be/src/fs/hdfs/hdfs_fs_cache.h`:
>     - Add `_owns_hdfs_fs` (default `true`); destructor now disconnects only if owned.
> - **Tests**:
>   - Add `be/test/fs/hdfs_fs_cache_test.cpp` covering decision logic and ownership/destructor behavior.
> - **Docs**:
>   - Document `hdfs_client_force_new_instance` and `hdfs_client_max_cache_size` in `docs/en/.../BE_configuration.md` and `docs/zh/.../BE_configuration.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a71438240a2a230ac46834af053ef70fc9611d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->