### PR TITLE
[UT] Fix unstable UT

### DIFF
--- a/test/sql/test_iceberg/R/test_iceberg_view
+++ b/test/sql/test_iceberg/R/test_iceberg_view
@@ -2,56 +2,72 @@
 create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
 -- result:
 -- !result
-create view if not exists iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_${uuid0} as select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.day_partition;
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/test_iceberg_view${uuid0}/iceberg_db/${uuid0}"
+);
 -- result:
 -- !result
-select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_${uuid0};
--- result:
-1	2024-08-08 15:32:51.751000
--- !result
-drop view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_${uuid0};
--- result:
--- !result
-create view if not exists iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0}
-properties ("owner"="alex") as select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+CREATE TABLE iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.`day_partition` (
+ `k1` int(11) DEFAULT NULL,
+ `ts` datetime DEFAULT NULL
+)
+PARTITION BY day(`ts`);
 -- result:
 -- !result
-select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0} order by k1;
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.`day_partition` values (1, '2023-06-01 00:00:00');
+-- result:
+-- !result
+create view if not exists iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_${uuid0} as select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.day_partition;
+-- result:
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_${uuid0};
+-- result:
+1	2023-06-01 00:00:00
+-- !result
+drop view iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_${uuid0};
+-- result:
+-- !result
+CREATE TABLE iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.`iceberg_v2_parquet_partitioned_table` (
+ `k1` int(11) DEFAULT NULL,
+ `k2` string DEFAULT NULL,
+ `k3` string DEFAULT NULL
+)
+PARTITION BY (`k3`);
+-- result:
+-- !result
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.`iceberg_v2_parquet_partitioned_table` values (1, 'beijing', 'zhangsan'), (2, 'shanghai', 'lisi');
+-- result:
+-- !result
+create view if not exists iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_with_properties_${uuid0}
+properties ("owner"="alex") as select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_v2_parquet_partitioned_table;
+-- result:
+-- !result
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_with_properties_${uuid0} order by k1;
 -- result:
 1	beijing	zhangsan
 2	shanghai	lisi
 -- !result
-show create table iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
--- result:
-iceberg_v2_parquet_partitioned_table	CREATE TABLE `iceberg_v2_parquet_partitioned_table` (
-  `k1` int(11) DEFAULT NULL,
-  `k2` varchar(1073741824) DEFAULT NULL,
-  `k3` varchar(1073741824) DEFAULT NULL
-)
-PARTITION BY (`k3`)
-PROPERTIES ("write-format" = "parquet", "location" = "oss://starrocks-ci-test/iceberg_ci_db/iceberg_v2_parquet_partitioned_table", "write.upsert.enabled" = "true");
--- !result
-show create view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0};
+show create view iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_with_properties_${uuid0};
 -- result:
 [REGEX].*"owner" = "alex".*
 -- !result
-drop view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0};
+drop view iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_with_properties_${uuid0};
 -- result:
 -- !result
-create view if not exists iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0}
-properties ("owner"="alex", "comment"="this is a test view") as select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+create view if not exists iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_with_properties_${uuid0}
+properties ("owner"="alex", "comment"="this is a test view") as select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_v2_parquet_partitioned_table;
 -- result:
 -- !result
-select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0} order by k1;
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_with_properties_${uuid0} order by k1;
 -- result:
 1	beijing	zhangsan
 2	shanghai	lisi
 -- !result
-show create view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0};
+show create view iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_with_properties_${uuid0};
 -- result:
 [REGEX].*("owner" = "alex".*"comment" = "this is a test view"|"comment" = "this is a test view".*"owner" = "alex").*
 -- !result
-drop view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0};
+drop view iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_with_properties_${uuid0};
 -- result:
 -- !result
 create database default_catalog.test_internal_db_${uuid0};
@@ -64,59 +80,73 @@ E: (1064, 'Getting analyzing error. Detail message: Setting properties is only s
 drop database default_catalog.test_internal_db_${uuid0};
 -- result:
 -- !result
-create view if not exists iceberg_sql_test_${uuid0}.iceberg_ci_db.test_alter_iceberg_view_${uuid0} as select k1, k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+create view if not exists iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_alter_iceberg_view_${uuid0} as select k1, k2 from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_v2_parquet_partitioned_table;
 -- result:
 -- !result
-select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_alter_iceberg_view_${uuid0} order by k1;
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_alter_iceberg_view_${uuid0} order by k1;
 -- result:
 1	beijing
 2	shanghai
 -- !result
-alter view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_alter_iceberg_view_${uuid0} add dialect select k1, k2, k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+alter view iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_alter_iceberg_view_${uuid0} add dialect select k1, k2, k3 from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_v2_parquet_partitioned_table;
 -- result:
 E: (1064, 'Invalid view version: Cannot add multiple queries for dialect starrocks')
 -- !result
-alter view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_alter_iceberg_view_${uuid0} add dialect starrocks select k1, k2, k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+alter view iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_alter_iceberg_view_${uuid0} add dialect starrocks select k1, k2, k3 from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_v2_parquet_partitioned_table;
 -- result:
 E: (1064, 'Invalid view version: Cannot add multiple queries for dialect starrocks')
 -- !result
-alter view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_alter_iceberg_view_${uuid0} modify dialect starrocks select k1, k2, k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+alter view iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_alter_iceberg_view_${uuid0} modify dialect starrocks select k1, k2, k3 from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_v2_parquet_partitioned_table;
 -- result:
 -- !result
-select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_alter_iceberg_view_${uuid0} order by k1;
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_alter_iceberg_view_${uuid0} order by k1;
 -- result:
 1	beijing	zhangsan
 2	shanghai	lisi
 -- !result
-alter view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_alter_iceberg_view_${uuid0} set properties ('k1'='v1');
+alter view iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_alter_iceberg_view_${uuid0} set properties ('k1'='v1');
 -- result:
 -- !result
-drop view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_alter_iceberg_view_${uuid0};
+drop view iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_alter_iceberg_view_${uuid0};
 -- result:
 -- !result
-create view if not exists iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_cte_${uuid0} as
+create view if not exists iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_cte_${uuid0} as
 with cte as (select 1 as col1) select * from cte;
 -- result:
 -- !result
-select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_cte_${uuid0};
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_cte_${uuid0};
 -- result:
 1
 -- !result
-drop view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_cte_${uuid0};
+drop view iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_cte_${uuid0};
 -- result:
 -- !result
-create view if not exists iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_cte_${uuid0} as
-with cte as (select k1, k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table) select * from cte;
+create view if not exists iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_cte_${uuid0} as
+with cte as (select k1, k2 from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_v2_parquet_partitioned_table) select * from cte;
 -- result:
 -- !result
-select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_cte_${uuid0} order by k1;
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_cte_${uuid0} order by k1;
 -- result:
 1	beijing
 2	shanghai
 -- !result
-drop view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_cte_${uuid0};
+drop view iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_cte_${uuid0};
+-- result:
+-- !result
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.day_partition;
+-- result:
+-- !result
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_v2_parquet_partitioned_table;
+-- result:
+-- !result
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
 -- result:
 -- !result
 drop catalog iceberg_sql_test_${uuid0};
 -- result:
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_view${uuid0}/iceberg_db/${uuid0} > /dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
 -- !result

--- a/test/sql/test_iceberg/R/test_table_operation
+++ b/test/sql/test_iceberg/R/test_table_operation
@@ -1,4 +1,4 @@
--- name: test_table_operation
+-- name: test_table_operation @sequential
 create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
 -- result:
 -- !result

--- a/test/sql/test_iceberg/T/test_iceberg_view
+++ b/test/sql/test_iceberg/T/test_iceberg_view
@@ -2,31 +2,48 @@
 
 create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
 
-create view if not exists iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_${uuid0} as select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.day_partition;
+create database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0} properties (
+    "location" = "oss://${oss_bucket}/test_iceberg_view${uuid0}/iceberg_db/${uuid0}"
+);
 
-select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_${uuid0};
+ CREATE TABLE iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.`day_partition` (
+  `k1` int(11) DEFAULT NULL,
+  `ts` datetime DEFAULT NULL
+)
+PARTITION BY day(`ts`);
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.`day_partition` values (1, '2023-06-01 00:00:00');
 
-drop view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_${uuid0};
+create view if not exists iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_${uuid0} as select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.day_partition;
 
-create view if not exists iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0}
-properties ("owner"="alex") as select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_${uuid0};
 
-select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0} order by k1;
+drop view iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_${uuid0};
 
-show create table iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+ CREATE TABLE iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.`iceberg_v2_parquet_partitioned_table` (
+  `k1` int(11) DEFAULT NULL,
+  `k2` string DEFAULT NULL,
+  `k3` string DEFAULT NULL
+)
+PARTITION BY (`k3`);
+insert into iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.`iceberg_v2_parquet_partitioned_table` values (1, 'beijing', 'zhangsan'), (2, 'shanghai', 'lisi');
 
-show create view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0};
+create view if not exists iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_with_properties_${uuid0}
+properties ("owner"="alex") as select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_v2_parquet_partitioned_table;
 
-drop view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0};
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_with_properties_${uuid0} order by k1;
 
-create view if not exists iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0}
-properties ("owner"="alex", "comment"="this is a test view") as select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+show create view iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_with_properties_${uuid0};
 
-select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0} order by k1;
+drop view iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_with_properties_${uuid0};
 
-show create view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0};
+create view if not exists iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_with_properties_${uuid0}
+properties ("owner"="alex", "comment"="this is a test view") as select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_v2_parquet_partitioned_table;
 
-drop view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_with_properties_${uuid0};
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_with_properties_${uuid0} order by k1;
+
+show create view iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_with_properties_${uuid0};
+
+drop view iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_with_properties_${uuid0};
 
 create database default_catalog.test_internal_db_${uuid0};
 
@@ -34,35 +51,40 @@ create view if not exists default_catalog.test_internal_db_${uuid0}.test_interna
 
 drop database default_catalog.test_internal_db_${uuid0};
 
-create view if not exists iceberg_sql_test_${uuid0}.iceberg_ci_db.test_alter_iceberg_view_${uuid0} as select k1, k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+create view if not exists iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_alter_iceberg_view_${uuid0} as select k1, k2 from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_v2_parquet_partitioned_table;
 
-select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_alter_iceberg_view_${uuid0} order by k1;
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_alter_iceberg_view_${uuid0} order by k1;
 
-alter view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_alter_iceberg_view_${uuid0} add dialect select k1, k2, k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+alter view iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_alter_iceberg_view_${uuid0} add dialect select k1, k2, k3 from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_v2_parquet_partitioned_table;
 
-alter view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_alter_iceberg_view_${uuid0} add dialect starrocks select k1, k2, k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+alter view iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_alter_iceberg_view_${uuid0} add dialect starrocks select k1, k2, k3 from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_v2_parquet_partitioned_table;
 
-alter view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_alter_iceberg_view_${uuid0} modify dialect starrocks select k1, k2, k3 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table;
+alter view iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_alter_iceberg_view_${uuid0} modify dialect starrocks select k1, k2, k3 from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_v2_parquet_partitioned_table;
 
-select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_alter_iceberg_view_${uuid0} order by k1;
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_alter_iceberg_view_${uuid0} order by k1;
 
-alter view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_alter_iceberg_view_${uuid0} set properties ('k1'='v1');
+alter view iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_alter_iceberg_view_${uuid0} set properties ('k1'='v1');
 
-drop view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_alter_iceberg_view_${uuid0};
+drop view iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_alter_iceberg_view_${uuid0};
 
 -- test iceberg view with CTE
-create view if not exists iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_cte_${uuid0} as
+create view if not exists iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_cte_${uuid0} as
 with cte as (select 1 as col1) select * from cte;
 
-select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_cte_${uuid0};
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_cte_${uuid0};
 
-drop view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_cte_${uuid0};
+drop view iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_cte_${uuid0};
 
-create view if not exists iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_cte_${uuid0} as
-with cte as (select k1, k2 from iceberg_sql_test_${uuid0}.iceberg_ci_db.iceberg_v2_parquet_partitioned_table) select * from cte;
+create view if not exists iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_cte_${uuid0} as
+with cte as (select k1, k2 from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_v2_parquet_partitioned_table) select * from cte;
 
-select * from iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_cte_${uuid0} order by k1;
+select * from iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_cte_${uuid0} order by k1;
 
-drop view iceberg_sql_test_${uuid0}.iceberg_ci_db.test_iceberg_view_cte_${uuid0};
+drop view iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.test_iceberg_view_cte_${uuid0};
 
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.day_partition;
+drop table iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}.iceberg_v2_parquet_partitioned_table;
+drop database iceberg_sql_test_${uuid0}.iceberg_db_${uuid0};
 drop catalog iceberg_sql_test_${uuid0};
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_iceberg_view${uuid0}/iceberg_db/${uuid0} > /dev/null || echo "exit 0" >/dev/null

--- a/test/sql/test_iceberg/T/test_table_operation
+++ b/test/sql/test_iceberg/T/test_table_operation
@@ -1,4 +1,4 @@
--- name: test_table_operation
+-- name: test_table_operation @sequential
 
 create external catalog iceberg_sql_test_${uuid0} PROPERTIES ("type"="iceberg", "iceberg.catalog.type"="hive", "iceberg.catalog.hive.metastore.uris"="${iceberg_catalog_hive_metastore_uris}","enable_iceberg_metadata_cache"="true","aws.s3.access_key" = "${oss_ak}","aws.s3.secret_key" = "${oss_sk}","aws.s3.endpoint" = "${oss_endpoint}");
 


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:
 Fix unstable UT
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [X] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stabilizes Iceberg SQL tests by using an isolated per-run DB with explicit setup/teardown, marks table ops as sequential, and updates view/table operation flows and cleanup.
> 
> - **Tests (Iceberg)**:
>   - **Isolation & setup**: Create per-run DB `iceberg_sql_test_${uuid0}.iceberg_db_${uuid0}` with OSS location; define `day_partition` and `iceberg_v2_parquet_partitioned_table`; seed data.
>   - **View tests**: Point views/queries to the new DB; verify properties via `show create`; exercise alter-dialect flows and CTE-based views.
>   - **Teardown**: Drop created views/tables/db/catalog and invoke `ossutil64` to clean OSS paths.
> - **Tests (Table operations)**:
>   - Mark `test_table_operation` as `@sequential`.
>   - Execute branch/fast_forward/cherrypick/expire_snapshots flows with both positional and named args; validate results; add full cleanup including OSS deletion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98dbe60120514ed28d34f9605a2e5de536f64829. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->