### PR TITLE
[BugFix] Fix infinite recursion in ReplaceColumnRefRewriter

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ReplaceColumnRefRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ReplaceColumnRefRewriter.java
@@ -15,12 +15,14 @@
 package com.starrocks.sql.optimizer.rewrite;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 // Replace the corresponding ColumnRef with ScalarOperator
 public class ReplaceColumnRefRewriter {
@@ -65,6 +67,10 @@ public class ReplaceColumnRefRewriter {
     }
 
     private class Rewriter extends ScalarOperatorVisitor<ScalarOperator, Void> {
+        // Track keys that are temporarily excluded from replacement during recursive rewriting
+        // to prevent cycles when a replaced expression contains the original column reference
+        private final Set<ColumnRefOperator> excludedKeys = Sets.newHashSet();
+
         @Override
         public ScalarOperator visit(ScalarOperator scalarOperator, Void context) {
             List<ScalarOperator> children = Lists.newArrayList(scalarOperator.getChildren());
@@ -76,6 +82,10 @@ public class ReplaceColumnRefRewriter {
 
         @Override
         public ScalarOperator visitVariableReference(ColumnRefOperator column, Void context) {
+            // If this column is excluded, don't replace it (prevents cycles)
+            if (excludedKeys.contains(column)) {
+                return column;
+            }
             if (!operatorMap.containsKey(column)) {
                 return column;
             }
@@ -98,8 +108,17 @@ public class ReplaceColumnRefRewriter {
                     mapperOperator = mapped;
                 }
                 mapperOperator = mapperOperator.clone();
-                for (int i = 0; i < mapperOperator.getChildren().size(); ++i) {
-                    mapperOperator.setChild(i, mapperOperator.getChild(i).accept(this, null));
+                
+                // Temporarily exclude this key from replacement when recursively rewriting children
+                // to prevent cycles when the replacement contains the original column reference
+                excludedKeys.add(column);
+                try {
+                    for (int i = 0; i < mapperOperator.getChildren().size(); ++i) {
+                        mapperOperator.setChild(i, mapperOperator.getChild(i).accept(this, null));
+                    }
+                } finally {
+                    // Restore the key after rewriting children
+                    excludedKeys.remove(column);
                 }
             }
             return mapperOperator;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ReplaceColumnRefRewriterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ReplaceColumnRefRewriterTest.java
@@ -15,13 +15,22 @@
 
 package com.starrocks.sql.optimizer.rewrite;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.starrocks.catalog.FunctionSet;
 import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.LambdaFunctionOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.operator.scalar.SubfieldOperator;
+import com.starrocks.type.ArrayType;
 import com.starrocks.type.IntegerType;
+import com.starrocks.type.StructField;
+import com.starrocks.type.StructType;
+import com.starrocks.type.VarcharType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -75,7 +84,61 @@ public class ReplaceColumnRefRewriterTest {
         Assertions.assertEquals(columnRef1, result2);
     }
 
+    @Test
+    public void testLambdaFunctionWithRecursiveRewrite() {
+        // Reproduces StackOverflowError when lambda parameter is in operatorMap with isRecursively=true
+        // Scenario: array_map(x -> named_struct('my_field', x.my_field), ...)
+        ColumnRefOperator lambdaParam = createColumnRef(100, "x");
+        SubfieldOperator subfield = new SubfieldOperator(lambdaParam, VarcharType.VARCHAR,
+                Lists.newArrayList("my_field"));
+
+        StructType structType = new StructType(Lists.newArrayList(
+                new StructField("my_field", VarcharType.VARCHAR)
+        ));
+        CallOperator namedStruct = new CallOperator(
+                FunctionSet.NAMED_STRUCT,
+                structType,
+                Lists.newArrayList(
+                        ConstantOperator.createVarchar("my_field"),
+                        subfield
+                )
+        );
+
+        LambdaFunctionOperator lambda = new LambdaFunctionOperator(
+                Lists.newArrayList(lambdaParam),
+                namedStruct,
+                ArrayType.ARRAY_VARCHAR);
+
+        // Map lambda parameter to subfield expression containing the lambda param
+        Map<ColumnRefOperator, ScalarOperator> operatorMap = Maps.newHashMap();
+        operatorMap.put(lambdaParam, subfield);
+
+        ReplaceColumnRefRewriter rewriter = new ReplaceColumnRefRewriter(operatorMap, true);
+
+        try {
+            ScalarOperator rewritten = rewriter.rewrite(lambda);
+
+            // Verify lambda parameter is NOT replaced
+            Assertions.assertInstanceOf(LambdaFunctionOperator.class, rewritten);
+            LambdaFunctionOperator rewrittenLambda = (LambdaFunctionOperator) rewritten;
+            Assertions.assertEquals(1, rewrittenLambda.getRefColumns().size());
+            Assertions.assertEquals(lambdaParam.getId(), rewrittenLambda.getRefColumns().get(0).getId());
+
+            ScalarOperator rewrittenExpr = rewrittenLambda.getLambdaExpr();
+            Assertions.assertInstanceOf(CallOperator.class, rewrittenExpr);
+            CallOperator rewrittenNamedStruct = (CallOperator) rewrittenExpr;
+            ScalarOperator secondArg = rewrittenNamedStruct.getChild(1);
+            Assertions.assertInstanceOf(SubfieldOperator.class, secondArg);
+        } catch (StackOverflowError e) {
+            Assertions.fail("StackOverflowError occurred - lambda parameter was incorrectly replaced");
+        }
+    }
+
     ColumnRefOperator createColumnRef(int id) {
         return new ColumnRefOperator(id, IntegerType.INT, "ref" + id, false);
+    }
+
+    ColumnRefOperator createColumnRef(int id, String name) {
+        return new ColumnRefOperator(id, IntegerType.INT, name, false);
     }
 }


### PR DESCRIPTION
## Why I'm doing:

Fixing an infinite recursion / stack overflow bug that occurs in ReplaceColumnRefRewriter under certain circumstances when using `isRecursively=true`

## What I'm doing:

When recursively replacing columns if the expression we are using to replace a column reference also contains that column reference we enter an infinite recursion. This change excludes the column ref that is being replaced from also being replaced in the replacement expression, preventing the infinite recursion. 

Fixes #65826 

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents recursive replacement cycles by temporarily excluding the current column ref during child rewrites, and adds a unit test covering a lambda/subfield case.
> 
> - **Optimizer/Rewriter (`ReplaceColumnRefRewriter`)**:
>   - Prevent recursive replacement cycles by tracking `excludedKeys` and skipping replacements for the currently processed `ColumnRefOperator`.
>   - Wrap recursive child rewrites in try/finally to add/remove the excluded key safely.
> - **Tests**:
>   - Add `testLambdaFunctionWithRecursiveRewrite` to validate no `StackOverflowError` when lambda param maps to a subfield containing itself.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 204c372514321a0e69819700473653dfc6d0c7ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->