### PR TITLE
[Enhancement] Iceberg manifest-list cache

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/SnapshotManifests.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/SnapshotManifests.java
@@ -1,0 +1,42 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import org.apache.iceberg.ManifestFile;
+
+import java.util.List;
+
+/**
+ * Holds cached manifest lists for an Iceberg snapshot.
+ * This avoids re-reading and re-parsing the manifest-list file (snap-*.avro)
+ * on every query to the same snapshot.
+ */
+public class SnapshotManifests {
+    private final List<ManifestFile> dataManifests;
+    private final List<ManifestFile> deleteManifests;
+
+    public SnapshotManifests(List<ManifestFile> dataManifests, List<ManifestFile> deleteManifests) {
+        this.dataManifests = dataManifests;
+        this.deleteManifests = deleteManifests;
+    }
+
+    public List<ManifestFile> getDataManifests() {
+        return dataManifests;
+    }
+
+    public List<ManifestFile> getDeleteManifests() {
+        return deleteManifests;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/StarRocksIcebergTableScanContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/StarRocksIcebergTableScanContext.java
@@ -17,6 +17,7 @@ package com.starrocks.connector.iceberg;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.starrocks.connector.PlanMode;
 import com.starrocks.connector.iceberg.CachingIcebergCatalog.IcebergTableName;
+import com.starrocks.connector.iceberg.SnapshotManifests;
 import com.starrocks.qe.ConnectContext;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
@@ -33,6 +34,7 @@ public class StarRocksIcebergTableScanContext {
     private Cache<String, Set<DataFile>> dataFileCache;
     private Cache<String, Set<DeleteFile>> deleteFileCache;
     private Map<IcebergTableName, Set<String>> metaFileCacheMap;
+    private Cache<Long, SnapshotManifests> manifestListCache;
     private boolean onlyReadCache;
     private int localParallelism;
     private long localPlanningMaxSlotSize;
@@ -94,6 +96,14 @@ public class StarRocksIcebergTableScanContext {
 
     public void setMetaFileCacheMap(Map<IcebergTableName, Set<String>> metaFileCacheMap) {
         this.metaFileCacheMap = metaFileCacheMap;
+    }
+
+    public Cache<Long, SnapshotManifests> getManifestListCache() {
+        return manifestListCache;
+    }
+
+    public void setManifestListCache(Cache<Long, SnapshotManifests> manifestListCache) {
+        this.manifestListCache = manifestListCache;
     }
 
     public boolean isOnlyReadCache() {


### PR DESCRIPTION
## Why I'm doing:
Avoid io on query plannig for caching iceberg catalog

## What I'm doing:
Add missing manifest list cache
```
  When planning an Iceberg table scan, the following caches are consulted in order:

  1. Table (from tables cache)
     └─ CachingIcebergCatalog.getTable()
     └─ Cache: tables (IcebergTableCacheKey -> Table)
     └─ On miss: reads metadata.json from S3/HDFS

  2. Snapshot (from Table object)
     └─ table.currentSnapshot() or table.snapshot(snapshotId)
     └─ Not cached separately — part of the Table object

  3. List<ManifestFile> (from manifestListCache) ← NEW
     └─ StarRocksIcebergTableScan.getDataManifestsWithCache()
     └─ Cache: manifestListCache (snapshotId -> SnapshotManifests)
     └─ On miss: snapshot.dataManifests(io()) — reads snap-*.avro

  4. Manifest filtering
     └─ StarRocksIcebergTableScan.findMatchingDataManifests()
     └─ Applies partition filter to ManifestFile.partitions()
     └─ Prunes manifests that cannot contain matching data

  5. Set<DataFile> per manifest
     └─ ManifestReader / StarRocksManifestReader
     └─ Cache: dataFileCache (manifest path -> Set<DataFile>)
     └─ On miss: reads *.avro manifest file
     └─ Records path in metaFileCacheMap for invalidation

  6. DataFile filtering
     └─ Applies residual filter to each DataFile
     └─ Checks column statistics (min/max/null count)

  7. Same flow for DeleteFiles
     └─ getDeleteManifestsWithCache() → deleteFileCache

  Cache hierarchy:
  metadata.json ─[tables cache]─► Table
                                    │
                                    ▼
                                Snapshot
                                    │
                      ┌─[manifestListCache]─┐
                      │                     │
                      ▼                     ▼
              List<ManifestFile>     List<ManifestFile>
                (data)                 (delete)
                      │                     │
           ┌─[dataFileCache]─┐    ┌─[deleteFileCache]─┐
           │                 │    │                   │
           ▼                 ▼    ▼                   ▼
      Set<DataFile>    Set<DataFile>  Set<DeleteFile> ...
```
Fixes #67033

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
