### PR TITLE
[BugFix] Fix query profile API to return a unified JSON format

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/ProfileActionV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/ProfileActionV2.java
@@ -24,6 +24,7 @@ import com.starrocks.http.rest.RestBaseAction;
 import com.starrocks.persist.gson.GsonUtils;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import org.json.JSONException;
 
 import java.util.List;
 
@@ -71,15 +72,19 @@ public class ProfileActionV2 extends RestBaseAction {
             List<String> profileList = fetchResultFromOtherFrontendNodes(queryPath, authorization, HttpMethod.GET, false);
             for (String profile : profileList) {
                 if (profile != null) {
-                    RestBaseResultV2<String> queryProfileResult = GsonUtils.GSON.fromJson(
-                            profile,
-                            new TypeToken<RestBaseResultV2<String>>() {
-                            }.getType());
-                    if (queryProfileResult.getResult() == null) {
-                        continue;
+                    try {
+                        RestBaseResultV2<String> queryProfileResult = GsonUtils.GSON.fromJson(
+                                profile,
+                                new TypeToken<RestBaseResultV2<String>>() {
+                                }.getType());
+                        if (queryProfileResult == null || queryProfileResult.getResult() == null) {
+                            continue;
+                        }
+                        sendSuccessResponse(response, queryProfileResult.getResult(), request);
+                        return;
+                    } catch (JSONException exception) {
+                        // skip invalid json
                     }
-                    sendSuccessResponse(response, queryProfileResult.getResult(), request);
-                    return;
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/ProfileActionV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/ProfileActionV2.java
@@ -75,6 +75,9 @@ public class ProfileActionV2 extends RestBaseAction {
                             profile,
                             new TypeToken<RestBaseResultV2<String>>() {
                             }.getType());
+                    if (queryProfileResult.getResult() == null) {
+                        continue;
+                    }
                     sendSuccessResponse(response, queryProfileResult.getResult(), request);
                     return;
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/ProfileActionV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/ProfileActionV2.java
@@ -14,12 +14,14 @@
 
 package com.starrocks.http.rest.v2;
 
+import com.google.gson.reflect.TypeToken;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
 import com.starrocks.http.IllegalArgException;
 import com.starrocks.http.rest.RestBaseAction;
+import com.starrocks.persist.gson.GsonUtils;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
 
@@ -69,7 +71,11 @@ public class ProfileActionV2 extends RestBaseAction {
             List<String> profileList = fetchResultFromOtherFrontendNodes(queryPath, authorization, HttpMethod.GET, false);
             for (String profile : profileList) {
                 if (profile != null) {
-                    sendSuccessResponse(response, profile, request);
+                    RestBaseResultV2<String> queryProfileResult = GsonUtils.GSON.fromJson(
+                            profile,
+                            new TypeToken<RestBaseResultV2<String>>() {
+                            }.getType());
+                    sendSuccessResponse(response, queryProfileResult.getResult(), request);
                     return;
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/ProfileActionV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/ProfileActionV2.java
@@ -24,7 +24,6 @@ import com.starrocks.http.rest.RestBaseAction;
 import com.starrocks.persist.gson.GsonUtils;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
-import org.json.JSONException;
 
 import java.util.List;
 
@@ -69,18 +68,19 @@ public class ProfileActionV2 extends RestBaseAction {
             // If the query profile is not found in the local fe's ProfileManager,
             // we will query other frontend nodes to get the query profile.
             String queryPath = String.format(QUERY_PLAN_URI, queryId);
-            List<String> profileList = fetchResultFromOtherFrontendNodes(queryPath, authorization, HttpMethod.GET, false);
+            List<String> profileList =
+                    fetchResultFromOtherFrontendNodes(queryPath, authorization, HttpMethod.GET, false);
             for (String profile : profileList) {
                 if (profile != null) {
-                        RestBaseResultV2<String> queryProfileResult = GsonUtils.GSON.fromJson(
-                                profile,
-                                new TypeToken<RestBaseResultV2<String>>() {
-                                }.getType());
-                        if (queryProfileResult == null || queryProfileResult.getResult() == null) {
-                            continue;
-                        }
-                        sendSuccessResponse(response, queryProfileResult.getResult(), request);
-                        return;
+                    RestBaseResultV2<String> queryProfileResult = GsonUtils.GSON.fromJson(
+                            profile,
+                            new TypeToken<RestBaseResultV2<String>>() {
+                            }.getType());
+                    if (queryProfileResult == null || queryProfileResult.getResult() == null) {
+                        continue;
+                    }
+                    sendSuccessResponse(response, queryProfileResult.getResult(), request);
+                    return;
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/ProfileActionV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/v2/ProfileActionV2.java
@@ -72,7 +72,6 @@ public class ProfileActionV2 extends RestBaseAction {
             List<String> profileList = fetchResultFromOtherFrontendNodes(queryPath, authorization, HttpMethod.GET, false);
             for (String profile : profileList) {
                 if (profile != null) {
-                    try {
                         RestBaseResultV2<String> queryProfileResult = GsonUtils.GSON.fromJson(
                                 profile,
                                 new TypeToken<RestBaseResultV2<String>>() {
@@ -82,9 +81,6 @@ public class ProfileActionV2 extends RestBaseAction {
                         }
                         sendSuccessResponse(response, queryProfileResult.getResult(), request);
                         return;
-                    } catch (JSONException exception) {
-                        // skip invalid json
-                    }
                 }
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/ProfileActionV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/ProfileActionV2Test.java
@@ -14,11 +14,14 @@
 
 package com.starrocks.http.rest.v2;
 
+import com.google.common.reflect.TypeToken;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.http.StarRocksHttpTestCase;
+import com.starrocks.http.rest.ActionStatus;
 import com.starrocks.http.rest.RestBaseAction;
+import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Frontend;
 import mockit.Expectations;
@@ -164,7 +167,12 @@ public class ProfileActionV2Test extends StarRocksHttpTestCase {
                 .build();
         Response response = networkClient.newCall(request).execute();
         String respStr = response.body().string();
-        Assertions.assertEquals(response.code(), 200);
-        Assertions.assertTrue(respStr.contains("Query ID: eaff21d2-3734-11ee-909f-8e20563011de"));
+        RestBaseResultV2<String> queryProfileResult = GsonUtils.GSON.fromJson(
+                respStr,
+                new TypeToken<RestBaseResultV2<String>>() {
+                }.getType());
+        Assertions.assertEquals(queryProfileResult.getStatus(), ActionStatus.OK);
+        Assertions.assertTrue(queryProfileResult.getResult().contains("Query ID: eaff21d2-3734-11ee-909f-8e20563011de"));
+        Assertions.assertFalse(queryProfileResult.getResult().contains("\"result\":"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/ProfileActionV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/ProfileActionV2Test.java
@@ -15,6 +15,8 @@
 package com.starrocks.http.rest.v2;
 
 import com.google.common.reflect.TypeToken;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonSyntaxException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.util.ProfileManager;
 import com.starrocks.ha.FrontendNodeType;
@@ -173,9 +175,9 @@ public class ProfileActionV2Test extends StarRocksHttpTestCase {
                 }.getType());
         Assertions.assertEquals(queryProfileResult.getStatus(), ActionStatus.OK);
         Assertions.assertTrue(queryProfileResult.getResult().contains("Query ID: eaff21d2-3734-11ee-909f-8e20563011de"));
-        Assertions.assertFalse(
-                queryProfileResult.getResult().contains("\"result\":"),
-                "Query profile should be raw text, not wrapped in a JSON 'result' field"
-        );
+        Assertions.assertThrows(
+                JsonSyntaxException.class,
+                () -> GsonUtils.GSON.fromJson(queryProfileResult.getResult(), JsonElement.class),
+                "Query profile should be plain text, not a JSON object");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/ProfileActionV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/rest/v2/ProfileActionV2Test.java
@@ -173,6 +173,9 @@ public class ProfileActionV2Test extends StarRocksHttpTestCase {
                 }.getType());
         Assertions.assertEquals(queryProfileResult.getStatus(), ActionStatus.OK);
         Assertions.assertTrue(queryProfileResult.getResult().contains("Query ID: eaff21d2-3734-11ee-909f-8e20563011de"));
-        Assertions.assertFalse(queryProfileResult.getResult().contains("\"result\":"));
+        Assertions.assertFalse(
+                queryProfileResult.getResult().contains("\"result\":"),
+                "Query profile should be raw text, not wrapped in a JSON 'result' field"
+        );
     }
 }


### PR DESCRIPTION
## Why I'm doing:
as title
## What I'm doing:

as title

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns cross-FE profile fetching to return the plain-text profile inside the standard JSON envelope.
> 
> - In `ProfileActionV2`, when querying other FEs, parse their JSON (`RestBaseResultV2<String>`) and return only the `result` (plain text); skip null results
> - Add `GsonUtils`/`TypeToken` usage to deserialize remote responses
> - Update `ProfileActionV2Test` to assert JSON envelope (`status=OK`) and that the embedded profile is plain text (not JSON)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a58535ab01219fc298f0254e7b2058c68503360a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->