### PR TITLE
[Enhancement] MetaScanNode supports Fast Schema Evolution v2 in shared-data mode (backport #66970)

### DIFF
--- a/be/src/exec/lake_meta_scanner.cpp
+++ b/be/src/exec/lake_meta_scanner.cpp
@@ -15,6 +15,7 @@
 #include "exec/lake_meta_scanner.h"
 
 #include "exec/lake_meta_scan_node.h"
+#include "gen_cpp/tablet_schema.pb.h"
 #include "runtime/global_dict/config.h"
 #include "testutil/sync_point.h"
 
@@ -44,6 +45,15 @@ Status LakeMetaScanner::_real_init() {
     reader_params.low_card_threshold = _parent->_meta_scan_node.__isset.low_cardinality_threshold
                                                ? _parent->_meta_scan_node.low_cardinality_threshold
                                                : DICT_DECODE_MAX_SIZE;
+
+    if (_parent->_meta_scan_node.__isset.schema_key) {
+        const auto& t_schema_key = _parent->_meta_scan_node.schema_key;
+        reader_params.schema_key.emplace();
+        reader_params.schema_key->set_schema_id(t_schema_key.schema_id);
+        reader_params.schema_key->set_db_id(t_schema_key.db_id);
+        reader_params.schema_key->set_table_id(t_schema_key.table_id);
+    }
+
     // Pass column access paths and extend schema similar to OLAP path
     if (_parent->_meta_scan_node.__isset.column_access_paths && !_parent->_column_access_paths.empty()) {
         reader_params.column_access_paths = &_parent->_column_access_paths;

--- a/be/src/exec/lake_meta_scanner.h
+++ b/be/src/exec/lake_meta_scanner.h
@@ -22,21 +22,14 @@
 #include "runtime/runtime_state.h"
 #include "storage/lake_meta_reader.h"
 
-#ifdef BE_TEST
-// remove final declaration for UT
-#define DECL_FINAL
-#else
-#define DECL_FINAL final
-#endif
-
 namespace starrocks {
 
 class LakeMetaScanNode;
 
-class LakeMetaScanner DECL_FINAL : public MetaScanner {
+class LakeMetaScanner final : public MetaScanner {
 public:
     LakeMetaScanner(LakeMetaScanNode* parent);
-    ~LakeMetaScanner() DECL_FINAL = default;
+    ~LakeMetaScanner() final = default;
 
     LakeMetaScanner(const LakeMetaScanner&) = delete;
     LakeMetaScanner(LakeMetaScanner&) = delete;
@@ -53,6 +46,8 @@ public:
 
     bool has_more() override;
 
+    LakeMetaReader* TEST_reader() { return _reader.get(); }
+
 protected:
     Status _lazy_init(RuntimeState* runtime_state, const MetaScannerParams& params);
     Status _real_init();
@@ -63,5 +58,3 @@ protected:
 };
 
 } // namespace starrocks
-
-#undef DECL_FINAL

--- a/be/src/exec/olap_meta_scanner.cpp
+++ b/be/src/exec/olap_meta_scanner.cpp
@@ -49,9 +49,13 @@ Status OlapMetaScanner::_init_meta_reader_params() {
     _reader_params.low_card_threshold = _parent->_meta_scan_node.__isset.low_cardinality_threshold
                                                 ? _parent->_meta_scan_node.low_cardinality_threshold
                                                 : DICT_DECODE_MAX_SIZE;
-
-    if (_parent->_meta_scan_node.__isset.schema_id && _parent->_meta_scan_node.schema_id > 0 &&
-        _parent->_meta_scan_node.schema_id == _tablet->tablet_schema()->id()) {
+    int64_t schema_id = -1;
+    if (_parent->_meta_scan_node.__isset.schema_key) {
+        schema_id = _parent->_meta_scan_node.schema_key.schema_id;
+    } else if (_parent->_meta_scan_node.__isset.schema_id) {
+        schema_id = _parent->_meta_scan_node.schema_id;
+    }
+    if (schema_id > 0 && schema_id == _tablet->tablet_schema()->id()) {
         _reader_params.tablet_schema = _tablet->tablet_schema();
     }
 

--- a/be/src/storage/lake_meta_reader.h
+++ b/be/src/storage/lake_meta_reader.h
@@ -20,23 +20,13 @@
 #include "column/vectorized_fwd.h"
 #include "storage/lake/versioned_tablet.h"
 #include "storage/meta_reader.h"
-#include "storage/tablet_schema.h"
-
-#ifdef BE_TEST
-#define DECL_FINAL
-#define UT_VIRTUAL virtual
-#else
-#define DECL_FINAL final
-#define UT_VIRTUAL
-#endif
 
 namespace starrocks {
-class TabletSchema;
 
 struct LakeMetaReaderParams : MetaReaderParams {
     LakeMetaReaderParams() = default;
-    // Optional extended schema and access paths, mirroring OlapMetaReaderParams
-    TabletSchemaCSPtr tablet_schema;
+    // The key of the schema used for reading. no value for legacy compatibility.
+    std::optional<TableSchemaKeyPB> schema_key;
     std::vector<ColumnAccessPathPtr>* column_access_paths = nullptr;
 };
 
@@ -48,17 +38,17 @@ class VersionedTablet;
 // MetaReader will implements
 // 1. read meta info from segment footer
 // 2. read dict info from dict page if column is dict encoding type
-class LakeMetaReader DECL_FINAL : public MetaReader {
+class LakeMetaReader final : public MetaReader {
 public:
     LakeMetaReader();
     ~LakeMetaReader() override;
 
-    UT_VIRTUAL Status init(const LakeMetaReaderParams& read_params);
+    Status init(const LakeMetaReaderParams& read_params);
 
     Status do_get_next(ChunkPtr* chunk) override;
 
 private:
-    Status _build_collect_context(const lake::VersionedTablet& tablet, const LakeMetaReaderParams& read_params);
+    Status _build_collect_context(const TabletSchemaCSPtr& tablet_schema, const LakeMetaReaderParams& read_params);
 
     Status _init_seg_meta_collecters(const lake::VersionedTablet& tablet, const LakeMetaReaderParams& read_params);
 
@@ -66,5 +56,3 @@ private:
 };
 
 } // namespace starrocks
-
-#undef DECL_FINAL

--- a/be/src/storage/meta_reader.h
+++ b/be/src/storage/meta_reader.h
@@ -84,6 +84,8 @@ public:
         std::vector<int32_t> result_slot_ids;
     };
 
+    const TabletSchemaCSPtr& TEST_tablet_schema() { return _collect_context.seg_collecter_params.tablet_schema; }
+
 protected:
     CollectContext _collect_context;
     bool _is_init;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/AbstractOlapTableScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/AbstractOlapTableScanNode.java
@@ -1,0 +1,114 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.analysis.TupleDescriptor;
+import com.starrocks.catalog.MaterializedIndexMeta;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.SchemaInfo;
+import com.starrocks.sql.common.MetaUtils;
+import com.starrocks.thrift.TTableSchemaKey;
+
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+// An abstract node to scan data or meta from an OlapTable.
+public abstract class AbstractOlapTableScanNode extends ScanNode {
+
+    protected final OlapTable olapTable;
+    protected final SelectedMaterializedIndex index;
+
+    /**
+     * Constructs a node to scan from an OlapTable.
+     * <p>
+     * This constructor may access the schema information of the {@link OlapTable}.
+     * To ensure thread-safe access, the caller must guarantee that the table's metadata
+     * is protected, either by holding an external lock or by operating on a query-specific
+     * copy of the table (e.g., created via {@link OlapTable#copyOnlyForQuery(OlapTable)}).
+     *
+     * @param id The unique identifier for this plan node.
+     * @param desc The tuple descriptor for the data produced by this scan node.
+     * @param planNodeName The name of the plan node.
+     * @param selectedIndexId The ID of the materialized index to be scanned. If this value is -1,
+     *                        the base index of the OlapTable will be used.
+     */
+    public AbstractOlapTableScanNode(
+            PlanNodeId id, TupleDescriptor desc, String planNodeName, OlapTable olapTable, long selectedIndexId) {
+        super(id, desc, planNodeName);
+        this.olapTable = olapTable;
+        this.index = SelectedMaterializedIndex.build(olapTable, selectedIndexId);
+    }
+
+    public OlapTable getOlapTable() {
+        return olapTable;
+    }
+
+    public TTableSchemaKey getSchemaKey() {
+        TTableSchemaKey schemaKey = new TTableSchemaKey();
+        schemaKey.setDb_id(MetaUtils.lookupDbIdByTable(olapTable));
+        schemaKey.setTable_id(olapTable.getId());
+        schemaKey.setSchema_id(index.schemaId);
+        return schemaKey;
+    }
+
+    /**
+     * Returns the cached schema information for the selected materialized index.
+     */
+    public Optional<SchemaInfo> getSchema() {
+        return index.cachedSchema;
+    }
+
+
+    /** Selected materialized index to scan. */
+    protected static class SelectedMaterializedIndex {
+
+        final long indexId;
+        final long schemaId;
+
+        /**
+         * Cached schema information used for query plan.
+         * <p>
+         * This field stores the schema information that was used when generating the plan, enabling
+         * backend nodes to retrieve the exact schema from the frontend during query execution. This is
+         * particularly important for Fast Schema Evolution scenarios where schema changes are not
+         * immediately propagated schema metadata to backend nodes. Currently, this mechanism is only
+         * used in shared-data mode.
+         * </p>
+         */
+        private final Optional<SchemaInfo> cachedSchema;
+
+        private SelectedMaterializedIndex(long indexId, long schemaId, @Nullable SchemaInfo cachedSchema) {
+            this.indexId = indexId;
+            this.schemaId = schemaId;
+            this.cachedSchema = Optional.ofNullable(cachedSchema);
+        }
+
+        static SelectedMaterializedIndex build(OlapTable olapTable, long selectedIndexId) {
+            long indexId = selectedIndexId == -1 ? olapTable.getBaseIndexId() : selectedIndexId;
+            MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(indexId);
+            if (indexMeta == null) {
+                throw new RuntimeException(String.format(
+                        "can't find index, table name: %s, table id: %s, index id: %s",
+                        olapTable.getName(), olapTable.getId(), indexId));
+            }
+            long schemaId = indexMeta.getSchemaId();
+            SchemaInfo schema = null;
+            if (olapTable.isCloudNativeTableOrMaterializedView()) {
+                schema = SchemaInfo.fromMaterializedIndex(olapTable, indexId, indexMeta);
+            }
+            return new SelectedMaterializedIndex(indexId, schemaId, schema);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/MetaScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/MetaScanNode.java
@@ -21,7 +21,6 @@ import com.starrocks.catalog.Column;
 import com.starrocks.common.Pair;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
-import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
@@ -43,6 +42,7 @@ import com.starrocks.thrift.TPlanNodeType;
 import com.starrocks.thrift.TScanRange;
 import com.starrocks.thrift.TScanRangeLocation;
 import com.starrocks.thrift.TScanRangeLocations;
+import com.starrocks.thrift.TTableSchemaKey;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
@@ -56,24 +56,20 @@ import java.util.stream.Collectors;
 
 import static com.starrocks.sql.common.ErrorType.INTERNAL_ERROR;
 
-public class MetaScanNode extends ScanNode {
+public class MetaScanNode extends AbstractOlapTableScanNode {
     private static final Logger LOG = LogManager.getLogger(MetaScanNode.class);
     private final Map<Integer, Pair<String, Column>> columnIdToColumns;
-    private final OlapTable olapTable;
     private final List<Column> tableSchema;
     private final List<String> selectPartitionNames;
     private final List<TScanRangeLocations> result = Lists.newArrayList();
-    private long selectedIndexId = -1;
 
     public MetaScanNode(PlanNodeId id, TupleDescriptor desc, OlapTable olapTable,
                         Map<Integer, Pair<String, Column>> aggColumnIdToColumns, List<String> selectPartitionNames,
                         long selectedIndexId, ComputeResource computeResource) {
-        super(id, desc, "MetaScan");
-        this.olapTable = olapTable;
+        super(id, desc, "MetaScan", olapTable, selectedIndexId);
         this.tableSchema = olapTable.getBaseSchema();
         this.columnIdToColumns = aggColumnIdToColumns;
         this.selectPartitionNames = selectPartitionNames;
-        this.selectedIndexId = selectedIndexId;
         this.computeResource = computeResource;
     }
 
@@ -190,13 +186,10 @@ public class MetaScanNode extends ScanNode {
             columnsDesc.add(tColumn);
         }
         msg.meta_scan_node.setColumns(columnsDesc);
-        if (selectedIndexId != -1) {
-            MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(selectedIndexId);
-            if (indexMeta != null) {
-                long schemaId = indexMeta.getSchemaId();
-                msg.meta_scan_node.setSchema_id(schemaId);
-            }
-        }
+        TTableSchemaKey schemaKey = getSchemaKey();
+        msg.meta_scan_node.setSchema_key(schemaKey);
+        // also set schema id for legacy compatibility
+        msg.meta_scan_node.setSchema_id(schemaKey.getSchema_id());
 
         if (CollectionUtils.isNotEmpty(columnAccessPaths)) {
             msg.meta_scan_node.setColumn_access_paths(columnAccessPathToThrift());

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -69,7 +69,6 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Replica;
-import com.starrocks.catalog.SchemaInfo;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
@@ -111,7 +110,6 @@ import com.starrocks.thrift.TScanRange;
 import com.starrocks.thrift.TScanRangeLocation;
 import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.thrift.TTableSampleOptions;
-import com.starrocks.thrift.TTableSchemaKey;
 import com.starrocks.warehouse.Warehouse;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.commons.collections4.CollectionUtils;
@@ -132,7 +130,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-public class OlapScanNode extends ScanNode {
+public class OlapScanNode extends AbstractOlapTableScanNode {
     private static final Logger LOG = LogManager.getLogger(OlapScanNode.class);
 
     // Cached value of estimated scan range memory footprint
@@ -165,8 +163,6 @@ public class OlapScanNode extends ScanNode {
      */
     private boolean isPreAggregation = false;
     private String reasonOfPreAggregation = null;
-    private final OlapTable olapTable;
-    private final SelectedIndex index;
     private long selectedTabletsNum = 0;
     private long totalTabletsNum = 0;
     private int selectedPartitionNum = 0;
@@ -214,24 +210,8 @@ public class OlapScanNode extends ScanNode {
     long backPressureThrottleTime = -1;
     long backPressureNumRows = -1;
 
-    /**
-     * Constructs a node to scan data from an OlapTable.
-     * <p>
-     * This constructor may access the schema information of the {@link OlapTable}.
-     * To ensure thread-safe access, the caller must guarantee that the table's metadata
-     * is protected, either by holding an external lock or by operating on a query-specific
-     * copy of the table (e.g., created via {@link OlapTable#copyOnlyForQuery()}).
-     *
-     * @param id The unique identifier for this plan node.
-     * @param desc The tuple descriptor for the data produced by this scan node.
-     * @param planNodeName The name of the plan node.
-     * @param selectedIndexId The ID of the materialized index to be scanned. If this value is -1,
-     *                        the base index of the OlapTable will be used.
-     */
     public OlapScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName, long selectedIndexId) {
-        super(id, desc, planNodeName);
-        olapTable = (OlapTable) desc.getTable();
-        index = SelectedIndex.build(olapTable, selectedIndexId);
+        super(id, desc, planNodeName, (OlapTable) desc.getTable(), selectedIndexId);
     }
 
     public OlapScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName, long selectedIndexId, ComputeResource computeResource) {
@@ -366,17 +346,6 @@ public class OlapScanNode extends ScanNode {
                 unUsedOutputStringColumns.add(slot.getColumn().getColumnId().getId());
             }
         }
-    }
-
-    public OlapTable getOlapTable() {
-        return olapTable;
-    }
-
-    /**
-     * Returns the cached schema information for the selected materialized index.
-     */
-    public Optional<SchemaInfo> getSchema() {
-        return index.schema;
     }
 
     @Override
@@ -1128,14 +1097,7 @@ public class OlapScanNode extends ScanNode {
             }
 
             msg.lake_scan_node.setOutput_asc_hint(sortKeyAscHint);
-            TTableSchemaKey schemaKey = new TTableSchemaKey();
-            schemaKey.setDb_id(MetaUtils.lookupDbIdByTable(olapTable));
-            schemaKey.setTable_id(olapTable.getId());
-            Preconditions.checkState(index.schema.isPresent(), String.format(
-                    "schema not cached, table name: %s, table id: %s, index id: %s",
-                    olapTable.getName(), olapTable.getId(), index.indexId));
-            schemaKey.setSchema_id(index.schema.get().getId());
-            msg.lake_scan_node.setSchema_key(schemaKey);
+            msg.lake_scan_node.setSchema_key(getSchemaKey());
         } else { // If you find yourself changing this code block, see also the above code block
             msg.node_type = TPlanNodeType.OLAP_SCAN_NODE;
             msg.olap_scan_node =
@@ -1696,42 +1658,5 @@ public class OlapScanNode extends ScanNode {
             }
         }
         return accept;
-    }
-
-    private static class SelectedIndex {
-
-        final long indexId;
-
-        /**
-         * Cached schema information used for query plan.
-         * <p>
-         * This field stores the schema information that was used when generating the plan, enabling
-         * backend nodes to retrieve the exact schema from the frontend during query execution. This is
-         * particularly important for Fast Schema Evolution scenarios where schema changes are not
-         * immediately propagated schema metadata to backend nodes. Currently, this mechanism is only
-         * used in shared-data mode.
-         * </p>
-         */
-        final Optional<SchemaInfo> schema;
-
-        SelectedIndex(long indexId, SchemaInfo schema) {
-            this.indexId = indexId;
-            this.schema = Optional.ofNullable(schema);
-        }
-
-        static SelectedIndex build(OlapTable olapTable, long selectedIndexId) {
-            long indexId = selectedIndexId == -1 ? olapTable.getBaseIndexId() : selectedIndexId;
-            SchemaInfo schema = null;
-            if (olapTable.isCloudNativeTableOrMaterializedView()) {
-                MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(indexId);
-                if (indexMeta == null) {
-                    throw new RuntimeException(String.format(
-                            "can't find index, table name: %s, table id: %s, index id: %s",
-                            olapTable.getName(), olapTable.getId(), indexId));
-                }
-                schema = SchemaInfo.fromMaterializedIndex(olapTable, indexId, indexMeta);
-            }
-            return new SelectedIndex(indexId, schema);
-        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/service/TableSchemaService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/TableSchemaService.java
@@ -25,7 +25,7 @@ import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.concurrent.lock.AutoCloseableLock;
 import com.starrocks.common.util.concurrent.lock.LockType;
 import com.starrocks.common.util.concurrent.lock.Locker;
-import com.starrocks.planner.OlapScanNode;
+import com.starrocks.planner.AbstractOlapTableScanNode;
 import com.starrocks.qe.QeProcessorImpl;
 import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.server.GlobalStateMgr;
@@ -190,8 +190,8 @@ public class TableSchemaService {
         }
         Optional<SchemaInfo> schemaInfo = Optional.ofNullable(coordinator.getScanNodes())
                 .orElse(Collections.emptyList()).stream()
-                .filter(OlapScanNode.class::isInstance)
-                .map(node -> ((OlapScanNode) node).getSchema())
+                .filter(AbstractOlapTableScanNode.class::isInstance)
+                .map(node -> ((AbstractOlapTableScanNode) node).getSchema())
                 .filter(schema -> schema.isPresent() && schema.get().getId() == schemaId)
                 .map(Optional::get)
                 .findFirst();

--- a/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/qe/scheduler/DefaultSharedDataWorkerProviderTest.java
@@ -22,8 +22,11 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.analysis.TupleId;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.planner.OlapScanNode;
@@ -45,6 +48,7 @@ import com.starrocks.thrift.TInternalScanRange;
 import com.starrocks.thrift.TScanRange;
 import com.starrocks.thrift.TScanRangeLocation;
 import com.starrocks.thrift.TScanRangeLocations;
+import com.starrocks.thrift.TStorageType;
 import com.starrocks.warehouse.cngroup.ComputeResource;
 import mockit.Expectations;
 import mockit.Mock;
@@ -466,6 +470,10 @@ public class DefaultSharedDataWorkerProviderTest {
         // copy from fe/fe-core/src/test/java/com/starrocks/qe/ColocatedBackendSelectorTest.java
         TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
         OlapTable table = new OlapTable();
+        table.maySetDatabaseId(1L);
+        table.setBaseIndexId(1L);
+        table.setIndexMeta(1L, "base", Collections.singletonList(new Column("c0", Type.INT)),
+                0, 0, (short) 1, TStorageType.COLUMN, KeysType.DUP_KEYS);
         table.setDefaultDistributionInfo(new HashDistributionInfo(numBuckets, Collections.emptyList()));
         desc.setTable(table);
         return new OlapScanNode(new PlanNodeId(id), desc, "OlapScanNode", table.getBaseIndexId());

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ColocatedBackendSelectorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ColocatedBackendSelectorTest.java
@@ -19,8 +19,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.analysis.TupleId;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.lake.qe.scheduler.DefaultSharedDataWorkerProvider;
 import com.starrocks.planner.OlapScanNode;
@@ -34,6 +37,7 @@ import com.starrocks.thrift.TInternalScanRange;
 import com.starrocks.thrift.TScanRange;
 import com.starrocks.thrift.TScanRangeLocation;
 import com.starrocks.thrift.TScanRangeLocations;
+import com.starrocks.thrift.TStorageType;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -291,6 +295,10 @@ public class ColocatedBackendSelectorTest {
     private OlapScanNode genOlapScanNode(int id, int numBuckets) {
         TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
         OlapTable table = new OlapTable();
+        table.maySetDatabaseId(1L);
+        table.setBaseIndexId(1L);
+        table.setIndexMeta(1L, "base", Collections.singletonList(new Column("c0", Type.INT)),
+                0, 0, (short) 1, TStorageType.COLUMN, KeysType.DUP_KEYS);
         table.setDefaultDistributionInfo(new HashDistributionInfo(numBuckets, Collections.emptyList()));
         desc.setTable(table);
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
@@ -20,7 +20,9 @@ import com.starrocks.analysis.SlotDescriptor;
 import com.starrocks.analysis.SlotId;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.analysis.TupleId;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.StarRocksException;
@@ -45,6 +47,7 @@ import com.starrocks.thrift.TBinlogOffset;
 import com.starrocks.thrift.TDescriptorTable;
 import com.starrocks.thrift.TPartitionType;
 import com.starrocks.thrift.TScanRangeParams;
+import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
@@ -107,6 +110,10 @@ public class CoordinatorTest extends PlanTestBase {
         execFragment.addInstance(instance2);
 
         OlapTable table = new OlapTable();
+        table.maySetDatabaseId(1L);
+        table.setBaseIndexId(1L);
+        table.setIndexMeta(1L, "base", Collections.singletonList(new Column("c0", Type.INT)),
+                0, 0, (short) 1, TStorageType.COLUMN, KeysType.DUP_KEYS);
         table.setDefaultDistributionInfo(new HashDistributionInfo(6, Collections.emptyList()));
         TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
         desc.setTable(table);

--- a/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/WarehouseManagerTest.java
@@ -17,10 +17,13 @@ package com.starrocks.server;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.analysis.TupleId;
+import com.starrocks.catalog.Column;
 import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReportException;
 import com.starrocks.common.ExceptionChecker;
@@ -32,6 +35,7 @@ import com.starrocks.planner.PlanNodeId;
 import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
+import com.starrocks.thrift.TStorageType;
 import com.starrocks.warehouse.DefaultWarehouse;
 import com.starrocks.warehouse.Warehouse;
 import com.starrocks.warehouse.cngroup.CRAcquireContext;
@@ -403,6 +407,10 @@ public class WarehouseManagerTest {
     private OlapScanNode newOlapScanNode() {
         TupleDescriptor desc = new TupleDescriptor(new TupleId(0));
         OlapTable table = new OlapTable();
+        table.maySetDatabaseId(1L);
+        table.setBaseIndexId(1L);
+        table.setIndexMeta(1L, "base", Collections.singletonList(new Column("c0", Type.INT)),
+                0, 0, (short) 1, TStorageType.COLUMN, KeysType.DUP_KEYS);
         table.setDefaultDistributionInfo(new HashDistributionInfo(3, Collections.emptyList()));
         desc.setTable(table);
         return new OlapScanNode(new PlanNodeId(1), desc, "OlapScanNode", table.getBaseIndexId());

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -1286,7 +1286,9 @@ struct TMetaScanNode {
     2: optional list<Descriptors.TColumn> columns
     3: optional i32 low_cardinality_threshold
     4: optional list<TColumnAccessPath> column_access_paths
+    // deprecated. use schema key instead
     5: optional i64 schema_id
+    6: optional Descriptors.TTableSchemaKey schema_key
 }
 
 struct TDecodeNode {


### PR DESCRIPTION
## Why I'm doing:
backport #66970

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [X] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

