### PR TITLE
[Feature] Support read file_path and row position for iceberg table

### DIFF
--- a/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
@@ -126,7 +126,7 @@ Status HdfsScanner::_build_scanner_context() {
     for (size_t i = 0; i < _scanner_params.materialize_slots.size(); i++) {
         auto* slot = _scanner_params.materialize_slots[i];
         if (slot->col_name() == ICEBERG_ROW_ID || slot->col_name() == "_row_source_id" ||
-            slot->col_name() == "_scan_range_id") {
+            slot->col_name() == "_row_source_id" || slot->col_name() == ICEBERG_ROW_POSITION) {
             ctx.reserved_field_slots.emplace_back(slot);
         } else {
             HdfsScannerContext::ColumnInfo column;

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.cpp
@@ -126,7 +126,7 @@ Status HdfsScanner::_build_scanner_context() {
     for (size_t i = 0; i < _scanner_params.materialize_slots.size(); i++) {
         auto* slot = _scanner_params.materialize_slots[i];
         if (slot->col_name() == ICEBERG_ROW_ID || slot->col_name() == "_row_source_id" ||
-            slot->col_name() == "_row_source_id" || slot->col_name() == ICEBERG_ROW_POSITION) {
+            slot->col_name() == "_scan_range_id" || slot->col_name() == ICEBERG_ROW_POSITION) {
             ctx.reserved_field_slots.emplace_back(slot);
         } else {
             HdfsScannerContext::ColumnInfo column;

--- a/be/src/exec/hdfs_scanner/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner/hdfs_scanner.h
@@ -507,6 +507,7 @@ protected:
 
 public:
     static constexpr const char* ICEBERG_ROW_ID = "_row_id";
+    static constexpr const char* ICEBERG_ROW_POSITION = "_pos";
 };
 
 } // namespace starrocks

--- a/be/src/formats/CMakeLists.txt
+++ b/be/src/formats/CMakeLists.txt
@@ -92,6 +92,7 @@ ADD_BE_LIB(Formats
         parquet/variant.cpp
         parquet/iceberg_row_id_reader.cpp
         parquet/row_source_reader.cpp
+        parquet/parquet_pos_reader.cpp
         disk_range.hpp
         )
 

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -32,6 +32,7 @@
 #include "formats/parquet/column_reader_factory.h"
 #include "formats/parquet/iceberg_row_id_reader.h"
 #include "formats/parquet/metadata.h"
+#include "formats/parquet/parquet_pos_reader.h"
 #include "formats/parquet/predicate_filter_evaluator.h"
 #include "formats/parquet/row_source_reader.h"
 #include "formats/parquet/scalar_column_reader.h"
@@ -384,6 +385,8 @@ Status GroupReader::_create_column_readers() {
                 }
             } else if (slot->col_name() == "_scan_range_id") {
                 _column_readers.emplace(slot->id(), std::make_unique<FixedValueColumnReader>(_param.scan_range_id));
+            } else if (slot->col_name() == HdfsScanner::ICEBERG_ROW_POSITION) {
+                _column_readers.emplace(slot->id(), std::make_unique<ParquetPosReader>(_row_group_first_row));
             }
         }
     }

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -386,7 +386,7 @@ Status GroupReader::_create_column_readers() {
             } else if (slot->col_name() == "_scan_range_id") {
                 _column_readers.emplace(slot->id(), std::make_unique<FixedValueColumnReader>(_param.scan_range_id));
             } else if (slot->col_name() == HdfsScanner::ICEBERG_ROW_POSITION) {
-                _column_readers.emplace(slot->id(), std::make_unique<ParquetPosReader>(_row_group_first_row));
+                _column_readers.emplace(slot->id(), std::make_unique<ParquetPosReader>());
             }
         }
     }

--- a/be/src/formats/parquet/parquet_pos_reader.cpp
+++ b/be/src/formats/parquet/parquet_pos_reader.cpp
@@ -23,8 +23,8 @@ Status ParquetPosReader::read_range(const Range<uint64_t>& range, const Filter* 
     if (filter == nullptr) {
         // No filter, generate positions for all rows in the range
         for (uint64_t i = range.begin(); i < range.end(); ++i) {
-            // Generate position based on the row group first row and the current row index.
-            int64_t pos = _row_group_first_row + i;
+            // Generate position based on the absolute row position in the file.
+            int64_t pos = i;
             dst->as_mutable_raw_ptr()->append_datum(Datum(pos));
         }
     } else {
@@ -33,8 +33,8 @@ Status ParquetPosReader::read_range(const Range<uint64_t>& range, const Filter* 
         for (uint64_t i = range.begin(); i < range.end(); ++i) {
             size_t filter_index = i - range.begin();
             if ((*filter)[filter_index]) {
-                // Generate position based on the row group first row and the current row index.
-                int64_t pos = _row_group_first_row + i;
+                // Generate position based on the absolute row position in the file.
+                int64_t pos = i;
                 dst->as_mutable_raw_ptr()->append_datum(Datum(pos));
             }
         }

--- a/be/src/formats/parquet/parquet_pos_reader.cpp
+++ b/be/src/formats/parquet/parquet_pos_reader.cpp
@@ -1,0 +1,45 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/parquet/parquet_pos_reader.h"
+
+#include "column/datum.h"
+#include "storage/range.h"
+
+namespace starrocks::parquet {
+
+Status ParquetPosReader::read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst) {
+    if (filter == nullptr) {
+        // No filter, generate positions for all rows in the range
+        for (uint64_t i = range.begin(); i < range.end(); ++i) {
+            // Generate position based on the row group first row and the current row index.
+            int64_t pos = _row_group_first_row + i;
+            dst->as_mutable_raw_ptr()->append_datum(Datum(pos));
+        }
+    } else {
+        // Apply filter, only generate positions for selected rows
+        DCHECK_EQ(filter->size(), range.span_size()) << "Filter size must match range size";
+        for (uint64_t i = range.begin(); i < range.end(); ++i) {
+            size_t filter_index = i - range.begin();
+            if ((*filter)[filter_index]) {
+                // Generate position based on the row group first row and the current row index.
+                int64_t pos = _row_group_first_row + i;
+                dst->as_mutable_raw_ptr()->append_datum(Datum(pos));
+            }
+        }
+    }
+    return Status::OK();
+}
+
+} // namespace starrocks::parquet

--- a/be/src/formats/parquet/parquet_pos_reader.h
+++ b/be/src/formats/parquet/parquet_pos_reader.h
@@ -21,13 +21,10 @@ namespace starrocks::parquet {
 // ParquetPosReader reads the $row_pos virtual column for Parquet files.
 // This column represents the position of a row within a file (file-internal offset),
 // which is used for Iceberg position delete operations.
-//
-// The position is calculated as: _row_group_first_row + i, where i is the row index within the row group.
 class ParquetPosReader final : public ColumnReader {
 public:
     // row_group_first_row: The starting position of this row group within the file
-    explicit ParquetPosReader(int64_t row_group_first_row)
-            : ColumnReader(nullptr), _row_group_first_row(row_group_first_row) {}
+    explicit ParquetPosReader() : ColumnReader(nullptr) {}
     ~ParquetPosReader() override = default;
 
     Status prepare() override { return Status::OK(); }
@@ -54,9 +51,6 @@ public:
         // Position column does not support page index filtering
         return false;
     }
-
-private:
-    int64_t _row_group_first_row = 0;
 };
 
 } // namespace starrocks::parquet

--- a/be/src/formats/parquet/parquet_pos_reader.h
+++ b/be/src/formats/parquet/parquet_pos_reader.h
@@ -1,0 +1,62 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "formats/parquet/column_reader.h"
+
+namespace starrocks::parquet {
+
+// ParquetPosReader reads the $row_pos virtual column for Parquet files.
+// This column represents the position of a row within a file (file-internal offset),
+// which is used for Iceberg position delete operations.
+//
+// The position is calculated as: _row_group_first_row + i, where i is the row index within the row group.
+class ParquetPosReader final : public ColumnReader {
+public:
+    // row_group_first_row: The starting position of this row group within the file
+    explicit ParquetPosReader(int64_t row_group_first_row)
+            : ColumnReader(nullptr), _row_group_first_row(row_group_first_row) {}
+    ~ParquetPosReader() override = default;
+
+    Status prepare() override { return Status::OK(); }
+
+    Status read_range(const Range<uint64_t>& range, const Filter* filter, ColumnPtr& dst) override;
+    void get_levels(level_t** def_levels, level_t** rep_levels, size_t* num_levels) override {}
+    void set_need_parse_levels(bool need_parse_levels) override {}
+
+    void collect_column_io_range(std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset,
+                                 ColumnIOTypeFlags types, bool active) override {}
+
+    void select_offset_index(const SparseRange<uint64_t>& range, const uint64_t rg_first_row) override {}
+
+    StatusOr<bool> row_group_zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
+                                             CompoundNodeType pred_relation, const uint64_t rg_first_row,
+                                             const uint64_t rg_num_rows) const override {
+        // Position column does not support zone map filtering
+        return false;
+    }
+
+    StatusOr<bool> page_index_zone_map_filter(const std::vector<const ColumnPredicate*>& predicates,
+                                              SparseRange<uint64_t>* row_ranges, CompoundNodeType pred_relation,
+                                              const uint64_t rg_first_row, const uint64_t rg_num_rows) override {
+        // Position column does not support page index filtering
+        return false;
+    }
+
+private:
+    int64_t _row_group_first_row = 0;
+};
+
+} // namespace starrocks::parquet

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -252,6 +252,7 @@ set(EXEC_FILES
         ./formats/parquet/parquet_cli_reader_test.cpp
         ./formats/parquet/parquet_ut_base.cpp
         ./formats/parquet/parquet_variant_test.cpp
+        ./formats/parquet/parquet_pos_reader_test.cpp
         ./formats/parquet/page_index_test.cpp
         ./formats/parquet/dict_encoding_test.cpp
         ./formats/disk_range_test.cpp

--- a/be/test/formats/parquet/parquet_pos_reader_test.cpp
+++ b/be/test/formats/parquet/parquet_pos_reader_test.cpp
@@ -31,22 +31,22 @@ protected:
 TEST_F(ParquetPosReaderTest, TestReadRangeWithoutFilter) {
     // Create a ParquetPosReader
     ParquetPosReader reader;
-    
+
     // Prepare the reader (should always return OK)
     ASSERT_TRUE(reader.prepare().ok());
-    
+
     // Create a range representing rows 100-105 (absolute positions in file)
     Range<uint64_t> range(100, 105);
-    
+
     // Create a column to store the results
     ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), false);
-    
+
     // Read the range
     ASSERT_TRUE(reader.read_range(range, nullptr, column).ok());
-    
+
     // Check that we got 5 rows (positions 100, 101, 102, 103, 104)
     ASSERT_EQ(column->size(), 5);
-    
+
     // Check the values
     for (int i = 0; i < 5; i++) {
         ASSERT_EQ(column->get(i).get_int64(), 100 + i);
@@ -57,25 +57,25 @@ TEST_F(ParquetPosReaderTest, TestReadRangeWithoutFilter) {
 TEST_F(ParquetPosReaderTest, TestReadRangeWithFilter) {
     // Create a ParquetPosReader
     ParquetPosReader reader;
-    
+
     // Prepare the reader
     ASSERT_TRUE(reader.prepare().ok());
-    
+
     // Create a range representing rows 200-205 (absolute positions in file)
     Range<uint64_t> range(200, 205);
-    
+
     // Create a filter that selects only positions 201 and 203
     Filter filter = {false, true, false, true, false}; // Size 5, positions 1 and 3 (0-indexed)
-    
+
     // Create a column to store the results
     ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), false);
-    
+
     // Read the range with filter
     ASSERT_TRUE(reader.read_range(range, &filter, column).ok());
-    
+
     // Check that we got 2 rows (positions 201 and 203)
     ASSERT_EQ(column->size(), 2);
-    
+
     // Check the values
     ASSERT_EQ(column->get(0).get_int64(), 201);
     ASSERT_EQ(column->get(1).get_int64(), 203);
@@ -85,22 +85,22 @@ TEST_F(ParquetPosReaderTest, TestReadRangeWithFilter) {
 TEST_F(ParquetPosReaderTest, TestReadLargeRange) {
     // Create a ParquetPosReader
     ParquetPosReader reader;
-    
+
     // Prepare the reader
     ASSERT_TRUE(reader.prepare().ok());
-    
+
     // Create a range representing rows 1000-1010 (absolute positions in file)
     Range<uint64_t> range(1000, 1010);
-    
+
     // Create a column to store the results
     ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), false);
-    
+
     // Read the range
     ASSERT_TRUE(reader.read_range(range, nullptr, column).ok());
-    
+
     // Check that we got 10 rows
     ASSERT_EQ(column->size(), 10);
-    
+
     // Check the values
     for (int i = 0; i < 10; i++) {
         ASSERT_EQ(column->get(i).get_int64(), 1000 + i);
@@ -111,19 +111,19 @@ TEST_F(ParquetPosReaderTest, TestReadLargeRange) {
 TEST_F(ParquetPosReaderTest, TestReadEmptyRange) {
     // Create a ParquetPosReader
     ParquetPosReader reader;
-    
+
     // Prepare the reader
     ASSERT_TRUE(reader.prepare().ok());
-    
+
     // Create an empty range
     Range<uint64_t> range(500, 500);
-    
+
     // Create a column to store the results
     ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), false);
-    
+
     // Read the range
     ASSERT_TRUE(reader.read_range(range, nullptr, column).ok());
-    
+
     // Check that we got 0 rows
     ASSERT_EQ(column->size(), 0);
 }
@@ -132,22 +132,22 @@ TEST_F(ParquetPosReaderTest, TestReadEmptyRange) {
 TEST_F(ParquetPosReaderTest, TestReadRangeWithNoSelectedRows) {
     // Create a ParquetPosReader
     ParquetPosReader reader;
-    
+
     // Prepare the reader
     ASSERT_TRUE(reader.prepare().ok());
-    
+
     // Create a range representing rows 300-303 (absolute positions in file)
     Range<uint64_t> range(300, 303);
-    
+
     // Create a filter that selects no rows
     Filter filter = {false, false, false}; // Size 3, no selected rows
-    
+
     // Create a column to store the results
     ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), false);
-    
+
     // Read the range with filter
     ASSERT_TRUE(reader.read_range(range, &filter, column).ok());
-    
+
     // Check that we got 0 rows
     ASSERT_EQ(column->size(), 0);
 }
@@ -156,25 +156,25 @@ TEST_F(ParquetPosReaderTest, TestReadRangeWithNoSelectedRows) {
 TEST_F(ParquetPosReaderTest, TestReadRangeWithAllRowsSelected) {
     // Create a ParquetPosReader
     ParquetPosReader reader;
-    
+
     // Prepare the reader
     ASSERT_TRUE(reader.prepare().ok());
-    
+
     // Create a range representing rows 400-404 (absolute positions in file)
     Range<uint64_t> range(400, 404);
-    
+
     // Create a filter that selects all rows
     Filter filter = {true, true, true, true}; // Size 4, all selected
-    
+
     // Create a column to store the results
     ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), false);
-    
+
     // Read the range with filter
     ASSERT_TRUE(reader.read_range(range, &filter, column).ok());
-    
+
     // Check that we got 4 rows
     ASSERT_EQ(column->size(), 4);
-    
+
     // Check the values
     for (int i = 0; i < 4; i++) {
         ASSERT_EQ(column->get(i).get_int64(), 400 + i);

--- a/be/test/formats/parquet/parquet_pos_reader_test.cpp
+++ b/be/test/formats/parquet/parquet_pos_reader_test.cpp
@@ -1,0 +1,184 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "formats/parquet/parquet_pos_reader.h"
+
+#include <gtest/gtest.h>
+
+#include "column/column_helper.h"
+#include "storage/range.h"
+
+namespace starrocks::parquet {
+
+class ParquetPosReaderTest : public testing::Test {
+protected:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+// Test basic functionality of ParquetPosReader
+TEST_F(ParquetPosReaderTest, TestReadRangeWithoutFilter) {
+    // Create a ParquetPosReader
+    ParquetPosReader reader;
+    
+    // Prepare the reader (should always return OK)
+    ASSERT_TRUE(reader.prepare().ok());
+    
+    // Create a range representing rows 100-105 (absolute positions in file)
+    Range<uint64_t> range(100, 105);
+    
+    // Create a column to store the results
+    ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), false);
+    
+    // Read the range
+    ASSERT_TRUE(reader.read_range(range, nullptr, column).ok());
+    
+    // Check that we got 5 rows (positions 100, 101, 102, 103, 104)
+    ASSERT_EQ(column->size(), 5);
+    
+    // Check the values
+    for (int i = 0; i < 5; i++) {
+        ASSERT_EQ(column->get(i).get_int64(), 100 + i);
+    }
+}
+
+// Test ParquetPosReader with a filter
+TEST_F(ParquetPosReaderTest, TestReadRangeWithFilter) {
+    // Create a ParquetPosReader
+    ParquetPosReader reader;
+    
+    // Prepare the reader
+    ASSERT_TRUE(reader.prepare().ok());
+    
+    // Create a range representing rows 200-205 (absolute positions in file)
+    Range<uint64_t> range(200, 205);
+    
+    // Create a filter that selects only positions 201 and 203
+    Filter filter = {false, true, false, true, false}; // Size 5, positions 1 and 3 (0-indexed)
+    
+    // Create a column to store the results
+    ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), false);
+    
+    // Read the range with filter
+    ASSERT_TRUE(reader.read_range(range, &filter, column).ok());
+    
+    // Check that we got 2 rows (positions 201 and 203)
+    ASSERT_EQ(column->size(), 2);
+    
+    // Check the values
+    ASSERT_EQ(column->get(0).get_int64(), 201);
+    ASSERT_EQ(column->get(1).get_int64(), 203);
+}
+
+// Test ParquetPosReader with a larger range
+TEST_F(ParquetPosReaderTest, TestReadLargeRange) {
+    // Create a ParquetPosReader
+    ParquetPosReader reader;
+    
+    // Prepare the reader
+    ASSERT_TRUE(reader.prepare().ok());
+    
+    // Create a range representing rows 1000-1010 (absolute positions in file)
+    Range<uint64_t> range(1000, 1010);
+    
+    // Create a column to store the results
+    ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), false);
+    
+    // Read the range
+    ASSERT_TRUE(reader.read_range(range, nullptr, column).ok());
+    
+    // Check that we got 10 rows
+    ASSERT_EQ(column->size(), 10);
+    
+    // Check the values
+    for (int i = 0; i < 10; i++) {
+        ASSERT_EQ(column->get(i).get_int64(), 1000 + i);
+    }
+}
+
+// Test ParquetPosReader with empty range
+TEST_F(ParquetPosReaderTest, TestReadEmptyRange) {
+    // Create a ParquetPosReader
+    ParquetPosReader reader;
+    
+    // Prepare the reader
+    ASSERT_TRUE(reader.prepare().ok());
+    
+    // Create an empty range
+    Range<uint64_t> range(500, 500);
+    
+    // Create a column to store the results
+    ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), false);
+    
+    // Read the range
+    ASSERT_TRUE(reader.read_range(range, nullptr, column).ok());
+    
+    // Check that we got 0 rows
+    ASSERT_EQ(column->size(), 0);
+}
+
+// Test ParquetPosReader with filter that selects no rows
+TEST_F(ParquetPosReaderTest, TestReadRangeWithNoSelectedRows) {
+    // Create a ParquetPosReader
+    ParquetPosReader reader;
+    
+    // Prepare the reader
+    ASSERT_TRUE(reader.prepare().ok());
+    
+    // Create a range representing rows 300-303 (absolute positions in file)
+    Range<uint64_t> range(300, 303);
+    
+    // Create a filter that selects no rows
+    Filter filter = {false, false, false}; // Size 3, no selected rows
+    
+    // Create a column to store the results
+    ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), false);
+    
+    // Read the range with filter
+    ASSERT_TRUE(reader.read_range(range, &filter, column).ok());
+    
+    // Check that we got 0 rows
+    ASSERT_EQ(column->size(), 0);
+}
+
+// Test ParquetPosReader with all rows selected by filter
+TEST_F(ParquetPosReaderTest, TestReadRangeWithAllRowsSelected) {
+    // Create a ParquetPosReader
+    ParquetPosReader reader;
+    
+    // Prepare the reader
+    ASSERT_TRUE(reader.prepare().ok());
+    
+    // Create a range representing rows 400-404 (absolute positions in file)
+    Range<uint64_t> range(400, 404);
+    
+    // Create a filter that selects all rows
+    Filter filter = {true, true, true, true}; // Size 4, all selected
+    
+    // Create a column to store the results
+    ColumnPtr column = ColumnHelper::create_column(TypeDescriptor::from_logical_type(LogicalType::TYPE_BIGINT), false);
+    
+    // Read the range with filter
+    ASSERT_TRUE(reader.read_range(range, &filter, column).ok());
+    
+    // Check that we got 4 rows
+    ASSERT_EQ(column->size(), 4);
+    
+    // Check the values
+    for (int i = 0; i < 4; i++) {
+        ASSERT_EQ(column->get(i).get_int64(), 400 + i);
+    }
+}
+
+} // namespace starrocks::parquet

--- a/be/test/formats/parquet/parquet_pos_reader_test.cpp
+++ b/be/test/formats/parquet/parquet_pos_reader_test.cpp
@@ -17,12 +17,12 @@
 #include <gtest/gtest.h>
 
 #include "column/column_helper.h"
-#include "storage/range.h"
-#include "storage/predicate_tree/predicate_tree_fwd.h"
+#include "common/logging.h"
 #include "formats/parquet/column_reader.h"
 #include "formats/parquet/types.h"
 #include "formats/parquet/utils.h"
-#include "common/logging.h"
+#include "storage/predicate_tree/predicate_tree_fwd.h"
+#include "storage/range.h"
 
 namespace starrocks::parquet {
 
@@ -190,7 +190,7 @@ TEST_F(ParquetPosReaderTest, TestReadRangeWithAllRowsSelected) {
 TEST_F(ParquetPosReaderTest, TestPrepare) {
     // Create a ParquetPosReader
     ParquetPosReader reader;
-    
+
     // Prepare should always return OK
     ASSERT_TRUE(reader.prepare().ok());
 }
@@ -199,13 +199,13 @@ TEST_F(ParquetPosReaderTest, TestPrepare) {
 TEST_F(ParquetPosReaderTest, TestGetLevels) {
     // Create a ParquetPosReader
     ParquetPosReader reader;
-    
+
     // Call get_levels (should not crash)
     level_t* def_levels = nullptr;
     level_t* rep_levels = nullptr;
     size_t num_levels = 0;
     reader.get_levels(&def_levels, &rep_levels, &num_levels);
-    
+
     // Values should remain nullptr/0 as the method is a no-op
     ASSERT_EQ(def_levels, nullptr);
     ASSERT_EQ(rep_levels, nullptr);
@@ -216,7 +216,7 @@ TEST_F(ParquetPosReaderTest, TestGetLevels) {
 TEST_F(ParquetPosReaderTest, TestSetNeedParseLevels) {
     // Create a ParquetPosReader
     ParquetPosReader reader;
-    
+
     // Call set_need_parse_levels (should not crash)
     reader.set_need_parse_levels(true);
     reader.set_need_parse_levels(false);
@@ -226,7 +226,7 @@ TEST_F(ParquetPosReaderTest, TestSetNeedParseLevels) {
 TEST_F(ParquetPosReaderTest, TestCollectColumnIoRange) {
     // Create a ParquetPosReader
     ParquetPosReader reader;
-    
+
     // Call collect_column_io_range (should not crash)
     std::vector<io::SharedBufferedInputStream::IORange> ranges;
     int64_t end_offset = 0;
@@ -238,7 +238,7 @@ TEST_F(ParquetPosReaderTest, TestCollectColumnIoRange) {
 TEST_F(ParquetPosReaderTest, TestSelectOffsetIndex) {
     // Create a ParquetPosReader
     ParquetPosReader reader;
-    
+
     // Call select_offset_index (should not crash)
     SparseRange<uint64_t> range;
     reader.select_offset_index(range, 100);
@@ -248,11 +248,11 @@ TEST_F(ParquetPosReaderTest, TestSelectOffsetIndex) {
 TEST_F(ParquetPosReaderTest, TestRowGroupZoneMapFilter) {
     // Create a ParquetPosReader
     ParquetPosReader reader;
-    
+
     // Call row_group_zone_map_filter
     std::vector<const ColumnPredicate*> predicates;
     auto result = reader.row_group_zone_map_filter(predicates, CompoundNodeType::AND, 100, 50);
-    
+
     // Should return false (position column does not support zone map filtering)
     ASSERT_TRUE(result.ok());
     ASSERT_FALSE(result.value());
@@ -262,12 +262,12 @@ TEST_F(ParquetPosReaderTest, TestRowGroupZoneMapFilter) {
 TEST_F(ParquetPosReaderTest, TestPageIndexZoneMapFilter) {
     // Create a ParquetPosReader
     ParquetPosReader reader;
-    
+
     // Call page_index_zone_map_filter
     std::vector<const ColumnPredicate*> predicates;
     SparseRange<uint64_t> row_ranges;
     auto result = reader.page_index_zone_map_filter(predicates, &row_ranges, CompoundNodeType::AND, 100, 50);
-    
+
     // Should return false (position column does not support page index filtering)
     ASSERT_TRUE(result.ok());
     ASSERT_FALSE(result.value());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -65,6 +65,7 @@ import com.starrocks.thrift.TTableType;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.Type;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.NullOrder;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
@@ -85,6 +86,7 @@ import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
@@ -102,6 +104,12 @@ public class IcebergTable extends Table {
     public static final String SPEC_ID = "$spec_id";
     public static final String EQUALITY_DELETE_TABLE_COMMENT = "equality_delete_table_comment";
     public static final String ROW_ID = "_row_id";
+    public static final String FILE_PATH = MetadataColumns.FILE_PATH.name();
+    public static final String ROW_POSITION = MetadataColumns.ROW_POSITION.name();
+
+    public static final Set<String> ICEBERG_META_COLUMNS = Set.of(
+            DATA_SEQUENCE_NUMBER, SPEC_ID, ROW_ID, FILE_PATH, ROW_POSITION
+    );
 
     private String catalogName;
     @SerializedName(value = "dn")

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -44,6 +44,7 @@ import com.starrocks.type.IntegerType;
 import com.starrocks.type.MapType;
 import com.starrocks.type.PrimitiveType;
 import com.starrocks.type.ScalarType;
+import com.starrocks.type.StringType;
 import com.starrocks.type.StructField;
 import com.starrocks.type.StructType;
 import com.starrocks.type.Type;
@@ -303,9 +304,20 @@ public class IcebergApiConverter {
         throw new StarRocksConnectorException("Unsupported complex column type %s", type);
     }
 
+    private static void addMetaColumns(List<Column> fullSchema) {
+        Column column = new Column(IcebergTable.FILE_PATH, StringType.STRING, true);
+        column.setIsHidden(true);
+        fullSchema.add(column);
+
+        column = new Column(IcebergTable.ROW_POSITION, IntegerType.BIGINT, true);
+        column.setIsHidden(true);
+        fullSchema.add(column);
+    }
+
     public static List<Column> toFullSchemas(Schema schema, Table table) {
         List<Column> fullSchema = toFullSchemas(schema);
         if (table instanceof BaseTable) {
+            addMetaColumns(fullSchema);
             if (((BaseTable) table).operations().current().formatVersion() >= 3) {
                 boolean hasRowId = fullSchema.stream().anyMatch(column -> column.getName().equals(IcebergTable.ROW_ID));
                 if (!hasRowId) {

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -902,6 +902,9 @@ public class FrontendServiceImpl implements FrontendService.Iface {
             tableKeysType = olapTable.getKeysType().name().substring(0, 3).toUpperCase();
         }
         for (Column column : table.getBaseSchema()) {
+            if (column.isHidden()) {
+                continue;
+            }
             final TColumnDesc desc =
                     new TColumnDesc(column.getName(), TypeSerializer.toThrift(column.getPrimitiveType()));
             final Integer precision = column.getType().getPrecision();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -292,6 +292,13 @@ public class InsertPlanner {
             outputFullSchema = targetTable.getFullSchema();
         }
 
+        if (targetTable.isIcebergTable()) {
+            outputBaseSchema = outputBaseSchema.stream().filter(col ->
+                    !IcebergTable.ICEBERG_META_COLUMNS.contains(col.getName())).toList();
+            outputFullSchema = outputFullSchema.stream().filter(col ->
+                    !IcebergTable.ICEBERG_META_COLUMNS.contains(col.getName())).toList();
+        }
+
         refreshExternalTable(insertStmt.getQueryStatement(), session);
 
         //1. Process the literal value of the insert values type and cast it into the type of the target table

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -250,7 +250,8 @@ public class InsertAnalyzer {
                 IcebergTable icebergTable = (IcebergTable) table;
                 targetColumns = new ArrayList<>();
                 icebergTable.getFullSchema().forEach(column -> {
-                    if (!column.getName().startsWith(FeConstants.GENERATED_PARTITION_COLUMN_PREFIX)) {
+                    if (!column.getName().startsWith(FeConstants.GENERATED_PARTITION_COLUMN_PREFIX) &&
+                            !IcebergTable.ICEBERG_META_COLUMNS.contains(column.getName())) {
                         targetColumns.add(column);
                     }
                 });

--- a/test/sql/test_iceberg/R/test_iceberg_file_path_position
+++ b/test/sql/test_iceberg/R/test_iceberg_file_path_position
@@ -1,0 +1,66 @@
+-- name: test_iceberg_file_path_position
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+-- result:
+-- !result
+select max(_file) from iceberg_sql_test_${uuid0}.iceberg_oss_db.entity;
+-- result:
+oss://starrocks-ci-test/dla_test_data/iceberg/entity/data/019a710b-41e1-7699-bfb4-bc3a548dd192_0_0_0.parquet
+-- !result
+select count(distinct _file) from iceberg_sql_test_${uuid0}.iceberg_oss_db.entity;
+-- result:
+1
+-- !result
+select distinct _file from iceberg_sql_test_${uuid0}.iceberg_oss_db.entity;
+-- result:
+oss://starrocks-ci-test/dla_test_data/iceberg/entity/data/019a710b-41e1-7699-bfb4-bc3a548dd192_0_0_0.parquet
+-- !result
+select count(distinct _file) from iceberg_sql_test_${uuid0}.iceberg_oss_db.partsupp_two_bucket;
+-- result:
+4
+-- !result
+select distinct _file from iceberg_sql_test_${uuid0}.iceberg_oss_db.partsupp_two_bucket order by _file;
+-- result:
+oss://starrocks-ci-test/dla_test_data/iceberg/partsupp_two_bucket/data/ps_partkey_bucket=6/ps_suppkey_bucket=11/00000-11-f80d7d69-13ac-4ce0-9b71-e30afe2ef92d-00002.parquet
+oss://starrocks-ci-test/dla_test_data/iceberg/partsupp_two_bucket/data/ps_partkey_bucket=6/ps_suppkey_bucket=12/00000-11-f80d7d69-13ac-4ce0-9b71-e30afe2ef92d-00003.parquet
+oss://starrocks-ci-test/dla_test_data/iceberg/partsupp_two_bucket/data/ps_partkey_bucket=6/ps_suppkey_bucket=40/00000-11-f80d7d69-13ac-4ce0-9b71-e30afe2ef92d-00004.parquet
+oss://starrocks-ci-test/dla_test_data/iceberg/partsupp_two_bucket/data/ps_partkey_bucket=6/ps_suppkey_bucket=8/00000-11-f80d7d69-13ac-4ce0-9b71-e30afe2ef92d-00001.parquet
+-- !result
+select min(_pos), max(_pos) from iceberg_sql_test_${uuid0}.iceberg_oss_db.entity;
+-- result:
+0	1000012
+-- !result
+select count(distinct _pos) from iceberg_sql_test_${uuid0}.iceberg_oss_db.entity;
+-- result:
+1000013
+-- !result
+select min(_pos), max(_pos) from iceberg_sql_test_${uuid0}.iceberg_oss_db.partsupp_two_bucket;
+-- result:
+0	2
+-- !result
+select count(distinct _pos) from iceberg_sql_test_${uuid0}.iceberg_oss_db.partsupp_two_bucket;
+-- result:
+3
+-- !result
+select entity_id,_file, _pos from iceberg_sql_test_${uuid0}.iceberg_oss_db.entity where entity_id = 'e_635571';
+-- result:
+e_635571	oss://starrocks-ci-test/dla_test_data/iceberg/entity/data/019a710b-41e1-7699-bfb4-bc3a548dd192_0_0_0.parquet	56208
+-- !result
+select entity_id,_file, _pos from iceberg_sql_test_${uuid0}.iceberg_oss_db.entity order by entity_id,_file,_pos limit 5;
+-- result:
+a	oss://starrocks-ci-test/dla_test_data/iceberg/entity/data/019a710b-41e1-7699-bfb4-bc3a548dd192_0_0_0.parquet	795336
+a	oss://starrocks-ci-test/dla_test_data/iceberg/entity/data/019a710b-41e1-7699-bfb4-bc3a548dd192_0_0_0.parquet	799670
+b	oss://starrocks-ci-test/dla_test_data/iceberg/entity/data/019a710b-41e1-7699-bfb4-bc3a548dd192_0_0_0.parquet	26998
+b	oss://starrocks-ci-test/dla_test_data/iceberg/entity/data/019a710b-41e1-7699-bfb4-bc3a548dd192_0_0_0.parquet	39331
+b	oss://starrocks-ci-test/dla_test_data/iceberg/entity/data/019a710b-41e1-7699-bfb4-bc3a548dd192_0_0_0.parquet	244332
+-- !result
+select ps_partkey, ps_suppkey, _file, _pos from iceberg_sql_test_${uuid0}.iceberg_oss_db.partsupp_two_bucket  order by ps_partkey,ps_suppkey,_file,_pos limit 5;
+-- result:
+1	2	oss://starrocks-ci-test/dla_test_data/iceberg/partsupp_two_bucket/data/ps_partkey_bucket=6/ps_suppkey_bucket=12/00000-11-f80d7d69-13ac-4ce0-9b71-e30afe2ef92d-00003.parquet	0
+1	2	oss://starrocks-ci-test/dla_test_data/iceberg/partsupp_two_bucket/data/ps_partkey_bucket=6/ps_suppkey_bucket=12/00000-11-f80d7d69-13ac-4ce0-9b71-e30afe2ef92d-00003.parquet	1
+1	2	oss://starrocks-ci-test/dla_test_data/iceberg/partsupp_two_bucket/data/ps_partkey_bucket=6/ps_suppkey_bucket=12/00000-11-f80d7d69-13ac-4ce0-9b71-e30afe2ef92d-00003.parquet	2
+1	2502	oss://starrocks-ci-test/dla_test_data/iceberg/partsupp_two_bucket/data/ps_partkey_bucket=6/ps_suppkey_bucket=40/00000-11-f80d7d69-13ac-4ce0-9b71-e30afe2ef92d-00004.parquet	0
+1	2502	oss://starrocks-ci-test/dla_test_data/iceberg/partsupp_two_bucket/data/ps_partkey_bucket=6/ps_suppkey_bucket=40/00000-11-f80d7d69-13ac-4ce0-9b71-e30afe2ef92d-00004.parquet	1
+-- !result
+drop catalog iceberg_sql_test_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_iceberg/R/test_iceberg_v2
+++ b/test/sql/test_iceberg/R/test_iceberg_v2
@@ -157,11 +157,11 @@ function: assert_explain_verbose_contains('select * from iceberg_sql_test_${uuid
 -- result:
 None
 -- !result
-function: assert_explain_verbose_contains('select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table', '[11: k1, INT, true] | [12: k2, VARCHAR(1073741824), true] | [13: k3, VARCHAR(1073741824), true]')
+function: assert_explain_verbose_contains('select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table', '[15: k1, INT, true] | [16: k2, VARCHAR(1073741824), true] | [17: k3, VARCHAR(1073741824), true]')
 -- result:
 None
 -- !result
-function: assert_explain_verbose_contains('select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table', '[4: k1, INT, true] | [5: k2, VARCHAR(1073741824), true] | [6: k3, VARCHAR(1073741824), true]')
+function: assert_explain_verbose_contains('select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table', '[6: k1, INT, true] | [7: k2, VARCHAR(1073741824), true] | [8: k3, VARCHAR(1073741824), true]')
 -- result:
 None
 -- !result

--- a/test/sql/test_iceberg/T/test_iceberg_file_path_position
+++ b/test/sql/test_iceberg/T/test_iceberg_file_path_position
@@ -1,0 +1,23 @@
+-- name: test_iceberg_file_path_position
+
+create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
+
+-- Test _file column (should be string, not null)
+select max(_file) from iceberg_sql_test_${uuid0}.iceberg_oss_db.entity;
+select count(distinct _file) from iceberg_sql_test_${uuid0}.iceberg_oss_db.entity;
+select distinct _file from iceberg_sql_test_${uuid0}.iceberg_oss_db.entity;
+select count(distinct _file) from iceberg_sql_test_${uuid0}.iceberg_oss_db.partsupp_two_bucket;
+select distinct _file from iceberg_sql_test_${uuid0}.iceberg_oss_db.partsupp_two_bucket order by _file;
+
+-- Test _pos column (should be bigint, not null)
+select min(_pos), max(_pos) from iceberg_sql_test_${uuid0}.iceberg_oss_db.entity;
+select count(distinct _pos) from iceberg_sql_test_${uuid0}.iceberg_oss_db.entity;
+select min(_pos), max(_pos) from iceberg_sql_test_${uuid0}.iceberg_oss_db.partsupp_two_bucket;
+select count(distinct _pos) from iceberg_sql_test_${uuid0}.iceberg_oss_db.partsupp_two_bucket;
+
+-- Test combination of _file and _pos
+select entity_id,_file, _pos from iceberg_sql_test_${uuid0}.iceberg_oss_db.entity where entity_id = 'e_635571';
+select entity_id,_file, _pos from iceberg_sql_test_${uuid0}.iceberg_oss_db.entity order by entity_id,_file,_pos limit 5;
+select ps_partkey, ps_suppkey, _file, _pos from iceberg_sql_test_${uuid0}.iceberg_oss_db.partsupp_two_bucket  order by ps_partkey,ps_suppkey,_file,_pos limit 5;
+
+drop catalog iceberg_sql_test_${uuid0};

--- a/test/sql/test_iceberg/T/test_iceberg_v2
+++ b/test/sql/test_iceberg/T/test_iceberg_v2
@@ -109,7 +109,7 @@ select count(*) from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_
 select k1,k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table group by k1,k3 having count(1) > 1;
 
 function: assert_explain_verbose_contains('select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table', '[1, INT, true] | [2, VARCHAR(1073741824), true] | [3, VARCHAR(1073741824), true]')
-function: assert_explain_verbose_contains('select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table', '[11: k1, INT, true] | [12: k2, VARCHAR(1073741824), true] | [13: k3, VARCHAR(1073741824), true]')
-function: assert_explain_verbose_contains('select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table', '[4: k1, INT, true] | [5: k2, VARCHAR(1073741824), true] | [6: k3, VARCHAR(1073741824), true]')
+function: assert_explain_verbose_contains('select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table', '[15: k1, INT, true] | [16: k2, VARCHAR(1073741824), true] | [17: k3, VARCHAR(1073741824), true]')
+function: assert_explain_verbose_contains('select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_orc_partitioned_table', '[6: k1, INT, true] | [7: k2, VARCHAR(1073741824), true] | [8: k3, VARCHAR(1073741824), true]')
 
 drop catalog iceberg_sql_test_${uuid0};


### PR DESCRIPTION
## Why I'm doing:
#66944
## What I'm doing:
This pull request adds support for exposing the Iceberg metadata columns `_file` (file path) and `_pos` (row position) when querying Iceberg tables. These columns enable users to retrieve the file path and row position for each row, which is useful for advanced operations like position deletes and auditing. The implementation includes changes on both the FE (frontend) and BE (backend) to support these virtual columns, as well as a new test to verify their behavior.

The most important changes are:

**Iceberg Metadata Columns Support:**

* Added `FILE_PATH` (`_file`) and `ROW_POSITION` (`_pos`) constants to `IcebergTable`, and updated the set of Iceberg meta columns (`ICEBERG_META_COLUMNS`). These columns are now recognized as hidden metadata columns.
* Updated schema generation and scan range building in the FE to include `_file` and `_pos` as hidden columns, and to handle their values correctly when building scan ranges. [[1]](diffhunk://#diff-837069fd6fe0dcd7ab4db96b41671d5b1bb5e80b025c9c9e0f5bdf3a9b3168e4R307-R320) [[2]](diffhunk://#diff-7113dbb77afdd6dafb5312e5ef08d610aad89cdd6089af4277d062b3f34d572eL332-R343)
* Excluded Iceberg meta columns from `INSERT` planning and analysis to prevent them from being targeted in DML operations. [[1]](diffhunk://#diff-72d46804d438f539aefef998405eec6c858edbf551b17f422915d147e09554f9R295-R301) [[2]](diffhunk://#diff-6586acb4b2a522efe875498b60c6ed815c52b5c460525a2da2549a9e93c4cfedL253-R254)

**Backend Implementation for `_pos`:**

* Introduced a new `ParquetPosReader` class to generate the row position (`_pos`) for each row in Parquet files, and integrated it into the Parquet group reader logic. [[1]](diffhunk://#diff-6d9a50e8b642298a28adcdd30b7fa6b0f3ec5981f26138f263647ce371041ebcR1-R45) [[2]](diffhunk://#diff-ba354d215c1ce041f83c26c0229903418a961824767a60ff123ae59bc9a3ce27R1-R62) [[3]](diffhunk://#diff-ac4fac431e507dbb79f58d1e243bdc0e6f38447545c4c58c2ec3d1b3ce99390cR388-R389)
* Updated the scanner context to recognize `_pos` as a reserved field for Iceberg tables.
* Added the `ICEBERG_ROW_POSITION` constant to `HdfsScanner`.

**Testing:**

* Added a new SQL test file to validate the exposure and behavior of the `_file` and `_pos` columns in various query scenarios on Iceberg tables.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expose Iceberg `_file` (file path) and `_pos` (row position) as hidden columns; generate `_pos` in BE via ParquetPosReader; exclude meta columns from INSERT; add tests.
> 
> - **Iceberg metadata columns**:
>   - Add hidden columns `_file` and `_pos` in `IcebergTable` and include them in full schema; track via `ICEBERG_META_COLUMNS`.
>   - FE builds scan ranges with `_file` extended value and filters out Iceberg meta columns from INSERT planning/analysis.
>   - Hide meta columns from column descriptions in `FrontendServiceImpl`.
> - **Backend (Parquet)**:
>   - New `ParquetPosReader` to emit absolute row positions for `_pos`; integrated in `GroupReader` for reserved field handling.
>   - Recognize `_pos` as reserved field in `HdfsScanner`; add `ICEBERG_ROW_POSITION` constant.
>   - Wire-up in build (`CMakeLists.txt`).
> - **Tests**:
>   - Add BE unit tests for `ParquetPosReader`.
>   - Add SQL tests validating `_file` and `_pos` on Iceberg tables; adjust existing Iceberg v2 explain expectations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7cb7a81ddc7341ad4b37e782ecb22673a4f7244e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->