### PR TITLE
[Enhancement] Bridge java.util.logging to slf4j to fix log leakage

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -437,6 +437,12 @@ under the License.
             <artifactId>slf4j-api</artifactId>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/org.slf4j/jul-to-slf4j -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/com.github.oshi/oshi-core -->
         <dependency>
             <groupId>com.github.oshi</groupId>

--- a/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
@@ -45,6 +45,9 @@ import org.apache.logging.log4j.core.config.ConfigurationSource;
 import org.apache.logging.log4j.core.config.xml.XmlConfiguration;
 import org.apache.logging.log4j.core.lookup.Interpolator;
 import org.apache.logging.log4j.core.lookup.StrSubstitutor;
+import org.slf4j.bridge.SLF4JBridgeHandler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -335,6 +338,21 @@ public class Log4jConfig extends XmlConfiguration {
     }
 
     private static void reconfig() throws IOException {
+        SLF4JBridgeHandler.removeHandlersForRootLogger();
+        SLF4JBridgeHandler.install();
+
+        Level targetJulLevel = Level.INFO;
+        if (sysLogLevel != null) {
+            if ("DEBUG".equalsIgnoreCase(sysLogLevel)) {
+                targetJulLevel = Level.FINE;
+            } else if ("WARN".equalsIgnoreCase(sysLogLevel)) {
+                targetJulLevel = Level.WARNING;
+            } else if ("ERROR".equalsIgnoreCase(sysLogLevel) || "FATAL".equalsIgnoreCase(sysLogLevel)) {
+                targetJulLevel = Level.SEVERE;
+            }
+        }
+        Logger.getLogger("").setLevel(targetJulLevel);
+
         String xmlConfTemplate = generateActiveLog4jXmlConfig();
         if (!FeConstants.runningUnitTest && !FeConstants.isReplayFromQueryDump) {
             System.out.println("=====");

--- a/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Log4jConfig.java
@@ -338,22 +338,31 @@ public class Log4jConfig extends XmlConfiguration {
     }
 
     private static void reconfig() throws IOException {
+
+        String xmlConfTemplate = generateActiveLog4jXmlConfig();
+
         SLF4JBridgeHandler.removeHandlersForRootLogger();
         SLF4JBridgeHandler.install();
 
         Level targetJulLevel = Level.INFO;
         if (sysLogLevel != null) {
-            if ("DEBUG".equalsIgnoreCase(sysLogLevel)) {
-                targetJulLevel = Level.FINE;
-            } else if ("WARN".equalsIgnoreCase(sysLogLevel)) {
-                targetJulLevel = Level.WARNING;
-            } else if ("ERROR".equalsIgnoreCase(sysLogLevel) || "FATAL".equalsIgnoreCase(sysLogLevel)) {
-                targetJulLevel = Level.SEVERE;
+            String normalizedLevel = sysLogLevel.toUpperCase();
+            if (DEBUG_LEVELS.contains(normalizedLevel)) {
+                if ("DEBUG".equals(normalizedLevel)) {
+                    targetJulLevel = Level.FINE;
+                } else if ("INFO".equals(normalizedLevel)) {
+                    targetJulLevel = Level.INFO;
+                } else if ("WARN".equals(normalizedLevel)) {
+                    targetJulLevel = Level.WARNING;
+                } else if ("ERROR".equals(normalizedLevel) || "FATAL".equals(normalizedLevel)) {
+                    targetJulLevel = Level.SEVERE;
+                }
+            } else {
+                targetJulLevel = Level.INFO;
             }
         }
         Logger.getLogger("").setLevel(targetJulLevel);
 
-        String xmlConfTemplate = generateActiveLog4jXmlConfig();
         if (!FeConstants.runningUnitTest && !FeConstants.isReplayFromQueryDump) {
             System.out.println("=====");
             System.out.println(xmlConfTemplate);

--- a/fe/fe-core/src/test/java/com/starrocks/common/Log4jConfigTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/Log4jConfigTest.java
@@ -155,18 +155,34 @@ public class Log4jConfigTest {
     @Test
     public void testJulLevelMapping() throws IOException {
 
-        Log4jConfig.updateLogging("DEBUG", null, null);
-        Assertions.assertEquals(java.util.logging.Level.FINE, java.util.logging.Logger.getLogger("").getLevel());
+        java.util.logging.Logger rootLogger = java.util.logging.Logger.getLogger("");
 
-        Log4jConfig.updateLogging("WARN", null, null);
-        Assertions.assertEquals(java.util.logging.Level.WARNING, java.util.logging.Logger.getLogger("").getLevel());
+        try {
+            Log4jConfig.updateLogging("DEBUG", null, null);
+            Assertions.assertEquals(java.util.logging.Level.FINE, rootLogger.getLevel());
 
-        Log4jConfig.updateLogging("ERROR", null, null);
-        Assertions.assertEquals(java.util.logging.Level.SEVERE, java.util.logging.Logger.getLogger("").getLevel());
+            Log4jConfig.updateLogging("WARN", null, null);
+            Assertions.assertEquals(java.util.logging.Level.WARNING, rootLogger.getLevel());
 
-        Log4jConfig.updateLogging("FATAL", null, null);
-        Assertions.assertEquals(java.util.logging.Level.SEVERE, java.util.logging.Logger.getLogger("").getLevel());
+            Log4jConfig.updateLogging("ERROR", null, null);
+            Assertions.assertEquals(java.util.logging.Level.SEVERE, rootLogger.getLevel());
 
-        Log4jConfig.updateLogging("INFO", null, null);
+            Log4jConfig.updateLogging("FATAL", null, null);
+            Assertions.assertEquals(java.util.logging.Level.SEVERE, rootLogger.getLevel());
+
+            Log4jConfig.updateLogging("INFO", null, null);
+            Assertions.assertEquals(java.util.logging.Level.INFO, rootLogger.getLevel());
+
+            try {
+                Log4jConfig.updateLogging("TRACE", null, null);
+                Assertions.fail("Expected IOException was not thrown for unsupported TRACE level");
+            } catch (IOException e) {
+                Assertions.assertTrue(e.getMessage().contains("sys_log_level config error"));
+            }
+            Assertions.assertEquals(java.util.logging.Level.INFO, rootLogger.getLevel());
+
+        } finally {
+            Log4jConfig.updateLogging("INFO", null, null);
+        }
     }
 }

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -595,6 +595,13 @@ under the License.
                 <version>1.7.30</version>
             </dependency>
 
+            <!-- https://mvnrepository.com/artifact/org.slf4j/jul-to-slf4j -->
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jul-to-slf4j</artifactId>
+                <version>1.7.30</version>
+            </dependency>
+
             <!-- https://mvnrepository.com/artifact/com.github.oshi/oshi-core -->
             <dependency>
                 <groupId>com.github.oshi</groupId>


### PR DESCRIPTION
## Why I'm doing:

Currently, third-party libraries that rely on `java.util.logging` (JUL), such as `jprotobuf-rpc-socket`, print logs directly to `stdout` (which redirects to `fe.out`) instead of the standard log files. This happens because the JUL-to-SLF4J bridge is not properly initialized, causing log leakage and making debugging difficult as these logs are missing from `fe.log`.

## What I'm doing:

I have implemented the standard bridging mechanism to route `java.util.logging` calls to SLF4J (Log4j2).

Changes:
1.  Added the `org.slf4j:jul-to-slf4j` dependency in `fe/pom.xml` and `fe/fe-core/pom.xml`.
2.  Initialized `LogManager.getLogManager().reset()` and `SLF4JBridgeHandler.install()` in `Log4jConfig.java` to redirect logs.
3.  Added a unit test `testJulToSlf4jBridge` in `Log4jConfigTest.java` to verify that JUL logs are correctly captured by Log4j2.

This PR supersedes and fixes the unmerged PR #56156.

Fixes #31777

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc. (Logging behavior improvement)

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 4.0
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures logs from JUL-based libraries flow into the existing SLF4J/Log4j2 pipeline and match configured log levels.
> 
> - Add `org.slf4j:jul-to-slf4j` dependency in `fe/pom.xml` and `fe/fe-core/pom.xml`
> - In `Log4jConfig.reconfig()`, install `SLF4JBridgeHandler`, remove root JUL handlers, and set JUL root level based on `sys_log_level` (`DEBUG`→`FINE`, `INFO`→`INFO`, `WARN`→`WARNING`, `ERROR|FATAL`→`SEVERE`)
> - Add unit tests in `Log4jConfigTest`: `testJulToSlf4jBridge` (JUL logs captured by Log4j2) and `testJulLevelMapping` (JUL level mapping and invalid level handling)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1aaf5e477b8b878700da7b04372a80f7c168155. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->