### PR TITLE
[Enhancement] optimize flatjson iteration with sequential iteration

### DIFF
--- a/be/src/util/json_flattener.cpp
+++ b/be/src/util/json_flattener.cpp
@@ -582,7 +582,7 @@ void JsonPathDeriver::_clean_sparsity_path(const std::string_view& name, JsonFla
 }
 
 void JsonPathDeriver::_visit_json_paths(const vpack::Slice& value, JsonFlatPath* root, size_t mark_row) {
-    vpack::ObjectIterator it(value, false);
+    vpack::ObjectIterator it(value, true);
 
     for (; it.valid(); it.next()) {
         auto current = (*it);
@@ -845,7 +845,7 @@ void JsonFlattener::flatten(const Column* json_column) {
 template <bool REMAIN>
 bool JsonFlattener::_flatten_json(const vpack::Slice& value, const JsonFlatPath* root, vpack::Builder* builder,
                                   uint32_t* hit_count) {
-    vpack::ObjectIterator it(value, false);
+    vpack::ObjectIterator it(value, true);
     for (; it.valid(); it.next()) {
         auto current = (*it);
         // sub-object
@@ -1105,7 +1105,7 @@ void JsonMerger::_merge_impl(size_t rows) {
 template <bool IN_TREE>
 void JsonMerger::_merge_json_with_remain(const JsonFlatPath* root, const vpack::Slice* remain, vpack::Builder* builder,
                                          size_t index) {
-    vpack::ObjectIterator it(*remain, false);
+    vpack::ObjectIterator it(*remain, true);
     for (; it.valid(); it.next()) {
         auto k = it.key().stringView();
         auto v = it.value();


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

What is sequential iteration can be faster:
- Sequential: Accesses memory in a strictly linear fashion. It's more cpu-cache friendly
- Indexed: The "Index Table" is located at the end of the object, while the actual "Data" is at the beginning. The default iterator must jump to the end to read an offset and then jump back to the beginning to read the data. This constant "ping-ponging" between memory regions often causes cache misses.


Experiment:
```
before
----------------------------------------------------------------
Benchmark                      Time             CPU   Iterations
----------------------------------------------------------------
BM_JsonPathDeriver/10       20.1 ms         20.1 ms           35
BM_JsonPathDeriver/20       44.0 ms         44.0 ms           17
BM_JsonPathDeriver/40       81.8 ms         81.8 ms            9
BM_JsonPathDeriver/80        170 ms          170 ms            4

after:
----------------------------------------------------------------
Benchmark                      Time             CPU   Iterations
----------------------------------------------------------------
BM_JsonPathDeriver/10       18.7 ms         18.7 ms           37
BM_JsonPathDeriver/20       36.7 ms         36.7 ms           19
BM_JsonPathDeriver/40       72.2 ms         72.1 ms           10
BM_JsonPathDeriver/80        148 ms          148 ms            5
```

Fixes https://github.com/StarRocks/starrocks/pull/66941

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches to sequential `vpack::ObjectIterator(value, true)` for path derivation, flattening, and merging to improve iteration/cache locality.
> 
> - **Performance**: use sequential object iteration via `vpack::ObjectIterator(value, true)`
>   - `be/src/util/json_flattener.cpp`
>     - `JsonPathDeriver::_visit_json_paths`
>     - `JsonFlattener::_flatten_json`
>     - `JsonMerger::_merge_json_with_remain`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1335b838b5e65a8280710a82a0e95a9b24365c3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->