### PR TITLE
[BugFix] fix profile's stmt when multi stmt submited

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpConnectProcessor.java
@@ -77,7 +77,9 @@ public class HttpConnectProcessor extends ConnectProcessor {
         executor = new StmtExecutor(ctx, parsedStmt);
         ctx.setExecutor(executor);
 
+        // http sql doesn't support multi stmt
         ctx.setIsLastStmt(true);
+        ctx.setSingleStmt(true);
 
         //  for http protocal, if current FE can't read, just let client talk with leader
         if (executor.isForwardToLeader()) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -208,6 +208,7 @@ public class ConnectContext {
     //    or current processing stmt is the last stmt for multi stmts
     // used to set mysql result package
     protected boolean isLastStmt = true;
+    protected boolean isSingleStmt = false;
     // set true when user dump query through HTTP
     protected boolean isHTTPQueryDump = false;
 
@@ -1733,5 +1734,13 @@ public class ConnectContext {
         } catch (Exception e) {
             LOG.warn("set cn group name failed", e);
         }
+    }
+
+    public boolean isSingleStmt() {
+        return isSingleStmt;
+    }
+
+    public void setSingleStmt(boolean singleStmt) {
+        isSingleStmt = singleStmt;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -519,6 +519,7 @@ public class ConnectProcessor {
             ctx.setExecutor(executor);
 
             ctx.setIsLastStmt(i == stmts.size() - 1);
+            ctx.setSingleStmt(stmts.size() == 1);
 
             //Build View SQL without Policy Rewrite
             new AstTraverser<Void, Void>() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -390,11 +390,14 @@ public class StmtExecutor {
                 String.format("%s-%s", Version.STARROCKS_VERSION, Version.STARROCKS_COMMIT_HASH));
         summaryProfile.addInfoString(ProfileManager.USER, context.getQualifiedUser());
         summaryProfile.addInfoString(ProfileManager.DEFAULT_DB, context.getDatabase());
+        // only print the sepecific sql in multi statement
+        String sql = context.isSingleStmt() ? originStmt.originStmt :
+                AstToSQLBuilder.toSQLOrDefault(parsedStmt, originStmt.originStmt);
         if (AuditEncryptionChecker.needEncrypt(parsedStmt)) {
             summaryProfile.addInfoString(ProfileManager.SQL_STATEMENT,
                     AstToSQLBuilder.toSQLOrDefault(parsedStmt, originStmt.originStmt));
         } else {
-            summaryProfile.addInfoString(ProfileManager.SQL_STATEMENT, originStmt.originStmt);
+            summaryProfile.addInfoString(ProfileManager.SQL_STATEMENT, sql);
         }
         summaryProfile.addInfoString(ProfileManager.WAREHOUSE_CNGROUP, GlobalStateMgr.getCurrentState().getWarehouseMgr()
                 .getWarehouseComputeResourceName(context.getCurrentComputeResource()));

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -290,6 +290,7 @@ public class TaskRun implements Comparable<TaskRun> {
         context.getState().reset();
         context.setQueryId(UUID.fromString(status.getQueryId()));
         context.setIsLastStmt(true);
+        context.setSingleStmt(true);
         context.resetSessionVariable();
         // Preserve critical session variables from parent context if available
         // This ensures that settings like enableSingleNodeSchedule are inherited

--- a/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/arrow/flight/sql/ArrowFlightSqlConnectProcessor.java
@@ -310,6 +310,7 @@ public class ArrowFlightSqlConnectProcessor extends ConnectProcessor {
 
         executor = new StmtExecutor(ctx, parsedStmt, deploymentFinished);
         ctx.setIsLastStmt(true);
+        ctx.setSingleStmt(true);
         ctx.setExecutor(executor);
 
         executor.addRunningQueryDetail(parsedStmt);

--- a/test/sql/test_profile/R/test_profile
+++ b/test/sql/test_profile/R/test_profile
@@ -72,3 +72,22 @@ shell: env mysql_cmd="${mysql_cmd} -D${db[0]}" bash ${root_path}/sql/test_profil
 NonDefaultSessionVariables contains 'pipeline_dop'
 NonDefaultSessionVariables contains 'pipeline_dop'
 -- !result
+create view profile_filter_stmt as
+select trim(unnest) 
+from table(unnest(split(get_query_profile(last_query_id()), '\n')))
+where unnest like '%Sql Statement%'
+order by unnest;\
+set enable_async_profile=false;
+-- result:
+-- !result
+select count(*) from t0;select sum(1) from t0;
+-- result:
+12
+-- !result
+select * from profile_filter_stmt;
+-- result:
+- Sql Statement: SELECT sum(1) AS `sum(1)`
+-- !result
+set enable_async_profile=true;
+-- result:
+-- !result

--- a/test/sql/test_profile/T/test_profile
+++ b/test/sql/test_profile/T/test_profile
@@ -50,3 +50,12 @@ INSERT INTO `temp1` (v1, v2, v3) values
 
 shell: env mysql_cmd="${mysql_cmd} -D${db[0]}" bash ${root_path}/sql/test_profile/T/test_profile_analysis.sh
 shell: env mysql_cmd="${mysql_cmd} -D${db[0]}" bash ${root_path}/sql/test_profile/T/test_profile_non_default_variables.sh
+create view profile_filter_stmt as
+select trim(unnest) 
+from table(unnest(split(get_query_profile(last_query_id()), '\n')))
+where unnest like '%Sql Statement%'
+order by unnest;\
+set enable_async_profile=false;
+select count(*) from t0;select sum(1) from t0;
+select * from profile_filter_stmt;
+set enable_async_profile=true;


### PR DESCRIPTION
## Why I'm doing:
for multi stmt like "select * from table; select count(*) from table", currently there are two profiles in http interface, but every profile's stmt is :"select * from table; select count(*) from table"

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [x] 3.4
  - [x] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Track single vs multi statements in `ConnectContext` and use it to render the precise SQL in profiles; set the flag across MySQL/HTTP/ArrowFlight/scheduler paths and add tests.
> 
> - **Profiling/Execution**:
>   - Add `ConnectContext.isSingleStmt` with getters/setter; set in `ConnectProcessor` per parsed batch size and force true in HTTP/ArrowFlight/scheduler paths.
>   - Update `StmtExecutor` profile output to render exact SQL for multi-statement using `AstToSQLBuilder`; keep original SQL for single statements and honor encryption rules.
> - **Connect Paths**:
>   - `HttpConnectProcessor`, `ArrowFlightSqlConnectProcessor`, `TaskRun` now set `isSingleStmt(true)`.
> - **Tests**:
>   - Extend `test_profile` to validate profile contains the correct "Sql Statement" for multi-statement queries and related setup via a helper view.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eaeef5b4fe2cbc08e1aae664193abaae171817ac. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->