### PR TITLE
[BugFix] fix incorrect predicate rewrite for outer join with constant-side column reference

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/EliminateJoinWithConstantRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/EliminateJoinWithConstantRule.java
@@ -136,6 +136,13 @@ public class EliminateJoinWithConstantRule extends TransformationRule {
                 ScalarOperator t = transformOuterJoinOnPredicate(joinOperator, value, rewrittenCondition);
                 outputs.put(key, t);
             });
+            // For outer join, if predicate references constant-side columns, we need to rewrite
+            // the predicate using the CASE WHEN expressions in outputs instead of constant values.
+            // This is because the constant-side columns are now represented as CASE WHEN expressions.
+            if (predicate != null) {
+                ReplaceColumnRefRewriter outputRewriter = new ReplaceColumnRefRewriter(outputs);
+                rewrittenPredicate = outputRewriter.rewrite(predicate);
+            }
         } else {
             rewrittenPredicate = Utils.compoundAnd(rewrittenPredicate, rewrittenCondition);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -3450,7 +3450,8 @@ public class JoinTest extends PlanTestBase {
         assertContainsIgnoreColRefs(plan, "  0:OlapScanNode\n" +
                 "     TABLE: t0\n" +
                 "     PREAGGREGATION: ON\n" +
-                "     PREDICATES: coalesce('cccc', CAST(1: v1 AS VARCHAR)) = '1'");
+                "     PREDICATES: " +
+                "coalesce(if(CAST(1: v1 AS VARCHAR(1048576)) = 'cccc', 'cccc', NULL), CAST(1: v1 AS VARCHAR)) = '1'");
     }
 
     @Test


### PR DESCRIPTION

## Why I'm doing:

## What I'm doing:

Fixes #67076

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures correct predicate handling when eliminating joins with a single-row constant side, especially for outer joins.
> 
> - Updates `EliminateJoinWithConstantRule`: after generating `CASE WHEN` outputs for outer joins, rewrites any filter `predicate` to reference those outputs (via `ReplaceColumnRefRewriter`) instead of raw constants.
> - Adds/updates tests to validate left/right outer joins with predicates on constant-side columns (including `IS NULL`), CTE/analytic scenarios, and adjusts expected plans (e.g., `coalesce(if(...), ...)`) in `JoinTest` and `EliminateConstantValueTest`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46b7407120db85b40855447ad7a5da96fc9f388f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->