### PR TITLE
[BugFix] capture spiller in when loading partition

### DIFF
--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
@@ -39,10 +39,13 @@ bool SpillableAggregateBlockingSinkOperator::need_input() const {
 }
 
 bool SpillableAggregateBlockingSinkOperator::is_finished() const {
-    if (!spilled()) {
-        return _is_finished || AggregateBlockingSinkOperator::is_finished();
+    if (_is_finished) {
+        return true;
     }
-    return _is_finished || _aggregator->is_finished();
+    if (!spilled()) {
+        return AggregateBlockingSinkOperator::is_finished();
+    }
+    return _aggregator->is_finished();
 }
 
 Status SpillableAggregateBlockingSinkOperator::set_finishing(RuntimeState* state) {

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -56,7 +56,10 @@ Status SpillableHashJoinProbeOperator::prepare(RuntimeState* state) {
 
 void SpillableHashJoinProbeOperator::close(RuntimeState* state) {
     _probe_spiller.reset();
-    _reset_load_partitions();
+    // all task finished reset partitions
+    if (_latch.ready()) {
+        _reset_load_partitions();
+    }
     HashJoinProbeOperator::close(state);
     DCHECK(!has_output());
     DCHECK(is_finished());
@@ -65,6 +68,9 @@ void SpillableHashJoinProbeOperator::close(RuntimeState* state) {
 bool SpillableHashJoinProbeOperator::has_output() const {
     if (!is_ready()) {
         DCHECK(false) << "is_ready() must be true before call has_output";
+        return false;
+    }
+    if (_is_finished) {
         return false;
     }
     if (!spilled()) {
@@ -78,9 +84,6 @@ bool SpillableHashJoinProbeOperator::has_output() const {
 
     if (!_status().ok()) {
         return true;
-    }
-    if (_is_finished) {
-        return false;
     }
 
     if (_processing_partitions.empty()) {
@@ -135,15 +138,16 @@ bool SpillableHashJoinProbeOperator::need_input() const {
         DCHECK(false) << "is_ready() must be true before call has_output";
         return false;
     }
+
+    if (_is_finished) {
+        return false;
+    }
+
     if (!spilled()) {
         return HashJoinProbeOperator::need_input();
     }
 
     if (!_latch.ready()) {
-        return false;
-    }
-
-    if (_is_finished) {
         return false;
     }
 
@@ -313,28 +317,30 @@ Status SpillableHashJoinProbeOperator::_load_all_partition_build_side(RuntimeSta
     auto query_ctx = state->query_ctx()->weak_from_this();
     for (size_t i = 0; i < _processing_partitions.size(); ++i) {
         std::shared_ptr<spill::SpillerReader> reader = std::move(spill_readers[i]);
-        auto task = [this, state, reader, i, query_ctx, driver_id](auto& yield_ctx) {
-            if (auto acquired = query_ctx.lock()) {
-                SCOPED_SET_TRACE_INFO(driver_id, state->query_id(), state->fragment_instance_id());
-                SCOPED_SET_TRACE_PLAN_NODE_ID(get_plan_node_id());
-                auto defer = CancelableDefer([&]() {
-                    _latch.count_down();
-                    yield_ctx.set_finished();
-                });
-                if (!_status().ok()) {
-                    return;
+        auto guard = TRACKER_WITH_SPILLER_RES_GUARD(state, _join_builder->spiller());
+        auto task = [this, state, reader, i, query_ctx, driver_id, guard](auto& yield_ctx) {
+            auto yield_defer = yield_ctx.defer_finished();
+            RETURN_IF(!guard.scoped_begin(), (void)0);
+            DEFER_GUARD_END(guard);
+            SCOPED_SET_TRACE_INFO(driver_id, state->query_id(), state->fragment_instance_id());
+            SCOPED_SET_TRACE_PLAN_NODE_ID(get_plan_node_id());
+            auto defer = CancelableDefer([&]() {
+                if (_latch.count_down() && _is_finished) {
+                    _reset_load_partitions();
                 }
-                if (!yield_ctx.task_context_data.has_value()) {
-                    yield_ctx.task_context_data = std::make_shared<spill::SpillIOTaskContext>();
-                }
-                yield_ctx.time_spent_ns = 0;
-                yield_ctx.need_yield = false;
-                _update_status(_load_partition_build_side(yield_ctx, state, reader, i));
-                if (yield_ctx.need_yield) {
-                    defer.cancel();
-                }
-            } else {
-                yield_ctx.set_finished();
+            });
+            if (!_status().ok()) {
+                return;
+            }
+            if (!yield_ctx.task_context_data.has_value()) {
+                yield_ctx.task_context_data = std::make_shared<spill::SpillIOTaskContext>();
+            }
+            yield_ctx.time_spent_ns = 0;
+            yield_ctx.need_yield = false;
+            _update_status(_load_partition_build_side(yield_ctx, state, reader, i));
+            if (yield_ctx.need_yield) {
+                defer.cancel();
+                yield_defer.cancel();
             }
         };
         auto yield_func = [&](workgroup::ScanTask&& task) { spill::IOTaskExecutor::force_submit(std::move(task)); };
@@ -382,6 +388,8 @@ void SpillableHashJoinProbeOperator::_check_partitions() {
 }
 
 void SpillableHashJoinProbeOperator::_reset_load_partitions() {
+    DCHECK(_latch.ready());
+    std::lock_guard guard(_mutex);
     // release memory
     _processing_partitions.clear();
     _current_reader.clear();
@@ -490,7 +498,7 @@ StatusOr<ChunkPtr> SpillableHashJoinProbeOperator::pull_chunk(RuntimeState* stat
 }
 
 bool SpillableHashJoinProbeOperator::spilled() const {
-    return _join_builder->spiller() && _join_builder->spiller()->spilled();
+    return _join_builder->spiller()->spilled();
 }
 
 void SpillableHashJoinProbeOperator::_acquire_next_partitions() {

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.h
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.h
@@ -35,9 +35,10 @@ namespace starrocks::pipeline {
 struct NoBlockCountDownLatch {
     void reset(int32_t total) { _count_down = total; }
 
-    void count_down() {
-        _count_down--;
-        DCHECK_GE(_count_down, 0);
+    // return true if this is the last count down
+    bool count_down() {
+        DCHECK_GT(_count_down, 0);
+        return _count_down.fetch_sub(1) == 1;
     }
 
     bool ready() const { return _count_down == 0; }

--- a/test/sql/test_spill/T/test_spill_hash_join_restore_cancelled
+++ b/test/sql/test_spill/T/test_spill_hash_join_restore_cancelled
@@ -1,4 +1,4 @@
--- name: test_spill_hash_join_restore_cancelled
+-- name: test_spill_hash_join_restore_cancelled @sequential
 
 CREATE TABLE `t0` (
   `c0` int(11) NULL COMMENT "",


### PR DESCRIPTION
## Why I'm doing:

fix UAF introduced in #66669

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Safeguards hash-join probe partition loading with spiller/memory guards and latch semantics, refines finished/need_input/has_output logic, and adds a sequential SQL test for cancelled spill restore.
> 
> - **Hash Join Probe (`spillable_hash_join_probe_operator`)**:
>   - Add spiller resource guard around partition-build load tasks and proper yield/finish defers.
>   - Gate `has_output`/`need_input` early on `_is_finished`; only reset partitions in `close` when latch ready.
>   - Convert latch to atomic with boolean-returning `count_down`; reset partitions on last countdown when already finished; add mutex-protected `_reset_load_partitions()` with `DCHECK`.
>   - Simplify `spilled()` and remove nullable spiller check.
> - **Aggregate Sink (`spillable_aggregate_blocking_sink_operator`)**:
>   - Refine `is_finished()` to early-return on `_is_finished` and rely on base/aggregator states without OR-ing local flag.
> - **Tests**:
>   - Mark `test_spill_hash_join_restore_cancelled` as `@sequential` and add SQL to validate cancelled restore behavior with failpoint.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 18adb06aee67e4a90157a7b241c8523e63e79024. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->