### PR TITLE
[Doc] docs(be_config): update en, zh, ja documentation

### DIFF
--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -2230,22 +2230,13 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Description: The maximum concurrency of compaction on a disk. This addresses the issue of uneven I/O across disks due to compaction. This issue can cause excessively high I/O for certain disks.
 - Introduced in: v3.0.9
 
-##### pk_parallel_execution_threshold_bytes
-
-- Default: 104857600
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: When enable_pk_parallel_execution is set to true, the Primary Key table parallel execution strategy will be enabled if the data generated during import or compaction exceeds this threshold. Default is 100MB.
-- Introduced in: -
-
-##### pk_index_parallel_compaction_threadpool_max_threads
+##### pk_index_memtable_flush_threadpool_max_threads
 
 - Default: 4
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: The maximum number of threads in the thread pool for cloud native primary key index parallel compaction in shared-data mode.
+- Description: The maximum number of threads in the thread pool for primary key index memtable flush in shared-data mode.
 - Introduced in: -
 
 ##### pk_index_parallel_compaction_task_split_threshold_bytes
@@ -2257,58 +2248,13 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Description: The splitting threshold for primary key index compaction tasks. When the total size of the files involved in a task is smaller than this threshold, the task will not be split. Default is 100MB.
 - Introduced in: -
 
-##### pk_index_target_file_size
+##### pk_index_parallel_compaction_threadpool_max_threads
 
-- Default: 67108864
+- Default: 4
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: Target file size for primary key index in shared-data mode. Default is 64MB.
-- Introduced in: -
-
-##### pk_index_compaction_score_ratio
-
-- Default: 1.5
-- Type: Double
-- Unit: -
-- Is mutable: Yes
-- Description: Compaction score ratio for primary key index in shared-data mode. For example, if there are N filesets, the compaction score will be N * pk_index_compaction_score_ratio.
-- Introduced in: -
-
-##### pk_index_ingest_sst_compaction_threshold
-
-- Default: 5
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: Ingest SST compaction threshold for primary key index in shared-data mode.
-- Introduced in: -
-
-##### enable_pk_index_parallel_compaction
-
-- Default: false
-- Type: Boolean
-- Unit: -
-- Is mutable: Yes
-- Description: Whether to enable parallel compaction for primary key index in shared-data mode.
-- Introduced in: -
-
-##### enable_pk_index_parallel_get
-
-- Default: false
-- Type: Boolean
-- Unit: -
-- Is mutable: Yes
-- Description: Whether to enable parallel get for primary key index in shared-data mode.
-- Introduced in: -
-
-##### pk_index_parallel_get_min_rows
-
-- Default: 16384
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: The minimum rows threshold to enable parallel get for primary key index in shared-data mode.
+- Description: The maximum number of threads in the thread pool for cloud native primary key index parallel compaction in shared-data mode.
 - Introduced in: -
 
 ##### pk_index_parallel_get_threadpool_max_threads
@@ -2320,22 +2266,22 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Description: The maximum number of threads in the thread pool for primary key index parallel get in shared-data mode. 0 means auto configuration.
 - Introduced in: -
 
-##### pk_index_memtable_flush_threadpool_max_threads
+##### pk_index_size_tiered_level_multiplier
 
-- Default: 4
+- Default: 10
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: The maximum number of threads in the thread pool for primary key index memtable flush in shared-data mode.
+- Description: The level multiple parameter for primary key index size-tiered compaction strategy.
 - Introduced in: -
 
-##### pk_index_memtable_max_count
+##### pk_index_size_tiered_max_level
 
-- Default: 3
+- Default: 5
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: The maximum number of memtables for primary key index in shared-data mode.
+- Description: The level number parameter for primary key index size-tiered compaction strategy.
 - Introduced in: -
 
 ##### pk_index_size_tiered_min_level_size
@@ -2347,22 +2293,22 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Description: The minimum level size parameter for primary key index size-tiered compaction strategy.
 - Introduced in: -
 
-##### pk_index_size_tiered_level_multiplier 
+##### pk_index_target_file_size
 
-- Default: 10
+- Default: 67108864
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: The level multiple parameter for primary key index size-tiered compaction strategy.
+- Description: Target file size for primary key index in shared-data mode. Default is 64MB.
 - Introduced in: -
 
-##### pk_index_size_tiered_max_level 
+##### pk_parallel_execution_threshold_bytes
 
-- Default: 5
+- Default: 104857600
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: The level number parameter for primary key index size-tiered compaction strategy.
+- Description: When enable_pk_parallel_execution is set to true, the Primary Key table parallel execution strategy will be enabled if the data generated during import or compaction exceeds this threshold. Default is 100MB.
 - Introduced in: -
 
 ##### primary_key_limit_size

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -177,6 +177,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：bRPC 最大的包容量。
 - 引入版本：-
 
+##### brpc_max_connections_per_server
+
+- 默认值: 1
+- 类型: Int
+- 単位: -
+- 是否可变: No
+- 描述: 客户端为每个远程服务器端点保持的最大持久 bRPC 连接数。对于每个端点，`BrpcStubCache` 会创建一个 `StubPool`，其 `_stubs` 向量会预留为此大小。首次访问时，会创建新的 stub，直到达到限制。之后，现有的 stub 会以轮询（round‑robin）方式返回。增大此值可以提升每个端点的并发性（减少单个 channel 的争用），但代价是使用更多的文件描述符、内存和 channel。
+- 引入版本: v3.2.0
+
 ##### brpc_num_threads
 
 - 默认值：-1
@@ -311,6 +320,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 是否可变: 是
 - 描述: 在决定是否以压缩形式通过网络发送序列化的 row-batches 时使用的阈值（uncompressed_size / compressed_size）。当尝试压缩时（例如在 DataStreamSender、exchange sink、tablet sink 的索引通道、dictionary cache writer 中），StarRocks 会计算 compress_ratio = uncompressed_size / compressed_size；仅当 compress_ratio `>` rpc_compress_ratio_threshold 时才使用压缩后的负载。默认值 1.1 意味着压缩数据必须至少比未压缩小约 9.1% 才会被使用。将该值调低以偏好压缩（以更多 CPU 换取更小的带宽）；将其调高以避免压缩开销，除非压缩能带来更大的尺寸缩减。注意：此项适用于 RPC/shuffle 序列化，仅在启用 row-batch 压缩（compress_rowbatches）时生效。
 - 引入版本: v3.2.0
+
+##### ssl_private_key_path
+
+- 默认值: An empty string
+- 类型: String
+- 単位: -
+- 是否可变: No
+- 描述: 指向 BE 的 brpc 服务器用于默认证书的 TLS/SSL 私钥（PEM）文件的文件系统路径。当 `enable_https` 设置为 `true` 时，系统在进程启动时将 `brpc::ServerOptions::ssl_options().default_cert.private_key` 设置为此路径。该文件必须对 BE 进程可访问，且必须与由 `ssl_certificate_path` 提供的证书相匹配。如果未设置此值或文件丢失或不可访问，则不会配置 HTTPS，并且 bRPC 服务器可能无法启动。请使用严格的文件系统权限（例如 600）保护此文件。
+- 引入版本: v4.0.0
 
 ##### thrift_client_retry_interval_ms
 
@@ -1166,6 +1184,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：汇报磁盘状态的间隔。汇报各个磁盘的状态，以及其中数据量等。
 - 引入版本：-
 
+##### report_resource_usage_interval_ms
+
+- 默认值: 1000
+- 类型: Int
+- 单位: Milliseconds
+- 是否可变: 是
+- 描述: BE agent 向 FE (master) 周期性上报资源使用情况的时间间隔，单位为毫秒。agent 工作线程收集 TResourceUsage（正在运行的查询数、已用/限额内存、CPU 使用千分比以及 resource-group 使用情况），然后调用 report_task，随后在该配置的间隔内休眠（参见 task_worker_pool）。较小的值可提升上报的及时性，但会增加 CPU、网络和 master 的负载；较大的值可降低开销但使资源信息不够实时。上报会更新相关指标（report_resource_usage_requests_total、report_resource_usage_requests_failed）。请根据集群规模和 FE 负载进行调整。
+- 引入版本: v3.2.0
+
 ##### report_tablet_interval_seconds
 
 - 默认值：60
@@ -1410,6 +1437,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 是否动态：否
 - 描述：是否开启 Event-based Compaction Framework。`true` 代表开启。`false` 代表关闭。开启则能够在 Tablet 数比较多或者单个 Tablet 数据量比较大的场景下大幅降低 Compaction 的开销。
 - 引入版本：-
+
+##### enable_lazy_delta_column_compaction
+
+- 默认值: true
+- 类型: Boolean
+- 単位: -
+- 是否可变: Yes
+- 描述: 启用时，compaction 对由部分列更新产生的 delta columns 会优先采用“懒惰”策略：StarRocks 将尽量避免主动将 delta-column 文件合并回其主 segment 文件，以节省 compaction 的 I/O。实际上，compaction 选择逻辑会检查是否存在部分列更新的 rowsets 以及多个候选项；如果发现且该标志为 true，引擎要么停止向当前 compaction 添加更多输入，要么仅合并空的 rowsets（level -1），将 delta columns 保持分离。这会在 compaction 期间降低即时 I/O 和 CPU 使用，但代价是合并被延迟（可能产生更多 segments 和临时存储开销）。正确性和查询语义不受影响。
+- 引入版本: v3.2.3
 
 ##### enable_new_load_on_memory_limit_exceeded
 
@@ -1699,22 +1735,13 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：每块盘 Compaction 的最大并发数，用于解决 Compaction 在磁盘之间不均衡导致个别磁盘 I/O 过高的问题。
 - 引入版本：v3.0.9
 
-##### pk_parallel_execution_threshold_bytes
-
-- 默认值：104857600
-- 类型：Int
-- 单位：-
-- 是否动态：是
-- 描述：当enable_pk_parallel_execution设置为true后，导入或者compaction生成的数据大于该阈值时，Primary Key 表并行执行策略将被启用。默认为 100MB。
-- 引入版本：-
-
-##### pk_index_parallel_compaction_threadpool_max_threads
+##### pk_index_memtable_flush_threadpool_max_threads
 
 - 默认值：4
 - 类型：Int
 - 单位：-
 - 是否动态：是
-- 描述：存算分离模式下，主键索引并行 Compaction 的线程池最大线程数。
+- 描述：存算分离模式下，主键索引 Memtable 刷盘的线程池最大线程数。
 - 引入版本：-
 
 ##### pk_index_parallel_compaction_task_split_threshold_bytes
@@ -1726,58 +1753,13 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：主键索引 Compaction 任务拆分的阈值。当任务涉及的文件总大小小于此阈值时，任务将不会被拆分。默认为 100MB。
 - 引入版本：-
 
-##### pk_index_target_file_size
+##### pk_index_parallel_compaction_threadpool_max_threads
 
-- 默认值：67108864
+- 默认值：4
 - 类型：Int
 - 单位：-
 - 是否动态：是
-- 描述：存算分离模式下，主键索引的目标文件大小。默认为 64MB。
-- 引入版本：-
-
-##### pk_index_compaction_score_ratio
-
-- 默认值：1.5
-- 类型：Double
-- 单位：-
-- 是否动态：是
-- 描述：存算分离模式下，主键索引的 Compaction 分数比率。例如，如果有 N 个文件集，Compaction 分数将为 N * pk_index_compaction_score_ratio。
-- 引入版本：-
-
-##### pk_index_ingest_sst_compaction_threshold
-
-- 默认值：5
-- 类型：Int
-- 单位：-
-- 是否动态：是
-- 描述：存算分离模式下，主键索引 Ingest SST Compaction 的阈值。
-- 引入版本：-
-
-##### enable_pk_index_parallel_compaction
-
-- 默认值：false
-- 类型：Boolean
-- 单位：-
-- 是否动态：是
-- 描述：是否启用存算分离模式下主键索引的并行 Compaction。
-- 引入版本：-
-
-##### enable_pk_index_parallel_get
-
-- 默认值：false
-- 类型：Boolean
-- 单位：-
-- 是否动态：是
-- 描述：是否启用存算分离模式下主键索引的并行读取。
-- 引入版本：-
-
-##### pk_index_parallel_get_min_rows
-
-- 默认值：16384
-- 类型：Int
-- 单位：-
-- 是否动态：是
-- 描述：存算分离模式下，启用主键索引并行读取的最小行数阈值。
+- 描述：存算分离模式下，主键索引并行 Compaction 的线程池最大线程数。
 - 引入版本：-
 
 ##### pk_index_parallel_get_threadpool_max_threads
@@ -1789,22 +1771,22 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：存算分离模式下，主键索引并行读取的线程池最大线程数。0 表示自动配置。
 - 引入版本：-
 
-##### pk_index_memtable_flush_threadpool_max_threads
+##### pk_index_size_tiered_level_multiplier
 
-- 默认值：4
+- 默认值：10
 - 类型：Int
 - 单位：-
 - 是否动态：是
-- 描述：存算分离模式下，主键索引 Memtable 刷盘的线程池最大线程数。
+- 描述：主键索引 Size-Tiered Compaction 策略的层级倍数参数。
 - 引入版本：-
 
-##### pk_index_memtable_max_count
+##### pk_index_size_tiered_max_level
 
-- 默认值：3
+- 默认值：5
 - 类型：Int
 - 单位：-
 - 是否动态：是
-- 描述：存算分离模式下，主键索引的最大 Memtable 数量。
+- 描述：主键索引 Size-Tiered Compaction 策略的层级数量参数。
 - 引入版本：-
 
 ##### pk_index_size_tiered_min_level_size
@@ -1816,22 +1798,22 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：主键索引 Size-Tiered Compaction 策略的最小层级大小参数。
 - 引入版本：-
 
-##### pk_index_size_tiered_level_multiplier 
+##### pk_index_target_file_size
 
-- 默认值：10
+- 默认值：67108864
 - 类型：Int
 - 单位：-
 - 是否动态：是
-- 描述：主键索引 Size-Tiered Compaction 策略的层级倍数参数。
+- 描述：存算分离模式下，主键索引的目标文件大小。默认为 64MB。
 - 引入版本：-
 
-##### pk_index_size_tiered_max_level 
+##### pk_parallel_execution_threshold_bytes
 
-- 默认值：5
+- 默认值：104857600
 - 类型：Int
 - 单位：-
 - 是否动态：是
-- 描述：主键索引 Size-Tiered Compaction 策略的层级数量参数。
+- 描述：当enable_pk_parallel_execution设置为true后，导入或者compaction生成的数据大于该阈值时，Primary Key 表并行执行策略将被启用。默认为 100MB。
 - 引入版本：-
 
 ##### primary_key_limit_size
@@ -2088,6 +2070,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 是否动态：是
 - 描述：主键表 Compaction 的检查间隔。
 - 引入版本：-
+
+##### update_compaction_chunk_size_for_row_store
+
+- 默认值: 0
+- 类型: Int
+- 単位: Rows
+- 是否可变: Yes
+- 描述: 覆盖对使用 column-with-row-store 表示法的 tablet 在 update compaction 期间使用的 chunk 大小（每个 chunk 的行数）。默认（0）时，StarRocks 根据 compaction 内存限制、vector chunk 大小、总输入行数和内存占用，通过 CompactionUtils::get_read_chunk_size 计算每个列组的 chunk 大小。当此配置被设置为正整数且 tablet.is_column_with_row_store() 为 true 时，RowsetMerger 会在水平和垂直 update compaction 路径中（rowset_merger.cpp）强制将 _chunk_size 设为该值。仅在自动计算产生次优结果时使用非零值；增大该值可以减少写入/IO 开销但会提升峰值内存使用，减小则在降低内存压力的同时产生更多 chunk 并可能影响性能。
+- 引入版本: v3.2.3
 
 ##### update_compaction_delvec_file_io_amp_ratio
 
@@ -2591,6 +2582,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 是否动态：是
 - 描述：用于向 FE 汇报执行状态的 RPC 请求的重试次数。默认值为 10，意味着如果该 RPC 请求失败（仅限于 fragment instance 的 finish RPC），将最多重试 10 次。该请求对于导入任务（load job）非常重要，如果某个 fragment instance 的完成状态报告失败，整个导入任务将会一直挂起，直到超时。
 -引入版本：-
+
+##### sleep_one_second
+
+- 默认值: 1
+- 类型: Int
+- 单位: Seconds
+- 是否可变: 否
+- 描述: 一个全局的小睡眠间隔（秒），由 BE agent 的工作线程在 master 地址/心跳尚不可用或需要短暂重试/回退时用作一秒暂停。代码中多个上报工作池（如 ReportDiskStateTaskWorkerPool、ReportOlapTableTaskWorkerPool、ReportWorkgroupTaskWorkerPool）引用它，以避免忙等待并在重试时降低 CPU 消耗。增大该值会降低重试频率并降低对 master 可用性的响应速度；减小该值会增加轮询速率和 CPU 使用。仅在权衡响应性与资源使用的情况下进行调整。
+- 引入版本: v3.2.0
 
 ##### small_file_dir
 


### PR DESCRIPTION

## Why I'm doing:

## What I'm doing:  

    EXECUTION SUMMARY
    Document Type: be_config
    Duration: 398.40 seconds
    Command: /home/seaven/documents/workspace/DocsAgent/src/docsagent/main.py -g -t be_config --force_search_code -tv -l 50 --pr
    Arguments:
      ├─ ci: False
      ├─ force_search_code: True
      ├─ generate: True
      ├─ include_miss_usage: False
      ├─ limit: 50
      ├─ meta: False
      ├─ name: None
      ├─ pr: True
      ├─ track_version: True
      ├─ type: be_config
      ├─ without_llm: False
    
    ITEM EXTRACTION:
      ├─ Items from meta files: 676
      ├─ Items from code parsing: 0
      └─ Total unique items: 0
    
    DOCUMENT GENERATION:
      ├─ JA: 4 documents
      ├─ ZH: 3 documents
      └─ Total: 7 documents
    
    AGENT INVOCATIONS:
      ├─ TranslationAgent_ja: 4 calls
      ├─ TranslationAgent_zh: 3 calls
      └─ Total: 7 calls
    
    TRANSLATED ITEMS:
      ├─ Total: 50 items
      ├─ pprof_profile_dir
      ├─ load_diagnose_rpc_timeout_stack_trace_threshold_ms
      ├─ memory_ratio_for_sorting_schema_change
      ├─ profile_report_interval
      ├─ es_scroll_keepalive
      ├─ enable_zero_copy_from_page_cache
      ├─ lz4_expected_compression_speed_mbps
      ├─ load_channel_rpc_thread_pool_queue_size
      ├─ transaction_apply_worker_idle_time_ms
      ├─ load_fp_brpc_timeout_ms
      ├─ download_buffer_size
      ├─ report_resource_usage_interval_ms
      ├─ pull_load_task_dir
      ├─ broker_write_timeout_seconds
      ├─ dictionary_encoding_ratio
      ├─ max_queueing_memtable_per_tablet
      ├─ dictionary_page_size
      ├─ lz4_expected_compression_ratio
      ├─ stale_memtable_flush_time_sec
      ├─ be_service_threads
      ├─ rpc_compress_ratio_threshold
      ├─ ssl_private_key_path
      ├─ create_tablet_worker_count
      ├─ memory_urgent_level
      ├─ transaction_publish_version_thread_pool_num_min
      ├─ sleep_one_second
      ├─ enable_system_metrics
      ├─ udf_thread_pool_size
      ├─ clear_udf_cache_when_start
      ├─ partial_update_memory_limit_per_worker
      ├─ size_tiered_max_compaction_level
      ├─ max_hdfs_scanner_num
      ├─ chaos_test_enable_random_compaction_strategy
      ├─ enable_streaming_load_thread_pool
      ├─ brpc_max_connections_per_server
      ├─ dictionary_speculate_min_chunk_size
      ├─ thrift_connect_timeout_seconds
      ├─ delete_worker_count_high_priority
      ├─ parallel_clone_task_per_path
      ├─ update_compaction_chunk_size_for_row_store
      ├─ enable_lazy_delta_column_compaction
      ├─ metadata_cache_memory_limit_percent
      ├─ update_memory_limit_percent
      ├─ lz4_acceleration
      ├─ routine_load_pulsar_timeout_second
      ├─ load_channel_rpc_thread_pool_num
      ├─ transaction_apply_worker_count
      ├─ abort_on_large_memory_allocation
      ├─ upload_buffer_size
      └─ web_log_bytes
    

This Pr is generated by [DocsAgent](https://github.com/StarRocks/DocsAgent)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3