### PR TITLE
[Doc] Improve Query Profile example and fix typos

### DIFF
--- a/docs/en/best_practices/query_tuning/query_profile_overview.md
+++ b/docs/en/best_practices/query_tuning/query_profile_overview.md
@@ -82,20 +82,25 @@ Example workflow:
 
 ```sql
 -- Enable the profiling feature.
-set enable_profile = true;
--- Run a simple query.
-select 1;
+SET enable_profile = true;
+
+-- Run a query that performs a scan and aggregation to generate a meaningful profile.
+-- (Using a system table ensures this works on any cluster)
+SELECT count(*) FROM information_schema.columns;
+
 -- Get the query_id of the query.
-select last_query_id();
+SELECT last_query_id();
 +--------------------------------------+
 | last_query_id()                      |
 +--------------------------------------+
-| bd3335ce-8dde-11ee-92e4-3269eb8da7d1 |
+| 019b364f-10c4-704c-b79a-af2cc3a77b89 |
 +--------------------------------------+
+
 -- Get the list of profiles
-show profilelist;
+SHOW PROFILELIST;
+
 -- Obtain the query profile.
-select get_query_profile('502f3c04-8f5c-11ee-a41f-b22a2c00f66b')\G
+SELECT get_query_profile('019b364f-10c4-704c-b79a-af2cc3a77b89')\G
 ```
 
 ### In Managed Version
@@ -108,7 +113,7 @@ In StarRocks Managed (Enterprise) environments, you can conveniently access quer
 
 Most users may find it challenging to analyze the raw text directly. StarRocks provides a [Text-based Query Profile Visualized Analysis](./query_profile_text_based_analysis.md) method for a more intuitive understanding.
 
-### Manged Version
+### Managed Version
 
 In the StarRocks Enterprise Edition (EE), the Managed Version provides a built-in visualization tool for query profiles. This tool offers an interactive, graphical interface that makes it much easier to interpret complex query execution details compared to raw text output.
 

--- a/docs/ja/best_practices/query_tuning/query_profile_overview.md
+++ b/docs/ja/best_practices/query_tuning/query_profile_overview.md
@@ -81,20 +81,25 @@ SET runtime_profile_report_interval = 30;
 
 ```sql
 -- プロファイリング機能を有効にします。
-set enable_profile = true;
--- シンプルなクエリを実行します。
-select 1;
+SET enable_profile = true;
+
+-- スキャンと集計を実行して、詳細なプロファイルを生成するクエリを実行します。
+-- （システムテーブルを使用することで、どのクラスタでも動作します）
+SELECT count(*) FROM information_schema.columns;
+
 -- クエリの query_id を取得します。
-select last_query_id();
+SELECT last_query_id();
 +--------------------------------------+
 | last_query_id()                      |
 +--------------------------------------+
-| bd3335ce-8dde-11ee-92e4-3269eb8da7d1 |
+| 019b364f-10c4-704c-b79a-af2cc3a77b89 |
 +--------------------------------------+
+
 -- プロファイルのリストを取得します。
-show profilelist;
+SHOW PROFILELIST;
+
 -- クエリプロファイルを取得します。
-select get_query_profile('502f3c04-8f5c-11ee-a41f-b22a2c00f66b')\G
+SELECT get_query_profile('019b364f-10c4-704c-b79a-af2cc3a77b89')\G
 ```
 
 ### マネージドバージョンで

--- a/docs/zh/best_practices/query_tuning/query_profile_overview.md
+++ b/docs/zh/best_practices/query_tuning/query_profile_overview.md
@@ -81,20 +81,25 @@ SET runtime_profile_report_interval = 30;
 
 ```sql
 -- 启用 profiling 功能。
-set enable_profile = true;
--- 运行一个简单的查询。
-select 1;
+SET enable_profile = true;
+
+-- 运行一个包含扫描和聚合的查询以生成有意义的 Profile。
+-- （使用系统表确保该查询可在任何集群上运行）
+SELECT count(*) FROM information_schema.columns;
+
 -- 获取查询的 query_id。
-select last_query_id();
+SELECT last_query_id();
 +--------------------------------------+
 | last_query_id()                      |
 +--------------------------------------+
-| bd3335ce-8dde-11ee-92e4-3269eb8da7d1 |
+| 019b364f-10c4-704c-b79a-af2cc3a77b89 |
 +--------------------------------------+
+
 -- 获取 profile 列表
-show profilelist;
+SHOW PROFILELIST;
+
 -- 获取查询 profile。
-select get_query_profile('502f3c04-8f5c-11ee-a41f-b22a2c00f66b')\G
+SELECT get_query_profile('019b364f-10c4-704c-b79a-af2cc3a77b89')\G
 ```
 
 ### 在托管版本中


### PR DESCRIPTION
## Why I'm doing:

The current documentation uses `SELECT 1` as an example to demonstrate Query Profiling. However, `SELECT 1` often executes instantly (0ms), causing two main issues for learners:
1. It sometimes does not appear in `SHOW PROFILELIST` due to its speed.
2. It generates an empty or trivial Query Profile tree (no Scan, Join, or Aggregation nodes), which makes it a poor example for explaining how to interpret a profile.

Additionally, I found a typo ("Manged") in the English documentation.

## What I'm doing:

1. **Improved Example:** I updated `docs/en`, `docs/zh`, and `docs/ja` versions of `query_profile_overview.md`.
   - Replaced `SELECT 1` with `SELECT count(*) FROM information_schema.columns;`.
   - This query works on any cluster (no user data required) and guarantees the execution of Scan and Aggregation nodes, producing a meaningful profile graph for demonstration.

2. **Typo Fix:** Fixed `Manged Version` -> `Managed Version` in the English documentation.

Fixes #

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3