### PR TITLE
[Enhancement] Optimize the error message when getting external table failed

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ExternalTablesProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ExternalTablesProcDir.java
@@ -57,7 +57,12 @@ public class ExternalTablesProcDir implements ProcDirInterface {
         if (db == null) {
             throw new AnalysisException("db: " + dbName + " not exists");
         }
-        Table tbl = metadataMgr.getTable(new ConnectContext(), catalogName, dbName, name);
+        Table tbl = null;
+        try {
+            tbl = metadataMgr.getTable(new ConnectContext(), catalogName, dbName, name);
+        } catch (Exception e) {
+            throw new AnalysisException(e.getMessage());
+        }
         if (tbl == null) {
             throw new AnalysisException("table : " + name + " not exists");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
@@ -38,6 +38,7 @@ import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.statistics.StatisticsUtils;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -55,6 +56,7 @@ import io.delta.kernel.internal.actions.DeletionVectorDescriptor;
 import io.delta.kernel.internal.actions.Metadata;
 import io.delta.kernel.types.StructType;
 import io.delta.kernel.utils.CloseableIterator;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -351,8 +353,16 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
         try {
             return deltaOps.getTable(dbName, tblName);
         } catch (Exception e) {
-            LOG.error("Failed to get table {}.{}", dbName, tblName, e);
-            return null;
+            LOG.error("Failed to get deltalake table {}.{}.{}", catalogName, dbName, tblName, e);
+            String errMsg = e.getMessage();
+            Throwable ce = ExceptionUtils.getRootCause(e);
+            if (ce instanceof SemanticException se) {
+                errMsg = se.getDetailMsg();
+            } else if (ce != null) {
+                errMsg = String.format("Failed to get deltalake table %s.%s.%s. %s", catalogName, dbName, tblName,
+                        ce.getMessage());
+            }
+            throw new StarRocksConnectorException(errMsg, e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -72,6 +72,7 @@ import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.thrift.THiveFileInfo;
 import com.starrocks.thrift.TSinkCommitInfo;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.hadoop.fs.Path;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -291,12 +292,12 @@ public class HiveMetadata implements ConnectorMetadata {
         Table table;
         try {
             table = hmsOps.getTable(dbName, tblName);
-        } catch (StarRocksConnectorException e) {
-            LOG.error("Failed to get hive table [{}.{}.{}]", catalogName, dbName, tblName, e);
-            throw e;
         } catch (Exception e) {
             LOG.error("Failed to get hive table [{}.{}.{}]", catalogName, dbName, tblName, e);
-            return null;
+            Throwable ce = ExceptionUtils.getRootCause(e);
+            String errMsg = ce != null ? ce.getMessage() : e.getMessage();
+            throw new StarRocksConnectorException(String.format("Failed to get hive table %s.%s.%s. %s",
+                    catalogName, dbName, tblName, errMsg), e);
         }
 
         return table;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
@@ -47,6 +47,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Statistics;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -131,7 +132,10 @@ public class HudiMetadata implements ConnectorMetadata {
             table = hmsOps.getTable(dbName, tblName);
         } catch (Exception e) {
             LOG.error("Failed to get hudi table [{}.{}.{}]", catalogName, dbName, tblName, e);
-            return null;
+            Throwable ce = ExceptionUtils.getRootCause(e);
+            String errMsg = ce != null ? ce.getMessage() : e.getMessage();
+            throw new StarRocksConnectorException(String.format("Failed to get hudi table %s.%s.%s. %s",
+                    catalogName, dbName, tblName, errMsg), e);
         }
 
         return table;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -31,6 +31,7 @@ import com.starrocks.connector.iceberg.rest.IcebergRESTCatalog;
 import com.starrocks.mysql.MysqlCommand;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
@@ -231,7 +232,10 @@ public class CachingIcebergCatalog implements IcebergCatalog {
         } catch (NoSuchTableException e) {
             throw e;
         } catch (Exception e) {
-            throw new StarRocksConnectorException("Load table failed: " + dbName + "." + tableName, e);
+            Throwable ce = ExceptionUtils.getRootCause(e);
+            String errMsg = ce != null ? ce.getMessage() : e.getMessage();
+            throw new StarRocksConnectorException(String.format("Failed to get iceberg table %s.%s.%s. %s",
+                    catalogName, dbName, tableName, errMsg), e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -469,7 +469,7 @@ public class IcebergMetadata implements ConnectorMetadata {
             return table;
         } catch (StarRocksConnectorException e) {
             LOG.error("Failed to get iceberg table {}", identifier, e);
-            return null;
+            throw e;
         } catch (NoSuchTableException e) {
             return getView(context, dbName, tblName);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -434,7 +434,8 @@ public class IcebergMetadataTest extends TableTestBase {
 
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
                 Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor(), null);
-        Assertions.assertNull(metadata.getTable(connectContext, "db", "tbl2"));
+        Assertions.assertThrows(StarRocksConnectorException.class,
+                () -> metadata.getTable(connectContext, "db", "tbl2"));
     }
 
     @Test


### PR DESCRIPTION

## Why I'm doing:
When querying deltalake catalog, if operations such as getting table metadata fail due to insufficient permissions, StarRocks will return an error such as "Getting analyzing error. Detail message: Unknown table ...", which does not provide useful information to help users troubleshoot the problem.

Therefore, the error message for this type of problem needs to be optimized so that users can clearly see the root cause of the failure from the error message, rather than simply receiving a uniform "Unknown table".

## What I'm doing:
Optimize the error message when getting external table failed, to provide more clear information to help users debug the issue.

After this optimization, the returned error message for the above case will look like:
```
Failed to get latest snapshot for delta_catalog.test_db.test_table, Failed to list the files in delta log. caused by : java.nio.file.AccessDeniedException: 
s3://delta-metastore-86e9be31/metastore/670a36cc-4d6b-4f46-8d57-1234567/tables/04ff0f5a-6cd6-4f5b-a69c-fec484cbd7aa/_delta_log
: getFileStatus on 
s3://delta-metastore-86e9be31/metastore/670a36cc-4d6b-4f46-8d57-1234567/tables/04ff0f5a-6cd6-4f5b-a69c-fec484cbd7aa/_delta_log
: software.amazon.awssdk.services.s3.model.S3Exception: Forbidden (Service: S3, Status Code: 403, Request ID: 79QKZXW00ZM59ABE)
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves getTable error handling across Delta/Hive/Hudi/Iceberg to throw StarRocksConnectorException with root cause details, and adds targeted unit tests.
> 
> - **Error handling improvements**
>   - Delta: `DeltaLakeMetadata.getTable` now logs catalog-qualified path, extracts root cause (special-cases `SemanticException`), and throws `StarRocksConnectorException` with informative message.
>   - Hive: `HiveMetadata.getTable` wraps failures using root cause via `ExceptionUtils` and throws `StarRocksConnectorException` instead of returning null.
>   - Hudi: `HudiMetadata.getTable` similarly wraps and rethrows with catalog/db/table and root cause message.
>   - Iceberg:
>     - `CachingIcebergCatalog.getTable` wraps non-`NoSuchTableException` errors with catalog/db/table and root cause.
>     - `IcebergMetadata.getTable` no longer returns null on `StarRocksConnectorException`; it rethrows.
> - **Tests**
>   - Added unit tests verifying informative error propagation for Delta, Hudi, and CachingIcebergCatalog; updated Iceberg tests to expect thrown exceptions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e8eee65d450b354c4f0ba2c59e4e62b856345e30. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->