### PR TITLE
[Feature] Implement path_column for files()

### DIFF
--- a/be/src/exec/file_scanner/avro_cpp_scanner.cpp
+++ b/be/src/exec/file_scanner/avro_cpp_scanner.cpp
@@ -57,7 +57,9 @@ Status AvroCppScanner::open() {
         if (rng.num_of_columns_from_file != first_range.num_of_columns_from_file) {
             return Status::InvalidArgument("Column count from file of range mismatch");
         }
-        if (rng.num_of_columns_from_file + rng.columns_from_path.size() != _src_slot_descriptors.size()) {
+        int path_column_count = (rng.__isset.include_file_path_column && rng.include_file_path_column) ? 1 : 0;
+        if (rng.num_of_columns_from_file + rng.columns_from_path.size() + path_column_count !=
+            _src_slot_descriptors.size()) {
             return Status::InvalidArgument("Slot descriptor and column count mismatch");
         }
     }
@@ -118,8 +120,12 @@ StatusOr<ChunkPtr> AvroCppScanner::get_next() {
         }
     }
 
-    fill_columns_from_path(src_chunk, _num_of_columns_from_file, _scan_range.ranges[_next_range - 1].columns_from_path,
-                           src_chunk->num_rows());
+    const auto& range = _scan_range.ranges[_next_range - 1];
+    fill_columns_from_path(src_chunk, _num_of_columns_from_file, range.columns_from_path, src_chunk->num_rows());
+    if (range.__isset.include_file_path_column && range.include_file_path_column) {
+        int path_column_slot = _num_of_columns_from_file + range.columns_from_path.size();
+        fill_file_path_column(src_chunk, path_column_slot, range.path, src_chunk->num_rows());
+    }
 
     return materialize(src_chunk, src_chunk);
 }

--- a/be/src/exec/file_scanner/csv_scanner.cpp
+++ b/be/src/exec/file_scanner/csv_scanner.cpp
@@ -194,7 +194,9 @@ Status CSVScanner::open() {
         if (rng.num_of_columns_from_file != first_range.num_of_columns_from_file) {
             return Status::InvalidArgument("CSV column count of range mismatch");
         }
-        if (rng.num_of_columns_from_file + rng.columns_from_path.size() != _src_slot_descriptors.size()) {
+        int path_column_count = (rng.__isset.include_file_path_column && rng.include_file_path_column) ? 1 : 0;
+        if (rng.num_of_columns_from_file + rng.columns_from_path.size() + path_column_count !=
+            _src_slot_descriptors.size()) {
             return Status::InvalidArgument("slot descriptor and column count mismatch");
         }
     }
@@ -308,6 +310,11 @@ StatusOr<ChunkPtr> CSVScanner::get_next() {
     do {
         RETURN_IF_ERROR(_init_reader());
 
+        // No more files to process
+        if (_curr_reader == nullptr) {
+            return Status::EndOfFile("");
+        }
+
         src_chunk->set_num_rows(0);
         Status status = Status::OK();
         if (!_use_v2) {
@@ -322,7 +329,7 @@ StatusOr<ChunkPtr> CSVScanner::get_next() {
             } else if (status.is_time_out()) {
                 // if timeout happens at the beginning of reading src_chunk, we return the error state
                 // else we will _materialize the lines read before timeout
-                if (src_chunk->num_rows() == 0) {
+                if (src_chunk->num_rows() == 0 && _parsed_rows_for_path_columns == 0) {
                     _reusable_empty_chunk.swap(src_chunk);
                     return status;
                 }
@@ -334,10 +341,17 @@ StatusOr<ChunkPtr> CSVScanner::get_next() {
         if (src_chunk->num_rows() > 0) {
             _materialize_src_chunk_adaptive_nullable_column(src_chunk);
         }
-    } while ((src_chunk)->num_rows() == 0);
+    } while (src_chunk->num_rows() == 0 && _parsed_rows_for_path_columns == 0);
 
-    fill_columns_from_path(src_chunk, _num_fields_in_csv, _scan_range.ranges[_curr_file_index].columns_from_path,
-                           src_chunk->num_rows());
+    // When chunk has no file columns, use tracked row count for path columns
+    size_t rows_for_path = src_chunk->num_columns() > 0 ? src_chunk->num_rows() : _parsed_rows_for_path_columns;
+
+    const auto& range = _scan_range.ranges[_curr_file_index];
+    fill_columns_from_path(src_chunk, _num_fields_in_csv, range.columns_from_path, rows_for_path);
+    if (range.__isset.include_file_path_column && range.include_file_path_column) {
+        int path_column_slot = _num_fields_in_csv + range.columns_from_path.size();
+        fill_file_path_column(src_chunk, path_column_slot, range.path, rows_for_path);
+    }
     ASSIGN_OR_RETURN(chunk, materialize(nullptr, src_chunk));
 
     return std::move(chunk);
@@ -355,9 +369,15 @@ Status CSVScanner::_parse_csv_v2(Chunk* chunk) {
     }
 
     csv::Converter::Options options{.invalid_field_as_null = !_strict_mode};
-    for (size_t num_rows = chunk->num_rows(); num_rows < capacity; /**/) {
+    size_t num_rows = 0;
+    for (num_rows = chunk->num_rows(); num_rows < capacity; /**/) {
         status = _curr_reader->next_record(row);
         if (!status.ok() && !status.is_end_of_file()) {
+            // See _parse_csv: preserve partial path-only row count across a timeout return so
+            // the reader's already-consumed records still get materialized as path columns.
+            if (num_columns == 0 && status.is_time_out()) {
+                _parsed_rows_for_path_columns = num_rows;
+            }
             return status;
         }
 
@@ -460,6 +480,13 @@ Status CSVScanner::_parse_csv_v2(Chunk* chunk) {
         }
     }
     row.columns.clear();
+    // When no file columns are materialized (only path_column or columns_from_path),
+    // chunk has no columns so num_rows() returns 0. Track row count separately.
+    if (num_columns == 0 && num_rows > 0) {
+        _parsed_rows_for_path_columns = num_rows;
+        return Status::OK();
+    }
+    _parsed_rows_for_path_columns = 0;
     return chunk->num_rows() > 0 ? Status::OK() : Status::EndOfFile("");
 }
 
@@ -477,11 +504,21 @@ Status CSVScanner::_parse_csv(Chunk* chunk) {
 
     csv::Converter::Options options{.invalid_field_as_null = !_strict_mode};
 
-    for (size_t num_rows = chunk->num_rows(); num_rows < capacity; /**/) {
+    size_t num_rows = 0;
+    for (num_rows = chunk->num_rows(); num_rows < capacity; /**/) {
         status = _curr_reader->next_record(&record);
         if (status.is_end_of_file()) {
             break;
         } else if (!status.ok()) {
+            // For a path-only scan (num_columns == 0) the row count for fill_columns_from_path /
+            // fill_file_path_column lives in _parsed_rows_for_path_columns instead of chunk->num_rows().
+            // If timeout fires after some records have already been consumed by the reader, dropping
+            // num_rows here would lose those rows (the reader's cursor is past them, retry skips them).
+            // Mirror the column-chunk timeout path: keep the partial count so the caller materializes
+            // the path rows we already paid for.
+            if (num_columns == 0 && status.is_time_out()) {
+                _parsed_rows_for_path_columns = num_rows;
+            }
             return status;
         } else if (record.empty()) {
             // always skip blank rows.
@@ -561,6 +598,13 @@ Status CSVScanner::_parse_csv(Chunk* chunk) {
         num_rows += !has_error;
     }
     fields.clear();
+    // When no file columns are materialized (only path_column or columns_from_path),
+    // chunk has no columns so num_rows() returns 0. Track row count separately.
+    if (num_columns == 0 && num_rows > 0) {
+        _parsed_rows_for_path_columns = num_rows;
+        return Status::OK();
+    }
+    _parsed_rows_for_path_columns = 0;
     return chunk->num_rows() > 0 ? Status::OK() : Status::EndOfFile("");
 }
 

--- a/be/src/exec/file_scanner/csv_scanner.h
+++ b/be/src/exec/file_scanner/csv_scanner.h
@@ -102,6 +102,10 @@ private:
     // It's mainly for optimizing the performance where get_next() returns Status::Timeout
     // frequently by avoiding creating a chunk in each call
     ChunkPtr _reusable_empty_chunk = nullptr;
+
+    // When no file columns are materialized (only path_column or columns_from_path),
+    // we need to track row count separately since chunk->num_rows() returns 0 for empty chunks
+    size_t _parsed_rows_for_path_columns = 0;
 };
 
 } // namespace starrocks

--- a/be/src/exec/file_scanner/file_scanner.cpp
+++ b/be/src/exec/file_scanner/file_scanner.cpp
@@ -176,6 +176,17 @@ void FileScanner::fill_columns_from_path(starrocks::ChunkPtr& chunk, int slot_st
     }
 }
 
+void FileScanner::fill_file_path_column(starrocks::ChunkPtr& chunk, int slot_index, const std::string& file_path,
+                                        int size) {
+    auto varchar_type = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
+    auto slot_desc = _src_slot_descriptors.at(slot_index);
+    if (slot_desc == nullptr) return;
+    auto col = ColumnHelper::create_column(varchar_type, slot_desc->is_nullable());
+    Slice s(file_path.c_str(), file_path.size());
+    col->append_value_multiple_times(&s, size);
+    chunk->append_column(std::move(col), slot_desc->id());
+}
+
 StatusOr<ChunkPtr> FileScanner::materialize(const starrocks::ChunkPtr& src, starrocks::ChunkPtr& cast) {
     SCOPED_RAW_TIMER(&_counter->materialize_ns);
 

--- a/be/src/exec/file_scanner/file_scanner.h
+++ b/be/src/exec/file_scanner/file_scanner.h
@@ -133,6 +133,8 @@ public:
 protected:
     void fill_columns_from_path(ChunkPtr& chunk, int slot_start, const std::vector<std::string>& columns_from_path,
                                 int size);
+    // fill the file path column with the full file path for all rows in the chunk
+    void fill_file_path_column(ChunkPtr& chunk, int slot_index, const std::string& file_path, int size);
     // materialize is used to transform source chunk depicted by src_slot_descriptors into destination
     // chunk depicted by dest_slot_descriptors
     StatusOr<ChunkPtr> materialize(const starrocks::ChunkPtr& src, starrocks::ChunkPtr& cast);

--- a/be/src/exec/file_scanner/parquet_scanner.cpp
+++ b/be/src/exec/file_scanner/parquet_scanner.cpp
@@ -211,10 +211,14 @@ Status ParquetScanner::finalize_src_chunk(ChunkPtr* chunk) {
             column = ColumnHelper::unfold_const_column(slot_desc->type(), (*chunk)->num_rows(), column);
             cast_chunk->append_column(column, slot_desc->id());
         }
-        auto range = _scan_range.ranges.at(_next_file - 1);
+        const auto& range = _scan_range.ranges.at(_next_file - 1);
         if (range.__isset.num_of_columns_from_file) {
             fill_columns_from_path(cast_chunk, range.num_of_columns_from_file, range.columns_from_path,
                                    cast_chunk->num_rows());
+        }
+        if (range.__isset.include_file_path_column && range.include_file_path_column) {
+            int path_column_slot = range.num_of_columns_from_file + range.columns_from_path.size();
+            fill_file_path_column(cast_chunk, path_column_slot, range.path, cast_chunk->num_rows());
         }
         if (VLOG_ROW_IS_ON) {
             VLOG_ROW << "after finalize chunk: " << cast_chunk->debug_columns();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -125,6 +125,7 @@ public class TableFunctionTable extends Table {
     public static final String PROPERTY_PARTITION_BY = "partition_by";
 
     public static final String PROPERTY_COLUMNS_FROM_PATH = "columns_from_path";
+    public static final String PROPERTY_PATH_COLUMN = "path_column";
     private static final String PROPERTY_STRICT_MODE = LoadStmt.STRICT_MODE;
 
     public static final String PROPERTY_AUTO_DETECT_SAMPLE_FILES = "auto_detect_sample_files";
@@ -186,6 +187,7 @@ public class TableFunctionTable extends Table {
     private boolean autoDetectTypes = true;
 
     private List<String> columnsFromPath = new ArrayList<>();
+    private String pathColumnName = null;
     private boolean strictMode = false;
     private final Map<String, String> properties;
 
@@ -274,6 +276,11 @@ public class TableFunctionTable extends Table {
 
         // get columns from path
         columns.addAll(getSchemaFromPath());
+
+        // add path column if specified
+        if (pathColumnName != null) {
+            columns.add(new Column(pathColumnName, StringType.DEFAULT_STRING, true));
+        }
 
         // check duplicate columns
         checkDuplicateColumns(columns);
@@ -506,6 +513,11 @@ public class TableFunctionTable extends Table {
             for (String col : colsFromPath) {
                 columnsFromPath.add(col.trim());
             }
+        }
+
+        String pathColumnProp = properties.get(PROPERTY_PATH_COLUMN);
+        if (!Strings.isNullOrEmpty(pathColumnProp)) {
+            pathColumnName = pathColumnProp.trim();
         }
 
         if (properties.containsKey(PROPERTY_STRICT_MODE)) {
@@ -778,6 +790,14 @@ public class TableFunctionTable extends Table {
 
     public List<String> getColumnsFromPath() {
         return columnsFromPath;
+    }
+
+    public String getPathColumnName() {
+        return pathColumnName;
+    }
+
+    public boolean hasPathColumn() {
+        return pathColumnName != null;
     }
 
     public boolean isStrictMode() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/BrokerFileGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/BrokerFileGroup.java
@@ -91,6 +91,8 @@ public class BrokerFileGroup implements Writable {
     // fileFieldNames should be filled automatically according to schema and mapping when loading from hive table.
     private List<String> fileFieldNames;
     private List<String> columnsFromPath;
+    // if true, the file path will be exposed as an additional column after columnsFromPath
+    private boolean hasPathColumn = false;
     // columnExprList includes all fileFieldNames, columnsFromPath and column mappings
     // this param will be recreated by data desc when the log replay
     private List<ImportColumnDesc> columnExprList;
@@ -143,6 +145,7 @@ public class BrokerFileGroup implements Writable {
 
         this.columnExprList = table.getColumnExprList(scanColumns);
         this.columnsFromPath = table.getColumnsFromPath();
+        this.hasPathColumn = table.hasPathColumn();
     }
 
     public BrokerFileGroup(DataDescription dataDescription) {
@@ -324,6 +327,10 @@ public class BrokerFileGroup implements Writable {
 
     public List<String> getColumnsFromPath() {
         return columnsFromPath;
+    }
+
+    public boolean hasPathColumn() {
+        return hasPathColumn;
     }
 
     public List<ImportColumnDesc> getColumnExprList() {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
@@ -584,7 +584,9 @@ public class FileScanNode extends LoadScanNode {
             TFileFormatType formatType = Load.getFormatType(context.fileGroup.getFileFormat(), fileStatus.path);
             List<String> columnsFromPath = HdfsUtil.parseColumnsFromPath(fileStatus.path,
                     context.fileGroup.getColumnsFromPath());
-            int numberOfColumnsFromFile = context.slotDescByName.size() - columnsFromPath.size();
+            boolean hasPathColumn = context.fileGroup.hasPathColumn();
+            int numberOfColumnsFromFile = context.slotDescByName.size() - columnsFromPath.size()
+                    - (hasPathColumn ? 1 : 0);
 
             smallestLocations = locationsHeap.poll();
             long leftBytes = fileStatus.size - curFileOffset;
@@ -602,7 +604,7 @@ public class FileScanNode extends LoadScanNode {
 
             TBrokerRangeDesc rangeDesc =
                     createBrokerRangeDesc(curFileOffset, fileStatus, formatType, rangeBytes, columnsFromPath,
-                            numberOfColumnsFromFile);
+                            numberOfColumnsFromFile, hasPathColumn);
 
             rangeDesc.setStrip_outer_array(jsonOptions.stripOuterArray);
             rangeDesc.setJsonpaths(jsonOptions.jsonPaths);
@@ -645,7 +647,8 @@ public class FileScanNode extends LoadScanNode {
 
     private TBrokerRangeDesc createBrokerRangeDesc(long curFileOffset, TBrokerFileStatus fileStatus,
                                                    TFileFormatType formatType, long rangeBytes,
-                                                   List<String> columnsFromPath, int numberOfColumnsFromFile) {
+                                                   List<String> columnsFromPath, int numberOfColumnsFromFile,
+                                                   boolean hasPathColumn) {
         TBrokerRangeDesc rangeDesc = new TBrokerRangeDesc();
         rangeDesc.setFile_type(TFileType.FILE_BROKER);
         rangeDesc.setFormat_type(formatType);
@@ -656,6 +659,7 @@ public class FileScanNode extends LoadScanNode {
         rangeDesc.setFile_size(fileStatus.size);
         rangeDesc.setNum_of_columns_from_file(numberOfColumnsFromFile);
         rangeDesc.setColumns_from_path(columnsFromPath);
+        rangeDesc.setInclude_file_path_column(hasPathColumn);
         return rangeDesc;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TableFunctionTableTest.java
@@ -579,4 +579,90 @@ public class TableFunctionTableTest {
             );
         }
     }
+
+    @Test
+    public void testPathColumn() {
+        // Test path_column property parsing
+        Assertions.assertDoesNotThrow(() -> {
+            Map<String, String> properties = newProperties();
+            properties.put("path_column", "_filepath");
+            TableFunctionTable table = new TableFunctionTable(properties);
+
+            // Check path_column is parsed correctly
+            Assertions.assertTrue(table.hasPathColumn());
+            Assertions.assertEquals("_filepath", table.getPathColumnName());
+
+            // Check schema includes path column after columns_from_path
+            List<Column> schema = table.getFullSchema();
+            // Schema: col_int, col_string (from file) + col_path1, col_path2, col_path3 (from path) + _filepath (path column)
+            Assertions.assertEquals(6, schema.size());
+            Assertions.assertEquals(new Column("col_int", IntegerType.INT), schema.get(0));
+            Assertions.assertEquals(new Column("col_string", VarcharType.VARCHAR), schema.get(1));
+            Assertions.assertEquals(new Column("col_path1", StringType.DEFAULT_STRING, true), schema.get(2));
+            Assertions.assertEquals(new Column("col_path2", StringType.DEFAULT_STRING, true), schema.get(3));
+            Assertions.assertEquals(new Column("col_path3", StringType.DEFAULT_STRING, true), schema.get(4));
+            Assertions.assertEquals(new Column("_filepath", StringType.DEFAULT_STRING, true), schema.get(5));
+        });
+    }
+
+    @Test
+    public void testPathColumnWithoutColumnsFromPath() {
+        // Test path_column without columns_from_path
+        Assertions.assertDoesNotThrow(() -> {
+            Map<String, String> properties = new HashMap<>();
+            properties.put("path", "fake://some_bucket/some_path/*");
+            properties.put("format", "ORC");
+            properties.put("path_column", "source_file");
+            TableFunctionTable table = new TableFunctionTable(properties);
+
+            Assertions.assertTrue(table.hasPathColumn());
+            Assertions.assertEquals("source_file", table.getPathColumnName());
+
+            // Schema: col_int, col_string (from file) + source_file (path column)
+            List<Column> schema = table.getFullSchema();
+            Assertions.assertEquals(3, schema.size());
+            Assertions.assertEquals(new Column("source_file", StringType.DEFAULT_STRING, true), schema.get(2));
+        });
+    }
+
+    @Test
+    public void testNoPathColumn() {
+        // Test without path_column
+        Assertions.assertDoesNotThrow(() -> {
+            Map<String, String> properties = newProperties();
+            TableFunctionTable table = new TableFunctionTable(properties);
+
+            Assertions.assertFalse(table.hasPathColumn());
+            Assertions.assertNull(table.getPathColumnName());
+        });
+    }
+
+    @Test
+    public void testDuplicatePathColumnName() {
+        // Test duplicate path_column name with file column
+        Map<String, String> properties = newProperties();
+        properties.put("path_column", "col_int");
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                "Duplicate column name 'col_int'",
+                () -> new TableFunctionTable(properties));
+
+        // Test duplicate path_column name with columns_from_path
+        properties.put("path_column", "col_path1");
+        ExceptionChecker.expectThrowsWithMsg(DdlException.class,
+                "Duplicate column name 'col_path1'",
+                () -> new TableFunctionTable(properties));
+    }
+
+    @Test
+    public void testPathColumnWithWhitespace() {
+        // Test path_column with leading/trailing whitespace
+        Assertions.assertDoesNotThrow(() -> {
+            Map<String, String> properties = newProperties();
+            properties.put("path_column", "  _filepath  ");
+            TableFunctionTable table = new TableFunctionTable(properties);
+
+            Assertions.assertTrue(table.hasPathColumn());
+            Assertions.assertEquals("_filepath", table.getPathColumnName());
+        });
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/load/BrokerFileGroupTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/BrokerFileGroupTest.java
@@ -185,4 +185,41 @@ public class BrokerFileGroupTest {
         Assertions.assertEquals("\1", fileGroup.getColumnSeparator());
         Assertions.assertEquals("\2", fileGroup.getRowDelimiter());
     }
+
+    @Test
+    public void testTableFunctionTableWithPathColumn() throws StarRocksException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("path", "fake://some_bucket/some_path/*");
+        properties.put("format", "CSV");
+        properties.put("path_column", "_filepath");
+
+        TableFunctionTable table = new TableFunctionTable(properties);
+        BrokerFileGroup fileGroup = new BrokerFileGroup(table, Sets.newHashSet());
+        Assertions.assertTrue(fileGroup.hasPathColumn());
+    }
+
+    @Test
+    public void testTableFunctionTableWithoutPathColumn() throws StarRocksException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("path", "fake://some_bucket/some_path/*");
+        properties.put("format", "CSV");
+
+        TableFunctionTable table = new TableFunctionTable(properties);
+        BrokerFileGroup fileGroup = new BrokerFileGroup(table, Sets.newHashSet());
+        Assertions.assertFalse(fileGroup.hasPathColumn());
+    }
+
+    @Test
+    public void testTableFunctionTableWithPathColumnAndColumnsFromPath() throws StarRocksException {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("path", "fake://some_bucket/some_path/*");
+        properties.put("format", "CSV");
+        properties.put("columns_from_path", "year,month");
+        properties.put("path_column", "source_file");
+
+        TableFunctionTable table = new TableFunctionTable(properties);
+        BrokerFileGroup fileGroup = new BrokerFileGroup(table, Sets.newHashSet());
+        Assertions.assertTrue(fileGroup.hasPathColumn());
+        Assertions.assertEquals(Arrays.asList("year", "month"), fileGroup.getColumnsFromPath());
+    }
 }

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -199,6 +199,9 @@ struct TBrokerRangeDesc {
     15: optional TEnvelopeType envelope
     // last modification time of the file in milliseconds (epoch), for rejected-record anchors
     16: optional i64 modification_time
+    // If true, the file path will be exposed as an additional column
+    // The path column comes after columns_from_path in the schema
+    17: optional bool include_file_path_column
 }
 
 enum TObjectStoreType {


### PR DESCRIPTION
## Why I'm doing:
Users need filepath for row lineage

## What I'm doing:
Add filepath like columns_from_path
```
SELECT * FROM files(
    'path'='s3://path/*.csv',
    'format'='csv',
    'path_column'='_filepath'
  );

$1: col_data
_filepath: s3://path/file.csv
```

Fixes #66973 #66976

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional `path_column` to files() that appends the source file path as a VARCHAR column across CSV/Parquet/ORC/Avro, plumbed via planner and thrift.
> 
> - **Files() feature**:
>   - Add optional `path_column` property; schema appends path column after `columns_from_path` in `TableFunctionTable`.
> - **Planner** (`FileScanNode`, `BrokerFileGroup`):
>   - Compute `hasPathColumn`; adjust `num_of_columns_from_file` and set `include_file_path_column` in `TBrokerRangeDesc`.
> - **Thrift API** (`PlanNodes.thrift`):
>   - Add `include_file_path_column` to `TBrokerRangeDesc`.
> - **Backend scanners**:
>   - CSV/Parquet/ORC/Avro scanners: validate slot counts with path column; fill path via `fill_file_path_column(...)` when requested.
>   - CSV: handle empty file-columns case by tracking `_parsed_rows_for_path_columns`; refine timeout/loop conditions.
>   - Core: add `FileScanner::fill_file_path_column(...)` helper.
> - **Tests**:
>   - FE and load tests covering `path_column` parsing, schema placement, duplicates, and planner propagation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da5030f867388f2b19cb82f235ae4ddca9bb7818. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

