### PR TITLE
[BugFix] Error log not records the row for invalid decimal/varchar data

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -900,7 +900,7 @@ Status OlapTableSink::close_wait(RuntimeState* state, Status close_status) {
     return status;
 }
 
-void OlapTableSink::_print_varchar_error_msg(RuntimeState* state, const Slice& str, SlotDescriptor* desc) {
+void OlapTableSink::_print_varchar_error_msg(RuntimeState* state, const Slice& str, SlotDescriptor* desc, Chunk* chunk, int32_t row_index) {
     if (state->has_reached_max_error_msg_num()) {
         return;
     }
@@ -913,39 +913,28 @@ void OlapTableSink::_print_varchar_error_msg(RuntimeState* state, const Slice& s
     }
     std::string error_msg = strings::Substitute("String '$0'(length=$1) is too long. The max length of '$2' is $3",
                                                 error_str, str.get_size(), desc->col_name(), desc->type().len);
-#if BE_TEST
-    LOG(INFO) << error_msg;
-#else
-    state->append_error_msg_to_file("", error_msg);
-#endif
+    state->append_error_msg_to_file(chunk->debug_row(row_index), error_msg);
 }
 
-void OlapTableSink::_print_decimal_error_msg(RuntimeState* state, const DecimalV2Value& decimal, SlotDescriptor* desc) {
+void OlapTableSink::_print_decimal_error_msg(RuntimeState* state, const DecimalV2Value& decimal, SlotDescriptor* desc, Chunk* chunk, int32_t row_index) {
     if (state->has_reached_max_error_msg_num()) {
         return;
     }
     std::string error_msg = strings::Substitute("Decimal '$0' is out of range. The type of '$1' is $2'",
                                                 decimal.to_string(), desc->col_name(), desc->type().debug_string());
-#if BE_TEST
-    LOG(INFO) << error_msg;
-#else
-    state->append_error_msg_to_file("", error_msg);
-#endif
+    state->append_error_msg_to_file(chunk->debug_row(row_index), error_msg);
 }
 
 template <LogicalType LT, typename CppType = RunTimeCppType<LT>>
-void _print_decimalv3_error_msg(RuntimeState* state, const CppType& decimal, const SlotDescriptor* desc) {
+void _print_decimalv3_error_msg(RuntimeState* state, const CppType& decimal, const SlotDescriptor* desc,
+    Chunk* chunk, int32_t row_index) {
     if (state->has_reached_max_error_msg_num()) {
         return;
     }
     auto decimal_str = DecimalV3Cast::to_string<CppType>(decimal, desc->type().precision, desc->type().scale);
     std::string error_msg = strings::Substitute("Decimal '$0' is out of range. The type of '$1' is $2'", decimal_str,
                                                 desc->col_name(), desc->type().debug_string());
-#if BE_TEST
-    LOG(INFO) << error_msg;
-#else
-    state->append_error_msg_to_file("", error_msg);
-#endif
+    state->append_error_msg_to_file(chunk->debug_row(row_index), error_msg);
 }
 
 template <LogicalType LT>
@@ -966,7 +955,7 @@ void OlapTableSink::_validate_decimal(RuntimeState* state, Chunk* chunk, Column*
             const auto& datum = data[i];
             if (datum > max_decimal || datum < min_decimal) {
                 (*validate_selection)[i] = VALID_SEL_FAILED;
-                _print_decimalv3_error_msg<LT>(state, datum, desc);
+                _print_decimalv3_error_msg<LT>(state, datum, desc, chunk, i);
                 if (state->enable_log_rejected_record()) {
                     auto decimal_str =
                             DecimalV3Cast::to_string<CppType>(datum, desc->type().precision, desc->type().scale);
@@ -1089,7 +1078,7 @@ void OlapTableSink::_validate_data(RuntimeState* state, Chunk* chunk) {
                 if (_validate_selection[j] == VALID_SEL_OK) {
                     if (offset[j + 1] - offset[j] > len) {
                         _validate_selection[j] = VALID_SEL_FAILED;
-                        _print_varchar_error_msg(state, binary->get_slice(j), desc);
+                        _print_varchar_error_msg(state, binary->get_slice(j), desc, chunk, j);
                         if (state->enable_log_rejected_record()) {
                             std::string error_msg =
                                     strings::Substitute("String (length=$0) is too long. The max length of '$1' is $2",
@@ -1114,7 +1103,7 @@ void OlapTableSink::_validate_data(RuntimeState* state, Chunk* chunk) {
 
                     if (datas[j] > _max_decimalv2_val[i] || datas[j] < _min_decimalv2_val[i]) {
                         _validate_selection[j] = VALID_SEL_FAILED;
-                        _print_decimal_error_msg(state, datas[j], desc);
+                        _print_decimal_error_msg(state, datas[j], desc, chunk, j);
                         if (state->enable_log_rejected_record()) {
                             std::string error_msg = strings::Substitute(
                                     "Decimal '$0' is out of range. The type of '$1' is $2'", datas[j].to_string(),

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -900,7 +900,8 @@ Status OlapTableSink::close_wait(RuntimeState* state, Status close_status) {
     return status;
 }
 
-void OlapTableSink::_print_varchar_error_msg(RuntimeState* state, const Slice& str, SlotDescriptor* desc, Chunk* chunk, int32_t row_index) {
+void OlapTableSink::_print_varchar_error_msg(RuntimeState* state, const Slice& str, SlotDescriptor* desc, Chunk* chunk,
+                                             int32_t row_index) {
     if (state->has_reached_max_error_msg_num()) {
         return;
     }
@@ -916,7 +917,8 @@ void OlapTableSink::_print_varchar_error_msg(RuntimeState* state, const Slice& s
     state->append_error_msg_to_file(chunk->debug_row(row_index), error_msg);
 }
 
-void OlapTableSink::_print_decimal_error_msg(RuntimeState* state, const DecimalV2Value& decimal, SlotDescriptor* desc, Chunk* chunk, int32_t row_index) {
+void OlapTableSink::_print_decimal_error_msg(RuntimeState* state, const DecimalV2Value& decimal, SlotDescriptor* desc,
+                                             Chunk* chunk, int32_t row_index) {
     if (state->has_reached_max_error_msg_num()) {
         return;
     }
@@ -926,8 +928,8 @@ void OlapTableSink::_print_decimal_error_msg(RuntimeState* state, const DecimalV
 }
 
 template <LogicalType LT, typename CppType = RunTimeCppType<LT>>
-void _print_decimalv3_error_msg(RuntimeState* state, const CppType& decimal, const SlotDescriptor* desc,
-    Chunk* chunk, int32_t row_index) {
+void _print_decimalv3_error_msg(RuntimeState* state, const CppType& decimal, const SlotDescriptor* desc, Chunk* chunk,
+                                int32_t row_index) {
     if (state->has_reached_max_error_msg_num()) {
         return;
     }

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -118,9 +118,9 @@ private:
     // So we need to pad char column after compute buckect hash.
     void _padding_char_column(Chunk* chunk);
 
-    void _print_varchar_error_msg(RuntimeState* state, const Slice& str, SlotDescriptor* desc);
+    void _print_varchar_error_msg(RuntimeState* state, const Slice& str, SlotDescriptor* desc, Chunk* chunk, int32_t row_index);
 
-    static void _print_decimal_error_msg(RuntimeState* state, const DecimalV2Value& decimal, SlotDescriptor* desc);
+    static void _print_decimal_error_msg(RuntimeState* state, const DecimalV2Value& decimal, SlotDescriptor* desc, Chunk* chunk, int32_t row_index);
 
     Status _fill_auto_increment_id(Chunk* chunk);
 

--- a/be/src/exec/tablet_sink.h
+++ b/be/src/exec/tablet_sink.h
@@ -118,9 +118,11 @@ private:
     // So we need to pad char column after compute buckect hash.
     void _padding_char_column(Chunk* chunk);
 
-    void _print_varchar_error_msg(RuntimeState* state, const Slice& str, SlotDescriptor* desc, Chunk* chunk, int32_t row_index);
+    void _print_varchar_error_msg(RuntimeState* state, const Slice& str, SlotDescriptor* desc, Chunk* chunk,
+                                  int32_t row_index);
 
-    static void _print_decimal_error_msg(RuntimeState* state, const DecimalV2Value& decimal, SlotDescriptor* desc, Chunk* chunk, int32_t row_index);
+    static void _print_decimal_error_msg(RuntimeState* state, const DecimalV2Value& decimal, SlotDescriptor* desc,
+                                         Chunk* chunk, int32_t row_index);
 
     Status _fill_auto_increment_id(Chunk* chunk);
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -114,6 +114,7 @@ set(EXEC_FILES
         ./exec/sorting_test.cpp
         ./exec/tablet_sink_index_channel_test.cpp
         ./exec/tablet_sink_sender_range_test.cpp
+        ./exec/tablet_sink_test.cpp
         ./exec/table_function_node_test.cpp
         ./exec/olap_scan_prepare_test.cpp
         ./exec/file_scanner/avro_cpp_scanner_test.cpp

--- a/be/test/exec/tablet_sink_test.cpp
+++ b/be/test/exec/tablet_sink_test.cpp
@@ -163,7 +163,8 @@ protected:
                                        config::vector_chunk_size));
         runtime_state->set_desc_tbl(desc_tbl);
 
-        auto sink = std::make_unique<OlapTableSink>(_object_pool.get(), std::vector<TExpr>(), nullptr, runtime_state.get());
+        auto sink =
+                std::make_unique<OlapTableSink>(_object_pool.get(), std::vector<TExpr>(), nullptr, runtime_state.get());
         CHECK_OK(sink->init(_data_sink, runtime_state.get()));
         CHECK_OK(sink->prepare(runtime_state.get()));
         return sink;
@@ -214,9 +215,9 @@ protected:
 
     // Generic test helper for error message validation
     template <typename FillColumnFunc>
-    void _test_error_log(LogicalType test_type, size_t slot_index, size_t num_rows,
-                                           size_t error_row_index, FillColumnFunc fill_column,
-                                           const std::string& error_keyword1, const std::string& error_keyword2) {
+    void _test_error_log(LogicalType test_type, size_t slot_index, size_t num_rows, size_t error_row_index,
+                         FillColumnFunc fill_column, const std::string& error_keyword1,
+                         const std::string& error_keyword2) {
         std::unique_ptr<RuntimeState> runtime_state;
         DescriptorTbl* desc_tbl = nullptr;
         auto sink = _setup_sink(runtime_state, desc_tbl);

--- a/be/test/exec/tablet_sink_test.cpp
+++ b/be/test/exec/tablet_sink_test.cpp
@@ -1,0 +1,290 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/tablet_sink.h"
+
+#include <gtest/gtest.h>
+
+#include <fstream>
+#include <sstream>
+
+#include "column/column.h"
+#include "column/vectorized_fwd.h"
+#include "common/config.h"
+#include "exec/tablet_info.h"
+#include "runtime/decimalv2_value.h"
+#include "runtime/descriptor_helper.h"
+#include "runtime/runtime_state.h"
+#include "storage/chunk_helper.h"
+#include "testutil/assert.h"
+#include "util/defer_op.h"
+#include "util/slice.h"
+
+namespace starrocks {
+
+class TabletSinkTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        _db_id = 1;
+        _table_id = 2;
+        _txn_id = 3;
+        _exec_env = ExecEnv::GetInstance();
+        _object_pool = std::make_unique<ObjectPool>();
+        _desc_tbl = _build_descriptor_table();
+        _data_sink = _build_data_sink();
+    }
+
+protected:
+    std::unique_ptr<RuntimeState> _build_runtime_state() {
+        TQueryOptions query_options;
+        query_options.query_type = TQueryType::LOAD;
+        TUniqueId fragment_id;
+        TQueryGlobals query_globals;
+        auto runtime_state = std::make_unique<RuntimeState>(fragment_id, query_options, query_globals, _exec_env);
+        TUniqueId id;
+        runtime_state->init_mem_trackers(id);
+        runtime_state->set_db("test_db");
+        runtime_state->set_load_label("test_label");
+        runtime_state->set_txn_id(_txn_id);
+        return runtime_state;
+    }
+
+    TDescriptorTable _build_descriptor_table() {
+        TDescriptorTableBuilder dtb;
+        TTupleDescriptorBuilder tuple_builder;
+        tuple_builder.add_slot(TSlotDescriptorBuilder()
+                                       .type(TYPE_VARCHAR)
+                                       .column_name("varchar_col")
+                                       .column_pos(1)
+                                       .length(10)
+                                       .build());
+        tuple_builder.add_slot(TSlotDescriptorBuilder()
+                                       .type(TYPE_DECIMALV2)
+                                       .column_name("decimalv2_col")
+                                       .column_pos(2)
+                                       .precision(10)
+                                       .scale(2)
+                                       .build());
+        tuple_builder.add_slot(TSlotDescriptorBuilder()
+                                       .type(TYPE_DECIMAL64)
+                                       .column_name("decimal64_col")
+                                       .column_pos(3)
+                                       .precision(10)
+                                       .scale(2)
+                                       .build());
+        tuple_builder.add_slot(TSlotDescriptorBuilder().type(TYPE_INT).column_name("int_col").column_pos(4).build());
+        tuple_builder.build(&dtb);
+        return dtb.desc_tbl();
+    }
+
+    TDataSink _build_data_sink() {
+        TOlapTableSink table_sink;
+        table_sink.load_id.hi = 0;
+        table_sink.load_id.lo = 0;
+        table_sink.db_id = _db_id;
+        table_sink.db_name = "test";
+        table_sink.table_id = _table_id;
+        table_sink.table_name = "test";
+        table_sink.txn_id = _txn_id;
+        table_sink.num_replicas = 1;
+        table_sink.keys_type = TKeysType::DUP_KEYS;
+        table_sink.tuple_id = _desc_tbl.tupleDescriptors[0].id;
+
+        TOlapTableSchemaParam& schema = table_sink.schema;
+        schema.db_id = _db_id;
+        schema.table_id = _table_id;
+        schema.version = 0;
+        schema.tuple_desc = _desc_tbl.tupleDescriptors[0];
+        schema.slot_descs = _desc_tbl.slotDescriptors;
+        schema.indexes.resize(1);
+        schema.indexes[0].id = 0;
+        schema.indexes[0].columns = {"varchar_col", "decimalv2_col", "decimal64_col", "int_col"};
+
+        TOlapTablePartitionParam& partition = table_sink.partition;
+        partition.db_id = _db_id;
+        partition.table_id = _table_id;
+        partition.version = 0;
+        partition.distributed_columns.push_back("int_col");
+        partition.partitions.resize(1);
+        partition.partitions[0].id = 0;
+        partition.partitions[0].indexes.resize(1);
+        partition.partitions[0].indexes[0].index_id = 0;
+        partition.partitions[0].indexes[0].tablet_ids.push_back(0);
+
+        TOlapTableLocationParam& location = table_sink.location;
+        location.db_id = _db_id;
+        location.table_id = _table_id;
+        location.version = 0;
+        location.tablets.resize(1);
+        location.tablets[0].tablet_id = 0;
+        location.tablets[0].node_ids.push_back(0);
+
+        TNodesInfo& nodes_info = table_sink.nodes_info;
+        nodes_info.version = 0;
+        nodes_info.nodes.resize(1);
+        nodes_info.nodes[0].id = 0;
+        nodes_info.nodes[0].option = 0;
+        nodes_info.nodes[0].host = "127.0.0.1";
+        nodes_info.nodes[0].async_internal_port = 8060;
+
+        TDataSink data_sink;
+        data_sink.__set_olap_table_sink(table_sink);
+        return data_sink;
+    }
+
+    std::string _read_error_log_file(const std::string& relative_path, ExecEnv* exec_env) {
+        if (relative_path.empty()) {
+            return "";
+        }
+        std::string absolute_path = exec_env->load_path_mgr()->get_load_error_absolute_path(relative_path);
+        std::ifstream file(absolute_path);
+        if (!file.is_open()) {
+            return "";
+        }
+        std::stringstream buffer;
+        buffer << file.rdbuf();
+        return buffer.str();
+    }
+
+    std::unique_ptr<OlapTableSink> _setup_sink(std::unique_ptr<RuntimeState>& runtime_state, DescriptorTbl*& desc_tbl) {
+        runtime_state = _build_runtime_state();
+        CHECK_OK(DescriptorTbl::create(runtime_state.get(), _object_pool.get(), _desc_tbl, &desc_tbl,
+                                       config::vector_chunk_size));
+        runtime_state->set_desc_tbl(desc_tbl);
+
+        auto sink = std::make_unique<OlapTableSink>(_object_pool.get(), std::vector<TExpr>(), nullptr, runtime_state.get());
+        CHECK_OK(sink->init(_data_sink, runtime_state.get()));
+        CHECK_OK(sink->prepare(runtime_state.get()));
+        return sink;
+    }
+
+    void _fill_chunk_base_data(ChunkPtr& chunk, const std::vector<SlotDescriptor*>& slots, size_t num_rows,
+                               LogicalType skip_type) {
+        for (size_t i = 0; i < slots.size(); ++i) {
+            auto* slot = slots[i];
+            if (slot->type().type == skip_type) {
+                continue; // Skip the column being tested
+            }
+            auto* column = chunk->get_column_raw_ptr_by_slot_id(slot->id());
+            if (slot->type().type == TYPE_INT) {
+                for (size_t j = 0; j < num_rows; ++j) {
+                    column->append_datum(Datum(static_cast<int32_t>(100 + j * 100)));
+                }
+            } else {
+                // Fill other columns with default values
+                for (size_t j = 0; j < num_rows; ++j) {
+                    column->append_default();
+                }
+            }
+        }
+    }
+
+    void _setup_chunk_slot_map(ChunkPtr& chunk, const std::vector<SlotDescriptor*>& slots) {
+        chunk->reset_slot_id_to_index();
+        for (size_t i = 0; i < slots.size(); ++i) {
+            chunk->set_slot_id_to_index(slots[i]->id(), i);
+        }
+    }
+
+    void _verify_error_log_contains_row_info(const std::string& error_log_path, ExecEnv* exec_env,
+                                             const std::string& expected_row_debug, const std::string& error_keyword1,
+                                             const std::string& error_keyword2) {
+        std::string error_log_content = _read_error_log_file(error_log_path, exec_env);
+        ASSERT_FALSE(error_log_content.empty())
+                << "Error log file should not be empty. Relative path: " << error_log_path;
+        ASSERT_NE(error_log_content.find("Row:"), std::string::npos) << "Error log should contain 'Row:' marker";
+        ASSERT_NE(error_log_content.find(expected_row_debug), std::string::npos)
+                << "Error log should contain the row debug information";
+        ASSERT_NE(error_log_content.find(error_keyword1), std::string::npos)
+                << "Error log should contain '" << error_keyword1 << "'";
+        ASSERT_NE(error_log_content.find(error_keyword2), std::string::npos)
+                << "Error log should contain '" << error_keyword2 << "'";
+    }
+
+    // Generic test helper for error message validation
+    template <typename FillColumnFunc>
+    void _test_error_log(LogicalType test_type, size_t slot_index, size_t num_rows,
+                                           size_t error_row_index, FillColumnFunc fill_column,
+                                           const std::string& error_keyword1, const std::string& error_keyword2) {
+        std::unique_ptr<RuntimeState> runtime_state;
+        DescriptorTbl* desc_tbl = nullptr;
+        auto sink = _setup_sink(runtime_state, desc_tbl);
+
+        ChunkPtr chunk(ChunkHelper::new_chunk(desc_tbl->get_tuple_descriptor(0)->slots(), num_rows).release());
+        _fill_chunk_base_data(chunk, desc_tbl->get_tuple_descriptor(0)->slots(), num_rows, test_type);
+
+        auto* slot = desc_tbl->get_tuple_descriptor(0)->slots()[slot_index];
+        auto* column = chunk->get_column_raw_ptr_by_slot_id(slot->id());
+        fill_column(column);
+
+        chunk->materialized_nullable();
+        _setup_chunk_slot_map(chunk, desc_tbl->get_tuple_descriptor(0)->slots());
+        std::string expected_row_debug = chunk->debug_row(error_row_index);
+
+        (void)sink->send_chunk(runtime_state.get(), chunk.get());
+
+        std::string error_log_path = runtime_state->get_error_log_file_path();
+        ExecEnv* exec_env = runtime_state->exec_env();
+        // The destructor will close and flush the error log file
+        runtime_state.reset();
+
+        _verify_error_log_contains_row_info(error_log_path, exec_env, expected_row_debug, error_keyword1,
+                                            error_keyword2);
+    }
+
+    int64_t _db_id;
+    int64_t _table_id;
+    int64_t _txn_id;
+    ExecEnv* _exec_env;
+    std::unique_ptr<ObjectPool> _object_pool;
+    TDescriptorTable _desc_tbl;
+    TDataSink _data_sink;
+};
+
+TEST_F(TabletSinkTest, test_varchar_error_log) {
+    bool old_enable_check_string_lengths = config::enable_check_string_lengths;
+    config::enable_check_string_lengths = true;
+    DeferOp defer([&]() { config::enable_check_string_lengths = old_enable_check_string_lengths; });
+
+    _test_error_log(
+            TYPE_VARCHAR, 0, 3, 1,
+            [](Column* col) {
+                col->append_datum(Datum(Slice("short")));
+                col->append_datum(Datum(Slice("this_is_a_very_long_string_that_exceeds_max_length")));
+                col->append_datum(Datum(Slice("medium_str")));
+            },
+            "String", "too long");
+}
+
+TEST_F(TabletSinkTest, test_decimal_error_log) {
+    _test_error_log(
+            TYPE_DECIMALV2, 1, 2, 1,
+            [](Column* col) {
+                col->append_datum(Datum(DecimalV2Value(12345, 2)));
+                col->append_datum(Datum(DecimalV2Value(100000000, 0)));
+            },
+            "Decimal", "out of range");
+}
+
+TEST_F(TabletSinkTest, test_decimalv3_error_log) {
+    _test_error_log(
+            TYPE_DECIMAL64, 2, 2, 1,
+            [](Column* col) {
+                col->append_datum(Datum(static_cast<int64_t>(12345)));
+                col->append_datum(Datum(static_cast<int64_t>(10000000000LL)));
+            },
+            "Decimal", "out of range");
+}
+
+} // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
`Row` is empty in the error log, but should be `Row: [1, 111111111111.9999]`

```
CREATE TABLE `example_tbl` (
    `id` int,
    `val` decimal(14, 4)
 ) PROPERTIES (
    "replication_num" = "1"
);

mysql> insert into example_tbl values (1, 111111111111.9999);
ERROR 1064 (HY000): Insert has filtered data, txn_id = 51243, tracking sql = select tracking_log from information_schema.load_tracking_logs where job_id=62463
mysql>
mysql> select tracking_log from information_schema.load_tracking_logs where job_id=62463;
+----------------------------------------------------------------------------------------------------+
| tracking_log                                                                                       |
+----------------------------------------------------------------------------------------------------+
| Error: Decimal '111111111111.9999' is out of range. The type of 'val' is DECIMAL64(14, 4)'. Row:
 |
+----------------------------------------------------------------------------------------------------+
1 row in set (0.05 sec)

```

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure error logs record the offending row for invalid VARCHAR/DECIMAL data in TabletSink and add unit tests.
> 
> - **Backend (tablet sink)**
>   - Include row context in error logs for invalid `VARCHAR` and `DECIMAL` values by passing `Chunk*` and `row_index` to `_print_varchar_error_msg`, `_print_decimal_error_msg`, and `_print_decimalv3_error_msg`, and logging `chunk->debug_row(row_index)`.
>   - Update validation call sites in `OlapTableSink::_validate_data` and `_validate_decimal` to pass row context.
> - **Tests**
>   - Add `be/test/exec/tablet_sink_test.cpp` to verify error logs contain the row info for `VARCHAR`, `DECIMALV2`, and `DECIMAL64` violations; register test in `be/test/CMakeLists.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 73c9725f885b3665e5e432f16fc9469d23ad8fbb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->