### PR TITLE
[Enhancement] Validate strict weak ordering property of lambda comparator in array_sort

### DIFF
--- a/test/sql/test_array_fn/R/test_array_sort_lambda
+++ b/test/sql/test_array_fn/R/test_array_sort_lambda
@@ -85,13 +85,29 @@ SELECT distinct array_sort([1, 1, 1, 1], (x, y) -> IF(x < y, -1, IF(x = y, 0, 1)
 -- result:
 [1,1,1,1]
 -- !result
-SELECT distinct array_sort([3, 2, 5, 1, 2], (x, y) -> k0%3-2) <=3 from t0;
+SELECT distinct array_min(array_sort([3, 2, 5, 1, 2], (x, y) -> k0%3-2)) <=3 from t0;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 16 to line 1, column 64. Detail message: Column type array<tinyint(4)> does not support binary predicate operation with type tinyint(4).')
+E: (1064, 'Getting analyzing error. Detail message: Lambda function in sort_array should only depend on both two arguments and contain no non-deterministic functions.')
 -- !result
-SELECT distinct array_sort(c0, (x, y) -> k0%3-2)<=array_max(c0) from t0;
+SELECT distinct array_min(array_sort(c0, (x, y) -> k0%3-2))<=array_max(c0) from t0;
 -- result:
-E: (1064, 'Getting analyzing error from line 1, column 16 to line 1, column 62. Detail message: Column type array<tinyint(4)> does not support binary predicate operation with type tinyint(4).')
+E: (1064, 'Getting analyzing error. Detail message: Lambda function in sort_array should only depend on both two arguments and contain no non-deterministic functions.')
+-- !result
+SELECT array_sort([1,2,3,4,5,6,7,8], (x,y)->CASE WHEN x = 1 THEN -1 ELSE x - y END);
+-- result:
+[REGEX].*Comparator violates irreflexivity.*
+-- !result
+SELECT array_sort([1,2,3,4,5,6,7,8], (x,y)->CASE WHEN (x = 1 and y = 2) or (y = 1 and x = 2) THEN -1 ELSE x - y END);
+-- result:
+[REGEX].*Comparator violates asymmetry.*
+-- !result
+SELECT array_sort([1,2,3,4,5,6,7,8], (x,y)->CASE  WHEN x = 1 and y = 2 THEN -1 WHEN x <= 6 and y <= 6 THEN 1  ELSE x - y END);
+-- result:
+[REGEX].*Comparator violates incomparability transitivity.*
+-- !result
+SELECT array_sort([1,2,3,4,5,6,7,8], (x,y)->CASE WHEN (x = 1 and y = 2) or (x = 2 and y = 3) or (x = 3 and y = 1) THEN -1 WHEN x = 1 and y = 3 THEN 1 ELSE x - y END);
+-- result:
+[REGEX].*Comparator violates transitivity.*
 -- !result
 with cte as (
 select array_agg(k0) as arr
@@ -165,7 +181,7 @@ drop table t0;
 -- !result
 SELECT array_sort([3, 2, null, 5, null, 1, 2], (x, y) -> CASE WHEN x IS NULL THEN -1 WHEN y IS NULL THEN 1 WHEN x < y THEN 1 WHEN x = y THEN 0 ELSE -1 END);
 -- result:
-[null,null,5,3,2,2,1]
+[REGEX].*Comparator violates irreflexivity.*
 -- !result
 SELECT array_sort([3, 2, null, 5, null, 1, 2], (x, y) -> CASE WHEN x IS NULL THEN 1 WHEN y IS NULL THEN -1 WHEN x < y THEN 1 WHEN x = y THEN 0 ELSE -1 END);
 -- result:
@@ -187,7 +203,7 @@ from table(generate_series(0,10000)) t(i);
 -- !result
 SELECT distinct  array_sort([3, 2, null, 5, null, 1, 2], (x, y) -> CASE WHEN x IS NULL THEN -1 WHEN y IS NULL THEN 1 WHEN x < y THEN 1 WHEN x = y THEN 0 ELSE -1 END) from t0;
 -- result:
-[null,null,5,3,2,2,1]
+[REGEX].*Comparator violates irreflexivity.*
 -- !result
 SELECT distinct array_sort([3, 2, null, 5, null, 1, 2], (x, y) -> CASE WHEN x IS NULL THEN 1 WHEN y IS NULL THEN -1 WHEN x < y THEN 1 WHEN x = y THEN 0 ELSE -1 END) from t0;
 -- result:
@@ -195,7 +211,7 @@ SELECT distinct array_sort([3, 2, null, 5, null, 1, 2], (x, y) -> CASE WHEN x IS
 -- !result
 SELECT distinct array_sort(c0, (x, y) -> CASE WHEN x IS NULL THEN -1 WHEN y IS NULL THEN 1 WHEN x < y THEN 1 WHEN x = y THEN 0 ELSE -1 END) from t0;
 -- result:
-[null,null,5,3,2,2,1]
+[REGEX].*Comparator violates irreflexivity.*
 -- !result
 SELECT distinct array_sort(c0, (x, y) -> CASE WHEN x IS NULL THEN 1 WHEN y IS NULL THEN -1 WHEN x < y THEN 1 WHEN x = y THEN 0 ELSE -1 END) from t0;
 -- result:

--- a/test/sql/test_array_fn/T/test_array_sort_lambda
+++ b/test/sql/test_array_fn/T/test_array_sort_lambda
@@ -41,8 +41,13 @@ SELECT distinct array_sort([], (x, y) -> IF(x < y, -1, IF(x = y, 0, 1)));
 SELECT distinct array_sort([5], (x, y) -> IF(x < y, -1, IF(x = y, 0, 1)));
 SELECT distinct array_sort([1, 1, 1, 1], (x, y) -> IF(x < y, -1, IF(x = y, 0, 1)));
 
-SELECT distinct array_sort([3, 2, 5, 1, 2], (x, y) -> k0%3-2) <=3 from t0;
-SELECT distinct array_sort(c0, (x, y) -> k0%3-2)<=array_max(c0) from t0;
+SELECT distinct array_min(array_sort([3, 2, 5, 1, 2], (x, y) -> k0%3-2)) <=3 from t0;
+SELECT distinct array_min(array_sort(c0, (x, y) -> k0%3-2))<=array_max(c0) from t0;
+
+SELECT array_sort([1,2,3,4,5,6,7,8], (x,y)->CASE WHEN x = 1 THEN -1 ELSE x - y END);
+SELECT array_sort([1,2,3,4,5,6,7,8], (x,y)->CASE WHEN (x = 1 and y = 2) or (y = 1 and x = 2) THEN -1 ELSE x - y END);
+SELECT array_sort([1,2,3,4,5,6,7,8], (x,y)->CASE  WHEN x = 1 and y = 2 THEN -1 WHEN x <= 6 and y <= 6 THEN 1  ELSE x - y END);
+SELECT array_sort([1,2,3,4,5,6,7,8], (x,y)->CASE WHEN (x = 1 and y = 2) or (x = 2 and y = 3) or (x = 3 and y = 1) THEN -1 WHEN x = 1 and y = 3 THEN 1 ELSE x - y END);
 
 with cte as (
 select array_agg(k0) as arr


### PR DESCRIPTION
## Why I'm doing:
Improve #https://github.com/StarRocks/starrocks/pull/66607 to check strict weak ordering property of lambda comparator, if not satisfies the property. BE report an error to user.
## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add strict weak ordering validation and arg-only enforcement for `array_sort` lambda comparator, refactor comparator/evaluation, and update tests accordingly.
> 
> - **Backend (exprs)**:
>   - **`ArraySortLambdaExpr`**:
>     - Add `check_lambda_only_depends_on_args` and `validate_strict_weak_ordering` (with cached result) to enforce comparator correctness (irreflexivity, asymmetry, transitivity) and dependency on only `x,y`.
>     - Introduce unique-element extraction for validator and use `SortComparator` to probe ordering.
>     - Refactor: remove templated paths; simplify `SortComparator` and `evaluate_lambda_expr` to always set lambda args and array start; streamline sorting and error propagation (e.g., NULL comparator result).
> - **Tests (SQL)**:
>   - Update/extend cases to expect analyzer errors for non-arg or non-deterministic comparators and regex-matched errors for ordering violations.
>   - Minor query adjustments (e.g., use `array_min(...)` wrappers) to exercise validation paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39b571ed0e6b02f7ea9fe69cc53b91609bbbad54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->