### PR TITLE
[BugFix] Fix check can_use_bf when merging runtime filter

### DIFF
--- a/test/sql/test_runtime_filter/R/test_runtime_filter_partial_exceed
+++ b/test/sql/test_runtime_filter/R/test_runtime_filter_partial_exceed
@@ -1,0 +1,155 @@
+-- name: test_runtime_filter_partial_exceed
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+-- result:
+-- !result
+insert into __row_util_base select * from __row_util_base; -- 20000
+insert into __row_util_base select * from __row_util_base; -- 40000
+insert into __row_util_base select * from __row_util_base; -- 80000
+insert into __row_util_base select * from __row_util_base; -- 160000
+
+CREATE TABLE __row_util (
+  idx bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into __row_util select row_number() over() as idx from __row_util_base;
+-- result:
+-- !result
+CREATE TABLE `t1` (
+  `idx` bigint(20) NULL COMMENT "",
+  `c1` bigint(20) NULL COMMENT "",
+  `c2` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 32
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1 select idx, 1, 1 from __row_util;
+-- result:
+-- !result
+insert into t1 select idx, 2, 2 from __row_util where idx < 160000 - 10;
+-- result:
+-- !result
+insert into t1 select idx, 3, 3 from __row_util where idx < 160000 - 10;
+-- result:
+-- !result
+insert into t1 select idx, 4, 4 from __row_util where idx < 160000 - 10;
+-- result:
+-- !result
+insert into t1 select idx, 5, 5 from __row_util where idx < 160000 - 10;
+-- result:
+-- !result
+insert into t1 select idx, 6, 6 from __row_util where idx < 160000 - 10;
+-- result:
+-- !result
+insert into t1 select idx, idx, idx  from __row_util where idx > 4;
+-- result:
+-- !result
+[UC]analyze table t1;
+-- result:
+test_db_b04c71e57dc14ea187423c8853d0f38e.t1	analyze	status	OK
+-- !result
+set pipeline_dop = 100;
+-- result:
+-- !result
+set enable_join_runtime_bitset_filter = false;
+-- result:
+-- !result
+set semi_join_deduplicat_mode = -1;
+-- result:
+-- !result
+set global_runtime_filter_wait_timeout = 10000;
+-- result:
+-- !result
+set runtime_filter_scan_wait_time = 10000;
+-- result:
+-- !result
+set global_runtime_filter_build_max_size = 320001;
+-- result:
+-- !result
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+-- result:
+959950
+-- !result
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+-- result:
+959950
+-- !result
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+-- result:
+959950
+-- !result
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+-- result:
+959950
+-- !result
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+-- result:
+959950
+-- !result
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+-- result:
+959950
+-- !result
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+-- result:
+959950
+-- !result
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+-- result:
+959950
+-- !result
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+-- result:
+959950
+-- !result
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+-- result:
+959950
+-- !result
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+-- result:
+959950
+-- !result
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+-- result:
+959950
+-- !result
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+-- result:
+959950
+-- !result
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+-- result:
+959950
+-- !result
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+-- result:
+959950
+-- !result
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+-- result:
+959950
+-- !result
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+-- result:
+959950
+-- !result

--- a/test/sql/test_runtime_filter/T/test_runtime_filter_partial_exceed
+++ b/test/sql/test_runtime_filter/T/test_runtime_filter_partial_exceed
@@ -1,0 +1,70 @@
+-- name: test_runtime_filter_partial_exceed
+CREATE TABLE __row_util_base (
+  k1 bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util_base select generate_series from TABLE(generate_series(0, 10000 - 1));
+insert into __row_util_base select * from __row_util_base; -- 20000
+insert into __row_util_base select * from __row_util_base; -- 40000
+insert into __row_util_base select * from __row_util_base; -- 80000
+insert into __row_util_base select * from __row_util_base; -- 160000
+
+CREATE TABLE __row_util (
+  idx bigint NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 32
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into __row_util select row_number() over() as idx from __row_util_base;
+
+CREATE TABLE `t1` (
+  `idx` bigint(20) NULL COMMENT "",
+  `c1` bigint(20) NULL COMMENT "",
+  `c2` bigint(20) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`idx`)
+DISTRIBUTED BY HASH(`idx`) BUCKETS 32
+PROPERTIES (
+"replication_num" = "1"
+);
+insert into t1 select idx, 1, 1 from __row_util;
+insert into t1 select idx, 2, 2 from __row_util where idx < 160000 - 10;
+insert into t1 select idx, 3, 3 from __row_util where idx < 160000 - 10;
+insert into t1 select idx, 4, 4 from __row_util where idx < 160000 - 10;
+insert into t1 select idx, 5, 5 from __row_util where idx < 160000 - 10;
+insert into t1 select idx, 6, 6 from __row_util where idx < 160000 - 10;
+insert into t1 select idx, idx, idx  from __row_util where idx > 4;
+
+[UC]analyze table t1;
+
+set pipeline_dop = 100;
+set enable_join_runtime_bitset_filter = false;
+set semi_join_deduplicat_mode = -1;
+set global_runtime_filter_wait_timeout = 10000;
+set runtime_filter_scan_wait_time = 10000;
+set global_runtime_filter_build_max_size = 320001;
+
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+select count(1) from t1 left semi join [shuffle] t1 t2 on t1.c1 = t2.c1 and t2.c2 < 10;
+


### PR DESCRIPTION
## Why I'm doing:

### Wrong can_use_bf
Since 3.5.2 , the invocation semantics of `merge_membership_filter` changed: it is now invoked only once after **ALL** partial runtime filters have arrived, instead of being invoked on each arrival as before.This change causes the `can_use_bf` check to become incorrect:

- It only checks whether the **last** partial runtime filter can use a Bloom filter (`can_use_bf`).
- It only checks whether the **last** partial runtime filter’s size exceeds `global_runtime_filter_build_max_size`, instead of checking whether the **sum** of all partial runtime filters exceeds `global_runtime_filter_build_max_size`.

### Causing wrong result
As a result, when both of the following conditions are met, the system will incorrectly conclude that the final runtime filter is usable, leading to **wrong results:**

- One partial runtime filter exceeds `global_runtime_filter_build_max_size`, while the others do not.
- The oversized partial runtime filter arrives earlier, and the last-arriving partial runtime filter is within the threshold.

### Causing crash
In addition, the logic that concatenates all partial runtime filters works as follows:

1. If `can_use_bf` is `false`, convert all partial runtime filters to `RuntimeEmptyFilter`.
2. Concatenate all partial runtime filters together.

Note that step 2 assumes all partial runtime filters are of **the same type**—either all `RuntimeEmptyFilter` or all `RuntimeBloomFilter`. However, due to the incorrect `can_use_bf` decision, step 1 is skipped, so a `RuntimeBloomFilter` and a `RuntimeEmptyFilter` may be concatenated together. This causes `RuntimeEmptyFilter` to be forcibly cast to `RuntimeBloomFilter`, resulting in a crash.

## What I'm doing:

Fixes #63754

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
