### PR TITLE
[Enhancement] Improve spill strategy under concurrent workloads

### DIFF
--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -191,7 +191,8 @@ void QueryContext::init_mem_tracker(int64_t query_mem_limit, MemTracker* parent,
 Status QueryContext::init_spill_manager(const TQueryOptions& query_options) {
     Status st;
     std::call_once(_init_spill_manager_once, [this, &st, &query_options]() {
-        _spill_manager = std::make_unique<spill::QuerySpillManager>(_query_id);
+        auto* g_spill_manager = ExecEnv::GetInstance()->global_spill_manager();
+        _spill_manager = std::make_unique<spill::QuerySpillManager>(_query_id, g_spill_manager);
         st = _spill_manager->init_block_manager(query_options);
     });
     return st;

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -176,6 +176,7 @@ public:
                           std::optional<double> spill_mem_limit = std::nullopt, workgroup::WorkGroup* wg = nullptr,
                           RuntimeState* state = nullptr, int connector_scan_node_number = 1);
     std::shared_ptr<MemTracker> mem_tracker() { return _mem_tracker; }
+    const std::shared_ptr<MemTracker>& mem_tracker() const { return _mem_tracker; }
     MemTracker* connector_scan_mem_tracker() { return _connector_scan_mem_tracker.get(); }
 
     Status init_spill_manager(const TQueryOptions& query_options);

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -622,6 +622,8 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
     _spill_dir_mgr = std::make_shared<spill::DirManager>();
     RETURN_IF_ERROR(_spill_dir_mgr->init(config::spill_local_storage_dir));
 
+    _global_spill_manager = std::make_shared<spill::GlobalSpillManager>();
+
     _diagnose_daemon = new DiagnoseDaemon();
     RETURN_IF_ERROR(_diagnose_daemon->init());
 #ifdef STARROCKS_JIT_ENABLE

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -42,6 +42,7 @@
 #include "exec/pipeline/pipeline_fwd.h"
 #include "exec/pipeline/schedule/pipeline_timer.h"
 #include "exec/query_cache/cache_manager.h"
+#include "exec/spill/query_spill_manager.h"
 #include "exec/workgroup/work_group_fwd.h"
 #include "runtime/base_load_path_mgr.h"
 #include "runtime/lookup_stream_mgr.h"
@@ -80,7 +81,7 @@ class SmallFileMgr;
 class RuntimeFilterWorker;
 class RuntimeFilterCache;
 class ProfileReportWorker;
-class QuerySpillManager;
+class GlobalSpillManager;
 struct RfTracePoint;
 
 class BackendServiceClient;
@@ -353,6 +354,8 @@ public:
 
     spill::DirManager* spill_dir_mgr() const { return _spill_dir_mgr.get(); }
 
+    spill::GlobalSpillManager* global_spill_manager() const { return _global_spill_manager.get(); }
+
     ThreadPool* delete_file_thread_pool();
 
     ThreadPool* put_aggregate_metadata_thread_pool() { return _put_aggregate_metadata_thread_pool.get(); }
@@ -441,6 +444,7 @@ private:
     AgentServer* _agent_server = nullptr;
     query_cache::CacheManagerRawPtr _cache_mgr;
     std::shared_ptr<spill::DirManager> _spill_dir_mgr;
+    std::shared_ptr<spill::GlobalSpillManager> _global_spill_manager;
     DiagnoseDaemon* _diagnose_daemon = nullptr;
     LookUpDispatcherMgr* _lookup_dispatcher_mgr;
 };

--- a/be/src/runtime/mem_tracker.h
+++ b/be/src/runtime/mem_tracker.h
@@ -280,11 +280,9 @@ public:
                 tracker->_consumption->add(bytes);
             } else {
                 // If this tracker is not shared, ignore shared_reserve_bytes
-                if (!tracker->is_shared()) {
-                    shared_reserve_bytes = 0;
-                }
+                size_t reserve = !tracker->is_shared() ? 0 : shared_reserve_bytes;
                 // Adjust limit to account for reserved memory
-                int64_t adjusted_limit = limit - shared_reserve_bytes;
+                int64_t adjusted_limit = limit - reserve;
                 if (adjusted_limit < 0) {
                     adjusted_limit = 0;
                 }

--- a/be/src/runtime/mem_tracker.h
+++ b/be/src/runtime/mem_tracker.h
@@ -263,25 +263,36 @@ public:
         return nullptr;
     }
 
+    // Attempts to consume `bytes` memory from all trackers in the hierarchy.
     WARN_UNUSED_RESULT
-    MemTracker* try_consume_with_limited(int64_t bytes) {
+    MemTracker* try_consume_with_limited(int64_t bytes, size_t shared_reserve_bytes) {
         if (UNLIKELY(bytes <= 0)) return nullptr;
         int64_t i;
-        // Walk the tracker tree top-down.
         for (i = _all_trackers.size() - 1; i >= 0; --i) {
             MemTracker* tracker = _all_trackers[i];
             int64_t limit = tracker->reserve_limit();
             if (limit < 0) {
                 limit = tracker->limit();
             }
+
             if (limit < 0) {
                 DCHECK_EQ(limit, -1);
-                tracker->_consumption->add(bytes); // No limit at this tracker.
+                tracker->_consumption->add(bytes);
             } else {
-                if (LIKELY(tracker->_consumption->try_add(bytes, limit))) {
+                // If this tracker is not shared, ignore shared_reserve_bytes
+                if (!tracker->is_shared()) {
+                    shared_reserve_bytes = 0;
+                }
+                // Adjust limit to account for reserved memory
+                int64_t adjusted_limit = limit - shared_reserve_bytes;
+                if (adjusted_limit < 0) {
+                    adjusted_limit = 0;
+                }
+                // Try to consume memory under the adjusted limit
+                if (LIKELY(tracker->_consumption->try_add(bytes, adjusted_limit))) {
                     continue;
                 } else {
-                    // Failed for this mem tracker. Roll back the ones that succeeded.
+                    // fail to consume, roll back
                     for (int64_t j = _all_trackers.size() - 1; j > i; --j) {
                         _all_trackers[j]->_consumption->add(-bytes);
                     }
@@ -289,9 +300,37 @@ public:
                 }
             }
         }
-        // Everyone succeeded, return.
         DCHECK_EQ(i, -1);
         return nullptr;
+    }
+
+    // Checks if there is still available memory above the reserved amount for all trackers.
+    bool has_enough_reserved_memory(size_t shared_reserve_bytes) const {
+        for (int64_t i = _all_trackers.size() - 1; i >= 0; --i) {
+            const MemTracker* tracker = _all_trackers[i];
+            int64_t limit = tracker->reserve_limit();
+            if (limit < 0) {
+                limit = tracker->limit();
+            }
+
+            // Unlimited tracker, always has enough memory
+            if (limit < 0) {
+                DCHECK_EQ(limit, -1);
+                continue;
+            }
+
+            // If tracker is not shared, ignore reserve
+            size_t reserve = !tracker->is_shared() ? 0 : shared_reserve_bytes;
+            int64_t adjusted_limit = limit - reserve;
+            if (adjusted_limit < 0) adjusted_limit = 0;
+
+            // Check if current consumption has already exceeded adjusted limit
+            if (tracker->_consumption->current_value() > adjusted_limit) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /// Decreases consumption of this tracker and its ancestors by 'bytes'.
@@ -414,6 +453,11 @@ public:
     std::list<MemTracker*> _child_trackers;
 
     std::list<MemTracker*> getChild() { return _child_trackers; }
+
+    bool is_shared() const {
+        return _type == MemTrackerType::PROCESS || _type == MemTrackerType::QUERY_POOL ||
+               _type == MemTrackerType::RESOURCE_GROUP || _type == MemTrackerType::RESOURCE_GROUP_SHARED_MEMORY_POOL;
+    }
 
 private:
     // Walks the MemTracker hierarchy and populates _all_trackers and _limit_trackers

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -79,6 +79,7 @@ set(EXEC_FILES
         ./exec/pipeline/local_bucket_shuffle_test.cpp
         ./exec/pipeline/mem_limited_chunk_queue_test.cpp
         ./exec/pipeline/exec_group_test.cpp
+        ./exec/query_spill_manager_test.cpp
         ./exec/query_cache/query_cache_test.cpp
         ./exec/query_cache/transform_operator.cpp
         ./exec/schema_columns_scanner_test.cpp

--- a/be/test/exec/query_spill_manager_test.cpp
+++ b/be/test/exec/query_spill_manager_test.cpp
@@ -1,0 +1,102 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/spill/query_spill_manager.h"
+
+#include <gtest/gtest.h>
+
+#include "exec/pipeline/operator.h"
+#include "exec/spill/operator_mem_resource_manager.h"
+#include "runtime/runtime_state.h"
+#include "util/uid_util.h"
+
+namespace starrocks::spill {
+using namespace starrocks::pipeline;
+
+class MockedDummyOperatrator final : public pipeline::Operator {
+public:
+    MockedDummyOperatrator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
+                           bool spillable, bool releaseable)
+            : Operator(factory, id, "mocked_dummy_operator", plan_node_id, false, driver_sequence),
+              _spillable(spillable),
+              _releaseable(releaseable) {}
+    bool spillable() const override { return _spillable; }
+    bool releaseable() const override { return _releaseable; }
+    // dummy functions:
+    bool has_output() const override { return false; }
+    bool need_input() const override { return true; }
+    bool is_finished() const override { return false; }
+
+    Status prepare(RuntimeState* state) override { return Status::OK(); }
+    void close(RuntimeState* state) override {}
+    Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override { return Status::OK(); }
+    StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override { return nullptr; }
+
+private:
+    bool _spillable = false;
+    bool _releaseable = false;
+};
+
+class MockedDummyOperatorFactory final : public pipeline::OperatorFactory {
+public:
+    MockedDummyOperatorFactory(int32_t id, int32_t plan_node_id, RuntimeState* state, bool spillable = false,
+                               bool releaseable = false)
+            : pipeline::OperatorFactory(id, "mocked_dummy_operator_factory", plan_node_id),
+              _spillable(spillable),
+              _releaseable(releaseable) {
+        set_runtime_state(state);
+    }
+    ~MockedDummyOperatorFactory() override = default;
+    Status prepare(RuntimeState* state) override { return Status::OK(); }
+    void close(RuntimeState* state) override {}
+    pipeline::OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
+        return std::make_shared<MockedDummyOperatrator>(this, _id, _plan_node_id, driver_sequence, _spillable,
+                                                        _releaseable);
+    }
+
+private:
+    bool _spillable = false;
+    bool _releaseable = false;
+};
+
+class QuerySpillManagerTest : public ::testing::Test {
+public:
+    void SetUp() override { dummy_query_id = generate_uuid(); }
+
+    void TearDown() override {}
+
+protected:
+    RuntimeState _dummy_state;
+    TUniqueId dummy_query_id;
+    GlobalSpillManager _global_mgr;
+};
+
+TEST_F(QuerySpillManagerTest, test_inc) {
+    QuerySpillManager query_spill_manager_1(dummy_query_id, &_global_mgr);
+
+    auto factory_1 = std::make_unique<MockedDummyOperatorFactory>(1, 1, &_dummy_state, true, true);
+    auto op = factory_1->create(1, 1);
+
+    OperatorMemoryResourceManager op_mem_res_mgr;
+    op_mem_res_mgr.prepare(op.get(), &query_spill_manager_1);
+    EXPECT_EQ(_global_mgr.spillable_operators(), 1);
+
+    auto factory_2 = std::make_unique<MockedDummyOperatorFactory>(1, 1, &_dummy_state, false, true);
+    auto op2 = factory_2->create(1, 1);
+    OperatorMemoryResourceManager op_mem_res_mgr_2;
+    op_mem_res_mgr_2.prepare(op2.get(), nullptr);
+    EXPECT_EQ(_global_mgr.spillable_operators(), 1);
+}
+
+} // namespace starrocks::spill


### PR DESCRIPTION
## Why I'm doing:

This PR improves the spill strategy in StarRocks by enhancing how shared memory trackers handle memory reservation for releaseable operators. When operators require additional memory, the shared memtracker now attempts to reserve memory in advance. If the reservation fails, the corresponding operator is marked for spill, ensuring that memory pressure is handled gracefully and preventing OOM issues under concurrent workloads.

## What I'm doing:

support more concurrency for such query:
```
INSERT INTO blackhole() SELECT col1,col2,col3,DATE_TRUNC('month',col14) AS gb_month,DATE_TRUNC('year',col15) AS gb_year,col17,col18,col24,col28,col29,col40,col41,col57,COUNT(*) AS cnt_all,COUNT(DISTINCT col19) AS cntd_col19,SUM(col19*col23) AS sum_expr,AVG(col33/NULLIF(col34,1)) AS avg_safe,MAX_BY(col24,col23+col31) AS max_by_24,MIN_BY(col25,col31-col19) AS min_by_25,MAX(col88) AS max_col88,MIN(col89) AS min_col89,COUNT(DISTINCT col40) AS cntd_col40,SUM(DISTINCT col97) AS sumd_col97,AVG(DISTINCT col98) AS avgd_col98,MAX_BY(col41,col44+col45) AS max_by_41,MIN_BY(col42,col46*2) AS min_by_42,SUM(CASE WHEN col28='Y' THEN col31 ELSE 0 END) AS cond_sum1,SUM(CASE WHEN col29='A' AND col23>10 THEN col33 ELSE 0 END) AS cond_sum2 FROM etl_scan_test GROUP BY col1,col2,col3,DATE_TRUNC('month',col14),DATE_TRUNC('year',col15),col17,col18,col24,col28,col29,col40,col41,col57;
```

```
INSERT INTO blackhole() 
    SELECT col1,col2,col3,DATE_TRUNC('month',col14) AS gb_month,DATE_TRUNC('year',col15) AS gb_year,col17,col18,col24,col28,col29,col40,col41,col57,COUNT(*) AS cnt_all,COUNT(DISTINCT col19) AS cntd_col19,SUM(col19*col23) AS sum_expr,AVG(col33/NULLIF(col34,1)) AS avg_safe,MAX_BY(col24,col23+col31) AS max_by_24,MIN_BY(col25,col31-col19) AS min_by_25,MAX(col88) AS max_col88,MIN(col89) AS min_col89,COUNT(DISTINCT col40) AS cntd_col40,SUM(DISTINCT col97) AS sumd_col97,AVG(DISTINCT col98) AS avgd_col98,MAX_BY(col41,col44+col45) AS max_by_41,MIN_BY(col42,col46*2) AS min_by_42,SUM(CASE WHEN col28='Y' THEN col31 ELSE 0 END) AS cond_sum1,SUM(CASE WHEN col29='A' AND col23>10 THEN col33 ELSE 0 END) AS cond_sum2 FROM etl_scan_test GROUP BY col1,col2,col3,DATE_TRUNC('month',col14),DATE_TRUNC('year',col15),col17,col18,col24,col28,col29,col40,col41,col57
    union all
    SELECT col1,col2,col3,DATE_TRUNC('month',col14) AS gb_month,DATE_TRUNC('year',col15) AS gb_year,col17,col18,col24,col28,col29,col40,col41,col57,COUNT(*) AS cnt_all,COUNT(DISTINCT col19) AS cntd_col19,SUM(col19*col23) AS sum_expr,AVG(col33/NULLIF(col34,1)) AS avg_safe,MAX_BY(col24,col23+col31) AS max_by_24,MIN_BY(col25,col31-col19) AS min_by_25,MAX(col88) AS max_col88,MIN(col89) AS min_col89,COUNT(DISTINCT col40) AS cntd_col40,SUM(DISTINCT col97) AS sumd_col97,AVG(DISTINCT col98) AS avgd_col98,MAX_BY(col41,col44+col45) AS max_by_41,MIN_BY(col42,col46*2) AS min_by_42,SUM(CASE WHEN col28='Y' THEN col31 ELSE 0 END) AS cond_sum1,SUM(CASE WHEN col29='A' AND col23>10 THEN col33 ELSE 0 END) AS cond_sum2 FROM etl_scan_test GROUP BY col1,col2,col3,DATE_TRUNC('month',col14),DATE_TRUNC('year',col15),col17,col18,col24,col28,col29,col40,col41,col57
;
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a global spill manager and extends mem-tracking/reservation APIs so operators/pipelines account for shared reserved bytes when deciding to spill or release buffers.
> 
> - **Spill/Memory Management**:
>   - **Global manager**: Add `spill::GlobalSpillManager` (tracked in `ExecEnv`) to aggregate `spillable_operators` and `spill_expected_reserved_bytes`.
>   - **Query-level wiring**: `QuerySpillManager` now references `GlobalSpillManager`; `QueryContext::init_spill_manager` passes it through.
>   - **Operator resource guard**: Refactor `OperatorMemoryResourceManager` with `ResGuard` to auto-inc/dec reserved bytes and spillable-operator counts; compute per-operator reserved bytes (spillable or exchange buffer).
>   - **Spill triggers**: `PipelineDriver` consults global `shared_reserved` when reserving memory and releasing buffers; uses `CurrentThread::has_enough_reserved_memory` to enter low-memory mode earlier under pressure.
> - **Runtime/MemTracker APIs**:
>   - Extend `MemTracker::try_consume_with_limited(bytes, shared)` and add `has_enough_reserved_memory(shared)`; respect shared vs non-shared trackers via `is_shared()` and adjusted limits.
>   - Extend `CurrentThread` reservation path to accept `shared_reserve_bytes` and expose `has_enough_reserved_memory`.
> - **ExecEnv**:
>   - Instantiate and expose `GlobalSpillManager`.
> - **Misc**:
>   - Minor const-correctness and log formatting tweaks; remove unused releasing state checks in buffer release path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7ffe77927d78272349b78d6ab6016f1ae8286f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->