### PR TITLE
[BugFix] Change deallocation order in exec_env->destroy to prevent Use-After-Free in MemTracker::~MemTracker

### DIFF
--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -864,6 +864,8 @@ void ExecEnv::destroy() {
     SAFE_DELETE(_query_rpc_pool);
     SAFE_DELETE(_datacache_rpc_pool);
     _load_rpc_pool.reset();
+    SAFE_DELETE(_stream_mgr);
+    SAFE_DELETE(_query_context_mgr);
     _workgroup_manager->destroy();
     _workgroup_manager.reset();
     SAFE_DELETE(_thread_pool);
@@ -874,7 +876,6 @@ void ExecEnv::destroy() {
         _lake_tablet_manager->prune_metacache();
     }
 
-    SAFE_DELETE(_query_context_mgr);
     // WorkGroupManager should release MemTracker of WorkGroups belongs to itself before deallocate
     // _query_pool_mem_tracker.
     SAFE_DELETE(_runtime_filter_cache);
@@ -893,7 +894,6 @@ void ExecEnv::destroy() {
     SAFE_DELETE(_backend_client_cache);
     SAFE_DELETE(_result_queue_mgr);
     SAFE_DELETE(_result_mgr);
-    SAFE_DELETE(_stream_mgr);
     SAFE_DELETE(_lookup_dispatcher_mgr);
     SAFE_DELETE(_batch_write_mgr);
     SAFE_DELETE(_external_scan_context_mgr);

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -203,7 +203,8 @@ MemTracker::~MemTracker() {
 #ifdef DEBUG
     {
         std::unique_lock<std::mutex> lock(_child_trackers_lock);
-        DCHECK(_child_trackers.size() == 0) << err_msg("Child mem trackers have not been released, may cause corruption" );
+        DCHECK(_child_trackers.size() == 0)
+                << err_msg("Child mem trackers have not been released, may cause corruption");
     }
 #endif
 

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -203,8 +203,7 @@ MemTracker::~MemTracker() {
 #ifdef DEBUG
     {
         std::unique_lock<std::mutex> lock(_child_trackers_lock);
-        DCHECK(_child_trackers.empty())
-                << err_msg("Child mem trackers have not been released, may cause corruption");
+        DCHECK(_child_trackers.empty()) << err_msg("Child mem trackers have not been released, may cause corruption");
     }
 #endif
 

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -199,6 +199,14 @@ MemTracker::~MemTracker() {
     if (parent()) {
         unregister_from_parent();
     }
+
+#ifdef DEBUG
+    {
+        std::unique_lock<std::mutex> lock(_child_trackers_lock);
+        DCHECK(_child_trackers.size() == 0) << err_msg("Child mem trackers have not been released, may cause corruption" );
+    }
+#endif
+
     // When the mem_tracker is destroyed, manually setting _consumption to null can easily
     // trigger a use-after-free bug in MemTracker.
     _consumption = nullptr;

--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -203,7 +203,7 @@ MemTracker::~MemTracker() {
 #ifdef DEBUG
     {
         std::unique_lock<std::mutex> lock(_child_trackers_lock);
-        DCHECK(_child_trackers.size() == 0)
+        DCHECK(_child_trackers.empty())
                 << err_msg("Child mem trackers have not been released, may cause corruption");
     }
 #endif


### PR DESCRIPTION
## Why I'm doing:

### Problem
MemTrackers are organized hierarchically. A typical query hierarchy looks like this:
1. `_query_pool_mem_tracker` (root)
2. `WorkGroup::_mem_tracker` (parent)
3. `QueryContext::_query_mem_tracker` (child)
4. `RuntimeState::_instance_mem_tracker` (grandchild - held by `DataStreamRecvr`)

### The Issue

During BE shutdown while a query is still running, the destruction order in `ExecEnv::destroy` causes a Use-After-Free:
1. `WorkGroupManager` is destroyed first
2. `QueryContextManager` is deleted next. This is safe because it holds a shared_ptr ref to WorkGroup. WorkGroup along its MemTrackers can get deallocated now.
3. When `DataStreamMgr` is destroyed, its `_query_mem_tracker` destructor attempts to release the remaining memory quota to its parent.
4. Since the parent (`WorkGroup` tracker) was already freed in step 2, accessing the raw pointer results in a **SEGFAULT**.

## What I'm doing:
I have modified the deallocation order in `ExecEnv::destroy`.
I moved the destruction of `WorkGroupManager` to occur **after** `QueryContextManager` and `DataStreamMgr`. This ensures that the parent `WorkGroup` tracker remains valid until all child query trackers have been safely destroyed.

Fixes #67026

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents potential use-after-free during BE shutdown by ensuring child query trackers are destroyed before their parent workgroup trackers.
> 
> - Reorders teardown in `ExecEnv::destroy`: delete `DataStreamMgr` and `QueryContextManager` before calling `WorkGroupManager::destroy()`
> - Adds DEBUG-only guard in `MemTracker::~MemTracker` to assert `_child_trackers` is empty (with locking)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8dc45cc8e6158f9edb72b12402f0af9c0c0aafc9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->