### PR TITLE
[BugFix] fix RewriteUnnestBitmapRule cause project's output column's type is wrong

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteUnnestBitmapRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteUnnestBitmapRule.java
@@ -102,7 +102,11 @@ public class RewriteUnnestBitmapRule extends TransformationRule {
         //  use bitmap_and(t0.b2, t1.b2) as b2 to replace bitmap_to_array(b2)
         final ScalarOperator bitmapToArrayArg = bitmapToArray.second.getChild(0);
         final ColumnRefOperator bitmapColumn = bitmapToArray.first;
-        columnRefMap.put(bitmapColumn, bitmapToArrayArg);
+        columnRefMap.remove(bitmapColumn);
+        ColumnRefOperator newBitmapColumn =
+                new ColumnRefOperator(bitmapColumn.getId(), bitmapToArrayArg.getType(), bitmapToArrayArg.toString(),
+                        bitmapToArrayArg.isNullable());
+        columnRefMap.put(newBitmapColumn, bitmapToArrayArg);
 
         TableFunction unnestBitmapFn =
                 (TableFunction) ExprUtils.getBuiltinFunction(FunctionSet.UNNEST_BITMAP, new Type[] {BitmapType.BITMAP},

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteUnnestBitmapRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteUnnestBitmapRule.java
@@ -112,7 +112,7 @@ public class RewriteUnnestBitmapRule extends TransformationRule {
                 (TableFunction) ExprUtils.getBuiltinFunction(FunctionSet.UNNEST_BITMAP, new Type[] {BitmapType.BITMAP},
                         Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
         List<Pair<ColumnRefOperator, ScalarOperator>> fnParamColumnProject =
-                Lists.newArrayList(Pair.create(bitmapColumn, bitmapColumn));
+                Lists.newArrayList(Pair.create(newBitmapColumn, newBitmapColumn));
 
         LogicalTableFunctionOperator newTableFunctionOperator =
                 new LogicalTableFunctionOperator(originalTableFunctionOperator.getFnResultColRefs(), unnestBitmapFn,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TableFunctionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TableFunctionTest.java
@@ -289,10 +289,13 @@ public class TableFunctionTest extends PlanTestBase {
                 "\t r2 as (select sub_bitmap(b1, 0, 10) as b2 from test_agg),\n" +
                 "\t r3 as (select bitmap_and(t0.b2, t1.b2) as b2 from r1 t0 join r2 t1)\n" +
                 "select unnest as r1 from r3, unnest(bitmap_to_array(b2)) order by r1;";
-        String plan = getFragmentPlan(sql);
-        PlanTestBase.assertContains(plan, "5:Project\n" +
-                "  |  <slot 28> : bitmap_and(10: b1, 25: sub_bitmap)");
+        String plan = getCostExplain(sql);
+        PlanTestBase.assertContains(plan, "5:Project\n" + "  |  output columns:\n" +
+                "  |  28 <-> bitmap_and[([10: b1, BITMAP, true], [25: sub_bitmap, BITMAP, true]);");
         PlanTestBase.assertContains(plan, "tableFunctionName: unnest_bitmap");
+        PlanTestBase.assertContains(plan, "2:Project\n" + "  |  output columns:\n" +
+                "  |  25 <-> sub_bitmap[([22: b1, BITMAP, true], 0, 10); args: BITMAP,BIGINT,BIGINT; result: BITMAP; " +
+                "args nullable: true; result nullable: true]");
         PlanTestBase.assertNotContains(plan, "bitmap_to_array");
     }
 


### PR DESCRIPTION
## Why I'm doing:
https://github.com/StarRocks/starrocks/pull/55168 cause project's output column's type is wrong
like below: array_to_bitmap's output type should be bitmap, instead of array<BIGINT>

```
mysql> explain costs with cte as(select array_to_bitmap([1,2,4]) c) select t.c from  cte,unnest(bitmap_to_array(cte.c)) t(c);
+------------------------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                               |
+------------------------------------------------------------------------------------------------------------------------------+
| PLAN COST                                                                                                                    |
|   CPU: 0.0                                                                                                                   |
|   Memory: 0.0                                                                                                                |
|                                                                                                                              |
| PLAN FRAGMENT 0(F00)                                                                                                         |
|   Output Exprs:3: c                                                                                                          |
|   Input Partition: UNPARTITIONED                                                                                             |
|   RESULT SINK                                                                                                                |
|                                                                                                                              |
|   2:TableValueFunction                                                                                                       |
|   |  tableFunctionName: unnest_bitmap                                                                                        |
|   |  columns: [unnest_bitmap]                                                                                                |
|   |  returnTypes: [BIGINT]                                                                                                   |
|   |  cardinality: 1                                                                                                          |
|   |  column statistics:                                                                                                      |
|   |  * c-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN                                                                      |
|   |                                                                                                                          |
|   1:Project                                                                                                                  |
|   |  output columns:                                                                                                         |
|   |  4 <-> array_to_bitmap[([1,2,4]); args: INVALID_TYPE; result: ARRAY<BIGINT>; args nullable: true; result nullable: true] |
|   |  cardinality: 1                                                                                                          |
|   |  column statistics:                                                                                                      |
|   |  * bitmap_to_array-->[-Infinity, Infinity, 0.0, 1048576.0, 1.0] ESTIMATE                                                 |
|   |                                                                                                                          |
|   0:UNION                                                                                                                    |
|      constant exprs:                                                                                                         |
|          NULL                                                                                                                |
|      cardinality: 1                                                                                                          |
|      column statistics:                                                                                                      |
|      * -->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN                                                                       |
|      * bitmap_to_array-->[-Infinity, Infinity, 0.0, 1048576.0, 1.0] ESTIMATE                                                 |
+------------------------------------------------------------------------------------------------------------------------------+

```
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure `bitmap_to_array` → `unnest_bitmap` rewrite preserves bitmap column type by replacing the column ref; update tests to verify plans with cost explain.
> 
> - **Optimizer**:
>   - In `RewriteUnnestBitmapRule.transform`, replace the original `bitmapColumn` with a new `ColumnRefOperator` derived from `bitmap_to_array`'s argument (type/name/nullability), ensuring correct bitmap type propagation.
>   - Update function param projection to use the new column ref when building `unnest_bitmap` `LogicalTableFunctionOperator`.
> - **Tests**:
>   - Adjust `TableFunctionTest.testUnnesetBitmapToArrayToUnnestBitmapRewrite` to use `getCostExplain` and verify projected outputs (`bitmap_and`, `sub_bitmap`) and `tableFunctionName: unnest_bitmap`; ensure `bitmap_to_array` is absent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 428af8a485d5e2f37d5db22ccb8714a9e34f2362. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->