### PR TITLE
[Enhancement] Add BE TableSchemaService for Fast Schema Evolution in shared-data (backport #66699)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1775,4 +1775,6 @@ CONF_mInt64(two_level_memory_threshold, "-1");
 
 CONF_mBool(enable_pipeline_driver_parallel_prepare, "true");
 
+// For table schema service: max retry attempts for fetching schema from FE.
+CONF_mInt32(table_schema_service_max_retries, "3");
 } // namespace starrocks::config

--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -189,7 +189,7 @@ Status LakeDataSource::get_tablet(const TInternalScanRange& scan_range) {
                                                  schema_key_pb, tablet_id, _runtime_state->query_id(),
                                                  _runtime_state->fragment_ctx()->fe_addr(), _tablet.metadata()));
     } else {
-        // no table schema meta indicates FE has not been upgraded to use fast schema evolution v2,
+        // no table schema meta indicates FE has not been upgraded to support table schema service,
         // so fallback to the old way to get schema from tablet metadata
         _tablet_schema = _tablet.get_schema();
     }

--- a/be/src/connector/lake_connector.h
+++ b/be/src/connector/lake_connector.h
@@ -60,6 +60,8 @@ public:
     // to the share-nothing mode.
     Status parse_runtime_filters(RuntimeState* state) override { return Status::OK(); }
 
+    TabletSchemaCSPtr TEST_tablet_schema() const { return _tablet_schema; }
+
 private:
     Status get_tablet(const TInternalScanRange& scan_range);
     Status init_global_dicts(TabletReaderParams* params);

--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -805,6 +805,7 @@ Status LakeTabletsChannel::_create_delta_writers(const PTabletWriterOpenRequest&
                                               .set_slot_descriptors(slots)
                                               .set_merge_condition(params.merge_condition())
                                               .set_miss_auto_increment_column(params.miss_auto_increment_column())
+                                              .set_db_id(_schema->db_id())
                                               .set_table_id(params.table_id())
                                               .set_immutable_tablet_size(params.immutable_tablet_size())
                                               .set_mem_tracker(_mem_tracker)

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -277,7 +277,8 @@ set(STORAGE_FILES
     index/vector/tenann/tenann_index_builder.cpp
     index/vector/tenann/tenann_index_utils.cpp
     record_predicate/record_predicate_helper.cpp
-    record_predicate/column_hash_is_congruent.cpp)
+    record_predicate/column_hash_is_congruent.cpp
+    lake/table_schema_service.cpp)
 
 if (NOT BUILD_FORMAT_LIB)
     list(APPEND STORAGE_FILES  lake/starlet_location_provider.cpp)

--- a/be/src/storage/lake/async_delta_writer.cpp
+++ b/be/src/storage/lake/async_delta_writer.cpp
@@ -409,6 +409,7 @@ StatusOr<AsyncDeltaWriterBuilder::AsyncDeltaWriterPtr> AsyncDeltaWriterBuilder::
                                           .set_tablet_manager(_tablet_mgr)
                                           .set_txn_id(_txn_id)
                                           .set_tablet_id(_tablet_id)
+                                          .set_db_id(_db_id)
                                           .set_table_id(_table_id)
                                           .set_partition_id(_partition_id)
                                           .set_slot_descriptors(_slots)

--- a/be/src/storage/lake/async_delta_writer.h
+++ b/be/src/storage/lake/async_delta_writer.h
@@ -148,6 +148,11 @@ public:
         return *this;
     }
 
+    AsyncDeltaWriterBuilder& set_db_id(int64_t db_id) {
+        _db_id = db_id;
+        return *this;
+    }
+
     AsyncDeltaWriterBuilder& set_table_id(int64_t table_id) {
         _table_id = table_id;
         return *this;
@@ -228,6 +233,7 @@ public:
 private:
     TabletManager* _tablet_mgr{nullptr};
     int64_t _txn_id{0};
+    int64_t _db_id{0};
     int64_t _table_id{0};
     int64_t _partition_id{0};
     int64_t _schema_id{0};

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -33,6 +33,7 @@
 #include "storage/lake/metacache.h"
 #include "storage/lake/pk_tablet_writer.h"
 #include "storage/lake/spill_mem_table_sink.h"
+#include "storage/lake/table_schema_service.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_writer.h"
@@ -85,15 +86,16 @@ class DeltaWriterImpl {
 public:
     explicit DeltaWriterImpl(TabletManager* tablet_manager, int64_t tablet_id, int64_t txn_id, int64_t partition_id,
                              const std::vector<SlotDescriptor*>* slots, std::string merge_condition,
-                             bool miss_auto_increment_column, int64_t table_id, int64_t immutable_tablet_size,
-                             MemTracker* mem_tracker, int64_t max_buffer_size, int64_t schema_id,
-                             const PartialUpdateMode& partial_update_mode,
+                             bool miss_auto_increment_column, int64_t db_id, int64_t table_id,
+                             int64_t immutable_tablet_size, MemTracker* mem_tracker, int64_t max_buffer_size,
+                             int64_t schema_id, const PartialUpdateMode& partial_update_mode,
                              const std::map<string, string>* column_to_expr_value, PUniqueId load_id,
                              RuntimeProfile* profile, BundleWritableFileContext* bundle_writable_file_context,
                              GlobalDictByNameMaps* global_dicts, bool is_multi_statements_txn)
             : _tablet_manager(tablet_manager),
               _tablet_id(tablet_id),
               _txn_id(txn_id),
+              _db_id(db_id),
               _table_id(table_id),
               _partition_id(partition_id),
               _schema_id(schema_id),
@@ -190,6 +192,7 @@ private:
     TabletManager* _tablet_manager;
     const int64_t _tablet_id;
     const int64_t _txn_id;
+    const int64_t _db_id;
     const int64_t _table_id;
     const int64_t _partition_id;
     const int64_t _schema_id;
@@ -400,18 +403,14 @@ inline Status DeltaWriterImpl::init_tablet_schema() {
         return Status::OK();
     }
     ASSIGN_OR_RETURN(auto tablet, _tablet_manager->get_tablet(_tablet_id));
-    auto res = tablet.get_schema_by_id(_schema_id);
-    if (res.ok()) {
-        _tablet_schema = std::move(res).value();
-        return Status::OK();
-    } else if (res.status().is_not_found()) {
-        LOG(WARNING) << "No schema file of id=" << _schema_id << " for tablet=" << _tablet_id;
-        // schema file does not exist, fetch tablet schema from tablet metadata
-        ASSIGN_OR_RETURN(_tablet_schema, tablet.get_schema());
-        return Status::OK();
-    } else {
-        return res.status();
-    }
+    TabletMetadataPtr latest_metadata = _tablet_manager->get_latest_cached_tablet_metadata(_tablet_id);
+    TableSchemaKeyPB schema_key;
+    schema_key.set_schema_id(_schema_id);
+    schema_key.set_db_id(_db_id);
+    schema_key.set_table_id(_table_id);
+    ASSIGN_OR_RETURN(_tablet_schema, _tablet_manager->table_schema_service()->get_schema_for_load(
+                                             schema_key, _tablet_id, _txn_id, latest_metadata));
+    return Status::OK();
 }
 
 inline Status DeltaWriterImpl::manual_flush() {
@@ -612,6 +611,10 @@ StatusOr<TxnLogPtr> DeltaWriterImpl::finish_with_txnlog(DeltaWriterFinishMode mo
         *txn_log->mutable_load_id() = _load_id;
     }
     auto op_write = txn_log->mutable_op_write();
+    auto table_schema_key = op_write->mutable_schema_key();
+    table_schema_key->set_db_id(_db_id);
+    table_schema_key->set_table_id(_table_id);
+    table_schema_key->set_schema_id(_tablet_schema->id());
 
     for (auto& f : _tablet_writer->files()) {
         if (is_segment(f.path)) {
@@ -989,10 +992,11 @@ StatusOr<DeltaWriterBuilder::DeltaWriterPtr> DeltaWriterBuilder::build() {
     if (UNLIKELY(_schema_id == 0)) {
         return Status::InvalidArgument("schema_id not set");
     }
-    auto impl = new DeltaWriterImpl(_tablet_mgr, _tablet_id, _txn_id, _partition_id, _slots, _merge_condition,
-                                    _miss_auto_increment_column, _table_id, _immutable_tablet_size, _mem_tracker,
-                                    _max_buffer_size, _schema_id, _partial_update_mode, _column_to_expr_value, _load_id,
-                                    _profile, _bundle_writable_file_context, _global_dicts, _is_multi_statements_txn);
+    auto impl =
+            new DeltaWriterImpl(_tablet_mgr, _tablet_id, _txn_id, _partition_id, _slots, _merge_condition,
+                                _miss_auto_increment_column, _db_id, _table_id, _immutable_tablet_size, _mem_tracker,
+                                _max_buffer_size, _schema_id, _partial_update_mode, _column_to_expr_value, _load_id,
+                                _profile, _bundle_writable_file_context, _global_dicts, _is_multi_statements_txn);
     return std::make_unique<DeltaWriter>(impl);
 }
 

--- a/be/src/storage/lake/delta_writer.h
+++ b/be/src/storage/lake/delta_writer.h
@@ -186,6 +186,11 @@ public:
         return *this;
     }
 
+    DeltaWriterBuilder& set_db_id(int64_t db_id) {
+        _db_id = db_id;
+        return *this;
+    }
+
     DeltaWriterBuilder& set_table_id(int64_t table_id) {
         _table_id = table_id;
         return *this;
@@ -276,6 +281,7 @@ public:
 private:
     TabletManager* _tablet_mgr{nullptr};
     int64_t _txn_id{0};
+    int64_t _db_id{0};
     int64_t _table_id{0};
     int64_t _partition_id{0};
     int64_t _schema_id{0};

--- a/be/src/storage/lake/table_schema_service.cpp
+++ b/be/src/storage/lake/table_schema_service.cpp
@@ -1,0 +1,405 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/table_schema_service.h"
+
+#include <bvar/bvar.h>
+#include <fmt/format.h>
+
+#include <algorithm>
+#ifdef BE_TEST
+#include <array>
+#endif
+
+#include "agent/master_info.h"
+#include "common/config.h"
+#include "common/status.h"
+#include "gen_cpp/lake_types.pb.h"
+#include "runtime/client_cache.h"
+#include "storage/lake/tablet.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/metadata_util.h"
+#include "testutil/sync_point.h"
+#include "util/defer_op.h"
+#include "util/failpoint/fail_point.h"
+#include "util/thrift_rpc_helper.h"
+#include "util/uid_util.h"
+
+namespace starrocks::lake {
+
+// Number of schema lookups that hit the schema cache (fastest path).
+bvar::Adder<int64_t> g_schema_cache_hit("table_schema_service", "schema_cache_hit");
+// Number of schema lookups that hit the tablet metadata (fallback when schema cache misses).
+bvar::Adder<int64_t> g_tablet_metadata_hit("table_schema_service", "tablet_metadata_hit");
+// Number of schema lookups that miss both schema cache and tablet metadata, requiring remote fetch.
+// Note: g_schema_cache_hit + g_tablet_metadata_hit + g_local_miss represents total local lookup attempts.
+bvar::Adder<int64_t> g_local_miss("table_schema_service", "local_miss");
+// Total latency (in microseconds) for remote schema fetches, including all retry attempts.
+// This measures the end-to-end time from initiating remote fetch to completion.
+bvar::LatencyRecorder g_remote_fetch_latency_us("table_schema_service", "remote_fetch_us");
+// Number of retry attempts for remote schema fetches (excludes the initial attempt).
+bvar::Adder<int64_t> g_remote_fetch_retries("table_schema_service", "remote_fetch_retries");
+// Latency (in microseconds) for individual RPC calls to FE for schema fetching.
+// This measures single RPC latency, while g_remote_fetch_latency_us measures total time including retries.
+bvar::LatencyRecorder g_schema_rpc_latency_us("table_schema_service", "schema_rpc_us");
+
+// Failpoint to disable remote schema fetching for load operations in tests.
+// Previously, tests would fallback to local tablet metadata files when schema is not in schema cache
+// and cached latest meta. After introducing remote schema service, these tests would normally need to
+// mock thrift RPC calls to fetch schemas, which requires significant effort. As a compromise, this
+// failpoint is introduced to maintain compatibility with existing tests.
+DEFINE_FAIL_POINT(table_schema_service_disable_remote_schema_for_load);
+
+std::string TableSchemaService::SingleFlightExecutionContext::to_string() const {
+    std::stringstream ss;
+    ss << "[target_fe: " << target_fe.hostname << ":" << target_fe.port
+       << ", source_type: " << ::starrocks::to_string(request_source);
+    if (request_source == TTableSchemaRequestSource::LOAD) {
+        ss << ", txn_id: " << txn_id;
+    } else if (request_source == TTableSchemaRequestSource::SCAN) {
+        ss << ", query_id: " << print_id(query_id);
+    }
+    ss << "]";
+    return ss.str();
+}
+
+StatusOr<TabletSchemaPtr> TableSchemaService::get_schema_for_load(const TableSchemaKeyPB& schema_key, int64_t tablet_id,
+                                                                  int64_t txn_id,
+                                                                  const TabletMetadataPtr& tablet_meta) {
+    int64_t schema_id = schema_key.schema_id();
+    TabletSchemaPtr schema = _get_local_schema(schema_id, tablet_meta);
+    if (schema != nullptr) {
+        VLOG(2) << "get load schema from local. db_id: " << schema_key.db_id()
+                << ", table_id: " << schema_key.table_id() << ", schema_id: " << schema_id
+                << ", tablet_id: " << tablet_id << ", txn_id: " << txn_id;
+        return schema;
+    }
+
+    TTableSchemaKey thrift_schema_key;
+    thrift_schema_key.__set_schema_id(schema_id);
+    thrift_schema_key.__set_db_id(schema_key.db_id());
+    thrift_schema_key.__set_table_id(schema_key.table_id());
+
+    TGetTableSchemaRequest request;
+    request.__set_schema_key(thrift_schema_key);
+    request.__set_source(TTableSchemaRequestSource::LOAD);
+    request.__set_txn_id(txn_id);
+    request.__set_tablet_id(tablet_id);
+
+    TNetworkAddress coordinator_fe = get_master_address();
+    auto status_or_schema = _get_remote_schema(request, coordinator_fe);
+
+    FAIL_POINT_TRIGGER_EXECUTE(table_schema_service_disable_remote_schema_for_load,
+                               { status_or_schema = Status::NotSupported("disable remote schema for testing"); });
+
+    if (status_or_schema.status().is_not_supported()) {
+        // If FE doesn't support table schema service which indicates
+        // fast schema change v2 does not work, fallback to schema file.
+        return _fallback_load_to_schema_file(schema_id, tablet_id);
+    }
+    return status_or_schema;
+}
+
+StatusOr<TabletSchemaPtr> TableSchemaService::get_schema_for_scan(const TableSchemaKeyPB& schema_key, int64_t tablet_id,
+                                                                  const TUniqueId& query_id,
+                                                                  const TNetworkAddress& coordinator_fe,
+                                                                  const TabletMetadataPtr& tablet_meta) {
+    int64_t schema_id = schema_key.schema_id();
+    TabletSchemaPtr schema = _get_local_schema(schema_id, tablet_meta);
+    if (schema != nullptr) {
+        VLOG(2) << "get scan schema from local. db_id: " << schema_key.db_id()
+                << ", table_id: " << schema_key.table_id() << ", schema_id: " << schema_id
+                << ", tablet_id: " << tablet_id << ", query_id: " << print_id(query_id);
+        return schema;
+    }
+
+    TTableSchemaKey thrift_schema_key;
+    thrift_schema_key.__set_schema_id(schema_id);
+    thrift_schema_key.__set_db_id(schema_key.db_id());
+    thrift_schema_key.__set_table_id(schema_key.table_id());
+
+    TGetTableSchemaRequest request;
+    request.__set_schema_key(thrift_schema_key);
+    request.__set_source(TTableSchemaRequestSource::SCAN);
+    request.__set_tablet_id(tablet_id);
+    request.__set_query_id(query_id);
+
+    // SCAN path has check whether FE supports table schema service in LakeDataSource::get_tablet,
+    // so Status::is_not_supported should not happen, and not check it
+    return _get_remote_schema(request, coordinator_fe);
+}
+
+TabletSchemaPtr TableSchemaService::_get_local_schema(int64_t schema_id, const TabletMetadataPtr& tablet_meta) {
+    auto schema = _tablet_mgr->get_cached_schema(schema_id);
+    if (schema != nullptr) {
+        g_schema_cache_hit << 1;
+        return schema;
+    }
+
+    if (tablet_meta != nullptr) {
+        const TabletSchemaPB* schema_pb = nullptr;
+        if (schema_id == tablet_meta->schema().id()) {
+            schema_pb = &tablet_meta->schema();
+        } else {
+            auto it = tablet_meta->historical_schemas().find(schema_id);
+            if (it != tablet_meta->historical_schemas().end()) {
+                schema_pb = &it->second;
+            }
+        }
+        if (schema_pb != nullptr) {
+            schema = TabletSchema::create(*schema_pb);
+            _tablet_mgr->cache_schema(schema);
+            g_tablet_metadata_hit << 1;
+            VLOG(2) << "get schema from tablet metadata. schema_id: " << schema_id
+                    << ", tablet_id: " << tablet_meta->id() << ", metadata version: " << tablet_meta->version();
+            return schema;
+        }
+    }
+
+    g_local_miss << 1;
+    return nullptr;
+}
+
+StatusOr<TabletSchemaPtr> TableSchemaService::_get_remote_schema(const TGetTableSchemaRequest& request,
+                                                                 const TNetworkAddress& fe) {
+    // Deduplication & Reliability Strategy:
+    // 1. SingleFlight: Deduplicates concurrent requests for the same schema to the same FE.
+    //    Grouping by FE (schema + FE) isolates failures/latency across different FEs, avoiding cross-FE interference
+    //    and improving overall availability (one unhealthy FE won't block schema fetches from other FEs).
+    // 2. Fail-Fast Conditions: thrift rpc error or table not exist.
+    // 3. Interference Handling (Cross-Query/Txn):
+    //    - If the "leader" request (the one that actually executed) belonged to the SAME query/txn as us,
+    //      and it failed, we accept the failure and stop retrying.
+    //    - If the "leader" belonged to a DIFFERENT query/txn, its failure might be specific to that context.
+    //      We should retry.
+    // 4. Isolation Strategy (Last Retry):
+    //    - On the final retry attempt, we switch the grouping strategy to include QueryID or TxnID.
+    //    - This ensures we execute a dedicated RPC for our own context, avoiding any interference from others.
+    auto start = butil::gettimeofday_us();
+    DeferOp defer([&]() { g_remote_fetch_latency_us << (butil::gettimeofday_us() - start); });
+    const int max_retries = std::max(1, config::table_schema_service_max_retries);
+    SingleFlightResultPtr sf_result;
+    GroupStrategy group_strategy = GroupStrategy::SCHEMA_AND_FE;
+    for (int attempt = 0; attempt < max_retries; ++attempt) {
+        g_remote_fetch_retries << (attempt == 0 ? 0 : 1);
+        const std::string group_key = _group_key(group_strategy, request, fe);
+        auto t = butil::gettimeofday_us();
+        sf_result = _select_single_flight_group(group_key).Do(group_key,
+                                                              [&]() { return _fetch_schema_via_rpc(request, fe); });
+
+        auto& rpc_result = sf_result->rpc_result;
+        auto& exec_ctx = sf_result->execution_ctx;
+
+        VLOG(2) << "get schema from remote. " << _print_request_info(request) << ", attempt: " << attempt + 1 << "/"
+                << max_retries << ", latency: " << (butil::gettimeofday_us() - t)
+                << "us, execution_ctx: " << exec_ctx.to_string() << ", status: " << rpc_result.status();
+
+        if (rpc_result.ok()) {
+            return rpc_result;
+        }
+
+        const auto& status = rpc_result.status();
+
+        if (status.is_thrift_rpc_error()) {
+            if (status.message().find("Invalid method name 'getTableSchema'") != std::string::npos) {
+                return Status::NotSupported(fmt::format("FE [{}:{}] haven't upgraded to support table schema service.",
+                                                        fe.hostname, fe.port));
+            }
+            break;
+        }
+
+        if (status.is_table_not_exist()) {
+            break;
+        }
+
+        bool is_same_query_or_txn = false;
+        if (request.source == TTableSchemaRequestSource::LOAD &&
+            exec_ctx.request_source == TTableSchemaRequestSource::LOAD) {
+            is_same_query_or_txn = request.txn_id == exec_ctx.txn_id;
+        } else if (request.source == TTableSchemaRequestSource::SCAN &&
+                   exec_ctx.request_source == TTableSchemaRequestSource::SCAN) {
+            is_same_query_or_txn = request.query_id == exec_ctx.query_id;
+        }
+
+        if (is_same_query_or_txn) {
+            break;
+        }
+
+        // The last retry is isolated by query/txn to avoid cross-query/txn interference.
+        if (attempt == max_retries - 2) {
+            if (request.source == TTableSchemaRequestSource::LOAD) {
+                group_strategy = GroupStrategy::SCHEMA_AND_TXN;
+            } else if (request.source == TTableSchemaRequestSource::SCAN) {
+                group_strategy = GroupStrategy::SCHEMA_AND_QUERY;
+            }
+        }
+    }
+
+    if (sf_result != nullptr) {
+        return sf_result->rpc_result;
+    }
+    // should not reach here normally.
+    return Status::InternalError("get schema rpc result is null");
+}
+
+TableSchemaService::SingleFlightResultPtr TableSchemaService::_fetch_schema_via_rpc(
+        const TGetTableSchemaRequest& request, const TNetworkAddress& fe) {
+    // TODO: TBatchGetTableSchemaRequest currently contains only one schema request.
+    // We haven't implemented merging different schema ids into a single RPC because requests are already deduplicated
+    // by schema id via SingleFlight. Therefore, per FE, the effective RPC concurrency is mainly bounded by table count
+    // and QPS, which is not expected to be a bottleneck currently. Keep it simple for now, and only add true batching
+    // if/when FE schema RPC becomes a performance hotspot.
+    TBatchGetTableSchemaRequest request_batch;
+    request_batch.__set_requests(std::vector<TGetTableSchemaRequest>{request});
+
+    TBatchGetTableSchemaResponse response_batch;
+    Status status;
+    bool mock_thrift_rpc = false;
+
+#ifdef BE_TEST
+    // Test hook payload: { request*, response_batch*, status*, mock_thrift_rpc* }
+    std::array<void*, 4> test_ctx{(void*)&request, (void*)&response_batch, (void*)&status, (void*)&mock_thrift_rpc};
+    TEST_SYNC_POINT_CALLBACK("TableSchemaService::_fetch_schema_via_rpc::test_hook", &test_ctx);
+#endif
+
+    int64_t rpc_latency_us = 0;
+    if (!mock_thrift_rpc) {
+        auto start = butil::gettimeofday_us();
+        status = ThriftRpcHelper::rpc<FrontendServiceClient>(
+                fe.hostname, fe.port,
+                [&request_batch, &response_batch](FrontendServiceConnection& client) {
+                    client->getTableSchema(response_batch, request_batch);
+                },
+                config::thrift_rpc_timeout_ms);
+        rpc_latency_us = butil::gettimeofday_us() - start;
+    }
+    g_schema_rpc_latency_us << rpc_latency_us;
+
+    auto result = std::make_shared<TableSchemaService::SingleFlightResult>();
+    result->execution_ctx.target_fe = fe;
+    result->execution_ctx.request_source = request.source;
+    if (request.source == TTableSchemaRequestSource::SCAN) {
+        result->execution_ctx.query_id = request.query_id;
+    } else if (request.source == TTableSchemaRequestSource::LOAD) {
+        result->execution_ctx.txn_id = request.txn_id;
+    }
+
+    auto log_helper = [&](const char* msg, const Status& st = Status::OK()) {
+        std::stringstream ss;
+        ss << msg << ". " << _print_request_info(request) << ", fe: " << fe.hostname
+           << ", rpc latency: " << rpc_latency_us << "us";
+        if (!st.ok()) {
+            ss << ", error: " << st;
+        }
+        return ss.str();
+    };
+
+    if (!status.ok()) {
+        LOG(WARNING) << log_helper("get schema rpc failed", status);
+        result->rpc_result = status;
+        return result;
+    }
+
+    status = Status(response_batch.status);
+    if (!status.ok()) {
+        LOG(WARNING) << log_helper("batch get schema failed", status);
+        result->rpc_result = status;
+        return result;
+    }
+
+    if (!response_batch.__isset.responses || response_batch.responses.empty()) {
+        status = Status::InternalError("response is empty");
+        LOG(WARNING) << log_helper("batch get schema failed", status);
+        result->rpc_result = status;
+        return result;
+    }
+
+    auto& response = response_batch.responses[0];
+    status = Status(response.status);
+    if (!status.ok()) {
+        LOG(WARNING) << log_helper("failed to get schema", status);
+        result->rpc_result = status;
+        return result;
+    }
+
+    TabletSchemaPB schema_pb;
+    status = convert_t_schema_to_pb_schema(response.schema, &schema_pb);
+    if (!status.ok()) {
+        LOG(WARNING) << log_helper("failed to get schema", status);
+        result->rpc_result =
+                Status::InternalError("Failed to convert thrift schema to proto schema: " + status.to_string());
+        return result;
+    }
+    TabletSchemaSPtr schema = TabletSchema::create(schema_pb);
+    _tablet_mgr->cache_schema(schema);
+    VLOG(2) << log_helper("get schema success");
+    result->rpc_result = schema;
+    return result;
+}
+
+std::string TableSchemaService::_group_key(GroupStrategy strategy, const TGetTableSchemaRequest& request,
+                                           const TNetworkAddress& fe) {
+    int64_t schema_id = request.schema_key.schema_id;
+    switch (strategy) {
+    case GroupStrategy::SCHEMA_AND_QUERY:
+        return fmt::format("q{}:{}:{}", schema_id, request.query_id.hi, request.query_id.lo);
+    case GroupStrategy::SCHEMA_AND_TXN:
+        return fmt::format("t{}:{}", schema_id, request.txn_id);
+    case GroupStrategy::SCHEMA_AND_FE:
+    default:
+        return fmt::format("f{}:{}:{}", schema_id, fe.hostname, fe.port);
+    }
+}
+
+std::string TableSchemaService::_print_request_info(const TGetTableSchemaRequest& request) {
+    std::stringstream ss;
+    auto& schema_key = request.schema_key;
+    ss << "db_id: " << schema_key.db_id << ", table_id: " << schema_key.table_id
+       << ", schema_id: " << schema_key.schema_id << ", tablet_id: " << request.tablet_id;
+    if (request.source == TTableSchemaRequestSource::LOAD) {
+        ss << ", txn_id: " << request.txn_id;
+    } else if (request.source == TTableSchemaRequestSource::SCAN) {
+        ss << ", query_id: " << print_id(request.query_id);
+    }
+    return ss.str();
+}
+
+StatusOr<TabletSchemaPtr> TableSchemaService::_fallback_load_to_schema_file(int64_t schema_id, int64_t tablet_id) {
+    auto result = _tablet_mgr->get_tablet_schema_by_id(tablet_id, schema_id);
+    if (result.ok() || !result.status().is_not_found()) {
+        VLOG(2) << "get schema from schema file. schema_id: " << schema_id << ", tablet_id: " << tablet_id
+                << ", status: " << result.status();
+        return result;
+    }
+    // This is for the compatibility before introducing schema file
+    auto tablet_res = _tablet_mgr->get_tablet(tablet_id);
+    VLOG(2) << "get schema from tablet, schema_id: " << schema_id << ", tablet_id: " << tablet_id
+            << ", status: " << tablet_res.status();
+    if (!tablet_res.ok()) {
+        return tablet_res.status();
+    }
+    auto tablet_schema_res = tablet_res->get_schema();
+    if (!tablet_schema_res.ok()) {
+        return tablet_schema_res.status();
+    }
+    auto tablet_schema = std::move(tablet_schema_res).value();
+    if (tablet_schema->id() != schema_id) {
+        return Status::NotFound(
+                fmt::format("schema not match, tablet id: {}, tablet schema id/version: {}/{}, expected schema id: {}",
+                            tablet_id, tablet_schema->id(), tablet_schema->schema_version(), schema_id));
+    }
+    return tablet_schema;
+}
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/table_schema_service.h
+++ b/be/src/storage/lake/table_schema_service.h
@@ -1,0 +1,213 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+
+#include "common/statusor.h"
+#include "gen_cpp/FrontendService_types.h"
+#include "storage/lake/tablet_metadata.h"
+#include "storage/lake/types_fwd.h"
+#include "util/bthreads/single_flight.h"
+
+namespace starrocks::lake {
+
+class TabletManager;
+
+/**
+ * @brief Service for managing and retrieving table schemas in the shared-data mode.
+ * 
+ * This service handles schema retrieval requests for both LOAD and SCAN operations, supporting
+ * Fast Schema Evolution scenarios where schema changes don't propagate schema metas to backends.
+ *
+ * Core capabilities:
+ * 1. Two-level Local Cache:
+ *    - Schema cached in tablet manager.
+ *    - Tablet Metadata Lookup: Checks the in-memory metadata of the specific tablet.
+ *
+ * 2. Remote Fetch via Frontend (FE):
+ *    - If a schema is missing locally, it fetches explicitly from the FE via RPC.
+ *
+ * 3. Request Deduplication (SingleFlight):
+ *    - Uses a SingleFlight mechanism to merge concurrent requests for the same schema, reducing pressure on the FE.
+ *
+ * Terminology & Relationships:
+ *
+ * 1. Table Schema (Logical Concept):
+ *    Represents the schema of a table in the catalog. As schema evolves (Schema Evolution),
+ *    a table generates multiple schema versions, each identified by a unique `schema_id`.
+ *
+ * 2. @ref starrocks::TabletSchema (In-Memory Representation):
+ *    Despite the name "Tablet"Schema, this C++ class represents a specific VERSION of a
+ *    Table Schema.
+ *    - In Shared-Data mode, we maintain a "Schema Cache" (schema_id -> TabletSchemaPtr)
+ *      via @ref starrocks::lake::TabletManager::cache_schema() to allow thousands of tablets
+ *      belonging to the same table to share the same underlying TabletSchema object, saving memory.
+ *
+ * 3. TabletMetadataPB::schema (Persistence/Metadata):
+ *    A field in the tablet's metadata recording the "latest" schema version known to this tablet.
+ *    - After Fast Schema Evolution, new imports use the new schema to generate data.
+ *      This field is updated during publish, while historical versions might be referenced in
+ *      `TabletMetadataPB::historical_schemas`.
+ */
+class TableSchemaService {
+public:
+    TableSchemaService(TabletManager* tablet_mgr) : _tablet_mgr(tablet_mgr) {}
+    ~TableSchemaService() = default;
+
+    /**
+     * @brief Retrieves the table schema for a LOAD operation.
+     * 
+     * @param schema_key Basic information to identify the schema (db_id/table_id/schema_id).
+     * @param tablet_id The tablet that sends the request.
+     * @param txn_id The transaction ID associated with the load.
+     * @param tablet_meta Optional pointer to tablet metadata for local lookup.
+     * @return A shared pointer to the TabletSchema on success, or an error status.
+     */
+    StatusOr<TabletSchemaPtr> get_schema_for_load(const TableSchemaKeyPB& schema_key, int64_t tablet_id, int64_t txn_id,
+                                                  const TabletMetadataPtr& tablet_meta = nullptr);
+
+    /**
+     * @brief Retrieves the table schema for a SCAN operation.
+     *
+     * @param schema_key Identifiers for the target schema (db_id/table_id/schema_id).
+     * @param tablet_id The tablet that sends the request.
+     * @param query_id Query ID for the scan.
+     * @param coordinator_fe Address of the coordinator FE.
+     * @param tablet_meta Optional pointer to tablet metadata for local lookup.
+     * @return A shared pointer to the TabletSchema on success, or an error status.
+     */
+    StatusOr<TabletSchemaPtr> get_schema_for_scan(const TableSchemaKeyPB& schema_key, int64_t tablet_id,
+                                                  const TUniqueId& query_id, const TNetworkAddress& coordinator_fe,
+                                                  const TabletMetadataPtr& tablet_meta = nullptr);
+
+private:
+    /**
+     * @brief Context of the actual RPC executed by the SingleFlight leader.
+     *
+     * When multiple callers request the same schema, one "leader" performs the RPC.
+     * This struct records the context (Query ID or Txn ID) of that leader request.
+     * It allows followers to determine if the result is valid for their context or if they
+     * need to retry (e.g., for stricter isolation).
+     */
+    struct SingleFlightExecutionContext {
+        TNetworkAddress target_fe;
+        TTableSchemaRequestSource::type request_source;
+        // valid if request_source is SCAN
+        TUniqueId query_id;
+        // valid if request_source is LOAD
+        int64_t txn_id;
+
+        std::string to_string() const;
+    };
+
+    /**
+     * @brief Result of a SingleFlight execution, shared among all waiters.
+     */
+    struct SingleFlightResult {
+        SingleFlightExecutionContext execution_ctx;
+        StatusOr<TabletSchemaPtr> rpc_result;
+    };
+    using SingleFlightResultPtr = std::shared_ptr<const SingleFlightResult>;
+
+    /**
+     * @brief Grouping strategies for SingleFlight.
+     */
+    enum class GroupStrategy {
+        SCHEMA_AND_FE,    ///< Group by Schema ID and Frontend.
+        SCHEMA_AND_QUERY, ///< Group by Schema ID and Query ID.
+        SCHEMA_AND_TXN    ///< Group by Schema ID and Transaction ID.
+    };
+
+    /**
+     * @brief Attempts to retrieve the schema from local sources.
+     * 
+     * Checks the schema cache and the provided tablet metadata (if any).
+     * 
+     * @param schema_id The ID of the schema to retrieve.
+     * @param tablet_meta Optional pointer to tablet metadata.
+     * @return The TabletSchema if found locally, otherwise nullptr.
+     */
+    TabletSchemaPtr _get_local_schema(int64_t schema_id, const TabletMetadataPtr& tablet_meta = nullptr);
+
+    /**
+     * @brief Retrieves the schema from a remote Frontend via RPC.
+     * 
+     * Uses SingleFlight to merge duplicate requests and handles retries.
+     * 
+     * @param request The Thrift request to send.
+     * @param fe The address of the target Frontend.
+     * @return The retrieved TabletSchema or an error status.
+     */
+    StatusOr<TabletSchemaPtr> _get_remote_schema(const TGetTableSchemaRequest& request, const TNetworkAddress& fe);
+
+    /**
+     * @brief Executes the actual RPC call to the Frontend.
+     * 
+     * This method is called by the SingleFlight mechanism.
+     * 
+     * @param request The Thrift request to send.
+     * @param fe The address of the target Frontend.
+     * @return A SingleFlightResultPtr containing the response and execution context.
+     */
+    SingleFlightResultPtr _fetch_schema_via_rpc(const TGetTableSchemaRequest& request, const TNetworkAddress& fe);
+
+    /**
+     * @brief Generates a unique string key for SingleFlight grouping.
+     * 
+     * @param strategy The grouping strategy to use.
+     * @param request The request containing schema and ID information.
+     * @param fe The target Frontend address.
+     * @return A string key uniquely identifying the request group.
+     */
+    std::string _group_key(GroupStrategy strategy, const TGetTableSchemaRequest& request, const TNetworkAddress& fe);
+
+    /**
+     * @brief Formats the request information for logging.
+     * 
+     * @param request The Thrift request containing schema info.
+     * @return A string containing key fields from the request.
+     */
+    static std::string _print_request_info(const TGetTableSchemaRequest& request);
+
+    /**
+     * @brief LOAD-only compatibility fallback to read schema from schema file.
+     *
+     * Triggered when FE doesn't support getTableSchema (NotSupported). This is intentionally LOAD-only.
+     *
+     * @param schema_id The ID of the schema to retrieve.
+     * @param tablet_id The ID of the tablet to search in.
+     * @return The TabletSchema if found, otherwise an error status.
+     */
+    StatusOr<TabletSchemaPtr> _fallback_load_to_schema_file(int64_t schema_id, int64_t tablet_id);
+
+    using SingleFlightGroup = bthreads::singleflight::Group<std::string, SingleFlightResultPtr>;
+    static constexpr size_t kSingleFlightGroupShards = 128;
+    static_assert((kSingleFlightGroupShards & (kSingleFlightGroupShards - 1)) == 0,
+                  "kSingleFlightGroupShards must be power of two");
+
+    SingleFlightGroup& _select_single_flight_group(const std::string& group_key) {
+        const size_t h = std::hash<std::string>{}(group_key);
+        return _single_flight_groups[h & (kSingleFlightGroupShards - 1)];
+    }
+
+    TabletManager* _tablet_mgr;
+    std::array<SingleFlightGroup, kSingleFlightGroupShards> _single_flight_groups;
+};
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/table_schema_service.h
+++ b/be/src/storage/lake/table_schema_service.h
@@ -186,15 +186,16 @@ private:
     static std::string _print_request_info(const TGetTableSchemaRequest& request);
 
     /**
-     * @brief LOAD-only compatibility fallback to read schema from schema file.
+     * @brief LOAD-only compatibility fallback to read schema from tablet.
      *
-     * Triggered when FE doesn't support getTableSchema (NotSupported). This is intentionally LOAD-only.
+     * Triggered when schema file not found and FE doesn't support table schema service.
+     * This is for the compatibility before introducing schema file
      *
      * @param schema_id The ID of the schema to retrieve.
      * @param tablet_id The ID of the tablet to search in.
      * @return The TabletSchema if found, otherwise an error status.
      */
-    StatusOr<TabletSchemaPtr> _fallback_load_to_schema_file(int64_t schema_id, int64_t tablet_id);
+    StatusOr<TabletSchemaPtr> _fallback_load_to_tablet_schema(int64_t schema_id, int64_t tablet_id);
 
     using SingleFlightGroup = bthreads::singleflight::Group<std::string, SingleFlightResultPtr>;
     static constexpr size_t kSingleFlightGroupShards = 128;

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -38,6 +38,7 @@
 #include "storage/lake/meta_file.h"
 #include "storage/lake/metacache.h"
 #include "storage/lake/options.h"
+#include "storage/lake/table_schema_service.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_metadata.h"
 #include "storage/lake/txn_log.h"
@@ -76,12 +77,15 @@ TabletManager::TabletManager(std::shared_ptr<LocationProvider> location_provider
         : _location_provider(std::move(location_provider)),
           _metacache(std::make_unique<Metacache>(cache_capacity)),
           _compaction_scheduler(std::make_unique<CompactionScheduler>(this)),
-          _update_mgr(update_mgr) {
+          _update_mgr(update_mgr),
+          _table_schema_service(std::make_unique<TableSchemaService>(this)) {
     _update_mgr->set_tablet_mgr(this);
 }
 
 TabletManager::TabletManager(std::shared_ptr<LocationProvider> location_provider, int64_t cache_capacity)
-        : _location_provider(std::move(location_provider)), _metacache(std::make_unique<Metacache>(cache_capacity)) {}
+        : _location_provider(std::move(location_provider)),
+          _metacache(std::make_unique<Metacache>(cache_capacity)),
+          _table_schema_service(std::make_unique<TableSchemaService>(this)) {}
 
 TabletManager::~TabletManager() = default;
 
@@ -1409,4 +1413,20 @@ StatusOr<TabletAndRowsets> TabletManager::capture_tablet_and_rowsets(int64_t tab
 
     return std::make_tuple(std::move(tablet_ptr), std::move(rowsets));
 }
+
+void TabletManager::cache_schema(const TabletSchemaPtr& schema) {
+    // GlobalTabletSchemaMap and metadata cache overlap in functionality, but because many places
+    // previously relied on GlobalTabletSchemaMap, caching is still performed in GlobalTabletSchemaMap
+    // here. In the future, it may be possible to refactor and remove GlobalTabletSchemaMap.
+    auto [cached_schema, inserted] = GlobalTabletSchemaMap::Instance()->emplace(schema);
+    auto cache_key = global_schema_cache_key(cached_schema->id());
+    auto cache_size = inserted ? cached_schema->mem_usage() : 0;
+    _metacache->cache_tablet_schema(cache_key, cached_schema, cache_size);
+}
+
+TabletSchemaPtr TabletManager::get_cached_schema(int64_t schema_id) {
+    auto cache_key = global_schema_cache_key(schema_id);
+    return _metacache->lookup_tablet_schema(cache_key);
+}
+
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -52,10 +52,12 @@ using TabletAndRowsets = std::tuple<std::shared_ptr<Tablet>, std::vector<BaseRow
 class CompactionScheduler;
 class Metacache;
 class VersionedTablet;
+class TableSchemaService;
 
 class TabletManager {
     friend class Tablet;
     friend class MetaFileBuilder;
+    friend class TableSchemaService;
 
 public:
     // Does NOT take the ownership of |location_provider| and |location_provider| must outlive
@@ -215,6 +217,8 @@ public:
 
     void update_metacache_limit(size_t limit);
 
+    TableSchemaService* table_schema_service() { return _table_schema_service.get(); }
+
     // The return value will never be null.
     Metacache* metacache() { return _metacache.get(); }
 
@@ -258,6 +262,13 @@ public:
 
     void stop();
 
+    // Cache the schema into the metadata cache.
+    void cache_schema(const TabletSchemaPtr& schema);
+
+    // Get the schema from the metadata cache.
+    // Return nullptr if not found.
+    TabletSchemaPtr get_cached_schema(int64_t schema_id);
+
 private:
     static std::string global_schema_cache_key(int64_t index_id);
     static std::string tablet_schema_cache_key(int64_t tablet_id);
@@ -285,6 +296,7 @@ private:
     std::unique_ptr<Metacache> _metacache;
     std::unique_ptr<CompactionScheduler> _compaction_scheduler;
     UpdateManager* _update_mgr = nullptr;
+    std::unique_ptr<TableSchemaService> _table_schema_service;
 
     std::shared_mutex _meta_lock;
     std::unordered_map<int64_t, int64_t> _tablet_in_writing_size;

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -20,6 +20,7 @@
 #include "storage/lake/lake_primary_index.h"
 #include "storage/lake/lake_primary_key_recover.h"
 #include "storage/lake/meta_file.h"
+#include "storage/lake/table_schema_service.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_metadata.h"
 #include "storage/lake/update_manager.h"
@@ -98,6 +99,60 @@ Status apply_alter_meta_log(TabletMetadataPB* metadata, const TxnLogPB_OpAlterMe
     }
     return Status::OK();
 }
+
+/**
+ * @brief Updates the tablet metadata with the latest schema from the transaction log.
+ * 
+ * If the write operation contains a newer schema version than the current tablet schema,
+ * this function attempts to fetch the new schema via TableSchemaService and update
+ * the tablet metadata. It also archives the old schema into the historical schemas list.
+ * 
+ * @param op_write The write operation from the transaction log.
+ * @param txn_id The transaction ID.
+ * @param tablet_meta Pointer to the mutable tablet metadata to be updated.
+ * @param tablet_mgr Pointer to the tablet manager.
+ * @return Status::OK() on success or if no update is needed, otherwise an error status.
+ */
+Status update_metadata_schema(const TxnLogPB_OpWrite& op_write, int64_t txn_id,
+                              const MutableTabletMetadataPtr& tablet_meta, TabletManager* tablet_mgr) {
+    if (!op_write.has_schema_key()) {
+        // not fast schema evolution v2, skip to update
+        return Status::OK();
+    }
+    auto& schema_key = op_write.schema_key();
+    if (schema_key.schema_id() == tablet_meta->schema().id() ||
+        tablet_meta->historical_schemas().contains(schema_key.schema_id())) {
+        return Status::OK();
+    }
+    ASSIGN_OR_RETURN(auto new_schema, tablet_mgr->table_schema_service()->get_schema_for_load(
+                                              schema_key, tablet_meta->id(), txn_id, tablet_meta));
+    auto& old_schema = tablet_meta->schema();
+    if (new_schema->schema_version() <= old_schema.schema_version()) {
+        return Status::OK();
+    }
+
+    LOG(INFO) << "update metadata schema. db_id: " << schema_key.db_id() << ", table_id: " << schema_key.table_id()
+              << ", tablet_id: " << tablet_meta->id() << ", metadata version: " << tablet_meta->version()
+              << ", txn_id: " << txn_id << ", new schema id/version: " << new_schema->id() << "/"
+              << new_schema->schema_version() << ", old schema id/version: " << old_schema.id() << "/"
+              << old_schema.schema_version();
+
+    bool record_old_schema_in_history = false;
+    for (auto& rowset : tablet_meta->rowsets()) {
+        if (tablet_meta->rowset_to_schema().count(rowset.id()) <= 0) {
+            record_old_schema_in_history = true;
+            tablet_meta->mutable_rowset_to_schema()->insert({rowset.id(), old_schema.id()});
+        }
+    }
+    if (record_old_schema_in_history && tablet_meta->historical_schemas().count(old_schema.id()) <= 0) {
+        auto& item = (*tablet_meta->mutable_historical_schemas())[old_schema.id()];
+        item.CopyFrom(old_schema);
+    }
+    tablet_meta->mutable_schema()->Clear();
+    new_schema->to_schema_pb(tablet_meta->mutable_schema());
+    return Status::OK();
+}
+
 } // namespace
 
 class PrimaryKeyTxnLogApplier : public TxnLogApplier {
@@ -216,6 +271,7 @@ public:
         for (const auto& log : txn_logs) {
             if (log->has_op_write()) {
                 const auto& op_write = log->op_write();
+                RETURN_IF_ERROR(update_metadata_schema(op_write, log->txn_id(), _metadata, _tablet.tablet_mgr()));
                 if (is_column_mode_partial_update(op_write)) {
                     RETURN_IF_ERROR(_tablet.update_mgr()->publish_column_mode_partial_update(
                             op_write, log->txn_id(), _metadata, &_tablet, &_builder, _base_version));
@@ -307,6 +363,7 @@ private:
     }
 
     Status apply_write_log(const TxnLogPB_OpWrite& op_write, int64_t txn_id) {
+        RETURN_IF_ERROR(update_metadata_schema(op_write, txn_id, _metadata, _tablet.tablet_mgr()));
         // get lock to avoid gc
         _tablet.update_mgr()->lock_shard_pk_index_shard(_tablet.id());
         DeferOp defer([&]() { _tablet.update_mgr()->unlock_shard_pk_index_shard(_tablet.id()); });
@@ -465,7 +522,7 @@ public:
 
     Status apply(const TxnLogPB& log) override {
         if (log.has_op_write()) {
-            RETURN_IF_ERROR(apply_write_log(log.op_write()));
+            RETURN_IF_ERROR(apply_write_log(log.op_write(), log.txn_id()));
         }
         if (log.has_op_compaction()) {
             RETURN_IF_ERROR(apply_compaction_log(log.op_compaction()));
@@ -501,6 +558,7 @@ public:
         for (const auto& log : txn_logs) {
             if (log->has_op_write()) {
                 const auto& op_write = log->op_write();
+                RETURN_IF_ERROR(update_metadata_schema(op_write, log->txn_id(), _metadata, _tablet.tablet_mgr()));
                 if (op_write.has_rowset() && op_write.rowset().num_rows() > 0) {
                     const auto& rowset = op_write.rowset();
 
@@ -601,8 +659,9 @@ public:
     }
 
 private:
-    Status apply_write_log(const TxnLogPB_OpWrite& op_write) {
+    Status apply_write_log(const TxnLogPB_OpWrite& op_write, int64_t txn_id) {
         TEST_ERROR_POINT("NonPrimaryKeyTxnLogApplier::apply_write_log");
+        RETURN_IF_ERROR(update_metadata_schema(op_write, txn_id, _metadata, _tablet.tablet_mgr()));
         if (op_write.has_rowset() && (op_write.rowset().num_rows() > 0 || op_write.rowset().has_delete_predicate())) {
             auto rowset = _metadata->add_rowsets();
             rowset->CopyFrom(op_write.rowset());
@@ -793,7 +852,7 @@ private:
 
         if (txn_meta.incremental_snapshot()) {
             for (const auto& op_write : op_replication.op_writes()) {
-                RETURN_IF_ERROR(apply_write_log(op_write));
+                RETURN_IF_ERROR(apply_write_log(op_write, txn_meta.txn_id()));
             }
             LOG(INFO) << "Apply incremental replication log finish. tablet_id: " << _tablet.id()
                       << ", base_version: " << _metadata->version() << ", new_version: " << _new_version
@@ -803,7 +862,7 @@ private:
             _metadata->mutable_rowsets()->Clear();
 
             for (const auto& op_write : op_replication.op_writes()) {
-                RETURN_IF_ERROR(apply_write_log(op_write));
+                RETURN_IF_ERROR(apply_write_log(op_write, txn_meta.txn_id()));
             }
 
             _metadata->set_cumulative_point(0);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -584,6 +584,8 @@ set(EXEC_FILES
         ./udf/java/java_udf_test.cpp
         ./util/table_metrics_mgr_test.cpp
         ./util/jvm_metrics_test.cpp
+        ./storage/lake/table_schema_service_test.cpp
+        ./storage/lake/fast_schema_evolution_v2_test.cpp    
         )
 
 if (${USE_AVX512})

--- a/be/test/runtime/lake_tablets_channel_test.cpp
+++ b/be/test/runtime/lake_tablets_channel_test.cpp
@@ -84,6 +84,7 @@ public:
         auto index = _open_request.mutable_schema()->add_indexes();
         index->set_id(kIndexId);
         index->set_schema_hash(0);
+        index->set_schema_id(_schema_id);
         for (int i = 0, sz = metadata->schema().column_size(); i < sz; i++) {
             auto slot = _open_request.mutable_schema()->add_slot_descs();
             slot->set_id(i);

--- a/be/test/runtime/load_channel_test.cpp
+++ b/be/test/runtime/load_channel_test.cpp
@@ -81,6 +81,7 @@ public:
         auto index = _open_request.mutable_schema()->add_indexes();
         index->set_id(kIndexId);
         index->set_schema_hash(0);
+        index->set_schema_id(_schema_id);
         for (int i = 0, sz = metadata->schema().column_size(); i < sz; i++) {
             auto slot = _open_request.mutable_schema()->add_slot_descs();
             slot->set_id(i);

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -2161,6 +2161,7 @@ TEST_F(LakeServiceTest, test_abort_txn2) {
         auto index = request.mutable_schema()->add_indexes();
         index->set_id(index_id);
         index->set_schema_hash(0);
+        index->set_schema_id(metadata->schema().id());
         for (int i = 0, sz = metadata->schema().column_size(); i < sz; i++) {
             const auto& column = metadata->schema().column(i);
             auto slot = request.mutable_schema()->add_slot_descs();

--- a/be/test/storage/lake/fast_schema_evolution_v2_test.cpp
+++ b/be/test/storage/lake/fast_schema_evolution_v2_test.cpp
@@ -1,0 +1,443 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "gen_cpp/FrontendService_types.h"
+#include "runtime/exec_env.h"
+#include "storage/lake/tablet.h"
+#include "storage/lake/tablet_metadata.h"
+#include "storage/lake/txn_log_applier.h"
+#include "testutil/assert.h"
+#include "testutil/id_generator.h"
+#include "testutil/sync_point.h"
+
+namespace starrocks::lake {
+
+using namespace starrocks;
+
+namespace {
+
+class ScopedSyncPoint {
+public:
+    ScopedSyncPoint() { SyncPoint::GetInstance()->EnableProcessing(); }
+    ~ScopedSyncPoint() {
+        SyncPoint::GetInstance()->ClearAllCallBacks();
+        SyncPoint::GetInstance()->DisableProcessing();
+    }
+};
+
+} // namespace
+
+class FastSchemaEvolutionV2Test : public ::testing::Test {
+public:
+    void SetUp() override {
+        _sp = std::make_unique<ScopedSyncPoint>();
+        ASSERT_NE(ExecEnv::GetInstance(), nullptr);
+        ASSERT_NE(ExecEnv::GetInstance()->lake_tablet_manager(), nullptr);
+    }
+
+    void TearDown() override { _sp.reset(); }
+
+protected:
+    struct RpcTestHookArgs {
+        const TGetTableSchemaRequest* request = nullptr;
+        TBatchGetTableSchemaResponse* response = nullptr;
+        Status* rpc_status = nullptr;
+        bool* mock_thrift_rpc = nullptr;
+    };
+
+    static void set_status(TStatus* status, TStatusCode::type code, std::string msg = "") {
+        status->__set_status_code(code);
+        if (!msg.empty()) {
+            status->__set_error_msgs(std::vector<std::string>{std::move(msg)});
+        }
+    }
+
+    static TTabletSchema make_thrift_schema(TKeysType::type keys_type, int64_t schema_id, int32_t schema_version,
+                                            int num_columns) {
+        TTabletSchema t_schema;
+        t_schema.__set_id(schema_id);
+        t_schema.__set_schema_version(schema_version);
+        t_schema.__set_short_key_column_count(1);
+        t_schema.__set_keys_type(keys_type);
+
+        TColumn c0;
+        c0.__set_column_name("c0");
+        c0.column_type.__set_type(TPrimitiveType::INT);
+        c0.__set_col_unique_id(1);
+        c0.__set_is_key(true);
+        c0.__set_is_allow_null(false);
+        t_schema.columns.push_back(c0);
+
+        TColumn c1;
+        c1.__set_column_name("c1");
+        c1.column_type.__set_type(TPrimitiveType::INT);
+        c1.__set_col_unique_id(2);
+        c1.__set_is_key(false);
+        c1.__set_is_allow_null(false);
+        t_schema.columns.push_back(c1);
+
+        for (int i = 2; i < num_columns; i++) {
+            TColumn c;
+            c.__set_column_name("c" + std::to_string(i));
+            c.column_type.__set_type(TPrimitiveType::INT);
+            c.__set_col_unique_id(i + 1);
+            c.__set_is_key(false);
+            c.__set_is_allow_null(false);
+            t_schema.columns.push_back(c);
+        }
+
+        return t_schema;
+    }
+
+    static RpcTestHookArgs unpack_rpc_test_hook_args(void* arg) {
+        auto* arr = static_cast<std::array<void*, 4>*>(arg);
+        RpcTestHookArgs out;
+        out.request = static_cast<const TGetTableSchemaRequest*>((*arr)[0]);
+        out.response = static_cast<TBatchGetTableSchemaResponse*>((*arr)[1]);
+        out.rpc_status = static_cast<Status*>((*arr)[2]);
+        out.mock_thrift_rpc = static_cast<bool*>((*arr)[3]);
+        return out;
+    }
+
+    static void install_rpc_hook(const std::function<void(const RpcTestHookArgs&)>& hook) {
+        SyncPoint::GetInstance()->SetCallBack("TableSchemaService::_fetch_schema_via_rpc::test_hook",
+                                              [hook](void* arg) { hook(unpack_rpc_test_hook_args(arg)); });
+    }
+
+    static std::unique_ptr<TxnLogApplier> new_applier(int64_t tablet_id, const MutableTabletMetadataPtr& meta) {
+        Tablet tablet(ExecEnv::GetInstance()->lake_tablet_manager(), tablet_id);
+        return new_txn_log_applier(tablet, meta, /*new_version=*/2, /*rebuild_pindex=*/false,
+                                   /*skip_write_tablet_metadata=*/true);
+    }
+
+    static void mock_schema_rpc(TKeysType::type keys_type, int64_t schema_id, int32_t schema_version, int num_columns) {
+        install_rpc_hook([keys_type, schema_id, schema_version, num_columns](const RpcTestHookArgs& ctx) {
+            *ctx.mock_thrift_rpc = true;
+            *ctx.rpc_status = Status::OK();
+            set_status(&ctx.response->status, TStatusCode::OK);
+            ctx.response->__set_responses(std::vector<TGetTableSchemaResponse>{});
+            auto& resp = ctx.response->responses.emplace_back();
+            set_status(&resp.status, TStatusCode::OK);
+            resp.__set_schema(make_thrift_schema(keys_type, schema_id, schema_version, num_columns));
+        });
+    }
+
+    static MutableTabletMetadataPtr make_meta(int64_t tablet_id, KeysType keys_type, int64_t schema_id,
+                                              int32_t schema_version) {
+        auto m = std::make_shared<TabletMetadata>();
+        m->set_id(tablet_id);
+        m->set_version(1);
+        m->set_next_rowset_id(0);
+
+        auto* schema = m->mutable_schema();
+        schema->set_id(schema_id);
+        schema->set_keys_type(keys_type);
+        schema->set_schema_version(schema_version);
+        schema->set_num_short_key_columns(1);
+
+        // Two-column base schema: {c0(key), c1(value)}.
+        schema->set_next_column_unique_id(3);
+        auto* c0 = schema->add_column();
+        c0->set_unique_id(1);
+        c0->set_name("c0");
+        c0->set_type("INT");
+        c0->set_is_key(true);
+        c0->set_is_nullable(false);
+        c0->set_length(4);
+
+        auto* c1 = schema->add_column();
+        c1->set_unique_id(2);
+        c1->set_name("c1");
+        c1->set_type("INT");
+        c1->set_is_key(false);
+        c1->set_is_nullable(false);
+        c1->set_length(4);
+        return m;
+    }
+
+    static TxnLogPB make_write_log(int64_t txn_id, int64_t schema_id, int64_t db_id, int64_t table_id) {
+        TxnLogPB log;
+        log.set_txn_id(txn_id);
+        auto* op_write = log.mutable_op_write();
+        auto* schema_key = op_write->mutable_schema_key();
+        schema_key->set_schema_id(schema_id);
+        schema_key->set_db_id(db_id);
+        schema_key->set_table_id(table_id);
+        return log;
+    }
+
+    static std::shared_ptr<TxnLogPB> make_write_log_ptr(int64_t txn_id, int64_t schema_id, int64_t db_id,
+                                                        int64_t table_id) {
+        auto log = std::make_shared<TxnLogPB>();
+        log->set_txn_id(txn_id);
+        auto* op_write = log->mutable_op_write();
+        auto* schema_key = op_write->mutable_schema_key();
+        schema_key->set_schema_id(schema_id);
+        schema_key->set_db_id(db_id);
+        schema_key->set_table_id(table_id);
+        return log;
+    }
+
+    std::unique_ptr<ScopedSyncPoint> _sp;
+};
+
+TEST_F(FastSchemaEvolutionV2Test, no_schema_update) {
+    // Verify update is skipped when schema_key is missing or schema_version is not newer.
+    const int64_t kOldSchemaId = next_id();
+    const int32_t kOldSchemaVersion = 10;
+
+    {
+        // 1) Prepare metadata with an existing schema in TabletMetadataPB::schema.
+        auto tablet_id = next_id();
+        auto meta = make_meta(tablet_id, DUP_KEYS, kOldSchemaId, kOldSchemaVersion);
+        auto applier = new_applier(tablet_id, meta);
+
+        // 2) Install a hook to detect whether schema fetch is attempted.
+        bool invoked = false;
+        install_rpc_hook([&](const RpcTestHookArgs&) { invoked = true; });
+
+        // 3) Apply an op_write without schema_key.
+        TxnLogPB log;
+        log.set_txn_id(next_id());
+        (void)log.mutable_op_write();
+
+        // 4) Assert: schema unchanged, and no remote schema fetch attempted.
+        auto st = applier->apply(log);
+        ASSERT_TRUE(st.ok()) << st;
+        ASSERT_FALSE(invoked);
+        ASSERT_EQ(meta->schema().id(), kOldSchemaId);
+        ASSERT_EQ(meta->schema().schema_version(), kOldSchemaVersion);
+    }
+
+    {
+        // 1) Prepare metadata with an existing schema in TabletMetadataPB::schema.
+        auto tablet_id = next_id();
+        auto meta = make_meta(tablet_id, DUP_KEYS, kOldSchemaId, kOldSchemaVersion);
+        auto applier = new_applier(tablet_id, meta);
+
+        // 2) Install a hook to detect whether schema fetch is attempted.
+        bool invoked = false;
+        install_rpc_hook([&](const RpcTestHookArgs&) { invoked = true; });
+
+        // 3) Apply an op_write with schema_key.schema_id == current.
+        auto log = make_write_log(next_id(), /*schema_id=*/kOldSchemaId, /*db_id=*/1, /*table_id=*/2);
+
+        // 4) Assert: schema unchanged, and no remote schema fetch attempted.
+        auto st = applier->apply(log);
+        ASSERT_TRUE(st.ok()) << st;
+        ASSERT_FALSE(invoked);
+        ASSERT_EQ(meta->schema().id(), kOldSchemaId);
+        ASSERT_EQ(meta->schema().schema_version(), kOldSchemaVersion);
+    }
+
+    {
+        // 1) Prepare metadata with two existing schema in TabletMetadataPB::schema and TabletMetadataPB::historical_schemas.
+        auto tablet_id = next_id();
+        auto meta = make_meta(tablet_id, DUP_KEYS, kOldSchemaId, kOldSchemaVersion);
+        const int64_t historical_schema_id = kOldSchemaId - 1;
+        TabletSchemaPB historical;
+        historical.set_id(historical_schema_id);
+        historical.set_schema_version(kOldSchemaVersion - 1);
+        meta->mutable_historical_schemas()->insert({historical_schema_id, historical});
+        auto applier = new_applier(tablet_id, meta);
+
+        // 2) Install a hook to detect whether schema fetch is attempted.
+        bool invoked = false;
+        install_rpc_hook([&](const RpcTestHookArgs&) { invoked = true; });
+
+        // 3) Apply an op_write whose schema_id already exists in historical_schemas.
+        auto log = make_write_log(next_id(), /*schema_id=*/historical_schema_id, /*db_id=*/1, /*table_id=*/2);
+
+        // 4) Assert: schema unchanged, and no remote schema fetch attempted.
+        auto st = applier->apply(log);
+        ASSERT_TRUE(st.ok()) << st;
+        ASSERT_FALSE(invoked);
+        ASSERT_EQ(meta->schema().id(), kOldSchemaId);
+        ASSERT_EQ(meta->schema().schema_version(), kOldSchemaVersion);
+        ASSERT_EQ(meta->historical_schemas().size(), 1);
+    }
+
+    {
+        // 1) Prepare metadata with an existing schema TabletMetadataPB::schema.
+        auto tablet_id = next_id();
+        auto meta = make_meta(tablet_id, DUP_KEYS, kOldSchemaId, kOldSchemaVersion);
+        auto applier = new_applier(tablet_id, meta);
+
+        // 2) Mock FE schema RPC to return an older schema (id/version controlled by the test).
+        const int64_t new_schema_id = next_id();
+        mock_schema_rpc(TKeysType::DUP_KEYS, new_schema_id, /*schema_version=*/5, /*num_columns=*/3);
+
+        // 3) Apply an op_write with schema_version < current.
+        auto log = make_write_log(next_id(), /*schema_id=*/new_schema_id, /*db_id=*/1, /*table_id=*/2);
+
+        // 4) Assert: schema unchanged, and no remote schema fetch attempted.
+        auto st = applier->apply(log);
+        ASSERT_TRUE(st.ok()) << st;
+        ASSERT_EQ(meta->schema().id(), kOldSchemaId);
+        ASSERT_EQ(meta->schema().schema_version(), kOldSchemaVersion);
+    }
+}
+
+TEST_F(FastSchemaEvolutionV2Test, schema_update) {
+    // Verify metadata schema is updated when schema_key.schema_version is newer.
+    for (auto keys_type : {DUP_KEYS, PRIMARY_KEYS}) {
+        SCOPED_TRACE(keys_type == DUP_KEYS ? "dup_keys" : "primary_keys");
+        auto tablet_id = next_id();
+        auto meta = make_meta(tablet_id, keys_type, /*schema_id=*/next_id(), /*schema_version=*/10);
+        auto applier = new_applier(tablet_id, meta);
+
+        // 1) Mock FE schema RPC to return a newer schema (id/version controlled by the test).
+        const int64_t new_schema_id = next_id();
+        mock_schema_rpc(keys_type == DUP_KEYS ? TKeysType::DUP_KEYS : TKeysType::PRIMARY_KEYS, new_schema_id,
+                        /*schema_version=*/20, /*num_columns=*/3);
+
+        // 2) Apply an op_write with schema version newer than metadata.
+        auto log = make_write_log(next_id(), new_schema_id, /*db_id=*/1, /*table_id=*/2);
+
+        // 3) Assert: metadata schema replaced by fetched schema.
+        auto st = applier->apply(log);
+        ASSERT_TRUE(st.ok()) << st;
+        ASSERT_EQ(meta->schema().id(), new_schema_id);
+        ASSERT_EQ(meta->schema().schema_version(), 20);
+        ASSERT_EQ(meta->schema().column_size(), 3);
+        ASSERT_EQ(meta->schema().column(2).name(), "c2");
+    }
+}
+
+TEST_F(FastSchemaEvolutionV2Test, archive_to_history) {
+    // Verify rowset_to_schema backfill and old schema is archived into historical_schemas.
+    auto tablet_id = next_id();
+    const int64_t kOldSchemaId = next_id();
+    auto meta = make_meta(tablet_id, DUP_KEYS, kOldSchemaId, /*schema_version=*/10);
+    auto* rs1 = meta->add_rowsets();
+    rs1->set_id(111);
+    auto* rs2 = meta->add_rowsets();
+    rs2->set_id(222);
+    TabletSchemaPB old_schema = meta->schema();
+
+    // 1) Prepare applier and mock schema fetch.
+    auto applier = new_applier(tablet_id, meta);
+
+    const int64_t new_schema_id = next_id();
+    mock_schema_rpc(TKeysType::DUP_KEYS, new_schema_id, /*schema_version=*/20, /*num_columns=*/3);
+
+    // 2) Apply an op_write with a newer schema.
+    auto log = make_write_log(next_id(), new_schema_id, /*db_id=*/1, /*table_id=*/2);
+    auto st = applier->apply(log);
+    ASSERT_TRUE(st.ok()) << st;
+
+    // 3) Assert: missing rowset_to_schema mappings are backfilled to old schema id.
+    auto it1 = meta->rowset_to_schema().find(111);
+    ASSERT_TRUE(it1 != meta->rowset_to_schema().end());
+    ASSERT_EQ(it1->second, kOldSchemaId);
+    auto it2 = meta->rowset_to_schema().find(222);
+    ASSERT_TRUE(it2 != meta->rowset_to_schema().end());
+    ASSERT_EQ(it2->second, kOldSchemaId);
+    // 4) Assert: old schema archived.
+    auto hs_it = meta->historical_schemas().find(kOldSchemaId);
+    ASSERT_TRUE(hs_it != meta->historical_schemas().end());
+    ASSERT_EQ(hs_it->second.DebugString(), old_schema.DebugString());
+}
+
+TEST_F(FastSchemaEvolutionV2Test, no_archive_to_history) {
+    // Verify historical_schemas is not modified when no backfill is needed.
+    auto tablet_id = next_id();
+    const int64_t kOldSchemaId = next_id();
+    auto meta = make_meta(tablet_id, DUP_KEYS, kOldSchemaId, /*schema_version=*/10);
+    auto* rs1 = meta->add_rowsets();
+    rs1->set_id(111);
+    auto* rs2 = meta->add_rowsets();
+    rs2->set_id(222);
+    meta->mutable_rowset_to_schema()->insert({111, kOldSchemaId});
+    meta->mutable_rowset_to_schema()->insert({222, kOldSchemaId});
+    TabletSchemaPB existing;
+    existing.set_id(kOldSchemaId);
+    existing.set_schema_version(777);
+    meta->mutable_historical_schemas()->insert({kOldSchemaId, existing});
+
+    // 1) Prepare applier and mock schema fetch.
+    auto applier = new_applier(tablet_id, meta);
+
+    const int64_t new_schema_id = next_id();
+    mock_schema_rpc(TKeysType::DUP_KEYS, new_schema_id, /*schema_version=*/20, /*num_columns=*/3);
+
+    // 2) Apply an op_write with a newer schema.
+    auto log = make_write_log(next_id(), new_schema_id, /*db_id=*/1, /*table_id=*/2);
+    auto st = applier->apply(log);
+    ASSERT_TRUE(st.ok()) << st;
+    // 3) Assert: existing historical schema entry remains unchanged.
+    ASSERT_EQ(meta->historical_schemas().size(), 1);
+    auto hs_it = meta->historical_schemas().find(kOldSchemaId);
+    ASSERT_TRUE(hs_it != meta->historical_schemas().end());
+    ASSERT_EQ(hs_it->second.schema_version(), 777);
+}
+
+TEST_F(FastSchemaEvolutionV2Test, apply_log_vector_updates_schema) {
+    // Verify batch apply updates schema to the latest (newest schema_version among logs).
+    for (auto keys_type : {DUP_KEYS, PRIMARY_KEYS}) {
+        SCOPED_TRACE(keys_type == DUP_KEYS ? "dup_keys" : "primary_keys");
+        auto tablet_id = next_id();
+        const int64_t kOldSchemaId = next_id();
+        auto meta = make_meta(tablet_id, keys_type, kOldSchemaId, /*schema_version=*/50);
+        auto applier = new_applier(tablet_id, meta);
+
+        // 1) Mock schema fetch: each schema version has a different schema id, and newer schemas add new columns.
+        std::array<int32_t, 3> returned_versions{100, 101, 102};
+        std::array<int64_t, 3> schema_ids{next_id(), next_id(), next_id()};
+        std::unordered_map<int64_t, int32_t> schema_id_to_version;
+        for (size_t i = 0; i < schema_ids.size(); i++) {
+            schema_id_to_version.emplace(schema_ids[i], returned_versions[i]);
+        }
+        install_rpc_hook([&](const RpcTestHookArgs& ctx) {
+            const int64_t req_schema_id = ctx.request->schema_key.schema_id;
+            auto it = schema_id_to_version.find(req_schema_id);
+            ASSERT_TRUE(it != schema_id_to_version.end()) << "unexpected schema_id: " << req_schema_id;
+            *ctx.mock_thrift_rpc = true;
+            *ctx.rpc_status = Status::OK();
+            set_status(&ctx.response->status, TStatusCode::OK);
+            ctx.response->__set_responses(std::vector<TGetTableSchemaResponse>{});
+            auto& resp = ctx.response->responses.emplace_back();
+            set_status(&resp.status, TStatusCode::OK);
+            // version 100 => 2 cols, 101 => 3 cols, 102 => 4 cols
+            resp.__set_schema(make_thrift_schema(keys_type == DUP_KEYS ? TKeysType::DUP_KEYS : TKeysType::PRIMARY_KEYS,
+                                                 req_schema_id, it->second, /*num_columns=*/it->second - 98));
+        });
+
+        // 2) Apply a log vector with increasing schema_id.
+        TxnLogVector logs;
+        logs.push_back(make_write_log_ptr(next_id(), schema_ids[0], /*db_id=*/1, /*table_id=*/2));
+        logs.push_back(make_write_log_ptr(next_id(), schema_ids[1], /*db_id=*/1, /*table_id=*/2));
+        logs.push_back(make_write_log_ptr(next_id(), schema_ids[2], /*db_id=*/1, /*table_id=*/2));
+
+        // 3) Assert: schema updated to latest.
+        auto st = applier->apply(logs);
+        ASSERT_TRUE(st.ok()) << st;
+        ASSERT_EQ(meta->schema().id(), schema_ids[2]);
+        ASSERT_EQ(meta->schema().schema_version(), 102);
+        ASSERT_EQ(meta->schema().column_size(), 4);
+        ASSERT_EQ(meta->schema().column(2).name(), "c2");
+        ASSERT_EQ(meta->schema().column(3).name(), "c3");
+    }
+}
+
+} // namespace starrocks::lake

--- a/be/test/storage/lake/lake_data_source_test.cpp
+++ b/be/test/storage/lake/lake_data_source_test.cpp
@@ -14,6 +14,10 @@
 
 #include <gtest/gtest.h>
 
+#include <array>
+#include <atomic>
+#include <vector>
+
 #include "column/chunk.h"
 #include "column/fixed_length_column.h"
 #include "column/schema.h"
@@ -21,22 +25,39 @@
 #include "common/logging.h"
 #include "connector/lake_connector.h"
 #include "exec/connector_scan_node.h"
+#include "exec/pipeline/fragment_context.h"
+#include "exec/pipeline/scan/morsel.h"
+#include "fs/fs_util.h"
+#include "runtime/descriptor_helper.h"
+#include "runtime/descriptors.h"
+#include "runtime/exec_env.h"
+#include "runtime/mem_tracker.h"
 #include "storage/chunk_helper.h"
+#include "storage/lake/filenames.h"
+#include "storage/lake/fixed_location_provider.h"
+#include "storage/lake/join_path.h"
 #include "storage/lake/metacache.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_writer.h"
+#include "storage/lake/update_manager.h"
+#include "storage/rowset/base_rowset.h"
 #include "storage/tablet_schema.h"
 #include "test_util.h"
 #include "testutil/assert.h"
 #include "testutil/id_generator.h"
+#include "testutil/sync_point.h"
+#include "util/defer_op.h"
+#include "util/runtime_profile.h"
 
 namespace starrocks::lake {
 
 using namespace starrocks;
 
-class LakeDataSourceTest : public TestBase {
+class LakeDataSourceTest : public ::testing::Test {
 public:
-    LakeDataSourceTest() : TestBase(kTestDirectory) {
+    LakeDataSourceTest()
+            : _tablet_mgr(ExecEnv::GetInstance()->lake_tablet_manager()),
+              _location_provider(std::make_shared<FixedLocationProvider>(kRootLocation)) {
         _tablet_metadata = std::make_unique<TabletMetadata>();
         _tablet_metadata->set_id(next_id());
         _tablet_metadata->set_version(1);
@@ -72,12 +93,21 @@ public:
     }
 
     void SetUp() override {
-        clear_and_init_test_dir();
+        _backup_location_provider = _tablet_mgr->TEST_set_location_provider(_location_provider);
+        (void)FileSystem::Default()->create_dir_recursive(lake::join_path(kRootLocation, lake::kSegmentDirectoryName));
+        (void)FileSystem::Default()->create_dir_recursive(lake::join_path(kRootLocation, lake::kMetadataDirectoryName));
+        (void)FileSystem::Default()->create_dir_recursive(lake::join_path(kRootLocation, lake::kTxnLogDirectoryName));
         CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
     }
 
-    void TearDown() override { remove_test_dir_ignore_error(); }
+    void TearDown() override {
+        CHECK_OK(fs::remove_all(kRootLocation));
+        if (_backup_location_provider != nullptr) {
+            (void)_tablet_mgr->TEST_set_location_provider(_backup_location_provider);
+        }
+    }
 
+protected:
     void create_rowsets_for_testing(TabletMetadata* tablet_metadata, int64_t version) {
         std::vector<int> k0{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22}; // 23 rows
         std::vector<int> v0{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 41, 44};
@@ -137,8 +167,18 @@ public:
         CHECK_OK(_tablet_mgr->put_tablet_metadata(*tablet_metadata));
     }
 
-protected:
-    constexpr static const char* const kTestDirectory = "test_lake_data_source_test";
+    static void set_status(TStatus* status, TStatusCode::type code, std::string msg = "") {
+        status->__set_status_code(code);
+        if (!msg.empty()) {
+            status->__set_error_msgs(std::vector<std::string>{std::move(msg)});
+        }
+    }
+
+    constexpr static const char* const kRootLocation = "test_lake_data_source_test";
+
+    TabletManager* _tablet_mgr = nullptr;
+    std::shared_ptr<LocationProvider> _location_provider;
+    std::shared_ptr<LocationProvider> _backup_location_provider;
 
     std::unique_ptr<TabletMetadata> _tablet_metadata;
     std::shared_ptr<TabletSchema> _tablet_schema;
@@ -161,7 +201,7 @@ TEST_F(LakeDataSourceTest, test_convert_scan_range_to_morsel_queue) {
     std::map<int32_t, std::vector<TScanRangeParams>> no_scan_ranges_per_driver_seq;
 
     auto data_source_provider = dynamic_cast<connector::LakeDataSourceProvider*>(scan_node->data_source_provider());
-    data_source_provider->set_lake_tablet_manager(_tablet_mgr.get());
+    data_source_provider->set_lake_tablet_manager(_tablet_mgr);
 
     ASSERT_TRUE(data_source_provider->always_shared_scan());
 
@@ -185,6 +225,151 @@ TEST_F(LakeDataSourceTest, test_convert_scan_range_to_morsel_queue) {
     ASSERT_TRUE(morsel_queue_factory->is_shared());
     auto morsel_queue = morsel_queue_factory->create(1);
     ASSERT_TRUE(morsel_queue->max_degree_of_parallelism() > 1);
+}
+
+TEST_F(LakeDataSourceTest, get_tablet_schema) {
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([&]() {
+        SyncPoint::GetInstance()->ClearAllCallBacks();
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    create_rowsets_for_testing(_tablet_metadata.get(), 2);
+
+    // 1) Build a TLakeScanNode with schema_key.
+    int64_t schema_id = next_id(); // Ensure schema_id misses local schema and triggers RPC fetch.
+    if (schema_id == _tablet_metadata->schema().id()) {
+        schema_id = next_id();
+    }
+    const int64_t db_id = 100;
+    const int64_t table_id = 101;
+
+    TLakeScanNode lake_scan_node;
+    lake_scan_node.__set_tuple_id(0);
+    TTableSchemaKey schema_key;
+    schema_key.__set_schema_id(schema_id);
+    schema_key.__set_db_id(db_id);
+    schema_key.__set_table_id(table_id);
+    lake_scan_node.__set_schema_key(schema_key);
+
+    TPlanNode plan_node;
+    plan_node.__set_node_id(0);
+    plan_node.__set_lake_scan_node(lake_scan_node);
+
+    // 2) Prepare runtime state: descriptor table + fragment ctx (fe_addr for schema RPC).
+    auto runtime_state = create_runtime_state();
+    pipeline::FragmentContext fragment_ctx;
+    TNetworkAddress fe;
+    fe.hostname = "127.0.0.1";
+    fe.port = 9020;
+    fragment_ctx.set_fe_addr(fe);
+    runtime_state->set_fragment_ctx(&fragment_ctx);
+
+    // Build a minimal descriptor table with required column names.
+    TDescriptorTableBuilder desc_tbl_builder;
+    TSlotDescriptorBuilder slot_desc_builder;
+    auto slot0 = slot_desc_builder.type(LogicalType::TYPE_INT).column_name("c0").column_pos(0).nullable(true).build();
+    auto slot1 = slot_desc_builder.type(LogicalType::TYPE_INT).column_name("c1").column_pos(1).nullable(true).build();
+    TTupleDescriptorBuilder tuple_desc_builder;
+    tuple_desc_builder.add_slot(slot0);
+    tuple_desc_builder.add_slot(slot1);
+    tuple_desc_builder.build(&desc_tbl_builder);
+
+    DescriptorTbl* desc_tbl = nullptr;
+    CHECK(DescriptorTbl::create(runtime_state.get(), runtime_state->obj_pool(), desc_tbl_builder.desc_tbl(), &desc_tbl,
+                                config::vector_chunk_size)
+                  .ok());
+    runtime_state->set_desc_tbl(desc_tbl);
+
+    // Connector scan open path needs tuple->table_desc() to be non-null for profile strings.
+    TTableDescriptor tdesc;
+    tdesc.__set_id(0);
+    tdesc.__set_tableType(TTableType::OLAP_TABLE);
+    tdesc.__set_tableName("test_table");
+    tdesc.__set_dbName("test_db");
+    auto* table_desc = runtime_state->obj_pool()->add(new OlapTableDescriptor(tdesc));
+    desc_tbl->get_tuple_descriptor(0)->set_table_desc(table_desc);
+
+    // 4) Install schema RPC hook: validate request fields and return a schema.
+    std::atomic<bool> invoked{false};
+    SyncPoint::GetInstance()->SetCallBack("TableSchemaService::_fetch_schema_via_rpc::test_hook", [&](void* arg) {
+        invoked.store(true);
+        auto* arr = static_cast<std::array<void*, 4>*>(arg);
+        auto* request_ptr = static_cast<const TGetTableSchemaRequest*>((*arr)[0]);
+        auto* response_batch = static_cast<TBatchGetTableSchemaResponse*>((*arr)[1]);
+        auto* status = static_cast<Status*>((*arr)[2]);
+        auto* mock_thrift_rpc = static_cast<bool*>((*arr)[3]);
+
+        ASSERT_EQ(request_ptr->source, TTableSchemaRequestSource::SCAN);
+        ASSERT_EQ(request_ptr->tablet_id, _tablet_metadata->id());
+        ASSERT_EQ(request_ptr->query_id, runtime_state->query_id());
+        ASSERT_EQ(request_ptr->schema_key.schema_id, schema_id);
+        ASSERT_EQ(request_ptr->schema_key.db_id, db_id);
+        ASSERT_EQ(request_ptr->schema_key.table_id, table_id);
+
+        *mock_thrift_rpc = true;
+        *status = Status::OK();
+        set_status(&response_batch->status, TStatusCode::OK);
+        response_batch->__set_responses(std::vector<TGetTableSchemaResponse>{});
+        auto& resp = response_batch->responses.emplace_back();
+        set_status(&resp.status, TStatusCode::OK);
+
+        // Minimal schema payload; LakeDataSource::get_tablet only needs schema fetch to succeed.
+        TTabletSchema t_schema;
+        t_schema.__set_id(schema_id);
+        t_schema.__set_keys_type(TKeysType::DUP_KEYS);
+        t_schema.__set_short_key_column_count(1);
+
+        TColumn c0;
+        c0.__set_column_name("c0");
+        c0.column_type.__set_type(TPrimitiveType::INT);
+        c0.__set_is_key(true);
+        c0.__set_is_allow_null(false);
+        t_schema.columns.push_back(c0);
+
+        TColumn c1;
+        c1.__set_column_name("c1");
+        c1.column_type.__set_type(TPrimitiveType::INT);
+        c1.__set_is_key(false);
+        c1.__set_is_allow_null(false);
+        t_schema.columns.push_back(c1);
+
+        resp.__set_schema(t_schema);
+    });
+
+    // 5) Explicitly construct a LakeDataSource and call open().
+    starrocks::connector::LakeDataSourceProvider provider(/*scan_node=*/nullptr, plan_node);
+
+    TInternalScanRange internal_scan_range;
+    internal_scan_range.__set_tablet_id(_tablet_metadata->id());
+    internal_scan_range.__set_version(std::to_string(_tablet_metadata->version()));
+
+    TScanRange scan_range;
+    scan_range.__set_internal_scan_range(internal_scan_range);
+
+    // Prepare morsel with rowsets so LakeDataSource can initialize safely.
+    ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id(), _tablet_metadata->version()));
+    auto lake_rowsets = tablet.get_rowsets();
+    std::vector<BaseRowsetSharedPtr> base_rowsets;
+    base_rowsets.reserve(lake_rowsets.size());
+    for (auto& rs : lake_rowsets) {
+        base_rowsets.emplace_back(rs);
+    }
+
+    pipeline::ScanMorsel morsel(plan_node.node_id, scan_range);
+    morsel.set_rowsets(base_rowsets);
+
+    starrocks::connector::LakeDataSource ds(&provider, scan_range);
+    RuntimeProfile parent_profile("LakeDataSourceTest");
+    ds.set_runtime_profile(&parent_profile);
+    ds.set_morsel(&morsel);
+    DeferOp close_guard([&] { ds.close(runtime_state.get()); });
+    ASSERT_OK(ds.open(runtime_state.get()));
+    ASSERT_TRUE(invoked.load());
+
+    auto tablet_schema = ds.TEST_tablet_schema();
+    ASSERT_TRUE(tablet_schema != nullptr);
+    ASSERT_EQ(schema_id, tablet_schema->id());
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/lake_replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/lake_replication_txn_manager_test.cpp
@@ -1,0 +1,381 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/lake_replication_txn_manager.h"
+
+#include <fmt/format.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <random>
+
+#include "column/chunk.h"
+#include "column/datum_tuple.h"
+#include "column/fixed_length_column.h"
+#include "column/schema.h"
+#include "column/vectorized_fwd.h"
+#include "common/config.h"
+#include "fs/key_cache.h"
+#include "gutil/strings/join.h"
+#include "runtime/exec_env.h"
+#include "service/staros_worker.h"
+#include "storage/chunk_helper.h"
+#include "storage/lake/delta_writer.h"
+#include "storage/lake/fixed_location_provider.h"
+#include "storage/lake/join_path.h"
+#include "storage/lake/meta_file.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_reader.h"
+#include "storage/lake/transactions.h"
+#include "storage/lake/update_manager.h"
+#include "storage/options.h"
+#include "storage/rowset/rowset_options.h"
+#include "storage/rowset/segment.h"
+#include "storage/tablet_manager.h"
+#include "storage/tablet_schema.h"
+#include "testutil/assert.h"
+#include "testutil/id_generator.h"
+#include "util/failpoint/fail_point.h"
+
+namespace starrocks::lake {
+
+// UT for shared data cross-cluster replication
+class SharedDataReplicationTxnManagerTest : public testing::TestWithParam<KeysType> {
+public:
+    SharedDataReplicationTxnManagerTest() { _test_dir = kTestDirectory; }
+
+    ~SharedDataReplicationTxnManagerTest() override = default;
+
+protected:
+    void SetUp() override {
+        (void)fs::remove_all(_test_dir);
+        CHECK_OK(fs::create_directories(lake::join_path(_test_dir, lake::kSegmentDirectoryName)));
+        CHECK_OK(fs::create_directories(lake::join_path(_test_dir, lake::kMetadataDirectoryName)));
+        CHECK_OK(fs::create_directories(lake::join_path(_test_dir, lake::kTxnLogDirectoryName)));
+        _location_provider = std::make_shared<lake::FixedLocationProvider>(_test_dir);
+        _mem_tracker = std::make_unique<MemTracker>(1024 * 1024);
+        _update_manager = std::make_unique<lake::UpdateManager>(_location_provider, _mem_tracker.get());
+        _tablet_mgr = std::make_unique<lake::TabletManager>(_location_provider, _update_manager.get(), 16384);
+        _replication_txn_manager = std::make_unique<lake::LakeReplicationTxnManager>(_tablet_mgr.get());
+
+        _src_tablet_metadata = generate_tablet_metadata(GetParam());
+        _target_tablet_metadata = generate_tablet_metadata(GetParam());
+
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*_src_tablet_metadata));
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*_target_tablet_metadata));
+
+        _src_tablet_id = _src_tablet_metadata->id();
+        _target_tablet_id = _target_tablet_metadata->id();
+        // target visible version
+        _version = _target_tablet_metadata->version();
+
+        PFailPointTriggerMode trigger_mode;
+        trigger_mode.set_mode(FailPointTriggerModeType::ENABLE);
+        auto fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get(
+                "table_schema_service_disable_remote_schema_for_load");
+        if (fp != nullptr) {
+            fp->setMode(trigger_mode);
+        }
+    }
+
+    void TearDown() override {
+        PFailPointTriggerMode trigger_mode;
+        trigger_mode.set_mode(FailPointTriggerModeType::DISABLE);
+        auto fp = starrocks::failpoint::FailPointRegistry::GetInstance()->get(
+                "table_schema_service_disable_remote_schema_for_load");
+        if (fp != nullptr) {
+            fp->setMode(trigger_mode);
+        }
+
+#ifdef USE_STAROS
+        if (config::starlet_cache_dir.compare(0, 5, std::string("/tmp/")) == 0) {
+            // Clean cache directory
+            std::string cmd = fmt::format("rm -rf {}", config::starlet_cache_dir);
+            ::system(cmd.c_str());
+        }
+#endif
+
+        config::enable_transparent_data_encryption = false;
+
+        // check primary index cache's ref
+        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        // check trash files already removed
+        for (const auto& file : _trash_files) {
+            EXPECT_FALSE(fs::path_exist(file));
+        }
+        ASSERT_OK(fs::remove_all(_test_dir));
+    }
+
+    std::shared_ptr<TabletMetadataPB> generate_tablet_metadata(KeysType keys_type) {
+        auto metadata = std::make_shared<TabletMetadata>();
+        metadata->set_id(next_id());
+        metadata->set_version(1);
+        metadata->set_cumulative_point(0);
+        metadata->set_next_rowset_id(1);
+        //
+        //  | column | type | KEY | NULL |
+        //  +--------+------+-----+------+
+        //  |   c0   |  INT | YES |  NO  |
+        //  |   c1   |  INT | NO  |  NO  |
+        auto schema = metadata->mutable_schema();
+        schema->set_keys_type(keys_type);
+        schema->set_id(next_id());
+        schema->set_num_short_key_columns(1);
+        schema->set_num_rows_per_row_block(65535);
+        auto c0 = schema->add_column();
+        {
+            c0->set_unique_id(next_id());
+            c0->set_name("c0");
+            c0->set_type("INT");
+            c0->set_is_key(true);
+            c0->set_is_nullable(false);
+        }
+        auto c1 = schema->add_column();
+        {
+            c1->set_unique_id(next_id());
+            c1->set_name("c1");
+            c1->set_type("INT");
+            c1->set_is_key(false);
+            c1->set_is_nullable(false);
+            c1->set_aggregation(keys_type == DUP_KEYS ? "NONE" : "REPLACE");
+        }
+        return metadata;
+    }
+
+    Chunk generate_data(int64_t chunk_size, int shift, int update_ratio) {
+        std::vector<int> v0(chunk_size);
+        std::vector<int> v1(chunk_size);
+        std::vector<int> v2(chunk_size);
+        for (int i = 0; i < chunk_size; i++) {
+            v0[i] = i + shift * chunk_size;
+        }
+        auto rng = std::default_random_engine{};
+        std::shuffle(v0.begin(), v0.end(), rng);
+        for (int i = 0; i < chunk_size; i++) {
+            v1[i] = v0[i] * update_ratio;
+        }
+
+        auto c0 = Int32Column::create();
+        auto c1 = Int32Column::create();
+        c0->append_numbers(v0.data(), v0.size() * sizeof(int));
+        c1->append_numbers(v1.data(), v1.size() * sizeof(int));
+
+        for (int i = 0; i < chunk_size; i++) {
+            v2[i] = v0[i] * 4;
+        }
+        auto c2 = Int32Column::create();
+        c2->append_numbers(v2.data(), v2.size() * sizeof(int));
+        return Chunk({std::move(c0), std::move(c1), std::move(c2)}, _slot_cid_map);
+    }
+
+    void write_src_tablet_data() {
+        auto chunk0 = generate_data(kChunkSize, 0, 3);
+        auto chunk1 = generate_data(kChunkSize, 0, 3);
+        auto indexes = std::vector<uint32_t>(kChunkSize);
+        for (int i = 0; i < kChunkSize; i++) {
+            indexes[i] = i;
+        }
+
+        auto version = 1;
+        // normal write
+        for (int i = 0; i < 3; i++) {
+            auto txn_id = next_id();
+            ASSIGN_OR_ABORT(auto delta_writer, lake::DeltaWriterBuilder()
+                                                       .set_tablet_manager(_tablet_mgr.get())
+                                                       .set_tablet_id(_src_tablet_id)
+                                                       .set_txn_id(txn_id)
+                                                       .set_partition_id(_src_partition_id)
+                                                       .set_mem_tracker(_mem_tracker.get())
+                                                       .set_schema_id(_src_tablet_metadata->schema().id())
+                                                       .build());
+            ASSERT_OK(delta_writer->open());
+            ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+            ASSERT_OK(delta_writer->finish_with_txnlog());
+            delta_writer->close();
+            // Publish version
+            auto txn_info = TxnInfoPB();
+            txn_info.set_txn_id(txn_id);
+            txn_info.set_combined_txn_log(false);
+            txn_info.set_commit_time(0);
+            auto txn_info_span = std::span<const TxnInfoPB>(&txn_info, 1);
+            ASSERT_OK(lake::publish_version(_tablet_mgr.get(), _src_tablet_id, version, version + 1, txn_info_span,
+                                            false));
+            version++;
+        }
+        ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(_src_tablet_id, version));
+        EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
+        EXPECT_EQ(new_tablet_metadata->version(), 4);
+        // src visible version
+        _src_version = new_tablet_metadata->version();
+    }
+
+protected:
+    constexpr static const char* const kTestDirectory = "test_lake_replication";
+    constexpr static int kChunkSize = 12;
+
+    std::unique_ptr<TabletManager> _tablet_mgr;
+    std::shared_ptr<lake::LocationProvider> _location_provider;
+    std::unique_ptr<MemTracker> _mem_tracker;
+    std::unique_ptr<lake::UpdateManager> _update_manager;
+    std::unique_ptr<lake::LakeReplicationTxnManager> _replication_txn_manager;
+
+    int64_t _src_tablet_id = 10000;
+    int64_t _target_tablet_id = 20000;
+
+    std::shared_ptr<TabletMetadata> _src_tablet_metadata;
+    std::shared_ptr<TabletMetadata> _target_tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::shared_ptr<Schema> _schema;
+    std::vector<std::string> _trash_files;
+    std::vector<SlotDescriptor> _slots;
+    std::vector<SlotDescriptor*> _slot_pointers;
+    Chunk::SlotHashMap _slot_cid_map;
+
+    std::string _test_dir;
+
+    int64_t _transaction_id = 300;
+    int64_t _table_id = 30001;
+    int64_t _partition_id = 30002;
+    int64_t _version = 1;
+    int64_t _src_version = 1;
+    int32_t _schema_hash = 368169781;
+    int64_t _virtual_tablet_id = 40001;
+    int64_t _src_db_id = 40002;
+    int64_t _src_table_id = 40003;
+    int64_t _src_partition_id = 40004;
+};
+
+TEST_P(SharedDataReplicationTxnManagerTest, test_replicate_no_missing_versions) {
+    TReplicateSnapshotRequest request;
+    request.__set_transaction_id(_transaction_id);
+    request.__set_table_id(_table_id);
+    request.__set_partition_id(_partition_id);
+    request.__set_tablet_id(_target_tablet_id);
+    request.__set_tablet_type(TTabletType::TABLET_TYPE_LAKE);
+    request.__set_schema_hash(_schema_hash);
+    request.__set_visible_version(_version);
+    request.__set_data_version(_version);
+    // src tablet
+    request.__set_src_tablet_id(_src_tablet_id);
+    request.__set_src_tablet_type(TTabletType::TABLET_TYPE_LAKE);
+    request.__set_src_visible_version(_version); // same as `data_version`
+    request.__set_src_db_id(_src_db_id);
+    request.__set_src_table_id(_src_tablet_id);
+    request.__set_src_partition_id(_src_partition_id);
+
+    // virtual tablet
+    request.__set_virtual_tablet_id(_virtual_tablet_id);
+
+    Status status = _replication_txn_manager->replicate_lake_remote_storage(request);
+    EXPECT_FALSE(status.ok());
+}
+
+TEST_P(SharedDataReplicationTxnManagerTest, test_replicate_normal) {
+    // write data
+    write_src_tablet_data();
+
+    TReplicateSnapshotRequest request;
+    request.__set_transaction_id(_transaction_id);
+    request.__set_table_id(_table_id);
+    request.__set_partition_id(_partition_id);
+    request.__set_tablet_id(_target_tablet_id);
+    request.__set_tablet_type(TTabletType::TABLET_TYPE_LAKE);
+    request.__set_schema_hash(_schema_hash);
+    request.__set_visible_version(_version);
+    request.__set_data_version(_version);
+    // src tablet
+    request.__set_src_tablet_id(_src_tablet_id);
+    request.__set_src_tablet_type(TTabletType::TABLET_TYPE_LAKE);
+    request.__set_src_visible_version(_src_version);
+    request.__set_src_db_id(_src_db_id);
+    request.__set_src_table_id(_src_table_id);
+    request.__set_src_partition_id(_src_partition_id);
+
+    // virtual tablet
+    request.__set_virtual_tablet_id(_virtual_tablet_id);
+
+    Status status = _replication_txn_manager->replicate_lake_remote_storage(request);
+    EXPECT_TRUE(status.ok()) << status;
+
+    auto txn_info = TxnInfoPB();
+    txn_info.set_txn_id(_transaction_id);
+    txn_info.set_combined_txn_log(false);
+    txn_info.set_commit_time(0);
+    auto txn_info_span = std::span<const TxnInfoPB>(&txn_info, 1);
+    auto status_or =
+            lake::publish_version(_tablet_mgr.get(), _target_tablet_id, _version, _src_version, txn_info_span, false);
+    EXPECT_TRUE(status_or.ok()) << status_or.status();
+
+    EXPECT_EQ(_src_version, status_or.value()->version());
+}
+
+TEST_P(SharedDataReplicationTxnManagerTest, test_replicate_normal_encrypted) {
+    EncryptionKeyPB pb;
+    pb.set_id(EncryptionKey::DEFAULT_MASTER_KYE_ID);
+    pb.set_type(EncryptionKeyTypePB::NORMAL_KEY);
+    pb.set_algorithm(EncryptionAlgorithmPB::AES_128);
+    pb.set_plain_key("0000000000000000");
+    std::unique_ptr<EncryptionKey> root_encryption_key = EncryptionKey::create_from_pb(pb).value();
+    auto val_st = root_encryption_key->generate_key();
+    EXPECT_TRUE(val_st.ok());
+    std::unique_ptr<EncryptionKey> encryption_key = std::move(val_st.value());
+    encryption_key->set_id(2);
+    KeyCache::instance().add_key(root_encryption_key);
+    KeyCache::instance().add_key(encryption_key);
+
+    // write source tablet data (without encryption)
+    write_src_tablet_data();
+
+    // enable transparent data encryption
+    config::enable_transparent_data_encryption = true;
+
+    TReplicateSnapshotRequest request;
+    request.__set_transaction_id(_transaction_id);
+    request.__set_table_id(_table_id);
+    request.__set_partition_id(_partition_id);
+    request.__set_tablet_id(_target_tablet_id);
+    request.__set_tablet_type(TTabletType::TABLET_TYPE_LAKE);
+    request.__set_schema_hash(_schema_hash);
+    request.__set_visible_version(_version);
+    request.__set_data_version(_version);
+    // src tablet
+    request.__set_src_tablet_id(_src_tablet_id);
+    request.__set_src_tablet_type(TTabletType::TABLET_TYPE_LAKE);
+    request.__set_src_visible_version(_src_version);
+    request.__set_src_db_id(_src_db_id);
+    request.__set_src_table_id(_src_table_id);
+    request.__set_src_partition_id(_src_partition_id);
+
+    // virtual tablet
+    request.__set_virtual_tablet_id(_virtual_tablet_id);
+
+    Status status = _replication_txn_manager->replicate_lake_remote_storage(request);
+    EXPECT_TRUE(status.ok()) << status;
+
+    auto txn_info = TxnInfoPB();
+    txn_info.set_txn_id(_transaction_id);
+    txn_info.set_combined_txn_log(false);
+    txn_info.set_commit_time(0);
+    auto txn_info_span = std::span<const TxnInfoPB>(&txn_info, 1);
+    auto status_or =
+            lake::publish_version(_tablet_mgr.get(), _target_tablet_id, _version, _src_version, txn_info_span, false);
+    EXPECT_TRUE(status_or.ok()) << status_or.status();
+
+    EXPECT_EQ(_src_version, status_or.value()->version());
+}
+
+INSTANTIATE_TEST_SUITE_P(SharedDataReplicationTxnManagerTest, SharedDataReplicationTxnManagerTest,
+                         testing::Values(KeysType::DUP_KEYS, KeysType::AGG_KEYS, KeysType::PRIMARY_KEYS));
+
+} // namespace starrocks::lake

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -102,6 +102,7 @@ public:
     void SetUp() override {
         clear_and_init_test_dir();
         CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+        CHECK_OK(_tablet_mgr->create_schema_file(_tablet_metadata->id(), _tablet_metadata->schema()));
     }
 
     void TearDown() override {

--- a/be/test/storage/lake/table_schema_service_test.cpp
+++ b/be/test/storage/lake/table_schema_service_test.cpp
@@ -1,0 +1,764 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/table_schema_service.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include "common/config.h"
+#include "fs/fs_util.h"
+#include "runtime/mem_tracker.h"
+#include "storage/lake/filenames.h"
+#include "storage/lake/fixed_location_provider.h"
+#include "storage/lake/join_path.h"
+#include "storage/lake/tablet.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_metadata.h"
+#include "storage/lake/update_manager.h"
+#include "storage/metadata_util.h"
+#include "storage/tablet_schema.h"
+#include "testutil/assert.h"
+#include "testutil/id_generator.h"
+#include "testutil/sync_point.h"
+
+namespace starrocks::lake {
+
+using namespace starrocks;
+
+namespace {
+
+class ScopedSyncPoint {
+public:
+    ScopedSyncPoint() { SyncPoint::GetInstance()->EnableProcessing(); }
+    ~ScopedSyncPoint() {
+        SyncPoint::GetInstance()->ClearAllCallBacks();
+        SyncPoint::GetInstance()->DisableProcessing();
+    }
+};
+
+class ScopedConfig {
+public:
+    explicit ScopedConfig(int32_t* target, int32_t new_value) : _target(target), _old(*target) { *_target = new_value; }
+    ~ScopedConfig() { *_target = _old; }
+
+private:
+    int32_t* _target;
+    int32_t _old;
+};
+
+// SingleFlightBarrier provides a deterministic way to reproduce "leader + follower join" in singleflight::Group
+// without relying on timing (e.g. sleep_for).
+//
+// How it works:
+// - It hooks singleflight::Group::Do:2 (leader path, right before executing the real function) and blocks there.
+// - It waits until the follower path hits singleflight::Group::Do:1 (join path, finding an in-flight future).
+//
+// Typical usage in a test:
+// 1) SingleFlightBarrier barrier(timeout); barrier.install();
+// 2) Start leader thread (first request)
+// 3) ASSERT_TRUE(barrier.wait_for_leader_reached_exec_point());
+// 4) Start follower thread (second request, same key)
+// 5) Join threads; ASSERT_FALSE(barrier.timed_out());
+class SingleFlightBarrier {
+public:
+    explicit SingleFlightBarrier(std::chrono::milliseconds timeout) : _timeout(timeout) {}
+
+    void install() {
+        SyncPoint::GetInstance()->SetCallBack("singleflight::Group::Do:1", [&](void*) {
+            std::lock_guard lk(_mu);
+            _follower_seen++;
+            _cv.notify_all();
+        });
+        SyncPoint::GetInstance()->SetCallBack("singleflight::Group::Do:2", [&](void*) {
+            std::unique_lock lk(_mu);
+            if (!_leader_blocked_once) {
+                _leader_blocked_once = true;
+                _leader_reached_exec_point = true;
+                _cv.notify_all();
+                const bool ok = _cv.wait_for(lk, _timeout, [&] { return _follower_seen >= 1; });
+                if (!ok) {
+                    _timed_out = true;
+                    _cv.notify_all();
+                }
+            }
+        });
+    }
+
+    // Wait until the leader thread reaches the hook point right before executing the real function.
+    bool wait_for_leader_reached_exec_point() {
+        std::unique_lock lk(_mu);
+        return _cv.wait_for(lk, _timeout, [&] { return _leader_reached_exec_point; });
+    }
+
+    bool timed_out() const {
+        std::lock_guard lk(_mu);
+        return _timed_out;
+    }
+
+private:
+    const std::chrono::milliseconds _timeout;
+    mutable std::mutex _mu;
+    mutable std::condition_variable _cv;
+    int _follower_seen = 0;
+    bool _leader_blocked_once = false;
+    bool _leader_reached_exec_point = false;
+    bool _timed_out = false;
+};
+
+} // namespace
+
+class TableSchemaServiceTest : public testing::Test {
+public:
+    TableSchemaServiceTest() : _test_directory("test_table_schema_service") {
+        _mem_tracker = std::make_unique<MemTracker>(1024 * 1024);
+        _location_provider = std::make_shared<FixedLocationProvider>(_test_directory);
+        _update_manager = std::make_unique<UpdateManager>(_location_provider, _mem_tracker.get());
+        _tablet_manager = std::make_unique<TabletManager>(_location_provider, _update_manager.get(), 1024 * 1024);
+        _schema_service = _tablet_manager->table_schema_service();
+    }
+
+    void SetUp() override { clear_and_init_test_dir(); }
+
+    void TearDown() override { remove_test_dir_ignore_error(); }
+
+protected:
+    struct RpcHookArgs {
+        const TGetTableSchemaRequest* request = nullptr;
+        TBatchGetTableSchemaResponse* response = nullptr;
+        Status* status = nullptr;
+        bool* mock_thrift_rpc = nullptr;
+    };
+
+    static TTabletSchema make_thrift_schema(int64_t schema_id) {
+        TTabletSchema schema;
+        schema.__set_id(schema_id);
+        schema.__set_short_key_column_count(1);
+        schema.__set_keys_type(TKeysType::DUP_KEYS);
+
+        TColumn c0;
+        c0.__set_column_name("c0");
+        c0.column_type.__set_type(TPrimitiveType::INT);
+        c0.__set_is_key(true);
+        c0.__set_is_allow_null(false);
+        schema.columns.push_back(c0);
+
+        TColumn c1;
+        c1.__set_column_name("c1");
+        c1.column_type.__set_type(TPrimitiveType::INT);
+        c1.__set_is_key(false);
+        c1.__set_is_allow_null(false);
+        schema.columns.push_back(c1);
+
+        return schema;
+    }
+
+    static void set_status(TStatus* status, TStatusCode::type code, std::string msg = "") {
+        status->__set_status_code(code);
+        if (!msg.empty()) {
+            status->__set_error_msgs(std::vector<std::string>{std::move(msg)});
+        }
+    }
+
+    static TabletSchemaPB make_schema_pb(int64_t schema_id, int32_t schema_version) {
+        TabletSchemaPB schema_pb;
+        schema_pb.set_id(schema_id);
+        schema_pb.set_num_short_key_columns(1);
+        schema_pb.set_keys_type(DUP_KEYS);
+        schema_pb.set_num_rows_per_row_block(65535);
+        schema_pb.set_schema_version(schema_version);
+
+        auto c0 = schema_pb.add_column();
+        c0->set_unique_id(next_id());
+        c0->set_name("c0");
+        c0->set_type("INT");
+        c0->set_is_key(true);
+        c0->set_is_nullable(false);
+
+        auto c1 = schema_pb.add_column();
+        c1->set_unique_id(next_id());
+        c1->set_name("c1");
+        c1->set_type("INT");
+        c1->set_is_key(false);
+        c1->set_is_nullable(false);
+        return schema_pb;
+    }
+
+    static RpcHookArgs unpack_rpc_hook_args(void* arg) {
+        auto* arr = static_cast<std::array<void*, 4>*>(arg);
+        RpcHookArgs out;
+        out.request = static_cast<const TGetTableSchemaRequest*>((*arr)[0]);
+        out.response = static_cast<TBatchGetTableSchemaResponse*>((*arr)[1]);
+        out.status = static_cast<Status*>((*arr)[2]);
+        out.mock_thrift_rpc = static_cast<bool*>((*arr)[3]);
+        return out;
+    }
+    void clear_and_init_test_dir() {
+        (void)fs::remove_all(_test_directory);
+        CHECK_OK(fs::create_directories(join_path(_test_directory, kSegmentDirectoryName)));
+        CHECK_OK(fs::create_directories(join_path(_test_directory, kMetadataDirectoryName)));
+        CHECK_OK(fs::create_directories(join_path(_test_directory, kTxnLogDirectoryName)));
+    }
+
+    void remove_test_dir_ignore_error() { (void)fs::remove_all(_test_directory); }
+
+    TabletSchemaPtr create_test_schema(int64_t schema_id) { return TabletSchema::create(make_schema_pb(schema_id, 1)); }
+
+    MutableTabletMetadataPtr create_tablet_metadata(int64_t tablet_id, int64_t schema_id) {
+        auto metadata = std::make_shared<TabletMetadata>();
+        metadata->set_id(tablet_id);
+        metadata->set_version(1);
+
+        metadata->mutable_schema()->CopyFrom(make_schema_pb(schema_id, 1));
+
+        return metadata;
+    }
+
+    MutableTabletMetadataPtr create_tablet_metadata_with_historical_schema(int64_t tablet_id, int64_t current_schema_id,
+                                                                           int64_t historical_schema_id) {
+        auto metadata = create_tablet_metadata(tablet_id, current_schema_id);
+
+        auto historical_schema = make_schema_pb(historical_schema_id, 0);
+        metadata->mutable_historical_schemas()->insert({historical_schema_id, historical_schema});
+
+        return metadata;
+    }
+
+    TableSchemaKeyPB create_schema_info(int64_t schema_id, int64_t db_id, int64_t table_id) {
+        TableSchemaKeyPB schema_key;
+        schema_key.set_schema_id(schema_id);
+        schema_key.set_db_id(db_id);
+        schema_key.set_table_id(table_id);
+        return schema_key;
+    }
+
+    TUniqueId create_query_id() {
+        TUniqueId query_id;
+        query_id.hi = next_id();
+        query_id.lo = next_id();
+        return query_id;
+    }
+
+    TNetworkAddress create_fe_address() {
+        TNetworkAddress fe;
+        fe.hostname = "127.0.0.1";
+        fe.port = 9020;
+        return fe;
+    }
+
+    void setup_rpc_test_hook(std::function<void(const RpcHookArgs&)> hook) {
+        SyncPoint::GetInstance()->SetCallBack(
+                "TableSchemaService::_fetch_schema_via_rpc::test_hook",
+                [hook](void* arg) { hook(TableSchemaServiceTest::unpack_rpc_hook_args(arg)); });
+    }
+
+    void setup_rpc_success_schema(int64_t return_schema_id, std::atomic<int>* rpc_calls = nullptr) {
+        setup_rpc_test_hook([return_schema_id, rpc_calls](const RpcHookArgs& ctx) {
+            if (rpc_calls != nullptr) {
+                rpc_calls->fetch_add(1);
+            }
+            *ctx.mock_thrift_rpc = true;
+            *ctx.status = Status::OK();
+            TableSchemaServiceTest::set_status(&ctx.response->status, TStatusCode::OK);
+            ctx.response->__set_responses(std::vector<TGetTableSchemaResponse>{});
+            auto& resp = ctx.response->responses.emplace_back();
+            TableSchemaServiceTest::set_status(&resp.status, TStatusCode::OK);
+            resp.__set_schema(TableSchemaServiceTest::make_thrift_schema(return_schema_id));
+        });
+    }
+
+    void setup_rpc_expect_request_and_return_schema(std::function<void(const TGetTableSchemaRequest&)> expect,
+                                                    int64_t return_schema_id) {
+        setup_rpc_test_hook([expect = std::move(expect), return_schema_id](const RpcHookArgs& ctx) {
+            if (expect != nullptr) {
+                expect(*ctx.request);
+            }
+            *ctx.mock_thrift_rpc = true;
+            *ctx.status = Status::OK();
+            TableSchemaServiceTest::set_status(&ctx.response->status, TStatusCode::OK);
+            ctx.response->__set_responses(std::vector<TGetTableSchemaResponse>{});
+            auto& resp = ctx.response->responses.emplace_back();
+            TableSchemaServiceTest::set_status(&resp.status, TStatusCode::OK);
+            resp.__set_schema(TableSchemaServiceTest::make_thrift_schema(return_schema_id));
+        });
+    }
+
+    void mock_tablet_schema_by_id(StatusOr<std::shared_ptr<const TabletSchema>> schema_or) {
+        SyncPoint::GetInstance()->SetCallBack("get_tablet_schema_by_id.1",
+                                              [](void* arg) { ((std::shared_ptr<const TabletSchema>*)arg)->reset(); });
+        SyncPoint::GetInstance()->SetCallBack("get_tablet_schema_by_id.2",
+                                              [schema_or = std::move(schema_or)](void* arg) {
+                                                  *((StatusOr<std::shared_ptr<const TabletSchema>>*)arg) = schema_or;
+                                              });
+    }
+
+    void setup_rpc_batch_status_error(TStatusCode::type code) {
+        setup_rpc_test_hook([code](const RpcHookArgs& ctx) {
+            *ctx.mock_thrift_rpc = true;
+            *ctx.status = Status::OK();
+            TableSchemaServiceTest::set_status(&ctx.response->status, code, "mocked batch status error");
+            ctx.response->__set_responses(std::vector<TGetTableSchemaResponse>{});
+        });
+    }
+
+    void setup_rpc_empty_responses() {
+        setup_rpc_test_hook([](const RpcHookArgs& ctx) {
+            *ctx.mock_thrift_rpc = true;
+            *ctx.status = Status::OK();
+            TableSchemaServiceTest::set_status(&ctx.response->status, TStatusCode::OK);
+            ctx.response->__set_responses(std::vector<TGetTableSchemaResponse>{});
+        });
+    }
+
+    void setup_rpc_response_status_error(TStatusCode::type code) {
+        setup_rpc_test_hook([code](const RpcHookArgs& ctx) {
+            *ctx.mock_thrift_rpc = true;
+            *ctx.status = Status::OK();
+            TableSchemaServiceTest::set_status(&ctx.response->status, TStatusCode::OK);
+            ctx.response->__set_responses(std::vector<TGetTableSchemaResponse>{});
+            auto& resp = ctx.response->responses.emplace_back();
+            TableSchemaServiceTest::set_status(&resp.status, code, "mocked response status error");
+        });
+    }
+
+    void setup_rpc_method_not_found() {
+        setup_rpc_test_hook([](const RpcHookArgs& ctx) {
+            *ctx.mock_thrift_rpc = true;
+            *ctx.status = Status::ThriftRpcError("Invalid method name 'getTableSchema'");
+        });
+    }
+
+    void setup_rpc_other_thrift_error() {
+        setup_rpc_test_hook([](const RpcHookArgs& ctx) {
+            *ctx.mock_thrift_rpc = true;
+            *ctx.status = Status::ThriftRpcError("mocked thrift rpc error");
+        });
+    }
+
+    void setup_rpc_table_not_exist() {
+        setup_rpc_test_hook([](const RpcHookArgs& ctx) {
+            *ctx.mock_thrift_rpc = true;
+            *ctx.status = Status::OK();
+            TableSchemaServiceTest::set_status(&ctx.response->status, TStatusCode::OK);
+            ctx.response->__set_responses(std::vector<TGetTableSchemaResponse>{});
+            auto& resp = ctx.response->responses.emplace_back();
+            TableSchemaServiceTest::set_status(&resp.status, TStatusCode::TABLE_NOT_EXIST, "mocked table not exist");
+        });
+    }
+
+    std::string _test_directory;
+    std::unique_ptr<MemTracker> _mem_tracker;
+    std::shared_ptr<FixedLocationProvider> _location_provider;
+    std::unique_ptr<UpdateManager> _update_manager;
+    std::unique_ptr<TabletManager> _tablet_manager;
+    TableSchemaService* _schema_service;
+};
+
+TEST_F(TableSchemaServiceTest, schema_cache_hit) {
+    // 1) Put schema into global cache.
+    // 2) Verify both LOAD and SCAN return from cache without RPC.
+    int64_t schema_id = next_id();
+    auto schema = create_test_schema(schema_id);
+    _tablet_manager->cache_schema(schema);
+
+    // LOAD path should hit global cache.
+    auto load_result = _schema_service->get_schema_for_load(create_schema_info(schema_id, 100, 101), 1000, 1);
+    ASSERT_OK(load_result);
+    ASSERT_EQ(load_result.value()->id(), schema_id);
+
+    // SCAN path should hit global cache.
+    auto scan_result = _schema_service->get_schema_for_scan(create_schema_info(schema_id, 100, 101), 1000,
+                                                            create_query_id(), create_fe_address());
+    ASSERT_OK(scan_result);
+    ASSERT_EQ(scan_result.value()->id(), schema_id);
+}
+
+TEST_F(TableSchemaServiceTest, tablet_metadata_hit) {
+    // 1) Put tablet metadata with both current and historical schemas.
+    // 2) Fetch schemas by id and verify they are cached into global cache.
+    int64_t tablet_id = next_id();
+    int64_t current_schema_id = next_id();
+    int64_t historical_schema_id = next_id();
+    auto metadata = create_tablet_metadata_with_historical_schema(tablet_id, current_schema_id, historical_schema_id);
+    ASSERT_OK(_tablet_manager->put_tablet_metadata(*metadata));
+
+    {
+        SCOPED_TRACE("current_schema");
+        auto result = _schema_service->get_schema_for_load(create_schema_info(current_schema_id, 100, 101), tablet_id,
+                                                           1, metadata);
+        ASSERT_OK(result);
+        ASSERT_EQ(result.value()->id(), current_schema_id);
+        auto cached_schema = _tablet_manager->get_cached_schema(current_schema_id);
+        ASSERT_NE(cached_schema, nullptr);
+        ASSERT_EQ(cached_schema->id(), current_schema_id);
+    }
+
+    {
+        SCOPED_TRACE("historical_schema");
+        auto result = _schema_service->get_schema_for_load(create_schema_info(historical_schema_id, 100, 101),
+                                                           tablet_id, 1, metadata);
+        ASSERT_OK(result);
+        ASSERT_EQ(result.value()->id(), historical_schema_id);
+        auto cached_schema = _tablet_manager->get_cached_schema(historical_schema_id);
+        ASSERT_NE(cached_schema, nullptr);
+        ASSERT_EQ(cached_schema->id(), historical_schema_id);
+    }
+}
+
+TEST_F(TableSchemaServiceTest, remote_hit) {
+    // 1) Force remote RPC success.
+    // 2) Verify returned schema is cached into global cache.
+    ScopedSyncPoint sp;
+    int64_t schema_id = next_id();
+    setup_rpc_success_schema(schema_id);
+
+    auto result = _schema_service->get_schema_for_load(create_schema_info(schema_id, 100, 101), 1000, 1);
+    ASSERT_OK(result);
+    ASSERT_EQ(result.value()->id(), schema_id);
+
+    auto cached_schema = _tablet_manager->get_cached_schema(schema_id);
+    ASSERT_NE(cached_schema, nullptr);
+    ASSERT_EQ(cached_schema->id(), schema_id);
+}
+
+TEST_F(TableSchemaServiceTest, rpc_request_fields_verify) {
+    // Verify generated thrift request fields for both LOAD and SCAN paths.
+    // 1) LOAD: trigger schema fetch; validate request fields; return OK schema.
+    {
+        ScopedSyncPoint sp;
+        SCOPED_TRACE("load");
+        int64_t schema_id = next_id();
+        int64_t tablet_id = next_id();
+        int64_t txn_id = next_id();
+        std::atomic<bool> invoked{false};
+        setup_rpc_expect_request_and_return_schema(
+                [&](const TGetTableSchemaRequest& req) {
+                    invoked.store(true);
+                    ASSERT_EQ(req.source, TTableSchemaRequestSource::LOAD);
+                    ASSERT_EQ(req.txn_id, txn_id);
+                    ASSERT_EQ(req.tablet_id, tablet_id);
+                    ASSERT_EQ(req.schema_key.schema_id, schema_id);
+                    ASSERT_EQ(req.schema_key.db_id, 100);
+                    ASSERT_EQ(req.schema_key.table_id, 101);
+                },
+                schema_id);
+
+        auto result = _schema_service->get_schema_for_load(create_schema_info(schema_id, 100, 101), tablet_id, txn_id);
+        ASSERT_TRUE(invoked.load());
+        ASSERT_OK(result);
+    }
+
+    // 2) SCAN: trigger schema fetch; validate request fields; return OK schema.
+    {
+        ScopedSyncPoint sp;
+        SCOPED_TRACE("scan");
+        int64_t schema_id = next_id();
+        int64_t tablet_id = next_id();
+        auto query_id = create_query_id();
+        std::atomic<bool> invoked{false};
+        setup_rpc_expect_request_and_return_schema(
+                [&](const TGetTableSchemaRequest& req) {
+                    invoked.store(true);
+                    ASSERT_EQ(req.source, TTableSchemaRequestSource::SCAN);
+                    ASSERT_EQ(req.tablet_id, tablet_id);
+                    ASSERT_EQ(req.query_id, query_id);
+                    ASSERT_EQ(req.schema_key.schema_id, schema_id);
+                    ASSERT_EQ(req.schema_key.db_id, 100);
+                    ASSERT_EQ(req.schema_key.table_id, 101);
+                },
+                schema_id);
+
+        auto result = _schema_service->get_schema_for_scan(create_schema_info(schema_id, 100, 101), tablet_id, query_id,
+                                                           create_fe_address(), nullptr);
+        ASSERT_TRUE(invoked.load());
+        ASSERT_OK(result);
+    }
+}
+
+TEST_F(TableSchemaServiceTest, remote_error_handling) {
+    // Force different remote error responses and verify propagated Status.
+    struct Case {
+        const char* name;
+        std::function<void(TableSchemaServiceTest*)> setup;
+        std::function<void(const Status&)> check;
+    };
+
+    const std::vector<Case> cases{
+            {"method_not_found_maps_to_not_supported",
+             [](TableSchemaServiceTest* t) { t->setup_rpc_method_not_found(); },
+             [](const Status& st) { ASSERT_TRUE(st.is_not_found()) << st; }},
+            {"other_thrift_rpc_error_fail_fast", [](TableSchemaServiceTest* t) { t->setup_rpc_other_thrift_error(); },
+             [](const Status& st) { ASSERT_TRUE(st.is_thrift_rpc_error()) << st; }},
+            {"table_not_exist_fail_fast", [](TableSchemaServiceTest* t) { t->setup_rpc_table_not_exist(); },
+             [](const Status& st) { ASSERT_TRUE(st.is_table_not_exist()) << st; }},
+            {"batch_status_not_ok_propagates",
+             [](TableSchemaServiceTest* t) { t->setup_rpc_batch_status_error(TStatusCode::INTERNAL_ERROR); },
+             [](const Status& st) { ASSERT_TRUE(st.is_internal_error()) << st; }},
+            {"empty_responses_returns_internal_error",
+             [](TableSchemaServiceTest* t) { t->setup_rpc_empty_responses(); },
+             [](const Status& st) {
+                 ASSERT_TRUE(st.is_internal_error()) << st;
+                 ASSERT_TRUE(st.message().find("response is empty") != std::string::npos) << st;
+             }},
+            {"response_status_not_ok_propagates",
+             [](TableSchemaServiceTest* t) { t->setup_rpc_response_status_error(TStatusCode::INTERNAL_ERROR); },
+             [](const Status& st) { ASSERT_TRUE(st.is_internal_error()) << st; }},
+    };
+
+    for (const auto& c : cases) {
+        // Each sub-case runs in its own SyncPoint scope to avoid cross-test interference.
+        ScopedSyncPoint sp;
+        SCOPED_TRACE(c.name);
+        int64_t schema_id = next_id();
+        c.setup(this);
+        // Trigger LOAD path to exercise _get_remote_schema() error handling.
+        auto result = _schema_service->get_schema_for_load(create_schema_info(schema_id, 100, 101), 1000, 1);
+        c.check(result.status());
+    }
+}
+
+TEST_F(TableSchemaServiceTest, load_fallback_to_schema_file) {
+    // Verify LOAD falls back to schema-file path when FE does not support getTableSchema.
+    // Case 1) schema-file lookup succeeds: LOAD should return schema from schema-file path.
+    {
+        ScopedSyncPoint sp;
+        SCOPED_TRACE("schema_file_success");
+        int64_t tablet_id = next_id();
+        int64_t schema_id = next_id();
+        auto schema = create_test_schema(schema_id);
+
+        auto metadata = create_tablet_metadata(tablet_id, schema_id);
+        ASSERT_OK(_tablet_manager->put_tablet_metadata(*metadata));
+        ASSERT_OK(_tablet_manager->get_tablet(tablet_id));
+
+        setup_rpc_method_not_found();
+
+        // Force schema-file path to "hit" via TabletManager sync point.
+        mock_tablet_schema_by_id(schema);
+
+        auto result = _schema_service->get_schema_for_load(create_schema_info(schema_id, 100, 101), tablet_id, 1);
+        ASSERT_OK(result);
+        ASSERT_EQ(result.value()->id(), schema_id);
+    }
+
+    // Case 2) schema-file lookup returns non-NotFound error: the error should be propagated.
+    {
+        ScopedSyncPoint sp;
+        SCOPED_TRACE("schema_file_error_propagated");
+        int64_t tablet_id = next_id();
+        int64_t schema_id = next_id();
+        auto metadata = create_tablet_metadata(tablet_id, schema_id);
+        ASSERT_OK(_tablet_manager->put_tablet_metadata(*metadata));
+
+        setup_rpc_method_not_found();
+        mock_tablet_schema_by_id(Status::InternalError("mocked"));
+
+        auto result = _schema_service->get_schema_for_load(create_schema_info(schema_id, 100, 101), tablet_id, 1);
+        ASSERT_TRUE(result.status().is_internal_error());
+    }
+}
+
+TEST_F(TableSchemaServiceTest, load_fallback_to_tablet_schema) {
+    // Verify LOAD falls back to tablet's current schema when schema-file path is missing (NotFound).
+    // Case 1) tablet metadata is provided: LOAD should return tablet's current schema.
+    {
+        ScopedSyncPoint sp;
+        SCOPED_TRACE("tablet_schema_fallback_success");
+        int64_t tablet_id = next_id();
+        int64_t schema_id = next_id();
+        auto metadata = create_tablet_metadata(tablet_id, schema_id);
+        ASSERT_OK(_tablet_manager->put_tablet_metadata(*metadata));
+        ASSERT_OK(_tablet_manager->get_tablet(tablet_id));
+
+        setup_rpc_method_not_found();
+        mock_tablet_schema_by_id(Status::NotFound("mocked not found"));
+
+        auto result =
+                _schema_service->get_schema_for_load(create_schema_info(schema_id, 100, 101), tablet_id, 1, metadata);
+        ASSERT_OK(result);
+        ASSERT_EQ(result.value()->id(), schema_id);
+    }
+
+    // Case 2) tablet metadata/tablet object is missing: return NotFound.
+    {
+        ScopedSyncPoint sp;
+        SCOPED_TRACE("tablet_missing_returns_not_found");
+        int64_t tablet_id = next_id();
+        int64_t schema_id = next_id();
+
+        setup_rpc_method_not_found();
+        mock_tablet_schema_by_id(Status::NotFound("mocked not found"));
+
+        auto result = _schema_service->get_schema_for_load(create_schema_info(schema_id, 100, 101), tablet_id, 1);
+        ASSERT_TRUE(result.status().is_not_found());
+    }
+}
+
+TEST_F(TableSchemaServiceTest, rpc_request_deduplication) {
+    // 1) Two concurrent LOAD requests for same schema should share one in-flight future.
+    // 2) Verify only one RPC hook is executed.
+    ScopedSyncPoint sp;
+    ScopedConfig retry_guard(&config::table_schema_service_max_retries, 3);
+
+    std::atomic<int> rpc_call_count{0};
+    int64_t schema_id = next_id();
+    int64_t tablet_id = next_id();
+    SingleFlightBarrier barrier(std::chrono::minutes(1));
+    barrier.install();
+
+    setup_rpc_test_hook([&](const TableSchemaServiceTest::RpcHookArgs& ctx) {
+        rpc_call_count.fetch_add(1);
+        *ctx.mock_thrift_rpc = true;
+        *ctx.status = Status::OK();
+        TableSchemaServiceTest::set_status(&ctx.response->status, TStatusCode::OK);
+        ctx.response->__set_responses(std::vector<TGetTableSchemaResponse>{});
+        auto& resp = ctx.response->responses.emplace_back();
+        TableSchemaServiceTest::set_status(&resp.status, TStatusCode::OK);
+        resp.__set_schema(TableSchemaServiceTest::make_thrift_schema(schema_id));
+    });
+
+    auto worker = [&](int64_t txn_id, StatusOr<TabletSchemaPtr>* out) {
+        *out = _schema_service->get_schema_for_load(create_schema_info(schema_id, 100, 101), tablet_id, txn_id);
+    };
+
+    StatusOr<TabletSchemaPtr> r1;
+    StatusOr<TabletSchemaPtr> r2;
+    std::thread t1(worker, next_id(), &r1);
+    ASSERT_TRUE(barrier.wait_for_leader_reached_exec_point())
+            << "Timed out waiting for leader to reach singleflight::Group::Do:2";
+    std::thread t2(worker, next_id(), &r2);
+    t1.join();
+    t2.join();
+
+    ASSERT_FALSE(barrier.timed_out()) << "Timed out waiting for follower to join singleflight group";
+    ASSERT_OK(r1);
+    ASSERT_OK(r2);
+    ASSERT_EQ(rpc_call_count.load(), 1);
+}
+
+TEST_F(TableSchemaServiceTest, load_interference) {
+    // 1) txn_a becomes leader and returns a retryable error.
+    // 2) txn_b joins the in-flight future, sees failure from different txn, then retries and succeeds.
+    ScopedSyncPoint sp;
+    ScopedConfig retry_guard(&config::table_schema_service_max_retries, 3);
+
+    std::atomic<int> rpc_call_count{0};
+    int64_t schema_id = next_id();
+    int64_t tablet_id = next_id();
+
+    int64_t txn_a = next_id();
+    int64_t txn_b = next_id();
+    StatusOr<TabletSchemaPtr> ra;
+    StatusOr<TabletSchemaPtr> rb;
+
+    SingleFlightBarrier barrier(std::chrono::minutes(1));
+    barrier.install();
+
+    std::atomic<bool> leader_failed_once{false};
+    setup_rpc_test_hook([&](const TableSchemaServiceTest::RpcHookArgs& ctx) {
+        rpc_call_count.fetch_add(1);
+        *ctx.mock_thrift_rpc = true;
+        *ctx.status = Status::OK();
+        TableSchemaServiceTest::set_status(&ctx.response->status, TStatusCode::OK);
+        ctx.response->__set_responses(std::vector<TGetTableSchemaResponse>{});
+        auto& resp = ctx.response->responses.emplace_back();
+
+        if (ctx.request->txn_id == txn_a && !leader_failed_once.exchange(true)) {
+            // Make the leader fail once with a retryable error; follower (txn_b) should retry and succeed.
+            TableSchemaServiceTest::set_status(&resp.status, TStatusCode::INTERNAL_ERROR, "mocked retryable error");
+            return;
+        }
+        TableSchemaServiceTest::set_status(&resp.status, TStatusCode::OK);
+        resp.__set_schema(TableSchemaServiceTest::make_thrift_schema(schema_id));
+    });
+
+    auto call_load = [&](int64_t txn_id, StatusOr<TabletSchemaPtr>* out) {
+        *out = _schema_service->get_schema_for_load(create_schema_info(schema_id, 100, 101), tablet_id, txn_id);
+    };
+
+    std::thread t1(call_load, txn_a, &ra);
+    ASSERT_TRUE(barrier.wait_for_leader_reached_exec_point())
+            << "Timed out waiting for leader to reach singleflight::Group::Do:2";
+    std::thread t2(call_load, txn_b, &rb);
+    t1.join();
+    t2.join();
+
+    ASSERT_FALSE(barrier.timed_out()) << "Timed out waiting for follower to join singleflight group";
+    // One of them is expected to be the leader and return error without retry (same txn as exec ctx),
+    // while the other should retry and succeed.
+    ASSERT_TRUE((ra.ok() && !rb.ok()) || (!ra.ok() && rb.ok()));
+    ASSERT_GE(rpc_call_count.load(), 2);
+}
+
+TEST_F(TableSchemaServiceTest, query_interference) {
+    // 1) query q1 becomes leader and returns a retryable error.
+    // 2) query q2 joins, sees failure from different query, then retries and succeeds.
+    ScopedSyncPoint sp;
+    ScopedConfig retry_guard(&config::table_schema_service_max_retries, 3);
+
+    std::atomic<int> rpc_call_count{0};
+    int64_t schema_id = next_id();
+    int64_t tablet_id = next_id();
+    auto fe = create_fe_address();
+
+    auto q1 = create_query_id();
+    auto q2 = create_query_id();
+    StatusOr<TabletSchemaPtr> r1;
+    StatusOr<TabletSchemaPtr> r2;
+
+    SingleFlightBarrier barrier(std::chrono::minutes(1));
+    barrier.install();
+
+    std::atomic<bool> leader_failed_once{false};
+    setup_rpc_test_hook([&](const TableSchemaServiceTest::RpcHookArgs& ctx) {
+        rpc_call_count.fetch_add(1);
+        *ctx.mock_thrift_rpc = true;
+        *ctx.status = Status::OK();
+        TableSchemaServiceTest::set_status(&ctx.response->status, TStatusCode::OK);
+        ctx.response->__set_responses(std::vector<TGetTableSchemaResponse>{});
+        auto& resp = ctx.response->responses.emplace_back();
+
+        if (ctx.request->query_id == q1 && !leader_failed_once.exchange(true)) {
+            TableSchemaServiceTest::set_status(&resp.status, TStatusCode::INTERNAL_ERROR, "mocked retryable error");
+            return;
+        }
+        TableSchemaServiceTest::set_status(&resp.status, TStatusCode::OK);
+        resp.__set_schema(TableSchemaServiceTest::make_thrift_schema(schema_id));
+    });
+
+    auto call_scan = [&](const TUniqueId& q, StatusOr<TabletSchemaPtr>* out) {
+        *out = _schema_service->get_schema_for_scan(create_schema_info(schema_id, 100, 101), tablet_id, q, fe, nullptr);
+    };
+
+    std::thread t1(call_scan, q1, &r1);
+    ASSERT_TRUE(barrier.wait_for_leader_reached_exec_point())
+            << "Timed out waiting for leader to reach singleflight::Group::Do:2";
+    std::thread t2(call_scan, q2, &r2);
+    t1.join();
+    t2.join();
+
+    ASSERT_FALSE(barrier.timed_out()) << "Timed out waiting for follower to join singleflight group";
+    ASSERT_TRUE((r1.ok() && !r2.ok()) || (!r1.ok() && r2.ok()));
+    ASSERT_GE(rpc_call_count.load(), 2);
+}
+
+} // namespace starrocks::lake

--- a/docs/en/administration/management/BE_configuration.md
+++ b/docs/en/administration/management/BE_configuration.md
@@ -3692,6 +3692,15 @@ When this value is set to less than `0`, the system uses the product of its abso
 - Description: The reader's remote I/O buffer size for cloud-native table compaction in a shared-data cluster. The default value is 1MB. You can increase this value to accelerate compaction process.
 - Introduced in: v3.2.3
 
+##### table_schema_service_max_retries
+
+- Default: 3
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: The maximum number of retries for Table Schema Service requests.
+- Introduced in: v4.0
+
 <!--
 ##### experimental_lake_ignore_lost_segment
 

--- a/docs/ja/administration/management/BE_configuration.md
+++ b/docs/ja/administration/management/BE_configuration.md
@@ -1887,6 +1887,15 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 説明: 共有データクラスタでの主キーテーブルコンパクションタスクで許可される最大入力 rowset 数。このパラメータのデフォルト値は v3.2.4 および v3.1.10 以降 `5` から `1000` に、v3.3.1 および v3.2.9 以降 `500` に変更されました。主キーテーブルのためのサイズ階層型コンパクションポリシーが有効になった後 (`enable_pk_size_tiered_compaction_strategy` を `true` に設定することで)、StarRocks は各コンパクションの rowset 数を制限して書き込み増幅を減らす必要がなくなります。したがって、このパラメータのデフォルト値は増加しました。
 - 導入バージョン: v3.1.8, v3.2.3
 
+##### table_schema_service_max_retries
+
+- デフォルト: 3
+- タイプ: Int
+- 単位: -
+- 変更可能: はい
+- 説明: Table Schema Service リクエストの最大リトライ回数。
+- 導入バージョン: v4.0
+
 ### データレイク
 
 ##### jdbc_connection_pool_size

--- a/docs/zh/administration/management/BE_configuration.md
+++ b/docs/zh/administration/management/BE_configuration.md
@@ -3633,6 +3633,16 @@ curl http://<BE_IP>:<BE_HTTP_PORT>/varz
 - 描述：存算分离集群 Compaction 任务在远程 FS 读 I/O 阶段的 Buffer 大小。默认值为 1MB。您可以适当增大该配置项取值以加速 Compaction 任务。
 - 引入版本：v3.2.3
 
+=======
+##### table_schema_service_max_retries
+
+- 默认值：3
+- 类型：Int
+- 单位：-
+- 是否动态：是
+- 描述：Table Schema Service 请求的最大重试次数。
+- 引入版本：v4.0
+
 <!--
 ##### experimental_lake_ignore_lost_segment
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -112,8 +112,6 @@ import com.starrocks.thrift.TScanRangeLocation;
 import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.thrift.TTableSampleOptions;
 import com.starrocks.thrift.TTableSchemaKey;
-import com.starrocks.type.Type;
-import com.starrocks.type.TypeSerializer;
 import com.starrocks.warehouse.Warehouse;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.commons.collections4.CollectionUtils;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -111,7 +111,9 @@ import com.starrocks.thrift.TScanRange;
 import com.starrocks.thrift.TScanRangeLocation;
 import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.thrift.TTableSampleOptions;
-import com.starrocks.thrift.TTableSchemaMeta;
+import com.starrocks.thrift.TTableSchemaKey;
+import com.starrocks.type.Type;
+import com.starrocks.type.TypeSerializer;
 import com.starrocks.warehouse.Warehouse;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.commons.collections4.CollectionUtils;
@@ -1128,14 +1130,14 @@ public class OlapScanNode extends ScanNode {
             }
 
             msg.lake_scan_node.setOutput_asc_hint(sortKeyAscHint);
-            TTableSchemaMeta schemaMeta = new TTableSchemaMeta();
-            schemaMeta.setDb_id(MetaUtils.lookupDbIdByTable(olapTable));
-            schemaMeta.setTable_id(olapTable.getId());
+            TTableSchemaKey schemaKey = new TTableSchemaKey();
+            schemaKey.setDb_id(MetaUtils.lookupDbIdByTable(olapTable));
+            schemaKey.setTable_id(olapTable.getId());
             Preconditions.checkState(index.schema.isPresent(), String.format(
                     "schema not cached, table name: %s, table id: %s, index id: %s",
                     olapTable.getName(), olapTable.getId(), index.indexId));
-            schemaMeta.setSchema_id(index.schema.get().getId());
-            msg.lake_scan_node.setSchema_meta(schemaMeta);
+            schemaKey.setSchema_id(index.schema.get().getId());
+            msg.lake_scan_node.setSchema_key(schemaKey);
         } else { // If you find yourself changing this code block, see also the above code block
             msg.node_type = TPlanNodeType.OLAP_SCAN_NODE;
             msg.olap_scan_node =

--- a/fe/fe-core/src/main/java/com/starrocks/service/TableSchemaService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/TableSchemaService.java
@@ -33,7 +33,7 @@ import com.starrocks.thrift.TGetTableSchemaRequest;
 import com.starrocks.thrift.TGetTableSchemaResponse;
 import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
-import com.starrocks.thrift.TTableSchemaMeta;
+import com.starrocks.thrift.TTableSchemaKey;
 import com.starrocks.thrift.TTableSchemaRequestSource;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.TransactionState;
@@ -78,9 +78,9 @@ public class TableSchemaService {
             return response;
         }
 
-        long schemaId = request.getSchema_meta().getSchema_id();
-        long dbId = request.getSchema_meta().getDb_id();
-        long tableId = request.getSchema_meta().getTable_id();
+        long schemaId = request.getSchema_key().getSchema_id();
+        long dbId = request.getSchema_key().getDb_id();
+        long tableId = request.getSchema_key().getTable_id();
         TTableSchemaRequestSource requestSource = request.getSource();
 
         try {
@@ -231,11 +231,11 @@ public class TableSchemaService {
      */
     private static Status validateParameters(TGetTableSchemaRequest request) {
         try {
-            Preconditions.checkArgument(request.isSetSchema_meta(), "schema meta not set");
-            TTableSchemaMeta schemaMeta = request.getSchema_meta();
-            Preconditions.checkArgument(schemaMeta.isSetSchema_id(), "schema id not set");
-            Preconditions.checkArgument(schemaMeta.isSetDb_id(), "db id not set");
-            Preconditions.checkArgument(schemaMeta.isSetTable_id(), "table id meta not set");
+            Preconditions.checkArgument(request.isSetSchema_key(), "schema key not set");
+            TTableSchemaKey schemaKey = request.getSchema_key();
+            Preconditions.checkArgument(schemaKey.isSetSchema_id(), "schema id not set");
+            Preconditions.checkArgument(schemaKey.isSetDb_id(), "db id not set");
+            Preconditions.checkArgument(schemaKey.isSetTable_id(), "table id meta not set");
             Preconditions.checkArgument(request.isSetSource(), "request source not set");
             TTableSchemaRequestSource requestSource = request.getSource();
             switch (requestSource) {
@@ -261,12 +261,12 @@ public class TableSchemaService {
             // only log OK if debug enabled
             return response;
         }
-        TTableSchemaMeta schemaMeta = request.getSchema_meta();
+        TTableSchemaKey schemaKey = request.getSchema_key();
         StringBuilder sb = new StringBuilder();
         sb.append("table schema retrieval");
-        sb.append(", db: ").append(schemaMeta.getDb_id());
-        sb.append(", table: ").append(schemaMeta.getTable_id());
-        sb.append(", schema: ").append(schemaMeta.getSchema_id());
+        sb.append(", db: ").append(schemaKey.getDb_id());
+        sb.append(", table: ").append(schemaKey.getTable_id());
+        sb.append(", schema: ").append(schemaKey.getSchema_id());
         sb.append(", tablet: ").append(request.getTablet_id());
         if (request.getSource() == TTableSchemaRequestSource.SCAN) {
             sb.append(", query: ").append(DebugUtil.printId(request.getQuery_id()));

--- a/fe/fe-core/src/test/java/com/starrocks/service/TableSchemaServiceTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/service/TableSchemaServiceTest.java
@@ -37,7 +37,7 @@ import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TGetTableSchemaRequest;
 import com.starrocks.thrift.TGetTableSchemaResponse;
 import com.starrocks.thrift.TStatusCode;
-import com.starrocks.thrift.TTableSchemaMeta;
+import com.starrocks.thrift.TTableSchemaKey;
 import com.starrocks.thrift.TTableSchemaRequestSource;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.transaction.GlobalTransactionMgr;
@@ -129,17 +129,17 @@ public class TableSchemaServiceTest extends StarRocksTestBase {
         return coordinator;
     }
 
-    private static TTableSchemaMeta createSchemaMeta(long schemaId, long dbId, long tableId) {
-        TTableSchemaMeta schemaMeta = new TTableSchemaMeta();
-        schemaMeta.setSchema_id(schemaId);
-        schemaMeta.setDb_id(dbId);
-        schemaMeta.setTable_id(tableId);
-        return schemaMeta;
+    private static TTableSchemaKey createSchemaKey(long schemaId, long dbId, long tableId) {
+        TTableSchemaKey schemaKey = new TTableSchemaKey();
+        schemaKey.setSchema_id(schemaId);
+        schemaKey.setDb_id(dbId);
+        schemaKey.setTable_id(tableId);
+        return schemaKey;
     }
 
     private static TGetTableSchemaRequest createScanRequest(long schemaId, long dbId, long tableId, TUniqueId queryId) {
         TGetTableSchemaRequest request = new TGetTableSchemaRequest();
-        request.setSchema_meta(createSchemaMeta(schemaId, dbId, tableId));
+        request.setSchema_key(createSchemaKey(schemaId, dbId, tableId));
         request.setSource(TTableSchemaRequestSource.SCAN);
         request.setQuery_id(queryId);
         return request;
@@ -147,7 +147,7 @@ public class TableSchemaServiceTest extends StarRocksTestBase {
 
     private static TGetTableSchemaRequest createLoadRequest(long schemaId, long dbId, long tableId, long txnId) {
         TGetTableSchemaRequest request = new TGetTableSchemaRequest();
-        request.setSchema_meta(createSchemaMeta(schemaId, dbId, tableId));
+        request.setSchema_key(createSchemaKey(schemaId, dbId, tableId));
         request.setSource(TTableSchemaRequestSource.LOAD);
         request.setTxn_id(txnId);
         return request;
@@ -168,27 +168,27 @@ public class TableSchemaServiceTest extends StarRocksTestBase {
 
     private static Stream<Arguments> parameterValidationTestCases() {
         return Stream.of(
-                Arguments.of("MissingSchemaMeta",
+                Arguments.of("MissingSchemaKey",
                         (Consumer<TGetTableSchemaRequest>) request -> {
                             request.setSource(TTableSchemaRequestSource.SCAN);
                             request.setQuery_id(new TUniqueId(1, 1));
                         },
-                        "schema meta not set"),
+                        "schema key not set"),
                 Arguments.of("MissingRequestSource",
                         (Consumer<TGetTableSchemaRequest>) request -> {
-                            request.setSchema_meta(createSchemaMeta(1L, 1L, 1L));
+                            request.setSchema_key(createSchemaKey(1L, 1L, 1L));
                             request.setQuery_id(new TUniqueId(1, 1));
                         },
                         "request source not set"),
                 Arguments.of("ScanWithoutQueryId",
                         (Consumer<TGetTableSchemaRequest>) request -> {
-                            request.setSchema_meta(createSchemaMeta(1L, 1L, 1L));
+                            request.setSchema_key(createSchemaKey(1L, 1L, 1L));
                             request.setSource(TTableSchemaRequestSource.SCAN);
                         },
                         "query id not set for scan"),
                 Arguments.of("LoadWithoutTxnId",
                         (Consumer<TGetTableSchemaRequest>) request -> {
-                            request.setSchema_meta(createSchemaMeta(1L, 1L, 1L));
+                            request.setSchema_key(createSchemaKey(1L, 1L, 1L));
                             request.setSource(TTableSchemaRequestSource.LOAD);
                         },
                         "txn id not set for load")

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -197,6 +197,7 @@ message BundleTabletMetadataPB {
 }
 
 message TxnLogPB {
+
     message OpWrite {
         optional RowsetMetadataPB rowset = 1;
         // some txn semantic information bind to this rowset
@@ -205,6 +206,10 @@ message TxnLogPB {
         // for partial update, record dest rewrite segment names to avoid gc
         repeated string rewrite_segments = 4;
         repeated bytes del_encryption_metas = 5;
+
+        // The specific table schema used to generate this rowset
+        // Note this field is backported from v4.1, so use the same id as in v4.1 for compatibility
+        optional TableSchemaKeyPB schema_key = 8;
     }
 
     message OpCompaction {

--- a/gensrc/proto/tablet_schema.proto
+++ b/gensrc/proto/tablet_schema.proto
@@ -107,3 +107,10 @@ message TabletIndexPB {
     optional string index_properties = 5; // index meta
 }
 
+// Key for identifying a table schema version.
+// TabletSchemaPB is the physical representation of a specific table schema.
+message TableSchemaKeyPB {
+  optional int64 db_id = 1;
+  optional int64 table_id = 2;
+  optional int64 schema_id = 3;
+}

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -243,6 +243,13 @@ struct TColumn {
     21: optional Types.TTypeDesc type_desc         
 }
 
+// Key information for locating a specific table schema version.
+struct TTableSchemaKey {
+  1: optional i64 db_id
+  2: optional i64 table_id
+  3: optional i64 schema_id
+}
+
 struct TOlapTableIndexTablets {
     1: required i64 index_id
     2: required list<i64> tablets

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -2201,7 +2201,7 @@ enum TTableSchemaRequestSource {
 }
 
 struct TGetTableSchemaRequest {
-    1: optional PlanNodes.TTableSchemaMeta schema_meta;
+    1: optional Descriptors.TTableSchemaKey schema_key;
     2: optional TTableSchemaRequestSource source;
     3: optional i64 tablet_id;
     // Valid if request_source is SCAN

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -653,12 +653,6 @@ struct TJDBCScanNode {
   5: optional i64 limit
 }
 
-struct TTableSchemaMeta {
-  1: optional i64 db_id
-  2: optional i64 table_id
-  3: optional i64 schema_id
-}
-
 // If you find yourself changing this struct, see also TOlapScanNode
 struct TLakeScanNode {
   1: required Types.TTupleId tuple_id
@@ -690,7 +684,7 @@ struct TLakeScanNode {
   41: optional i64 back_pressure_throttle_time_upper_bound
   42: optional i64 back_pressure_num_rows
 
-  43: optional TTableSchemaMeta schema_meta
+  43: optional Descriptors.TTableSchemaKey schema_key
 }
 
 struct TEqJoinCondition {


### PR DESCRIPTION
## Why I'm doing:
Backport #66699 to branch-4.0 for compatibility if the table on v4.1 with fast schema change v2 wants to downgrade to v4.0. The backport is expected to not affect existing tables because
1. for query
    * before: must can get schema from tablet metadata
    * after: table schema service first get the schema from tablet metadata, then get it from FE, so for existing tables, it must hit the tablet metadata, and no actual RPC to FE
2. for load
    * before: must can get schema from schema file
    * after: table schema service first get it from schema file, then get it from FE, so for existing tables, it must hit the schema file, and no actual RPC to FE.  Note in the original pr, the order to get the schema is FE -> schema file, and this backport changes it to minimize the affect on existing tables

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3