### PR TITLE
[Enhancement] Support repairing cloud native table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -276,7 +276,10 @@ public class PropertyAnalyzer {
 
     public static final String PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD = "enable_statistic_collect_on_first_load";
 
+    // For admin repair cloud native table
+    // Enforces consistent version across all tablets in a physical partition
     public static final String PROPERTIES_ENFORCE_CONSISTENT_VERSION = "enforce_consistent_version";
+    // Allows empty tablet recovery of tablets with no valid metadata
     public static final String PROPERTIES_ALLOW_EMPTY_TABLET_RECOVERY = "allow_empty_tablet_recovery";
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -276,6 +276,9 @@ public class PropertyAnalyzer {
 
     public static final String PROPERTIES_ENABLE_STATISTIC_COLLECT_ON_FIRST_LOAD = "enable_statistic_collect_on_first_load";
 
+    public static final String PROPERTIES_ENFORCE_CONSISTENT_VERSION = "enforce_consistent_version";
+    public static final String PROPERTIES_ALLOW_EMPTY_TABLET_RECOVERY = "allow_empty_tablet_recovery";
+
     /**
      * Matches location labels like : ["*", "a:*", "bcd_123:*", "123bcd_:val_123", "  a :  b  "],
      * leading and trailing space of key and value will be ignored.

--- a/fe/fe-core/src/main/java/com/starrocks/lake/TabletRepairHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/TabletRepairHelper.java
@@ -608,7 +608,7 @@ public class TabletRepairHelper {
             for (Map.Entry<Long, Map<Long, String>> entry : partitionErrors.entrySet()) {
                 errorMsgs.add(
                         String.format("{partition: %d, error: %s}", entry.getKey(), entry.getValue().values().iterator().next()));
-                if (errorMsgs.size() > 3) {
+                if (errorMsgs.size() >= 3) {
                     break;
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/TabletRepairHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/TabletRepairHelper.java
@@ -19,7 +19,22 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedIndex.IndexExtState;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.OlapTable.OlapTableState;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.common.AlreadyExistsException;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.ErrorReport;
+import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.common.NoAliveBackendException;
 import com.starrocks.common.StarRocksException;
+import com.starrocks.common.util.concurrent.lock.LockType;
+import com.starrocks.common.util.concurrent.lock.Locker;
 import com.starrocks.proto.GetTabletMetadatasRequest;
 import com.starrocks.proto.GetTabletMetadatasResponse;
 import com.starrocks.proto.RepairTabletMetadataRequest;
@@ -31,17 +46,21 @@ import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
 import com.starrocks.rpc.RpcException;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.AdminRepairTableStmt;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.TStatusCode;
+import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import javax.validation.constraints.NotNull;
 
 public class TabletRepairHelper {
     private static final Logger LOG = LogManager.getLogger(TabletRepairHelper.class);
@@ -57,6 +76,106 @@ public class TabletRepairHelper {
             long maxVersion, // physical partition visible version
             long minVersion  // the min version that has not been vacuumed
     ) {
+    }
+
+    private static List<Long> getPhysicalPartitionIds(Database db, OlapTable table, @NotNull List<String> partitionNames)
+            throws StarRocksException {
+        List<Long> physicalPartitionIds = Lists.newArrayList();
+
+        Locker locker = new Locker();
+        locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
+        try {
+            // ensure the table still exists under the lock
+            if (GlobalStateMgr.getCurrentState().getLocalMetastore().getTableIncludeRecycleBin(db, table.getId()) == null) {
+                ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_ERROR, table.getName());
+            }
+
+            // table state should be NORMAL
+            if (table.getState() != OlapTableState.NORMAL) {
+                ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_STATE, table.getName());
+            }
+
+            if (partitionNames.isEmpty()) {
+                // if no partition specified, repair all partitions
+                for (PhysicalPartition physicalPartition : table.getPhysicalPartitions()) {
+                    physicalPartitionIds.add(physicalPartition.getId());
+                }
+            } else {
+                for (String partitionName : partitionNames) {
+                    Partition partition = table.getPartition(partitionName);
+                    if (partition == null) {
+                        ErrorReport.reportDdlException(ErrorCode.ERR_NO_SUCH_PARTITION, partitionName);
+                    }
+
+                    for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
+                        physicalPartitionIds.add(physicalPartition.getId());
+                    }
+                }
+            }
+        } finally {
+            locker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
+        }
+
+        return physicalPartitionIds;
+    }
+
+    private static PhysicalPartitionInfo getPhysicalPartitionInfo(Database db, OlapTable table, long physicalPartitionId,
+                                                                  boolean enforceConsistentVersion,
+                                                                  ComputeResource computeResource) throws StarRocksException {
+        Locker locker = new Locker();
+        locker.lockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
+        try {
+            // ensure the table still exists under the lock
+            if (GlobalStateMgr.getCurrentState().getLocalMetastore().getTableIncludeRecycleBin(db, table.getId()) == null) {
+                ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_ERROR, table.getName());
+            }
+
+            // skip if physical partition does not exist
+            PhysicalPartition physicalPartition = table.getPhysicalPartition(physicalPartitionId);
+            if (physicalPartition == null) {
+                throw new MetaNotFoundException(String.format("physical partition %d does not exist", physicalPartitionId));
+            }
+
+            long maxVersion = physicalPartition.getVisibleVersion();
+            long minVersion = enforceConsistentVersion ? 1L : Long.MAX_VALUE;
+
+            List<MaterializedIndex> indexes = physicalPartition.getMaterializedIndices(IndexExtState.VISIBLE);
+            if (indexes.size() > 1 && !enforceConsistentVersion) {
+                throw new StarRocksException(
+                        "table with multiple materialized indexes should be repaired with consistent version");
+            }
+
+            List<Long> allTablets = Lists.newArrayList();
+            Set<Long> unverifiedTablets = Sets.newHashSet();
+            Map<ComputeNode, Set<Long>> nodeToTablets = Maps.newHashMap();
+            for (MaterializedIndex index : indexes) {
+                for (Tablet tablet : index.getTablets()) {
+                    LakeTablet lakeTablet = (LakeTablet) tablet;
+
+                    long tabletId = lakeTablet.getId();
+                    allTablets.add(tabletId);
+                    unverifiedTablets.add(tabletId);
+
+                    ComputeNode computeNode = GlobalStateMgr.getCurrentState().getWarehouseMgr().getComputeNodeAssignedToTablet(
+                            computeResource, tabletId);
+                    if (computeNode == null) {
+                        throw new NoAliveBackendException("no alive backend");
+                    }
+                    nodeToTablets.computeIfAbsent(computeNode, k -> Sets.newHashSet()).add(tabletId);
+
+                    if (enforceConsistentVersion) {
+                        minVersion = Math.max(minVersion, lakeTablet.getMinVersion());
+                    } else {
+                        minVersion = Math.min(minVersion, lakeTablet.getMinVersion());
+                    }
+                }
+            }
+
+            return new PhysicalPartitionInfo(physicalPartition.getId(), allTablets, unverifiedTablets, nodeToTablets, maxVersion,
+                    minVersion);
+        } finally {
+            locker.unLockTableWithIntensiveDbLock(db.getId(), table.getId(), LockType.READ);
+        }
     }
 
     // returns a map of tablet IDs to valid tablet metadatas within the version range [minVersion, maxVersion]
@@ -262,7 +381,7 @@ public class TabletRepairHelper {
                 }
             }
             if (allHaveVisibleVersionMetadata) {
-                throw new StarRocksException(
+                throw new AlreadyExistsException(
                         String.format("all tablets have valid tablet metadata with version %d, no need for repair", maxVersion));
             } else {
                 return;
@@ -431,5 +550,58 @@ public class TabletRepairHelper {
 
         // repair the valid tablet metadata through backends
         return repairTabletMetadata(info, validMetadatas, isFileBundling);
+    }
+
+    // TODO:
+    // 1. ignore lost data files
+    public static void repair(AdminRepairTableStmt stmt, Database db, OlapTable table, @NotNull List<String> partitionNames,
+                              ComputeResource computeResource) throws StarRocksException {
+        boolean enforceConsistentVersion = stmt.isEnforceConsistentVersion();
+        boolean allowEmptyTabletRecovery = stmt.isAllowEmptyTabletRecovery();
+        boolean isFileBundling = table.isFileBundling();
+
+        // get physical partition ids in db table read lock
+        List<Long> physicalPartitionIds = getPhysicalPartitionIds(db, table, partitionNames);
+
+        // repair each physical partition
+        Map<Long, Map<Long, String>> partitionErrors = Maps.newHashMap();
+        for (Long physicalPartitionId : physicalPartitionIds) {
+            try {
+                PhysicalPartitionInfo info =
+                        getPhysicalPartitionInfo(db, table, physicalPartitionId, enforceConsistentVersion, computeResource);
+
+                Map<Long, String> tabletErrors =
+                        repairPhysicalPartition(info, enforceConsistentVersion, allowEmptyTabletRecovery, isFileBundling);
+                if (!tabletErrors.isEmpty()) {
+                    partitionErrors.put(physicalPartitionId, tabletErrors);
+                }
+            } catch (AlreadyExistsException | MetaNotFoundException e) {
+                // 1. all tablets have valid tablet metadata with visible version
+                // 2. physical partition does not exist
+                LOG.info("Skip repairing tablet metadata for partition {}, {}", physicalPartitionId, e.getMessage());
+            } catch (Exception e) {
+                LOG.warn("Fail to repair tablet metadata for partition {}", physicalPartitionId, e);
+                partitionErrors.put(physicalPartitionId, Collections.singletonMap(0L, e.getMessage()));
+            }
+        }
+
+        // check if any partitions fail
+        if (!partitionErrors.isEmpty()) {
+            LOG.warn("Fail to repair tablet metadata for {} partitions. db: {}, table: {}, partitions: {}",
+                    partitionErrors.size(), db.getId(), table.getId(), partitionErrors.keySet());
+
+            // throw exception with at most 3 failed partitions
+            List<String> errorMsgs = Lists.newArrayList();
+            for (Map.Entry<Long, Map<Long, String>> entry : partitionErrors.entrySet()) {
+                errorMsgs.add(
+                        String.format("{partition: %d, error: %s}", entry.getKey(), entry.getValue().values().iterator().next()));
+                if (errorMsgs.size() > 3) {
+                    break;
+                }
+            }
+            throw new StarRocksException(
+                    String.format("Fail to repair tablet metadata for %d partitions, the first %d partitions: [%s]",
+                            partitionErrors.size(), errorMsgs.size(), Joiner.on(", ").join(errorMsgs)));
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -22,6 +22,8 @@ import com.starrocks.authentication.UserAuthenticationInfo;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.FunctionName;
 import com.starrocks.catalog.FunctionSearchDesc;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
 import com.starrocks.catalog.UserIdentity;
 import com.starrocks.common.AlreadyExistsException;
 import com.starrocks.common.Config;
@@ -35,6 +37,7 @@ import com.starrocks.common.StarRocksException;
 import com.starrocks.datacache.DataCacheMgr;
 import com.starrocks.datacache.DataCacheSelectExecutor;
 import com.starrocks.datacache.DataCacheSelectMetrics;
+import com.starrocks.lake.TabletRepairHelper;
 import com.starrocks.load.EtlJobType;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.Task;
@@ -124,6 +127,7 @@ import com.starrocks.sql.ast.GrantRoleStmt;
 import com.starrocks.sql.ast.InstallPluginStmt;
 import com.starrocks.sql.ast.LoadStmt;
 import com.starrocks.sql.ast.ParseNode;
+import com.starrocks.sql.ast.PartitionRef;
 import com.starrocks.sql.ast.PauseRoutineLoadStmt;
 import com.starrocks.sql.ast.RecoverDbStmt;
 import com.starrocks.sql.ast.RecoverPartitionStmt;
@@ -172,6 +176,7 @@ import com.starrocks.statistic.NativeAnalyzeJob;
 import com.starrocks.statistic.StatisticExecutor;
 import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.statistic.StatsConstants;
+import com.starrocks.warehouse.cngroup.ComputeResource;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -815,7 +820,28 @@ public class DDLStmtExecutor {
         @Override
         public ShowResultSet visitAdminRepairTableStatement(AdminRepairTableStmt stmt, ConnectContext context) {
             ErrorReport.wrapWithRuntimeException(() -> {
-                GlobalStateMgr.getCurrentState().getTabletChecker().repairTable(context, stmt);
+                String dbName = stmt.getDbName() != null ? stmt.getDbName() : context.getDatabase();
+                Database db = GlobalStateMgr.getCurrentState().getLocalMetastore().getDb(dbName);
+                if (db == null) {
+                    ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
+                }
+
+                String tableName = stmt.getTblName();
+                Table table = db.getTable(tableName);
+                if (table == null) {
+                    ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_ERROR, tableName);
+                }
+
+                if (table.isCloudNativeTableOrMaterializedView()) {
+                    // cloud native table or mv
+                    PartitionRef partitionRef = stmt.getPartitionRef();
+                    List<String> partitionNames = partitionRef != null ? partitionRef.getPartitionNames() : Lists.newArrayList();
+                    ComputeResource computeResource = context.getCurrentComputeResource();
+                    TabletRepairHelper.repair(stmt, db, (OlapTable) table, partitionNames, computeResource);
+                } else {
+                    // olap table or mv
+                    GlobalStateMgr.getCurrentState().getTabletChecker().repairTable(context, stmt);
+                }
             });
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DDLStmtExecutor.java
@@ -832,12 +832,15 @@ public class DDLStmtExecutor {
                     ErrorReport.reportDdlException(ErrorCode.ERR_BAD_TABLE_ERROR, tableName);
                 }
 
-                if (table.isCloudNativeTableOrMaterializedView()) {
-                    // cloud native table or mv
+                if (table.isCloudNativeTable()) {
+                    // cloud native table
                     PartitionRef partitionRef = stmt.getPartitionRef();
                     List<String> partitionNames = partitionRef != null ? partitionRef.getPartitionNames() : Lists.newArrayList();
                     ComputeResource computeResource = context.getCurrentComputeResource();
                     TabletRepairHelper.repair(stmt, db, (OlapTable) table, partitionNames, computeResource);
+                } else if (table.isCloudNativeMaterializedView()) {
+                    // cloud native mv
+                    throw new DdlException("Repair cloud native materialized view is not supported");
                 } else {
                     // olap table or mv
                     GlobalStateMgr.getCurrentState().getTabletChecker().repairTable(context, stmt);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AdminStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AdminStmtAnalyzer.java
@@ -18,6 +18,8 @@ import com.google.common.base.Enums;
 import com.google.common.base.Strings;
 import com.starrocks.catalog.CatalogUtils;
 import com.starrocks.catalog.Replica;
+import com.starrocks.common.ErrorCode;
+import com.starrocks.common.ErrorReport;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.ast.AdminCancelRepairTableStmt;
@@ -38,6 +40,8 @@ import com.starrocks.sql.ast.expression.Expr;
 import com.starrocks.sql.ast.expression.SlotRef;
 import com.starrocks.sql.ast.expression.StringLiteral;
 import com.starrocks.sql.parser.NodePosition;
+
+import java.util.Map;
 
 import static com.starrocks.sql.parser.ErrorMsgProxy.PARSER_ERROR_MSG;
 
@@ -158,6 +162,21 @@ public class AdminStmtAnalyzer {
                 if (partitionRef.isTemp()) {
                     throw new SemanticException(PARSER_ERROR_MSG.unsupportedOpWithInfo("temp partitions"),
                             partitionRef.getPos());
+                }
+            }
+
+            Map<String, String> properties = adminRepairTableStmt.getProperties();
+            if (!properties.isEmpty()) {
+                boolean enforceConsistentVersion = PropertyAnalyzer.analyzeBooleanProp(
+                        properties, PropertyAnalyzer.PROPERTIES_ENFORCE_CONSISTENT_VERSION, true);
+                adminRepairTableStmt.setEnforceConsistentVersion(enforceConsistentVersion);
+
+                boolean allowEmptyTabletRecovery = PropertyAnalyzer.analyzeBooleanProp(
+                        properties, PropertyAnalyzer.PROPERTIES_ALLOW_EMPTY_TABLET_RECOVERY, false);
+                adminRepairTableStmt.setAllowEmptyTabletRecovery(allowEmptyTabletRecovery);
+
+                if (!properties.isEmpty()) {
+                    ErrorReport.reportSemanticException(ErrorCode.ERR_UNKNOWN_PROPERTY, properties);
                 }
             }
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -2765,9 +2765,8 @@ public class AstBuilder extends com.starrocks.sql.parser.StarRocksBaseVisitor<Pa
         }
 
         TableRef tableRef = new TableRef(normalizeName(qualifiedName), partitionRef, createPos(start, stop));
-        AdminRepairTableStmt stmt = new AdminRepairTableStmt(tableRef, createPos(context));
-        
-        return stmt;
+        Map<String, String> properties = getCaseSensitiveProperties(context.properties());
+        return new AdminRepairTableStmt(tableRef, properties, createPos(context));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/lake/TabletRepairHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/TabletRepairHelperTest.java
@@ -17,6 +17,16 @@ package com.starrocks.lake;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.ListPartitionInfo;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.PartitionType;
+import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.StarRocksException;
 import com.starrocks.common.jmockit.Deencapsulation;
@@ -31,24 +41,44 @@ import com.starrocks.proto.TabletMetadataRepairStatus;
 import com.starrocks.proto.TabletMetadatas;
 import com.starrocks.rpc.LakeServiceWithMetrics;
 import com.starrocks.rpc.RpcException;
+import com.starrocks.server.WarehouseManager;
+import com.starrocks.sql.ast.AdminRepairTableStmt;
+import com.starrocks.sql.ast.PartitionRef;
+import com.starrocks.sql.ast.QualifiedName;
+import com.starrocks.sql.ast.TableRef;
+import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.system.ComputeNode;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.type.VarcharType;
+import com.starrocks.warehouse.cngroup.ComputeResource;
+import com.starrocks.warehouse.cngroup.WarehouseComputeResource;
 import mockit.Mock;
 import mockit.MockUp;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
 public class TabletRepairHelperTest {
-    private final long physicalPartitionId = 100L;
-    private final long tabletId1 = 10001L;
-    private final long tabletId2 = 10002L;
+    private final long dbId = 1L;
+    private final long tableId = 2L;
+    private final long indexId = 3L;
+    private final long physicalPartitionId1 = 4L;
+    private final long tabletId11 = 11L;
+    private final long tabletId12 = 12L;
+    private final long physicalPartitionId2 = 5L;
+    private final long tabletId21 = 21L;
+    private final long tabletId22 = 22L;
     private final long maxVersion = 8L;
     private final long minVersion = 3L;
+
+    private Database db;
+    private OlapTable table;
 
     private ComputeNode node;
     private Map<ComputeNode, Set<Long>> nodeToTablets;
@@ -59,10 +89,138 @@ public class TabletRepairHelperTest {
         nodeToTablets = Maps.newHashMap();
         node = new ComputeNode(1L, "127.0.0.1", 9050);
         node.setBrpcPort(8060);
-        nodeToTablets.put(node, Sets.newHashSet(tabletId1, tabletId2));
+        nodeToTablets.put(node, Sets.newHashSet(tabletId11, tabletId12));
 
-        info = new PhysicalPartitionInfo(physicalPartitionId, Lists.newArrayList(tabletId1, tabletId2),
-                Sets.newHashSet(tabletId1, tabletId2), nodeToTablets, maxVersion, minVersion);
+        info = new PhysicalPartitionInfo(physicalPartitionId1, Lists.newArrayList(tabletId11, tabletId12),
+                Sets.newHashSet(tabletId11, tabletId12), nodeToTablets, maxVersion, minVersion);
+
+        // create table
+        List<Column> cols = Lists.newArrayList(new Column("province", VarcharType.VARCHAR));
+        PartitionInfo listPartitionInfo = new ListPartitionInfo(PartitionType.LIST, cols);
+        table = new OlapTable(tableId, "table", cols, null, listPartitionInfo, null);
+        table.getIndexNameToMetaId().put("index", indexId);
+
+        MaterializedIndex index1 = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
+        TabletMeta tabletMeta1 = new TabletMeta(dbId, tableId, physicalPartitionId1, indexId, TStorageMedium.HDD);
+        LakeTablet tablet11 = new LakeTablet(tabletId11);
+        tablet11.setMinVersion(minVersion);
+        index1.addTablet(tablet11, tabletMeta1);
+        LakeTablet tablet12 = new LakeTablet(tabletId12);
+        tablet12.setMinVersion(minVersion);
+        index1.addTablet(tablet12, tabletMeta1);
+
+        Partition partition1 =
+                new Partition(physicalPartitionId1, physicalPartitionId1, "p1", index1, new HashDistributionInfo(2, cols));
+        partition1.getDefaultPhysicalPartition().setVisibleVersion(maxVersion, 0L);
+        table.addPartition(partition1);
+
+        MaterializedIndex index2 = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
+        TabletMeta tabletMeta2 = new TabletMeta(dbId, tableId, physicalPartitionId2, indexId, TStorageMedium.HDD);
+        LakeTablet tablet21 = new LakeTablet(tabletId21);
+        tablet21.setMinVersion(minVersion);
+        index2.addTablet(tablet21, tabletMeta2);
+        LakeTablet tablet22 = new LakeTablet(tabletId22);
+        tablet22.setMinVersion(minVersion + 1);
+        index2.addTablet(tablet22, tabletMeta2);
+
+        Partition partition2 =
+                new Partition(physicalPartitionId2, physicalPartitionId2, "p2", index2, new HashDistributionInfo(2, cols));
+        partition2.getDefaultPhysicalPartition().setVisibleVersion(maxVersion, 0L);
+        table.addPartition(partition2);
+
+        db = new Database(dbId, "db");
+        db.registerTableUnlocked(table);
+    }
+
+    @Test
+    public void testGetPhysicalPartitionIds() {
+        // case 1: test no partition specified
+        {
+            List<Long> ids = Deencapsulation.invoke(TabletRepairHelper.class, "getPhysicalPartitionIds",
+                    db, table, Lists.newArrayList());
+            Assertions.assertEquals(2, ids.size());
+            Assertions.assertEquals("[4, 5]", ids.toString());
+        }
+
+        // case 2: test partition specified
+        {
+            List<Long> ids = Deencapsulation.invoke(TabletRepairHelper.class, "getPhysicalPartitionIds",
+                    db, table, Lists.newArrayList("p1"));
+
+            Assertions.assertEquals(1, ids.size());
+            Assertions.assertEquals("[4]", ids.toString());
+        }
+    }
+
+    @Test
+    public void testGetPhysicalPartitionInfo() {
+        // mock warehouse manager
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public ComputeNode getComputeNodeAssignedToTablet(ComputeResource computeResource, long tabletId) {
+                return node;
+            }
+        };
+
+        // case 1: test partition 1 with enforceConsistentVersion = true
+        {
+            PhysicalPartitionInfo info = Deencapsulation.invoke(TabletRepairHelper.class, "getPhysicalPartitionInfo",
+                    db, table, physicalPartitionId1, true, WarehouseComputeResource.DEFAULT);
+
+            Assertions.assertEquals(physicalPartitionId1, info.physicalPartitionId());
+            Assertions.assertEquals(2, info.allTablets().size());
+            Assertions.assertEquals("[11, 12]", info.allTablets().toString());
+            Assertions.assertEquals(2, info.unverifiedTablets().size());
+            Assertions.assertEquals("[11, 12]", info.unverifiedTablets().toString());
+            Assertions.assertTrue(info.nodeToTablets().containsKey(node));
+            Assertions.assertEquals(maxVersion, info.maxVersion());
+            Assertions.assertEquals(minVersion, info.minVersion());
+        }
+
+        // case 2: test partition 1 with enforceConsistentVersion = false
+        {
+            PhysicalPartitionInfo info = Deencapsulation.invoke(TabletRepairHelper.class, "getPhysicalPartitionInfo",
+                    db, table, physicalPartitionId1, false, WarehouseComputeResource.DEFAULT);
+
+            Assertions.assertEquals(physicalPartitionId1, info.physicalPartitionId());
+            Assertions.assertEquals(2, info.allTablets().size());
+            Assertions.assertEquals("[11, 12]", info.allTablets().toString());
+            Assertions.assertEquals(2, info.unverifiedTablets().size());
+            Assertions.assertEquals("[11, 12]", info.unverifiedTablets().toString());
+            Assertions.assertTrue(info.nodeToTablets().containsKey(node));
+            Assertions.assertEquals(maxVersion, info.maxVersion());
+            Assertions.assertEquals(minVersion, info.minVersion());
+        }
+
+        // case 3: test partition 2 with enforceConsistentVersion = true
+        {
+            PhysicalPartitionInfo info = Deencapsulation.invoke(TabletRepairHelper.class, "getPhysicalPartitionInfo",
+                    db, table, physicalPartitionId2, true, WarehouseComputeResource.DEFAULT);
+
+            Assertions.assertEquals(physicalPartitionId2, info.physicalPartitionId());
+            Assertions.assertEquals(2, info.allTablets().size());
+            Assertions.assertEquals("[21, 22]", info.allTablets().toString());
+            Assertions.assertEquals(2, info.unverifiedTablets().size());
+            Assertions.assertEquals("[21, 22]", info.unverifiedTablets().toString());
+            Assertions.assertTrue(info.nodeToTablets().containsKey(node));
+            Assertions.assertEquals(maxVersion, info.maxVersion());
+            Assertions.assertEquals(minVersion + 1, info.minVersion());
+        }
+
+        // case 4: test partition 2 with enforceConsistentVersion = false
+        {
+            PhysicalPartitionInfo info = Deencapsulation.invoke(TabletRepairHelper.class, "getPhysicalPartitionInfo",
+                    db, table, physicalPartitionId2, false, WarehouseComputeResource.DEFAULT);
+
+            Assertions.assertEquals(physicalPartitionId2, info.physicalPartitionId());
+            Assertions.assertEquals(2, info.allTablets().size());
+            Assertions.assertEquals("[21, 22]", info.allTablets().toString());
+            Assertions.assertEquals(2, info.unverifiedTablets().size());
+            Assertions.assertEquals("[21, 22]", info.unverifiedTablets().toString());
+            Assertions.assertTrue(info.nodeToTablets().containsKey(node));
+            Assertions.assertEquals(maxVersion, info.maxVersion());
+            Assertions.assertEquals(minVersion, info.minVersion());
+        }
     }
 
     @Test
@@ -76,24 +234,24 @@ public class TabletRepairHelperTest {
 
                 // tablet1 with 2 versions metadata
                 TabletMetadatas tm1 = new TabletMetadatas();
-                tm1.tabletId = tabletId1;
+                tm1.tabletId = tabletId11;
                 tm1.status = new StatusPB();
                 tm1.status.statusCode = 0;
                 tm1.versionMetadatas = Maps.newHashMap();
 
                 TabletMetadataPB meta11 = new TabletMetadataPB();
-                meta11.id = tabletId1;
+                meta11.id = tabletId11;
                 meta11.version = maxVersion;
                 tm1.versionMetadatas.put(maxVersion, meta11);
 
                 TabletMetadataPB meta12 = new TabletMetadataPB();
-                meta12.id = tabletId1;
+                meta12.id = tabletId11;
                 meta12.version = minVersion;
                 tm1.versionMetadatas.put(minVersion, meta12);
 
                 // tablet2 metadata not found
                 TabletMetadatas tm2 = new TabletMetadatas();
-                tm2.tabletId = tabletId2;
+                tm2.tabletId = tabletId12;
                 tm2.status = new StatusPB();
                 tm2.status.statusCode = 31;
                 tm2.versionMetadatas = Maps.newHashMap();
@@ -108,11 +266,11 @@ public class TabletRepairHelperTest {
                 TabletRepairHelper.class, "getTabletMetadatas", info, maxVersion, minVersion);
 
         Assertions.assertEquals(1, tabletVersionMetadatas.size());
-        Assertions.assertTrue(tabletVersionMetadatas.containsKey(tabletId1));
-        Assertions.assertEquals(2, tabletVersionMetadatas.get(tabletId1).size());
-        Assertions.assertEquals(maxVersion, tabletVersionMetadatas.get(tabletId1).get(maxVersion).version);
-        Assertions.assertEquals(minVersion, tabletVersionMetadatas.get(tabletId1).get(minVersion).version);
-        Assertions.assertFalse(tabletVersionMetadatas.containsKey(tabletId2));
+        Assertions.assertTrue(tabletVersionMetadatas.containsKey(tabletId11));
+        Assertions.assertEquals(2, tabletVersionMetadatas.get(tabletId11).size());
+        Assertions.assertEquals(maxVersion, tabletVersionMetadatas.get(tabletId11).get(maxVersion).version);
+        Assertions.assertEquals(minVersion, tabletVersionMetadatas.get(tabletId11).get(minVersion).version);
+        Assertions.assertFalse(tabletVersionMetadatas.containsKey(tabletId12));
     }
 
     @Test
@@ -169,19 +327,19 @@ public class TabletRepairHelperTest {
 
                 // tablet1 with 1 version metadata
                 TabletMetadatas tm1 = new TabletMetadatas();
-                tm1.tabletId = tabletId1;
+                tm1.tabletId = tabletId11;
                 tm1.status = new StatusPB();
                 tm1.status.statusCode = 0;
                 tm1.versionMetadatas = Maps.newHashMap();
 
                 TabletMetadataPB meta11 = new TabletMetadataPB();
-                meta11.id = tabletId1;
+                meta11.id = tabletId11;
                 meta11.version = maxVersion;
                 tm1.versionMetadatas.put(maxVersion, meta11);
 
                 // tablet2 get metadata failed
                 TabletMetadatas tm2 = new TabletMetadatas();
-                tm2.tabletId = tabletId2;
+                tm2.tabletId = tabletId12;
                 tm2.status = new StatusPB();
                 tm2.status.statusCode = 1;
                 tm2.status.errorMsgs = Lists.newArrayList("get tablet metadata failed");
@@ -209,24 +367,24 @@ public class TabletRepairHelperTest {
         {
             Map<Long, Map<Long, TabletMetadataPB>> tabletVersionMetadatas = Maps.newHashMap();
             Map<Long, TabletMetadataPB> tablet1Versions = Maps.newHashMap();
-            tablet1Versions.put(maxVersion - 1, createTabletMetadataPB(tabletId1, maxVersion - 1));
-            tablet1Versions.put(minVersion, createTabletMetadataPB(tabletId1, minVersion));
-            tabletVersionMetadatas.put(tabletId1, tablet1Versions);
+            tablet1Versions.put(maxVersion - 1, createTabletMetadataPB(tabletId11, maxVersion - 1));
+            tablet1Versions.put(minVersion, createTabletMetadataPB(tabletId11, minVersion));
+            tabletVersionMetadatas.put(tabletId11, tablet1Versions);
 
             Map<Long, TabletMetadataPB> tablet2Versions = Maps.newHashMap();
-            tablet2Versions.put(maxVersion - 1, createTabletMetadataPB(tabletId2, maxVersion - 1));
-            tablet2Versions.put(minVersion, createTabletMetadataPB(tabletId2, minVersion));
-            tabletVersionMetadatas.put(tabletId2, tablet2Versions);
+            tablet2Versions.put(maxVersion - 1, createTabletMetadataPB(tabletId12, maxVersion - 1));
+            tablet2Versions.put(minVersion, createTabletMetadataPB(tabletId12, minVersion));
+            tabletVersionMetadatas.put(tabletId12, tablet2Versions);
 
             Map<Long, TabletMetadataPB> validMetadatas = Maps.newHashMap();
             Deencapsulation.invoke(TabletRepairHelper.class, "findValidTabletMetadata",
                     info, tabletVersionMetadatas, maxVersion, minVersion, true, validMetadatas);
 
             Assertions.assertEquals(2, validMetadatas.size());
-            Assertions.assertTrue(validMetadatas.containsKey(tabletId1));
-            Assertions.assertEquals(maxVersion - 1, validMetadatas.get(tabletId1).version);
-            Assertions.assertTrue(validMetadatas.containsKey(tabletId2));
-            Assertions.assertEquals(maxVersion - 1, validMetadatas.get(tabletId2).version);
+            Assertions.assertTrue(validMetadatas.containsKey(tabletId11));
+            Assertions.assertEquals(maxVersion - 1, validMetadatas.get(tabletId11).version);
+            Assertions.assertTrue(validMetadatas.containsKey(tabletId12));
+            Assertions.assertEquals(maxVersion - 1, validMetadatas.get(tabletId12).version);
 
             ExceptionChecker.expectThrowsNoException(
                     () -> Deencapsulation.invoke(TabletRepairHelper.class, "checkOrCreateEmptyTabletMetadata",
@@ -237,12 +395,12 @@ public class TabletRepairHelperTest {
         {
             Map<Long, Map<Long, TabletMetadataPB>> tabletVersionMetadatas = Maps.newHashMap();
             Map<Long, TabletMetadataPB> tablet1Versions = Maps.newHashMap();
-            tablet1Versions.put(maxVersion, createTabletMetadataPB(tabletId1, maxVersion));
-            tabletVersionMetadatas.put(tabletId1, tablet1Versions);
+            tablet1Versions.put(maxVersion, createTabletMetadataPB(tabletId11, maxVersion));
+            tabletVersionMetadatas.put(tabletId11, tablet1Versions);
 
             Map<Long, TabletMetadataPB> tablet2Versions = Maps.newHashMap();
-            tablet2Versions.put(maxVersion - 1, createTabletMetadataPB(tabletId2, maxVersion - 1));
-            tabletVersionMetadatas.put(tabletId2, tablet2Versions);
+            tablet2Versions.put(maxVersion - 1, createTabletMetadataPB(tabletId12, maxVersion - 1));
+            tabletVersionMetadatas.put(tabletId12, tablet2Versions);
 
             Map<Long, TabletMetadataPB> validMetadatas = Maps.newHashMap();
             Deencapsulation.invoke(TabletRepairHelper.class, "findValidTabletMetadata",
@@ -260,23 +418,23 @@ public class TabletRepairHelperTest {
         {
             Map<Long, Map<Long, TabletMetadataPB>> tabletVersionMetadatas = Maps.newHashMap();
             Map<Long, TabletMetadataPB> tablet1Versions = Maps.newHashMap();
-            tablet1Versions.put(maxVersion, createTabletMetadataPB(tabletId1, maxVersion));
-            tablet1Versions.put(minVersion, createTabletMetadataPB(tabletId1, minVersion));
-            tabletVersionMetadatas.put(tabletId1, tablet1Versions);
+            tablet1Versions.put(maxVersion, createTabletMetadataPB(tabletId11, maxVersion));
+            tablet1Versions.put(minVersion, createTabletMetadataPB(tabletId11, minVersion));
+            tabletVersionMetadatas.put(tabletId11, tablet1Versions);
 
             Map<Long, TabletMetadataPB> tablet2Versions = Maps.newHashMap();
-            tablet2Versions.put(maxVersion - 1, createTabletMetadataPB(tabletId2, maxVersion - 1));
-            tabletVersionMetadatas.put(tabletId2, tablet2Versions);
+            tablet2Versions.put(maxVersion - 1, createTabletMetadataPB(tabletId12, maxVersion - 1));
+            tabletVersionMetadatas.put(tabletId12, tablet2Versions);
 
             Map<Long, TabletMetadataPB> validMetadatas = Maps.newHashMap();
             Deencapsulation.invoke(TabletRepairHelper.class, "findValidTabletMetadata",
                     info, tabletVersionMetadatas, maxVersion, minVersion, false, validMetadatas);
 
             Assertions.assertEquals(2, validMetadatas.size());
-            Assertions.assertTrue(validMetadatas.containsKey(tabletId1));
-            Assertions.assertEquals(maxVersion, validMetadatas.get(tabletId1).version);
-            Assertions.assertTrue(validMetadatas.containsKey(tabletId2));
-            Assertions.assertEquals(maxVersion - 1, validMetadatas.get(tabletId2).version);
+            Assertions.assertTrue(validMetadatas.containsKey(tabletId11));
+            Assertions.assertEquals(maxVersion, validMetadatas.get(tabletId11).version);
+            Assertions.assertTrue(validMetadatas.containsKey(tabletId12));
+            Assertions.assertEquals(maxVersion - 1, validMetadatas.get(tabletId12).version);
 
             ExceptionChecker.expectThrowsNoException(
                     () -> Deencapsulation.invoke(TabletRepairHelper.class, "checkOrCreateEmptyTabletMetadata",
@@ -287,8 +445,8 @@ public class TabletRepairHelperTest {
         {
             Map<Long, Map<Long, TabletMetadataPB>> tabletVersionMetadatas = Maps.newHashMap();
             Map<Long, TabletMetadataPB> tablet1Versions = Maps.newHashMap();
-            tablet1Versions.put(maxVersion, createTabletMetadataPB(tabletId1, maxVersion));
-            tabletVersionMetadatas.put(tabletId1, tablet1Versions);
+            tablet1Versions.put(maxVersion, createTabletMetadataPB(tabletId11, maxVersion));
+            tabletVersionMetadatas.put(tabletId11, tablet1Versions);
 
             // tabletId2 has no metadata
 
@@ -297,12 +455,12 @@ public class TabletRepairHelperTest {
                     maxVersion, minVersion, false, validMetadatas);
 
             Assertions.assertEquals(1, validMetadatas.size());
-            Assertions.assertTrue(validMetadatas.containsKey(tabletId1));
-            Assertions.assertEquals(maxVersion, validMetadatas.get(tabletId1).version);
-            Assertions.assertFalse(validMetadatas.containsKey(tabletId2));
+            Assertions.assertTrue(validMetadatas.containsKey(tabletId11));
+            Assertions.assertEquals(maxVersion, validMetadatas.get(tabletId11).version);
+            Assertions.assertFalse(validMetadatas.containsKey(tabletId12));
 
             ExceptionChecker.expectThrowsWithMsg(StarRocksException.class,
-                    "no tablet metadatas were found for tablets [10002]",
+                    "no tablet metadatas were found for tablets [12]",
                     () -> Deencapsulation.invoke(TabletRepairHelper.class, "checkOrCreateEmptyTabletMetadata",
                             info, validMetadatas, false, false));
 
@@ -310,29 +468,29 @@ public class TabletRepairHelperTest {
             ExceptionChecker.expectThrowsNoException(
                     () -> Deencapsulation.invoke(TabletRepairHelper.class, "checkOrCreateEmptyTabletMetadata",
                             info, validMetadatas, false, true));
-            Assertions.assertTrue(validMetadatas.containsKey(tabletId2));
-            Assertions.assertEquals(0L, validMetadatas.get(tabletId2).version);
+            Assertions.assertTrue(validMetadatas.containsKey(tabletId12));
+            Assertions.assertEquals(0L, validMetadatas.get(tabletId12).version);
         }
 
         // case 5: enforceConsistentVersion = false with pre-existing valid metadata
         {
             Map<Long, Map<Long, TabletMetadataPB>> tabletVersionMetadatas = Maps.newHashMap();
             Map<Long, TabletMetadataPB> tablet2Versions = Maps.newHashMap();
-            tablet2Versions.put(minVersion, createTabletMetadataPB(tabletId2, minVersion));
-            tablet2Versions.put(minVersion + 1, createTabletMetadataPB(tabletId2, minVersion + 1));
-            tabletVersionMetadatas.put(tabletId2, tablet2Versions);
+            tablet2Versions.put(minVersion, createTabletMetadataPB(tabletId12, minVersion));
+            tablet2Versions.put(minVersion + 1, createTabletMetadataPB(tabletId12, minVersion + 1));
+            tabletVersionMetadatas.put(tabletId12, tablet2Versions);
 
             Map<Long, TabletMetadataPB> validMetadatas = Maps.newHashMap();
-            validMetadatas.put(tabletId1, createTabletMetadataPB(tabletId1, maxVersion)); // Pre-existing
+            validMetadatas.put(tabletId11, createTabletMetadataPB(tabletId11, maxVersion)); // Pre-existing
 
             Deencapsulation.invoke(TabletRepairHelper.class, "findValidTabletMetadata", info, tabletVersionMetadatas,
                     maxVersion, minVersion, false, validMetadatas);
 
             Assertions.assertEquals(2, validMetadatas.size());
-            Assertions.assertTrue(validMetadatas.containsKey(tabletId1));
-            Assertions.assertEquals(maxVersion, validMetadatas.get(tabletId1).version); // Should remain as pre-existing
-            Assertions.assertTrue(validMetadatas.containsKey(tabletId2));
-            Assertions.assertEquals(minVersion + 1, validMetadatas.get(tabletId2).version);
+            Assertions.assertTrue(validMetadatas.containsKey(tabletId11));
+            Assertions.assertEquals(maxVersion, validMetadatas.get(tabletId11).version); // Should remain as pre-existing
+            Assertions.assertTrue(validMetadatas.containsKey(tabletId12));
+            Assertions.assertEquals(minVersion + 1, validMetadatas.get(tabletId12).version);
 
             ExceptionChecker.expectThrowsNoException(
                     () -> Deencapsulation.invoke(TabletRepairHelper.class, "checkOrCreateEmptyTabletMetadata",
@@ -343,8 +501,8 @@ public class TabletRepairHelperTest {
     @Test
     public void testRepairTabletMetadata() {
         Map<Long, TabletMetadataPB> validMetadatas = Maps.newHashMap();
-        validMetadatas.put(tabletId1, createTabletMetadataPB(tabletId1, maxVersion));
-        validMetadatas.put(tabletId2, createTabletMetadataPB(tabletId2, maxVersion));
+        validMetadatas.put(tabletId11, createTabletMetadataPB(tabletId11, maxVersion));
+        validMetadatas.put(tabletId12, createTabletMetadataPB(tabletId12, maxVersion));
 
         new MockUp<LakeServiceWithMetrics>() {
             @Mock
@@ -377,8 +535,8 @@ public class TabletRepairHelperTest {
     @Test
     public void testRepairTabletMetadataWithFileBundling() {
         Map<Long, TabletMetadataPB> validMetadatas = Maps.newHashMap();
-        validMetadatas.put(tabletId1, createTabletMetadataPB(tabletId1, maxVersion));
-        validMetadatas.put(tabletId2, createTabletMetadataPB(tabletId2, maxVersion));
+        validMetadatas.put(tabletId11, createTabletMetadataPB(tabletId11, maxVersion));
+        validMetadatas.put(tabletId12, createTabletMetadataPB(tabletId12, maxVersion));
 
         new MockUp<LakeServiceWithMetrics>() {
             @Mock
@@ -411,8 +569,8 @@ public class TabletRepairHelperTest {
     @Test
     public void testRepairTabletMetadataRpcException() {
         Map<Long, TabletMetadataPB> validMetadatas = Maps.newHashMap();
-        validMetadatas.put(tabletId1, createTabletMetadataPB(tabletId1, maxVersion));
-        validMetadatas.put(tabletId2, createTabletMetadataPB(tabletId2, maxVersion));
+        validMetadatas.put(tabletId11, createTabletMetadataPB(tabletId11, maxVersion));
+        validMetadatas.put(tabletId12, createTabletMetadataPB(tabletId12, maxVersion));
 
         new MockUp<LakeServiceWithMetrics>() {
             @Mock
@@ -430,8 +588,8 @@ public class TabletRepairHelperTest {
     @Test
     public void testRepairTabletMetadataResponseNull() {
         Map<Long, TabletMetadataPB> validMetadatas = Maps.newHashMap();
-        validMetadatas.put(tabletId1, createTabletMetadataPB(tabletId1, maxVersion));
-        validMetadatas.put(tabletId2, createTabletMetadataPB(tabletId2, maxVersion));
+        validMetadatas.put(tabletId11, createTabletMetadataPB(tabletId11, maxVersion));
+        validMetadatas.put(tabletId12, createTabletMetadataPB(tabletId12, maxVersion));
 
         new MockUp<LakeServiceWithMetrics>() {
             @Mock
@@ -448,8 +606,8 @@ public class TabletRepairHelperTest {
     @Test
     public void testRepairTabletMetadataRpcLevelStatusFail() {
         Map<Long, TabletMetadataPB> validMetadatas = Maps.newHashMap();
-        validMetadatas.put(tabletId1, createTabletMetadataPB(tabletId1, maxVersion));
-        validMetadatas.put(tabletId2, createTabletMetadataPB(tabletId2, maxVersion));
+        validMetadatas.put(tabletId11, createTabletMetadataPB(tabletId11, maxVersion));
+        validMetadatas.put(tabletId12, createTabletMetadataPB(tabletId12, maxVersion));
 
         new MockUp<LakeServiceWithMetrics>() {
             @Mock
@@ -470,8 +628,8 @@ public class TabletRepairHelperTest {
     @Test
     public void testRepairTabletMetadataPartialFailure() {
         Map<Long, TabletMetadataPB> validMetadatas = Maps.newHashMap();
-        validMetadatas.put(tabletId1, createTabletMetadataPB(tabletId1, maxVersion));
-        validMetadatas.put(tabletId2, createTabletMetadataPB(tabletId2, maxVersion));
+        validMetadatas.put(tabletId11, createTabletMetadataPB(tabletId11, maxVersion));
+        validMetadatas.put(tabletId12, createTabletMetadataPB(tabletId12, maxVersion));
 
         new MockUp<LakeServiceWithMetrics>() {
             @Mock
@@ -485,7 +643,7 @@ public class TabletRepairHelperTest {
                     TabletMetadataRepairStatus status = new TabletMetadataRepairStatus();
                     status.tabletId = metadata.id;
                     status.status = new StatusPB();
-                    if (metadata.id == tabletId2) {
+                    if (metadata.id == tabletId12) {
                         status.status.statusCode = 1;
                         status.status.errorMsgs = Lists.newArrayList("repair failed");
                     } else {
@@ -502,8 +660,8 @@ public class TabletRepairHelperTest {
                 info, validMetadatas, false);
 
         Assertions.assertEquals(1, tabletErrors.size());
-        Assertions.assertTrue(tabletErrors.containsKey(tabletId2));
-        Assertions.assertEquals("repair failed", tabletErrors.get(tabletId2));
+        Assertions.assertTrue(tabletErrors.containsKey(tabletId12));
+        Assertions.assertEquals("repair failed", tabletErrors.get(tabletId12));
     }
 
     @Test
@@ -517,28 +675,28 @@ public class TabletRepairHelperTest {
 
                 // tablet1 with 2 versions metadata
                 TabletMetadatas tm1 = new TabletMetadatas();
-                tm1.tabletId = tabletId1;
+                tm1.tabletId = tabletId11;
                 tm1.status = new StatusPB();
                 tm1.status.statusCode = 0;
                 tm1.versionMetadatas = Maps.newHashMap();
 
-                TabletMetadataPB meta11 = createTabletMetadataPB(tabletId1, maxVersion);
+                TabletMetadataPB meta11 = createTabletMetadataPB(tabletId11, maxVersion);
                 tm1.versionMetadatas.put(maxVersion, meta11);
 
-                TabletMetadataPB meta12 = createTabletMetadataPB(tabletId1, minVersion);
+                TabletMetadataPB meta12 = createTabletMetadataPB(tabletId11, minVersion);
                 tm1.versionMetadatas.put(minVersion, meta12);
 
                 // tablet2 with 2 versions metadata
                 TabletMetadatas tm2 = new TabletMetadatas();
-                tm2.tabletId = tabletId2;
+                tm2.tabletId = tabletId12;
                 tm2.status = new StatusPB();
                 tm2.status.statusCode = 0;
                 tm2.versionMetadatas = Maps.newHashMap();
 
-                TabletMetadataPB meta21 = createTabletMetadataPB(tabletId2, maxVersion - 1);
+                TabletMetadataPB meta21 = createTabletMetadataPB(tabletId12, maxVersion - 1);
                 tm2.versionMetadatas.put(maxVersion - 1, meta21);
 
-                TabletMetadataPB meta22 = createTabletMetadataPB(tabletId2, minVersion);
+                TabletMetadataPB meta22 = createTabletMetadataPB(tabletId12, minVersion);
                 tm2.versionMetadatas.put(minVersion, meta22);
 
                 response.tabletMetadatas = Lists.newArrayList(tm1, tm2);
@@ -577,9 +735,132 @@ public class TabletRepairHelperTest {
         Assertions.assertTrue(tabletErrors.isEmpty());
 
         // case 2: enforceConsistentVersion = false
-        info = new PhysicalPartitionInfo(physicalPartitionId, Lists.newArrayList(tabletId1, tabletId2),
-                Sets.newHashSet(tabletId1, tabletId2), nodeToTablets, maxVersion, minVersion);
+        info = new PhysicalPartitionInfo(physicalPartitionId1, Lists.newArrayList(tabletId11, tabletId12),
+                Sets.newHashSet(tabletId11, tabletId12), nodeToTablets, maxVersion, minVersion);
         tabletErrors = Deencapsulation.invoke(TabletRepairHelper.class, "repairPhysicalPartition", info, false, false, false);
         Assertions.assertTrue(tabletErrors.isEmpty());
+    }
+
+    @Test
+    public void testRepair() {
+        // mock warehouse manager
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public ComputeNode getComputeNodeAssignedToTablet(ComputeResource computeResource, long tabletId) {
+                return node;
+            }
+        };
+
+        new MockUp<LakeServiceWithMetrics>() {
+            @Mock
+            public Future<GetTabletMetadatasResponse> getTabletMetadatas(GetTabletMetadatasRequest request) {
+                GetTabletMetadatasResponse response = new GetTabletMetadatasResponse();
+                response.status = new StatusPB();
+                response.status.statusCode = 0;
+
+                // tablet1 with 2 versions metadata
+                TabletMetadatas tm1 = new TabletMetadatas();
+                tm1.tabletId = tabletId11;
+                tm1.status = new StatusPB();
+                tm1.status.statusCode = 0;
+                tm1.versionMetadatas = Maps.newHashMap();
+
+                TabletMetadataPB meta11 = createTabletMetadataPB(tabletId11, maxVersion);
+                tm1.versionMetadatas.put(maxVersion, meta11);
+
+                TabletMetadataPB meta12 = createTabletMetadataPB(tabletId11, minVersion);
+                tm1.versionMetadatas.put(minVersion, meta12);
+
+                // tablet2 with 2 versions metadata
+                TabletMetadatas tm2 = new TabletMetadatas();
+                tm2.tabletId = tabletId12;
+                tm2.status = new StatusPB();
+                tm2.status.statusCode = 0;
+                tm2.versionMetadatas = Maps.newHashMap();
+
+                TabletMetadataPB meta21 = createTabletMetadataPB(tabletId12, maxVersion - 1);
+                tm2.versionMetadatas.put(maxVersion - 1, meta21);
+
+                TabletMetadataPB meta22 = createTabletMetadataPB(tabletId12, minVersion);
+                tm2.versionMetadatas.put(minVersion, meta22);
+
+                response.tabletMetadatas = Lists.newArrayList(tm1, tm2);
+
+                return CompletableFuture.completedFuture(response);
+            }
+
+            @Mock
+            public Future<RepairTabletMetadataResponse> repairTabletMetadata(RepairTabletMetadataRequest request) {
+                Assertions.assertFalse(request.enableFileBundling);
+                Assertions.assertFalse(request.writeBundlingFile);
+                Assertions.assertEquals(2, request.tabletMetadatas.size());
+                Assertions.assertEquals(maxVersion, request.tabletMetadatas.get(0).version);
+                Assertions.assertEquals(maxVersion, request.tabletMetadatas.get(1).version);
+
+                RepairTabletMetadataResponse response = new RepairTabletMetadataResponse();
+                response.status = new StatusPB();
+                response.status.statusCode = 0;
+                response.tabletRepairStatuses = Lists.newArrayList();
+
+                for (TabletMetadataPB metadata : request.tabletMetadatas) {
+                    TabletMetadataRepairStatus status = new TabletMetadataRepairStatus();
+                    status.tabletId = metadata.id;
+                    status.status = new StatusPB();
+                    status.status.statusCode = 0;
+                    response.tabletRepairStatuses.add(status);
+                }
+
+                return CompletableFuture.completedFuture(response);
+            }
+        };
+
+        AdminRepairTableStmt stmt = new AdminRepairTableStmt(
+                new TableRef(QualifiedName.of(Lists.newArrayList("db", "table")),
+                        new PartitionRef(Lists.newArrayList("p1"), false, NodePosition.ZERO),
+                        NodePosition.ZERO),
+                Maps.newHashMap(),
+                NodePosition.ZERO);
+
+        // case 1: enforceConsistentVersion = true
+        stmt.setEnforceConsistentVersion(true);
+        ExceptionChecker.expectThrowsNoException(
+                () -> Deencapsulation.invoke(TabletRepairHelper.class, "repair", stmt, db, table, Lists.newArrayList("p1"),
+                        WarehouseComputeResource.DEFAULT));
+
+        // case 2: enforceConsistentVersion = false
+        stmt.setEnforceConsistentVersion(false);
+        ExceptionChecker.expectThrowsNoException(
+                () -> Deencapsulation.invoke(TabletRepairHelper.class, "repair", stmt, db, table, Lists.newArrayList("p1"),
+                        WarehouseComputeResource.DEFAULT));
+    }
+
+    @Test
+    public void testRepairFail() {
+        // mock warehouse manager
+        new MockUp<WarehouseManager>() {
+            @Mock
+            public ComputeNode getComputeNodeAssignedToTablet(ComputeResource computeResource, long tabletId) {
+                return node;
+            }
+        };
+
+        new MockUp<LakeServiceWithMetrics>() {
+            @Mock
+            public Future<GetTabletMetadatasResponse> getTabletMetadatas(GetTabletMetadatasRequest request) throws RpcException {
+                throw new RpcException("rpc exception");
+            }
+        };
+
+        AdminRepairTableStmt stmt = new AdminRepairTableStmt(
+                new TableRef(QualifiedName.of(Lists.newArrayList("db", "table")),
+                        new PartitionRef(Lists.newArrayList("p1"), false, NodePosition.ZERO),
+                        NodePosition.ZERO),
+                Maps.newHashMap(),
+                NodePosition.ZERO);
+
+        ExceptionChecker.expectThrowsWithMsg(StarRocksException.class,
+                "Fail to repair tablet metadata for 1 partitions, the first 1 partitions: [{partition: 4, error: rpc exception}]",
+                () -> Deencapsulation.invoke(TabletRepairHelper.class, "repair", stmt, db, table, Lists.newArrayList("p1"),
+                        WarehouseComputeResource.DEFAULT));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/TabletRepairHelperTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/TabletRepairHelperTest.java
@@ -859,7 +859,7 @@ public class TabletRepairHelperTest {
                 NodePosition.ZERO);
 
         ExceptionChecker.expectThrowsWithMsg(StarRocksException.class,
-                "Fail to repair tablet metadata for 1 partitions, the first 1 partitions: [{partition: 4, error: rpc exception}]",
+                "Fail to repair tablet metadata for 1 partition, the first 1 partition: [{partition: 4, error: rpc exception}]",
                 () -> Deencapsulation.invoke(TabletRepairHelper.class, "repair", stmt, db, table, Lists.newArrayList("p1"),
                         WarehouseComputeResource.DEFAULT));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/TabletRepairTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/TabletRepairTest.java
@@ -1,0 +1,64 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake;
+
+import com.starrocks.common.ExceptionChecker;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.StarRocksException;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.DDLStmtExecutor;
+import com.starrocks.server.RunMode;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class TabletRepairTest {
+    private static final String DB_NAME = "test_repair";
+    private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        FeConstants.runningUnitTest = true;
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withDatabase(DB_NAME).useDatabase(DB_NAME);
+    }
+
+    @Test
+    public void testRepairTableFail() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE t1(k1 DATE, k2 INT) PARTITION BY RANGE(k1) " +
+                        "(PARTITION p202510 VALUES LESS THAN ('2025-11-01'), " +
+                        " PARTITION p202511 VALUES LESS THAN ('2025-12-01')) " +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 2");
+        try {
+            String repairSql = "ADMIN REPAIR TABLE t1 " +
+                    "PROPERTIES('enforce_consistent_version' = 'true', 'allow_empty_tablet_recovery' = 'false')";
+            connectContext.setQueryId(UUIDUtil.genUUID());
+            StatementBase stmt2 = SqlParser.parseSingleStatement(repairSql, connectContext.getSessionVariable().getSqlMode());
+            // get_tablet_metadatas returns null response
+            ExceptionChecker.expectThrowsWithMsg(StarRocksException.class, "Fail to repair tablet metadata for 2 partitions",
+                    () -> DDLStmtExecutor.execute(stmt2, connectContext));
+        } catch (Exception e) {
+            Assertions.fail(e.getMessage());
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/qe/RedirectStatusTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/RedirectStatusTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.qe;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.starrocks.catalog.TableName;
 import com.starrocks.sql.ast.AddBackendBlackListStmt;
 import com.starrocks.sql.ast.AddComputeNodeBlackListStmt;
@@ -1420,7 +1421,7 @@ public class RedirectStatusTest {
     public void testAdminRepairTableStmt() {
         QualifiedName qualifiedName = QualifiedName.of(Lists.newArrayList("test_table"));
         TableRef tableRef = new TableRef(qualifiedName, null, NodePosition.ZERO);
-        AdminRepairTableStmt stmt = new AdminRepairTableStmt(tableRef, NodePosition.ZERO);
+        AdminRepairTableStmt stmt = new AdminRepairTableStmt(tableRef, Maps.newHashMap(), NodePosition.ZERO);
         Assertions.assertEquals(RedirectStatus.FORWARD_WITH_SYNC, RedirectStatus.getRedirectStatus(stmt));
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AdminRepairStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AdminRepairStmtTest.java
@@ -61,7 +61,6 @@ public class AdminRepairStmtTest {
         analyzeFail("ADMIN REPAIR TABLE");
         analyzeFail("ADMIN REPAIR TABLE test TEMPORARY PARTITION(p1, p2, p3);");
         analyzeFail("ADMIN REPAIR TABLE test properties('xxx' = 'yyy');");
-
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AdminRepairStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AdminRepairStmtTest.java
@@ -28,7 +28,7 @@ import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeFail;
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeSuccess;
 
 /**
- * AdminRepairTable: ADMIN REPAIR TABLE table_name[ PARTITION (p1,...)];
+ * AdminRepairTable: ADMIN REPAIR TABLE table_name[ PARTITION (p1,...)] PROPERTIES("key" = "value");
  * AdminCancelRepairTable: ADMIN CANCEL REPAIR TABLE table_name[ PARTITION (p1,...)];
  * AminCheckTablets: ADMIN CHECK TABLET (tablet_id1, tablet_id2, ...) PROPERTIES("type" = "...");
  */
@@ -43,13 +43,25 @@ public class AdminRepairStmtTest {
         AdminRepairTableStmt stmt = (AdminRepairTableStmt) analyzeSuccess("ADMIN REPAIR TABLE test;");
         Assertions.assertNull(stmt.getDbName()); // No database specified in SQL
         Assertions.assertEquals("test", stmt.getTblName());
+
         stmt = (AdminRepairTableStmt) analyzeSuccess("ADMIN REPAIR TABLE test PARTITION(p1, p2, p3);");
         Assertions.assertNull(stmt.getDbName()); // No database specified in SQL
         Assertions.assertEquals(Arrays.asList("p1", "p2", "p3"), stmt.getPartitionRef().getPartitionNames());
+        Assertions.assertTrue(stmt.isEnforceConsistentVersion());
+        Assertions.assertFalse(stmt.isAllowEmptyTabletRecovery());
+
+        stmt = (AdminRepairTableStmt) analyzeSuccess("ADMIN REPAIR TABLE test PARTITION(p1) " +
+                "properties('enforce_consistent_version' = 'false', 'allow_empty_tablet_recovery' = 'true');");
+        Assertions.assertFalse(stmt.isEnforceConsistentVersion());
+        Assertions.assertTrue(stmt.isAllowEmptyTabletRecovery());
+
         analyzeSuccess("ADMIN REPAIR TABLE test PARTITIONs(p1, p2, p3)");
+
         // bad cases
         analyzeFail("ADMIN REPAIR TABLE");
         analyzeFail("ADMIN REPAIR TABLE test TEMPORARY PARTITION(p1, p2, p3);");
+        analyzeFail("ADMIN REPAIR TABLE test properties('xxx' = 'yyy');");
+
     }
 
     @Test

--- a/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
+++ b/fe/fe-grammar/src/main/antlr/com/starrocks/grammar/StarRocks.g4
@@ -760,7 +760,7 @@ adminShowReplicaStatusStatement
     ;
 
 adminRepairTableStatement
-    : ADMIN REPAIR TABLE qualifiedName partitionNames?
+    : ADMIN REPAIR TABLE qualifiedName partitionNames? properties?
     ;
 
 adminCancelRepairTableStatement

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AdminRepairTableStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AdminRepairTableStmt.java
@@ -24,7 +24,9 @@ public class AdminRepairTableStmt extends DdlStmt {
     private final TableRef tblRef;
     private final Map<String, String> properties;
 
+    // Enforces consistent version across all tablets in a physical partition
     private boolean enforceConsistentVersion = true;
+    // Allows empty tablet recovery of tablets with no valid metadata
     private boolean allowEmptyTabletRecovery = false;
 
     public AdminRepairTableStmt(TableRef tblRef, Map<String, String> properties, NodePosition pos) {

--- a/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AdminRepairTableStmt.java
+++ b/fe/fe-parser/src/main/java/com/starrocks/sql/ast/AdminRepairTableStmt.java
@@ -16,14 +16,21 @@ package com.starrocks.sql.ast;
 
 import com.starrocks.sql.parser.NodePosition;
 
-//  ADMIN REPAIR TABLE table_name partitions;
+import java.util.Map;
+
+//  ADMIN REPAIR TABLE table_name partitions properties("key" = "value");
 public class AdminRepairTableStmt extends DdlStmt {
 
     private final TableRef tblRef;
+    private final Map<String, String> properties;
 
-    public AdminRepairTableStmt(TableRef tblRef, NodePosition pos) {
+    private boolean enforceConsistentVersion = true;
+    private boolean allowEmptyTabletRecovery = false;
+
+    public AdminRepairTableStmt(TableRef tblRef, Map<String, String> properties, NodePosition pos) {
         super(pos);
         this.tblRef = tblRef;
+        this.properties = properties;
     }
 
     public String getDbName() {
@@ -36,6 +43,26 @@ public class AdminRepairTableStmt extends DdlStmt {
 
     public PartitionRef getPartitionRef() {
         return tblRef.getPartitionDef();
+    }
+
+    public Map<String, String> getProperties() {
+        return properties;
+    }
+
+    public boolean isEnforceConsistentVersion() {
+        return enforceConsistentVersion;
+    }
+
+    public void setEnforceConsistentVersion(boolean enforceConsistentVersion) {
+        this.enforceConsistentVersion = enforceConsistentVersion;
+    }
+
+    public boolean isAllowEmptyTabletRecovery() {
+        return allowEmptyTabletRecovery;
+    }
+
+    public void setAllowEmptyTabletRecovery(boolean allowEmptyTabletRecovery) {
+        this.allowEmptyTabletRecovery = allowEmptyTabletRecovery;
     }
 
     @Override


### PR DESCRIPTION
## Why I'm doing:

## What I'm doing:

This PR introduces enhancements to the `ADMIN REPAIR TABLE` statement for repairing cloud native table.
1. adds additional properties for more granular control over repair operations.
2. implements table repair. 

```
admin repair table t1 partition (p1) 
properties(
  "enforce_consistent_version" = "true",
  "allow_empty_tablet_recovery" = "false"
);
```

https://github.com/StarRocks/starrocks/issues/66015

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [x] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables repairing cloud-native tables via SQL with configurable strategies.
> 
> - Parser/AST: `ADMIN REPAIR TABLE` now accepts `PROPERTIES`, captured in `AdminRepairTableStmt` (with `enforce_consistent_version`, `allow_empty_tablet_recovery`). Grammar and builder updated accordingly.
> - Analyzer: Validates and consumes the new properties; unknown properties error out.
> - Execution: `DDLStmtExecutor` routes cloud-native tables to `TabletRepairHelper.repair`; non-cloud-native paths unchanged.
> - Repair engine: `TabletRepairHelper` orchestrates per-physical-partition repair—collects tablet metadata across versions, enforces optional consistent versioning, optionally creates empty metadata, and issues `repairTabletMetadata` RPCs (supports file bundling). Throws `AlreadyExistsException` when no repair needed.
> - Utilities: `PropertyAnalyzer` adds constants and boolean parsing for the new properties.
> - Tests: Extensive UTs for repair flow, analyzer, parser, redirect status, and end-to-end failure handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 783c32b7663d187bd1d09593ea94e03bdceccc3a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->