### PR TITLE
[BugFix] Fix push down runtime bitset filter with other or predicates

### DIFF
--- a/be/src/exec/olap_scan_prepare.cpp
+++ b/be/src/exec/olap_scan_prepare.cpp
@@ -384,7 +384,7 @@ template <BoxedExprType E, CompoundNodeType Type>
 Status ChunkPredicateBuilder<E, Type>::_build_bitset_in_predicates(PredicateCompoundNode<Type>& tree_root,
                                                                    PredicateParser* parser,
                                                                    ColumnPredicatePtrs& col_preds_owner) {
-    if (_opts.runtime_filters == nullptr) {
+    if (!_is_root_builder || _opts.runtime_filters == nullptr) {
         return Status::OK();
     }
 

--- a/test/sql/test_runtime_filter/R/test_runtime_bitset_filter_with_or
+++ b/test/sql/test_runtime_filter/R/test_runtime_bitset_filter_with_or
@@ -1,6 +1,4 @@
 -- name: test_runtime_bitset_filter_with_or
-
--- # Prepare data.
 CREATE TABLE __row_util_base (
   k1 bigint NULL
 ) ENGINE=OLAP
@@ -9,7 +7,11 @@ DISTRIBUTED BY HASH(`k1`) BUCKETS 32
 PROPERTIES (
     "replication_num" = "1"
 );
+-- result:
+-- !result
 insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+-- result:
+-- !result
 insert into __row_util_base select * from __row_util_base; -- 20000
 insert into __row_util_base select * from __row_util_base; -- 40000
 insert into __row_util_base select * from __row_util_base; -- 80000
@@ -22,8 +24,11 @@ DISTRIBUTED BY HASH(`idx`) BUCKETS 32
 PROPERTIES (
     "replication_num" = "1"
 );
+-- result:
+-- !result
 insert into __row_util select row_number() over() as idx from __row_util_base;
-
+-- result:
+-- !result
 CREATE TABLE t1 (
   k1 bigint NULL,
   c_str_1 STRING NULL,
@@ -34,26 +39,31 @@ DISTRIBUTED BY HASH(`k1`) BUCKETS 32
 PROPERTIES (
     "replication_num" = "1"
 );
-
+-- result:
+-- !result
 INSERT INTO t1
 SELECT
     idx,
     concat('str-abc-', idx),
     concat('str-abc-', idx)
 FROM __row_util;
-
-
--- # Test query.
+-- result:
+-- !result
 with w1 as (
   select * from t1 where k1 = 1 and (c_str_1 like 'non-exist%' or c_str_2 like 'non-exist%')
 ), w2 as (
   select * from t1 where k1 = 1
 )
 select count(1) from w1 join [broadcast]  w2 on w1.k1 = w2.k1;
-
+-- result:
+0
+-- !result
 with w1 as (
   select * from t1 where k1 = 1 and (c_str_1 like 'str-abc%' or c_str_2 like 'str-abc%')
 ), w2 as (
   select * from t1 where k1 = 1
 )
 select count(1) from w1 join [broadcast]  w2 on w1.k1 = w2.k1;
+-- result:
+1
+-- !result

--- a/test/sql/test_runtime_filter/T/test_runtime_bitset_filter_with_or
+++ b/test/sql/test_runtime_filter/T/test_runtime_bitset_filter_with_or
@@ -1,0 +1,52 @@
+-- name: test_runtime_bitset_filter_with_or
+
+-- # Prepare data.
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+insert into __row_util_base select * from __row_util_base; -- 20000
+insert into __row_util_base select * from __row_util_base; -- 40000
+insert into __row_util_base select * from __row_util_base; -- 80000
+
+CREATE TABLE __row_util (
+  idx bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util select row_number() over() as idx from __row_util_base;
+
+CREATE TABLE t1 (
+  k1 bigint NULL,
+  c_str_1 STRING NULL,
+  c_str_2 STRING NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO t1
+SELECT
+    idx,
+    concat('str-abc-', idx),
+    concat('str-abc-', idx)
+FROM __row_util;
+
+
+-- # Test query.
+with w1 as (
+  select * from t1 where k1 = 1 and (c_str_1 = 'non-exist' or c_str_2 = 'non-exist')
+), w2 as (
+  select * from t1 where k1 = 1
+)
+select count(1) from w1 join [broadcast]  w2 on w1.k1 = w2.k1; 


### PR DESCRIPTION
## Why I'm doing:
When pushing a `BitsetInPredicate` down to the storage layer, it can only be pushed into the outermost predicate and cannot be pushed further down into the nested `OR` clause.


Here’s a concrete example: we incorrectly pushed `BitsetInPredicate(columnId=0, min_value=1, max_value=1)` (which is always true) into every level of the `PredicateTree`, causing the second-level `OR` predicate to become always true.

<img width="50%" src="https://github.com/user-attachments/assets/85a144e6-1394-4909-b6d1-b1ce5601979e" />

```json
{
    "and": [
        {
            "pred": "(columnId(0)=1)"
        },
        {
            "pred": "(ColumnId(0) IS NOT NULL)"
        },
        {
            "pred": "placeholder (column_id=0)"
        },
        {
            "pred": "BitsetInPredicate(columnId=0, min_value=1, max_value=1)"
        },
        {
            "or": [
                {
                    "pred": "BitsetInPredicate(columnId=0, min_value=1, max_value=1)"
                },
                {
                    "pred": "(columnId(2)=non_exist)"
                },
                {
                    "pred": "(columnId(1)=non_exist)"
                }
            ]
        }
    ]
}
```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restricts runtime bitset filter construction to the root builder to avoid incorrect propagation into nested ORs; adds regression SQL tests validating behavior.
> 
> - **Predicate building (be/src/exec/olap_scan_prepare.cpp)**:
>   - Only build `BITSET` runtime filter predicates when `_is_root_builder` is true, preventing insertion into nested `OR` nodes.
> - **Tests**:
>   - Add `test_runtime_bitset_filter_with_or` under `test/sql/test_runtime_filter/{T,R}/` to validate counts with `LIKE` predicates combined via `OR` and joined with broadcast.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2bf6264bea291f6fa2d82392efc4c0037e44c1ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->