### PR TITLE
[BugFix] Fix cache inconsistency in ObjectColumn

### DIFF
--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -55,7 +55,15 @@ public:
 
     ObjectColumn(const ObjectColumn& column) { DCHECK(false) << "Can't copy construct object column"; }
 
-    ObjectColumn(ObjectColumn&& object_column) noexcept : _pool(std::move(object_column._pool)) {}
+    ObjectColumn(ObjectColumn&& object_column) noexcept
+            : _pool(std::move(object_column._pool)),
+              _cache_ok(object_column._cache_ok),
+              _cache(std::move(object_column._cache)),
+              _slices(std::move(object_column._slices)),
+              _buffer(std::move(object_column._buffer)) {
+        // reset source column
+        object_column._cache_ok = false;
+    }
 
     void operator=(const ObjectColumn&) = delete;
 
@@ -90,9 +98,9 @@ public:
 
     size_t byte_size(size_t idx) const override;
 
-    void reserve(size_t n) override { _pool.reserve(n); }
+    void reserve(size_t n) override;
 
-    void resize(size_t n) override { _pool.resize(n); }
+    void resize(size_t n) override;
 
     void assign(size_t n, size_t idx) override;
 

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -55,16 +55,6 @@ public:
 
     ObjectColumn(const ObjectColumn& column) { DCHECK(false) << "Can't copy construct object column"; }
 
-    ObjectColumn(ObjectColumn&& object_column) noexcept
-            : _pool(std::move(object_column._pool)),
-              _cache_ok(object_column._cache_ok),
-              _cache(std::move(object_column._cache)),
-              _slices(std::move(object_column._slices)),
-              _buffer(std::move(object_column._buffer)) {
-        // reset source column
-        object_column._cache_ok = false;
-    }
-
     void operator=(const ObjectColumn&) = delete;
 
     ObjectColumn& operator=(ObjectColumn&& rhs) noexcept {


### PR DESCRIPTION
## Why I'm doing:

When retrieving a `JsonValue` from `ObjectColumn::get_data()`, it may sometimes return `nullptr`, which is not expected and cause segment fault.

## What I'm doing:

Ensure the object column's pointer cache is invalidated whenever the underlying data pool is modified or reallocated. This prevents dangling pointers in the cache which could lead to segmentation faults or data corruption.

- Invalidate cache by resetting `_cache_ok` in `reserve`, `resize`,  `deserialize_and_append`, and `filter_range`.
- `reserve`: it might expand the vector, which can invalidate pointers in `_cache`

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure ObjectColumn cache is invalidated on resize/reserve, deserialization append, and filtering, and correctly handled in move construction.
> 
> - **ObjectColumn<T>**:
>   - **Cache correctness**:
>     - Invalidate pointer cache (`_cache_ok = false`) on `resize`, `reserve`, `deserialize_and_append`, and `filter_range`.
>   - **Move semantics**:
>     - Move cache-related members (`_cache_ok`, `_cache`, `_slices`, `_buffer`) in move constructor and reset source `_cache_ok`.
>   - **Signatures**:
>     - Replace inline `reserve/resize` with overrides that invalidate cache.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06e8cb997c05c0ef8c304787fe9eaa9c07ba15ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->