### PR TITLE
[BugFix] support negative value in skew hint

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -8049,7 +8049,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
                 return new DecimalLiteral(val.negate(), node.getPos());
             } else if (node instanceof FloatLiteral) {
                 double val = ((FloatLiteral) node).getDoubleValue();
-                return new FloatLiteral(-val);
+                return new FloatLiteral(-val, node.getPos());
             }
         }
         return node;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -8049,7 +8049,7 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
                 return new DecimalLiteral(val.negate(), node.getPos());
             } else if (node instanceof FloatLiteral) {
                 double val = ((FloatLiteral) node).getDoubleValue();
-                return new FloatLiteral(-val, node.getPos());
+                return new FloatLiteral(-val);
             }
         }
         return node;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/InPredicateParserBench.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/InPredicateParserBench.java
@@ -61,13 +61,13 @@ public class InPredicateParserBench {
         sql = generateSQL();
     }
 
-    @Param({"5000", "50000"})
+    @Param({"5000", "50000", "200000"})
     public int count;
 
-    @Param({"true", "false"})
+    @Param({"false", "true"})
     public boolean positive;
 
-    public final int baseNumber = 1_000_000;
+    public final int baseNumber = 10_000_000;
 
     @Benchmark
     public void parseInPredicate() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/InPredicateParserBench.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/InPredicateParserBench.java
@@ -1,0 +1,108 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.parser;
+
+import com.starrocks.qe.GlobalVariable;
+import com.starrocks.qe.SqlModeHelper;
+import com.starrocks.sql.ast.StatementBase;
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.IdentityHashMap;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(time = 1, iterations = 3)
+@Measurement(time = 5, iterations = 3)
+public class InPredicateParserBench {
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(InPredicateParserBench.class.getSimpleName())
+                .build();
+        new Runner(opt).run();
+    }
+
+    private String sql;
+
+    @Setup
+    public void setup() {
+        sql = generateSQL();
+    }
+
+    @Param({"5000", "50000"})
+    public int count;
+
+    @Param({"true", "false"})
+    public boolean positive;
+
+    public final int baseNumber = 1_000_000;
+
+    @Benchmark
+    public void parseInPredicate() {
+        parseSql(sql);
+    }
+
+    private String generateSQL() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("SELECT * FROM t WHERE c1 IN (");
+        for (int i = 0; i < count; i++) {
+            if (i > 0) {
+                sb.append(",");
+            }
+            if (positive) {
+                sb.append(baseNumber + i);
+            } else {
+                sb.append(-i - baseNumber);
+            }
+        }
+        sb.append(") AND c2 > 1;");
+        return sb.toString();
+    }
+
+    private StatementBase parseSql(String sql) {
+        com.starrocks.sql.parser.StarRocksLexer lexer =
+                new com.starrocks.sql.parser.StarRocksLexer(new CaseInsensitiveStream(CharStreams.fromString(sql)));
+        CommonTokenStream tokenStream = new CommonTokenStream(lexer);
+        com.starrocks.sql.parser.StarRocksParser parser = new com.starrocks.sql.parser.StarRocksParser(tokenStream);
+        parser.removeErrorListeners();
+        parser.addErrorListener(new BaseErrorListener());
+        parser.removeParseListeners();
+        com.starrocks.sql.parser.StarRocksParser.SqlStatementsContext sqlStatements = parser.sqlStatements();
+        return (StatementBase) new AstBuilder(SqlModeHelper.MODE_DEFAULT, GlobalVariable.enableTableNameCaseInsensitive,
+                new IdentityHashMap<>())
+                .visitSingleStatement(sqlStatements.singleStatement(0));
+    }
+}
+

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
@@ -696,4 +696,23 @@ class ParserTest {
         SplitTabletClause splitTabletClause = new SplitTabletClause(null, null, null);
         Assertions.assertEquals(null, splitTabletClause.getPartitionNames());
     }
+
+    @Test
+    void testSkewHintWithNegativeValues() {
+        String[] sqls = {
+                "select * from t1 join [skew|t1.c_int(-100)] t2 on t1.c_int = t2.c_int",
+                "select * from t1 join [skew|t1.c_int(-100, -200)] t2 on t1.c_int = t2.c_int",
+                "select * from t1 join [skew|t1.c_float(-10.5)] t2 on t1.c_float = t2.c_float",
+                "select * from t1 join [skew|t1.c_decimal(-10.5)] t2 on t1.c_decimal = t2.c_decimal"
+        };
+        SessionVariable sessionVariable = new SessionVariable();
+        for (String sql : sqls) {
+            try {
+                SqlParser.parse(sql, sessionVariable);
+            } catch (Exception e) {
+                fail("sql should parse successfully: " + sql + ", error: " + e.getMessage());
+            }
+        }
+    }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
@@ -707,11 +707,7 @@ class ParserTest {
         };
         SessionVariable sessionVariable = new SessionVariable();
         for (String sql : sqls) {
-            try {
-                SqlParser.parse(sql, sessionVariable);
-            } catch (Exception e) {
-                fail("sql should parse successfully: " + sql + ", error: " + e.getMessage());
-            }
+            SqlParser.parse(sql, sessionVariable);
         }
     }
 

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -2678,7 +2678,7 @@ primaryExpression
     ;
 
 literalExpression
-    : number                                                                              #numericLiteral
+    : MINUS_SYMBOL? number                                                                #numericLiteral
     | NULL                                                                                #nullLiteral
     | booleanValue                                                                        #booleanLiteral
     | (DATE | DATETIME) string                                                            #dateLiteral

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -2497,7 +2497,7 @@ outerAndSemiJoinType
 
 bracketHint
     : '[' identifier (',' identifier)* ']'
-    | '[' identifier '|' primaryExpression literalExpressionList']'
+    | '[' identifier '|' primaryExpression generalLiteralExpressionList']'
     ;
 
 hintMap
@@ -2678,7 +2678,7 @@ primaryExpression
     ;
 
 literalExpression
-    : MINUS_SYMBOL? number                                                                #numericLiteral
+    : number                                                                              #numericLiteral
     | NULL                                                                                #nullLiteral
     | booleanValue                                                                        #booleanLiteral
     | (DATE | DATETIME) string                                                            #dateLiteral
@@ -2687,6 +2687,12 @@ literalExpression
     | unitBoundary                                                                        #unitBoundaryLiteral
     | binary                                                                              #binaryLiteral
     | PARAMETER                                                                           #Parameter
+    ;
+
+// can represents negative number along with other literal expression
+generalLiteralExpression
+    : literalExpression
+    | MINUS_SYMBOL number
     ;
 
 functionCall
@@ -2898,6 +2904,10 @@ integerList
 
 literalExpressionList
     : '(' literalExpression (',' literalExpression)* ')'
+    ;
+
+generalLiteralExpressionList
+    : '(' generalLiteralExpression (',' generalLiteralExpression)* ')'
     ;
 
 rangePartitionDesc

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/FloatLiteral.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/expression/FloatLiteral.java
@@ -35,6 +35,12 @@ public class FloatLiteral extends LiteralExpr {
         init(value);
     }
 
+    public FloatLiteral(Double value, NodePosition pos) {
+        super(pos);
+        checkValue(value);
+        init(value);
+    }
+
     /**
      * C'tor forcing type, e.g., due to implicit cast
      */


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

`literalExpression` cannot represent a negative value, while it is used in `bracketHint` syntax.

Fixes #66917

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables negative numeric values in `bracketHint` skew syntax by extending grammar and parser handling.
> 
> - Update grammar: add `generalLiteralExpression` and `generalLiteralExpressionList` (supports `- number`) and use them in `bracketHint`
> - Parser: `AstBuilder` now visits `generalLiteralExpression` and builds negated `IntLiteral`/`LargeIntLiteral`/`DecimalLiteral`/`FloatLiteral`; `bracketHint` now consumes `generalLiteralExpressionList`
> - Add `FloatLiteral(Double, NodePosition)` constructor to preserve source positions when creating negated floats
> - Tests: add `ParserTest.testSkewHintWithNegativeValues`
> - Benchmark: add `InPredicateParserBench` for large `IN` predicate parsing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 979d1837bc9d28123905860f47e389cfbc850f47. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->