### PR TITLE
[BugFix] Nullaware left anti join correlated subquery should not apply partition join

### DIFF
--- a/be/src/exec/hash_join_components.cpp
+++ b/be/src/exec/hash_join_components.cpp
@@ -33,6 +33,8 @@
 
 namespace starrocks {
 
+DEFINE_FAIL_POINT(always_use_partition_join);
+
 class SingleHashJoinProberImpl final : public HashJoinProberImpl {
 public:
     SingleHashJoinProberImpl(HashJoiner& hash_joiner) : HashJoinProberImpl(hash_joiner) {}
@@ -367,7 +369,9 @@ bool SingleHashJoinBuilder::anti_join_key_column_has_null() const {
     auto& column = _ht.get_key_columns()[0];
     if (column->is_nullable()) {
         const auto& null_column = ColumnHelper::as_raw_column<NullableColumn>(column)->null_column();
-        DCHECK_GT(null_column->size(), 0);
+        if (null_column->empty()) {
+            return false;
+        }
         return null_column->contain_value(1, null_column->size(), 1);
     }
     return false;
@@ -593,16 +597,19 @@ size_t AdaptivePartitionHashJoinBuilder::_estimate_cost_by_bytes<CacheLevel::MEM
 }
 
 bool AdaptivePartitionHashJoinBuilder::_need_partition_join_for_build(size_t ht_num_rows) const {
+    FAIL_POINT_TRIGGER_RETURN(always_use_partition_join, true);
     return (_partition_join_l2_min_rows < ht_num_rows && ht_num_rows <= _partition_join_l2_max_rows) ||
            (_partition_join_l3_min_rows < ht_num_rows && ht_num_rows <= _partition_join_l3_max_rows);
 }
 
 bool AdaptivePartitionHashJoinBuilder::_need_partition_join_for_append(size_t ht_num_rows) const {
+    FAIL_POINT_TRIGGER_RETURN(always_use_partition_join, true);
     return ht_num_rows <= _partition_join_l2_max_rows || ht_num_rows <= _partition_join_l3_max_rows;
 }
 
 void AdaptivePartitionHashJoinBuilder::_adjust_partition_rows(size_t hash_table_bytes_per_row,
                                                               size_t hash_table_probing_bytes_per_row) {
+    FAIL_POINT_TRIGGER_RETURN(always_use_partition_join, (void)0);
     if (hash_table_bytes_per_row == _hash_table_bytes_per_row &&
         hash_table_probing_bytes_per_row == _hash_table_probing_bytes_per_row) {
         return; // No need to adjust partition rows.

--- a/be/src/exec/hash_join_components.h
+++ b/be/src/exec/hash_join_components.h
@@ -175,7 +175,10 @@ public:
 
     ChunkPtr convert_to_spill_schema(const ChunkPtr& chunk) const override;
 
+    void set_is_sub_partition(bool is_sub_partition) { _is_sub_partition = is_sub_partition; }
+
 private:
+    bool _is_sub_partition = false;
     JoinHashTable _ht;
     Columns _key_columns;
 };

--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -100,7 +100,8 @@ HashJoiner::HashJoiner(const HashJoinerParam& param)
     }
 
     HashJoinBuildOptions build_options;
-    build_options.enable_partitioned_hash_join = param._enable_partition_hash_join;
+    build_options.enable_partitioned_hash_join =
+            param._enable_partition_hash_join && support_partitioned(_join_type, !_other_join_conjunct_ctxs.empty());
 
     _hash_join_builder = HashJoinBuilderFactory::create(_pool, build_options, *this);
     _hash_join_prober = _pool->add(new HashJoinProber(*this));

--- a/be/src/exec/hash_joiner.h
+++ b/be/src/exec/hash_joiner.h
@@ -143,6 +143,14 @@ inline bool has_post_probe(TJoinOp::type join_type) {
            join_type == TJoinOp::FULL_OUTER_JOIN;
 }
 
+inline bool support_partitioned(TJoinOp::type join_type, bool has_other_conjuncts) {
+    return join_type == TJoinOp::LEFT_SEMI_JOIN || join_type == TJoinOp::INNER_JOIN ||
+           join_type == TJoinOp::LEFT_ANTI_JOIN || join_type == TJoinOp::LEFT_OUTER_JOIN ||
+           join_type == TJoinOp::RIGHT_OUTER_JOIN || join_type == TJoinOp::RIGHT_ANTI_JOIN ||
+           join_type == TJoinOp::RIGHT_SEMI_JOIN || join_type == TJoinOp::FULL_OUTER_JOIN ||
+           (join_type == TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN && !has_other_conjuncts);
+}
+
 inline bool is_spillable(TJoinOp::type join_type) {
     return join_type == TJoinOp::LEFT_SEMI_JOIN || join_type == TJoinOp::INNER_JOIN ||
            join_type == TJoinOp::LEFT_ANTI_JOIN || join_type == TJoinOp::LEFT_OUTER_JOIN ||

--- a/be/src/exec/join/join_hash_table.cpp
+++ b/be/src/exec/join/join_hash_table.cpp
@@ -630,7 +630,7 @@ int64_t JoinHashTable::mem_usage() const {
     return usage;
 }
 
-Status JoinHashTable::build(RuntimeState* state) {
+Status JoinHashTable::build(RuntimeState* state, bool allow_build_empty_table) {
     CancelableDefer defer = CancelableDefer([&]() {
         _table_items->key_columns.clear();
         _table_items->build_chunk->columns().clear();
@@ -651,7 +651,7 @@ Status JoinHashTable::build(RuntimeState* state) {
 
     RETURN_IF_ERROR(_upgrade_key_columns_if_overflow());
 
-    if (_table_items->row_count == 0) {
+    if (_table_items->row_count == 0 && allow_build_empty_table) {
         _is_empty_map = true;
         _hash_map = std::make_unique<JoinHashMapForEmpty>(_table_items.get(), _probe_state.get());
     } else {

--- a/be/src/exec/join/join_hash_table.cpp
+++ b/be/src/exec/join/join_hash_table.cpp
@@ -66,8 +66,6 @@ private:
 
 std::tuple<JoinKeyConstructorUnaryType, JoinHashMapMethodUnaryType>
 JoinHashMapSelector::construct_key_and_determine_hash_map(RuntimeState* state, JoinHashTableItems* table_items) {
-    DCHECK_GT(table_items->row_count, 0);
-
     const auto key_constructor_type = _determine_key_constructor(state, table_items);
     dispatch_join_key_constructor_unary(key_constructor_type, [&]<JoinKeyConstructorUnaryType CT> {
         using KeyConstructor = typename JoinKeyConstructorUnaryTypeTraits<CT>::BuildType;

--- a/be/src/exec/join/join_hash_table.h
+++ b/be/src/exec/join/join_hash_table.h
@@ -44,7 +44,7 @@ public:
     void create(const HashTableParam& param);
     void close();
 
-    Status build(RuntimeState* state, bool allow_build_empty_table = false);
+    Status build(RuntimeState* state, bool allow_build_empty_table = true);
     void reset_probe_state(RuntimeState* state);
     Status probe(RuntimeState* state, const Columns& key_columns, ChunkPtr* probe_chunk, ChunkPtr* chunk, bool* eos);
     Status probe_remain(RuntimeState* state, ChunkPtr* chunk, bool* eos);

--- a/be/src/exec/join/join_hash_table.h
+++ b/be/src/exec/join/join_hash_table.h
@@ -44,7 +44,7 @@ public:
     void create(const HashTableParam& param);
     void close();
 
-    Status build(RuntimeState* state);
+    Status build(RuntimeState* state, bool allow_build_empty_table = false);
     void reset_probe_state(RuntimeState* state);
     Status probe(RuntimeState* state, const Columns& key_columns, ChunkPtr* probe_chunk, ChunkPtr* chunk, bool* eos);
     Status probe_remain(RuntimeState* state, ChunkPtr* chunk, bool* eos);

--- a/test/sql/test_join/R/test_force_partition_hash_join
+++ b/test/sql/test_join/R/test_force_partition_hash_join
@@ -29,13 +29,13 @@ PROPERTIES (
 );
 -- result:
 -- !result
-insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  409600));
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  40960));
 -- result:
 -- !result
 insert into t1 select * from t0;
 -- result:
 -- !result
-insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(409600, 409600 + 20000));
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(40960, 40960 + 20000));
 -- result:
 -- !result
 admin enable failpoint 'always_use_partition_join';
@@ -43,15 +43,15 @@ admin enable failpoint 'always_use_partition_join';
 -- !result
 select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join t1 r on l.c0 = r.c0 and l.c1 = r.c1;
 -- result:
-409601	204800.9999975586	409601	409601	409601
+40961	20480.999975586532	40961	40961	40961
 -- !result
 select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l left join t1 r on l.c0 = r.c0 and l.c1 = r.c1;
 -- result:
-429601	214800.9534428458	429601	429601	409601
+60961	30480.671904988434	60961	60961	40961
 -- !result
 select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l right join t1 r on l.c0 = r.c0 and l.c1 = r.c1;
 -- result:
-409601	204800.9999975586	409601	409601	409601
+40961	20480.999975586532	40961	40961	40961
 -- !result
 select count(*) from (select * from t0 where c0 not in (select c0 from t1)) t;
 -- result:

--- a/test/sql/test_join/R/test_force_partition_hash_join
+++ b/test/sql/test_join/R/test_force_partition_hash_join
@@ -1,0 +1,161 @@
+-- name: test_force_partition_hash_join @sequential
+CREATE TABLE `t0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+CREATE TABLE `t1` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  409600));
+-- result:
+-- !result
+insert into t1 select * from t0;
+-- result:
+-- !result
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(409600, 409600 + 20000));
+-- result:
+-- !result
+admin enable failpoint 'always_use_partition_join';
+-- result:
+-- !result
+select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join t1 r on l.c0 = r.c0 and l.c1 = r.c1;
+-- result:
+409601	204800.9999975586	409601	409601	409601
+-- !result
+select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l left join t1 r on l.c0 = r.c0 and l.c1 = r.c1;
+-- result:
+429601	214800.9534428458	429601	429601	409601
+-- !result
+select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l right join t1 r on l.c0 = r.c0 and l.c1 = r.c1;
+-- result:
+409601	204800.9999975586	409601	409601	409601
+-- !result
+select count(*) from (select * from t0 where c0 not in (select c0 from t1)) t;
+-- result:
+20000
+-- !result
+select count(*) from (select * from t0 where c0 not in (select c0 from t1 where t0.c1  )) t;
+-- result:
+20000
+-- !result
+insert into t1 values(null,null,null,null);
+-- result:
+-- !result
+select count(*) from (select * from t0 where c0 not in (select c0 from t1)) t;
+-- result:
+0
+-- !result
+CREATE TABLE `nullaware_anti_join_test` (
+  `k1` int(11) COMMENT "",
+  `k2` int(11)  COMMENT "",
+  `k3` int(11)
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into nullaware_anti_join_test values (1,1,1),(1,2,1),(1,3,2),(11,1,11),(11,2,1),(2,3,2),(2,3,null),(null,null,null);
+-- result:
+-- !result
+select * from nullaware_anti_join_test l1 where l1.k1 not in ( select l3.k1 from nullaware_anti_join_test l3 ) order by 1,2,3;
+-- result:
+-- !result
+select * from nullaware_anti_join_test l1 where l1.k1 in ( select l3.k1 from nullaware_anti_join_test l3 ) order by 1,2,3;
+-- result:
+1	1	1
+1	2	1
+1	3	2
+2	3	None
+2	3	2
+11	1	11
+11	2	1
+-- !result
+select * from nullaware_anti_join_test l1 where l1.k1 not in ( select l3.k1 from nullaware_anti_join_test l3 where  l3.k3 = l1.k3 ) order by 1,2,3;
+-- result:
+None	None	None
+2	3	None
+-- !result
+select * from nullaware_anti_join_test l1 where l1.k1 not in ( select l3.k1 from nullaware_anti_join_test l3 where  l3.k3 != l1.k3 ) order by 1,2,3;
+-- result:
+None	None	None
+2	3	None
+2	3	2
+-- !result
+select * from nullaware_anti_join_test l1 where not exists ( select 1 from nullaware_anti_join_test l3 where l3.k1 = l1.k1 and l3.k3 != l1.k3) order by 1,2,3;
+-- result:
+None	None	None
+2	3	None
+2	3	2
+-- !result
+CREATE TABLE `t2` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+CREATE TABLE `t3` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into t2 values(null,null,null,null);
+-- result:
+-- !result
+insert into t3 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  409600));
+-- result:
+-- !result
+select count(*) from (select * from t2 where c0 not in (select c0 from t3 where if(t3.c0=1,t2.c1, true)  )) t;
+-- result:
+0
+-- !result
+select count(*) from (select * from t2 where c0 not in (select c0 from t3 where if(t3.c0!=2,t2.c0 is not null, true)  )) t;
+-- result:
+0
+-- !result
+admin disable failpoint 'always_use_partition_join';
+-- result:
+-- !result

--- a/test/sql/test_join/T/test_force_partition_hash_join
+++ b/test/sql/test_join/T/test_force_partition_hash_join
@@ -28,9 +28,9 @@ PROPERTIES (
 "compression" = "LZ4"
 );
 
-insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  409600));
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  40960));
 insert into t1 select * from t0;
-insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(409600, 409600 + 20000));
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(40960, 40960 + 20000));
 
 admin enable failpoint 'always_use_partition_join';
 

--- a/test/sql/test_join/T/test_force_partition_hash_join
+++ b/test/sql/test_join/T/test_force_partition_hash_join
@@ -1,0 +1,97 @@
+-- name: test_force_partition_hash_join @sequential
+
+CREATE TABLE `t0` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "LZ4"
+);
+
+CREATE TABLE `t1` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "LZ4"
+);
+
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  409600));
+insert into t1 select * from t0;
+insert into t0 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(409600, 409600 + 20000));
+
+admin enable failpoint 'always_use_partition_join';
+
+select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l join t1 r on l.c0 = r.c0 and l.c1 = r.c1;
+select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l left join t1 r on l.c0 = r.c0 and l.c1 = r.c1;
+select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l right join t1 r on l.c0 = r.c0 and l.c1 = r.c1;
+
+-- null-aware left anti join
+select count(*) from (select * from t0 where c0 not in (select c0 from t1)) t;
+select count(*) from (select * from t0 where c0 not in (select c0 from t1 where t0.c1  )) t;
+insert into t1 values(null,null,null,null);
+-- null-aware left anti join
+select count(*) from (select * from t0 where c0 not in (select c0 from t1)) t;
+
+CREATE TABLE `nullaware_anti_join_test` (
+  `k1` int(11) COMMENT "",
+  `k2` int(11)  COMMENT "",
+  `k3` int(11)
+) ENGINE=OLAP
+DUPLICATE KEY(`k1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+insert into nullaware_anti_join_test values (1,1,1),(1,2,1),(1,3,2),(11,1,11),(11,2,1),(2,3,2),(2,3,null),(null,null,null);
+select * from nullaware_anti_join_test l1 where l1.k1 not in ( select l3.k1 from nullaware_anti_join_test l3 ) order by 1,2,3;
+select * from nullaware_anti_join_test l1 where l1.k1 in ( select l3.k1 from nullaware_anti_join_test l3 ) order by 1,2,3;
+select * from nullaware_anti_join_test l1 where l1.k1 not in ( select l3.k1 from nullaware_anti_join_test l3 where  l3.k3 = l1.k3 ) order by 1,2,3;
+select * from nullaware_anti_join_test l1 where l1.k1 not in ( select l3.k1 from nullaware_anti_join_test l3 where  l3.k3 != l1.k3 ) order by 1,2,3;
+select * from nullaware_anti_join_test l1 where not exists ( select 1 from nullaware_anti_join_test l3 where l3.k1 = l1.k1 and l3.k3 != l1.k3) order by 1,2,3;
+
+CREATE TABLE `t2` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "LZ4"
+);
+CREATE TABLE `t3` (
+  `c0` int(11) NULL COMMENT "",
+  `c1` varchar(20) NULL COMMENT "",
+  `c2` varchar(200) NULL COMMENT "",
+  `c3` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `c1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1",
+"compression" = "LZ4"
+);
+insert into t2 values(null,null,null,null);
+insert into t3 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  409600));
+select count(*) from (select * from t2 where c0 not in (select c0 from t3 where if(t3.c0=1,t2.c1, true)  )) t;
+select count(*) from (select * from t2 where c0 not in (select c0 from t3 where if(t3.c0!=2,t2.c0 is not null, true)  )) t;
+
+
+admin disable failpoint 'always_use_partition_join';


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

```
CREATE TABLE `t2` (
  `c0` int(11) NULL COMMENT "",
  `c1` varchar(20) NULL COMMENT "",
  `c2` varchar(200) NULL COMMENT "",
  `c3` int(11) NULL COMMENT ""
) ENGINE=OLAP
DUPLICATE KEY(`c0`, `c1`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`c0`) BUCKETS 4
PROPERTIES (
"replication_num" = "1",
"compression" = "LZ4"
);
CREATE TABLE `t3` (
  `c0` int(11) NULL COMMENT "",
  `c1` varchar(20) NULL COMMENT "",
  `c2` varchar(200) NULL COMMENT "",
  `c3` int(11) NULL COMMENT ""
) ENGINE=OLAP
DUPLICATE KEY(`c0`, `c1`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`c0`) BUCKETS 4
PROPERTIES (
"replication_num" = "1",
"compression" = "LZ4"
);
insert into t2 values(null,null,null,null);
insert into t3 SELECT generate_series, generate_series, generate_series, generate_series FROM TABLE(generate_series(1,  409600));
select count(*) from (select * from t2 where c0 not in (select c0 from t3 where if(t3.c0!=2,t2.c0 is not null, true)  )) t;
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Gates partitioned hash join based on join type/other predicates, adds a failpoint to force partitioning, avoids building empty sub-partition hash tables, and introduces SQL tests covering these cases.
> 
> - **Hash Join behavior**:
>   - `support_partitioned(...)` added and used to enable partitioned hash join only for supported `TJoinOp`s and when no disallowed other conjuncts for null-aware anti join (`be/src/exec/hash_joiner.h`, `be/src/exec/hash_joiner.cpp`).
>   - Add failpoint `always_use_partition_join` to force partitioned join path; integrated into decision points and partition row adjustment (`be/src/exec/hash_join_components.cpp`).
>   - Skip partitioned join when build-side hash table is empty; ensure builders mark sub-partitions and pass `allow_build_empty_table=false` for sub-partitions (`SingleHashJoinBuilder::_is_sub_partition`, `build(state, !_is_sub_partition)`).
>   - Expose `JoinHashTable::build(state, bool allow_build_empty_table)` and update callers (`be/src/exec/join/join_hash_table.{h,cpp}`, `be/src/exec/hash_join_components.cpp`).
>   - Fix null check in `SingleHashJoinBuilder::anti_join_key_column_has_null()` for empty null bitmap.
> - **Tests**:
>   - Add `test/sql/test_join/{T,R}/test_force_partition_hash_join` exercising joins (inner/left/right, null-aware anti, correlated cases) with the failpoint enabled/disabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dc67030dc7020b7ff9a278f3174a04ee30cb244f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->