### PR TITLE
[Doc] Fix Wrong TimeTravel Syntax

### DIFF
--- a/docs/en/data_source/catalog/iceberg/iceberg_timetravel.md
+++ b/docs/en/data_source/catalog/iceberg/iceberg_timetravel.md
@@ -172,18 +172,18 @@ EXECUTE cherrypick_snapshot(54321);
 
 You can expire snapshots earlier than a specific point of time. This operation will delete the data files of the expired snapshots.
 
-**`expire_snapshot` Syntax**
+**`expire_snapshots` Syntax**
 
 ```SQL
 ALTER TABLE [catalog.][database.]table_name
-EXECUTE expire_snapshot('<datetime>')
+EXECUTE expire_snapshots('<datetime>')
 ```
 
 **Example**
 
 ```SQL
 ALTER TABLE iceberg.sales.order
-EXECUTE expire_snapshot('2023-12-17 00:14:38')
+EXECUTE expire_snapshots('2023-12-17 00:14:38')
 ```
 
 ### Drop a branch or a tag

--- a/docs/ja/data_source/catalog/iceberg/iceberg_timetravel.md
+++ b/docs/ja/data_source/catalog/iceberg/iceberg_timetravel.md
@@ -172,18 +172,18 @@ EXECUTE cherrypick_snapshot(54321);
 
 特定の時点よりも前のスナップショットを期限切れにできます。この操作により、期限切れのスナップショットのデータファイルが削除されます。
 
-**`expire_snapshot` 構文**
+**`expire_snapshots` 構文**
 
 ```SQL
 ALTER TABLE [catalog.][database.]table_name
-EXECUTE expire_snapshot('<datetime>')
+EXECUTE expire_snapshots('<datetime>')
 ```
 
 **例**
 
 ```SQL
 ALTER TABLE iceberg.sales.order
-EXECUTE expire_snapshot('2023-12-17 00:14:38')
+EXECUTE expire_snapshots('2023-12-17 00:14:38')
 ```
 
 ### ブランチまたはタグの削除

--- a/docs/zh/data_source/catalog/iceberg/iceberg_timetravel.md
+++ b/docs/zh/data_source/catalog/iceberg/iceberg_timetravel.md
@@ -172,18 +172,18 @@ EXECUTE cherrypick_snapshot(54321);
 
 您可以使快照在特定时间点之前过期。此操作将删除过期快照的数据文件。
 
-**`expire_snapshot` 语法**
+**`expire_snapshots` 语法**
 
 ```SQL
 ALTER TABLE [catalog.][database.]table_name
-EXECUTE expire_snapshot('<datetime>')
+EXECUTE expire_snapshots('<datetime>')
 ```
 
 **示例**
 
 ```SQL
 ALTER TABLE iceberg.sales.order
-EXECUTE expire_snapshot('2023-12-17 00:14:38')
+EXECUTE expire_snapshots('2023-12-17 00:14:38')
 ```
 
 ### 删除分支或标记


### PR DESCRIPTION
Fix #66862
Signed-off-by: EsoragotoSpirit <wanglichen@starrocks.com>

## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Corrects the Iceberg Time Travel docs to use `expire_snapshots` (plural) syntax across EN/JA/ZH, updating syntax blocks and examples.
> 
> - **Docs (Iceberg Time Travel)**:
>   - Correct `expire_snapshot` to `expire_snapshots` in `docs/en/.../iceberg_timetravel.md`, `docs/ja/.../iceberg_timetravel.md`, and `docs/zh/.../iceberg_timetravel.md`.
>     - Update headings to **`expire_snapshots` Syntax**.
>     - Update SQL examples: `EXECUTE expire_snapshots('<datetime>')` and example datetime call.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb9a06e7e7ae47ba62fac3d6645ad3a26e01db99. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->