### PR TITLE
[Enhancement] Support default values for JSON type columns

### DIFF
--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -421,7 +421,7 @@ Status LakeDataSource::init_tablet_reader(RuntimeState* runtime_state) {
 // This method extracts the default value of a JSON subfield based on the access path
 // and sets it to the column if extraction succeeds.
 void LakeDataSource::_inherit_default_value_from_json(TabletColumn* column, const TabletColumn& root_column,
-                                                       const ColumnAccessPath* path) {
+                                                      const ColumnAccessPath* path) {
     if (!root_column.has_default_value() || root_column.type() != TYPE_JSON) {
         return;
     }

--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -434,8 +434,8 @@ void LakeDataSource::_inherit_default_value_from_json(TabletColumn* column, cons
     }
 
     // Extract the sub path from linear path, e.g. "profile.level" -> "$.level"
-    std::string linear = path->linear_path();
-    std::string parent = path->path();
+    const std::string& linear = path->linear_path();
+    const std::string& parent = path->path();
     std::string json_path_str;
     if (linear.size() > parent.size() && linear.compare(0, parent.size(), parent) == 0) {
         // linear = "profile.level", parent = "profile" -> sub = ".level" -> "$level"

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -75,7 +75,7 @@ private:
 
     Status _extend_schema_by_access_paths();
     void _inherit_default_value_from_json(TabletColumn* column, const TabletColumn& root_column,
-                                           const ColumnAccessPath* path);
+                                          const ColumnAccessPath* path);
     Status init_column_access_paths(Schema* schema);
     Status prune_schema_by_access_paths(Schema* schema);
 

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -74,6 +74,8 @@ private:
     void update_counter(RuntimeState* state);
 
     Status _extend_schema_by_access_paths();
+    void _inherit_default_value_from_json(TabletColumn* column, const TabletColumn& root_column,
+                                           const ColumnAccessPath* path);
     Status init_column_access_paths(Schema* schema);
     Status prune_schema_by_access_paths(Schema* schema);
 

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -510,7 +510,7 @@ void OlapChunkSource::_inherit_default_value_from_json(TabletColumn* column, con
     }
 
     // Extract the sub path from linear path, e.g. "profile.level" -> "$.level"
-    std::string linear = path->linear_path();
+    const std::string& linear = path->linear_path();
     const std::string& parent = path->path();
     std::string json_path_str;
     if (linear.size() > parent.size() && linear.compare(0, parent.size(), parent) == 0) {

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -497,7 +497,7 @@ Status OlapChunkSource::_prune_schema_by_access_paths(Schema* schema) {
 // This method extracts the default value of a JSON subfield based on the access path
 // and sets it to the column if extraction succeeds.
 void OlapChunkSource::_inherit_default_value_from_json(TabletColumn* column, const TabletColumn& root_column,
-                                                        const ColumnAccessPath* path) {
+                                                       const ColumnAccessPath* path) {
     if (!root_column.has_default_value() || root_column.type() != TYPE_JSON) {
         return;
     }

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -493,6 +493,75 @@ Status OlapChunkSource::_prune_schema_by_access_paths(Schema* schema) {
     return Status::OK();
 }
 
+// Inherit default value from JSON parent column for extended subcolumn.
+// This method extracts the default value of a JSON subfield based on the access path
+// and sets it to the column if extraction succeeds.
+void OlapChunkSource::_inherit_default_value_from_json(TabletColumn* column, const TabletColumn& root_column,
+                                                        const ColumnAccessPath* path) {
+    if (!root_column.has_default_value() || root_column.type() != TYPE_JSON) {
+        return;
+    }
+
+    const std::string& json_default = root_column.default_value();
+    auto json_value_or = JsonValue::parse_json_or_string(Slice(json_default));
+    if (!json_value_or.ok()) {
+        LOG(WARNING) << "Failed to parse JSON default value: " << json_value_or.status();
+        return;
+    }
+
+    // Extract the sub path from linear path, e.g. "profile.level" -> "$.level"
+    std::string linear = path->linear_path();
+    const std::string& parent = path->path();
+    std::string json_path_str;
+    if (linear.size() > parent.size() && linear.compare(0, parent.size(), parent) == 0) {
+        // linear = "profile.level", parent = "profile" -> sub = ".level" -> "$level"
+        json_path_str = "$" + linear.substr(parent.size());
+    } else {
+        json_path_str = "$";
+    }
+
+    auto json_path_or = JsonPath::parse(Slice(json_path_str));
+    if (!json_path_or.ok()) {
+        LOG(WARNING) << "Failed to parse JSON path: " << json_path_str;
+        return;
+    }
+
+    vpack::Builder builder;
+    vpack::Slice extracted = JsonPath::extract(&json_value_or.value(), json_path_or.value(), &builder);
+    if (extracted.isNone()) {
+        return;
+    }
+
+    std::string default_value_str;
+    LogicalType value_type = column->type();
+
+    // For string types (VARCHAR/CHAR), extract the raw string value without JSON quotes
+    // For other types (INT/DOUBLE/BOOLEAN/etc), use JSON representation
+    if (value_type == TYPE_VARCHAR || value_type == TYPE_CHAR) {
+        if (extracted.isString()) {
+            default_value_str = extracted.copyString();
+        } else {
+            JsonValue extracted_value(extracted);
+            auto result_or = extracted_value.to_string();
+            if (result_or.ok()) {
+                default_value_str = *result_or;
+            } else {
+                return;
+            }
+        }
+    } else {
+        JsonValue extracted_value(extracted);
+        auto result_or = extracted_value.to_string();
+        if (result_or.ok()) {
+            default_value_str = *result_or;
+        } else {
+            return;
+        }
+    }
+
+    column->set_default_value(default_value_str);
+}
+
 // Extend the schema fields based on the column access paths.
 // This ensures that only the necessary subfields required by the query are retained in the schema.
 Status OlapChunkSource::_extend_schema_by_access_paths() {
@@ -525,57 +594,7 @@ Status OlapChunkSource::_extend_schema_by_access_paths() {
 
         // Inherit default value from parent column if exists
         const auto& root_column = _tablet_schema->column(static_cast<size_t>(root_column_index));
-        if (root_column.has_default_value() && root_column.type() == TYPE_JSON) {
-            const std::string& json_default = root_column.default_value();
-            auto json_or = JsonValue::parse_json_or_string(Slice(json_default));
-            if (json_or.ok()) {
-                // Extract the sub path from linear path, e.g. "profile.level" -> "$.level"
-                std::string linear = path->linear_path();
-                std::string parent = path->path();
-                std::string json_path_str;
-                if (linear.size() > parent.size() && linear.compare(0, parent.size(), parent) == 0) {
-                    // linear = "profile.level", parent = "profile" -> sub = ".level" -> "$level"
-                    json_path_str = "$" + linear.substr(parent.size());
-                } else {
-                    json_path_str = "$";
-                }
-
-                auto json_path_or = JsonPath::parse(Slice(json_path_str));
-                if (json_path_or.ok()) {
-                    vpack::Builder builder;
-                    vpack::Slice extracted = JsonPath::extract(&json_or.value(), json_path_or.value(), &builder);
-                    if (!extracted.isNone()) {
-                        std::string default_value_str;
-
-                        // For string types (VARCHAR/CHAR), extract the raw string value without JSON quotes
-                        // For other types (INT/DOUBLE/BOOLEAN/etc), use JSON representation
-                        if (value_type == TYPE_VARCHAR || value_type == TYPE_CHAR) {
-                            if (extracted.isString()) {
-                                default_value_str = extracted.copyString();
-                            } else {
-                                // If not a string in JSON, convert to JSON string
-                                JsonValue extracted_value(extracted);
-                                auto result_str = extracted_value.to_string();
-                                if (result_str.ok()) {
-                                    default_value_str = *result_str;
-                                }
-                            }
-                        } else {
-                            // For non-string types, use JSON representation
-                            JsonValue extracted_value(extracted);
-                            auto result_str = extracted_value.to_string();
-                            if (result_str.ok()) {
-                                default_value_str = *result_str;
-                            }
-                        }
-
-                        if (!default_value_str.empty()) {
-                            column.set_default_value(default_value_str);
-                        }
-                    }
-                }
-            }
-        }
+        _inherit_default_value_from_json(&column, root_column, path.get());
 
         // For UNIQUE/AGG tables, extended flat JSON subcolumns act as value columns and
         // must have a valid aggregation method for pre-aggregation. Use REPLACE, which is

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -70,6 +70,8 @@ private:
     Status _init_column_access_paths(Schema* schema);
     Status _prune_schema_by_access_paths(Schema* schema);
     Status _extend_schema_by_access_paths();
+    void _inherit_default_value_from_json(TabletColumn* column, const TabletColumn& root_column,
+                                           const ColumnAccessPath* path);
 
 private:
     TabletReaderParams _params{};

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -71,7 +71,7 @@ private:
     Status _prune_schema_by_access_paths(Schema* schema);
     Status _extend_schema_by_access_paths();
     void _inherit_default_value_from_json(TabletColumn* column, const TabletColumn& root_column,
-                                           const ColumnAccessPath* path);
+                                          const ColumnAccessPath* path);
 
 private:
     TabletReaderParams _params{};

--- a/be/src/storage/rowset/default_value_column_iterator.cpp
+++ b/be/src/storage/rowset/default_value_column_iterator.cpp
@@ -83,7 +83,7 @@ Status DefaultValueColumnIterator::init(const ColumnIteratorOptions& opts) {
                 if (!json_or.ok()) {
                     // If JSON parse fails, treat as NULL to avoid query errors
                     // This prevents returning malformed data when FE validation is bypassed
-                    LOG(ERROR) << "Failed to parse JSON default value '" << _default_value
+                    LOG(WARNING) << "Failed to parse JSON default value '" << _default_value
                                << "', treating as NULL: " << json_or.status();
                     _is_default_value_null = true;
                 } else {

--- a/be/src/storage/rowset/default_value_column_iterator.cpp
+++ b/be/src/storage/rowset/default_value_column_iterator.cpp
@@ -84,7 +84,7 @@ Status DefaultValueColumnIterator::init(const ColumnIteratorOptions& opts) {
                     // If JSON parse fails, treat as NULL to avoid query errors
                     // This prevents returning malformed data when FE validation is bypassed
                     LOG(WARNING) << "Failed to parse JSON default value '" << _default_value
-                               << "', treating as NULL: " << json_or.status();
+                                 << "', treating as NULL: " << json_or.status();
                     _is_default_value_null = true;
                 } else {
                     Slice json_slice = json_or.value().get_slice();

--- a/be/src/storage/rowset/default_value_column_iterator.cpp
+++ b/be/src/storage/rowset/default_value_column_iterator.cpp
@@ -37,6 +37,7 @@
 #include "column/column.h"
 #include "storage/range.h"
 #include "storage/types.h"
+#include "util/json.h"
 #include "util/mem_util.hpp"
 
 namespace starrocks {
@@ -77,6 +78,25 @@ Status DefaultValueColumnIterator::init(const ColumnIteratorOptions& opts) {
                 memory_copy(string_buffer, _default_value.c_str(), length);
                 (static_cast<Slice*>(_mem_value))->size = length;
                 (static_cast<Slice*>(_mem_value))->data = string_buffer;
+            } else if (_type_info->type() == TYPE_JSON) {
+                auto json_or = JsonValue::parse_json_or_string(Slice(_default_value));
+                if (!json_or.ok()) {
+                    // If JSON parse fails, treat as NULL to avoid query errors
+                    // This prevents returning malformed data when FE validation is bypassed
+                    LOG(ERROR) << "Failed to parse JSON default value '" << _default_value
+                               << "', treating as NULL: " << json_or.status();
+                    _is_default_value_null = true;
+                } else {
+                    Slice json_slice = json_or.value().get_slice();
+                    auto length = static_cast<int32_t>(json_slice.size);
+                    char* string_buffer = reinterpret_cast<char*>(_pool.allocate(length));
+                    if (UNLIKELY(string_buffer == nullptr)) {
+                        return Status::InternalError("Mem usage has exceed the limit of BE");
+                    }
+                    memory_copy(string_buffer, json_slice.data, length);
+                    (static_cast<Slice*>(_mem_value))->size = length;
+                    (static_cast<Slice*>(_mem_value))->data = string_buffer;
+                }
             } else if (_type_info->type() == TYPE_ARRAY || _type_info->type() == TYPE_MAP ||
                        _type_info->type() == TYPE_STRUCT) {
                 // @todo: need support complex type literal
@@ -101,7 +121,7 @@ Status DefaultValueColumnIterator::next_batch(size_t* n, Column* dst) {
         DCHECK(ok) << "cannot append null to non-nullable column";
     } else {
         if (_type_info->type() == TYPE_OBJECT || _type_info->type() == TYPE_HLL ||
-            _type_info->type() == TYPE_PERCENTILE) {
+            _type_info->type() == TYPE_PERCENTILE || _type_info->type() == TYPE_JSON) {
             std::vector<Slice> slices;
             slices.reserve(*n);
             for (size_t i = 0; i < *n; i++) {
@@ -136,7 +156,7 @@ Status DefaultValueColumnIterator::next_batch(const SparseRange<>& range, Column
         DCHECK(ok) << "cannot append null to non-nullable column";
     } else {
         if (_type_info->type() == TYPE_OBJECT || _type_info->type() == TYPE_HLL ||
-            _type_info->type() == TYPE_PERCENTILE) {
+            _type_info->type() == TYPE_PERCENTILE || _type_info->type() == TYPE_JSON) {
             std::vector<Slice> slices;
             slices.reserve(to_read);
             for (size_t i = 0; i < to_read; i++) {

--- a/be/src/storage/schema_change_utils.cpp
+++ b/be/src/storage/schema_change_utils.cpp
@@ -637,9 +637,6 @@ Status SchemaChangeUtils::parse_request_normal(const TabletSchemaCSPtr& base_sch
                 *sc_directly = true;
             }
 
-            LOG(ERROR) << "[DEFAULT_VALUE_PATH_3] Schema change parsing new column: " << new_column.name()
-                       << ", type: " << new_column.type() << ", has_default: " << (new_column.has_default_value())
-                       << ", default_value: " << new_column.default_value();
             if (!init_column_mapping(column_mapping, new_column, new_column.default_value()).ok()) {
                 LOG(WARNING) << "init column mapping failed. column=" << new_column.name();
                 return Status::InternalError("init column mapping failed");

--- a/be/src/storage/schema_change_utils.cpp
+++ b/be/src/storage/schema_change_utils.cpp
@@ -822,8 +822,8 @@ Status SchemaChangeUtils::init_column_mapping(ColumnMapping* column_mapping, con
             if (!json_or.ok()) {
                 // If JSON parse fails, treat as NULL to avoid query errors
                 // This prevents returning malformed data when FE validation is bypassed
-                LOG(ERROR) << "Failed to parse JSON default value '" << value
-                           << "', treating as NULL: " << json_or.status();
+                LOG(WARNING) << "Failed to parse JSON default value '" << value
+                             << "', treating as NULL: " << json_or.status();
                 column_mapping->default_value_datum.set_null();
             } else {
                 column_mapping->default_json = std::make_unique<JsonValue>(std::move(json_or.value()));

--- a/test/sql/test_default_value/R/test_json_default.sql
+++ b/test/sql/test_default_value/R/test_json_default.sql
@@ -1,0 +1,597 @@
+-- name: test_json_default
+DROP DATABASE IF EXISTS test_json_default_db;
+-- result:
+-- !result
+CREATE DATABASE test_json_default_db;
+-- result:
+-- !result
+USE test_json_default_db;
+-- result:
+-- !result
+CREATE TABLE basic_json_types (
+    id INT NOT NULL,
+    json_object JSON DEFAULT '{"status": "active", "count": 0}',
+    json_array JSON DEFAULT '[1, 2, 3]',
+    json_string JSON DEFAULT '"hello"',
+    json_number JSON DEFAULT '42',
+    json_boolean JSON DEFAULT 'true',
+    json_null JSON DEFAULT 'null',
+    empty_object JSON DEFAULT '{}',
+    empty_array JSON DEFAULT '[]',
+    empty_string JSON DEFAULT '',
+    no_default JSON
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO basic_json_types (id) VALUES (1);
+-- result:
+-- !result
+SELECT * FROM basic_json_types ORDER BY id;
+-- result:
+1	{"count": 0, "status": "active"}	[1, 2, 3]	"hello"	"42"	"true"	"null"	{}	[]	""	None
+-- !result
+CREATE TABLE with_default (
+    id INT,
+    data JSON DEFAULT '{"default": true}'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+CREATE TABLE without_default (
+    id INT,
+    data JSON
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO with_default (id) VALUES (1);
+-- result:
+-- !result
+INSERT INTO without_default (id) VALUES (1);
+-- result:
+-- !result
+SELECT 
+    'with_default' AS table_name,
+    data,
+    data IS NULL AS is_null
+FROM with_default
+UNION ALL
+SELECT 
+    'without_default',
+    data,
+    data IS NULL
+FROM without_default;
+-- result:
+with_default	{"default": true}	0
+without_default	None	1
+-- !result
+CREATE TABLE empty_string_test (
+    id INT,
+    empty_unquoted JSON DEFAULT '',
+    empty_quoted JSON DEFAULT '""'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO empty_string_test (id) VALUES (1);
+-- result:
+-- !result
+INSERT INTO empty_string_test VALUES (2, '', '""');
+-- result:
+-- !result
+SELECT 
+    id,
+    empty_unquoted,
+    empty_quoted,
+    empty_unquoted = empty_quoted AS are_equal
+FROM empty_string_test
+ORDER BY id;
+-- result:
+1	""	""	1
+2	""	""	1
+-- !result
+CREATE TABLE fast_schema_change (
+    id INT NOT NULL,
+    name VARCHAR(50)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+-- result:
+-- !result
+INSERT INTO fast_schema_change VALUES (1, 'alice'), (2, 'bob');
+-- result:
+-- !result
+ALTER TABLE fast_schema_change ADD COLUMN metadata JSON DEFAULT '{"version": 1, "enabled": true}';
+-- result:
+-- !result
+SELECT id, name, metadata FROM fast_schema_change ORDER BY id;
+-- result:
+1	alice	{"enabled": true, "version": 1}
+2	bob	{"enabled": true, "version": 1}
+-- !result
+INSERT INTO fast_schema_change VALUES (3, 'charlie', '{"version": 2, "enabled": false}');
+-- result:
+-- !result
+SELECT id, name, metadata FROM fast_schema_change ORDER BY id;
+-- result:
+1	alice	{"enabled": true, "version": 1}
+2	bob	{"enabled": true, "version": 1}
+3	charlie	{"enabled": false, "version": 2}
+-- !result
+CREATE TABLE traditional_schema_change (
+    id INT NOT NULL,
+    value INT
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "false");
+-- result:
+-- !result
+INSERT INTO traditional_schema_change VALUES (1, 100), (2, 200);
+-- result:
+-- !result
+ALTER TABLE traditional_schema_change ADD COLUMN metadata JSON DEFAULT '{"source": "migration", "timestamp": 0}';
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SELECT count(*) FROM traditional_schema_change;
+-- result:
+2
+-- !result
+CREATE TABLE extended_column_basic (
+    id INT NOT NULL,
+    user_data JSON
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO extended_column_basic VALUES 
+    (1, '{"user": {"name": "alice", "age": 25}}'),
+    (2, '{"user": {"name": "bob", "age": 30}}');
+-- result:
+-- !result
+ALTER TABLE extended_column_basic ADD COLUMN profile JSON DEFAULT '{"level": 1, "vip": false, "tags": ["default"]}';
+-- result:
+-- !result
+SELECT 
+    id,
+    cast(get_json_int(profile, '$.level') AS INT) AS level,
+    cast(get_json_bool(profile, '$.vip') AS BOOLEAN) AS vip,
+    get_json_string(profile, '$.tags[0]') AS first_tag
+FROM extended_column_basic
+ORDER BY id;
+-- result:
+1	1	0	default
+2	1	0	default
+-- !result
+SELECT 
+    id,
+    json_query(profile, '$.tags') AS tags,
+    cast(get_json_int(profile, '$.level') AS INT) AS level
+FROM extended_column_basic
+ORDER BY id;
+-- result:
+1	["default"]	1
+2	["default"]	1
+-- !result
+INSERT INTO extended_column_basic VALUES 
+    (3, '{"user": {"name": "charlie", "age": 35}}', '{"level": 10, "vip": true, "tags": ["premium"]}');
+-- result:
+-- !result
+SELECT 
+    id,
+    get_json_string(user_data, '$.user.name') AS user_name,
+    cast(get_json_int(profile, '$.level') AS INT) AS level,
+    cast(get_json_bool(profile, '$.vip') AS BOOLEAN) AS vip,
+    get_json_string(profile, '$.tags[0]') AS first_tag
+FROM extended_column_basic
+ORDER BY id;
+-- result:
+1	alice	1	0	default
+2	bob	1	0	default
+3	charlie	10	1	premium
+-- !result
+CREATE TABLE extended_complex_types (
+    id INT NOT NULL,
+    name VARCHAR(50)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO extended_complex_types VALUES (1, 'alice'), (2, 'bob'), (3, 'charlie');
+-- result:
+-- !result
+ALTER TABLE extended_complex_types 
+ADD COLUMN profile JSON DEFAULT '{"level": 10, "vip": true, "score": 95.5, "tags": ["gold", "premium"], "meta": {"city": "Beijing", "age": 25}}';
+-- result:
+-- !result
+SELECT 
+    id,
+    name,
+    cast(get_json_int(profile, '$.level') AS INT) AS level,
+    cast(get_json_bool(profile, '$.vip') AS BOOLEAN) AS vip,
+    cast(get_json_double(profile, '$.score') AS DOUBLE) AS score,
+    get_json_string(profile, '$.tags[0]') AS first_tag,
+    get_json_string(profile, '$.tags[1]') AS second_tag,
+    get_json_string(profile, '$.meta.city') AS city,
+    cast(get_json_int(profile, '$.meta.age') AS INT) AS age
+FROM extended_complex_types
+ORDER BY id;
+-- result:
+1	alice	10	0	95.5	gold	premium	Beijing	25
+2	bob	10	0	95.5	gold	premium	Beijing	25
+3	charlie	10	0	95.5	gold	premium	Beijing	25
+-- !result
+INSERT INTO extended_complex_types VALUES 
+    (4, 'david', '{"level": 99, "vip": false, "score": 88.8, "tags": ["silver"], "meta": {"city": "Shanghai", "age": 30}}');
+-- result:
+-- !result
+SELECT 
+    id,
+    name,
+    cast(get_json_int(profile, '$.level') AS INT) AS level,
+    cast(get_json_bool(profile, '$.vip') AS BOOLEAN) AS vip
+FROM extended_complex_types
+ORDER BY id;
+-- result:
+1	alice	10	0
+2	bob	10	0
+3	charlie	10	0
+4	david	99	0
+-- !result
+CREATE TABLE extended_multi_json (
+    id INT NOT NULL,
+    name VARCHAR(50)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO extended_multi_json VALUES (1, 'user1'), (2, 'user2');
+-- result:
+-- !result
+ALTER TABLE extended_multi_json ADD COLUMN config JSON DEFAULT '{"theme": "dark", "lang": "en"}';
+-- result:
+-- !result
+ALTER TABLE extended_multi_json ADD COLUMN stats JSON DEFAULT '{"views": 100, "likes": 50}';
+-- result:
+-- !result
+SELECT 
+    id,
+    name,
+    get_json_string(config, '$.theme') AS theme,
+    get_json_string(config, '$.lang') AS lang,
+    cast(get_json_int(stats, '$.views') AS INT) AS views,
+    cast(get_json_int(stats, '$.likes') AS INT) AS likes
+FROM extended_multi_json
+ORDER BY id;
+-- result:
+1	user1	dark	en	100	50
+2	user2	dark	en	100	50
+-- !result
+CREATE TABLE extended_null_values (
+    id INT NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO extended_null_values VALUES (1), (2);
+-- result:
+-- !result
+ALTER TABLE extended_null_values ADD COLUMN data JSON DEFAULT '{"value": null, "count": 0, "name": "test"}';
+-- result:
+-- !result
+SELECT 
+    id,
+    get_json_string(data, '$.value') AS value_field,
+    cast(get_json_int(data, '$.count') AS INT) AS count_field,
+    get_json_string(data, '$.name') AS name_field
+FROM extended_null_values
+ORDER BY id;
+-- result:
+1	null	0	test
+2	null	0	test
+-- !result
+CREATE TABLE extended_empty_structures (
+    id INT NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO extended_empty_structures VALUES (1), (2);
+-- result:
+-- !result
+ALTER TABLE extended_empty_structures ADD COLUMN info JSON DEFAULT '{"tags": [], "meta": {}}';
+-- result:
+-- !result
+SELECT 
+    id,
+    json_query(info, '$.tags') AS tags,
+    json_query(info, '$.meta') AS meta,
+    get_json_string(info, '$.tags[0]') AS first_tag
+FROM extended_empty_structures
+ORDER BY id;
+-- result:
+1	[]	{}	None
+2	[]	{}	None
+-- !result
+CREATE TABLE extended_deep_nested (
+    id INT NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO extended_deep_nested VALUES (1), (2);
+-- result:
+-- !result
+ALTER TABLE extended_deep_nested ADD COLUMN deep JSON DEFAULT '{"level1": {"level2": {"level3": {"value": 42, "flag": true}}}}';
+-- result:
+-- !result
+SELECT 
+    id,
+    cast(get_json_int(deep, '$.level1.level2.level3.value') AS INT) AS nested_value,
+    cast(get_json_bool(deep, '$.level1.level2.level3.flag') AS BOOLEAN) AS nested_flag,
+    json_query(deep, '$.level1.level2') AS level2_obj
+FROM extended_deep_nested
+ORDER BY id;
+-- result:
+1	42	0	{"level3": {"flag": true, "value": 42}}
+2	42	0	{"level3": {"flag": true, "value": 42}}
+-- !result
+CREATE TABLE extended_arrays (
+    id INT NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO extended_arrays VALUES (1), (2), (3);
+-- result:
+-- !result
+ALTER TABLE extended_arrays ADD COLUMN items JSON DEFAULT '{"products": ["apple", "banana", "orange"], "prices": [1.5, 2.0, 1.8]}';
+-- result:
+-- !result
+SELECT 
+    id,
+    get_json_string(items, '$.products[0]') AS product_0,
+    get_json_string(items, '$.products[1]') AS product_1,
+    get_json_string(items, '$.products[2]') AS product_2,
+    cast(get_json_double(items, '$.prices[0]') AS DOUBLE) AS price_0,
+    cast(get_json_double(items, '$.prices[1]') AS DOUBLE) AS price_1,
+    json_query(items, '$.products') AS all_products
+FROM extended_arrays
+ORDER BY id;
+-- result:
+1	apple	banana	orange	1.5	2.0	["apple", "banana", "orange"]
+2	apple	banana	orange	1.5	2.0	["apple", "banana", "orange"]
+3	apple	banana	orange	1.5	2.0	["apple", "banana", "orange"]
+-- !result
+CREATE TABLE extended_function_compat (
+    id INT NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO extended_function_compat VALUES (1), (2);
+-- result:
+-- !result
+ALTER TABLE extended_function_compat ADD COLUMN profile JSON DEFAULT '{"user": {"name": "Alice", "age": 25}, "score": 95}';
+-- result:
+-- !result
+SELECT 
+    id,
+    json_query(profile, '$.user.name') AS name_via_query,
+    get_json_string(profile, '$.user.name') AS name_via_get,
+    json_query(profile, '$.score') AS score_via_query,
+    cast(get_json_int(profile, '$.score') AS INT) AS score_via_get
+FROM extended_function_compat
+ORDER BY id;
+-- result:
+1	"Alice"	Alice	95	95
+2	"Alice"	Alice	95	95
+-- !result
+CREATE TABLE pk_basic_defaults (
+    user_id INT NOT NULL,
+    username VARCHAR(50),
+    profile JSON DEFAULT '{"level": 1, "vip": false, "status": "active"}',
+    settings JSON DEFAULT '{"notifications": true, "theme": "light"}'
+) PRIMARY KEY(user_id)
+DISTRIBUTED BY HASH(user_id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO pk_basic_defaults (user_id, username) VALUES (1, 'user1');
+-- result:
+-- !result
+INSERT INTO pk_basic_defaults (user_id, username) VALUES (2, 'user2');
+-- result:
+-- !result
+SELECT 
+    user_id,
+    username,
+    profile,
+    settings
+FROM pk_basic_defaults
+ORDER BY user_id;
+-- result:
+1	user1	{"level": 1, "status": "active", "vip": false}	{"notifications": true, "theme": "light"}
+2	user2	{"level": 1, "status": "active", "vip": false}	{"notifications": true, "theme": "light"}
+-- !result
+SELECT 
+    user_id,
+    username,
+    cast(get_json_int(profile, '$.level') AS INT) AS level,
+    cast(get_json_bool(profile, '$.vip') AS BOOLEAN) AS vip,
+    get_json_string(profile, '$.status') AS status,
+    cast(get_json_bool(settings, '$.notifications') AS BOOLEAN) AS notifications
+FROM pk_basic_defaults
+ORDER BY user_id;
+-- result:
+1	user1	1	0	active	1
+2	user2	1	0	active	1
+-- !result
+INSERT INTO pk_basic_defaults VALUES 
+    (3, 'user3', '{"level": 10, "vip": true, "status": "premium"}', '{"notifications": false, "theme": "dark"}');
+-- result:
+-- !result
+SELECT 
+    user_id,
+    username,
+    cast(get_json_int(profile, '$.level') AS INT) AS level,
+    cast(get_json_bool(profile, '$.vip') AS BOOLEAN) AS vip
+FROM pk_basic_defaults
+ORDER BY user_id;
+-- result:
+1	user1	1	0
+2	user2	1	0
+3	user3	10	1
+-- !result
+CREATE TABLE pk_partial_update (
+    order_id INT NOT NULL,
+    product_name VARCHAR(50),
+    quantity INT DEFAULT '1',
+    config JSON DEFAULT '{"priority": "normal", "tracking": true}',
+    metadata JSON DEFAULT '{"source": "web", "version": 1}'
+) PRIMARY KEY(order_id)
+DISTRIBUTED BY HASH(order_id) BUCKETS 2
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+SET partial_update_mode = 'column';
+-- result:
+-- !result
+INSERT INTO pk_partial_update (order_id, product_name) VALUES (1, 'laptop');
+-- result:
+-- !result
+INSERT INTO pk_partial_update (order_id, product_name) VALUES (2, 'phone');
+-- result:
+-- !result
+INSERT INTO pk_partial_update (order_id, product_name) VALUES (3, 'tablet');
+-- result:
+-- !result
+SELECT 
+    order_id,
+    product_name,
+    quantity,
+    get_json_string(config, '$.priority') AS priority,
+    cast(get_json_bool(config, '$.tracking') AS BOOLEAN) AS tracking,
+    get_json_string(metadata, '$.source') AS source,
+    cast(get_json_int(metadata, '$.version') AS INT) AS version
+FROM pk_partial_update 
+ORDER BY order_id;
+-- result:
+1	laptop	1	normal	1	web	1
+2	phone	1	normal	1	web	1
+3	tablet	1	normal	1	web	1
+-- !result
+INSERT INTO pk_partial_update (order_id, product_name, config) 
+VALUES (4, 'monitor', '{"priority": "high", "tracking": false}');
+-- result:
+-- !result
+INSERT INTO pk_partial_update (order_id, product_name, metadata) 
+VALUES (5, 'keyboard', '{"source": "mobile", "version": 2}');
+-- result:
+-- !result
+SELECT 
+    order_id,
+    product_name,
+    get_json_string(config, '$.priority') AS priority,
+    get_json_string(metadata, '$.source') AS source
+FROM pk_partial_update 
+ORDER BY order_id;
+-- result:
+1	laptop	normal	web
+2	phone	normal	web
+3	tablet	normal	web
+4	monitor	high	web
+5	keyboard	normal	mobile
+-- !result
+ALTER TABLE pk_partial_update ADD COLUMN extras JSON DEFAULT '{"discount": 0.0, "tax": 0.08}';
+-- result:
+-- !result
+INSERT INTO pk_partial_update (order_id, product_name) VALUES (6, 'mouse');
+-- result:
+-- !result
+INSERT INTO pk_partial_update (order_id, product_name, quantity) VALUES (7, 'headset', 3);
+-- result:
+-- !result
+SELECT 
+    order_id,
+    product_name,
+    quantity,
+    get_json_string(config, '$.priority') AS priority,
+    get_json_string(metadata, '$.source') AS source,
+    cast(get_json_double(extras, '$.discount') AS DOUBLE) AS discount,
+    cast(get_json_double(extras, '$.tax') AS DOUBLE) AS tax
+FROM pk_partial_update 
+ORDER BY order_id;
+-- result:
+1	laptop	1	normal	web	0.0	0.08
+2	phone	1	normal	web	0.0	0.08
+3	tablet	1	normal	web	0.0	0.08
+4	monitor	1	high	web	0.0	0.08
+5	keyboard	1	normal	mobile	0.0	0.08
+6	mouse	1	normal	web	0.0	0.08
+7	headset	3	normal	web	0.0	0.08
+-- !result
+SET partial_update_mode = 'auto';
+-- result:
+-- !result
+CREATE TABLE flatjson_field_absence (
+    id INT NOT NULL,
+    data JSON
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO flatjson_field_absence VALUES 
+    (1, '{"name": "alice", "age": 25, "city": "Beijing"}'),
+    (2, '{"name": "bob", "age": 30, "city": "Shanghai"}'),
+    (3, '{"name": "charlie", "age": 35, "city": "Guangzhou"}');
+-- result:
+-- !result
+INSERT INTO flatjson_field_absence VALUES 
+    (4, '{"name": "david", "age": 40, "city": "Shenzhen", "optional_field": "value1"}'),
+    (5, '{"name": "eve", "age": 45, "city": "Hangzhou", "optional_field": "value2"}');
+-- result:
+-- !result
+SELECT 
+    id,
+    get_json_string(data, '$.name') AS name,
+    get_json_string(data, '$.optional_field') AS optional_field_get,
+    json_query(data, '$.optional_field') AS optional_field_query
+FROM flatjson_field_absence
+ORDER BY id;
+-- result:
+1	alice	None	None
+2	bob	None	None
+3	charlie	None	None
+4	david	value1	"value1"
+5	eve	value2	"value2"
+-- !result
+SELECT 
+    id,
+    get_json_string(data, '$.completely_missing') AS missing_field
+FROM flatjson_field_absence
+ORDER BY id;
+-- result:
+1	None
+2	None
+3	None
+4	None
+5	None
+-- !result

--- a/test/sql/test_default_value/R/test_json_strict_validation.sql
+++ b/test/sql/test_default_value/R/test_json_strict_validation.sql
@@ -1,0 +1,184 @@
+-- name: test_json_strict_validation
+DROP DATABASE IF EXISTS test_json_strict_db;
+-- result:
+-- !result
+CREATE DATABASE test_json_strict_db;
+-- result:
+-- !result
+USE test_json_strict_db;
+-- result:
+-- !result
+CREATE TABLE test_json_strict_valid (
+    id INT,
+    data1 JSON DEFAULT '{"key": "value"}',
+    data2 JSON DEFAULT '{"name": "Alice", "age": 30}',
+    data3 JSON DEFAULT '{}',
+    data4 JSON DEFAULT 'null',
+    data5 JSON DEFAULT '""',
+    data6 JSON DEFAULT '123',
+    data7 JSON DEFAULT 'true'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO test_json_strict_valid (id) VALUES (1);
+-- result:
+-- !result
+SELECT * FROM test_json_strict_valid;
+-- result:
+1	{"key": "value"}	{"age": 30, "name": "Alice"}	{}	"null"	""	"123"	"true"
+-- !result
+CREATE TABLE test_json_strict_invalid_unquoted_key (
+    id INT,
+    data JSON DEFAULT '{key: "value"}'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Invalid default value for \'data\': Invalid JSON format for default value: {key: "value"}. Error: com.google.gson.stream.MalformedJsonException: Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $..')
+-- !result
+CREATE TABLE test_json_strict_invalid_trailing_comma (
+    id INT,
+    data JSON DEFAULT '{"key": "value",}'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Invalid default value for \'data\': Invalid JSON format for default value: {"key": "value",}. Error: com.google.gson.stream.MalformedJsonException: Expected name at line 1 column 18 path $.key.')
+-- !result
+CREATE TABLE test_json_strict_invalid_single_quote (
+    id INT,
+    data JSON DEFAULT "{'key': 'value'}"
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Invalid default value for 'data': Invalid JSON format for default value: {'key': 'value'}. Error: com.google.gson.stream.MalformedJsonException: Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 3 path $..")
+-- !result
+CREATE TABLE test_json_strict_invalid_comment (
+    id INT,
+    data JSON DEFAULT '{"key": "value" /* comment */}'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Invalid default value for \'data\': Invalid JSON format for default value: {"key": "value" /* comment */}. Error: com.google.gson.stream.MalformedJsonException: Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 18 path $.key.')
+-- !result
+CREATE TABLE test_json_strict_valid_complex (
+    id INT,
+    data JSON DEFAULT '{"user": {"name": "Bob", "age": 25, "address": {"city": "Beijing", "zip": "100000"}}, "tags": ["a", "b", "c"], "active": true, "score": 95.5}'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO test_json_strict_valid_complex (id) VALUES (1);
+-- result:
+-- !result
+SELECT * FROM test_json_strict_valid_complex;
+-- result:
+1	{"active": true, "score": 95.5, "tags": ["a", "b", "c"], "user": {"address": {"city": "Beijing", "zip": "100000"}, "age": 25, "name": "Bob"}}
+-- !result
+CREATE TABLE test_json_strict_valid_nested (
+    id INT,
+    data JSON DEFAULT '{"level1": {"level2": {"level3": {"level4": {"level5": "deep"}}}}}'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO test_json_strict_valid_nested (id) VALUES (1);
+-- result:
+-- !result
+SELECT * FROM test_json_strict_valid_nested;
+-- result:
+1	{"level1": {"level2": {"level3": {"level4": {"level5": "deep"}}}}}
+-- !result
+CREATE TABLE test_json_strict_valid_array (
+    id INT,
+    data1 JSON DEFAULT '[1, 2, 3, 4, 5]',
+    data2 JSON DEFAULT '[{"name": "Alice"}, {"name": "Bob"}]',
+    data3 JSON DEFAULT '[[1, 2], [3, 4], [5, 6]]',
+    data4 JSON DEFAULT '[]'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO test_json_strict_valid_array (id) VALUES (1);
+-- result:
+-- !result
+SELECT * FROM test_json_strict_valid_array;
+-- result:
+1	[1, 2, 3, 4, 5]	[{"name": "Alice"}, {"name": "Bob"}]	[[1, 2], [3, 4], [5, 6]]	[]
+-- !result
+CREATE TABLE test_json_strict_edge_cases (
+    id INT,
+    empty_obj JSON DEFAULT '{}',
+    empty_arr JSON DEFAULT '[]',
+    null_val JSON DEFAULT 'null',
+    empty_str JSON DEFAULT '""',
+    zero_num JSON DEFAULT '0',
+    neg_num JSON DEFAULT '-123.45',
+    bool_true JSON DEFAULT 'true',
+    bool_false JSON DEFAULT 'false',
+    unicode JSON DEFAULT '{"text": "你好世界🌍"}',
+    escaped JSON DEFAULT '{"text": "line1\\nline2\\ttab"}'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+INSERT INTO test_json_strict_edge_cases (id) VALUES (1);
+-- result:
+-- !result
+SELECT * FROM test_json_strict_edge_cases;
+-- result:
+1	{}	[]	"null"	""	"0"	"-123.45"	"true"	"false"	{"text": "你好世界🌍"}	{"text": "line1\nline2\ttab"}
+-- !result
+CREATE TABLE test_json_strict_invalid_array_trailing_comma (
+    id INT,
+    data JSON DEFAULT '[1, 2, 3,]'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Invalid default value for 'data': Invalid JSON format for default value: [1, 2, 3,]. Error: com.google.gson.stream.MalformedJsonException: Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 11 path $[3].")
+-- !result
+CREATE TABLE test_json_strict_invalid_multi_trailing_comma (
+    id INT,
+    data JSON DEFAULT '{"a": 1,,}'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Invalid default value for \'data\': Invalid JSON format for default value: {"a": 1,,}. Error: com.google.gson.stream.MalformedJsonException: Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 10 path $.a.')
+-- !result
+CREATE TABLE test_json_strict_invalid_unquoted_value (
+    id INT,
+    data JSON DEFAULT '{"key": value}'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Invalid default value for \'data\': Invalid JSON format for default value: {"key": value}. Error: com.google.gson.stream.MalformedJsonException: Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 9 path $.key.')
+-- !result
+CREATE TABLE test_json_strict_invalid_nan (
+    id INT,
+    data JSON DEFAULT '{"value": NaN}'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Invalid default value for \'data\': Invalid JSON format for default value: {"value": NaN}. Error: com.google.gson.stream.MalformedJsonException: Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 11 path $.value.')
+-- !result
+CREATE TABLE test_json_strict_invalid_infinity (
+    id INT,
+    data JSON DEFAULT '{"value": Infinity}'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Invalid default value for \'data\': Invalid JSON format for default value: {"value": Infinity}. Error: com.google.gson.stream.MalformedJsonException: Use JsonReader.setLenient(true) to accept malformed JSON at line 1 column 11 path $.value.')
+-- !result

--- a/test/sql/test_default_value/T/test_json_default.sql
+++ b/test/sql/test_default_value/T/test_json_default.sql
@@ -1,0 +1,524 @@
+-- name: test_json_default
+-- Test JSON column default value support across various scenarios
+-- Covers fast/traditional schema evolution, extended columns, and PRIMARY KEY tables
+
+DROP DATABASE IF EXISTS test_json_default_db;
+CREATE DATABASE test_json_default_db;
+USE test_json_default_db;
+
+-- ====================================================================================
+-- SECTION 1: Basic JSON Default Values
+-- ====================================================================================
+
+-- Test: All JSON value types as defaults
+CREATE TABLE basic_json_types (
+    id INT NOT NULL,
+    json_object JSON DEFAULT '{"status": "active", "count": 0}',
+    json_array JSON DEFAULT '[1, 2, 3]',
+    json_string JSON DEFAULT '"hello"',
+    json_number JSON DEFAULT '42',
+    json_boolean JSON DEFAULT 'true',
+    json_null JSON DEFAULT 'null',
+    empty_object JSON DEFAULT '{}',
+    empty_array JSON DEFAULT '[]',
+    empty_string JSON DEFAULT '',
+    no_default JSON
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- Insert using all defaults
+INSERT INTO basic_json_types (id) VALUES (1);
+
+-- Verify all default values
+SELECT * FROM basic_json_types ORDER BY id;
+
+-- Test: Comparing columns with and without defaults
+CREATE TABLE with_default (
+    id INT,
+    data JSON DEFAULT '{"default": true}'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+CREATE TABLE without_default (
+    id INT,
+    data JSON
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO with_default (id) VALUES (1);
+INSERT INTO without_default (id) VALUES (1);
+
+-- Compare: default value vs NULL
+SELECT 
+    'with_default' AS table_name,
+    data,
+    data IS NULL AS is_null
+FROM with_default
+UNION ALL
+SELECT 
+    'without_default',
+    data,
+    data IS NULL
+FROM without_default;
+
+-- Test: Empty string handling
+CREATE TABLE empty_string_test (
+    id INT,
+    empty_unquoted JSON DEFAULT '',
+    empty_quoted JSON DEFAULT '""'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO empty_string_test (id) VALUES (1);
+INSERT INTO empty_string_test VALUES (2, '', '""');
+
+SELECT 
+    id,
+    empty_unquoted,
+    empty_quoted,
+    empty_unquoted = empty_quoted AS are_equal
+FROM empty_string_test
+ORDER BY id;
+
+-- ====================================================================================
+-- SECTION 2: ALTER TABLE ADD COLUMN - Fast Schema Evolution
+-- ====================================================================================
+
+-- Test: Add JSON column to existing table (fast schema evolution)
+CREATE TABLE fast_schema_change (
+    id INT NOT NULL,
+    name VARCHAR(50)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "true");
+
+-- Insert data before adding JSON column
+INSERT INTO fast_schema_change VALUES (1, 'alice'), (2, 'bob');
+
+-- Add JSON column with default value
+ALTER TABLE fast_schema_change ADD COLUMN metadata JSON DEFAULT '{"version": 1, "enabled": true}';
+
+-- Old rows should use default value
+SELECT id, name, metadata FROM fast_schema_change ORDER BY id;
+
+-- New rows can have actual values
+INSERT INTO fast_schema_change VALUES (3, 'charlie', '{"version": 2, "enabled": false}');
+
+SELECT id, name, metadata FROM fast_schema_change ORDER BY id;
+
+-- ====================================================================================
+-- SECTION 3: ALTER TABLE ADD COLUMN - Traditional Schema Change
+-- ====================================================================================
+
+-- Test: Add JSON column with data rewrite (traditional schema change)
+CREATE TABLE traditional_schema_change (
+    id INT NOT NULL,
+    value INT
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1", "fast_schema_evolution" = "false");
+
+INSERT INTO traditional_schema_change VALUES (1, 100), (2, 200);
+
+-- Add JSON column - triggers full data rewrite
+ALTER TABLE traditional_schema_change ADD COLUMN metadata JSON DEFAULT '{"source": "migration", "timestamp": 0}';
+
+function: wait_alter_table_finish()
+
+SELECT count(*) FROM traditional_schema_change;
+
+-- ====================================================================================
+-- SECTION 4: Extended Column with JSON Functions (FlatJSON Optimization)
+-- ====================================================================================
+
+-- Test: JSON subfield extraction with extended columns
+-- When using get_json_int/bool/string functions on JSON columns added via ALTER TABLE,
+-- StarRocks creates "Extended Columns" as a FlatJSON optimization.
+-- Old rows (before ALTER) must correctly use the JSON default value.
+
+CREATE TABLE extended_column_basic (
+    id INT NOT NULL,
+    user_data JSON
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- Insert data before adding new JSON column
+INSERT INTO extended_column_basic VALUES 
+    (1, '{"user": {"name": "alice", "age": 25}}'),
+    (2, '{"user": {"name": "bob", "age": 30}}');
+
+-- Add NEW JSON column with nested default value
+ALTER TABLE extended_column_basic ADD COLUMN profile JSON DEFAULT '{"level": 1, "vip": false, "tags": ["default"]}';
+
+-- Query JSON subfields using get_json_* functions
+-- This creates Extended Columns (e.g., profile.level, profile.vip)
+-- Old rows should correctly extract values from the default JSON
+SELECT 
+    id,
+    cast(get_json_int(profile, '$.level') AS INT) AS level,
+    cast(get_json_bool(profile, '$.vip') AS BOOLEAN) AS vip,
+    get_json_string(profile, '$.tags[0]') AS first_tag
+FROM extended_column_basic
+ORDER BY id;
+
+-- Also test with json_query function
+SELECT 
+    id,
+    json_query(profile, '$.tags') AS tags,
+    cast(get_json_int(profile, '$.level') AS INT) AS level
+FROM extended_column_basic
+ORDER BY id;
+
+-- Insert new data with actual values
+INSERT INTO extended_column_basic VALUES 
+    (3, '{"user": {"name": "charlie", "age": 35}}', '{"level": 10, "vip": true, "tags": ["premium"]}');
+
+-- Query again: mix of default values (rows 1-2) and actual values (row 3)
+SELECT 
+    id,
+    get_json_string(user_data, '$.user.name') AS user_name,
+    cast(get_json_int(profile, '$.level') AS INT) AS level,
+    cast(get_json_bool(profile, '$.vip') AS BOOLEAN) AS vip,
+    get_json_string(profile, '$.tags[0]') AS first_tag
+FROM extended_column_basic
+ORDER BY id;
+
+-- ====================================================================================
+-- SECTION 5: Extended Column - Comprehensive Scenarios
+-- ====================================================================================
+
+-- Test 5.1: Complex nested JSON with all function types
+CREATE TABLE extended_complex_types (
+    id INT NOT NULL,
+    name VARCHAR(50)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO extended_complex_types VALUES (1, 'alice'), (2, 'bob'), (3, 'charlie');
+
+ALTER TABLE extended_complex_types 
+ADD COLUMN profile JSON DEFAULT '{"level": 10, "vip": true, "score": 95.5, "tags": ["gold", "premium"], "meta": {"city": "Beijing", "age": 25}}';
+
+-- Test all JSON extraction function types
+SELECT 
+    id,
+    name,
+    cast(get_json_int(profile, '$.level') AS INT) AS level,
+    cast(get_json_bool(profile, '$.vip') AS BOOLEAN) AS vip,
+    cast(get_json_double(profile, '$.score') AS DOUBLE) AS score,
+    get_json_string(profile, '$.tags[0]') AS first_tag,
+    get_json_string(profile, '$.tags[1]') AS second_tag,
+    get_json_string(profile, '$.meta.city') AS city,
+    cast(get_json_int(profile, '$.meta.age') AS INT) AS age
+FROM extended_complex_types
+ORDER BY id;
+
+-- Mix default and actual values
+INSERT INTO extended_complex_types VALUES 
+    (4, 'david', '{"level": 99, "vip": false, "score": 88.8, "tags": ["silver"], "meta": {"city": "Shanghai", "age": 30}}');
+
+SELECT 
+    id,
+    name,
+    cast(get_json_int(profile, '$.level') AS INT) AS level,
+    cast(get_json_bool(profile, '$.vip') AS BOOLEAN) AS vip
+FROM extended_complex_types
+ORDER BY id;
+
+-- Test 5.2: Multiple JSON columns with different defaults
+CREATE TABLE extended_multi_json (
+    id INT NOT NULL,
+    name VARCHAR(50)
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO extended_multi_json VALUES (1, 'user1'), (2, 'user2');
+
+ALTER TABLE extended_multi_json ADD COLUMN config JSON DEFAULT '{"theme": "dark", "lang": "en"}';
+
+ALTER TABLE extended_multi_json ADD COLUMN stats JSON DEFAULT '{"views": 100, "likes": 50}';
+
+-- Query subfields from multiple JSON columns
+SELECT 
+    id,
+    name,
+    get_json_string(config, '$.theme') AS theme,
+    get_json_string(config, '$.lang') AS lang,
+    cast(get_json_int(stats, '$.views') AS INT) AS views,
+    cast(get_json_int(stats, '$.likes') AS INT) AS likes
+FROM extended_multi_json
+ORDER BY id;
+
+-- Test 5.3: JSON with null values
+CREATE TABLE extended_null_values (
+    id INT NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO extended_null_values VALUES (1), (2);
+
+ALTER TABLE extended_null_values ADD COLUMN data JSON DEFAULT '{"value": null, "count": 0, "name": "test"}';
+
+SELECT 
+    id,
+    get_json_string(data, '$.value') AS value_field,
+    cast(get_json_int(data, '$.count') AS INT) AS count_field,
+    get_json_string(data, '$.name') AS name_field
+FROM extended_null_values
+ORDER BY id;
+
+-- Test 5.4: Empty arrays and objects
+CREATE TABLE extended_empty_structures (
+    id INT NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO extended_empty_structures VALUES (1), (2);
+
+ALTER TABLE extended_empty_structures ADD COLUMN info JSON DEFAULT '{"tags": [], "meta": {}}';
+
+SELECT 
+    id,
+    json_query(info, '$.tags') AS tags,
+    json_query(info, '$.meta') AS meta,
+    get_json_string(info, '$.tags[0]') AS first_tag
+FROM extended_empty_structures
+ORDER BY id;
+
+-- Test 5.5: Deep nested structures
+CREATE TABLE extended_deep_nested (
+    id INT NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO extended_deep_nested VALUES (1), (2);
+
+ALTER TABLE extended_deep_nested ADD COLUMN deep JSON DEFAULT '{"level1": {"level2": {"level3": {"value": 42, "flag": true}}}}';
+
+SELECT 
+    id,
+    cast(get_json_int(deep, '$.level1.level2.level3.value') AS INT) AS nested_value,
+    cast(get_json_bool(deep, '$.level1.level2.level3.flag') AS BOOLEAN) AS nested_flag,
+    json_query(deep, '$.level1.level2') AS level2_obj
+FROM extended_deep_nested
+ORDER BY id;
+
+-- Test 5.6: Arrays with multiple elements
+CREATE TABLE extended_arrays (
+    id INT NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO extended_arrays VALUES (1), (2), (3);
+
+ALTER TABLE extended_arrays ADD COLUMN items JSON DEFAULT '{"products": ["apple", "banana", "orange"], "prices": [1.5, 2.0, 1.8]}';
+
+SELECT 
+    id,
+    get_json_string(items, '$.products[0]') AS product_0,
+    get_json_string(items, '$.products[1]') AS product_1,
+    get_json_string(items, '$.products[2]') AS product_2,
+    cast(get_json_double(items, '$.prices[0]') AS DOUBLE) AS price_0,
+    cast(get_json_double(items, '$.prices[1]') AS DOUBLE) AS price_1,
+    json_query(items, '$.products') AS all_products
+FROM extended_arrays
+ORDER BY id;
+
+-- Test 5.7: Function compatibility (json_query vs get_json_*)
+CREATE TABLE extended_function_compat (
+    id INT NOT NULL
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+INSERT INTO extended_function_compat VALUES (1), (2);
+
+ALTER TABLE extended_function_compat ADD COLUMN profile JSON DEFAULT '{"user": {"name": "Alice", "age": 25}, "score": 95}';
+
+-- Both function styles should return consistent results
+SELECT 
+    id,
+    json_query(profile, '$.user.name') AS name_via_query,
+    get_json_string(profile, '$.user.name') AS name_via_get,
+    json_query(profile, '$.score') AS score_via_query,
+    cast(get_json_int(profile, '$.score') AS INT) AS score_via_get
+FROM extended_function_compat
+ORDER BY id;
+
+-- ====================================================================================
+-- SECTION 6: PRIMARY KEY Table Tests
+-- ====================================================================================
+
+-- Test 6.1: Basic PRIMARY KEY table with JSON defaults
+-- This tests default value filling when inserting partial columns into PRIMARY KEY table
+CREATE TABLE pk_basic_defaults (
+    user_id INT NOT NULL,
+    username VARCHAR(50),
+    profile JSON DEFAULT '{"level": 1, "vip": false, "status": "active"}',
+    settings JSON DEFAULT '{"notifications": true, "theme": "light"}'
+) PRIMARY KEY(user_id)
+DISTRIBUTED BY HASH(user_id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- Insert with partial columns (profile and settings should use defaults)
+INSERT INTO pk_basic_defaults (user_id, username) VALUES (1, 'user1');
+INSERT INTO pk_basic_defaults (user_id, username) VALUES (2, 'user2');
+
+-- Verify defaults were used
+SELECT 
+    user_id,
+    username,
+    profile,
+    settings
+FROM pk_basic_defaults
+ORDER BY user_id;
+
+-- Query JSON subfields from default values
+SELECT 
+    user_id,
+    username,
+    cast(get_json_int(profile, '$.level') AS INT) AS level,
+    cast(get_json_bool(profile, '$.vip') AS BOOLEAN) AS vip,
+    get_json_string(profile, '$.status') AS status,
+    cast(get_json_bool(settings, '$.notifications') AS BOOLEAN) AS notifications
+FROM pk_basic_defaults
+ORDER BY user_id;
+
+-- Insert with explicit values for comparison
+INSERT INTO pk_basic_defaults VALUES 
+    (3, 'user3', '{"level": 10, "vip": true, "status": "premium"}', '{"notifications": false, "theme": "dark"}');
+
+-- Mix of default and explicit values
+SELECT 
+    user_id,
+    username,
+    cast(get_json_int(profile, '$.level') AS INT) AS level,
+    cast(get_json_bool(profile, '$.vip') AS BOOLEAN) AS vip
+FROM pk_basic_defaults
+ORDER BY user_id;
+
+-- Test 6.2: Column mode partial update
+-- This tests that JSON default values are correctly filled when using
+-- partial_update_mode = 'column' and inserting only some columns
+
+CREATE TABLE pk_partial_update (
+    order_id INT NOT NULL,
+    product_name VARCHAR(50),
+    quantity INT DEFAULT '1',
+    config JSON DEFAULT '{"priority": "normal", "tracking": true}',
+    metadata JSON DEFAULT '{"source": "web", "version": 1}'
+) PRIMARY KEY(order_id)
+DISTRIBUTED BY HASH(order_id) BUCKETS 2
+PROPERTIES("replication_num" = "1");
+
+-- Enable column mode for partial updates
+SET partial_update_mode = 'column';
+
+-- Insert rows with only some columns (others should use defaults)
+INSERT INTO pk_partial_update (order_id, product_name) VALUES (1, 'laptop');
+INSERT INTO pk_partial_update (order_id, product_name) VALUES (2, 'phone');
+INSERT INTO pk_partial_update (order_id, product_name) VALUES (3, 'tablet');
+
+
+-- Verify JSON defaults were correctly filled
+SELECT 
+    order_id,
+    product_name,
+    quantity,
+    get_json_string(config, '$.priority') AS priority,
+    cast(get_json_bool(config, '$.tracking') AS BOOLEAN) AS tracking,
+    get_json_string(metadata, '$.source') AS source,
+    cast(get_json_int(metadata, '$.version') AS INT) AS version
+FROM pk_partial_update 
+ORDER BY order_id;
+
+-- Insert with partial JSON columns
+INSERT INTO pk_partial_update (order_id, product_name, config) 
+VALUES (4, 'monitor', '{"priority": "high", "tracking": false}');
+
+INSERT INTO pk_partial_update (order_id, product_name, metadata) 
+VALUES (5, 'keyboard', '{"source": "mobile", "version": 2}');
+
+
+SELECT 
+    order_id,
+    product_name,
+    get_json_string(config, '$.priority') AS priority,
+    get_json_string(metadata, '$.source') AS source
+FROM pk_partial_update 
+ORDER BY order_id;
+
+-- Add another JSON column after data exists
+ALTER TABLE pk_partial_update ADD COLUMN extras JSON DEFAULT '{"discount": 0.0, "tax": 0.08}';
+
+-- Insert with partial columns again
+INSERT INTO pk_partial_update (order_id, product_name) VALUES (6, 'mouse');
+INSERT INTO pk_partial_update (order_id, product_name, quantity) VALUES (7, 'headset', 3);
+
+-- Verify all JSON defaults including newly added column
+SELECT 
+    order_id,
+    product_name,
+    quantity,
+    get_json_string(config, '$.priority') AS priority,
+    get_json_string(metadata, '$.source') AS source,
+    cast(get_json_double(extras, '$.discount') AS DOUBLE) AS discount,
+    cast(get_json_double(extras, '$.tax') AS DOUBLE) AS tax
+FROM pk_partial_update 
+ORDER BY order_id;
+
+-- Reset to default mode
+SET partial_update_mode = 'auto';
+
+-- ====================================================================================
+-- SECTION 7: FlatJSON Field Absence Optimization
+-- ====================================================================================
+
+-- Test: Query JSON fields that don't exist in some segments
+-- This tests FlatJSON's bloom filter optimization for quickly returning NULL
+-- when a field is provably absent from a segment
+
+CREATE TABLE flatjson_field_absence (
+    id INT NOT NULL,
+    data JSON
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- Batch 1: Insert JSONs WITHOUT 'optional_field'
+INSERT INTO flatjson_field_absence VALUES 
+    (1, '{"name": "alice", "age": 25, "city": "Beijing"}'),
+    (2, '{"name": "bob", "age": 30, "city": "Shanghai"}'),
+    (3, '{"name": "charlie", "age": 35, "city": "Guangzhou"}');
+
+-- Batch 2: Insert JSONs WITH 'optional_field'
+INSERT INTO flatjson_field_absence VALUES 
+    (4, '{"name": "david", "age": 40, "city": "Shenzhen", "optional_field": "value1"}'),
+    (5, '{"name": "eve", "age": 45, "city": "Hangzhou", "optional_field": "value2"}');
+
+-- Query optional field: NULL for batch 1, actual values for batch 2
+SELECT 
+    id,
+    get_json_string(data, '$.name') AS name,
+    get_json_string(data, '$.optional_field') AS optional_field_get,
+    json_query(data, '$.optional_field') AS optional_field_query
+FROM flatjson_field_absence
+ORDER BY id;
+
+-- Query completely missing field: NULL for all rows
+SELECT 
+    id,
+    get_json_string(data, '$.completely_missing') AS missing_field
+FROM flatjson_field_absence
+ORDER BY id;

--- a/test/sql/test_default_value/T/test_json_strict_validation.sql
+++ b/test/sql/test_default_value/T/test_json_strict_validation.sql
@@ -1,0 +1,189 @@
+-- name: test_json_strict_validation
+-- Test strict JSON validation for default values
+-- using strict JSON parsing (rejects non-standard JSON syntax)
+
+DROP DATABASE IF EXISTS test_json_strict_db;
+CREATE DATABASE test_json_strict_db;
+USE test_json_strict_db;
+
+-- ============================================
+-- Test 1: Valid Standard JSON - Should succeed
+-- ============================================
+CREATE TABLE test_json_strict_valid (
+    id INT,
+    data1 JSON DEFAULT '{"key": "value"}',
+    data2 JSON DEFAULT '{"name": "Alice", "age": 30}',
+    data3 JSON DEFAULT '{}',
+    data4 JSON DEFAULT 'null',
+    data5 JSON DEFAULT '""',
+    data6 JSON DEFAULT '123',
+    data7 JSON DEFAULT 'true'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- Verify: Insert data and query
+INSERT INTO test_json_strict_valid (id) VALUES (1);
+SELECT * FROM test_json_strict_valid;
+
+-- ============================================
+-- Test 2: Unquoted Keys - Should fail
+-- ============================================
+-- Expected: ERROR 1064 (HY000): Invalid JSON format
+CREATE TABLE test_json_strict_invalid_unquoted_key (
+    id INT,
+    data JSON DEFAULT '{key: "value"}'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- ============================================
+-- Test 3: Trailing Comma - Should fail
+-- ============================================
+-- Expected: ERROR 1064 (HY000): Invalid JSON format
+CREATE TABLE test_json_strict_invalid_trailing_comma (
+    id INT,
+    data JSON DEFAULT '{"key": "value",}'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- ============================================
+-- Test 4: Single Quotes - Should fail
+-- ============================================
+-- Expected: ERROR 1064 (HY000): Invalid JSON format
+CREATE TABLE test_json_strict_invalid_single_quote (
+    id INT,
+    data JSON DEFAULT "{'key': 'value'}"
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- ============================================
+-- Test 5: JavaScript-style Comments - Should fail
+-- ============================================
+-- Expected: ERROR 1064 (HY000): Invalid JSON format
+CREATE TABLE test_json_strict_invalid_comment (
+    id INT,
+    data JSON DEFAULT '{"key": "value" /* comment */}'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- ============================================
+-- Test 6: Complex Nested JSON - Should succeed
+-- ============================================
+CREATE TABLE test_json_strict_valid_complex (
+    id INT,
+    data JSON DEFAULT '{"user": {"name": "Bob", "age": 25, "address": {"city": "Beijing", "zip": "100000"}}, "tags": ["a", "b", "c"], "active": true, "score": 95.5}'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- Verify: Insert data and query
+INSERT INTO test_json_strict_valid_complex (id) VALUES (1);
+SELECT * FROM test_json_strict_valid_complex;
+
+-- ============================================
+-- Test 7: Deep Nested JSON - Should succeed
+-- ============================================
+CREATE TABLE test_json_strict_valid_nested (
+    id INT,
+    data JSON DEFAULT '{"level1": {"level2": {"level3": {"level4": {"level5": "deep"}}}}}'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- Verify: Insert data and query
+INSERT INTO test_json_strict_valid_nested (id) VALUES (1);
+SELECT * FROM test_json_strict_valid_nested;
+
+-- ============================================
+-- Test 8: Array-based JSON - Should succeed
+-- ============================================
+CREATE TABLE test_json_strict_valid_array (
+    id INT,
+    data1 JSON DEFAULT '[1, 2, 3, 4, 5]',
+    data2 JSON DEFAULT '[{"name": "Alice"}, {"name": "Bob"}]',
+    data3 JSON DEFAULT '[[1, 2], [3, 4], [5, 6]]',
+    data4 JSON DEFAULT '[]'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- Verify: Insert data and query
+INSERT INTO test_json_strict_valid_array (id) VALUES (1);
+SELECT * FROM test_json_strict_valid_array;
+
+-- ============================================
+-- Test 9: Edge Cases - Should succeed
+-- ============================================
+CREATE TABLE test_json_strict_edge_cases (
+    id INT,
+    empty_obj JSON DEFAULT '{}',
+    empty_arr JSON DEFAULT '[]',
+    null_val JSON DEFAULT 'null',
+    empty_str JSON DEFAULT '""',
+    zero_num JSON DEFAULT '0',
+    neg_num JSON DEFAULT '-123.45',
+    bool_true JSON DEFAULT 'true',
+    bool_false JSON DEFAULT 'false',
+    unicode JSON DEFAULT '{"text": "你好世界🌍"}',
+    escaped JSON DEFAULT '{"text": "line1\\nline2\\ttab"}'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- Verify: Insert data and query
+INSERT INTO test_json_strict_edge_cases (id) VALUES (1);
+SELECT * FROM test_json_strict_edge_cases;
+
+-- ============================================
+-- Test 10: More Invalid Formats - Should fail
+-- ============================================
+
+-- 10.1: Array with trailing comma
+-- Expected: ERROR
+CREATE TABLE test_json_strict_invalid_array_trailing_comma (
+    id INT,
+    data JSON DEFAULT '[1, 2, 3,]'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- 10.2: Multiple trailing commas
+-- Expected: ERROR
+CREATE TABLE test_json_strict_invalid_multi_trailing_comma (
+    id INT,
+    data JSON DEFAULT '{"a": 1,,}'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- 10.3: Unquoted string value
+-- Expected: ERROR
+CREATE TABLE test_json_strict_invalid_unquoted_value (
+    id INT,
+    data JSON DEFAULT '{"key": value}'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- 10.4: NaN (non-standard JSON)
+-- Expected: ERROR
+CREATE TABLE test_json_strict_invalid_nan (
+    id INT,
+    data JSON DEFAULT '{"value": NaN}'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+
+-- 10.5: Infinity (non-standard JSON)
+-- Expected: ERROR
+CREATE TABLE test_json_strict_invalid_infinity (
+    id INT,
+    data JSON DEFAULT '{"value": Infinity}'
+) DUPLICATE KEY(id)
+DISTRIBUTED BY HASH(id) BUCKETS 1
+PROPERTIES("replication_num" = "1");
+


### PR DESCRIPTION
## Why I'm doing:

Add support for JSON type column default values in StarRocks, enabling users to specify default JSON values when creating tables or adding columns via `ALTER TABLE`.

## What I'm doing:

### 1. JSON Default Value Support

Implemented JSON default value support for table columns, allowing users to specify JSON defaults in DDL statements.

**Supported JSON Types:**
- JSON objects: `DEFAULT '{"key": "value"}'`
- JSON arrays: `DEFAULT '[1, 2, 3]'`
- JSON strings: `DEFAULT '"hello"'`
- JSON numbers: `DEFAULT '42'`
- JSON booleans: `DEFAULT 'true'`
- JSON null: `DEFAULT 'null'`
- Empty JSON object: `DEFAULT '{}'`
- Empty JSON array: `DEFAULT '[]'`
- Empty string (unquoted): `DEFAULT ''`
- Empty string (quoted): `DEFAULT '""'`


**Example Usage:**
```
-- Create table with JSON default values
CREATE TABLE users (
    id INT NOT NULL,
    username VARCHAR(50),
    profile JSON DEFAULT '{"level": 1, "vip": false}',
    settings JSON DEFAULT '{"notifications": true, "theme": "light"}'
) PRIMARY KEY(id) 
PROPERTIES("replication_num" = "1");

-- Insert with partial columns (using defaults)
INSERT INTO users (id, username) VALUES (1, 'alice');

-- Query: profile and settings will use default values
SELECT id, username, profile, settings FROM users;
+------+----------+----------------------------+-------------------------------------------+
| id   | username | profile                    | settings                                  |
+------+----------+----------------------------+-------------------------------------------+
|    1 | alice    | {"level": 1, "vip": false} | {"notifications": true, "theme": "light"} |
+------+----------+----------------------------+-------------------------------------------+

-- Query JSON subfields
SELECT 
    id,
    cast(get_json_int(profile, '$.level') AS INT) AS level,
    cast(get_json_bool(profile, '$.vip') AS BOOLEAN) AS vip
FROM users;
+------+-------+------+
| id   | level | vip  |
+------+-------+------+
|    1 |     1 |    0 |
+------+-------+------+

-- Add JSON column with default to existing table
CREATE TABLE test (id INT, name VARCHAR(50)) DUPLICATE KEY(id) 
PROPERTIES("replication_num" = "1");

INSERT INTO test VALUES (1, 'alice'), (2, 'bob');

ALTER TABLE test ADD COLUMN metadata JSON DEFAULT '{"version": 1, "enabled": true}';

-- Old rows automatically use the default value
SELECT * FROM test;
-- Result:
+------+-------+---------------------------------+
| id   | name  | metadata                        |
+------+-------+---------------------------------+
|    1 | alice | {"enabled": true, "version": 1} |
|    2 | bob   | {"enabled": true, "version": 1} |
+------+-------+---------------------------------+

-- deep nested 
CREATE TABLE extended_deep_nested (
    id INT NOT NULL
) DUPLICATE KEY(id)
DISTRIBUTED BY HASH(id) BUCKETS 1
PROPERTIES("replication_num" = "1");

INSERT INTO extended_deep_nested VALUES (1), (2);

ALTER TABLE extended_deep_nested ADD COLUMN deep JSON DEFAULT '{"level1": {"level2": {"level3": {"value": 42, "flag": true}}}}';

SELECT 
    id,
    cast(get_json_int(deep, '$.level1.level2.level3.value') AS INT) AS nested_value,
    cast(get_json_bool(deep, '$.level1.level2.level3.flag') AS BOOLEAN) AS nested_flag,
    json_query(deep, '$.level1.level2') AS level2_obj
FROM extended_deep_nested
ORDER BY id;

+------+--------------+-------------+-----------------------------------------+
| id   | nested_value | nested_flag | level2_obj                              |
+------+--------------+-------------+-----------------------------------------+
|    1 |           42 |           0 | {"level3": {"flag": true, "value": 42}} |
|    2 |           42 |           0 | {"level3": {"flag": true, "value": 42}} |
+------+--------------+-------------+-----------------------------------------+
```

### 2. Key Features

✅ **CREATE TABLE with JSON defaults** - Specify default JSON values when creating tables
✅ **ALTER TABLE ADD COLUMN** - Add JSON columns with defaults to existing tables (fast/traditional schema evolution)
✅ **PRIMARY KEY tables** - Support for PRIMARY KEY tables with partial column insert
✅ **JSON subfield extraction** - `get_json_int/bool/double/string` functions work correctly with default values
✅ **Strict JSON validation** - Invalid JSON format is rejected at table creation time

### 3. Implementation

**Backend:**
- `be/src/exec/pipeline/scan/olap_chunk_source.cpp`: Extended Column default value inheritance for JSON subfield access
- `be/src/storage/rowset/default_value_column_iterator.cpp`: JSON default value iterator support

**Frontend:**
- `fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ColumnDefAnalyzer.java`: JSON default value validation with strict mode

**Tests:**
- `test/sql/test_default_value/T/test_json_default.sql`: 20+ comprehensive test scenarios (525 lines)
- `test/sql/test_default_value/T/test_json_strict_validation.sql`: Strict JSON validation tests

### 4. Test Coverage

- ✅ All JSON value types (objects, arrays, primitives)
- ✅ Nested objects and arrays
- ✅ ALTER TABLE fast/traditional schema evolution
- ✅ PRIMARY KEY table partial updates
- ✅ JSON subfield extraction functions
- ✅ Invalid JSON format rejection

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds end-to-end support for JSON column default values and ensures consistent behavior across creation, schema evolution, and scanning.
> 
> - FE: Enforce strict JSON validation for default values in `ColumnDefAnalyzer` (rejects malformed JSON via non-lenient Gson parsing)
> - BE scan path: Inherit parent JSON default values for extended subcolumns in `OlapChunkSource` and `LakeDataSource` using `JsonPath` extraction
> - BE storage: `DefaultValueColumnIterator` parses `TYPE_JSON` defaults; on parse failure, logs warning and treats as NULL; include JSON in fast string append path
> - Schema change: During default mapping for `TYPE_JSON`, parse JSON or fallback to NULL on error with warning
> - Tests: Add extensive SQL tests covering JSON defaults, strict validation errors, ALTER TABLE (fast/traditional), extended columns, PK/partial updates, nested/array cases
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1c6ea8ffda4f532452e7d8ac50d825301e080167. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->