### PR TITLE
[Enhancement] optimize performance of flatjson path derive 

### DIFF
--- a/be/src/bench/CMakeLists.txt
+++ b/be/src/bench/CMakeLists.txt
@@ -34,3 +34,5 @@ ADD_BE_BENCH(${SRC_DIR}/bench/object_cache_bench)
 ADD_BE_BENCH(${SRC_DIR}/bench/parquet_encoding_bench)
 ADD_BE_BENCH(${SRC_DIR}/bench/delta_decode_bench)
 ADD_BE_BENCH(${SRC_DIR}/bench/table_metrics_mgr_bench)
+ADD_BE_BENCH(${SRC_DIR}/bench/json_path_deriver_bench)
+

--- a/be/src/bench/json_path_deriver_bench.cpp
+++ b/be/src/bench/json_path_deriver_bench.cpp
@@ -59,11 +59,18 @@ private:
 };
 
 static void BM_JsonPathDeriver(benchmark::State& state) {
-    const char* bench_file = std::getenv("BENCH_FILE");
-    std::string path = bench_file ? bench_file : "";
-    if (path.empty()) {
-        state.SkipWithError("empty BENCH_FILE");
-        return;
+    int num_fields = state.range(0);
+    std::string path;
+    if (num_fields == 0) {
+        // read from env
+        const char* bench_file = std::getenv("BENCH_FILE");
+        path = bench_file ? bench_file : "";
+        if (path.empty()) {
+            state.SkipWithError("empty BENCH_FILE");
+            return;
+        }
+    } else {
+        path = fmt::format("test_{}.json", num_fields);
     }
 
     JsonPathDeriverBench bench;
@@ -82,7 +89,8 @@ static void BM_JsonPathDeriver(benchmark::State& state) {
     }
 }
 
-BENCHMARK(BM_JsonPathDeriver)->Unit(benchmark::kMillisecond);
+// BENCHMARK(BM_JsonPathDeriver)->Unit(benchmark::kMillisecond);
+BENCHMARK(BM_JsonPathDeriver)->Unit(benchmark::kMillisecond)->Arg(10)->Arg(20)->Arg(40)->Arg(80);
 
 } // namespace starrocks
 

--- a/be/src/bench/json_path_deriver_bench.cpp
+++ b/be/src/bench/json_path_deriver_bench.cpp
@@ -1,0 +1,89 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <benchmark/benchmark.h>
+#include <glog/logging.h>
+
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "column/json_column.h"
+#include "gutil/casts.h"
+#include "util/json.h"
+#include "util/json_flattener.h"
+
+namespace starrocks {
+
+class JsonPathDeriverBench {
+public:
+    JsonPathDeriverBench() = default;
+
+    void SetUp(const std::string& filepath) {
+        auto json_column = JsonColumn::create();
+
+        std::ifstream file(filepath);
+        if (!file.is_open()) {
+            std::cerr << "Could not open file: " << filepath << ", using empty column" << std::endl;
+            return;
+        }
+
+        std::string line;
+        while (std::getline(file, line)) {
+            if (line.empty()) continue;
+            auto json_value = JsonValue::parse(line);
+            if (json_value.ok()) {
+                json_column->append(std::move(json_value.value()));
+            }
+        }
+        _json_column = std::move(json_column);
+        std::cout << "Loaded " << _json_column->size() << " rows from " << filepath << std::endl;
+    }
+
+    const JsonColumn* get_column() const { return down_cast<JsonColumn*>(_json_column.get()); }
+
+private:
+    MutableColumnPtr _json_column;
+};
+
+static void BM_JsonPathDeriver(benchmark::State& state) {
+    const char* bench_file = std::getenv("BENCH_FILE");
+    std::string path = bench_file ? bench_file : "";
+    if (path.empty()) {
+        state.SkipWithError("empty BENCH_FILE");
+        return;
+    }
+
+    JsonPathDeriverBench bench;
+    bench.SetUp(path);
+
+    const JsonColumn* json_col = bench.get_column();
+    if (json_col->size() == 0) {
+        state.SkipWithError("No data to benchmark");
+        return;
+    }
+    std::vector<const Column*> columns{json_col};
+
+    for (auto _ : state) {
+        JsonPathDeriver deriver;
+        deriver.derived(columns);
+    }
+}
+
+BENCHMARK(BM_JsonPathDeriver)->Unit(benchmark::kMillisecond);
+
+} // namespace starrocks
+
+BENCHMARK_MAIN();

--- a/be/test/fuzzy/builtin_functions_fuzzy_test.cpp
+++ b/be/test/fuzzy/builtin_functions_fuzzy_test.cpp
@@ -371,7 +371,7 @@ protected:
         //     variations.push_back(make_const(make_nullable(array_column->clone())));
         // }
 
-        return std::move(variations);
+        return variations;
     }
 
     struct FnTypeDesc {

--- a/be/test/util/json_flattener_test.cpp
+++ b/be/test/util/json_flattener_test.cpp
@@ -607,7 +607,7 @@ public:
 
         JsonFlattener flattener(paths, types, has_remain);
         flattener.flatten(input.get());
-        return ColumnHelper::to_columns(std::move(flattener.mutable_result()));
+        return ColumnHelper::to_columns(flattener.mutable_result());
     }
 };
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Optimizations:
1. Remove `JsonPathDeriver:: _derived_maps`, put stats into `JsonFlatPath` directly. In this way we can eliminate the overhead of lookuping the hashmap when processing JSON

Benefit:
```
env:
Run on (104 X 3800 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x52)
  L1 Instruction 32 KiB (x52)
  L2 Unified 1024 KiB (x52)
  L3 Unified 36608 KiB (x2)

before:
----------------------------------------------------------------
Benchmark                      Time             CPU   Iterations
----------------------------------------------------------------
BM_JsonPathDeriver/10       32.7 ms         32.7 ms           25
BM_JsonPathDeriver/20       61.9 ms         61.9 ms            9
BM_JsonPathDeriver/40        173 ms          173 ms            4
BM_JsonPathDeriver/80        336 ms          336 ms            2

after:
----------------------------------------------------------------
Benchmark                      Time             CPU   Iterations
----------------------------------------------------------------
BM_JsonPathDeriver/10       19.8 ms         19.8 ms           35
BM_JsonPathDeriver/20       39.2 ms         39.2 ms           18
BM_JsonPathDeriver/40       79.8 ms         79.8 ms            8
BM_JsonPathDeriver/80        168 ms          168 ms            4
```


Fixes https://github.com/StarRocks/starrocks/issues/66790

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Optimizes flat JSON path derivation by moving stats into `JsonFlatPath` and refactoring traversal for fewer lookups, plus adds a dedicated benchmark and minor test cleanups.
> 
> - **Core (util/json_flattener)**:
>   - Inline path-derivation stats into `JsonFlatPath` (e.g., `hits`, `json_type`, `base_type_count`, `max_uint`, `last_row`, `multi_times`) and remove `JsonPathDeriver::_derived_maps`.
>   - Refactor path building/visitation to use `try_emplace` and update node fields directly; adjust sparsity cleaning, type conflict handling, sorting, and finalize logic (including `dfs_downgrade_uint`).
>   - Minor logic tweaks around remain/filter generation and flat-json extraction/read paths.
> - **Benchmark**:
>   - Add `bench/json_path_deriver_bench.cpp` and register in `be/src/bench/CMakeLists.txt`.
> - **Tests**:
>   - Small cleanups in fuzzy and json flattener tests (return/move fixes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9bb52753062c78c12301eb1c3bcf4a7120cd6efe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->