### PR TITLE
[Enhancement] Also consider NULL fractions in `SkewJoinOptimizeRule`

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SkewJoinOptimizeRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SkewJoinOptimizeRule.java
@@ -21,10 +21,11 @@ import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.TableFunction;
 import com.starrocks.common.Pair;
 import com.starrocks.connector.exception.StarRocksConnectorException;
-import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.ast.HintNode;
 import com.starrocks.sql.ast.JoinOperator;
 import com.starrocks.sql.ast.expression.ExprUtils;
+import com.starrocks.sql.common.ErrorType;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.common.TypeManager;
 import com.starrocks.sql.optimizer.JoinHelper;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -52,7 +53,7 @@ import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import com.starrocks.sql.optimizer.rule.Rule;
 import com.starrocks.sql.optimizer.rule.RuleType;
-import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.optimizer.skew.DataSkew;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.type.ArrayType;
 import com.starrocks.type.BooleanType;
@@ -63,7 +64,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -137,8 +137,6 @@ public class SkewJoinOptimizeRule extends TransformationRule {
         if (leftChildStats == null) {
             return false;
         }
-        double leftRowCount = leftChildStats.getOutputRowCount();
-
         for (BinaryPredicateOperator equalConj : equalConjs) {
             if (!equalConj.getChild(0).isColumnRef() || !equalConj.getChild(1).isColumnRef()) {
                 // only support column equal column
@@ -146,7 +144,7 @@ public class SkewJoinOptimizeRule extends TransformationRule {
             }
             ColumnRefOperator leftColumn = (ColumnRefOperator) equalConj.getChild(0);
             ColumnRefOperator rightColumn = (ColumnRefOperator) equalConj.getChild(1);
-            ColumnRefOperator skewJoinColumn = null;
+            ColumnRefOperator skewJoinColumn;
             // choose the skew join column, it could be left or right column of the predicate
             if (leftOutputColumns.contains(leftColumn.getId())) {
                 skewJoinColumn = leftColumn;
@@ -156,36 +154,41 @@ public class SkewJoinOptimizeRule extends TransformationRule {
             if (!leftChildStats.getColumnStatistics().containsKey(skewJoinColumn)) {
                 continue;
             }
-            ColumnStatistic leftColumnStats = leftChildStats.getColumnStatistic(skewJoinColumn);
-            if (leftColumnStats == null || leftColumnStats.getHistogram() == null) {
-                // only support column with histogram stats
+            final var skewColumnStats = leftChildStats.getColumnStatistic(skewJoinColumn);
+
+            if (skewColumnStats == null) {
+                // Only support column with some stats
                 continue;
             }
-            // sort the MCV by value
-            List<Pair<String, Long>> leftChildMCV = Lists.newArrayList();
-            int useMCVCount = Math.min(context.getSessionVariable().getSkewJoinOptimizeUseMCVCount(),
-                    leftColumnStats.getHistogram().getMCV().size());
-            leftColumnStats.getHistogram().getMCV().entrySet().stream().
-                    sorted(Map.Entry.comparingByValue(Comparator.reverseOrder())).limit(useMCVCount).
-                    forEach(entry -> {
-                        leftChildMCV.add(Pair.create(entry.getKey(), entry.getValue()));
-                    });
-            if (isDataSkew(leftChildMCV, leftRowCount, context.getSessionVariable())) {
+
+            final var mcvLimit = context.getSessionVariable().getSkewJoinOptimizeUseMCVCount();
+            final var rowPercentageThreshold = context.getSessionVariable().getSkewJoinDataSkewThreshold();
+            final var skewInfo = DataSkew.getColumnSkewInfo(leftChildStats, skewColumnStats,
+                    new DataSkew.Thresholds(mcvLimit, rowPercentageThreshold));
+
+            if (skewInfo.isSkewed()) {
                 joinOperator.setSkewColumn(skewJoinColumn);
-                joinOperator.setSkewValues(leftChildMCV.stream().map(pair -> ConstantOperator.createVarchar(pair.first)).
-                        collect(Collectors.toList()));
+
+                // Handle NULL-only skew case: when MCV is empty but NULL fraction indicates skew
+                List<ScalarOperator> skewValues;
+                if (skewInfo.type() == DataSkew.SkewType.SKEWED_NULL) {
+                    // Create a special NULL skew value for NULL-only skew cases
+                    skewValues = Lists.newArrayList(ConstantOperator.createNull(skewJoinColumn.getType()));
+                } else if (skewInfo.type() == DataSkew.SkewType.SKEWED_MCV) {
+                    // Use MCV-based skew values
+                    skewValues = skewInfo.maybeMcvs().get()
+                            .stream() //
+                            .map(pair -> ConstantOperator.createVarchar(pair.first)) //
+                            .collect(Collectors.toList());
+                } else {
+                    throw new StarRocksPlannerException("Did not handle skew type in SkewOptimizeRule", ErrorType.INTERNAL_ERROR);
+                }
+
+                joinOperator.setSkewValues(skewValues);
                 return true;
             }
         }
         return false;
-    }
-
-    private boolean isDataSkew(List<Pair<String, Long>> mcvList, double rowCount, SessionVariable sessionVariable) {
-        if (rowCount < 1) {
-            return false;
-        }
-        long mcvRowCount = mcvList.stream().mapToLong(pair -> pair.second).sum();
-        return ((double) mcvRowCount / rowCount) > sessionVariable.getSkewJoinDataSkewThreshold();
     }
 
     @Override
@@ -312,15 +315,20 @@ public class SkewJoinOptimizeRule extends TransformationRule {
 
         List<ScalarOperator> inPredicateArgs = Lists.newArrayList();
         inPredicateArgs.add(skewColumn);
-        skewValues.remove(ConstantOperator.createNull(NullType.NULL));
-        inPredicateArgs.addAll(skewValues);
+        // build a defensive copy and remove NULL from it
+        List<ScalarOperator> nonNullSkewValues = Lists.newArrayList(skewValues);
+        nonNullSkewValues.removeIf(value -> value instanceof ConstantOperator && ((ConstantOperator) value).isNull());
+        inPredicateArgs.addAll(nonNullSkewValues);
         InPredicateOperator inPredicateOperator = new InPredicateOperator(false, inPredicateArgs);
 
         List<ScalarOperator> when = Lists.newArrayList();
         when.add(isNullPredicateOperator);
         when.add(roundFnOperator);
-        when.add(inPredicateOperator);
-        when.add(roundFnOperator);
+        // only add IN branch when we indeed have non-null skew values
+        if (!nonNullSkewValues.isEmpty()) {
+            when.add(inPredicateOperator);
+            when.add(roundFnOperator);
+        }
         ScalarOperator caseWhenOperator = new CaseWhenOperator(roundFnOperator.getType(), null,
                 ConstantOperator.createBigint(0), when);
         ScalarOperatorRewriter rewriter = new ScalarOperatorRewriter();
@@ -419,6 +427,10 @@ public class SkewJoinOptimizeRule extends TransformationRule {
     private OptExpression addSaltForRightChild(LogicalJoinOperator oldJoinOperator, OptExpression input,
                                                ScalarOperator rightSkewColumn, OptimizerContext context) {
         List<ScalarOperator> skewValues = oldJoinOperator.getSkewValues();
+        // If skew values is empty or contains only NULL, still proceed to create salt table.
+        if (skewValues == null || skewValues.isEmpty()) {
+            skewValues = Lists.newArrayList(ConstantOperator.createNull(NullType.NULL));
+        }
         OptExpression skewValueSaltOpt = createSkewValueSaltTable(skewValues, context);
         Map<ColumnRefOperator, ScalarOperator> skewValueSaltProjects =
                 ((LogicalProjectOperator) skewValueSaltOpt.getOp()).getColumnRefMap();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SkewJoinOptimizeRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SkewJoinOptimizeRule.java
@@ -427,10 +427,6 @@ public class SkewJoinOptimizeRule extends TransformationRule {
     private OptExpression addSaltForRightChild(LogicalJoinOperator oldJoinOperator, OptExpression input,
                                                ScalarOperator rightSkewColumn, OptimizerContext context) {
         List<ScalarOperator> skewValues = oldJoinOperator.getSkewValues();
-        // If skew values is empty or contains only NULL, still proceed to create salt table.
-        if (skewValues == null || skewValues.isEmpty()) {
-            skewValues = Lists.newArrayList(ConstantOperator.createNull(NullType.NULL));
-        }
         OptExpression skewValueSaltOpt = createSkewValueSaltTable(skewValues, context);
         Map<ColumnRefOperator, ScalarOperator> skewValueSaltProjects =
                 ((LogicalProjectOperator) skewValueSaltOpt.getOp()).getColumnRefMap();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkew.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkew.java
@@ -45,8 +45,6 @@ public class DataSkew {
         SKEWED_MCV
     }
 
-    ;
-
     public record SkewInfo(SkewType type, Optional<List<Pair<String, Long>>> maybeMcvs) {
         public SkewInfo(SkewType type) {
             this(type, Optional.empty());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkew.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/skew/DataSkew.java
@@ -21,6 +21,7 @@ import com.starrocks.sql.optimizer.statistics.Statistics;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import javax.validation.constraints.NotNull;
 
 public class DataSkew {
@@ -38,30 +39,40 @@ public class DataSkew {
         }
     }
 
-    /**
-     * Utility method to check if a certain column is skewed based on statistics.
-     */
-    public static boolean isColumnSkewed(@NotNull Statistics statistics, @NotNull ColumnStatistic columnStatistic,
-                                         Thresholds thresholds) {
-        if (columnStatistic.getNullsFraction() >= thresholds.relativeRowThreshold) {
-            // A lot of NULL values also indicate skew.
-            return true;
+    public enum SkewType {
+        NOT_SKEWED,
+        SKEWED_NULL,
+        SKEWED_MCV
+    }
+
+    ;
+
+    public record SkewInfo(SkewType type, Optional<List<Pair<String, Long>>> maybeMcvs) {
+        public SkewInfo(SkewType type) {
+            this(type, Optional.empty());
         }
 
+        public boolean isSkewed() {
+            return type != SkewType.NOT_SKEWED;
+        }
+    }
+
+    private record McvSkewInfo(boolean skewed, Optional<Double> mcvSkewFactor, Optional<List<Pair<String, Long>>> mcvs) {
+        public McvSkewInfo(boolean skewed) {
+            this(skewed, Optional.empty(), Optional.empty());
+        }
+    }
+
+    private static McvSkewInfo getMcvSkewInfo(@NotNull Statistics statistics, @NotNull ColumnStatistic columnStatistic,
+                                              Thresholds thresholds) {
         final var rowCount = statistics.getOutputRowCount();
-        if (statistics.isTableRowCountMayInaccurate() || rowCount < 1 || columnStatistic.isUnknown() ||
-                columnStatistic.isUnknownValue()) {
-            // Without sufficient information we can not make a decision.
-            return false;
-        }
-
         final var histogram = columnStatistic.getHistogram();
         if (histogram != null) {
             final var mcv = histogram.getMCV();
 
             if (mcv != null) {
-                List<Pair<String, Long>> mcvs = Lists.newArrayList();
                 int mcvLimit = Math.min(thresholds.mcvLimit, mcv.size());
+                List<Pair<String, Long>> mcvs = Lists.newArrayList();
                 mcv.entrySet().stream()
                         .sorted(Map.Entry.comparingByValue(Comparator.reverseOrder())) //
                         .limit(mcvLimit)
@@ -70,12 +81,75 @@ public class DataSkew {
                         });
 
                 long rowCountOfMcvs = mcvs.stream().mapToLong(pair -> pair.second).sum();
-                return ((double) rowCountOfMcvs / rowCount) > thresholds.relativeRowThreshold;
+                final var mcvSkewFactor = rowCountOfMcvs / rowCount;
+
+                if (mcvSkewFactor > thresholds.relativeRowThreshold) {
+                    return new McvSkewInfo(true, Optional.of(mcvSkewFactor), Optional.of(mcvs));
+                }
             }
         }
 
-        // No histogram information, can not deduce skew.
-        return false;
+        return new McvSkewInfo(false);
+    }
+
+    private record NullSkewInfo(boolean skewed, Optional<Double> nullSkewFactor) {
+        public NullSkewInfo(boolean skewed) {
+            this(skewed, Optional.empty());
+        }
+    }
+
+    private static NullSkewInfo getNullSkewInfo(@NotNull ColumnStatistic columnStatistic, Thresholds thresholds) {
+        if (columnStatistic.getNullsFraction() >= thresholds.relativeRowThreshold) {
+            // A lot of NULL values also indicate skew.
+            return new NullSkewInfo(true, Optional.of(columnStatistic.getNullsFraction()));
+        }
+
+        return new NullSkewInfo(false);
+    }
+
+    /**
+     * Utility method to get detailed information about if a column is skewed and how it is skewed.
+     */
+    public static SkewInfo getColumnSkewInfo(@NotNull Statistics statistics, @NotNull ColumnStatistic columnStatistic) {
+        return getColumnSkewInfo(statistics, columnStatistic, DEFAULT_THRESHOLDS);
+    }
+
+    /**
+     * Utility method to get detailed information about if a column is skewed and how it is skewed.
+     */
+    public static SkewInfo getColumnSkewInfo(@NotNull Statistics statistics, @NotNull ColumnStatistic columnStatistic,
+                                             Thresholds thresholds) {
+        if (statistics.isTableRowCountMayInaccurate() || statistics.getOutputRowCount() < 1) {
+            // Without sufficient information we can not make a decision.
+            return new SkewInfo(SkewType.NOT_SKEWED);
+        }
+
+        final var nullSkewInfo = getNullSkewInfo(columnStatistic, thresholds);
+        final var mcvSkewInfo = getMcvSkewInfo(statistics, columnStatistic, thresholds);
+
+        if (nullSkewInfo.skewed && mcvSkewInfo.skewed) {
+            // If there is skew in the MCVs as well as NULLs, we decide for the one that is more skewed.
+            if (nullSkewInfo.nullSkewFactor.get() >= mcvSkewInfo.mcvSkewFactor.get()) {
+                return new SkewInfo(SkewType.SKEWED_NULL);
+            } else {
+                return new SkewInfo(SkewType.SKEWED_MCV, mcvSkewInfo.mcvs);
+            }
+        } else if (nullSkewInfo.skewed) {
+            return new SkewInfo(SkewType.SKEWED_NULL);
+        } else if (mcvSkewInfo.skewed) {
+            return new SkewInfo(SkewType.SKEWED_MCV, mcvSkewInfo.mcvs);
+        }
+
+        // Can not deduce skew.
+        return new SkewInfo(SkewType.NOT_SKEWED);
+    }
+
+    /**
+     * Utility method to check if a certain column is skewed based on statistics.
+     */
+    public static boolean isColumnSkewed(@NotNull Statistics statistics, @NotNull ColumnStatistic columnStatistic,
+                                         Thresholds thresholds) {
+        return getColumnSkewInfo(statistics, columnStatistic, thresholds).isSkewed();
     }
 
     /* Always using default thresholds */

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/BinaryPredicateStatisticCalculator.java
@@ -24,6 +24,8 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.type.BooleanType;
 import com.starrocks.type.Type;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -452,7 +454,7 @@ public class BinaryPredicateStatisticCalculator {
                 estimateBucketToBucket(leftHistogram, leftColumnDistinctCount, leftColumnType, rightHistogram,
                         rightColumnDistinctCount, rightColumnType);
 
-        if (estimatedMcv.isEmpty() && estimatedBuckets.isEmpty()) {
+        if (MapUtils.isEmpty(estimatedMcv) && CollectionUtils.isEmpty(estimatedBuckets)) {
             return Optional.empty();
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/skew/DataSkewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/skew/DataSkewTest.java
@@ -161,11 +161,11 @@ public class DataSkewTest {
         assertTrue(nullAndMcvButMoreMcvSkewInfo.maybeMcvs().isPresent());
 
         final var expectedMcvs =
-                List.of(Pair.create("1", 50000), Pair.create("2", 20000), Pair.create("3", 10000), Pair.create("4", 5000),
-                        Pair.create("5", 500));
+                List.of(Pair.create("1", 50000L), Pair.create("2", 20000L), Pair.create("3", 10000L), Pair.create("4", 5000L),
+                        Pair.create("5", 500L));
         assertEquals(expectedMcvs.size(), nullAndMcvButMoreMcvSkewInfo.maybeMcvs().get().size());
         for (final var value : expectedMcvs) {
-            nullAndMcvButMoreMcvSkewInfo.maybeMcvs().get().contains(value);
+            assertTrue(nullAndMcvButMoreMcvSkewInfo.maybeMcvs().get().contains(value));
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SkewJoinTest.java
@@ -15,8 +15,12 @@
 package com.starrocks.sql.plan;
 
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.common.StarRocksPlannerException;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.optimizer.statistics.EmptyStatisticStorage;
+import com.starrocks.sql.optimizer.statistics.Histogram;
 import com.starrocks.statistic.MockHistogramStatisticStorage;
 import com.starrocks.type.IntegerType;
 import org.junit.jupiter.api.AfterAll;
@@ -26,6 +30,8 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -91,7 +97,6 @@ public class SkewJoinTest extends PlanTestBase {
         PlanTestBase.afterClass();
     }
 
-
     @Test
     public void testSkewJoin() throws Exception {
         String sql = "select v2, v5 from t0 join[skew|t0.v1(1,2)] t1 on v1 = v4 ";
@@ -127,14 +132,12 @@ public class SkewJoinTest extends PlanTestBase {
         assertCContains(sqlPlan, "LEFT ANTI JOIN (PARTITIONED)");
     }
 
-
     @Test
     public void testSkewJoinWithException1() {
         String sql = "select v2, v5 from t0 right join[skew|t0.v1(1,2)] t1 on v1 = v4 ";
         Throwable exception = assertThrows(StarRocksPlannerException.class, () -> getFragmentPlan(sql));
         assertThat(exception.getMessage(), containsString("RIGHT JOIN does not support SKEW JOIN optimize"));
     }
-
 
     @Test
     public void testSkewJoinWithException2() {
@@ -229,10 +232,10 @@ public class SkewJoinTest extends PlanTestBase {
                 "join[skew|test.struct_tbl.c1.a(1,2)] test.t0 on t0.v1 = c1.a ";
         sqlPlan = getFragmentPlan(sql);
         assertCContains(sqlPlan, "HASH JOIN\n" +
-                "  |  join op: INNER JOIN (PARTITIONED)\n" +
-                "  |  colocate: false, reason: \n" +
-                "  |  equal join conjunct: 10: rand_col = 17: rand_col\n" +
-                "  |  equal join conjunct: 9: cast = 5: v1",
+                        "  |  join op: INNER JOIN (PARTITIONED)\n" +
+                        "  |  colocate: false, reason: \n" +
+                        "  |  equal join conjunct: 10: rand_col = 17: rand_col\n" +
+                        "  |  equal join conjunct: 9: cast = 5: v1",
                 "<slot 10> : CASE WHEN 2: c1.a[true] IS NULL THEN 23: round WHEN 2: c1.a[true] IN (1, 2) THEN " +
                         "23: round ELSE 0 END");
     }
@@ -322,6 +325,102 @@ public class SkewJoinTest extends PlanTestBase {
         String sql = "select * from test.customer join test.part on P_SIZE = C_NATIONKEY and p_partkey = c_custkey";
         String sqlPlan = getFragmentPlan(sql);
         assertCContains(sqlPlan, "C_NATIONKEY IN (22, 23, 24, 10, 11)");
+    }
+
+    @Test
+    void testSkewJoinWithNullOnlySkewByStats() throws Exception {
+        final var oldStatisticsStorage = connectContext.getGlobalStateMgr().getStatisticStorage();
+        final double oldThreshold = connectContext.getSessionVariable().getSkewJoinDataSkewThreshold();
+        try {
+            final var emptyStatisticsStorage = new EmptyStatisticStorage() {
+                @Override
+                public ColumnStatistic getColumnStatistic(Table table, String column) {
+                    if (table.getName().equalsIgnoreCase("t0") && column.equalsIgnoreCase("v1")) {
+                        return ColumnStatistic.builder() //
+                                .setNullsFraction(0.8) //
+                                .build();
+                    }
+
+                    return ColumnStatistic.builder() //
+                            .setNullsFraction(0.1) //
+                            .build();
+                }
+            };
+            setTableStatistics(getOlapTable("t0"), 1337);
+            connectContext.getGlobalStateMgr().setStatisticStorage(emptyStatisticsStorage);
+            connectContext.getSessionVariable().setSkewJoinDataSkewThreshold(0.1);
+            connectContext.getSessionVariable().setEnableStatsToOptimizeSkewJoin(true);
+            connectContext.getSessionVariable().setEnableOptimizerSkewJoinByQueryRewrite(true);
+
+            // Important to use a LEFT JOIN here so NULLs are preserved.
+            String sql = "select * from t0 left join t1 on t0.v1 = t1.v4";
+            String plan = getFragmentPlan(sql);
+
+            // Rewrite should add rand_col equality and build skew value salt infra
+            assertCContains(plan, "rand_col = ");
+            assertCContains(plan, "unnest");
+            assertCContains(plan, "generate_serials");
+            // Left side should include CASE WHEN <col> IS NULL THEN round(...)
+            assertCContains(plan, "IS NULL THEN");
+            assertCContains(plan, """
+                      5:Project
+                      |  <slot 9> : [NULL]
+                    """);
+        } finally {
+            // Restore threshold
+            connectContext.getSessionVariable().setSkewJoinDataSkewThreshold(oldThreshold);
+            connectContext.getGlobalStateMgr().setStatisticStorage(oldStatisticsStorage);
+        }
+    }
+
+    @Test
+    void testSkewJoinWithNullOnlySkewAndMcvSkew() throws Exception {
+        final var oldStatisticsStorage = connectContext.getGlobalStateMgr().getStatisticStorage();
+        final double oldThreshold = connectContext.getSessionVariable().getSkewJoinDataSkewThreshold();
+        try {
+            final var emptyStatisticsStorage = new EmptyStatisticStorage() {
+                @Override
+                public ColumnStatistic getColumnStatistic(Table table, String column) {
+                    if (table.getName().equalsIgnoreCase("t0") && column.equalsIgnoreCase("v1")) {
+                        return ColumnStatistic.builder() //
+                                .setNullsFraction(0.3) // NULL skew
+                                .setHistogram(new Histogram(List.of(), Map.of("a", 400L, "b", 200L))) // MCV skew
+                                .build();
+                    }
+
+                    return ColumnStatistic.builder() //
+                            .setNullsFraction(0.1) //
+                            .build();
+                }
+            };
+            setTableStatistics(getOlapTable("t0"), 1337);
+            connectContext.getGlobalStateMgr().setStatisticStorage(emptyStatisticsStorage);
+            connectContext.getSessionVariable().setSkewJoinDataSkewThreshold(0.1);
+            connectContext.getSessionVariable().setEnableStatsToOptimizeSkewJoin(true);
+            connectContext.getSessionVariable().setEnableOptimizerSkewJoinByQueryRewrite(true);
+
+            // Important to use a LEFT JOIN here so NULLs are preserved.
+            String sql = "select * from t0 left join t1 on t0.v1 = t1.v4";
+            String plan = getFragmentPlan(sql);
+
+            // Rewrite should add rand_col equality and build skew value salt infra
+            assertCContains(plan, "rand_col = ");
+            assertCContains(plan, "unnest");
+            assertCContains(plan, "generate_serials");
+            // Left side should include CASE WHEN <col> IS NULL THEN round(...)
+            assertCContains(plan, "IS NULL THEN");
+
+            // In this case, the MCV should be selected since:
+            //  - 0.3 null fractions * 1337 rows < 400 rows (a) + 300 rows (b)
+            assertCContains(plan, """
+                      5:Project
+                      |  <slot 9> : ['a','b']
+                    """);
+        } finally {
+            // Restore threshold
+            connectContext.getSessionVariable().setSkewJoinDataSkewThreshold(oldThreshold);
+            connectContext.getGlobalStateMgr().setStatisticStorage(oldStatisticsStorage);
+        }
     }
 
     private static File newFolder(File root, String... subDirs) throws IOException {


### PR DESCRIPTION
## Why I'm doing:

This PR adds automatic detection of NULL-skewed join columns based on null fractions. Previously, only MCVs were looked at.
Essentially, when you have a query of the form:
```sql
SELECT
    expensive_agg(...)
FROM
    TABLE1 t1
    LEFT JOIN TABLE2 t2 ON t1.TABLE2_ID = t2.ID
```
where `t1.TABLE2_ID` is NULL-skewed, `expensive_agg(...)` is executed on a single thread because all the NULLs are handled by a single pipeline driver (so essentially single-threaded). 
Previously, you could mitigate this by annotating the query like this:
```sql
SELECT
    expensive_agg(...)
FROM
    TABLE1 t1
    LEFT JOIN [skew|t1.TABLE2_ID(null)] TABLE2 t2 ON t1.TABLE2_ID = t2.ID
```

With my PR, you can just set `enable_stats_to_optimize_skew_join = true` and run the query without hints and the skew is automatically detected.

Here is a [profile](https://gist.github.com/OliLay/c27ad6c4a5f8c1a275e7fbdbff03e483) without automatic detection (42s wall time) and [with automatic detection](https://gist.github.com/OliLay/3d576b80d643f63c032b9831773b3ffc) (22s wall time).

## What I'm doing:
- Refactoring of the skew detection by reusing `DataSkew` class added in https://github.com/StarRocks/starrocks/pull/66640. This removes duplicate code and unified skew detection.
- Adding NULL skew detection to `SkewJoinOptimizeRule::check()`.
- Minor changes to `SkewJoinOptimizeRule::transform()` so that `IN` predicate is omitted if we only have NULL skew.

Note: This PR is based on Murphy's work in https://github.com/StarRocks/starrocks/pull/62539. I took it over since Murphy has no capacity to work on it.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies and extends skew detection to include NULL-heavy columns, improving automatic skew-join rewrites.
> 
> - Refactors `SkewJoinOptimizeRule` to use `DataSkew.getColumnSkewInfo(...)` with session thresholds; supports `SKEWED_NULL` and `SKEWED_MCV`
> - On `SKEWED_NULL`, sets skew values to `[NULL]`; `transform()` now removes NULL from `IN` args and omits the `IN` branch when only NULL skew exists
> - Introduces richer `DataSkew` API (`SkewType`, `SkewInfo`, `Thresholds`) to decide between NULL- and MCV-based skew and expose selected MCVs
> - Minor robustness in `BinaryPredicateStatisticCalculator.updateHistWithJoin` (empty checks via commons-collections)
> - Adds targeted tests in `DataSkewTest` and `SkewJoinTest` covering NULL-only and mixed NULL/MCV skew, and plan assertions for the rewritten CASE/UNNEST paths
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c180d7d6afc22bc5248bfd1cc74e1854647101dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->