### PR TITLE
[Doc] docs(fe_config): update en, zh, ja documentation

### DIFF
--- a/docs/en/administration/management/FE_configuration.md
+++ b/docs/en/administration/management/FE_configuration.md
@@ -277,6 +277,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Description: Directory used by the FE logging subsystem for storing internal logs (`fe.internal.log`). This configuration is substituted into the Log4j configuration and determines where the InternalFile appender writes internal/materialized view/statistics logs and where per-module loggers under `internal.<module>` place their files. Ensure the directory exists, is writable, and has sufficient disk space. Log rotation and retention for files in this directory are controlled by `log_roll_size_mb`, `internal_log_roll_num`, `internal_log_delete_age`, and `internal_log_roll_interval`. If `sys_log_to_console` is enabled, internal logs may be written to console instead of this directory.
 - Introduced in: v3.2.4
 
+##### internal_log_json_format
+
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: When `internal_log_json_format` is true, internal statistic/audit entries emitted by AuditInternalLog.handleInternalLog are written as compact JSON objects to the statistic audit logger. The JSON contains keys "executeType" (InternalType: QUERY or DML), "queryId", "sql", and "time" (elapsed milliseconds). When false, the same information is logged as a single formatted text line ("statistic execute: ... | QueryId: [...] | SQL: ..."). Enabling JSON improves machine parsing and integration with log processors but also causes raw SQL text to be included in logs, which may expose sensitive information and increase log size.
+- Introduced in: -
+
 ##### internal_log_modules
 
 - Default: `{"base", "statistic"}`
@@ -375,6 +384,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Is mutable: No
 - Description: The maximum size of a system log file or an audit log file.
 - Introduced in: -
+
+##### proc_profile_file_retained_days
+
+- Default: 1
+- Type: Int
+- Unit: Days
+- Is mutable: Yes
+- Description: Number of days to retain process profiling files (CPU and memory) generated under `sys_log_dir/proc_profile`. The ProcProfileCollector computes a cutoff by subtracting `proc_profile_file_retained_days` days from the current time (formatted as yyyyMMdd-HHmmss) and deletes profile files whose timestamp portion is lexicographically earlier than that cutoff (i.e., timePart.compareTo(timeToDelete) &lt; 0). File deletion also respects the size-based cutoff controlled by `proc_profile_file_retained_size_bytes`. Profile files use the prefixes `cpu-profile-` and `mem-profile-` and are compressed after collection.
+- Introduced in: v3.2.12
+
+##### proc_profile_file_retained_size_bytes
+
+- Default: 2L * 1024 * 1024 * 1024 (2147483648)
+- Type: Long
+- Unit: Bytes
+- Is mutable: Yes
+- Description: Maximum total bytes of collected CPU and memory profile files (files named with prefixes "cpu-profile-" and "mem-profile-") to keep under the ProcProfileCollector profile directory. When the sum of valid profile files exceeds `proc_profile_file_retained_size_bytes`, the collector deletes the oldest profile files until the remaining total size &lt;= `proc_profile_file_retained_size_bytes`. Files older than `proc_profile_file_retained_days` are also removed regardless of size. This setting controls disk usage for profile archives and interacts with `proc_profile_file_retained_days` to determine deletion order and retention.
+- Introduced in: v3.2.12
 
 ##### profile_log_delete_age
 
@@ -749,6 +776,33 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Description: The maximum number of threads that can be run by the MySQL server in the FE node to process tasks.
 - Introduced in: -
 
+##### max_task_runs_threads_num
+
+- Default: 512
+- Type: Int
+- Unit: Threads
+- Is mutable: No
+- Description: Controls the maximum number of threads in the task-run executor thread pool. StarRocks uses `max_task_runs_threads_num` in TaskRunExecutor to create a daemon cached thread pool (named "starrocks-taskrun-pool") that runs TaskRunExecutor.executeTaskRun asynchronously. This value is the upper bound of concurrent task-run executions; increasing it raises parallelism but also increases CPU, memory, and connection usage, while reducing it can cause task-run backlog and higher latency. Because it is not mutable at runtime, changes require a restart to take effect. Tune this value according to expected concurrent scheduled jobs and available system resources.
+- Introduced in: v3.2.0
+
+##### memory_tracker_enable
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Enables the FE memory tracker subsystem. When `memory_tracker_enable` is true, MemoryUsageTracker periodically scans registered metadata modules (see `MemoryUsageTracker.registerMemoryTracker`), updates the in-memory `MemoryUsageTracker.MEMORY_USAGE` map, logs totals, and causes `MetricRepo` to expose memory usage and object-count gauges (`GAUGE_MEMORY_USAGE_STATS` and `GAUGE_OBJECT_COUNT_STATS`) in metrics output. Use `memory_tracker_interval_seconds` to control the sampling interval. Turning this on helps monitoring and debugging memory consumption but introduces CPU and I/O overhead and additional metric cardinality.
+- Introduced in: v3.2.4
+
+##### memory_tracker_interval_seconds
+
+- Default: 60
+- Type: long
+- Unit: Seconds
+- Is mutable: Yes
+- Description: Interval in seconds for the FE MemoryUsageTracker daemon to poll and record memory usage of the FE process and registered MemoryTrackable modules. The value is converted to milliseconds (multiplied by 1000L) to set the daemon interval. When `memory_tracker_enable` is true, the tracker runs on this cadence, updates MEMORY_USAGE, and logs aggregated JVM and tracked-module usage. Because the daemon calls setInterval from the running loop, updates to `memory_tracker_interval_seconds` take effect at runtime on the next scheduled iteration without a process restart.
+- Introduced in: v3.2.4
+
 ##### mysql_nio_backlog_num
 
 - Default: 1024
@@ -779,6 +833,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Description: The maximum number of threads that can be run by the MySQL server in the FE node to process I/O events.
 - Introduced in: -
 
+##### mysql_service_kill_after_disconnect
+
+- Default: true
+- Type: boolean
+- Unit: -
+- Is mutable: No
+- Description: When the MySQL TCP connection is detected closed (EOF on read), `mysql_service_kill_after_disconnect` controls how the server handles that session. If true, the server immediately kills any running query for that connection (calls ctx.kill) and performs immediate cleanup. If false, the server does not kill running queries on disconnect and only performs cleanup when there are no pending request tasks, allowing long-running queries to continue after client disconnect. Note: despite a brief comment suggesting TCP keep‑alive, this flag specifically governs post-disconnect killing behavior and should be set according to whether you want orphaned queries terminated (recommended behind unreliable/load‑balanced clients) or allowed to finish.
+- Introduced in: -
+
 ##### mysql_service_nio_enable_keep_alive
 
 - Default: true
@@ -805,6 +868,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Is mutable: No
 - Description: Declares a selection strategy for servers that have multiple IP addresses. Note that at most one IP address must match the list specified by this parameter. The value of this parameter is a list that consists of entries, which are separated with semicolons (;) in CIDR notation, such as 10.10.10.0/24. If no IP address matches the entries in this list, an available IP address of the server will be randomly selected. From v3.3.0, StarRocks supports deployment based on IPv6. If the server has both IPv4 and IPv6 addresses, and this parameter is not specified, the system uses an IPv4 address by default. You can change this behavior by setting `net_use_ipv6_when_priority_networks_empty` to `true`.
 - Introduced in: -
+
+##### proc_profile_cpu_enable
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: When enabled, the background `ProcProfileCollector` will collect CPU profiles using AsyncProfiler and write HTML reports under `sys_log_dir`/proc_profile. Each collection run records CPU stacks for the duration configured by `proc_profile_collect_time_s` and uses `proc_profile_jstack_depth` for Java stack depth. Generated profiles are compressed and old files are pruned according to `proc_profile_file_retained_days` and `proc_profile_file_retained_size_bytes`. AsyncProfiler requires the native library (libasyncProfiler.so); the code sets the `one.profiler.extractPath` to `STARROCKS_HOME_DIR`/bin to avoid noexec issues on /tmp.
+- Introduced in: v3.2.12
 
 ##### qe_max_connection
 
@@ -859,6 +931,24 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Is mutable: No
 - Description: Comma separated list, with regex support to whitelist ssl cipher suites by IANA names. If both whitelist and blacklist are set, blacklist takes precedence.
 - Introduced in: v4.0
+
+##### task_runs_concurrency
+
+- Default: 4
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: Global limit of concurrently running TaskRun instances. The `TaskRunScheduler` stops scheduling new runs when current running count &gt;= `task_runs_concurrency`, so this value caps parallel TaskRun execution across the scheduler. It is also used by `MVPCTRefreshPartitioner` to compute per-TaskRun partition refresh granularity as ceil(totalPartitions &#47; Math.max(1, `task_runs_concurrency`)). Increasing the value raises parallelism (and resource usage); decreasing it reduces concurrency and makes partition refreshes larger per run. Do not set to 0 or negative unless intentionally disabling scheduling: 0 (or negative) will effectively prevent new TaskRuns from being scheduled by `TaskRunScheduler`.
+- Introduced in: v3.2.0
+
+##### task_runs_queue_length
+
+- Default: 500
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: Limits the maximum number of pending TaskRun items kept in the pending queue. TaskRunManager checks the current pending count via taskRunScheduler.getPendingQueueCount() and rejects new submissions when validPendingCount &gt;= Config.task_runs_queue_length (`task_runs_queue_length`), returning a REJECTED SubmitResult. The same limit is rechecked in arrangeTaskRun() before adding merged/accepted TaskRuns. Tune this value to balance memory and scheduling backlog: set higher for large bursty workloads to avoid rejects, or lower to bound memory and reduce pending backlog.
+- Introduced in: v3.2.0
 
 ##### thrift_backlog_num
 
@@ -1141,6 +1231,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Description: Whether to collect the profile of a query. If this parameter is set to `TRUE`, the system collects the profile of the query. If this parameter is set to `FALSE`, the system does not collect the profile of the query.
 - Introduced in: -
 
+##### enable_create_partial_partition_in_batch
+
+- Default: false
+- Type: boolean
+- Unit: -
+- Is mutable: Yes
+- Description: When `enable_create_partial_partition_in_batch` is false (default), StarRocks enforces that batch-created range partitions align to the standard time unit boundaries; PartitionDescAnalyzer.checkManualAddPartitionDateAligned will reject non‑aligned ranges to avoid creating holes. Setting `enable_create_partial_partition_in_batch=true` disables that alignment check and allows creating partial (non‑standard) partitions in batch. Enabling this can produce gaps or misaligned partition ranges and should only be used when you intentionally need partial batch partitions and accept the associated risks.
+- Introduced in: v3.2.0
+
 ##### enable_internal_sql
 
 - Default: true
@@ -1158,6 +1257,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Is mutable: Yes
 - Description: Whether to enable the Legacy Compatibility for Replication. StarRocks may behave differently between the old and new versions, causing problems during cross-cluster data migration. Therefore, you must enable Legacy Compatibility for the target cluster before data migration and disable it after data migration is completed. `true` indicates enabling this mode.
 - Introduced in: v3.1.10, v3.2.6
+
+##### enable_show_materialized_views_include_all_task_runs
+
+- Default: true
+- Type: boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Controls how task runs are returned by the ShowMaterializedViews command. When `enable_show_materialized_views_include_all_task_runs` is false, StarRocks returns only the newest task run per task (legacy behavior for compatibility). When true (default), TaskManager may include additional task runs for the same task only when they share the same start task run id (i.e., belong to the same job), preventing unrelated duplicate runs from appearing while allowing multiple statuses tied to one job to be shown. Toggle this to restore older single-run output or to surface multi-run job history for debugging and monitoring.
+- Introduced in: v3.3.0, v3.4.0, v3.5.0
 
 ##### enable_statistics_collect_profile
 
@@ -1233,6 +1341,15 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - Is mutable: Yes
 - Description: Whether non-Leader FEs ignore the metadata gap from the Leader FE. If the value is TRUE, non-Leader FEs ignore the metadata gap from the Leader FE and continue providing data reading services. This parameter ensures continuous data reading services even when you stop the Leader FE for a long period of time. If the value is FALSE, non-Leader FEs do not ignore the metadata gap from the Leader FE and stop providing data reading services.
 - Introduced in: -
+
+##### ignore_task_run_history_replay_error
+
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: When StarRocks deserializes task run history rows for information_schema.task_runs, a corrupted or invalid JSON row will normally cause deserialization to log a warning and throw a RuntimeException. If `ignore_task_run_history_replay_error` is set to true, TaskRunStatus.fromResultBatch will catch deserialization errors, skip the malformed record, and continue processing remaining rows instead of failing the query. Enable this to make information_schema.task_runs queries tolerant of bad entries in the _statistics_.task_run_history table; note that enabling it will silently drop corrupted history records (potential data loss) instead of surfacing an explicit error.
+- Introduced in: v3.3.3, v3.4.0, v3.5.0
 
 ##### lock_checker_interval_second
 
@@ -1635,6 +1752,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: Whether to enable the creation of materialized views.
 - Introduced in: -
 
+##### enable_materialized_view_external_table_precise_refresh
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Enables an internal optimization for materialized view (MV) refresh when a base table is an external (non-cloud-native) table. When enabled, the MV refresh processor (BaseMVRefreshProcessor) computes candidate partitions (via PCT methods such as getPCTMVToRefreshedPartitions and getPCTRefTableRefreshPartitions) and refreshes only the affected base-table partitions instead of all partitions, reducing IO and refresh cost. The flag is read during processor construction and controls the path taken by syncAndCheckPCTPartitions. If candidate-partition computation fails for missing base tables, the code may swallow certain errors and fall back to the full-sync path. Set to false to force full-partition refresh of external tables.
+- Introduced in: v3.2.9
+
 ##### enable_materialized_view_metrics_collect
 
 - Default: true
@@ -1670,6 +1796,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Is mutable: Yes
 - Description: Whether to enable the system to automatically check and re-activate the asynchronous materialized views that are set inactive because their base tables (views) had undergone Schema Change or had been dropped and re-created. Please note that this feature will not re-activate the materialized views that are manually set inactive by users.
 - Introduced in: v3.1.6
+
+##### enable_mv_automatic_repairing_for_broken_base_tables
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: When `enable_mv_automatic_repairing_for_broken_base_tables` is enabled, StarRocks will attempt to automatically repair materialized view (MV) base-table metadata when a base external table is dropped and recreated or its table identifier changes. The repair flow (MVPCTMetaRepairer) can update the MV's BaseTableInfo, collect partition-level repair info (last-file-modified time and file count) for external partitions, and drive partition refresh decisions for async auto-refresh MVs while honoring autoRefreshPartitionsLimit. Currently the automated repair supports Hive external tables; unsupported table kinds will cause the MV to be set inactive and a repair exception. Partition-info collection is non-blocking and failures are logged.
+- Introduced in: v3.3.19, v3.4.8, v3.5.6
 
 ##### enable_predicate_columns_collection
 
@@ -1831,6 +1966,24 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: Threshold of low cardinality dictionary.
 - Introduced in: v3.5.0
 
+##### materialized_view_min_refresh_interval
+
+- Default: 60
+- Type: Int
+- Unit: Seconds
+- Is mutable: Yes
+- Description: The minimum allowed refresh interval (in seconds) for ASYNC materialized view schedules. When a materialized view is created with a time-based interval, the interval is converted to seconds and must not be &lt; `materialized_view_min_refresh_interval`; otherwise the CREATE/ALTER operation fails with a DDL error. If `materialized_view_min_refresh_interval` &gt; 0 the check is enforced; set it to 0 or a negative value to disable the limit. This prevents excessive TaskManager scheduling and high FE memory/CPU use from overly frequent refreshes. Does not apply to EVENT_TRIGGERED refreshes (timeUnit == null).
+- Introduced in: v3.3.0, v3.4.0, v3.5.0
+
+##### materialized_view_refresh_ascending
+
+- Default: false
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: When true, materialized view partition refresh will iterate partitions in ascending partition-key order (oldest to newest); when false (default) it iterates in descending order (newest to oldest). StarRocks uses this flag in both list and range MV refresh logic to choose which partitions to process when partition refresh limits apply and to compute the next start/end partition boundaries for subsequent TaskRun executions. Changing this setting alters which partitions are refreshed first and how the next partition range is derived; for range MVs the scheduler validates new start/end and will raise an error if a change would create a repeated boundary (dead-loop), so switch this flag with care.
+- Introduced in: v3.3.1, v3.4.0, v3.5.0
+
 ##### max_allowed_in_element_num_of_delete
 
 - Default: 10000
@@ -1929,6 +2082,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Is mutable: Yes
 - Description: When the background active_checker thread is enabled, the system will periodically detect and automatically reactivate materialized views that became Inactive due to schema changes or rebuilds of their base tables (or views). This parameter controls the scheduling interval of the checker thread, in seconds. The default value is system-defined.
 - Introduced in: v3.1.6
+
+##### mv_rewrite_consider_data_layout_mode
+
+- Default: "enable"
+- Type: String
+- Unit: -
+- Is mutable: Yes
+- Description: Controls whether materialized view (MV) rewrite should take the underlying table data layout into account when selecting the best MV. Valid values: "disable" — never use data-layout criteria when choosing between candidate MVs; "enable" — use data-layout criteria only when the query is recognized as layout-sensitive (checked by MvUtils.isLogicalSP, e.g., colocation and sort-key compatibility); "force" — always apply data-layout criteria when selecting the best MV. Changing this affects BestMvSelector behavior and can improve or broaden rewrite applicability depending on whether physical layout matters for plan correctness or performance.
+- Introduced in: -
 
 ##### publish_version_interval_ms
 
@@ -2118,6 +2280,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Is mutable: Yes
 - Description: Minimum allowed schedule interval (in seconds) for task schedules checked by the SQL layer. When a task is submitted, TaskAnalyzer converts the schedule period to seconds and rejects the submission with ERR_INVALID_PARAMETER if the period is smaller than `task_min_schedule_interval_s`. This prevents creating tasks that run too frequently and protects the scheduler from high-frequency tasks. If a schedule has no explicit start time, TaskAnalyzer sets the start time to the current epoch seconds.
 - Introduced in: v3.3.0, v3.4.0, v3.5.0
+
+##### task_runs_timeout_second
+
+- Default: 4 * 3600
+- Type: Int
+- Unit: Seconds
+- Is mutable: Yes
+- Description: Default execution timeout (in seconds) for a TaskRun. `task_runs_timeout_second` is used by TaskRun.getExecuteTimeoutS() as the baseline timeout. If the task run's properties include session variables `query_timeout` or `insert_timeout` with a positive integer value, the runtime uses the larger of that session timeout and `task_runs_timeout_second`. The effective timeout is then bounded to not exceed the configured `task_runs_ttl_second` and `task_ttl_second`. Set this to limit how long a task run may execute; very large values may be clipped by the task/task-run TTL settings.
+- Introduced in: -
 
 ### Loading and unloading
 
@@ -2623,6 +2794,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 
 ### Statistic report
 
+##### enable_collect_warehouse_metrics
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: When `enable_collect_warehouse_metrics` is true, MetricRepo will invoke the cluster BaseSlotManager to collect and export per-warehouse metrics (via slotManager.collectWarehouseMetrics(visitor)). Enabling it adds warehouse-level metrics (slot/usage/availability) to the metric output and increases metric cardinality and collection overhead. Disable it to omit warehouse-specific metrics and reduce CPU/network and monitoring storage cost. This flag is similar in purpose to other metric gating flags such as `enable_routine_load_lag_metrics` and `memory_tracker_enable`.
+- Introduced in: v3.5.0
+
 ##### enable_http_detail_metrics
 
 - Default: false
@@ -2631,6 +2811,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Is mutable: Yes
 - Description: When true, the HTTP server computes and exposes detailed HTTP worker metrics (notably the `HTTP_WORKER_PENDING_TASKS_NUM` gauge). Enabling this causes the server to iterate over Netty worker executors and call `pendingTasks()` on each `NioEventLoop` to sum pending task counts; when disabled the gauge returns 0 to avoid that cost. This extra collection can be CPU- and latency-sensitive — enable only for debugging or detailed investigation.
 - Introduced in: v3.2.3
+
+##### proc_profile_collect_time_s
+
+- Default: 120
+- Type: Long
+- Unit: Seconds
+- Is mutable: Yes
+- Description: Duration in seconds for a single process profile collection performed by ProcProfileCollector. When `proc_profile_cpu_enable` or `proc_profile_mem_enable` is true, AsyncProfiler is started, the collector thread sleeps for `proc_profile_collect_time_s * 1000L`, then the profiler is stopped and the profile is written (use of `proc_profile_jstack_depth` affects stack capture depth). Larger values increase sample coverage and file size but prolong profiler runtime and delay subsequent collections; smaller values reduce overhead but may produce insufficient samples. Ensure this value aligns with retention settings such as `proc_profile_file_retained_days` and `proc_profile_file_retained_size_bytes`.
+- Introduced in: v3.2.12
 
 ### Storage
 
@@ -2669,6 +2858,42 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Is mutable: Yes
 - Description: The timeout duration for a replica consistency check. You can set this parameter based on the size of your tablet.
 - Introduced in: -
+
+##### consistency_check_cooldown_time_second
+
+- Default: 24 * 3600L
+- Type: long
+- Unit: Seconds
+- Is mutable: Yes
+- Description: Controls the minimal interval (in seconds) required between consistency checks of the same tablet. During tablet selection (chooseTablets), a tablet is considered eligible only if tablet.getLastCheckTime() &lt; (currentTimeMillis - consistency_check_cooldown_time_second * 1000). The default (24 * 3600L) enforces roughly one check per tablet per day to reduce backend disk I/O. Lowering this value increases check frequency and resource use; raising it reduces I/O at the cost of slower detection of inconsistencies. The value is applied globally when filtering cooldownedTablets from an index's tablet list.
+- Introduced in: v3.5.5
+
+##### consistency_check_end_time
+
+- Default: "4"
+- Type: String
+- Unit: Hour of day (0-23)
+- Is mutable: No
+- Description: Specifies the end hour (hour-of-day) of the ConsistencyChecker work window. The value is parsed with SimpleDateFormat("HH") in the system time zone and accepted as 0–23 (single or two-digit). StarRocks converts this to an integer `endTime` and uses it with `consistency_check_start_time` to decide when to schedule and add consistency-check jobs. When `startTime` &gt; `endTime` the window spans midnight (e.g., default is `consistency_check_start_time` = "23" to `consistency_check_end_time` = "4"); when `startTime` == `endTime` the checker never runs. Parsing failure will cause FE startup to log an error and exit, so provide a valid hour string.
+- Introduced in: v3.2.0
+
+##### consistency_check_start_time
+
+- Default: "23"
+- Type: String
+- Unit: Hour of day (00-23)
+- Is mutable: No
+- Description: Hour (formatted as "HH") when the periodic consistency checker begins its work window. `consistency_check_start_time` is parsed using the system time zone and converted to an integer hour. The checker runs from `consistency_check_start_time` to `consistency_check_end_time`; if `start == end` the checker is disabled. Cross-midnight windows are supported (when start &gt; end the window runs until end of next day). An invalid value (unparseable as "HH") causes startup failure of the FE process. Specify a two-digit hour between "00" and "23" (for example the default represents 23:00).
+- Introduced in: v3.2.0
+
+##### consistency_tablet_meta_check_interval_ms
+
+- Default: 2 * 3600 * 1000L
+- Type: Long
+- Unit: Milliseconds
+- Is mutable: Yes
+- Description: Interval used by the ConsistencyChecker to run a full tablet-meta consistency scan between TabletInvertedIndex and LocalMetastore. The daemon in runAfterCatalogReady triggers checkTabletMetaConsistency when current time minus lastTabletMetaCheckTime exceeds this value. When an invalid tablet is first detected, its toBeCleanedTime is set to now + (consistency_tablet_meta_check_interval_ms / 2) so actual deletion is delayed until a subsequent scan. Increase to reduce scan frequency and load (slower cleanup); decrease to detect and remove stale tablets faster (higher overhead).
+- Introduced in: v3.2.0
 
 ##### default_replication_num
 
@@ -2766,6 +2991,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Is mutable: Yes
 - Description: The maximum number of partitions can be created in a table.
 - Introduced in: v3.3.2
+
+##### max_task_consecutive_fail_count
+
+- Default: 10
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: Maximum number of consecutive failures a task may have before the scheduler automatically suspends it. When `TaskSource.MV.equals(task.getSource())` and `max_task_consecutive_fail_count` &gt; 0, if a task's consecutive failure counter reaches or exceeds (`&gt;=`) `max_task_consecutive_fail_count`, the task is suspended via the TaskManager and, for materialized-view tasks, the MV is inactivated by calling AlterMVJobExecutor.inactiveForConsecutiveFailures. An exception is thrown indicating suspension and how to reactivate (e.g., `ALTER MATERIALIZED VIEW &lt;name&gt; ACTIVE`). Set to 0 or a negative value to disable automatic suspension.
+- Introduced in: -
 
 ##### partition_recycle_retention_period_secs
 
@@ -4079,6 +4313,24 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Description: Whether plugins can be installed on FEs. Plugins can be installed or uninstalled only on the Leader FE.
 - Introduced in: -
 
+##### proc_profile_jstack_depth
+
+- Default: 128
+- Type: Int
+- Unit: Stack frames
+- Is mutable: Yes
+- Description: Maximum Java stack depth passed to AsyncProfiler's jstackdepth option when ProcProfileCollector collects CPU and memory profiles. This value controls how many Java stack frames are captured for each sampled stack: larger values increase trace detail and output size and may add profiling overhead, while smaller values reduce detail. ProcProfileCollector uses this setting when starting the profiler for both CPU and memory profiling, so adjust it to balance diagnostic needs and performance impact.
+- Introduced in: -
+
+##### proc_profile_mem_enable
+
+- Default: true
+- Type: Boolean
+- Unit: -
+- Is mutable: Yes
+- Description: Enable collection of process memory allocation profiles via AsyncProfiler. When true, ProcProfileCollector generates an HTML profile named mem-profile-&lt;timestamp&gt;.html under `sys_log_dir`/proc_profile, sleeps for `proc_profile_collect_time_s` seconds while sampling, and uses `proc_profile_jstack_depth` for Java stack depth. Generated files are compressed and purged according to `proc_profile_file_retained_days` and `proc_profile_file_retained_size_bytes`. The collector adjusts AsyncProfiler's native extraction path using `STARROCKS_HOME_DIR` to avoid /tmp noexec issues. Intended for troubleshooting memory-allocation hotspots; enabling increases CPU, I/O and disk usage and may produce large files.
+- Introduced in: v3.2.12
+
 ##### query_detail_explain_level
 
 - Default: COSTS
@@ -4132,6 +4384,15 @@ Starting from version 3.3.0, the system defaults to refreshing one partition at 
 - Is mutable: Yes
 - Description: The timeout duration for synchronization tasks.
 - Introduced in: v3.3.5
+
+##### skip_whole_phase_lock_mv_limit
+
+- Default: 5
+- Type: Int
+- Unit: -
+- Is mutable: Yes
+- Description: Controls when StarRocks applies the "non-lock" optimization for tables that have related materialized views. When `skip_whole_phase_lock_mv_limit` &lt; 0: always apply non-lock optimization and do not copy related materialized views for queries (reduces FE memory use and metadata copy/lock contention but can increase risk of metadata concurrency issues). When `skip_whole_phase_lock_mv_limit` = 0: disable non-lock optimization (always use the safe, copy-and-lock path). When `skip_whole_phase_lock_mv_limit` &gt; 0: apply non-lock optimization only for tables whose number of related materialized views is &lt;= the configured threshold. Additionally, when the value is &gt;= 0 the planner records query OLAP tables into the optimizer context to enable MV-related rewrite paths; when &lt; 0 that step is skipped.
+- Introduced in: v3.2.1
 
 ##### small_file_dir
 

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -98,30 +98,30 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### bdbje_log_level
 
-- 默认值: INFO
-- 类型: String
-- 单位: -
+- 默认值：INFO
+- 类型：String
+- 单位：-
 - 是否动态：否
-- 描述: 控制 StarRocks 中 BDB JE 使用的日志级别。在 BDB 环境初始化期间，此值将会应用到 `com.sleepycat.je` 包的 Java logger 以及 BDB JE 环境的文件日志级别。有效值：`SEVERE`、`WARNING`、`INFO`、`CONFIG`、`FINE`、`FINER`、`FINEST`、`ALL`、`OFF`。设置为 `ALL` 将启用所有日志消息。增加冗长度会提高日志量，可能影响磁盘 I/O 和性能。
-- 引入版本: v3.2.0
+- 描述：控制 StarRocks 中 BDB JE 使用的日志级别。在 BDB 环境初始化期间，此值将会应用到 `com.sleepycat.je` 包的 Java logger 以及 BDB JE 环境的文件日志级别。有效值：`SEVERE`、`WARNING`、`INFO`、`CONFIG`、`FINE`、`FINER`、`FINEST`、`ALL`、`OFF`。设置为 `ALL` 将启用所有日志消息。增加冗长度会提高日志量，可能影响磁盘 I/O 和性能。
+- 引入版本：v3.2.0
 
 ##### big_query_log_modules
 
-- 默认值: `{"query"}`
-- 类型: String[]
-- 单位: -
+- 默认值：`{"query"}`
+- 类型：String[]
+- 单位：-
 - 是否动态：否
-- 描述: 启用按模块大查询日志的模块名后缀列表。典型值为逻辑组件名称。例如，默认的 `query` 会产生 `big_query.query`。
-- 引入版本: v3.2.0
+- 描述：启用按模块大查询日志的模块名后缀列表。典型值为逻辑组件名称。例如，默认的 `query` 会产生 `big_query.query`。
+- 引入版本：v3.2.0
 
 ##### big_query_log_roll_num
 
-- 默认值: 10
-- 类型: Int
-- 单位: -
+- 默认值：10
+- 类型：Int
+- 单位：-
 - 是否动态：否
-- 描述: 每个 `big_query_log_roll_interval` 周期内要保留的已滚动 FE 大查询日志文件的最大数量。当日志按时间或按 `log_roll_size_mb` 滚动时，StarRocks 最多保留 `big_query_log_roll_num` 个带索引的文件。超过此数量的旧文件可能会被 rollover 删除，且可以通过 `big_query_log_delete_age` 根据最后修改时间进一步删除文件。
-- 引入版本: v3.2.0
+- 描述：每个 `big_query_log_roll_interval` 周期内要保留的已滚动 FE 大查询日志文件的最大数量。当日志按时间或按 `log_roll_size_mb` 滚动时，StarRocks 最多保留 `big_query_log_roll_num` 个带索引的文件。超过此数量的旧文件可能会被 rollover 删除，且可以通过 `big_query_log_delete_age` 根据最后修改时间进一步删除文件。
+- 引入版本：v3.2.0
 
 ##### dump_log_delete_age
 
@@ -172,93 +172,93 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### edit_log_write_slow_log_threshold_ms
 
-- 默认值: 2000
-- 类型: Int
-- 单位: Milliseconds
-- 是否可变: Yes
-- 描述: JournalWriter 用于检测并记录缓慢 edit-log 批量写入的阈值（以毫秒为单位）。在一次批量提交后，如果该批次的持续时间超过此值，JournalWriter 会发出带有批次大小、持续时间和当前 journal 队列大小的 WARN（速率限制为大约每 ~2s 一次）。此设置仅控制 FE leader 上潜在 IO 或复制延迟的日志/告警；它不会更改提交或滚动行为（参见 `edit_log_roll_num` 和与提交相关的设置）。无论此阈值如何，指标更新仍会发生。
-- 引入版本: v3.2.3
+- 默认值：2000
+- 类型：Int
+- 单位：毫秒
+- 是否动态：是
+- 描述：JournalWriter 用于检测并记录缓慢 Edit Log 批量写入的阈值（以毫秒为单位）。在一次批量提交后，如果该批次的持续时间超过此值，JournalWriter 会发出带有批次大小、持续时间和当前 Journal 队列大小的 WARN（速率限制为大约每 ~2s 一次）。此设置仅控制 FE Leader 上潜在 I/O 或复制延迟的日志/告警；它不会更改提交或滚动行为（参见 `edit_log_roll_num` 和与提交相关的设置）。无论此阈值如何，指标更新仍会发生。
+- 引入版本：v3.2.3
 
 ##### enable_audit_sql
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
+- 默认值：true
+- 类型：Boolean
+- 单位：-
 - 是否动态：否
-- 描述: 是否启用 SQL 审计。当此项设置为 `true` 时，FE 审计子系统会将由 ConnectProcessor 处理的语句的 SQL 文本记录到 FE 审计日志（`fe.audit.log`）。存储的语句遵循其他控制：加密语句会被脱敏（`AuditEncryptionChecker`），如果设置了 `enable_sql_desensitize_in_log`，敏感凭据可能会被屏蔽或脱敏，摘要记录由 `enable_sql_digest` 控制。当设置为 `false` 时，ConnectProcessor 会在审计事件中将语句文本替换为 "?" —— 其他审计字段（user、host、duration、status、通过 `qe_slow_log_ms` 检测的慢查询以及指标）仍然会被记录。启用 SQL 审计可以提高取证和故障排查的可见性，但可能暴露敏感的 SQL 内容并增加日志量和 I/O；禁用它可提高隐私，但代价是审计日志中失去完整语句的可见性。
-- 引入版本: -
+- 描述：是否启用 SQL 审计。当此项设置为 `true` 时，FE 审计子系统会将由 ConnectProcessor 处理的语句的 SQL 文本记录到 FE 审计日志（`fe.audit.log`）。存储的语句遵循其他控制：加密语句会被脱敏（`AuditEncryptionChecker`），如果设置了 `enable_sql_desensitize_in_log`，敏感凭据可能会被屏蔽或脱敏，摘要记录由 `enable_sql_digest` 控制。当设置为 `false` 时，ConnectProcessor 会在审计事件中将语句文本替换为 "?" —— 其他审计字段（user、host、duration、status、通过 `qe_slow_log_ms` 检测的慢查询以及指标）仍然会被记录。启用 SQL 审计可以提高取证和故障排查的可见性，但可能暴露敏感的 SQL 内容并增加日志量和 I/O；禁用它可提高隐私，但代价是审计日志中失去完整语句的可见性。
+- 引入版本：-
 
 ##### enable_profile_log
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: 否
-- 描述: 是否启用 profile 日志。当此功能启用时，FE 会将每个查询的 profile 日志（由 `ProfileManager` 生成并序列化的 `queryDetail` JSON）写入 profile log sink。只有在 `enable_collect_query_detail_info` 也启用时才会执行此日志记录；当启用 `enable_profile_log_compress` 时，JSON 可能会在记录前进行 gzip 压缩。profile 日志文件由 `profile_log_dir`、`profile_log_roll_num`、`profile_log_roll_interval` 管理，并根据 `profile_log_delete_age` 进行轮转/删除（支持 `7d`、`10h`、`60m`、`120s` 等格式）。禁用此功能会停止写入 profile 日志（从而减少磁盘 I/O、压缩 CPU 和存储使用）。
-- 引入版本: v3.2.5
+- 默认值：True
+- 类型：Boolean
+- 单位：-
+- 是否动态：否
+- 描述：是否启用 Profile 日志。当此功能启用时，FE 会将每个查询的 Profile 日志（由 `ProfileManager` 生成并序列化的 `queryDetail` JSON）写入 Profile Log Sink。只有在 `enable_collect_query_detail_info` 也启用时才会执行此日志记录；当启用 `enable_profile_log_compress` 时，JSON 可能会在记录前进行 gzip 压缩。Profile 日志文件由 `profile_log_dir`、`profile_log_roll_num`、`profile_log_roll_interval` 管理，并根据 `profile_log_delete_age` 进行轮转/删除（支持 `7d`、`10h`、`60m`、`120s` 等格式）。禁用此功能会停止写入 Profile 日志（从而减少磁盘 I/O、压缩 CPU 和存储使用）。
+- 引入版本：v3.2.5
 
 ##### enable_qe_slow_log
 
-- 默认值: true
-- 类型: Boolean
-- 单位: N/A
-- 是否可变: 是
-- 描述: 启用后，FE 内置的审计插件 (AuditLogBuilder) 会将测得执行时间（"Time" 字段）超过由 qe_slow_log_ms 配置的阈值的查询事件写入慢查询审计日志（AuditLog.getSlowAudit）。如果禁用，则这些慢查询条目将被抑制（常规查询和连接审计日志不受影响）。慢审计条目遵循全局 audit_log_json_format 设置（JSON 与纯字符串）。使用此标志可以独立于常规审计日志控制慢查询审计的生成；当 qe_slow_log_ms 较低或工作负载产生大量长时间运行查询时，关闭它可能减少日志 I/O。
-- 引入版本: 3.2.11
+- 默认值：True
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：启用后，FE 内置的审计插件会将测得执行时间（"Time" 字段）超过由 `qe_slow_log_ms` 配置的阈值的查询事件写入慢查询审计日志。如果禁用，则这些慢查询条目将被抑制（常规查询和连接审计日志不受影响）。慢审计条目遵循全局 `audit_log_json_format` 设置。使用此标志可以独立于常规审计日志控制慢查询审计的生成；当 `qe_slow_log_ms` 较低或工作负载产生大量长时间运行查询时，关闭它可能减少日志 I/O。
+- 引入版本：3.2.11
 
 ##### enable_sql_desensitize_in_log
 
-- 默认值: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: 否
-- 描述: 当此项设置为 `true` 时，系统在将 SQL 写入日志和 query-detail 记录之前会替换或隐藏敏感的 SQL 内容。遵循此配置的代码路径包括 ConnectProcessor.formatStmt（审计日志）、StmtExecutor.addRunningQueryDetail（查询详情）和 SimpleExecutor.formatSQL（内部执行器日志）。启用该功能后，非法的 SQL 可能会被替换为固定的脱敏消息，凭证（user/password）会被隐藏，并且要求 SQL 格式化器生成已清理的表示（也可以启用 digest 风格的输出）。这可以减少审计/内部日志中敏感字面量和凭证的泄露，但也意味着日志和查询详情不再包含原始完整的 SQL 文本（可能影响重放或调试）。
-- 引入版本: -
+- 默认值：False
+- 类型：Boolean
+- 单位：-
+- 是否动态：否
+- 描述：当此项设置为 `true` 时，系统在将 SQL 写入日志和 Query Detail 记录之前会替换或隐藏敏感的 SQL 内容。遵循此配置的代码路径包括审计日志、查询详情和内部执行器日志。启用该功能后，非法的 SQL 可能会被替换为固定的脱敏消息，凭证（user/password）会被隐藏，并且要求 SQL 格式化器生成已清理的表示（也可以启用 Digest 风格的输出）。这可以减少审计/内部日志中敏感字面量和凭证的泄露，但也意味着日志和查询详情不再包含原始完整的 SQL 文本（可能影响重放或调试）。
+- 引入版本：-
 
 ##### internal_log_dir
 
-- 默认值: `Config.STARROCKS_HOME_DIR + "/log"`
-- 类型: String
-- 单位: -
+- 默认值：`Config.STARROCKS_HOME_DIR + "/log"`
+- 类型：String
+- 单位：-
 - 是否动态：否
-- 描述: FE 日志子系统用于存放内部日志（`fe.internal.log`）的目录。此配置会被替换到 Log4j 配置中，用于决定 InternalFile appender 将内部/物化视图/统计日志写入何处，以及 `internal.<module>` 下的各模块 logger 将其文件放置到哪里。请确保该目录存在、可写且有足够的磁盘空间。该目录中文件的日志轮转与保留由 `log_roll_size_mb`、`internal_log_roll_num`、`internal_log_delete_age` 和 `internal_log_roll_interval` 控制。如果启用了 `sys_log_to_console`，内部日志可能会写到控制台而不是该目录。
-- 引入版本: v3.2.4
+- 描述：FE 日志子系统用于存放内部日志（`fe.internal.log`）的目录。此配置会被替换到 Log4j 配置中，用于决定 InternalFile appender 将内部/物化视图/统计日志写入何处，以及 `internal.<module>` 下的各模块 logger 将其文件放置到哪里。请确保该目录存在、可写且有足够的磁盘空间。该目录中文件的日志轮转与保留由 `log_roll_size_mb`、`internal_log_roll_num`、`internal_log_delete_age` 和 `internal_log_roll_interval` 控制。如果启用了 `sys_log_to_console`，内部日志可能会写到控制台而不是该目录。
+- 引入版本：v3.2.4
 
 ##### internal_log_json_format
 
-- 默认值: false
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 当 `internal_log_json_format` 为 true 时，AuditInternalLog.handleInternalLog 发出的内部统计/审计条目会作为紧凑的 JSON 对象写入 statistic audit logger。该 JSON 包含键 "executeType"（InternalType: QUERY 或 DML）、"queryId"、"sql" 和 "time"（耗时毫秒）。当为 false 时，相同的信息作为单行格式化文本记录（"statistic execute: ... | QueryId: [...] | SQL: ..."）。启用 JSON 有利于机器解析和与日志处理器的集成，但也会在日志中包含原始 SQL 文本，可能暴露敏感信息并增加日志大小。
-- 引入版本: -
+- 默认值：False
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：当 `internal_log_json_format` 为 true 时，系统发出的内部统计/审计条目会作为紧凑的 JSON 对象写入 Statistic Audit Logger。该 JSON 包含键 "executeType"（InternalType: QUERY 或 DML）、"queryId"、"sql" 和 "time"（耗时毫秒）。当为 false 时，相同的信息作为单行格式化文本记录（"statistic execute: ... | QueryId: [...] | SQL: ..."）。启用 JSON 有利于机器解析和与日志处理器的集成，但也会在日志中包含原始 SQL 文本，可能暴露敏感信息并增加日志大小。
+- 引入版本：-
 
 ##### internal_log_modules
 
-- 默认值: `{"base", "statistic"}`
-- 类型: String[]
-- 单位: -
+- 默认值：`{"base", "statistic"}`
+- 类型：String[]
+- 单位：-
 - 是否动态：否
-- 描述: 一个将接收专用内部日志记录的模块标识符列表。对于每个条目 X，Log4j 会创建一个名为 `internal.&lt;X&gt;` 的 logger，级别为 INFO 且 additivity="false"。这些 logger 会被路由到 internal appender（写入 `fe.internal.log`），当启用 `sys_log_to_console` 时则输出到控制台。根据需要使用简短名称或包片段 —— 精确的 logger 名称将成为 `internal.` + 配置的字符串。内部日志文件的滚动和保留遵循 `internal_log_dir`、`internal_log_roll_num`、`internal_log_delete_age`、`internal_log_roll_interval` 和 `log_roll_size_mb` 的设置。添加模块会将其运行时消息分离到内部 logger 流中，便于调试和审计。
-- 引入版本: v3.2.4
+- 描述：一个将接收专用内部日志记录的模块标识符列表。对于每个条目 X，Log4j 会创建一个名为 `internal.&lt;X&gt;` 的 logger，级别为 INFO 且 additivity="false"。这些 logger 会被路由到 internal appender（写入 `fe.internal.log`），当启用 `sys_log_to_console` 时则输出到控制台。根据需要使用简短名称或包片段 —— 精确的 logger 名称将成为 `internal.` + 配置的字符串。内部日志文件的滚动和保留遵循 `internal_log_dir`、`internal_log_roll_num`、`internal_log_delete_age`、`internal_log_roll_interval` 和 `log_roll_size_mb` 的设置。添加模块会将其运行时消息分离到内部 logger 流中，便于调试和审计。
+- 引入版本：v3.2.4
 
 ##### internal_log_roll_interval
 
-- 默认值: DAY
-- 类型: String
-- 单位: -
+- 默认值：DAY
+- 类型：String
+- 单位：-
 - 是否动态：否
-- 描述: 控制 FE 内部日志 appender 的基于时间的滚动间隔。接受（不区分大小写）的值为 `HOUR` 和 `DAY`。`HOUR` 生成每小时的文件模式 (`"%d{yyyyMMddHH}"`)，`DAY` 生成每日的文件模式 (`"%d{yyyyMMdd}"`)，这些模式由 RollingFile TimeBasedTriggeringPolicy 用于命名旋转后的 `fe.internal.log` 文件。无效的值会导致初始化失败（在构建活动 Log4j 配置时会抛出 IOException）。滚动行为还取决于相关设置，例如 `internal_log_dir`、`internal_roll_maxsize`、`internal_log_roll_num` 和 `internal_log_delete_age`。
-- 引入版本: v3.2.4
+- 描述：控制 FE 内部日志 appender 的基于时间的滚动间隔。接受（不区分大小写）的值为 `HOUR` 和 `DAY`。`HOUR` 生成每小时的文件模式 (`"%d{yyyyMMddHH}"`)，`DAY` 生成每日的文件模式 (`"%d{yyyyMMdd}"`)，这些模式由 RollingFile TimeBasedTriggeringPolicy 用于命名旋转后的 `fe.internal.log` 文件。无效的值会导致初始化失败（在构建活动 Log4j 配置时会抛出 IOException）。滚动行为还取决于相关设置，例如 `internal_log_dir`、`internal_roll_maxsize`、`internal_log_roll_num` 和 `internal_log_delete_age`。
+- 引入版本：v3.2.4
 
 ##### internal_log_roll_num
 
-- 默认值: 90
-- 类型: Int
-- 单位: -
+- 默认值：90
+- 类型：Int
+- 单位：-
 - 是否动态：否
-- 描述: 内部 appender（`fe.internal.log`）保留的最大已滚动内部 FE 日志文件数。该值作为 Log4j DefaultRolloverStrategy 的 `max` 属性使用；在发生滚动时，StarRocks 会保留最多 `internal_log_roll_num` 个归档文件并删除更旧的文件（也受 `internal_log_delete_age` 控制）。较低的值可减少磁盘使用但缩短日志历史；较高的值可保留更多历史内部日志。该项与 `internal_log_dir`、`internal_log_roll_interval` 和 `internal_roll_maxsize` 配合工作。
-- 引入版本: v3.2.4
+- 描述：内部 appender（`fe.internal.log`）保留的最大已滚动内部 FE 日志文件数。该值作为 Log4j DefaultRolloverStrategy 的 `max` 属性使用；在发生滚动时，StarRocks 会保留最多 `internal_log_roll_num` 个归档文件并删除更旧的文件（也受 `internal_log_delete_age` 控制）。较低的值可减少磁盘使用但缩短日志历史；较高的值可保留更多历史内部日志。该项与 `internal_log_dir`、`internal_log_roll_interval` 和 `internal_roll_maxsize` 配合工作。
+- 引入版本：v3.2.4
 
 ##### log_cleaner_audit_log_min_retention_days
 
@@ -316,75 +316,75 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### profile_log_delete_age
 
-- 默认值: 1d
-- 类型: String
-- 单位: -
-- 是否可变: 否
-- 描述: 控制 FE profile 日志文件在可删除之前保留的时长。该值被注入到 Log4j 的 `&lt;IfLastModified age="..."/&gt;` 策略（通过 `Log4jConfig`）中，并与诸如 `profile_log_roll_interval` 和 `profile_log_roll_num` 的轮转设置一起生效。支持的后缀：`d`（天）、`h`（小时）、`m`（分钟）、`s`（秒）。例如：`7d`（7 天）、`10h`（10 小时）、`60m`（60 分钟）、`120s`（120 秒）。
-- 引入版本: v3.2.5
+- 默认值：1d
+- 类型：String
+- 单位：-
+- 是否动态：否
+- 描述：控制 FE profile 日志文件在可删除之前保留的时长。该值被注入到 Log4j 的 `&lt;IfLastModified age="..."/&gt;` 策略（通过 `Log4jConfig`）中，并与诸如 `profile_log_roll_interval` 和 `profile_log_roll_num` 的轮转设置一起生效。支持的后缀：`d`（天）、`h`（小时）、`m`（分钟）、`s`（秒）。例如：`7d`（7 天）、`10h`（10 小时）、`60m`（60 分钟）、`120s`（120 秒）。
+- 引入版本：v3.2.5
 
 ##### profile_log_dir
 
-- 默认值: `Config.STARROCKS_HOME_DIR + "/log"`
-- 类型: String
-- 单位: -
+- 默认值：`Config.STARROCKS_HOME_DIR + "/log"`
+- 类型：String
+- 单位：-
 - 是否动态：否
-- 描述: FE profile 日志写入的目录路径。`Log4jConfig` 使用此值来放置与 profile 相关的 appender（在该目录下创建类似 `fe.profile.log` 和 `fe.features.log` 的文件）。这些文件的轮换和保留由 `profile_log_roll_size_mb`、`profile_log_roll_num` 和 `profile_log_delete_age` 控制；时间戳后缀格式由 `profile_log_roll_interval` 控制（支持 DAY 或 HOUR）。由于默认值位于 `STARROCKS_HOME_DIR` 内，请确保 FE 进程对该目录具有写入及轮换/删除权限。
-- 引入版本: v3.2.5
+- 描述：FE profile 日志写入的目录路径。`Log4jConfig` 使用此值来放置与 profile 相关的 appender（在该目录下创建类似 `fe.profile.log` 和 `fe.features.log` 的文件）。这些文件的轮换和保留由 `profile_log_roll_size_mb`、`profile_log_roll_num` 和 `profile_log_delete_age` 控制；时间戳后缀格式由 `profile_log_roll_interval` 控制（支持 DAY 或 HOUR）。由于默认值位于 `STARROCKS_HOME_DIR` 内，请确保 FE 进程对该目录具有写入及轮换/删除权限。
+- 引入版本：v3.2.5
 
 ##### profile_log_roll_interval
 
-- 默认值: DAY
-- 类型: String
-- 单位: -
-- 是否可变: 否
-- 描述: 控制用于生成 profile 日志文件名中日期部分的时间粒度。合法值（不区分大小写）为 `HOUR` 和 `DAY`。`HOUR` 会产生 `"%d{yyyyMMddHH}"` 模式（按小时分桶），`DAY` 会产生 `"%d{yyyyMMdd}"`（按天分桶）。该值在计算 Log4j 配置中的 `profile_file_pattern` 时使用，仅影响基于时间的轮转文件名部分；基于大小的轮转仍由 `profile_log_roll_size_mb` 控制，保留由 `profile_log_roll_num` / `profile_log_delete_age` 控制。无效值会在日志初始化期间引发 IOException（错误信息："profile_log_roll_interval config error: <value>"）。对于高流量的 profiling 场景请选择 `HOUR` 以限制每小时每文件大小，或选择 `DAY` 进行日级聚合。
-- 引入版本: v3.2.5
+- 默认值：DAY
+- 类型：String
+- 单位：-
+- 是否动态：否
+- 描述：控制用于生成 Profile 日志文件名中日期部分的时间粒度。有效值（不区分大小写）为 `HOUR` 和 `DAY`。`HOUR` 模式会产生 `"%d{yyyyMMddHH}"`（按小时分桶），`DAY` 模式会产生 `"%d{yyyyMMdd}"`（按天分桶）。该值在计算 Log4j 配置中的 `profile_file_pattern` 时使用，仅影响基于时间的轮转文件名部分；基于大小的轮转仍由 `profile_log_roll_size_mb` 控制，保留行为由 `profile_log_roll_num` / `profile_log_delete_age` 控制。无效值会在日志初始化期间引发 IOException（Error Message: "profile_log_roll_interval config error: <value>"）。对于高流量的 Profiling 场景请选择 `HOUR` 以限制每小时每文件大小，或选择 `DAY` 进行日级聚合。
+- 引入版本：v3.2.5
 
 ##### profile_log_roll_num
 
-- 默认值: 5
-- 类型: Int
-- 单位: Number of files
+- 默认值：5
+- 类型：Int
+- 单位：Number of files
 - 是否动态：否
-- 描述: 指定 Log4j 的 DefaultRolloverStrategy 为 profile logger 保留的最大轮换 profile 日志文件数。该值会作为 `${profile_log_roll_num}` 注入到日志 XML 中（例如 `&lt;DefaultRolloverStrategy max="${profile_log_roll_num}" fileIndex="min"&gt;`）。轮换由 `profile_log_roll_size_mb` 或 `profile_log_roll_interval` 触发；发生轮换时，Log4j 最多保留这么多带索引的文件，较旧的索引文件将成为可删除对象。磁盘上的实际保留还受 `profile_log_delete_age` 和 `profile_log_dir` 位置的影响。较低的值可降低磁盘使用，但限制可保留的历史；较高的值则保留更多历史 profile 日志。
-- 引入版本: v3.2.5
+- 描述：指定 Log4j 的 DefaultRolloverStrategy 为 profile logger 保留的最大轮换 profile 日志文件数。该值会作为 `${profile_log_roll_num}` 注入到日志 XML 中（例如 `&lt;DefaultRolloverStrategy max="${profile_log_roll_num}" fileIndex="min"&gt;`）。轮换由 `profile_log_roll_size_mb` 或 `profile_log_roll_interval` 触发；发生轮换时，Log4j 最多保留这么多带索引的文件，较旧的索引文件将成为可删除对象。磁盘上的实际保留还受 `profile_log_delete_age` 和 `profile_log_dir` 位置的影响。较低的值可降低磁盘使用，但限制可保留的历史；较高的值则保留更多历史 profile 日志。
+- 引入版本：v3.2.5
 
 ##### profile_log_roll_size_mb
 
-- 默认值: 1024
-- 类型: Int
-- 单位: MB
-- 是否可变: 否
-- 描述: 设置触发基于大小的 FE profile 日志文件滚动的阈值（以兆字节为单位）。该值被 Log4j 的 RollingFile SizeBasedTriggeringPolicy 用于 `ProfileFile` appender；当 profile 日志超过 `profile_log_roll_size_mb` 时会发生轮转。达到 `profile_log_roll_interval` 时也会按时间发生轮转 —— 任一条件满足都会触发轮转。结合 `profile_log_roll_num` 和 `profile_log_delete_age` 使用，该项控制保留多少历史 profile 文件以及何时删除旧文件。轮转文件的压缩由 `enable_profile_log_compress` 控制。
-- 引入版本: v3.2.5
+- 默认值：1024
+- 类型：Int
+- 单位：MB
+- 是否动态：否
+- 描述：设置触发基于大小的 FE profile 日志文件滚动的阈值（以兆字节为单位）。该值被 Log4j 的 RollingFile SizeBasedTriggeringPolicy 用于 `ProfileFile` appender；当 profile 日志超过 `profile_log_roll_size_mb` 时会发生轮转。达到 `profile_log_roll_interval` 时也会按时间发生轮转 —— 任一条件满足都会触发轮转。结合 `profile_log_roll_num` 和 `profile_log_delete_age` 使用，该项控制保留多少历史 profile 文件以及何时删除旧文件。轮转文件的压缩由 `enable_profile_log_compress` 控制。
+- 引入版本：v3.2.5
 
 ##### qe_slow_log_ms
 
 - 默认值：5000
 - 类型：Long
-- 单位：Milliseconds
+- 单位：毫秒
 - 是否动态：是
 - 描述：Slow query 的认定时长。如果查询的响应时间超过此阈值，则会在审计日志 `fe.audit.log` 中记录为 slow query。
 - 引入版本：-
 
 ##### slow_lock_log_every_ms
 
-- 默认值: 3000L
-- 类型: Long
-- 单位: 毫秒
-- 是否可变: 是
-- 描述: 在对同一个 SlowLockLogStats 实例再次输出“慢锁”警告之前，至少要等待的最小间隔（毫秒）。当锁等待时间超过 `slow_lock_threshold_ms` 后，LockUtils 会检查此值并在最近一次记录的慢锁事件发生到现在未达到 `slow_lock_log_every_ms` 毫秒时抑制额外警告。在长时间争用期间使用较大的值以减少日志量，或使用较小的值以获取更频繁的诊断信息。更改在运行时对后续检查生效。
-- 引入版本: v3.2.0
+- 默认值：3000L
+- 类型：Long
+- 单位：毫秒
+- 是否动态：是
+- 描述：在对同一个 SlowLockLogStats 实例再次输出“慢锁”警告之前，至少要等待的最小间隔（毫秒）。当锁等待时间超过 `slow_lock_threshold_ms` 后，LockUtils 会检查此值并在最近一次记录的慢锁事件发生到现在未达到 `slow_lock_log_every_ms` 毫秒时抑制额外警告。在长时间争用期间使用较大的值以减少日志量，或使用较小的值以获取更频繁的诊断信息。更改在运行时对后续检查生效。
+- 引入版本：v3.2.0
 
 ##### slow_lock_threshold_ms
 
-- 默认值: 3000L
-- 类型: long
-- 单位: 毫秒
-- 是否可变: 是
-- 描述: 用于将一个锁操作或持有的锁归类为“慢”的阈值（毫秒）。当锁的等待时间或持有时间超过此值时，StarRocks 将（视上下文）输出诊断日志、包含堆栈跟踪或 waiter/owner 信息，并且在 LockManager 中在该延迟后启动死锁检测。此配置由 LockUtils（慢锁日志）、QueryableReentrantReadWriteLock（筛选慢读取者）、LockManager（死锁检测延迟和慢锁跟踪）、LockChecker（周期性慢锁检测）以及其他调用方（例如 DiskAndTabletLoadReBalancer 日志）使用。降低该值会提高敏感度并增加日志/诊断开销；将其设置为 0 或负值会禁用基于初始等待的死锁检测延迟行为。请与 `slow_lock_log_every_ms`、`slow_lock_print_stack` 和 `slow_lock_stack_trace_reserve_levels` 一起调整。
-- 引入版本: 3.2.0
+- 默认值：3000L
+- 类型：long
+- 单位：毫秒
+- 是否动态：是
+- 描述：用于将一个锁操作或持有的锁归类为“慢”的阈值（毫秒）。当锁的等待时间或持有时间超过此值时，StarRocks 将（视上下文）输出诊断日志、包含堆栈跟踪或 waiter/owner 信息，并且在 LockManager 中在该延迟后启动死锁检测。此配置由 LockUtils（慢锁日志）、QueryableReentrantReadWriteLock（筛选慢读取者）、LockManager（死锁检测延迟和慢锁跟踪）、LockChecker（周期性慢锁检测）以及其他调用方（例如 DiskAndTabletLoadReBalancer 日志）使用。降低该值会提高敏感度并增加日志/诊断开销；将其设置为 0 或负值会禁用基于初始等待的死锁检测延迟行为。请与 `slow_lock_log_every_ms`、`slow_lock_print_stack` 和 `slow_lock_stack_trace_reserve_levels` 一起调整。
+- 引入版本：3.2.0
 
 ##### sys_log_delete_age
 
@@ -406,39 +406,39 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### sys_log_enable_compress
 
-- 默认值: false
-- 类型: boolean
-- 单位: -
+- 默认值：false
+- 类型：boolean
+- 单位：-
 - 是否动态：否
-- 描述: 当此项设置为 `true` 时，系统会在轮转的系统日志文件名后追加 ".gz" 后缀，从而使 Log4j 在轮转时生成 gzip 压缩的 FE 系统日志（例如，`fe.log.*`）。此值在生成 Log4j 配置时读取（Log4jConfig.initLogging / generateActiveLog4jXmlConfig），并控制用于 RollingFile filePattern 的 `sys_file_postfix` 属性。启用此功能可减少保留日志的磁盘占用，但会在轮转期间增加 CPU 和 I/O 开销，并改变日志文件名，因此读取日志的工具或脚本必须能够处理 .gz 文件。注意，审计日志使用单独的压缩配置，即 `audit_log_enable_compress`。
-- 引入版本: v3.2.12
+- 描述：当此项设置为 `true` 时，系统会在轮转的系统日志文件名后追加 ".gz" 后缀，从而使 Log4j 在轮转时生成 gzip 压缩的 FE 系统日志（例如，`fe.log.*`）。此值在生成 Log4j 配置时读取（Log4jConfig.initLogging / generateActiveLog4jXmlConfig），并控制用于 RollingFile filePattern 的 `sys_file_postfix` 属性。启用此功能可减少保留日志的磁盘占用，但会在轮转期间增加 CPU 和 I/O 开销，并改变日志文件名，因此读取日志的工具或脚本必须能够处理 .gz 文件。注意，审计日志使用单独的压缩配置，即 `audit_log_enable_compress`。
+- 引入版本：v3.2.12
 
 ##### sys_log_format
 
-- 默认值: "plaintext"
-- 类型: String
-- 单位: -
+- 默认值："plaintext"
+- 类型：String
+- 单位：-
 - 是否动态：否
-- 描述: 选择用于 FE 日志的 Log4j layout。有效值：`"plaintext"`（默认）和 `"json"`。值不区分大小写。`"plaintext"` 配置 PatternLayout，包含可读的时间戳、级别、线程、class.method:line 以及 WARN/ERROR 的堆栈跟踪。`"json"` 配置 JsonTemplateLayout，输出结构化 JSON 事件（UTC 时间戳、级别、线程 id/name、源文件/方法/行、消息、异常 stackTrace），适合日志聚合器（ELK、Splunk）。JSON 输出遵守 `sys_log_json_max_string_length` 和 `sys_log_json_profile_max_string_length` 关于最大字符串长度的限制。
-- 引入版本: v3.2.10
+- 描述：选择用于 FE 日志的 Log4j layout。有效值：`"plaintext"`（默认）和 `"json"`。值不区分大小写。`"plaintext"` 配置 PatternLayout，包含可读的时间戳、级别、线程、class.method:line 以及 WARN/ERROR 的堆栈跟踪。`"json"` 配置 JsonTemplateLayout，输出结构化 JSON 事件（UTC 时间戳、级别、线程 id/name、源文件/方法/行、消息、异常 stackTrace），适合日志聚合器（ELK、Splunk）。JSON 输出遵守 `sys_log_json_max_string_length` 和 `sys_log_json_profile_max_string_length` 关于最大字符串长度的限制。
+- 引入版本：v3.2.10
 
 ##### sys_log_json_max_string_length
 
-- 默认值: 1048576
-- 类型: Int
-- 单位: Bytes
-- 是否可变: 否
-- 描述: 设置用于系统 JSON 格式系统日志的 JsonTemplateLayout 的 "maxStringLength" 值。当 `sys_log_format` 被设置为 `"json"` 时，如果字符串类型字段（例如 "message" 和字符串化的异常堆栈跟踪）的长度超过此限制则会被截断。该值在 `Log4jConfig.generateActiveLog4jXmlConfig()` 中注入到生成的 Log4j XML，并应用于 default、warning、audit、dump 和 bigquery 布局；Profile 布局使用单独的配置（`sys_log_json_profile_max_string_length`）。降低此值可减少日志大小，但可能截断有用信息。由于此设置不可变，更改需要重启或重新配置负责重新生成 Log4j 配置的进程。
-- 引入版本: v3.2.11
+- 默认值：1048576
+- 类型：Int
+- 单位：Bytes
+- 是否动态：否
+- 描述：设置用于系统 JSON 格式系统日志的 JsonTemplateLayout 的 "maxStringLength" 值。当 `sys_log_format` 被设置为 `"json"` 时，如果字符串类型字段（例如 "message" 和字符串化的异常堆栈跟踪）的长度超过此限制则会被截断。该值在 `Log4jConfig.generateActiveLog4jXmlConfig()` 中注入到生成的 Log4j XML，并应用于 default、warning、audit、dump 和 bigquery 布局；Profile 布局使用单独的配置（`sys_log_json_profile_max_string_length`）。降低此值可减少日志大小，但可能截断有用信息。由于此设置不可变，更改需要重启或重新配置负责重新生成 Log4j 配置的进程。
+- 引入版本：v3.2.11
 
 ##### sys_log_json_profile_max_string_length
 
-- 默认值: 104857600 (100 MB)
-- 类型: Int
-- 单位: Bytes
-- 是否可变: 否
-- 描述: 当 `sys_log_format` 为 `"json"` 时，为 Profile（及相关功能）日志 Appender 设置 JsonTemplateLayout 的 maxStringLength。JSON 格式的 Profile 日志中的字符串字段值将被截断到此字节长度；非字符串字段不受影响。此设置在 Log4jConfig（JsonTemplateLayout 的 maxStringLength）中应用，在使用纯文本日志时被忽略。请将值设置为能够包含所需完整消息的足够大值，但注意过大的值会增加日志大小和 I/O。
-- 引入版本: v3.2.11
+- 默认值：104857600 (100 MB)
+- 类型：Int
+- 单位：Bytes
+- 是否动态：否
+- 描述：当 `sys_log_format` 为 `"json"` 时，为 Profile（及相关功能）日志 Appender 设置 JsonTemplateLayout 的 maxStringLength。JSON 格式的 Profile 日志中的字符串字段值将被截断到此字节长度；非字符串字段不受影响。此设置在 Log4jConfig（JsonTemplateLayout 的 maxStringLength）中应用，在使用纯文本日志时被忽略。请将值设置为能够包含所需完整消息的足够大值，但注意过大的值会增加日志大小和 I/O。
+- 引入版本：v3.2.11
 
 ##### sys_log_level
 
@@ -471,12 +471,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### sys_log_to_console
 
-- 默认值: false (除非环境变量 `SYS_LOG_TO_CONSOLE` 被设置为 "1")
-- 类型: Boolean
-- 单位: -
+- 默认值：false (除非环境变量 `SYS_LOG_TO_CONSOLE` 被设置为 "1")
+- 类型：Boolean
+- 单位：-
 - 是否动态：否
-- 描述: 当此项设置为 `true` 时，系统会配置 Log4j 将所有日志发送到控制台（ConsoleErr appender），而不是基于文件的 appender。该值在生成活动的 Log4j XML 配置时读取（影响 root logger 和按模块的 logger appender 选择）。其值在进程启动时从环境变量 `SYS_LOG_TO_CONSOLE` 捕获。运行时更改不会生效。该配置常用于容器化或 CI 环境，在这些环境中更偏向于通过 stdout/stderr 收集日志而不是写入日志文件。
-- 引入版本: v3.2.0
+- 描述：当此项设置为 `true` 时，系统会配置 Log4j 将所有日志发送到控制台（ConsoleErr appender），而不是基于文件的 appender。该值在生成活动的 Log4j XML 配置时读取（影响 root logger 和按模块的 logger appender 选择）。其值在进程启动时从环境变量 `SYS_LOG_TO_CONSOLE` 捕获。运行时更改不会生效。该配置常用于容器化或 CI 环境，在这些环境中更偏向于通过 stdout/stderr 收集日志而不是写入日志文件。
+- 引入版本：v3.2.0
 
 ##### sys_log_verbose_modules
 
@@ -489,12 +489,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### sys_log_warn_modules
 
-- 默认值: `{}`
-- 类型: String[]
-- 单位: -
+- 默认值：`{}`
+- 类型：String[]
+- 单位：-
 - 是否动态：否
-- 描述: 一个记录器名称或包前缀列表，系统在启动时会将其配置为 WARN 级别的记录器并路由到警告 appender（SysWF）— 即 `fe.warn.log` 文件。条目会被插入到生成的 Log4j 配置中（与内置的 warn 模块一起，例如 org.apache.kafka、org.apache.hudi 和 org.apache.hadoop.io.compress），并生成类似 `<Logger name="... " level="WARN"><AppenderRef ref="SysWF"/></Logger>` 的 logger 元素。建议使用完全限定的包和类前缀（例如 "com.example.lib"）来抑制在常规日志中产生噪声的 INFO/DEBUG 输出，并允许将警告单独捕获。
-- 引入版本: v3.2.13
+- 描述：一个记录器名称或包前缀列表，系统在启动时会将其配置为 WARN 级别的记录器并路由到警告 appender（SysWF）— 即 `fe.warn.log` 文件。条目会被插入到生成的 Log4j 配置中（与内置的 warn 模块一起，例如 org.apache.kafka、org.apache.hudi 和 org.apache.hadoop.io.compress），并生成类似 `<Logger name="... " level="WARN"><AppenderRef ref="SysWF"/></Logger>` 的 logger 元素。建议使用完全限定的包和类前缀（例如 "com.example.lib"）来抑制在常规日志中产生噪声的 INFO/DEBUG 输出，并允许将警告单独捕获。
+- 引入版本：v3.2.13
 
 ### 服务器
 
@@ -563,12 +563,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### http_max_initial_line_length
 
-- 默认值: `4096`
-- 类型: Int
-- 单位: Bytes
-- 是否可变: 否
-- 描述: 设置由 HttpServer 中使用的 Netty `HttpServerCodec` 接受的 HTTP 初始请求行（method + request-target + HTTP version）的最大允许长度（字节）。该值会传递给 Netty 的解码器，初始行长度超过此值的请求将被拒绝（TooLongFrameException）。仅在必须支持非常长的请求 URI 时才增大此值；更大的值会增加内存使用并可能提高对畸形请求或滥用请求的暴露面。应与 `http_max_header_size` 和 `http_max_chunk_size` 一起调整。
-- 引入版本: `v3.2.0`
+- 默认值：`4096`
+- 类型：Int
+- 单位：Bytes
+- 是否动态：否
+- 描述：设置由 HttpServer 中使用的 Netty `HttpServerCodec` 接受的 HTTP 初始请求行（method + request-target + HTTP version）的最大允许长度（字节）。该值会传递给 Netty 的解码器，初始行长度超过此值的请求将被拒绝（TooLongFrameException）。仅在必须支持非常长的请求 URI 时才增大此值；更大的值会增加内存使用并可能提高对畸形请求或滥用请求的暴露面。应与 `http_max_header_size` 和 `http_max_chunk_size` 一起调整。
+- 引入版本：`v3.2.0`
 
 ##### http_port
 
@@ -608,12 +608,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### memory_tracker_interval_seconds
 
-- 默认值: 60
-- 类型: long
-- 单位: Seconds
-- 是否可变: Yes
-- 描述: FE MemoryUsageTracker 守护线程轮询并记录 FE 进程和已注册 MemoryTrackable 模块内存使用情况的时间间隔（以秒为单位）。该值会转换为毫秒（乘以 1000L）以设置守护线程间隔。当 `memory_tracker_enable` 为 true 时，tracker 按此节奏运行，更新 MEMORY_USAGE，并记录聚合的 JVM 与被跟踪模块的使用情况。由于守护线程在运行循环中调用 setInterval，对 `memory_tracker_interval_seconds` 的更新将在下一个预定迭代时在运行时生效，无需重启进程。
-- 引入版本: v3.2.4
+- 默认值：60
+- 类型：Int
+- 单位：Seconds
+- 是否动态：是
+- 描述：FE MemoryUsageTracker 守护线程轮询并记录 FE 进程和已注册 MemoryTrackable 模块内存使用情况的时间间隔（以秒为单位）。当 `memory_tracker_enable` 为 `true` 时，tracker 按此节奏运行，更新 MEMORY_USAGE，并记录聚合的 JVM 与被跟踪模块的使用情况。
+- 引入版本：v3.2.4
 
 ##### mysql_nio_backlog_num
 
@@ -647,12 +647,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### mysql_service_nio_enable_keep_alive
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: 否
-- 描述: 是否为 MySQL 连接启用 TCP Keep-Alive。适用于位于负载均衡器后且长时间空闲的连接。
-- 引入版本: -
+- 默认值：true
+- 类型：Boolean
+- 单位：-
+- 是否动态：否
+- 描述：是否为 MySQL 连接启用 TCP Keep-Alive。适用于位于负载均衡器后且长时间空闲的连接。
+- 引入版本：-
 
 ##### net_use_ipv6_when_priority_networks_empty
 
@@ -701,21 +701,21 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### ssl_cipher_blacklist
 
-- 默认值: Empty string
-- 类型: String
-- 单位: -
+- 默认值：Empty string
+- 类型：String
+- 单位：-
 - 是否动态：否
 - 描述:基于 IANA 名称的 SSL 密文 Suite 黑名单，多项以逗号分隔，支持正则表达式。如果同时设置了白名单和黑名单，则黑名单优先。
-- 引入版本: v4.0
+- 引入版本：v4.0
 
 ##### ssl_cipher_whitelist
 
-- 默认值: Empty string
-- 类型: String
-- 单位: -
+- 默认值：Empty string
+- 类型：String
+- 单位：-
 - 是否动态：否
-- 描述: 基于 IANA 名称的 SSL 密文 Suite 白名单，多项以逗号分隔，支持正则表达式。如果同时设置了白名单和黑名单，则黑名单优先。
-- 引入版本: v4.0
+- 描述：基于 IANA 名称的 SSL 密文 Suite 白名单，多项以逗号分隔，支持正则表达式。如果同时设置了白名单和黑名单，则黑名单优先。
+- 引入版本：v4.0
 
 ##### thrift_backlog_num
 
@@ -730,19 +730,19 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 - 默认值：5000
 - 类型：Int
-- 单位：Milliseconds
+- 单位：毫秒
 - 是否动态：否
 - 描述：Thrift 客户端链接的空闲超时时间，即链接超过该时间无新请求后则将链接断开。
 - 引入版本：-
 
 ##### thrift_rpc_max_body_size
 
-- 默认值: `-1`
-- 类型: Int
-- 单位: Bytes
+- 默认值：`-1`
+- 类型：Int
+- 单位：Bytes
 - 是否动态：否
-- 描述: 控制在构造服务器的 Thrift 协议（传递给 `ThriftServer` 中的 TBinaryProtocol.Factory）时允许的最大 Thrift RPC 消息体大小（以字节为单位）。值为 `-1` 表示禁用限制（无界）。设置为正值会强制上限，使得超过该大小的消息会被 Thrift 层拒绝，这有助于限制内存使用并降低超大请求或 DoS 风险。请将此值设置为足够大的大小以容纳预期的有效载荷（大型 struct 或批量数据），以避免拒绝合法请求。
-- 引入版本: `v3.2.0`
+- 描述：控制在构造服务器的 Thrift 协议（传递给 `ThriftServer` 中的 TBinaryProtocol.Factory）时允许的最大 Thrift RPC 消息体大小（以字节为单位）。值为 `-1` 表示禁用限制（无界）。设置为正值会强制上限，使得超过该大小的消息会被 Thrift 层拒绝，这有助于限制内存使用并降低超大请求或 DoS 风险。请将此值设置为足够大的大小以容纳预期的有效载荷（大型 struct 或批量数据），以避免拒绝合法请求。
+- 引入版本：`v3.2.0`
 
 ##### thrift_server_max_worker_threads
 
@@ -766,12 +766,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### alter_max_worker_queue_size
 
-- 默认值: `4096`
-- 类型: Int
-- 单位: Tasks
+- 默认值：`4096`
+- 类型：Int
+- 单位：Tasks
 - 是否动态：否
-- 描述: 控制 alter 子系统使用的内部工作线程池队列的容量。该值与 `alter_max_worker_threads` 一起在 `AlterHandler` 中传递给 `ThreadPoolManager.newDaemonCacheThreadPool`。当待处理的 alter 任务数量超过 `alter_max_worker_queue_size` 时，新提交的任务将被拒绝，可能会抛出 `RejectedExecutionException`（参见 `AlterHandler.handleFinishAlterTask`）。调整此值以在内存使用与允许的并发 alter 任务积压量之间取得平衡。
-- 引入版本: `v3.2.0`
+- 描述：控制 alter 子系统使用的内部工作线程池队列的容量。该值与 `alter_max_worker_threads` 一起在 `AlterHandler` 中传递给 `ThreadPoolManager.newDaemonCacheThreadPool`。当待处理的 alter 任务数量超过 `alter_max_worker_queue_size` 时，新提交的任务将被拒绝，可能会抛出 `RejectedExecutionException`（参见 `AlterHandler.handleFinishAlterTask`）。调整此值以在内存使用与允许的并发 alter 任务积压量之间取得平衡。
+- 引入版本：`v3.2.0`
 
 ##### automated_cluster_snapshot_interval_seconds
 
@@ -786,7 +786,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 - 默认值：600000
 - 类型：Int
-- 单位：Milliseconds
+- 单位：毫秒
 - 是否动态：是
 - 描述：接连两次 Hive 元数据缓存刷新之间的间隔。
 - 引入版本：v2.5.5
@@ -829,12 +829,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### bdbje_reserved_disk_size
 
-- 默认值: `512L * 1024 * 1024` (536870912)
-- 类型: Long
-- 单位: Bytes
+- 默认值：`512L * 1024 * 1024` (536870912)
+- 类型：Long
+- 单位：Bytes
 - 是否动态：否
-- 描述: 限制 Berkeley DB JE 将被保留为“未保护”（可删除）的日志/数据文件的字节数。StarRocks 通过 BDBEnvironment 中的 `EnvironmentConfig.RESERVED_DISK` 将此值传递给 JE；JE 的内置默认值为 0（无限制）。StarRocks 的默认值（512 MiB）可防止 JE 为未保护文件保留过多磁盘空间，同时允许安全清理过期文件。在磁盘受限的系统上调整此值：减小它可以让 JE 更早释放文件，增大它可以让 JE 保留更多保留空间。更改需要重启进程才能生效。
-- 引入版本: `v3.2.0`
+- 描述：限制 Berkeley DB JE 将被保留为“未保护”（可删除）的日志/数据文件的字节数。StarRocks 通过 BDBEnvironment 中的 `EnvironmentConfig.RESERVED_DISK` 将此值传递给 JE；JE 的内置默认值为 0（无限制）。StarRocks 的默认值（512 MiB）可防止 JE 为未保护文件保留过多磁盘空间，同时允许安全清理过期文件。在磁盘受限的系统上调整此值：减小它可以让 JE 更早释放文件，增大它可以让 JE 保留更多保留空间。更改需要重启进程才能生效。
+- 引入版本：`v3.2.0`
 
 ##### bdbje_reset_election_group
 
@@ -865,30 +865,30 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### brpc_connection_pool_size
 
-- 默认值: `16`
-- 类型: Int
-- 单位: Connections
+- 默认值：`16`
+- 类型：Int
+- 单位：Connections
 - 是否动态：否
-- 描述: FE 的 BrpcProxy 为每个端点使用的最大池化 BRPC 连接数。此值通过 `setMaxTotoal` 和 `setMaxIdleSize` 应用到 RpcClientOptions，因此它直接限制了并发的出站 BRPC 请求数，因为每个请求都必须从连接池借用一个连接。在高并发场景下增加此值以避免请求排队；增加会提高 socket 和内存使用，并可能增加远端服务器负载。调优时需考虑相关设置，例如 `brpc_idle_wait_max_time`、`brpc_short_connection`、`brpc_inner_reuse_pool`、`brpc_reuse_addr` 和 `brpc_min_evictable_idle_time_ms`。更改此值不会热重载，需要重启生效。
-- 引入版本: `v3.2.0`
+- 描述：FE 的 BrpcProxy 为每个端点使用的最大池化 BRPC 连接数。此值通过 `setMaxTotoal` 和 `setMaxIdleSize` 应用到 RpcClientOptions，因此它直接限制了并发的出站 BRPC 请求数，因为每个请求都必须从连接池借用一个连接。在高并发场景下增加此值以避免请求排队；增加会提高 socket 和内存使用，并可能增加远端服务器负载。调优时需考虑相关设置，例如 `brpc_idle_wait_max_time`、`brpc_short_connection`、`brpc_inner_reuse_pool`、`brpc_reuse_addr` 和 `brpc_min_evictable_idle_time_ms`。更改此值不会热重载，需要重启生效。
+- 引入版本：`v3.2.0`
 
 ##### catalog_try_lock_timeout_ms
 
 - 默认值：5000
 - 类型：Long
-- 单位：Milliseconds
+- 单位：毫秒
 - 是否动态：是
 - 描述：全局锁（Global Lock）获取的超时时长。
 - 引入版本：-
 
 ##### checkpoint_timeout_seconds
 
-- 默认值: `24 * 3600`
-- 类型: Long
-- 单位: 秒
+- 默认值：`24 * 3600`
+- 类型：Long
+- 单位：秒
 - 是否动态：是
-- 描述: leader 的 CheckpointController 在等待某个 checkpoint worker 完成 checkpoint 时的最长等待时间（单位：秒）。控制器会将该值转换为纳秒并轮询 worker 的结果队列；如果在此超时时间内未收到成功完成，则将该 checkpoint 视为失败，createImage 返回失败。增大此值可以容纳运行时间更长的 checkpoint，但会延迟失败检测及随后镜像传播；减小此值可以更快触发故障转移/重试，但可能对较慢的 worker 产生误超时。此设置仅控制 CheckpointController 在创建 checkpoint 时的等待时长，不会改变 worker 的内部 checkpoint 行为。
-- 引入版本: `v3.4.0, v3.5.0`
+- 描述：leader 的 CheckpointController 在等待某个 checkpoint worker 完成 checkpoint 时的最长等待时间（单位：秒）。控制器会将该值转换为纳秒并轮询 worker 的结果队列；如果在此超时时间内未收到成功完成，则将该 checkpoint 视为失败，createImage 返回失败。增大此值可以容纳运行时间更长的 checkpoint，但会延迟失败检测及随后镜像传播；减小此值可以更快触发故障转移/重试，但可能对较慢的 worker 产生误超时。此设置仅控制 CheckpointController 在创建 checkpoint 时的等待时长，不会改变 worker 的内部 checkpoint 行为。
+- 引入版本：`v3.4.0, v3.5.0`
 
 ##### db_used_data_quota_update_interval_secs
 
@@ -955,12 +955,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### enable_internal_sql
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
+- 默认值：true
+- 类型：Boolean
+- 单位：-
 - 是否动态：否
-- 描述: 当此项设置为 `true` 时，内部组件（例如 SimpleExecutor）执行的内部 SQL 语句会被保留并写入内部审计或日志消息（如果设置了 `enable_sql_desensitize_in_log`，还可以进一步脱敏）。当设置为 `false` 时，内部 SQL 文本会被压制：格式化代码（`SimpleExecutor.formatSQL`）返回 "?"，实际语句不会输出到内部审计或日志消息。此配置不会改变内部语句的执行语义，仅控制内部 SQL 的日志记录和可见性以保护隐私或安全。
-- 引入版本: -
+- 描述：当此项设置为 `true` 时，内部组件（例如 SimpleExecutor）执行的内部 SQL 语句会被保留并写入内部审计或日志消息（如果设置了 `enable_sql_desensitize_in_log`，还可以进一步脱敏）。当设置为 `false` 时，内部 SQL 文本会被压制：格式化代码（`SimpleExecutor.formatSQL`）返回 "?"，实际语句不会输出到内部审计或日志消息。此配置不会改变内部语句的执行语义，仅控制内部 SQL 的日志记录和可见性以保护隐私或安全。
+- 引入版本：-
 
 ##### enable_legacy_compatibility_for_replication
 
@@ -994,21 +994,21 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### enable_task_history_archive
 
-- 默认值: `true`
-- 类型: Boolean
-- 单位: -
+- 默认值：`true`
+- 类型：Boolean
+- 单位：-
 - 是否动态：是
-- 描述: 启用后，已完成的 task-run 记录会归档到持久化的 task-run history 表，并记录到 edit log，这样查找（例如 `lookupHistory`、`lookupHistoryByTaskNames`、`lookupLastJobOfTasks`）会包含归档结果。归档由 FE leader 执行，在单元测试期间会跳过（`FeConstants.runningUnitTest`）。启用时，会绕过内存过期和强制 GC 路径（代码会在 `removeExpiredRuns` 和 `forceGC` 中提前返回），因此保留/驱逐由持久化归档处理，而不是由 `task_runs_ttl_second` 和 `task_runs_max_history_number` 控制。禁用时，历史保留在内存中并由这些配置进行裁剪。
-- 引入版本: v3.3.1, v3.4.0, v3.5.0
+- 描述：启用后，已完成的 task-run 记录会归档到持久化的 task-run history 表，并记录到 edit log，这样查找（例如 `lookupHistory`、`lookupHistoryByTaskNames`、`lookupLastJobOfTasks`）会包含归档结果。归档由 FE leader 执行，在单元测试期间会跳过（`FeConstants.runningUnitTest`）。启用时，会绕过内存过期和强制 GC 路径（代码会在 `removeExpiredRuns` 和 `forceGC` 中提前返回），因此保留/驱逐由持久化归档处理，而不是由 `task_runs_ttl_second` 和 `task_runs_max_history_number` 控制。禁用时，历史保留在内存中并由这些配置进行裁剪。
+- 引入版本：v3.3.1, v3.4.0, v3.5.0
 
 ##### enable_task_run_fe_evaluation
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
+- 默认值：true
+- 类型：Boolean
+- 单位：-
 - 是否动态：是
-- 描述: 启用后，FE 将在 `TaskRunsSystemTable.supportFeEvaluation` 中对系统表 `task_runs` 执行本地评估。FE 端评估仅允许对列与常量进行的合取等值谓词，并且仅限于列 `QUERY_ID` 和 `TASK_NAME`。启用此项可通过避免更广泛的扫描或额外的远程处理来提高针对性查找的性能；禁用会强制 planner 跳过对 `task_runs` 的 FE 评估，可能降低谓词裁剪效果并影响这些过滤条件的查询延迟。
-- 引入版本: v3.3.13, v3.4.3, v3.5.0
+- 描述：启用后，FE 将在 `TaskRunsSystemTable.supportFeEvaluation` 中对系统表 `task_runs` 执行本地评估。FE 端评估仅允许对列与常量进行的合取等值谓词，并且仅限于列 `QUERY_ID` 和 `TASK_NAME`。启用此项可通过避免更广泛的扫描或额外的远程处理来提高针对性查找的性能；禁用会强制 planner 跳过对 `task_runs` 的 FE 评估，可能降低谓词裁剪效果并影响这些过滤条件的查询延迟。
+- 引入版本：v3.3.13, v3.4.3, v3.5.0
 
 ##### heartbeat_mgr_blocking_queue_size
 
@@ -1048,12 +1048,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### lock_checker_interval_second
 
-- 默认值: 30
-- 类型: long
-- 単位: Seconds
-- 是否可变: 是
-- 描述: LockChecker 前端守护进程（名为 "deadlock-checker"）两次执行之间的时间间隔，单位为秒。该守护进程执行死锁检测和慢锁扫描；配置值会乘以 1000 以毫秒为单位设置定时器。减小该值可降低检测延迟，但会增加调度和 CPU 开销；增大该值可减少开销但会延迟检测和慢锁上报。更改在运行时生效，因为守护进程每次运行都会重设间隔。此设置与 `lock_checker_enable_deadlock_check`（启用死锁检查）和 `slow_lock_threshold_ms`（定义何谓慢锁）相关联。
-- 引入版本: v3.2.0
+- 默认值：30
+- 类型：Int
+- 单位： Seconds
+- 是否动态：是
+- 描述：LockChecker 前端守护进程（名为 "deadlock-checker"）两次执行之间的时间间隔，单位为秒。该守护进程执行死锁检测和慢锁扫描。减小该值可降低检测延迟，但会增加调度和 CPU 开销；增大该值可减少开销但会延迟检测和慢锁上报。设置与 `lock_checker_enable_deadlock_check`（启用死锁检查）和 `slow_lock_threshold_ms`（定义何谓慢锁）相关联。
+- 引入版本：v3.2.0
 
 ##### master_sync_policy
 
@@ -1074,7 +1074,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 - 默认值：5000
 - 类型：Long
-- 单位：Milliseconds
+- 单位：毫秒
 - 是否动态：否
 - 描述：FE 所在 StarRocks 集群中 Leader FE 与非 Leader FE 之间能够容忍的最大时钟偏移。
 - 引入版本：-
@@ -1138,30 +1138,30 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### thrift_rpc_retry_times
 
-- 默认值: 3
-- 类型: Int
-- 单位: -
-- 是否可变: Yes
-- 描述: 控制 Thrift RPC 调用的总重试次数。该值被 `ThriftRPCRequestExecutor`（及其调用者如 `NodeMgr`、`VariableMgr`）用作重试循环次数——例如值为 3 表示最多包含初次尝试在内共三次尝试。遇到 `TTransportException` 时，executor 会尝试重开连接并重试直到达到该次数；若原因是 `SocketTimeoutException` 或重开连接失败，则不会重试。每次尝试都受 `thrift_rpc_timeout_ms` 配置的单次尝试超时限制。增大此值可提高对瞬时连接故障的鲁棒性，但可能增加总体 RPC 延迟和资源消耗。
-- 引入版本: v3.2.0
+- 默认值：3
+- 类型：Int
+- 单位：-
+- 是否动态：是
+- 描述：控制 Thrift RPC 调用的总重试次数。该值被 `ThriftRPCRequestExecutor`（及其调用者如 `NodeMgr`、`VariableMgr`）用作重试循环次数——例如值为 3 表示最多包含初次尝试在内共三次尝试。遇到 `TTransportException` 时，Executor 会尝试重开连接并重试直到达到该次数；若原因是 `SocketTimeoutException` 或重开连接失败，则不会重试。每次尝试都受 `thrift_rpc_timeout_ms` 配置的单次尝试超时限制。增大此值可提高对瞬时连接故障的鲁棒性，但可能增加总体 RPC 延迟和资源消耗。
+- 引入版本：v3.2.0
 
 ##### thrift_rpc_timeout_ms
 
-- 默认值: 10000
-- 类型: Int
-- 单位: Milliseconds
-- 是否可变: Yes
-- 描述: 用作 Thrift RPC 调用的默认网络/套接字超时时间（以毫秒为单位）。在 `ThriftConnectionPool`（前端和后端池使用）创建 Thrift 客户端时，此值会传给 TSocket；在计算如 `ConfigBase`、`LeaderOpExecutor`、`GlobalStateMgr`、`NodeMgr`、`VariableMgr` 和 `CheckpointWorker` 等位置的 RPC 调用超时时，也会将其加入到操作的执行超时中（例如 ExecTimeout*1000 + `thrift_rpc_timeout_ms`）。增大此值可使 RPC 调用容忍更长的网络或远端处理延迟；减小则在慢网络上更快失败切换。更改此值会影响执行 Thrift RPC 的 FE 代码路径中的连接创建和请求截止时间。
-- 引入版本: v3.2.0
+- 默认值：10000
+- 类型：Int
+- 单位：毫秒
+- 是否动态：是
+- 描述：用作 Thrift RPC 调用的默认网络/套接字超时时间。在 `ThriftConnectionPool`（前端和后端池使用）创建 Thrift 客户端时，此值会传给 TSocket；在计算如 `ConfigBase`、`LeaderOpExecutor`、`GlobalStateMgr`、`NodeMgr`、`VariableMgr` 和 `CheckpointWorker` 等位置的 RPC 调用超时时，也会将其加入到操作的执行超时中（例如 `ExecTimeout*1000 + thrift_rpc_timeout_ms`）。增大此值可使 RPC 调用容忍更长的网络或远端处理延迟；减小则在慢网络上更快失败切换。更改此值会影响执行 Thrift RPC 的 FE 代码路径中的连接创建和请求截止时间。
+- 引入版本：v3.2.0
 
 ##### txn_latency_metric_report_groups
 
 - 默认值：空字符串
 - 类型：String
 - 单位：-
-- 是否可变: 是
+- 是否动态：是
 - 描述：需要汇报的事务延迟监控指标组，多个指标组通过逗号分隔。导入类型基于监控组分类，被启用的组其名称会作为 'type' 标签添加到监控指标中。常见的组包括 `stream_load`、`routine_load`、`broker_load`、`insert`，以及 `compaction` (仅适用于存算分离集群)。示例：`"stream_load,routine_load"`。
-- 引入版本: v4.0
+- 引入版本：v4.0
 
 ##### txn_rollback_limit
 
@@ -1176,12 +1176,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### enable_task_info_mask_credential
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 当为 true 时，StarRocks 会在通过 information_schema.tasks 和 information_schema.task_runs 返回任务定义前，对其中的凭据进行脱敏处理，方法是对 DEFINITION 列应用 SqlCredentialRedactor.redact。在 `information_schema.task_runs` 中，无论定义来自任务运行状态还是在为空时来自任务定义查找，都会应用相同的脱敏。当为 false 时，将返回原始任务定义（可能会暴露凭据）。掩码是 CPU/字符串处理工作，当任务或 task_runs 数量很大时可能耗时；仅在你需要未脱敏定义且接受安全风险时禁用。
-- 引入版本: v3.5.6
+- 默认值：True
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：当为 true 时，StarRocks 会在通过 `information_schema.tasks` 和 `information_schema.task_runs` 返回任务定义前，对其中的凭据进行脱敏处理。在 `information_schema.task_runs` 中，无论定义来自任务运行状态还是在为空时来自任务定义查找，都会应用相同的脱敏。当为 false 时，将返回原始任务定义（可能会暴露凭据）。掩码是 CPU/字符串处理工作，当任务或 TaskRun 数量很大时可能耗时；仅在你需要未脱敏定义且接受安全风险时禁用。
+- 引入版本：v3.5.6
 
 ##### privilege_max_role_depth
 
@@ -1272,7 +1272,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 类型：Int
 - 单位：-
 - 是否动态：是
-- 描述： 当一次物化视图刷新涉及多个分区时，该参数用于控制默认每次刷新多少个分区。
+- 描述：当一次物化视图刷新涉及多个分区时，该参数用于控制默认每次刷新多少个分区。
 从 3.3.0 版本开始，系统默认每次仅刷新一个分区，以避免内存占用过高的问题；而在此前的版本中，系统会尝试一次性刷新所有分区，这可能导致刷新任务因内存不足（OOM）而失败。但也需注意：当每次物化视图刷新涉及大量分区时，默认每次仅刷新一个分区可能导致调度频繁、整体刷新耗时较长，甚至生成过多的刷新记录。因此，在特定场景下，可适当调整该参数值，以提升刷新效率并控制调度开销。
 - 引入版本：v3.3.0
 
@@ -1557,19 +1557,19 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 - 默认值：5000
 - 类型：Int
-- 单位：Milliseconds
+- 单位：毫秒
 - 是否动态：是
 - 描述：如果一条 HTTP 请求的时间超过了该参数指定的时长，会生成日志来跟踪该请求。
 - 引入版本：v2.5.15，v3.1.5
 
 ##### lock_checker_enable_deadlock_check
 
-- 默认值: false
-- 类型: Boolean
-- 単位: -
-- 是否可变: 是
-- 描述: 启用后，LockChecker 线程会使用 ThreadMXBean.findDeadlockedThreads() 在 JVM 级别执行死锁检测，并记录违规线程的堆栈跟踪。该检查在 LockChecker 守护进程内运行（其频率由 `lock_checker_interval_second` 控制），并将详细的堆栈信息写入日志，这可能会消耗大量 CPU 和 I/O。仅在排查正在发生或可复现的死锁问题时启用该选项；在正常运行中保持启用会增加开销并产生大量日志。
-- 引入版本: v3.2.0
+- 默认值：False
+- 类型：Boolean
+- 单位： -
+- 是否动态：是
+- 描述：启用后，系统在 JVM 级别执行死锁检测，并记录违规线程的堆栈跟踪。该检查在 LockChecker 守护进程内运行（其频率由 `lock_checker_interval_second` 控制），并将详细的堆栈信息写入日志，这可能会消耗大量 CPU 和 I/O。仅在排查正在发生或可复现的死锁问题时启用该选项；在正常运行中保持启用会增加开销并产生大量日志。
+- 引入版本：v3.2.0
 
 ##### low_cardinality_threshold
 
@@ -1674,37 +1674,40 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 - 默认值：10
 - 类型：Int
-- 单位：Milliseconds
+- 单位：毫秒
 - 是否动态：否
 - 描述：两个版本发布操作之间的时间间隔。
 - 引入版本：-
 
 ##### query_queue_v2_concurrency_level
 
-- 默认值: 4
-- 类型: Int
-- 単位: -
-- 是否可变: Yes
-- 描述: 控制在计算系统总查询槽位（total query slots）时使用多少个逻辑并发“层”。在 shared-nothing 模式下，总槽位 = `query_queue_v2_concurrency_level` * number_of_BEs * cores_per_BE（从 BackendResourceStat 推导）。在 multi-warehouse 模式下，有效并发会缩减为 max(1, `query_queue_v2_concurrency_level` / 4)。如果配置值为非正数，则视为 `4`。更改此值会增加或减少 totalSlots（从而影响并发查询容量）并影响每槽资源：memBytesPerSlot 通过将每个 worker 的内存除以 (cores_per_worker * concurrency) 得到，CPU 记账使用 `query_queue_v2_cpu_costs_per_slot`。应根据集群规模成比例设置；非常大的值可能会降低每槽内存并导致资源碎片化。
-- 引入版本: v3.3.4, v3.4.0, v3.5.0
+- 默认值：4
+- 类型：Int
+- 单位： -
+- 是否动态：是
+- 描述：控制在计算系统总查询槽位（total query slots）时使用多少个逻辑并发“层”。在存算一体模式下，总槽位 = `query_queue_v2_concurrency_level * number_of_BEs * cores_per_BE`（从 BackendResourceStat 推导）。在多 Warehouse 模式下，有效并发会缩减为 `max(1, query_queue_v2_concurrency_level / 4)`。如果配置值为非正数，则视为 `4`。更改此值会增加或减少 totalSlots（从而影响并发查询容量）并影响每槽资源：memBytesPerSlot 通过将每个 worker 的内存除以 `(cores_per_worker * concurrency)` 得到，CPU 记账使用 `query_queue_v2_cpu_costs_per_slot`。应根据集群规模成比例设置；非常大的值可能会降低每槽内存并导致资源碎片化。
+- 引入版本：v3.3.4, v3.4.0, v3.5.0
 
 ##### query_queue_v2_cpu_costs_per_slot
 
-- 默认值: `1000000000`
-- 类型: Long
-- 单位: planner CPU cost units
-- 是否可变: 是
-- 描述: 每个 slot 的 CPU 成本阈值，用于根据查询的 planner CPU cost 估算该查询需要多少 slot。调度器将以 integer(plan_cpu_costs / `query_queue_v2_cpu_costs_per_slot`) 的方式计算 slot 数量，然后将结果限定在 [1, totalSlots] 范围内（totalSlots 来源于查询队列 V2 的 `V2` 参数）。V2 代码会将非正值规范化为 1（Math.max(1, value)），因此非正值实际上等同于 `1`。增大此值会减少每个查询分配的 slot（偏向更少但每个占用更多 slot 的查询）；减小此值会增加每个查询的 slot。应与 `query_queue_v2_num_rows_per_slot` 及并发设置一起调整，以在并行度与资源粒度之间取得平衡。
-- 引入版本: v3.3.4, v3.4.0, v3.5.0
+- 默认值：`1000000000`
+- 类型：Long
+- 单位：planner CPU cost units
+- 是否动态：是
+- 描述：每个 slot 的 CPU 成本阈值，用于根据查询的 planner CPU cost 估算该查询需要多少 slot。调度器将以 integer(plan_cpu_costs / `query_queue_v2_cpu_costs_per_slot`) 的方式计算 slot 数量，然后将结果限定在 [1, totalSlots] 范围内（totalSlots 来源于查询队列 V2 的 `V2` 参数）。V2 代码会将非正值规范化为 1（Math.max(1, value)），因此非正值实际上等同于 `1`。增大此值会减少每个查询分配的 slot（偏向更少但每个占用更多 slot 的查询）；减小此值会增加每个查询的 slot。应与 `query_queue_v2_num_rows_per_slot` 及并发设置一起调整，以在并行度与资源粒度之间取得平衡。
+- 引入版本：v3.3.4, v3.4.0, v3.5.0
 
 ##### query_queue_v2_schedule_strategy
 
-- 默认值: SWRR
-- 类型: String
-- 単位: -
-- 是否可变: Yes
-- 描述: 选择 Query Queue V2 用于对待处理查询排序的调度策略。支持的值（不区分大小写）为 `SWRR`（Smooth Weighted Round Robin）——默认值，适合需要公平加权共享的混合/混合型负载——和 `SJF`（Short Job First + Aging）——优先短作业并使用 aging 防止饥饿。该值通过不区分大小写的枚举查找解析；无法识别的值会记录为错误并使用默认策略。此配置仅在启用 Query Queue V2 时生效，并与 V2 的大小调整设置（如 `query_queue_v2_concurrency_level`）相互作用。
-- 引入版本: v3.3.12, v3.4.2, v3.5.0
+- 默认值：SWRR
+- 类型：String
+- 单位： -
+- 是否动态：是
+- 描述：选择 Query Queue V2 用于对待处理查询排序的调度策略。有效值（不区分大小写）
+  - `SWRR`（Smooth Weighted Round Robin）（默认值）：适合需要公平加权共享的混合/混合型负载
+  - `SJF`（Short Job First + Aging）：优先短作业并使用 Aging 防止饥饿。该值通过不区分大小写的枚举查找解析
+  无法识别的值会记录为错误并使用默认策略。此配置仅在启用 Query Queue V2 时生效，并与 Query Queue V2 的大小调整设置（如 `query_queue_v2_concurrency_level`）相互作用。
+- 引入版本：v3.3.12, v3.4.2, v3.5.0
 
 ##### semi_sync_collect_statistic_await_seconds
 
@@ -1825,12 +1828,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### task_check_interval_second
 
-- 默认值: 60
-- 类型: Int
-- 单位: 秒
+- 默认值：60
+- 类型：Int
+- 单位：秒
 - 是否动态：是
-- 描述: 任务后台作业执行之间的间隔。减小该值会使后台维护（任务清理、检查）更频繁地运行并更快地响应，但会增加 CPU 和 I/O 开销；增大该值则减少开销但会延迟清理和过期任务的检测。请根据维护响应速度和资源使用情况来调整此值。
-- 引入版本: v3.2.0
+- 描述：任务后台作业执行之间的间隔。减小该值会使后台维护（任务清理、检查）更频繁地运行并更快地响应，但会增加 CPU 和 I/O 开销；增大该值则减少开销但会延迟清理和过期任务的检测。请根据维护响应速度和资源使用情况来调整此值。
+- 引入版本：v3.2.0
 
 ### 导入导出
 
@@ -1950,19 +1953,19 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 - 默认值：10000
 - 类型：Int
-- 单位：Milliseconds
+- 单位：毫秒
 - 是否动态：是
 - 描述：发布写事务到 StarRocks 外表的超时时长，单位为毫秒。默认值 `10000` 表示超时时长为 10 秒。
 - 引入版本：-
 
 ##### finish_transaction_default_lock_timeout_ms
 
-- 默认值: 1000
-- 类型: Int
-- 单位: MilliSeconds
-- 是否可变: 是
-- 描述: 完成事务时获取数据库和表锁的默认超时时间。
-- 引入版本: v4.0.0, v3.5.8
+- 默认值：1000
+- 类型：Int
+- 单位：毫秒
+- 是否动态：是
+- 描述：完成事务时获取数据库和表锁的默认超时时间。
+- 引入版本：v4.0.0, v3.5.8
 
 ##### history_job_keep_max_second
 
@@ -2029,21 +2032,21 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### loads_history_retained_days
 
-- 默认值: 30
-- 类型: Int
-- 单位: 天
+- 默认值：30
+- 类型：Int
+- 单位：天
 - 是否动态：是
-- 描述: 在内部表 `_statistics_.loads_history` 中保留导入历史信息的天数。增加或减少此值会调整已完成导入作业在每日分区中保留的时长；它影响新表的创建和 keeper 的修剪行为，但不会自动重建过去的分区。`LoadsHistorySyncer` 在管理导入历史生命周期时依赖此保留策略；其同步节奏由 `loads_history_sync_interval_second` 控制。
-- 引入版本: v3.3.6, v3.4.0, v3.5.0
+- 描述：在内部表 `_statistics_.loads_history` 中保留导入历史信息的天数。增加或减少此值会调整已完成导入作业在每日分区中保留的时长；它影响新表的创建和 keeper 的修剪行为，但不会自动重建过去的分区。`LoadsHistorySyncer` 在管理导入历史生命周期时依赖此保留策略；其同步节奏由 `loads_history_sync_interval_second` 控制。
+- 引入版本：v3.3.6, v3.4.0, v3.5.0
 
 ##### loads_history_sync_interval_second
 
-- 默认值: 60
-- 类型: Int
-- 单位: 秒
+- 默认值：60
+- 类型：Int
+- 单位：秒
 - 是否动态：是
-- 描述: 由 LoadsHistorySyncer 用于调度周期性同步的时间间隔（秒），用于将已完成的 load 作业从 `information_schema.loads` 同步到内部表 `_statistics_.loads_history`。构造函数中将该值乘以 1000L 以设置 FrontendDaemon 的间隔。syncer 在每次运行时也会重新读取该配置，并在变化时调用 setInterval，因此更新可以在运行时生效而无需重启。syncer 会跳过首次运行（以允许表创建），且仅导入结束时间超过一分钟的 load；较小的频繁值会增加 DML 和 executor 负载，而较大的值会延迟历史 load 记录的可用性。关于目标表的保留/分区行为，请参见 `loads_history_retained_days`。
-- 引入版本: v3.3.6, v3.4.0, v3.5.0
+- 描述：由 LoadsHistorySyncer 用于调度周期性同步的时间间隔（秒），用于将已完成的 load 作业从 `information_schema.loads` 同步到内部表 `_statistics_.loads_history`。构造函数中将该值乘以 1000L 以设置 FrontendDaemon 的间隔。syncer 在每次运行时也会重新读取该配置，并在变化时调用 setInterval，因此更新可以在运行时生效而无需重启。syncer 会跳过首次运行（以允许表创建），且仅导入结束时间超过一分钟的 load；较小的频繁值会增加 DML 和 executor 负载，而较大的值会延迟历史 load 记录的可用性。关于目标表的保留/分区行为，请参见 `loads_history_retained_days`。
+- 引入版本：v3.3.6, v3.4.0, v3.5.0
 
 ##### max_broker_load_job_concurrency
 
@@ -2246,12 +2249,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### stream_load_task_keep_max_second
 
-- 默认值: 3 * 24 * 3600
-- 类型: Int
-- 单位: 秒
+- 默认值：3 * 24 * 3600
+- 类型：Int
+- 单位：秒
 - 是否动态：是
-- 描述: 已完成或已取消的 StreamLoad 任务的保留窗口（秒）。当任务达到最终状态且其结束时间戳早于此阈值时（代码以毫秒比较：currentMs - endTimeMs > stream_load_task_keep_max_second * 1000），该任务将有资格被 `StreamLoadMgr.cleanOldStreamLoadTasks` 移除，并在加载持久化状态时被丢弃。适用于 `StreamLoadTask` 和 `StreamLoadMultiStmtTask`。如果总任务数超过 `stream_load_task_keep_max_num`，可能会提前触发清理（同步任务由 `cleanSyncStreamLoadTasks` 优先处理）。请根据历史记录/可调试性与内存使用之间的权衡设置此值。
-- 引入版本: v3.2.0
+- 描述：已完成或已取消的 StreamLoad 任务的保留窗口（秒）。当任务达到最终状态且其结束时间戳早于此阈值时（代码以毫秒比较：currentMs - endTimeMs > stream_load_task_keep_max_second * 1000），该任务将有资格被 `StreamLoadMgr.cleanOldStreamLoadTasks` 移除，并在加载持久化状态时被丢弃。适用于 `StreamLoadTask` 和 `StreamLoadMultiStmtTask`。如果总任务数超过 `stream_load_task_keep_max_num`，可能会提前触发清理（同步任务由 `cleanSyncStreamLoadTasks` 优先处理）。请根据历史记录/可调试性与内存使用之间的权衡设置此值。
+- 引入版本：v3.2.0
 
 ##### transaction_clean_interval_second
 
@@ -2331,21 +2334,21 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### consistency_check_cooldown_time_second
 
-- 默认值: 24 * 3600L
-- 类型: long
-- 单位: Seconds
-- 是否可变: Yes
-- 描述: 控制对同一 tablet 进行一致性检查的最小间隔（以秒为单位）。在 tablet 选择（chooseTablets）期间，只有当 tablet.getLastCheckTime() < (currentTimeMillis - consistency_check_cooldown_time_second * 1000) 时，该 tablet 才被视为可选。默认值 (24 * 3600L) 大致保证每个 tablet 每天最多检查一次，以减少后端磁盘 I/O。降低此值会增加检查频率和资源使用；提高此值会减少 I/O，但会降低不一致性检测的速度。该值在从索引的 tablet 列表中过滤 cooldownedTablets 时全局生效。
-- 引入版本: v3.5.5
+- 默认值：24 * 3600
+- 类型：Int
+- 单位：Seconds
+- 是否动态：是
+- 描述：控制对同一 Tablet 进行一致性检查的最小间隔。在 Tablet 选择期间，只有当 `tablet.getLastCheckTime() < (currentTimeMillis - consistency_check_cooldown_time_second * 1000)` 时，该 Tablet 才被视为可选。默认值 (24 * 3600) 大致保证每个 Tablet 每天最多检查一次，以减少后端磁盘 I/O。降低此值会增加检查频率和资源使用；提高此值会减少 I/O，但会降低不一致性检测的速度。该值在从索引的 Tablet 列表中过滤 cooldownedTablets 时全局生效。
+- 引入版本：v3.5.5
 
 ##### consistency_tablet_meta_check_interval_ms
 
-- 默认值: 2 * 3600 * 1000L
-- 类型: Long
-- 单位: Milliseconds
-- 是否可变: Yes
-- 描述: ConsistencyChecker 用于在 TabletInvertedIndex 与 LocalMetastore 之间运行完整 tablet-meta 一致性扫描的间隔。当 runAfterCatalogReady 中的守护线程检测到 current time 减去 lastTabletMetaCheckTime 超过此值时，会触发 checkTabletMetaConsistency。首次发现无效 tablet 时，会将其 toBeCleanedTime 设置为 now + (consistency_tablet_meta_check_interval_ms / 2)，因此实际删除会延迟到后续一次扫描。增大此值可降低扫描频率和负载（清理更慢）；减小此值可更快地检测并移除陈旧 tablet（开销更高）。
-- 引入版本: v3.2.0
+- 默认值：2 * 3600 * 1000
+- 类型：Int
+- 单位：毫秒
+- 是否动态：是
+- 描述：用于在 TabletInvertedIndex 与 LocalMetastore 之间运行完整 Tablet Meta 一致性扫描的间隔。当 runAfterCatalogReady 中的守护线程检测到 current time 减去 lastTabletMetaCheckTime 超过此值时，会触发 一致性检查。首次发现无效 Tablet 时，会将其 toBeCleanedTime 设置为当前时间加 (consistency_tablet_meta_check_interval_ms / 2)，因此实际删除会延迟到后续一次扫描。增大此值可降低扫描频率和负载（清理更慢）；减小此值可更快地检测并移除陈旧 tablet（开销更高）。
+- 引入版本：v3.2.0
 
 ##### default_replication_num
 
@@ -2393,12 +2396,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### enable_online_optimize_table
 
-- 默认值: `true`
-- 类型: Boolean
-- 单位: -
+- 默认值：`true`
+- 类型：Boolean
+- 单位：-
 - 是否动态：是
-- 描述: 控制在创建优化（optimize）任务时 StarRocks 是否使用非阻塞的在线优化路径。当 `enable_online_optimize_table` 为 true 且目标表满足兼容性检查（没有分区/键/排序规范，分发方式不是 `RandomDistributionDesc`，存储类型不是 `COLUMN_WITH_ROW`，启用了副本存储，并且该表不是云原生表或物化视图）时，planner 会创建 `OnlineOptimizeJobV2` 来执行优化而不阻塞写入。如果为 false 或任一兼容性条件不满足，StarRocks 将回退到 `OptimizeJobV2`，在优化期间可能会阻塞写操作。
-- 引入版本: `v3.3.3, v3.4.0, v3.5.0`
+- 描述：控制在创建优化（optimize）任务时 StarRocks 是否使用非阻塞的在线优化路径。当 `enable_online_optimize_table` 为 true 且目标表满足兼容性检查（没有分区/键/排序规范，分发方式不是 `RandomDistributionDesc`，存储类型不是 `COLUMN_WITH_ROW`，启用了副本存储，并且该表不是云原生表或物化视图）时，planner 会创建 `OnlineOptimizeJobV2` 来执行优化而不阻塞写入。如果为 false 或任一兼容性条件不满足，StarRocks 将回退到 `OptimizeJobV2`，在优化期间可能会阻塞写操作。
+- 引入版本：`v3.3.3, v3.4.0, v3.5.0`
 
 ##### enable_strict_storage_medium_check
 
@@ -2498,7 +2501,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 - 默认值：1000
 - 类型：Int
-- 单位：Milliseconds
+- 单位：毫秒
 - 是否动态：是
 - 描述：Tablet Checker 在释放并重新获取表锁之前，每个周期持有锁的最大时间（毫秒）。小于 100 的值将被视为 100。
 - 引入版本：v3.5.9, v4.0.2
@@ -2594,7 +2597,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 - 默认值：15 * 60 * 1000
 - 类型：Long
-- 单位：Milliseconds
+- 单位：毫秒
 - 是否动态：是
 - 描述：克隆 Tablet 调度时，如果超过该时间一直未被调度，则将该 Tablet 的调度优先级升高，以尽可能优先调度。
 - 引入版本：-
@@ -2955,12 +2958,12 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### hdfs_file_system_expire_seconds
 
-- 默认值: 300
-- 类型: Int
-- 单位: 秒
+- 默认值：300
+- 类型：Int
+- 单位：秒
 - 是否动态：是
-- 描述: HdfsFsManager 管理的未使用缓存 HDFS/ObjectStore FileSystem 的生存时间（以秒为单位）。FileSystemExpirationChecker（每 60s 运行一次）使用此值调用每个 HdfsFs.isExpired(...)；当过期时，管理器会关闭底层 FileSystem 并将其从缓存中移除。访问器方法（例如 `HdfsFs.getDFSFileSystem`、`getUserName`、`getConfiguration`）会更新最后访问时间戳，因此过期基于不活动时间。较低的值可以减少空闲资源占用但会增加重开销；较高的值会更长时间保留句柄，可能会消耗更多资源。
-- 引入版本: v3.2.0
+- 描述：HdfsFsManager 管理的未使用缓存 HDFS/ObjectStore FileSystem 的生存时间（以秒为单位）。FileSystemExpirationChecker（每 60s 运行一次）使用此值调用每个 HdfsFs.isExpired(...)；当过期时，管理器会关闭底层 FileSystem 并将其从缓存中移除。访问器方法（例如 `HdfsFs.getDFSFileSystem`、`getUserName`、`getConfiguration`）会更新最后访问时间戳，因此过期基于不活动时间。较低的值可以减少空闲资源占用但会增加重开销；较高的值会更长时间保留句柄，可能会消耗更多资源。
+- 引入版本：v3.2.0
 
 ##### lake_autovacuum_grace_period_minutes
 
@@ -3000,7 +3003,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 
 ##### lake_compaction_allow_partial_success
 
-- 默认值: true
+- 默认值：true
 - 类型：Boolean
 - 单位：-
 - 是否动态：是
@@ -3142,12 +3145,12 @@ Compaction Score 代表了一个表分区是否值得进行 Compaction 的评分
 
 ##### lake_batch_publish_min_version_num
 
-- 默认值: `1`
-- 类型: Int
-- 单位: -
-- 是否可变: 是
-- 描述: 设置形成 lake 表发布批次所需的连续事务版本的最小数量。DatabaseTransactionMgr.getReadyToPublishTxnListBatch 将此值与 `lake_batch_publish_max_version_num` 一起传递给 transactionGraph.getTxnsWithTxnDependencyBatch 用于选择依赖事务。值为 `1` 允许单事务发布（不进行批处理）。值 >1 要求至少有该数量的连续版本、单表、非复制事务可用；如果版本不连续、出现复制事务，或架构变更消耗了某个版本，则中止批处理。增大此值可以通过将提交分组来提高发布吞吐，但在等待足够数量的连续事务时可能会延迟发布。
-- 引入版本: v3.2.0
+- 默认值：`1`
+- 类型：Int
+- 单位：-
+- 是否动态：是
+- 描述：设置形成 lake 表发布批次所需的连续事务版本的最小数量。DatabaseTransactionMgr.getReadyToPublishTxnListBatch 将此值与 `lake_batch_publish_max_version_num` 一起传递给 transactionGraph.getTxnsWithTxnDependencyBatch 用于选择依赖事务。值为 `1` 允许单事务发布（不进行批处理）。值 >1 要求至少有该数量的连续版本、单表、非复制事务可用；如果版本不连续、出现复制事务，或架构变更消耗了某个版本，则中止批处理。增大此值可以通过将提交分组来提高发布吞吐，但在等待足够数量的连续事务时可能会延迟发布。
+- 引入版本：v3.2.0
 
 ##### lake_enable_batch_publish_version
 
@@ -3160,12 +3163,12 @@ Compaction Score 代表了一个表分区是否值得进行 Compaction 的评分
 
 ##### lake_use_combined_txn_log
 
-- 默认值: `false`
-- 类型: Boolean
-- 单位: -
-- 是否可变: 是
-- 描述: 启用时，StarRocks 允许 Lake 表对相关事务使用 combined transaction log 路径。仅在集群以 shared-data 模式运行（RunMode.isSharedDataMode()）时此标志才会被考虑。设置 `lake_use_combined_txn_log = true` 时，类型为 BACKEND_STREAMING、ROUTINE_LOAD_TASK、INSERT_STREAMING 和 BATCH_LOAD_JOB 的加载事务将有资格使用 combined txn logs（参见 LakeTableHelper.supportCombinedTxnLog）。包含 compaction 的代码路径通过 isTransactionSupportCombinedTxnLog 检查 combined-log 支持。如果禁用或不在 shared-data 模式下，则不使用 combined transaction log 行为。
-- 引入版本: `v3.3.7, v3.4.0, v3.5.0`
+- 默认值：`false`
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：启用时，StarRocks 允许 Lake 表对相关事务使用 combined transaction log 路径。仅在集群以 shared-data 模式运行（RunMode.isSharedDataMode()）时此标志才会被考虑。设置 `lake_use_combined_txn_log = true` 时，类型为 BACKEND_STREAMING、ROUTINE_LOAD_TASK、INSERT_STREAMING 和 BATCH_LOAD_JOB 的加载事务将有资格使用 combined txn logs（参见 LakeTableHelper.supportCombinedTxnLog）。包含 compaction 的代码路径通过 isTransactionSupportCombinedTxnLog 检查 combined-log 支持。如果禁用或不在 shared-data 模式下，则不使用 combined transaction log 行为。
+- 引入版本：`v3.3.7, v3.4.0, v3.5.0`
 
 ### 其他
 
@@ -3173,7 +3176,7 @@ Compaction Score 代表了一个表分区是否值得进行 Compaction 的评分
 
 - 默认值：5000
 - 类型：Long
-- 单位：Milliseconds
+- 单位：毫秒
 - 是否动态：是
 - 描述：Agent task 重新发送前的等待时间。当代理任务的创建时间已设置，并且距离现在超过该值，才能重新发送代理任务。该参数用于防止过于频繁的代理任务发送。
 - 引入版本：-
@@ -3254,19 +3257,19 @@ Compaction Score 代表了一个表分区是否值得进行 Compaction 的评分
 
 - 默认值：86400 * 1000
 - 类型：Int
-- 单位：Milliseconds
+- 单位：毫秒
 - 是否动态：是
 - 描述：Backup 作业的超时时间。
 - 引入版本：-
 
 ##### enable_collect_tablet_num_in_show_proc_backend_disk_path
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: 是
-- 描述: 是否在 `SHOW PROC /BACKENDS/{id}` 命令中启用对每个磁盘的 tablet 数量的采集
-- 引入版本: v4.0.1, v3.5.8
+- 默认值：true
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：是否在 `SHOW PROC /BACKENDS/{id}` 命令中启用对每个磁盘的 tablet 数量的采集
+- 引入版本：v4.0.1, v3.5.8
 
 ##### enable_colocate_restore
 
@@ -3279,12 +3282,12 @@ Compaction Score 代表了一个表分区是否值得进行 Compaction 的评分
 
 ##### enable_materialized_view_concurrent_prepare
 
-- 默认值: true
-- 类型: Boolean
-- 单位:
-- 是否可变: Yes
-- 描述: 是否并发准备物化视图以提高性能。
-- 引入版本: v3.4.4
+- 默认值：True
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：是否并发准备物化视图以提高性能。
+- 引入版本：v3.4.4
 
 ##### enable_metric_calculator
 
@@ -3311,7 +3314,7 @@ Compaction Score 代表了一个表分区是否值得进行 Compaction 的评分
 - Unit:
 - 是否动态：是
 - 描述：是否开启Query级别的用于透明加速改写的物化视图Cache，用于加速改写性能。
-- 引入版本： v3.3
+- 引入版本：v3.3
 
 ##### enable_mv_refresh_collect_profile
 
@@ -3380,7 +3383,7 @@ Compaction Score 代表了一个表分区是否值得进行 Compaction 的评分
 
 - 默认值：600000
 - 类型：Int
-- 单位：Milliseconds
+- 单位：毫秒
 - 是否动态：否
 - 描述：访问 JDBC Catalog 时，连接建立的超时时长。超过参数取值时间的连接被认为是 idle 状态。
 - 引入版本：-
@@ -3554,7 +3557,7 @@ Compaction Score 代表了一个表分区是否值得进行 Compaction 的评分
 - Unit:
 - 是否动态：是
 - 描述：用于物化视图改写的 MV 计划缓存的最大大小。如果存在大量用于透明改写的物化视图，可以考虑增加此配置项的大小。默认1000个。
-- 引入版本： v3.2
+- 引入版本：v3.2
 
 ##### mv_plan_cache_thread_pool_size
 
@@ -3563,7 +3566,7 @@ Compaction Score 代表了一个表分区是否值得进行 Compaction 的评分
 - Unit:
 - 是否动态：是
 - 描述：用于物化视图改写的 MV 计划缓存的默认线程池大小，默认3个。
-- 引入版本： v3.2
+- 引入版本：v3.2
 
 ##### mv_refresh_default_planner_optimize_timeout
 
@@ -3693,12 +3696,12 @@ Compaction Score 代表了一个表分区是否值得进行 Compaction 的评分
 
 ##### proc_profile_mem_enable
 
-- 默认值: true
-- 类型: Boolean
-- 单位: -
-- 是否可变: Yes
-- 描述: 通过 AsyncProfiler 启用进程内存分配剖析采集。当为 true 时，ProcProfileCollector 会在 `sys_log_dir`/proc_profile 下生成名为 mem-profile-&lt;timestamp&gt;.html 的 HTML 剖析文件，在采样期间睡眠 `proc_profile_collect_time_s` 秒，并使用 `proc_profile_jstack_depth` 控制 Java 栈深度。生成的文件会根据 `proc_profile_file_retained_days` 和 `proc_profile_file_retained_size_bytes` 进行压缩和清理。Collector 会使用 `STARROCKS_HOME_DIR` 调整 AsyncProfiler 的本地提取路径以避免 /tmp 的 noexec 问题。该功能用于排查内存分配热点；启用会增加 CPU、I/O 和磁盘使用，并可能产生较大文件。
-- 引入版本: v3.2.12
+- 默认值：True
+- 类型：Boolean
+- 单位：-
+- 是否动态：是
+- 描述：通过 AsyncProfiler 启用进程内存分配 Profile 采集。当为 true 时，ProcProfileCollector 会在 `sys_log_dir/proc_profile` 下生成名为 `mem-profile-<timestamp>.html` 的 HTML Profile 文件，在采样期间睡眠 `proc_profile_collect_time_s` 秒，并使用 `proc_profile_jstack_depth` 控制 Java 栈深度。生成的文件会根据 `proc_profile_file_retained_days` 和 `proc_profile_file_retained_size_bytes` 进行压缩和清理。Collector 会使用 `STARROCKS_HOME_DIR` 调整 AsyncProfiler 的本地提取路径以避免 `/tmp` 的 noexec 问题。该功能用于排查内存分配热点；启用会增加 CPU、I/O 和磁盘使用，并可能产生较大文件。
+- 引入版本：v3.2.12
 
 ##### query_detail_explain_level
 
@@ -3765,12 +3768,12 @@ Compaction Score 代表了一个表分区是否值得进行 Compaction 的评分
 
 ##### task_runs_max_history_number
 
-- 默认值: 10000
-- 类型: Int
-- 单位: -
-- 是否可变: 是
-- 描述: 内存中保留的任务运行记录的最大数量，并在查询归档的 task-run 历史时用作默认的 LIMIT。当 `enable_task_history_archive` 为 false 时，此值约束内存中的历史：Force GC 会修剪较旧的条目，使得只保留最新的 `task_runs_max_history_number` 条记录。当查询归档历史（且未提供显式 LIMIT）时，如果该值大于 0，`TaskRunHistoryTable.lookup` 会使用 `"ORDER BY create_time DESC LIMIT <value>"`。注意：将此值设置为 0 会禁用查询侧的 LIMIT（无限制），但会导致内存中的历史被截断为零（除非启用了归档）。
-- 引入版本: v3.2.0
+- 默认值：10000
+- 类型：Int
+- 单位：-
+- 是否动态：是
+- 描述：内存中保留的任务运行记录的最大数量，并在查询归档的 task-run 历史时用作默认的 LIMIT。当 `enable_task_history_archive` 为 false 时，此值约束内存中的历史：Force GC 会修剪较旧的条目，使得只保留最新的 `task_runs_max_history_number` 条记录。当查询归档历史（且未提供显式 LIMIT）时，如果该值大于 0，`TaskRunHistoryTable.lookup` 会使用 `"ORDER BY create_time DESC LIMIT <value>"`。注意：将此值设置为 0 会禁用查询侧的 LIMIT（无限制），但会导致内存中的历史被截断为零（除非启用了归档）。
+- 引入版本：v3.2.0
 
 ##### tmp_dir
 

--- a/docs/zh/administration/management/FE_configuration.md
+++ b/docs/zh/administration/management/FE_configuration.md
@@ -338,7 +338,7 @@ ADMIN SET FRONTEND CONFIG ("key" = "value");
 - 类型：String
 - 单位：-
 - 是否动态：否
-- 描述：控制用于生成 Profile 日志文件名中日期部分的时间粒度。有效值（不区分大小写）为 `HOUR` 和 `DAY`。`HOUR` 模式会产生 `"%d{yyyyMMddHH}"`（按小时分桶），`DAY` 模式会产生 `"%d{yyyyMMdd}"`（按天分桶）。该值在计算 Log4j 配置中的 `profile_file_pattern` 时使用，仅影响基于时间的轮转文件名部分；基于大小的轮转仍由 `profile_log_roll_size_mb` 控制，保留行为由 `profile_log_roll_num` / `profile_log_delete_age` 控制。无效值会在日志初始化期间引发 IOException（Error Message: "profile_log_roll_interval config error: <value>"）。对于高流量的 Profiling 场景请选择 `HOUR` 以限制每小时每文件大小，或选择 `DAY` 进行日级聚合。
+- 描述：控制用于生成 Profile 日志文件名中日期部分的时间粒度。有效值（不区分大小写）为 `HOUR` 和 `DAY`。`HOUR` 模式会产生 `"%d{yyyyMMddHH}"`（按小时分桶），`DAY` 模式会产生 `"%d{yyyyMMdd}"`（按天分桶）。该值在计算 Log4j 配置中的 `profile_file_pattern` 时使用，仅影响基于时间的轮转文件名部分；基于大小的轮转仍由 `profile_log_roll_size_mb` 控制，保留行为由 `profile_log_roll_num` / `profile_log_delete_age` 控制。无效值会在日志初始化期间引发 `IOException（Error Message: "profile_log_roll_interval config error: <value>"）`。对于高流量的 Profiling 场景请选择 `HOUR` 以限制每小时每文件大小，或选择 `DAY` 进行日级聚合。
 - 引入版本：v3.2.5
 
 ##### profile_log_roll_num


### PR DESCRIPTION

## Why I'm doing:

## What I'm doing:  

    EXECUTION SUMMARY
    Document Type: fe_config
    Duration: 1443.67 seconds
    Command: /home/seaven/documents/workspace/DocsAgent/src/docsagent/main.py -g -t fe_config --force_search_code -tv -l 100 --pr
    Arguments:
      ├─ ci: False
      ├─ force_search_code: True
      ├─ generate: True
      ├─ include_miss_usage: False
      ├─ limit: 100
      ├─ meta: False
      ├─ name: None
      ├─ pr: True
      ├─ track_version: True
      ├─ type: fe_config
      ├─ without_llm: False
    
    ITEM EXTRACTION:
      ├─ Items from meta files: 741
      ├─ Items from code parsing: 0
      └─ Total unique items: 0
    
    DOCUMENT GENERATION:
      ├─ EN: 29 documents
      ├─ JA: 9 documents
      ├─ ZH: 9 documents
      └─ Total: 47 documents
    
    AGENT INVOCATIONS:
      ├─ ConfigDocAgent: 29 calls
      ├─ TranslationAgent_ja: 9 calls
      ├─ TranslationAgent_zh: 9 calls
      └─ Total: 47 calls
    
    TOOL INVOCATIONS:
      ├─ read_file: 39 calls
      ├─ search_code: 3 calls
      └─ Total: 42 calls
    
    GENERATED ITEMS:
      ├─ Total: 29 items
      ├─ internal_log_json_format
      ├─ max_task_consecutive_fail_count
      ├─ task_runs_timeout_second
      ├─ mysql_service_kill_after_disconnect
      ├─ task_runs_queue_length
      ├─ task_runs_concurrency
      ├─ max_task_runs_threads_num
      ├─ consistency_check_start_time
      ├─ consistency_check_end_time
      ├─ consistency_tablet_meta_check_interval_ms
      ├─ consistency_check_cooldown_time_second
      ├─ materialized_view_refresh_ascending
      ├─ enable_materialized_view_external_table_precise_refresh
      ├─ ignore_task_run_history_replay_error
      ├─ enable_show_materialized_views_include_all_task_runs
      ├─ materialized_view_min_refresh_interval
      ├─ skip_whole_phase_lock_mv_limit
      ├─ memory_tracker_enable
      ├─ enable_collect_warehouse_metrics
      ├─ memory_tracker_interval_seconds
      ├─ proc_profile_mem_enable
      ├─ proc_profile_cpu_enable
      ├─ proc_profile_collect_time_s
      ├─ proc_profile_file_retained_days
      ├─ proc_profile_file_retained_size_bytes
      ├─ proc_profile_jstack_depth
      ├─ enable_create_partial_partition_in_batch
      ├─ mv_rewrite_consider_data_layout_mode
      └─ enable_mv_automatic_repairing_for_broken_base_tables
    
    TRANSLATED ITEMS:
      ├─ Total: 100 items
      ├─ enable_task_info_mask_credential
      ├─ enable_materialized_view_concurrent_prepare
      ├─ lock_checker_enable_deadlock_check
      ├─ materialized_view_refresh_ascending
      ├─ checkpoint_only_on_leader
      ├─ consistency_tablet_meta_check_interval_ms
      ├─ proc_profile_file_retained_days
      ├─ load_parallel_instance_num
      ├─ max_dynamic_partition_num
      ├─ enable_http_detail_metrics
      ├─ internal_log_json_format
      ├─ task_runs_concurrency
      ├─ enable_create_partial_partition_in_batch
      ├─ max_task_runs_threads_num
      ├─ memory_tracker_interval_seconds
      ├─ big_query_log_roll_interval
      ├─ lock_checker_interval_second
      ├─ spark_load_submit_timeout_second
      ├─ materialized_view_min_refresh_interval
      ├─ thrift_rpc_retry_times
      ├─ http_max_chunk_size
      ├─ stream_load_task_keep_max_second
      ├─ proc_profile_mem_enable
      ├─ task_ttl_second
      ├─ capacity_used_percent_high_water
      ├─ enable_materialized_view_external_table_precise_refresh
      ├─ proc_profile_cpu_enable
      ├─ profile_log_dir
      ├─ enable_http_validate_headers
      ├─ bdbje_log_level
      ├─ query_queue_slots_estimator_strategy
      ├─ task_runs_timeout_second
      ├─ bdbje_cleaner_threads
      ├─ brpc_min_evictable_idle_time_ms
      ├─ audit_log_enable_compress
      ├─ proc_profile_collect_time_s
      ├─ internal_log_delete_age
      ├─ mv_rewrite_consider_data_layout_mode
      ├─ stream_load_task_keep_max_num
      ├─ task_check_interval_second
      ├─ task_runs_ttl_second
      ├─ enable_qe_slow_log
      ├─ lake_enable_batch_publish_version
      ├─ skip_whole_phase_lock_mv_limit
      ├─ enable_profile_log
      ├─ proc_profile_jstack_depth
      ├─ ignore_task_run_history_replay_error
      ├─ internal_log_roll_interval
      ├─ edit_log_write_slow_log_threshold_ms
      ├─ slow_lock_print_stack
      ├─ consistency_check_end_time
      ├─ enable_sql_desensitize_in_log
      ├─ starmgr_grpc_server_max_worker_threads
      ├─ consistency_check_start_time
      ├─ profile_log_roll_num
      ├─ task_runs_max_history_number
      ├─ start_with_incomplete_meta
      ├─ enable_mv_automatic_repairing_for_broken_base_tables
      ├─ query_queue_v2_concurrency_level
      ├─ audit_log_json_format
      ├─ bdbje_replay_cost_percent
      ├─ brpc_reuse_addr
      ├─ max_task_consecutive_fail_count
      ├─ mysql_service_kill_after_disconnect
      ├─ max_query_queue_history_slots_number
      ├─ starmgr_grpc_timeout_seconds
      ├─ query_queue_v2_schedule_strategy
      ├─ alter_max_worker_threads
      ├─ task_min_schedule_interval_s
      ├─ task_runs_queue_length
      ├─ profile_log_delete_age
      ├─ profile_log_roll_interval
      ├─ memory_tracker_enable
      ├─ dns_cache_ttl_seconds
      ├─ log_register_and_unregister_query_id
      ├─ brpc_inner_reuse_pool
      ├─ hdfs_read_buffer_size_kb
      ├─ query_queue_v2_num_rows_per_slot
      ├─ brpc_short_connection
      ├─ stream_load_max_txn_num_per_be
      ├─ proc_profile_file_retained_size_bytes
      ├─ big_query_log_delete_age
      ├─ big_query_log_dir
      ├─ thrift_rpc_timeout_ms
      ├─ brpc_send_plan_fragment_timeout_ms
      ├─ log_plan_cancelled_by_crash_be
      ├─ lake_batch_publish_max_version_num
      ├─ enable_show_materialized_views_include_all_task_runs
      ├─ hdfs_write_buffer_size_kb
      ├─ loads_history_sync_interval_second
      ├─ http_web_page_display_hardware
      ├─ enable_collect_warehouse_metrics
      ├─ table_keeper_interval_second
      ├─ slow_lock_stack_trace_reserve_levels
      ├─ thrift_rpc_strict_mode
      ├─ consistency_check_cooldown_time_second
      ├─ enable_query_queue_v2
      ├─ http_max_header_size
      ├─ files_enable_insert_push_down_schema
      └─ lake_enable_tablet_creation_optimization
    

This Pr is generated by [DocsAgent](https://github.com/StarRocks/DocsAgent)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.1
  - [ ] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refreshes FE configuration documentation across English, Japanese, and Chinese with new items and clearer behavior/retention details.
> 
> - Adds/clarifies logging options: `internal_log_json_format`, `audit_log_enable_compress`, `sys_log_*`, internal/profile log roll/retention fields, warn-module routing
> - Introduces process profiling controls: `proc_profile_cpu_enable`, `proc_profile_mem_enable`, `proc_profile_collect_time_s`, `proc_profile_file_retained_*`, `proc_profile_jstack_depth`
> - Expands task/MV scheduling controls: `task_runs_concurrency`, `task_runs_queue_length`, `task_runs_timeout_second`, `max_task_runs_threads_num`, `max_task_consecutive_fail_count`, `task_min_schedule_interval_s`, MV refresh/options (`materialized_view_min_refresh_interval`, `materialized_view_refresh_ascending`, `enable_materialized_view_external_table_precise_refresh`, `mv_rewrite_consider_data_layout_mode`, auto-repair)
> - Adds consistency/maintenance settings: `consistency_check_start_time/end_time`, `consistency_check_cooldown_time_second`, `consistency_tablet_meta_check_interval_ms`, `table_keeper_interval_second`
> - Documents session/network behaviors: `mysql_service_kill_after_disconnect`, `thrift_rpc_timeout_ms`, `thrift_rpc_retry_times`
> - Adds observability toggles: `memory_tracker_enable`, `memory_tracker_interval_seconds`, `enable_collect_warehouse_metrics`, HTTP/detail metrics
> - Other: partition creation (`enable_create_partial_partition_in_batch`), MV/task history visibility flags, Query Queue V2 knobs, and safety/ignore switches (`ignore_task_run_history_replay_error`, `enable_task_info_mask_credential`, etc.)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 303fc04d61d1fb9d6a40cc40f2e501fd7143c0db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->