### PR TITLE
[Enhancement] Use more sophisticated statistics to infer skew for GroupByCountDistinctDataSkewEliminateRule (backport #66640)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -834,6 +834,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // control on/off of this bucketization optimization.
     public static final String DISTINCT_COLUMN_BUCKETS = "count_distinct_column_buckets";
     public static final String ENABLE_DISTINCT_COLUMN_BUCKETIZATION = "enable_distinct_column_bucketization";
+    public static final String DATA_SKEW_ROW_PERCENTAGE_THRESHOLD = "data_skew_row_percentage_threshold";
     public static final String HDFS_BACKEND_SELECTOR_SCAN_RANGE_SHUFFLE = "hdfs_backend_selector_scan_range_shuffle";
 
     public static final String SQL_QUOTE_SHOW_CREATE = "sql_quote_show_create";
@@ -2636,6 +2637,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = ENABLE_DISTINCT_COLUMN_BUCKETIZATION)
     private boolean enableDistinctColumnBucketization = false;
 
+    @VariableMgr.VarAttr(name = DATA_SKEW_ROW_PERCENTAGE_THRESHOLD)
+    private double dataSkewRowPercentageThreshold = 0.2;
+
     @VariableMgr.VarAttr(name = HDFS_BACKEND_SELECTOR_SCAN_RANGE_SHUFFLE, flag = VariableMgr.INVISIBLE)
     private boolean hdfsBackendSelectorScanRangeShuffle = false;
 
@@ -3164,6 +3168,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean isEnableDistinctColumnBucketization() {
         return enableDistinctColumnBucketization;
+    }
+
+    public void setDataSkewRowPercentageThreshold(double threshold) {
+        dataSkewRowPercentageThreshold = threshold;
+    }
+
+    public double getDataSkewRowPercentageThreshold() {
+        return dataSkewRowPercentageThreshold;
     }
 
     public boolean getHudiMORForceJNIReader() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalAggregationOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalAggregationOperator.java
@@ -28,7 +28,6 @@ import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.AggType;
 import com.starrocks.sql.optimizer.operator.ColumnOutputInfo;
-import com.starrocks.sql.optimizer.operator.DataSkewInfo;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
@@ -37,6 +36,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorUtil;
 import com.starrocks.sql.optimizer.property.DomainProperty;
 import com.starrocks.sql.optimizer.property.DomainPropertyDeriver;
+import com.starrocks.sql.optimizer.skew.DataSkewInfo;
 import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.ArrayList;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashAggregateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashAggregateOperator.java
@@ -27,7 +27,6 @@ import com.starrocks.sql.optimizer.RowOutputInfo;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.AggType;
 import com.starrocks.sql.optimizer.operator.ColumnOutputInfo;
-import com.starrocks.sql.optimizer.operator.DataSkewInfo;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.OperatorVisitor;
 import com.starrocks.sql.optimizer.operator.Projection;
@@ -35,6 +34,7 @@ import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.skew.DataSkewInfo;
 import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.List;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkew.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkew.java
@@ -1,0 +1,85 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.sql.optimizer.skew;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.Pair;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.optimizer.statistics.Statistics;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import javax.validation.constraints.NotNull;
+
+public class DataSkew {
+    private static final int DEFAULT_MCV_LIMIT = 5;
+    private static final double DEFAULT_RELATIVE_ROW_THRESHOLD = 0.2;
+    private static final Thresholds DEFAULT_THRESHOLDS = new Thresholds(DEFAULT_MCV_LIMIT, DEFAULT_RELATIVE_ROW_THRESHOLD);
+
+    public record Thresholds(int mcvLimit, double relativeRowThreshold) {
+        public static Thresholds withRelativeRowThreshold(double relativeRowThreshold) {
+            return new Thresholds(DEFAULT_MCV_LIMIT, relativeRowThreshold);
+        }
+
+        public static Thresholds withMcvLimit(int mcvLimit) {
+            return new Thresholds(mcvLimit, DEFAULT_RELATIVE_ROW_THRESHOLD);
+        }
+    }
+
+    /**
+     * Utility method to check if a certain column is skewed based on statistics.
+     */
+    public static boolean isColumnSkewed(@NotNull Statistics statistics, @NotNull ColumnStatistic columnStatistic,
+                                         Thresholds thresholds) {
+        if (columnStatistic.getNullsFraction() >= thresholds.relativeRowThreshold) {
+            // A lot of NULL values also indicate skew.
+            return true;
+        }
+
+        final var rowCount = statistics.getOutputRowCount();
+        if (statistics.isTableRowCountMayInaccurate() || rowCount < 1 || columnStatistic.isUnknown() ||
+                columnStatistic.isUnknownValue()) {
+            // Without sufficient information we can not make a decision.
+            return false;
+        }
+
+        final var histogram = columnStatistic.getHistogram();
+        if (histogram != null) {
+            final var mcv = histogram.getMCV();
+
+            if (mcv != null) {
+                List<Pair<String, Long>> mcvs = Lists.newArrayList();
+                int mcvLimit = Math.min(thresholds.mcvLimit, mcv.size());
+                mcv.entrySet().stream()
+                        .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder())) //
+                        .limit(mcvLimit)
+                        .forEach(entry -> {
+                            mcvs.add(Pair.create(entry.getKey(), entry.getValue()));
+                        });
+
+                long rowCountOfMcvs = mcvs.stream().mapToLong(pair -> pair.second).sum();
+                return ((double) rowCountOfMcvs / rowCount) > thresholds.relativeRowThreshold;
+            }
+        }
+
+        // No histogram information, can not deduce skew.
+        return false;
+    }
+
+    /* Always using default thresholds */
+    public static boolean isColumnSkewed(@NotNull Statistics statistics, @NotNull ColumnStatistic columnStatistic) {
+        return isColumnSkewed(statistics, columnStatistic, DEFAULT_THRESHOLDS);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkewInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkewInfo.java
@@ -12,21 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package com.starrocks.sql.optimizer.operator;
+package com.starrocks.sql.optimizer.skew;
 
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 
 public class DataSkewInfo {
     private ColumnRefOperator skewColumnRef;
-    private double penaltyFactor = 1.0;
-    private int stage = 0;
+    private double penaltyFactor;
+    private int stage;
 
     public ColumnRefOperator getSkewColumnRef() {
         return skewColumnRef;
-    }
-
-    public void setSkewColumnRef(ColumnRefOperator skewColumnRef) {
-        this.skewColumnRef = skewColumnRef;
     }
 
     public double getPenaltyFactor() {
@@ -43,6 +39,10 @@ public class DataSkewInfo {
 
     public void setStage(int stage) {
         this.stage = stage;
+    }
+
+    public void setSkewColumnRef(ColumnRefOperator skewColumnRef) {
+        this.skewColumnRef = skewColumnRef;
     }
 
     public DataSkewInfo(ColumnRefOperator skewColumnRef, double penaltyFactor, int stage) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/skew/DataSkewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/skew/DataSkewTest.java
@@ -1,0 +1,164 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.skew;
+
+import com.google.crypto.tink.subtle.Random;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.statistics.Bucket;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.optimizer.statistics.Histogram;
+import com.starrocks.sql.optimizer.statistics.Statistics;
+import com.starrocks.type.IntegerType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DataSkewTest {
+
+    private static ColumnRefOperator createNewTestColumn() {
+        return new ColumnRefOperator(Random.randInt(), IntegerType.INT, UUID.randomUUID().toString(), true);
+    }
+
+    @Test
+    void itShouldDetectNullSkew() {
+        // GIVEN
+        final var skewedCol = createNewTestColumn();
+        final var skewedColStats = ColumnStatistic.builder()
+                .setNullsFraction(0.9 /* heavily null skewed */) //
+                .build();
+
+        final var nonSkewedCol = createNewTestColumn();
+        final var nonSkewedColStats = ColumnStatistic.builder()
+                .setNullsFraction(0.1 /* not null skewed */) //
+                .build();
+
+        final var stats = new Statistics.Builder()
+                .addColumnStatistic(skewedCol, skewedColStats) //
+                .addColumnStatistic(nonSkewedCol, nonSkewedColStats) //
+                .build();
+
+        // WHEN / THEN
+        assertTrue(DataSkew.isColumnSkewed(stats, skewedColStats));
+        assertFalse(DataSkew.isColumnSkewed(stats, nonSkewedColStats));
+    }
+
+    @Test
+    void itShouldReturnFalseWhenNoStatistics() {
+        // GIVEN
+        final var col = createNewTestColumn();
+        final var colStats = ColumnStatistic.unknown();
+
+        final var stats = new Statistics.Builder()
+                .addColumnStatistic(col, colStats) //
+                .build();
+
+        // WHEN / THEN
+        assertFalse(DataSkew.isColumnSkewed(stats, colStats));
+    }
+
+    @Test
+    void itShouldRespectCustomThresholds() {
+        // GIVEN
+        final var skewedCol = createNewTestColumn();
+        final var skewedColStats = ColumnStatistic.builder()
+                .setNullsFraction(0.7) //
+                .build();
+
+        final var nonSkewedCol = createNewTestColumn();
+        final var nonSkewedColStats = ColumnStatistic.builder()
+                .setNullsFraction(0.6) //
+                .build();
+
+        final var stats = new Statistics.Builder()
+                .addColumnStatistic(skewedCol, skewedColStats) //
+                .addColumnStatistic(nonSkewedCol, nonSkewedColStats) //
+                .build();
+
+        // WHEN / THEN
+        assertTrue(DataSkew.isColumnSkewed(stats, skewedColStats, new DataSkew.Thresholds(5, 0.7)));
+        assertFalse(DataSkew.isColumnSkewed(stats, skewedColStats, new DataSkew.Thresholds(5, 0.71)));
+        assertFalse(DataSkew.isColumnSkewed(stats, nonSkewedColStats, new DataSkew.Thresholds(5, 0.7)));
+    }
+
+    @Test
+    void itShouldDetectHistogramSkew() {
+        // GIVEN
+        final var skewedHistogram = getSkewedHistogram();
+        final var skewedCol = createNewTestColumn();
+        final var skewedColStats = ColumnStatistic.builder()
+                .setNullsFraction(0.01) //
+                .setHistogram(skewedHistogram) //
+                .build();
+
+        final var nonSkewedHistogram = getNonSkewedHistogram();
+        final var nonSkewedCol = createNewTestColumn();
+        final var nonSkewedColStats = ColumnStatistic.builder()
+                .setNullsFraction(0.02) //
+                .setHistogram(nonSkewedHistogram) //
+                .build();
+
+        final var stats = new Statistics.Builder()
+                .setOutputRowCount(100_000)
+                .addColumnStatistic(skewedCol, skewedColStats) //
+                .addColumnStatistic(nonSkewedCol, nonSkewedColStats) //
+                .build();
+
+        // WHEN / THEN
+        assertTrue(DataSkew.isColumnSkewed(stats, skewedColStats));
+        assertFalse(DataSkew.isColumnSkewed(stats, nonSkewedColStats));
+    }
+
+    private static Histogram getSkewedHistogram() {
+        List<Bucket> skewedBuckets = List.of(
+                new Bucket(6, 20, 1000L, 50L), // skew
+                new Bucket(21, 100, 1200L, 10L),
+                new Bucket(101, 1000, 1250L, 1L),
+                new Bucket(1001, 10000, 1260L, 1L)
+        );
+
+        Map<String, Long> skewedMcv = Map.of(
+                "1", 50000L,  // skew
+                "2", 20000L,
+                "3", 10000L,
+                "4", 5000L,
+                "5", 500L
+        );
+
+        return new Histogram(skewedBuckets, skewedMcv);
+    }
+
+    private static Histogram getNonSkewedHistogram() {
+        Map<String, Long> uniformMcv = Map.of(
+                "50", 10L,
+                "150", 10L,
+                "250", 10L,
+                "350", 10L
+        );
+
+        List<Bucket> uniformBuckets = List.of(
+                new Bucket(0, 99, 990L, 10L),
+                new Bucket(100, 199, 1980L, 10L),
+                new Bucket(200, 299, 2970L, 10L),
+                new Bucket(300, 399, 3960L, 10L)
+        );
+
+        return new Histogram(uniformBuckets, uniformMcv);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/skew/DataSkewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/skew/DataSkewTest.java
@@ -15,12 +15,12 @@
 package com.starrocks.sql.optimizer.skew;
 
 import com.google.crypto.tink.subtle.Random;
+import com.starrocks.catalog.Type;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.statistics.Bucket;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Histogram;
 import com.starrocks.sql.optimizer.statistics.Statistics;
-import com.starrocks.type.IntegerType;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -33,7 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 public class DataSkewTest {
 
     private static ColumnRefOperator createNewTestColumn() {
-        return new ColumnRefOperator(Random.randInt(), IntegerType.INT, UUID.randomUUID().toString(), true);
+        return new ColumnRefOperator(Random.randInt(), Type.INT, UUID.randomUUID().toString(), true);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistinctAggSkewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistinctAggSkewTest.java
@@ -1,0 +1,89 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.common.FeConstants;
+import com.starrocks.sql.optimizer.statistics.CachedStatisticStorage;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class DistinctAggSkewTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        FeConstants.runningUnitTest = true;
+
+        connectContext.getGlobalStateMgr().setStatisticStorage(new CachedStatisticStorage());
+
+        starRocksAssert.withTable("CREATE TABLE `null_skew_table` (\n" +
+                "  `id` bigint NULL COMMENT \"\",\n" +
+                "  `group` bigint NULL COMMENT \"\",\n" +
+                "  `value` bigint NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`id`, `group`, `value`)\n" +
+                "DISTRIBUTED BY HASH(`id`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\"\n" +
+                ");");
+    }
+
+    @Test
+    void testDistinctWithNullSkew() throws Exception {
+        String sql = "select `group`, count(distinct value) as cnt from null_skew_table group by `group`";
+
+        final var skewedColumnStat = ColumnStatistic.builder().setNullsFraction(0.8).build();
+        final var nonSkewedColumnStat = ColumnStatistic.builder().setNullsFraction(0.01).build();
+
+        final var table = getOlapTable("null_skew_table");
+
+        final var statisticStorage = connectContext.getGlobalStateMgr().getStatisticStorage();
+        statisticStorage.addColumnStatistic(table, "group", skewedColumnStat);
+        statisticStorage.addColumnStatistic(table, "value", nonSkewedColumnStat);
+
+        connectContext.getSessionVariable().setEnableDistinctColumnBucketization(true);
+        setTableStatistics(table, 1337);
+
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  2:Project\n" +
+                "  |  <slot 2> : 2: group\n" +
+                "  |  <slot 3> : 3: value\n" +
+                "  |  <slot 5> : CAST(murmur_hash3_32(CAST(3: value AS VARCHAR)) % 512 AS SMALLINT)");
+    }
+
+    @Test
+    void testDistinctWithoutNullSkew() throws Exception {
+        String sql = "select `group`, count(distinct value) as cnt from null_skew_table group by `group`";
+
+        final var nonSkewedColumnStat = ColumnStatistic.unknown();
+
+        final var table = getOlapTable("null_skew_table");
+
+        final var statisticStorage = connectContext.getGlobalStateMgr().getStatisticStorage();
+        statisticStorage.addColumnStatistic(table, "group", nonSkewedColumnStat);
+        statisticStorage.addColumnStatistic(table, "value", nonSkewedColumnStat);
+
+        connectContext.getSessionVariable().setEnableDistinctColumnBucketization(true);
+        setTableStatistics(table, 1337);
+
+        String plan = getFragmentPlan(sql);
+        assertNotContains(plan, "  2:Project\n" +
+                "  |  <slot 2> : 2: group\n" +
+                "  |  <slot 3> : 3: value\n" +
+                "  |  <slot 5> : CAST(murmur_hash3_32(CAST(3: value AS VARCHAR)) % 512 AS SMALLINT)");
+    }
+}


### PR DESCRIPTION
## Why I'm doing:

This is a backport to 4.0 for #66640.

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
