### PR TITLE
[Enhancement] use `tableExists` instead of `getTable` to avoid refresh table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
@@ -540,9 +540,10 @@ public class AnalyzeMgr implements Writable {
         for (Map.Entry<StatsMetaKey, ExternalBasicStatsMeta> entry : externalBasicStatsMetaMap.entrySet()) {
             StatsMetaKey tableKey = entry.getKey();
             try {
-                Table table = GlobalStateMgr.getCurrentState().getMetadataMgr()
-                        .getTable(new ConnectContext(), tableKey.getCatalogName(), tableKey.getDbName(), tableKey.getTableName());
-                if (table == null) {
+                boolean exists = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                        .tableExists(new ConnectContext(), tableKey.getCatalogName(), tableKey.getDbName(),
+                                tableKey.getTableName());
+                if (!exists) {
                     LOG.warn("Table {}.{}.{} not exists, clear it's statistics", tableKey.getCatalogName(),
                             tableKey.getDbName(), tableKey.getTableName());
                     droppedTables.add(tableKey);


### PR DESCRIPTION
## Why I'm doing:

I find that in this stack trace, the manager uses `getTable` to check existence of table. However this operation will trigger  table refresh if table exists.  However there is a more proper method for this case `tabeExists`

```
ts=2025-12-19 22:43:32.826;thread_name=statistics meta manager;id=27;is_daemon=true;priority=5;TCCL=jdk.internal.loader.ClassLoaders$AppClassLoader@30946e09
    @com.starrocks.connector.delta.CachingDeltaLakeMetastore.getCachedSnapshot()
        at com.starrocks.connector.delta.CachingDeltaLakeMetastore.getTable(CachingDeltaLakeMetastore.java:144)
        at com.starrocks.connector.delta.DeltaMetastoreOperations.getTable(DeltaMetastoreOperations.java:48)
        at com.starrocks.connector.delta.DeltaLakeMetadata.getTable(DeltaLakeMetadata.java:345)
        at com.starrocks.connector.CatalogConnectorMetadata.getTable(CatalogConnectorMetadata.java:148)
        at com.starrocks.server.MetadataMgr.lambda$getTable$5(MetadataMgr.java:507)
        at java.util.Optional.map(Optional.java:260)
        at com.starrocks.server.MetadataMgr.getTable(MetadataMgr.java:507)
        at com.starrocks.statistic.AnalyzeMgr.clearStatisticFromExternalDroppedTable(AnalyzeMgr.java:518)
        at com.starrocks.statistic.AnalyzeMgr.clearStatisticFromDroppedTable(AnalyzeMgr.java:475)
        at com.starrocks.statistic.StatisticsMetaManager.runAfterCatalogReady(StatisticsMetaManager.java:522)
        at com.starrocks.common.util.FrontendDaemon.runOneCycle(FrontendDaemon.java:72)
        at com.starrocks.common.util.Daemon.run(Daemon.java:98)
```

## What I'm doing:

use `tableExists` instead of  `getTable` at here.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3
