### PR TITLE
[Doc] v3.4 behavior changes

### DIFF
--- a/docs/en/release_notes/release-3.4.md
+++ b/docs/en/release_notes/release-3.4.md
@@ -299,14 +299,17 @@ Release date: January 24, 2025
 
 ### Behavior Changes
 
-Because the Data Cache instance used in both shared-data architecture and data lake query scenarios is now unified, there will be the following behavior changes after the upgrade to v3.4.0:
+- Because the Data Cache instance used in both shared-data architecture and data lake query scenarios is now unified, there will be the following behavior changes after the upgrade to v3.4.0:
 
-- BE configuration item `datacache_disk_path` is now deprecated. The data will be cached under the directory `${storage_root_path}/datacache`. If you want to allocate a dedicated disk for data cache, you can manually point the directory to the directory mentioned above using a symlink.
-- Cached data in the shared-data cluster will be automatically migrated to `${storage_root_path}/datacache` and can be re-used after the upgrade.
-- The behavior changes of `datacache_disk_size`:
+  - BE configuration item `datacache_disk_path` is now deprecated. The data will be cached under the directory `${storage_root_path}/datacache`. If you want to allocate a dedicated disk for data cache, you can manually point the directory to the directory mentioned above using a symlink.
+  - Cached data in the shared-data cluster will be automatically migrated to `${storage_root_path}/datacache` and can be re-used after the upgrade.
+  - The behavior changes of `datacache_disk_size`:
 
-  - When `datacache_disk_size` is `0` (Default), the automatic adjustment of cache capacity is enabled (consistent with the behavior before the upgrade).
-  - When `datacache_disk_size` is set to a value greater than `0`, the system will pick a larger value between `datacache_disk_size` and  `starlet_star_cache_disk_size_percent` as the cache capacity.
+    - When `datacache_disk_size` is `0` (Default), the automatic adjustment of cache capacity is enabled (consistent with the behavior before the upgrade).
+    - When `datacache_disk_size` is set to a value greater than `0`, the system will pick a larger value between `datacache_disk_size` and  `starlet_star_cache_disk_size_percent` as the cache capacity.
+
+- From v3.4.0 onwards, `insert_timeout` applies to operations involved INSERT (for example, UPDATE, DELETE, CTAS, materialized view refresh, statistics collection, and PIPE), replacing `query_timeout`.
+- From v3.4.0 onwards, the default value of `mysql_server_version` is changed to `8.0.33`.
 
 ### Downgrade Notes
 

--- a/docs/ja/release_notes/release-3.4.md
+++ b/docs/ja/release_notes/release-3.4.md
@@ -300,14 +300,17 @@ displayed_sidebar: docs
 
 ### 動作の変更
 
-共有データアーキテクチャとデータレイククエリシナリオの両方で使用される Data Cache インスタンスが統一されたため、v3.4.0 へのアップグレード後に以下の動作が変更されます：
+- 共有データアーキテクチャとデータレイククエリシナリオの両方で使用される Data Cache インスタンスが統一されたため、v3.4.0 へのアップグレード後に以下の動作が変更されます：
 
-- BE の設定項目 `datacache_disk_path` は廃止された。データは `${storage_root_path}/datacache` ディレクトリ以下にキャッシュされる。Data Cache 専用のディスクを割り当てたい場合は、シンボリックリンクを使用して手動で上記のディレクトリを指定してください。
-- 共有データクラスタのキャッシュデータは自動的に `${storage_root_path}/datacache` に移行され、アップグレード後も再利用できる。
-- `datacache_disk_size` の動作が変わる：
+  - BE の設定項目 `datacache_disk_path` は廃止された。データは `${storage_root_path}/datacache` ディレクトリ以下にキャッシュされる。Data Cache 専用のディスクを割り当てたい場合は、シンボリックリンクを使用して手動で上記のディレクトリを指定してください。
+  - 共有データクラスタのキャッシュデータは自動的に `${storage_root_path}/datacache` に移行され、アップグレード後も再利用できる。
+  - `datacache_disk_size` の動作が変わる：
 
-  - `datacache_disk_size` が `0` (デフォルト) の場合、キャッシュ容量の自動調整が有効になる (アップグレード前の動作と同じ)。
-  - `datacache_disk_size` が `0` より大きい値に設定されている場合、システムは `datacache_disk_size` と `starlet_star_cache_disk_size_percent` の間の大きい値をキャッシュ容量として選択する。
+    - `datacache_disk_size` が `0` (デフォルト) の場合、キャッシュ容量の自動調整が有効になる (アップグレード前の動作と同じ)。
+    - `datacache_disk_size` が `0` より大きい値に設定されている場合、システムは `datacache_disk_size` と `starlet_star_cache_disk_size_percent` の間の大きい値をキャッシュ容量として選択する。
+
+- v3.4.0 以降、`insert_timeout` は INSERT に関与する操作（例: UPDATE、DELETE、CTAS、マテリアライズドビューのリフレッシュ、統計収集、PIPE）に適用され、`query_timeout` を置き換えます。
+- v3.4.0 以降、`mysql_server_version` のデフォルト値は `8.0.33` に変更されました。
 
 ### ダウングレードノート
 

--- a/docs/zh/release_notes/release-3.4.md
+++ b/docs/zh/release_notes/release-3.4.md
@@ -299,14 +299,17 @@ displayed_sidebar: docs
 
 ### 行为变更
 
-由于存算分离架构和数据湖查询场景中使用统一的 Data Cache 实例，升级到 v3.4.0 后将会有以下行为变更：
+- 由于存算分离架构和数据湖查询场景中使用统一的 Data Cache 实例，升级到 v3.4.0 后将会有以下行为变更：
 
-- BE 配置项 `datacache_disk_path` 现已废弃。数据将缓存在 `${storage_root_path}/datacache` 目录下。如果要为 Data Cache 分配专用磁盘，可以使用 Symlink 手动将该目录指向上述目录。
-- 存算分离集群中的缓存数据将自动迁移到 `${storage_root_path}/datacache`，升级后可重新使用。
-- `datacache_disk_size` 的行为变更：
+  - BE 配置项 `datacache_disk_path` 现已废弃。数据将缓存在 `${storage_root_path}/datacache` 目录下。如果要为 Data Cache 分配专用磁盘，可以使用 Symlink 手动将该目录指向上述目录。
+  - 存算分离集群中的缓存数据将自动迁移到 `${storage_root_path}/datacache`，升级后可重新使用。
+  - `datacache_disk_size` 的行为变更：
 
-  - 当 `datacache_disk_size` 为 `0`（默认值）时，将启用缓存容量自动调整（与升级前的行为一致）。
-  - 当 `datacache_disk_size` 设置为大于 `0` 时，系统将在 `datacache_disk_size` 和 `starlet_star_cache_disk_size_percent` 之间选择一个较大的值作为缓存容量。
+    - 当 `datacache_disk_size` 为 `0`（默认值）时，将启用缓存容量自动调整（与升级前的行为一致）。
+    - 当 `datacache_disk_size` 设置为大于 `0` 时，系统将在 `datacache_disk_size` 和 `starlet_star_cache_disk_size_percent` 之间选择一个较大的值作为缓存容量。
+
+- 从 v3.4.0 版本开始，`insert_timeout` 作用于所有涉及 INSERT 的操作（例如，UPDATE、DELETE、CTAS、物化视图刷新、统计信息收集和 PIPE），替代原本的 `query_timeout`。
+- 从 v3.4.0 版本开始，`mysql_server_version` 默认值变更为 `8.0.33`。
 
 ### 降级说明
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds two behavior change items to v3.4 release notes across EN/JA/ZH and fixes list formatting in the Data Cache section.
> 
> - **Docs – v3.4 Release Notes**
>   - **Behavior Changes**: Added bullets documenting that `insert_timeout` replaces `query_timeout` for INSERT-related operations and the default `mysql_server_version` is `8.0.33`.
>   - **List formatting**: Normalized nested bullets in the Data Cache behavior changes section for clarity (EN/JA/ZH).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98521fdcfcb4a1784cb7d3af501d763d6a8c66d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->