### PR TITLE
[UT] Let test_load_ha/test_load_brpc_reached_timeout work in shared-data

### DIFF
--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -576,6 +576,12 @@ void LakeTabletsChannel::add_chunk(Chunk* chunk, const PTabletWriterAddChunkRequ
     auto start_wait_writer_ts = watch.elapsed_time();
     // Block the current bthread(not pthread) until all `write()` and `finish()` tasks finished.
     count_down_latch.wait();
+    FAIL_POINT_TRIGGER_EXECUTE(tablets_channel_add_chunk_wait_write_block, {
+        int32_t timeout_ms = config::load_fp_tablets_channel_add_chunk_block_ms;
+        if (timeout_ms > 0) {
+            bthread_usleep(timeout_ms * 1000);
+        }
+    });
 
     auto finish_wait_writer_ts = watch.elapsed_time();
 

--- a/test/sql/test_load/R/test_load_ha
+++ b/test/sql/test_load/R/test_load_ha
@@ -1,4 +1,4 @@
--- name: test_load_ha @sequential
+-- name: test_load_ha @sequential @native
 create database db_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_load/T/test_load_ha
+++ b/test/sql/test_load/T/test_load_ha
@@ -1,4 +1,4 @@
--- name: test_load_ha @sequential
+-- name: test_load_ha @sequential @native
 
 create database db_${uuid0};
 use db_${uuid0};


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [X] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a failpoint to optionally sleep after writer wait in `LakeTabletsChannel::add_chunk` and marks `test_load_ha` tests as `@native`.
> 
> - **Backend**:
>   - Add failpoint `tablets_channel_add_chunk_wait_write_block` in `be/src/runtime/lake_tablets_channel.cpp` to optionally sleep after writer wait using `config::load_fp_tablets_channel_add_chunk_block_ms`.
> - **Tests**:
>   - Mark `test/sql/test_load/{R,T}/test_load_ha` as `@native`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c2d637d8ebb51b9a89ddb6acaa7d897c8fb8f6b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->