### PR TITLE
[BugFix] fix nullable property mismatched error when rewriting meta scan by stats

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToMetaScanRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSimpleAggToMetaScanRule.java
@@ -375,7 +375,7 @@ public class RewriteSimpleAggToMetaScanRule extends TransformationRule {
             // all aggregations can be replaced
             Preconditions.checkState(newAggCalls.isEmpty());
             LogicalValuesOperator row = new LogicalValuesOperator(scanOperator.getOutputColumns().subList(0, 1),
-                    List.of(List.of(ConstantOperator.createNull(IntegerType.BIGINT))));
+                    List.of(List.of(ConstantOperator.createExampleValueByType(IntegerType.BIGINT))));
             return Optional.of(OptExpression.create(project, OptExpression.create(row)));
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateMetaTest.java
@@ -48,7 +48,7 @@ public class AggregateMetaTest extends PlanTestBase {
                 + "  |  \n"
                 + "  0:UNION\n"
                 + "     constant exprs: \n"
-                + "         NULL");
+                + "         1");
         new MockUp<ColumnMinMaxMgr>() {
             @Mock
             public Optional<IMinMaxStatsMgr.ColumnMinMax> getStats(ColumnIdentifier identifier, StatsVersion version) {
@@ -91,6 +91,23 @@ public class AggregateMetaTest extends PlanTestBase {
                 "  |  \n" +
                 "  0:UNION\n" +
                 "     constant exprs: \n" +
-                "         NULL");
+                "         1");
+        sql = "SELECT cast(9 as INT), cast(226237 as BIGINT), cast(COUNT(1) as BIGINT), cast(COUNT(1)\n" +
+                "* 1024 as BIGINT), hex(hll_serialize(hll_empty())), cast(0 as BIGINT), '', '' , cast(-1 as BIGINT) FROM " +
+                "(select `v1` as column_key from `t0` partition `t0`) tt;";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  1:Project\n" +
+                "  |  <slot 4> : 3\n" +
+                "  |  <slot 5> : 9\n" +
+                "  |  <slot 6> : 226237\n" +
+                "  |  <slot 7> : 3072\n" +
+                "  |  <slot 8> : hex(hll_serialize(hll_empty()))\n" +
+                "  |  <slot 9> : 0\n" +
+                "  |  <slot 11> : ''\n" +
+                "  |  <slot 12> : -1\n" +
+                "  |  \n" +
+                "  0:UNION\n" +
+                "     constant exprs: \n" +
+                "         1");
     }
 }


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #67052 https://github.com/StarRocks/StarRocksTest/issues/10748

When the column ref in the UnionNode is NOT null, filling it with NULL will cause an execution error.
Since we don't care about the specific data returned by the UnionNode, we'll directly use the example value here.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace NULL with an example BIGINT value when emitting the `LogicalValuesOperator` row in simple agg-to-meta-scan rewrite; adjust and expand tests accordingly.
> 
> - **Optimizer (RewriteSimpleAggToMetaScanRule)**
>   - When all aggs are replaced by metadata, emit `LogicalValuesOperator` with `ConstantOperator.createExampleValueByType(IntegerType.BIGINT)` instead of `NULL`.
> - **Tests (AggregateMetaTest)**
>   - Update expected UNION constant from `NULL` to `1`.
>   - Add/extend test validating complex projection with counts/constants and UNION constant `1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17b71e713496ea458a254738a85788689a8a8d6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->