### PR TITLE
[UT] Use ID instead of StartTime to detect new analyze jobs

### DIFF
--- a/test/sql/test_analyze_statistics/R/test_update_trigger_statistics
+++ b/test/sql/test_analyze_statistics/R/test_update_trigger_statistics
@@ -25,11 +25,18 @@ where table_name = "test_update_trigger_statistics.test_update_stats" ;
 -- !result
 CREATE VIEW analyze_status_verify AS
 select `Table`, Columns, Type, 
-    IF(StartTime >= @last_analyze, 'new analyze', 'no analyze') as is_new from information_schema.analyze_status
+    IF(cast(Id as bigint) > @last_analyze_id, 'new analyze', 'no analyze') as is_new from information_schema.analyze_status
 where 
     `Database` = 'test_update_trigger_statistics' 
     and `Table` = "test_update_stats" 
-order by StartTime desc limit 1;
+order by cast(Id as bigint) desc limit 1;
+-- result:
+-- !result
+CREATE VIEW last_analyze_id_view AS
+select ifnull(max(cast(Id as bigint)), 0) as last_id
+from information_schema.analyze_status 
+where `Database` = 'test_update_trigger_statistics' 
+  and `Table` = "test_update_stats";
 -- result:
 -- !result
 delete from _statistics_.column_statistics where table_name='test_update_trigger_statistics.test_update_stats';
@@ -43,7 +50,7 @@ select * from statistic_verify order by column_name;
 k2	test_update_stats	1000000	1000000	1
 k3	test_update_stats	1000000	data	data
 -- !result
-set @last_analyze=(select now());
+set @last_analyze_id=(select last_id from last_analyze_id_view);
 -- result:
 -- !result
 update test_update_stats set k3 = '1updated' where k2 = 1;
@@ -70,7 +77,7 @@ select * from analyze_status_verify;
 -- result:
 test_update_stats	ALL	SAMPLE	no analyze
 -- !result
-set @last_analyze=(select now());
+set @last_analyze_id=(select last_id from last_analyze_id_view);
 -- result:
 -- !result
 update test_update_stats set k3 = '3updated3' where k2 < 200*1000;
@@ -85,7 +92,7 @@ select * from analyze_status_verify;
 -- result:
 test_update_stats	ALL	FULL	new analyze
 -- !result
-set @last_analyze=(select now());
+set @last_analyze_id=(select last_id from last_analyze_id_view);
 -- result:
 -- !result
 update test_update_stats set k3 = '4updated4' where k2 < 1000000000;
@@ -102,6 +109,9 @@ drop view  statistic_verify;
 -- result:
 -- !result
 drop view  analyze_status_verify;
+-- result:
+-- !result
+drop view  last_analyze_id_view;
 -- result:
 -- !result
 delete from _statistics_.column_statistics where table_name='test_update_trigger_statistics.test_update_stats';

--- a/test/sql/test_analyze_statistics/T/test_update_trigger_statistics
+++ b/test/sql/test_analyze_statistics/T/test_update_trigger_statistics
@@ -18,14 +18,22 @@ select column_name, partition_name, row_count, max, min
 from _statistics_.column_statistics 
 where table_name = "test_update_trigger_statistics.test_update_stats" ;
 
+-- check if there's a new analyze job since last analyze id
 CREATE VIEW analyze_status_verify AS
 select `Table`, Columns, Type, 
-    IF(StartTime >= @last_analyze, 'new analyze', 'no analyze') as is_new 
+    IF(cast(Id as bigint) > @last_analyze_id, 'new analyze', 'no analyze') as is_new 
 from information_schema.analyze_status
 where 
     `Database` = 'test_update_trigger_statistics' 
     and `Table` = "test_update_stats" 
-order by StartTime desc limit 1;
+order by cast(Id as bigint) desc limit 1;
+
+-- last_id: last analyze id in information_schema.analyze_status
+CREATE VIEW last_analyze_id_view AS
+select ifnull(max(cast(Id as bigint)), 0) as last_id
+from information_schema.analyze_status 
+where `Database` = 'test_update_trigger_statistics' 
+  and `Table` = "test_update_stats";
 
 
 -- Clear any existing statistics
@@ -36,7 +44,7 @@ insert into test_update_stats select generate_series, 'data' from table(generate
 select * from statistic_verify order by column_name;
 
 -- UPDATE a few rows should not trigger statistics collection
-set @last_analyze=(select now());
+set @last_analyze_id=(select last_id from last_analyze_id_view);
 update test_update_stats set k3 = '1updated' where k2 = 1;
 select * from statistic_verify order by column_name;
 select * from analyze_status_verify;
@@ -45,13 +53,13 @@ select * from statistic_verify order by column_name;
 select * from analyze_status_verify;
 
 -- UPDATE lots of rows 
-set @last_analyze=(select now());
+set @last_analyze_id=(select last_id from last_analyze_id_view);
 update test_update_stats set k3 = '3updated3' where k2 < 200*1000;
 select * from statistic_verify order by column_name;
 select * from analyze_status_verify;
 
 -- UPDATE all rows 
-set @last_analyze=(select now());
+set @last_analyze_id=(select last_id from last_analyze_id_view);
 update test_update_stats set k3 = '4updated4' where k2 < 1000000000;
 -- sample result is not stable
 -- select * from statistic_verify order by column_name;
@@ -60,4 +68,5 @@ select * from analyze_status_verify;
 drop table test_update_stats;
 drop view  statistic_verify;
 drop view  analyze_status_verify;
+drop view  last_analyze_id_view;
 delete from _statistics_.column_statistics where table_name='test_update_trigger_statistics.test_update_stats';


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

fix `test_update_trigger_statistics`

The `test_update_trigger_statistics` SQL test previously relied on `now()` and `StartTime` to identify new analyze jobs. However, this approach was susceptible to flakiness due to the second-level precision of these timestamps, potentially causing jobs started within the same second as the reference time to be misidentified.

This update replaces the use of timestamps with the monotonically increasing `Id` from `information_schema.analyze_status`, ensuring a more reliable method for identifying new jobs.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
