### PR TITLE
[BugFix] union struct by field name

### DIFF
--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -1828,15 +1828,15 @@ StatusOr<Expr*> VectorizedCastExprFactory::create_cast_expr(ObjectPool* pool, co
         std::vector<int> source_field_indices(to_type.children.size());
 
         for (int i = 0; i < to_type.children.size(); ++i) {
-            // Find the source field index by matching field names (case-insensitive)
             std::string target_name = to_type.field_names[i];
             std::transform(target_name.begin(), target_name.end(), target_name.begin(), ::tolower);
 
-            int source_idx = i;  // Default to positional matching
             auto it = from_field_name_to_index.find(target_name);
-            if (it != from_field_name_to_index.end()) {
-                source_idx = it->second;
+            if (it == from_field_name_to_index.end()) {
+                return Status::NotSupported(
+                        fmt::format("Struct field '{}' not found in source struct.", to_type.field_names[i]));
             }
+            int source_idx = it->second;
             source_field_indices[i] = source_idx;
 
             ASSIGN_OR_RETURN(field_casts[i],

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -23,9 +23,11 @@
 
 #include <ryu/ryu.h>
 
+#include <algorithm>
 #include <limits>
 #include <stdexcept>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 
 #include "column/column_builder.h"
@@ -1813,16 +1815,38 @@ StatusOr<Expr*> VectorizedCastExprFactory::create_cast_expr(ObjectPool* pool, co
         if (to_type.field_names.empty() || from_type.field_names.size() != to_type.field_names.size()) {
             return Status::NotSupported("Not support cast struct with different field of children.");
         }
-        std::vector<Expr*> field_casts{from_type.children.size()};
-        for (int i = 0; i < from_type.children.size(); ++i) {
+
+        // Build a map from source field names (lowercase) to their indices
+        std::unordered_map<std::string, int> from_field_name_to_index;
+        for (int i = 0; i < from_type.field_names.size(); ++i) {
+            std::string lower_name = from_type.field_names[i];
+            std::transform(lower_name.begin(), lower_name.end(), lower_name.begin(), ::tolower);
+            from_field_name_to_index[lower_name] = i;
+        }
+
+        std::vector<Expr*> field_casts{to_type.children.size()};
+        std::vector<int> source_field_indices(to_type.children.size());
+
+        for (int i = 0; i < to_type.children.size(); ++i) {
+            // Find the source field index by matching field names (case-insensitive)
+            std::string target_name = to_type.field_names[i];
+            std::transform(target_name.begin(), target_name.end(), target_name.begin(), ::tolower);
+
+            int source_idx = i;  // Default to positional matching
+            auto it = from_field_name_to_index.find(target_name);
+            if (it != from_field_name_to_index.end()) {
+                source_idx = it->second;
+            }
+            source_field_indices[i] = source_idx;
+
             ASSIGN_OR_RETURN(field_casts[i],
-                             create_cast_expr(pool, from_type.children[i], to_type.children[i], allow_throw_exception));
+                             create_cast_expr(pool, from_type.children[source_idx], to_type.children[i], allow_throw_exception));
             pool->add(field_casts[i]);
-            auto cast_input = create_slot_ref(from_type.children[i]);
+            auto cast_input = create_slot_ref(from_type.children[source_idx]);
             field_casts[i]->add_child(cast_input.get());
             pool->add(cast_input.release());
         }
-        return new CastStructExpr(node, std::move(field_casts));
+        return new CastStructExpr(node, std::move(field_casts), std::move(source_field_indices));
     }
     if ((from_type.type == TYPE_NULL || from_type.type == TYPE_BOOLEAN) && to_type.is_complex_type()) {
         return new MustNullExpr(node);

--- a/be/src/exprs/cast_expr.h
+++ b/be/src/exprs/cast_expr.h
@@ -253,6 +253,8 @@ public:
         for (int i = 0; i < _field_casts.size(); ++i) {
             if (_field_casts[i] != nullptr) {
                 cloned->_field_casts.emplace_back(Expr::copy(pool, _field_casts[i]));
+            } else {
+                cloned->_field_casts.emplace_back(nullptr);
             }
         }
         cloned->_source_field_indices = _source_field_indices;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
@@ -124,13 +124,21 @@ public class TypeManager {
         }
         ArrayList<StructField> fields = Lists.newArrayList();
         for (int i = 0; i < t1.getFields().size(); ++i) {
-            Type fieldCommon = getCommonSuperType(t1.getField(i).getType(), t2.getField(i).getType());
+            StructField field1 = t1.getField(i);
+            // Match fields by name (case-insensitive) instead of by position
+            // to handle UNION ALL with STRUCT columns where field order differs
+            StructField field2 = t2.getField(field1.getName());
+            if (field2 == null) {
+                // Field name not found in t2, fall back to positional matching
+                field2 = t2.getField(i);
+            }
+            Type fieldCommon = getCommonSuperType(field1.getType(), field2.getType());
             if (!fieldCommon.isValid()) {
                 return InvalidType.INVALID;
             }
 
             // default t1's field name
-            fields.add(new StructField(t1.getField(i).getName(), fieldCommon));
+            fields.add(new StructField(field1.getName(), fieldCommon));
         }
         return new StructType(fields);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
@@ -382,8 +382,13 @@ public class TypeManager {
             if (fromStruct.getFields().size() != toStruct.getFields().size()) {
                 return false;
             }
-            for (int i = 0; i < fromStruct.getFields().size(); ++i) {
-                if (!canCastTo(fromStruct.getField(i).getType(), toStruct.getField(i).getType())) {
+            for (int i = 0; i < toStruct.getFields().size(); ++i) {
+                StructField toField = toStruct.getField(i);
+                StructField fromField = fromStruct.getField(toField.getName());
+                if (fromField == null) {
+                    return false;
+                }
+                if (!canCastTo(fromField.getType(), toField.getType())) {
                     return false;
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
@@ -125,19 +125,14 @@ public class TypeManager {
         ArrayList<StructField> fields = Lists.newArrayList();
         for (int i = 0; i < t1.getFields().size(); ++i) {
             StructField field1 = t1.getField(i);
-            // Match fields by name (case-insensitive) instead of by position
-            // to handle UNION ALL with STRUCT columns where field order differs
             StructField field2 = t2.getField(field1.getName());
             if (field2 == null) {
-                // Field name not found in t2, fall back to positional matching
-                field2 = t2.getField(i);
+                return InvalidType.INVALID;
             }
             Type fieldCommon = getCommonSuperType(field1.getType(), field2.getType());
             if (!fieldCommon.isValid()) {
                 return InvalidType.INVALID;
             }
-
-            // default t1's field name
             fields.add(new StructField(field1.getName(), fieldCommon));
         }
         return new StructType(fields);

--- a/test/sql/test_semi/R/test_struct_union_field_order
+++ b/test/sql/test_semi/R/test_struct_union_field_order
@@ -1,0 +1,101 @@
+-- name: test_struct_union_field_order
+-- Test that UNION ALL correctly handles STRUCT columns with same field names but different order
+
+-- Test case 1: Basic UNION ALL with different field order using parse_json
+with source_1 as (
+    select parse_json('{"product_id": "id_100", "price": 100}') as dimensions
+),
+source_2 as (
+    select parse_json('{"product_id": "id_200", "price": 200}') as dimensions
+),
+source_3 as (
+    select CAST(
+        source_1.dimensions AS STRUCT<`product_id` VARCHAR, `price` INT>
+    ) AS `product`
+    from source_1
+),
+source_4 as (
+    select CAST(
+        source_2.dimensions AS STRUCT<`price` INT, `product_id` VARCHAR>
+    ) AS `product`
+    from source_2
+)
+select product.product_id, product.price from (
+    select product from source_3
+    union all
+    select product from source_4
+) t order by product.product_id;
+-- result:
+id_100	100
+id_200	200
+-- !result
+-- Test case 2: Direct STRUCT construction with different field order
+with cte1 as (
+    select named_struct('a', 1, 'b', 'hello') as s
+),
+cte2 as (
+    select named_struct('b', 'world', 'a', 2) as s
+)
+select s.a, s.b from (
+    select s from cte1
+    union all
+    select s from cte2
+) t order by s.a;
+-- result:
+1	hello
+2	world
+-- !result
+-- Test case 3: Three-way UNION with mixed field orders
+with cte1 as (
+    select named_struct('x', 10, 'y', 20, 'z', 30) as s
+),
+cte2 as (
+    select named_struct('z', 33, 'x', 11, 'y', 22) as s
+),
+cte3 as (
+    select named_struct('y', 222, 'z', 333, 'x', 111) as s
+)
+select s.x, s.y, s.z from (
+    select s from cte1
+    union all
+    select s from cte2
+    union all
+    select s from cte3
+) t order by s.x;
+-- result:
+10	20	30
+11	22	33
+111	222	333
+-- !result
+-- Test case 4: Nested STRUCT with different field order
+with cte1 as (
+    select named_struct('outer_a', 1, 'inner', named_struct('inner_x', 100, 'inner_y', 200)) as s
+),
+cte2 as (
+    select named_struct('inner', named_struct('inner_y', 400, 'inner_x', 300), 'outer_a', 2) as s
+)
+select s.outer_a, s.inner.inner_x, s.inner.inner_y from (
+    select s from cte1
+    union all
+    select s from cte2
+) t order by s.outer_a;
+-- result:
+1	100	200
+2	300	400
+-- !result
+-- Test case 5: UNION ALL with NULL values and different field order
+with cte1 as (
+    select named_struct('a', 1, 'b', 'test') as s
+),
+cte2 as (
+    select named_struct('b', null, 'a', 2) as s
+)
+select s.a, s.b from (
+    select s from cte1
+    union all
+    select s from cte2
+) t order by s.a;
+-- result:
+1	test
+2	None
+-- !result

--- a/test/sql/test_semi/T/test_struct_union_field_order
+++ b/test/sql/test_semi/T/test_struct_union_field_order
@@ -1,0 +1,84 @@
+-- name: test_struct_union_field_order
+-- Test that UNION ALL correctly handles STRUCT columns with same field names but different order
+
+-- Test case 1: Basic UNION ALL with different field order using parse_json
+with source_1 as (
+    select parse_json('{"product_id": "id_100", "price": 100}') as dimensions
+),
+source_2 as (
+    select parse_json('{"product_id": "id_200", "price": 200}') as dimensions
+),
+source_3 as (
+    select CAST(
+        source_1.dimensions AS STRUCT<`product_id` VARCHAR, `price` INT>
+    ) AS `product`
+    from source_1
+),
+source_4 as (
+    select CAST(
+        source_2.dimensions AS STRUCT<`price` INT, `product_id` VARCHAR>
+    ) AS `product`
+    from source_2
+)
+select product.product_id, product.price from (
+    select product from source_3
+    union all
+    select product from source_4
+) t order by product.product_id;
+
+-- Test case 2: Direct STRUCT construction with different field order
+with cte1 as (
+    select named_struct('a', 1, 'b', 'hello') as s
+),
+cte2 as (
+    select named_struct('b', 'world', 'a', 2) as s
+)
+select s.a, s.b from (
+    select s from cte1
+    union all
+    select s from cte2
+) t order by s.a;
+
+-- Test case 3: Three-way UNION with mixed field orders
+with cte1 as (
+    select named_struct('x', 10, 'y', 20, 'z', 30) as s
+),
+cte2 as (
+    select named_struct('z', 33, 'x', 11, 'y', 22) as s
+),
+cte3 as (
+    select named_struct('y', 222, 'z', 333, 'x', 111) as s
+)
+select s.x, s.y, s.z from (
+    select s from cte1
+    union all
+    select s from cte2
+    union all
+    select s from cte3
+) t order by s.x;
+
+-- Test case 4: Nested STRUCT with different field order
+with cte1 as (
+    select named_struct('outer_a', 1, 'inner', named_struct('inner_x', 100, 'inner_y', 200)) as s
+),
+cte2 as (
+    select named_struct('inner', named_struct('inner_y', 400, 'inner_x', 300), 'outer_a', 2) as s
+)
+select s.outer_a, s.inner.inner_x, s.inner.inner_y from (
+    select s from cte1
+    union all
+    select s from cte2
+) t order by s.outer_a;
+
+-- Test case 5: UNION ALL with NULL values and different field order
+with cte1 as (
+    select named_struct('a', 1, 'b', 'test') as s
+),
+cte2 as (
+    select named_struct('b', null, 'a', 2) as s
+)
+select s.a, s.b from (
+    select s from cte1
+    union all
+    select s from cte2
+) t order by s.a;


### PR DESCRIPTION
## Why I'm doing:
When performing a UNION ALL between two CTEs where a STRUCT column has the same field names but in a different order, StarRocks incorrectly aligns the data by position instead of by field name. This leads to data corruption in the result set where values are placed into the wrong fields.

## What I'm doing:
  Fix STRUCT-to-STRUCT casting to match fields by name (case-insensitive) instead of by position.

  BE changes:
  - CastStructExpr now stores _source_field_indices vector that maps target field index → source field index
  - When creating CastStructExpr, build field mapping by matching field names between source and target types
  - During cast evaluation, use the mapping to get the correct source field

  FE changes:
  - TypeManager.getCommonStructType() now matches fields by name when determining the common type for UNION operations
  
Fixes #67031

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns STRUCT fields by name during casts and UNION, preventing misaligned data when field orders differ.
> 
> - BE: `CastStructExpr` now stores `source_field_indices`; `create_cast_expr` builds a lowercase name→index map to wire children from the correct source fields; `evaluate_checked` uses the mapping to read fields; cloning preserved mapping
> - FE: `TypeManager` updates `getCommonStructType` and `canCastTo` to match STRUCT fields by name and validate existence/types
> - Tests: New BE unit tests for struct field reordering (including 2- and 3-field cases); new SQL semi tests verifying UNION ALL with differing STRUCT field orders (including nested structs and NULLs)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ff0003ba3d34241f7839f4d5ac8f661e835d02f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->