### PR TITLE
[BugFix] Fix Java UDAF causes OOM may happened in Java Heap Error

### DIFF
--- a/be/src/udf/java/java_data_converter.cpp
+++ b/be/src/udf/java/java_data_converter.cpp
@@ -540,7 +540,8 @@ Status JavaDataTypeConverter::convert_to_boxed_array(FunctionContext* ctx, const
     JNIEnv* env = helper.getEnv();
     for (int i = 0; i < num_cols; ++i) {
         jobject arg = nullptr;
-        if (columns[i]->only_null()) {
+        if (columns[i]->only_null() ||
+            (columns[i]->is_nullable() && down_cast<const NullableColumn*>(columns[i])->null_count() == num_rows)) {
             arg = helper.create_array(num_rows);
         } else if (columns[i]->is_constant()) {
             auto* data_column = down_cast<const ConstColumn*>(columns[i])->data_column_raw_ptr();

--- a/test/sql/test_udf/R/test_jvm_udf
+++ b/test/sql/test_udf/R/test_jvm_udf
@@ -336,3 +336,14 @@ select count(*) from (select * from t1 where any_match((x)->cast(echoint(1) as b
 -- result:
 40960
 -- !result
+select sumbigint(null);
+-- result:
+0
+-- !result
+select sumbigint(x)
+from (
+  select null as x
+)t;
+-- result:
+0
+-- !result

--- a/test/sql/test_udf/T/test_jvm_udf
+++ b/test/sql/test_udf/T/test_jvm_udf
@@ -214,3 +214,9 @@ PROPERTIES (
 
 insert into t1 SELECT generate_series, 4096 - generate_series, [generate_series] FROM TABLE(generate_series(1,  40960));
 select count(*) from (select * from t1 where any_match((x)->cast(echoint(1) as boolean), c2)) t;
+
+select sumbigint(null);
+select sumbigint(x)
+from (
+  select null as x
+)t;


### PR DESCRIPTION
## Why I'm doing:
Fixes #67024
## What I'm doing:

Fixes #67024

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Handle all-null nullable columns in Java UDF argument conversion and add tests ensuring sumbigint(null) returns 0.
> 
> - **Backend (Java UDF arg conversion)**:
>   - Update `JavaDataTypeConverter::convert_to_boxed_array` to treat nullable columns with `null_count == num_rows` as all-null and create a pre-sized array via `helper.create_array(num_rows)`.
> - **Tests**:
>   - Add SQL cases in `test/sql/test_udf/{T,R}/test_jvm_udf` validating `sumbigint(null)` and `sumbigint` over a `null` column return `0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c24a5002174cb66e5a7568e3fb7303bbba7da275. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->