### PR TITLE
[BugFix] fix the column not found issue in skew join hint

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -901,7 +901,7 @@ public class QueryAnalyzer {
             }
 
             if (!join.getJoinHint().isEmpty()) {
-                analyzeJoinHints(join);
+                analyzeJoinHints(join, leftScope, rightScope);
             }
 
             if (joinEqual != null) {
@@ -1155,7 +1155,7 @@ public class QueryAnalyzer {
             return resultType;
         }
 
-        private void analyzeJoinHints(JoinRelation join) {
+        private void analyzeJoinHints(JoinRelation join, Scope leftScope, Scope rightScope) {
             if (HintNode.HINT_JOIN_BROADCAST.equals(join.getJoinHint())) {
                 if (join.getJoinOp() == JoinOperator.RIGHT_OUTER_JOIN
                         || join.getJoinOp() == JoinOperator.FULL_OUTER_JOIN
@@ -1185,7 +1185,9 @@ public class QueryAnalyzer {
                     if (!(join.getSkewColumn() instanceof SlotRef)) {
                         throw new SemanticException("Skew join column must be a column reference");
                     }
-                    analyzeExpression(join.getSkewColumn(), new AnalyzeState(), join.getLeft().getScope());
+                    Scope joinScope = new Scope(RelationId.of(join),
+                            leftScope.getRelationFields().joinWith(rightScope.getRelationFields()));
+                    analyzeExpression(join.getSkewColumn(), new AnalyzeState(), joinScope);
                 } else {
                     throw new SemanticException("Skew join column must be specified");
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -1096,7 +1096,9 @@ public class RelationTransformer implements AstVisitorExtendInterface<LogicalPla
         if (node.getSkewColumn() != null) {
             skewColumn = SqlToScalarOperatorTranslator.translate(node.getSkewColumn(),
                     expressionMapping, columnRefFactory,
-                    session, cteContext, leftOpt, null, false);
+                    session, cteContext,
+                    new OptExprBuilder(null, Lists.newArrayList(leftOpt, rightOpt), expressionMapping),
+                    null, false);
         }
 
         List<ScalarOperator> skewValues = Lists.newArrayList();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
@@ -98,6 +98,14 @@ public class SkewJoinTest extends PlanTestBase {
     }
 
     @Test
+    public void testSkewJoinWithRightSideHint() throws Exception {
+        String sql = "select * from t0 left join [skew|t1.v4(100)] t1 on t0.v1 = t1.v4";
+        String sqlPlan = getFragmentPlan(sql);
+        assertCContains(sqlPlan, "equal join conjunct: 7: rand_col = 14: rand_col");
+        assertCContains(sqlPlan, "equal join conjunct: 1: v1 = 4: v4");
+    }
+
+    @Test
     public void testSkewJoin() throws Exception {
         String sql = "select v2, v5 from t0 join[skew|t0.v1(1,2)] t1 on v1 = v4 ";
         String sqlPlan = getFragmentPlan(sql);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
@@ -101,7 +101,7 @@ public class SkewJoinTest extends PlanTestBase {
     public void testSkewJoinWithRightSideHint() throws Exception {
         String sql = "select * from t0 left join [skew|t1.v4(100)] t1 on t0.v1 = t1.v4";
         String sqlPlan = getFragmentPlan(sql);
-        assertCContains(sqlPlan, "equal join conjunct: 7: rand_col = 14: rand_col");
+        assertCContains(sqlPlan, "equal join conjunct: 14: rand_col = 7: rand_col");
         assertCContains(sqlPlan, "equal join conjunct: 1: v1 = 4: v4");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
@@ -244,8 +244,8 @@ public class SkewJoinTest extends PlanTestBase {
                         "  |  colocate: false, reason: \n" +
                         "  |  equal join conjunct: 10: rand_col = 17: rand_col\n" +
                         "  |  equal join conjunct: 9: cast = 5: v1",
-                "<slot 10> : CASE WHEN 2: c1.a[true] IS NULL THEN 23: round WHEN 2: c1.a[true] IN (1, 2) THEN " +
-                        "23: round ELSE 0 END");
+                "<slot 10> : CASE WHEN 22: cast IS NULL THEN 24: round WHEN 22: cast IN (1, 2) THEN 24: round " +
+                        "ELSE 0 END");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinV2Test.java
@@ -33,6 +33,13 @@ public class SkewJoinV2Test extends PlanTestBase {
     }
 
     @Test
+    public void testSkewJoinV2WithRightSideHint() throws Exception {
+        String sql = "select v2, v5 from t0 join[skew|t1.v4(1,2)] t1 on v1 = v4 ";
+        String sqlPlan = getVerboseExplain(sql);
+        assertCContains(sqlPlan, "Split expr: [4: v4, BIGINT, true] IN (1, 2)");
+    }
+
+    @Test
     public void testSkewJoinV2() throws Exception {
         String sql = "select v2, v5 from t0 join[skew|t0.v1(1,2)] t1 on v1 = v4 ";
         String sqlPlan = getVerboseExplain(sql);


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Skew join hint should be able to support both left side and right side.

Fixes https://github.com/StarRocks/starrocks/issues/66924

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves skew-join hint handling to work when the hinted column is on either join side and to resolve it reliably.
> 
> - Analyzer: `analyzeJoinHints` now takes `leftScope`/`rightScope`; validates `skewColumn` in the combined join scope and casts `skewValues`
> - Optimizer: find the counterpart column for `skewColumn` across both sides (including through `Project`/casts); salt the skew side via `addSaltForSkewChild` and the other side via `addSaltForOtherChild`; rename variables for clarity
> - Transformer: translate `skewColumn` with a builder containing both children so column resolution works on the right side too
> - Tests: add right-side skew-hint cases for both V1 and V2 paths; adjust struct-type stats expectation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c55aca879b0713d8106268f41966a60cddd26d56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->