### PR TITLE
[BugFix] Fix incorrect broadcast rewrite for right/full outer joins in Plan Advisor

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/feedback/guide/LeftChildEstimationErrorTuningGuide.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/feedback/guide/LeftChildEstimationErrorTuningGuide.java
@@ -18,6 +18,7 @@ import com.google.common.collect.Lists;
 import com.starrocks.qe.feedback.NodeExecStats;
 import com.starrocks.qe.feedback.skeleton.JoinNode;
 import com.starrocks.qe.feedback.skeleton.SkeletonNode;
+import com.starrocks.sql.ast.JoinOperator;
 import com.starrocks.sql.optimizer.JoinHelper;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.base.DistributionSpec;
@@ -67,6 +68,11 @@ public class LeftChildEstimationErrorTuningGuide extends JoinTuningGuide {
         }
 
         PhysicalHashJoinOperator joinOperator = (PhysicalHashJoinOperator) optExpression.getOp();
+        JoinOperator joinType = joinOperator.getJoinType();
+        if (joinType.isAsofJoin() || joinType.isNullAwareLeftAntiJoin()) {
+            return Optional.empty();
+        }
+
         SkeletonNode rightChildNode = joinNode.getChild(1);
 
         NodeExecStats rightNodeExecStats = rightChildNode.getNodeExecStats();

--- a/test/sql/test_feedback/R/test_join_feedback
+++ b/test/sql/test_feedback/R/test_join_feedback
@@ -69,5 +69,99 @@ set enable_plan_advisor_blacklist=true;
 -- !result
 truncate plan advisor;
 -- result:
-[REGEX]Clear all plan advisor in FE*
+[REGEX].*
+-- !result
+CREATE TABLE `skew_table` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` char(50) NULL COMMENT "",
+  `c2` int(11) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 5
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into skew_table select generate_series, 'a', generate_series, generate_series from TABLE(generate_series(1, 10000));
+-- result:
+-- !result
+insert into skew_table select generate_series, 'b', generate_series, generate_series from TABLE(generate_series(10001, 20000));
+-- result:
+-- !result
+insert into skew_table select generate_series, 'c', generate_series, generate_series from TABLE(generate_series(20001, 30000));
+-- result:
+-- !result
+insert into skew_table select generate_series, 'd', generate_series, generate_series from TABLE(generate_series(30001, 40000));
+-- result:
+-- !result
+insert into skew_table select generate_series, 'e', generate_series, generate_series from TABLE(generate_series(40001, 50000));
+-- result:
+-- !result
+insert into skew_table select generate_series, 'f', generate_series, 10000000 from TABLE(generate_series(40001, 5100000));
+-- result:
+-- !result
+analyze table skew_table;
+-- result:
+[REGEX].*
+-- !result
+set enable_global_runtime_filter = false;
+-- result:
+-- !result
+set enable_plan_advisor_blacklist=false;
+-- result:
+-- !result
+alter plan advisor add SELECT  COUNT(*) FROM (SELECT  * FROM skew_table t1 left JOIN ( SELECT  * FROM skew_table WHERE c3 = 10000000) t2 ON t1.c2 = t2.c2 where t1.c1 in ('a', 'b', 'c', 'd', 'e') ) t;
+-- result:
+[REGEX].*
+-- !result
+function: assert_trace_values_contains("SELECT  COUNT(*) FROM (SELECT  * FROM skew_table t1 left JOIN ( SELECT  * FROM skew_table WHERE c3 = 10000000) t2 ON t1.c2 = t2.c2 where t1.c1 in ('a', 'b', 'c', 'd', 'e') ) t", "CandidateTuningGuides")
+-- result:
+None
+-- !result
+function: assert_explain_not_contains("SELECT  COUNT(*) FROM (SELECT  * FROM skew_table t1 left JOIN ( SELECT  * FROM skew_table WHERE c3 = 10000000) t2 ON t1.c2 = t2.c2 where t1.c1 in ('a', 'b', 'c', 'd', 'e') ) t", "RIGHT OUTER JOIN")
+-- result:
+None
+-- !result
+alter plan advisor add SELECT  COUNT(*) FROM (SELECT  * FROM skew_table t1 NULL AWARE LEFT ANTI JOIN ( SELECT  * FROM skew_table WHERE c3 = 10000000) t2 ON t1.c2 = t2.c2 where t1.c1 in ('a', 'b', 'c', 'd', 'e') ) t;
+-- result:
+[REGEX].*
+-- !result
+function: assert_trace_values_contains("SELECT  COUNT(*) FROM (SELECT  * FROM skew_table t1 NULL AWARE LEFT ANTI JOIN ( SELECT  * FROM skew_table WHERE c3 = 10000000) t2 ON t1.c2 = t2.c2 where t1.c1 in ('a', 'b', 'c', 'd', 'e') ) t", "CandidateTuningGuides")
+-- result:
+None
+-- !result
+function: assert_explain_not_contains("SELECT  COUNT(*) FROM (SELECT  * FROM skew_table t1 NULL AWARE LEFT ANTI JOIN ( SELECT  * FROM skew_table WHERE c3 = 10000000) t2 ON t1.c2 = t2.c2 where t1.c1 in ('a', 'b', 'c', 'd', 'e') ) t", "RIGHT OUTER JOIN")
+-- result:
+None
+-- !result
+set broadcast_row_limit = -1;
+-- result:
+-- !result
+alter plan advisor add SELECT  COUNT(*) FROM (SELECT  * FROM skew_table t1 left JOIN ( SELECT  * FROM skew_table WHERE c3 = 10000000) t2 ON t1.c2 = t2.c2 where t1.c1 in ('a', 'b', 'c', 'd', 'e') ) t;
+-- result:
+[REGEX].*
+-- !result
+function: assert_trace_values_contains("SELECT  COUNT(*) FROM (SELECT  * FROM skew_table t1 left JOIN ( SELECT  * FROM skew_table WHERE c3 = 10000000) t2 ON t1.c2 = t2.c2 where t1.c1 in ('a', 'b', 'c', 'd', 'e') ) t", "CandidateTuningGuides")
+-- result:
+None
+-- !result
+function: assert_explain_not_contains("SELECT  COUNT(*) FROM (SELECT  * FROM skew_table t1 left JOIN ( SELECT  * FROM skew_table WHERE c3 = 10000000) t2 ON t1.c2 = t2.c2 where t1.c1 in ('a', 'b', 'c', 'd', 'e') ) t", "RIGHT OUTER JOIN")
+-- result:
+None
+-- !result
+set broadcast_row_limit = 15000000;
+-- result:
+-- !result
+set enable_plan_advisor_blacklist=true;
+-- result:
+-- !result
+truncate plan advisor;
+-- result:
+[REGEX].*
 -- !result

--- a/test/sql/test_feedback/T/test_join_feedback
+++ b/test/sql/test_feedback/T/test_join_feedback
@@ -31,3 +31,49 @@ function: assert_trace_values_contains("select count(*) from (select * from c1_s
 function: assert_trace_values_contains("select count(*) from (select * from c1_skew t1 join (select * from c1_skew where c1 = 'f') t2 on t1.c2 = t2.c2) t", "CandidateTuningGuides")
 set enable_plan_advisor_blacklist=true;
 truncate plan advisor;
+
+CREATE TABLE `skew_table` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` char(50) NULL COMMENT "",
+  `c2` int(11) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 5
+PROPERTIES (
+"compression" = "LZ4",
+"fast_schema_evolution" = "true",
+"replicated_storage" = "true",
+"replication_num" = "1"
+);
+
+insert into skew_table select generate_series, 'a', generate_series, generate_series from TABLE(generate_series(1, 10000));
+insert into skew_table select generate_series, 'b', generate_series, generate_series from TABLE(generate_series(10001, 20000));
+insert into skew_table select generate_series, 'c', generate_series, generate_series from TABLE(generate_series(20001, 30000));
+insert into skew_table select generate_series, 'd', generate_series, generate_series from TABLE(generate_series(30001, 40000));
+insert into skew_table select generate_series, 'e', generate_series, generate_series from TABLE(generate_series(40001, 50000));
+insert into skew_table select generate_series, 'f', generate_series, 10000000 from TABLE(generate_series(40001, 5100000));
+analyze table skew_table;
+set enable_global_runtime_filter = false;
+set enable_plan_advisor_blacklist=false;
+
+-- test RIGHT_INPUT_UNDERESTIMATED. and left outer join with broadcast won't rewrite to right outer join with broadcast
+alter plan advisor add SELECT  COUNT(*) FROM (SELECT  * FROM skew_table t1 left JOIN ( SELECT  * FROM skew_table WHERE c3 = 10000000) t2 ON t1.c2 = t2.c2 where t1.c1 in ('a', 'b', 'c', 'd', 'e') ) t;
+function: assert_trace_values_contains("SELECT  COUNT(*) FROM (SELECT  * FROM skew_table t1 left JOIN ( SELECT  * FROM skew_table WHERE c3 = 10000000) t2 ON t1.c2 = t2.c2 where t1.c1 in ('a', 'b', 'c', 'd', 'e') ) t", "CandidateTuningGuides")
+function: assert_explain_not_contains("SELECT  COUNT(*) FROM (SELECT  * FROM skew_table t1 left JOIN ( SELECT  * FROM skew_table WHERE c3 = 10000000) t2 ON t1.c2 = t2.c2 where t1.c1 in ('a', 'b', 'c', 'd', 'e') ) t", "RIGHT OUTER JOIN")
+
+-- test RIGHT_INPUT_UNDERESTIMATED. NULL AWARE LEFT ANTI JOIN won't suffer NPE
+alter plan advisor add SELECT  COUNT(*) FROM (SELECT  * FROM skew_table t1 NULL AWARE LEFT ANTI JOIN ( SELECT  * FROM skew_table WHERE c3 = 10000000) t2 ON t1.c2 = t2.c2 where t1.c1 in ('a', 'b', 'c', 'd', 'e') ) t;
+function: assert_trace_values_contains("SELECT  COUNT(*) FROM (SELECT  * FROM skew_table t1 NULL AWARE LEFT ANTI JOIN ( SELECT  * FROM skew_table WHERE c3 = 10000000) t2 ON t1.c2 = t2.c2 where t1.c1 in ('a', 'b', 'c', 'd', 'e') ) t", "CandidateTuningGuides")
+function: assert_explain_not_contains("SELECT  COUNT(*) FROM (SELECT  * FROM skew_table t1 NULL AWARE LEFT ANTI JOIN ( SELECT  * FROM skew_table WHERE c3 = 10000000) t2 ON t1.c2 = t2.c2 where t1.c1 in ('a', 'b', 'c', 'd', 'e') ) t", "RIGHT OUTER JOIN")
+
+-- test RIGHT_INPUT_UNDERESTIMATED. LEFT OUTER JOIN with shuffle won't rewrite to right outer join with broadcast
+set broadcast_row_limit = -1;
+alter plan advisor add SELECT  COUNT(*) FROM (SELECT  * FROM skew_table t1 left JOIN ( SELECT  * FROM skew_table WHERE c3 = 10000000) t2 ON t1.c2 = t2.c2 where t1.c1 in ('a', 'b', 'c', 'd', 'e') ) t;
+function: assert_trace_values_contains("SELECT  COUNT(*) FROM (SELECT  * FROM skew_table t1 left JOIN ( SELECT  * FROM skew_table WHERE c3 = 10000000) t2 ON t1.c2 = t2.c2 where t1.c1 in ('a', 'b', 'c', 'd', 'e') ) t", "CandidateTuningGuides")
+function: assert_explain_not_contains("SELECT  COUNT(*) FROM (SELECT  * FROM skew_table t1 left JOIN ( SELECT  * FROM skew_table WHERE c3 = 10000000) t2 ON t1.c2 = t2.c2 where t1.c1 in ('a', 'b', 'c', 'd', 'e') ) t", "RIGHT OUTER JOIN")
+
+set broadcast_row_limit = 15000000;
+set enable_plan_advisor_blacklist=true;
+truncate plan advisor;


### PR DESCRIPTION
## Why I'm doing:

The Plan Advisor could generate incorrect query plans where RIGHT OUTER JOIN 
(and other null-preserving joins like RIGHT SEMI/ANTI, FULL OUTER) are executed 
with BROADCAST distribution, leading to wrong query results.

When RightChildEstimationErrorTuningGuide detects right child underestimation,
it attempts to commute the join and broadcast the smaller table. However, the
correctness check was using the original join type instead of the commuted type.
For example, a LEFT OUTER JOIN could be commuted to RIGHT OUTER JOIN (BROADCAST),
which violates semantic correctness because broadcasting the null-preserving side
is incorrect.

## What I'm doing:

- Add explicit checks using the commuted join type before applying broadcast rewrites
- Introduce shouldDisallowBroadcastAfterCommute() helper method to verify if the 
  commuted join type would make broadcast distribution incorrect
- Prevent broadcast rewrites for RIGHT OUTER/SEMI/ANTI and FULL OUTER joins after 
  commutation
- Add early exit for ASOF and NULL_AWARE_LEFT_ANTI joins which should not be 
  rewritten by this tuning guide. and this type join will suffer NPE.

This ensures the Plan Advisor only generates semantically correct query plans
for null-preserving joins.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents broadcasting the null-preserving side after join commutation and adds guards to skip ASOF/NULL_AWARE_LEFT_ANTI joins, with tests validating no RIGHT OUTER rewrites/NPEs.
> 
> - **Plan Advisor (Join tuning guides)**:
>   - `RightChildEstimationErrorTuningGuide`:
>     - Use commuted join type to validate rewrites; add `shouldDisallowBroadcastAfterCommute()`.
>     - Disallow broadcast after commutation for `RIGHT OUTER/SEMI/ANTI` and `FULL OUTER` joins.
>     - Early-exit for `ASOF` and `NULL_AWARE_LEFT_ANTI` joins.
>   - `LeftChildEstimationErrorTuningGuide`:
>     - Early-exit for `ASOF` and `NULL_AWARE_LEFT_ANTI` joins.
> - **Tests**:
>   - Add `skew_table` fixtures and queries validating no rewrite to `RIGHT OUTER JOIN` and avoiding NPEs.
>   - Update regex expectations for `truncate plan advisor` outputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 57c28a76f0c132187568dd7b69211cb5a6e4ba44. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->