### PR TITLE
[Enhancement] MetaScanNode supports Fast Schema Evolution v2 in shared-data mode

### DIFF
--- a/be/src/exec/lake_meta_scanner.cpp
+++ b/be/src/exec/lake_meta_scanner.cpp
@@ -15,6 +15,7 @@
 #include "exec/lake_meta_scanner.h"
 
 #include "exec/lake_meta_scan_node.h"
+#include "gen_cpp/tablet_schema.pb.h"
 #include "runtime/global_dict/config.h"
 #include "testutil/sync_point.h"
 
@@ -44,6 +45,15 @@ Status LakeMetaScanner::_real_init() {
     reader_params.low_card_threshold = _parent->_meta_scan_node.__isset.low_cardinality_threshold
                                                ? _parent->_meta_scan_node.low_cardinality_threshold
                                                : DICT_DECODE_MAX_SIZE;
+
+    if (_parent->_meta_scan_node.__isset.schema_key) {
+        const auto& t_schema_key = _parent->_meta_scan_node.schema_key;
+        reader_params.schema_key.emplace();
+        reader_params.schema_key->set_schema_id(t_schema_key.schema_id);
+        reader_params.schema_key->set_db_id(t_schema_key.db_id);
+        reader_params.schema_key->set_table_id(t_schema_key.table_id);
+    }
+
     // Pass column access paths and extend schema similar to OLAP path
     if (_parent->_meta_scan_node.__isset.column_access_paths && !_parent->_column_access_paths.empty()) {
         reader_params.column_access_paths = &_parent->_column_access_paths;

--- a/be/src/exec/lake_meta_scanner.h
+++ b/be/src/exec/lake_meta_scanner.h
@@ -22,21 +22,14 @@
 #include "runtime/runtime_state.h"
 #include "storage/lake_meta_reader.h"
 
-#ifdef BE_TEST
-// remove final declaration for UT
-#define DECL_FINAL
-#else
-#define DECL_FINAL final
-#endif
-
 namespace starrocks {
 
 class LakeMetaScanNode;
 
-class LakeMetaScanner DECL_FINAL : public MetaScanner {
+class LakeMetaScanner final : public MetaScanner {
 public:
     LakeMetaScanner(LakeMetaScanNode* parent);
-    ~LakeMetaScanner() DECL_FINAL = default;
+    ~LakeMetaScanner() final = default;
 
     LakeMetaScanner(const LakeMetaScanner&) = delete;
     LakeMetaScanner(LakeMetaScanner&) = delete;
@@ -53,6 +46,8 @@ public:
 
     bool has_more() override;
 
+    LakeMetaReader* TEST_reader() { return _reader.get(); }
+
 protected:
     Status _lazy_init(RuntimeState* runtime_state, const MetaScannerParams& params);
     Status _real_init();
@@ -63,5 +58,3 @@ protected:
 };
 
 } // namespace starrocks
-
-#undef DECL_FINAL

--- a/be/src/exec/olap_meta_scanner.cpp
+++ b/be/src/exec/olap_meta_scanner.cpp
@@ -49,9 +49,13 @@ Status OlapMetaScanner::_init_meta_reader_params() {
     _reader_params.low_card_threshold = _parent->_meta_scan_node.__isset.low_cardinality_threshold
                                                 ? _parent->_meta_scan_node.low_cardinality_threshold
                                                 : DICT_DECODE_MAX_SIZE;
-
-    if (_parent->_meta_scan_node.__isset.schema_id && _parent->_meta_scan_node.schema_id > 0 &&
-        _parent->_meta_scan_node.schema_id == _tablet->tablet_schema()->id()) {
+    int64_t schema_id = -1;
+    if (_parent->_meta_scan_node.__isset.schema_key) {
+        schema_id = _parent->_meta_scan_node.schema_key.schema_id;
+    } else if (_parent->_meta_scan_node.__isset.schema_id) {
+        schema_id = _parent->_meta_scan_node.schema_id;
+    }
+    if (schema_id > 0 && schema_id == _tablet->tablet_schema()->id()) {
         _reader_params.tablet_schema = _tablet->tablet_schema();
     }
 

--- a/be/src/storage/lake_meta_reader.cpp
+++ b/be/src/storage/lake_meta_reader.cpp
@@ -19,9 +19,11 @@
 #include "column/chunk.h"
 #include "column/column_helper.h"
 #include "common/status.h"
+#include "exec/pipeline/fragment_context.h"
 #include "runtime/exec_env.h"
 #include "runtime/global_dict/config.h"
 #include "storage/lake/rowset.h"
+#include "storage/lake/table_schema_service.h"
 #include "storage/rowset/column_iterator.h"
 #include "storage/rowset/rowset.h"
 
@@ -34,11 +36,22 @@ LakeMetaReader::~LakeMetaReader() = default;
 Status LakeMetaReader::init(const LakeMetaReaderParams& read_params) {
     _params = read_params;
 
-    ASSIGN_OR_RETURN(auto tablet, ExecEnv::GetInstance()->lake_tablet_manager()->get_tablet(
-                                          read_params.tablet_id, read_params.version.second));
+    lake::TabletManager* tablet_manager = ExecEnv::GetInstance()->lake_tablet_manager();
+    ASSIGN_OR_RETURN(auto tablet, tablet_manager->get_tablet(read_params.tablet_id, read_params.version.second));
+
+    TabletSchemaCSPtr base_schema;
+    if (read_params.schema_key.has_value()) {
+        auto runtime_state = read_params.runtime_state;
+        ASSIGN_OR_RETURN(base_schema, tablet_manager->table_schema_service()->get_schema_for_scan(
+                                              *read_params.schema_key, read_params.tablet_id, runtime_state->query_id(),
+                                              runtime_state->fragment_ctx()->fe_addr(), tablet.metadata()));
+    } else {
+        // no schema key indicates FE has not been upgraded to use fast schema evolution v2,
+        // so fallback to the old way to get schema from tablet metadata
+        base_schema = tablet.get_schema();
+    }
 
     // Build and possibly extend tablet schema using access paths
-    TabletSchemaCSPtr base_schema = tablet.get_schema();
     TabletSchemaCSPtr tablet_schema = base_schema;
     if (read_params.column_access_paths != nullptr && !read_params.column_access_paths->empty()) {
         TabletSchemaSPtr tmp_schema = TabletSchema::copy(*base_schema);
@@ -62,11 +75,7 @@ Status LakeMetaReader::init(const LakeMetaReaderParams& read_params) {
         tablet_schema = tmp_schema;
     }
 
-    // Store the effective schema into params for downstream collectors
-    _params.desc_tbl = read_params.desc_tbl;
-    _collect_context.seg_collecter_params.tablet_schema = tablet_schema;
-
-    RETURN_IF_ERROR(_build_collect_context(tablet, read_params));
+    RETURN_IF_ERROR(_build_collect_context(tablet_schema, read_params));
     RETURN_IF_ERROR(_init_seg_meta_collecters(tablet, read_params));
 
     _collect_context.cursor_idx = 0;
@@ -75,13 +84,8 @@ Status LakeMetaReader::init(const LakeMetaReaderParams& read_params) {
     return Status::OK();
 }
 
-Status LakeMetaReader::_build_collect_context(const lake::VersionedTablet& tablet,
+Status LakeMetaReader::_build_collect_context(const TabletSchemaCSPtr& tablet_schema,
                                               const LakeMetaReaderParams& read_params) {
-    auto tablet_schema = tablet.get_schema();
-    // If schema was extended in init(), prefer that one
-    if (_collect_context.seg_collecter_params.tablet_schema != nullptr) {
-        tablet_schema = _collect_context.seg_collecter_params.tablet_schema;
-    }
     for (const auto& it : *(read_params.id_to_names)) {
         std::string col_name = "";
         std::string collect_field = "";

--- a/be/src/storage/lake_meta_reader.h
+++ b/be/src/storage/lake_meta_reader.h
@@ -20,23 +20,13 @@
 #include "column/vectorized_fwd.h"
 #include "storage/lake/versioned_tablet.h"
 #include "storage/meta_reader.h"
-#include "storage/tablet_schema.h"
-
-#ifdef BE_TEST
-#define DECL_FINAL
-#define UT_VIRTUAL virtual
-#else
-#define DECL_FINAL final
-#define UT_VIRTUAL
-#endif
 
 namespace starrocks {
-class TabletSchema;
 
 struct LakeMetaReaderParams : MetaReaderParams {
     LakeMetaReaderParams() = default;
-    // Optional extended schema and access paths, mirroring OlapMetaReaderParams
-    TabletSchemaCSPtr tablet_schema;
+    // The key of the schema used for reading. no value for legacy compatibility.
+    std::optional<TableSchemaKeyPB> schema_key;
     std::vector<ColumnAccessPathPtr>* column_access_paths = nullptr;
 };
 
@@ -48,17 +38,17 @@ class VersionedTablet;
 // MetaReader will implements
 // 1. read meta info from segment footer
 // 2. read dict info from dict page if column is dict encoding type
-class LakeMetaReader DECL_FINAL : public MetaReader {
+class LakeMetaReader final : public MetaReader {
 public:
     LakeMetaReader();
     ~LakeMetaReader() override;
 
-    UT_VIRTUAL Status init(const LakeMetaReaderParams& read_params);
+    Status init(const LakeMetaReaderParams& read_params);
 
     Status do_get_next(ChunkPtr* chunk) override;
 
 private:
-    Status _build_collect_context(const lake::VersionedTablet& tablet, const LakeMetaReaderParams& read_params);
+    Status _build_collect_context(const TabletSchemaCSPtr& tablet_schema, const LakeMetaReaderParams& read_params);
 
     Status _init_seg_meta_collecters(const lake::VersionedTablet& tablet, const LakeMetaReaderParams& read_params);
 
@@ -66,5 +56,3 @@ private:
 };
 
 } // namespace starrocks
-
-#undef DECL_FINAL

--- a/be/src/storage/meta_reader.h
+++ b/be/src/storage/meta_reader.h
@@ -84,6 +84,8 @@ public:
         std::vector<int32_t> result_slot_ids;
     };
 
+    const TabletSchemaCSPtr& TEST_tablet_schema() { return _collect_context.seg_collecter_params.tablet_schema; }
+
 protected:
     CollectContext _collect_context;
     bool _is_init;

--- a/be/test/exec/lake_meta_scanner_test.cpp
+++ b/be/test/exec/lake_meta_scanner_test.cpp
@@ -12,40 +12,40 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#ifndef BE_TEST
+#define BE_TEST
+#endif
+
 #include "exec/lake_meta_scanner.h"
 
 #include <gtest/gtest.h>
 
+#include "common/status.h"
 #include "exec/lake_meta_scan_node.h"
+#include "exec/pipeline/fragment_context.h"
 #include "fs/fs_util.h"
+#include "gen_cpp/FrontendService_types.h"
+#include "gen_cpp/Types_types.h"
+#include "gen_cpp/tablet_schema.pb.h"
 #include "runtime/descriptor_helper.h"
 #include "runtime/exec_env.h"
+#include "runtime/mem_tracker.h"
+#include "runtime/runtime_state.h"
 #include "storage/lake/fixed_location_provider.h"
 #include "storage/lake/join_path.h"
 #include "storage/lake/location_provider.h"
+#include "storage/lake/table_schema_service.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_metadata.h"
 #include "storage/lake_meta_reader.h"
+#include "storage/meta_reader.h"
+#include "storage/tablet_schema.h"
 #include "testutil/id_generator.h"
 #include "testutil/sync_point.h"
+#include "util/defer_op.h"
 
 namespace starrocks {
-
-// provides an empty implementation of the reader
-struct MockLakeMetaReader : public LakeMetaReader {
-public:
-    Status init(const LakeMetaReaderParams& read_params) override { return Status::OK(); }
-};
-
-// access the protected members of LakeMetaScanner
-struct MockLakeMetaScanner : public LakeMetaScanner {
-public:
-    MockLakeMetaScanner(LakeMetaScanNode* parent) : LakeMetaScanner(parent) {}
-
-    const std::unique_ptr<LakeMetaReader>& reader() { return _reader; }
-    int64_t tablet_id() const { return _tablet_id; }
-    bool is_opened() const { return _is_open; }
-};
 
 class LakeMetaScannerTest : public ::testing::Test {
 public:
@@ -54,18 +54,25 @@ public:
         _location_provider = std::make_shared<lake::FixedLocationProvider>(kRootLocation);
         _tablet_mgr = ExecEnv::GetInstance()->lake_tablet_manager();
         _backup_location_provider = _tablet_mgr->TEST_set_location_provider(_location_provider);
-        FileSystem::Default()->create_dir_recursive(lake::join_path(kRootLocation, lake::kSegmentDirectoryName));
-        FileSystem::Default()->create_dir_recursive(lake::join_path(kRootLocation, lake::kMetadataDirectoryName));
-        FileSystem::Default()->create_dir_recursive(lake::join_path(kRootLocation, lake::kTxnLogDirectoryName));
+        CHECK(FileSystem::Default()
+                      ->create_dir_recursive(lake::join_path(kRootLocation, lake::kSegmentDirectoryName))
+                      .ok());
+        CHECK(FileSystem::Default()
+                      ->create_dir_recursive(lake::join_path(kRootLocation, lake::kMetadataDirectoryName))
+                      .ok());
+        CHECK(FileSystem::Default()
+                      ->create_dir_recursive(lake::join_path(kRootLocation, lake::kTxnLogDirectoryName))
+                      .ok());
 
         {
-            // create the tablet with its schema prepared
-            TabletMetadata metadata;
-            metadata.set_id(_tablet_id);
-            metadata.set_version(2);
+            // create the tablet with its schema prepared (no rowsets)
+            auto metadata = std::make_shared<TabletMetadata>();
+            metadata->set_id(_tablet_id);
+            metadata->set_version(2);
 
-            auto schema = metadata.mutable_schema();
+            auto schema = metadata->mutable_schema();
             schema->set_id(10);
+            schema->set_schema_version(1);
             schema->set_num_short_key_columns(1);
             schema->set_keys_type(DUP_KEYS);
             schema->set_num_rows_per_row_block(65535);
@@ -75,14 +82,28 @@ public:
             c0->set_type("INT");
             c0->set_is_key(true);
             c0->set_is_nullable(false);
-            auto st = _tablet_mgr->put_tablet_metadata(metadata);
-            EXPECT_TRUE(st.ok());
+            auto st = _tablet_mgr->put_tablet_metadata(*metadata);
+            CHECK(st.ok()) << st;
 
             auto tablet_or = _tablet_mgr->get_tablet(_tablet_id, 2);
             EXPECT_TRUE(tablet_or.ok());
         }
 
-        _state = _pool.add(new RuntimeState(TQueryGlobals()));
+        TUniqueId query_id;
+        TUniqueId fragment_id;
+        TQueryOptions query_options;
+        TQueryGlobals query_globals;
+        _state = _pool.add(
+                new RuntimeState(query_id, fragment_id, query_options, query_globals, ExecEnv::GetInstance()));
+        _state->init_mem_trackers(query_id);
+
+        // Setup FragmentContext with fe_addr for schema RPC
+        _fragment_ctx = std::make_unique<pipeline::FragmentContext>();
+        TNetworkAddress fe;
+        fe.hostname = "127.0.0.1";
+        fe.port = 9020;
+        _fragment_ctx->set_fe_addr(fe);
+        _state->set_fragment_ctx(_fragment_ctx.get());
 
         std::vector<::starrocks::TTupleId> tuple_ids{0};
         _tnode = std::make_unique<TPlanNode>();
@@ -90,6 +111,9 @@ public:
         _tnode->__set_node_type(TPlanNodeType::LAKE_SCAN_NODE);
         _tnode->__set_row_tuples(tuple_ids);
         _tnode->__set_limit(-1);
+
+        // Setup id_to_names for meta scan: slot_id -> "field:column_name"
+        _tnode->meta_scan_node.id_to_names[0] = "rows:c0";
 
         TDescriptorTableBuilder table_desc_builder;
         TSlotDescriptorBuilder slot_desc_builder;
@@ -105,10 +129,9 @@ public:
         _parent = std::make_unique<LakeMetaScanNode>(&_pool, *_tnode, *_tbl);
     }
 
-    ~LakeMetaScannerTest() {
-        auto st = fs::remove_all(kRootLocation);
-        EXPECT_TRUE(st.ok());
+    ~LakeMetaScannerTest() override {
         (void)_tablet_mgr->TEST_set_location_provider(_backup_location_provider);
+        (void)fs::remove_all(kRootLocation);
     }
 
 public:
@@ -123,39 +146,174 @@ public:
     std::unique_ptr<TPlanNode> _tnode;
     DescriptorTbl* _tbl;
     std::unique_ptr<LakeMetaScanNode> _parent;
+    std::unique_ptr<pipeline::FragmentContext> _fragment_ctx;
 };
 
 TEST_F(LakeMetaScannerTest, test_init_lazy_and_real) {
     auto range = _pool.add(new TInternalScanRange());
     range->tablet_id = _tablet_id;
-    range->version = 2;
+    range->version = "2";
     MetaScannerParams params{.scan_range = range};
 
-    MockLakeMetaScanner scanner(_parent.get());
+    LakeMetaScanner scanner(_parent.get());
+    DeferOp defer([&]() { scanner.close(_state); });
     auto st = scanner.init(_state, params);
     // after init() called, reader is not created at all
-    EXPECT_TRUE(st.ok());
-    EXPECT_TRUE(scanner.reader().get() == nullptr);
-    EXPECT_EQ(range->tablet_id, scanner.tablet_id());
+    ASSERT_TRUE(st.ok()) << st;
+    ASSERT_EQ(nullptr, scanner.TEST_reader());
 
-    std::unique_ptr<LakeMetaReader> mock_reader(new MockLakeMetaReader);
-    LakeMetaReader* raw_reader_ptr = mock_reader.get();
-    SyncPoint::GetInstance()->SetCallBack("lake_meta_scanner:open_mock_reader", [&](void* arg) {
-        auto* reader = static_cast<std::unique_ptr<LakeMetaReader>*>(arg);
-        // non-empty reader
-        EXPECT_TRUE((*reader).get() != nullptr);
-        *reader = std::move(mock_reader);
+    auto st2 = scanner.open(_state);
+    // after open() called, reader is created and initialized
+    ASSERT_TRUE(st2.ok()) << st2;
+    ASSERT_NE(nullptr, scanner.TEST_reader());
+}
+
+TEST_F(LakeMetaScannerTest, test_read_schema) {
+    auto range = _pool.add(new TInternalScanRange());
+    range->tablet_id = _tablet_id;
+    range->version = "2";
+    MetaScannerParams params{.scan_range = range};
+
+    DeferOp defer_hook([&]() {
+        SyncPoint::GetInstance()->ClearCallBack("TableSchemaService::_fetch_schema_via_rpc::test_hook");
+        SyncPoint::GetInstance()->DisableProcessing();
     });
     SyncPoint::GetInstance()->EnableProcessing();
 
-    auto st2 = scanner.open(nullptr);
-    // after open() called, reader is created
-    EXPECT_TRUE(st2.ok()) << st2;
-    EXPECT_EQ(raw_reader_ptr, scanner.reader().get());
-    EXPECT_TRUE(scanner.is_opened());
+    // Test case 1: With schema_key (fast schema evolution v2 path)
+    {
+        // Arrange: Set schema_key in TMetaScanNode
+        TTableSchemaKey t_schema_key;
+        t_schema_key.__set_schema_id(200);
+        t_schema_key.__set_db_id(1);
+        t_schema_key.__set_table_id(1);
+        _tnode->meta_scan_node.__set_schema_key(t_schema_key);
 
-    SyncPoint::GetInstance()->ClearCallBack("lake_meta_scanner:open_mock_reader");
-    SyncPoint::GetInstance()->DisableProcessing();
+        // Setup test hook to mock RPC response with schema_id=200, version=5, columns: c0(INT, key), c1(INT, non-key)
+        SyncPoint::GetInstance()->SetCallBack("TableSchemaService::_fetch_schema_via_rpc::test_hook", [](void* arg) {
+            auto* arr = static_cast<std::array<void*, 4>*>(arg);
+            auto* request = static_cast<const TGetTableSchemaRequest*>((*arr)[0]);
+            auto* response_batch = static_cast<TBatchGetTableSchemaResponse*>((*arr)[1]);
+            auto* status = static_cast<Status*>((*arr)[2]);
+            auto* mock_thrift_rpc = static_cast<bool*>((*arr)[3]);
+
+            // Verify request
+            ASSERT_EQ(request->schema_key.schema_id, 200);
+            ASSERT_EQ(request->schema_key.db_id, 1);
+            ASSERT_EQ(request->schema_key.table_id, 1);
+
+            // Mock RPC: skip actual RPC call
+            *mock_thrift_rpc = true;
+            *status = Status::OK();
+
+            // Set batch response status
+            response_batch->status.__set_status_code(TStatusCode::OK);
+            response_batch->__set_responses(std::vector<TGetTableSchemaResponse>{});
+
+            // Create response with schema_id=200, version=5
+            auto& resp = response_batch->responses.emplace_back();
+            resp.status.__set_status_code(TStatusCode::OK);
+
+            // Create TTabletSchema with schema_id=200, version=5, columns: c0(INT, key), c1(INT, non-key)
+            TTabletSchema thrift_schema;
+            thrift_schema.__set_id(200);
+            thrift_schema.__set_schema_version(5);
+            thrift_schema.__set_short_key_column_count(1);
+            thrift_schema.__set_keys_type(TKeysType::DUP_KEYS);
+
+            // Column c0: INT, key
+            TColumn c0;
+            c0.__set_column_name("c0");
+            c0.column_type.__set_type(TPrimitiveType::INT);
+            c0.__set_is_key(true);
+            c0.__set_is_allow_null(false);
+            thrift_schema.columns.push_back(c0);
+
+            // Column c1: INT, non-key
+            TColumn c1;
+            c1.__set_column_name("c1");
+            c1.column_type.__set_type(TPrimitiveType::INT);
+            c1.__set_is_key(false);
+            c1.__set_is_allow_null(false);
+            thrift_schema.columns.push_back(c1);
+
+            resp.__set_schema(thrift_schema);
+        });
+
+        // Recreate parent with updated tnode
+        _parent = std::make_unique<LakeMetaScanNode>(&_pool, *_tnode, *_tbl);
+
+        LakeMetaScanner scanner(_parent.get());
+        auto st = scanner.init(_state, params);
+        DeferOp defer([&]() { scanner.close(_state); });
+        ASSERT_TRUE(st.ok()) << st;
+
+        auto st2 = scanner.open(_state);
+        ASSERT_TRUE(st2.ok()) << st2;
+
+        // Verify the schema was fetched and used (schema_id=200, version=5, with c0 and c1 columns)
+        auto* reader = scanner.TEST_reader();
+        ASSERT_NE(reader, nullptr);
+        // Access TEST_tablet_schema - LakeMetaReader inherits from MetaReader
+        const auto& schema = reader->TEST_tablet_schema();
+        ASSERT_NE(schema, nullptr);
+
+        // Verify schema_id=200, version=5
+        ASSERT_EQ(schema->id(), 200);
+        ASSERT_EQ(schema->schema_version(), 5);
+
+        // Verify schema has 2 columns: c0 (INT, key) and c1 (INT, non-key)
+        ASSERT_EQ(schema->num_columns(), 2);
+
+        // Verify column c0: INT, key
+        const auto& col0 = schema->column(0);
+        ASSERT_EQ(col0.name(), "c0");
+        ASSERT_EQ(col0.type(), LogicalType::TYPE_INT);
+        ASSERT_TRUE(col0.is_key());
+
+        // Verify column c1: INT, non-key
+        const auto& col1 = schema->column(1);
+        ASSERT_EQ(col1.name(), "c1");
+        ASSERT_EQ(col1.type(), LogicalType::TYPE_INT);
+        ASSERT_FALSE(col1.is_key());
+    }
+
+    // Test case 2: Without schema_key (legacy path)
+    {
+        // Arrange: Do NOT set schema_key in TMetaScanNode (legacy path)
+        _tnode->meta_scan_node.__isset.schema_key = false;
+
+        // Recreate parent with updated tnode
+        _parent = std::make_unique<LakeMetaScanNode>(&_pool, *_tnode, *_tbl);
+
+        LakeMetaScanner scanner(_parent.get());
+        DeferOp defer([&]() { scanner.close(_state); });
+        auto st = scanner.init(_state, params);
+        ASSERT_TRUE(st.ok()) << st;
+
+        auto st2 = scanner.open(_state);
+        ASSERT_TRUE(st2.ok()) << st2;
+
+        // Verify the schema was from tablet metadata (schema_id=10, version=1, with c0 column)
+        auto* reader = scanner.TEST_reader();
+        ASSERT_NE(reader, nullptr);
+        // Access TEST_tablet_schema - LakeMetaReader inherits from MetaReader
+        const auto& schema = reader->TEST_tablet_schema();
+        ASSERT_NE(schema, nullptr);
+
+        // Verify schema_id=10, version=1 (from tablet metadata)
+        ASSERT_EQ(schema->id(), 10);
+        ASSERT_EQ(schema->schema_version(), 1);
+
+        // Verify schema has 1 column: c0 (INT, key)
+        ASSERT_EQ(schema->num_columns(), 1);
+
+        // Verify column c0: INT, key
+        const auto& col0 = schema->column(0);
+        ASSERT_EQ(col0.name(), "c0");
+        ASSERT_EQ(col0.type(), LogicalType::TYPE_INT);
+        ASSERT_TRUE(col0.is_key());
+    }
 }
 
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/planner/AbstractOlapTableScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AbstractOlapTableScanNode.java
@@ -24,7 +24,7 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 
 // An abstract node to scan data or meta from an OlapTable.
-public abstract class AbstractOlapTableScanNode extends ScanNode{
+public abstract class AbstractOlapTableScanNode extends ScanNode {
 
     protected final OlapTable olapTable;
     protected final SelectedMaterializedIndex index;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/AbstractOlapTableScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AbstractOlapTableScanNode.java
@@ -1,0 +1,113 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.catalog.MaterializedIndexMeta;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.SchemaInfo;
+import com.starrocks.sql.common.MetaUtils;
+import com.starrocks.thrift.TTableSchemaKey;
+
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+// An abstract node to scan data or meta from an OlapTable.
+public abstract class AbstractOlapTableScanNode extends ScanNode{
+
+    protected final OlapTable olapTable;
+    protected final SelectedMaterializedIndex index;
+
+    /**
+     * Constructs a node to scan from an OlapTable.
+     * <p>
+     * This constructor may access the schema information of the {@link OlapTable}.
+     * To ensure thread-safe access, the caller must guarantee that the table's metadata
+     * is protected, either by holding an external lock or by operating on a query-specific
+     * copy of the table (e.g., created via {@link OlapTable#copyOnlyForQuery(OlapTable)}).
+     *
+     * @param id The unique identifier for this plan node.
+     * @param desc The tuple descriptor for the data produced by this scan node.
+     * @param planNodeName The name of the plan node.
+     * @param selectedIndexId The ID of the materialized index to be scanned. If this value is -1,
+     *                        the base index of the OlapTable will be used.
+     */
+    public AbstractOlapTableScanNode(
+            PlanNodeId id, TupleDescriptor desc, String planNodeName, OlapTable olapTable, long selectedIndexId) {
+        super(id, desc, planNodeName);
+        this.olapTable = olapTable;
+        this.index = SelectedMaterializedIndex.build(olapTable, selectedIndexId);
+    }
+
+    public OlapTable getOlapTable() {
+        return olapTable;
+    }
+
+    public TTableSchemaKey getSchemaKey() {
+        TTableSchemaKey schemaKey = new TTableSchemaKey();
+        schemaKey.setDb_id(MetaUtils.lookupDbIdByTable(olapTable));
+        schemaKey.setTable_id(olapTable.getId());
+        schemaKey.setSchema_id(index.schemaId);
+        return schemaKey;
+    }
+
+    /**
+     * Returns the cached schema information for the selected materialized index.
+     */
+    public Optional<SchemaInfo> getSchema() {
+        return index.cachedSchema;
+    }
+
+
+    /** Selected materialized index to scan. */
+    protected static class SelectedMaterializedIndex {
+
+        final long indexId;
+        final long schemaId;
+
+        /**
+         * Cached schema information used for query plan.
+         * <p>
+         * This field stores the schema information that was used when generating the plan, enabling
+         * backend nodes to retrieve the exact schema from the frontend during query execution. This is
+         * particularly important for Fast Schema Evolution scenarios where schema changes are not
+         * immediately propagated schema metadata to backend nodes. Currently, this mechanism is only
+         * used in shared-data mode.
+         * </p>
+         */
+        private final Optional<SchemaInfo> cachedSchema;
+
+        private SelectedMaterializedIndex(long indexId, long schemaId, @Nullable SchemaInfo cachedSchema) {
+            this.indexId = indexId;
+            this.schemaId = schemaId;
+            this.cachedSchema = Optional.ofNullable(cachedSchema);
+        }
+
+        static SelectedMaterializedIndex build(OlapTable olapTable, long selectedIndexId) {
+            long indexId = selectedIndexId == -1 ? olapTable.getBaseIndexMetaId() : selectedIndexId;
+            MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(indexId);
+            if (indexMeta == null) {
+                throw new RuntimeException(String.format(
+                        "can't find index, table name: %s, table id: %s, index id: %s",
+                        olapTable.getName(), olapTable.getId(), indexId));
+            }
+            long schemaId = indexMeta.getSchemaId();
+            SchemaInfo schema = null;
+            if (olapTable.isCloudNativeTableOrMaterializedView()) {
+                schema = SchemaInfo.fromMaterializedIndex(olapTable, indexId, indexMeta);
+            }
+            return new SelectedMaterializedIndex(indexId, schemaId, schema);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/service/TableSchemaService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/TableSchemaService.java
@@ -25,7 +25,7 @@ import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
-import com.starrocks.planner.OlapScanNode;
+import com.starrocks.planner.AbstractOlapTableScanNode;
 import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.server.GlobalStateMgr;
@@ -190,8 +190,8 @@ public class TableSchemaService {
         }
         Optional<SchemaInfo> schemaInfo = Optional.ofNullable(coordinator.getScanNodes())
                 .orElse(Collections.emptyList()).stream()
-                .filter(OlapScanNode.class::isInstance)
-                .map(node -> ((OlapScanNode) node).getSchema())
+                .filter(AbstractOlapTableScanNode.class::isInstance)
+                .map(node -> ((AbstractOlapTableScanNode) node).getSchema())
                 .filter(schema -> schema.isPresent() && schema.get().getId() == schemaId)
                 .map(Optional::get)
                 .findFirst();

--- a/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.ExceptionChecker;
@@ -38,6 +39,7 @@ import com.starrocks.qe.scheduler.NonRecoverableException;
 import com.starrocks.qe.scheduler.WorkerProvider;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
+import com.starrocks.sql.ast.KeysType;
 import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
@@ -45,6 +47,8 @@ import com.starrocks.thrift.TInternalScanRange;
 import com.starrocks.thrift.TScanRange;
 import com.starrocks.thrift.TScanRangeLocation;
 import com.starrocks.thrift.TScanRangeLocations;
+import com.starrocks.thrift.TStorageType;
+import com.starrocks.type.IntegerType;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import mockit.Expectations;
 import mockit.Mock;
@@ -466,6 +470,10 @@ public class DefaultSharedDataWorkerProviderTest {
         // copy from fe/fe-core/src/test/java/com/starrocks/qe/ColocatedBackendSelectorTest.java
         TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
         OlapTable table = new OlapTable();
+        table.maySetDatabaseId(1L);
+        table.setBaseIndexMetaId(1L);
+        table.setIndexMeta(1L, "base", Collections.singletonList(new Column("c0", IntegerType.INT)),
+                0, 0, (short) 1, TStorageType.COLUMN, KeysType.DUP_KEYS);
         table.setDefaultDistributionInfo(new HashDistributionInfo(numBuckets, Collections.emptyList()));
         desc.setTable(table);
         return new OlapScanNode(new PlanNodeId(id), desc, "OlapScanNode", table.getBaseIndexMetaId());

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ColocatedBackendSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ColocatedBackendSelectorTest.java
@@ -17,6 +17,7 @@ package com.starrocks.qe;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.StarRocksException;
@@ -29,11 +30,14 @@ import com.starrocks.qe.scheduler.DefaultWorkerProvider;
 import com.starrocks.qe.scheduler.NonRecoverableException;
 import com.starrocks.qe.scheduler.WorkerProvider;
 import com.starrocks.server.WarehouseManager;
+import com.starrocks.sql.ast.KeysType;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.TInternalScanRange;
 import com.starrocks.thrift.TScanRange;
 import com.starrocks.thrift.TScanRangeLocation;
 import com.starrocks.thrift.TScanRangeLocations;
+import com.starrocks.thrift.TStorageType;
+import com.starrocks.type.IntegerType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -291,6 +295,10 @@ public class ColocatedBackendSelectorTest {
     private OlapScanNode genOlapScanNode(int id, int numBuckets) {
         TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
         OlapTable table = new OlapTable();
+        table.maySetDatabaseId(1L);
+        table.setBaseIndexMetaId(1L);
+        table.setIndexMeta(1L, "base", Collections.singletonList(new Column("c0", IntegerType.INT)),
+                0, 0, (short) 1, TStorageType.COLUMN, KeysType.DUP_KEYS);
         table.setDefaultDistributionInfo(new HashDistributionInfo(numBuckets, Collections.emptyList()));
         desc.setTable(table);
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.qe;
 
 import com.google.common.collect.ImmutableList;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.StarRocksException;
@@ -37,6 +38,7 @@ import com.starrocks.planner.stream.StreamAggNode;
 import com.starrocks.qe.scheduler.dag.ExecutionFragment;
 import com.starrocks.qe.scheduler.dag.FragmentInstance;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.KeysType;
 import com.starrocks.sql.plan.PlanTestBase;
 import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.system.Backend;
@@ -44,6 +46,7 @@ import com.starrocks.thrift.TBinlogOffset;
 import com.starrocks.thrift.TDescriptorTable;
 import com.starrocks.thrift.TPartitionType;
 import com.starrocks.thrift.TScanRangeParams;
+import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.type.IntegerType;
 import com.starrocks.utframe.UtFrameUtils;
@@ -107,6 +110,10 @@ public class CoordinatorTest extends PlanTestBase {
         execFragment.addInstance(instance2);
 
         OlapTable table = new OlapTable();
+        table.maySetDatabaseId(1L);
+        table.setBaseIndexMetaId(1L);
+        table.setIndexMeta(1L, "base", Collections.singletonList(new Column("c0", IntegerType.INT)),
+                0, 0, (short) 1, TStorageType.COLUMN, KeysType.DUP_KEYS);
         table.setDefaultDistributionInfo(new HashDistributionInfo(6, Collections.emptyList()));
         TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
         desc.setTable(table);

--- a/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.server;
 
 import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
@@ -29,9 +30,12 @@ import com.starrocks.planner.OlapScanNode;
 import com.starrocks.planner.PlanNodeId;
 import com.starrocks.planner.TupleDescriptor;
 import com.starrocks.planner.TupleId;
+import com.starrocks.sql.ast.KeysType;
 import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TStorageType;
+import com.starrocks.type.IntegerType;
 import com.starrocks.warehouse.DefaultWarehouse;
 import com.starrocks.warehouse.Warehouse;
 import com.starrocks.warehouse.cngroup.CRAcquireContext;
@@ -404,6 +408,10 @@ public class WarehouseManagerTest {
     private OlapScanNode newOlapScanNode() {
         TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
         OlapTable table = new OlapTable();
+        table.maySetDatabaseId(1L);
+        table.setBaseIndexMetaId(1L);
+        table.setIndexMeta(1L, "base", Collections.singletonList(new Column("c0", IntegerType.INT)),
+                0, 0, (short) 1, TStorageType.COLUMN, KeysType.DUP_KEYS);
         table.setDefaultDistributionInfo(new HashDistributionInfo(3, Collections.emptyList()));
         desc.setTable(table);
         return new OlapScanNode(new PlanNodeId(1), desc, "OlapScanNode", table.getBaseIndexMetaId());

--- a/fe/fe-core/src/test/java/com/starrocks/service/TableSchemaServiceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/TableSchemaServiceTest.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.lake.LakeTable;
+import com.starrocks.planner.MetaScanNode;
 import com.starrocks.planner.OlapScanNode;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DefaultCoordinator;
@@ -36,6 +37,9 @@ import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TGetTableSchemaRequest;
 import com.starrocks.thrift.TGetTableSchemaResponse;
+import com.starrocks.thrift.TLakeScanNode;
+import com.starrocks.thrift.TMetaScanNode;
+import com.starrocks.thrift.TPlan;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TTableSchemaKey;
 import com.starrocks.thrift.TTableSchemaRequestSource;
@@ -53,6 +57,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -196,33 +201,81 @@ public class TableSchemaServiceTest extends StarRocksTestBase {
     }
 
     @Test
+    public void testScanNodeCacheSchema() throws Exception {
+        LakeTable table = createTable("t_scan_node_cache_schema");
+        long indexId = table.getBaseIndexMetaId();
+        SchemaInfo schemaInfo = SchemaInfo.fromMaterializedIndex(table, indexId, table.getIndexMetaByIndexId(indexId));
+
+        // Generate OlapScanNode
+        ExecPlan plan1 = UtFrameUtils.getPlanAndFragment(
+                connectContext, "SELECT * FROM t_scan_node_cache_schema").second;
+
+        // Verify plan has OlapScanNode with schema
+        List<OlapScanNode> olapScanNodes = plan1.getScanNodes().stream()
+                .filter(OlapScanNode.class::isInstance)
+                .map(OlapScanNode.class::cast)
+                .toList();
+        Assertions.assertEquals(1, olapScanNodes.size());
+        Assertions.assertEquals(schemaInfo, olapScanNodes.get(0).getSchema().orElse(null));
+        TPlan tPlan1 = olapScanNodes.get(0).treeToThrift();
+        Assertions.assertEquals(1, tPlan1.getNodesSize());
+        TLakeScanNode lakeScanNode = tPlan1.getNodes().get(0).getLake_scan_node();
+        TTableSchemaKey schemaKey1 = lakeScanNode == null ? null : lakeScanNode.getSchema_key();
+        Assertions.assertNotNull(schemaKey1);
+        Assertions.assertEquals(db.getId(), schemaKey1.getDb_id());
+        Assertions.assertEquals(table.getId(), schemaKey1.getTable_id());
+        Assertions.assertEquals(schemaInfo.getId(), schemaKey1.getSchema_id());
+
+        // Generate MetaScanNode
+        ExecPlan plan2 = UtFrameUtils.getPlanAndFragment(
+                connectContext, "SELECT COUNT(*) FROM t_scan_node_cache_schema [_META_]").second;
+
+        // Verify plan has OlapScanNode with schema
+        List<MetaScanNode> metaScanNodes = plan2.getScanNodes().stream()
+                .filter(MetaScanNode.class::isInstance)
+                .map(MetaScanNode.class::cast)
+                .toList();
+        Assertions.assertEquals(1, metaScanNodes.size());
+        Assertions.assertEquals(schemaInfo, metaScanNodes.get(0).getSchema().orElse(null));
+        TPlan tPlan2 = metaScanNodes.get(0).treeToThrift();
+        Assertions.assertEquals(1, tPlan2.getNodesSize());
+        TMetaScanNode metaScanNode = tPlan2.getNodes().get(0).getMeta_scan_node();
+        TTableSchemaKey schemaKey2 = metaScanNode == null ? null : metaScanNode.getSchema_key();
+        Assertions.assertNotNull(schemaKey2);
+        Assertions.assertEquals(db.getId(), schemaKey2.getDb_id());
+        Assertions.assertEquals(table.getId(), schemaKey2.getTable_id());
+        Assertions.assertEquals(schemaInfo.getId(), schemaKey2.getSchema_id());
+    }
+
+    @Test
     public void testFoundInQueryCoordinator() throws Exception {
         LakeTable table = createTable("t_scan_coordinator");
         long indexId = table.getBaseIndexMetaId();
         SchemaInfo schemaInfo = SchemaInfo.fromMaterializedIndex(table, indexId, table.getIndexMetaByIndexId(indexId));
 
-        // Execute query to create coordinator with scan nodes
-        TUniqueId queryId = UUIDUtil.genTUniqueId();
-        Assertions.assertNull(QeProcessorImpl.INSTANCE.getCoordinator(queryId),
+        // Execute query to create coordinator with OlapScanNode
+        TUniqueId queryId1 = UUIDUtil.genTUniqueId();
+        Assertions.assertNull(QeProcessorImpl.INSTANCE.getCoordinator(queryId1),
                 "Query should not exist in QeProcessorImpl");
-        String sql = "SELECT * FROM t_scan_coordinator";
-        Coordinator coordinator = executeQueryAndRegister(sql, queryId);
+        String sql1 = "SELECT * FROM t_scan_coordinator";
+        executeQueryAndRegister(sql1, queryId1);
 
-        // Verify coordinator has scan nodes with schema
-        List<OlapScanNode> scanNodes = coordinator.getScanNodes().stream()
-                .filter(OlapScanNode.class::isInstance)
-                .map(OlapScanNode.class::cast)
-                .toList();
-        Assertions.assertEquals(1, scanNodes.size());
-        Assertions.assertEquals(schemaInfo, scanNodes.get(0).getSchema().orElse(null));
+        // Execute query to create coordinator with MetaScanNode
+        TUniqueId queryId2 = UUIDUtil.genTUniqueId();
+        Assertions.assertNull(QeProcessorImpl.INSTANCE.getCoordinator(queryId2),
+                "Query should not exist in QeProcessorImpl");
+        String sql2 = "SELECT COUNT(*) FROM t_scan_coordinator [_META_]";
+        executeQueryAndRegister(sql2, queryId2);
 
         // Request schema from coordinator
-        TGetTableSchemaRequest request = createScanRequest(schemaInfo.getId(), db.getId(), table.getId(), queryId);
-        TGetTableSchemaResponse response = TableSchemaService.getTableSchema(request);
+        for (TUniqueId queryId : Arrays.asList(queryId1, queryId2)) {
+            TGetTableSchemaRequest request = createScanRequest(schemaInfo.getId(), db.getId(), table.getId(), queryId);
+            TGetTableSchemaResponse response = TableSchemaService.getTableSchema(request);
 
-        Assertions.assertEquals(TStatusCode.OK, response.getStatus().getStatus_code());
-        Assertions.assertNotNull(response.getSchema());
-        Assertions.assertEquals(schemaInfo.toTabletSchema(), response.getSchema());
+            Assertions.assertEquals(TStatusCode.OK, response.getStatus().getStatus_code());
+            Assertions.assertNotNull(response.getSchema());
+            Assertions.assertEquals(schemaInfo.toTabletSchema(), response.getSchema());
+        }
     }
 
     @Test

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -1290,7 +1290,9 @@ struct TMetaScanNode {
     2: optional list<Descriptors.TColumn> columns
     3: optional i32 low_cardinality_threshold
     4: optional list<TColumnAccessPath> column_access_paths
+    // deprecated. use schema key instead
     5: optional i64 schema_id
+    6: optional Descriptors.TTableSchemaKey schema_key
 }
 
 struct TDecodeNode {


### PR DESCRIPTION
## Why I'm doing:

This PR extends `MetaScanNode` to support Fast Schema Evolution v2 , complementing PR #66142 which initially only `OlapScanNode` supports it. 

## What I'm doing:

`MetaScanNode` supports FSE v2 by also caching schema, and FE/BE table schema service can retrieve the schema from it.

**Frontend Changes:**
- Introduced `AbstractOlapTableScanNode` base class to extract common schema handling logic shared by `OlapScanNode` and `MetaScanNode`
- Refactored `MetaScanNode` to extend `AbstractOlapTableScanNode` and support `TTableSchemaKey` in the thrift plan
- Updated `TableSchemaService` to recognize both `OlapScanNode` and `MetaScanNode` when searching for cached schemas in query coordinators

**Backend Changes:**
- Extended `LakeMetaScanner` and `OlapMetaScanner` to accept and process `schema_key` from the plan
- Modified `LakeMetaReader` to fetch schema via `TableSchemaService` when `schema_key` is provided, with fallback to tablet metadata for legacy compatibility

**Testing:**
- Enhanced `LakeMetaScannerTest` with comprehensive test cases covering both fast schema evolution v2 path (with `schema_key`) and legacy path (without `schema_key`)
- Updated `TableSchemaServiceTest` to verify schema caching for both `OlapScanNode` and `MetaScanNode`

**Thrift Changes:**
- Added `schema_key` field to `TMetaScanNode` in `PlanNodes.thrift`
- Marked `schema_id` as deprecated in favor of `schema_key` for better schema identification

Fixes #65706 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

**Note:** This PR maintains backward compatibility. When `schema_key` is not provided (legacy FE), the system falls back to the old schema retrieval mechanism from tablet metadata.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds FSE v2 to MetaScan by propagating schema_key, caching schema in scan nodes, and fetching schema from FE; updates BE readers and Thrift accordingly.
> 
> - **Planner/FE**:
>   - Introduce `AbstractOlapTableScanNode` to share schema handling for `OlapScanNode` and `MetaScanNode`.
>   - `MetaScanNode` extends the base class and embeds `schema_key` in `TMetaScanNode` (also sets legacy `schema_id`).
>   - `TableSchemaService` now scans all `AbstractOlapTableScanNode` instances to serve schema requests.
> - **BE Readers/Scanners**:
>   - `LakeMetaScanner` forwards `schema_key` to `LakeMetaReader`.
>   - `LakeMetaReader` fetches schema via FE `TableSchemaService` when `schema_key` is present; falls back to tablet metadata otherwise.
>   - `OlapMetaScanner` honors `schema_key` (or legacy `schema_id`) when selecting tablet schema.
> - **Thrift/Protocol**:
>   - Add `Descriptors.TTableSchemaKey schema_key` to `TMetaScanNode`; mark `schema_id` deprecated.
> - **Testing**:
>   - New/updated UTs: `LakeMetaScannerTest` (schema_key vs legacy), `TableSchemaServiceTest` (schema caching for both scan nodes), scheduler/warehouse tests adjusted to build minimal valid tables.
> - **Misc**:
>   - Minor refactors (remove DECL_FINAL macros, expose minimal test helpers).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4cd088ffbddd84cc7ccbdb9ed374d42475b13489. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->