### PR TITLE
[BugFix] Fix CN crash when querying non-partitioned Iceberg tables with DATE predicates

### DIFF
--- a/be/src/formats/parquet/column_converter.cpp
+++ b/be/src/formats/parquet/column_converter.cpp
@@ -598,7 +598,7 @@ Status parquet::Int32ToDateConverter::convert(const Column* src, Column* dst) {
     auto& src_null_data = src_nullable_column->null_column()->get_data();
     auto& dst_null_data = dst_nullable_column->null_column_raw_ptr()->get_data();
 
-    size_t size = src_column->size();
+    size_t size = dst_null_data.size();
     memcpy(dst_null_data.data(), src_null_data.data(), size);
     for (size_t i = 0; i < size; i++) {
         dst_data[i]._julian = src_data[i] + date::UNIX_EPOCH_JULIAN;
@@ -622,7 +622,7 @@ Status Int32ToTimeConverter::convert(const Column* src, Column* dst) {
     auto& src_null_data = src_nullable_column->null_column()->get_data();
     auto& dst_null_data = dst_nullable_column->null_column_raw_ptr()->get_data();
 
-    size_t size = src_column->size();
+    size_t size = dst_null_data.size();
 
     for (size_t i = 0; i < size; i++) {
         dst_null_data[i] = src_null_data[i];
@@ -649,7 +649,7 @@ Status parquet::Int32ToDateTimeConverter::convert(const Column* src, Column* dst
     auto& src_null_data = src_nullable_column->null_column()->get_data();
     auto& dst_null_data = dst_nullable_column->null_column_raw_ptr()->get_data();
 
-    size_t size = src_column->size();
+    size_t size = dst_null_data.size();
     for (size_t i = 0; i < size; i++) {
         dst_null_data[i] = src_null_data[i];
         if (!src_null_data[i]) {
@@ -688,7 +688,7 @@ Status Int96ToDateTimeConverter::convert(const Column* src, Column* dst) {
     auto& src_null_data = src_nullable_column->null_column()->get_data();
     auto& dst_null_data = dst_nullable_column->null_column_raw_ptr()->get_data();
 
-    size_t size = src_column->size();
+    size_t size = dst_null_data.size();
 
     auto fill_dst_fn = [&]<bool FAST_TZ>() {
         for (size_t i = 0; i < size; i++) {
@@ -789,7 +789,7 @@ Status Int64ToDateTimeConverter::convert(const Column* src, Column* dst) {
     auto& src_null_data = src_nullable_column->null_column()->get_data();
     auto& dst_null_data = dst_nullable_column->null_column_raw_ptr()->get_data();
 
-    size_t size = src_column->size();
+    size_t size = dst_null_data.size();
     auto fill_dst_fn = [&]<bool UTC_TO_TZ, bool FAST_TZ>() {
         for (size_t i = 0; i < size; i++) {
             dst_null_data[i] = src_null_data[i];
@@ -841,7 +841,7 @@ Status Int64ToTimeConverter::convert(const Column* src, Column* dst) {
     auto& src_null_data = src_nullable_column->null_column()->get_data();
     auto& dst_null_data = dst_nullable_column->null_column_raw_ptr()->get_data();
 
-    size_t size = src_column->size();
+    size_t size = dst_null_data.size();
 
     for (size_t i = 0; i < size; i++) {
         dst_null_data[i] = src_null_data[i];


### PR DESCRIPTION
Fix CN SIGSEGV crashes on ARM64/Graviton when querying non-partitioned Iceberg tables with DATE/TIME/DATETIME predicates.

## Why I'm doing:
PR #63294 fixed the out-of-order instruction execution issue in NumericToNumericConverter but missed applying the same fix to other converter classes. This causes CN SIGSEGV crashes on ARM64/Graviton when querying non-partitioned Iceberg tables with DATE predicates.

  On ARM64/Graviton CPUs, out-of-order instruction execution can cause `memcpy` or loop operations to execute before `resize_uninitialized()` completes, leading to
  memory access violations.

## What I'm doing:
Apply the same fix pattern (use dst_null_data.size() instead of src_column->size()) to:
- Int32ToDateConverter
- Int32ToTimeConverter
- Int32ToDateTimeConverter
- Int96ToDateTimeConverter
- Int64ToDateTimeConverter
- Int64ToTimeConverter

Fixes #issue
Fixes #66863
Related: #64667

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
   - Note: This fix addresses an ARM64-specific memory ordering issue that's difficult to unit test deterministically. The original PR #63294 that fixed NumericToNumericConverter also didn't add tests for the same reason. The fix has been validated manually on ARM64/Graviton.
- [X] This pr needs user documentation (for new or modified features or behaviors)
- [X] I have added documentation for my new feature or new function
- [X] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch converters to use `dst_null_data.size()` for memcpy/loop bounds across parquet DATE/TIME/DATETIME paths.
> 
> - **Parquet converters**:
>   - Use `dst_null_data.size()` (post-`resize_uninitialized`) for memcpy/loop bounds instead of `src_column->size()`.
>   - Updated converters:
>     - `Int32ToDateConverter`
>     - `Int32ToTimeConverter`
>     - `Int32ToDateTimeConverter`
>     - `Int96ToDateTimeConverter`
>     - `Int64ToDateTimeConverter`
>     - `Int64ToTimeConverter`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c60115ddfe6ff8f040eeb2d05df8c3c3187870d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->