### PR TITLE
[BugFix] Fix tablet range is null for LakeTablet when FE restart

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTablet.java
@@ -60,6 +60,10 @@ public class LakeTablet extends Tablet {
 
     public long rebuildPindexVersion = 0L;
 
+    public LakeTablet() {
+        super();
+    }
+
     public LakeTablet(long id) {
         super(id);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeTabletTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeTabletTest.java
@@ -1,0 +1,44 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake;
+
+import com.starrocks.persist.gson.GsonUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class LakeTabletTest {
+
+    @Test
+    public void testSerialization() {
+        LakeTablet tablet = new LakeTablet(10001L);
+        tablet.setDataSize(100L);
+        tablet.setRowCount(10L);
+
+        String json = GsonUtils.GSON.toJson(tablet);
+        LakeTablet deserializedTablet = GsonUtils.GSON.fromJson(json, LakeTablet.class);
+
+        Assertions.assertEquals(tablet.getId(), deserializedTablet.getId());
+        Assertions.assertEquals(tablet.getDataSize(true), deserializedTablet.getDataSize(true));
+        Assertions.assertEquals(tablet.getRowCount(0), deserializedTablet.getRowCount(0));
+        Assertions.assertNotNull(deserializedTablet.getRange());
+    }
+
+    @Test
+    public void testDefaultConstructor() {
+        LakeTablet tablet = new LakeTablet();
+        Assertions.assertNotNull(tablet.getRange());
+    }
+}
+


### PR DESCRIPTION
## Why I'm doing:
When FE restart, the tablet range is not initialized for LakeTablet, because the LakeTablet has no empty constructor.

## What I'm doing:
Add an empty constructor for LakeTablet.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
