### PR TITLE
[Refactor] refactor the aggregation function pointer to reduce code bloat

### DIFF
--- a/be/src/exec/aggregator.h
+++ b/be/src/exec/aggregator.h
@@ -515,7 +515,7 @@ protected:
     int64_t _agg_state_mem_usage = 0;
 
     // aggregate combinator functions since they are not persisted in agg hash map
-    std::vector<AggregateFunctionPtr> _combinator_function;
+    std::vector<const AggregateFunction*> _combinator_function;
 
     pipeline::PipeObservable _pip_observable;
 

--- a/be/src/exprs/agg/aggregate.h
+++ b/be/src/exprs/agg/aggregate.h
@@ -462,7 +462,7 @@ public:
     }
 };
 
-using AggregateFunctionPtr = std::shared_ptr<AggregateFunction>;
+// AggregateFunctionPtr is removed. Use const AggregateFunction* instead.
 
 struct AggregateFunctionEmptyState {};
 

--- a/be/src/exprs/agg/aggregate.h
+++ b/be/src/exprs/agg/aggregate.h
@@ -462,7 +462,7 @@ public:
     }
 };
 
-// AggregateFunctionPtr is removed. Use const AggregateFunction* instead.
+using AggregateFunctionPtr = const AggregateFunction*;
 
 struct AggregateFunctionEmptyState {};
 

--- a/be/src/exprs/agg/combinator/agg_state_utils.h
+++ b/be/src/exprs/agg/combinator/agg_state_utils.h
@@ -75,9 +75,9 @@ public:
 
     // Get the aggregate state function according to the agg_state_desc and function name.
     // If the function is not an aggregate state function, return nullptr.
-    static StatusOr<AggregateFunctionPtr> get_agg_state_function(const AggStateDesc& agg_state_desc,
-                                                                 const std::string& func_name,
-                                                                 const std::vector<TypeDescriptor>& arg_types);
+    static StatusOr<const AggregateFunction*> get_agg_state_function(const AggStateDesc& agg_state_desc,
+                                                                     const std::string& func_name,
+                                                                     const std::vector<TypeDescriptor>& arg_types);
 
     // Get the aggregate state function according to the TAggStateDesc and function name.
     // If the function is not an aggregate state function, return nullptr.

--- a/be/src/exprs/agg/factory/aggregate_factory.cpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.cpp
@@ -43,77 +43,81 @@ AggregateFuncResolver::AggregateFuncResolver() {
     register_boolean();
 }
 
-AggregateFuncResolver::~AggregateFuncResolver() = default;
-
-AggregateFunctionPtr AggregateFactory::MakeBitmapUnionAggregateFunction() {
-    return std::make_shared<BitmapUnionAggregateFunction>();
+AggregateFuncResolver::~AggregateFuncResolver() {
+    for (const auto* func : _functions) {
+        delete func;
+    }
 }
 
-AggregateFunctionPtr AggregateFactory::MakeBitmapIntersectAggregateFunction() {
-    return std::make_shared<BitmapIntersectAggregateFunction>();
+const AggregateFunction* AggregateFactory::MakeBitmapUnionAggregateFunction() {
+    return new BitmapUnionAggregateFunction();
 }
 
-AggregateFunctionPtr AggregateFactory::MakeBitmapUnionCountAggregateFunction() {
-    return std::make_shared<BitmapUnionCountAggregateFunction>();
-}
-AggregateFunctionPtr AggregateFactory::MakeDictMergeAggregateFunction() {
-    return std::make_shared<DictMergeAggregateFunction>();
+const AggregateFunction* AggregateFactory::MakeBitmapIntersectAggregateFunction() {
+    return new BitmapIntersectAggregateFunction();
 }
 
-AggregateFunctionPtr AggregateFactory::MakeRetentionAggregateFunction() {
-    return std::make_shared<RetentionAggregateFunction>();
+const AggregateFunction* AggregateFactory::MakeBitmapUnionCountAggregateFunction() {
+    return new BitmapUnionCountAggregateFunction();
+}
+const AggregateFunction* AggregateFactory::MakeDictMergeAggregateFunction() {
+    return new DictMergeAggregateFunction();
 }
 
-AggregateFunctionPtr AggregateFactory::MakeHllUnionAggregateFunction() {
-    return std::make_shared<HllUnionAggregateFunction>();
+const AggregateFunction* AggregateFactory::MakeRetentionAggregateFunction() {
+    return new RetentionAggregateFunction();
 }
 
-AggregateFunctionPtr AggregateFactory::MakeHllUnionCountAggregateFunction() {
-    return std::make_shared<HllUnionCountAggregateFunction>();
+const AggregateFunction* AggregateFactory::MakeHllUnionAggregateFunction() {
+    return new HllUnionAggregateFunction();
 }
 
-AggregateFunctionPtr AggregateFactory::MakePercentileApproxAggregateFunction() {
-    return std::make_shared<PercentileApproxAggregateFunction>();
+const AggregateFunction* AggregateFactory::MakeHllUnionCountAggregateFunction() {
+    return new HllUnionCountAggregateFunction();
 }
 
-AggregateFunctionPtr AggregateFactory::MakePercentileApproxArrayAggregateFunction() {
-    return std::make_shared<PercentileApproxArrayAggregateFunction>();
+const AggregateFunction* AggregateFactory::MakePercentileApproxAggregateFunction() {
+    return new PercentileApproxAggregateFunction();
 }
 
-AggregateFunctionPtr AggregateFactory::MakePercentileApproxWeightedAggregateFunction() {
-    return std::make_shared<PercentileApproxWeightedAggregateFunction>();
+const AggregateFunction* AggregateFactory::MakePercentileApproxArrayAggregateFunction() {
+    return new PercentileApproxArrayAggregateFunction();
 }
 
-AggregateFunctionPtr AggregateFactory::MakePercentileApproxWeightedArrayAggregateFunction() {
-    return std::make_shared<PercentileApproxWeightedArrayAggregateFunction>();
+const AggregateFunction* AggregateFactory::MakePercentileApproxWeightedAggregateFunction() {
+    return new PercentileApproxWeightedAggregateFunction();
 }
 
-AggregateFunctionPtr AggregateFactory::MakePercentileUnionAggregateFunction() {
-    return std::make_shared<PercentileUnionAggregateFunction>();
+const AggregateFunction* AggregateFactory::MakePercentileApproxWeightedArrayAggregateFunction() {
+    return new PercentileApproxWeightedArrayAggregateFunction();
 }
 
-AggregateFunctionPtr AggregateFactory::MakeDenseRankWindowFunction() {
-    return std::make_shared<DenseRankWindowFunction>();
+const AggregateFunction* AggregateFactory::MakePercentileUnionAggregateFunction() {
+    return new PercentileUnionAggregateFunction();
 }
 
-AggregateFunctionPtr AggregateFactory::MakeRankWindowFunction() {
-    return std::make_shared<RankWindowFunction>();
+const AggregateFunction* AggregateFactory::MakeDenseRankWindowFunction() {
+    return new DenseRankWindowFunction();
 }
 
-AggregateFunctionPtr AggregateFactory::MakeRowNumberWindowFunction() {
-    return std::make_shared<RowNumberWindowFunction>();
+const AggregateFunction* AggregateFactory::MakeRankWindowFunction() {
+    return new RankWindowFunction();
 }
 
-AggregateFunctionPtr AggregateFactory::MakeCumeDistWindowFunction() {
-    return std::make_shared<CumeDistWindowFunction>();
+const AggregateFunction* AggregateFactory::MakeRowNumberWindowFunction() {
+    return new RowNumberWindowFunction();
 }
 
-AggregateFunctionPtr AggregateFactory::MakePercentRankWindowFunction() {
-    return std::make_shared<PercentRankWindowFunction>();
+const AggregateFunction* AggregateFactory::MakeCumeDistWindowFunction() {
+    return new CumeDistWindowFunction();
 }
 
-AggregateFunctionPtr AggregateFactory::MakeNtileWindowFunction() {
-    return std::make_shared<NtileWindowFunction>();
+const AggregateFunction* AggregateFactory::MakePercentRankWindowFunction() {
+    return new PercentRankWindowFunction();
+}
+
+const AggregateFunction* AggregateFactory::MakeNtileWindowFunction() {
+    return new NtileWindowFunction();
 }
 
 static const AggregateFunction* get_function(const std::string& name, LogicalType arg_type, LogicalType return_type,

--- a/be/src/exprs/agg/factory/aggregate_factory.cpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.cpp
@@ -49,80 +49,80 @@ AggregateFuncResolver::~AggregateFuncResolver() {
     }
 }
 
-const AggregateFunction* AggregateFactory::MakeBitmapUnionAggregateFunction() {
+AggregateFunctionPtr AggregateFactory::MakeBitmapUnionAggregateFunction() {
     return new BitmapUnionAggregateFunction();
 }
 
-const AggregateFunction* AggregateFactory::MakeBitmapIntersectAggregateFunction() {
+AggregateFunctionPtr AggregateFactory::MakeBitmapIntersectAggregateFunction() {
     return new BitmapIntersectAggregateFunction();
 }
 
-const AggregateFunction* AggregateFactory::MakeBitmapUnionCountAggregateFunction() {
+AggregateFunctionPtr AggregateFactory::MakeBitmapUnionCountAggregateFunction() {
     return new BitmapUnionCountAggregateFunction();
 }
-const AggregateFunction* AggregateFactory::MakeDictMergeAggregateFunction() {
+AggregateFunctionPtr AggregateFactory::MakeDictMergeAggregateFunction() {
     return new DictMergeAggregateFunction();
 }
 
-const AggregateFunction* AggregateFactory::MakeRetentionAggregateFunction() {
+AggregateFunctionPtr AggregateFactory::MakeRetentionAggregateFunction() {
     return new RetentionAggregateFunction();
 }
 
-const AggregateFunction* AggregateFactory::MakeHllUnionAggregateFunction() {
+AggregateFunctionPtr AggregateFactory::MakeHllUnionAggregateFunction() {
     return new HllUnionAggregateFunction();
 }
 
-const AggregateFunction* AggregateFactory::MakeHllUnionCountAggregateFunction() {
+AggregateFunctionPtr AggregateFactory::MakeHllUnionCountAggregateFunction() {
     return new HllUnionCountAggregateFunction();
 }
 
-const AggregateFunction* AggregateFactory::MakePercentileApproxAggregateFunction() {
+AggregateFunctionPtr AggregateFactory::MakePercentileApproxAggregateFunction() {
     return new PercentileApproxAggregateFunction();
 }
 
-const AggregateFunction* AggregateFactory::MakePercentileApproxArrayAggregateFunction() {
+AggregateFunctionPtr AggregateFactory::MakePercentileApproxArrayAggregateFunction() {
     return new PercentileApproxArrayAggregateFunction();
 }
 
-const AggregateFunction* AggregateFactory::MakePercentileApproxWeightedAggregateFunction() {
+AggregateFunctionPtr AggregateFactory::MakePercentileApproxWeightedAggregateFunction() {
     return new PercentileApproxWeightedAggregateFunction();
 }
 
-const AggregateFunction* AggregateFactory::MakePercentileApproxWeightedArrayAggregateFunction() {
+AggregateFunctionPtr AggregateFactory::MakePercentileApproxWeightedArrayAggregateFunction() {
     return new PercentileApproxWeightedArrayAggregateFunction();
 }
 
-const AggregateFunction* AggregateFactory::MakePercentileUnionAggregateFunction() {
+AggregateFunctionPtr AggregateFactory::MakePercentileUnionAggregateFunction() {
     return new PercentileUnionAggregateFunction();
 }
 
-const AggregateFunction* AggregateFactory::MakeDenseRankWindowFunction() {
+AggregateFunctionPtr AggregateFactory::MakeDenseRankWindowFunction() {
     return new DenseRankWindowFunction();
 }
 
-const AggregateFunction* AggregateFactory::MakeRankWindowFunction() {
+AggregateFunctionPtr AggregateFactory::MakeRankWindowFunction() {
     return new RankWindowFunction();
 }
 
-const AggregateFunction* AggregateFactory::MakeRowNumberWindowFunction() {
+AggregateFunctionPtr AggregateFactory::MakeRowNumberWindowFunction() {
     return new RowNumberWindowFunction();
 }
 
-const AggregateFunction* AggregateFactory::MakeCumeDistWindowFunction() {
+AggregateFunctionPtr AggregateFactory::MakeCumeDistWindowFunction() {
     return new CumeDistWindowFunction();
 }
 
-const AggregateFunction* AggregateFactory::MakePercentRankWindowFunction() {
+AggregateFunctionPtr AggregateFactory::MakePercentRankWindowFunction() {
     return new PercentRankWindowFunction();
 }
 
-const AggregateFunction* AggregateFactory::MakeNtileWindowFunction() {
+AggregateFunctionPtr AggregateFactory::MakeNtileWindowFunction() {
     return new NtileWindowFunction();
 }
 
-static const AggregateFunction* get_function(const std::string& name, LogicalType arg_type, LogicalType return_type,
-                                             bool is_window_function, bool is_null,
-                                             TFunctionBinaryType::type binary_type, int func_version) {
+static AggregateFunctionPtr get_function(const std::string& name, LogicalType arg_type, LogicalType return_type,
+                                         bool is_window_function, bool is_null, TFunctionBinaryType::type binary_type,
+                                         int func_version) {
     std::string func_name = name;
     if (func_version > 1) {
         if (name == "multi_distinct_sum") {
@@ -170,14 +170,14 @@ static const AggregateFunction* get_function(const std::string& name, LogicalTyp
     return nullptr;
 }
 
-const AggregateFunction* get_aggregate_function(const std::string& name, LogicalType arg_type, LogicalType return_type,
-                                                bool is_null, TFunctionBinaryType::type binary_type, int func_version) {
+AggregateFunctionPtr get_aggregate_function(const std::string& name, LogicalType arg_type, LogicalType return_type,
+                                            bool is_null, TFunctionBinaryType::type binary_type, int func_version) {
     FAIL_POINT_TRIGGER_RETURN(not_exist_agg_function, nullptr);
     return get_function(name, arg_type, return_type, false, is_null, binary_type, func_version);
 }
 
-const AggregateFunction* get_window_function(const std::string& name, LogicalType arg_type, LogicalType return_type,
-                                             bool is_null, TFunctionBinaryType::type binary_type, int func_version) {
+AggregateFunctionPtr get_window_function(const std::string& name, LogicalType arg_type, LogicalType return_type,
+                                         bool is_null, TFunctionBinaryType::type binary_type, int func_version) {
     if (binary_type == TFunctionBinaryType::BUILTIN) {
         return get_function(name, arg_type, return_type, true, is_null, binary_type, func_version);
     } else if (binary_type == TFunctionBinaryType::SRJAR) {
@@ -186,9 +186,9 @@ const AggregateFunction* get_window_function(const std::string& name, LogicalTyp
     return nullptr;
 }
 
-const AggregateFunction* get_aggregate_function(const std::string& agg_func_name, const TypeDescriptor& return_type,
-                                                const std::vector<TypeDescriptor>& arg_types, bool is_result_nullable,
-                                                TFunctionBinaryType::type binary_type, int func_version) {
+AggregateFunctionPtr get_aggregate_function(const std::string& agg_func_name, const TypeDescriptor& return_type,
+                                            const std::vector<TypeDescriptor>& arg_types, bool is_result_nullable,
+                                            TFunctionBinaryType::type binary_type, int func_version) {
     // get function
     if (agg_func_name == "count") {
         return get_aggregate_function("count", TYPE_BIGINT, TYPE_BIGINT, is_result_nullable);

--- a/be/src/exprs/agg/factory/aggregate_factory.hpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.hpp
@@ -66,405 +66,401 @@ class AggregateFactory {
 public:
     // The function should be placed by alphabetical order
     template <LogicalType LT>
-    static const AggregateFunction* MakeAvgAggregateFunction() {
+    static auto MakeAvgAggregateFunction() {
         return new AvgAggregateFunction<LT>();
     }
 
     template <LogicalType LT>
-    static const AggregateFunction* MakeDecimalAvgAggregateFunction() {
+    static auto MakeDecimalAvgAggregateFunction() {
         return new DecimalAvgAggregateFunction<LT>();
     }
 
     template <LogicalType LT>
-    static const AggregateFunction* MakeBitmapUnionIntAggregateFunction() {
+    static AggregateFunctionPtr MakeBitmapUnionIntAggregateFunction() {
         return new BitmapUnionIntAggregateFunction<LT>();
     }
 
-    static const AggregateFunction* MakeBitmapUnionAggregateFunction();
+    static AggregateFunctionPtr MakeBitmapUnionAggregateFunction();
 
     template <LogicalType LT>
-    static const AggregateFunction* MakeBitmapAggAggregateFunction();
+    static AggregateFunctionPtr MakeBitmapAggAggregateFunction();
 
-    static const AggregateFunction* MakeBitmapIntersectAggregateFunction();
+    static AggregateFunctionPtr MakeBitmapIntersectAggregateFunction();
 
-    static const AggregateFunction* MakeBitmapUnionCountAggregateFunction();
-
-    template <LogicalType LT>
-    static const AggregateFunction* MakeWindowfunnelAggregateFunction();
+    static AggregateFunctionPtr MakeBitmapUnionCountAggregateFunction();
 
     template <LogicalType LT>
-    static const AggregateFunction* MakeIntersectCountAggregateFunction();
+    static AggregateFunctionPtr MakeWindowfunnelAggregateFunction();
+
+    template <LogicalType LT>
+    static AggregateFunctionPtr MakeIntersectCountAggregateFunction();
 
     template <bool IsWindowFunc>
-    static const AggregateFunction* MakeCountAggregateFunction();
+    static AggregateFunctionPtr MakeCountAggregateFunction();
 
     template <LogicalType LT>
-    static const AggregateFunction* MakeCountDistinctAggregateFunction();
+    static auto MakeCountDistinctAggregateFunction();
     template <LogicalType LT>
-    static const AggregateFunction* MakeCountDistinctAggregateFunctionV2();
+    static auto MakeCountDistinctAggregateFunctionV2();
 
     template <LogicalType LT>
-    static const AggregateFunction* MakeGroupConcatAggregateFunction();
+    static AggregateFunctionPtr MakeGroupConcatAggregateFunction();
 
     template <bool IsWindowFunc>
-    static const AggregateFunction* MakeCountNullableAggregateFunction();
+    static AggregateFunctionPtr MakeCountNullableAggregateFunction();
 
     template <AggExchangePerfType PerfType>
-    static const AggregateFunction* MakeExchangePerfAggregateFunction() {
+    static AggregateFunctionPtr MakeExchangePerfAggregateFunction() {
         return new ExchangePerfAggregateFunction<PerfType>();
     }
 
     template <typename ArrayAggState>
-    static const AggregateFunction* MakeArrayAggAggregateFunctionV2() {
+    static AggregateFunctionPtr MakeArrayAggAggregateFunctionV2() {
         return new ArrayAggAggregateFunctionV2<ArrayAggState>();
     }
 
-    static const AggregateFunction* MakeGroupConcatAggregateFunctionV2() {
-        return new GroupConcatAggregateFunctionV2();
-    }
+    static AggregateFunctionPtr MakeGroupConcatAggregateFunctionV2() { return new GroupConcatAggregateFunctionV2(); }
 
-    static const AggregateFunction* MakeMannWhitneyUTestAggregateFunction() {
-        return new MannWhitneyUTestAggregateFunction();
-    }
+    static auto MakeMannWhitneyUTestAggregateFunction() { return new MannWhitneyUTestAggregateFunction(); }
 
     template <LogicalType LT>
-    static const AggregateFunction* MakeMaxAggregateFunction();
+    static auto MakeMaxAggregateFunction();
 
     template <LogicalType LT, bool not_filter_nulls>
-    static const AggregateFunction* MakeMaxByAggregateFunction();
+    static auto MakeMaxByAggregateFunction();
 
     template <LogicalType LT, bool not_filter_nulls>
-    static const AggregateFunction* MakeMinByAggregateFunction();
+    static auto MakeMinByAggregateFunction();
 
     template <LogicalType LT>
-    static const AggregateFunction* MakeMinAggregateFunction();
+    static auto MakeMinAggregateFunction();
 
     template <LogicalType LT>
-    static const AggregateFunction* MakeAnyValueAggregateFunction();
+    static AggregateFunctionPtr MakeAnyValueAggregateFunction();
 
-    static const AggregateFunction* MakeAnyValueSemiAggregateFunction() { return new AnyValueSemiAggregateFunction(); }
+    static AggregateFunctionPtr MakeAnyValueSemiAggregateFunction() { return new AnyValueSemiAggregateFunction(); }
 
     template <typename NestedState, bool IsWindowFunc, bool IgnoreNull = true,
-              typename NestedFunctionPtr = const AggregateFunction*,
+              typename NestedFunctionPtr = AggregateFunctionPtr,
               IsAggNullPred<NestedState> AggNullPred = AggNonNullPred<NestedState>>
-    static const AggregateFunction* MakeNullableAggregateFunctionUnary(NestedFunctionPtr nested_function,
-                                                                       AggNullPred null_pred = AggNullPred());
+    static AggregateFunctionPtr MakeNullableAggregateFunctionUnary(NestedFunctionPtr nested_function,
+                                                                   AggNullPred null_pred = AggNullPred());
 
     template <typename NestedState, IsAggNullPred<NestedState> AggNullPredType = AggNonNullPred<NestedState>>
-    static const AggregateFunction* MakeNullableAggregateFunctionVariadic(
-            const AggregateFunction* nested_function, AggNullPredType null_pred = AggNullPredType());
+    static AggregateFunctionPtr MakeNullableAggregateFunctionVariadic(AggregateFunctionPtr nested_function,
+                                                                      AggNullPredType null_pred = AggNullPredType());
 
     template <LogicalType LT>
-    static const AggregateFunction* MakeSumAggregateFunction();
+    static auto MakeSumAggregateFunction();
 
     template <LogicalType LT>
-    static const AggregateFunction* MakeDecimalSumAggregateFunction();
+    static auto MakeDecimalSumAggregateFunction();
 
     template <LogicalType LT, bool is_sample>
-    static const AggregateFunction* MakeVarianceAggregateFunction();
+    static auto MakeVarianceAggregateFunction();
 
     template <LogicalType LT, bool is_sample>
-    static const AggregateFunction* MakeStddevAggregateFunction();
+    static auto MakeStddevAggregateFunction();
 
     template <LogicalType LT, bool is_sample>
-    static const AggregateFunction* MakeCovarianceAggregateFunction();
+    static auto MakeCovarianceAggregateFunction();
 
     template <LogicalType LT>
-    static const AggregateFunction* MakeCorelationAggregateFunction();
+    static auto MakeCorelationAggregateFunction();
 
     template <LogicalType LT>
-    static const AggregateFunction* MakeSumDistinctAggregateFunction();
+    static auto MakeSumDistinctAggregateFunction();
     template <LogicalType LT>
-    static const AggregateFunction* MakeSumDistinctAggregateFunctionV2();
+    static auto MakeSumDistinctAggregateFunctionV2();
     template <LogicalType LT>
-    static const AggregateFunction* MakeDecimalSumDistinctAggregateFunction();
+    static auto MakeDecimalSumDistinctAggregateFunction();
     template <LogicalType LT, int compute_bits>
-    static const AggregateFunction* MakeFusedMultiDistinctAggregateFunction();
+    static auto MakeFusedMultiDistinctAggregateFunction();
 
-    static const AggregateFunction* MakeDictMergeAggregateFunction();
-    static const AggregateFunction* MakeRetentionAggregateFunction();
+    static AggregateFunctionPtr MakeDictMergeAggregateFunction();
+    static AggregateFunctionPtr MakeRetentionAggregateFunction();
 
     // Hyperloglog functions:
-    static const AggregateFunction* MakeHllUnionAggregateFunction();
+    static AggregateFunctionPtr MakeHllUnionAggregateFunction();
 
-    static const AggregateFunction* MakeHllUnionCountAggregateFunction();
-
-    template <LogicalType T>
-    static const AggregateFunction* MakeHllNdvAggregateFunction();
+    static AggregateFunctionPtr MakeHllUnionCountAggregateFunction();
 
     template <LogicalType T>
-    static const AggregateFunction* MakeHllSketchAggregateFunction();
+    static AggregateFunctionPtr MakeHllNdvAggregateFunction();
 
     template <LogicalType T>
-    static const AggregateFunction* MakeThetaSketchAggregateFunction();
+    static AggregateFunctionPtr MakeHllSketchAggregateFunction();
 
     template <LogicalType T>
-    static const AggregateFunction* MakeHllRawAggregateFunction();
+    static AggregateFunctionPtr MakeThetaSketchAggregateFunction();
 
-    static const AggregateFunction* MakePercentileApproxAggregateFunction();
+    template <LogicalType T>
+    static AggregateFunctionPtr MakeHllRawAggregateFunction();
 
-    static const AggregateFunction* MakePercentileApproxArrayAggregateFunction();
+    static AggregateFunctionPtr MakePercentileApproxAggregateFunction();
 
-    static const AggregateFunction* MakePercentileApproxWeightedAggregateFunction();
+    static AggregateFunctionPtr MakePercentileApproxArrayAggregateFunction();
 
-    static const AggregateFunction* MakePercentileApproxWeightedArrayAggregateFunction();
+    static AggregateFunctionPtr MakePercentileApproxWeightedAggregateFunction();
 
-    static const AggregateFunction* MakePercentileUnionAggregateFunction();
+    static AggregateFunctionPtr MakePercentileApproxWeightedArrayAggregateFunction();
+
+    static AggregateFunctionPtr MakePercentileUnionAggregateFunction();
 
     template <LogicalType LT>
-    static const AggregateFunction* MakePercentileContAggregateFunction();
+    static AggregateFunctionPtr MakePercentileContAggregateFunction();
 
     template <LogicalType PT>
-    static const AggregateFunction* MakePercentileDiscAggregateFunction();
+    static AggregateFunctionPtr MakePercentileDiscAggregateFunction();
 
     template <LogicalType LT>
-    static const AggregateFunction* MakeLowCardPercentileBinAggregateFunction();
+    static AggregateFunctionPtr MakeLowCardPercentileBinAggregateFunction();
 
     template <LogicalType PT>
-    static const AggregateFunction* MakeLowCardPercentileCntAggregateFunction();
+    static AggregateFunctionPtr MakeLowCardPercentileCntAggregateFunction();
 
     // Windows functions:
-    static const AggregateFunction* MakeDenseRankWindowFunction();
+    static AggregateFunctionPtr MakeDenseRankWindowFunction();
 
-    static const AggregateFunction* MakeRankWindowFunction();
+    static AggregateFunctionPtr MakeRankWindowFunction();
 
-    static const AggregateFunction* MakeRowNumberWindowFunction();
+    static AggregateFunctionPtr MakeRowNumberWindowFunction();
 
-    static const AggregateFunction* MakeCumeDistWindowFunction();
+    static AggregateFunctionPtr MakeCumeDistWindowFunction();
 
-    static const AggregateFunction* MakePercentRankWindowFunction();
+    static AggregateFunctionPtr MakePercentRankWindowFunction();
 
-    static const AggregateFunction* MakeNtileWindowFunction();
+    static AggregateFunctionPtr MakeNtileWindowFunction();
 
     template <LogicalType LT, bool ignoreNulls>
-    static const AggregateFunction* MakeFirstValueWindowFunction() {
+    static AggregateFunctionPtr MakeFirstValueWindowFunction() {
         return new FirstValueWindowFunction<LT, ignoreNulls>();
     }
 
     template <LogicalType LT, bool ignoreNulls>
-    static const AggregateFunction* MakeLastValueWindowFunction() {
+    static AggregateFunctionPtr MakeLastValueWindowFunction() {
         return new LastValueWindowFunction<LT, ignoreNulls>();
     }
 
     template <LogicalType LT, bool ignoreNulls, bool isLag>
-    static const AggregateFunction* MakeLeadLagWindowFunction() {
+    static AggregateFunctionPtr MakeLeadLagWindowFunction() {
         return new LeadLagWindowFunction<LT, ignoreNulls, isLag>();
     }
 
     template <LogicalType LT>
-    static const AggregateFunction* MakeSessionNumberWindowFunction() {
+    static AggregateFunctionPtr MakeSessionNumberWindowFunction() {
         return new SessionNumberWindowFunction<LT>();
     }
 
     template <LogicalType LT>
-    static const AggregateFunction* MakeApproxTopKAggregateFunction() {
+    static AggregateFunctionPtr MakeApproxTopKAggregateFunction() {
         return new ApproxTopKAggregateFunction<LT>();
     }
 
     template <LogicalType LT>
-    static const AggregateFunction* MakeHistogramAggregationFunction() {
+    static AggregateFunctionPtr MakeHistogramAggregationFunction() {
         return new HistogramAggregationFunction<LT>();
     }
 
     template <LogicalType LT>
-    static const AggregateFunction* MakeHistogramHllNdvAggregationFunction() {
+    static AggregateFunctionPtr MakeHistogramHllNdvAggregationFunction() {
         return new HistogramHllNdvAggregateFunction<LT>();
     }
 
     // Stream MV Retractable Agg Functions
     template <LogicalType LT>
-    static const AggregateFunction* MakeRetractMinAggregateFunction();
+    static auto MakeRetractMinAggregateFunction();
 
     template <LogicalType LT>
-    static const AggregateFunction* MakeRetractMaxAggregateFunction();
+    static auto MakeRetractMaxAggregateFunction();
 };
 
 // The function should be placed by alphabetical order
 
 template <LogicalType LT>
-const AggregateFunction* AggregateFactory::MakeIntersectCountAggregateFunction() {
+AggregateFunctionPtr AggregateFactory::MakeIntersectCountAggregateFunction() {
     return new IntersectCountAggregateFunction<LT>();
 }
 
 template <bool IsWindowFunc>
-const AggregateFunction* AggregateFactory::MakeCountAggregateFunction() {
+AggregateFunctionPtr AggregateFactory::MakeCountAggregateFunction() {
     return new CountAggregateFunction<IsWindowFunc>();
 }
 
 template <LogicalType LT>
-const AggregateFunction* AggregateFactory::MakeWindowfunnelAggregateFunction() {
+AggregateFunctionPtr AggregateFactory::MakeWindowfunnelAggregateFunction() {
     return new WindowFunnelAggregateFunction<LT>();
 }
 
 template <LogicalType LT>
-const AggregateFunction* AggregateFactory::MakeCountDistinctAggregateFunction() {
+auto AggregateFactory::MakeCountDistinctAggregateFunction() {
     return new DistinctAggregateFunction<LT, AggDistinctType::COUNT>();
 }
 
 template <LogicalType LT>
-const AggregateFunction* AggregateFactory::MakeCountDistinctAggregateFunctionV2() {
+auto AggregateFactory::MakeCountDistinctAggregateFunctionV2() {
     return new DistinctAggregateFunctionV2<LT, AggDistinctType::COUNT>();
 }
 
 template <LogicalType LT>
-const AggregateFunction* AggregateFactory::MakeGroupConcatAggregateFunction() {
+AggregateFunctionPtr AggregateFactory::MakeGroupConcatAggregateFunction() {
     return new GroupConcatAggregateFunction<LT>();
 }
 
 template <bool IsWindowFunc>
-const AggregateFunction* AggregateFactory::MakeCountNullableAggregateFunction() {
+AggregateFunctionPtr AggregateFactory::MakeCountNullableAggregateFunction() {
     return new CountNullableAggregateFunction<IsWindowFunc>();
 }
 
 template <LogicalType LT>
-const AggregateFunction* AggregateFactory::MakeMaxAggregateFunction() {
+auto AggregateFactory::MakeMaxAggregateFunction() {
     return new MaxMinAggregateFunction<LT, MaxAggregateData<LT>, MaxElement<LT, MaxAggregateData<LT>>>();
 }
 
 template <LogicalType LT, bool not_filter_nulls>
-const AggregateFunction* AggregateFactory::MakeMaxByAggregateFunction() {
+auto AggregateFactory::MakeMaxByAggregateFunction() {
     using AggData = MaxByAggregateData<LT, not_filter_nulls>;
     return new MaxMinByAggregateFunction<LT, AggData, MaxByElement<LT, AggData>>();
 }
 
 template <LogicalType LT, bool not_filter_nulls>
-const AggregateFunction* AggregateFactory::MakeMinByAggregateFunction() {
+auto AggregateFactory::MakeMinByAggregateFunction() {
     using AggData = MinByAggregateData<LT, not_filter_nulls>;
     return new MaxMinByAggregateFunction<LT, AggData, MinByElement<LT, AggData>>();
 }
 
 template <LogicalType LT>
-const AggregateFunction* AggregateFactory::MakeMinAggregateFunction() {
+auto AggregateFactory::MakeMinAggregateFunction() {
     return new MaxMinAggregateFunction<LT, MinAggregateData<LT>, MinElement<LT, MinAggregateData<LT>>>();
 }
 
 template <LogicalType LT>
-const AggregateFunction* AggregateFactory::MakeAnyValueAggregateFunction() {
+AggregateFunctionPtr AggregateFactory::MakeAnyValueAggregateFunction() {
     return new AnyValueAggregateFunction<LT, AnyValueAggregateData<LT>,
                                          AnyValueElement<LT, AnyValueAggregateData<LT>>>();
 }
 
 template <typename NestedState, bool IsWindowFunc, bool IgnoreNull, typename NestedFunctionPtr,
           IsAggNullPred<NestedState> AggNullPred>
-const AggregateFunction* AggregateFactory::MakeNullableAggregateFunctionUnary(NestedFunctionPtr nested_function,
-                                                                              AggNullPred null_pred) {
+AggregateFunctionPtr AggregateFactory::MakeNullableAggregateFunctionUnary(NestedFunctionPtr nested_function,
+                                                                          AggNullPred null_pred) {
     using AggregateDataType = NullableAggregateFunctionState<NestedState, IsWindowFunc>;
     return new NullableAggregateFunctionUnary<NestedFunctionPtr, AggregateDataType, IsWindowFunc, IgnoreNull,
                                               AggNullPred>(nested_function, std::move(null_pred));
 }
 
 template <typename NestedState, IsAggNullPred<NestedState> AggNullPredType>
-const AggregateFunction* AggregateFactory::MakeNullableAggregateFunctionVariadic(
-        const AggregateFunction* nested_function, AggNullPredType null_pred) {
+AggregateFunctionPtr AggregateFactory::MakeNullableAggregateFunctionVariadic(AggregateFunctionPtr nested_function,
+                                                                             AggNullPredType null_pred) {
     using AggregateDataType = NullableAggregateFunctionState<NestedState, false>;
-    return new NullableAggregateFunctionVariadic<const AggregateFunction*, AggregateDataType, AggNullPredType>(
+    return new NullableAggregateFunctionVariadic<AggregateFunctionPtr, AggregateDataType, AggNullPredType>(
             nested_function, std::move(null_pred));
 }
 
 template <LogicalType LT>
-const AggregateFunction* AggregateFactory::MakeSumAggregateFunction() {
+auto AggregateFactory::MakeSumAggregateFunction() {
     return new SumAggregateFunction<LT>();
 }
 
 template <LogicalType LT>
-const AggregateFunction* AggregateFactory::MakeDecimalSumAggregateFunction() {
+auto AggregateFactory::MakeDecimalSumAggregateFunction() {
     return new DecimalSumAggregateFunction<LT>();
 }
 
 template <LogicalType LT, bool is_sample>
-const AggregateFunction* AggregateFactory::MakeVarianceAggregateFunction() {
+auto AggregateFactory::MakeVarianceAggregateFunction() {
     return new VarianceAggregateFunction<LT, is_sample>();
 }
 
 template <LogicalType LT, bool is_sample>
-const AggregateFunction* AggregateFactory::MakeStddevAggregateFunction() {
+auto AggregateFactory::MakeStddevAggregateFunction() {
     return new StddevAggregateFunction<LT, is_sample>();
 }
 
 template <LogicalType LT, bool is_sample>
-const AggregateFunction* AggregateFactory::MakeCovarianceAggregateFunction() {
+auto AggregateFactory::MakeCovarianceAggregateFunction() {
     return new CorVarianceAggregateFunction<LT, is_sample>();
 }
 
 template <LogicalType LT>
-const AggregateFunction* AggregateFactory::MakeCorelationAggregateFunction() {
+auto AggregateFactory::MakeCorelationAggregateFunction() {
     return new CorelationAggregateFunction<LT>();
 }
 
 template <LogicalType LT>
-const AggregateFunction* AggregateFactory::MakeSumDistinctAggregateFunction() {
+auto AggregateFactory::MakeSumDistinctAggregateFunction() {
     return new DistinctAggregateFunction<LT, AggDistinctType::SUM>();
 }
 
 template <LogicalType LT>
-const AggregateFunction* AggregateFactory::MakeSumDistinctAggregateFunctionV2() {
+auto AggregateFactory::MakeSumDistinctAggregateFunctionV2() {
     return new DistinctAggregateFunctionV2<LT, AggDistinctType::SUM>();
 }
 
 template <LogicalType LT>
-const AggregateFunction* AggregateFactory::MakeDecimalSumDistinctAggregateFunction() {
+auto AggregateFactory::MakeDecimalSumDistinctAggregateFunction() {
     return new DecimalDistinctAggregateFunction<LT, AggDistinctType::SUM>();
 }
 
 template <LogicalType LT, int compute_bits>
-const AggregateFunction* AggregateFactory::MakeFusedMultiDistinctAggregateFunction() {
+auto AggregateFactory::MakeFusedMultiDistinctAggregateFunction() {
     return new FusedMultiDistinctFunction<LT, compute_bits>();
 }
 
 template <LogicalType LT>
-const AggregateFunction* AggregateFactory::MakeHllNdvAggregateFunction() {
+AggregateFunctionPtr AggregateFactory::MakeHllNdvAggregateFunction() {
     return new HllNdvAggregateFunction<LT, false>();
 }
 
 template <LogicalType LT>
-const AggregateFunction* AggregateFactory::MakeHllSketchAggregateFunction() {
+AggregateFunctionPtr AggregateFactory::MakeHllSketchAggregateFunction() {
     return new HllSketchAggregateFunction<LT>();
 }
 
 template <LogicalType LT>
-const AggregateFunction* AggregateFactory::MakeThetaSketchAggregateFunction() {
+AggregateFunctionPtr AggregateFactory::MakeThetaSketchAggregateFunction() {
     return new ThetaSketchAggregateFunction<LT>();
 }
 
 template <LogicalType LT>
-const AggregateFunction* AggregateFactory::MakeHllRawAggregateFunction() {
+AggregateFunctionPtr AggregateFactory::MakeHllRawAggregateFunction() {
     return new HllNdvAggregateFunction<LT, true>();
 }
 
 template <LogicalType LT>
-const AggregateFunction* AggregateFactory::MakePercentileContAggregateFunction() {
+AggregateFunctionPtr AggregateFactory::MakePercentileContAggregateFunction() {
     return new PercentileContAggregateFunction<LT>();
 }
 
 template <LogicalType PT>
-const AggregateFunction* AggregateFactory::MakePercentileDiscAggregateFunction() {
+AggregateFunctionPtr AggregateFactory::MakePercentileDiscAggregateFunction() {
     return new PercentileDiscAggregateFunction<PT>();
 }
 
 template <LogicalType PT>
-const AggregateFunction* AggregateFactory::MakeLowCardPercentileBinAggregateFunction() {
+AggregateFunctionPtr AggregateFactory::MakeLowCardPercentileBinAggregateFunction() {
     return new LowCardPercentileBinAggregateFunction<PT>();
 }
 
 template <LogicalType PT>
-const AggregateFunction* AggregateFactory::MakeLowCardPercentileCntAggregateFunction() {
+AggregateFunctionPtr AggregateFactory::MakeLowCardPercentileCntAggregateFunction() {
     return new LowCardPercentileCntAggregateFunction<PT>();
 }
 
 template <LogicalType LT>
-const AggregateFunction* AggregateFactory::MakeBitmapAggAggregateFunction() {
+AggregateFunctionPtr AggregateFactory::MakeBitmapAggAggregateFunction() {
     return new BitmapAggAggregateFunction<LT>();
 }
 
 // Stream MV Retractable Aggregate Functions
 template <LogicalType LT>
-const AggregateFunction* AggregateFactory::MakeRetractMinAggregateFunction() {
+auto AggregateFactory::MakeRetractMinAggregateFunction() {
     return new MaxMinAggregateFunctionRetractable<LT, MinAggregateDataRetractable<LT>,
                                                   MinElement<LT, MinAggregateDataRetractable<LT>>>();
 }
 
 template <LogicalType LT>
-const AggregateFunction* AggregateFactory::MakeRetractMaxAggregateFunction() {
+auto AggregateFactory::MakeRetractMaxAggregateFunction() {
     return new MaxMinAggregateFunctionRetractable<LT, MaxAggregateDataRetractable<LT>,
                                                   MaxElement<LT, MaxAggregateDataRetractable<LT>>>();
 }

--- a/be/src/exprs/agg/factory/aggregate_factory.hpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.hpp
@@ -66,410 +66,407 @@ class AggregateFactory {
 public:
     // The function should be placed by alphabetical order
     template <LogicalType LT>
-    static auto MakeAvgAggregateFunction() {
-        return std::make_shared<AvgAggregateFunction<LT>>();
+    static const AggregateFunction* MakeAvgAggregateFunction() {
+        return new AvgAggregateFunction<LT>();
     }
 
     template <LogicalType LT>
-    static auto MakeDecimalAvgAggregateFunction() {
-        return std::make_shared<DecimalAvgAggregateFunction<LT>>();
+    static const AggregateFunction* MakeDecimalAvgAggregateFunction() {
+        return new DecimalAvgAggregateFunction<LT>();
     }
 
     template <LogicalType LT>
-    static AggregateFunctionPtr MakeBitmapUnionIntAggregateFunction() {
-        return std::make_shared<BitmapUnionIntAggregateFunction<LT>>();
+    static const AggregateFunction* MakeBitmapUnionIntAggregateFunction() {
+        return new BitmapUnionIntAggregateFunction<LT>();
     }
 
-    static AggregateFunctionPtr MakeBitmapUnionAggregateFunction();
+    static const AggregateFunction* MakeBitmapUnionAggregateFunction();
 
     template <LogicalType LT>
-    static AggregateFunctionPtr MakeBitmapAggAggregateFunction();
+    static const AggregateFunction* MakeBitmapAggAggregateFunction();
 
-    static AggregateFunctionPtr MakeBitmapIntersectAggregateFunction();
+    static const AggregateFunction* MakeBitmapIntersectAggregateFunction();
 
-    static AggregateFunctionPtr MakeBitmapUnionCountAggregateFunction();
-
-    template <LogicalType LT>
-    static AggregateFunctionPtr MakeWindowfunnelAggregateFunction();
+    static const AggregateFunction* MakeBitmapUnionCountAggregateFunction();
 
     template <LogicalType LT>
-    static AggregateFunctionPtr MakeIntersectCountAggregateFunction();
+    static const AggregateFunction* MakeWindowfunnelAggregateFunction();
+
+    template <LogicalType LT>
+    static const AggregateFunction* MakeIntersectCountAggregateFunction();
 
     template <bool IsWindowFunc>
-    static AggregateFunctionPtr MakeCountAggregateFunction();
+    static const AggregateFunction* MakeCountAggregateFunction();
 
     template <LogicalType LT>
-    static auto MakeCountDistinctAggregateFunction();
+    static const AggregateFunction* MakeCountDistinctAggregateFunction();
     template <LogicalType LT>
-    static auto MakeCountDistinctAggregateFunctionV2();
+    static const AggregateFunction* MakeCountDistinctAggregateFunctionV2();
 
     template <LogicalType LT>
-    static AggregateFunctionPtr MakeGroupConcatAggregateFunction();
+    static const AggregateFunction* MakeGroupConcatAggregateFunction();
 
     template <bool IsWindowFunc>
-    static AggregateFunctionPtr MakeCountNullableAggregateFunction();
+    static const AggregateFunction* MakeCountNullableAggregateFunction();
 
     template <AggExchangePerfType PerfType>
-    static AggregateFunctionPtr MakeExchangePerfAggregateFunction() {
-        return std::make_shared<ExchangePerfAggregateFunction<PerfType>>();
+    static const AggregateFunction* MakeExchangePerfAggregateFunction() {
+        return new ExchangePerfAggregateFunction<PerfType>();
     }
 
     template <typename ArrayAggState>
-    static AggregateFunctionPtr MakeArrayAggAggregateFunctionV2() {
-        return std::make_shared<ArrayAggAggregateFunctionV2<ArrayAggState>>();
+    static const AggregateFunction* MakeArrayAggAggregateFunctionV2() {
+        return new ArrayAggAggregateFunctionV2<ArrayAggState>();
     }
 
-    static AggregateFunctionPtr MakeGroupConcatAggregateFunctionV2() {
-        return std::make_shared<GroupConcatAggregateFunctionV2>();
+    static const AggregateFunction* MakeGroupConcatAggregateFunctionV2() {
+        return new GroupConcatAggregateFunctionV2();
     }
 
-    static auto MakeMannWhitneyUTestAggregateFunction() {
-        return std::make_shared<MannWhitneyUTestAggregateFunction>();
+    static const AggregateFunction* MakeMannWhitneyUTestAggregateFunction() {
+        return new MannWhitneyUTestAggregateFunction();
     }
 
     template <LogicalType LT>
-    static auto MakeMaxAggregateFunction();
+    static const AggregateFunction* MakeMaxAggregateFunction();
 
     template <LogicalType LT, bool not_filter_nulls>
-    static auto MakeMaxByAggregateFunction();
+    static const AggregateFunction* MakeMaxByAggregateFunction();
 
     template <LogicalType LT, bool not_filter_nulls>
-    static auto MakeMinByAggregateFunction();
+    static const AggregateFunction* MakeMinByAggregateFunction();
 
     template <LogicalType LT>
-    static auto MakeMinAggregateFunction();
+    static const AggregateFunction* MakeMinAggregateFunction();
 
     template <LogicalType LT>
-    static AggregateFunctionPtr MakeAnyValueAggregateFunction();
+    static const AggregateFunction* MakeAnyValueAggregateFunction();
 
-    static AggregateFunctionPtr MakeAnyValueSemiAggregateFunction() {
-        return std::make_shared<AnyValueSemiAggregateFunction>();
-    }
+    static const AggregateFunction* MakeAnyValueSemiAggregateFunction() { return new AnyValueSemiAggregateFunction(); }
 
     template <typename NestedState, bool IsWindowFunc, bool IgnoreNull = true,
-              typename NestedFunctionPtr = AggregateFunctionPtr,
+              typename NestedFunctionPtr = const AggregateFunction*,
               IsAggNullPred<NestedState> AggNullPred = AggNonNullPred<NestedState>>
-    static AggregateFunctionPtr MakeNullableAggregateFunctionUnary(NestedFunctionPtr nested_function,
-                                                                   AggNullPred null_pred = AggNullPred());
+    static const AggregateFunction* MakeNullableAggregateFunctionUnary(NestedFunctionPtr nested_function,
+                                                                       AggNullPred null_pred = AggNullPred());
 
-    template <typename NestedState, IsAggNullPred<NestedState> AggNullPred = AggNonNullPred<NestedState>>
-    static AggregateFunctionPtr MakeNullableAggregateFunctionVariadic(AggregateFunctionPtr nested_function,
-                                                                      AggNullPred null_pred = AggNullPred());
-
-    template <LogicalType LT>
-    static auto MakeSumAggregateFunction();
+    template <typename NestedState, IsAggNullPred<NestedState> AggNullPredType = AggNonNullPred<NestedState>>
+    static const AggregateFunction* MakeNullableAggregateFunctionVariadic(
+            const AggregateFunction* nested_function, AggNullPredType null_pred = AggNullPredType());
 
     template <LogicalType LT>
-    static auto MakeDecimalSumAggregateFunction();
+    static const AggregateFunction* MakeSumAggregateFunction();
+
+    template <LogicalType LT>
+    static const AggregateFunction* MakeDecimalSumAggregateFunction();
 
     template <LogicalType LT, bool is_sample>
-    static auto MakeVarianceAggregateFunction();
+    static const AggregateFunction* MakeVarianceAggregateFunction();
 
     template <LogicalType LT, bool is_sample>
-    static auto MakeStddevAggregateFunction();
+    static const AggregateFunction* MakeStddevAggregateFunction();
 
     template <LogicalType LT, bool is_sample>
-    static auto MakeCovarianceAggregateFunction();
+    static const AggregateFunction* MakeCovarianceAggregateFunction();
 
     template <LogicalType LT>
-    static auto MakeCorelationAggregateFunction();
+    static const AggregateFunction* MakeCorelationAggregateFunction();
 
     template <LogicalType LT>
-    static auto MakeSumDistinctAggregateFunction();
+    static const AggregateFunction* MakeSumDistinctAggregateFunction();
     template <LogicalType LT>
-    static auto MakeSumDistinctAggregateFunctionV2();
+    static const AggregateFunction* MakeSumDistinctAggregateFunctionV2();
     template <LogicalType LT>
-    static auto MakeDecimalSumDistinctAggregateFunction();
+    static const AggregateFunction* MakeDecimalSumDistinctAggregateFunction();
     template <LogicalType LT, int compute_bits>
-    static auto MakeFusedMultiDistinctAggregateFunction();
+    static const AggregateFunction* MakeFusedMultiDistinctAggregateFunction();
 
-    static AggregateFunctionPtr MakeDictMergeAggregateFunction();
-    static AggregateFunctionPtr MakeRetentionAggregateFunction();
+    static const AggregateFunction* MakeDictMergeAggregateFunction();
+    static const AggregateFunction* MakeRetentionAggregateFunction();
 
     // Hyperloglog functions:
-    static AggregateFunctionPtr MakeHllUnionAggregateFunction();
+    static const AggregateFunction* MakeHllUnionAggregateFunction();
 
-    static AggregateFunctionPtr MakeHllUnionCountAggregateFunction();
-
-    template <LogicalType T>
-    static AggregateFunctionPtr MakeHllNdvAggregateFunction();
+    static const AggregateFunction* MakeHllUnionCountAggregateFunction();
 
     template <LogicalType T>
-    static AggregateFunctionPtr MakeHllSketchAggregateFunction();
+    static const AggregateFunction* MakeHllNdvAggregateFunction();
 
     template <LogicalType T>
-    static AggregateFunctionPtr MakeThetaSketchAggregateFunction();
+    static const AggregateFunction* MakeHllSketchAggregateFunction();
 
     template <LogicalType T>
-    static AggregateFunctionPtr MakeHllRawAggregateFunction();
+    static const AggregateFunction* MakeThetaSketchAggregateFunction();
 
-    static AggregateFunctionPtr MakePercentileApproxAggregateFunction();
+    template <LogicalType T>
+    static const AggregateFunction* MakeHllRawAggregateFunction();
 
-    static AggregateFunctionPtr MakePercentileApproxArrayAggregateFunction();
+    static const AggregateFunction* MakePercentileApproxAggregateFunction();
 
-    static AggregateFunctionPtr MakePercentileApproxWeightedAggregateFunction();
+    static const AggregateFunction* MakePercentileApproxArrayAggregateFunction();
 
-    static AggregateFunctionPtr MakePercentileApproxWeightedArrayAggregateFunction();
+    static const AggregateFunction* MakePercentileApproxWeightedAggregateFunction();
 
-    static AggregateFunctionPtr MakePercentileUnionAggregateFunction();
+    static const AggregateFunction* MakePercentileApproxWeightedArrayAggregateFunction();
+
+    static const AggregateFunction* MakePercentileUnionAggregateFunction();
 
     template <LogicalType LT>
-    static AggregateFunctionPtr MakePercentileContAggregateFunction();
+    static const AggregateFunction* MakePercentileContAggregateFunction();
 
     template <LogicalType PT>
-    static AggregateFunctionPtr MakePercentileDiscAggregateFunction();
+    static const AggregateFunction* MakePercentileDiscAggregateFunction();
 
     template <LogicalType LT>
-    static AggregateFunctionPtr MakeLowCardPercentileBinAggregateFunction();
+    static const AggregateFunction* MakeLowCardPercentileBinAggregateFunction();
 
     template <LogicalType PT>
-    static AggregateFunctionPtr MakeLowCardPercentileCntAggregateFunction();
+    static const AggregateFunction* MakeLowCardPercentileCntAggregateFunction();
 
     // Windows functions:
-    static AggregateFunctionPtr MakeDenseRankWindowFunction();
+    static const AggregateFunction* MakeDenseRankWindowFunction();
 
-    static AggregateFunctionPtr MakeRankWindowFunction();
+    static const AggregateFunction* MakeRankWindowFunction();
 
-    static AggregateFunctionPtr MakeRowNumberWindowFunction();
+    static const AggregateFunction* MakeRowNumberWindowFunction();
 
-    static AggregateFunctionPtr MakeCumeDistWindowFunction();
+    static const AggregateFunction* MakeCumeDistWindowFunction();
 
-    static AggregateFunctionPtr MakePercentRankWindowFunction();
+    static const AggregateFunction* MakePercentRankWindowFunction();
 
-    static AggregateFunctionPtr MakeNtileWindowFunction();
+    static const AggregateFunction* MakeNtileWindowFunction();
 
     template <LogicalType LT, bool ignoreNulls>
-    static AggregateFunctionPtr MakeFirstValueWindowFunction() {
-        return std::make_shared<FirstValueWindowFunction<LT, ignoreNulls>>();
+    static const AggregateFunction* MakeFirstValueWindowFunction() {
+        return new FirstValueWindowFunction<LT, ignoreNulls>();
     }
 
     template <LogicalType LT, bool ignoreNulls>
-    static AggregateFunctionPtr MakeLastValueWindowFunction() {
-        return std::make_shared<LastValueWindowFunction<LT, ignoreNulls>>();
+    static const AggregateFunction* MakeLastValueWindowFunction() {
+        return new LastValueWindowFunction<LT, ignoreNulls>();
     }
 
     template <LogicalType LT, bool ignoreNulls, bool isLag>
-    static AggregateFunctionPtr MakeLeadLagWindowFunction() {
-        return std::make_shared<LeadLagWindowFunction<LT, ignoreNulls, isLag>>();
+    static const AggregateFunction* MakeLeadLagWindowFunction() {
+        return new LeadLagWindowFunction<LT, ignoreNulls, isLag>();
     }
 
     template <LogicalType LT>
-    static AggregateFunctionPtr MakeSessionNumberWindowFunction() {
-        return std::make_shared<SessionNumberWindowFunction<LT>>();
+    static const AggregateFunction* MakeSessionNumberWindowFunction() {
+        return new SessionNumberWindowFunction<LT>();
     }
 
     template <LogicalType LT>
-    static AggregateFunctionPtr MakeApproxTopKAggregateFunction() {
-        return std::make_shared<ApproxTopKAggregateFunction<LT>>();
+    static const AggregateFunction* MakeApproxTopKAggregateFunction() {
+        return new ApproxTopKAggregateFunction<LT>();
     }
 
     template <LogicalType LT>
-    static AggregateFunctionPtr MakeHistogramAggregationFunction() {
-        return std::make_shared<HistogramAggregationFunction<LT>>();
+    static const AggregateFunction* MakeHistogramAggregationFunction() {
+        return new HistogramAggregationFunction<LT>();
     }
 
     template <LogicalType LT>
-    static AggregateFunctionPtr MakeHistogramHllNdvAggregationFunction() {
-        return std::make_shared<HistogramHllNdvAggregateFunction<LT>>();
+    static const AggregateFunction* MakeHistogramHllNdvAggregationFunction() {
+        return new HistogramHllNdvAggregateFunction<LT>();
     }
 
     // Stream MV Retractable Agg Functions
     template <LogicalType LT>
-    static auto MakeRetractMinAggregateFunction();
+    static const AggregateFunction* MakeRetractMinAggregateFunction();
 
     template <LogicalType LT>
-    static auto MakeRetractMaxAggregateFunction();
+    static const AggregateFunction* MakeRetractMaxAggregateFunction();
 };
 
 // The function should be placed by alphabetical order
 
 template <LogicalType LT>
-AggregateFunctionPtr AggregateFactory::MakeIntersectCountAggregateFunction() {
-    return std::make_shared<IntersectCountAggregateFunction<LT>>();
+const AggregateFunction* AggregateFactory::MakeIntersectCountAggregateFunction() {
+    return new IntersectCountAggregateFunction<LT>();
 }
 
 template <bool IsWindowFunc>
-AggregateFunctionPtr AggregateFactory::MakeCountAggregateFunction() {
-    return std::make_shared<CountAggregateFunction<IsWindowFunc>>();
+const AggregateFunction* AggregateFactory::MakeCountAggregateFunction() {
+    return new CountAggregateFunction<IsWindowFunc>();
 }
 
 template <LogicalType LT>
-AggregateFunctionPtr AggregateFactory::MakeWindowfunnelAggregateFunction() {
-    return std::make_shared<WindowFunnelAggregateFunction<LT>>();
+const AggregateFunction* AggregateFactory::MakeWindowfunnelAggregateFunction() {
+    return new WindowFunnelAggregateFunction<LT>();
 }
 
 template <LogicalType LT>
-auto AggregateFactory::MakeCountDistinctAggregateFunction() {
-    return std::make_shared<DistinctAggregateFunction<LT, AggDistinctType::COUNT>>();
+const AggregateFunction* AggregateFactory::MakeCountDistinctAggregateFunction() {
+    return new DistinctAggregateFunction<LT, AggDistinctType::COUNT>();
 }
 
 template <LogicalType LT>
-auto AggregateFactory::MakeCountDistinctAggregateFunctionV2() {
-    return std::make_shared<DistinctAggregateFunctionV2<LT, AggDistinctType::COUNT>>();
+const AggregateFunction* AggregateFactory::MakeCountDistinctAggregateFunctionV2() {
+    return new DistinctAggregateFunctionV2<LT, AggDistinctType::COUNT>();
 }
 
 template <LogicalType LT>
-AggregateFunctionPtr AggregateFactory::MakeGroupConcatAggregateFunction() {
-    return std::make_shared<GroupConcatAggregateFunction<LT>>();
+const AggregateFunction* AggregateFactory::MakeGroupConcatAggregateFunction() {
+    return new GroupConcatAggregateFunction<LT>();
 }
 
 template <bool IsWindowFunc>
-AggregateFunctionPtr AggregateFactory::MakeCountNullableAggregateFunction() {
-    return std::make_shared<CountNullableAggregateFunction<IsWindowFunc>>();
+const AggregateFunction* AggregateFactory::MakeCountNullableAggregateFunction() {
+    return new CountNullableAggregateFunction<IsWindowFunc>();
 }
 
 template <LogicalType LT>
-auto AggregateFactory::MakeMaxAggregateFunction() {
-    return std::make_shared<MaxMinAggregateFunction<LT, MaxAggregateData<LT>, MaxElement<LT, MaxAggregateData<LT>>>>();
+const AggregateFunction* AggregateFactory::MakeMaxAggregateFunction() {
+    return new MaxMinAggregateFunction<LT, MaxAggregateData<LT>, MaxElement<LT, MaxAggregateData<LT>>>();
 }
 
 template <LogicalType LT, bool not_filter_nulls>
-auto AggregateFactory::MakeMaxByAggregateFunction() {
+const AggregateFunction* AggregateFactory::MakeMaxByAggregateFunction() {
     using AggData = MaxByAggregateData<LT, not_filter_nulls>;
-    return std::make_shared<MaxMinByAggregateFunction<LT, AggData, MaxByElement<LT, AggData>>>();
+    return new MaxMinByAggregateFunction<LT, AggData, MaxByElement<LT, AggData>>();
 }
 
 template <LogicalType LT, bool not_filter_nulls>
-auto AggregateFactory::MakeMinByAggregateFunction() {
+const AggregateFunction* AggregateFactory::MakeMinByAggregateFunction() {
     using AggData = MinByAggregateData<LT, not_filter_nulls>;
-    return std::make_shared<MaxMinByAggregateFunction<LT, AggData, MinByElement<LT, AggData>>>();
+    return new MaxMinByAggregateFunction<LT, AggData, MinByElement<LT, AggData>>();
 }
 
 template <LogicalType LT>
-auto AggregateFactory::MakeMinAggregateFunction() {
-    return std::make_shared<MaxMinAggregateFunction<LT, MinAggregateData<LT>, MinElement<LT, MinAggregateData<LT>>>>();
+const AggregateFunction* AggregateFactory::MakeMinAggregateFunction() {
+    return new MaxMinAggregateFunction<LT, MinAggregateData<LT>, MinElement<LT, MinAggregateData<LT>>>();
 }
 
 template <LogicalType LT>
-AggregateFunctionPtr AggregateFactory::MakeAnyValueAggregateFunction() {
-    return std::make_shared<
-            AnyValueAggregateFunction<LT, AnyValueAggregateData<LT>, AnyValueElement<LT, AnyValueAggregateData<LT>>>>();
+const AggregateFunction* AggregateFactory::MakeAnyValueAggregateFunction() {
+    return new AnyValueAggregateFunction<LT, AnyValueAggregateData<LT>,
+                                         AnyValueElement<LT, AnyValueAggregateData<LT>>>();
 }
 
 template <typename NestedState, bool IsWindowFunc, bool IgnoreNull, typename NestedFunctionPtr,
           IsAggNullPred<NestedState> AggNullPred>
-AggregateFunctionPtr AggregateFactory::MakeNullableAggregateFunctionUnary(NestedFunctionPtr nested_function,
-                                                                          AggNullPred null_pred) {
+const AggregateFunction* AggregateFactory::MakeNullableAggregateFunctionUnary(NestedFunctionPtr nested_function,
+                                                                              AggNullPred null_pred) {
     using AggregateDataType = NullableAggregateFunctionState<NestedState, IsWindowFunc>;
-    return std::make_shared<NullableAggregateFunctionUnary<NestedFunctionPtr, AggregateDataType, IsWindowFunc,
-                                                           IgnoreNull, AggNullPred>>(nested_function,
-                                                                                     std::move(null_pred));
+    return new NullableAggregateFunctionUnary<NestedFunctionPtr, AggregateDataType, IsWindowFunc, IgnoreNull,
+                                              AggNullPred>(nested_function, std::move(null_pred));
 }
 
-template <typename NestedState, IsAggNullPred<NestedState> AggNullPred>
-AggregateFunctionPtr AggregateFactory::MakeNullableAggregateFunctionVariadic(AggregateFunctionPtr nested_function,
-                                                                             AggNullPred null_pred) {
+template <typename NestedState, IsAggNullPred<NestedState> AggNullPredType>
+const AggregateFunction* AggregateFactory::MakeNullableAggregateFunctionVariadic(
+        const AggregateFunction* nested_function, AggNullPredType null_pred) {
     using AggregateDataType = NullableAggregateFunctionState<NestedState, false>;
-    return std::make_shared<NullableAggregateFunctionVariadic<AggregateDataType, AggNullPred>>(nested_function,
-                                                                                               std::move(null_pred));
+    return new NullableAggregateFunctionVariadic<const AggregateFunction*, AggregateDataType, AggNullPredType>(
+            nested_function, std::move(null_pred));
 }
 
 template <LogicalType LT>
-auto AggregateFactory::MakeSumAggregateFunction() {
-    return std::make_shared<SumAggregateFunction<LT>>();
+const AggregateFunction* AggregateFactory::MakeSumAggregateFunction() {
+    return new SumAggregateFunction<LT>();
 }
 
 template <LogicalType LT>
-auto AggregateFactory::MakeDecimalSumAggregateFunction() {
-    return std::make_shared<DecimalSumAggregateFunction<LT>>();
+const AggregateFunction* AggregateFactory::MakeDecimalSumAggregateFunction() {
+    return new DecimalSumAggregateFunction<LT>();
 }
 
 template <LogicalType LT, bool is_sample>
-auto AggregateFactory::MakeVarianceAggregateFunction() {
-    return std::make_shared<VarianceAggregateFunction<LT, is_sample>>();
+const AggregateFunction* AggregateFactory::MakeVarianceAggregateFunction() {
+    return new VarianceAggregateFunction<LT, is_sample>();
 }
 
 template <LogicalType LT, bool is_sample>
-auto AggregateFactory::MakeStddevAggregateFunction() {
-    return std::make_shared<StddevAggregateFunction<LT, is_sample>>();
+const AggregateFunction* AggregateFactory::MakeStddevAggregateFunction() {
+    return new StddevAggregateFunction<LT, is_sample>();
 }
 
 template <LogicalType LT, bool is_sample>
-auto AggregateFactory::MakeCovarianceAggregateFunction() {
-    return std::make_shared<CorVarianceAggregateFunction<LT, is_sample>>();
+const AggregateFunction* AggregateFactory::MakeCovarianceAggregateFunction() {
+    return new CorVarianceAggregateFunction<LT, is_sample>();
 }
 
 template <LogicalType LT>
-auto AggregateFactory::MakeCorelationAggregateFunction() {
-    return std::make_shared<CorelationAggregateFunction<LT>>();
+const AggregateFunction* AggregateFactory::MakeCorelationAggregateFunction() {
+    return new CorelationAggregateFunction<LT>();
 }
 
 template <LogicalType LT>
-auto AggregateFactory::MakeSumDistinctAggregateFunction() {
-    return std::make_shared<DistinctAggregateFunction<LT, AggDistinctType::SUM>>();
+const AggregateFunction* AggregateFactory::MakeSumDistinctAggregateFunction() {
+    return new DistinctAggregateFunction<LT, AggDistinctType::SUM>();
 }
 
 template <LogicalType LT>
-auto AggregateFactory::MakeSumDistinctAggregateFunctionV2() {
-    return std::make_shared<DistinctAggregateFunctionV2<LT, AggDistinctType::SUM>>();
+const AggregateFunction* AggregateFactory::MakeSumDistinctAggregateFunctionV2() {
+    return new DistinctAggregateFunctionV2<LT, AggDistinctType::SUM>();
 }
 
 template <LogicalType LT>
-auto AggregateFactory::MakeDecimalSumDistinctAggregateFunction() {
-    return std::make_shared<DecimalDistinctAggregateFunction<LT, AggDistinctType::SUM>>();
+const AggregateFunction* AggregateFactory::MakeDecimalSumDistinctAggregateFunction() {
+    return new DecimalDistinctAggregateFunction<LT, AggDistinctType::SUM>();
 }
 
 template <LogicalType LT, int compute_bits>
-auto AggregateFactory::MakeFusedMultiDistinctAggregateFunction() {
-    return std::make_shared<FusedMultiDistinctFunction<LT, compute_bits>>();
+const AggregateFunction* AggregateFactory::MakeFusedMultiDistinctAggregateFunction() {
+    return new FusedMultiDistinctFunction<LT, compute_bits>();
 }
 
 template <LogicalType LT>
-AggregateFunctionPtr AggregateFactory::MakeHllNdvAggregateFunction() {
-    return std::make_shared<HllNdvAggregateFunction<LT, false>>();
+const AggregateFunction* AggregateFactory::MakeHllNdvAggregateFunction() {
+    return new HllNdvAggregateFunction<LT, false>();
 }
 
 template <LogicalType LT>
-AggregateFunctionPtr AggregateFactory::MakeHllSketchAggregateFunction() {
-    return std::make_shared<HllSketchAggregateFunction<LT>>();
+const AggregateFunction* AggregateFactory::MakeHllSketchAggregateFunction() {
+    return new HllSketchAggregateFunction<LT>();
 }
 
 template <LogicalType LT>
-AggregateFunctionPtr AggregateFactory::MakeThetaSketchAggregateFunction() {
-    return std::make_shared<ThetaSketchAggregateFunction<LT>>();
+const AggregateFunction* AggregateFactory::MakeThetaSketchAggregateFunction() {
+    return new ThetaSketchAggregateFunction<LT>();
 }
 
 template <LogicalType LT>
-AggregateFunctionPtr AggregateFactory::MakeHllRawAggregateFunction() {
-    return std::make_shared<HllNdvAggregateFunction<LT, true>>();
+const AggregateFunction* AggregateFactory::MakeHllRawAggregateFunction() {
+    return new HllNdvAggregateFunction<LT, true>();
 }
 
 template <LogicalType LT>
-AggregateFunctionPtr AggregateFactory::MakePercentileContAggregateFunction() {
-    return std::make_shared<PercentileContAggregateFunction<LT>>();
+const AggregateFunction* AggregateFactory::MakePercentileContAggregateFunction() {
+    return new PercentileContAggregateFunction<LT>();
 }
 
 template <LogicalType PT>
-AggregateFunctionPtr AggregateFactory::MakePercentileDiscAggregateFunction() {
-    return std::make_shared<PercentileDiscAggregateFunction<PT>>();
+const AggregateFunction* AggregateFactory::MakePercentileDiscAggregateFunction() {
+    return new PercentileDiscAggregateFunction<PT>();
 }
 
 template <LogicalType PT>
-AggregateFunctionPtr AggregateFactory::MakeLowCardPercentileBinAggregateFunction() {
-    return std::make_shared<LowCardPercentileBinAggregateFunction<PT>>();
+const AggregateFunction* AggregateFactory::MakeLowCardPercentileBinAggregateFunction() {
+    return new LowCardPercentileBinAggregateFunction<PT>();
 }
 
 template <LogicalType PT>
-AggregateFunctionPtr AggregateFactory::MakeLowCardPercentileCntAggregateFunction() {
-    return std::make_shared<LowCardPercentileCntAggregateFunction<PT>>();
+const AggregateFunction* AggregateFactory::MakeLowCardPercentileCntAggregateFunction() {
+    return new LowCardPercentileCntAggregateFunction<PT>();
 }
 
 template <LogicalType LT>
-AggregateFunctionPtr AggregateFactory::MakeBitmapAggAggregateFunction() {
-    return std::make_shared<BitmapAggAggregateFunction<LT>>();
+const AggregateFunction* AggregateFactory::MakeBitmapAggAggregateFunction() {
+    return new BitmapAggAggregateFunction<LT>();
 }
 
 // Stream MV Retractable Aggregate Functions
 template <LogicalType LT>
-auto AggregateFactory::MakeRetractMinAggregateFunction() {
-    return std::make_shared<MaxMinAggregateFunctionRetractable<LT, MinAggregateDataRetractable<LT>,
-                                                               MinElement<LT, MinAggregateDataRetractable<LT>>>>();
+const AggregateFunction* AggregateFactory::MakeRetractMinAggregateFunction() {
+    return new MaxMinAggregateFunctionRetractable<LT, MinAggregateDataRetractable<LT>,
+                                                  MinElement<LT, MinAggregateDataRetractable<LT>>>();
 }
 
 template <LogicalType LT>
-auto AggregateFactory::MakeRetractMaxAggregateFunction() {
-    return std::make_shared<MaxMinAggregateFunctionRetractable<LT, MaxAggregateDataRetractable<LT>,
-                                                               MaxElement<LT, MaxAggregateDataRetractable<LT>>>>();
+const AggregateFunction* AggregateFactory::MakeRetractMaxAggregateFunction() {
+    return new MaxMinAggregateFunctionRetractable<LT, MaxAggregateDataRetractable<LT>,
+                                                  MaxElement<LT, MaxAggregateDataRetractable<LT>>>();
 }
 
 } // namespace starrocks

--- a/be/src/exprs/agg/factory/aggregate_factory.hpp
+++ b/be/src/exprs/agg/factory/aggregate_factory.hpp
@@ -353,8 +353,8 @@ template <typename NestedState, IsAggNullPred<NestedState> AggNullPredType>
 AggregateFunctionPtr AggregateFactory::MakeNullableAggregateFunctionVariadic(AggregateFunctionPtr nested_function,
                                                                              AggNullPredType null_pred) {
     using AggregateDataType = NullableAggregateFunctionState<NestedState, false>;
-    return new NullableAggregateFunctionVariadic<AggregateFunctionPtr, AggregateDataType, AggNullPredType>(
-            nested_function, std::move(null_pred));
+    return new NullableAggregateFunctionVariadic<AggregateDataType, AggNullPredType>(nested_function,
+                                                                                     std::move(null_pred));
 }
 
 template <LogicalType LT>

--- a/be/src/exprs/agg/factory/aggregate_resolver.hpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver.hpp
@@ -99,7 +99,8 @@ public:
         return pair->second;
     }
 
-    void add_general_mapping_notnull(const std::string& name, bool is_window, const AggregateFunction* fun) {
+    template <typename SpecificAggFunctionPtr = AggregateFunctionPtr>
+    void add_general_mapping_notnull(const std::string& name, bool is_window, SpecificAggFunctionPtr fun) {
         track_function(fun);
         _general_mapping.emplace(std::make_tuple(name, false, false), fun);
         _general_mapping.emplace(std::make_tuple(name, false, true), fun);
@@ -109,14 +110,15 @@ public:
         }
     }
 
-    void add_general_window_mapping_notnull(const std::string& name, const AggregateFunction* fun) {
+    template <typename SpecificAggFunctionPtr = AggregateFunctionPtr>
+    void add_general_window_mapping_notnull(const std::string& name, SpecificAggFunctionPtr fun) {
         track_function(fun);
         _general_mapping.emplace(std::make_tuple(name, true, false), fun);
         _general_mapping.emplace(std::make_tuple(name, true, true), fun);
     }
 
-    template <class StateType, bool IgnoreNull = true>
-    void add_general_mapping(const std::string& name, bool is_window, const AggregateFunction* fun) {
+    template <class StateType, typename SpecificAggFunctionPtr = AggregateFunctionPtr, bool IgnoreNull = true>
+    void add_general_mapping(const std::string& name, bool is_window, SpecificAggFunctionPtr fun) {
         track_function(fun);
         _general_mapping.emplace(std::make_tuple(name, false, false), fun);
         auto nullable_agg = AggregateFactory::MakeNullableAggregateFunctionUnary<StateType, false, IgnoreNull>(fun);
@@ -129,8 +131,8 @@ public:
         }
     }
 
-    template <LogicalType ArgType, LogicalType RetType>
-    void add_aggregate_mapping_notnull(const std::string& name, bool is_window, const AggregateFunction* fun) {
+    template <LogicalType ArgType, LogicalType RetType, typename SpecificAggFunctionPtr = AggregateFunctionPtr>
+    void add_aggregate_mapping_notnull(const std::string& name, bool is_window, SpecificAggFunctionPtr fun) {
         track_function(fun);
         _infos_mapping.emplace(std::make_tuple(name, ArgType, RetType, false, false), fun);
         _infos_mapping.emplace(std::make_tuple(name, ArgType, RetType, false, true), fun);
@@ -140,9 +142,10 @@ public:
         }
     }
 
-    template <LogicalType ArgType, LogicalType RetType, class StateType, bool IgnoreNull = true,
+    template <LogicalType ArgType, LogicalType RetType, class StateType,
+              typename SpecificAggFunctionPtr = AggregateFunctionPtr, bool IgnoreNull = true,
               IsAggNullPred<StateType> AggNullPred = AggNonNullPred<StateType>>
-    void add_aggregate_mapping(const std::string& name, bool is_window, const AggregateFunction* fun,
+    void add_aggregate_mapping(const std::string& name, bool is_window, SpecificAggFunctionPtr fun,
                                AggNullPred null_pred = AggNullPred()) {
         track_function(fun);
         _infos_mapping.emplace(std::make_tuple(name, ArgType, RetType, false, false), fun);
@@ -158,9 +161,10 @@ public:
         }
     }
 
-    template <LogicalType ArgType, LogicalType RetType, class StateType, bool IgnoreNull = true,
+    template <LogicalType ArgType, LogicalType RetType, class StateType,
+              typename SpecificAggFunctionPtr = AggregateFunctionPtr, bool IgnoreNull = true,
               IsAggNullPred<StateType> AggNullPred = AggNonNullPred<StateType>>
-    void add_window_mapping(const std::string& name, const AggregateFunction* fun,
+    void add_window_mapping(const std::string& name, SpecificAggFunctionPtr fun,
                             AggNullPred null_pred = AggNullPred()) {
         track_function(fun);
         _infos_mapping.emplace(std::make_tuple(name, ArgType, RetType, true, false), fun);
@@ -170,8 +174,9 @@ public:
     }
 
     template <LogicalType ArgType, LogicalType RetType, class StateType,
+              typename SpecificAggFunctionPtr = AggregateFunctionPtr,
               IsAggNullPred<StateType> AggNullPred = AggNonNullPred<StateType>>
-    void add_aggregate_mapping_variadic(const std::string& name, bool is_window, const AggregateFunction* fun,
+    void add_aggregate_mapping_variadic(const std::string& name, bool is_window, SpecificAggFunctionPtr fun,
                                         AggNullPred null_pred = AggNullPred()) {
         track_function(fun);
         _infos_mapping.emplace(std::make_tuple(name, ArgType, RetType, false, false), fun);
@@ -289,9 +294,9 @@ public:
     }
 
 private:
-    std::unordered_map<AggregateFuncKey, const AggregateFunction*, AggregateFuncMapHash> _infos_mapping;
-    std::unordered_map<GeneralFuncKey, const AggregateFunction*, GeneralFuncMapHash> _general_mapping;
-    std::unordered_set<const AggregateFunction*> _functions;
+    std::unordered_map<AggregateFuncKey, AggregateFunctionPtr, AggregateFuncMapHash> _infos_mapping;
+    std::unordered_map<GeneralFuncKey, AggregateFunctionPtr, GeneralFuncMapHash> _general_mapping;
+    std::unordered_set<AggregateFunctionPtr> _functions;
 };
 
 } // namespace starrocks

--- a/be/src/exprs/agg/factory/aggregate_resolver.hpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver.hpp
@@ -214,16 +214,16 @@ public:
     }
 
     template <LogicalType ArgLT, LogicalType ResultLT, bool IsNull>
-    const AggregateFunction* create_array_function(std::string& name) {
+    AggregateFunctionPtr create_array_function(std::string& name) {
         if constexpr (IsNull) {
             if (name == "dict_merge") {
                 auto dict_merge = track_function(AggregateFactory::MakeDictMergeAggregateFunction());
                 return track_function(
                         AggregateFactory::MakeNullableAggregateFunctionUnary<DictMergeState, false>(dict_merge));
             } else if (name == "retention") {
-                auto retentoin = track_function(AggregateFactory::MakeRetentionAggregateFunction());
+                auto retention = track_function(AggregateFactory::MakeRetentionAggregateFunction());
                 return track_function(
-                        AggregateFactory::MakeNullableAggregateFunctionUnary<RetentionState, false>(retentoin));
+                        AggregateFactory::MakeNullableAggregateFunctionUnary<RetentionState, false>(retention));
             } else if (name == "window_funnel") {
                 if constexpr (ArgLT == TYPE_INT || ArgLT == TYPE_BIGINT || ArgLT == TYPE_DATE ||
                               ArgLT == TYPE_DATETIME) {
@@ -250,7 +250,7 @@ public:
     }
 
     template <LogicalType ArgLT, LogicalType ResultLT, bool IsWindowFunc, bool IsNull>
-    std::enable_if_t<isArithmeticLT<ArgLT>, const AggregateFunction*> create_decimal_function(std::string& name) {
+    std::enable_if_t<isArithmeticLT<ArgLT>, AggregateFunctionPtr> create_decimal_function(std::string& name) {
         static_assert(lt_is_decimal128<ResultLT> || lt_is_decimal256<ResultLT>);
         if constexpr (IsNull) {
             using ResultType = RunTimeCppType<ResultLT>;

--- a/be/src/exprs/agg/factory/aggregate_resolver.hpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver.hpp
@@ -212,17 +212,17 @@ public:
     const AggregateFunction* create_array_function(std::string& name) {
         if constexpr (IsNull) {
             if (name == "dict_merge") {
-                auto dict_merge = AggregateFactory::MakeDictMergeAggregateFunction();
+                auto dict_merge = track_function(AggregateFactory::MakeDictMergeAggregateFunction());
                 return track_function(
                         AggregateFactory::MakeNullableAggregateFunctionUnary<DictMergeState, false>(dict_merge));
             } else if (name == "retention") {
-                auto retentoin = AggregateFactory::MakeRetentionAggregateFunction();
+                auto retentoin = track_function(AggregateFactory::MakeRetentionAggregateFunction());
                 return track_function(
                         AggregateFactory::MakeNullableAggregateFunctionUnary<RetentionState, false>(retentoin));
             } else if (name == "window_funnel") {
                 if constexpr (ArgLT == TYPE_INT || ArgLT == TYPE_BIGINT || ArgLT == TYPE_DATE ||
                               ArgLT == TYPE_DATETIME) {
-                    auto windowfunnel = AggregateFactory::MakeWindowfunnelAggregateFunction<ArgLT>();
+                    auto windowfunnel = track_function(AggregateFactory::MakeWindowfunnelAggregateFunction<ArgLT>());
                     return track_function(
                             AggregateFactory::MakeNullableAggregateFunctionVariadic<WindowFunnelState<ArgLT>>(
                                     windowfunnel));
@@ -250,17 +250,17 @@ public:
         if constexpr (IsNull) {
             using ResultType = RunTimeCppType<ResultLT>;
             if (name == "decimal_avg") {
-                auto avg = AggregateFactory::MakeDecimalAvgAggregateFunction<ArgLT>();
+                auto avg = track_function(AggregateFactory::MakeDecimalAvgAggregateFunction<ArgLT>());
                 return track_function(
                         AggregateFactory::MakeNullableAggregateFunctionUnary<AvgAggregateState<ResultType>,
                                                                              IsWindowFunc>(avg));
             } else if (name == "decimal_sum") {
-                auto sum = AggregateFactory::MakeDecimalSumAggregateFunction<ArgLT>();
+                auto sum = track_function(AggregateFactory::MakeDecimalSumAggregateFunction<ArgLT>());
                 return track_function(
                         AggregateFactory::MakeNullableAggregateFunctionUnary<AvgAggregateState<ResultType>,
                                                                              IsWindowFunc>(sum));
             } else if (name == "decimal_multi_distinct_sum") {
-                auto distinct_sum = AggregateFactory::MakeDecimalSumDistinctAggregateFunction<ArgLT>();
+                auto distinct_sum = track_function(AggregateFactory::MakeDecimalSumDistinctAggregateFunction<ArgLT>());
                 return track_function(
                         AggregateFactory::MakeNullableAggregateFunctionUnary<DistinctAggregateState<ArgLT, ResultLT>,
                                                                              IsWindowFunc>(distinct_sum));

--- a/be/src/exprs/agg/factory/aggregate_resolver_approx.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_approx.cpp
@@ -57,7 +57,7 @@ struct ApproxTopKBuilder {
         if constexpr (lt_is_integer<lt> || lt_is_decimal<lt> || lt_is_float<lt> || lt_is_string<lt> ||
                       lt_is_date_or_datetime<lt> || lt_is_boolean<lt>) {
             using ApproxTopKState = ApproxTopKState<lt>;
-            resolver->add_aggregate_mapping<lt, TYPE_ARRAY, ApproxTopKState, AggregateFunctionPtr, false>(
+            resolver->add_aggregate_mapping<lt, TYPE_ARRAY, ApproxTopKState, false>(
                     "approx_top_k", true, AggregateFactory::MakeApproxTopKAggregateFunction<lt>());
         }
     }

--- a/be/src/exprs/agg/factory/aggregate_resolver_approx.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_approx.cpp
@@ -57,7 +57,7 @@ struct ApproxTopKBuilder {
         if constexpr (lt_is_integer<lt> || lt_is_decimal<lt> || lt_is_float<lt> || lt_is_string<lt> ||
                       lt_is_date_or_datetime<lt> || lt_is_boolean<lt>) {
             using ApproxTopKState = ApproxTopKState<lt>;
-            resolver->add_aggregate_mapping<lt, TYPE_ARRAY, ApproxTopKState, false>(
+            resolver->add_aggregate_mapping<lt, TYPE_ARRAY, ApproxTopKState, AggregateFunctionPtr, false>(
                     "approx_top_k", true, AggregateFactory::MakeApproxTopKAggregateFunction<lt>());
         }
     }

--- a/be/src/exprs/agg/factory/aggregate_resolver_avg.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_avg.cpp
@@ -39,7 +39,8 @@ struct ArrayAggDispatcher {
         if constexpr (lt_is_aggregate<lt> || lt_is_json<lt>) {
             auto func = new ArrayAggAggregateFunction<lt, false>();
             using AggState = ArrayAggAggregateState<lt, false>;
-            resolver->add_aggregate_mapping<lt, TYPE_ARRAY, AggState, false>("array_agg", true, func);
+            resolver->add_aggregate_mapping<lt, TYPE_ARRAY, AggState, AggregateFunctionPtr, false>("array_agg", true,
+                                                                                                   func);
         }
     }
 };
@@ -53,17 +54,20 @@ struct ArrayUniqueAggDispatcher {
                 using MyHashSet = phmap::flat_hash_set<CppType, Hash128WithSeed<PhmapSeed1>>;
                 auto func = new ArrayUnionAggAggregateFunction<pt, true, MyHashSet>();
                 using AggState = ArrayUnionAggAggregateState<pt, true, MyHashSet>;
-                resolver->add_aggregate_mapping<pt, TYPE_ARRAY, AggState, false>("array_unique_agg", false, func);
+                resolver->add_aggregate_mapping<pt, TYPE_ARRAY, AggState, AggregateFunctionPtr, false>(
+                        "array_unique_agg", false, func);
             } else if constexpr (lt_is_fixedlength<pt>) {
                 using MyHashSet = phmap::flat_hash_set<CppType, StdHash<CppType>>;
                 auto func = new ArrayUnionAggAggregateFunction<pt, true, MyHashSet>();
                 using AggState = ArrayUnionAggAggregateState<pt, true, MyHashSet>;
-                resolver->add_aggregate_mapping<pt, TYPE_ARRAY, AggState, false>("array_unique_agg", false, func);
+                resolver->add_aggregate_mapping<pt, TYPE_ARRAY, AggState, AggregateFunctionPtr, false>(
+                        "array_unique_agg", false, func);
             } else if constexpr (lt_is_string<pt>) {
                 using MyHashSet = SliceHashSet;
                 auto func = new ArrayUnionAggAggregateFunction<pt, true, MyHashSet>();
                 using AggState = ArrayUnionAggAggregateState<pt, true, MyHashSet>;
-                resolver->add_aggregate_mapping<pt, TYPE_ARRAY, AggState, false>("array_unique_agg", false, func);
+                resolver->add_aggregate_mapping<pt, TYPE_ARRAY, AggState, AggregateFunctionPtr, false>(
+                        "array_unique_agg", false, func);
             } else {
                 throw std::runtime_error("array_unique_agg does not support " + type_to_string(pt));
             }
@@ -87,11 +91,13 @@ struct ArrayAggDistinctDispatcher {
             }
             auto func = new ArrayAggAggregateFunction<pt, true, MyHashSet>();
             using AggState = ArrayAggAggregateState<pt, true, MyHashSet>;
-            resolver->add_aggregate_mapping<pt, TYPE_ARRAY, AggState, false>("array_agg_distinct", false, func);
+            resolver->add_aggregate_mapping<pt, TYPE_ARRAY, AggState, AggregateFunctionPtr, false>("array_agg_distinct",
+                                                                                                   false, func);
 
             using WindowAggState = ArrayAggWindowState<pt, true, MyHashSet>;
             auto window_func = new ArrayAggAggregateWindowFunction<pt, true, MyHashSet>();
-            resolver->add_window_mapping<pt, TYPE_ARRAY, WindowAggState, false>("array_agg_distinct", window_func);
+            resolver->add_window_mapping<pt, TYPE_ARRAY, WindowAggState, AggregateFunctionPtr, false>(
+                    "array_agg_distinct", window_func);
         }
     }
 };

--- a/be/src/exprs/agg/factory/aggregate_resolver_avg.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_avg.cpp
@@ -37,10 +37,9 @@ struct ArrayAggDispatcher {
     template <LogicalType lt>
     void operator()(AggregateFuncResolver* resolver) {
         if constexpr (lt_is_aggregate<lt> || lt_is_json<lt>) {
-            auto func = std::make_shared<ArrayAggAggregateFunction<lt, false>>();
+            auto func = new ArrayAggAggregateFunction<lt, false>();
             using AggState = ArrayAggAggregateState<lt, false>;
-            resolver->add_aggregate_mapping<lt, TYPE_ARRAY, AggState, AggregateFunctionPtr, false>("array_agg", true,
-                                                                                                   func);
+            resolver->add_aggregate_mapping<lt, TYPE_ARRAY, AggState, false>("array_agg", true, func);
         }
     }
 };
@@ -52,22 +51,19 @@ struct ArrayUniqueAggDispatcher {
             using CppType = RunTimeCppType<pt>;
             if constexpr (lt_is_largeint<pt>) {
                 using MyHashSet = phmap::flat_hash_set<CppType, Hash128WithSeed<PhmapSeed1>>;
-                auto func = std::make_shared<ArrayUnionAggAggregateFunction<pt, true, MyHashSet>>();
+                auto func = new ArrayUnionAggAggregateFunction<pt, true, MyHashSet>();
                 using AggState = ArrayUnionAggAggregateState<pt, true, MyHashSet>;
-                resolver->add_aggregate_mapping<pt, TYPE_ARRAY, AggState, AggregateFunctionPtr, false>(
-                        "array_unique_agg", false, func);
+                resolver->add_aggregate_mapping<pt, TYPE_ARRAY, AggState, false>("array_unique_agg", false, func);
             } else if constexpr (lt_is_fixedlength<pt>) {
                 using MyHashSet = phmap::flat_hash_set<CppType, StdHash<CppType>>;
-                auto func = std::make_shared<ArrayUnionAggAggregateFunction<pt, true, MyHashSet>>();
+                auto func = new ArrayUnionAggAggregateFunction<pt, true, MyHashSet>();
                 using AggState = ArrayUnionAggAggregateState<pt, true, MyHashSet>;
-                resolver->add_aggregate_mapping<pt, TYPE_ARRAY, AggState, AggregateFunctionPtr, false>(
-                        "array_unique_agg", false, func);
+                resolver->add_aggregate_mapping<pt, TYPE_ARRAY, AggState, false>("array_unique_agg", false, func);
             } else if constexpr (lt_is_string<pt>) {
                 using MyHashSet = SliceHashSet;
-                auto func = std::make_shared<ArrayUnionAggAggregateFunction<pt, true, MyHashSet>>();
+                auto func = new ArrayUnionAggAggregateFunction<pt, true, MyHashSet>();
                 using AggState = ArrayUnionAggAggregateState<pt, true, MyHashSet>;
-                resolver->add_aggregate_mapping<pt, TYPE_ARRAY, AggState, AggregateFunctionPtr, false>(
-                        "array_unique_agg", false, func);
+                resolver->add_aggregate_mapping<pt, TYPE_ARRAY, AggState, false>("array_unique_agg", false, func);
             } else {
                 throw std::runtime_error("array_unique_agg does not support " + type_to_string(pt));
             }
@@ -89,15 +85,13 @@ struct ArrayAggDistinctDispatcher {
             if constexpr (std::is_same_v<void, MyHashSet>) {
                 throw std::runtime_error("array_agg_distinct does not support " + type_to_string(pt));
             }
-            auto func = std::make_shared<ArrayAggAggregateFunction<pt, true, MyHashSet>>();
+            auto func = new ArrayAggAggregateFunction<pt, true, MyHashSet>();
             using AggState = ArrayAggAggregateState<pt, true, MyHashSet>;
-            resolver->add_aggregate_mapping<pt, TYPE_ARRAY, AggState, AggregateFunctionPtr, false>("array_agg_distinct",
-                                                                                                   false, func);
+            resolver->add_aggregate_mapping<pt, TYPE_ARRAY, AggState, false>("array_agg_distinct", false, func);
 
             using WindowAggState = ArrayAggWindowState<pt, true, MyHashSet>;
-            auto window_func = std::make_shared<ArrayAggAggregateWindowFunction<pt, true, MyHashSet>>();
-            resolver->add_window_mapping<pt, TYPE_ARRAY, WindowAggState, AggregateFunctionPtr, false>(
-                    "array_agg_distinct", window_func);
+            auto window_func = new ArrayAggAggregateWindowFunction<pt, true, MyHashSet>();
+            resolver->add_window_mapping<pt, TYPE_ARRAY, WindowAggState, false>("array_agg_distinct", window_func);
         }
     }
 };
@@ -109,17 +103,17 @@ struct MapAggDispatcher {
             using KeyCppType = RunTimeCppType<kt>;
             if constexpr (lt_is_largeint<kt>) {
                 using MyHashMap = phmap::flat_hash_map<KeyCppType, size_t, Hash128WithSeed<PhmapSeed1>>;
-                auto func = std::make_shared<MapAggAggregateFunction<kt, MyHashMap>>();
-                resolver->add_aggregate_mapping_notnull<kt, TYPE_MAP, AggregateFunctionPtr>("map_agg", false, func);
+                auto func = new MapAggAggregateFunction<kt, MyHashMap>();
+                resolver->add_aggregate_mapping_notnull<kt, TYPE_MAP>("map_agg", false, func);
             } else if constexpr (lt_is_fixedlength<kt>) {
                 using MyHashMap = phmap::flat_hash_map<KeyCppType, size_t, StdHash<KeyCppType>>;
-                auto func = std::make_shared<MapAggAggregateFunction<kt, MyHashMap>>();
-                resolver->add_aggregate_mapping_notnull<kt, TYPE_MAP, AggregateFunctionPtr>("map_agg", false, func);
+                auto func = new MapAggAggregateFunction<kt, MyHashMap>();
+                resolver->add_aggregate_mapping_notnull<kt, TYPE_MAP>("map_agg", false, func);
             } else if constexpr (lt_is_string<kt>) {
                 using MyHashMap =
                         phmap::flat_hash_map<SliceWithHash, size_t, HashOnSliceWithHash, EqualOnSliceWithHash>;
-                auto func = std::make_shared<MapAggAggregateFunction<kt, MyHashMap>>();
-                resolver->add_aggregate_mapping_notnull<kt, TYPE_MAP, AggregateFunctionPtr>("map_agg", false, func);
+                auto func = new MapAggAggregateFunction<kt, MyHashMap>();
+                resolver->add_aggregate_mapping_notnull<kt, TYPE_MAP>("map_agg", false, func);
             } else {
                 throw std::runtime_error("map_agg does not support key type " + type_to_string(kt));
             }

--- a/be/src/exprs/agg/factory/aggregate_resolver_boolean.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_boolean.cpp
@@ -21,7 +21,7 @@
 namespace starrocks {
 
 void AggregateFuncResolver::register_boolean() {
-    auto bool_or_func = std::make_shared<BoolOrAggregateFunction>();
+    auto bool_or_func = new BoolOrAggregateFunction();
     add_aggregate_mapping_notnull<TYPE_BOOLEAN, TYPE_BOOLEAN>("bool_or", true, bool_or_func);
 }
 

--- a/be/src/exprs/agg/factory/aggregate_resolver_sumcount.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_sumcount.cpp
@@ -63,13 +63,13 @@ void AggregateFuncResolver::register_sumcount() {
     }
 
     _infos_mapping.emplace(std::make_tuple("count", TYPE_BIGINT, TYPE_BIGINT, false, false),
-                           track_function(AggregateFactory::MakeCountAggregateFunction<false>()));
+                           AggregateFactory::MakeCountAggregateFunction<false>());
     _infos_mapping.emplace(std::make_tuple("count", TYPE_BIGINT, TYPE_BIGINT, true, false),
-                           track_function(AggregateFactory::MakeCountAggregateFunction<true>()));
+                           AggregateFactory::MakeCountAggregateFunction<true>());
     _infos_mapping.emplace(std::make_tuple("count", TYPE_BIGINT, TYPE_BIGINT, false, true),
-                           track_function(AggregateFactory::MakeCountNullableAggregateFunction<false>()));
+                           AggregateFactory::MakeCountNullableAggregateFunction<false>());
     _infos_mapping.emplace(std::make_tuple("count", TYPE_BIGINT, TYPE_BIGINT, true, true),
-                           track_function(AggregateFactory::MakeCountNullableAggregateFunction<true>()));
+                           AggregateFactory::MakeCountNullableAggregateFunction<true>());
 }
 
 } // namespace starrocks

--- a/be/src/exprs/agg/factory/aggregate_resolver_sumcount.cpp
+++ b/be/src/exprs/agg/factory/aggregate_resolver_sumcount.cpp
@@ -45,8 +45,7 @@ struct StorageSumDispatcher {
         if constexpr (lt_is_sum_in_storage<lt>) {
             using SumState = SumAggregateState<RunTimeCppType<lt>>;
             resolver->add_aggregate_mapping<lt, lt, SumState>(
-                    "sum", true,
-                    std::make_shared<SumAggregateFunction<lt, RunTimeCppType<lt>, lt, RunTimeCppType<lt>>>());
+                    "sum", true, new SumAggregateFunction<lt, RunTimeCppType<lt>, lt, RunTimeCppType<lt>>());
         }
     }
 };
@@ -64,13 +63,13 @@ void AggregateFuncResolver::register_sumcount() {
     }
 
     _infos_mapping.emplace(std::make_tuple("count", TYPE_BIGINT, TYPE_BIGINT, false, false),
-                           AggregateFactory::MakeCountAggregateFunction<false>());
+                           track_function(AggregateFactory::MakeCountAggregateFunction<false>()));
     _infos_mapping.emplace(std::make_tuple("count", TYPE_BIGINT, TYPE_BIGINT, true, false),
-                           AggregateFactory::MakeCountAggregateFunction<true>());
+                           track_function(AggregateFactory::MakeCountAggregateFunction<true>()));
     _infos_mapping.emplace(std::make_tuple("count", TYPE_BIGINT, TYPE_BIGINT, false, true),
-                           AggregateFactory::MakeCountNullableAggregateFunction<false>());
+                           track_function(AggregateFactory::MakeCountNullableAggregateFunction<false>()));
     _infos_mapping.emplace(std::make_tuple("count", TYPE_BIGINT, TYPE_BIGINT, true, true),
-                           AggregateFactory::MakeCountNullableAggregateFunction<true>());
+                           track_function(AggregateFactory::MakeCountNullableAggregateFunction<true>()));
 }
 
 } // namespace starrocks

--- a/be/src/exprs/agg/nullable_aggregate.h
+++ b/be/src/exprs/agg/nullable_aggregate.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "column/column.h"
+#include "exprs/agg/aggregate.h"
 #ifdef __x86_64__
 #include <immintrin.h>
 #elif defined(__ARM_NEON) && defined(__aarch64__)
@@ -108,7 +109,7 @@ struct AggNonNullPred {
 //    For this case, the serialized output type is non-nullable, because only the state of input needs to be serialized.
 // If all the rows are NULL or `AggNullPred` returns true, we will return NULL.
 // The State must be NullableAggregateFunctionState
-template <typename NestedFuncPtr, typename State, bool IsWindowFunc, bool IgnoreNull = true,
+template <typename NestedAggregateFunctionPtr, typename State, bool IsWindowFunc, bool IgnoreNull = true,
           IsAggNullPred<typename State::NestedState> AggNullPred = AggNonNullPred<typename State::NestedState>>
 class NullableAggregateFunctionBase : public AggregateFunctionStateHelper<State> {
     using NestedState = typename State::NestedState;
@@ -117,7 +118,8 @@ class NullableAggregateFunctionBase : public AggregateFunctionStateHelper<State>
 public:
     bool is_exception_safe() const override { return nested_function->is_exception_safe(); }
 
-    explicit NullableAggregateFunctionBase(NestedFuncPtr nested_function_, AggNullPred null_pred = AggNullPred())
+    explicit NullableAggregateFunctionBase(NestedAggregateFunctionPtr nested_function_,
+                                           AggNullPred null_pred = AggNullPred())
             : nested_function(std::move(nested_function_)), null_pred(std::move(null_pred)) {}
     // as array_agg is not nullable, so it needn't create() here.
 
@@ -311,17 +313,19 @@ public:
     }
 
 protected:
-    NestedFuncPtr nested_function;
+    NestedAggregateFunctionPtr nested_function;
     AggNullPred null_pred;
 };
 
-template <typename NestedFuncPtr, typename State, bool IsWindowFunc, bool IgnoreNull = true,
+template <typename NestedAggregateFunctionPtr, typename State, bool IsWindowFunc, bool IgnoreNull = true,
           IsAggNullPred<typename State::NestedState> AggNullPred = AggNonNullPred<typename State::NestedState>>
 class NullableAggregateFunctionUnary final
-        : public NullableAggregateFunctionBase<NestedFuncPtr, State, IsWindowFunc, IgnoreNull, AggNullPred> {
+        : public NullableAggregateFunctionBase<NestedAggregateFunctionPtr, State, IsWindowFunc, IgnoreNull,
+                                               AggNullPred> {
 public:
-    explicit NullableAggregateFunctionUnary(const NestedFuncPtr& nested_function, AggNullPred null_pred = AggNullPred())
-            : NullableAggregateFunctionBase<NestedFuncPtr, State, IsWindowFunc, IgnoreNull, AggNullPred>(
+    explicit NullableAggregateFunctionUnary(const NestedAggregateFunctionPtr& nested_function,
+                                            AggNullPred null_pred = AggNullPred())
+            : NullableAggregateFunctionBase<NestedAggregateFunctionPtr, State, IsWindowFunc, IgnoreNull, AggNullPred>(
                       nested_function, std::move(null_pred)) {}
 
     // NOTE: In stream MV, need handle input row by row, so need support single update.
@@ -948,14 +952,15 @@ public:
     }
 };
 
-template <typename NestedFuncPtr, typename State,
+template <typename State,
           IsAggNullPred<typename State::NestedState> AggNullPredType = AggNonNullPred<typename State::NestedState>>
 class NullableAggregateFunctionVariadic final
-        : public NullableAggregateFunctionBase<NestedFuncPtr, State, false, true, AggNullPredType> {
+        : public NullableAggregateFunctionBase<AggregateFunctionPtr, State, false, true, AggNullPredType> {
 public:
-    NullableAggregateFunctionVariadic(NestedFuncPtr nested_function, AggNullPredType null_pred = AggNullPredType())
-            : NullableAggregateFunctionBase<NestedFuncPtr, State, false, true, AggNullPredType>(
-                      std::move(nested_function), std::move(null_pred)) {}
+    NullableAggregateFunctionVariadic(AggregateFunctionPtr nested_function,
+                                      AggNullPredType null_pred = AggNullPredType())
+            : NullableAggregateFunctionBase<AggregateFunctionPtr, State, false, true, AggNullPredType>(
+                      nested_function, std::move(null_pred)) {}
 
     void update(FunctionContext* ctx, const Column** columns, AggDataPtr __restrict state,
                 size_t row_num) const override {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Use raw pointer to replace `shared_ptr<AggregateFunction>` to reduce code size bloat.

`exprs/agg/factory`:
- DEBUG: 243MB -> 156MB
- RELEASE: 323MB -> 191MB

starrocks_be(RELEASE)
- BEFORE: starrocks_be(377M) + starrocks_be.debuginfo(993M)
- AFTER: starrocks_be(351M) + starrocks_be.debuginfo(959M)

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors aggregate function pointers to raw `const AggregateFunction*`, eliminating `shared_ptr` usage across factory/resolver/aggregator paths.
> 
> - Changes `AggregateFunctionPtr` to raw pointer and updates factory methods to `new` concrete functions
> - Adds allocation tracking in `AggregateFuncResolver` (tracks all created functions; deletes in destructor)
> - Aggregator now stores combinator functions as raw pointers and deletes them on `close`
> - `AggStateUtils::get_agg_state_function` returns raw pointers; callers assume ownership and free
> - Adjusts resolver helpers to track and wrap nullable/variadic functions properly
> - Updates function signatures (`get_aggregate_function`, window variants, etc.) and related templates to use raw pointers
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e838fb11366ea4c72cee7eea5f7852f10747e4d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->