### PR TITLE
[Doc] support creating iceberg view with properties

### DIFF
--- a/docs/en/data_source/catalog/iceberg/iceberg_catalog.md
+++ b/docs/en/data_source/catalog/iceberg/iceberg_catalog.md
@@ -1626,13 +1626,13 @@ CREATE VIEW IF NOT EXISTS iceberg.iceberg_db.iceberg_view1 AS
 SELECT k1, k2 FROM iceberg.iceberg_db.iceberg_table;
 ```
 
-You can specify the view attributes in the `"key" = "value"` format in `PROPERTIES`. This feature is supported from v4.0.3 onwards.
+From v4.0.3 onwards, you can specify the view attributes in the `"key" = "value"` format in `PROPERTIES`.
 
 ```SQL
 CREATE VIEW IF NOT EXISTS iceberg.iceberg_db.iceberg_view1
 PROPERTIES (
-  "owner" = "user1",
-  "application-name" = "sr-application1"
+  "key1" = "value1",
+  "key2" = "value2"
 )
 AS
 SELECT k1, k2 FROM iceberg.iceberg_db.iceberg_table;

--- a/docs/en/data_source/catalog/iceberg/iceberg_catalog.md
+++ b/docs/en/data_source/catalog/iceberg/iceberg_catalog.md
@@ -1613,6 +1613,7 @@ CREATE VIEW [IF NOT EXISTS]
     [, <column_name>[ COMMENT 'column comment'], ...]
 )
 [COMMENT 'view comment']
+[PROPERTIES ("key" = "value", ...)]
 AS <query_statement>
 ```
 
@@ -1622,6 +1623,18 @@ Create an Iceberg view `iceberg_view1` based on an Iceberg table `iceberg_table`
 
 ```SQL
 CREATE VIEW IF NOT EXISTS iceberg.iceberg_db.iceberg_view1 AS
+SELECT k1, k2 FROM iceberg.iceberg_db.iceberg_table;
+```
+
+You can specify the view attributes in the `"key" = "value"` format in `PROPERTIES`. This feature is supported from v4.0.3 onwards.
+
+```SQL
+CREATE VIEW IF NOT EXISTS iceberg.iceberg_db.iceberg_view1
+PROPERTIES (
+  "owner" = "user1",
+  "application-name" = "sr-application1"
+)
+AS
 SELECT k1, k2 FROM iceberg.iceberg_db.iceberg_table;
 ```
 

--- a/docs/ja/data_source/catalog/iceberg/iceberg_catalog.md
+++ b/docs/ja/data_source/catalog/iceberg/iceberg_catalog.md
@@ -1612,6 +1612,7 @@ CREATE VIEW [IF NOT EXISTS]
     [, <column_name>[ COMMENT 'column comment'], ...]
 )
 [COMMENT 'view comment']
+[PROPERTIES ("key" = "value", ...)]
 AS <query_statement>
 ```
 
@@ -1621,6 +1622,18 @@ Iceberg テーブル `iceberg_table` に基づいて Iceberg ビュー `iceberg_
 
 ```SQL
 CREATE VIEW IF NOT EXISTS iceberg.iceberg_db.iceberg_view1 AS
+SELECT k1, k2 FROM iceberg.iceberg_db.iceberg_table;
+```
+
+v4.0.3以降、`PROPERTIES `内でビュー属性を `"key" = "value"` 形式で指定できます。
+
+```SQL
+CREATE VIEW IF NOT EXISTS iceberg.iceberg_db.iceberg_view1
+PROPERTIES (
+  "key1" = "value1",
+  "key2" = "value2"
+)
+AS
 SELECT k1, k2 FROM iceberg.iceberg_db.iceberg_table;
 ```
 

--- a/docs/zh/data_source/catalog/iceberg/iceberg_catalog.md
+++ b/docs/zh/data_source/catalog/iceberg/iceberg_catalog.md
@@ -1651,6 +1651,7 @@ CREATE VIEW [IF NOT EXISTS]
     [, <column_name>[ COMMENT 'column comment'], ...]
 )
 [COMMENT 'view comment']
+[PROPERTIES ("key" = "value", ...)]
 AS <query_statement>
 ```
 
@@ -1660,6 +1661,18 @@ AS <query_statement>
 
 ```SQL
 CREATE VIEW IF NOT EXISTS iceberg.iceberg_db.iceberg_view1 AS
+SELECT k1, k2 FROM iceberg.iceberg_db.iceberg_table;
+```
+
+您可以在 `PROPERTIES` 中以 `"key" = "value"` 格式指定视图属性。此功能从 v4.0.3 开始支持。
+
+```SQL
+CREATE VIEW IF NOT EXISTS iceberg.iceberg_db.iceberg_view1
+PROPERTIES (
+  "owner" = "user1",
+  "application-name" = "sr-application1"
+)
+AS
 SELECT k1, k2 FROM iceberg.iceberg_db.iceberg_table;
 ```
 

--- a/docs/zh/data_source/catalog/iceberg/iceberg_catalog.md
+++ b/docs/zh/data_source/catalog/iceberg/iceberg_catalog.md
@@ -1664,13 +1664,13 @@ CREATE VIEW IF NOT EXISTS iceberg.iceberg_db.iceberg_view1 AS
 SELECT k1, k2 FROM iceberg.iceberg_db.iceberg_table;
 ```
 
-您可以在 `PROPERTIES` 中以 `"key" = "value"` 格式指定视图属性。此功能从 v4.0.3 开始支持。
+自 v4.0.3 起，您可以在 `PROPERTIES` 中以 `"key" = "value"` 格式指定视图属性。
 
 ```SQL
 CREATE VIEW IF NOT EXISTS iceberg.iceberg_db.iceberg_view1
 PROPERTIES (
-  "owner" = "user1",
-  "application-name" = "sr-application1"
+  "key1" = "value1",
+  "key2" = "value2"
 )
 AS
 SELECT k1, k2 FROM iceberg.iceberg_db.iceberg_table;


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Iceberg catalog docs (EN/JA/ZH) to include CREATE VIEW `PROPERTIES` syntax and example for setting view attributes (available from v4.0.3).
> 
> - **Docs — Iceberg catalog (`docs/*/data_source/catalog/iceberg/iceberg_catalog.md`)**:
>   - **CREATE VIEW syntax**: Add optional `PROPERTIES ("key" = "value", ...)` clause for Iceberg views.
>   - **Examples**: New snippet showing setting view attributes via `PROPERTIES`; notes availability from v4.0.3.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 226f2a13130c5748611518f6e8adf4dfe247d6cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->