### PR TITLE
[Feature] Support warehouses, cpu_weight_percent, exclusive_cpu_weight for resource group

### DIFF
--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -122,7 +122,6 @@ public:
     void init(std::shared_ptr<MemTracker>& parent_mem_tracker);
 
     TWorkGroup to_thrift() const;
-    TWorkGroup to_thrift_verbose() const;
     std::string to_string() const;
 
     // Copy metrics from the other work group

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
@@ -18,10 +18,13 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.qe.ShowResultSetMetaData;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.system.BackendResourceStat;
 import com.starrocks.thrift.TWorkGroup;
 import com.starrocks.thrift.TWorkGroupType;
 import com.starrocks.type.TypeFactory;
+import com.starrocks.warehouse.Warehouse;
 
 import java.text.DecimalFormat;
 import java.util.Collections;
@@ -42,7 +45,9 @@ public class ResourceGroup {
     public static final String PLAN_MEM_COST_RANGE = "plan_mem_cost_range";
     public static final String CPU_CORE_LIMIT = "cpu_core_limit";
     public static final String CPU_WEIGHT = "cpu_weight";
+    public static final String CPU_WEIGHT_PERCENT = "cpu_weight_percent";
     public static final String EXCLUSIVE_CPU_CORES = "exclusive_cpu_cores";
+    public static final String EXCLUSIVE_CPU_PERCENT = "exclusive_cpu_percent";
     public static final String MAX_CPU_CORES = "max_cpu_cores";
     public static final String MEM_LIMIT = "mem_limit";
     public static final String MEM_POOL = "mem_pool";
@@ -50,6 +55,7 @@ public class ResourceGroup {
     public static final String BIG_QUERY_SCAN_ROWS_LIMIT = "big_query_scan_rows_limit";
     public static final String BIG_QUERY_CPU_SECOND_LIMIT = "big_query_cpu_second_limit";
     public static final String CONCURRENCY_LIMIT = "concurrency_limit";
+    public static final String WAREHOUSES = "warehouses";
     public static final String DEFAULT_RESOURCE_GROUP_NAME = "default_wg";
     public static final String DISABLE_RESOURCE_GROUP_NAME = "disable_resource_group";
     public static final String DEFAULT_MEM_POOL = "default_mem_pool";
@@ -95,10 +101,16 @@ public class ResourceGroup {
                     (rg, classifier) -> "" + rg.getId()),
             new ColumnMeta(
                     new Column(CPU_WEIGHT, TypeFactory.createVarcharType(200)),
-                    (rg, classifier) -> "" + rg.geNormalizedCpuWeight()),
+                    (rg, classifier) -> "" + rg.getNormalizedCpuWeight(), false),
+            new ColumnMeta(
+                    new Column(CPU_WEIGHT_PERCENT, TypeFactory.createVarcharType(200)),
+                    (rg, classifier) -> "" + rg.getCpuWeightPercent()),
             new ColumnMeta(
                     new Column(EXCLUSIVE_CPU_CORES, TypeFactory.createVarcharType(200)),
-                    (rg, classifier) -> "" + rg.getNormalizedExclusiveCpuCores()),
+                    (rg, classifier) -> "" + rg.getNormalizedExclusiveCpuCores(), false),
+            new ColumnMeta(
+                    new Column(EXCLUSIVE_CPU_PERCENT, TypeFactory.createVarcharType(200)),
+                    (rg, classifier) -> "" + rg.getExclusiveCpuPercent()),
             new ColumnMeta(
                     new Column(MEM_LIMIT, TypeFactory.createVarcharType(200)),
                     (rg, classifier) -> (rg.getMemLimit() * 100) + "%"),
@@ -129,7 +141,10 @@ public class ResourceGroup {
                     (rg, classifier) -> classifier.toString()),
             new ColumnMeta(
                     new Column(MEM_POOL, TypeFactory.createVarcharType(200)),
-                    (rg, classifier) -> Objects.requireNonNullElse(rg.getMemPool(), DEFAULT_MEM_POOL), false)
+                    (rg, classifier) -> Objects.requireNonNullElse(rg.getMemPool(), DEFAULT_MEM_POOL), false),
+            new ColumnMeta(
+                    new Column(WAREHOUSES, TypeFactory.createVarcharType(1024)),
+                    (rg, classifier) -> rg.getWarehouses() == null ? "" : String.join(",", rg.getWarehouses()))
     );
 
     public static final ShowResultSetMetaData META_DATA;
@@ -156,8 +171,12 @@ public class ResourceGroup {
 
     @SerializedName(value = "cpuCoreLimit")
     private Integer cpuWeight;
+    @SerializedName(value = "cpuWeightPercent")
+    private Integer cpuWeightPercent;
     @SerializedName(value = "exclusiveCpuCores")
     private Integer exclusiveCpuCores;
+    @SerializedName(value = "exclusiveCpuPercent")
+    private Integer exclusiveCpuPercent;
 
     @SerializedName(value = "maxCpuCores")
     private Integer maxCpuCores;
@@ -181,6 +200,8 @@ public class ResourceGroup {
     private TWorkGroupType resourceGroupType;
     @SerializedName(value = "version")
     private long version;
+    @SerializedName(value = "warehouses")
+    private List<String> warehouses;
 
     public ResourceGroup() {
     }
@@ -236,6 +257,9 @@ public class ResourceGroup {
         TWorkGroup twg = new TWorkGroup();
         twg.setName(name);
         twg.setId(id);
+        if (cpuWeightPercent != null) {
+            twg.setCpu_weight_percent(cpuWeightPercent);
+        }
         if (cpuWeight != null) {
             twg.setCpu_core_limit(cpuWeight);
         }
@@ -272,7 +296,13 @@ public class ResourceGroup {
         if (memPool != null) {
             twg.setMem_pool(memPool);
         }
+        if (exclusiveCpuPercent != null) {
+            twg.setExclusive_cpu_percent(exclusiveCpuPercent);
+        }
         twg.setExclusive_cpu_cores(getNormalizedExclusiveCpuCores());
+        if (warehouses != null) {
+            twg.setWarehouses(warehouses);
+        }
 
         twg.setVersion(version);
         return twg;
@@ -286,8 +316,25 @@ public class ResourceGroup {
         this.cpuWeight = cpuWeight;
     }
 
-    public int geNormalizedCpuWeight() {
+    public Integer getCpuWeightPercent() {
+        return cpuWeightPercent;
+    }
+
+    public void setCpuWeightPercent(Integer cpuWeightPercent) {
+        this.cpuWeightPercent = cpuWeightPercent;
+    }
+
+    public int getNormalizedCpuWeight() {
+        if (exclusiveCpuPercent != null && exclusiveCpuPercent > 0) {
+            return 0;
+        }
         if (exclusiveCpuCores != null && exclusiveCpuCores > 0) {
+            return 0;
+        }
+        if (cpuWeightPercent != null && cpuWeightPercent > 0) {
+            return 0;
+        }
+        if (cpuWeight == null) {
             return 0;
         }
         return cpuWeight;
@@ -296,7 +343,7 @@ public class ResourceGroup {
     /**
      * The old version considers cpu_weight as a positive integer, but now it can be non-positive.
      * To be compatible with the old version, if cpu_weight is non-positive, it is stored as 1.
-     * And use geNormalizedCpuWeight() to get the normalized value when using cpu_weight.
+     * And use getNormalizedCpuWeight() to get the normalized value when using cpu_weight.
      */
     public void normalizeCpuWeight() {
         if (cpuWeight == null || cpuWeight <= 0) {
@@ -322,6 +369,14 @@ public class ResourceGroup {
 
     public void setExclusiveCpuCores(Integer exclusiveCpuCores) {
         this.exclusiveCpuCores = exclusiveCpuCores;
+    }
+
+    public Integer getExclusiveCpuPercent() {
+        return exclusiveCpuPercent;
+    }
+
+    public void setExclusiveCpuPercent(Integer exclusiveCpuPercent) {
+        this.exclusiveCpuPercent = exclusiveCpuPercent;
     }
 
     public boolean isMaxCpuCoresEffective() {
@@ -407,12 +462,21 @@ public class ResourceGroup {
     public String getMemPool() {
         return memPool;
     }
+
     public boolean hasDefaultMemPool() {
         return memPool == null || memPool.equals(DEFAULT_MEM_POOL);
     }
 
     public void setMemPool(String memPool) {
         this.memPool = memPool;
+    }
+
+    public List<String> getWarehouses() {
+        return warehouses;
+    }
+
+    public void setWarehouses(List<String> warehouses) {
+        this.warehouses = warehouses;
     }
 
     @Override
@@ -432,16 +496,89 @@ public class ResourceGroup {
         return Objects.hash(id, version);
     }
 
-    public static void validateCpuParameters(Integer cpuWeight, Integer exclusiveCpuCores) {
-        if ((cpuWeight == null || cpuWeight <= 0) && (exclusiveCpuCores == null || exclusiveCpuCores <= 0)) {
-            throw new SemanticException(String.format("property '%s' or '%s' must be positive",
-                    ResourceGroup.CPU_WEIGHT, ResourceGroup.EXCLUSIVE_CPU_CORES));
-        }
-        if ((cpuWeight != null && cpuWeight > 0) && (exclusiveCpuCores != null && exclusiveCpuCores > 0)) {
+    public static void validateCpuParameters(Integer cpuWeight, Integer cpuWeightPercent,
+                                             Integer exclusiveCpuCores, Integer exclusiveCpuPercent,
+                                             Integer maxCpuCores,
+                                             TWorkGroupType type, List<String> warehouses) {
+        final int minCoreNum = getMinNumHardwareCoresOfBe(warehouses);
+
+        final boolean hasCpuWeight = cpuWeight != null && cpuWeight > 0;
+        final boolean hasCpuWeightPercent = cpuWeightPercent != null && cpuWeightPercent > 0;
+        final boolean hasExclusiveCpuCores = exclusiveCpuCores != null && exclusiveCpuCores > 0;
+        final boolean hasExclusiveCpuPercent = exclusiveCpuPercent != null && exclusiveCpuPercent > 0;
+
+        int trueCount = 0;
+        trueCount += hasCpuWeight ? 1 : 0;
+        trueCount += hasCpuWeightPercent ? 1 : 0;
+        trueCount += hasExclusiveCpuCores ? 1 : 0;
+        trueCount += hasExclusiveCpuPercent ? 1 : 0;
+
+        if (trueCount > 1) {
             throw new SemanticException(
-                    String.format("property '%s' and '%s' cannot be present and positive at the same time",
-                            ResourceGroup.CPU_WEIGHT, ResourceGroup.EXCLUSIVE_CPU_CORES));
+                    String.format("Exactly only one of '%s', '%s', '%s' or '%s' can be present and positive at the same time",
+                            ResourceGroup.CPU_WEIGHT, ResourceGroup.CPU_WEIGHT_PERCENT,
+                            ResourceGroup.EXCLUSIVE_CPU_CORES, ResourceGroup.EXCLUSIVE_CPU_PERCENT));
         }
+        if (trueCount <= 0) {
+            throw new SemanticException(String.format("Exactly one of '%s', '%s', '%s' or '%s' must be a positive value",
+                    ResourceGroup.CPU_WEIGHT, ResourceGroup.CPU_WEIGHT_PERCENT,
+                    ResourceGroup.EXCLUSIVE_CPU_CORES, ResourceGroup.EXCLUSIVE_CPU_PERCENT));
+        }
+
+        if (hasCpuWeightPercent && type == TWorkGroupType.WG_SHORT_QUERY) {
+            throw new SemanticException(
+                    String.format("short query resource group should not set '%s'", ResourceGroup.CPU_WEIGHT_PERCENT));
+        }
+
+        if (hasExclusiveCpuPercent && type == TWorkGroupType.WG_SHORT_QUERY) {
+            throw new SemanticException(
+                    String.format("short query resource group should not set '%s'", ResourceGroup.EXCLUSIVE_CPU_PERCENT));
+        }
+
+        if (hasCpuWeight && warehouses != null && !warehouses.isEmpty()) {
+            if (cpuWeight > minCoreNum) {
+                throw new SemanticException("'cpu_weight' cannot be set when 'warehouses' is specified, " +
+                        "please use 'cpu_weight_percent' instead");
+            }
+        }
+
+        if (hasExclusiveCpuCores && warehouses != null && !warehouses.isEmpty()) {
+            throw new SemanticException("'exclusive_cpu_cores' cannot be set when 'warehouses' is specified, " +
+                    "please use 'exclusive_cpu_percent' instead");
+        }
+
+        if (maxCpuCores != null && maxCpuCores > 0 && warehouses != null && !warehouses.isEmpty()) {
+            throw new SemanticException("'max_cpu_cores' cannot be set when 'warehouses' is specified");
+        }
+
+        if (hasExclusiveCpuPercent) {
+            if (minCoreNum * exclusiveCpuPercent / 100 < 1) {
+                throw new SemanticException(String.format(
+                        "%s is too small, it must be at least %d%% to reserve one core on the smallest BE (with %d cores)",
+                        ResourceGroup.EXCLUSIVE_CPU_CORES, (100 + minCoreNum) / minCoreNum, minCoreNum));
+            }
+        }
+    }
+
+    private static int getMinNumHardwareCoresOfBe(List<String> warehouses) {
+        if (warehouses == null || warehouses.isEmpty()) {
+            return BackendResourceStat.getInstance().getMinNumCoresOfBe();
+        }
+
+        int minCoreNum = Integer.MAX_VALUE;
+        for (String warehouseName : warehouses) {
+            Warehouse warehouse = GlobalStateMgr.getCurrentState().getWarehouseMgr().getWarehouseAllowNull(warehouseName);
+            if (warehouse == null) {
+                continue;
+            }
+            minCoreNum = Math.min(minCoreNum,
+                    BackendResourceStat.getInstance().getMinNumCoresOfBe(warehouse.getId()));
+        }
+
+        if (minCoreNum == Integer.MAX_VALUE) { // All warehouses are invalid.
+            return BackendResourceStat.getInstance().getMinNumCoresOfBe();
+        }
+        return minCoreNum;
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupBuilder.java
@@ -64,7 +64,10 @@ public class ResourceGroupBuilder {
         }
 
         // Validate CPU parameters
-        ResourceGroup.validateCpuParameters(resourceGroup.getRawCpuWeight(), resourceGroup.getExclusiveCpuCores());
+        ResourceGroup.validateCpuParameters(resourceGroup.getRawCpuWeight(), resourceGroup.getCpuWeightPercent(),
+                resourceGroup.getExclusiveCpuCores(), resourceGroup.getExclusiveCpuPercent(),
+                resourceGroup.getMaxCpuCores(),
+                resourceGroup.getResourceGroupType(), resourceGroup.getWarehouses());
 
         // Validate required properties
         if (resourceGroup.getMemLimit() == null) {
@@ -124,17 +127,20 @@ public class ResourceGroupBuilder {
 
         // Validate that at least one property is specified
         if (changedProperties.getRawCpuWeight() == null &&
+                changedProperties.getCpuWeightPercent() == null &&
                 changedProperties.getExclusiveCpuCores() == null &&
+                changedProperties.getExclusiveCpuPercent() == null &&
                 changedProperties.getMemLimit() == null &&
                 changedProperties.getConcurrencyLimit() == null &&
                 changedProperties.getMaxCpuCores() == null &&
                 changedProperties.getBigQueryCpuSecondLimit() == null &&
                 changedProperties.getBigQueryMemLimit() == null &&
                 changedProperties.getBigQueryScanRowsLimit() == null &&
-                changedProperties.getSpillMemLimitThreshold() == null) {
-            throw new SemanticException("At least one of ('cpu_weight','exclusive_cpu_cores','mem_limit'," +
-                    "'max_cpu_cores','concurrency_limit','big_query_mem_limit', 'big_query_scan_rows_limit'," +
-                    "'big_query_cpu_second_limit','spill_mem_limit_threshold') " +
+                changedProperties.getSpillMemLimitThreshold() == null &&
+                changedProperties.getWarehouses() == null) {
+            throw new SemanticException("At least one of ('cpu_weight','cpu_weight_percent','exclusive_cpu_cores'," +
+                    "'exclusive_cpu_percent','mem_limit','max_cpu_cores','concurrency_limit','big_query_mem_limit', " +
+                    "'big_query_scan_rows_limit','big_query_cpu_second_limit','spill_mem_limit_threshold','warehouses') " +
                     "should be specified");
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
@@ -16,6 +16,7 @@ package com.starrocks.catalog;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.authorization.AuthorizationMgr;
 import com.starrocks.authorization.PrivilegeBuiltinConstants;
@@ -43,10 +44,12 @@ import com.starrocks.sql.ast.DropResourceGroupStmt;
 import com.starrocks.sql.ast.ShowResourceGroupStmt;
 import com.starrocks.sql.optimizer.cost.feature.CostPredictor;
 import com.starrocks.system.BackendResourceStat;
+import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.TWorkGroup;
 import com.starrocks.thrift.TWorkGroupOp;
 import com.starrocks.thrift.TWorkGroupOpType;
 import com.starrocks.thrift.TWorkGroupType;
+import com.starrocks.warehouse.Warehouse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -69,9 +72,6 @@ import static com.starrocks.server.WarehouseManager.DEFAULT_WAREHOUSE_ID;
 public class ResourceGroupMgr implements Writable {
     private static final Logger LOG = LogManager.getLogger(ResourceGroupMgr.class);
 
-    private static final String EXCEED_TOTAL_EXCLUSIVE_CPU_CORES_ERR_MSG =
-            "the sum of %s across all resource groups cannot exceed the minimum number of CPU cores " +
-                    "available on the backends minus one [%d]";
     public static final String SHORT_QUERY_SET_EXCLUSIVE_CPU_CORES_ERR_MSG =
             "'short_query' ResourceGroup cannot set 'exclusive_cpu_cores', " +
                     "since it use 'cpu_weight' as 'exclusive_cpu_cores'";
@@ -88,7 +88,6 @@ public class ResourceGroupMgr implements Writable {
     private final Map<Long, Map<Long, TWorkGroup>> activeResourceGroupsPerBe = new HashMap<>();
     private final Map<Long, Long> minVersionPerBe = new HashMap<>();
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
-    private int sumExclusiveCpuCores = 0;
     private volatile boolean hasCreatedDefaultResourceGroups = false;
 
     private void readLock() {
@@ -139,12 +138,8 @@ public class ResourceGroupMgr implements Writable {
                 throw new DdlException("This type Resource Group need define classifiers.");
             }
 
-            final int minCoreNum = BackendResourceStat.getInstance().getMinNumHardwareCoresOfBe();
-            if (wg.getNormalizedExclusiveCpuCores() > 0 &&
-                    sumExclusiveCpuCores + wg.getNormalizedExclusiveCpuCores() >= minCoreNum) {
-                throw new DdlException(String.format(EXCEED_TOTAL_EXCLUSIVE_CPU_CORES_ERR_MSG,
-                        ResourceGroup.EXCLUSIVE_CPU_CORES, minCoreNum - 1));
-            }
+            validateExclusiveCpuCoresInlock(
+                    wg.getNormalizedExclusiveCpuCores(), wg.getExclusiveCpuPercent(), wg.getWarehouses(), wg);
 
             if (needReplace) {
                 dropResourceGroupUnlocked(wg.getName());
@@ -318,6 +313,126 @@ public class ResourceGroupMgr implements Writable {
         }
     }
 
+    private int getExclusiveCpuCores(Integer exclusiveCpuCores, Integer exclusiveCpuPercent, int minCoreNum) {
+        if (exclusiveCpuCores != null && exclusiveCpuCores > 0) {
+            return exclusiveCpuCores;
+        } else if (exclusiveCpuPercent != null && exclusiveCpuPercent > 0) {
+            return minCoreNum * exclusiveCpuPercent / 100;
+        } else {
+            return 0;
+        }
+    }
+
+    private static class WarehouseCoresInfo {
+        private final int minCores;
+        private int sumExclusiveCpuCores = 0;
+
+        private WarehouseCoresInfo(int minCores) {
+            this.minCores = minCores;
+        }
+    }
+
+    /**
+     * For each warehouse, the sum of the exclusive CPU cores of all effective resource groups on that warehouse plus one must
+     * not exceed the number of CPU cores of the smallest BE in that resource group.
+     *
+     * <p> The resource groups that are effective on a warehouse are defined as follows:
+     * - For a warehouse with bound resource groups: both the resource groups bound to that warehouse and the resource groups not
+     * bound to any warehouse.
+     * - For a warehouse without bound resource groups: the resource groups not bound to any warehouse.
+     */
+    private void validateExclusiveCpuCoresInlock(Integer exclusiveCpuCores, Integer exclusiveCpuPercent, List<String> warehouses,
+                                                 ResourceGroup wg)
+            throws DdlException {
+        Set<Long> boundWhIds = Sets.newHashSet();
+        Map<String, WarehouseCoresInfo> boundWhToItem = new HashMap<>();
+
+        List<ResourceGroup> groups = new ArrayList<>(resourceGroupMap.values());
+        if (!resourceGroupMap.containsKey(wg.getName())) {
+            groups.add(wg);
+        }
+
+        // First, iterate over the resource groups that are bound to a warehouse to determine
+        // which warehouses have resource groups bound to them.
+        for (ResourceGroup group : groups) {
+            if (group.getWarehouses() == null || group.getWarehouses().isEmpty()) {
+                continue;
+            }
+
+            Integer curExclusiveCpuCores;
+            Integer curExclusiveCpuPercent;
+            List<String> curWarehouses;
+            if (group.getName().equals(wg.getName())) {
+                curExclusiveCpuCores = exclusiveCpuCores;
+                curExclusiveCpuPercent = exclusiveCpuPercent;
+                curWarehouses = warehouses;
+            } else {
+                curExclusiveCpuCores = group.getNormalizedExclusiveCpuCores();
+                curExclusiveCpuPercent = group.getExclusiveCpuPercent();
+                curWarehouses = group.getWarehouses();
+            }
+
+            for (String warehouseName : curWarehouses) {
+                WarehouseCoresInfo item = boundWhToItem.get(warehouseName);
+                if (item == null) {
+                    Warehouse wh = GlobalStateMgr.getCurrentState().getWarehouseMgr().getWarehouseAllowNull(warehouseName);
+                    if (wh == null) {
+                        continue;
+                    }
+                    boundWhIds.add(wh.getId());
+                    int minCores = BackendResourceStat.getInstance().getMinNumCoresOfBe(wh.getId());
+                    item = new WarehouseCoresInfo(minCores);
+                    boundWhToItem.put(warehouseName, item);
+                }
+
+                int exclusiveCores = getExclusiveCpuCores(curExclusiveCpuCores, curExclusiveCpuPercent, item.minCores);
+                item.sumExclusiveCpuCores += exclusiveCores;
+            }
+        }
+
+        // Then, iterate over the resource groups that are not bound to any warehouse.
+        final int nonBoundWhMinCores = BackendResourceStat.getInstance().getMinNumCoresOfBeExceptWarehouses(boundWhIds);
+        int nonBoundWhSumExclusiveCores = 0;
+        for (ResourceGroup group : groups) {
+            if (group.getWarehouses() != null && !group.getWarehouses().isEmpty()) {
+                continue;
+            }
+
+            Integer curExclusiveCpuCores;
+            Integer curExclusiveCpuPercent;
+            if (group.getName().equals(wg.getName())) {
+                curExclusiveCpuCores = exclusiveCpuCores;
+                curExclusiveCpuPercent = exclusiveCpuPercent;
+            } else {
+                curExclusiveCpuCores = group.getNormalizedExclusiveCpuCores();
+                curExclusiveCpuPercent = group.getExclusiveCpuPercent();
+            }
+
+            int nonUsedWhExclusiveCores = getExclusiveCpuCores(curExclusiveCpuCores, curExclusiveCpuPercent, nonBoundWhMinCores);
+            nonBoundWhSumExclusiveCores += nonUsedWhExclusiveCores;
+
+            for (WarehouseCoresInfo item : boundWhToItem.values()) {
+                int exclusiveCores = getExclusiveCpuCores(curExclusiveCpuCores, curExclusiveCpuPercent, item.minCores);
+                item.sumExclusiveCpuCores += exclusiveCores;
+            }
+        }
+
+        if (nonBoundWhSumExclusiveCores + 1 > nonBoundWhMinCores) {
+            throw new DdlException(String.format("The effective exclusive CPU allocation (%d) exceeds the available cores " +
+                    "(%d, that is, total cores minus one reserved for non-exclusive groups) on the smallest BE " +
+                    "not assigned to any warehouse.", nonBoundWhSumExclusiveCores, nonBoundWhMinCores - 1));
+        }
+        for (Map.Entry<String, WarehouseCoresInfo> entry : boundWhToItem.entrySet()) {
+            String warehouseName = entry.getKey();
+            WarehouseCoresInfo item = entry.getValue();
+            if (item.sumExclusiveCpuCores + 1 > item.minCores) {
+                throw new DdlException(String.format("The effective exclusive CPU allocation (%d) exceeds the available cores " +
+                        "(%d, that is, total cores minus one reserved for non-exclusive groups) on the smallest BE " +
+                        "of warehouse %s.", item.sumExclusiveCpuCores, item.minCores - 1, warehouseName));
+            }
+        }
+    }
+
     public void alterResourceGroup(AlterResourceGroupStmt stmt) throws DdlException {
         writeLock();
         try {
@@ -360,44 +475,41 @@ public class ResourceGroupMgr implements Writable {
 
                 Integer cpuWeight = changedProperties.getRawCpuWeight();
                 if (cpuWeight == null) {
-                    cpuWeight = wg.geNormalizedCpuWeight();
+                    cpuWeight = wg.getNormalizedCpuWeight();
+                }
+                Integer cpuWeightPercent = changedProperties.getCpuWeightPercent();
+                if (cpuWeightPercent == null) {
+                    cpuWeightPercent = wg.getCpuWeightPercent();
                 }
                 Integer exclusiveCpuCores = changedProperties.getExclusiveCpuCores();
                 if (exclusiveCpuCores == null) {
                     exclusiveCpuCores = wg.getExclusiveCpuCores();
                 }
-
-                ResourceGroup.validateCpuParameters(cpuWeight, exclusiveCpuCores);
-
-                if (exclusiveCpuCores != null && exclusiveCpuCores > 0) {
-                    if (sumExclusiveCpuCores + exclusiveCpuCores - wg.getNormalizedExclusiveCpuCores() >=
-                            BackendResourceStat.getInstance().getMinNumHardwareCoresOfBe()) {
-                        throw new DdlException(String.format(EXCEED_TOTAL_EXCLUSIVE_CPU_CORES_ERR_MSG,
-                                ResourceGroup.EXCLUSIVE_CPU_CORES,
-                                BackendResourceStat.getInstance().getMinNumHardwareCoresOfBe() - 1));
-                    }
+                Integer exclusiveCpuPercent = changedProperties.getExclusiveCpuPercent();
+                if (exclusiveCpuPercent == null) {
+                    exclusiveCpuPercent = wg.getExclusiveCpuPercent();
+                }
+                List<String> warehouses = changedProperties.getWarehouses();
+                if (warehouses == null) {
+                    warehouses = wg.getWarehouses();
+                }
+                Integer maxCpuCores = changedProperties.getMaxCpuCores();
+                if (maxCpuCores == null) {
+                    maxCpuCores = wg.getMaxCpuCores();
+                }
+                ResourceGroup.validateCpuParameters(cpuWeight, cpuWeightPercent,
+                        exclusiveCpuCores, exclusiveCpuPercent, maxCpuCores, wg.getResourceGroupType(), warehouses);
+                if ((exclusiveCpuCores != null && exclusiveCpuCores > 0) ||
+                        (exclusiveCpuPercent != null && exclusiveCpuPercent > 0)) {
+                    validateExclusiveCpuCoresInlock(exclusiveCpuCores, exclusiveCpuPercent, warehouses, wg);
                     if (wg.getResourceGroupType() == TWorkGroupType.WG_SHORT_QUERY) {
                         throw new SemanticException(SHORT_QUERY_SET_EXCLUSIVE_CPU_CORES_ERR_MSG);
                     }
-                }
-                // NOTE that validate cpu parameters should be called before setting properties.
-
-                if (cpuWeight != null) {
-                    alterResourceGroupLog.setCpuWeight(cpuWeight);
                 }
 
                 String memPool = wg.getMemPool();
                 if (wg.hasDefaultMemPool()) {
                     memPool = ResourceGroup.DEFAULT_MEM_POOL;
-                }
-
-                if (exclusiveCpuCores != null) {
-                    alterResourceGroupLog.setExclusiveCpuCores(exclusiveCpuCores);
-                }
-
-                Integer maxCpuCores = changedProperties.getMaxCpuCores();
-                if (maxCpuCores != null) {
-                    alterResourceGroupLog.setMaxCpuCores(maxCpuCores);
                 }
                 if (changedProperties.getMemPool() != null && !changedProperties.getMemPool().equals(memPool)) {
                     throw new DdlException("Property `mem_pool` cannot be altered [" + wg.getMemPool() + "].");
@@ -409,6 +521,31 @@ public class ResourceGroupMgr implements Writable {
                             "Property `mem_limit` cannot be altered for resource groups with mem_pool [" +
                                     wg.getMemPool() + "].");
                 }
+
+                // NOTE that validate parameters should be called before setting properties.
+
+                cpuWeightPercent = changedProperties.getCpuWeightPercent();
+                if (cpuWeightPercent != null) {
+                    alterResourceGroupLog.setCpuWeightPercent(cpuWeightPercent);
+                }
+                cpuWeight = changedProperties.getRawCpuWeight();
+                if (cpuWeight != null) {
+                    alterResourceGroupLog.setCpuWeight(cpuWeight);
+                }
+                exclusiveCpuCores = changedProperties.getExclusiveCpuCores();
+                if (exclusiveCpuCores != null) {
+                    alterResourceGroupLog.setExclusiveCpuCores(exclusiveCpuCores);
+                }
+                exclusiveCpuPercent = changedProperties.getExclusiveCpuPercent();
+                if (exclusiveCpuPercent != null) {
+                    alterResourceGroupLog.setExclusiveCpuPercent(exclusiveCpuPercent);
+                }
+
+                maxCpuCores = changedProperties.getMaxCpuCores();
+                if (maxCpuCores != null) {
+                    alterResourceGroupLog.setMaxCpuCores(maxCpuCores);
+                }
+
                 Double memLimit = changedProperties.getMemLimit();
                 if (memLimit != null) {
                     alterResourceGroupLog.setMemLimit(memLimit);
@@ -437,6 +574,11 @@ public class ResourceGroupMgr implements Writable {
                 Double spillMemLimitThreshold = changedProperties.getSpillMemLimitThreshold();
                 if (spillMemLimitThreshold != null) {
                     alterResourceGroupLog.setSpillMemLimitThreshold(spillMemLimitThreshold);
+                }
+
+                warehouses = changedProperties.getWarehouses();
+                if (warehouses != null) {
+                    alterResourceGroupLog.setWarehouses(warehouses);
                 }
 
                 // Type is guaranteed to be immutable during the analyzer phase.
@@ -483,10 +625,14 @@ public class ResourceGroupMgr implements Writable {
             wg.setCpuWeight(log.getCpuWeight());
             wg.normalizeCpuWeight();
         }
+        if (log.getCpuWeightPercent() != null) {
+            wg.setCpuWeightPercent(log.getCpuWeightPercent());
+        }
         if (log.getExclusiveCpuCores() != null) {
-            sumExclusiveCpuCores -= wg.getNormalizedExclusiveCpuCores();
             wg.setExclusiveCpuCores(log.getExclusiveCpuCores());
-            sumExclusiveCpuCores += wg.getNormalizedExclusiveCpuCores();
+        }
+        if (log.getExclusiveCpuPercent() != null) {
+            wg.setExclusiveCpuPercent(log.getExclusiveCpuPercent());
         }
         if (log.getMaxCpuCores() != null) {
             wg.setMaxCpuCores(log.getMaxCpuCores());
@@ -508,6 +654,9 @@ public class ResourceGroupMgr implements Writable {
         }
         if (log.getSpillMemLimitThreshold() != null) {
             wg.setSpillMemLimitThreshold(log.getSpillMemLimitThreshold());
+        }
+        if (log.getWarehouses() != null) {
+            wg.setWarehouses(log.getWarehouses());
         }
         if (log.getVersion() != 0) {
             wg.setVersion(log.getVersion());
@@ -584,7 +733,6 @@ public class ResourceGroupMgr implements Writable {
         if (wg.getResourceGroupType() == TWorkGroupType.WG_SHORT_QUERY) {
             shortQueryResourceGroup = null;
         }
-        sumExclusiveCpuCores -= wg.getNormalizedExclusiveCpuCores();
     }
 
     private void addResourceGroupInternal(ResourceGroup wg) {
@@ -596,20 +744,56 @@ public class ResourceGroupMgr implements Writable {
         if (wg.getResourceGroupType() == TWorkGroupType.WG_SHORT_QUERY) {
             shortQueryResourceGroup = wg;
         }
-        sumExclusiveCpuCores += wg.getNormalizedExclusiveCpuCores();
         if (ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME.equals(wg.getName())) {
             hasCreatedDefaultResourceGroups = true;
         }
     }
 
+    /**
+     * If a resource group is bound to specific warehouses, and the warehouse that the current BE belongs to is not among those
+     * bound warehouses, then the TWorkGroupOp sent to that BE will be marked as inactive, meaning this resource group will not
+     * take effect on that BE.
+     *
+     * <p> We separate the logic of pushing resource groups to BEs from the logic of deciding whether they should be inactive,
+     * to avoid complicated handling when the set of warehouses bound to a resource group changes.
+     *
+     * @param op            the resource group operation will be sent to this BE
+     * @param warehouseName the warehouse name that the current BE belongs to
+     * @return the TWorkGroupOp that may be marked as inactive
+     */
+    private TWorkGroupOp setInactiveOp(TWorkGroupOp op, String warehouseName) {
+        List<String> warehouses = op.getWorkgroup().getWarehouses();
+        if (warehouseName == null || warehouses == null || warehouses.isEmpty() || warehouses.contains(warehouseName)) {
+            return op;
+        }
+
+        // Only when we need to set `inactive` do we create a copied instance.
+        // In all other cases, all BEs share the same TWorkGroupOp instance.
+        TWorkGroupOp newOp = op.deepCopy();
+        newOp.getWorkgroup().setInactive(true);
+        return newOp;
+    }
+
     public List<TWorkGroupOp> getResourceGroupsNeedToDeliver(Long beId) {
+        ComputeNode computeNode = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackendOrComputeNode(beId);
+        String warehouseName = null;
+        if (computeNode != null) {
+            Warehouse wh = GlobalStateMgr.getCurrentState().getWarehouseMgr().getWarehouseAllowNull(computeNode.getWarehouseId());
+            if (wh != null) {
+                warehouseName = wh.getName();
+            }
+        }
+
         readLock();
         try {
             List<TWorkGroupOp> currentResourceGroupOps = new ArrayList<>();
             if (!activeResourceGroupsPerBe.containsKey(beId)) {
-                currentResourceGroupOps.addAll(resourceGroupOps);
+                for (TWorkGroupOp op : resourceGroupOps) {
+                    currentResourceGroupOps.add(setInactiveOp(op, warehouseName));
+                }
                 return currentResourceGroupOps;
             }
+
             Long minVersion = minVersionPerBe.get(beId);
             Map<Long, TWorkGroup> activeResourceGroup = activeResourceGroupsPerBe.get(beId);
             for (TWorkGroupOp op : resourceGroupOps) {
@@ -617,12 +801,14 @@ public class ResourceGroupMgr implements Writable {
                 if (twg.getVersion() < minVersion) {
                     continue;
                 }
+
                 boolean active = activeResourceGroup.containsKey(twg.getId());
                 if ((!active && id2ResourceGroupMap.containsKey(twg.getId())) ||
                         (active && twg.getVersion() > activeResourceGroup.get(twg.getId()).getVersion())) {
-                    currentResourceGroupOps.add(op);
+                    currentResourceGroupOps.add(setInactiveOp(op, warehouseName));
                 }
             }
+
             return currentResourceGroupOps;
         } finally {
             readUnlock();
@@ -734,10 +920,8 @@ public class ResourceGroupMgr implements Writable {
                 return;
             }
 
-            final int avgCpuCores = BackendResourceStat.getInstance().getAvgNumCoresOfBe(DEFAULT_WAREHOUSE_ID);
-
             Map<String, String> defaultWgProperties = ImmutableMap.of(
-                    ResourceGroup.CPU_WEIGHT, Integer.toString(avgCpuCores),
+                    ResourceGroup.CPU_WEIGHT_PERCENT, "100",
                     ResourceGroup.MEM_LIMIT, "1.0"
             );
             CreateResourceGroupStmt defaultWgStmt = new CreateResourceGroupStmt(ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME,
@@ -746,7 +930,7 @@ public class ResourceGroupMgr implements Writable {
             createResourceGroup(defaultWgStmt);
 
             Map<String, String> defaultMvWgProperties = ImmutableMap.of(
-                    ResourceGroup.CPU_WEIGHT, "1",
+                    ResourceGroup.CPU_WEIGHT_PERCENT, "1",
                     ResourceGroup.MEM_LIMIT, "0.8",
                     ResourceGroup.SPILL_MEM_LIMIT_THRESHOLD, "0.8"
             );

--- a/fe/fe-core/src/main/java/com/starrocks/persist/AlterResourceGroupLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/AlterResourceGroupLog.java
@@ -31,8 +31,14 @@ public class AlterResourceGroupLog implements Writable {
     @SerializedName(value = "cpuCoreLimit")
     private Integer cpuWeight;
 
+    @SerializedName(value = "cpuWeightPercent")
+    private Integer cpuWeightPercent;
+
     @SerializedName(value = "exclusiveCpuCores")
     private Integer exclusiveCpuCores;
+
+    @SerializedName(value = "exclusiveCpuPercent")
+    private Integer exclusiveCpuPercent;
 
     @SerializedName(value = "maxCpuCores")
     private Integer maxCpuCores;
@@ -64,6 +70,9 @@ public class AlterResourceGroupLog implements Writable {
     @SerializedName(value = "version")
     private long version;
 
+    @SerializedName(value = "warehouses")
+    private List<String> warehouses;
+
     public List<ResourceGroupClassifier> getClassifiers() {
         return classifiers;
     }
@@ -88,12 +97,28 @@ public class AlterResourceGroupLog implements Writable {
         this.cpuWeight = cpuWeight;
     }
 
+    public Integer getCpuWeightPercent() {
+        return cpuWeightPercent;
+    }
+
+    public void setCpuWeightPercent(Integer cpuWeightPercent) {
+        this.cpuWeightPercent = cpuWeightPercent;
+    }
+
     public Integer getExclusiveCpuCores() {
         return exclusiveCpuCores;
     }
 
     public void setExclusiveCpuCores(Integer exclusiveCpuCores) {
         this.exclusiveCpuCores = exclusiveCpuCores;
+    }
+
+    public Integer getExclusiveCpuPercent() {
+        return exclusiveCpuPercent;
+    }
+
+    public void setExclusiveCpuPercent(Integer exclusiveCpuPercent) {
+        this.exclusiveCpuPercent = exclusiveCpuPercent;
     }
 
     public Integer getMaxCpuCores() {
@@ -174,5 +199,13 @@ public class AlterResourceGroupLog implements Writable {
 
     public void setVersion(long version) {
         this.version = version;
+    }
+
+    public List<String> getWarehouses() {
+        return warehouses;
+    }
+
+    public void setWarehouses(List<String> warehouses) {
+        this.warehouses = warehouses;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ResourceGroupAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ResourceGroupAnalyzer.java
@@ -32,10 +32,12 @@ import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.system.BackendResourceStat;
 import com.starrocks.thrift.TWorkGroupType;
+import com.starrocks.warehouse.Warehouse;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.net.util.SubnetUtils;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -160,12 +162,23 @@ public class ResourceGroupAnalyzer {
     public static void analyzeProperties(ResourceGroup resourceGroup, Map<String, String> properties)
             throws SemanticException {
         final int avgCoreNum = BackendResourceStat.getInstance().getAvgNumCoresOfBe();
+        final boolean hasWarehouseProperty =
+                properties.keySet().stream().anyMatch(key -> key.equalsIgnoreCase(ResourceGroup.WAREHOUSES));
         for (Map.Entry<String, String> e : properties.entrySet()) {
             String key = e.getKey();
             String value = e.getValue();
             try {
+                if (key.equalsIgnoreCase(ResourceGroup.WAREHOUSES)) {
+                    List<String> warehouses = parseWarehouses(value);
+                    resourceGroup.setWarehouses(warehouses);
+                    continue;
+                }
                 if (key.equalsIgnoreCase(ResourceGroup.CPU_CORE_LIMIT) || key.equalsIgnoreCase(ResourceGroup.CPU_WEIGHT)) {
                     int cpuWeight = Integer.parseInt(value);
+                    if (cpuWeight > 0 && hasWarehouseProperty) {
+                        throw new SemanticException("'cpu_weight' cannot be set when 'warehouses' is specified, " +
+                                "please use 'cpu_weight_percent' instead");
+                    }
                     if (cpuWeight > avgCoreNum) {
                         throw new SemanticException(
                                 String.format("%s should range from 0 to %d", ResourceGroup.CPU_WEIGHT, avgCoreNum));
@@ -173,9 +186,22 @@ public class ResourceGroupAnalyzer {
                     resourceGroup.setCpuWeight(cpuWeight);
                     continue;
                 }
+                if (key.equalsIgnoreCase(ResourceGroup.CPU_WEIGHT_PERCENT)) {
+                    int cpuWeightPercent = Integer.parseInt(value);
+                    if (cpuWeightPercent < 0 || cpuWeightPercent > 100) {
+                        throw new SemanticException(
+                                String.format("%s should range from [0, 100]", ResourceGroup.CPU_WEIGHT_PERCENT));
+                    }
+                    resourceGroup.setCpuWeightPercent(cpuWeightPercent);
+                    continue;
+                }
                 if (key.equalsIgnoreCase(ResourceGroup.EXCLUSIVE_CPU_CORES)) {
                     final int exclusiveCpuCores = Integer.parseInt(value);
-                    final int minCoreNum = BackendResourceStat.getInstance().getMinNumHardwareCoresOfBe();
+                    if (exclusiveCpuCores > 0 && hasWarehouseProperty) {
+                        throw new SemanticException("'exclusive_cpu_cores' cannot be set when 'warehouses' is specified, " +
+                                "please use 'exclusive_cpu_percent' instead");
+                    }
+                    final int minCoreNum = BackendResourceStat.getInstance().getMinNumCoresOfBe();
                     if (exclusiveCpuCores >= minCoreNum) {
                         throw new SemanticException(String.format(
                                 "%s cannot exceed the minimum number of CPU cores available on the backends minus one [%d]",
@@ -184,8 +210,20 @@ public class ResourceGroupAnalyzer {
                     resourceGroup.setExclusiveCpuCores(exclusiveCpuCores);
                     continue;
                 }
+                if (key.equalsIgnoreCase(ResourceGroup.EXCLUSIVE_CPU_PERCENT)) {
+                    int exclusiveCpuPercent = Integer.parseInt(value);
+                    if (exclusiveCpuPercent < 0 || exclusiveCpuPercent >= 100) {
+                        throw new SemanticException(
+                                String.format("%s should range from [0, 100)", ResourceGroup.EXCLUSIVE_CPU_PERCENT));
+                    }
+                    resourceGroup.setExclusiveCpuPercent(exclusiveCpuPercent);
+                    continue;
+                }
                 if (key.equalsIgnoreCase(ResourceGroup.MAX_CPU_CORES)) {
                     int maxCpuCores = Integer.parseInt(value);
+                    if (maxCpuCores > 0 && hasWarehouseProperty) {
+                        throw new SemanticException("'max_cpu_cores' cannot be set when 'warehouses' is specified");
+                    }
                     if (maxCpuCores > avgCoreNum) {
                         throw new SemanticException(String.format("max_cpu_cores should range from 0 to %d", avgCoreNum));
                     }
@@ -318,7 +356,10 @@ public class ResourceGroupAnalyzer {
         }
 
         // Validate CPU parameters
-        ResourceGroup.validateCpuParameters(tempResourceGroup.getRawCpuWeight(), tempResourceGroup.getExclusiveCpuCores());
+        ResourceGroup.validateCpuParameters(tempResourceGroup.getRawCpuWeight(), tempResourceGroup.getCpuWeightPercent(),
+                tempResourceGroup.getExclusiveCpuCores(), tempResourceGroup.getExclusiveCpuPercent(),
+                tempResourceGroup.getMaxCpuCores(),
+                tempResourceGroup.getResourceGroupType(), tempResourceGroup.getWarehouses());
     }
 
     /**
@@ -338,26 +379,29 @@ public class ResourceGroupAnalyzer {
             // Create a temporary ResourceGroup to validate properties
             ResourceGroup tempResourceGroup = new ResourceGroup();
             analyzeProperties(tempResourceGroup, alterProperties.getProperties());
-            
+
             // Validate that type cannot be changed
             if (tempResourceGroup.getResourceGroupType() != null) {
                 throw new SemanticException("type of ResourceGroup is immutable");
             }
-            
+
             // Validate that at least one property is specified
             if (tempResourceGroup.getRawCpuWeight() == null &&
+                    tempResourceGroup.getCpuWeightPercent() == null &&
                     tempResourceGroup.getExclusiveCpuCores() == null &&
+                    tempResourceGroup.getExclusiveCpuPercent() == null &&
                     tempResourceGroup.getMemLimit() == null &&
                     tempResourceGroup.getConcurrencyLimit() == null &&
                     tempResourceGroup.getMaxCpuCores() == null &&
                     tempResourceGroup.getBigQueryCpuSecondLimit() == null &&
                     tempResourceGroup.getBigQueryMemLimit() == null &&
                     tempResourceGroup.getBigQueryScanRowsLimit() == null &&
-                    tempResourceGroup.getSpillMemLimitThreshold() == null) {
-                throw new SemanticException("At least one of ('cpu_weight','exclusive_cpu_cores','mem_limit'," +
-                        "'max_cpu_cores','concurrency_limit','big_query_mem_limit', 'big_query_scan_rows_limit'," +
-                        "'big_query_cpu_second_limit','spill_mem_limit_threshold') " +
-                        "should be specified");
+                    tempResourceGroup.getSpillMemLimitThreshold() == null &&
+                    tempResourceGroup.getWarehouses() == null) {
+                throw new SemanticException("At least one of ('cpu_weight','cpu_weight_percent'," +
+                        "'exclusive_cpu_cores','exclusive_cpu_percent','mem_limit','max_cpu_cores','concurrency_limit'," +
+                        "'big_query_mem_limit', 'big_query_scan_rows_limit','big_query_cpu_second_limit'," +
+                        "'spill_mem_limit_threshold','warehouses') should be specified");
             }
         }
 
@@ -372,5 +416,27 @@ public class ResourceGroupAnalyzer {
         if (ResourceGroup.BUILTIN_WG_NAMES.contains(name)) {
             throw new SemanticException(String.format("cannot drop builtin resource group [%s]", name));
         }
+    }
+
+    private static List<String> parseWarehouses(String warehousesValue) {
+        List<String> warehouses = new ArrayList<>();
+        for (String token : warehousesValue.split(",")) {
+            String name = token.trim();
+            if (!name.isEmpty()) {
+                warehouses.add(name);
+            }
+        }
+
+        Set<String> dedup = new HashSet<>();
+        for (String warehouseName : warehouses) {
+            if (!dedup.add(warehouseName)) {
+                throw new SemanticException(String.format("Duplicate warehouse in warehouses: %s", warehouseName));
+            }
+            Warehouse warehouse = GlobalStateMgr.getCurrentState().getWarehouseMgr().getWarehouseAllowNull(warehouseName);
+            if (warehouse == null) {
+                throw new SemanticException(String.format("Unknown warehouse: %s", warehouseName));
+            }
+        }
+        return warehouses;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ResourceGroupMgrEditLogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ResourceGroupMgrEditLogTest.java
@@ -172,7 +172,7 @@ public class ResourceGroupMgrEditLogTest {
         // Verify initial state
         ResourceGroup resourceGroup = masterResourceGroupMgr.getResourceGroup(resourceGroupName);
         Assertions.assertNotNull(resourceGroup);
-        Integer initialCpuWeight = resourceGroup.geNormalizedCpuWeight();
+        Integer initialCpuWeight = resourceGroup.getNormalizedCpuWeight();
         Double initialMemLimit = resourceGroup.getMemLimit();
         Integer initialConcurrencyLimit = resourceGroup.getConcurrencyLimit();
         Integer initialMaxCpuCores = resourceGroup.getMaxCpuCores();
@@ -202,7 +202,7 @@ public class ResourceGroupMgrEditLogTest {
         // 4. Verify master state - check all modified properties
         resourceGroup = masterResourceGroupMgr.getResourceGroup(resourceGroupName);
         Assertions.assertNotNull(resourceGroup);
-        Assertions.assertEquals(1, resourceGroup.geNormalizedCpuWeight());
+        Assertions.assertEquals(1, resourceGroup.getNormalizedCpuWeight());
         Assertions.assertEquals(0.6, resourceGroup.getMemLimit(), 0.001);
         Assertions.assertEquals(5, resourceGroup.getConcurrencyLimit());
         Assertions.assertEquals(1, resourceGroup.getMaxCpuCores());
@@ -231,7 +231,7 @@ public class ResourceGroupMgrEditLogTest {
         // 6. Verify follower state is consistent with master - check all properties
         ResourceGroup followerResourceGroup = followerResourceGroupMgr.getResourceGroup(resourceGroupName);
         Assertions.assertNotNull(followerResourceGroup);
-        Assertions.assertEquals(resourceGroup.geNormalizedCpuWeight(), followerResourceGroup.geNormalizedCpuWeight());
+        Assertions.assertEquals(resourceGroup.getNormalizedCpuWeight(), followerResourceGroup.getNormalizedCpuWeight());
         Assertions.assertEquals(resourceGroup.getMemLimit(), followerResourceGroup.getMemLimit());
         Assertions.assertEquals(resourceGroup.getConcurrencyLimit(), followerResourceGroup.getConcurrencyLimit());
         Assertions.assertEquals(resourceGroup.getMaxCpuCores(), followerResourceGroup.getMaxCpuCores());

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowStmtMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowStmtMetaTest.java
@@ -998,11 +998,11 @@ public class ShowStmtMetaTest {
     public void testShowResourceGroupStmt() {
         ShowResourceGroupStmt stmt = new ShowResourceGroupStmt("test_group", false, false, NodePosition.ZERO);
         ShowResultSetMetaData metaData = new ShowResultMetaFactory().getMetadata(stmt);
-        Assertions.assertEquals(11, metaData.getColumnCount());
+        Assertions.assertEquals(12, metaData.getColumnCount());
         Assertions.assertEquals("name", metaData.getColumn(0).getName());
         Assertions.assertEquals("id", metaData.getColumn(1).getName());
-        Assertions.assertEquals("cpu_weight", metaData.getColumn(2).getName());
-        Assertions.assertEquals("exclusive_cpu_cores", metaData.getColumn(3).getName());
+        Assertions.assertEquals("cpu_weight_percent", metaData.getColumn(2).getName());
+        Assertions.assertEquals("exclusive_cpu_percent", metaData.getColumn(3).getName());
         Assertions.assertEquals("mem_limit", metaData.getColumn(4).getName());
         Assertions.assertEquals("big_query_cpu_second_limit", metaData.getColumn(5).getName());
         Assertions.assertEquals("big_query_scan_rows_limit", metaData.getColumn(6).getName());
@@ -1010,6 +1010,7 @@ public class ShowStmtMetaTest {
         Assertions.assertEquals("concurrency_limit", metaData.getColumn(8).getName());
         Assertions.assertEquals("spill_mem_limit_threshold", metaData.getColumn(9).getName());
         Assertions.assertEquals("classifiers", metaData.getColumn(10).getName());
+        Assertions.assertEquals("warehouses", metaData.getColumn(11).getName());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/system/BackendResourceStatTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/system/BackendResourceStatTest.java
@@ -165,7 +165,7 @@ public class BackendResourceStatTest {
         stat.setNumCoresOfBe(DEFAULT_WAREHOUSE_ID, 1L, 4);
         stat.setNumCoresOfBe(1, 11L, 12);
         assertThat(stat.getAvgNumCoresOfBe()).isEqualTo(8);
-        assertThat(stat.getMinNumHardwareCoresOfBe()).isEqualTo(4);
+        assertThat(stat.getMinNumCoresOfBe()).isEqualTo(4);
 
         stat.setMemLimitBytesOfBe(DEFAULT_WAREHOUSE_ID, 0L, 100);
         stat.setMemLimitBytesOfBe(DEFAULT_WAREHOUSE_ID, 1L, 50);
@@ -177,7 +177,7 @@ public class BackendResourceStatTest {
         stat.reset();
 
         assertThat(stat.getAvgNumCoresOfBe()).isEqualTo(1);
-        assertThat(stat.getMinNumHardwareCoresOfBe()).isEqualTo(1);
+        assertThat(stat.getMinNumCoresOfBe()).isEqualTo(1);
         assertThat(stat.getAvgMemLimitBytes(DEFAULT_WAREHOUSE_ID)).isEqualTo(0);
         assertThat(stat.getNumBes(DEFAULT_WAREHOUSE_ID)).isEqualTo(0);
     }
@@ -233,27 +233,27 @@ public class BackendResourceStatTest {
     }
 
     @Test
-    public void testGetMinNumHardwareCoresOfBe() {
+    public void testGetMinNumCoresOfBe() {
         BackendResourceStat stat = BackendResourceStat.getInstance();
 
-        assertThat(stat.getMinNumHardwareCoresOfBe()).isEqualTo(1);
+        assertThat(stat.getMinNumCoresOfBe()).isEqualTo(1);
 
         stat.setNumCoresOfBe(DEFAULT_WAREHOUSE_ID, 0L, 0);
         stat.setNumCoresOfBe(1, 1L, 0);
-        assertThat(stat.getMinNumHardwareCoresOfBe()).isEqualTo(1);
-        assertThat(stat.getMinNumHardwareCoresOfBe()).isEqualTo(1);
+        assertThat(stat.getMinNumCoresOfBe()).isEqualTo(1);
+        assertThat(stat.getMinNumCoresOfBe()).isEqualTo(1);
 
         stat.setNumCoresOfBe(DEFAULT_WAREHOUSE_ID, 0L, 4);
-        assertThat(stat.getMinNumHardwareCoresOfBe()).isEqualTo(1);
+        assertThat(stat.getMinNumCoresOfBe()).isEqualTo(1);
 
         stat.setNumCoresOfBe(1, 1L, 8);
-        assertThat(stat.getMinNumHardwareCoresOfBe()).isEqualTo(4);
+        assertThat(stat.getMinNumCoresOfBe()).isEqualTo(4);
 
         stat.removeBe(DEFAULT_WAREHOUSE_ID, 0L);
-        assertThat(stat.getMinNumHardwareCoresOfBe()).isEqualTo(8);
+        assertThat(stat.getMinNumCoresOfBe()).isEqualTo(8);
 
         stat.removeBe(1, 1L);
-        assertThat(stat.getMinNumHardwareCoresOfBe()).isEqualTo(1);
+        assertThat(stat.getMinNumCoresOfBe()).isEqualTo(1);
     }
 
 }

--- a/gensrc/thrift/WorkGroup.thrift
+++ b/gensrc/thrift/WorkGroup.thrift
@@ -41,6 +41,12 @@ struct TWorkGroup {
 
   15: optional i32 exclusive_cpu_cores
   16: optional string mem_pool
+  17: optional i32 cpu_weight_percent
+  18: optional i32 exclusive_cpu_percent
+
+  50: optional list<string> warehouses
+  51: optional bool inactive
+
   100: optional i32 max_cpu_cores
 }
 

--- a/test/sql/test_resource_group/R/test_resource_group_exclusive_cpu_percent
+++ b/test/sql/test_resource_group/R/test_resource_group_exclusive_cpu_percent
@@ -1,0 +1,149 @@
+-- name: test_resource_group_exclusive_cpu_percent @sequential
+CREATE RESOURCE GROUP rgd1_${uuid0}
+TO ( user='user_${uuid0}' )
+WITH ( 'exclusive_cpu_percent' = '30', 'mem_limit' = '0.99' );
+-- result:
+-- !result
+CREATE RESOURCE GROUP rgd2_${uuid0}
+TO ( user='user_${uuid0}' )
+WITH ( 'exclusive_cpu_percent' = '50', 'mem_limit' = '0.99' );
+-- result:
+-- !result
+CREATE RESOURCE GROUP rgn1_${uuid0}
+TO ( user='user_${uuid0}' )
+WITH ( 'cpu_weight_percent' = '4', 'mem_limit' = '0.99' );
+-- result:
+-- !result
+CREATE RESOURCE GROUP rgn2_${uuid0}
+TO ( user='user_${uuid0}' )
+WITH ( 'cpu_weight_percent' = '5', 'mem_limit' = '0.99' );
+-- result:
+-- !result
+[UC]SELECT sleep(10);
+-- result:
+1
+-- !result
+[UC]function: num_cores=get_backend_cpu_cores()
+-- result:
+16
+-- !result
+[UC]function: rgd1_id=get_resource_group_id('rgd1_${uuid0}')
+-- result:
+11406
+-- !result
+[UC]function: rgd2_id=get_resource_group_id('rgd2_${uuid0}')
+-- result:
+11408
+-- !result
+[UC]function: rgn1_id=get_resource_group_id('rgn1_${uuid0}')
+-- result:
+11410
+-- !result
+[UC]function: rgn2_id=get_resource_group_id('rgn2_${uuid0}')
+-- result:
+11412
+-- !result
+select
+    min(bound_cpus)=cast(${num_cores}*0.3 as int),
+    max(bound_cpus)=cast(${num_cores}*0.3 as int)
+from information_schema.be_threads where name = 'pip_exec_${rgd1_id}';
+-- result:
+1	1
+-- !result
+select count(1)=cast(${num_cores}*0.3 as int) as num_threads from information_schema.be_threads where name = 'pip_exec_${rgd1_id}' and be_id = (select be_id from information_schema.be_threads where name = 'pip_exec_${rgd1_id}' limit 1);
+-- result:
+1
+-- !result
+select min(bound_cpus)=cast(${num_cores}*0.5 as int), max(bound_cpus)=cast(${num_cores}*0.5 as int) from information_schema.be_threads where name = 'pip_exec_${rgd2_id}';
+-- result:
+1	1
+-- !result
+select count(1)=cast(${num_cores}*0.5 as int) as num_threads from information_schema.be_threads where name = 'pip_exec_${rgd2_id}' and be_id = (select be_id from information_schema.be_threads where name = 'pip_exec_${rgd2_id}' limit 1);
+-- result:
+1
+-- !result
+select count(1) from information_schema.be_threads where name = 'pip_exec_${rgn1_id}';
+-- result:
+0
+-- !result
+select count(1) from information_schema.be_threads where name = 'pip_exec_${rgn2_id}';
+-- result:
+0
+-- !result
+select
+        min(bound_cpus) = array_min([${num_cores} - cast(${num_cores}*0.5 as int) - cast(${num_cores}*0.3 as int), cast(${num_cores}*0.5 as int),  cast(${num_cores}*0.3 as int)]),
+        max(bound_cpus) = array_max([${num_cores} - cast(${num_cores}*0.5 as int) - cast(${num_cores}*0.3 as int), cast(${num_cores}*0.5 as int),  cast(${num_cores}*0.3 as int)])
+from information_schema.be_threads where name = 'pip_exec_com';
+-- result:
+1	1
+-- !result
+select count(1) = ${num_cores} from information_schema.be_threads where name = 'pip_exec_com' and be_id = (select be_id from information_schema.be_threads where name = 'pip_exec_com' limit 1);
+-- result:
+1
+-- !result
+DROP RESOURCE GROUP rgd1_${uuid0};
+-- result:
+-- !result
+[UC]SELECT sleep(5);
+-- result:
+1
+-- !result
+select min(bound_cpus)=cast(${num_cores}*0.5 as int), max(bound_cpus)=cast(${num_cores}*0.5 as int) from information_schema.be_threads where name = 'pip_exec_${rgd2_id}';
+-- result:
+1	1
+-- !result
+select count(1)=cast(${num_cores}*0.5 as int) as num_threads from information_schema.be_threads where name = 'pip_exec_${rgd2_id}' and be_id = (select be_id from information_schema.be_threads where name = 'pip_exec_${rgd2_id}' limit 1);
+-- result:
+1
+-- !result
+select count(1) from information_schema.be_threads where name = 'pip_exec_${rgn1_id}';
+-- result:
+0
+-- !result
+select count(1) from information_schema.be_threads where name = 'pip_exec_${rgn2_id}';
+-- result:
+0
+-- !result
+select
+    min(bound_cpus) = array_min([${num_cores} - cast(${num_cores}*0.5 as int), cast(${num_cores}*0.5 as int)]),
+    max(bound_cpus) = array_max([${num_cores} - cast(${num_cores}*0.5 as int), cast(${num_cores}*0.5 as int)])
+from information_schema.be_threads where name = 'pip_exec_com';
+-- result:
+1	1
+-- !result
+select count(1) = ${num_cores} from information_schema.be_threads where name = 'pip_exec_com' and be_id = (select be_id from information_schema.be_threads where name = 'pip_exec_com' limit 1);
+-- result:
+1
+-- !result
+DROP RESOURCE GROUP rgd2_${uuid0};
+-- result:
+-- !result
+[UC]SELECT sleep(5);
+-- result:
+1
+-- !result
+select count(1) from information_schema.be_threads where name = 'pip_exec_${rgn1_id}';
+-- result:
+0
+-- !result
+select count(1) from information_schema.be_threads where name = 'pip_exec_${rgn2_id}';
+-- result:
+0
+-- !result
+select
+    min(bound_cpus) = ${num_cores},
+    max(bound_cpus) = ${num_cores}
+from information_schema.be_threads where name = 'pip_exec_com';
+-- result:
+1	1
+-- !result
+select count(1) = ${num_cores} from information_schema.be_threads where name = 'pip_exec_com' and be_id = (select be_id from information_schema.be_threads where name = 'pip_exec_com' limit 1);
+-- result:
+1
+-- !result
+DROP RESOURCE GROUP rgn1_${uuid0};
+-- result:
+-- !result
+DROP RESOURCE GROUP rgn2_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_resource_group/T/test_resource_group_exclusive_cpu_percent
+++ b/test/sql/test_resource_group/T/test_resource_group_exclusive_cpu_percent
@@ -1,0 +1,78 @@
+-- name: test_resource_group_exclusive_cpu_percent @sequential
+
+CREATE RESOURCE GROUP rgd1_${uuid0}
+TO ( user='user_${uuid0}' )
+WITH ( 'exclusive_cpu_percent' = '30', 'mem_limit' = '0.99' );
+CREATE RESOURCE GROUP rgd2_${uuid0}
+TO ( user='user_${uuid0}' )
+WITH ( 'exclusive_cpu_percent' = '50', 'mem_limit' = '0.99' );
+CREATE RESOURCE GROUP rgn1_${uuid0}
+TO ( user='user_${uuid0}' )
+WITH ( 'cpu_weight_percent' = '4', 'mem_limit' = '0.99' );
+CREATE RESOURCE GROUP rgn2_${uuid0}
+TO ( user='user_${uuid0}' )
+WITH ( 'cpu_weight_percent' = '5', 'mem_limit' = '0.99' );
+
+[UC]SELECT sleep(10);
+
+[UC]function: num_cores=get_backend_cpu_cores()
+[UC]function: rgd1_id=get_resource_group_id('rgd1_${uuid0}')
+[UC]function: rgd2_id=get_resource_group_id('rgd2_${uuid0}')
+[UC]function: rgn1_id=get_resource_group_id('rgn1_${uuid0}')
+[UC]function: rgn2_id=get_resource_group_id('rgn2_${uuid0}')
+
+
+select
+    min(bound_cpus)=cast(${num_cores}*0.3 as int),
+    max(bound_cpus)=cast(${num_cores}*0.3 as int)
+from information_schema.be_threads where name = 'pip_exec_${rgd1_id}';
+select count(1)=cast(${num_cores}*0.3 as int) as num_threads from information_schema.be_threads where name = 'pip_exec_${rgd1_id}' and be_id = (select be_id from information_schema.be_threads where name = 'pip_exec_${rgd1_id}' limit 1);
+
+select min(bound_cpus)=cast(${num_cores}*0.5 as int), max(bound_cpus)=cast(${num_cores}*0.5 as int) from information_schema.be_threads where name = 'pip_exec_${rgd2_id}';
+select count(1)=cast(${num_cores}*0.5 as int) as num_threads from information_schema.be_threads where name = 'pip_exec_${rgd2_id}' and be_id = (select be_id from information_schema.be_threads where name = 'pip_exec_${rgd2_id}' limit 1);
+
+select count(1) from information_schema.be_threads where name = 'pip_exec_${rgn1_id}';
+select count(1) from information_schema.be_threads where name = 'pip_exec_${rgn2_id}';
+
+select
+        min(bound_cpus) = array_min([${num_cores} - cast(${num_cores}*0.5 as int) - cast(${num_cores}*0.3 as int), cast(${num_cores}*0.5 as int),  cast(${num_cores}*0.3 as int)]),
+        max(bound_cpus) = array_max([${num_cores} - cast(${num_cores}*0.5 as int) - cast(${num_cores}*0.3 as int), cast(${num_cores}*0.5 as int),  cast(${num_cores}*0.3 as int)])
+from information_schema.be_threads where name = 'pip_exec_com';
+select count(1) = ${num_cores} from information_schema.be_threads where name = 'pip_exec_com' and be_id = (select be_id from information_schema.be_threads where name = 'pip_exec_com' limit 1);
+
+
+
+DROP RESOURCE GROUP rgd1_${uuid0};
+[UC]SELECT sleep(5);
+
+select min(bound_cpus)=cast(${num_cores}*0.5 as int), max(bound_cpus)=cast(${num_cores}*0.5 as int) from information_schema.be_threads where name = 'pip_exec_${rgd2_id}';
+select count(1)=cast(${num_cores}*0.5 as int) as num_threads from information_schema.be_threads where name = 'pip_exec_${rgd2_id}' and be_id = (select be_id from information_schema.be_threads where name = 'pip_exec_${rgd2_id}' limit 1);
+
+select count(1) from information_schema.be_threads where name = 'pip_exec_${rgn1_id}';
+select count(1) from information_schema.be_threads where name = 'pip_exec_${rgn2_id}';
+
+select
+    min(bound_cpus) = array_min([${num_cores} - cast(${num_cores}*0.5 as int), cast(${num_cores}*0.5 as int)]),
+    max(bound_cpus) = array_max([${num_cores} - cast(${num_cores}*0.5 as int), cast(${num_cores}*0.5 as int)])
+from information_schema.be_threads where name = 'pip_exec_com';
+select count(1) = ${num_cores} from information_schema.be_threads where name = 'pip_exec_com' and be_id = (select be_id from information_schema.be_threads where name = 'pip_exec_com' limit 1);
+
+
+
+DROP RESOURCE GROUP rgd2_${uuid0};
+[UC]SELECT sleep(5);
+
+select count(1) from information_schema.be_threads where name = 'pip_exec_${rgn1_id}';
+select count(1) from information_schema.be_threads where name = 'pip_exec_${rgn2_id}';
+
+select
+    min(bound_cpus) = ${num_cores},
+    max(bound_cpus) = ${num_cores}
+from information_schema.be_threads where name = 'pip_exec_com';
+select count(1) = ${num_cores} from information_schema.be_threads where name = 'pip_exec_com' and be_id = (select be_id from information_schema.be_threads where name = 'pip_exec_com' limit 1);
+
+
+DROP RESOURCE GROUP rgn1_${uuid0};
+DROP RESOURCE GROUP rgn2_${uuid0};
+
+


### PR DESCRIPTION
## Why I'm doing:

### I. Add an optional property `warehouses` to resource groups.
- When this property is set, the resource group is effective only in the specified warehouses.
- Requirements for the `warehouses` property:
  - Multiple warehouses can be specified, separated by `,`.
  - The property can be modified.

### II. Change `cpu_weight_percent` and `exclusive_cpu_percent` to percentages, allowing values in the range `[0, 100]`.

`cpu_weight_percent`
- For the default resource group `default_wg`, `cpu_weight_percent` is set to 100.

`exclusive_cpu_percent`
- Actual core allocation: on a BE, the actual number of allocated cores is  
  $$exclusive\\_cpu\\_cores = \lfloor exclusive\\_cpu\\_percent \times be\\_cores \rfloor$$
- Constraints:
  - When creating or modifying a resource group, it is not allowed to set `exclusive_cpu_percent` such that  
    `exclusive_cpu_percent * min_be_cpu_cores < 1`,  
    where `min_be_cpu_cores` is the minimum number of CPU cores of a single BE among all warehouses bound to this resource group.
  - When creating or modifying a resource group, the sum of  
    `exclusive_cpu_percent * min_be_cpu_cores`  
    across all resource groups effective on a warehouse must not exceed `min_be_cpu_cores - 1`.

- Issue: after a scale-down operation, `minBeCores` may become smaller, causing  
  `exclusive_cpu_percent * minBeCores < 1`.
  - Solution: there is no perfect solution; in this case, the resource group can only degrade to a non–hard-isolation resource group on that BE.

Compatibility considerations
- Only one of `cpu_weight_percent` and the legacy `cpu_weight` can be set.
  - `cpu_weight_percent` takes precedence if present; otherwise, `cpu_weight` is used.
  - When using `cpu_weight`, setting `warehouses` is not allowed.
- Only one of `exclusive_cpu_percent` and the legacy `exclusive_cpu_cores` can be set.
  - `exclusive_cpu_percent` takes precedence if present; otherwise, `exclusive_cpu_cores` is used.
  - When using `exclusive_cpu_cores`, setting `warehouses` is not allowed.

## What I'm doing:

Fixes #67195

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces warehouse-aware and percent-based CPU allocation for resource groups with full FE/BE integration and validations.
> 
> - Adds `warehouses` property; marks WG ops inactive on BEs outside bound warehouses; propagates via thrift
> - Supports `cpu_weight_percent` and `exclusive_cpu_percent` (mutually exclusive with legacy fields); BE computes weights from host cores; respects `inactive`
> - Enforces validations: exclusivity among CPU knobs, value ranges, warehouse constraints, min-1-core guarantee, and per-warehouse sum of exclusive cores
> - Extends `BackendResourceStat` with per-warehouse min/avg and "except warehouses" helpers
> - Defaults: builtin groups use percent (e.g., `default_wg` = 100%); SHOW output gains columns for percent and warehouses
> - Cleans BE API (remove `to_thrift_verbose`), add `<algorithm>` include; FE logs/ops carry new fields
> - Updates/extends unit tests for new columns, semantics, mem_pool interactions, and warehouse scenarios
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3412102416539ba7b44a26cfd2c4e57a3651ae89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->