### PR TITLE
[Feature] Support query range distribution table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/BoolVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/BoolVariant.java
@@ -15,6 +15,7 @@
 package com.starrocks.catalog;
 
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.thrift.TInfinityType;
 import com.starrocks.thrift.TVariant;
 import com.starrocks.type.BooleanType;
 import com.starrocks.type.TypeSerializer;
@@ -60,11 +61,12 @@ public class BoolVariant extends Variant {
         TVariant variant = new TVariant();
         variant.setType(TypeSerializer.toThrift(type));
         variant.setValue(getStringValue());
+        variant.setInfinity_type(TInfinityType.NONE_INFINITY);
         return variant;
     }
 
     @Override
-    public int compareTo(Variant other) {
+    protected int compareToImpl(Variant other) {
         if (other instanceof LargeIntVariant) {
             return -other.compareTo(this);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DateVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DateVariant.java
@@ -17,6 +17,7 @@ package com.starrocks.catalog;
 import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.util.DateUtils;
+import com.starrocks.thrift.TInfinityType;
 import com.starrocks.thrift.TVariant;
 import com.starrocks.type.Type;
 import com.starrocks.type.TypeSerializer;
@@ -62,11 +63,12 @@ public class DateVariant extends Variant {
         TVariant variant = new TVariant();
         variant.setType(TypeSerializer.toThrift(type));
         variant.setValue(getStringValue());
+        variant.setInfinity_type(TInfinityType.NONE_INFINITY);
         return variant;
     }
 
     @Override
-    public int compareTo(Variant other) {
+    protected int compareToImpl(Variant other) {
         Preconditions.checkArgument(other instanceof DateVariant, other);
         DateVariant otherDateTime = (DateVariant) other;
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IntVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IntVariant.java
@@ -16,6 +16,7 @@ package com.starrocks.catalog;
 
 import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.thrift.TInfinityType;
 import com.starrocks.thrift.TVariant;
 import com.starrocks.type.Type;
 import com.starrocks.type.TypeSerializer;
@@ -63,11 +64,12 @@ public class IntVariant extends Variant {
         TVariant variant = new TVariant();
         variant.setType(TypeSerializer.toThrift(type));
         variant.setValue(getStringValue());
+        variant.setInfinity_type(TInfinityType.NONE_INFINITY);
         return variant;
     }
 
     @Override
-    public int compareTo(Variant other) {
+    protected int compareToImpl(Variant other) {
         if (other instanceof LargeIntVariant) {
             return -other.compareTo(this);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LargeIntVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LargeIntVariant.java
@@ -16,6 +16,7 @@ package com.starrocks.catalog;
 
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.Int128;
+import com.starrocks.thrift.TInfinityType;
 import com.starrocks.thrift.TVariant;
 import com.starrocks.type.IntegerType;
 import com.starrocks.type.TypeSerializer;
@@ -62,6 +63,7 @@ public class LargeIntVariant extends Variant {
         TVariant variant = new TVariant();
         variant.setType(TypeSerializer.toThrift(type));
         variant.setValue(getStringValue());
+        variant.setInfinity_type(TInfinityType.NONE_INFINITY);
         return variant;
     }
 
@@ -70,7 +72,7 @@ public class LargeIntVariant extends Variant {
     }
 
     @Override
-    public int compareTo(Variant other) {
+    protected int compareToImpl(Variant other) {
         if (other instanceof LargeIntVariant) {
             return this.value.compareTo(((LargeIntVariant) other).value);
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaxVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaxVariant.java
@@ -1,0 +1,49 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.starrocks.thrift.TInfinityType;
+import com.starrocks.thrift.TVariant;
+import com.starrocks.type.Type;
+
+public class MaxVariant extends Variant {
+    public MaxVariant(Type type) {
+        super(type);
+    }
+
+    @Override
+    public String getStringValue() {
+        return "MAX";
+    }
+
+    @Override
+    public long getLongValue() {
+        return Long.MAX_VALUE;
+    }
+
+    @Override
+    public TVariant toThrift() {
+        TVariant variant = new TVariant();
+        variant.setType(com.starrocks.type.TypeSerializer.toThrift(type));
+        variant.setInfinity_type(TInfinityType.MAX);
+        return variant;
+    }
+
+    @Override
+    protected int compareToImpl(Variant other) {
+        throw new IllegalStateException("Should not reach here");
+    }
+}
+

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaxVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaxVariant.java
@@ -18,6 +18,8 @@ import com.starrocks.thrift.TInfinityType;
 import com.starrocks.thrift.TVariant;
 import com.starrocks.type.Type;
 
+import java.util.Objects;
+
 public class MaxVariant extends Variant {
     public MaxVariant(Type type) {
         super(type);
@@ -44,6 +46,23 @@ public class MaxVariant extends Variant {
     @Override
     protected int compareToImpl(Variant other) {
         throw new IllegalStateException("Should not reach here");
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (!(object instanceof MaxVariant)) {
+            return false;
+        }
+        MaxVariant other = (MaxVariant) object;
+        return Objects.equals(this.type, other.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(MaxVariant.class, type);
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaxVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaxVariant.java
@@ -37,7 +37,7 @@ public class MaxVariant extends Variant {
     public TVariant toThrift() {
         TVariant variant = new TVariant();
         variant.setType(com.starrocks.type.TypeSerializer.toThrift(type));
-        variant.setInfinity_type(TInfinityType.MAX);
+        variant.setInfinity_type(TInfinityType.MAXIMUM);
         return variant;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MinVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MinVariant.java
@@ -18,6 +18,8 @@ import com.starrocks.thrift.TInfinityType;
 import com.starrocks.thrift.TVariant;
 import com.starrocks.type.Type;
 
+import java.util.Objects;
+
 public class MinVariant extends Variant {
     public MinVariant(Type type) {
         super(type);
@@ -44,6 +46,23 @@ public class MinVariant extends Variant {
     @Override
     protected int compareToImpl(Variant other) {
         throw new IllegalStateException("Should not reach here");
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (!(object instanceof MinVariant)) {
+            return false;
+        }
+        MinVariant other = (MinVariant) object;
+        return Objects.equals(this.type, other.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(MinVariant.class, type);
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MinVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MinVariant.java
@@ -1,0 +1,49 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.starrocks.thrift.TInfinityType;
+import com.starrocks.thrift.TVariant;
+import com.starrocks.type.Type;
+
+public class MinVariant extends Variant {
+    public MinVariant(Type type) {
+        super(type);
+    }
+
+    @Override
+    public String getStringValue() {
+        return "MIN";
+    }
+
+    @Override
+    public long getLongValue() {
+        return Long.MIN_VALUE;
+    }
+
+    @Override
+    public TVariant toThrift() {
+        TVariant variant = new TVariant();
+        variant.setType(com.starrocks.type.TypeSerializer.toThrift(type));
+        variant.setInfinity_type(TInfinityType.MIN);
+        return variant;
+    }
+
+    @Override
+    protected int compareToImpl(Variant other) {
+        throw new IllegalStateException("Should not reach here");
+    }
+}
+

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MinVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MinVariant.java
@@ -37,7 +37,7 @@ public class MinVariant extends Variant {
     public TVariant toThrift() {
         TVariant variant = new TVariant();
         variant.setType(com.starrocks.type.TypeSerializer.toThrift(type));
-        variant.setInfinity_type(TInfinityType.MIN);
+        variant.setInfinity_type(TInfinityType.MINIMUM);
         return variant;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1210,6 +1210,8 @@ public class OlapTable extends Table {
         Set<String> distributionColumnNames = Sets.newHashSet();
         if (defaultDistributionInfo instanceof RandomDistributionInfo) {
             return distributionColumnNames;
+        } else if (defaultDistributionInfo instanceof RangeDistributionInfo) {
+            return MetaUtils.getRangeDistributionColumnNames(this).stream().collect(Collectors.toSet());
         }
         HashDistributionInfo hashDistributionInfo = (HashDistributionInfo) defaultDistributionInfo;
         List<Column> partitionColumns = MetaUtils.getColumnsByColumnIds(

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StringVariant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StringVariant.java
@@ -16,6 +16,7 @@ package com.starrocks.catalog;
 
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.util.StringUtils;
+import com.starrocks.thrift.TInfinityType;
 import com.starrocks.thrift.TVariant;
 import com.starrocks.type.Type;
 import com.starrocks.type.TypeSerializer;
@@ -48,11 +49,12 @@ public class StringVariant extends Variant {
         TVariant variant = new TVariant();
         variant.setType(TypeSerializer.toThrift(type));
         variant.setValue(getStringValue());
+        variant.setInfinity_type(TInfinityType.NONE_INFINITY);
         return variant;
     }
 
     @Override
-    public int compareTo(Variant other) {
+    protected int compareToImpl(Variant other) {
         // compare string with utf-8 byte array, same with DM,BE,StorageEngine
         return StringUtils.compareStringWithUTF8ByteArray(value, other.getStringValue());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Variant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Variant.java
@@ -106,9 +106,9 @@ public abstract class Variant implements Comparable<Variant> {
     public static Variant fromThrift(TVariant tVariant) {
         Type type = TypeDeserializer.fromThrift(tVariant.type);
         if (tVariant.isSetInfinity_type()) {
-            if (tVariant.getInfinity_type() == TInfinityType.MIN) {
+            if (tVariant.getInfinity_type() == TInfinityType.MINIMUM) {
                 return new MinVariant(type);
-            } else if (tVariant.getInfinity_type() == TInfinityType.MAX) {
+            } else if (tVariant.getInfinity_type() == TInfinityType.MAXIMUM) {
                 return new MaxVariant(type);
             }
         }
@@ -118,9 +118,9 @@ public abstract class Variant implements Comparable<Variant> {
     public static Variant fromProto(VariantPB variantPB) {
         Type type = TypeDeserializer.fromProtobuf(variantPB.type);
         if (variantPB.infinityType != null) {
-            if (variantPB.infinityType == InfinityTypePB.MIN) {
+            if (variantPB.infinityType == InfinityTypePB.MINIMUM) {
                 return new MinVariant(type);
-            } else if (variantPB.infinityType == InfinityTypePB.MAX) {
+            } else if (variantPB.infinityType == InfinityTypePB.MAXIMUM) {
                 return new MaxVariant(type);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Variant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Variant.java
@@ -78,11 +78,6 @@ public abstract class Variant implements Comparable<Variant> {
 
     public static Variant of(Type type, String value) {
         Preconditions.checkArgument(type.isValid());
-        if (value.equals("MAX")) {
-            return maxVariant(type);
-        } else if (value.equals("MIN")) {
-            return minVariant(type);
-        }
         switch (type.getPrimitiveType()) {
             case BOOLEAN:
                 return new BoolVariant(value);
@@ -134,6 +129,15 @@ public abstract class Variant implements Comparable<Variant> {
 
     public static int compatibleCompare(Variant key1, Variant key2) {
         if (key1.getClass() == key2.getClass()) {
+            return key1.compareTo(key2);
+        }
+
+        // If any side is an infinity sentinel (MIN/MAX), rely directly on Variant.compareTo().
+        // The compareTo implementation already encodes global ordering for MinVariant/MaxVariant
+        // across all underlying types, so we must NOT route them through Variant.of(...) again,
+        // otherwise their string representation ("MIN"/"MAX") would be parsed as normal values.
+        if (key1 instanceof MinVariant || key1 instanceof MaxVariant
+                || key2 instanceof MinVariant || key2 instanceof MaxVariant) {
             return key1.compareTo(key2);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Variant.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Variant.java
@@ -78,6 +78,11 @@ public abstract class Variant implements Comparable<Variant> {
 
     public static Variant of(Type type, String value) {
         Preconditions.checkArgument(type.isValid());
+        if (value.equals("MAX")) {
+            return maxVariant(type);
+        } else if (value.equals("MIN")) {
+            return minVariant(type);
+        }
         switch (type.getPrimitiveType()) {
             case BOOLEAN:
                 return new BoolVariant(value);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DistributionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DistributionPruner.java
@@ -17,12 +17,10 @@
 
 package com.starrocks.planner;
 
-import com.starrocks.common.AnalysisException;
-
 import java.util.Collection;
 
 public interface DistributionPruner {
     // return partition after prunning
-    public Collection<Long> prune() throws AnalysisException;
+    public Collection<Long> prune();
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -418,6 +418,10 @@ public class OlapScanNode extends AbstractOlapTableScanNode {
                     MetaUtils.getColumnsByColumnIds(olapTable, info.getDistributionColumns()),
                     columnFilters);
             return distributionPruner.prune();
+        } else if (DistributionInfo.DistributionInfoType.RANGE == distributionInfo.getType()) {
+            RangeDistributionPruner pruner = new RangeDistributionPruner(index.getTablets(),
+                    MetaUtils.getRangeDistributionColumns(olapTable), columnFilters);
+            return pruner.prune();
         } else {
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RangeDistributionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RangeDistributionPruner.java
@@ -1,0 +1,249 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.TabletRange;
+import com.starrocks.catalog.Tuple;
+import com.starrocks.catalog.Variant;
+import com.starrocks.common.Config;
+import com.starrocks.common.Range;
+import com.starrocks.sql.ast.expression.LiteralExpr;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NavigableMap;
+import java.util.Set;
+import java.util.TreeMap;
+
+public class RangeDistributionPruner implements DistributionPruner {
+    // tablets in range order
+    private final TreeMap<Range<Tuple>, Long> tabletInOrder;
+    // range distribution columns
+    private final List<Column> rangeDistributionColumns;
+    // distribution column filters
+    private final Map<String, PartitionColumnFilter> distributionColumnFilters;
+
+    public RangeDistributionPruner(List<Tablet> tabletsInOrder,
+                                   List<Column> rangeDistributionColumns,
+                                   Map<String, PartitionColumnFilter> distributionColumnFilters) {
+        this.tabletInOrder = new TreeMap<>();
+        for (Tablet tablet : tabletsInOrder) {
+            TabletRange tabletRange = tablet.getRange();
+            Preconditions.checkState(tabletRange != null && tabletRange.getRange() != null, "Tablet range is null");
+            Range<Tuple> range = tabletRange.getRange();
+            this.tabletInOrder.put(range, tablet.getId());
+            
+            int rangeColumnCount = 0;
+            if (!range.isMinimum()) {
+                rangeColumnCount = range.getLowerBound().getValues().size();
+            } else if (!range.isMaximum()) {
+                rangeColumnCount = range.getUpperBound().getValues().size();
+            }
+
+            if (!range.isAll()) {
+                Preconditions.checkState(rangeColumnCount == rangeDistributionColumns.size(), "Range column count mismatch");
+            }
+        }
+        this.rangeDistributionColumns = rangeDistributionColumns;
+        this.distributionColumnFilters = distributionColumnFilters;
+    }
+
+    @Override
+    public Collection<Long> prune() {
+        if (distributionColumnFilters == null || distributionColumnFilters.isEmpty() ||
+            (tabletInOrder.size() == 1 && tabletInOrder.firstEntry().getKey().isAll())) {
+            return new ArrayList<>(tabletInOrder.values());
+        }
+
+        List<List<Variant>> lowerValuesList = new ArrayList<>();
+        List<List<Variant>> upperValuesList = new ArrayList<>();
+
+        List<List<Boolean>> lowerValuesInclusiveList = new ArrayList<>();
+        List<List<Boolean>> upperValuesInclusiveList = new ArrayList<>();
+
+        int complex = 1;
+        for (Column column : rangeDistributionColumns) {
+            PartitionColumnFilter filter = distributionColumnFilters.get(column.getName());
+            // No filter / function call on this column => prune range by the prefix keys
+            if (filter == null || filter.isFromFunctionCall()) {
+                break;
+            }
+
+            List<Variant> lowerValues = new ArrayList<>();
+            List<Variant> upperValues = new ArrayList<>();
+            List<Boolean> lowerValuesInclusive = new ArrayList<>();
+            List<Boolean> upperValuesInclusive = new ArrayList<>();
+
+            // 1. IN predicate literals (point queries)
+            List<LiteralExpr> inPredicateLiterals = filter.getInPredicateLiterals();
+            if (inPredicateLiterals != null && !inPredicateLiterals.isEmpty()) {
+                for (LiteralExpr expr : inPredicateLiterals) {
+                    Variant v = Variant.of(column.getType(), expr.getStringValue());
+                    lowerValues.add(v);
+                    upperValues.add(v);
+                    lowerValuesInclusive.add(true);
+                    upperValuesInclusive.add(true);
+                }
+            }
+
+            // 2. Range bounds (>, >=, <, <=, BETWEEN, =)
+            Variant colMin = null;
+            Variant colMax = null;
+            LiteralExpr lowerBound = filter.getLowerBound();
+            if (lowerBound != null) {
+                colMin = Variant.of(column.getType(), lowerBound.getStringValue());
+            }
+
+            LiteralExpr upperBound = filter.getUpperBound();
+            if (upperBound != null) {
+                colMax = Variant.of(column.getType(), upperBound.getStringValue());
+            }
+
+            // 3. Fill unbounded sides with type-wide min/max
+            boolean hasRangeBound = colMin != null || colMax != null;
+            if (colMin == null) {
+                colMin = Variant.minVariant(column.getType());
+            }
+            if (colMax == null) {
+                colMax = Variant.maxVariant(column.getType());
+            }
+            if (hasRangeBound) {
+                lowerValues.add(colMin);
+                upperValues.add(colMax);
+                lowerValuesInclusive.add(filter.lowerBoundInclusive);
+                upperValuesInclusive.add(filter.upperBoundInclusive);
+            } else if (lowerValues.isEmpty() && upperValues.isEmpty()) {
+                // no any predicate on this column => prune range by the prefix keys
+                break;
+            }
+
+            complex = complex * lowerValues.size();
+            if (complex > Config.max_distribution_pruner_recursion_depth) {
+                // prevent combinatorial explosion, early stop
+                break;
+            }
+            lowerValuesList.add(lowerValues);
+            upperValuesList.add(upperValues);
+            lowerValuesInclusiveList.add(lowerValuesInclusive);
+            upperValuesInclusiveList.add(upperValuesInclusive);
+        }
+
+        // fast path: no range pruning is needed
+        if (lowerValuesList.isEmpty() && upperValuesList.isEmpty()) {
+            return new ArrayList<>(tabletInOrder.values());
+        }
+
+        List<Variant> currentLowerValue = new ArrayList<>();
+        List<Variant> currentUpperValue = new ArrayList<>();
+        List<Boolean> currentLowerValueInclusive = new ArrayList<>();
+        List<Boolean> currentUpperValueInclusive = new ArrayList<>();
+        return prune(0, lowerValuesList, upperValuesList, lowerValuesInclusiveList, upperValuesInclusiveList,
+                     currentLowerValue, currentUpperValue, currentLowerValueInclusive, currentUpperValueInclusive);
+    }
+
+    // Prune logic here is very similar to the one in RangePartitionPruner. Basically, it transaform sql range predicates
+    // into Range<Tuple> and then use binary search to find the overlapping tablets. But this transformation is not equivalent
+    // to the sql range predicates, for example: 1 <= c1 <= 2 AND 10 <= c2 <= 20 is subset of (1, 10) <= (c1, c2) <= (2, 20)
+    // But for simplicity, we still use the transformation to prune the tablets here and optimize it later.
+    // TODO: optimize the pruning logic by Skip-Scan
+    private Collection<Long> prune(int columnIdx, List<List<Variant>> lowerValuesList,
+                                   List<List<Variant>> upperValuesList,
+                                   List<List<Boolean>> lowerValuesInclusiveList,
+                                   List<List<Boolean>> upperValuesInclusiveList,
+                                   List<Variant> currentLowerValue,
+                                   List<Variant> currentUpperValue,
+                                   List<Boolean> currentLowerValueInclusive,
+                                   List<Boolean> currentUpperValueInclusive) {
+        // lowerValuesList / upperValuesList size may less than rangeDistributionColumns size
+        if (columnIdx == lowerValuesList.size()) {
+            int prefixKeyLength = columnIdx;
+            // Fill remaining columns with [-inf, +inf] to ensure the query range matches the tablet range length
+            for (int i = prefixKeyLength; i < rangeDistributionColumns.size(); i++) {
+                Column col = rangeDistributionColumns.get(i);
+                currentLowerValue.add(Variant.minVariant(col.getType()));
+                currentUpperValue.add(Variant.maxVariant(col.getType()));
+                // Fill remaining columns with inclusive to ensure the filling values do not affect the judgement of
+                // inclusive flag of the query range
+                currentLowerValueInclusive.add(true);
+                currentUpperValueInclusive.add(true);
+            }
+
+            Tuple lowerTuple = new Tuple(currentLowerValue);
+            Tuple upperTuple = new Tuple(currentUpperValue);
+            boolean lowerInclusive = currentLowerValueInclusive.stream().allMatch(Boolean::booleanValue);
+            boolean upperInclusive = currentUpperValueInclusive.stream().allMatch(Boolean::booleanValue);
+            Range<Tuple> queryRange = Range.of(lowerTuple, upperTuple, lowerInclusive, upperInclusive);
+
+            Set<Long> result = Sets.newHashSet();
+            NavigableMap<Range<Tuple>, Long> subMap;
+            Entry<Range<Tuple>, Long> lower = tabletInOrder.lowerEntry(queryRange);
+            Entry<Range<Tuple>, Long> upper = tabletInOrder.higherEntry(queryRange);
+
+            if (lower == null && upper == null) {
+                subMap = tabletInOrder;
+            } else if (lower != null && upper != null) {
+                subMap = tabletInOrder.subMap(lower.getKey(), false, upper.getKey(), false);
+            } else if (lower != null) {
+                subMap = tabletInOrder.tailMap(lower.getKey(), false);
+            } else {
+                subMap = tabletInOrder.headMap(upper.getKey(), false);
+            }
+
+            if (subMap != null && !subMap.isEmpty()) {
+                result.addAll(subMap.values());
+            }
+
+            for (int i = prefixKeyLength; i < rangeDistributionColumns.size(); i++) {
+                currentLowerValue.remove(currentLowerValue.size() - 1);
+                currentUpperValue.remove(currentUpperValue.size() - 1);
+                currentLowerValueInclusive.remove(currentLowerValueInclusive.size() - 1);
+                currentUpperValueInclusive.remove(currentUpperValueInclusive.size() - 1);
+            }
+
+            return result;
+        }
+
+        List<Variant> candidateLowerValues = lowerValuesList.get(columnIdx);
+        List<Variant> candidateUpperValues = upperValuesList.get(columnIdx);
+        Set<Long> resultSet = Sets.newHashSet();
+        for (int i = 0; i < candidateLowerValues.size(); i++) {
+            currentLowerValue.add(candidateLowerValues.get(i));
+            currentUpperValue.add(candidateUpperValues.get(i));
+            currentLowerValueInclusive.add(lowerValuesInclusiveList.get(columnIdx).get(i));
+            currentUpperValueInclusive.add(upperValuesInclusiveList.get(columnIdx).get(i));
+            resultSet.addAll(prune(columnIdx + 1,
+                    lowerValuesList, upperValuesList,
+                    lowerValuesInclusiveList, upperValuesInclusiveList,
+                    currentLowerValue, currentUpperValue,
+                    currentLowerValueInclusive, currentUpperValueInclusive));
+            currentLowerValueInclusive.remove(currentLowerValueInclusive.size() - 1);
+            currentUpperValueInclusive.remove(currentUpperValueInclusive.size() - 1);
+            currentLowerValue.remove(currentLowerValue.size() - 1);
+            currentUpperValue.remove(currentUpperValue.size() - 1);
+
+            if (resultSet.size() >= tabletInOrder.size()) {
+                break;
+            }
+        }
+        return resultSet;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/VariantTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/VariantTest.java
@@ -1072,32 +1072,21 @@ public class VariantTest {
     public void testMinMaxVariantEqualsHashCode() {
         Variant min1 = Variant.minVariant(IntegerType.INT);
         Variant min2 = Variant.minVariant(IntegerType.BIGINT);
-        Variant min3 = Variant.minVariant(IntegerType.INT);
         Variant max1 = Variant.maxVariant(IntegerType.INT);
         Variant max2 = Variant.maxVariant(IntegerType.BIGINT);
-        Variant max3 = Variant.maxVariant(IntegerType.INT);
 
-        // MinVariant equals and hashCode
-        Assertions.assertEquals(min1, min3);
-        Assertions.assertEquals(min1.hashCode(), min3.hashCode());
-        Assertions.assertEquals(0, min1.compareTo(min3));
-
+        // equals and hashCode are type-sensitive
         Assertions.assertNotEquals(min1, min2);
         Assertions.assertNotEquals(min1.hashCode(), min2.hashCode());
-        Assertions.assertNotEquals(0, min1.compareTo(min2));
-
-        // MaxVariant equals and hashCode
-        Assertions.assertEquals(max1, max3);
-        Assertions.assertEquals(max1.hashCode(), max3.hashCode());
-        Assertions.assertEquals(0, max1.compareTo(max3));
-
         Assertions.assertNotEquals(max1, max2);
         Assertions.assertNotEquals(max1.hashCode(), max2.hashCode());
-        Assertions.assertNotEquals(0, max1.compareTo(max2));
 
-        // In-equality
+        // compareTo is type-insensitive (assumes callers handle type compatibility)
+        Assertions.assertEquals(0, min1.compareTo(min2));
+        Assertions.assertEquals(0, max1.compareTo(max2));
+
+        // In-equality between Min and Max
         Assertions.assertNotEquals(min1, max1);
-        Assertions.assertNotEquals(min1.hashCode(), max1.hashCode());
         Assertions.assertTrue(min1.compareTo(max1) < 0);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/VariantTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/VariantTest.java
@@ -14,7 +14,14 @@
 
 package com.starrocks.catalog;
 
+import com.starrocks.proto.InfinityTypePB;
+import com.starrocks.proto.PScalarType;
+import com.starrocks.proto.PTypeDesc;
+import com.starrocks.proto.PTypeNode;
+import com.starrocks.proto.VariantPB;
+import com.starrocks.thrift.TPrimitiveType;
 import com.starrocks.thrift.TTuple;
+import com.starrocks.thrift.TTypeNodeType;
 import com.starrocks.thrift.TVariant;
 import com.starrocks.type.BooleanType;
 import com.starrocks.type.CharType;
@@ -29,6 +36,7 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -518,6 +526,32 @@ public class VariantTest {
         Assertions.assertEquals(0, Variant.compatibleCompare(empty, empty));
     }
 
+    @Test
+    public void testVariantMinMaxHelpersForBooleanAndInt() {
+        Variant boolMin = Variant.minVariant(BooleanType.BOOLEAN);
+        Variant boolMax = Variant.maxVariant(BooleanType.BOOLEAN);
+        Assertions.assertTrue(boolMin instanceof MinVariant);
+        Assertions.assertTrue(boolMax instanceof MaxVariant);
+
+        Variant intMin = Variant.minVariant(IntegerType.INT);
+        Variant intMax = Variant.maxVariant(IntegerType.INT);
+        Assertions.assertTrue(intMin instanceof MinVariant);
+        Assertions.assertTrue(intMax instanceof MaxVariant);
+    }
+
+    @Test
+    public void testVariantMinMaxHelpersForDate() {
+        Variant minDate = Variant.minVariant(DateType.DATE);
+        Variant maxDate = Variant.maxVariant(DateType.DATE);
+        Variant middleDate = Variant.of(DateType.DATE, "2024-01-01");
+
+        Assertions.assertTrue(minDate instanceof MinVariant);
+        Assertions.assertTrue(maxDate instanceof MaxVariant);
+        Assertions.assertTrue(Variant.compatibleCompare(minDate, middleDate) <= 0);
+        Assertions.assertTrue(Variant.compatibleCompare(middleDate, maxDate) <= 0);
+        Assertions.assertTrue(Variant.compatibleCompare(minDate, maxDate) < 0);
+    }
+
     // ==================== Cross-type Comparison Tests ====================
 
     @Test
@@ -928,6 +962,63 @@ public class VariantTest {
         DateVariant v2 = new DateVariant(DateType.DATETIME, "2024-01-15T10:30:00");
         Assertions.assertTrue(v1.equals(v2));
         Assertions.assertEquals(v1.hashCode(), v2.hashCode());
+    }
+
+    @Test
+    public void testMinMaxVariantToThrift() {
+        Variant minDate = Variant.minVariant(DateType.DATE);
+        TVariant tMin = minDate.toThrift();
+        Assertions.assertTrue(tMin.isSetInfinity_type());
+        Assertions.assertEquals(com.starrocks.thrift.TInfinityType.MIN, tMin.getInfinity_type());
+
+        Variant maxDate = Variant.maxVariant(DateType.DATE);
+        TVariant tMax = maxDate.toThrift();
+        Assertions.assertTrue(tMax.isSetInfinity_type());
+        Assertions.assertEquals(com.starrocks.thrift.TInfinityType.MAX, tMax.getInfinity_type());
+    }
+
+    @Test
+    public void testMinMaxVariantFromThrift() {
+        TVariant tMin = new TVariant();
+        tMin.setType(TypeSerializer.toThrift(DateType.DATE));
+        tMin.setInfinity_type(com.starrocks.thrift.TInfinityType.MIN);
+        Variant minVariant = Variant.fromThrift(tMin);
+        Assertions.assertTrue(minVariant instanceof MinVariant);
+        Assertions.assertEquals(DateType.DATE, minVariant.getType());
+
+        TVariant tMax = new TVariant();
+        tMax.setType(TypeSerializer.toThrift(DateType.DATE));
+        tMax.setInfinity_type(com.starrocks.thrift.TInfinityType.MAX);
+        Variant maxVariant = Variant.fromThrift(tMax);
+        Assertions.assertTrue(maxVariant instanceof MaxVariant);
+        Assertions.assertEquals(DateType.DATE, maxVariant.getType());
+    }
+
+    @Test
+    public void testMinMaxVariantFromProto() {
+        // Build a simple scalar PTypeDesc for DATE, consistent with TypeDeserializer.fromProtobuf.
+        PTypeDesc typeDesc = new PTypeDesc();
+        typeDesc.types = new ArrayList<>();
+
+        PTypeNode node = new PTypeNode();
+        node.type = TTypeNodeType.SCALAR.getValue();
+        node.scalarType = new PScalarType();
+        node.scalarType.type = TPrimitiveType.DATE.getValue();
+        typeDesc.types.add(node);
+
+        VariantPB pbMin = new VariantPB();
+        pbMin.type = typeDesc;
+        pbMin.infinityType = InfinityTypePB.MIN;
+        Variant minVariant = Variant.fromProto(pbMin);
+        Assertions.assertTrue(minVariant instanceof MinVariant);
+        Assertions.assertEquals(DateType.DATE, minVariant.getType());
+
+        VariantPB pbMax = new VariantPB();
+        pbMax.type = typeDesc;
+        pbMax.infinityType = InfinityTypePB.MAX;
+        Variant maxVariant = Variant.fromProto(pbMax);
+        Assertions.assertTrue(maxVariant instanceof MaxVariant);
+        Assertions.assertEquals(DateType.DATE, maxVariant.getType());
     }
 
     // ==================== Cross-Variant equals() Tests ====================

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/VariantTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/VariantTest.java
@@ -969,26 +969,26 @@ public class VariantTest {
         Variant minDate = Variant.minVariant(DateType.DATE);
         TVariant tMin = minDate.toThrift();
         Assertions.assertTrue(tMin.isSetInfinity_type());
-        Assertions.assertEquals(com.starrocks.thrift.TInfinityType.MIN, tMin.getInfinity_type());
+        Assertions.assertEquals(com.starrocks.thrift.TInfinityType.MINIMUM, tMin.getInfinity_type());
 
         Variant maxDate = Variant.maxVariant(DateType.DATE);
         TVariant tMax = maxDate.toThrift();
         Assertions.assertTrue(tMax.isSetInfinity_type());
-        Assertions.assertEquals(com.starrocks.thrift.TInfinityType.MAX, tMax.getInfinity_type());
+        Assertions.assertEquals(com.starrocks.thrift.TInfinityType.MAXIMUM, tMax.getInfinity_type());
     }
 
     @Test
     public void testMinMaxVariantFromThrift() {
         TVariant tMin = new TVariant();
         tMin.setType(TypeSerializer.toThrift(DateType.DATE));
-        tMin.setInfinity_type(com.starrocks.thrift.TInfinityType.MIN);
+        tMin.setInfinity_type(com.starrocks.thrift.TInfinityType.MINIMUM);
         Variant minVariant = Variant.fromThrift(tMin);
         Assertions.assertTrue(minVariant instanceof MinVariant);
         Assertions.assertEquals(DateType.DATE, minVariant.getType());
 
         TVariant tMax = new TVariant();
         tMax.setType(TypeSerializer.toThrift(DateType.DATE));
-        tMax.setInfinity_type(com.starrocks.thrift.TInfinityType.MAX);
+        tMax.setInfinity_type(com.starrocks.thrift.TInfinityType.MAXIMUM);
         Variant maxVariant = Variant.fromThrift(tMax);
         Assertions.assertTrue(maxVariant instanceof MaxVariant);
         Assertions.assertEquals(DateType.DATE, maxVariant.getType());
@@ -1008,14 +1008,14 @@ public class VariantTest {
 
         VariantPB pbMin = new VariantPB();
         pbMin.type = typeDesc;
-        pbMin.infinityType = InfinityTypePB.MIN;
+        pbMin.infinityType = InfinityTypePB.MINIMUM;
         Variant minVariant = Variant.fromProto(pbMin);
         Assertions.assertTrue(minVariant instanceof MinVariant);
         Assertions.assertEquals(DateType.DATE, minVariant.getType());
 
         VariantPB pbMax = new VariantPB();
         pbMax.type = typeDesc;
-        pbMax.infinityType = InfinityTypePB.MAX;
+        pbMax.infinityType = InfinityTypePB.MAXIMUM;
         Variant maxVariant = Variant.fromProto(pbMax);
         Assertions.assertTrue(maxVariant instanceof MaxVariant);
         Assertions.assertEquals(DateType.DATE, maxVariant.getType());

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/VariantTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/VariantTest.java
@@ -1038,4 +1038,66 @@ public class VariantTest {
         Assertions.assertFalse(intVar.equals(stringVar));
         Assertions.assertFalse(largeIntVar.equals(stringVar));
     }
+
+    @Test
+    public void testVariantOfMinMax() {
+        // Test numeric type with "MAX"/"MIN"
+        Variant maxInt = Variant.of(IntegerType.INT, "MAX");
+        Variant minInt = Variant.of(IntegerType.INT, "MIN");
+        Assertions.assertTrue(maxInt instanceof MaxVariant);
+        Assertions.assertTrue(minInt instanceof MinVariant);
+        Assertions.assertEquals(IntegerType.INT, maxInt.getType());
+        Assertions.assertEquals(IntegerType.INT, minInt.getType());
+
+        // Test string type with "MAX"/"MIN"
+        Variant maxStr = Variant.of(VarcharType.VARCHAR, "MAX");
+        Variant minStr = Variant.of(VarcharType.VARCHAR, "MIN");
+        Assertions.assertTrue(maxStr instanceof MaxVariant);
+        Assertions.assertTrue(minStr instanceof MinVariant);
+
+        // Test equality with direct factory methods
+        Assertions.assertEquals(Variant.maxVariant(IntegerType.INT), maxInt);
+        Assertions.assertEquals(Variant.minVariant(IntegerType.INT), minInt);
+        Assertions.assertEquals(Variant.maxVariant(IntegerType.INT).hashCode(), maxInt.hashCode());
+        Assertions.assertEquals(Variant.minVariant(IntegerType.INT).hashCode(), minInt.hashCode());
+
+        // Test that it's different from actual string "MAX" if it were a StringVariant
+        // Note: With your change, we can no longer create a StringVariant with value "MAX" via Variant.of
+        Variant normalStr = Variant.of(VarcharType.VARCHAR, "MAX_VALUE");
+        Assertions.assertTrue(normalStr instanceof StringVariant);
+        Assertions.assertNotEquals(maxStr, normalStr);
+    }
+
+    @Test
+    public void testMinMaxVariantEqualsHashCode() {
+        Variant min1 = Variant.minVariant(IntegerType.INT);
+        Variant min2 = Variant.minVariant(IntegerType.BIGINT);
+        Variant min3 = Variant.minVariant(IntegerType.INT);
+        Variant max1 = Variant.maxVariant(IntegerType.INT);
+        Variant max2 = Variant.maxVariant(IntegerType.BIGINT);
+        Variant max3 = Variant.maxVariant(IntegerType.INT);
+
+        // MinVariant equals and hashCode
+        Assertions.assertEquals(min1, min3);
+        Assertions.assertEquals(min1.hashCode(), min3.hashCode());
+        Assertions.assertEquals(0, min1.compareTo(min3));
+
+        Assertions.assertNotEquals(min1, min2);
+        Assertions.assertNotEquals(min1.hashCode(), min2.hashCode());
+        Assertions.assertNotEquals(0, min1.compareTo(min2));
+
+        // MaxVariant equals and hashCode
+        Assertions.assertEquals(max1, max3);
+        Assertions.assertEquals(max1.hashCode(), max3.hashCode());
+        Assertions.assertEquals(0, max1.compareTo(max3));
+
+        Assertions.assertNotEquals(max1, max2);
+        Assertions.assertNotEquals(max1.hashCode(), max2.hashCode());
+        Assertions.assertNotEquals(0, max1.compareTo(max2));
+
+        // In-equality
+        Assertions.assertNotEquals(min1, max1);
+        Assertions.assertNotEquals(min1.hashCode(), max1.hashCode());
+        Assertions.assertTrue(min1.compareTo(max1) < 0);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/VariantTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/VariantTest.java
@@ -1041,31 +1041,29 @@ public class VariantTest {
 
     @Test
     public void testVariantOfMinMax() {
-        // Test numeric type with "MAX"/"MIN"
-        Variant maxInt = Variant.of(IntegerType.INT, "MAX");
-        Variant minInt = Variant.of(IntegerType.INT, "MIN");
+        // Min/Max sentinels should only be created via dedicated helpers, not via Variant.of("MIN"/"MAX").
+        Variant maxInt = Variant.maxVariant(IntegerType.INT);
+        Variant minInt = Variant.minVariant(IntegerType.INT);
         Assertions.assertTrue(maxInt instanceof MaxVariant);
         Assertions.assertTrue(minInt instanceof MinVariant);
         Assertions.assertEquals(IntegerType.INT, maxInt.getType());
         Assertions.assertEquals(IntegerType.INT, minInt.getType());
 
-        // Test string type with "MAX"/"MIN"
-        Variant maxStr = Variant.of(VarcharType.VARCHAR, "MAX");
-        Variant minStr = Variant.of(VarcharType.VARCHAR, "MIN");
-        Assertions.assertTrue(maxStr instanceof MaxVariant);
-        Assertions.assertTrue(minStr instanceof MinVariant);
+        // String type: "MAX"/"MIN" should be treated as normal string values.
+        Variant strMaxLiteral = Variant.of(VarcharType.VARCHAR, "MAX");
+        Variant strMinLiteral = Variant.of(VarcharType.VARCHAR, "MIN");
+        Assertions.assertTrue(strMaxLiteral instanceof StringVariant);
+        Assertions.assertTrue(strMinLiteral instanceof StringVariant);
 
-        // Test equality with direct factory methods
-        Assertions.assertEquals(Variant.maxVariant(IntegerType.INT), maxInt);
-        Assertions.assertEquals(Variant.minVariant(IntegerType.INT), minInt);
-        Assertions.assertEquals(Variant.maxVariant(IntegerType.INT).hashCode(), maxInt.hashCode());
-        Assertions.assertEquals(Variant.minVariant(IntegerType.INT).hashCode(), minInt.hashCode());
+        // Min/Max sentinels for string types are only created explicitly.
+        Variant maxStrSentinel = Variant.maxVariant(VarcharType.VARCHAR);
+        Variant minStrSentinel = Variant.minVariant(VarcharType.VARCHAR);
+        Assertions.assertTrue(maxStrSentinel instanceof MaxVariant);
+        Assertions.assertTrue(minStrSentinel instanceof MinVariant);
 
-        // Test that it's different from actual string "MAX" if it were a StringVariant
-        // Note: With your change, we can no longer create a StringVariant with value "MAX" via Variant.of
-        Variant normalStr = Variant.of(VarcharType.VARCHAR, "MAX_VALUE");
-        Assertions.assertTrue(normalStr instanceof StringVariant);
-        Assertions.assertNotEquals(maxStr, normalStr);
+        // Ensure sentinels are different from literal string variants.
+        Assertions.assertNotEquals(maxStrSentinel, strMaxLiteral);
+        Assertions.assertNotEquals(minStrSentinel, strMinLiteral);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/RangeDistributionPrunerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/RangeDistributionPrunerTest.java
@@ -1,0 +1,550 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.TabletRange;
+import com.starrocks.catalog.Tuple;
+import com.starrocks.catalog.Variant;
+import com.starrocks.common.Config;
+import com.starrocks.common.Range;
+import com.starrocks.sql.ast.expression.LiteralExpr;
+import com.starrocks.sql.ast.expression.StringLiteral;
+import com.starrocks.type.BooleanType;
+import com.starrocks.type.DateType;
+import com.starrocks.type.IntegerType;
+import com.starrocks.type.VarcharType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class RangeDistributionPrunerTest {
+
+    @Test
+    public void testSingleColumnEqualityPrune() {
+        Column k1 = new Column("k1", IntegerType.INT, false);
+
+        List<Tablet> tablets = Lists.newArrayList();
+        tablets.add(createTablet(1L, "0", "9", k1));
+        tablets.add(createTablet(2L, "10", "19", k1));
+        tablets.add(createTablet(3L, "20", "29", k1));
+
+        PartitionColumnFilter filter = new PartitionColumnFilter();
+        filter.setLowerBound(new StringLiteral("15"), true);
+        filter.setUpperBound(new StringLiteral("15"), true);
+
+        Map<String, PartitionColumnFilter> filters = Maps.newHashMap();
+        filters.put("k1", filter);
+
+        RangeDistributionPruner pruner =
+                new RangeDistributionPruner(tablets, Lists.newArrayList(k1), filters);
+
+        Collection<Long> result = pruner.prune();
+        Assertions.assertEquals(Collections.singleton(2L), new HashSet<>(result));
+    }
+
+    @Test
+    public void testNoFilterReturnsAllTablets() {
+        Column k1 = new Column("k1", IntegerType.INT, false);
+
+        List<Tablet> tablets = Lists.newArrayList();
+        tablets.add(createTablet(1L, "0", "9", k1));
+        tablets.add(createTablet(2L, "10", "19", k1));
+        tablets.add(createTablet(3L, "20", "29", k1));
+
+        RangeDistributionPruner pruner =
+                new RangeDistributionPruner(tablets, Lists.newArrayList(k1), Maps.newHashMap());
+
+        Collection<Long> result = pruner.prune();
+        Assertions.assertEquals(
+                new HashSet<>(Lists.newArrayList(1L, 2L, 3L)),
+                new HashSet<>(result));
+    }
+
+    @Test
+    public void testInPredicatePrune() {
+        Column k1 = new Column("k1", IntegerType.INT, false);
+
+        List<Tablet> tablets = Lists.newArrayList();
+        tablets.add(createTablet(1L, "0", "9", k1));
+        tablets.add(createTablet(2L, "10", "19", k1));
+        tablets.add(createTablet(3L, "20", "29", k1));
+
+        PartitionColumnFilter filter = new PartitionColumnFilter();
+        List<LiteralExpr> inValues = Lists.newArrayList();
+        inValues.add(new StringLiteral("5"));   // tablet 1
+        inValues.add(new StringLiteral("25"));  // tablet 3
+        filter.setInPredicateLiterals(inValues);
+
+        Map<String, PartitionColumnFilter> filters = Maps.newHashMap();
+        filters.put("k1", filter);
+
+        RangeDistributionPruner pruner =
+                new RangeDistributionPruner(tablets, Lists.newArrayList(k1), filters);
+
+        Collection<Long> result = pruner.prune();
+        Assertions.assertEquals(
+                new HashSet<>(Lists.newArrayList(1L, 3L)),
+                new HashSet<>(result));
+    }
+
+    @Test
+    public void testTwoColumnsDateAndIntWithInAndRange() {
+        Column dateCol = new Column("d", DateType.DATE, false);
+        Column intCol = new Column("k", IntegerType.INT, false);
+        List<Column> columns = Lists.newArrayList(dateCol, intCol);
+
+        List<Tablet> tablets = Lists.newArrayList();
+        // d = 2024-01-01/02/03/04, k in [0, 99]
+        tablets.add(createTablet(1L, Lists.newArrayList("2024-01-01", "0"),
+                Lists.newArrayList("2024-01-01", "99"), columns));
+        tablets.add(createTablet(2L, Lists.newArrayList("2024-01-02", "0"),
+                Lists.newArrayList("2024-01-02", "99"), columns));
+        tablets.add(createTablet(3L, Lists.newArrayList("2024-01-03", "0"),
+                Lists.newArrayList("2024-01-03", "99"), columns));
+        tablets.add(createTablet(4L, Lists.newArrayList("2024-01-04", "0"),
+                Lists.newArrayList("2024-01-04", "99"), columns));
+
+        // d in ('2024-01-02', '2024-01-03')
+        PartitionColumnFilter dFilter = new PartitionColumnFilter();
+        List<LiteralExpr> dInValues = Lists.newArrayList();
+        dInValues.add(new StringLiteral("2024-01-02"));
+        dInValues.add(new StringLiteral("2024-01-03"));
+        dFilter.setInPredicateLiterals(dInValues);
+
+        // and k between 50 and 150
+        PartitionColumnFilter kFilter = new PartitionColumnFilter();
+        kFilter.setLowerBound(new StringLiteral("50"), true);
+        kFilter.setUpperBound(new StringLiteral("150"), true);
+
+        Map<String, PartitionColumnFilter> filters = Maps.newHashMap();
+        filters.put("d", dFilter);
+        filters.put("k", kFilter);
+
+        RangeDistributionPruner pruner =
+                new RangeDistributionPruner(tablets, columns, filters);
+
+        Set<Long> result = pruner.prune().stream().collect(Collectors.toSet());
+        Assertions.assertEquals(
+                new HashSet<>(Lists.newArrayList(2L, 3L)),
+                result);
+    }
+
+    @Test
+    public void testTwoColumnsStringAndBooleanInPredicate() {
+        Column flagCol = new Column("flag", BooleanType.BOOLEAN, false);
+        Column nameCol = new Column("name", VarcharType.VARCHAR, false);
+        List<Column> columns = Lists.newArrayList(flagCol, nameCol);
+
+        List<Tablet> tablets = Lists.newArrayList();
+        // tablet 1: flag = false, name in ['a', 'z']
+        tablets.add(createTablet(1L, Lists.newArrayList("false", "a"),
+                Lists.newArrayList("false", "z"), columns));
+        // tablet 2: flag = true, name in ['a', 'z']
+        tablets.add(createTablet(2L, Lists.newArrayList("true", "a"),
+                Lists.newArrayList("true", "z"), columns));
+
+        // flag in (true)
+        PartitionColumnFilter flagFilter = new PartitionColumnFilter();
+        List<LiteralExpr> flagInValues = Lists.newArrayList();
+        flagInValues.add(new StringLiteral("true"));
+        flagFilter.setInPredicateLiterals(flagInValues);
+
+        // name in ('p', 'q')
+        PartitionColumnFilter nameFilter = new PartitionColumnFilter();
+        List<LiteralExpr> nameInValues = Lists.newArrayList();
+        nameInValues.add(new StringLiteral("p"));
+        nameInValues.add(new StringLiteral("q"));
+        nameFilter.setInPredicateLiterals(nameInValues);
+
+        Map<String, PartitionColumnFilter> filters = Maps.newHashMap();
+        filters.put("flag", flagFilter);
+        filters.put("name", nameFilter);
+
+        RangeDistributionPruner pruner =
+                new RangeDistributionPruner(tablets, columns, filters);
+
+        Set<Long> result = pruner.prune().stream().collect(Collectors.toSet());
+        Assertions.assertEquals(Collections.singleton(2L), result);
+    }
+
+    @Test
+    public void testPrefixFilterStopsOnMissingSecondColumnFilter() {
+        Column dateCol = new Column("d", DateType.DATE, false);
+        Column intCol = new Column("k", IntegerType.INT, false);
+        List<Column> columns = Lists.newArrayList(dateCol, intCol);
+
+        List<Tablet> tablets = Lists.newArrayList();
+        tablets.add(createTablet(1L, Lists.newArrayList("2024-01-01", "0"),
+                Lists.newArrayList("2024-01-01", "99"), columns));
+        tablets.add(createTablet(2L, Lists.newArrayList("2024-01-02", "0"),
+                Lists.newArrayList("2024-01-02", "99"), columns));
+        tablets.add(createTablet(3L, Lists.newArrayList("2024-01-03", "0"),
+                Lists.newArrayList("2024-01-03", "99"), columns));
+        tablets.add(createTablet(4L, Lists.newArrayList("2024-01-04", "0"),
+                Lists.newArrayList("2024-01-04", "99"), columns));
+
+        // Only filter on first column d between '2024-01-02' and '2024-01-03'
+        PartitionColumnFilter dFilter = new PartitionColumnFilter();
+        dFilter.setLowerBound(new StringLiteral("2024-01-02"), true);
+        dFilter.setUpperBound(new StringLiteral("2024-01-03"), true);
+
+        Map<String, PartitionColumnFilter> filters = Maps.newHashMap();
+        filters.put("d", dFilter);
+
+        RangeDistributionPruner pruner =
+                new RangeDistributionPruner(tablets, columns, filters);
+
+        Set<Long> result = pruner.prune().stream().collect(Collectors.toSet());
+        Assertions.assertEquals(
+                new HashSet<>(Lists.newArrayList(2L, 3L)),
+                result);
+    }
+
+    @Test
+    public void testSingleColumnDatetimeLowerAndUpperBound() {
+        Column dt = new Column("dt", DateType.DATETIME, false);
+
+        List<Tablet> tablets = Lists.newArrayList();
+        tablets.add(createTablet(1L, "2024-01-01 00:00:00",
+                "2024-01-01 23:59:59.999999", dt));
+        tablets.add(createTablet(2L, "2024-01-02 00:00:00",
+                "2024-01-02 23:59:59.999999", dt));
+        tablets.add(createTablet(3L, "2024-01-03 00:00:00",
+                "2024-01-03 23:59:59.999999", dt));
+
+        // dt >= '2024-01-02'
+        PartitionColumnFilter lowerOnly = new PartitionColumnFilter();
+        lowerOnly.setLowerBound(new StringLiteral("2024-01-02 00:00:00"), true);
+
+        Map<String, PartitionColumnFilter> filters = Maps.newHashMap();
+        filters.put("dt", lowerOnly);
+
+        RangeDistributionPruner lowerPruner =
+                new RangeDistributionPruner(tablets, Lists.newArrayList(dt), filters);
+        Set<Long> lowerResult = lowerPruner.prune().stream().collect(Collectors.toSet());
+        Assertions.assertEquals(
+                new HashSet<>(Lists.newArrayList(2L, 3L)),
+                lowerResult);
+
+        // dt <= '2024-01-02 23:59:59.999999'
+        PartitionColumnFilter upperOnly = new PartitionColumnFilter();
+        upperOnly.setUpperBound(new StringLiteral("2024-01-02 23:59:59.999999"), true);
+
+        Map<String, PartitionColumnFilter> filters2 = Maps.newHashMap();
+        filters2.put("dt", upperOnly);
+
+        RangeDistributionPruner upperPruner =
+                new RangeDistributionPruner(tablets, Lists.newArrayList(dt), filters2);
+        Set<Long> upperResult = upperPruner.prune().stream().collect(Collectors.toSet());
+        Assertions.assertEquals(
+                new HashSet<>(Lists.newArrayList(1L, 2L)),
+                upperResult);
+    }
+
+    @Test
+    public void testEarlyStopNoPruningWhenComplexTooLarge() {
+        Column x = new Column("x", IntegerType.INT, false);
+        Column y = new Column("y", IntegerType.INT, false);
+        List<Column> columns = Lists.newArrayList(x, y);
+
+        // tablets cover x in {0,1,2}, y in {0,1}
+        List<Tablet> tablets = Lists.newArrayList();
+        tablets.add(createTablet(1L, Lists.newArrayList("0", "0"),
+                Lists.newArrayList("0", "0"), columns));
+        tablets.add(createTablet(2L, Lists.newArrayList("0", "1"),
+                Lists.newArrayList("0", "1"), columns));
+        tablets.add(createTablet(3L, Lists.newArrayList("1", "0"),
+                Lists.newArrayList("1", "0"), columns));
+        tablets.add(createTablet(4L, Lists.newArrayList("1", "1"),
+                Lists.newArrayList("1", "1"), columns));
+        tablets.add(createTablet(5L, Lists.newArrayList("2", "0"),
+                Lists.newArrayList("2", "0"), columns));
+        tablets.add(createTablet(6L, Lists.newArrayList("2", "1"),
+                Lists.newArrayList("2", "1"), columns));
+
+        PartitionColumnFilter xFilter = new PartitionColumnFilter();
+        List<LiteralExpr> xInValues = Lists.newArrayList();
+        xInValues.add(new StringLiteral("0"));
+        xInValues.add(new StringLiteral("1"));
+        xInValues.add(new StringLiteral("2"));
+        xInValues.add(new StringLiteral("3"));
+        xInValues.add(new StringLiteral("4"));
+        xFilter.setInPredicateLiterals(xInValues);
+
+        PartitionColumnFilter yFilter = new PartitionColumnFilter();
+        List<LiteralExpr> yInValues = Lists.newArrayList();
+        yInValues.add(new StringLiteral("0"));
+        yInValues.add(new StringLiteral("1"));
+        yInValues.add(new StringLiteral("2"));
+        yInValues.add(new StringLiteral("3"));
+        yInValues.add(new StringLiteral("4"));
+        yFilter.setInPredicateLiterals(yInValues);
+
+        Map<String, PartitionColumnFilter> filters = Maps.newHashMap();
+        filters.put("x", xFilter);
+        filters.put("y", yFilter);
+
+        int oldDepth = Config.max_distribution_pruner_recursion_depth;
+        try {
+            // 5 (x) * 5 (y) = 25 > 3, so pruning should early-stop and return all tablets
+            Config.max_distribution_pruner_recursion_depth = 3;
+            RangeDistributionPruner pruner =
+                    new RangeDistributionPruner(tablets, columns, filters);
+            Set<Long> result = pruner.prune().stream().collect(Collectors.toSet());
+            Assertions.assertEquals(
+                    new HashSet<>(Lists.newArrayList(1L, 2L, 3L, 4L, 5L, 6L)),
+                    result);
+        } finally {
+            Config.max_distribution_pruner_recursion_depth = oldDepth;
+        }
+    }
+
+    @Test
+    public void testEarlyStopUsesPrefixColumnsOnly() {
+        Column x = new Column("x", IntegerType.INT, false);
+        Column y = new Column("y", IntegerType.INT, false);
+        List<Column> columns = Lists.newArrayList(x, y);
+
+        // tablets cover x in {0,1,2}, y in {0,1}
+        List<Tablet> tablets = Lists.newArrayList();
+        tablets.add(createTablet(1L, Lists.newArrayList("0", "0"),
+                Lists.newArrayList("0", "0"), columns));
+        tablets.add(createTablet(2L, Lists.newArrayList("0", "1"),
+                Lists.newArrayList("0", "1"), columns));
+        tablets.add(createTablet(3L, Lists.newArrayList("1", "0"),
+                Lists.newArrayList("1", "0"), columns));
+        tablets.add(createTablet(4L, Lists.newArrayList("1", "1"),
+                Lists.newArrayList("1", "1"), columns));
+        tablets.add(createTablet(5L, Lists.newArrayList("2", "0"),
+                Lists.newArrayList("2", "0"), columns));
+        tablets.add(createTablet(6L, Lists.newArrayList("2", "1"),
+                Lists.newArrayList("2", "1"), columns));
+
+        PartitionColumnFilter xFilter = new PartitionColumnFilter();
+        List<LiteralExpr> xInValues = Lists.newArrayList();
+        xInValues.add(new StringLiteral("0"));
+        xInValues.add(new StringLiteral("1"));
+        xFilter.setInPredicateLiterals(xInValues);
+
+        PartitionColumnFilter yFilter = new PartitionColumnFilter();
+        List<LiteralExpr> yInValues = Lists.newArrayList();
+        yInValues.add(new StringLiteral("0"));
+        yInValues.add(new StringLiteral("1"));
+        yInValues.add(new StringLiteral("2"));
+        yInValues.add(new StringLiteral("3"));
+        yFilter.setInPredicateLiterals(yInValues);
+
+        Map<String, PartitionColumnFilter> filters = Maps.newHashMap();
+        filters.put("x", xFilter);
+        filters.put("y", yFilter);
+
+        int oldDepth = Config.max_distribution_pruner_recursion_depth;
+        try {
+            // 2 (x) * 4 (y) = 8 > 5, so only first column x is used for pruning
+            Config.max_distribution_pruner_recursion_depth = 5;
+
+            RangeDistributionPruner prunerWithEarlyStop =
+                    new RangeDistributionPruner(tablets, columns, filters);
+            Set<Long> resultWithEarlyStop =
+                    prunerWithEarlyStop.prune().stream().collect(Collectors.toSet());
+
+            Map<String, PartitionColumnFilter> prefixFilters = Maps.newHashMap();
+            prefixFilters.put("x", xFilter);
+            RangeDistributionPruner prefixOnlyPruner =
+                    new RangeDistributionPruner(tablets, columns, prefixFilters);
+            Set<Long> prefixResult =
+                    prefixOnlyPruner.prune().stream().collect(Collectors.toSet());
+
+            Assertions.assertEquals(prefixResult, resultWithEarlyStop);
+        } finally {
+            Config.max_distribution_pruner_recursion_depth = oldDepth;
+        }
+    }
+
+    @Test
+    public void testInclusiveAggregationPrunesBoundaryTabletWhenAnyColumnExclusive() {
+        Column x = new Column("x", IntegerType.INT, false);
+        Column y = new Column("y", IntegerType.INT, false);
+        List<Column> columns = Lists.newArrayList(x, y);
+
+        // Single tablet whose key range is exactly [(0,0), (0,0)]
+        List<Tablet> tablets = Lists.newArrayList();
+        tablets.add(createTablet(1L, Lists.newArrayList("0", "0"),
+                Lists.newArrayList("0", "0"), columns));
+
+        // Column x has open bounds (0,0) so both lower and upper are exclusive.
+        PartitionColumnFilter xFilter = new PartitionColumnFilter();
+        xFilter.setLowerBound(new StringLiteral("0"), false);
+        xFilter.setUpperBound(new StringLiteral("0"), false);
+
+        // Column y has closed bounds [0,0], so both lower and upper are inclusive.
+        PartitionColumnFilter yFilter = new PartitionColumnFilter();
+        yFilter.setLowerBound(new StringLiteral("0"), true);
+        yFilter.setUpperBound(new StringLiteral("0"), true);
+
+        Map<String, PartitionColumnFilter> filters = Maps.newHashMap();
+        filters.put("x", xFilter);
+        filters.put("y", yFilter);
+
+        RangeDistributionPruner pruner =
+                new RangeDistributionPruner(tablets, columns, filters);
+
+        Set<Long> result = pruner.prune().stream().collect(Collectors.toSet());
+
+        // Now we use allMatch for inclusive flag, so if any column is exclusive, the whole
+        // tuple range boundary is exclusive. Since x is exclusive, the boundary tablet is pruned.
+        Assertions.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testBinarySearchLowerAndUpperBothNull() {
+        Column k1 = new Column("k1", IntegerType.INT, false);
+        List<Tablet> tablets = Lists.newArrayList();
+        tablets.add(createTablet(1L, "10", "20", k1));
+        tablets.add(createTablet(2L, "21", "30", k1));
+
+        // query range [-inf, +inf] should make lower and upper entries both null
+        PartitionColumnFilter filter = new PartitionColumnFilter();
+        // no bounds set => defaults to min/max
+        Map<String, PartitionColumnFilter> filters = Maps.newHashMap();
+        filters.put("k1", filter);
+
+        RangeDistributionPruner pruner = new RangeDistributionPruner(tablets, Lists.newArrayList(k1), filters);
+        Collection<Long> result = pruner.prune();
+        Assertions.assertEquals(new HashSet<>(Lists.newArrayList(1L, 2L)), new HashSet<>(result));
+    }
+
+    @Test
+    public void testBinarySearchLowerNullUpperExists() {
+        Column k1 = new Column("k1", IntegerType.INT, false);
+        List<Tablet> tablets = Lists.newArrayList();
+        tablets.add(createTablet(1L, "10", "20", k1));
+        tablets.add(createTablet(2L, "30", "40", k1));
+        tablets.add(createTablet(3L, "50", "60", k1));
+
+        // query range [5, 35]
+        // lowerEntry (strictly < [5,35]) is null
+        // higherEntry (strictly > [5,35]) is Tablet 3 [50, 60]
+        // overlap should be {1, 2}
+        PartitionColumnFilter filter = new PartitionColumnFilter();
+        filter.setLowerBound(new StringLiteral("5"), true);
+        filter.setUpperBound(new StringLiteral("35"), true);
+
+        Map<String, PartitionColumnFilter> filters = Maps.newHashMap();
+        filters.put("k1", filter);
+
+        RangeDistributionPruner pruner = new RangeDistributionPruner(tablets, Lists.newArrayList(k1), filters);
+        Collection<Long> result = pruner.prune();
+        Assertions.assertEquals(new HashSet<>(Lists.newArrayList(1L, 2L)), new HashSet<>(result));
+    }
+
+    @Test
+    public void testBinarySearchLowerExistsUpperNull() {
+        Column k1 = new Column("k1", IntegerType.INT, false);
+        List<Tablet> tablets = Lists.newArrayList();
+        tablets.add(createTablet(1L, "10", "20", k1));
+        tablets.add(createTablet(2L, "30", "40", k1));
+        tablets.add(createTablet(3L, "50", "60", k1));
+
+        // query range [35, 100]
+        // lowerEntry (strictly < [35,100]) is Tablet 1 [10, 20]
+        // higherEntry (strictly > [35,100]) is null
+        // overlap should be {2, 3}
+        PartitionColumnFilter filter = new PartitionColumnFilter();
+        filter.setLowerBound(new StringLiteral("35"), true);
+        filter.setUpperBound(new StringLiteral("100"), true);
+
+        Map<String, PartitionColumnFilter> filters = Maps.newHashMap();
+        filters.put("k1", filter);
+
+        RangeDistributionPruner pruner = new RangeDistributionPruner(tablets, Lists.newArrayList(k1), filters);
+        Collection<Long> result = pruner.prune();
+        Assertions.assertEquals(new HashSet<>(Lists.newArrayList(2L, 3L)), new HashSet<>(result));
+    }
+
+    @Test
+    public void testBinarySearchLowerAndUpperBothExist() {
+        Column k1 = new Column("k1", IntegerType.INT, false);
+        List<Tablet> tablets = Lists.newArrayList();
+        tablets.add(createTablet(1L, "10", "20", k1));
+        tablets.add(createTablet(2L, "30", "40", k1));
+        tablets.add(createTablet(3L, "50", "60", k1));
+        tablets.add(createTablet(4L, "70", "80", k1));
+
+        // query range [35, 55]
+        // lowerEntry (< [35,55]) is Tablet 1 [10, 20]
+        // higherEntry (> [35,55]) is Tablet 4 [70, 80]
+        // subMap(T1, T4) should return {2, 3}
+        PartitionColumnFilter filter = new PartitionColumnFilter();
+        filter.setLowerBound(new StringLiteral("35"), true);
+        filter.setUpperBound(new StringLiteral("55"), true);
+
+        Map<String, PartitionColumnFilter> filters = Maps.newHashMap();
+        filters.put("k1", filter);
+
+        RangeDistributionPruner pruner = new RangeDistributionPruner(tablets, Lists.newArrayList(k1), filters);
+        Collection<Long> result = pruner.prune();
+        Assertions.assertEquals(new HashSet<>(Lists.newArrayList(2L, 3L)), new HashSet<>(result));
+    }
+
+    @Test
+    public void testConstructorThrowsWhenRangeIsNull() {
+        Column k1 = new Column("k1", IntegerType.INT, false);
+        LocalTablet tablet = new LocalTablet(1L);
+        tablet.setRange(null); // Ensure range is null
+
+        Assertions.assertThrows(IllegalStateException.class, () -> {
+            new RangeDistributionPruner(Lists.newArrayList(tablet), Lists.newArrayList(k1), Maps.newHashMap());
+        });
+    }
+
+    private Tablet createTablet(long id, String lower, String upper, Column column) {
+        LocalTablet tablet = new LocalTablet(id);
+        List<Variant> lowerValues = Lists.newArrayList(Variant.of(column.getType(), lower));
+        List<Variant> upperValues = Lists.newArrayList(Variant.of(column.getType(), upper));
+        Tuple lowerTuple = new Tuple(lowerValues);
+        Tuple upperTuple = new Tuple(upperValues);
+        tablet.setRange(new TabletRange(Range.of(lowerTuple, upperTuple, true, true)));
+        return tablet;
+    }
+
+    private Tablet createTablet(long id, List<String> lower, List<String> upper, List<Column> columns) {
+        LocalTablet tablet = new LocalTablet(id);
+        List<Variant> lowerValues = Lists.newArrayList();
+        List<Variant> upperValues = Lists.newArrayList();
+        for (int i = 0; i < columns.size(); i++) {
+            lowerValues.add(Variant.of(columns.get(i).getType(), lower.get(i)));
+            upperValues.add(Variant.of(columns.get(i).getType(), upper.get(i)));
+        }
+        Tuple lowerTuple = new Tuple(lowerValues);
+        Tuple upperTuple = new Tuple(upperValues);
+        tablet.setRange(new TabletRange(Range.of(lowerTuple, upperTuple, true, true)));
+        return tablet;
+    }
+}
+
+

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/DistributionPrunerRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/DistributionPrunerRuleTest.java
@@ -25,11 +25,13 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.planner.PartitionColumnFilter;
+import com.starrocks.planner.RangeDistributionPruner;
 import com.starrocks.sql.ast.expression.BinaryType;
 import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.InPredicate;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.ast.expression.StringLiteral;
+import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerFactory;
 import com.starrocks.sql.optimizer.Utils;
@@ -43,6 +45,8 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.type.CharType;
 import com.starrocks.type.DateType;
 import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
 import mockit.Mocked;
 import org.junit.jupiter.api.Test;
 
@@ -204,5 +208,96 @@ public class DistributionPrunerRuleTest {
                 .setSelectedTabletId(Lists.newArrayList(1L, 2L, 3L))
                 .build();
         assertEquals(3, newScanOperator.getSelectedTabletId().size());
+    }
+
+    @Test
+    public void transformRangeDistribution(@Mocked OlapTable olapTable, @Mocked Partition partition,
+                                           @Mocked PhysicalPartition physicalPartition,
+                                           @Mocked MaterializedIndex index,
+                                           @Mocked DistributionInfo distributionInfo) {
+        List<Long> tabletIds = Lists.newArrayList(1L, 2L, 3L);
+
+        final List<Column> columns = Lists.newArrayList(
+                new Column("dealDate", DateType.DATE, false));
+
+        Map<ColumnId, Column> idToColumn = Maps.newTreeMap(ColumnId.CASE_INSENSITIVE_ORDER);
+        for (Column column : columns) {
+            idToColumn.put(column.getColumnId(), column);
+        }
+
+        // Simple filter on range distribution column
+        PartitionColumnFilter dealDateFilter = new PartitionColumnFilter();
+        dealDateFilter.setLowerBound(new StringLiteral("2019-08-22"), true);
+        dealDateFilter.setUpperBound(new StringLiteral("2019-08-22"), true);
+
+        Map<String, PartitionColumnFilter> filters = Maps.newHashMap();
+        filters.put("dealDate", dealDateFilter);
+
+        ColumnRefFactory columnRefFactory = new ColumnRefFactory();
+        Map<ColumnRefOperator, Column> scanColumnMap = Maps.newHashMap();
+
+        ColumnRefOperator column1 = columnRefFactory.create("dealDate", DateType.DATE, false);
+        scanColumnMap.put(column1, new Column("dealDate", DateType.DATE, false));
+
+        BinaryPredicateOperator binaryPredicateOperator1 =
+                new BinaryPredicateOperator(BinaryType.GE, column1,
+                        ConstantOperator.createDate(LocalDateTime.of(2019, 8, 22, 0, 0, 0)));
+        BinaryPredicateOperator binaryPredicateOperator2 =
+                new BinaryPredicateOperator(BinaryType.LE, column1,
+                        ConstantOperator.createDate(LocalDateTime.of(2019, 8, 22, 0, 0, 0)));
+
+        ScalarOperator predicate = Utils.compoundAnd(binaryPredicateOperator1, binaryPredicateOperator2);
+
+        LogicalOlapScanOperator operator =
+                new LogicalOlapScanOperator(olapTable, scanColumnMap, Maps.newHashMap(), null, -1, predicate,
+                        1, Lists.newArrayList(1L), null, false, Lists.newArrayList(), Lists.newArrayList(), null,
+                        false);
+        operator.setPredicate(predicate);
+
+        // Mock RangeDistributionPruner to ensure RANGE branch in OptDistributionPruner is exercised
+        new MockUp<RangeDistributionPruner>() {
+            @Mock
+            public java.util.Collection<Long> prune() {
+                return tabletIds;
+            }
+        };
+
+        new MockUp<MetaUtils>() {
+            @Mock
+            public List<Column> getRangeDistributionColumns(OlapTable olapTable) {
+                return columns;
+            }
+        };
+
+        new Expectations() {
+            {
+                olapTable.getPartition(anyLong);
+                result = partition;
+
+                olapTable.getIdToColumn();
+                result = idToColumn;
+
+                partition.getSubPartitions();
+                result = Arrays.asList(physicalPartition);
+
+                physicalPartition.getIndex(anyLong);
+                result = index;
+
+                partition.getDistributionInfo();
+                result = distributionInfo;
+
+                distributionInfo.getType();
+                result = DistributionInfo.DistributionInfoType.RANGE;
+            }
+        };
+
+        DistributionPruneRule rule = new DistributionPruneRule();
+
+        assertEquals(0, operator.getSelectedTabletId().size());
+        OptExpression optExpression =
+                rule.transform(new OptExpression(operator), OptimizerFactory.mockContext(new ColumnRefFactory()))
+                        .get(0);
+
+        assertEquals(tabletIds, ((LogicalOlapScanOperator) optExpression.getOp()).getSelectedTabletId());
     }
 }

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -234,8 +234,8 @@ message TransactionStatePB {
 
 enum InfinityTypePB {
     NONE_INFINITY = 0;
-    MIN = 1;
-    MAX = 2;
+    MINIMUM = 1;
+    MAXIMUM = 2;
 }
 
 message VariantPB {

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -232,9 +232,16 @@ message TransactionStatePB {
     optional string reason = 3;
 }
 
+enum InfinityTypePB {
+    NONE_INFINITY = 0;
+    MIN = 1;
+    MAX = 2;
+}
+
 message VariantPB {
     optional PTypeDesc type = 1;
     optional string value = 2;
+    optional InfinityTypePB infinity_type = 3;
 }
 
 message TuplePB {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -633,8 +633,8 @@ struct TParquetOptions {
 
 enum TInfinityType {
     NONE_INFINITY = 0,
-    MIN = 1,
-    MAX = 2,
+    MINIMUM = 1,
+    MAXIMUM = 2,
 }
 
 struct TVariant {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -631,9 +631,16 @@ struct TParquetOptions {
     4: optional string version
 }
 
+enum TInfinityType {
+    NONE_INFINITY = 0,
+    MIN = 1,
+    MAX = 2,
+}
+
 struct TVariant {
     1: optional TTypeDesc type
     2: optional string value
+    3: optional TInfinityType infinity_type
 }
 
 struct TTuple {


### PR DESCRIPTION
## What I'm doing:
This PR cleanly adds FE support for range-distributed tables.
Introduces `RangeDistributionPruner` and wires it through OlapScanNode and OptDistributionPruner so RANGE distribution can participate in tablet pruning.

Fixes #64986

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables RANGE-distributed tables to participate in tablet pruning and adds explicit infinity semantics to `Variant`.
> 
> - New `RangeDistributionPruner` with binary-search pruning over tuple ranges; wired into `OlapScanNode` and `OptDistributionPruner` (RANGE branch) and supports range distribution columns in `OlapTable`
> - Refactors `Variant` comparison via `compareToImpl` and adds `MinVariant`/`MaxVariant`; `Variant.of/fromThrift/fromProto` handle "MIN"/"MAX" and new infinity types
> - All concrete variants now set `TVariant.infinity_type` (`NONE_INFINITY` for normal values); add helpers `minVariant`/`maxVariant`
> - Update `DistributionPruner` interface (remove checked exception)
> - Extend thrift/proto: add `TInfinityType`/`InfinityTypePB` and `infinity_type` on `TVariant`/`VariantPB`
> - Comprehensive tests for variants, tuple range overlap, RANGE pruning, and optimizer rule integration
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7565d62ee5f20a1da4c3728ee9ade49804dc5050. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->