### PR TITLE
[BugFix] segmentation fault in parquet statistics reading

### DIFF
--- a/be/src/formats/parquet/column_converter.cpp
+++ b/be/src/formats/parquet/column_converter.cpp
@@ -599,9 +599,11 @@ Status parquet::Int32ToDateConverter::convert(const Column* src, Column* dst) {
     auto& dst_null_data = dst_nullable_column->null_column_raw_ptr()->get_data();
 
     size_t size = src_column->size();
-    memcpy(dst_null_data.data(), src_null_data.data(), size);
     for (size_t i = 0; i < size; i++) {
-        dst_data[i]._julian = src_data[i] + date::UNIX_EPOCH_JULIAN;
+        dst_null_data[i] = src_null_data[i];
+        if (!src_null_data[i]) {
+            dst_data[i]._julian = src_data[i] + date::UNIX_EPOCH_JULIAN;
+        }
     }
     dst_nullable_column->set_has_null(src_nullable_column->has_null());
     return Status::OK();


### PR DESCRIPTION
## Why I'm doing:
[BugFix] Fix SIGSEGV in Int32ToDateConverter for NULL values on ARM64                                                                                                                           
                                                                                                                                                                                                
    The Int32ToDateConverter::convert() method was unconditionally accessing                                                                                                                        
    src_data[i] for all rows, including NULL values. When Parquet statistics                                                                                                                        
    contain NULL dates (common in Delta Lake tables with deletion vectors),                                                                                                                         
    the underlying data array is uninitialized, causing SIGSEGV when accessed.                                                                                                                      
                                                                                                                                                                                                    
    Reproduction case:                                                                                                                                                                              
    - Delta Lake table with DATE column                                                                                                                                                             
    - Query with date predicate: WHERE day > current_date - interval 1 day                                                                                                                          
    - Parquet row group statistics contain NULL min/max                                                                                                                                             
    - Zone map filtering calls Int32ToDateConverter::convert()                                                                                                                                      
    - Crash at: dst_data[i]._julian = src_data[i] + UNIX_EPOCH_JULIAN                                                                                                                               
                                                                                                                                                                                                   
   This crash was architecture-specific (ARM64/Graviton) because:                                                                                                                                  
    - ARM has stricter memory access patterns than x86_64                                                                                                                                           
    - Uninitialized memory contains different bit patterns on ARM                                                                                                                                   
    - x86_64 had the same latent bug but often didn't crash                                                                                                                                         
                                                                                                                                                                                                    
    Root cause:                                                                                                                                                                                     
    - resize_uninitialized() uses RawAllocator (no initialization for performance)                                                                                                                  
    - append_nulls() sets null flag but leaves data uninitialized                                                                                                                                   
    - Int32ToDateConverter accessed uninitialized data for NULL rows                                                                                                                                
                                                                                                                                                                                                    
     

## What I'm doing:

Fixes #issue

Fix: Add null check before accessing data, consistent with other                                                                                                                                
    converters (Int32ToTimeConverter, Int32ToDateTimeConverter).                                                                                                                                    
                                                                                                                                                                                                    
    Changes:                                                                                                                                                                                        
    - Add null flag check: if (!src_null_data[i])                                                                                                                                                   
    - Only convert non-null date values                                                                                                                                                             
    - Replace memcpy with loop for consistency                                                                                                                                                      
                                                                                                                                                                                                    
    Fixes: SIGSEGV during Parquet zone map filtering with NULL date statistics                                                                                                                      
    Tested: ARM64 (Graviton) and x86_64            

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Guard Int32-to-Date parquet conversion against NULLs by copying nulls and only converting non-null rows, preventing SIGSEGV.
> 
> - **Backend · Parquet**:
>   - **`Int32ToDateConverter::convert`**:
>     - Copy `null` flags row-by-row and only set `Date` values for non-null entries.
>     - Removes bulk `memcpy` of null bitmap and unconditional writes to `dst_data` that accessed uninitialized memory.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ebd9f58d5bd0be92760959381a3675d1a4849a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->