### PR TITLE
[Enhancement] use starrocks variable to config iceberg split size

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -237,7 +237,7 @@ public interface IcebergCatalog extends MemoryTrackable {
         return new StarRocksIcebergTableScan(
                 table,
                 table.schema(),
-                newTableScanContext(table),
+                newTableScanContext(table, srScanContext),
                 srScanContext);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/StarRocksIcebergTableScanContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/StarRocksIcebergTableScanContext.java
@@ -51,7 +51,7 @@ public class StarRocksIcebergTableScanContext {
         this.tableName = tableName;
         this.planMode = planMode;
         this.connectContext = connectContext;
-        if (connectContext != null) {
+        if (connectContext != null && connectContext.getSessionVariable() != null) {
             this.fileSplitSize = connectContext.getSessionVariable().getConnectorHugeFileSize();
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/StarRocksIcebergTableScanContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/StarRocksIcebergTableScanContext.java
@@ -37,6 +37,7 @@ public class StarRocksIcebergTableScanContext {
     private int localParallelism;
     private long localPlanningMaxSlotSize;
     private boolean enableCacheDataFileIdentifierColumnMetrics;
+    private long fileSplitSize;
     private ConnectContext connectContext;
 
     public StarRocksIcebergTableScanContext(String catalogName, String dbName, String tableName, PlanMode planMode) {
@@ -50,6 +51,9 @@ public class StarRocksIcebergTableScanContext {
         this.tableName = tableName;
         this.planMode = planMode;
         this.connectContext = connectContext;
+        if (connectContext != null) {
+            this.fileSplitSize = connectContext.getSessionVariable().getConnectorHugeFileSize();
+        }
     }
 
     public String getCatalogName() {
@@ -134,5 +138,9 @@ public class StarRocksIcebergTableScanContext {
 
     public ConnectContext getConnectContext() {
         return connectContext;
+    }
+
+    public long getFileSplitSize() {
+        return fileSplitSize;
     }
 }

--- a/fe/fe-core/src/main/java/org/apache/iceberg/StarRocksIcebergTableScan.java
+++ b/fe/fe-core/src/main/java/org/apache/iceberg/StarRocksIcebergTableScan.java
@@ -264,7 +264,7 @@ public class StarRocksIcebergTableScan
                     matchingCachedDeleteFiles.addAll(deleteFiles);
                 } else {
                     deleteFileCache.put(manifestFile.path(), ConcurrentHashMap.newKeySet());
-                    metaFileCacheMap.computeIfAbsent(icebergTableName, 
+                    metaFileCacheMap.computeIfAbsent(icebergTableName,
                             t -> ConcurrentHashMap.newKeySet()).add(manifestFile.path());
                     deleteManifestWithoutCache.add(manifestFile);
                 }
@@ -287,7 +287,7 @@ public class StarRocksIcebergTableScan
             } else {
                 if (!onlyReadCache) {
                     dataFileCache.put(manifestFile.path(), ConcurrentHashMap.newKeySet());
-                    metaFileCacheMap.computeIfAbsent(icebergTableName, 
+                    metaFileCacheMap.computeIfAbsent(icebergTableName,
                             t -> ConcurrentHashMap.newKeySet()).add(manifestFile.path());
                 }
                 dataManifestWithoutCache.add(manifestFile);
@@ -373,8 +373,8 @@ public class StarRocksIcebergTableScan
     public void refreshDataFileCache(List<ManifestFile> manifestFiles) {
         manifestFiles.forEach(manifestFile -> {
             dataFileCache.put(manifestFile.path(), Sets.newHashSet());
-            metaFileCacheMap.computeIfAbsent(icebergTableName, 
-                            t -> ConcurrentHashMap.newKeySet()).add(manifestFile.path());
+            metaFileCacheMap.computeIfAbsent(icebergTableName,
+                    t -> ConcurrentHashMap.newKeySet()).add(manifestFile.path());
         });
         this.deleteFileIndex = DeleteFileIndex.builderFor(new ArrayList<>()).build();
 
@@ -418,7 +418,7 @@ public class StarRocksIcebergTableScan
                     matchingCachedDeleteFiles.addAll(deleteFiles);
                 } else {
                     deleteFileCache.put(manifestFile.path(), ConcurrentHashMap.newKeySet());
-                    metaFileCacheMap.computeIfAbsent(icebergTableName, 
+                    metaFileCacheMap.computeIfAbsent(icebergTableName,
                             t -> ConcurrentHashMap.newKeySet()).add(manifestFile.path());
                     deleteManifestWithoutCache.add(manifestFile);
                 }
@@ -525,8 +525,12 @@ public class StarRocksIcebergTableScan
 
     @Override
     public CloseableIterable<CombinedScanTask> planTasks() {
+        long fileSplitSize = targetSplitSize();
+        if (scanContext.getFileSplitSize() > 0) {
+            fileSplitSize = scanContext.getFileSplitSize();
+        }
         return TableScanUtil.planTasks(
-                planFiles(), targetSplitSize(), splitLookback(), splitOpenFileCost());
+                planFiles(), fileSplitSize, splitLookback(), splitOpenFileCost());
     }
 
     private int liveFilesCount(List<ManifestFile> manifests) {


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Use starrocks session variable `connector_huge_file_size` as iceberg target split size

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Propagates StarRocks session variable `connector_huge_file_size` to Iceberg as `read.split.target-size` during table scan planning.
> 
> - **Iceberg scan configuration**:
>   - `StarRocksIcebergTableScan.newTableScanContext` now accepts `StarRocksIcebergTableScanContext` and sets option `read.split.target-size` when `scanContext.getFileSplitSize() > 0`.
>   - `IcebergCatalog.getTableScan` updated to call `newTableScanContext(table, srScanContext)`.
>   - `StarRocksIcebergTableScanContext`:
>     - Adds `fileSplitSize` (initialized from `ConnectContext.getSessionVariable().getConnectorHugeFileSize()` when available) and getter.
> - **Minor**:
>   - Small formatting adjustments in `metaFileCacheMap.computeIfAbsent(...)` calls.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17e928dd033ff3329c032da8416fbde61988fc91. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->