### PR TITLE
[Tool] Fix mac compile

### DIFF
--- a/build-mac/CMakeLists.txt
+++ b/build-mac/CMakeLists.txt
@@ -906,6 +906,7 @@ list(FILTER STARROCKS_SOURCES EXCLUDE REGEX ".*/formats/(avro|orc|parquet)/.*\\.
 list(FILTER STARROCKS_SOURCES EXCLUDE REGEX ".*/exec/file_scanner/(avro|orc|parquet)_.*\\.cpp$")
 list(FILTER STARROCKS_SOURCES EXCLUDE REGEX ".*(avro|orc|parquet|iceberg).*\\.cpp$")
 
+
 # ==============================================================================
 # EXCLUDE CLOUD STORAGE BACKENDS (S3, Azure, HDFS)
 # ==============================================================================
@@ -1001,6 +1002,16 @@ list(FILTER STARROCKS_SOURCES EXCLUDE REGEX ".*data_consumer_group.*\\.cpp$")
 list(FILTER STARROCKS_SOURCES EXCLUDE REGEX ".*iceberg.*sink.*\\.cpp$")
 list(FILTER STARROCKS_SOURCES EXCLUDE REGEX ".*iceberg_table_sink.*\\.cpp$")
 
+# Exclude lookup related files that depend on HiveDataSource
+list(FILTER STARROCKS_SOURCES EXCLUDE REGEX ".*/exec/pipeline/lookup_request\\.cpp$")
+list(FILTER STARROCKS_SOURCES EXCLUDE REGEX ".*/exec/pipeline/lookup_operator\\.cpp$")
+list(FILTER STARROCKS_SOURCES EXCLUDE REGEX ".*/exec/pipeline/fetch_task\\.cpp$")
+list(FILTER STARROCKS_SOURCES EXCLUDE REGEX ".*/exec/pipeline/fetch_processor\\.cpp$")
+list(FILTER STARROCKS_SOURCES EXCLUDE REGEX ".*/exec/fetch_node\\.cpp$")
+list(FILTER STARROCKS_SOURCES EXCLUDE REGEX ".*/exec/lookup_node\\.cpp$")
+list(FILTER STARROCKS_SOURCES EXCLUDE REGEX ".*/runtime/lookup_stream_mgr\\.cpp$")
+list(FILTER STARROCKS_SOURCES EXCLUDE REGEX ".*/runtime/lookup_dispatcher_mgr\\.cpp$")
+
 # Exclude Linux-only memory hook implementation on macOS
 list(FILTER STARROCKS_SOURCES EXCLUDE REGEX ".*/service/mem_hook\\.cpp$")
 
@@ -1054,6 +1065,7 @@ set(MACOS_SHIM_SOURCES
     "${CMAKE_CURRENT_LIST_DIR}/shims/src/inverted_index_stub.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/shims/src/java_window_function_stub.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/shims/src/missing_symbols_shim.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/shims/src/lookup_stub.cpp"
 )
 foreach(_shim_file IN LISTS MACOS_SHIM_SOURCES)
     if(EXISTS "${_shim_file}")

--- a/build-mac/shims/src/connector_shims.cpp
+++ b/build-mac/shims/src/connector_shims.cpp
@@ -16,6 +16,7 @@
 // under the License.
 
 #include "connector/connector.h"
+#include "connector/hive_connector.h"
 
 namespace starrocks::connector {
 
@@ -35,7 +36,9 @@ ConnectorManager* ConnectorManager::default_instance() {
     return &instance;
 }
 
-const Connector* ConnectorManager::get(const std::string& /*name*/) { return nullptr; }
+const Connector* ConnectorManager::get(const std::string& /*name*/) {
+    return nullptr;
+}
 void ConnectorManager::put(const std::string& /*name*/, std::unique_ptr<Connector> /*connector*/) {}
 
 // DataSource implementations (from connector_core_shim.cpp)
@@ -45,7 +48,9 @@ void DataSource::update_has_any_predicate() {
     _has_any_predicate = (!_conjunct_ctxs.empty()) || (_runtime_filters != nullptr && _runtime_filters->size() > 0);
 }
 
-Status DataSource::parse_runtime_filters(RuntimeState*) { return Status::OK(); }
+Status DataSource::parse_runtime_filters(RuntimeState*) {
+    return Status::OK();
+}
 
 void DataSource::update_profile(const Profile&) {}
 

--- a/build-mac/shims/src/gperftools_stubs.cpp
+++ b/build-mac/shims/src/gperftools_stubs.cpp
@@ -15,6 +15,8 @@
 // Stub implementations for gperftools/TCMalloc functions on macOS
 // We use jemalloc instead of TCMalloc on macOS
 
+#include <cstddef>
+
 extern "C" {
 
 // MallocExtension function (TCMalloc-specific)
@@ -33,6 +35,12 @@ int ProfilerStart(const char* fname) {
 
 void ProfilerStop() {
     // CPU profiling not supported on macOS build
+}
+
+// jemalloc mallctl stub - macOS system malloc doesn't have this
+int mallctl(const char* name, void* oldp, size_t* oldlenp, void* newp, size_t newlen) {
+    // Return error - jemalloc mallctl not available on macOS system malloc
+    return 1;
 }
 
 } // extern "C"

--- a/build-mac/shims/src/lake_manager_stub.cpp
+++ b/build-mac/shims/src/lake_manager_stub.cpp
@@ -17,6 +17,7 @@
 
 #include "common/status.h"
 #include "storage/lake/compaction_scheduler.h"
+#include "storage/lake/lake_persistent_index_parallel_compact_mgr.h"
 #include "storage/lake/lake_primary_index.h"
 #include "storage/lake/replication_txn_manager.h"
 #include "storage/lake/rowset.h"
@@ -24,6 +25,7 @@
 #include "storage/lake/schema_change.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_reader.h"
+#include "storage/lake/tablet_write_log_manager.h"
 #include "storage/lake/update_compaction_state.h"
 #include "storage/lake/update_manager.h"
 #include "storage/options.h"
@@ -71,7 +73,8 @@ StatusOr<TabletAndRowsets> TabletManager::capture_tablet_and_rowsets(int64_t /*t
 
 void TabletManager::clean_in_writing_data_size() {}
 
-Status TabletReader::parse_seek_range(const TabletSchema& /*schema*/, TabletReaderParams::RangeStartOperation /*start_op*/,
+Status TabletReader::parse_seek_range(const TabletSchema& /*schema*/,
+                                      TabletReaderParams::RangeStartOperation /*start_op*/,
                                       TabletReaderParams::RangeEndOperation /*end_op*/,
                                       const std::vector<OlapTuple>& /*start_keys*/,
                                       const std::vector<OlapTuple>& /*end_keys*/, std::vector<SeekRange>* /*ranges*/,
@@ -116,5 +119,25 @@ void SegmentPKEncodeResult::close() {
     _memory_usage = 0;
     _status = Status::NotSupported("Lake rowset update is disabled on macOS");
 }
+
+// TabletWriteLogManager stubs
+TabletWriteLogManager::TabletWriteLogManager() = default;
+
+TabletWriteLogManager* TabletWriteLogManager::instance() {
+    static TabletWriteLogManager instance;
+    return &instance;
+}
+
+std::vector<TabletWriteLogEntry> TabletWriteLogManager::get_logs(int64_t /*table_id*/, int64_t /*partition_id*/,
+                                                                 int64_t /*tablet_id*/, int64_t /*log_type*/,
+                                                                 int64_t /*start_finish_time*/,
+                                                                 int64_t /*end_finish_time*/) const {
+    return {};
+}
+
+// LakePersistentIndexParallelCompactMgr stubs
+LakePersistentIndexParallelCompactMgr::~LakePersistentIndexParallelCompactMgr() = default;
+
+void LakePersistentIndexParallelCompactMgr::shutdown() {}
 
 } // namespace starrocks::lake

--- a/build-mac/shims/src/lookup_stub.cpp
+++ b/build-mac/shims/src/lookup_stub.cpp
@@ -1,0 +1,93 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Stub implementations for lookup functionality on macOS
+
+#include "exec/fetch_node.h"
+#include "exec/lookup_node.h"
+#include "runtime/lookup_stream_mgr.h"
+
+namespace starrocks {
+
+// LookUpNode stubs
+LookUpNode::LookUpNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs)
+        : ExecNode(pool, tnode, descs) {}
+LookUpNode::~LookUpNode() = default;
+
+Status LookUpNode::init(const TPlanNode& tnode, RuntimeState* state) {
+    return Status::NotSupported("LookUpNode is disabled on macOS");
+}
+
+Status LookUpNode::prepare(RuntimeState* state) {
+    return Status::NotSupported("LookUpNode is disabled on macOS");
+}
+
+void LookUpNode::close(RuntimeState* state) {}
+
+std::vector<std::shared_ptr<pipeline::OperatorFactory>> LookUpNode::decompose_to_pipeline(
+        pipeline::PipelineBuilderContext* context) {
+    return {};
+}
+
+// FetchNode stubs
+FetchNode::FetchNode(ObjectPool* pool, const TPlanNode& tnode, const DescriptorTbl& descs)
+        : ExecNode(pool, tnode, descs) {}
+FetchNode::~FetchNode() = default;
+
+Status FetchNode::init(const TPlanNode& tnode, RuntimeState* state) {
+    return Status::NotSupported("FetchNode is disabled on macOS");
+}
+
+pipeline::OpFactories FetchNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {
+    return {};
+}
+
+// LookUpDispatcherMgr stubs
+LookUpDispatcherPtr LookUpDispatcherMgr::create_dispatcher(RuntimeState* /*state*/, const TUniqueId& /*query_id*/,
+                                                           PlanNodeId /*target_node_id*/,
+                                                           const std::vector<TupleId>& /*request_tuple_ids*/) {
+    return nullptr;
+}
+
+StatusOr<LookUpDispatcherPtr> LookUpDispatcherMgr::get_dispatcher(const TUniqueId& /*query_id*/,
+                                                                  PlanNodeId /*target_node_id*/) {
+    return Status::NotSupported("Lookup is disabled on macOS");
+}
+
+void LookUpDispatcherMgr::remove_dispatcher(const TUniqueId& /*query_id*/, PlanNodeId /*target_node_id*/) {}
+
+Status LookUpDispatcherMgr::lookup(const pipeline::RemoteLookUpRequestContextPtr& /*ctx*/) {
+    return Status::NotSupported("Lookup is disabled on macOS");
+}
+
+namespace pipeline {
+
+// RemoteLookUpRequestContext stubs
+Status RemoteLookUpRequestContext::collect_input_columns(ChunkPtr /*chunk*/) {
+    return Status::NotSupported("Lookup is disabled on macOS");
+}
+
+StatusOr<size_t> RemoteLookUpRequestContext::fill_response(const ChunkPtr& /*result_chunk*/, SlotId /*source_id_slot*/,
+                                                           const std::vector<SlotDescriptor*>& /*slots*/,
+                                                           size_t /*start_offset*/) {
+    return Status::NotSupported("Lookup is disabled on macOS");
+}
+
+void RemoteLookUpRequestContext::callback(const Status& /*status*/) {}
+
+} // namespace pipeline
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes macOS build by filtering out lookup-related sources and adding shims for lookup, lake components, and jemalloc mallctl.
> 
> - **Build (CMake/macOS)**:
>   - Excludes lookup-related sources: `exec/pipeline/lookup_request.cpp`, `exec/pipeline/lookup_operator.cpp`, `exec/pipeline/fetch_task.cpp`, `exec/pipeline/fetch_processor.cpp`, `exec/fetch_node.cpp`, `exec/lookup_node.cpp`, `runtime/lookup_stream_mgr.cpp`, `runtime/lookup_dispatcher_mgr.cpp`.
>   - Adds shim source `shims/src/lookup_stub.cpp` to `STARROCKS_SOURCES`.
> - **Shims/Stubs**:
>   - **Lookup**: New `shims/src/lookup_stub.cpp` providing stubs for `LookUpNode`, `FetchNode`, `LookUpDispatcherMgr`, and `pipeline::RemoteLookUpRequestContext`.
>   - **Lake**: Extend lake stubs with `TabletWriteLogManager` and `LakePersistentIndexParallelCompactMgr` definitions and no-op methods.
>   - **gperftools/memory**: Add `mallctl` stub in `gperftools_stubs.cpp`.
>   - **Connectors**: Minor shim tweak to include `connector/hive_connector.h` and small formatting adjustments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c93307a3b57ff91bf54320f48ac045164b391898. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->