### PR TITLE
[Doc] docs(be_config): update en, zh, ja documentation

### DIFF
--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -1175,7 +1175,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: Number of threads that are used for flushing MemTable in each store in shared-data mode. 
+- Description: Number of threads that are used for flushing MemTable in each store in a shared-data cluster. 
 When this value is set to `0`, the system uses twice of the CPU core count as the value.
 When this value is set to less than `0`, the system uses the product of its absolute value and the CPU core count as the value.
 - Introduced in: v3.1.12, 3.2.7
@@ -1876,7 +1876,7 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: Whether to enable parallel compaction for primary key index in shared-data mode.
+- Description: Whether to enable parallel Compaction for Primary Key index in a shared-data cluster.
 - Introduced in: -
 
 ##### enable_pk_index_parallel_get
@@ -1885,7 +1885,7 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Type: Boolean
 - Unit: -
 - Is mutable: Yes
-- Description: Whether to enable parallel get for primary key index in shared-data mode.
+- Description: Whether to enable parallel GET for Primary Key index in a shared-data cluster.
 - Introduced in: -
 
 ##### enable_pk_parallel_execution
@@ -2254,7 +2254,7 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Type: Double
 - Unit: -
 - Is mutable: Yes
-- Description: Compaction score ratio for primary key index in shared-data mode. For example, if there are N filesets, the compaction score will be N * pk_index_compaction_score_ratio.
+- Description: Compaction score ratio for Primary Key index in a shared-data cluster. For example, if there are N filesets, the Compaction score will be `N * pk_index_compaction_score_ratio`.
 - Introduced in: -
 
 ##### pk_index_ingest_sst_compaction_threshold
@@ -2263,7 +2263,7 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: Ingest SST compaction threshold for primary key index in shared-data mode.
+- Description: Ingest SST Compaction threshold for Primary Key index in a shared-data cluster.
 - Introduced in: -
 
 ##### pk_index_memtable_flush_threadpool_max_threads
@@ -2272,7 +2272,7 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: The maximum number of threads in the thread pool for primary key index memtable flush in shared-data mode.
+- Description: The maximum number of threads in the thread pool for Primary Key index MemTable flush in a shared-data cluster.
 - Introduced in: -
 
 ##### pk_index_memtable_max_count
@@ -2281,16 +2281,16 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: The maximum number of memtables for primary key index in shared-data mode.
+- Description: The maximum number of MemTables for Primary Key index in a shared-data cluster.
 - Introduced in: -
 
 ##### pk_index_parallel_compaction_task_split_threshold_bytes
 
 - Default: 104857600
 - Type: Int
-- Unit: -
+- Unit: Bytes
 - Is mutable: Yes
-- Description: The splitting threshold for primary key index compaction tasks. When the total size of the files involved in a task is smaller than this threshold, the task will not be split. Default is 100MB.
+- Description: The splitting threshold for Primary Key index Compaction tasks. When the total size of the files involved in a task is smaller than this threshold, the task will not be split.
 - Introduced in: -
 
 ##### pk_index_parallel_compaction_threadpool_max_threads
@@ -2299,7 +2299,7 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: The maximum number of threads in the thread pool for cloud native primary key index parallel compaction in shared-data mode.
+- Description: The maximum number of threads in the thread pool for cloud native Primary Key index parallel Compaction in a shared-data cluster.
 - Introduced in: -
 
 ##### pk_index_parallel_get_min_rows
@@ -2308,7 +2308,7 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: The minimum rows threshold to enable parallel get for primary key index in shared-data mode.
+- Description: The minimum rows threshold to enable parallel GET for Primary Key index in a shared-data cluster.
 - Introduced in: -
 
 ##### pk_index_parallel_get_threadpool_max_threads
@@ -2317,7 +2317,7 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: The maximum number of threads in the thread pool for primary key index parallel get in shared-data mode. 0 means auto configuration.
+- Description: The maximum number of threads in the thread pool for Primary Key index parallel GET in a shared-data cluster. `0` means adaptive configuration.
 - Introduced in: -
 
 ##### pk_index_size_tiered_level_multiplier
@@ -2326,7 +2326,7 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: The level multiple parameter for primary key index size-tiered compaction strategy.
+- Description: The level multiplier parameter for Primary Key index size-tiered Compaction strategy.
 - Introduced in: -
 
 ##### pk_index_size_tiered_max_level
@@ -2335,7 +2335,7 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: The level number parameter for primary key index size-tiered compaction strategy.
+- Description: The maximum level for Primary Key index size-tiered Compaction strategy.
 - Introduced in: -
 
 ##### pk_index_size_tiered_min_level_size
@@ -2344,25 +2344,25 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: The minimum level size parameter for primary key index size-tiered compaction strategy.
+- Description: The minimum level for Primary Key index size-tiered Compaction strategy.
 - Introduced in: -
 
 ##### pk_index_target_file_size
 
 - Default: 67108864
 - Type: Int
-- Unit: -
+- Unit: Bytes
 - Is mutable: Yes
-- Description: Target file size for primary key index in shared-data mode. Default is 64MB.
+- Description: The target file size for Primary Key index in a shared-data cluster.
 - Introduced in: -
 
 ##### pk_parallel_execution_threshold_bytes
 
 - Default: 104857600
 - Type: Int
-- Unit: -
+- Unit: Bytes
 - Is mutable: Yes
-- Description: When enable_pk_parallel_execution is set to true, the Primary Key table parallel execution strategy will be enabled if the data generated during import or compaction exceeds this threshold. Default is 100MB.
+- Description: When `enable_pk_parallel_execution` is set to true, the Primary Key table parallel execution strategy will be enabled if the data generated during import or compaction exceeds this threshold.
 - Introduced in: -
 
 ##### primary_key_limit_size

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -1870,6 +1870,24 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Description: Whether to allow new loading processes when the hard memory resource limit is reached. `true` indicates new loading processes will be allowed, and `false` indicates they will be rejected.
 - Introduced in: v3.3.2
 
+##### enable_pk_index_parallel_compaction
+
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether to enable parallel compaction for primary key index in shared-data mode.
+- Introduced in: -
+
+##### enable_pk_index_parallel_get
+
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Whether to enable parallel get for primary key index in shared-data mode.
+- Introduced in: -
+
 ##### enable_pk_parallel_execution
 
 - Default: true
@@ -2230,42 +2248,6 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Description: The maximum concurrency of compaction on a disk. This addresses the issue of uneven I/O across disks due to compaction. This issue can cause excessively high I/O for certain disks.
 - Introduced in: v3.0.9
 
-##### pk_parallel_execution_threshold_bytes
-
-- Default: 104857600
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: When enable_pk_parallel_execution is set to true, the Primary Key table parallel execution strategy will be enabled if the data generated during import or compaction exceeds this threshold. Default is 100MB.
-- Introduced in: -
-
-##### pk_index_parallel_compaction_threadpool_max_threads
-
-- Default: 4
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: The maximum number of threads in the thread pool for cloud native primary key index parallel compaction in shared-data mode.
-- Introduced in: -
-
-##### pk_index_parallel_compaction_task_split_threshold_bytes
-
-- Default: 104857600
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: The splitting threshold for primary key index compaction tasks. When the total size of the files involved in a task is smaller than this threshold, the task will not be split. Default is 100MB.
-- Introduced in: -
-
-##### pk_index_target_file_size
-
-- Default: 67108864
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: Target file size for primary key index in shared-data mode. Default is 64MB.
-- Introduced in: -
-
 ##### pk_index_compaction_score_ratio
 
 - Default: 1.5
@@ -2282,42 +2264,6 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Unit: -
 - Is mutable: Yes
 - Description: Ingest SST compaction threshold for primary key index in shared-data mode.
-- Introduced in: -
-
-##### enable_pk_index_parallel_compaction
-
-- Default: false
-- Type: Boolean
-- Unit: -
-- Is mutable: Yes
-- Description: Whether to enable parallel compaction for primary key index in shared-data mode.
-- Introduced in: -
-
-##### enable_pk_index_parallel_get
-
-- Default: false
-- Type: Boolean
-- Unit: -
-- Is mutable: Yes
-- Description: Whether to enable parallel get for primary key index in shared-data mode.
-- Introduced in: -
-
-##### pk_index_parallel_get_min_rows
-
-- Default: 16384
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: The minimum rows threshold to enable parallel get for primary key index in shared-data mode.
-- Introduced in: -
-
-##### pk_index_parallel_get_threadpool_max_threads
-
-- Default: 0
-- Type: Int
-- Unit: -
-- Is mutable: Yes
-- Description: The maximum number of threads in the thread pool for primary key index parallel get in shared-data mode. 0 means auto configuration.
 - Introduced in: -
 
 ##### pk_index_memtable_flush_threadpool_max_threads
@@ -2338,6 +2284,60 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Description: The maximum number of memtables for primary key index in shared-data mode.
 - Introduced in: -
 
+##### pk_index_parallel_compaction_task_split_threshold_bytes
+
+- Default: 104857600
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: The splitting threshold for primary key index compaction tasks. When the total size of the files involved in a task is smaller than this threshold, the task will not be split. Default is 100MB.
+- Introduced in: -
+
+##### pk_index_parallel_compaction_threadpool_max_threads
+
+- Default: 4
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: The maximum number of threads in the thread pool for cloud native primary key index parallel compaction in shared-data mode.
+- Introduced in: -
+
+##### pk_index_parallel_get_min_rows
+
+- Default: 16384
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: The minimum rows threshold to enable parallel get for primary key index in shared-data mode.
+- Introduced in: -
+
+##### pk_index_parallel_get_threadpool_max_threads
+
+- Default: 0
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: The maximum number of threads in the thread pool for primary key index parallel get in shared-data mode. 0 means auto configuration.
+- Introduced in: -
+
+##### pk_index_size_tiered_level_multiplier
+
+- Default: 10
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: The level multiple parameter for primary key index size-tiered compaction strategy.
+- Introduced in: -
+
+##### pk_index_size_tiered_max_level
+
+- Default: 5
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: The level number parameter for primary key index size-tiered compaction strategy.
+- Introduced in: -
+
 ##### pk_index_size_tiered_min_level_size
 
 - Default: 131072
@@ -2347,22 +2347,22 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Description: The minimum level size parameter for primary key index size-tiered compaction strategy.
 - Introduced in: -
 
-##### pk_index_size_tiered_level_multiplier 
+##### pk_index_target_file_size
 
-- Default: 10
+- Default: 67108864
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: The level multiple parameter for primary key index size-tiered compaction strategy.
+- Description: Target file size for primary key index in shared-data mode. Default is 64MB.
 - Introduced in: -
 
-##### pk_index_size_tiered_max_level 
+##### pk_parallel_execution_threshold_bytes
 
-- Default: 5
+- Default: 104857600
 - Type: Int
 - Unit: -
 - Is mutable: Yes
-- Description: The level number parameter for primary key index size-tiered compaction strategy.
+- Description: When enable_pk_parallel_execution is set to true, the Primary Key table parallel execution strategy will be enabled if the data generated during import or compaction exceeds this threshold. Default is 100MB.
 - Introduced in: -
 
 ##### primary_key_limit_size

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -2683,15 +2683,6 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Description: The time interval at which to check compaction for Primary Key tables.
 - Introduced in: -
 
-##### update_compaction_chunk_size_for_row_store
-
-- Default: 0
-- Type: Int
-- Unit: Rows
-- Is mutable: Yes
-- Description: Overrides the chunk size (number of rows per chunk) used during update compaction for tablets that use column-with-row-store representation. By default (0) StarRocks computes per-column-group chunk size with CompactionUtils::get_read_chunk_size based on compaction memory limit, vector chunk size, total input rows and memory footprint. When this config is set to a positive integer and tablet.is_column_with_row_store() is true, RowsetMerger forces _chunk_size to this value in both horizontal and vertical update compaction paths (rowset_merger.cpp). Use a non-zero value only when the automatic calculation is producing suboptimal results; increasing the value can reduce writer/IO overhead but raises peak memory use, while decreasing it reduces memory pressure at the cost of more chunks and potential performance impact.
-- Introduced in: v3.2.3
-
 ##### update_compaction_delvec_file_io_amp_ratio
 
 - Default: 2

--- a/docs/ja/administration/management/BE_configuration.md
+++ b/docs/ja/administration/management/BE_configuration.md
@@ -2163,15 +2163,6 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 説明: 主キーテーブルのコンパクションをチェックする時間間隔。
 - 導入バージョン: -
 
-##### update_compaction_chunk_size_for_row_store
-
-- デフォルト: 0
-- タイプ: Int
-- 単位: Rows
-- 変更可能: Yes
-- 説明: column-with-row-store 表現を使用する tablet の update compaction 中に使用されるチャンクサイズ（チャンクあたりの行数）を上書きします。デフォルト（0）の場合、StarRocks は compaction メモリ制限、vector チャンクサイズ、入力総行数、メモリフットプリントに基づき CompactionUtils::get_read_chunk_size でカラムグループごとのチャンクサイズを計算します。この設定が正の整数に設定され、かつ tablet.is_column_with_row_store() が true の場合、RowsetMerger は horizontal および vertical の両方の update compaction パスで _chunk_size をこの値に強制します（rowset_merger.cpp）。自動計算が最適でない結果を出している場合にのみ非ゼロ値を使用してください；値を増やすと writer/IO のオーバーヘッドを減らせますがピークメモリ使用量が増加し、値を減らすとメモリプレッシャーは下がるもののチャンク数が増えて性能に影響を与える可能性があります。
-- 導入バージョン: v3.2.3
-
 ##### update_compaction_delvec_file_io_amp_ratio
 
 - デフォルト: 2

--- a/docs/ja/administration/management/BE_configuration.md
+++ b/docs/ja/administration/management/BE_configuration.md
@@ -180,6 +180,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 説明: bRPC の最大ボディサイズ。
 - 導入バージョン: -
 
+##### brpc_max_connections_per_server
+
+- デフォルト: 1
+- タイプ: Int
+- 単位: -
+- 変更可能: いいえ
+- 説明: クライアントが各リモートサーバーエンドポイントごとに保持する永続的な bRPC 接続の最大数。各エンドポイントについて `BrpcStubCache` は `_stubs` ベクタをこのサイズに予約した `StubPool` を作成します。最初のアクセス時には制限に達するまで新しい stub が作成され、その後は既存の stub がラウンドロビン方式で返されます。この値を増やすとエンドポイントごとの並列性が高まり（単一チャネルでの競合が減る）、その代わりにファイルディスクリプタ、メモリ、チャネルが増えます。
+- 導入バージョン: v3.2.0
+
 ##### brpc_num_threads
 
 - デフォルト: -1
@@ -296,6 +305,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 可変: いいえ
 - 説明: BE プロセスのメモリ上限。パーセンテージ ("80%") または物理的な制限 ("100G") として設定できます。デフォルトのハードリミットはサーバーのメモリサイズの 90% で、ソフトリミットは 80% です。同じサーバーで他のメモリ集約型サービスと一緒に StarRocks をデプロイしたい場合、このパラメータを設定する必要があります。
 - 導入バージョン: -
+
+##### memory_urgent_level
+
+- デフォルト: 85
+- タイプ: long
+- 単位: Percentage (0-100)
+- 変更可能: はい
+- 説明: プロセスのメモリ上限に対するパーセンテージで表現される緊急メモリ水位。プロセスのメモリ使用量が `(limit * memory_urgent_level / 100)` を超えると、BE は即時のメモリ回収をトリガーします。これによりデータキャッシュの縮小、update キャッシュの追い出しが行われ、persistent/lake の MemTable は「満杯」と見なされて早期にフラッシュ／コンパクションされます。コードではこの設定が `memory_high_level` より大きく、`memory_high_level` は `1` 以上かつ `100` 以下であることを検証します。値を低くするとより積極的で早期の回収（頻繁なキャッシュ追い出しとフラッシュ）を招きます。値を高くすると回収が遅れ、100 に近すぎると OOM のリスクが高まります。`memory_high_level` および Data Cache 関連の自動調整設定と合わせてチューニングしてください。
+- 導入バージョン: v3.2.0
 
 ##### net_use_ipv6_when_priority_networks_empty
 
@@ -445,6 +463,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 導入バージョン: v4.0.0
 
 ### クエリエンジン
+
+##### dictionary_speculate_min_chunk_size
+
+- デフォルト: 10000
+- タイプ: Int
+- 単位: Rows
+- 変更可能: No
+- 説明: StringColumnWriter および DictColumnWriter が辞書エンコーディングの推測を開始するために使用する最小行数（チャンクサイズ）。受信カラム（または蓄積されたバッファに加えた受信行）のサイズが `dictionary_speculate_min_chunk_size` 以上であれば、ライターは即座に推測を実行してエンコーディング（DICT、PLAIN、または BIT_SHUFFLE のいずれか）を設定し、さらに行をバッファリングしません。推測では文字列カラムに対して `dictionary_encoding_ratio`、数値/非文字列カラムに対して `dictionary_encoding_ratio_for_non_string_column` を使用して辞書エンコーディングが有利かどうかを判断します。また、カラムのバイトサイズが大きく（UINT32_MAX 以上）なる場合は、`BinaryColumn<uint32_t>` のオーバーフローを避けるために即時に推測が行われます。
+- 導入バージョン: v3.2.0
 
 ##### disable_storage_page_cache
 
@@ -1103,6 +1130,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 説明: 有効にすると、load-channel の open RPC（例: PTabletWriterOpen）の処理が BRPC ワーカーから専用のスレッドプールへオフロードされます。リクエストハンドラは ChannelOpenTask を生成して内部 `_async_rpc_pool` に投入し、`LoadChannelMgr::_open` をインラインで実行しません。これにより BRPC スレッド内の作業量とブロッキングが減少し、`load_channel_rpc_thread_pool_num` と `load_channel_rpc_thread_pool_queue_size` で同時実行性を調整できるようになります。スレッドプールへの投入が失敗する（プールが満杯またはシャットダウン済み）と、リクエストはキャンセルされエラー状態が返されます。プールは `LoadChannelMgr::close()` でシャットダウンされるため、有効化する際は容量とライフサイクルを考慮し、リクエストの拒否や処理遅延を避けるようにしてください。
 - 導入バージョン: v3.5.0
 
+##### enable_streaming_load_thread_pool
+
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: Yes
+- 説明: ストリーミングロード用のスキャナを専用の streaming load スレッドプールに送るかどうかを制御します。有効で、かつクエリが `TLoadJobType::STREAM_LOAD` の LOAD の場合、ConnectorScanNode はスキャナタスクを `streaming_load_thread_pool`（INT32_MAX スレッドおよびキューサイズで構成され、事実上無制限）に送信します。無効にすると、スキャナは一般的な `thread_pool` とその `PriorityThreadPool` 提出ロジック（優先度計算、try_offer/offer の振る舞い）を使用します。有効にすると通常のクエリ実行からストリーミングロードの作業を分離して干渉を減らせますが、専用プールは事実上無制限であるため、トラフィックが多いと同時スレッド数やリソース使用量が増える可能性があります。このオプションはデフォルトでオンになっており、通常は変更を必要としません。
+- 導入バージョン: v3.2.0
+
 ##### es_http_timeout_ms
 
 - デフォルト: 5000
@@ -1350,6 +1386,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 説明: 各行ブロックに格納できる最大行数。
 - 導入バージョン: -
 
+##### delete_worker_count_high_priority
+
+- デフォルト: 1
+- タイプ: Int
+- 単位: Threads
+- 変更可能: No
+- 説明: DeleteTaskWorkerPool 内で HIGH-priority の削除スレッドとして割り当てられるワーカースレッドの数。起動時に AgentServer は total threads = delete_worker_count_normal_priority + delete_worker_count_high_priority で削除プールを作成し、最初の delete_worker_count_high_priority スレッドは専ら TPriority::HIGH タスクをポップしようとするようにマークされます（高優先度削除タスクがない場合はポーリングしてスリープ/ループします）。この値を増やすと高優先度削除リクエストの並列性が高まり、減らすと専用容量が減って高優先度削除のレイテンシが増加する可能性があります。
+- 導入バージョン: v3.2.0
+
 ##### disk_stat_monitor_interval
 
 - デフォルト: 5
@@ -1413,6 +1458,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 説明: イベントベースのコンパクションフレームワークを有効にするかどうか。`true` はイベントベースのコンパクションフレームワークが有効であることを示し、`false` は無効であることを示します。イベントベースのコンパクションフレームワークを有効にすると、多くのタブレットがある場合や単一のタブレットに大量のデータがある場合のコンパクションのオーバーヘッドを大幅に削減できます。
 - 導入バージョン: -
 
+##### enable_lazy_delta_column_compaction
+
+- デフォルト: true
+- タイプ: Boolean
+- 単位: -
+- 変更可能: Yes
+- 説明: 有効にすると、部分的なカラム更新によって生成される delta columns に対する compaction に「lazy」戦略を優先します。StarRocks は compaction の I/O を節約するために、delta-column ファイルをメインのセグメントファイルへ積極的にマージすることを避けます。実際には compaction 選択コードが部分カラム更新の rowset と複数の候補をチェックし、それらが見つかりこのフラグが true の場合、エンジンは compaction にさらに入力を追加するのを止めるか、空の rowset（レベル -1）のみをマージして delta columns を別に保持します。これにより compaction 時の即時 I/O と CPU が削減されますが、統合の遅延（セグメント数増加や一時的なストレージオーバーヘッドの可能性）というコストが発生します。正確性やクエリのセマンティクスに変更はありません。
+- 導入バージョン: v3.2.3
+
 ##### enable_new_load_on_memory_limit_exceeded
 
 - デフォルト: false
@@ -1421,6 +1475,24 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 可変: はい
 - 説明: ハードメモリリソース制限に達したときに新しいロードプロセスを許可するかどうか。`true` は新しいロードプロセスが許可されることを示し、`false` は拒否されることを示します。
 - 導入バージョン: v3.3.2
+
+##### enable_pk_index_parallel_compaction
+
+- デフォルト: false
+- タイプ: Boolean
+- 単位: -
+- 可変: はい
+- 説明: 共有データモードでプライマリキーインデックスの並列コンパクションを有効にするかどうか。
+- 導入バージョン: -
+
+##### enable_pk_index_parallel_get
+
+- デフォルト: false
+- タイプ: Boolean
+- 単位: -
+- 可変: はい
+- 説明: 共有データモードでプライマリキーインデックスの並列取得を有効にするかどうか。
+- 導入バージョン: -
 
 ##### enable_pk_parallel_execution
 
@@ -1692,6 +1764,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 説明: ストレージボリュームのガーベジコレクションの最小時間間隔。この設定は v3.0 以降、動的に変更されました。
 - 導入バージョン: -
 
+##### parallel_clone_task_per_path
+
+- デフォルト: 8
+- タイプ: Int
+- 単位: Threads
+- 変更可能: Yes
+- 説明: BE 上の各ストレージパスに割り当てられる並列 clone ワーカースレッドの数。BE 起動時にクローンスレッドプールの max threads は max(number_of_store_paths * parallel_clone_task_per_path, MIN_CLONE_TASK_THREADS_IN_POOL) として計算されます。例えばストレージパスが4つでデフォルト=8 の場合、クローンプールの max = 32 になります。この設定は BE が処理する CLONE タスク（tablet レプリカのコピー）の並列度を直接制御します：値を増やすと並列クローンスループットが向上しますが CPU、ディスク、ネットワークの競合も増えます；値を減らすと同時実行クローンタスクが制限され、FE がスケジュールしたクローン操作をスロットルする可能性があります。値は動的 clone スレッドプールに適用され、update-config パス経由でランタイムに変更可能です（agent_server がクローンプールの max threads を更新します）。
+- 導入バージョン: v3.2.0
+
 ##### pending_data_expire_time_sec
 
 - デフォルト: 1800
@@ -1710,42 +1791,6 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 説明: ディスク上のコンパクションの最大同時実行数。これは、コンパクションによるディスク間の不均一な I/O の問題に対処します。この問題は、特定のディスクに対して過度に高い I/O を引き起こす可能性があります。
 - 導入バージョン: v3.0.9
 
-##### pk_parallel_execution_threshold_bytes
-
-- デフォルト: 104857600
-- タイプ: Int
-- 単位: -
-- 可変: はい
-- 説明: enable_pk_parallel_execution が true に設定されている場合、インポートまたはコンパクションで生成されるデータがこの閾値を超えると、Primary Key テーブルの並列実行戦略が有効になります。デフォルトは 100MB です。
-- 導入バージョン: -
-
-##### pk_index_parallel_compaction_threadpool_max_threads
-
-- デフォルト: 4
-- タイプ: Int
-- 単位: -
-- 可変: はい
-- 説明: 共有データモードでのクラウドネイティブプライマリキーインデックス並列コンパクション用のスレッドプールの最大スレッド数。
-- 導入バージョン: -
-
-##### pk_index_parallel_compaction_task_split_threshold_bytes
-
-- デフォルト: 104857600
-- タイプ: Int
-- 単位: -
-- 可変: はい
-- 説明: プライマリキーインデックスコンパクションタスクの分割閾値。タスクに関連するファイルの合計サイズがこの閾値より小さい場合、タスクは分割されません。デフォルトは 100MB です。
-- 導入バージョン: -
-
-##### pk_index_target_file_size
-
-- デフォルト: 67108864
-- タイプ: Int
-- 単位: -
-- 可変: はい
-- 説明: 共有データモードでのプライマリキーインデックスのターゲットファイルサイズ。デフォルトは 64MB です。
-- 導入バージョン: -
-
 ##### pk_index_compaction_score_ratio
 
 - デフォルト: 1.5
@@ -1762,42 +1807,6 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 単位: -
 - 可変: はい
 - 説明: 共有データモードでのプライマリキーインデックス Ingest SST コンパクションの閾値。
-- 導入バージョン: -
-
-##### enable_pk_index_parallel_compaction
-
-- デフォルト: false
-- タイプ: Boolean
-- 単位: -
-- 可変: はい
-- 説明: 共有データモードでプライマリキーインデックスの並列コンパクションを有効にするかどうか。
-- 導入バージョン: -
-
-##### enable_pk_index_parallel_get
-
-- デフォルト: false
-- タイプ: Boolean
-- 単位: -
-- 可変: はい
-- 説明: 共有データモードでプライマリキーインデックスの並列取得を有効にするかどうか。
-- 導入バージョン: -
-
-##### pk_index_parallel_get_min_rows
-
-- デフォルト: 16384
-- タイプ: Int
-- 単位: -
-- 可変: はい
-- 説明: 共有データモードでプライマリキーインデックスの並列取得を有効にするための最小行数閾値。
-- 導入バージョン: -
-
-##### pk_index_parallel_get_threadpool_max_threads
-
-- デフォルト: 0
-- タイプ: Int
-- 単位: -
-- 可変: はい
-- 説明: 共有データモードでのプライマリキーインデックス並列取得用のスレッドプールの最大スレッド数。0 は自動設定を意味します。
 - 導入バージョン: -
 
 ##### pk_index_memtable_flush_threadpool_max_threads
@@ -1818,6 +1827,60 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 説明: 共有データモードでのプライマリキーインデックスの最大 Memtable 数。
 - 導入バージョン: -
 
+##### pk_index_parallel_compaction_task_split_threshold_bytes
+
+- デフォルト: 104857600
+- タイプ: Int
+- 単位: -
+- 可変: はい
+- 説明: プライマリキーインデックスコンパクションタスクの分割閾値。タスクに関連するファイルの合計サイズがこの閾値より小さい場合、タスクは分割されません。デフォルトは 100MB です。
+- 導入バージョン: -
+
+##### pk_index_parallel_compaction_threadpool_max_threads
+
+- デフォルト: 4
+- タイプ: Int
+- 単位: -
+- 可変: はい
+- 説明: 共有データモードでのクラウドネイティブプライマリキーインデックス並列コンパクション用のスレッドプールの最大スレッド数。
+- 導入バージョン: -
+
+##### pk_index_parallel_get_min_rows
+
+- デフォルト: 16384
+- タイプ: Int
+- 単位: -
+- 可変: はい
+- 説明: 共有データモードでプライマリキーインデックスの並列取得を有効にするための最小行数閾値。
+- 導入バージョン: -
+
+##### pk_index_parallel_get_threadpool_max_threads
+
+- デフォルト: 0
+- タイプ: Int
+- 単位: -
+- 可変: はい
+- 説明: 共有データモードでのプライマリキーインデックス並列取得用のスレッドプールの最大スレッド数。0 は自動設定を意味します。
+- 導入バージョン: -
+
+##### pk_index_size_tiered_level_multiplier
+
+- デフォルト: 10
+- タイプ: Int
+- 単位: -
+- 可変: はい
+- 説明: プライマリキーインデックス Size-Tiered コンパクション戦略のレベル倍数パラメータ。
+- 導入バージョン: -
+
+##### pk_index_size_tiered_max_level
+
+- デフォルト: 5
+- タイプ: Int
+- 単位: -
+- 可変: はい
+- 説明: プライマリキーインデックス Size-Tiered コンパクション戦略のレベル数パラメータ。
+- 導入バージョン: -
+
 ##### pk_index_size_tiered_min_level_size
 
 - デフォルト: 131072
@@ -1827,22 +1890,22 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 説明: プライマリキーインデックス Size-Tiered コンパクション戦略の最小レベルサイズパラメータ。
 - 導入バージョン: -
 
-##### pk_index_size_tiered_level_multiplier 
+##### pk_index_target_file_size
 
-- デフォルト: 10
+- デフォルト: 67108864
 - タイプ: Int
 - 単位: -
 - 可変: はい
-- 説明: プライマリキーインデックス Size-Tiered コンパクション戦略のレベル倍数パラメータ。
+- 説明: 共有データモードでのプライマリキーインデックスのターゲットファイルサイズ。デフォルトは 64MB です。
 - 導入バージョン: -
 
-##### pk_index_size_tiered_max_level 
+##### pk_parallel_execution_threshold_bytes
 
-- デフォルト: 5
+- デフォルト: 104857600
 - タイプ: Int
 - 単位: -
 - 可変: はい
-- 説明: プライマリキーインデックス Size-Tiered コンパクション戦略のレベル数パラメータ。
+- 説明: enable_pk_parallel_execution が true に設定されている場合、インポートまたはコンパクションで生成されるデータがこの閾値を超えると、Primary Key テーブルの並列実行戦略が有効になります。デフォルトは 100MB です。
 - 導入バージョン: -
 
 ##### primary_key_limit_size
@@ -2099,6 +2162,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 可変: はい
 - 説明: 主キーテーブルのコンパクションをチェックする時間間隔。
 - 導入バージョン: -
+
+##### update_compaction_chunk_size_for_row_store
+
+- デフォルト: 0
+- タイプ: Int
+- 単位: Rows
+- 変更可能: Yes
+- 説明: column-with-row-store 表現を使用する tablet の update compaction 中に使用されるチャンクサイズ（チャンクあたりの行数）を上書きします。デフォルト（0）の場合、StarRocks は compaction メモリ制限、vector チャンクサイズ、入力総行数、メモリフットプリントに基づき CompactionUtils::get_read_chunk_size でカラムグループごとのチャンクサイズを計算します。この設定が正の整数に設定され、かつ tablet.is_column_with_row_store() が true の場合、RowsetMerger は horizontal および vertical の両方の update compaction パスで _chunk_size をこの値に強制します（rowset_merger.cpp）。自動計算が最適でない結果を出している場合にのみ非ゼロ値を使用してください；値を増やすと writer/IO のオーバーヘッドを減らせますがピークメモリ使用量が増加し、値を減らすとメモリプレッシャーは下がるもののチャンク数が増えて性能に影響を与える可能性があります。
+- 導入バージョン: v3.2.3
 
 ##### update_compaction_delvec_file_io_amp_ratio
 

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -177,6 +177,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：bRPC 最大的包容量。
 - 引入版本：-
 
+##### brpc_max_connections_per_server
+
+- 默认值: 1
+- 类型: Int
+- 单位: -
+- 是否可变: 否
+- 描述: 客户端为每个远程服务器端点保持的最大持久 bRPC 连接数。对于每个端点，`BrpcStubCache` 会创建一个 `StubPool`，其 `_stubs` 向量会预留为此大小。首次访问时会创建新的 stub，直到达到限制。之后，现有的 stub 将以轮询方式返回。增加此值可以提高每个端点的并发度（降低单通道的争用），代价是更多的文件描述符、内存和通道数。
+- 引入版本: v3.2.0
+
 ##### brpc_num_threads
 
 - 默认值：-1
@@ -311,6 +320,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 是否可变: 是
 - 描述: 在决定是否以压缩形式通过网络发送序列化的 row-batches 时使用的阈值（uncompressed_size / compressed_size）。当尝试压缩时（例如在 DataStreamSender、exchange sink、tablet sink 的索引通道、dictionary cache writer 中），StarRocks 会计算 compress_ratio = uncompressed_size / compressed_size；仅当 compress_ratio `>` rpc_compress_ratio_threshold 时才使用压缩后的负载。默认值 1.1 意味着压缩数据必须至少比未压缩小约 9.1% 才会被使用。将该值调低以偏好压缩（以更多 CPU 换取更小的带宽）；将其调高以避免压缩开销，除非压缩能带来更大的尺寸缩减。注意：此项适用于 RPC/shuffle 序列化，仅在启用 row-batch 压缩（compress_rowbatches）时生效。
 - 引入版本: v3.2.0
+
+##### ssl_private_key_path
+
+- 默认值: 空字符串
+- 类型: String
+- 单位: -
+- 是否可变: 否
+- 描述: 文件系统中用于 BE 的 brpc 服务作为默认证书私钥的 TLS/SSL 私钥（PEM）文件路径。当 `enable_https` 设置为 `true` 时，系统在进程启动时将 `brpc::ServerOptions::ssl_options().default_cert.private_key` 设置为此路径。该文件必须对 BE 进程可访问，并且必须与由 `ssl_certificate_path` 提供的证书匹配。如果未设置此值或文件丢失或不可访问，则不会配置 HTTPS 并且 bRPC 服务器可能无法启动。请使用严格的文件系统权限（例如 600）保护此文件。
+- 引入版本: v4.0.0
 
 ##### thrift_client_retry_interval_ms
 
@@ -1166,6 +1184,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：汇报磁盘状态的间隔。汇报各个磁盘的状态，以及其中数据量等。
 - 引入版本：-
 
+##### report_resource_usage_interval_ms
+
+- 默认值: 1000
+- 类型: Int
+- 単位: Milliseconds
+- 是否可变: Yes
+- 描述: 由 BE agent 定期向 FE（master）发送资源使用报告的间隔（毫秒）。agent 的 worker 线程会收集 TResourceUsage（正在运行的查询数、已用/限制内存、CPU 使用千分比以及 resource-group 使用情况），调用 report_task，然后睡眠此配置的间隔（参见 task_worker_pool）。较低的值能提高报告的及时性，但会增加 CPU、网络和 master 的负载；较高的值可降低开销但会使资源信息不够实时。上报会更新相关指标（report_resource_usage_requests_total、report_resource_usage_requests_failed）。请根据集群规模和 FE 负载调整。
+- 引入版本: v3.2.0
+
 ##### report_tablet_interval_seconds
 
 - 默认值：60
@@ -1411,6 +1438,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：是否开启 Event-based Compaction Framework。`true` 代表开启。`false` 代表关闭。开启则能够在 Tablet 数比较多或者单个 Tablet 数据量比较大的场景下大幅降低 Compaction 的开销。
 - 引入版本：-
 
+##### enable_lazy_delta_column_compaction
+
+- 默认值: true
+- 类型: Boolean
+- 单位: -
+- 是否可变: Yes
+- 描述: 启用后，compaction 将对由部分列更新产生的 delta 列采用“懒惰”策略：StarRocks 会避免将 delta-column 文件急切地合并回其主段文件以节省 compaction 的 I/O。实际上，compaction 选择代码会检查是否存在部分列更新的 rowset 和多个候选项；如果发现且此标志为 true，引擎要么停止向 compaction 添加更多输入，要么仅合并空的 rowset（level -1），将 delta 列保持分离。这会减少 compaction 期间的即时 I/O 和 CPU 开销，但以延迟合并为代价（可能产生更多段和临时存储开销）。正确性和查询语义不受影响。
+- 引入版本: v3.2.3
+
 ##### enable_new_load_on_memory_limit_exceeded
 
 - 默认值：false
@@ -1419,6 +1455,24 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 是否动态：是
 - 描述：在导入线程内存占用达到硬上限后，是否允许新的导入线程。`true` 表示允许新导入线程，`false` 表示拒绝新导入线程。
 - 引入版本：v3.3.2
+
+##### enable_pk_index_parallel_compaction
+
+- 默认值：false
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：是否启用存算分离模式下主键索引的并行 Compaction。
+- 引入版本：-
+
+##### enable_pk_index_parallel_get
+
+- 默认值：false
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：是否启用存算分离模式下主键索引的并行读取。
+- 引入版本：-
 
 ##### enable_pk_parallel_execution
 
@@ -1699,42 +1753,6 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：每块盘 Compaction 的最大并发数，用于解决 Compaction 在磁盘之间不均衡导致个别磁盘 I/O 过高的问题。
 - 引入版本：v3.0.9
 
-##### pk_parallel_execution_threshold_bytes
-
-- 默认值：104857600
-- 类型：Int
-- 单位：-
-- 是否动态：是
-- 描述：当enable_pk_parallel_execution设置为true后，导入或者compaction生成的数据大于该阈值时，Primary Key 表并行执行策略将被启用。默认为 100MB。
-- 引入版本：-
-
-##### pk_index_parallel_compaction_threadpool_max_threads
-
-- 默认值：4
-- 类型：Int
-- 单位：-
-- 是否动态：是
-- 描述：存算分离模式下，主键索引并行 Compaction 的线程池最大线程数。
-- 引入版本：-
-
-##### pk_index_parallel_compaction_task_split_threshold_bytes
-
-- 默认值：104857600
-- 类型：Int
-- 单位：-
-- 是否动态：是
-- 描述：主键索引 Compaction 任务拆分的阈值。当任务涉及的文件总大小小于此阈值时，任务将不会被拆分。默认为 100MB。
-- 引入版本：-
-
-##### pk_index_target_file_size
-
-- 默认值：67108864
-- 类型：Int
-- 单位：-
-- 是否动态：是
-- 描述：存算分离模式下，主键索引的目标文件大小。默认为 64MB。
-- 引入版本：-
-
 ##### pk_index_compaction_score_ratio
 
 - 默认值：1.5
@@ -1751,42 +1769,6 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 单位：-
 - 是否动态：是
 - 描述：存算分离模式下，主键索引 Ingest SST Compaction 的阈值。
-- 引入版本：-
-
-##### enable_pk_index_parallel_compaction
-
-- 默认值：false
-- 类型：Boolean
-- 单位：-
-- 是否动态：是
-- 描述：是否启用存算分离模式下主键索引的并行 Compaction。
-- 引入版本：-
-
-##### enable_pk_index_parallel_get
-
-- 默认值：false
-- 类型：Boolean
-- 单位：-
-- 是否动态：是
-- 描述：是否启用存算分离模式下主键索引的并行读取。
-- 引入版本：-
-
-##### pk_index_parallel_get_min_rows
-
-- 默认值：16384
-- 类型：Int
-- 单位：-
-- 是否动态：是
-- 描述：存算分离模式下，启用主键索引并行读取的最小行数阈值。
-- 引入版本：-
-
-##### pk_index_parallel_get_threadpool_max_threads
-
-- 默认值：0
-- 类型：Int
-- 单位：-
-- 是否动态：是
-- 描述：存算分离模式下，主键索引并行读取的线程池最大线程数。0 表示自动配置。
 - 引入版本：-
 
 ##### pk_index_memtable_flush_threadpool_max_threads
@@ -1807,6 +1789,60 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：存算分离模式下，主键索引的最大 Memtable 数量。
 - 引入版本：-
 
+##### pk_index_parallel_compaction_task_split_threshold_bytes
+
+- 默认值：104857600
+- 类型：Int
+- 单位：-
+- 是否动态：是
+- 描述：主键索引 Compaction 任务拆分的阈值。当任务涉及的文件总大小小于此阈值时，任务将不会被拆分。默认为 100MB。
+- 引入版本：-
+
+##### pk_index_parallel_compaction_threadpool_max_threads
+
+- 默认值：4
+- 类型：Int
+- 单位：-
+- 是否动态：是
+- 描述：存算分离模式下，主键索引并行 Compaction 的线程池最大线程数。
+- 引入版本：-
+
+##### pk_index_parallel_get_min_rows
+
+- 默认值：16384
+- 类型：Int
+- 单位：-
+- 是否动态：是
+- 描述：存算分离模式下，启用主键索引并行读取的最小行数阈值。
+- 引入版本：-
+
+##### pk_index_parallel_get_threadpool_max_threads
+
+- 默认值：0
+- 类型：Int
+- 单位：-
+- 是否动态：是
+- 描述：存算分离模式下，主键索引并行读取的线程池最大线程数。0 表示自动配置。
+- 引入版本：-
+
+##### pk_index_size_tiered_level_multiplier
+
+- 默认值：10
+- 类型：Int
+- 单位：-
+- 是否动态：是
+- 描述：主键索引 Size-Tiered Compaction 策略的层级倍数参数。
+- 引入版本：-
+
+##### pk_index_size_tiered_max_level
+
+- 默认值：5
+- 类型：Int
+- 单位：-
+- 是否动态：是
+- 描述：主键索引 Size-Tiered Compaction 策略的层级数量参数。
+- 引入版本：-
+
 ##### pk_index_size_tiered_min_level_size
 
 - 默认值：131072
@@ -1816,22 +1852,22 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：主键索引 Size-Tiered Compaction 策略的最小层级大小参数。
 - 引入版本：-
 
-##### pk_index_size_tiered_level_multiplier 
+##### pk_index_target_file_size
 
-- 默认值：10
+- 默认值：67108864
 - 类型：Int
 - 单位：-
 - 是否动态：是
-- 描述：主键索引 Size-Tiered Compaction 策略的层级倍数参数。
+- 描述：存算分离模式下，主键索引的目标文件大小。默认为 64MB。
 - 引入版本：-
 
-##### pk_index_size_tiered_max_level 
+##### pk_parallel_execution_threshold_bytes
 
-- 默认值：5
+- 默认值：104857600
 - 类型：Int
 - 单位：-
 - 是否动态：是
-- 描述：主键索引 Size-Tiered Compaction 策略的层级数量参数。
+- 描述：当enable_pk_parallel_execution设置为true后，导入或者compaction生成的数据大于该阈值时，Primary Key 表并行执行策略将被启用。默认为 100MB。
 - 引入版本：-
 
 ##### primary_key_limit_size
@@ -2088,6 +2124,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 是否动态：是
 - 描述：主键表 Compaction 的检查间隔。
 - 引入版本：-
+
+##### update_compaction_chunk_size_for_row_store
+
+- 默认值: 0
+- 类型: Int
+- 单位: Rows
+- 是否可变: Yes
+- 描述: 覆盖对使用 column-with-row-store 表示的 tablet 在 update compaction 期间使用的 chunk 大小（每个 chunk 的行数）。默认（0）情况下，StarRocks 使用 CompactionUtils::get_read_chunk_size 基于 compaction 内存限制、vector chunk 大小、总输入行数和内存占用来计算每列组的 chunk 大小。当此配置被设置为正整数且 tablet.is_column_with_row_store() 为 true 时，RowsetMerger 会在水平和垂直更新 compaction 路径中强制将 _chunk_size 设为该值（见 rowset_merger.cpp）。仅在自动计算产生次优结果时使用非零值；增大该值可以减少写入者/IO 开销但会提高峰值内存使用，减小则可降低内存压力但会增加 chunk 数量并可能影响性能。
+- 引入版本: v3.2.3
 
 ##### update_compaction_delvec_file_io_amp_ratio
 
@@ -2591,6 +2636,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 是否动态：是
 - 描述：用于向 FE 汇报执行状态的 RPC 请求的重试次数。默认值为 10，意味着如果该 RPC 请求失败（仅限于 fragment instance 的 finish RPC），将最多重试 10 次。该请求对于导入任务（load job）非常重要，如果某个 fragment instance 的完成状态报告失败，整个导入任务将会一直挂起，直到超时。
 -引入版本：-
+
+##### sleep_one_second
+
+- 默认值: 1
+- 类型: Int
+- 単位: Seconds
+- 是否可变: No
+- 描述: 一个用于 BE agent worker 线程的全局短睡眠间隔（秒），当 master 地址/心跳尚不可用或需要短时间重试/退避时作为一秒的暂停。在代码中，多个 report worker pool（例如 ReportDiskStateTaskWorkerPool、ReportOlapTableTaskWorkerPool、ReportWorkgroupTaskWorkerPool）引用此值，以避免忙等（busy-waiting）并在重试时降低 CPU 消耗。增大此值会降低重试频率并减慢对 master 可用性的响应；减小会提高轮询频率并增加 CPU 使用。仅在权衡响应性与资源使用后调整。
+- 引入版本: v3.2.0
 
 ##### small_file_dir
 

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -44,8 +44,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值: `${STARROCKS_HOME}/log`
 - 类型: string
-- 単位: -
-- 是否可变: No
+- 单位：-
+- 是否动态：否
 - 描述: StarRocks 写入 pprof 工件（jemalloc 堆快照和 gperftools CPU 配置文件）的目录路径。代码会在此目录下构造文件名（例如 `heap_profile.<pid>.<rand>` 和 `starrocks_profile.<pid>.<rand>`），并且 /pprof/ 下的 HTTP 处理器会提供这些配置文件。在启动时，如果 `pprof_profile_dir` 非空，StarRocks 会尝试创建该目录。请确保该路径存在或对 BE 进程可写，并且有足够的磁盘空间；性能分析可能产生较大的文件，并在运行时影响性能。
 - 引入版本: v3.2.0
 
@@ -119,7 +119,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值: -1
 - 类型: Int
 - 单位: Port
-- 是否可变: 否
+- 是否动态：否
 - 描述: TCP 端口，用于 BE 的 Arrow Flight SQL 服务器。将其设置为 `-1` 以禁用 Arrow Flight 服务。在非 macOS 构建中，BE 在启动期间会调用通过该端口启动 Arrow Flight SQL Server；如果端口不可用，服务器启动会失败并且 BE 进程退出。配置的端口会在心跳负载中上报给 FE。
 - 引入版本: v3.4.0, v3.5.0
 
@@ -127,7 +127,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：60
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：否
 - 描述：磁盘挂起后触发 BE 进程退出的等待时间。
 - 引入版本：-
@@ -164,7 +164,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值: 64
 - 类型: Int
 - 单位: Threads
-- 是否可变: 否
+- 是否动态：否
 - 描述: BE Thrift 服务用于处理后端 RPC/执行请求的工作线程数。该值在创建 BackendService 时传递给 ThriftServer，用于控制可用的并发请求处理器数量；当所有工作线程都忙碌时，请求会排队。根据预期的并发 RPC 负载和可用的 CPU/内存调整：增大该值可以提高并发度，但也会增加每线程内存和上下文切换开销；减小则限制并行处理能力，可能增加请求延迟。
 - 引入版本: v3.2.0
 
@@ -182,7 +182,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值: 1
 - 类型: Int
 - 单位: -
-- 是否可变: 否
+- 是否动态：否
 - 描述: 客户端为每个远程服务器端点保持的最大持久 bRPC 连接数。对于每个端点，`BrpcStubCache` 会创建一个 `StubPool`，其 `_stubs` 向量会预留为此大小。首次访问时会创建新的 stub，直到达到限制。之后，现有的 stub 将以轮询方式返回。增加此值可以提高每个端点的并发度（降低单通道的争用），代价是更多的文件描述符、内存和通道数。
 - 引入版本: v3.2.0
 
@@ -209,7 +209,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值: 3600
 - 类型: Int
 - 单位: Seconds
-- 是否可变: Yes
+- 是否动态：是
 - 描述: BRPC stub 缓存的过期时间，默认 60 minutes。
 - 引入版本: -
 
@@ -226,8 +226,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值: 2
 - 类型: Int
-- 単位: Threads
-- 是否可变: No
+- 单位：Threads
+- 是否动态：否
 - 描述: 在 BE agent 上专门用于处理删除（REALTIME_PUSH with DELETE）任务的普通优先级工作线程数量。启动时，此值会与 delete_worker_count_high_priority 相加以确定 DeleteTaskWorkerPool 的大小（参见 agent_server.cpp）。线程池会将前 delete_worker_count_high_priority 个线程分配为 HIGH 优先级，其余为 NORMAL；普通优先级线程处理标准删除任务并有助于整体删除吞吐量。增加此值可提高并发删除能力（会增加 CPU/IO 使用）；减少则可降低资源争用。
 - 引入版本: v3.2.0
 
@@ -236,7 +236,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值: false
 - 类型: Boolean
 - 单位: -
-- 是否可变: No
+- 是否动态：否
 - 描述: 当此项设置为 `true` 时，BE 的 bRPC 服务配置为使用 TLS，并使用 `ssl_certificate_path` 和 `ssl_private_key_path` 指定的证书和私钥。这样会为传入的 bRPC 连接启用 HTTPS/TLS。客户端必须使用 TLS 连接。请确保证书和密钥文件存在、且 BE 进程可访问，并符合 bRPC/SSL 的要求。
 - 引入版本: v4.0.0
 
@@ -245,7 +245,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值: true
 - 类型: Boolean
 - 单位: -
-- 是否可变: 否
+- 是否动态：否
 - 描述: 该项设置为 `true` 时，BE 会启动一个后台线程（`jemalloc_tracker_daemon`），该线程以每秒一次的频率轮询 Jemalloc 统计信息，并将 Jemalloc 的 "stats.metadata" 值更新到 GlobalEnv 的 Jemalloc 元数据 MemTracker 中。这可确保 Jemalloc 元数据的消耗被计入 StarRocks 进程的内存统计，防止低报 Jemalloc 内部使用的内存。该 Tracker 仅在非 macOS 构建上编译/启动（#ifndef __APPLE__），并以名为 "jemalloc_tracker_daemon" 的守护线程运行。仅在未使用 Jemalloc 或者 Jemalloc 跟踪被有意以不同方式管理时才禁用，否则请保持启用以维护准确的内存计量和分配保护。
 - 引入版本: v3.2.12
 
@@ -253,8 +253,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值: 0
 - 类型: Int
-- 単位: -
-- 是否可变: 是
+- 单位：-
+- 是否动态：是
 - 描述: 为 UpdateManager 中的 "get_pindex" 线程池设置工作线程数，该线程池用于加载/获取持久化索引数据（在为主键表应用 rowset 时使用）。如果设置为大于 0 则系统应用该值；如果设置为 0 则运行时回调使用 CPU 核心数。在初始化时，改线程池的最大线程数计算为 `max(get_pindex_worker_count, max_apply_thread_cnt * 2)`，其中 `max_apply_thread_cnt` 是 apply-thread 池的最大值。增大此值可提高 pindex 加载的并行度；降低则减少并发和内存/CPU 使用。
 - 引入版本: v3.2.0
 
@@ -280,8 +280,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值: `${UDF_RUNTIME_DIR}`
 - 类型: string
-- 単位: -
-- 是否可变: 否
+- 单位：-
+- 是否动态：否
 - 描述: BE 上的本地目录，用于存放 UDF（用户自定义函数）库并作为 Python UDF worker 进程的工作目录。StarRocks 会将 UDF 库从 HDFS 复制到此路径，在 `<local_library_dir>/pyworker_<pid>` 创建每个 worker 的 Unix 域套接字，并在 exec 前将 Python worker 进程的工作目录切换到此目录。该目录必须存在、对 BE 进程可写，并且位于支持 Unix 域套接字的文件系统上（即本地文件系统）。由于该配置在运行时不可变，请在启动前设置并确保每个 BE 上具有足够的权限和磁盘空间。
 - 引入版本: v3.2.0
 
@@ -317,7 +317,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值: 1.1
 - 类型: Double
 - 单位: -
-- 是否可变: 是
+- 是否动态：是
 - 描述: 在决定是否以压缩形式通过网络发送序列化的 row-batches 时使用的阈值（uncompressed_size / compressed_size）。当尝试压缩时（例如在 DataStreamSender、exchange sink、tablet sink 的索引通道、dictionary cache writer 中），StarRocks 会计算 compress_ratio = uncompressed_size / compressed_size；仅当 compress_ratio `>` rpc_compress_ratio_threshold 时才使用压缩后的负载。默认值 1.1 意味着压缩数据必须至少比未压缩小约 9.1% 才会被使用。将该值调低以偏好压缩（以更多 CPU 换取更小的带宽）；将其调高以避免压缩开销，除非压缩能带来更大的尺寸缩减。注意：此项适用于 RPC/shuffle 序列化，仅在启用 row-batch 压缩（compress_rowbatches）时生效。
 - 引入版本: v3.2.0
 
@@ -326,15 +326,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值: 空字符串
 - 类型: String
 - 单位: -
-- 是否可变: 否
-- 描述: 文件系统中用于 BE 的 brpc 服务作为默认证书私钥的 TLS/SSL 私钥（PEM）文件路径。当 `enable_https` 设置为 `true` 时，系统在进程启动时将 `brpc::ServerOptions::ssl_options().default_cert.private_key` 设置为此路径。该文件必须对 BE 进程可访问，并且必须与由 `ssl_certificate_path` 提供的证书匹配。如果未设置此值或文件丢失或不可访问，则不会配置 HTTPS 并且 bRPC 服务器可能无法启动。请使用严格的文件系统权限（例如 600）保护此文件。
+- 是否动态：否
+- 描述: 文件系统中用于 BE 的 bRPC 服务作为默认证书私钥的 TLS/SSL 私钥（PEM）文件路径。当 `enable_https` 设置为 `true` 时生效。该文件必须对 BE 进程可访问，并且必须与由 `ssl_certificate_path` 提供的证书匹配。如果未设置此值或文件丢失或不可访问，则不会配置 HTTPS 并且 bRPC 服务器可能无法启动。请使用严格的文件系统权限（例如 600）保护此文件。
 - 引入版本: v4.0.0
 
 ##### thrift_client_retry_interval_ms
 
 - 默认值：100
 - 类型：Int
-- 单位：Milliseconds
+- 单位：毫秒
 - 是否动态：是
 - 描述：Thrift Client 默认的重试时间间隔。
 - 引入版本：-
@@ -343,8 +343,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值: 0
 - 类型: Int
-- 単位: -
-- 是否可变: 否
+- 单位：-
+- 是否动态：否
 - 描述: 用于导出基于 Thrift 的内部 BackendService 的端口。当进程以 Compute Node 模式运行且该项设置为非零值时，它会覆盖 `be_port` 并使 Thrift 服务器绑定到此值；否则使用 `be_port`。此配置已弃用 — 将非零 `thrift_port` 设置会记录警告，建议改用 `be_port`。
 - 引入版本: v3.2.0
 
@@ -379,7 +379,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：5000
 - 类型：Int
-- 单位：Milliseconds
+- 单位：毫秒
 - 是否动态：是
 - 描述：Thrift RPC 超时的时长。
 - 引入版本：-
@@ -388,8 +388,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值: 0
 - 类型: Int
-- 単位: Threads
-- 是否可变: 是
+- 单位：Threads
+- 是否动态：是
 - 描述: 为 BE 的 UpdateManager 中的 "update_apply" 线程池设置最小线程数。该线程池用于为主键表应用 rowset。值为 0 表示禁用固定最小值（不强制下限）；当 `transaction_apply_worker_count` 也为 0 时，该线程池的最大线程数默认为 CPU 核心数，因此有效的工作线程容量等于 CPU 核心数。可以增大此值以保证应用事务的基线并发；设置过高可能增加 CPU 争用。
 - 引入版本: v3.2.11
 
@@ -400,7 +400,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值: -1
 - 类型: Int
 - 单位: -
-- 是否可变: 否
+- 是否动态：否
 - 描述: BE 节点在集群的全局集群标识符。具有相同集群 ID 的 FE 或 BE 属于同一个 StarRocks 集群。取值范围：正整数。默认值 -1 表示在 Leader FE 首次启动时随机生成一个。
 - 引入版本: v3.2.0
 
@@ -408,8 +408,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值: 30
 - 类型: Int
-- 単位: Percent
-- 是否可变: Yes
+- 单位：Percent
+- 是否动态：是
 - 描述: 将元数据 LRU 缓存大小设置为进程内存限制的百分比。启动时 StarRocks 将缓存字节数计算为 (`process_mem_limit * metadata_cache_memory_limit_percent / 100`)，并将其传递给元数据缓存分配器。该缓存仅用于非 PRIMARY_KEYS 行集（不支持 PK 表），并且仅在 `metadata_cache_memory_limit_percent` 大于 0 时启用；将其设置为小于等于 0 可禁用元数据缓存。增加此值会提高元数据缓存容量，但会减少分配给其他组件的内存；请根据工作负载和系统内存进行调优。在 BE_TEST 构建中不生效。
 - 引入版本: v3.2.10
 
@@ -417,8 +417,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值: 3
 - 类型: Int
-- 単位: Threads
-- 是否可变: No
+- 单位：Threads
+- 是否动态：否
 - 描述: 配置后端用于处理 TTaskType::UPDATE_SCHEMA 任务的动态 ThreadPool（名称为 "update_schema"）中最大的工作线程数。该 ThreadPool 在 agent_server 启动时创建，最小线程数为 0（空闲时可缩减为零），最大线程数等于此设置；线程池使用默认的空闲超时并具有近乎无限的队列。增加此值可允许更多并发的 schema 更新任务（会增加 CPU 和内存使用），降低则可限制并行的 schema 操作。
 - 引入版本: v3.2.3
 
@@ -428,8 +428,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值: 
 - 类型: String
-- 単位: -
-- 是否可变: 否
+- 单位：-
+- 是否动态：否
 - 描述: 在 enable_https 为 true 时，BE 的 brpc server 将使用的 TLS/SSL 证书文件（PEM 格式）的绝对路径。在 BE 启动时，此值会复制到 `brpc::ServerOptions::ssl_options().default_cert.certificate`；你还必须将 `ssl_private_key_path` 设置为对应的私钥。若 CA 要求，提供服务器证书及任何中间证书的 PEM 格式（证书链）。该文件必须对 StarRocks BE 进程可读，并且仅在启动时应用。如果在 enable_https 启用时该值未设置或无效，brpc 的 TLS 配置可能失败并导致服务器无法正确启动。
 - 引入版本: v4.0.0
 
@@ -439,8 +439,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值: 10000
 - 类型: Int
-- 単位: Rows
-- 是否可变: No
+- 单位：Rows
+- 是否动态：否
 - 描述: StringColumnWriter 和 DictColumnWriter 用于触发字典编码推测的最小行数（chunk 大小）。如果传入列（或累积缓冲区加上传入行）大小大于等于 `dictionary_speculate_min_chunk_size`，写入器将立即运行推测并设置一种编码（DICT、PLAIN 或 BIT_SHUFFLE），而不是继续缓冲更多行。对于字符串列，推测使用 `dictionary_encoding_ratio` 来决定字典编码是否有利；对于数值/非字符串列，使用 `dictionary_encoding_ratio_for_non_string_column`。此外，如果列的 byte_size 很大（大于等于 UINT32_MAX），会强制立即进行推测以避免 `BinaryColumn<uint32_t>` 溢出。
 - 引入版本: v3.2.0
 
@@ -596,7 +596,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：2500
 - 类型：Int
-- 单位：Milliseconds
+- 单位：毫秒
 - 是否动态：否
 - 描述：发起 Hedged Read 请求前需要等待多少毫秒。例如，假设该参数设置为 `30`，那么如果一个 Read 任务未能在 30 毫秒内返回结果，则 HDFS 客户端会立即发起一个 Hedged Read，从目标数据块的副本上读取数据。该参数对应 HDFS 集群配置文件 **hdfs-site.xml** 中的 `dfs.client.hedged.read.threshold.millis` 参数。
 - 引入版本：v3.0
@@ -660,7 +660,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值: false
 - 类型: Boolean
 - 单位: -
-- 是否可变: Yes
+- 是否动态：是
 - 描述: 控制是否忽略 tablet rowset 元数据中可能由逻辑删除在列名重命名后引入到重复键（duplicate key）表中的无效 delete predicates 的布尔值。
 - 引入版本: v4.0
 
@@ -713,7 +713,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：-1
 - 类型：Int
-- 单位：Milliseconds
+- 单位：毫秒
 - 是否动态：否
 - 描述：对象存储 Socket 连接的超时时间。`-1` 表示使用 SDK 中的默认时间。
 - 引入版本：v3.0.9
@@ -722,7 +722,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：-1
 - 类型：Int
-- 单位：Milliseconds
+- 单位：毫秒
 - 是否动态：否
 - 描述：对象存储 HTTP 连接的超时时间。`-1` 表示使用 SDK 中的默认时间。
 - 引入版本：v3.0.9
@@ -750,7 +750,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值: true
 - 类型: Boolean
 - 单位: -
-- 是否可变: 是
+- 是否动态：是
 - 描述: 控制是否启用 Parquet 文件的布隆过滤器以提升性能的布尔值。`true` 表示启用布隆过滤器，`false` 表示禁用。也可以通过会话级别的系统变量 `enable_parquet_reader_bloom_filter` 控制此行为。Parquet 中的布隆过滤器是按“每个 row group 的列级别”维护的。如果 Parquet 文件为某些列维护了布隆过滤器，则对这些列的谓词可以高效地跳过不相关的 row group。
 - 引入版本: v3.5
 
@@ -767,7 +767,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：10
 - 类型：Int
-- 单位：Milliseconds
+- 单位：毫秒
 - 是否动态：是
 - 描述：多次连续 Scan 文件间隔时间。
 - 引入版本：-
@@ -776,7 +776,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：86400
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：GC 线程清理过期数据的间隔时间。
 - 引入版本：-
@@ -794,7 +794,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：-1
 - 类型：Int
-- 单位：Milliseconds
+- 单位：毫秒
 - 是否动态：是
 - 描述：当该值大于 `0` 时，则在轮询器中，如果某个 Driver 的单次调度时间超过了 `pipeline_poller_timeout_guard_ms` 的时间，则会打印该 Driver 以及 Operator 信息。
 - 引入版本：-
@@ -821,7 +821,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：-1
 - 类型：Int
-- 单位：Milliseconds
+- 单位：毫秒
 - 是否动态：是
 - 描述：当该值大于 `0` 时，如果 PREPARE 过程中 Plan Fragment 超过 `pipeline_prepare_timeout_guard_ms` 的时间，则会打印 Plan Fragment 的堆栈跟踪。
 - 引入版本：-
@@ -857,7 +857,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：300
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：BufferControlBlock 释放数据的等待时间。
 - 引入版本：-
@@ -911,8 +911,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值: 1
 - 类型: Int
-- 単位: Threads
-- 是否可变: 否
+- 单位：Threads
+- 是否动态：否
 - 描述: 设置在 ExecEnv 中创建的 UDF 调用 PriorityThreadPool 的大小（用于执行用户自定义函数/UDF 相关任务）。该值既作为线程池的线程数，也在构造线程池时作为队列容量（PriorityThreadPool("udf", thread_num, queue_size)）。增大该值可以允许更多并发的 UDF 执行；保持较小可避免过度的 CPU 和内存争用。
 - 引入版本: v3.2.0
 
@@ -920,8 +920,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值: 60
 - 类型: Int
-- 単位: Percent
-- 是否可变: No
+- 单位：Percent
+- 是否动态：否
 - 描述: BE 进程内存中为更新相关内存和缓存保留的比例。在启动期间，`GlobalEnv` 将更新的 `MemTracker` 计算为 process_mem_limit * clamp(update_memory_limit_percent, 0, 100) / 100。`UpdateManager` 也使用该百分比来确定其 primary-index/index-cache 的容量（index cache capacity = GlobalEnv::process_mem_limit * update_memory_limit_percent / 100）。HTTP 配置更新逻辑会注册一个回调，在配置更改时调用 update managers 的 `update_primary_index_memory_limit`，因此配置更改会应用到更新子系统。增加此值会为更新/primary-index 路径分配更多内存（减少其他内存池可用内存）；减少它会降低更新内存和缓存容量。值会被限定在 0–100 范围内。
 - 引入版本: v3.2.0
 
@@ -969,7 +969,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 类型：Int
 - 单位：-
 - 是否动态：是
-- 描述：在存算分离模式下，每个 Store 用以 Flush MemTable 的线程数。当该参数被设置为 `0` 时，系统使用 CPU 核数的两倍。
+- 描述：在存算分离集群中，每个 Store 用以 Flush MemTable 的线程数。当该参数被设置为 `0` 时，系统使用 CPU 核数的两倍。
 当该参数被设置为小于 `0` 时，系统使用该参数的绝对值与 CPU 核数的乘积。
 - 引入版本：3.1.12, 3.2.7
 
@@ -1067,7 +1067,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：1200
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：否
 - 描述：Stream Load 的 RPC 超时时长。
 - 引入版本：-
@@ -1106,7 +1106,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值: true
 - 类型: Boolean
 - 单位: -
-- 是否可变: 是
+- 是否动态：是
 - 描述: 启用后，load-channel Open 类型的 RPC（例如 PTabletWriterOpen）的处理会从 BRPC worker 转移到一个专用的线程池：请求处理器会创建一个 ChannelOpenTask 并将其提交到内部 `_async_rpc_pool`，而不是内联执行 `LoadChannelMgr::_open`。这样可以减少 BRPC 线程内的工作量和阻塞，并允许通过 `load_channel_rpc_thread_pool_num` 和 `load_channel_rpc_thread_pool_queue_size` 调整并发。如果线程池提交失败（池已满或已关闭），该请求会被取消并返回错误状态。该线程池会在 `LoadChannelMgr::close()` 时关闭，因此在启用该功能时需要考虑容量和生命周期，以避免请求被拒绝或处理延迟。
 - 引入版本: v3.5.0
 
@@ -1114,8 +1114,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值: true
 - 类型: Boolean
-- 単位: -
-- 是否可变: Yes
+- 单位：-
+- 是否动态：是
 - 描述: 控制是否将 streaming load 的 scanner 提交到专用的 streaming load 线程池。当启用且查询为带有 `TLoadJobType::STREAM_LOAD` 的 LOAD 时，ConnectorScanNode 会将 scanner 任务提交到 `streaming_load_thread_pool`（该池配置为 INT32_MAX 的线程数和队列大小，即实际上是无界的）。当禁用时，scanner 使用通用的 `thread_pool` 及其 `PriorityThreadPool` 提交逻辑（优先级计算、try_offer/offer 行为）。启用可以将 streaming-load 的工作与常规查询执行隔离以减少干扰；但由于专用池实际上是无界的，在重度 streaming-load 流量下启用可能会增加并发线程数和资源使用。此选项默认开启，通常无需修改。
 - 引入版本: v3.2.0
 
@@ -1123,8 +1123,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值: 600000
 - 类型: Int
-- 単位: Milliseconds
-- 是否可变: Yes
+- 单位：毫秒
+- 是否动态：是
 - 描述: 用于决定何时为长时间运行的 load RPC 请求远程堆栈跟踪的阈值（毫秒）。当 load RPC 超时并返回超时错误且实际的 RPC 超时时间（_rpc_timeout_ms）超过此值时，`OlapTableSink`/`NodeChannel` 将在发往目标 BE 的 `load_diagnose` RPC 中包含 `stack_trace=true`，以便 BE 返回用于调试的堆栈跟踪。`LocalTabletsChannel::SecondaryReplicasWaiter` 也会在等待 secondary replicas 超过该间隔时触发从 primary 的尽力堆栈跟踪诊断。此行为依赖于 `enable_load_diagnose` 并使用 `load_diagnose_send_rpc_timeout_ms` 作为诊断 RPC 的超时；性能分析由 `load_diagnose_rpc_timeout_profile_threshold_ms` 单独控制。降低此值会更积极地请求堆栈跟踪。
 - 引入版本: v3.5.0
 
@@ -1132,8 +1132,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值: -1
 - 类型: Int
-- 単位: Milliseconds
-- 是否可变: Yes
+- 单位：毫秒
+- 是否动态：是
 - 描述: 在触发 `node_channel_set_brpc_timeout` fail point 时，覆盖 OlapTableSink 所使用的每通道 brpc RPC 超时。如果设置为正值，NodeChannel 会将其内部 `_rpc_timeout_ms` 设置为该值（毫秒），使 open/add-chunk/cancel RPC 使用更短的超时，从而模拟产生 “[E1008]Reached timeout” 错误的 brpc 超时。默认值（`-1`）禁用覆盖。更改此值用于测试和故障注入；较小的值可能导致虚假超时并触发 load 诊断（参见 `enable_load_diagnose`、`load_diagnose_rpc_timeout_profile_threshold_ms`、`load_diagnose_rpc_timeout_stack_trace_threshold_ms` 和 `load_diagnose_send_rpc_timeout_ms`）。
 - 引入版本: v3.5.0
 
@@ -1141,8 +1141,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值: `${STARROCKS_HOME}/var/pull_load`
 - 类型: string
-- 単位: -
-- 是否可变: No
+- 单位：-
+- 是否动态：否
 - 描述: BE 存储 “pull load” 任务的数据和工作文件（下载的源文件、任务状态、临时输出等）的文件系统路径。该目录必须对 BE 进程可写，并且具有足够的磁盘空间以容纳下载的内容。
 - 引入版本: v3.2.0
 
@@ -1150,8 +1150,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值: 10
 - 类型: Int
-- 単位: Seconds
-- 是否可变: 否
+- 单位：秒
+- 是否动态：否
 - 描述: BE 在请求未提供显式超时时使用的 Pulsar 相关 routine load 操作的默认超时（秒）。具体地，`PInternalServiceImplBase::get_pulsar_info` 将该值乘以 1000，形成以毫秒为单位的超时值，传递给用于获取 Pulsar 分区元数据和 backlog 的 routine load 任务执行器方法。增大该值可在 Pulsar 响应较慢时减少超时失败，但会延长故障检测时间；减小该值可在 broker 响应慢时更快失败。与用于 Kafka 的 `routine_load_kafka_timeout_second` 类似。
 - 引入版本: v3.2.0
 
@@ -1161,8 +1161,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值: true
 - 类型: Boolean
-- 単位: -
-- 是否可变: No
+- 单位：-
+- 是否动态：否
 - 描述: 为 true 时，StarRocks 在启动期间初始化系统级监控：它会根据配置的存储路径发现磁盘设备并枚举网络接口，然后将这些信息传入 metrics 子系统以启用磁盘 I/O、网络流量和内存相关的系统指标采集。如果设备或接口发现失败，初始化会记录警告并中止系统指标的设置。该标志仅控制是否初始化系统指标；周期性指标聚合线程由 `enable_metric_calculator` 单独控制，JVM 指标初始化由 `enable_jvm_metrics` 控制。更改此值需要重启。
 - 引入版本: v3.2.0
 
@@ -1171,7 +1171,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值: 30
 - 类型: Int
 - 单位: Seconds
-- 是否可变: Yes
+- 是否动态：是
 - 描述: ProfileReportWorker 用于（1）决定何时上报 LOAD 查询的每个 fragment 的 profile 信息以及（2）在上报周期之间休眠的间隔（秒）。该 worker 使用 (profile_report_interval * 1000) ms 将当前时间与每个任务的 last_report_time 进行比较，以确定是否需要对非 pipeline 和 pipeline 的 load 任务重新上报 profile。在每次循环中，worker 会读取当前值（运行时可变）；如果配置值小于等于 0，worker 会强制将其设为 1 并发出警告。修改此值会影响下一次的上报判断和休眠时长。
 - 引入版本: v3.2.0
 
@@ -1179,7 +1179,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：60
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：汇报磁盘状态的间隔。汇报各个磁盘的状态，以及其中数据量等。
 - 引入版本：-
@@ -1188,16 +1188,16 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值: 1000
 - 类型: Int
-- 単位: Milliseconds
-- 是否可变: Yes
-- 描述: 由 BE agent 定期向 FE（master）发送资源使用报告的间隔（毫秒）。agent 的 worker 线程会收集 TResourceUsage（正在运行的查询数、已用/限制内存、CPU 使用千分比以及 resource-group 使用情况），调用 report_task，然后睡眠此配置的间隔（参见 task_worker_pool）。较低的值能提高报告的及时性，但会增加 CPU、网络和 master 的负载；较高的值可降低开销但会使资源信息不够实时。上报会更新相关指标（report_resource_usage_requests_total、report_resource_usage_requests_failed）。请根据集群规模和 FE 负载调整。
+- 单位：毫秒
+- 是否动态：是
+- 描述: 由 BE Agent 定期向 FE 发送资源使用报告的间隔（毫秒）。较低的值能提高报告的及时性，但会增加 CPU、网络和 FE 的负载；较高的值可降低开销但会使资源信息不够实时。上报会更新相关指标（`report_resource_usage_requests_total`、`report_resource_usage_requests_failed`）。请根据集群规模和 FE 负载调整。
 - 引入版本: v3.2.0
 
 ##### report_tablet_interval_seconds
 
 - 默认值：60
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：汇报 Tablet 的间隔。汇报所有的 Tablet 的最新版本。
 - 引入版本：-
@@ -1206,7 +1206,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：10
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：汇报单个任务的间隔。建表，删除表，导入，Schema Change 都可以被认定是任务。
 - 引入版本：-
@@ -1215,7 +1215,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：5
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：汇报 Workgroup 的间隔。汇报所有 Workgroup 的最新版本。
 - 引入版本：-
@@ -1244,7 +1244,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：60
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：Base Compaction 线程轮询的间隔。
 - 引入版本：-
@@ -1253,7 +1253,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：86400
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：上一轮 Base Compaction 距今的间隔。此项为 Base Compaction 触发条件之一。
 - 引入版本：-
@@ -1281,7 +1281,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值: false
 - 类型: Boolean
 - 单位: -
-- 是否可变: 是
+- 是否动态：是
 - 描述: 当此项设置为 `true` 时，TabletUpdates::compaction() 将使用为混沌测试准备的随机压缩策略（compaction_random）。此标志强制在平板的压缩选择中采用非确定性/随机策略，而不是正常策略（例如 size-tiered compaction），并在压缩选择时具有优先权。仅用于可控的测试场景：启用后可能导致不可预测的压缩顺序、增加的 I/O/CPU 和测试不稳定性。请勿在生产环境中启用；仅用于故障注入或混沌测试场景。
 - 引入版本: v3.3.12, 3.4.2, 3.5.0, 4.0.0
 
@@ -1298,7 +1298,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：3600
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：系统清除异常同步遗留的过期快照的时间间隔。
 - 引入版本：v3.3.5
@@ -1317,7 +1317,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值: 2147483648
 - 类型: Int
 - 单位: Bytes
-- 是否可变: No
+- 是否动态：否
 - 描述: 每个 Compaction 线程允许的最大内存大小。
 - 引入版本: -
 
@@ -1325,7 +1325,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：60
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：单次 Compaction 打印 Trace 的时间阈值，如果单次 Compaction 时间超过该阈值就打印 Trace。
 - 引入版本：-
@@ -1334,7 +1334,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：1
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：Cumulative Compaction 线程轮询的间隔。
 - 引入版本：-
@@ -1353,7 +1353,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值: 65536
 - 类型: Int
 - 单位: Bytes
-- 是否可变: No
+- 是否动态：否
 - 描述: 构建列数据与索引页时使用的目标未压缩 Page 大小（以字节为单位）。该值会被 Page Builder 用来决定何时完成一个 Page 以及预留多少内存。值为 0 会在构建器中禁用 Page 大小限制。更改此值会影响 Page 数量、元数据开销、内存预留以及 I/O/压缩的权衡（Page 越小 → Page 数和元数据越多；Page 越大 → Page 更少，压缩比更大，但内存峰值可能更大）。
 - 引入版本: v3.2.4
 
@@ -1371,7 +1371,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值: 1
 - 类型: Int
 - 单位: Threads
-- 是否可变: No
+- 是否动态：否
 - 描述: 在 DeleteTaskWorkerPool 中被分配为高优先级删除线程的工作线程数。启动时 AgentServer 使用 total threads = delete_worker_count_normal_priority + delete_worker_count_high_priority 创建删除线程池；前 delete_worker_count_high_priority 个线程被标记为专门尝试弹出 TPriority::HIGH 任务（它们轮询高优先级删除任务，若无可用任务则睡眠/循环）。增加此值可以提高高优先级删除请求的并发性；减少它会降低专用容量并可能增加高优先级删除的延迟。更改需要重启进程才能生效。
 - 引入版本: v3.2.0
 
@@ -1379,7 +1379,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：5
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：磁盘健康状态检测的间隔。
 - 引入版本：-
@@ -1397,7 +1397,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：300
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：单个 HTTP 请求持续以低于 `download_low_speed_limit_kbps` 值的速度运行时，允许运行的最长时间。在配置项中指定的时间跨度内，当一个 HTTP 请求持续以低于该值的速度运行时，该请求将被中止。
 - 引入版本：-
@@ -1443,8 +1443,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值: true
 - 类型: Boolean
 - 单位: -
-- 是否可变: Yes
-- 描述: 启用后，compaction 将对由部分列更新产生的 delta 列采用“懒惰”策略：StarRocks 会避免将 delta-column 文件急切地合并回其主段文件以节省 compaction 的 I/O。实际上，compaction 选择代码会检查是否存在部分列更新的 rowset 和多个候选项；如果发现且此标志为 true，引擎要么停止向 compaction 添加更多输入，要么仅合并空的 rowset（level -1），将 delta 列保持分离。这会减少 compaction 期间的即时 I/O 和 CPU 开销，但以延迟合并为代价（可能产生更多段和临时存储开销）。正确性和查询语义不受影响。
+- 是否动态：是
+- 描述: 启用后，Compaction 将对由部分列更新产生的 Delta 列采用“懒惰”策略：StarRocks 会避免将 Delta-column 文件立即合并回其主段文件以节省 Compaction 的 I/O。实际上，Compaction 选择代码会检查是否存在部分列更新的 Rowset 和多个候选项；如果发现以上情况且此配置项为 `true`，引擎要么停止向 Compaction 添加更多输入，要么仅合并空的 Rowset（level -1），将 Delta 列保持分离。这会减少 Compaction 期间的即时 I/O 和 CPU 开销，但以延迟合并为代价（可能产生更多段和临时存储开销）。正确性和查询语义不受影响。
 - 引入版本: v3.2.3
 
 ##### enable_new_load_on_memory_limit_exceeded
@@ -1462,7 +1462,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 类型：Boolean
 - 单位：-
 - 是否动态：是
-- 描述：是否启用存算分离模式下主键索引的并行 Compaction。
+- 描述：是否启用存算分离集群中主键索引的并行 Compaction。
 - 引入版本：-
 
 ##### enable_pk_index_parallel_get
@@ -1471,7 +1471,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 类型：Boolean
 - 单位：-
 - 是否动态：是
-- 描述：是否启用存算分离模式下主键索引的并行读取。
+- 描述：是否启用存算分离集群中主键索引的并行读取。
 - 引入版本：-
 
 ##### enable_pk_parallel_execution
@@ -1480,7 +1480,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 类型：Boolean
 - 单位：-
 - 是否动态：是
-- 描述：是否为 Primary Key 表并行执行策略。当并行执行策略开启时，pk索引文件会在导入和compaction阶段生成。
+- 描述：是否为 Primary Key 表并行执行策略。当并行执行策略开启时，Primary Key 索引文件会在导入和compaction阶段生成。
 - 引入版本：-
 
 ##### enable_pk_size_tiered_compaction_strategy
@@ -1490,7 +1490,9 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 单位：-
 - 是否动态：否
 - 描述：是否为 Primary Key 表开启 Size-tiered Compaction 策略。`true` 代表开启。`false` 代表关闭。
-- 引入版本：存算分离集群自 v3.2.4, v3.1.10 起生效，存算一体集群自 v3.2.5, v3.1.10 起生效
+- 引入版本：
+  - 存算分离集群自 v3.2.4, v3.1.10 起生效
+  - 存算一体集群自 v3.2.5, v3.1.10 起生效
 
 ##### enable_rowset_verify
 
@@ -1516,7 +1518,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 类型：Boolean
 - 单位：-
 - 是否动态：是
-- 描述：当enable_strict_delvec_crc_check设置为true后，我们会对delete vector的crc32进行严格检查，如果不一致，将返回失败。
+- 描述：当此项设置为 `true` 后，系统会对 Delete Vector 的 crc32 进行严格检查，如果不一致，将返回失败。
 - 引入版本：-
 
 ##### enable_transparent_data_encryption
@@ -1524,7 +1526,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值: false
 - 类型: Boolean
 - 单位: -
-- 是否可变: 否
+- 是否动态：否
 - 描述: 启用后，StarRocks 将为新写入的存储对象（segment 文件、delete/update 文件、rowset segments、lake SSTs、persistent index 文件等）进行磁盘加密。写入路径（RowsetWriter/SegmentWriter、lake UpdateManager/LakePersistentIndex 及相关代码路径）会从 KeyCache 请求加密信息，将 encryption_info 附加到可写文件，并将 encryption_meta 持久化到 rowset / segment / sstable 元数据中（如 segment_encryption_metas、delete/update encryption metadata）。FE 与 FE/CN 的加密标志必须匹配。如果不匹配会导致 BE 在心跳时中止（LOG(FATAL)）。此参数不可在运行时修改，必须在第一次部署集群前启用，并确保密钥管理（KEK）与 KeyCache 已在集群中正确配置并同步。
 - 引入版本: v3.3.1
 
@@ -1532,7 +1534,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：3600
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：文件描述符缓存清理的间隔，用于清理长期不用的文件描述符。
 - 引入版本：-
@@ -1541,7 +1543,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：1800
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：导入生效的数据，存储引擎保留的时间，用于增量克隆。
 - 引入版本：-
@@ -1631,7 +1633,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：3600
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：磁盘进行垃圾清理的最大间隔。自 3.0 版本起，该参数由静态变为动态。
 - 引入版本：-
@@ -1677,7 +1679,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值: 0.8
 - 类型: Double
 - 单位: - (unitless ratio)
-- 是否可变: Yes
+- 是否动态：是
 - 描述: 在排序型 schema-change 操作期间，用作 memtable 最大缓冲区大小的每线程 schema-change 内存限制的比例。该比例会与 memory_limitation_per_thread_for_schema_change（以 GB 配置并转换为字节）相乘以计算 max_buffer_size，且结果上限为 4GB。SchemaChangeWithSorting 和 SortedSchemaChange 在创建 MemTable/DeltaWriter 时使用此值。增大该比例允许更大的内存缓冲区（减少 flush/merge 次数），但会增加内存压力风险；减小该比例会导致更频繁的 flush，从而增加 I/O/merge 开销。
 - 引入版本: v3.2.0
 
@@ -1694,7 +1696,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：120
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：Tablet Compaction 失败之后，再次被调度的间隔。
 - 引入版本：-
@@ -1703,7 +1705,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：30
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：Cumulative Compaction 失败后的最小重试间隔。
 - 引入版本：-
@@ -1721,7 +1723,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：180
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：磁盘进行垃圾清理的最小间隔。自 3.0 版本起，该参数由静态变为动态。
 - 引入版本：-
@@ -1731,7 +1733,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值: 8
 - 类型: Int
 - 单位: Threads
-- 是否可变: Yes
+- 是否动态：是
 - 描述: 在 BE 的每个存储路径上分配的并行 clone 工作线程数。BE 启动时，clone 线程池的最大线程数计算为 max(number_of_store_paths * parallel_clone_task_per_path, MIN_CLONE_TASK_THREADS_IN_POOL)。例如，若有 4 个存储路径且默认=8，则 clone 池最大 = 32。此设置直接控制 BE 处理的 CLONE 任务（tablet 副本拷贝）的并发度：增加它会提高并行 clone 吞吐量，但也会增加 CPU、磁盘和网络争用；减少它会限制同时进行的 clone 任务并可能限制 FE 调度的 clone 操作。该值应用于动态 clone 线程池，可通过 update-config 路径在运行时更改（会导致 agent_server 更新 clone 池的最大线程数）。
 - 引入版本: v3.2.0
 
@@ -1739,7 +1741,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：1800
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：存储引擎保留的未生效数据的最大时长。
 - 引入版本：-
@@ -1759,7 +1761,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 类型：Double
 - 单位：-
 - 是否动态：是
-- 描述：存算分离模式下，主键索引的 Compaction 分数比率。例如，如果有 N 个文件集，Compaction 分数将为 N * pk_index_compaction_score_ratio。
+- 描述：存算分离集群中，主键索引的 Compaction 分数比率。例如，如果有 N 个文件集，Compaction 分数将为 `N * pk_index_compaction_score_ratio`。
 - 引入版本：-
 
 ##### pk_index_ingest_sst_compaction_threshold
@@ -1768,7 +1770,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 类型：Int
 - 单位：-
 - 是否动态：是
-- 描述：存算分离模式下，主键索引 Ingest SST Compaction 的阈值。
+- 描述：存算分离集群中，主键索引 Ingest SST Compaction 的阈值。
 - 引入版本：-
 
 ##### pk_index_memtable_flush_threadpool_max_threads
@@ -1777,7 +1779,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 类型：Int
 - 单位：-
 - 是否动态：是
-- 描述：存算分离模式下，主键索引 Memtable 刷盘的线程池最大线程数。
+- 描述：存算分离集群中，主键索引 MemTable 刷盘的线程池最大线程数。
 - 引入版本：-
 
 ##### pk_index_memtable_max_count
@@ -1786,7 +1788,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 类型：Int
 - 单位：-
 - 是否动态：是
-- 描述：存算分离模式下，主键索引的最大 Memtable 数量。
+- 描述：存算分离集群中，主键索引的最大 MemTable 数量。
 - 引入版本：-
 
 ##### pk_index_parallel_compaction_task_split_threshold_bytes
@@ -1804,7 +1806,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 类型：Int
 - 单位：-
 - 是否动态：是
-- 描述：存算分离模式下，主键索引并行 Compaction 的线程池最大线程数。
+- 描述：存算分离集群中，主键索引并行 Compaction 的线程池最大线程数。
 - 引入版本：-
 
 ##### pk_index_parallel_get_min_rows
@@ -1813,7 +1815,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 类型：Int
 - 单位：-
 - 是否动态：是
-- 描述：存算分离模式下，启用主键索引并行读取的最小行数阈值。
+- 描述：存算分离集群中，启用主键索引并行读取的最小行数阈值。
 - 引入版本：-
 
 ##### pk_index_parallel_get_threadpool_max_threads
@@ -1822,7 +1824,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 类型：Int
 - 单位：-
 - 是否动态：是
-- 描述：存算分离模式下，主键索引并行读取的线程池最大线程数。0 表示自动配置。
+- 描述：存算分离集群中，主键索引并行读取的线程池最大线程数。0 表示自动配置。
 - 引入版本：-
 
 ##### pk_index_size_tiered_level_multiplier
@@ -1856,18 +1858,18 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：67108864
 - 类型：Int
-- 单位：-
+- 单位：Bytes
 - 是否动态：是
-- 描述：存算分离模式下，主键索引的目标文件大小。默认为 64MB。
+- 描述：存算分离集群中，主键索引的目标文件大小。
 - 引入版本：-
 
 ##### pk_parallel_execution_threshold_bytes
 
 - 默认值：104857600
 - 类型：Int
-- 单位：-
+- 单位：Bytes
 - 是否动态：是
-- 描述：当enable_pk_parallel_execution设置为true后，导入或者compaction生成的数据大于该阈值时，Primary Key 表并行执行策略将被启用。默认为 100MB。
+- 描述：当 `enable_pk_parallel_execution` 设置为 `true` 后，导入或者 Compaction 生成的数据大于该阈值时，主键表并行执行策略将被启用。
 - 引入版本：-
 
 ##### primary_key_limit_size
@@ -1892,7 +1894,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：600
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：Repair Compaction 线程轮询的间隔。
 - 引入版本：-
@@ -1919,7 +1921,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：300
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：同步线程低于最低速度所允许的持续时间。如果实际速度低于 `replication_min_speed_limit_kbps` 的时间超过此值，同步将失败。
 - 引入版本：v3.3.5
@@ -1973,7 +1975,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：172800
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：快照文件清理的间隔。
 - 引入版本：-
@@ -2057,7 +2059,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：600
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：TabletMeta Checkpoint 线程轮询的时间间隔。
 - 引入版本：-
@@ -2075,7 +2077,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：1800
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：失效 Rowset 的清理间隔。
 - 引入版本：-
@@ -2084,7 +2086,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：300
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：Tablet Stat Cache 的更新间隔。
 - 引入版本：-
@@ -2093,7 +2095,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：86400
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：回收站清理的间隔。自 v2.5.17、v3.0.9 以及 v3.1.6 起，默认值由 259200 变为 86400。
 - 引入版本：-
@@ -2102,7 +2104,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：30
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：清理过期 Rowset 的时间间隔。
 - 引入版本：-
@@ -2111,7 +2113,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：360
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：Update Cache 的过期时间。
 - 引入版本：-
@@ -2120,19 +2122,10 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：10
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：主键表 Compaction 的检查间隔。
 - 引入版本：-
-
-##### update_compaction_chunk_size_for_row_store
-
-- 默认值: 0
-- 类型: Int
-- 单位: Rows
-- 是否可变: Yes
-- 描述: 覆盖对使用 column-with-row-store 表示的 tablet 在 update compaction 期间使用的 chunk 大小（每个 chunk 的行数）。默认（0）情况下，StarRocks 使用 CompactionUtils::get_read_chunk_size 基于 compaction 内存限制、vector chunk 大小、总输入行数和内存占用来计算每列组的 chunk 大小。当此配置被设置为正整数且 tablet.is_column_with_row_store() 为 true 时，RowsetMerger 会在水平和垂直更新 compaction 路径中强制将 _chunk_size 设为该值（见 rowset_merger.cpp）。仅在自动计算产生次优结果时使用非零值；增大该值可以减少写入者/IO 开销但会提高峰值内存使用，减小则可降低内存压力但会增加 chunk 数量并可能影响性能。
-- 引入版本: v3.2.3
 
 ##### update_compaction_delvec_file_io_amp_ratio
 
@@ -2156,7 +2149,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：120
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：主键表每个 Tablet 做 Compaction 的最小时间间隔。
 - 引入版本：-
@@ -2277,7 +2270,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 类型：Int
 - 单位：-
 - 是否动态：否
-- 描述：存算分离模式下，Data Cache 最多可使用的磁盘容量百分比。
+- 描述：存算分离集群中，Data Cache 最多可使用的磁盘容量百分比。
 - 引入版本：v3.1
 
 ##### starlet_use_star_cache
@@ -2286,7 +2279,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 类型：Boolean
 - 单位：-
 - 是否动态：是
-- 描述：存算分离模式下是否使用 Data Cache。`true` 表示启用该功能，`false` 表示禁用。自 v3.2.3 起，默认值由 `false` 调整为 `true`。
+- 描述：存算分离集群中是否使用 Data Cache。`true` 表示启用该功能，`false` 表示禁用。自 v3.2.3 起，默认值由 `false` 调整为 `true`。
 - 引入版本：v3.1
 
 ##### starlet_write_file_with_tag
@@ -2313,7 +2306,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：10
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：Data Cache 容量自动调整周期。每隔这段时间系统会进行一次缓存磁盘使用率检测，必要时触发相应扩缩容操作。
 - 引入版本：v3.3.0
@@ -2322,7 +2315,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：7200
 - 类型：Int
-- 单位：Seconds
+- 单位：秒
 - 是否动态：是
 - 描述：Data Cache 自动扩容最小等待时间。只有当磁盘使用率在 `datacache_disk_low_level` 以下持续时间超过该时长，才会触发自动扩容。
 - 引入版本：v3.3.0
@@ -2430,7 +2423,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值：600000
 - 类型：Int
-- 单位：Milliseconds
+- 单位：毫秒
 - 是否动态：否
 - 描述：JDBC 空闲连接超时时间。如果 JDBC 连接池内的连接空闲时间超过此值，连接池会关闭超过 `jdbc_minimum_idle_connections` 配置项中指定数量的空闲连接。
 - 引入版本：-
@@ -2578,8 +2571,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值: 5m
 - 类型: String
-- 単位: Minutes (string with suffix, e.g. "5m")
-- 是否可变: 否
+- 单位：Minutes (string with suffix, e.g. "5m")
+- 是否动态：否
 - 描述: 发送给 Elasticsearch 的 scroll 搜索上下文的 keep-alive 时长。该值在构建初始 scroll URL (`?scroll=<value>`) 以及发送后续 scroll 请求（通过 ESScrollQueryBuilder）时按字面使用（例如 "5m"）。此设置控制 ES 端在垃圾回收前保留搜索上下文的时间；设置更长会让 scroll 上下文存活更久，但会延长 ES 集群的资源占用。该值在启动时由 ES scan reader 读取，运行时不可更改。
 - 引入版本: v3.2.0
 
@@ -2588,7 +2581,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值: 2000
 - 类型: Int
 - 单位: Milliseconds
-- 是否可变: Yes
+- 是否动态：是
 - 描述: 当上一次检查的 RPC 失败时，从副本向主副本检查其状态的时间间隔。
 - 引入版本: v3.5.1
 
@@ -2597,7 +2590,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值: 15000
 - 类型: Int
 - 单位: Milliseconds
-- 是否可变: Yes
+- 是否动态：是
 - 描述: 当上一次检查的 RPC 成功时，从副本向主副本检查其状态的时间间隔。
 - 引入版本: v3.5.1
 
@@ -2624,7 +2617,7 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 默认值: 75
 - 类型: Long
 - 单位: Percent
-- 是否可变: 是
+- 是否动态：是
 - 描述: 以进程内存上限的百分比表示的高水位内存阈值。当总内存消耗上升超过该百分比时，BE 开始逐步释放内存（目前通过驱逐 data cache 和 update cache）以缓解压力。监控器使用此值来计算 `memory_high = mem_limit * memory_high_level / 100`，并且如果消耗大于 memory_high，则在 GC advisor 的指导下执行受控驱逐；如果消耗超过 memory_urgent_level（一个单独的配置），则会进行更激进的即时回收。此值还用于在超过阈值时禁用某些高内存消耗的操作（例如 primary-key preload）。必须满足与 memory_urgent_level 的校验关系（memory_urgent_level `>` memory_high_level，memory_high_level `>=` 1，memory_urgent_level `<=` 100）。
 - 引入版本: v3.2.0
 
@@ -2641,9 +2634,9 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值: 1
 - 类型: Int
-- 単位: Seconds
-- 是否可变: No
-- 描述: 一个用于 BE agent worker 线程的全局短睡眠间隔（秒），当 master 地址/心跳尚不可用或需要短时间重试/退避时作为一秒的暂停。在代码中，多个 report worker pool（例如 ReportDiskStateTaskWorkerPool、ReportOlapTableTaskWorkerPool、ReportWorkgroupTaskWorkerPool）引用此值，以避免忙等（busy-waiting）并在重试时降低 CPU 消耗。增大此值会降低重试频率并减慢对 master 可用性的响应；减小会提高轮询频率并增加 CPU 使用。仅在权衡响应性与资源使用后调整。
+- 单位：秒
+- 是否动态：否
+- 描述: BE Agent Worker 线程的全局短睡眠间隔，当 Master 地址/心跳尚不可用或需要短时间重试/退避时作为一秒的暂停。多个 Report Worker Pool（例如 ReportDiskStateTaskWorkerPool、ReportOlapTableTaskWorkerPool、ReportWorkgroupTaskWorkerPool）引用此值，以避免忙等（busy-waiting）并在重试时降低 CPU 消耗。增大此值会降低重试频率并减慢对 Master 可用性的响应；减小会提高轮询频率并增加 CPU 使用。请在权衡响应性与资源使用后调整该项。
 - 引入版本: v3.2.0
 
 ##### small_file_dir
@@ -2668,8 +2661,8 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 
 - 默认值: 1048576 (1 MB)
 - 类型: long
-- 単位: Bytes
-- 是否可变: 否
+- 单位：Bytes
+- 是否动态：否
 - 描述: 从 INFO 日志文件读取并在 BE 调试 Web Server 的日志页面上显示的最大字节数。该处理器使用此值计算一个 seek 偏移量（显示最后 N 字节），以避免读取或提供非常大的日志文件。如果日志文件小于该值则显示整个文件。注意：在当前实现中，用于读取并服务 INFO 日志的代码被注释掉了，处理器会报告无法打开 INFO 日志文件，因此除非启用日志服务代码，否则此参数可能无效。
 - 引入版本: v3.2.0
 


### PR DESCRIPTION

## Why I'm doing:

## What I'm doing:  

    EXECUTION SUMMARY
    Document Type: be_config
    Duration: 392.80 seconds
    Command: /home/seaven/documents/workspace/DocsAgent/src/docsagent/main.py -g -t be_config --force_search_code -tv -l 50 --pr
    Arguments:
      ├─ ci: False
      ├─ force_search_code: True
      ├─ generate: True
      ├─ include_miss_usage: False
      ├─ limit: 50
      ├─ meta: False
      ├─ name: None
      ├─ pr: True
      ├─ track_version: True
      ├─ type: be_config
      ├─ without_llm: False
    
    ITEM EXTRACTION:
      ├─ Items from meta files: 682
      ├─ Items from code parsing: 0
      └─ Total unique items: 0
    
    DOCUMENT GENERATION:
      ├─ JA: 4 documents
      ├─ ZH: 3 documents
      └─ Total: 7 documents
    
    AGENT INVOCATIONS:
      ├─ TranslationAgent_ja: 4 calls
      ├─ TranslationAgent_zh: 3 calls
      └─ Total: 7 calls
    
    TRANSLATED ITEMS:
      ├─ Total: 50 items
      ├─ sleep_one_second
      ├─ lz4_expected_compression_ratio
      ├─ enable_zero_copy_from_page_cache
      ├─ lz4_expected_compression_speed_mbps
      ├─ load_channel_rpc_thread_pool_num
      ├─ enable_streaming_load_thread_pool
      ├─ transaction_publish_version_thread_pool_num_min
      ├─ thrift_connect_timeout_seconds
      ├─ brpc_max_connections_per_server
      ├─ clear_udf_cache_when_start
      ├─ ssl_private_key_path
      ├─ transaction_apply_worker_count
      ├─ routine_load_pulsar_timeout_second
      ├─ enable_lazy_delta_column_compaction
      ├─ update_compaction_chunk_size_for_row_store
      ├─ max_queueing_memtable_per_tablet
      ├─ upload_buffer_size
      ├─ transaction_apply_worker_idle_time_ms
      ├─ be_service_threads
      ├─ lz4_acceleration
      ├─ pprof_profile_dir
      ├─ dictionary_encoding_ratio
      ├─ update_memory_limit_percent
      ├─ partial_update_memory_limit_per_worker
      ├─ report_resource_usage_interval_ms
      ├─ download_buffer_size
      ├─ udf_thread_pool_size
      ├─ memory_urgent_level
      ├─ memory_ratio_for_sorting_schema_change
      ├─ abort_on_large_memory_allocation
      ├─ create_tablet_worker_count
      ├─ max_hdfs_scanner_num
      ├─ pull_load_task_dir
      ├─ load_fp_brpc_timeout_ms
      ├─ load_channel_rpc_thread_pool_queue_size
      ├─ es_scroll_keepalive
      ├─ dictionary_speculate_min_chunk_size
      ├─ rpc_compress_ratio_threshold
      ├─ chaos_test_enable_random_compaction_strategy
      ├─ broker_write_timeout_seconds
      ├─ metadata_cache_memory_limit_percent
      ├─ enable_system_metrics
      ├─ delete_worker_count_high_priority
      ├─ parallel_clone_task_per_path
      ├─ web_log_bytes
      ├─ stale_memtable_flush_time_sec
      ├─ dictionary_page_size
      ├─ profile_report_interval
      ├─ size_tiered_max_compaction_level
      └─ load_diagnose_rpc_timeout_stack_trace_threshold_ms
    

This Pr is generated by [DocsAgent](https://github.com/StarRocks/DocsAgent)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates BE configuration docs (EN/JA/ZH) with PK index parallel options and tunables, several new params (BRPC connections, memory thresholds, streaming/load diagnostics), and broad wording/unit clarifications; removes one obsolete item.
> 
> - **Primary Key index (shared-data)**:
>   - Add `enable_pk_index_parallel_compaction`, `enable_pk_index_parallel_get`, and tunables: `pk_index_compaction_score_ratio`, `pk_index_ingest_sst_compaction_threshold`, `pk_index_memtable_flush_threadpool_max_threads`, `pk_index_memtable_max_count`, `pk_index_parallel_compaction_task_split_threshold_bytes`, `pk_index_parallel_compaction_threadpool_max_threads`, `pk_index_parallel_get_min_rows`, `pk_index_parallel_get_threadpool_max_threads`, `pk_index_size_tiered_{level_multiplier,max_level,min_level_size}`, `pk_index_target_file_size`, `pk_parallel_execution_threshold_bytes`.
> - **Loading/streaming & diagnostics**:
>   - Document `enable_load_channel_rpc_async`, `enable_streaming_load_thread_pool`, `load_channel_rpc_thread_pool_{num,queue_size}`, `load_diagnose_rpc_timeout_stack_trace_threshold_ms`, `load_fp_brpc_timeout_ms`; clarify `streaming_load_*` and `write_buffer_size`.
> - **Networking/BRPC/Thrift**:
>   - Add `brpc_max_connections_per_server`; refine `brpc_stub_expire_s`, `thrift_*` details.
> - **Memory/threads**:
>   - Add/clarify `memory_urgent_level` (JA), `be_service_threads`, `parallel_clone_task_per_path`, `delete_worker_count_high_priority`, `sleep_one_second`.
> - **Lake/Shared-data & Data cache**:
>   - Tweak `lake_flush_thread_num_per_store` wording; add/clarify Data Cache and Starlet settings.
> - **Compaction/storage**:
>   - Add `enable_lazy_delta_column_compaction`; refine compaction intervals and limits.
> - **Misc**:
>   - Add `ssl_private_key_path`, `pprof_profile_dir`, `dictionary_speculate_min_chunk_size`, `report_resource_usage_interval_ms`.
>   - Remove `update_compaction_chunk_size_for_row_store` (EN).
>   - Widespread unit/term localization fixes and description clarifications across EN/JA/ZH.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 99831406fc20ffa4e30d978760f159fdf63e56bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->